### PR TITLE
feat: limit the maximum width of message content.

### DIFF
--- a/src/renderer/src/assets/styles/markdown.scss
+++ b/src/renderer/src/assets/styles/markdown.scss
@@ -3,6 +3,7 @@
   line-height: 1.6;
   user-select: text;
   word-break: break-word;
+  overflow-x: auto;
 
   h1:first-child,
   h2:first-child,

--- a/src/renderer/src/pages/home/Messages/Message.tsx
+++ b/src/renderer/src/pages/home/Messages/Message.tsx
@@ -192,6 +192,9 @@ const MessageContainer = styled.div`
   padding: 15px 20px 0 20px;
   position: relative;
   transition: background-color 0.3s ease;
+  max-width: 780px;
+  width: 100%;
+  margin: 0 auto;
   &.message-highlight {
     background-color: var(--color-primary-mute);
   }


### PR DESCRIPTION
## 修改说明
1. 修改 `MessageContainer` 的最大宽度为 780px，提高全屏模式下的可阅读性;
2. 为 Markdown 组件添加 `overflow-x: auto;` CSS 样式，在遇到过长的行内代码(它不可打断)时显示横向滚动条；

Closes #422