### PR TITLE
fix: 修复 message 显示时间过长的问题

### DIFF
--- a/src/renderer/src/components/TopView/index.tsx
+++ b/src/renderer/src/components/TopView/index.tsx
@@ -28,7 +28,10 @@ const TopViewContainer: React.FC<Props> = ({ children }) => {
   const elementsRef = useRef<ElementItem[]>([])
   elementsRef.current = elements
 
-  const [messageApi, messageContextHolder] = message.useMessage()
+  // 消息提示默认为 1s 后关闭，使用方法 window.message 代替 antd message
+  const [messageApi, messageContextHolder] = message.useMessage({
+    duration: 1
+  })
   const [modal, modalContextHolder] = Modal.useModal()
 
   useAppInit()

--- a/src/renderer/src/pages/settings/DataSettings/DataSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/DataSettings.tsx
@@ -3,7 +3,7 @@ import { HStack } from '@renderer/components/Layout'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import { backup, reset, restore } from '@renderer/services/BackupService'
 import { AppInfo } from '@renderer/types'
-import { Button, message, Modal, Typography } from 'antd'
+import { Button, Modal, Typography } from 'antd'
 import { FC, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -42,9 +42,9 @@ const DataSettings: FC = () => {
       onOk: async () => {
         try {
           await window.api.clearCache()
-          message.success(t('settings.data.clear_cache.success'))
+          window.message.success(t('settings.data.clear_cache.success'))
         } catch (error) {
-          message.error(t('settings.data.clear_cache.error'))
+          window.message.error(t('settings.data.clear_cache.error'))
         }
       }
     })


### PR DESCRIPTION
close #634
重置了 message  默认显示时间为1s，更改了清除缓存后的 message 为 window.message
![image](https://github.com/user-attachments/assets/872dd5a4-f4dd-495e-819f-b390c2ef019a)
![image](https://github.com/user-attachments/assets/4abcd6a5-2129-4067-90a2-f1da4bfcaa5f)
