### PR TITLE
fix:未被$$包裹的mathcal/underline在markdown中的渲染

### DIFF
--- a/src/renderer/src/pages/home/Markdown/Markdown.tsx
+++ b/src/renderer/src/pages/home/Markdown/Markdown.tsx
@@ -34,7 +34,8 @@ const Markdown: FC<Props> = ({ message }) => {
   const messageContent = useMemo(() => {
     const empty = isEmpty(message.content)
     const paused = message.status === 'paused'
-    const content = empty && paused ? t('message.chat.completion.paused') : message.content
+    let content = empty && paused ? t('message.chat.completion.paused') : message.content
+    content = content.replace(/(?<!\$)\\?(mathcal|underline){([^}]+)}(?!\$)/g, '$\\$1{$2}$')
     return removeSvgEmptyLines(escapeBrackets(content))
   }, [message.content, message.status, t])
 


### PR DESCRIPTION
修正某些情况下，mathcal/underline未被$$包裹时数学公式渲染问题