### PR TITLE
feat(backup): 添加Github Gist备份支持

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -98,6 +98,7 @@ export function registerIpc(mainWindow: BrowserWindow, app: Electron.App) {
   ipcMain.handle('backup:restore', backupManager.restore)
   ipcMain.handle('backup:backupToWebdav', backupManager.backupToWebdav)
   ipcMain.handle('backup:restoreFromWebdav', backupManager.restoreFromWebdav)
+  ipcMain.handle('backup:restoreFromGist', backupManager.restoreFromGist)
 
   // file
   ipcMain.handle('file:open', fileManager.open)

--- a/src/main/services/BackupManager.ts
+++ b/src/main/services/BackupManager.ts
@@ -16,6 +16,7 @@ class BackupManager {
     this.restore = this.restore.bind(this)
     this.backupToWebdav = this.backupToWebdav.bind(this)
     this.restoreFromWebdav = this.restoreFromWebdav.bind(this)
+    this.restoreFromGist = this.restoreFromGist.bind(this)
   }
 
   async backup(
@@ -114,6 +115,18 @@ class BackupManager {
 
     await fs.writeFileSync(backupedFilePath, retrievedFile as Buffer)
 
+    return await this.restore(_, backupedFilePath)
+  }
+
+  async restoreFromGist(_: Electron.IpcMainInvokeEvent, data: Buffer) {
+    const filename = 'cherry-studio.backup.zip'
+    const backupedFilePath = path.join(this.backupDir, filename)
+
+    if (!fs.existsSync(this.backupDir)) {
+      fs.mkdirSync(this.backupDir, { recursive: true })
+    }
+
+    fs.writeFileSync(backupedFilePath, data)
     return await this.restore(_, backupedFilePath)
   }
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -30,6 +30,7 @@ declare global {
         restore: (backupPath: string) => Promise<string>
         backupToWebdav: (data: string, webdavConfig: WebDavConfig) => Promise<boolean>
         restoreFromWebdav: (webdavConfig: WebDavConfig) => Promise<string>
+        restoreFromGist: (data: Buffer) => Promise<string>
       }
       file: {
         select: (options?: OpenDialogOptions) => Promise<FileType[] | null>
@@ -52,6 +53,7 @@ declare global {
         base64Image: (fileId: string) => Promise<{ mime: string; base64: string; data: string }>
         download: (url: string) => Promise<FileType | null>
         copy: (fileId: string, destPath: string) => Promise<void>
+        readRaw: (filePath: string | internal.Readable) => Promise<Buffer>
       }
       export: {
         toWord: (markdown: string, fileName: string) => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -24,7 +24,8 @@ const api = {
     restore: (backupPath: string) => ipcRenderer.invoke('backup:restore', backupPath),
     backupToWebdav: (data: string, webdavConfig: WebDavConfig) =>
       ipcRenderer.invoke('backup:backupToWebdav', data, webdavConfig),
-    restoreFromWebdav: (webdavConfig: WebDavConfig) => ipcRenderer.invoke('backup:restoreFromWebdav', webdavConfig)
+    restoreFromWebdav: (webdavConfig: WebDavConfig) => ipcRenderer.invoke('backup:restoreFromWebdav', webdavConfig),
+    restoreFromGist: (data: Buffer) => ipcRenderer.invoke('backup:restoreFromGist', data)
   },
   file: {
     select: (options?: OpenDialogOptions) => ipcRenderer.invoke('file:select', options),
@@ -43,7 +44,8 @@ const api = {
     saveImage: (name: string, data: string) => ipcRenderer.invoke('file:saveImage', name, data),
     base64Image: (fileId: string) => ipcRenderer.invoke('file:base64Image', fileId),
     download: (url: string) => ipcRenderer.invoke('file:download', url),
-    copy: (fileId: string, destPath: string) => ipcRenderer.invoke('file:copy', fileId, destPath)
+    copy: (fileId: string, destPath: string) => ipcRenderer.invoke('file:copy', fileId, destPath),
+    readRaw: (filePath: string) => ipcRenderer.invoke('file:readRaw', filePath)
   },
   export: {
     toWord: (markdown: string, fileName: string) => ipcRenderer.invoke('export:word', markdown, fileName)

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -378,7 +378,21 @@
         "webdav.autoSync.off": "Off",
         "webdav.noSync": "Waiting for next sync",
         "webdav.syncError": "Sync Error",
-        "webdav.lastSync": "Last Sync"
+        "webdav.lastSync": "Last Sync Time",
+        "gist": {
+          "title": "GitHub Gist",
+          "backup.button": "Backup to Gist",
+          "restore.button": "Restore from Gist",
+          "github_token": "GitHub Token",
+          "github_gist_id": "GitHub Gist ID (Optional)",
+          "github_auto_sync": "Auto Sync",
+          "github_sync_interval": "Gist Sync Interval (Minutes)",
+          "invalid_github_token": "Please configure GitHub Token first",
+          "invalid_github_settings": "Invalid Gist settings, please check Token and Gist ID",
+          "gist_created": "Gist created and saved automatically",
+          "backup.success": "Gist backup successful",
+          "restore.success": "Gist restore successful"
+        }
       },
       "display.title": "Display Settings",
       "font_size.title": "Message font size",

--- a/src/renderer/src/i18n/locales/ja-jp.json
+++ b/src/renderer/src/i18n/locales/ja-jp.json
@@ -376,7 +376,21 @@
         "webdav.autoSync.off": "オフ",
         "webdav.noSync": "次回の同期を待っています",
         "webdav.syncError": "同期エラー",
-        "webdav.lastSync": "最終同期"
+        "webdav.lastSync": "最終同期時刻",
+        "gist": {
+          "title": "GitHub Gist",
+          "backup.button": "Gistにバックアップ",
+          "restore.button": "Gistから復元",
+          "github_token": "GitHub トークン",
+          "github_gist_id": "GitHub Gist ID（オプション）",
+          "github_auto_sync": "自動同期",
+          "github_sync_interval": "Gist同期間隔（分）",
+          "invalid_github_token": "GitHub トークンを設定してください",
+          "invalid_github_settings": "Gist設定が無効です。トークンとGist IDを確認してください",
+          "gist_created": "Gistが自動作成され保存されました",
+          "backup.success": "Gistバックアップ成功",
+          "restore.success": "Gist復元成功"
+        }
       },
       "display.title": "表示設定",
       "font_size.title": "メッセージのフォントサイズ",

--- a/src/renderer/src/i18n/locales/ru-ru.json
+++ b/src/renderer/src/i18n/locales/ru-ru.json
@@ -378,7 +378,21 @@
         "webdav.autoSync.off": "Выключено",
         "webdav.noSync": "Ожидание следующей синхронизации",
         "webdav.syncError": "Ошибка синхронизации",
-        "webdav.lastSync": "Последняя синхронизация"
+        "webdav.lastSync": "Время последней синхронизации",
+        "gist": {
+          "title": "GitHub Gist",
+          "backup.button": "Резервное копирование в Gist",
+          "restore.button": "Восстановить из Gist",
+          "github_token": "GitHub токен",
+          "github_gist_id": "GitHub Gist ID (Необязательно)",
+          "github_auto_sync": "Автоматическая синхронизация",
+          "github_sync_interval": "Интервал синхронизации Gist (минуты)",
+          "invalid_github_token": "Пожалуйста, настройте GitHub токен",
+          "invalid_github_settings": "Неверные настройки Gist, проверьте токен и Gist ID",
+          "gist_created": "Gist создан и сохранен автоматически",
+          "backup.success": "Gist резервное копирование успешно",
+          "restore.success": "Gist восстановление успешно"
+        }
       },
       "display.title": "Настройки отображения",
       "font_size.title": "Размер шрифта сообщений",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -379,7 +379,21 @@
         "webdav.autoSync.off": "关闭",
         "webdav.noSync": "等待下次同步",
         "webdav.syncError": "同步错误",
-        "webdav.lastSync": "上次同步时间"
+        "webdav.lastSync": "上次同步时间",
+        "gist": {
+          "title": "GitHub Gist",
+          "backup.button": "备份到 Gist",
+          "restore.button": "从 Gist 恢复",
+          "github_token": "GitHub Token",
+          "github_gist_id": "GitHub Gist ID（选填）",
+          "github_auto_sync": "自动同步",
+          "github_sync_interval": "Gist 同步间隔（分钟）",
+          "invalid_github_token": "请先配置 GitHub Token",
+          "invalid_github_settings": "Gist 配置无效，请检查 Token 和 Gist ID",
+          "gist_created": "已自动创建 Gist 并保存",
+          "backup.success": "Gist 备份成功",
+          "restore.success": "Gist 恢复成功"
+        }
       },
       "display.title": "显示设置",
       "font_size.title": "消息字体大小",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -378,7 +378,21 @@
         "webdav.autoSync.off": "關閉",
         "webdav.noSync": "等待下次同步",
         "webdav.syncError": "同步錯誤",
-        "webdav.lastSync": "上次同步時間"
+        "webdav.lastSync": "上次同步時間",
+        "gist": {
+          "title": "GitHub Gist",
+          "backup.button": "備份到 Gist",
+          "restore.button": "從 Gist 恢復",
+          "github_token": "GitHub Token",
+          "github_gist_id": "GitHub Gist ID（選填）",
+          "github_auto_sync": "自動同步",
+          "github_sync_interval": "Gist 同步間隔（分鐘）",
+          "invalid_github_token": "請先配置 GitHub Token",
+          "invalid_github_settings": "Gist 配置無效，請檢查 Token 和 Gist ID",
+          "gist_created": "已自動創建 Gist 並保存",
+          "backup.success": "Gist 備份成功",
+          "restore.success": "Gist 恢復成功"
+        }
       },
       "display.title": "顯示設定",
       "font_size.title": "訊息字體大小",

--- a/src/renderer/src/init.ts
+++ b/src/renderer/src/init.ts
@@ -1,6 +1,6 @@
 import KeyvStorage from '@kangfenmao/keyv-storage'
 
-import { startAutoSync } from './services/BackupService'
+import { startAutoSync, startGistAutoSync } from './services/BackupService'
 import store from './store'
 
 function initKeyv() {
@@ -12,6 +12,11 @@ function initAutoSync() {
   const { webdavAutoSync } = store.getState().settings
   if (webdavAutoSync) {
     startAutoSync()
+  }
+
+  const { githubGistAutoSync } = store.getState().settings
+  if (githubGistAutoSync) {
+    startGistAutoSync()
   }
 }
 

--- a/src/renderer/src/pages/settings/DataSettings/DataSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/DataSettings.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 import { SettingContainer, SettingDivider, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '..'
+import GistSettings from './GistSettings'
 import WebDavSettings from './WebDavSettings'
 
 const DataSettings: FC = () => {
@@ -78,6 +79,9 @@ const DataSettings: FC = () => {
       </SettingGroup>
       <SettingGroup theme={theme}>
         <WebDavSettings />
+      </SettingGroup>
+      <SettingGroup theme={theme}>
+        <GistSettings />
       </SettingGroup>
       <SettingGroup theme={theme}>
         <SettingTitle>{t('settings.data.data.title')}</SettingTitle>

--- a/src/renderer/src/pages/settings/DataSettings/GistSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/GistSettings.tsx
@@ -1,0 +1,189 @@
+import { ExportOutlined, FolderOpenOutlined, SaveOutlined, SyncOutlined } from '@ant-design/icons'
+import { HStack } from '@renderer/components/Layout'
+import { useRuntime } from '@renderer/hooks/useRuntime'
+import { useSettings } from '@renderer/hooks/useSettings'
+import { backupToGist, restoreFromGist, startGistAutoSync, stopGistAutoSync } from '@renderer/services/GistService'
+import { useAppDispatch } from '@renderer/store'
+import {
+  setGithubGistAutoSync,
+  setGithubGistId as _setGithubGistId,
+  setGithubGistSyncInterval as _setGithubSyncInterval,
+  setGithubToken as _setGithubToken
+} from '@renderer/store/settings'
+import { Button, Input, Select, Typography } from 'antd'
+import dayjs from 'dayjs'
+import { FC, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { SettingDivider, SettingRow, SettingRowTitle, SettingTitle } from '..'
+
+const { Link } = Typography
+
+const GistSettings: FC = () => {
+  const {
+    githubToken: githubTokenFromStore,
+    githubGistId: githubGistIdFromStore,
+    githubGistSyncInterval: githubSyncIntervalFromStore = 0
+  } = useSettings()
+
+  const [githubToken, setGithubToken] = useState<string | undefined>(githubTokenFromStore)
+  const [githubGistId, setGithubGistId] = useState<string | undefined>(githubGistIdFromStore)
+  const [syncInterval, setSyncInterval] = useState<number>(githubSyncIntervalFromStore)
+
+  const [backuping, setBackuping] = useState(false)
+  const [restoring, setRestoring] = useState(false)
+
+  const dispatch = useAppDispatch()
+  const { t } = useTranslation()
+  const { gistSync } = useRuntime()
+
+  useEffect(() => {
+    if (githubGistIdFromStore) {
+      setGithubGistId(githubGistIdFromStore)
+    }
+  }, [githubGistIdFromStore])
+
+  useEffect(() => {
+    if (githubGistId === undefined && githubGistIdFromStore !== undefined) {
+      setGithubGistId(githubGistIdFromStore)
+    }
+  }, [githubGistIdFromStore, githubGistId])
+
+  const onBackup = async () => {
+    if (!githubToken) {
+      window.message.error({ content: t('settings.data.gist.invalid_github_token'), key: 'github-error' })
+      return
+    }
+    setBackuping(true)
+    await backupToGist()
+    setBackuping(false)
+  }
+
+  const onRestore = async () => {
+    if (!githubToken || !githubGistId) {
+      window.message.error({ content: t('settings.data.gist.invalid_github_settings'), key: 'restore' })
+      return
+    }
+    setRestoring(true)
+    await restoreFromGist()
+    setRestoring(false)
+  }
+
+  const onSyncIntervalChange = (value: number) => {
+    setSyncInterval(value)
+    dispatch(_setGithubSyncInterval(value))
+    if (value === 0) {
+      dispatch(setGithubGistAutoSync(false))
+      stopGistAutoSync()
+    } else {
+      dispatch(setGithubGistAutoSync(true))
+      startGistAutoSync()
+    }
+  }
+
+  const renderSyncStatus = () => {
+    if (!githubToken || !githubGistId) return null
+
+    if (!gistSync?.lastSyncTime && !gistSync?.syncing && !gistSync?.lastSyncError) {
+      return <span style={{ color: 'var(--text-secondary)' }}>{t('settings.data.webdav.noSync')}</span>
+    }
+
+    return (
+      <HStack gap="5px" alignItems="center">
+        {gistSync?.syncing && <SyncOutlined spin />}
+        {gistSync?.lastSyncTime && (
+          <span style={{ color: 'var(--text-secondary)' }}>
+            {t('settings.data.webdav.lastSync')}: {dayjs(gistSync.lastSyncTime).format('HH:mm:ss')}
+          </span>
+        )}
+        {gistSync?.lastSyncError && (
+          <span style={{ color: 'var(--error-color)' }}>
+            {t('settings.data.webdav.syncError')}: {gistSync.lastSyncError}
+          </span>
+        )}
+      </HStack>
+    )
+  }
+
+  return (
+    <>
+      <SettingTitle>{t('settings.data.gist.title')}</SettingTitle>
+      <SettingDivider />
+      <SettingRow>
+        <SettingRowTitle>
+          <HStack gap="5px" alignItems="center">
+            {t('settings.data.gist.github_token')}
+            <Link href="https://github.com/settings/tokens/new" target="_blank">
+              <ExportOutlined style={{ fontSize: '12px', color: 'var(--color-text)' }} />
+            </Link>
+          </HStack>
+        </SettingRowTitle>
+        <Input.Password
+          placeholder={t('settings.data.gist.github_token')}
+          value={githubToken}
+          onChange={(e) => setGithubToken(e.target.value)}
+          style={{ width: 250 }}
+          onBlur={() => dispatch(_setGithubToken(githubToken || ''))}
+        />
+      </SettingRow>
+      <SettingDivider />
+      <SettingRow>
+        <SettingRowTitle>
+          <HStack gap="5px" alignItems="center">
+            {t('settings.data.gist.github_gist_id')}
+            <Link href={`https://gist.github.com/${githubGistId}`} target="_blank">
+              <ExportOutlined style={{ fontSize: '12px', color: 'var(--color-text)' }} />
+            </Link>
+          </HStack>
+        </SettingRowTitle>
+        <Input
+          placeholder={t('settings.data.gist.github_gist_id')}
+          value={githubGistId}
+          onChange={(e) => setGithubGistId(e.target.value)}
+          style={{ width: 250 }}
+          onBlur={() => dispatch(_setGithubGistId(githubGistId || ''))}
+        />
+      </SettingRow>
+      <SettingDivider />
+      <SettingRow>
+        <SettingRowTitle>{t('settings.general.backup.title')}</SettingRowTitle>
+        <HStack gap="5px" justifyContent="space-between">
+          <Button onClick={onBackup} icon={<SaveOutlined />} loading={backuping}>
+            {t('settings.data.gist.backup.button')}
+          </Button>
+          <Button onClick={onRestore} icon={<FolderOpenOutlined />} loading={restoring} disabled={!githubGistId}>
+            {t('settings.data.gist.restore.button')}
+          </Button>
+        </HStack>
+      </SettingRow>
+      <SettingDivider />
+      <SettingRow>
+        <SettingRowTitle>{t('settings.data.gist.github_auto_sync')}</SettingRowTitle>
+        <Select
+          value={syncInterval}
+          onChange={onSyncIntervalChange}
+          disabled={!githubToken || !githubGistId}
+          style={{ width: 120 }}>
+          <Select.Option value={0}>{t('settings.data.webdav.autoSync.off')}</Select.Option>
+          <Select.Option value={1}>1 {t('settings.data.webdav.minutes')}</Select.Option>
+          <Select.Option value={5}>5 {t('settings.data.webdav.minutes')}</Select.Option>
+          <Select.Option value={15}>15 {t('settings.data.webdav.minutes')}</Select.Option>
+          <Select.Option value={30}>30 {t('settings.data.webdav.minutes')}</Select.Option>
+          <Select.Option value={60}>60 {t('settings.data.webdav.minutes')}</Select.Option>
+          <Select.Option value={120}>120 {t('settings.data.webdav.minutes')}</Select.Option>
+        </Select>
+      </SettingRow>
+      {gistSync && syncInterval > 0 && (
+        <>
+          <SettingDivider />
+          <SettingRow>
+            <SettingRowTitle>{t('settings.data.webdav.syncStatus')}</SettingRowTitle>
+            {renderSyncStatus()}
+          </SettingRow>
+        </>
+      )}
+    </>
+  )
+}
+
+export default GistSettings

--- a/src/renderer/src/services/BackupService.ts
+++ b/src/renderer/src/services/BackupService.ts
@@ -4,6 +4,8 @@ import store from '@renderer/store'
 import { setWebDAVSyncState } from '@renderer/store/runtime'
 import dayjs from 'dayjs'
 
+export { backupToGist, restoreFromGist, startGistAutoSync, stopGistAutoSync } from './GistService'
+
 export async function backup() {
   const filename = `cherry-studio.${dayjs().format('YYYYMMDDHHmm')}.zip`
   const fileContnet = await getBackupData()
@@ -202,7 +204,7 @@ export function stopAutoSync() {
   autoSyncStarted = false
 }
 
-async function getBackupData() {
+export async function getBackupData() {
   return JSON.stringify({
     time: new Date().getTime(),
     version: 3,
@@ -212,7 +214,7 @@ async function getBackupData() {
 }
 
 /************************************* Backup Utils ************************************** */
-async function handleData(data: Record<string, any>) {
+export async function handleData(data: Record<string, any>) {
   if (data.version === 1) {
     await clearDatabase()
 
@@ -242,7 +244,7 @@ async function handleData(data: Record<string, any>) {
   window.message.error({ content: i18n.t('error.backup.file_format'), key: 'restore' })
 }
 
-async function backupDatabase() {
+export async function backupDatabase() {
   const tables = db.tables
   const backup = {}
 
@@ -253,7 +255,7 @@ async function backupDatabase() {
   return backup
 }
 
-async function restoreDatabase(backup: Record<string, any>) {
+export async function restoreDatabase(backup: Record<string, any>) {
   await db.transaction('rw', db.tables, async () => {
     for (const tableName in backup) {
       await db.table(tableName).clear()
@@ -262,7 +264,7 @@ async function restoreDatabase(backup: Record<string, any>) {
   })
 }
 
-async function clearDatabase() {
+export async function clearDatabase() {
   const storeNames = await db.tables.map((table) => table.name)
 
   await db.transaction('rw', db.tables, async () => {

--- a/src/renderer/src/services/GistService.ts
+++ b/src/renderer/src/services/GistService.ts
@@ -1,0 +1,238 @@
+import i18n from '@renderer/i18n'
+import store from '@renderer/store'
+import { setGistSyncState } from '@renderer/store/runtime'
+import { setGithubGistId } from '@renderer/store/settings'
+import { Buffer } from 'buffer'
+
+import { getBackupData, handleData } from './BackupService'
+
+const GIST_BACKUP_DATA_FILE = 'cherry-studio-backup.zip'
+
+let isGistBackupRunning = false
+let gistSyncTimeout: NodeJS.Timeout | null = null
+let isGistAutoBackupRunning = false
+
+async function createNewGist(token: string): Promise<string> {
+  const response = await fetch('https://api.github.com/gists', {
+    method: 'POST',
+    headers: {
+      Authorization: `token ${token}`
+    },
+    body: JSON.stringify({
+      description: 'Cherry Studio Backup Storage',
+      public: false,
+      files: {
+        [GIST_BACKUP_DATA_FILE]: {
+          content: 'Cherry Studio Backup Storage'
+        }
+      }
+    })
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to create gist: ${response.statusText}`)
+  }
+
+  const data = await response.json()
+  return data.id
+}
+
+// 删除 Gist 中的所有文件
+async function clearGistFiles(token: string, gistId: string) {
+  const response = await fetch(`https://api.github.com/gists/${gistId}`, {
+    headers: {
+      Authorization: `token ${token}`
+    }
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to get gist: ${response.statusText}`)
+  }
+
+  const data = await response.json()
+  const files = data.files
+
+  const deleteFiles: Record<string, null> = {}
+  for (const filename in files) {
+    deleteFiles[filename] = null
+  }
+
+  const deleteResponse = await fetch(`https://api.github.com/gists/${gistId}`, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `token ${token}`
+    },
+    body: JSON.stringify({
+      files: deleteFiles
+    })
+  })
+
+  if (!deleteResponse.ok) {
+    throw new Error(`Failed to delete gist files: ${deleteResponse.statusText}`)
+  }
+}
+
+// 备份到 GitHub Gist
+export async function backupToGist() {
+  const { githubToken, githubGistId } = store.getState().settings
+
+  if (!githubToken) {
+    window.message.error({ content: i18n.t('settings.data.gist.invalid_github_token'), key: 'backup' })
+    return
+  }
+
+  if (isGistBackupRunning) {
+    return
+  }
+
+  isGistBackupRunning = true
+  store.dispatch(setGistSyncState({ syncing: true, lastSyncError: null }))
+
+  try {
+    let gistId = githubGistId
+    if (!gistId) {
+      gistId = await createNewGist(githubToken)
+      store.dispatch(setGithubGistId(gistId))
+      window.message.success({ content: i18n.t('settings.data.gist.gist_created'), key: 'gist-create' })
+    } else {
+      await clearGistFiles(githubToken, gistId)
+    }
+
+    const backupData = await getBackupData()
+    const backupFile = await window.api.backup.backup(GIST_BACKUP_DATA_FILE, backupData)
+    const fileContent = await window.api.file.readRaw(backupFile)
+    const base64Content = Buffer.from(fileContent).toString('base64')
+    await updateGistFile(githubToken, gistId, GIST_BACKUP_DATA_FILE, base64Content)
+
+    store.dispatch(setGistSyncState({ lastSyncTime: Date.now(), lastSyncError: null }))
+    window.message.success({ content: i18n.t('settings.data.gist.backup.success'), key: 'backup' })
+  } catch (error: any) {
+    console.error('[backup] backupToGithub: Error uploading to Github:', error)
+    store.dispatch(setGistSyncState({ lastSyncError: error.message }))
+    window.message.error({ content: error.message, key: 'backup' })
+  } finally {
+    isGistBackupRunning = false
+    store.dispatch(setGistSyncState({ syncing: false }))
+  }
+}
+
+// 从 GitHub Gist 恢复
+export async function restoreFromGist() {
+  const { githubToken, githubGistId } = store.getState().settings
+
+  if (!githubToken || !githubGistId) {
+    window.message.error({ content: i18n.t('settings.data.gist.invalid_github_settings'), key: 'restore' })
+    return
+  }
+
+  store.dispatch(setGistSyncState({ syncing: true, lastSyncError: null }))
+
+  try {
+    const gistFiles = await getGistFile(githubToken, githubGistId)
+    const backupData = await getGistFileContent(githubToken, gistFiles[GIST_BACKUP_DATA_FILE].raw_url)
+    const data = await window.api.backup.restoreFromGist(Buffer.from(backupData, 'base64'))
+    await handleData(JSON.parse(data))
+  } catch (error: any) {
+    console.error('[backup] restoreFromGithub: Error downloading from Github:', error)
+    store.dispatch(setGistSyncState({ lastSyncError: error.message }))
+    window.modal.error({
+      title: i18n.t('message.restore.failed'),
+      content: error.message
+    })
+  } finally {
+    store.dispatch(setGistSyncState({ syncing: false }))
+  }
+}
+
+// 更新 Gist 文件
+async function updateGistFile(token: string, gistId: string, filename: string, content: string) {
+  const response = await fetch(`https://api.github.com/gists/${gistId}`, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `token ${token}`
+    },
+    body: JSON.stringify({
+      files: {
+        [filename]: {
+          content
+        }
+      }
+    })
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to update gist file: ${response.statusText}`)
+  }
+}
+
+async function getGistFile(token: string, gistId: string): Promise<string> {
+  const response = await fetch(`https://api.github.com/gists/${gistId}`, {
+    headers: {
+      Authorization: `token ${token}`
+    }
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to get gist: ${response.statusText}`)
+  }
+
+  const data = await response.json()
+
+  return data.files
+}
+
+async function getGistFileContent(token: string, rawUrl: string): Promise<string> {
+  const response = await fetch(rawUrl, {
+    headers: {
+      Authorization: `token ${token}`
+    }
+  })
+
+  return response.text()
+}
+
+// 启动自动备份
+export function startGistAutoSync() {
+  if (isGistAutoBackupRunning) {
+    return
+  }
+
+  const { githubGistAutoSync, githubGistSyncInterval } = store.getState().settings
+  if (!githubGistAutoSync || !githubGistSyncInterval) {
+    return
+  }
+
+  isGistAutoBackupRunning = true
+  performGistAutoBackup()
+}
+
+// 停止自动备份
+export function stopGistAutoSync() {
+  isGistAutoBackupRunning = false
+  if (gistSyncTimeout) {
+    clearTimeout(gistSyncTimeout)
+    gistSyncTimeout = null
+  }
+}
+
+// 执行自动备份
+async function performGistAutoBackup() {
+  if (!isGistAutoBackupRunning) {
+    return
+  }
+
+  const { githubGistAutoSync, githubGistSyncInterval } = store.getState().settings
+  if (!githubGistAutoSync || !githubGistSyncInterval) {
+    isGistAutoBackupRunning = false
+    return
+  }
+
+  try {
+    await backupToGist()
+  } catch (error) {
+    console.error('[AutoBackup] Github backup failed:', error)
+  }
+
+  // 安排下一次备份
+  gistSyncTimeout = setTimeout(performGistAutoBackup, githubGistSyncInterval * 60 * 1000)
+}

--- a/src/renderer/src/store/runtime.ts
+++ b/src/renderer/src/store/runtime.ts
@@ -11,6 +11,12 @@ export interface UpdateState {
 }
 
 export interface WebDAVSyncState {
+  syncing: boolean
+  lastSyncTime?: number
+  lastSyncError?: string | null
+}
+
+export interface GistSyncState {
   lastSyncTime: number | null
   syncing: boolean
   lastSyncError: string | null
@@ -24,6 +30,7 @@ export interface RuntimeState {
   filesPath: string
   update: UpdateState
   webdavSync: WebDAVSyncState
+  gistSync: GistSyncState
 }
 
 const initialState: RuntimeState = {
@@ -40,6 +47,11 @@ const initialState: RuntimeState = {
     available: false
   },
   webdavSync: {
+    syncing: false,
+    lastSyncTime: undefined,
+    lastSyncError: null
+  },
+  gistSync: {
     lastSyncTime: null,
     syncing: false,
     lastSyncError: null
@@ -70,6 +82,9 @@ const runtimeSlice = createSlice({
     },
     setWebDAVSyncState: (state, action: PayloadAction<Partial<WebDAVSyncState>>) => {
       state.webdavSync = { ...state.webdavSync, ...action.payload }
+    },
+    setGistSyncState: (state, action: PayloadAction<Partial<GistSyncState>>) => {
+      state.gistSync = { ...state.gistSync, ...action.payload }
     }
   }
 })
@@ -81,7 +96,8 @@ export const {
   setSearching,
   setFilesPath,
   setUpdateState,
-  setWebDAVSyncState
+  setWebDAVSyncState,
+  setGistSyncState
 } = runtimeSlice.actions
 
 export default runtimeSlice.reducer

--- a/src/renderer/src/store/settings.ts
+++ b/src/renderer/src/store/settings.ts
@@ -49,6 +49,11 @@ export interface SettingsState {
   showFilesIcon: boolean
   customCss: string
   topicNamingPrompt: string
+  // GitHub Gist settings
+  githubToken: string
+  githubGistId: string
+  githubGistAutoSync: boolean
+  githubGistSyncInterval: number
 }
 
 const initialState: SettingsState = {
@@ -93,7 +98,11 @@ const initialState: SettingsState = {
   showKnowledgeIcon: true,
   showFilesIcon: true,
   customCss: '',
-  topicNamingPrompt: ''
+  topicNamingPrompt: '',
+  githubToken: '',
+  githubGistId: '',
+  githubGistAutoSync: false,
+  githubGistSyncInterval: 0
 }
 
 const settingsSlice = createSlice({
@@ -232,6 +241,18 @@ const settingsSlice = createSlice({
     },
     setTopicNamingPrompt: (state, action: PayloadAction<string>) => {
       state.topicNamingPrompt = action.payload
+    },
+    setGithubToken: (state, action: PayloadAction<string>) => {
+      state.githubToken = action.payload
+    },
+    setGithubGistId: (state, action: PayloadAction<string>) => {
+      state.githubGistId = action.payload
+    },
+    setGithubGistAutoSync: (state, action: PayloadAction<boolean>) => {
+      state.githubGistAutoSync = action.payload
+    },
+    setGithubGistSyncInterval: (state, action: PayloadAction<number>) => {
+      state.githubGistSyncInterval = action.payload
     }
   }
 })
@@ -280,7 +301,11 @@ export const {
   setShowFilesIcon,
   setPasteLongTextThreshold,
   setCustomCss,
-  setTopicNamingPrompt
+  setTopicNamingPrompt,
+  setGithubToken,
+  setGithubGistId,
+  setGithubGistAutoSync,
+  setGithubGistSyncInterval
 } = settingsSlice.actions
 
 export default settingsSlice.reducer


### PR DESCRIPTION
feat(backup): 添加Github Gist备份支持

仅支持备份模型配置，对话历史这些，如果还有一些大文件的话会备份失败。

<img width="1166" alt="image" src="https://github.com/user-attachments/assets/cce88c6e-015b-480c-8c8e-aa4c332a5025" />
