### PR TITLE
fix: 修正o1模型无法使用的问题

### DIFF
--- a/src/renderer/src/providers/OpenAIProvider.ts
+++ b/src/renderer/src/providers/OpenAIProvider.ts
@@ -187,7 +187,7 @@ export default class OpenAIProvider extends BaseProvider {
       userMessages.push(await this.getMessageParam(message, model))
     }
 
-    const isOpenAIo1 = model.id.includes('o1-')
+    const isOpenAIo1 = model.id.includes('o1-') || model.id === 'o1'
 
     const isSupportStreamOutput = () => {
       if (this.provider.id === 'github' && isOpenAIo1) {


### PR DESCRIPTION
修正 #703 
这个是因为判断o1模型的逻辑问题，应该判断是openai且是o1，因为正式版就o1没有后面的-