### PR TITLE
fix issue#762 upon clicking to resend, the conversation content is cleared

### DIFF
--- a/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
@@ -96,9 +96,9 @@ const MessageMenubar: FC<Props> = (props) => {
       })
     }
 
-    if (!nextMessage) {
-      onDeleteMessage?.(message)
+    if (!nextMessage || nextMessage.role === 'user') {
       EventEmitter.emit(EVENT_NAMES.SEND_MESSAGE, { ...message, id: uuid() })
+      onDeleteMessage?.(message)
     }
   }, [assistantModel?.id, message, model?.id, onDeleteMessage, onGetMessages])
 


### PR DESCRIPTION
fix https://github.com/CherryHQ/cherry-studio/issues/762
1. If there is no subsequent message or if the next message is from the user, this message should be resent. 
2. delete the old message after processing is complete.