### PR TITLE
fix: apikey and ApiHost incorrectly set to empty

### DIFF
--- a/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
@@ -67,8 +67,22 @@ const ProviderSetting: FC<Props> = ({ provider: _provider }) => {
     setApiHost(provider.apiHost)
   }, [provider])
 
-  const onUpdateApiKey = () => updateProvider({ ...provider, apiKey })
-  const onUpdateApiHost = () => updateProvider({ ...provider, apiHost })
+  const onUpdateApiKey = () => {
+    if (apiKey.trim()) {
+      updateProvider({ ...provider, apiKey })
+    } else {
+      setApiKey(provider.apiKey)
+    }
+  }
+
+  const onUpdateApiHost = () => {
+    if (apiHost.trim()) {
+      updateProvider({ ...provider, apiHost })
+    } else {
+      setApiHost(provider.apiHost)
+    }
+  }
+
   const onUpdateApiVersion = () => updateProvider({ ...provider, apiVersion })
   const onManageModel = () => EditModelsPopup.show({ provider })
   const onAddModel = () => AddModelPopup.show({ title: t('settings.models.add.add_model'), provider })


### PR DESCRIPTION
当在模型服务中剪切或者误删除key 后，会自动保存一个空的 key，导致翻译服务和其他服务出现问题，现在调整为只有编辑了实际性的内容才会保存对应 apikey 和 host，否则还是原本的值