### PR TITLE
fix: 新建助手直接修改 defaultModel 不生效的问题

### DIFF
--- a/src/renderer/src/pages/settings/AssistantSettings/AssistantModelSettings.tsx
+++ b/src/renderer/src/pages/settings/AssistantSettings/AssistantModelSettings.tsx
@@ -173,7 +173,9 @@ const AssistantModelSettings: FC<Props> = ({ assistant, updateAssistant, updateA
       setDefaultModel(selectedModel)
       updateAssistant({
         ...assistant,
-        defaultModel: selectedModel
+        defaultModel: selectedModel,
+        // 使用该条件判断是新建助手下的新话题
+        model: assistant.topics.length === 1 && !assistant.topics[0].messages.length ? selectedModel : assistant.model
       })
     }
   }


### PR DESCRIPTION
![Cherry Studio](https://github.com/user-attachments/assets/a2343070-a86e-4298-9e67-14d1faca32b7)
如演示所示，发现一个问题，在新增助手后，直接设置 defaultModel 对当前的新会话不生效，作为用户感觉是预期之外的，尝试修复一下这个问题

另外的建议：
查看代码发现 defaultModel 在【autoResetModel】设置不打开的情况下，全生命周期都是无效的，
消费侧代码的判断都是 
assistant.model || defaultModel（这个 defaultModel 是 app 设置的 defaultModel，不是 assistant.defaultModel）

建议设置 defaultModel 后，自动开启【autoResetModel】，或者说可以去掉 defaultModel 这个概念，因为调整模型本身就很方便 ～

新年快乐 🎉