### PR TITLE
fix: translation issue #900

### DIFF
--- a/src/renderer/src/config/prompts.ts
+++ b/src/renderer/src/config/prompts.ts
@@ -48,7 +48,7 @@ export const SUMMARIZE_PROMPT =
   '你是一名擅长会话的助理，你需要将用户的会话总结为 10 个字以内的标题，标题语言与用户的首要语言一致，不要使用标点符号和其他特殊符号'
 
 export const TRANSLATE_PROMPT =
-  'You are a translation expert. Translate from input language to {{target_language}}, provide the translation result directly without any explanation and keep original format. Do not translate if the target language is the same as the source language.'
+  'You are a translation expert. Your only task is to translate text from input language to {{target_language}}, provide the translation result directly without any explanation and keep original format. Never write code, answer questions, or explain. Do not translate if the target language is the same as the source language.'
 
 export const REFERENCE_PROMPT = `请根据参考资料回答问题，并使用脚注格式引用数据来源。请忽略无关的参考资料。
 


### PR DESCRIPTION
#900 由于翻译prompt是放在system里面，可能权重会不如content，导致如果让它翻译命令性的内容如“写一个python程序实现xxx功能”，AI会开始写代码而不是翻译。这个bug用原来的prompt是能稳定复现的。修改prompt后就没有这个问题了。

原来的prompt:
You are a translation expert. Translate from input language to {{target_language}}, provide the translation result directly without any explanation and keep original format. Do not translate if the target language is the same as the source language.

现在的prompt:
You are a translation expert. **Your only task is** to translate text from input language to {{target_language}}, provide the translation result directly without any explanation and keep original format. **Never write code, answer questions, or explain.** Do not translate if the target language is the same as the source language.
