### PR TITLE
fix: KnowledgeSearchPopup keyword highlighting issue

### DIFF
--- a/src/renderer/src/pages/knowledge/components/KnowledgeSearchPopup.tsx
+++ b/src/renderer/src/pages/knowledge/components/KnowledgeSearchPopup.tsx
@@ -69,7 +69,11 @@ const PopupContainer: React.FC<Props> = ({ base, resolve }) => {
 
   const highlightText = (text: string) => {
     if (!searchKeyword) return text
-    const parts = text.split(new RegExp(`(${searchKeyword})`, 'gi'))
+
+    // Escape special characters in the search keyword
+    const escapedKeyword = searchKeyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const parts = text.split(new RegExp(`(${escapedKeyword})`, 'gi'))
+
     return parts.map((part, i) =>
       part.toLowerCase() === searchKeyword.toLowerCase() ? <mark key={i}>{part}</mark> : part
     )


### PR DESCRIPTION
Uncaught exception when searching text like `C++` in KnowledgeSearchPopup:
```
SyntaxError: Invalid regular expression: /(C++)/gi: Nothing to repeat (at index-EAyXJG9M.js:224275:31)
    at new RegExp (<anonymous>)
    at highlightText (index-EAyXJG9M.js:224275:31)
    at renderItem (index-EAyXJG9M.js:224313:78)
    at renderInnerItem (index-EAyXJG9M.js:66552:8)
    at index-EAyXJG9M.js:66636:57
    at Array.map (<anonymous>)
    at InternalList (index-EAyXJG9M.js:66636:35)
    at Nh (index-EAyXJG9M.js:17550:8)
    at Yi (index-EAyXJG9M.js:18144:8)
    at Vk (index-EAyXJG9M.js:20573:96)
```

