### PR TITLE
Bug Fix: Correct Thinking Time Calculation for Deepseek R1

### DIFF
--- a/src/renderer/src/providers/OpenAIProvider.ts
+++ b/src/renderer/src/providers/OpenAIProvider.ts
@@ -233,7 +233,8 @@ export default class OpenAIProvider extends BaseProvider {
         time_first_token_millsec = new Date().getTime() - start_time_millsec
       }
 
-      if (time_first_content_millsec == 0 && chunk.choices[0]?.delta?.content) {
+      //修复逻辑判断，当content为</think>时，time_first_content_millsec才会被赋值，原有代码无意义.
+      if (time_first_content_millsec == 0 && chunk.choices[0]?.delta?.content == '</think>') {
         time_first_content_millsec = new Date().getTime()
       }
 


### PR DESCRIPTION
#### Description
Fixed the calculation of thinking time for the Deepseek R1 model. Previously, the code would update `time_first_content_millsec` incorrectly, leading to inaccurate thinking time measurements.

#### Changes Made
```typescript
// Before
if (time_first_content_millsec == 0 && chunk.choices[0]?.delta?.content) {
  time_first_content_millsec = new Date().getTime()
}

// After
if (time_first_content_millsec == 0 && chunk.choices[0]?.delta?.content == '</think>') {
  time_first_content_millsec = new Date().getTime()
}
```

#### Testing
- Tested with Deepseek R1 model
- Verified thinking time is only updated when '</think>' token is received
- Confirmed more accurate timing measurements