### PR TITLE
feat: 知识库文件支持 html 类型

### DIFF
--- a/src/main/services/KnowledgeService.ts
+++ b/src/main/services/KnowledgeService.ts
@@ -178,6 +178,17 @@ class KnowledgeService {
 
       const fileContent = fs.readFileSync(file.path, 'utf-8')
 
+      if (['.html'].includes(file.ext)) {
+        return await ragApplication.addLoader(
+          new WebLoader({
+            urlOrContent: fileContent,
+            chunkSize: base.chunkSize,
+            chunkOverlap: base.chunkOverlap
+          }) as any,
+          forceReload
+        )
+      }
+
       return await ragApplication.addLoader(
         new TextLoader({ text: fileContent, chunkSize: base.chunkSize, chunkOverlap: base.chunkOverlap }),
         forceReload

--- a/src/renderer/src/pages/knowledge/KnowledgeContent.tsx
+++ b/src/renderer/src/pages/knowledge/KnowledgeContent.tsx
@@ -33,7 +33,7 @@ interface KnowledgeContentProps {
   selectedBase: KnowledgeBase
 }
 
-const fileTypes = ['.pdf', '.docx', '.pptx', '.xlsx', '.txt', '.md']
+const fileTypes = ['.pdf', '.docx', '.pptx', '.xlsx', '.txt', '.md', '.html']
 
 const KnowledgeContent: FC<KnowledgeContentProps> = ({ selectedBase }) => {
   const { t } = useTranslation()


### PR DESCRIPTION
feature  #1248

HTML 类知识库文件效果（embedjs WebLoader 的原因，索引的文件名显示的是HTML 内容，不是文件名）
<img width="1242" alt="image" src="https://github.com/user-attachments/assets/4a587887-a81c-479b-8ccb-0a337c9d5320" />

对比使用 URL 的效果
<img width="1242" alt="image" src="https://github.com/user-attachments/assets/268a8a4f-8c56-410c-966d-83a7fd2b8891" />
