### PR TITLE
Fix code naming issues

### DIFF
--- a/src/renderer/src/pages/home/Messages/MessageThought.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageThought.tsx
@@ -24,7 +24,7 @@ const MessageThought: FC<Props> = ({ message }) => {
   }
 
   const thinkingTime = message.metrics?.time_thinking_millsec || 0
-  const thinkingTimeSecounds = (thinkingTime / 1000).toFixed(1)
+  const thinkingTimeSeconds = (thinkingTime / 1000).toFixed(1)
 
   return (
     <CollapseContainer
@@ -37,7 +37,7 @@ const MessageThought: FC<Props> = ({ message }) => {
           label: (
             <MessageTitleLabel>
               <TinkingText>
-                {isThinking ? t('chat.thinking') : t('chat.deeply_thought', { secounds: thinkingTimeSecounds })}
+                {isThinking ? t('chat.thinking') : t('chat.deeply_thought', { secounds: thinkingTimeSeconds })}
               </TinkingText>
               {isThinking && <BarLoader color="#9254de" />}
             </MessageTitleLabel>


### PR DESCRIPTION
Fix code naming issues.

thinkingTimeSecounds => thinkingTimeSeconds