### PR TITLE
fix: 修复多模型下重新生成会切换默认模型

### DIFF
--- a/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
@@ -197,7 +197,7 @@ const MessageMenubar: FC<Props> = (props) => {
 
   const onRegenerate = async () => {
     await modelGenerating()
-    const _message: Message = resetAssistantMessage(message, message.model || model || assistantModel)
+    const _message: Message = resetAssistantMessage(message, model || assistantModel)
     onEditMessage?.(_message)
   }
 

--- a/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
@@ -197,7 +197,7 @@ const MessageMenubar: FC<Props> = (props) => {
 
   const onRegenerate = async () => {
     await modelGenerating()
-    const _message: Message = resetAssistantMessage(message, assistantModel)
+    const _message: Message = resetAssistantMessage(message, message.model || model || assistantModel)
     onEditMessage?.(_message)
   }
 


### PR DESCRIPTION
## 问题描述
在使用onMentionModel选择新模型后，点击重新生成(Regenerate)按钮时，模型会切换回默认模型，导致用户选择的模型设置丢失。

https://github.com/user-attachments/assets/7fe32bc5-8e59-4641-a5e6-19bf46eaa267


## 修改内容
修改了`onRegenerate`函数，使其优先使用：
1. 如果消息没有指定模型，则使用当前选择的模型（model）
2. 如果以上都没有，才会使用默认的助手模型（assistantModel）

## 测试
- [✔] 使用onMentionModel选择新模型
- [✔] 点击重新生成按钮，确认使用的是选择的模型而不是默认模型