### PR TITLE
fix: Label text was obscured in create agent page

### DIFF
--- a/src/renderer/src/pages/agents/components/AddAgentPopup.tsx
+++ b/src/renderer/src/pages/agents/components/AddAgentPopup.tsx
@@ -14,6 +14,7 @@ import { Button, Form, FormInstance, Input, Modal, Popover, Select, SelectProps 
 import TextArea from 'antd/es/input/TextArea'
 import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import stringWidth from 'string-width'
 
 interface Props {
   resolve: (data: Agent | null) => void
@@ -104,6 +105,11 @@ const PopupContainer: React.FC<Props> = ({ resolve }) => {
     setLoading(false)
   }
 
+  // Compute label width based on the longest label
+  const labelWidth = [t('agents.add.name'), t('agents.add.prompt'), t('agents.add.knowledge_base')]
+    .map((labelText) => stringWidth(labelText) * 8)
+    .reduce((maxWidth, currentWidth) => Math.max(maxWidth, currentWidth), 80)
+
   return (
     <Modal
       title={t('agents.add.title')}
@@ -117,7 +123,7 @@ const PopupContainer: React.FC<Props> = ({ resolve }) => {
       <Form
         ref={formRef}
         form={form}
-        labelCol={{ flex: '80px' }}
+        labelCol={{ flex: `${labelWidth}px` }}
         labelAlign="left"
         colon={false}
         style={{ marginTop: 25 }}


### PR DESCRIPTION
Fix #1483

根据最长的标签，自适应标签宽度

![ch](https://github.com/user-attachments/assets/ffc0cf8c-d2d8-46a8-8bb5-18757a0565c5)
![en](https://github.com/user-attachments/assets/0c8e028f-2bfb-48ae-9dde-b39dec1bcb3d)
![jp](https://github.com/user-attachments/assets/67f28fd2-13d4-4351-8754-dfcf5d87ffb1)
![ru](https://github.com/user-attachments/assets/a8e3dcf7-26db-48ac-b08e-312f1300954f)
