### PR TITLE
feat: Implement circular selection in model selector

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/MentionModelsButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/MentionModelsButton.tsx
@@ -180,10 +180,10 @@ const MentionModelsButton: FC<Props> = ({ mentionModels, onMentionModel: onSelec
 
       if (e.key === 'ArrowDown') {
         e.preventDefault()
-        setSelectedIndex((prev) => (prev < flatModelItems.length - 1 ? prev + 1 : prev))
+        setSelectedIndex((prev) => (prev < flatModelItems.length - 1 ? prev + 1 : 0))
       } else if (e.key === 'ArrowUp') {
         e.preventDefault()
-        setSelectedIndex((prev) => (prev > 0 ? prev - 1 : prev))
+        setSelectedIndex((prev) => (prev > 0 ? prev - 1 : flatModelItems.length - 1))
       } else if (e.key === 'Enter') {
         e.preventDefault()
         if (selectedIndex >= 0 && selectedIndex < flatModelItems.length) {


### PR DESCRIPTION
#1458 增加了使用 @ 呼出模型选择列表的功能, 但是箭头按键无法循环选择模型, 也就是当前选择列表中第一个模型时, 继续按压向上箭头无法跳转到列表中最后一个模型, 向下箭头同理. 这个 PR 增加了这个功能.