### PR TITLE
feat: implement select mode menu autoscroll for long mode lists

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/MentionModelsButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/MentionModelsButton.tsx
@@ -271,20 +271,16 @@ const MentionModelsButton: FC<Props> = ({ mentionModels, onMentionModel: onSelec
           <div key={group.key} className="ant-dropdown-menu-item-group">
             <div className="ant-dropdown-menu-item-group-title">{group.label}</div>
             <div>
-              {group.children.map((item, idx) => {
-                // calculate item global idx
-                const index = startIndex + idx
-                return (
-                  <div
-                    key={item.key}
-                    ref={(el) => setItemRef(index, el)}
-                    className={`ant-dropdown-menu-item ${selectedIndex === index ? 'ant-dropdown-menu-item-selected' : ''}`}
-                    onClick={item.onClick}>
-                    <span className="ant-dropdown-menu-item-icon">{item.icon}</span>
-                    {item.label}
-                  </div>
-                )
-              })}
+              {group.children.map((item, idx) => (
+                <div
+                  key={item.key}
+                  ref={(el) => setItemRef(startIndex + idx, el)}
+                  className={`ant-dropdown-menu-item ${selectedIndex === startIndex + idx ? 'ant-dropdown-menu-item-selected' : ''}`}
+                  onClick={item.onClick}>
+                  <span className="ant-dropdown-menu-item-icon">{item.icon}</span>
+                  {item.label}
+                </div>
+              ))}
             </div>
           </div>
         )


### PR DESCRIPTION
在 #1586 中提到了模型 list 过长需要滚动显示菜单的问题, 这个 PR 完成了这个需求