### PR TITLE
fix: Translation error when passing empty user messages to certain models.(Revised)

### DIFF
--- a/src/renderer/src/providers/OpenAIProvider.ts
+++ b/src/renderer/src/providers/OpenAIProvider.ts
@@ -287,13 +287,12 @@ export default class OpenAIProvider extends BaseProvider {
   async translate(message: Message, assistant: Assistant, onResponse?: (text: string) => void) {
     const defaultModel = getDefaultModel()
     const model = assistant.model || defaultModel
-    if (!message.content) {
-      message.content = ' '
-    }
-    const messages = [
-      { role: 'system', content: assistant.prompt },
-      { role: 'user', content: message.content }
-    ]
+    const messages = message.content
+      ? [
+          { role: 'system', content: assistant.prompt },
+          { role: 'user', content: message.content }
+        ]
+      : [{ role: 'user', content: assistant.prompt }]
 
     const isOpenAIo1 = this.isOpenAIo1(model)
 


### PR DESCRIPTION
真是不好意思，刚刚晚上发版之后才发现那个 `role: user` 消息留一个空格的方法只对腾讯云的部署是一个有效的解决方案……测试不充分，红豆泥私密马赛。

这次应该是一个逻辑上“完全正确”的解决方法了，我想不出来哪个 API 必须有 `role: system` 不可，只有 `role: user` 是必要的。

![Snipaste_2025-02-14_19-12-39](https://github.com/user-attachments/assets/8342128e-3844-4bc2-8fd1-e0db8edcd757)
![Snipaste_2025-02-14_19-11-46](https://github.com/user-attachments/assets/ae3715f9-f001-4420-8f77-8dd1fdf31421)
![Snipaste_2025-02-14_19-11-02](https://github.com/user-attachments/assets/1795ae91-de2c-49af-9fc7-9a4bb71fc827)
