### PR TITLE
Improvement(shortcut): 调整`show_app`快捷键功能的交互逻辑

### DIFF
--- a/src/main/services/ShortcutService.ts
+++ b/src/main/services/ShortcutService.ts
@@ -22,7 +22,11 @@ function getShortcutHandler(shortcut: Shortcut) {
     case 'show_app':
       return (window: BrowserWindow) => {
         if (window.isVisible()) {
-          window.hide()
+          if (window.isFocused()) {
+            window.hide()
+          } else {
+            window.focus()
+          }
         } else {
           window.show()
           window.focus()


### PR DESCRIPTION
调整"显示应用"的快捷键功能逻辑。

原本只是在隐藏窗口和显示窗口之间切换，实际场景有：如果用户在Cherry Studio对话完后，没有手动关闭Cherry Studio，只是切到了其他窗口，随后又希望快捷键快捷打开Cherry Studio，这只会隐藏窗口，而不是“再次打开”Cherry Studio。

新的调整会更符合用户意图。