### PR TITLE
Fix: Font size and Latex problem, resolve CherryHQ#1034 CherryHQ#1596

### DIFF
--- a/src/renderer/src/pages/home/Messages/MessageThought.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageThought.tsx
@@ -1,10 +1,11 @@
 import { Message } from '@renderer/types'
 import { Collapse } from 'antd'
-import { FC, useEffect, useState } from 'react'
+import { FC, useEffect, useState, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import ReactMarkdown from 'react-markdown'
 import BarLoader from 'react-spinners/BarLoader'
 import styled from 'styled-components'
+import Markdown from '../Markdown/Markdown'
+import { useSettings } from '@renderer/hooks/useSettings'
 
 interface Props {
   message: Message
@@ -14,6 +15,12 @@ const MessageThought: FC<Props> = ({ message }) => {
   const [activeKey, setActiveKey] = useState<'thought' | ''>('thought')
   const isThinking = !message.content
   const { t } = useTranslation()
+  const { messageFont, fontSize } = useSettings()
+  const fontFamily = useMemo(() => {
+    return messageFont === 'serif'
+      ? 'serif'
+      : '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans","Helvetica Neue", sans-serif'
+  }, [messageFont])
 
   useEffect(() => {
     if (!isThinking) setActiveKey('')
@@ -42,7 +49,7 @@ const MessageThought: FC<Props> = ({ message }) => {
               {isThinking && <BarLoader color="#9254de" />}
             </MessageTitleLabel>
           ),
-          children: <ReactMarkdown className="markdown">{message.reasoning_content}</ReactMarkdown>
+          children: <Markdown message={{ ...message, content: message.reasoning_content }} style={{ fontFamily, fontSize }} />
         }
       ]}
     />

--- a/src/renderer/src/pages/home/Messages/MessageThought.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageThought.tsx
@@ -49,7 +49,11 @@ const MessageThought: FC<Props> = ({ message }) => {
               {isThinking && <BarLoader color="#9254de" />}
             </MessageTitleLabel>
           ),
-          children: <Markdown message={{ ...message, content: message.reasoning_content }} style={{ fontFamily, fontSize }} />
+          children: (
+            <div style={{ fontFamily, fontSize }}>
+              <Markdown message={{ ...message, content: message.reasoning_content }} />
+            </div>
+          )
         }
       ]}
     />


### PR DESCRIPTION
fix #1034 
fix #1596 

代码是AI改的，可能会有点问题（我不会typescript和react-js）

从结果来看，编译通过了。latex正常加载了，也随着设定的字体改动了。

参考：
1. https://github.com/oldjyeric/cherry-studio/actions/runs/13344397141
2. https://github.com/oldjyeric/cherry-studio/releases
<img width="1008" alt="image" src="https://github.com/user-attachments/assets/d0e87e54-634b-453f-bcf9-49c5a690a968" />
