### PR TITLE
fix: unregister global shortcuts

### DIFF
--- a/src/main/services/ShortcutService.ts
+++ b/src/main/services/ShortcutService.ts
@@ -79,11 +79,11 @@ export function registerShortcuts(window: BrowserWindow) {
 
         const accelerator = formatShortcutKey(shortcut.shortcut)
 
-        if (shortcut.key === 'show_app') {
+        if (shortcut.key === 'show_app' && shortcut.enabled) {
           showAppAccelerator = accelerator
         }
 
-        if (shortcut.key === 'mini_window') {
+        if (shortcut.key === 'mini_window' && shortcut.enabled) {
           showMiniWindowAccelerator = accelerator
         }
 


### PR DESCRIPTION
两个全局快捷键的 enabled 没使用，导致没有正确反注册，可能全局占用
