### PR TITLE
feat: allow knowledge base multiple search #1346

### DIFF
--- a/src/renderer/src/hooks/useKnowledge.ts
+++ b/src/renderer/src/hooks/useKnowledge.ts
@@ -307,16 +307,22 @@ export const useKnowledgeBases = () => {
 
     // remove assistant knowledge_base
     const _assistants = assistants.map((assistant) => {
-      if (assistant.knowledge_base?.id === baseId) {
-        return { ...assistant, knowledge_base: undefined }
+      if (assistant.knowledge_bases?.find((kb) => kb.id === baseId)) {
+        return {
+          ...assistant,
+          knowledge_bases: assistant.knowledge_bases.filter((kb) => kb.id !== baseId)
+        }
       }
       return assistant
     })
 
     // remove agent knowledge_base
     const _agents = agents.map((agent) => {
-      if (agent.knowledge_base?.id === baseId) {
-        return { ...agent, knowledge_base: undefined }
+      if (agent.knowledge_bases?.find((kb) => kb.id === baseId)) {
+        return {
+          ...agent,
+          knowledge_bases: agent.knowledge_bases.filter((kb) => kb.id !== baseId)
+        }
       }
       return agent
     })

--- a/src/renderer/src/pages/agents/components/AddAgentPopup.tsx
+++ b/src/renderer/src/pages/agents/components/AddAgentPopup.tsx
@@ -9,7 +9,7 @@ import { useSidebarIconShow } from '@renderer/hooks/useSidebarIcon'
 import { fetchGenerate } from '@renderer/services/ApiService'
 import { getDefaultModel } from '@renderer/services/AssistantService'
 import { useAppSelector } from '@renderer/store'
-import { Agent } from '@renderer/types'
+import { Agent, KnowledgeBase } from '@renderer/types'
 import { getLeadingEmoji, uuid } from '@renderer/utils'
 import { Button, Form, FormInstance, Input, Modal, Popover, Select, SelectProps } from 'antd'
 import TextArea from 'antd/es/input/TextArea'
@@ -25,7 +25,7 @@ type FieldType = {
   id: string
   name: string
   prompt: string
-  knowledge_base_id: string
+  knowledge_base_id: string[]
 }
 
 const PopupContainer: React.FC<Props> = ({ resolve }) => {
@@ -57,7 +57,9 @@ const PopupContainer: React.FC<Props> = ({ resolve }) => {
     const _agent: Agent = {
       id: uuid(),
       name: values.name,
-      knowledge_base: knowledgeState.bases.find((t) => t.id === values.knowledge_base_id),
+      knowledge_bases: values.knowledge_base_id
+        .map((id) => knowledgeState.bases.find((t) => t.id === id))
+        .filter((base): base is KnowledgeBase => base !== undefined),
       emoji: _emoji,
       prompt: values.prompt,
       defaultModel: getDefaultModel(),
@@ -156,6 +158,7 @@ const PopupContainer: React.FC<Props> = ({ resolve }) => {
         {showKnowledgeIcon && (
           <Form.Item name="knowledge_base_id" label={t('agents.add.knowledge_base')} rules={[{ required: false }]}>
             <Select
+              mode="multiple"
               allowClear
               placeholder={t('agents.add.knowledge_base.placeholder')}
               menuItemSelectedIcon={<CheckOutlined />}

--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -52,7 +52,6 @@ interface Props {
 
 let _text = ''
 let _files: FileType[] = []
-let _bases: KnowledgeBase[] | []
 
 const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic }) => {
   const [text, setText] = useState(_text)
@@ -83,7 +82,7 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic }) => {
   const [spaceClickCount, setSpaceClickCount] = useState(0)
   const spaceClickTimer = useRef<NodeJS.Timeout>()
   const [isTranslating, setIsTranslating] = useState(false)
-  const [selectedKnowledgeBases, setSelectedKnowledgeBases] = useState<KnowledgeBase[] | []>(_bases)
+  const [selectedKnowledgeBases, setSelectedKnowledgeBases] = useState<KnowledgeBase[]>([])
   const [mentionModels, setMentionModels] = useState<Model[]>([])
   const [isMentionPopupOpen, setIsMentionPopupOpen] = useState(false)
 
@@ -104,7 +103,6 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic }) => {
 
   _text = text
   _files = files
-  _bases = selectedKnowledgeBases
 
   const sendMessage = useCallback(async () => {
     await modelGenerating()
@@ -458,6 +456,7 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic }) => {
   }, [])
 
   useEffect(() => {
+    // if assistant knowledge bases are undefined return []
     setSelectedKnowledgeBases(showKnowledgeIcon ? (assistant.knowledge_bases ?? []) : [])
   }, [assistant.id, assistant.knowledge_bases, showKnowledgeIcon])
 

--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -461,10 +461,6 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic }) => {
     setSelectedKnowledgeBases(showKnowledgeIcon ? (assistant.knowledge_bases ?? []) : [])
   }, [assistant.id, assistant.knowledge_bases, showKnowledgeIcon])
 
-  useEffect(() => {
-    console.warn('selected bases updated', selectedKnowledgeBases)
-  }, [selectedKnowledgeBases])
-
   const textareaRows = window.innerHeight >= 1000 || isBubbleStyle ? 2 : 1
 
   const handleKnowledgeBaseSelect = (bases?: KnowledgeBase[]) => {

--- a/src/renderer/src/pages/home/Inputbar/KnowledgeBaseButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/KnowledgeBaseButton.tsx
@@ -31,11 +31,6 @@ const KnowledgeBaseSelector: FC<Props> = ({ selectedBases, onSelect }) => {
         <EmptyMessage>{t('knowledge.no_bases')}</EmptyMessage>
       ) : (
         <>
-          {/* {selectedBases && ( */}
-          {/*   <Button type="link" block onClick={() => onSelect([])} style={{ textAlign: 'left' }}> */}
-          {/*     {t('knowledge.clear_selection')} */}
-          {/*   </Button> */}
-          {/* )} */}
           <Select
             mode="multiple"
             defaultValue={selectedBases?.map((base) => base.id)}
@@ -44,19 +39,8 @@ const KnowledgeBaseSelector: FC<Props> = ({ selectedBases, onSelect }) => {
             menuItemSelectedIcon={<CheckOutlined />}
             options={knowledgeOptions}
             onChange={(value) => onSelect(knowledgeState.bases.filter((b) => value.includes(b.id)))}
-            style={{ width: '100px' }}
+            style={{ width: '200px' }}
           />
-
-          {/* {knowledgeState.bases.map((base) => ( */}
-          {/*   <Button */}
-          {/*     key={base.id} */}
-          {/*     type={selectedBase?.id === base.id ? 'primary' : 'text'} */}
-          {/*     block */}
-          {/*     onClick={() => onSelect(base)} */}
-          {/*     style={{ textAlign: 'left' }}> */}
-          {/*     {base.name} */}
-          {/*   </Button> */}
-          {/* ))} */}
         </>
       )}
     </SelectorContainer>

--- a/src/renderer/src/pages/home/Inputbar/KnowledgeBaseButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/KnowledgeBaseButton.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components'
 
 interface Props {
   selectedBases?: KnowledgeBase[]
-  onSelect: (bases?: KnowledgeBase[]) => void
+  onSelect: (bases: KnowledgeBase[]) => void
   disabled?: boolean
   ToolbarButton?: any
 }
@@ -16,32 +16,29 @@ interface Props {
 const KnowledgeBaseSelector: FC<Props> = ({ selectedBases, onSelect }) => {
   const { t } = useTranslation()
   const knowledgeState = useAppSelector((state) => state.knowledge)
-  const knowledgeOptions: SelectProps['options'] = []
-
-  knowledgeState.bases.forEach((base) => {
-    knowledgeOptions.push({
-      label: base.name,
-      value: base.id
-    })
-  })
+  const knowledgeOptions: SelectProps['options'] = knowledgeState.bases.map((base) => ({
+    label: base.name,
+    value: base.id
+  }))
 
   return (
     <SelectorContainer>
       {knowledgeState.bases.length === 0 ? (
         <EmptyMessage>{t('knowledge.no_bases')}</EmptyMessage>
       ) : (
-        <>
-          <Select
-            mode="multiple"
-            value={selectedBases?.map((base) => base.id)}
-            allowClear
-            placeholder={t('agents.add.knowledge_base.placeholder')}
-            menuItemSelectedIcon={<CheckOutlined />}
-            options={knowledgeOptions}
-            onChange={(value) => onSelect(knowledgeState.bases.filter((b) => value.includes(b.id)))}
-            style={{ width: '200px' }}
-          />
-        </>
+        <Select
+          mode="multiple"
+          value={selectedBases?.map((base) => base.id)}
+          allowClear
+          placeholder={t('agents.add.knowledge_base.placeholder')}
+          menuItemSelectedIcon={<CheckOutlined />}
+          options={knowledgeOptions}
+          onChange={(ids) => {
+            const newSelected = knowledgeState.bases.filter((base) => ids.includes(base.id))
+            onSelect(newSelected)
+          }}
+          style={{ width: '200px' }}
+        />
       )}
     </SelectorContainer>
   )
@@ -57,8 +54,10 @@ const KnowledgeBaseButton: FC<Props> = ({ selectedBases, onSelect, disabled, Too
         content={<KnowledgeBaseSelector selectedBases={selectedBases} onSelect={onSelect} />}
         overlayStyle={{ maxWidth: 400 }}
         trigger="click">
-        <ToolbarButton type="text" onClick={() => selectedBases} disabled={disabled}>
-          <FileSearchOutlined style={{ color: selectedBases ? 'var(--color-link)' : 'var(--color-icon)' }} />
+        <ToolbarButton type="text" disabled={disabled}>
+          <FileSearchOutlined
+            style={{ color: selectedBases && selectedBases?.length > 0 ? 'var(--color-link)' : 'var(--color-icon)' }}
+          />
         </ToolbarButton>
       </Popover>
     </Tooltip>

--- a/src/renderer/src/pages/home/Inputbar/KnowledgeBaseButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/KnowledgeBaseButton.tsx
@@ -1,21 +1,29 @@
-import { FileSearchOutlined } from '@ant-design/icons'
+import { CheckOutlined, FileSearchOutlined } from '@ant-design/icons'
 import { useAppSelector } from '@renderer/store'
 import { KnowledgeBase } from '@renderer/types'
-import { Button, Popover, Tooltip } from 'antd'
+import { Popover, Select, SelectProps, Tooltip } from 'antd'
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 interface Props {
-  selectedBase?: KnowledgeBase
-  onSelect: (base?: KnowledgeBase) => void
+  selectedBases?: KnowledgeBase[]
+  onSelect: (bases?: KnowledgeBase[]) => void
   disabled?: boolean
   ToolbarButton?: any
 }
 
-const KnowledgeBaseSelector: FC<Props> = ({ selectedBase, onSelect }) => {
+const KnowledgeBaseSelector: FC<Props> = ({ selectedBases, onSelect }) => {
   const { t } = useTranslation()
   const knowledgeState = useAppSelector((state) => state.knowledge)
+  const knowledgeOptions: SelectProps['options'] = []
+
+  knowledgeState.bases.forEach((base) => {
+    knowledgeOptions.push({
+      label: base.name,
+      value: base.id
+    })
+  })
 
   return (
     <SelectorContainer>
@@ -23,49 +31,60 @@ const KnowledgeBaseSelector: FC<Props> = ({ selectedBase, onSelect }) => {
         <EmptyMessage>{t('knowledge.no_bases')}</EmptyMessage>
       ) : (
         <>
-          {selectedBase && (
-            <Button type="link" block onClick={() => onSelect(undefined)} style={{ textAlign: 'left' }}>
-              {t('knowledge.clear_selection')}
-            </Button>
-          )}
-          {knowledgeState.bases.map((base) => (
-            <Button
-              key={base.id}
-              type={selectedBase?.id === base.id ? 'primary' : 'text'}
-              block
-              onClick={() => onSelect(base)}
-              style={{ textAlign: 'left' }}>
-              {base.name}
-            </Button>
-          ))}
+          {/* {selectedBases && ( */}
+          {/*   <Button type="link" block onClick={() => onSelect([])} style={{ textAlign: 'left' }}> */}
+          {/*     {t('knowledge.clear_selection')} */}
+          {/*   </Button> */}
+          {/* )} */}
+          <Select
+            mode="multiple"
+            defaultValue={selectedBases?.map((base) => base.id)}
+            allowClear
+            placeholder={t('agents.add.knowledge_base.placeholder')}
+            menuItemSelectedIcon={<CheckOutlined />}
+            options={knowledgeOptions}
+            onChange={(value) => onSelect(knowledgeState.bases.filter((b) => value.includes(b.id)))}
+            style={{ width: '100px' }}
+          />
+
+          {/* {knowledgeState.bases.map((base) => ( */}
+          {/*   <Button */}
+          {/*     key={base.id} */}
+          {/*     type={selectedBase?.id === base.id ? 'primary' : 'text'} */}
+          {/*     block */}
+          {/*     onClick={() => onSelect(base)} */}
+          {/*     style={{ textAlign: 'left' }}> */}
+          {/*     {base.name} */}
+          {/*   </Button> */}
+          {/* ))} */}
         </>
       )}
     </SelectorContainer>
   )
 }
 
-const KnowledgeBaseButton: FC<Props> = ({ selectedBase, onSelect, disabled, ToolbarButton }) => {
+const KnowledgeBaseButton: FC<Props> = ({ selectedBases, onSelect, disabled, ToolbarButton }) => {
   const { t } = useTranslation()
 
-  if (selectedBase) {
-    return (
-      <Tooltip placement="top" title={selectedBase.name} arrow>
-        <ToolbarButton type="text" onClick={() => onSelect(undefined)}>
-          <FileSearchOutlined style={{ color: selectedBase ? 'var(--color-link)' : 'var(--color-icon)' }} />
-        </ToolbarButton>
-      </Tooltip>
-    )
-  }
+  // if (selectedBases && selectedBases?.length > 0) {
+  //   return (
+  //     <Tooltip placement="top" title={selectedBases[0].name} arrow>
+  //       <ToolbarButton type="text" onClick={() => onSelect([])}>
+  //         <FileSearchOutlined style={{ color: selectedBases[0] ? 'var(--color-link)' : 'var(--color-icon)' }} />
+  //       </ToolbarButton>
+  //     </Tooltip>
+  //   )
+  // }
 
   return (
     <Tooltip placement="top" title={t('chat.input.knowledge_base')} arrow>
       <Popover
         placement="top"
-        content={<KnowledgeBaseSelector selectedBase={selectedBase} onSelect={onSelect} />}
+        content={<KnowledgeBaseSelector selectedBases={selectedBases} onSelect={onSelect} />}
         overlayStyle={{ maxWidth: 400 }}
         trigger="click">
-        <ToolbarButton type="text" onClick={() => selectedBase && onSelect(undefined)} disabled={disabled}>
-          <FileSearchOutlined style={{ color: selectedBase ? 'var(--color-link)' : 'var(--color-icon)' }} />
+        <ToolbarButton type="text" onClick={() => selectedBases} disabled={disabled}>
+          <FileSearchOutlined style={{ color: selectedBases ? 'var(--color-link)' : 'var(--color-icon)' }} />
         </ToolbarButton>
       </Popover>
     </Tooltip>

--- a/src/renderer/src/pages/home/Inputbar/KnowledgeBaseButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/KnowledgeBaseButton.tsx
@@ -33,7 +33,7 @@ const KnowledgeBaseSelector: FC<Props> = ({ selectedBases, onSelect }) => {
         <>
           <Select
             mode="multiple"
-            defaultValue={selectedBases?.map((base) => base.id)}
+            value={selectedBases?.map((base) => base.id)}
             allowClear
             placeholder={t('agents.add.knowledge_base.placeholder')}
             menuItemSelectedIcon={<CheckOutlined />}
@@ -49,16 +49,6 @@ const KnowledgeBaseSelector: FC<Props> = ({ selectedBases, onSelect }) => {
 
 const KnowledgeBaseButton: FC<Props> = ({ selectedBases, onSelect, disabled, ToolbarButton }) => {
   const { t } = useTranslation()
-
-  // if (selectedBases && selectedBases?.length > 0) {
-  //   return (
-  //     <Tooltip placement="top" title={selectedBases[0].name} arrow>
-  //       <ToolbarButton type="text" onClick={() => onSelect([])}>
-  //         <FileSearchOutlined style={{ color: selectedBases[0] ? 'var(--color-link)' : 'var(--color-icon)' }} />
-  //       </ToolbarButton>
-  //     </Tooltip>
-  //   )
-  // }
 
   return (
     <Tooltip placement="top" title={t('chat.input.knowledge_base')} arrow>

--- a/src/renderer/src/pages/settings/AssistantSettings/AssistantKnowledgeBaseSettings.tsx
+++ b/src/renderer/src/pages/settings/AssistantSettings/AssistantKnowledgeBaseSettings.tsx
@@ -26,8 +26,9 @@ const AssistantKnowledgeBaseSettings: React.FC<Props> = ({ assistant, updateAssi
   })
 
   const onUpdate = (value) => {
-    const knowledge_base = knowledgeState.bases.find((t) => t.id === value)
-    const _assistant = { ...assistant, knowledge_base }
+    const knowledge_bases = value.map((id) => knowledgeState.bases.find((b) => b.id === id))
+    const _assistant = { ...assistant, knowledge_bases }
+    console.warn('_assistant', _assistant)
     updateAssistant(_assistant)
   }
 

--- a/src/renderer/src/pages/settings/AssistantSettings/AssistantKnowledgeBaseSettings.tsx
+++ b/src/renderer/src/pages/settings/AssistantSettings/AssistantKnowledgeBaseSettings.tsx
@@ -37,8 +37,9 @@ const AssistantKnowledgeBaseSettings: React.FC<Props> = ({ assistant, updateAssi
         {t('common.knowledge_base')}
       </Box>
       <Select
+        mode="multiple"
         allowClear
-        defaultValue={assistant.knowledge_base?.id}
+        defaultValue={assistant.knowledge_bases?.map((b) => b.id)}
         placeholder={t('agents.add.knowledge_base.placeholder')}
         menuItemSelectedIcon={<CheckOutlined />}
         options={knowledgeOptions}

--- a/src/renderer/src/pages/settings/AssistantSettings/AssistantKnowledgeBaseSettings.tsx
+++ b/src/renderer/src/pages/settings/AssistantSettings/AssistantKnowledgeBaseSettings.tsx
@@ -28,7 +28,6 @@ const AssistantKnowledgeBaseSettings: React.FC<Props> = ({ assistant, updateAssi
   const onUpdate = (value) => {
     const knowledge_bases = value.map((id) => knowledgeState.bases.find((b) => b.id === id))
     const _assistant = { ...assistant, knowledge_bases }
-    console.warn('_assistant', _assistant)
     updateAssistant(_assistant)
   }
 
@@ -40,7 +39,7 @@ const AssistantKnowledgeBaseSettings: React.FC<Props> = ({ assistant, updateAssi
       <Select
         mode="multiple"
         allowClear
-        defaultValue={assistant.knowledge_bases?.map((b) => b.id)}
+        value={assistant.knowledge_bases?.map((b) => b.id)}
         placeholder={t('agents.add.knowledge_base.placeholder')}
         menuItemSelectedIcon={<CheckOutlined />}
         options={knowledgeOptions}

--- a/src/renderer/src/services/KnowledgeService.ts
+++ b/src/renderer/src/services/KnowledgeService.ts
@@ -3,7 +3,6 @@ import { DEFAULT_KNOWLEDGE_DOCUMENT_COUNT, DEFAULT_KNOWLEDGE_THRESHOLD } from '@
 import { getEmbeddingMaxContext } from '@renderer/config/embedings'
 import AiProvider from '@renderer/providers/AiProvider'
 import { FileType, KnowledgeBase, KnowledgeBaseParams, Message } from '@renderer/types'
-import { t } from 'i18next'
 import { take } from 'lodash'
 
 import { getProviderByModel } from './AssistantService'
@@ -91,14 +90,6 @@ export const getKnowledgeReferences = async (base: KnowledgeBase, message: Messa
         return item.score >= threshold
       })
     )
-  if (searchResults.length === 0) {
-    window.message.info({
-      content: t('knowledge.no_match'),
-      duration: 4,
-      key: 'knowledge-base-no-match-info'
-    })
-    return { referencesContent: '', referencesCount: 0 }
-  }
 
   const _searchResults = await Promise.all(
     searchResults.map(async (item) => {

--- a/src/renderer/src/services/KnowledgeService.ts
+++ b/src/renderer/src/services/KnowledgeService.ts
@@ -121,7 +121,5 @@ export const getKnowledgeReferences = async (base: KnowledgeBase, message: Messa
     })
   )
 
-  const referencesContent = `\`\`\`json\n${JSON.stringify(references, null, 2)}\n\`\`\``
-
-  return { referencesContent, referencesCount: references.length }
+  return references
 }

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -5,7 +5,7 @@ export type Assistant = {
   id: string
   name: string
   prompt: string
-  knowledge_base?: KnowledgeBase
+  knowledge_bases?: KnowledgeBase[]
   topics: Topic[]
   type: string
   emoji?: string


### PR DESCRIPTION
feat #1346 #1722
有一个小bug：如果之前查询问答的内容未查询到结果，在本次聊天仍会触发toast。
复现过程：
1. 先询问一个知识库中无法查询的问题，会显示toast: '未查询到结果'
2. 询问一个知识库中能找到的问题，问答中会显示数据库的引用，但仍会有toast: '未查询到结果'

![CleanShot 2025-02-16 at 20 22 14@2x](https://github.com/user-attachments/assets/85fc6602-d1a2-4cbf-ad83-30105761d09b)

![CleanShot 2025-02-16 at 20 22 49@2x](https://github.com/user-attachments/assets/d96dcd18-722c-483b-aa65-cbafbea5e705)

看起来每一次询问都会获取历史记录，第三次询问时则会输出三段内容(两次历史，一次当前)
![CleanShot 2025-02-16 at 20 25 11@2x](https://github.com/user-attachments/assets/d0f36813-637e-41c1-a5ca-5eaa304d235e)

在BaseProvide/getMessageContent中加入console即可查看
![CleanShot 2025-02-16 at 20 25 57@2x](https://github.com/user-attachments/assets/c78fc59d-458a-4918-80e9-e6cc4f08c5fc)
