### PR TITLE
fix: 修复切换助手时无法正确切换到助手默认模型的问题

### DIFF
--- a/src/renderer/src/hooks/useAssistant.ts
+++ b/src/renderer/src/hooks/useAssistant.ts
@@ -44,7 +44,7 @@ export function useAssistant(id: string) {
 
   return {
     assistant,
-    model: assistant?.model ?? defaultModel,
+    model: assistant?.model ?? assistant?.defaultModel ?? defaultModel,
     addTopic: (topic: Topic) => dispatch(addTopic({ assistantId: assistant.id, topic })),
     removeTopic: (topic: Topic) => {
       TopicManager.removeTopic(topic.id)


### PR DESCRIPTION
修复了切换助手时助手默认会话模型fallback顺序的问题，修复issue #1740
后续可能需要修改一下模型的各个定义，全局的defaultModel和assistant的defaultModel需要区分一下以便维护。
> 已在Windows平台Build&Run，功能一切正常