### PR TITLE
feat: improve model mention autocomplete behavior under IME

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/MentionModelsButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/MentionModelsButton.tsx
@@ -28,6 +28,8 @@ const MentionModelsButton: FC<Props> = ({ mentionModels, onMentionModel: onSelec
   const menuRef = useRef<HTMLDivElement>(null)
   const [searchText, setSearchText] = useState('')
   const itemRefs = useRef<Array<HTMLDivElement | null>>([])
+  // Add a new state to track if menu was dismissed
+  const [menuDismissed, setMenuDismissed] = useState(false)
 
   const setItemRef = (index: number, el: HTMLDivElement | null) => {
     itemRefs.current[index] = el
@@ -186,6 +188,7 @@ const MentionModelsButton: FC<Props> = ({ mentionModels, onMentionModel: onSelec
       setIsOpen(true)
       setSelectedIndex(0)
       setSearchText('')
+      setMenuDismissed(false) // Reset dismissed flag when manually showing selector
     }
 
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -218,6 +221,7 @@ const MentionModelsButton: FC<Props> = ({ mentionModels, onMentionModel: onSelec
       } else if (e.key === 'Escape') {
         setIsOpen(false)
         setSearchText('')
+        setMenuDismissed(true) // Set dismissed flag when Escape is pressed
       }
     }
 
@@ -230,10 +234,14 @@ const MentionModelsButton: FC<Props> = ({ mentionModels, onMentionModel: onSelec
       if (lastAtIndex === -1 || textBeforeCursor.slice(lastAtIndex + 1).includes(' ')) {
         setIsOpen(false)
         setSearchText('')
-      } else if (lastAtIndex !== -1) {
-        // Get the text after @ for search
-        const searchStr = textBeforeCursor.slice(lastAtIndex + 1)
-        setSearchText(searchStr)
+        setMenuDismissed(false) // Reset dismissed flag when @ is removed
+      } else {
+        // Only open menu if it wasn't explicitly dismissed
+        if (!menuDismissed) {
+          setIsOpen(true)
+          const searchStr = textBeforeCursor.slice(lastAtIndex + 1)
+          setSearchText(searchStr)
+        }
       }
     }
 
@@ -252,39 +260,42 @@ const MentionModelsButton: FC<Props> = ({ mentionModels, onMentionModel: onSelec
         textArea.removeEventListener('input', handleTextChange)
       }
     }
-  }, [isOpen, selectedIndex, flatModelItems, mentionModels])
-
-  // Hide dropdown if no models available
-  if (flatModelItems.length === 0) {
-    return null
-  }
+  }, [isOpen, selectedIndex, flatModelItems, mentionModels, menuDismissed])
 
   const menu = (
     <div ref={menuRef} className="ant-dropdown-menu">
-      {modelMenuItems.map((group, groupIndex) => {
-        if (!group) return null
+      {flatModelItems.length > 0 ? (
+        modelMenuItems.map((group, groupIndex) => {
+          if (!group) return null
 
-        // Calculate the starting index for this group's items
-        const startIndex = modelMenuItems.slice(0, groupIndex).reduce((acc, g) => acc + (g?.children?.length || 0), 0)
+          // Calculate starting index for items in this group
+          const startIndex = modelMenuItems.slice(0, groupIndex).reduce((acc, g) => acc + (g?.children?.length || 0), 0)
 
-        return (
-          <div key={group.key} className="ant-dropdown-menu-item-group">
-            <div className="ant-dropdown-menu-item-group-title">{group.label}</div>
-            <div>
-              {group.children.map((item, idx) => (
-                <div
-                  key={item.key}
-                  ref={(el) => setItemRef(startIndex + idx, el)}
-                  className={`ant-dropdown-menu-item ${selectedIndex === startIndex + idx ? 'ant-dropdown-menu-item-selected' : ''}`}
-                  onClick={item.onClick}>
-                  <span className="ant-dropdown-menu-item-icon">{item.icon}</span>
-                  {item.label}
-                </div>
-              ))}
+          return (
+            <div key={group.key} className="ant-dropdown-menu-item-group">
+              <div className="ant-dropdown-menu-item-group-title">{group.label}</div>
+              <div>
+                {group.children.map((item, idx) => (
+                  <div
+                    key={item.key}
+                    ref={(el) => setItemRef(startIndex + idx, el)}
+                    className={`ant-dropdown-menu-item ${
+                      selectedIndex === startIndex + idx ? 'ant-dropdown-menu-item-selected' : ''
+                    }`}
+                    onClick={item.onClick}>
+                    <span className="ant-dropdown-menu-item-icon">{item.icon}</span>
+                    {item.label}
+                  </div>
+                ))}
+              </div>
             </div>
-          </div>
-        )
-      })}
+          )
+        })
+      ) : (
+        <div className="ant-dropdown-menu-item-group">
+          <div className="ant-dropdown-menu-item no-results">{t('models.no_matches')}</div>
+        </div>
+      )}
     </div>
   )
 
@@ -333,6 +344,17 @@ const DropdownMenuStyle = createGlobalStyle`
 
       &::-webkit-scrollbar-track {
         background: transparent;
+      }
+
+      .no-results {
+        padding: 8px 12px;
+        color: var(--color-text-3);
+        cursor: default;
+        font-size: 14px;
+        
+        &:hover {
+          background: none;
+        }
       }
     }
 


### PR DESCRIPTION
增强使用拼音输入法 @ 符号选择模型时的体验.

在使用拼音输入法时, 如果想输入简短的英文, 我们并不需要切换回英文, 而是直接压回车, 即可输入当前已经输入的英文内容. 但是在使用 @ 符号选择模型时会出问题, 因为在使用拼音输入法时输入的英文字母并不是连续的, 而是会被空格隔开, 直到压了回车, 输入的字符才变成连续的, 但是当前@ 符号匹配模型列表时一旦不匹配, 则模型选择 menu 会永远关闭, 直到用户下次输入 @ 符号才会再次打开, 这样就造成一些问题, 如图
<img width="361" alt="image" src="https://github.com/user-attachments/assets/521a7432-4e7b-4975-ab18-03b7b40fc579" />
此时因为 llam 中存在空格, 所以模型菜单由于不匹配, 会关闭, 即使我压了回车得到 `@llam` 也无济于事, 需要删除这些内容, 切换到英语输入法, 然后重新选择模型, 非常麻烦.

这个 PR 会让 @ 持续匹配,  而不是永久关闭, 虽然在拼音输入法的瞬间由于空格等因素无法真正的匹配, 但是一旦用户压了回车, 得到 `@llam` 这样的序列后, 则会再次弹出菜单, 并且显示已经匹配的列表.

所以现在的行为是, 在拼音输入法的时候显示如下, 我增加了一个小的提示框
<img width="388" alt="image" src="https://github.com/user-attachments/assets/34f4db53-36fc-487f-9d11-e847a802dc31" />

一旦用户压了回车, 则变成如下显示
<img width="424" alt="image" src="https://github.com/user-attachments/assets/ea278f32-22ae-4c4d-a09a-ed01ddf333f8" />

这个改动同时优化了在英文输入法下选择模型的体验, 以前如果用户错误的输入了模型名称, 比如 `@llan` 那菜单直接关闭, 需要从头开始, 但是现在则会显示 `models.no_matches` 并且只要删除最后的 n, 菜单又会重新打开.

当然有时候比如要输入邮箱, 里面一定有 @ 符号, 如果持续显示 `models.no_matches` 会很烦人, 所以我增加了 esc 按键取消匹配, 此时 menu 菜单会和之前一样彻底关闭, 直到用户输入下一个 @ 符, 又会开启匹配.

总结一下目前的行为:
1. @ 符号后的输入会反复匹配, 如果输入出错, 删除错误字符后会继续弹出模型选择菜单
2. 拼音输入法输入的瞬间可能会出现不匹配, 因为有空格的存在, 但是压了回车后得到真正的输入序列会继续尝试匹配
3. 压 esc 按钮会彻底关闭本次 @ 符号的匹配
4. @ 符号后跟空格会彻底关闭本次 @ 符号的匹配



