### PR TITLE
fix: open current webview URL when launching external link

### DIFF
--- a/src/renderer/src/components/MinApp/index.tsx
+++ b/src/renderer/src/components/MinApp/index.tsx
@@ -49,7 +49,10 @@ const PopupContainer: React.FC<Props> = ({ app, resolve }) => {
   }
 
   const onOpenLink = () => {
-    window.api.openWebsite(app.url)
+    if (webviewRef.current) {
+      const currentUrl = webviewRef.current.getURL()
+      window.api.openWebsite(currentUrl)
+    }
   }
 
   const onTogglePin = () => {


### PR DESCRIPTION
使用浏览器打开 Webview 页面时，使用 Webview 此时所在的实际网址
resolve #1724 