### PR TITLE
fix: Clicking the help button always opens a new webview

### DIFF
--- a/src/renderer/src/components/app/Sidebar.tsx
+++ b/src/renderer/src/components/app/Sidebar.tsx
@@ -50,6 +50,7 @@ const Sidebar: FC = () => {
 
   const onOpenDocs = () => {
     MinApp.start({
+      id: 'docs',
       name: t('docs.title'),
       url: 'https://docs.cherry-ai.com/',
       logo: AppLogo


### PR DESCRIPTION
修复当帮助文档已经打开，再次点击帮助文档按钮时，总是会打开一个新的 webview 的问题
部分解决 #1649 的问题