### PR TITLE
fix: init zoom

### DIFF
--- a/src/main/services/ShortcutService.ts
+++ b/src/main/services/ShortcutService.ts
@@ -47,8 +47,8 @@ function formatShortcutKey(shortcut: string[]): string {
 
 function handleZoom(delta: number) {
   return (window: BrowserWindow) => {
-    const currentZoom = window.webContents.getZoomFactor()
-    const newZoom = currentZoom + delta
+    const currentZoom = configManager.getZoomFactor()
+    const newZoom = Number((currentZoom + delta).toFixed(1))
     if (newZoom >= 0.1 && newZoom <= 5.0) {
       window.webContents.setZoomFactor(newZoom)
       configManager.setZoomFactor(newZoom)
@@ -110,7 +110,9 @@ const convertShortcutRecordedByKeyboardEventKeyValueToElectronGlobalShortcutForm
 }
 
 export function registerShortcuts(window: BrowserWindow) {
-  window.webContents.setZoomFactor(configManager.getZoomFactor())
+  window.once('ready-to-show', () => {
+    window.webContents.setZoomFactor(configManager.getZoomFactor())
+  })
 
   const register = () => {
     if (window.isDestroyed()) return


### PR DESCRIPTION
#1307 

经测试，确实会概率出现这种情况，实际缩放因子和存储里的缩放因子只会在窗口初始化时可能出现差异，electron老问题并且看起来依然存在，参考[electron issues#10572](https://github.com/electron/electron/issues/10572)

此外，把缩放因子限定在了实在的1位小数，浮点问题