### PR TITLE
style: Disable text selection globally with selective text input exce…

### DIFF
--- a/src/renderer/src/assets/styles/index.scss
+++ b/src/renderer/src/assets/styles/index.scss
@@ -68,6 +68,13 @@
   --list-item-border-radius: 16px;
 }
 
+body {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
 body[theme-mode='light'] {
   --color-white: #ffffff;
   --color-white-soft: #f2f2f2;
@@ -154,6 +161,19 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   transition: background-color 0.3s linear;
+}
+
+input,
+textarea,
+[contenteditable='true'],
+.markdown,
+.selectable,
+pre,
+code {
+  -webkit-user-select: text !important;
+  -moz-user-select: text !important;
+  -ms-user-select: text !important;
+  user-select: text !important;
 }
 
 a {


### PR DESCRIPTION
- 问题:https://github.com/CherryHQ/cherry-studio/issues/1840
- 解决:全局禁用选中,排除`input\textarea\.markdown\.selectable\pre\code`,保证用户正常使用