### PR TITLE
fix: 修复mac下快捷键注册control被替换成command的问题

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -53,7 +53,6 @@ if (!app.requestSingleInstanceLock()) {
         windowService.showMainWindow()
       }
     })
-
     registerShortcuts(mainWindow)
 
     registerIpc(mainWindow, app)

--- a/src/main/services/ShortcutService.ts
+++ b/src/main/services/ShortcutService.ts
@@ -70,10 +70,12 @@ const convertShortcutRecordedByKeyboardEventKeyValueToElectronGlobalShortcutForm
   return accelerator
     .map((key) => {
       switch (key) {
+        case 'Command':
+          return 'CommandOrControl'
         case 'Control':
-          return 'CommandOrControl'
+          return 'Control'
         case 'Ctrl':
-          return 'CommandOrControl'
+          return 'Control'
         case 'ArrowUp':
           return 'Up'
         case 'ArrowDown':


### PR DESCRIPTION
## 修复bug
- Mac 系统中，注册快捷键的Control键注册全局快捷键时被注册成Command，注册快捷键时的键位映射逻辑错误
