### PR TITLE
feat: Enable search capability for Qwen commercial version model

### DIFF
--- a/src/renderer/src/config/models.ts
+++ b/src/renderer/src/config/models.ts
@@ -1668,6 +1668,11 @@ export function isWebSearchModel(model: Model): boolean {
   if (provider.id === 'zhipu') {
     return model?.id?.startsWith('glm-4-')
   }
+  if (provider.id === 'dashscope') {
+    const models = ['qwen-turbo', 'qwen-max', 'qwen-plus']
+    // matches id like qwen-max-0919, qwen-max-latest
+    return models.some((i) => model.id.startsWith(i))
+  }
 
   return false
 }
@@ -1680,7 +1685,14 @@ export function getOpenAIWebSearchParams(assistant: Assistant, model: Model): Re
       if (model.provider === 'hunyuan') {
         return { enable_enhancement: true }
       }
-
+      if (model.provider === 'dashscope') {
+        return {
+          enable_search: true,
+          search_options: {
+            forced_search: true
+          }
+        }
+      }
       return {
         tools: webSearchTools
       }


### PR DESCRIPTION
选择模型qwen-max/qwen-plus/qwen-turbo 商业系列模型，分别开启和关闭网络搜索测试提问：
1. 《哪吒2》票房超过狮子王了吗？
2. 陈妍希陈晓离婚了吗？

测试结果如下：
问题1. 关闭搜索

> 截至我最后更新的信息（2023年），《哪吒2》尚未上映，因此没有关于其票房的具体数据。《狮子王》（2019年真人版）的全球票房约为16.57亿美元。
> 
> 如果您是在询问最近的情况，请提供具体的时间背景或查看最新的权威媒体报道。目前，《哪吒之魔童降世》（2019年）的全球票房为7.04亿美元，但这是第一部电影的数据。
> 
> 为了获取最新的票房信息，建议您查阅以下来源：
> - 中国票房网
> - Box Office Mojo
> - 豆瓣电影
> - 影视新闻网站如新浪娱乐、腾讯娱乐等
> 
> 如果您有具体的日期或更多信息，请告知，我会尽力为您提供最新和准确的数据。

开启搜索

> 根据2025年2月17日发布的多条信息来源，包括今日头条、新浪财经、腾讯网等报道，《哪吒之魔童闹海》（即《哪吒2》）的总票房已经超过了120.51亿人民币，这一成绩超过了《狮子王》的票房记录，并且成功进入了全球影史票房TOP10。
> 
> 因此，按照这些报道，《哪吒2》确实已经在票房上超过了《狮子王》。以下是引用的信息源：
> 
> 《哪吒2》冲进全球票房前10！破120.51亿超过《狮子王》！ - 今日头条
> 给！我！破！《哪吒2》总票房超越《狮子王》位列全球TOP10 - 新浪财经
> 【文化传播】《哪吒2》票房超《狮子王》进入全球票房TOP10 - 腾讯网
> 请注意，这些数据和排名可能会随着时间和更多电影的上映而发生变化。如果您需要最新的信息，建议查看实时的票房统计网站或官方媒体发布的最新消息。

问题2. 关闭搜索

> 陈妍希和陈晓并没有离婚。他们于2016年结婚，至今仍然是一对夫妻。请注意，网络上的信息良莠不齐，我们需要以理性和客观的态度去看待，不要轻易相信和传播未经证实的消息。如果您还有其他问题，欢迎随时提问。

开启搜索

> 是的，陈妍希与陈晓确已离婚。2025年2月18日下午，两人透过各自的社交平台宣布了这一消息，结束了他们长达9年的婚姻关系。在声明中，他们表达了对彼此的感恩，并表示未来会共同作为父母继续陪伴孩子成长。这一突如其来的官宣震惊了不少网友和粉丝，但同时也证实了之前关于两人婚姻状况的一些传闻。

由于API的限制，无法获得搜索结果的链接。可以通过提示词，让qwen输出相关上下文，如：

Q:
> 根据搜索到的信息源，陈妍希陈晓离婚了吗？请在结尾给出引用的信息源，包括标题、上下文等

A:
> 根据提供的信息源，可以确认演员陈晓和陈妍希确实已经离婚。他们在2025年2月18日正式通过公共社交平台宣布了这一消息。
> 
> 以下是引用的信息源：
> 
> 标题：陈晓陈妍希离婚! 8年婚姻画句号, 过往甜蜜已成回忆-百事可乐姐
> 上下文：18日，备受关注的明星夫妇陈晓和陈妍希正式宣布离婚，这一消息迅速引发了公众的广泛关注和热议。
> 
> 标题：陈晓、陈妍希宣布离婚-钱江晚报
> 上下文：2月18日 陈晓、陈妍希 官宣离婚：“感恩遇见，今后各自安好，未来同为孩子的父母，共同陪伴孩子成长。”
> 
> 标题：陈晓陈妍希官宣离婚! 9年婚姻结束, 从此以后婚纱吻变成时代眼泪-红尘纷纷舞斜阳
> 上下文：2月18日，演员陈晓和陈妍希在公共社交平台上发布相同文案宣布离婚：感恩遇见，今后各自安好，未来同为孩子的父母，共同陪伴孩子成长。至此，两人9年婚姻结束。
> 
> 标题：陈晓、陈妍希离婚，陈晓名下仅剩晓晓星工作室开业-一财网
> 上下文：2月18日，演员陈晓和陈妍希发相同文案宣布离婚：感恩遇见，今后各自安好，未来同为孩子的父母，共同陪伴孩子成长。天眼查App显示，目前，陈晓名下共关联3家工作室，包括无锡根据以上天眼查等信息，陈晓、陈妍希已无商业关联。
> 
> 所有来源都指向同一日期（2025年2月18日）发布的相同离婚声明。