### PR TITLE
feat: Add Doubao provider support for model type detection

### DIFF
--- a/src/renderer/src/config/models.ts
+++ b/src/renderer/src/config/models.ts
@@ -196,8 +196,8 @@ export function getModelLogo(modelId: string) {
     glm: isLight ? ChatGLMModelLogo : ChatGLMModelLogoDark,
     deepseek: isLight ? DeepSeekModelLogo : DeepSeekModelLogoDark,
     qwen: isLight ? QwenModelLogo : QwenModelLogoDark,
-    "qwq-": isLight ? QwenModelLogo : QwenModelLogoDark,
-    "qvq-": isLight ? QwenModelLogo : QwenModelLogoDark,
+    'qwq-': isLight ? QwenModelLogo : QwenModelLogoDark,
+    'qvq-': isLight ? QwenModelLogo : QwenModelLogoDark,
     Omni: isLight ? QwenModelLogo : QwenModelLogoDark,
     gemma: isLight ? GemmaModelLogo : GemmaModelLogoDark,
     'yi-': isLight ? YiModelLogo : YiModelLogoDark,
@@ -1604,6 +1604,10 @@ export function isEmbeddingModel(model: Model): boolean {
     return false
   }
 
+  if (model.provider === 'doubao') {
+    return EMBEDDING_REGEX.test(model.name)
+  }
+
   return EMBEDDING_REGEX.test(model.id) || model.type?.includes('embedding') || false
 }
 
@@ -1612,12 +1616,20 @@ export function isVisionModel(model: Model): boolean {
     return false
   }
 
+  if (model.provider === 'doubao') {
+    return VISION_REGEX.test(model.name) || model.type?.includes('vision') || false
+  }
+
   return VISION_REGEX.test(model.id) || model.type?.includes('vision') || false
 }
 
 export function isReasoningModel(model: Model): boolean {
   if (!model) {
     return false
+  }
+
+  if (model.provider === 'doubao') {
+    return REASONING_REGEX.test(model.name) || model.type?.includes('reasoning') || false
   }
 
   return REASONING_REGEX.test(model.id) || model.type?.includes('reasoning') || false

--- a/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
@@ -192,9 +192,15 @@ const ProviderSetting: FC<Props> = ({ provider: _provider }) => {
   const modelTypeContent = (model: Model) => {
     // 获取默认选中的类型
     const defaultTypes = [
-      ...(VISION_REGEX.test(model.id) ? ['vision'] : []),
-      ...(EMBEDDING_REGEX.test(model.id) ? ['embedding'] : []),
-      ...(REASONING_REGEX.test(model.id) ? ['reasoning'] : [])
+      ...((model.provider === 'doubao' ? VISION_REGEX.test(model.name) : VISION_REGEX.test(model.id))
+        ? ['vision']
+        : []),
+      ...((model.provider === 'doubao' ? EMBEDDING_REGEX.test(model.name) : EMBEDDING_REGEX.test(model.id))
+        ? ['embedding']
+        : []),
+      ...((model.provider === 'doubao' ? REASONING_REGEX.test(model.name) : REASONING_REGEX.test(model.id))
+        ? ['reasoning']
+        : [])
     ] as ModelType[]
 
     // 合并现有选择和默认类型
@@ -206,9 +212,21 @@ const ProviderSetting: FC<Props> = ({ provider: _provider }) => {
           value={selectedTypes}
           onChange={(types) => onUpdateModelTypes(model, types as ModelType[])}
           options={[
-            { label: t('models.type.vision'), value: 'vision', disabled: VISION_REGEX.test(model.id) },
-            { label: t('models.type.embedding'), value: 'embedding', disabled: EMBEDDING_REGEX.test(model.id) },
-            { label: t('models.type.reasoning'), value: 'reasoning', disabled: REASONING_REGEX.test(model.id) }
+            {
+              label: t('models.type.vision'),
+              value: 'vision',
+              disabled: model.provider === 'doubao' ? VISION_REGEX.test(model.name) : VISION_REGEX.test(model.id)
+            },
+            {
+              label: t('models.type.embedding'),
+              value: 'embedding',
+              disabled: model.provider === 'doubao' ? EMBEDDING_REGEX.test(model.name) : EMBEDDING_REGEX.test(model.id)
+            },
+            {
+              label: t('models.type.reasoning'),
+              value: 'reasoning',
+              disabled: model.provider === 'doubao' ? REASONING_REGEX.test(model.name) : REASONING_REGEX.test(model.id)
+            }
           ]}
         />
       </div>

--- a/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
@@ -10,7 +10,7 @@ import {
 import { HStack } from '@renderer/components/Layout'
 import ModelTags from '@renderer/components/ModelTags'
 import OAuthButton from '@renderer/components/OAuth/OAuthButton'
-import { EMBEDDING_REGEX, getModelLogo, REASONING_REGEX, VISION_REGEX } from '@renderer/config/models'
+import { getModelLogo, isEmbeddingModel, isReasoningModel, isVisionModel } from '@renderer/config/models'
 import { PROVIDER_CONFIG } from '@renderer/config/providers'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import { useAssistants, useDefaultModel } from '@renderer/hooks/useAssistant'
@@ -192,15 +192,9 @@ const ProviderSetting: FC<Props> = ({ provider: _provider }) => {
   const modelTypeContent = (model: Model) => {
     // 获取默认选中的类型
     const defaultTypes = [
-      ...((model.provider === 'doubao' ? VISION_REGEX.test(model.name) : VISION_REGEX.test(model.id))
-        ? ['vision']
-        : []),
-      ...((model.provider === 'doubao' ? EMBEDDING_REGEX.test(model.name) : EMBEDDING_REGEX.test(model.id))
-        ? ['embedding']
-        : []),
-      ...((model.provider === 'doubao' ? REASONING_REGEX.test(model.name) : REASONING_REGEX.test(model.id))
-        ? ['reasoning']
-        : [])
+      ...(isVisionModel(model) ? ['vision'] : []),
+      ...(isEmbeddingModel(model) ? ['embedding'] : []),
+      ...(isReasoningModel(model) ? ['reasoning'] : [])
     ] as ModelType[]
 
     // 合并现有选择和默认类型
@@ -215,17 +209,17 @@ const ProviderSetting: FC<Props> = ({ provider: _provider }) => {
             {
               label: t('models.type.vision'),
               value: 'vision',
-              disabled: model.provider === 'doubao' ? VISION_REGEX.test(model.name) : VISION_REGEX.test(model.id)
+              disabled: isVisionModel(model)
             },
             {
               label: t('models.type.embedding'),
               value: 'embedding',
-              disabled: model.provider === 'doubao' ? EMBEDDING_REGEX.test(model.name) : EMBEDDING_REGEX.test(model.id)
+              disabled: isEmbeddingModel(model)
             },
             {
               label: t('models.type.reasoning'),
               value: 'reasoning',
-              disabled: model.provider === 'doubao' ? REASONING_REGEX.test(model.name) : REASONING_REGEX.test(model.id)
+              disabled: isReasoningModel(model)
             }
           ]}
         />


### PR DESCRIPTION
Fix #1558 
火山引擎添加的模型，通过模型名字而不是模型 ID 来判断模型类型，比如 ep-20250211104135-wgso1 之类的模型 id 被判断为推理类型等情况