### PR TITLE
fix Uncaught Error: handle empty code block

### DIFF
--- a/src/renderer/src/context/SyntaxHighlighterProvider.tsx
+++ b/src/renderer/src/context/SyntaxHighlighterProvider.tsx
@@ -42,7 +42,11 @@ export const SyntaxHighlighterProvider: React.FC<PropsWithChildren> = ({ childre
       })
 
       setHighlighter(hl)
-
+      // Load theme if not already loaded
+      if (!hl.getLoadedThemes().includes(highlighterTheme)) {
+        console.debug('Loading theme:', highlighterTheme)
+        await hl.loadTheme(highlighterTheme as BundledTheme)
+      }
       // Load all themes and languages
       // hl.loadTheme(...(Object.keys(bundledThemes) as BundledTheme[]))
       // hl.loadLanguage(...(Object.keys(bundledLanguages) as BundledLanguage[]))

--- a/src/renderer/src/pages/home/Markdown/CodeBlock.tsx
+++ b/src/renderer/src/pages/home/Markdown/CodeBlock.tsx
@@ -3,6 +3,7 @@ import CopyIcon from '@renderer/components/Icons/CopyIcon'
 import { HStack } from '@renderer/components/Layout'
 import { useSyntaxHighlighter } from '@renderer/context/SyntaxHighlighterProvider'
 import { useSettings } from '@renderer/hooks/useSettings'
+import { Spin } from 'antd'
 import dayjs from 'dayjs'
 import React, { memo, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -35,6 +36,7 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ children, className }) => {
 
   useEffect(() => {
     const loadHighlightedCode = async () => {
+      if (!children) return
       const highlightedHtml = await codeToHtml(children, language)
       setHtml(highlightedHtml)
     }
@@ -58,7 +60,9 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ children, className }) => {
       }
     }
   }, [codeCollapsible])
-
+  if (!children) {
+    return <Spin />
+  }
   if (language === 'mermaid') {
     return <Mermaid chart={children} />
   }


### PR DESCRIPTION

 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'trimEnd')
    at codeToHtml2 (index-kCV543dl.js:199652:19)
    at loadHighlightedCode (index-kCV543dl.js:200817:37)
    at index-kCV543dl.js:200820:5
    at Qj (index-kCV543dl.js:19516:22)
    at Hk (index-kCV543dl.js:20751:19)
    at index-kCV543dl.js:20621:5
    at J2 (index-kCV543dl.js:14946:20)
    at MessagePort.R2 (index-kCV543dl.js:14974:14)