### PR TITLE
fix: ensure '{{target_language}}' in the translation prompt is fully …

### DIFF
--- a/src/renderer/src/services/AssistantService.ts
+++ b/src/renderer/src/services/AssistantService.ts
@@ -30,8 +30,8 @@ export function getDefaultTranslateAssistant(targetLanguage: string, text: strin
 
   assistant.prompt = store
     .getState()
-    .settings.translateModelPrompt.replace('{{target_language}}', targetLanguage)
-    .replace('{{text}}', text)
+    .settings.translateModelPrompt.replace(/\{\{target_language\}\}/g, targetLanguage)
+    .replace(/\{\{text\}\}/g, text)
   return assistant
 }
 


### PR DESCRIPTION
In the translation assistant prompt, "{{target_language}}" appeared twice, but because the first parameter passed to ES5's `replace` method was a string, it was not fully replaced. This commit fixes this.