### PR TITLE
fix(KnowledgeBase): fallback to text processing on JSON parse failure

### DIFF
--- a/src/main/loader/index.ts
+++ b/src/main/loader/index.ts
@@ -123,13 +123,22 @@ export async function addFileLoader(
 
   // JSON类型
   if (['.json'].includes(file.ext)) {
-    const jsonObject = JSON.parse(fileContent)
-    const loaderReturn = await ragApplication.addLoader(new JsonLoader({ object: jsonObject }))
-    return {
-      entriesAdded: loaderReturn.entriesAdded,
-      uniqueId: loaderReturn.uniqueId,
-      uniqueIds: [loaderReturn.uniqueId],
-      loaderType: loaderReturn.loaderType
+    let jsonObject = {}
+    let jsonParsed = true
+    try {
+      jsonObject = JSON.parse(fileContent)
+    } catch (error) {
+      jsonParsed = false
+      Logger.warn('[KnowledgeBase] failed parsing json file, failling back to text processing:', file.path, error)
+    }
+    if (jsonParsed) {
+      const loaderReturn = await ragApplication.addLoader(new JsonLoader({ object: jsonObject }))
+      return {
+        entriesAdded: loaderReturn.entriesAdded,
+        uniqueId: loaderReturn.uniqueId,
+        uniqueIds: [loaderReturn.uniqueId],
+        loaderType: loaderReturn.loaderType
+      }
     }
   }
 


### PR DESCRIPTION
知识库添加目录时， 目录中可能存在特殊格式的json文件，兼容处理其解析失败时回退为文本文件类型，避免显示报错而影响正常的进度显示。
handle JSON parse failure by falling back to text file processing to avoid error display affecting normal progress indication.