### PR TITLE
feat: 为模型选择弹窗添加键盘导航功能

### DIFF
--- a/src/renderer/src/components/Popups/SelectModelPopup.tsx
+++ b/src/renderer/src/components/Popups/SelectModelPopup.tsx
@@ -7,7 +7,7 @@ import { getModelUniqId } from '@renderer/services/ModelService'
 import { Model } from '@renderer/types'
 import { Avatar, Divider, Empty, Input, InputRef, Menu, MenuProps, Modal } from 'antd'
 import { first, sortBy } from 'lodash'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
@@ -33,6 +33,7 @@ const PopupContainer: React.FC<PopupContainerProps> = ({ model, resolve }) => {
   const { providers } = useProviders()
   const [pinnedModels, setPinnedModels] = useState<string[]>([])
   const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const [keyboardSelectedId, setKeyboardSelectedId] = useState<string>('')
 
   useEffect(() => {
     const loadPinnedModels = async () => {
@@ -176,6 +177,77 @@ const PopupContainer: React.FC<PopupContainerProps> = ({ model, resolve }) => {
     }
   }, [open, model])
 
+  // 获取所有可见的模型项
+  const getVisibleModelItems = useCallback(() => {
+    const items: { key: string; model: Model }[] = []
+
+    // 如果有置顶模型且没有搜索文本，添加置顶模型
+    if (pinnedModels.length > 0 && searchText.length === 0) {
+      providers
+        .flatMap((p) => p.models || [])
+        .filter((m) => pinnedModels.includes(getModelUniqId(m)))
+        .forEach((m) => items.push({ key: getModelUniqId(m), model: m }))
+    }
+
+    // 添加其他过滤后的模型
+    providers.forEach((p) => {
+      if (p.models) {
+        sortBy(p.models, ['group', 'name'])
+          .filter((m) => !isEmbeddingModel(m))
+          .filter((m) =>
+            [m.name + m.provider + t('provider.' + p.id)].join('').toLowerCase().includes(searchText.toLowerCase())
+          )
+          .forEach((m) => items.push({ key: getModelUniqId(m), model: m }))
+      }
+    })
+
+    return items
+  }, [pinnedModels, searchText, providers, t])
+
+  // 处理键盘导航
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      const items = getVisibleModelItems()
+      if (items.length === 0) return
+
+      if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+        e.preventDefault()
+        const currentIndex = items.findIndex((item) => item.key === keyboardSelectedId)
+        let nextIndex
+
+        if (currentIndex === -1) {
+          nextIndex = e.key === 'ArrowDown' ? 0 : items.length - 1
+        } else {
+          nextIndex =
+            e.key === 'ArrowDown' ? (currentIndex + 1) % items.length : (currentIndex - 1 + items.length) % items.length
+        }
+
+        const nextItem = items[nextIndex]
+        setKeyboardSelectedId(nextItem.key)
+
+        const element = document.querySelector(`[data-menu-id="${nextItem.key}"]`)
+        element?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+      } else if (e.key === 'Enter' && keyboardSelectedId) {
+        const selectedItem = items.find((item) => item.key === keyboardSelectedId)
+        if (selectedItem) {
+          resolve(selectedItem.model)
+          setOpen(false)
+        }
+      }
+    },
+    [keyboardSelectedId, getVisibleModelItems, resolve, setOpen]
+  )
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [handleKeyDown])
+
+  // 搜索文本改变时重置键盘选中状态
+  useEffect(() => {
+    setKeyboardSelectedId('')
+  }, [searchText])
+
   return (
     <Modal
       centered
@@ -210,18 +282,19 @@ const PopupContainer: React.FC<PopupContainerProps> = ({ model, resolve }) => {
           style={{ paddingLeft: 0 }}
           bordered={false}
           size="middle"
+          onKeyDown={(e) => {
+            // 防止上下键移动光标
+            if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+              e.preventDefault()
+            }
+          }}
         />
       </HStack>
       <Divider style={{ margin: 0, borderBlockStartWidth: 0.5 }} />
       <Scrollbar style={{ height: '50vh' }} ref={scrollContainerRef}>
         <Container>
           {filteredItems.length > 0 ? (
-            <StyledMenu
-              items={filteredItems}
-              selectedKeys={model ? [getModelUniqId(model)] : []}
-              mode="inline"
-              inlineIndent={6}
-            />
+            <StyledMenu items={filteredItems} selectedKeys={[keyboardSelectedId]} mode="inline" inlineIndent={6} />
           ) : (
             <EmptyState>
               <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />


### PR DESCRIPTION
模型弹出增加上下键盘导航及回车确认。

另外我想加一个快捷键，快速弹出模型选择弹框，便于快速选择，但是我看引用处挺多，不知道加快捷键是否会影响 src/renderer/src/components/Popups/SelectModelPopup.tsx 的其他业务