### PR TITLE
feat: Add message completion abort functionality

### DIFF
--- a/src/renderer/src/store/abortController.ts
+++ b/src/renderer/src/store/abortController.ts
@@ -1,0 +1,25 @@
+export const abortMap = new Map<string, () => void>()
+
+export const addAbortController = (messageId: string, abortFn: () => void) => {
+  let callback = abortFn
+  const existingCallback = abortMap.get(messageId)
+  if (existingCallback) {
+    callback = () => {
+      existingCallback?.()
+      abortFn()
+    }
+  }
+  abortMap.set(messageId, callback)
+}
+
+export const removeAbortController = (messageId: string) => {
+  abortMap.delete(messageId)
+}
+
+export const abortCompletion = (messageId: string) => {
+  const abortFn = abortMap.get(messageId)
+  if (abortFn) {
+    abortFn()
+    removeAbortController(messageId)
+  }
+}


### PR DESCRIPTION
- 问题:https://github.com/CherryHQ/cherry-studio/issues/1830  (**消息没暂停成功**.虽然解决的问题跟这个issue不是那么重合,但是是在复现issue时发现的问题)
- 原因:代码中**暂停**逻辑是:
```ts
window.keyv.set(EVENT_NAMES.CHAT_COMPLETION_PAUSED, true)
// ⬇️
for await (const chunk of stream){
  if(window.keyv.get(EVENT_NAMES.CHAT_COMPLETION_PAUSED){
    break // or abort()
  }
}
```
 - 有两个问题:
   - 当接口报错,会有重试逻辑,此时当用户发起第二次请求的时候 `EVENT_NAMES.CHAT_COMPLETION_PAUSED`会变成true,所以当重试的接口碰巧成功了,那么会出现第一次请求的消息“复活了”
   - 如果接口报错了,代码走不到`for`循环,`stream`都拿不到

解决:通过给请求传入`signal`,及时`cancel request`