### PR TITLE
fix: 知识库设置窗口没有和应用窗口同比例缩放

### DIFF
--- a/src/renderer/src/pages/knowledge/components/KnowledgeSettingsPopup.tsx
+++ b/src/renderer/src/pages/knowledge/components/KnowledgeSettingsPopup.tsx
@@ -97,7 +97,9 @@ const PopupContainer: React.FC<Props> = ({ base: _base, resolve }) => {
       afterClose={onClose}
       destroyOnClose
       maskClosable={false}
-      centered>
+      centered
+      width="80%"
+      bodyStyle={{ maxHeight: '70vh', overflowY: 'auto', paddingRight: '20px' }}>
       <Form form={form} layout="vertical">
         <Form.Item
           name="name"
@@ -121,7 +123,7 @@ const PopupContainer: React.FC<Props> = ({ base: _base, resolve }) => {
           label={t('knowledge.document_count')}
           tooltip={{ title: t('knowledge.document_count_help') }}>
           <Slider
-            style={{ width: '100%' }}
+            style={{ width: 'calc(100% - 20px)'}}
             min={1}
             max={30}
             step={1}


### PR DESCRIPTION
old

原来在小窗口下（cherry默认大小）很难受

![image](https://github.com/user-attachments/assets/c6aa0ea4-8520-4697-ae79-df0a52d1d60e)

new

![image](https://github.com/user-attachments/assets/edb9ca51-2d6a-4e76-98ba-fffd625b2d44)
![image](https://github.com/user-attachments/assets/3c5ae6ca-0530-455a-9d79-58c0a4cea990)
