### PR TITLE
fix: 默认助手设置窗口没有和应用窗口同比例缩放

### DIFF
--- a/src/renderer/src/pages/settings/ModalSettings/DefaultAssistantSettings.tsx
+++ b/src/renderer/src/pages/settings/ModalSettings/DefaultAssistantSettings.tsx
@@ -261,7 +261,8 @@ const PopupContainer: React.FC<Props> = ({ resolve }) => {
       onCancel={onCancel}
       afterClose={onClose}
       centered
-      width={800}
+      width="80%"
+      bodyStyle={{ maxHeight: '70vh', overflowY: 'auto', paddingRight: '20px' }}
       footer={null}>
       <AssistantSettings />
     </Modal>


### PR DESCRIPTION
old

原来在小窗口下（cherry默认大小）很难受

![image](https://github.com/user-attachments/assets/fce7056f-7a39-46c2-a460-010af7065cd1)

new

![image](https://github.com/user-attachments/assets/be3031d4-6501-4f48-924d-26303d54fcda)
![image](https://github.com/user-attachments/assets/cd060ab7-87bd-47fb-8909-44a6b3a090e5)

