### PR TITLE
fix: 添加目录到知识库任意一个失败界面上会展示失败

### DIFF
--- a/src/main/services/KnowledgeService.ts
+++ b/src/main/services/KnowledgeService.ts
@@ -102,8 +102,8 @@ class KnowledgeService {
         sendDirectoryProcessingPercent(totalFiles, processedFiles)
         return result
       })
-      const loaderResults = await Promise.all(loaderPromises)
-      const uniqueIds = loaderResults.map((result) => result.uniqueId)
+      const loaderResults = await Promise.allSettled(loaderPromises)
+      const uniqueIds = loaderResults.filter(result => result.status === 'fulfilled').map((result) => result.uniqueId)
       return {
         entriesAdded: loaderResults.length,
         uniqueId: `DirectoryLoader_${uuidv4()}`,


### PR DESCRIPTION
当前在把一个目录添加到知识库的时候，遇到任意一个失败，界面上就会展示失败，但是其余的文件还在处理。因为任意一个失败，Promise.all 就会reject。这里改成 Promise.allSettled 并且配合filter来把成功了的找出来。