### PR TITLE
fix: Restore textarea focus after selecting mention model via mouse

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -487,6 +487,9 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic }) => {
 
       setMentionModels((prev) => [...prev, model])
       setIsMentionPopupOpen(false)
+      setTimeout(() => {
+        textareaRef.current?.focus()
+      }, 0)
     }
   }
 


### PR DESCRIPTION
修复当使用鼠标选择完模型后，光标不自动聚焦到输入框的问题