### PR TITLE
fix: 添加多个目录到知识库多个进度之间展示混淆 #2197

### DIFF
--- a/src/main/services/KnowledgeService.ts
+++ b/src/main/services/KnowledgeService.ts
@@ -87,7 +87,10 @@ class KnowledgeService {
 
     const sendDirectoryProcessingPercent = (totalFiles: number, processedFiles: number) => {
       const mainWindow = windowService.getMainWindow()
-      mainWindow?.webContents.send(base.id, (processedFiles / totalFiles) * 100)
+      mainWindow?.webContents.send('directory-processing-percent', {
+        itemId: item.id,
+        percent: (processedFiles / totalFiles) * 100
+      })
     }
 
     if (item.type === 'directory') {

--- a/src/renderer/src/hooks/useKnowledge.ts
+++ b/src/renderer/src/hooks/useKnowledge.ts
@@ -207,9 +207,14 @@ export const useKnowledge = (baseId: string) => {
         return
       }
 
-      const cleanup = window.electron.ipcRenderer.on(itemId, (_, progressingPercent: number) => {
-        setPercent(progressingPercent)
-      })
+      const cleanup = window.electron.ipcRenderer.on(
+        'directory-processing-percent',
+        (_, { itemId: id, percent }: { itemId: string; percent: number }) => {
+          if (itemId === id) {
+            setPercent(percent)
+          }
+        }
+      )
 
       return () => {
         cleanup()

--- a/src/renderer/src/pages/knowledge/KnowledgeContent.tsx
+++ b/src/renderer/src/pages/knowledge/KnowledgeContent.tsx
@@ -65,7 +65,7 @@ const KnowledgeContent: FC<KnowledgeContentProps> = ({ selectedBase }) => {
     return null
   }
 
-  const progressingPercent = getDirectoryProcessingPercent(base?.id)
+  const getProgressingPercentForItem = (itemId: string) => getDirectoryProcessingPercent(itemId)
 
   const handleAddFile = () => {
     if (disabled) {
@@ -278,7 +278,7 @@ const KnowledgeContent: FC<KnowledgeContentProps> = ({ selectedBase }) => {
                       sourceId={item.id}
                       base={base}
                       getProcessingStatus={getProcessingStatus}
-                      progressingPercent={progressingPercent}
+                      getProcessingPercent={getProgressingPercentForItem}
                       type="directory"
                     />
                   </StatusIconWrapper>

--- a/src/renderer/src/pages/knowledge/components/StatusIcon.tsx
+++ b/src/renderer/src/pages/knowledge/components/StatusIcon.tsx
@@ -9,13 +9,14 @@ interface StatusIconProps {
   sourceId: string
   base: KnowledgeBase
   getProcessingStatus: (sourceId: string) => ProcessingStatus | undefined
-  progressingPercent?: number
+  getProcessingPercent?: (sourceId: string) => number | undefined
   type: string
 }
 
-const StatusIcon: FC<StatusIconProps> = ({ sourceId, base, getProcessingStatus, progressingPercent, type }) => {
+const StatusIcon: FC<StatusIconProps> = ({ sourceId, base, getProcessingStatus, getProcessingPercent, type }) => {
   const { t } = useTranslation()
   const status = getProcessingStatus(sourceId)
+  const percent = getProcessingPercent?.(sourceId)
   const item = base.items.find((item) => item.id === sourceId)
   const errorText = item?.processingError
 
@@ -44,7 +45,7 @@ const StatusIcon: FC<StatusIconProps> = ({ sourceId, base, getProcessingStatus, 
 
     case 'processing': {
       return type === 'directory' ? (
-        <Progress type="circle" size={14} percent={Number(progressingPercent?.toFixed(0))} />
+        <Progress type="circle" size={14} percent={Number(percent?.toFixed(0))} />
       ) : (
         <Tooltip title={t('knowledge.status_processing')} placement="left">
           <StatusDot $status="processing" />


### PR DESCRIPTION
修复问题 https://github.com/CherryHQ/cherry-studio/issues/2197