### PR TITLE
fix: undesired assistant selection menu popup when no ' ' before '@'

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/MentionModelsButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/MentionModelsButton.tsx
@@ -231,14 +231,14 @@ const MentionModelsButton: FC<Props> = ({ mentionModels, onMentionModel: onSelec
       const cursorPosition = textArea.selectionStart
       const textBeforeCursor = textArea.value.substring(0, cursorPosition)
       const lastAtIndex = textBeforeCursor.lastIndexOf('@')
-
+      const textBeforeLastAt = textBeforeCursor.slice(0, lastAtIndex)
       if (lastAtIndex === -1 || textBeforeCursor.slice(lastAtIndex + 1).includes(' ')) {
         setIsOpen(false)
         setSearchText('')
         setMenuDismissed(false) // Reset dismissed flag when @ is removed
       } else {
         // Only open menu if it wasn't explicitly dismissed
-        if (!menuDismissed) {
+        if (!menuDismissed && (textBeforeLastAt.slice(-1) === ' ' || lastAtIndex === 0)) {
           setIsOpen(true)
           const searchStr = textBeforeCursor.slice(lastAtIndex + 1)
           setSearchText(searchStr)


### PR DESCRIPTION
当在文本框的非空格字符后输入‘@’会弹出选择助手菜单但是按enter会直接发送消息。

统一为只有前一个字符是空格才认为用户想要选择助手

问题展示：
![cherry3](https://github.com/user-attachments/assets/8ac3b957-763d-4d18-a500-82ccdba470d6)

