### PR TITLE
feat: Add support for Gemini 2.0 and update Yi model configurations

### DIFF
--- a/src/renderer/src/config/models.ts
+++ b/src/renderer/src/config/models.ts
@@ -136,6 +136,7 @@ const visionAllowedModels = [
   'moondream',
   'minicpm',
   'gemini-1\\.5',
+  'gemini-2\\.0',
   'gemini-exp',
   'claude-3',
   'vision',
@@ -451,10 +452,22 @@ export const SYSTEM_MODELS: Record<string, Model[]> = {
       group: 'Gemini 1.5'
     },
     {
+      id: 'gemini-1.5-flash-8b',
+      provider: 'gemini',
+      name: 'Gemini 1.5 Flash (8B)',
+      group: 'Gemini 1.5'
+    },
+    {
       id: 'gemini-1.5-pro',
       name: 'Gemini 1.5 Pro',
       provider: 'gemini',
-      group: 'gemini-1.5'
+      group: 'Gemini 1.5'
+    },
+    {
+      id: 'gemini-2.0-flash',
+      provider: 'gemini',
+      name: 'Gemini 2.0 Flash',
+      group: 'Gemini 2.0'
     }
   ],
   anthropic: [
@@ -830,10 +843,12 @@ export const SYSTEM_MODELS: Record<string, Model[]> = {
     }
   ],
   yi: [
-    { id: 'yi-lightning', name: 'yi-lightning', provider: 'yi', group: 'yi-lightning', owned_by: '01.ai' },
-    { id: 'yi-medium', name: 'yi-medium', provider: 'yi', group: 'yi-medium', owned_by: '01.ai' },
-    { id: 'yi-large', name: 'yi-large', provider: 'yi', group: 'yi-large', owned_by: '01.ai' },
-    { id: 'yi-vision', name: 'yi-vision', provider: 'yi', group: 'yi-vision', owned_by: '01.ai' }
+    { id: 'yi-lightning', name: 'Yi Lightning', provider: 'yi', group: 'yi-lightning', owned_by: '01.ai' },
+    // yi-medium, yi-large, yi-vision 已被 yi-lightning 替代 (详见 https://archive.ph/0Idg3)
+    // { id: 'yi-medium', name: 'yi-medium', provider: 'yi', group: 'yi-medium', owned_by: '01.ai' },
+    // { id: 'yi-large', name: 'yi-large', provider: 'yi', group: 'yi-large', owned_by: '01.ai' },
+    // { id: 'yi-vision', name: 'yi-vision', provider: 'yi', group: 'yi-vision', owned_by: '01.ai' }
+    { id: 'yi-vision-v2', name: 'Yi Vision v2', provider: 'yi', group: 'yi-vision', owned_by: '01.ai' }
   ],
   zhipu: [
     {


### PR DESCRIPTION
- Introduced new Gemini models in `SYSTEM_MODELS`:
  - `gemini-1.5-flash-8b`
  - `gemini-2.0-flash`
- Updated Yi model configurations:
  - Renamed `yi-lightning` to "Yi Lightning".
  - Deprecated `yi-medium` and `yi-large` (replaced by `yi-lightning` per documentation).
  - Added `yi-vision-v2` as a new version of Yi Vision.