### PR TITLE
fix: providersetting popover checkbox error

### DIFF
--- a/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
@@ -210,17 +210,17 @@ const ProviderSetting: FC<Props> = ({ provider: _provider }) => {
             {
               label: t('models.type.vision'),
               value: 'vision',
-              disabled: isVisionModel(model)
+              disabled: isVisionModel(model) && !selectedTypes.includes('vision')
             },
             {
               label: t('models.type.embedding'),
               value: 'embedding',
-              disabled: isEmbeddingModel(model)
+              disabled: isEmbeddingModel(model) && !selectedTypes.includes('embedding')
             },
             {
               label: t('models.type.reasoning'),
               value: 'reasoning',
-              disabled: isReasoningModel(model)
+              disabled: isReasoningModel(model) && !selectedTypes.includes('reasoning')
             }
           ]}
         />


### PR DESCRIPTION
这个文件悬浮框中的checkbox逻辑似乎存在问题
https://github.com/CherryHQ/cherry-studio/blob/main/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
![image](https://github.com/user-attachments/assets/32d245f6-f0e5-41e8-804a-ae2fd809f5df)
比如用户添加推理的tag之后就无法取消
似乎是因为直接将选择类型直接和默认类型进行了合并而默认类型又无法修改导致的