### PR TITLE
fix: count reasoning content into token estimation

### DIFF
--- a/src/renderer/src/services/TokenService.ts
+++ b/src/renderer/src/services/TokenService.ts
@@ -64,7 +64,8 @@ export async function estimateMessageUsage(message: Message): Promise<Completion
     }
   }
 
-  const tokens = estimateTextTokens(message.content)
+  const combinedContent = [message.content, message.reasoning_content].filter((s) => s !== undefined).join(' ')
+  const tokens = estimateTextTokens(combinedContent)
 
   return {
     prompt_tokens: tokens,


### PR DESCRIPTION
For model with reasoning, the reasoning is not counted in the estimated tokens(counted in api platform's pricing). This PR fix this.
带有深度思考模式的模型的思考部分没有被计入总token量，但api平台算钱的时候是计入的。 此PR修复了这个问题。