### PR TITLE
feat: 添加更多C++文件扩展名支持

### DIFF
--- a/packages/shared/config/constant.ts
+++ b/packages/shared/config/constant.ts
@@ -93,7 +93,13 @@ export const textExts = [
   '.cs', // C# 代码文件
   '.cpp', // C++ 代码文件
   '.c', // C++ 代码文件
-  '.h' // C++ 头文件
+  '.h', // C++ 头文件
+  '.hpp', // C++ 头文件
+  '.cc', // C++ 源文件
+  '.cxx', // C++ 源文件
+  '.cppm', // C++20 模块接口文件
+  '.ipp', // 模板实现文件
+  '.ixx' // C++20 模块实现文件
 ]
 
 export const ZOOM_SHORTCUTS = [


### PR DESCRIPTION
在 `textExts` 数组中添加了以下C++文件扩展名：
- `.hpp`: C++ 头文件
- `.cc`: C++ 源文件
- `.cxx`: C++ 源文件
- `.cppm`: C++20 模块接口文件
- `.ipp`: 模板实现文件
- `.ixx`: C++20 模块实现文件