### PR TITLE
feat: 为助手和话题列表项添加悬浮显示完整内容功能

### DIFF
--- a/src/renderer/src/pages/home/Tabs/AssistantItem.tsx
+++ b/src/renderer/src/pages/home/Tabs/AssistantItem.tsx
@@ -112,7 +112,7 @@ const AssistantItem: FC<AssistantItemProps> = ({ assistant, isActive, onSwitch, 
   return (
     <Dropdown menu={{ items: getMenuItems(assistant) }} trigger={['contextMenu']}>
       <Container onClick={handleSwitch} className={isActive ? 'active' : ''}>
-        <AssistantName className="name">
+        <AssistantName className="name" title={assistantName}>
           {assistant.emoji ? `${assistant.emoji} ${assistantName}` : assistantName}
         </AssistantName>
         {isActive && (

--- a/src/renderer/src/pages/home/Tabs/TopicsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/TopicsTab.tsx
@@ -293,16 +293,18 @@ const Topics: FC<Props> = ({ assistant: _assistant, activeTopic, setActiveTopic 
       <DragableList list={assistant.topics} onUpdate={updateTopics}>
         {(topic) => {
           const isActive = topic.id === activeTopic?.id
+          const topicName = topic.name.replace('`', '')
+          const topicPrompt = topic.prompt
           return (
             <Dropdown menu={{ items: getTopicMenuItems(topic) }} trigger={['contextMenu']} key={topic.id}>
               <TopicListItem
                 className={isActive ? 'active' : ''}
                 onClick={() => onSwitchTopic(topic)}
                 style={{ borderRadius }}>
-                <TopicName className="name">{topic.name.replace('`', '')}</TopicName>
-                {topic.prompt && (
-                  <TopicPromptText className="prompt">
-                    {t('common.prompt')}: {topic.prompt}
+                <TopicName className="name" title={topicName}>{topicName}</TopicName>
+                {topicPrompt && (
+                  <TopicPromptText className="prompt" title={topicPrompt}>
+                    {t('common.prompt')}: {topicPrompt}
                   </TopicPromptText>
                 )}
                 {showTopicTime && (


### PR DESCRIPTION
- 使用 `<div>` 的 title 属性实现鼠标悬浮展示完整内容
- 优化长文本的可读性和用户体验