### PR TITLE
feat: Add search button to the knowledge base, and adjusted the display for drag-and-drop uploads

### DIFF
--- a/src/renderer/src/pages/knowledge/KnowledgeContent.tsx
+++ b/src/renderer/src/pages/knowledge/KnowledgeContent.tsx
@@ -90,17 +90,19 @@ const KnowledgeContent: FC<KnowledgeContentProps> = ({ selectedBase }) => {
     }
 
     if (files) {
-      const _files: FileType[] = files.map((file) => ({
-        id: file.name,
-        name: file.name,
-        path: file.path,
-        size: file.size,
-        ext: `.${file.name.split('.').pop()}`,
-        count: 1,
-        origin_name: file.name,
-        type: file.type as FileTypes,
-        created_at: new Date()
-      }))
+      const _files: FileType[] = files
+        .map((file) => ({
+          id: file.name,
+          name: file.name,
+          path: file.path,
+          size: file.size,
+          ext: `.${file.name.split('.').pop()}`,
+          count: 1,
+          origin_name: file.name,
+          type: file.type as FileTypes,
+          created_at: new Date()
+        }))
+        .filter(({ ext }) => fileTypes.includes(ext))
       console.debug('[KnowledgeContent] Uploading files:', _files, files)
       const uploadedFiles = await FileManager.uploadFiles(_files)
       addFiles(uploadedFiles)

--- a/src/renderer/src/pages/knowledge/KnowledgeContent.tsx
+++ b/src/renderer/src/pages/knowledge/KnowledgeContent.tsx
@@ -241,7 +241,7 @@ const KnowledgeContent: FC<KnowledgeContentProps> = ({ selectedBase }) => {
         </TitleWrapper>
         <Dragger
           showUploadList={false}
-          customRequest={({ file }) => handleDrop([file as File])}
+          onDrop={({ dataTransfer }) => handleDrop([...dataTransfer.files])}
           multiple={true}
           accept={fileTypes.join(',')}
           style={{ marginTop: 10, background: 'transparent' }}>
@@ -253,7 +253,7 @@ const KnowledgeContent: FC<KnowledgeContentProps> = ({ selectedBase }) => {
       </FileSection>
 
       <FileListSection>
-        {fileItems.map((item) => {
+        {fileItems.reverse().map((item) => {
           const file = item.content as FileType
           return (
             <ItemCard key={item.id}>
@@ -287,7 +287,7 @@ const KnowledgeContent: FC<KnowledgeContentProps> = ({ selectedBase }) => {
           </Button>
         </TitleWrapper>
         <FlexColumn>
-          {directoryItems.map((item) => (
+          {directoryItems.reverse().map((item) => (
             <ItemCard key={item.id}>
               <ItemContent>
                 <ItemInfo>
@@ -325,7 +325,7 @@ const KnowledgeContent: FC<KnowledgeContentProps> = ({ selectedBase }) => {
           </Button>
         </TitleWrapper>
         <FlexColumn>
-          {urlItems.map((item) => (
+          {urlItems.reverse().map((item) => (
             <ItemCard key={item.id}>
               <ItemContent>
                 <ItemInfo>
@@ -379,7 +379,7 @@ const KnowledgeContent: FC<KnowledgeContentProps> = ({ selectedBase }) => {
           </Button>
         </TitleWrapper>
         <FlexColumn>
-          {sitemapItems.map((item) => (
+          {sitemapItems.reverse().map((item) => (
             <ItemCard key={item.id}>
               <ItemContent>
                 <ItemInfo>
@@ -416,7 +416,7 @@ const KnowledgeContent: FC<KnowledgeContentProps> = ({ selectedBase }) => {
           </Button>
         </TitleWrapper>
         <FlexColumn>
-          {noteItems.map((note) => (
+          {noteItems.reverse().map((note) => (
             <ItemCard key={note.id}>
               <ItemContent>
                 <ItemInfo onClick={() => handleEditNote(note)} style={{ cursor: 'pointer' }}>

--- a/src/renderer/src/pages/knowledge/KnowledgePage.tsx
+++ b/src/renderer/src/pages/knowledge/KnowledgePage.tsx
@@ -1,10 +1,21 @@
-import { DeleteOutlined, EditOutlined, FileTextOutlined, PlusOutlined, SettingOutlined } from '@ant-design/icons'
-import { Navbar, NavbarCenter } from '@renderer/components/app/Navbar'
+import {
+  DeleteOutlined,
+  EditOutlined,
+  FileTextOutlined,
+  PlusOutlined,
+  SearchOutlined,
+  SettingOutlined
+} from '@ant-design/icons'
+import { Navbar, NavbarCenter, NavbarRight as NavbarRightFromComponents } from '@renderer/components/app/Navbar'
 import DragableList from '@renderer/components/DragableList'
+import { HStack } from '@renderer/components/Layout'
 import ListItem from '@renderer/components/ListItem'
 import PromptPopup from '@renderer/components/Popups/PromptPopup'
 import Scrollbar from '@renderer/components/Scrollbar'
 import { useKnowledgeBases } from '@renderer/hooks/useKnowledge'
+import { useShortcut } from '@renderer/hooks/useShortcuts'
+import { NavbarIcon } from '@renderer/pages/home/Navbar'
+import KnowledgeSearchPopup from '@renderer/pages/knowledge/components/KnowledgeSearchPopup'
 import { KnowledgeBase } from '@renderer/types'
 import { Dropdown, Empty, MenuProps } from 'antd'
 import { FC, useCallback, useEffect, useState } from 'react'
@@ -81,10 +92,23 @@ const KnowledgePage: FC = () => {
     [deleteKnowledgeBase, renameKnowledgeBase, t]
   )
 
+  useShortcut('search_message', () => {
+    if (selectedBase) {
+      KnowledgeSearchPopup.show({ base: selectedBase }).then()
+    }
+  })
+
   return (
     <Container>
       <Navbar>
         <NavbarCenter style={{ borderRight: 'none' }}>{t('knowledge.title')}</NavbarCenter>
+        <NavbarRight>
+          <HStack alignItems="center">
+            <NarrowIcon onClick={() => selectedBase && KnowledgeSearchPopup.show({ base: selectedBase })}>
+              <SearchOutlined />
+            </NarrowIcon>
+          </HStack>
+        </NavbarRight>
       </Navbar>
       <ContentContainer id="content-container">
         <SideNav>
@@ -219,6 +243,17 @@ const AddKnowledgeName = styled.div`
   -webkit-box-orient: vertical;
   overflow: hidden;
   font-size: 13px;
+`
+
+const NarrowIcon = styled(NavbarIcon)`
+  @media (max-width: 1000px) {
+    display: none;
+  }
+`
+
+const NavbarRight = styled(NavbarRightFromComponents)`
+  min-width: auto;
+  padding-right: 140px;
 `
 
 export default KnowledgePage


### PR DESCRIPTION
#2046 
#2327 

- 现在新上传的文件靠前，多选文件立刻显示，保持多选文件的选择顺序，前后对比：

![before](https://github.com/user-attachments/assets/af88361e-1fdb-4748-bc04-739ddabbc04a)

![after](https://github.com/user-attachments/assets/166a7d05-4f7b-45c9-a618-8275e0b89977)

- 顶部添加搜索知识库按钮，并同样绑定了`search_message`快捷键
