### PR TITLE
fix:修复备份恢复完成后可能无权限清理临时目录 (#2247)

### DIFF
--- a/src/main/services/BackupManager.ts
+++ b/src/main/services/BackupManager.ts
@@ -131,6 +131,7 @@ class BackupManager {
       Logger.log('[backup] step 4: clean up temp directory')
 
       // 清理临时目录
+      await this.setWritableRecursive(this.tempDir)
       await fs.remove(this.tempDir)
 
       Logger.log('[backup] step 5: Restore completed successfully')


### PR DESCRIPTION
修复了清理临时目录时可能权限不足的问题。

![image](https://github.com/user-attachments/assets/a5b6eba3-b6e2-4dc5-a7a2-6bdb3804246c)
