### PR TITLE
fix: Remove doubao from unsupported file providers list

### DIFF
--- a/src/renderer/src/providers/OpenAIProvider.ts
+++ b/src/renderer/src/providers/OpenAIProvider.ts
@@ -42,7 +42,7 @@ export default class OpenAIProvider extends BaseProvider {
   }
 
   private get isNotSupportFiles() {
-    const providers = ['deepseek', 'baichuan', 'minimax', 'doubao']
+    const providers = ['deepseek', 'baichuan', 'minimax']
     return providers.includes(this.provider.id)
   }
 


### PR DESCRIPTION
<img width="1160" alt="image" src="https://github.com/user-attachments/assets/858a5b3d-376d-474b-9ddd-fe17bc479e7d" />
之前在 #1165 上看到说关掉是因为豆包官方的视觉API不支持array，然后今天查看官方文档已经支持了，感觉可以加回来了

下面是简单测试

<img width="1171" alt="image" src="https://github.com/user-attachments/assets/c13cafce-0d06-4cc3-b129-d276d30d9dcb" />


![image](https://github.com/user-attachments/assets/f50bf124-5077-4224-a4d9-4e76af8ef1aa)
