### PR TITLE
Use the Russian language label

### DIFF
--- a/src/renderer/src/pages/settings/GeneralSettings.tsx
+++ b/src/renderer/src/pages/settings/GeneralSettings.tsx
@@ -64,7 +64,7 @@ const GeneralSettings: FC = () => {
     { value: 'zh-TW', label: '中文（繁体）', flag: '🇭🇰' },
     { value: 'en-US', label: 'English', flag: '🇺🇸' },
     { value: 'ja-JP', label: '日本語', flag: '🇯🇵' },
-    { value: 'ru-RU', label: 'Russian', flag: '🇷🇺' }
+    { value: 'ru-RU', label: 'Русский', flag: '🇷🇺' }
   ]
 
   return (


### PR DESCRIPTION
A minor fix.

This ensures the language label aligns with others (using its own language name instead of English).