### PR TITLE
Switch to `@use` and module system for scss

### DIFF
--- a/src/renderer/src/assets/styles/ant.scss
+++ b/src/renderer/src/assets/styles/ant.scss
@@ -1,3 +1,5 @@
+@use './container.scss';
+
 #inputbar {
   resize: none;
 }

--- a/src/renderer/src/assets/styles/container.scss
+++ b/src/renderer/src/assets/styles/container.scss
@@ -1,0 +1,7 @@
+#content-container {
+  background-color: var(--color-background);
+  border-top: 0.5px solid var(--color-border);
+  border-top-left-radius: 10px;
+  border-left: 0.5px solid var(--color-border);
+  box-shadow: -2px 0px 20px -4px rgba(0, 0, 0, 0.06);
+}

--- a/src/renderer/src/assets/styles/index.scss
+++ b/src/renderer/src/assets/styles/index.scss
@@ -1,6 +1,7 @@
-@import './markdown.scss';
-@import './ant.scss';
-@import './scrollbar.scss';
+@use './markdown.scss';
+@use './ant.scss';
+@use './scrollbar.scss';
+@use './container.scss';
 @import '../fonts/icon-fonts/iconfont.css';
 @import '../fonts/ubuntu/ubuntu.css';
 
@@ -174,14 +175,6 @@ body,
   display: flex;
   flex-direction: row;
   flex: 1;
-}
-
-#content-container {
-  background-color: var(--color-background);
-  border-top: 0.5px solid var(--color-border);
-  border-top-left-radius: 10px;
-  border-left: 0.5px solid var(--color-border);
-  box-shadow: -2px 0px 20px -4px rgba(0, 0, 0, 0.06);
 }
 
 .loader {


### PR DESCRIPTION
This pull request updates SCSS files to enhance modularity and maintainability by replacing `@import` with the `@use` rule. Currently, `yarn dev` generates warnings such as:

![截屏2025-02-27 23 24 06](https://github.com/user-attachments/assets/d839d748-5bd1-4bc4-9e53-d86028c1814b)

Starting from Sass 1.80.0, the `@import` rule was deprecated and will cause errors in future versions. Due to modularization, `ant.scss` can no longer locate `#content-container`, originally defined in `index.scss`. Therefore, the related content must be moved to its own module.

With changes in the PR, we can expect a cleaner console when running the app:

![截屏2025-02-27 23 25 58](https://github.com/user-attachments/assets/aaace3b0-42bf-4342-b30e-89912b04f75c)
