### PR TITLE
Remove unused protocol register and open url code

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -20,25 +20,6 @@ if (!app.requestSingleInstanceLock()) {
   app.whenReady().then(async () => {
     await updateUserDataPath()
 
-    // Register custom protocol
-    if (!app.isDefaultProtocolClient('cherrystudio')) {
-      app.setAsDefaultProtocolClient('cherrystudio')
-    }
-
-    // Handle protocol open
-    app.on('open-url', (event, url) => {
-      event.preventDefault()
-      const parsedUrl = new URL(url)
-      if (parsedUrl.pathname === 'siliconflow.oauth.login') {
-        const code = parsedUrl.searchParams.get('code')
-        if (code) {
-          // Handle the OAuth code here
-          console.log('OAuth code received:', code)
-          // You can send this code to your renderer process via IPC if needed
-        }
-      }
-    })
-
     // Set app user model id for windows
     electronApp.setAppUserModelId(import.meta.env.VITE_MAIN_BUNDLE_ID || 'com.kangfenmao.CherryStudio')
 


### PR DESCRIPTION
This code was introduced in #976 but appears unused. 

It seems to be test code for implementing an OAuth 2.0 `code` flow, but a frontend message post was ultimately used to retrieve the key instead. If this is correct, the code can be removed to avoid confusion.