### PR TITLE
feat: Add Hunyuan TurboS model (launched on February 26)

### DIFF
--- a/src/renderer/src/config/models.ts
+++ b/src/renderer/src/config/models.ts
@@ -1408,6 +1408,18 @@ export const SYSTEM_MODELS: Record<string, Model[]> = {
       provider: 'hunyuan',
       name: 'hunyuan-turbo',
       group: 'Hunyuan'
+    },
+    {
+      id: 'hunyuan-turbos-latest',
+      provider: 'hunyuan',
+      name: 'hunyuan-turbos-latest',
+      group: 'Hunyuan'
+    },
+    {
+      id: 'hunyuan-embedding',
+      provider: 'hunyuan',
+      name: 'hunyuan-embedding',
+      group: 'Embedding'
     }
   ],
   nvidia: [
@@ -1855,6 +1867,12 @@ export function isWebSearchModel(model: Model): boolean {
   const provider = getProviderByModel(model)
 
   if (!provider) {
+    return false
+  }
+
+  const isEmbedding = isEmbeddingModel(model)
+
+  if (isEmbedding) {
     return false
   }
 


### PR DESCRIPTION
- Add hunyuan-turbos-latest (https://cloud.tencent.com/document/product/1729/104753)
- Add hunyuan-embedding (https://cloud.tencent.com/document/product/1729/111007#95185fe4-0c2d-4aa4-a7b0-edc526746c88)
- Fix the issue of the embedding model displaying the internet icon (when the provider fully supports web search)