### PR TITLE
refactor: Improve Ellipsis component and usage

### DIFF
--- a/src/renderer/src/components/Ellipsis/index.tsx
+++ b/src/renderer/src/components/Ellipsis/index.tsx
@@ -18,6 +18,7 @@ const multiLineEllipsis = css<{ $maxLine: number }>`
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: ${({ $maxLine }) => $maxLine};
+  overflow-wrap: break-word;
 `
 
 const singleLineEllipsis = css`

--- a/src/renderer/src/components/Ellipsis/index.tsx
+++ b/src/renderer/src/components/Ellipsis/index.tsx
@@ -1,26 +1,34 @@
-import React from 'react'
-import styled from 'styled-components'
+import type { HTMLAttributes } from 'react'
+import styled, { css } from 'styled-components'
 
 type Props = {
-  text: string | number
   maxLine?: number
-} & React.HTMLAttributes<HTMLDivElement>
+} & HTMLAttributes<HTMLDivElement>
 
 const Ellipsis = (props: Props) => {
-  const { text, maxLine = 1, ...rest } = props
+  const { maxLine = 1, children, ...rest } = props
   return (
-    <EllipsisContainer maxLine={maxLine} {...rest}>
-      {text}
+    <EllipsisContainer $maxLine={maxLine} {...rest}>
+      {children}
     </EllipsisContainer>
   )
 }
 
-const EllipsisContainer = styled.div<{ maxLine: number }>`
+const multiLineEllipsis = css<{ $maxLine: number }>`
   display: -webkit-box;
   -webkit-box-orient: vertical;
-  text-overflow: ellipsis;
+  -webkit-line-clamp: ${({ $maxLine }) => $maxLine};
+`
+
+const singleLineEllipsis = css`
+  display: block;
+  white-space: nowrap;
+`
+
+const EllipsisContainer = styled.div<{ $maxLine: number }>`
   overflow: hidden;
-  -webkit-line-clamp: ${({ maxLine }) => maxLine};
+  text-overflow: ellipsis;
+  ${({ $maxLine }) => ($maxLine > 1 ? multiLineEllipsis : singleLineEllipsis)}
 `
 
 export default Ellipsis

--- a/src/renderer/src/pages/knowledge/KnowledgeContent.tsx
+++ b/src/renderer/src/pages/knowledge/KnowledgeContent.tsx
@@ -263,9 +263,9 @@ const KnowledgeContent: FC<KnowledgeContentProps> = ({ selectedBase }) => {
                 <ItemInfo>
                   <FileIcon />
                   <ClickableSpan onClick={() => window.api.file.openPath(file.path)}>
-                    <Tooltip title={file.origin_name}>
-                      <Ellipsis text={file.origin_name} />
-                    </Tooltip>
+                    <Ellipsis>
+                      <Tooltip title={file.origin_name}>{file.origin_name}</Tooltip>
+                    </Ellipsis>
                   </ClickableSpan>
                 </ItemInfo>
                 <FlexAlignCenter>
@@ -295,9 +295,9 @@ const KnowledgeContent: FC<KnowledgeContentProps> = ({ selectedBase }) => {
                 <ItemInfo>
                   <FolderOutlined />
                   <ClickableSpan onClick={() => window.api.file.openPath(item.content as string)}>
-                    <Tooltip title={item.content as string}>
-                      <Ellipsis text={item.content as string} />
-                    </Tooltip>
+                    <Ellipsis>
+                      <Tooltip title={item.content as string}>{item.content as string}</Tooltip>
+                    </Ellipsis>
                   </ClickableSpan>
                 </ItemInfo>
                 <FlexAlignCenter>
@@ -353,11 +353,11 @@ const KnowledgeContent: FC<KnowledgeContentProps> = ({ selectedBase }) => {
                       ]
                     }}
                     trigger={['contextMenu']}>
-                    <a href={item.content as string} target="_blank" rel="noopener noreferrer">
-                      <Tooltip title={item.content as string}>
-                        <Ellipsis text={item.remark || (item.content as string)} />
-                      </Tooltip>
-                    </a>
+                    <Ellipsis>
+                      <a href={item.content as string} target="_blank" rel="noopener noreferrer">
+                        <Tooltip title={item.content as string}>{item.remark || (item.content as string)}</Tooltip>
+                      </a>
+                    </Ellipsis>
                   </Dropdown>
                 </ItemInfo>
                 <FlexAlignCenter>
@@ -388,7 +388,7 @@ const KnowledgeContent: FC<KnowledgeContentProps> = ({ selectedBase }) => {
                   <GlobalOutlined />
                   <a href={item.content as string} target="_blank" rel="noopener noreferrer">
                     <Tooltip title={item.content as string}>
-                      <Ellipsis text={item.content as string} />
+                      <Ellipsis>{item.content as string}</Ellipsis>
                     </Tooltip>
                   </a>
                 </ItemInfo>
@@ -570,6 +570,8 @@ const FlexAlignCenter = styled.div`
 
 const ClickableSpan = styled.span`
   cursor: pointer;
+  flex: 1;
+  width: 0;
 `
 
 const FileIcon = styled(FileTextOutlined)`

--- a/src/renderer/src/pages/knowledge/KnowledgeContent.tsx
+++ b/src/renderer/src/pages/knowledge/KnowledgeContent.tsx
@@ -353,11 +353,15 @@ const KnowledgeContent: FC<KnowledgeContentProps> = ({ selectedBase }) => {
                       ]
                     }}
                     trigger={['contextMenu']}>
-                    <Ellipsis>
-                      <a href={item.content as string} target="_blank" rel="noopener noreferrer">
-                        <Tooltip title={item.content as string}>{item.remark || (item.content as string)}</Tooltip>
-                      </a>
-                    </Ellipsis>
+                    <ClickableSpan>
+                      <Tooltip title={item.content as string}>
+                        <Ellipsis>
+                          <a href={item.content as string} target="_blank" rel="noopener noreferrer">
+                            {item.remark || (item.content as string)}
+                          </a>
+                        </Ellipsis>
+                      </Tooltip>
+                    </ClickableSpan>
                   </Dropdown>
                 </ItemInfo>
                 <FlexAlignCenter>
@@ -386,11 +390,15 @@ const KnowledgeContent: FC<KnowledgeContentProps> = ({ selectedBase }) => {
               <ItemContent>
                 <ItemInfo>
                   <GlobalOutlined />
-                  <a href={item.content as string} target="_blank" rel="noopener noreferrer">
+                  <ClickableSpan>
                     <Tooltip title={item.content as string}>
-                      <Ellipsis>{item.content as string}</Ellipsis>
+                      <Ellipsis>
+                        <a href={item.content as string} target="_blank" rel="noopener noreferrer">
+                          {item.content as string}
+                        </a>
+                      </Ellipsis>
                     </Tooltip>
-                  </a>
+                  </ClickableSpan>
                 </ItemInfo>
                 <FlexAlignCenter>
                   {item.uniqueId && <Button type="text" icon={<RefreshIcon />} onClick={() => refreshItem(item)} />}
@@ -530,13 +538,6 @@ const ItemInfo = styled.div`
   align-items: center;
   gap: 8px;
   flex: 1;
-
-  a {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    max-width: 600px;
-  }
 `
 
 const IndexSection = styled.div`


### PR DESCRIPTION
- fix:https://github.com/CherryHQ/cherry-studio/issues/2470
- Modify Ellipsis component to use children instead of text prop
- Add support for multi-line and single-line ellipsis with styled-components
- Update KnowledgeContent to use new Ellipsis component structure
- Enhance ClickableSpan styling for better text truncation