### PR TITLE
fix bug: #2306

### DIFF
--- a/src/renderer/src/assets/styles/ant.scss
+++ b/src/renderer/src/assets/styles/ant.scss
@@ -12,6 +12,10 @@
   outline: none;
 }
 
+.ant-tabs-tabpane:focus-visible {
+  outline: none;
+}
+
 .ant-segmented-group {
   gap: 4px;
 }


### PR DESCRIPTION
fix #2306
原因是ant-tabs-tabpane在focus-visible时候存在默认样式
outline: 3px solid #0e462e;