### PR TITLE
feat: Add KaTeX copy-tex and mhchem support

### DIFF
--- a/src/renderer/src/pages/home/Markdown/Markdown.tsx
+++ b/src/renderer/src/pages/home/Markdown/Markdown.tsx
@@ -1,4 +1,5 @@
 import 'katex/dist/katex.min.css'
+import 'katex/dist/contrib/copy-tex'
 
 import { useSettings } from '@renderer/hooks/useSettings'
 import { Message } from '@renderer/types'
@@ -13,6 +14,8 @@ import rehypeMathjax from 'rehype-mathjax'
 import rehypeRaw from 'rehype-raw'
 import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
+
+import 'katex/dist/contrib/mhchem'
 
 import CodeBlock from './CodeBlock'
 import ImagePreview from './ImagePreview'


### PR DESCRIPTION
添加 KaTeX copy-tex 与 mhchem 支持：
- copy-tex 允许选中部分数学公式，按 <kbd>Ctrl</kbd> + <kbd>C</kbd> 后全选对应数学公式块并复制 LaTeX 数学公式，相较于直接复制整个回复或进入编辑来说更便捷
- mhchem 添加了 `\ce` 与 `\pu` 命令，可以支持显示部分化学式与单位

效果如图所示：

![katex](https://github.com/user-attachments/assets/1b55a84b-c302-40bf-91fb-b81937900bb1)
