### PR TITLE
fix: Token estimate count cannot be updated on the UI when typing quickly.

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -94,11 +94,24 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic }) => {
 
   const showKnowledgeIcon = useSidebarIconShow('knowledge')
 
-  const estimateTextTokens = useCallback(debounce(estimateTxtTokens, 1000), [])
-  const inputTokenCount = useMemo(
-    () => (showInputEstimatedTokens ? estimateTextTokens(text) || 0 : 0),
-    [estimateTextTokens, showInputEstimatedTokens, text]
-  )
+  const [tokenCount, setTokenCount] = useState(0);
+
+  const debouncedEstimate = useCallback(
+  debounce((newText) => {
+      if (showInputEstimatedTokens) {
+      const count = estimateTxtTokens(newText) || 0;
+      setTokenCount(count);
+      }
+  }, 500),
+  [showInputEstimatedTokens]
+  );
+
+  useEffect(() => {
+  debouncedEstimate(text);
+  }, [text, debouncedEstimate]);
+
+  const inputTokenCount = showInputEstimatedTokens ? tokenCount : 0;
+
   const newTopicShortcut = useShortcutDisplay('new_topic')
   const newContextShortcut = useShortcutDisplay('toggle_new_context')
   const cleanTopicShortcut = useShortcutDisplay('clear_topic')


### PR DESCRIPTION
原来的估算逻辑当中有一个 `debounce`，这个函数只会在用户停止更新 text 1000ms 之后计算 Token 数量。但是真要等待 1000ms 之后，算出来了这个值，UI 元素不会刷新，这个新值不能显示出来。

实际效果就是：我必须等 1 秒，然后按一下空格。它才会刷新。

现在的这个逻辑基本上可以保证用户在最后一次文本更改 500ms 之后一定会看到新的 Token 数量，测试了键入、快速翻译和粘贴。

代码是 Claude 3.7 Sonnet 写的。