### PR TITLE
fix: disable AddButtonWrapper while dragging a provider item

### DIFF
--- a/src/renderer/src/pages/settings/ProviderSettings/index.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/index.tsx
@@ -148,13 +148,11 @@ const ProvidersList: FC = () => {
             </DragDropContext>
           </ProviderList>
         </Scrollbar>
-        {!dragging && (
-          <AddButtonWrapper>
-            <Button style={{ width: '100%' }} icon={<PlusOutlined />} onClick={onAddProvider}>
-              {t('button.add')}
-            </Button>
-          </AddButtonWrapper>
-        )}
+        <AddButtonWrapper isDragging={dragging}>
+          <Button style={{ width: '100%' }} icon={<PlusOutlined />} onClick={onAddProvider}>
+            {t('button.add')}
+          </Button>
+        </AddButtonWrapper>
       </ProviderListContainer>
       <ProviderSetting provider={selectedProvider} key={JSON.stringify(selectedProvider)} />
     </Container>
@@ -215,12 +213,14 @@ const ProviderItemName = styled.div`
   font-family: Ubuntu;
 `
 
-const AddButtonWrapper = styled.div`
+const AddButtonWrapper = styled.div<{ isDragging: boolean }>`
   height: 50px;
   flex-direction: row;
   justify-content: center;
   align-items: center;
   padding: 10px 8px;
+  opacity: ${(props) => (props.isDragging ? 0.5 : 1)};
+  pointer-events: ${(props) => (props.isDragging ? 'none' : 'auto')};
 `
 
 export default ProvidersList


### PR DESCRIPTION
Provider 列表的元素被拖动时，AddButtonWrapper 消失导致列表底部元素重叠。我尝试改为拖动时禁用按钮，而不是直接去掉。

修改前：

![cherry-studio-provider-list-bug](https://github.com/user-attachments/assets/c426c5c0-4f24-4030-a421-bbf4414a9fcc)

修改后：

![cherry-studio-provider-list-fix](https://github.com/user-attachments/assets/c97870cc-eb7b-43e9-a323-7bb763445ff1)
