### PR TITLE
feat: improve SelectModelPopup

### DIFF
--- a/src/renderer/src/components/Popups/SelectModelPopup.tsx
+++ b/src/renderer/src/components/Popups/SelectModelPopup.tsx
@@ -65,14 +65,24 @@ const PopupContainer: React.FC<PopupContainerProps> = ({ model, resolve }) => {
 
   // 根据输入的文本筛选模型
   const getFilteredModels = useCallback(
-    (provider) =>
-      sortBy(provider.models, ['group', 'name']).filter(
-        (m) =>
-          !isEmbeddingModel(m) &&
-          (provider.isSystem ? `${m.name}${m.provider}${t('provider.' + provider.id)}` : `${m.name}${m.provider}`)
-            .toLowerCase()
-            .includes(searchText.toLowerCase())
-      ),
+    (provider) => {
+      const nonEmbeddingModels = provider.models.filter((m) => !isEmbeddingModel(m))
+
+      if (!searchText.trim()) {
+        return sortBy(nonEmbeddingModels, ['group', 'name'])
+      }
+
+      const keywords = searchText.toLowerCase().split(/\s+/).filter(Boolean)
+
+      return sortBy(nonEmbeddingModels, ['group', 'name']).filter((m) => {
+        const fullName = provider.isSystem
+          ? `${m.name}${m.provider}${t('provider.' + provider.id)}`
+          : `${m.name}${m.provider}`
+
+        const lowerFullName = fullName.toLowerCase()
+        return keywords.every((keyword) => lowerFullName.includes(keyword))
+      })
+    },
     [searchText, t]
   )
 


### PR DESCRIPTION
## 修复

对于自定义 provider，用于匹配的字符串不应该包含 provider.id，因为这个 id 里面有 `provider` 子串。修复前的行为：

![image](https://github.com/user-attachments/assets/048c4152-12e9-4a72-9c2e-00096abf4198)

## 增强

- [x] 匹配空格分隔的多个词

