### PR TITLE
feat: 修改WebsearchButton样式，为后续接入更多websearch provider适配

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -853,7 +853,9 @@
         "blacklist_description": "Results from the following websites will not appear in search results",
         "blacklist_tooltip": "Please use the following format (separated by line breaks)\nexample.com\nhttps://www.example.com\nhttps://example.com\n*://*.example.com",
         "search_max_result": "Number of search results",
-        "search_result_default": "Default"
+        "search_result_default": "Default",
+        "no_provider": "No search engine available.",
+        "select_provider": "Please select a search engine."
       }
     },
     "translate": {

--- a/src/renderer/src/i18n/locales/ja-jp.json
+++ b/src/renderer/src/i18n/locales/ja-jp.json
@@ -853,7 +853,9 @@
         "blacklist_description": "以下のウェブサイトの結果は検索結果に表示されません",
         "blacklist_tooltip": "以下の形式を使用してください(改行区切り)\nexample.com\nhttps://www.example.com\nhttps://example.com\n*://*.example.com",
         "search_max_result": "検索結果の数",
-        "search_result_default": "デフォルト"
+        "search_result_default": "デフォルト",
+        "no_provider": "現在、検索エンジンはありません。",
+        "select_provider": "検索エンジンを選択してください"
       }
     },
     "translate": {

--- a/src/renderer/src/i18n/locales/ru-ru.json
+++ b/src/renderer/src/i18n/locales/ru-ru.json
@@ -853,7 +853,9 @@
         "blacklist_description": "Результаты из следующих веб-сайтов не будут отображаться в результатах поиска",
         "blacklist_tooltip": "Пожалуйста, используйте следующий формат (разделенный переносами строк)\nexample.com\nhttps://www.example.com\nhttps://example.com\n*://*.example.com",
         "search_max_result": "Количество результатов поиска",
-        "search_result_default": "По умолчанию"
+        "search_result_default": "По умолчанию",
+        "no_provider": "Нет поисковых систем.",
+        "select_provider": "Пожалуйста, выберите поисковую систему"
       }
     },
     "translate": {

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -840,6 +840,8 @@
       "assistant.show.icon": "显示模型图标",
       "tray.title": "启用系统托盘图标",
       "websearch": {
+        "no_provider": "暂无搜索引擎",
+        "select_provider": "请选择搜索引擎",
         "blacklist": "黑名单",
         "blacklist_description": "在搜索结果中不会出现以下网站的结果",
         "blacklist_tooltip": "请使用以下格式(换行分隔)\nexample.com\nhttps://www.example.com\nhttps://example.com\n*://*.example.com",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -852,7 +852,9 @@
         "blacklist_description": "以下網站不會出現在搜索結果中",
         "blacklist_tooltip": "請使用以下格式(換行分隔)\nexample.com\nhttps://www.example.com\nhttps://example.com\n*://*.example.com",
         "search_max_result": "搜索結果個數",
-        "search_result_default": "預設"
+        "search_result_default": "預設",
+        "no_provider": "暫無搜尋引擎",
+        "select_provider": "請選擇搜尋引擎"
       },
       "display.assistant.title": "助手設定"
     },

--- a/src/renderer/src/pages/home/Inputbar/WebSearchButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/WebSearchButton.tsx
@@ -1,0 +1,126 @@
+import { GlobalOutlined } from '@ant-design/icons'
+import { isWebSearchModel } from '@renderer/config/models'
+import { useWebSearchProviders } from '@renderer/hooks/useWebSearchProviders'
+import WebSearchService from '@renderer/services/WebSearchService'
+import { Assistant, Model, WebSearchProvider } from '@renderer/types'
+import { Popover, Select, SelectProps, Tooltip } from 'antd'
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+
+interface Props {
+  selectedWebSearchProvider?: WebSearchProvider
+  onSelect: (provider?: WebSearchProvider) => void
+  model: Model
+  assistant: Assistant
+  onEnableWebSearch?: () => void
+  disabled?: boolean
+  ToolbarButton?: any
+}
+
+const WebSearchSelector: FC<Props> = ({ selectedWebSearchProvider, onSelect }) => {
+  const { t } = useTranslation()
+  const providers = useWebSearchProviders()
+
+  const searchOptions: SelectProps['options'] = providers.map((provider) => ({
+    label: provider.name,
+    value: provider.id
+  }))
+
+  return (
+    <SelectorContainer>
+      {providers.length === 0 ? (
+        <EmptyMessage>{t('settings.websearch.no_providers')}</EmptyMessage>
+      ) : (
+        <Select
+          allowClear
+          value={selectedWebSearchProvider?.id}
+          placeholder={t('settings.websearch.select_provider')}
+          options={searchOptions}
+          style={{ width: '150px' }}
+          onChange={(selectedId: string) => {
+            const selectedProvider = providers.find((p) => p.id === selectedId)
+            onSelect(selectedProvider)
+          }}
+          filterOption={(input, option) =>
+            String(option?.label ?? '')
+              .toLowerCase()
+              .includes(input.toLowerCase())
+          }
+        />
+      )}
+    </SelectorContainer>
+  )
+}
+
+const WebSearchButton: FC<Props> = ({
+  selectedWebSearchProvider,
+  onSelect,
+  model,
+  assistant,
+  onEnableWebSearch,
+  disabled,
+  ToolbarButton
+}) => {
+  const { t } = useTranslation()
+
+  // 检查是否支持网络搜索
+  const supportsWebSearch = isWebSearchModel(model)
+  const webSearchEnabled = WebSearchService.isWebSearchEnabled()
+
+  // 如果不支持网络搜索且功能也未启用，则不显示按钮
+  if (!supportsWebSearch && !webSearchEnabled) {
+    return null
+  }
+
+  // 计算按钮状态
+  const isActive = assistant.enableWebSearch
+  const iconColor = isActive ? 'var(--color-link)' : 'var(--color-icon)'
+
+  // 如果支持网络搜索模型，则只显示简单的开关按钮
+  if (supportsWebSearch) {
+    return (
+      <Tooltip placement="top" title={t('chat.input.web_search')} arrow>
+        <ToolbarButton type="text" onClick={onEnableWebSearch}>
+          <GlobalOutlined style={{ color: iconColor }} />
+        </ToolbarButton>
+      </Tooltip>
+    )
+  }
+
+  // 否则，显示带有提供商选择的按钮
+  return (
+    <Tooltip placement="top" title={t('chat.input.web_search')} arrow>
+      <Popover
+        placement="top"
+        content={
+          <WebSearchSelector
+            selectedWebSearchProvider={selectedWebSearchProvider}
+            onSelect={onSelect}
+            model={model}
+            assistant={assistant}
+          />
+        }
+        overlayStyle={{ maxWidth: 400 }}
+        trigger="click">
+        <ToolbarButton type="text" disabled={disabled}>
+          <GlobalOutlined style={{ color: selectedWebSearchProvider ? iconColor : 'var(--color-icon)' }} />
+        </ToolbarButton>
+      </Popover>
+    </Tooltip>
+  )
+}
+
+const SelectorContainer = styled.div`
+  max-height: 300px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`
+
+const EmptyMessage = styled.div`
+  padding: 8px;
+`
+
+export default WebSearchButton

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -17,6 +17,7 @@ export type Assistant = {
   settings?: Partial<AssistantSettings>
   messages?: AssistantMessage[]
   enableWebSearch?: boolean
+  websearch?: WebSearchProvider
 }
 
 export type AssistantMessage = {


### PR DESCRIPTION
模型为联网模型时保持原操作逻辑，非联网模型且开启联网搜索功能时，样式如下，与知识库一样为select，后续适配更多搜索模型时可供选择，且每个assistant可以单独设置搜索引擎
![CleanShot 2025-03-04 at 12 21 39@2x](https://github.com/user-attachments/assets/e5dd84b4-b9c7-4ef0-91ef-f48d4c313dab)
