### PR TITLE
fix: Token counter display issues when translating assistant messages.

### DIFF
--- a/src/renderer/src/pages/home/Messages/Message.tsx
+++ b/src/renderer/src/pages/home/Messages/Message.tsx
@@ -97,8 +97,10 @@ const MessageItem: FC<Props> = ({
 
   const onEditMessage = useCallback(
     async (msg: Message) => {
-      const usage = await estimateMessageUsage(msg)
-      msg.usage = usage
+      if (msg.role === 'user') {
+        const usage = await estimateMessageUsage(msg)
+        msg.usage = usage
+      }
 
       setMessage(msg)
       const messages = onGetMessages?.()?.map((m) => (m.id === message.id ? msg : m))


### PR DESCRIPTION
现有版本的 Token 计数器在使用消息翻译的时候会产生问题：

![image](https://github.com/user-attachments/assets/22c69e78-4ab5-4fbe-945e-44fa3454d6c2)

我的行为预期是：这个右下角的小计数器可以准确地告诉我“为了获得这个回复，我花了多少 Token”。因为翻译输入和输出的 Token 数相差无几，也没有上下文，当同时存在“原文”和“翻译”的时候，它应该输出“原文”的 Token 消耗。

退一步讲，就算想要看“翻译”功能的 Token 消耗，这个三个数都是同一个值也是明显不对的。

---

我查了一下 Blame，猫哥在这里使用 `estimateMessageUsage()` 似乎是为了解决带图片和附件的时候会卡住的问题。所以我姑且确信这个东西只应该在修改 user Message 的时候发挥作用。

![image](https://github.com/user-attachments/assets/fa7ab5c8-0460-4e43-b9a9-9a48c3c249a6)

这是修改之后我认为比较正常的效果。

BTW，如果人为修改了 assistant 的回答：

![image](https://github.com/user-attachments/assets/d24be33e-1111-47c5-9a02-55cea17783e8)

这三个“1”也是没有意义的。


![image](https://github.com/user-attachments/assets/d92650b7-d3ed-42f7-a70d-a18a7a330ea6)

相比之下修改之后会卡住不动，但是这多少有点用（你当初发这个东西的时候用了多少 Token）。 