### PR TITLE
fix(mcp): add required to tool call parameters

### DIFF
--- a/src/renderer/src/providers/OpenAIProvider.ts
+++ b/src/renderer/src/providers/OpenAIProvider.ts
@@ -234,7 +234,8 @@ export default class OpenAIProvider extends BaseProvider {
         description: tool.description,
         parameters: {
           type: 'object',
-          properties: tool.inputSchema.properties
+          properties: tool.inputSchema.properties,
+          required: tool.inputSchema.required
         }
       }
     }))


### PR DESCRIPTION
in [OpenAI Platform Tool Calling Documentation](https://platform.openai.com/docs/assistants/tools/function-calling?lang=node.js) ，`type`, `properties`, `required`, should be at the same level within the object `parameters` .