### PR TITLE
feat: Improve devtools font on Windows

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,5 @@
 import { electronApp, optimizer } from '@electron-toolkit/utils'
+import { replaceDevtoolsFont } from '@main/utils/windowUtil'
 import { app } from 'electron'
 import installExtension, { REDUX_DEVTOOLS } from 'electron-devtools-installer'
 
@@ -38,6 +39,8 @@ if (!app.requestSingleInstanceLock()) {
     registerShortcuts(mainWindow)
 
     registerIpc(mainWindow, app)
+
+    replaceDevtoolsFont(mainWindow)
 
     if (process.env.NODE_ENV === 'development') {
       installExtension(REDUX_DEVTOOLS)

--- a/src/main/utils/windowUtil.ts
+++ b/src/main/utils/windowUtil.ts
@@ -1,3 +1,5 @@
+import { BrowserWindow } from 'electron'
+
 function isTilingWindowManager() {
   if (process.platform === 'darwin') {
     return false
@@ -11,6 +13,35 @@ function isTilingWindowManager() {
   const tilingSystems = ['hyprland', 'i3', 'sway', 'bspwm', 'dwm', 'awesome', 'qtile', 'herbstluftwm', 'xmonad']
 
   return tilingSystems.some((system) => desktopEnv?.includes(system))
+}
+
+export const replaceDevtoolsFont = (browserWindow: BrowserWindow) => {
+  if (process.platform === 'win32') {
+    browserWindow.webContents.on('devtools-opened', () => {
+      const css = `
+        :root {
+            --sys-color-base: var(--ref-palette-neutral100);
+            --source-code-font-family: consolas;
+            --source-code-font-size: 12px;
+            --monospace-font-family: consolas;
+            --monospace-font-size: 12px;
+            --default-font-family: system-ui, sans-serif;
+            --default-font-size: 12px;
+        }
+        .-theme-with-dark-background {
+            --sys-color-base: var(--ref-palette-secondary25);
+        }
+        body {
+            --default-font-family: system-ui,sans-serif;
+        }`
+
+      browserWindow.webContents.devToolsWebContents?.executeJavaScript(`
+        const overriddenStyle = document.createElement('style');
+        overriddenStyle.innerHTML = '${css.replaceAll('\n', ' ')}';
+        document.body.append(overriddenStyle);
+        document.body.classList.remove('platform-windows');`)
+    })
+  }
 }
 
 export { isTilingWindowManager }


### PR DESCRIPTION
#2799 

默认字体确实不好辨识，也没办法点点点换字体，参考 [electron issues#42055](https://github.com/electron/electron/issues/42055)。

只替换Windows的devtools字体。

以个人为例，前后对比：

![image](https://github.com/user-attachments/assets/48f99500-f7df-494a-b954-6b5796041ca8)

![image](https://github.com/user-attachments/assets/384e61c9-5cc5-4318-b1f4-0087f476b720)

