### PR TITLE
fix: slider max number incorrectly display #2900

### DIFF
--- a/src/renderer/src/pages/home/Tabs/SettingsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/SettingsTab.tsx
@@ -171,7 +171,7 @@ const SettingsTab: FC<Props> = (props) => {
           <Col span={24}>
             <Slider
               min={0}
-              max={10}
+              max={20}
               onChange={setContextCount}
               onChangeComplete={onContextCountChange}
               value={typeof contextCount === 'number' ? contextCount : 0}


### PR DESCRIPTION
fix: change `contextCount` in `settingTab` max number from 10 to 20. Align with `AssistantModelSettings` in #2900 