### PR TITLE
fix(message): edit message in place

### DIFF
--- a/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
@@ -295,7 +295,7 @@ const MessageMenubar: FC<Props> = (props) => {
 
     const _message: Message = resetAssistantMessage(message, selectedModel)
 
-    if (message.askId && message.model) {
+    if (message.askId && message.model && isGrouped) {
       return EventEmitter.emit(EVENT_NAMES.APPEND_MESSAGE, { ..._message, id: uuid() })
     }
 

--- a/src/renderer/src/pages/home/Messages/Messages.tsx
+++ b/src/renderer/src/pages/home/Messages/Messages.tsx
@@ -95,9 +95,31 @@ const Messages: FC<Props> = ({ assistant, topic, setActiveTopic }) => {
   const onAppendMessage = useCallback(
     (message: Message) => {
       setMessages((prev) => {
-        const messages = prev.concat([message])
-        db.topics.put({ id: topic.id, messages })
-        return messages
+        // Find the index of the last message with the same askId
+        let sameAskIdLastIndex = -1
+
+        if (message.askId) {
+          // Iterate from the end to find the last message with the same askId
+          for (let i = prev.length - 1; i >= 0; i--) {
+            if (prev[i].askId === message.askId) {
+              sameAskIdLastIndex = i
+              break
+            }
+          }
+        }
+
+        // If a message with the same askId is found
+        if (sameAskIdLastIndex !== -1) {
+          // Create a new array with the message inserted after the last message with the same askId
+          const newMessages = [...prev.slice(0, sameAskIdLastIndex + 1), message, ...prev.slice(sameAskIdLastIndex + 1)]
+          db.topics.put({ id: topic.id, messages: newMessages })
+          return newMessages
+        } else {
+          // If no message with the same askId is found, append to the end as before
+          const messages = prev.concat([message])
+          db.topics.put({ id: topic.id, messages })
+          return messages
+        }
       })
     },
     [topic.id]


### PR DESCRIPTION
fix #1073 #2154 

保证用 @ 切换模型回答的新消息总是插入到当前消息组。

![cherry-studio-edit-in-place](https://github.com/user-attachments/assets/33fcc85e-a0e8-48eb-8552-9352a5f1b703)
