### PR TITLE
fix(ui): Improve dropdown menu styling with dynamic inner glow opacity

### DIFF
--- a/src/renderer/src/assets/styles/index.scss
+++ b/src/renderer/src/assets/styles/index.scss
@@ -26,6 +26,7 @@
   --color-background-soft: var(--color-black-soft);
   --color-background-mute: var(--color-black-mute);
   --color-background-opacity: rgba(34, 34, 34, 0.7);
+  --inner-glow-opacity: 0.3; // For the glassmorphism effect in the dropdown menu
 
   --color-primary: #00b96b;
   --color-primary-soft: #00b96b99;
@@ -90,6 +91,7 @@ body[theme-mode='light'] {
   --color-background-soft: var(--color-white-soft);
   --color-background-mute: var(--color-white-mute);
   --color-background-opacity: rgba(235, 235, 235, 0.7);
+  --inner-glow-opacity: 0.1;
 
   --color-primary: #00b96b;
   --color-primary-soft: #00b96b99;

--- a/src/renderer/src/pages/home/Inputbar/MentionModelsButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/MentionModelsButton.tsx
@@ -397,7 +397,7 @@ const DropdownMenuStyle = createGlobalStyle`
       box-shadow: 0 0 0 0.5px rgba(0, 0, 0, 0.15),
                   0 4px 16px rgba(0, 0, 0, 0.15),
                   0 2px 8px rgba(0, 0, 0, 0.12),
-                  inset 0 0 0 0.5px rgba(255, 255, 255, 0.1);
+                  inset 0 0 0 0.5px rgba(255, 255, 255, var(--inner-glow-opacity, 0.1));
       transform-origin: top;
       will-change: transform, opacity;
       transition: all 0.15s cubic-bezier(0.4, 0.0, 0.2, 1);
@@ -420,23 +420,21 @@ const DropdownMenuStyle = createGlobalStyle`
         border: 4px solid transparent;
         background-clip: padding-box;
         border-radius: 7px;
-        background-color: transparent;
+        background-color: var(--color-scrollbar-thumb);
         min-height: 50px;
         transition: all 0.2s;
       }
 
       &:hover::-webkit-scrollbar-thumb {
-        background-color: rgba(0, 0, 0, 0.2);
+        background-color: var(--color-scrollbar-thumb);
       }
 
       &::-webkit-scrollbar-thumb:hover {
-        background-color: rgba(0, 0, 0, 0.3);
-        border: 4px solid transparent;
+        background-color: var(--color-scrollbar-thumb-hover);
       }
 
       &::-webkit-scrollbar-thumb:active {
-        background-color: rgba(0, 0, 0, 0.4);
-        border: 3px solid transparent;
+        background-color: var(--color-scrollbar-thumb-hover);
       }
 
       &::-webkit-scrollbar-track {
@@ -444,11 +442,6 @@ const DropdownMenuStyle = createGlobalStyle`
         border-radius: 7px;
       }
     }
-
-    // // Apply margin to the last group
-    // .ant-dropdown-menu-item-group:last-child {
-    //   margin-bottom: 40px;
-    // }
 
     .ant-dropdown-menu-item-group {
       margin-bottom: 4px;


### PR DESCRIPTION
### Changes
- Added `--inner-glow-opacity` CSS variable for better control of glassmorphism effect
  - Dark mode: 0.3 opacity for stronger effect
  - Light mode: 0.1 opacity for subtle effect
- Refactored scrollbar styling to use global CSS variables
- Removed hardcoded color values for better maintainability

### Why
- Improves dark mode support by adjusting inner glow opacity based on theme, as inner grow should be different in light and  dark theme  for visibility. 
- Enhances code maintainability by using global variables instead of hardcoded values
- Makes the dropdown menu styling more consistent across themes
- Follows DRY principles by reusing existing color variables

### Testing
- Verified dropdown menu appearance in both light and dark modes
- Checked scrollbar behavior and styling
- Ensured smooth transitions and hover states
<img width="428" alt="Screenshot 2025-03-07 at 1 03 34 PM" src="https://github.com/user-attachments/assets/a1342aa8-3bb9-4c40-9eca-6fe67c990916" />

