### PR TITLE
fix: unify context length setting ui in assistant settings and settings tab

### DIFF
--- a/src/renderer/src/pages/home/Tabs/SettingsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/SettingsTab.tsx
@@ -168,13 +168,14 @@ const SettingsTab: FC<Props> = (props) => {
           </Tooltip>
         </Row>
         <Row align="middle" gutter={10}>
-          <Col span={24}>
+          <Col span={24} style={{ paddingRight: 10 }}>
             <Slider
               min={0}
-              max={10}
+              max={20}
               onChange={setContextCount}
               onChangeComplete={onContextCountChange}
               value={typeof contextCount === 'number' ? contextCount : 0}
+              marks={{ 0: '0', 5: '5', 10: '10', 15: '15', 20: t('chat.settings.max') }}
               step={1}
             />
           </Col>


### PR DESCRIPTION
让聊天设置里的上下文限制和助手设置里的ui一致，具体而言：
1. 上限设置成20
2. 调成20时的mark为“无限”