### PR TITLE
fix(mcp): 修复了mcp无法调用功能的问题

### DIFF
--- a/src/renderer/src/providers/mcpToolUtils.ts
+++ b/src/renderer/src/providers/mcpToolUtils.ts
@@ -52,8 +52,11 @@ export function openAIToolsToMcpTool(
   if (!tool) {
     return undefined
   }
-  tool.inputSchema = JSON.parse(llmTool.function.arguments)
-  return tool
+  // 创建工具对象的副本，而不是直接修改原对象
+  return {
+    ...tool,
+    inputSchema: JSON.parse(llmTool.function.arguments)
+  }
 }
 
 export async function callMCPTool(tool: MCPTool): Promise<any> {
@@ -82,9 +85,12 @@ export function anthropicToolUseToMcpTool(mcpTools: MCPTool[] | undefined, toolU
   if (!tool) {
     return undefined
   }
-  // @ts-ignore ignore type as it it unknow
-  tool.inputSchema = toolUse.input
-  return tool
+  // 创建工具对象的副本，而不是直接修改原对象
+  return {
+    ...tool,
+    // @ts-ignore ignore type as it it unknow
+    inputSchema: toolUse.input
+  }
 }
 
 export function mcpToolsToGeminiTools(mcpTools: MCPTool[] | undefined): geminiToool[] {
@@ -120,9 +126,12 @@ export function geminiFunctionCallToMcpTool(
   if (!tool) {
     return undefined
   }
-  // @ts-ignore schema is not a valid property
-  tool.inputSchema = fcall.args
-  return tool
+  // 创建工具对象的副本，而不是直接修改原对象
+  return {
+    ...tool,
+    // @ts-ignore schema is not a valid property
+    inputSchema: fcall.args
+  }
 }
 
 export function upsertMCPToolResponse(


### PR DESCRIPTION
## 修改内容

1. 重构了`upsertMCPToolResponse`函数，避免直接修改原数组
   - 创建新数组而不是修改原数组
   - 添加了错误处理逻辑
   - 确保在所有情况下都调用回调函数

2. 修复了`filterMCPTools`函数中的问题
   - 添加了日志输出以便调试
   - 临时处理了`enabledServers`参数一直为undefined的问题
   - 添加了TODO注释说明问题

## 修改原因

1. 原来的实现直接修改了传入的数组，这可能导致意外的副作用。新的实现创建了一个新数组，保持了函数的纯粹性，更符合React的数据流理念。

2. 在`filterMCPTools`函数中，发现上游并没有正常传入`enabledServers`参数，一直都是undefined。原来的实现会在这种情况下将`mcpTools`设置为空数组，导致MCP无法调用功能。修改后的实现通过临时处理避免了这个问题，同时添加了TODO注释以便后续彻底解决。

## 测试

已验证修改后MCP功能可以正常调用。