### PR TITLE
fix: Correct MIME type for JPG images for Gemini 2.0 Pro

### DIFF
--- a/src/main/services/FileStorage.ts
+++ b/src/main/services/FileStorage.ts
@@ -255,7 +255,8 @@ class FileStorage {
     const filePath = path.join(this.storageDir, id)
     const data = await fs.promises.readFile(filePath)
     const base64 = data.toString('base64')
-    const mime = `image/${path.extname(filePath).slice(1)}`
+    const ext = path.extname(filePath).slice(1) == 'jpg' ? 'jpeg' : path.extname(filePath).slice(1)
+    const mime = `image/${ext}`
     return {
       mime,
       base64,


### PR DESCRIPTION
修复Gemini 2.0Pro API不接受MIME为image/jpg的图像，谷歌这一手真的是 🤣 ，还是修改一下防止jpg在未来出现问题。
解决 #2987 