### PR TITLE
feat: 实现小程序的缓存功能

### DIFF
--- a/src/renderer/src/components/MinApp/index.tsx
+++ b/src/renderer/src/components/MinApp/index.tsx
@@ -8,10 +8,9 @@ import { useMinapps } from '@renderer/hooks/useMinapps'
 import store from '@renderer/store'
 import { setMinappShow } from '@renderer/store/runtime'
 import { MinAppType } from '@renderer/types'
-import { delay } from '@renderer/utils'
 import { Avatar, Drawer } from 'antd'
 import { WebviewTag } from 'electron'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import BeatLoader from 'react-spinners/BeatLoader'
 import styled from 'styled-components'
 
@@ -22,51 +21,299 @@ interface Props {
   resolve: (data: any) => void
 }
 
-const PopupContainer: React.FC<Props> = ({ app, resolve }) => {
+const MiniAppContainer: React.FC<Props> = ({ app, resolve }) => {
+  return <MiniAppRenderer app={app} resolve={resolve} />
+}
+
+interface MiniAppRendererProps {
+  app: MinAppType
+  resolve: (data: any) => void
+}
+
+// MiniApp渲染器，用于在TopView中渲染所有MiniApp实例
+const MiniAppRenderer: React.FC<MiniAppRendererProps> = ({ resolve }) => {
+  // 从MinApp类获取所有实例数据
+  const [instances, setInstances] = useState<
+    Map<
+      string | number,
+      {
+        visible: boolean
+        app: MinAppType
+        lastUsed: number
+      }
+    >
+  >(new Map())
+
+  // 同步实例状态
+  useEffect(() => {
+    const updateInstances = () => {
+      setInstances(new Map(MinApp.appInstances))
+    }
+
+    // 初始更新
+    updateInstances()
+
+    // 创建一个定时器，定期检查是否有新实例
+    const intervalId = setInterval(updateInstances, 500)
+
+    return () => {
+      clearInterval(intervalId)
+    }
+  }, [])
+
+  // 渲染所有MiniApp实例，但只显示visible=true的实例
+  return (
+    <>
+      {Array.from(instances.entries()).map(([id, instance]) => (
+        <PopupContainer key={`miniapp-${id}`} app={instance.app} resolve={resolve} visible={instance.visible} />
+      ))}
+    </>
+  )
+}
+
+interface Props {
+  app: MinAppType
+  resolve: (data: any) => void
+  visible?: boolean
+}
+
+const PopupContainer: React.FC<Props> = ({ app, resolve, visible = true }) => {
   const { pinned, updatePinnedMinapps } = useMinapps()
   const isPinned = pinned.some((p) => p.id === app.id)
-  const [open, setOpen] = useState(true)
+  const [open, setOpen] = useState(visible)
   const [opened, setOpened] = useState(false)
   const [isReady, setIsReady] = useState(false)
   const webviewRef = useRef<WebviewTag | null>(null)
+  const [cachedState, setCachedState] = useState<any>(null)
+
+  // 用于防止重复调用onClose
+  const isClosingRef = useRef(false)
 
   useBridge()
+
+  // 当visible属性变化时，更新open状态
+  useEffect(() => {
+    setOpen(visible)
+  }, [visible])
+
+  // 从缓存加载状态
+  useEffect(() => {
+    if (app.id) {
+      const cache = MinApp.getFromCache(app.id)
+      if (cache) {
+        console.log(`[MinApp] 从缓存加载 ${app.name} (ID: ${app.id})，URL: ${cache.webviewSrc}`)
+        setCachedState(cache)
+      } else {
+        console.log(`[MinApp] 未找到 ${app.name} (ID: ${app.id}) 的缓存`)
+      }
+    }
+
+    // 状态初始化完成后，打开webview
+    const timer = setTimeout(() => setOpened(true), 350)
+    return () => clearTimeout(timer)
+  }, [app.id, app.name])
+
+  // 简化的同步保存函数
+  const saveStateSync = useCallback(() => {
+    if (!app.id || !webviewRef.current) return undefined
+
+    try {
+      const currentUrl = webviewRef.current.getURL()
+
+      MinApp.webviewCache.set(app.id, {
+        webviewSrc: currentUrl,
+        webviewState: { scrollTop: 0 }
+      })
+
+      // 如果缓存大小超过限制，删除最早的缓存
+      if (MinApp.webviewCache.size > MinApp.MAX_INSTANCES) {
+        const firstKey = MinApp.webviewCache.keys().next().value
+        if (firstKey) {
+          MinApp.webviewCache.delete(firstKey)
+        }
+      }
+    } catch (error) {
+      console.error('[MinApp] 同步保存失败:', error)
+    }
+  }, [app.id])
+
+  // 关闭处理函数
+  const handleClose = useCallback(async () => {
+    // 防止重复调用
+    if (isClosingRef.current) {
+      console.log('[MinApp] 关闭操作已在进行中，忽略重复调用')
+      return undefined
+    }
+
+    isClosingRef.current = true
+    console.log(`[MinApp] 开始关闭 ${app.name}`)
+
+    try {
+      // 保存当前状态
+      saveStateSync()
+    } catch (err) {
+      console.error('[MinApp] 关闭时保存状态失败:', err)
+    }
+
+    // 更新MinApp类中的实例状态
+    if (app.id) {
+      const instance = MinApp.getAppInstance(app.id)
+      if (instance) {
+        instance.visible = false
+        MinApp.appInstances.set(app.id, instance)
+      }
+    }
+
+    // 隐藏当前实例
+    setOpen(false)
+
+    // 延迟后完成关闭
+    return new Promise<void>((resolveClose) => {
+      setTimeout(() => {
+        resolve({})
+        resolveClose()
+      }, 300)
+    })
+  }, [app.name, app.id, saveStateSync, resolve])
+
+  // 设置全局关闭函数引用
+  useEffect(() => {
+    // 只有当当前实例可见时，才设置为全局onClose
+    if (visible) {
+      MinApp.onClose = () => {
+        handleClose()
+      }
+    }
+
+    return () => {
+      // 重置，避免引用过期的函数
+      if (MinApp.onClose.toString() === handleClose.toString()) {
+        MinApp.onClose = () => {}
+      }
+    }
+  }, [handleClose, visible])
+
+  // Webview 事件处理
+  useEffect(() => {
+    if (!opened || !open) return
+
+    const webview = webviewRef.current
+    let scrollTrackingTimer: number | null = null
+
+    if (webview) {
+      const handleNewWindow = (event: any) => {
+        event.preventDefault()
+        if (webview.loadURL) {
+          webview.loadURL(event.url)
+        }
+      }
+
+      const onLoaded = () => {
+        setIsReady(true)
+        console.log(`[MinApp] ${app.name} webview 已加载: ${webview.getURL()}`)
+
+        // 恢复滚动位置
+        if (cachedState?.webviewState?.scrollTop) {
+          try {
+            const scrollPos = cachedState.webviewState.scrollTop
+            webview.executeJavaScript(`
+              setTimeout(() => {
+                window.scrollTo(0, ${scrollPos});
+                console.log('[MinApp] 已恢复滚动位置到: ${scrollPos}');
+              }, 100);
+            `)
+          } catch (error) {
+            console.error('[MinApp] 恢复滚动位置失败:', error)
+          }
+        }
+      }
+
+      const addScrollListener = () => {
+        try {
+          webview.executeJavaScript(`
+            window.addEventListener('scroll', () => {
+              window.currentScrollY = window.scrollY || document.documentElement.scrollTop || 0;
+            }, { passive: true });
+          `)
+
+          // 定期获取滚动位置并保存
+          scrollTrackingTimer = window.setInterval(() => {
+            if (app.id && !isClosingRef.current) {
+              webview
+                .executeJavaScript('window.currentScrollY || 0')
+                .then((scrollTop) => {
+                  if (app.id) {
+                    MinApp.webviewCache.set(app.id, {
+                      webviewSrc: webview.getURL(),
+                      webviewState: { scrollTop }
+                    })
+                  }
+                })
+                .catch((err) => {
+                  console.error('[MinApp] 获取滚动位置失败:', err)
+                })
+            }
+          }, 30000) as unknown as number
+        } catch (error) {
+          console.error('[MinApp] 添加滚动监听器失败:', error)
+        }
+      }
+
+      webview.addEventListener('new-window', handleNewWindow)
+      webview.addEventListener('did-finish-load', onLoaded)
+      webview.addEventListener('dom-ready', addScrollListener)
+
+      return () => {
+        if (scrollTrackingTimer) {
+          clearInterval(scrollTrackingTimer)
+        }
+
+        try {
+          webview.removeEventListener('new-window', handleNewWindow)
+          webview.removeEventListener('did-finish-load', onLoaded)
+          webview.removeEventListener('dom-ready', addScrollListener)
+        } catch (e) {
+          // 忽略清理过程中的错误
+        }
+      }
+    }
+    return undefined
+  }, [opened, open, cachedState, app.id, app.name])
 
   const canOpenExternalLink = app.url.startsWith('http://') || app.url.startsWith('https://')
   const canPinned = DEFAULT_MIN_APPS.some((i) => i.id === app?.id)
 
-  const onClose = async (_delay = 0.3) => {
-    setOpen(false)
-    await delay(_delay)
-    resolve({})
-  }
-
-  MinApp.onClose = onClose
-  const openDevTools = () => {
+  // 各种按钮处理函数，使用useCallback提高性能
+  const openDevTools = useCallback(() => {
     if (webviewRef.current) {
       webviewRef.current.openDevTools()
     }
-  }
-  const onReload = () => {
+  }, [])
+
+  const onReload = useCallback(() => {
     if (webviewRef.current) {
+      setCachedState(null) // 清除缓存状态
       webviewRef.current.src = app.url
     }
-  }
+  }, [app.url])
 
-  const onOpenLink = () => {
+  const onOpenLink = useCallback(() => {
     if (webviewRef.current) {
       const currentUrl = webviewRef.current.getURL()
       window.api.openWebsite(currentUrl)
     }
-  }
+  }, [])
 
-  const onTogglePin = () => {
+  const onTogglePin = useCallback(() => {
     const newPinned = isPinned ? pinned.filter((item) => item.id !== app.id) : [...pinned, app]
     updatePinnedMinapps(newPinned)
-  }
+  }, [isPinned, pinned, app.id, updatePinnedMinapps])
+
   const isInDevelopment = process.env.NODE_ENV === 'development'
-  const Title = () => {
-    return (
+
+  // 使用useMemo缓存Title组件以提高性能
+  const Title = useMemo(
+    () => (
       <TitleContainer style={{ justifyContent: 'space-between' }}>
         <TitleText>{app.name}</TitleText>
         <ButtonsGroup className={isWindows ? 'windows' : ''}>
@@ -88,72 +335,62 @@ const PopupContainer: React.FC<Props> = ({ app, resolve }) => {
               <CodeOutlined />
             </Button>
           )}
-          <Button onClick={() => onClose()}>
+          <Button onClick={handleClose}>
             <CloseOutlined />
           </Button>
         </ButtonsGroup>
       </TitleContainer>
-    )
+    ),
+    [
+      app.name,
+      handleClose,
+      onReload,
+      onOpenLink,
+      onTogglePin,
+      openDevTools,
+      isPinned,
+      canPinned,
+      canOpenExternalLink,
+      isInDevelopment
+    ]
+  )
+
+  // 使用CSS控制显示/隐藏，而不是卸载组件
+  const containerStyle: React.CSSProperties = {
+    display: open ? 'block' : 'none'
   }
 
-  useEffect(() => {
-    const webview = webviewRef.current
-
-    if (webview) {
-      const handleNewWindow = (event: any) => {
-        event.preventDefault()
-        if (webview.loadURL) {
-          webview.loadURL(event.url)
-        }
-      }
-
-      const onLoaded = () => setIsReady(true)
-
-      webview.addEventListener('new-window', handleNewWindow)
-      webview.addEventListener('did-finish-load', onLoaded)
-
-      return () => {
-        webview.removeEventListener('new-window', handleNewWindow)
-        webview.removeEventListener('did-finish-load', onLoaded)
-      }
-    }
-
-    return () => {}
-  }, [opened])
-
-  useEffect(() => {
-    setTimeout(() => setOpened(true), 350)
-  }, [])
-
   return (
-    <Drawer
-      title={<Title />}
-      placement="bottom"
-      onClose={() => onClose()}
-      open={open}
-      mask={true}
-      rootClassName="minapp-drawer"
-      maskClassName="minapp-mask"
-      height={'100%'}
-      maskClosable={false}
-      closeIcon={null}
-      style={{ marginLeft: 'var(--sidebar-width)' }}>
-      {!isReady && (
-        <EmptyView>
-          <Avatar src={app.logo} size={80} style={{ border: '1px solid var(--color-border)', marginTop: -150 }} />
-          <BeatLoader color="var(--color-text-2)" size="10" style={{ marginTop: 15 }} />
-        </EmptyView>
-      )}
-      {opened && (
-        <webview
-          src={app.url}
-          ref={webviewRef}
-          style={WebviewStyle}
-          allowpopups={'true' as any}
-          partition="persist:webview"
-        />
-      )}
-    </Drawer>
+    <div style={containerStyle}>
+      <Drawer
+        title={Title}
+        placement="bottom"
+        onClose={handleClose}
+        open={open}
+        mask={true}
+        rootClassName="minapp-drawer"
+        maskClassName="minapp-mask"
+        height={'100%'}
+        maskClosable={false}
+        closeIcon={null}
+        style={{ marginLeft: 'var(--sidebar-width)' }}>
+        {!isReady && opened && (
+          <EmptyView>
+            <Avatar src={app.logo} size={80} style={{ border: '1px solid var(--color-border)', marginTop: -150 }} />
+            <BeatLoader color="var(--color-text-2)" size="10" style={{ marginTop: 15 }} />
+          </EmptyView>
+        )}
+        {opened && (
+          <webview
+            src={cachedState ? cachedState.webviewSrc : app.url}
+            ref={webviewRef}
+            style={WebviewStyle}
+            allowpopups={'true' as any}
+            partition="persist:webview"
+          />
+        )}
+      </Drawer>
+    </div>
   )
 }
 
@@ -238,27 +475,142 @@ export default class MinApp {
   static onClose = () => {}
   static app: MinAppType | null = null
 
-  static async start(app: MinAppType) {
-    if (app?.id && MinApp.app?.id === app?.id) {
-      return
+  // 保存最近打开的miniapp实例
+  static appInstances: Map<
+    string | number,
+    {
+      visible: boolean
+      app: MinAppType
+      lastUsed: number
+    }
+  > = new Map()
+
+  // 最大缓存数量
+  static MAX_INSTANCES = 5
+
+  // 获取当前可见的miniapp
+  static getVisibleApp(): MinAppType | null {
+    for (const [, instance] of MinApp.appInstances) {
+      if (instance.visible) {
+        return instance.app
+      }
+    }
+    return null
+  }
+
+  // 隐藏所有miniapp
+  static hideAllApps() {
+    for (const [id, instance] of MinApp.appInstances) {
+      instance.visible = false
+      MinApp.appInstances.set(id, instance)
+    }
+  }
+
+  // 添加或更新miniapp实例
+  static updateAppInstance(app: MinAppType, visible: boolean = true) {
+    if (!app.id) return undefined
+
+    // 更新使用时间
+    const now = Date.now()
+
+    MinApp.appInstances.set(app.id, {
+      visible,
+      app,
+      lastUsed: now
+    })
+
+    // 清理过多实例
+    if (MinApp.appInstances.size > MinApp.MAX_INSTANCES) {
+      let oldestId: string | number | null = null
+      let oldestTime = Infinity
+
+      for (const [id, instance] of MinApp.appInstances) {
+        if (!instance.visible && instance.lastUsed < oldestTime) {
+          oldestTime = instance.lastUsed
+          oldestId = id
+        }
+      }
+
+      // 如果所有app都可见，则移除最早使用的
+      if (oldestId === null) {
+        for (const [id, instance] of MinApp.appInstances) {
+          if (instance.lastUsed < oldestTime) {
+            oldestTime = instance.lastUsed
+            oldestId = id
+          }
+        }
+      }
+
+      if (oldestId !== null) {
+        console.log(`[MinApp] 移除最久未使用的应用: ${oldestId}`)
+        MinApp.appInstances.delete(oldestId)
+      }
     }
 
-    if (MinApp.app) {
-      // @ts-ignore delay params
-      await MinApp.onClose(0)
-      await delay(0)
+    console.log(`[MinApp] 当前应用池: ${MinApp.appInstances.size}/${MinApp.MAX_INSTANCES}个`)
+  }
+
+  // 获取miniapp实例
+  static getAppInstance(id: string | number) {
+    return MinApp.appInstances.get(id)
+  }
+
+  // 获取当前应用ID (用于导航栏判断高亮状态)
+  static getCurrentAppId(): string | number | null {
+    if (!MinApp.app || !MinApp.app.id) return null
+    return MinApp.app.id
+  }
+
+  // 缓存webview状态
+  static webviewCache = new Map<string | number, any>()
+
+  static getFromCache(id: string | number) {
+    return this.webviewCache.get(id)
+  }
+
+  static async start(app: MinAppType) {
+    console.log(`[MinApp] 启动应用: ${app.name} (ID: ${app?.id})`)
+
+    if (!app.id) {
+      console.warn('[MinApp] 应用没有ID，无法缓存')
+      return await MinApp.startNewApp(app)
     }
+
+    // 检查是否是当前正在显示的应用
+    if (app?.id && MinApp.app?.id === app?.id) {
+      console.log(`[MinApp] ${app.name} 已经打开，不重新加载`)
+      return undefined
+    }
+
+    // 启动新应用
+    return await MinApp.startNewApp(app)
+  }
+
+  // 启动一个miniapp
+  static async startNewApp(app: MinAppType) {
+    console.log(`[MinApp] 启动新应用: ${app.name}`)
+
+    // 隐藏当前可见的应用
+    MinApp.hideAllApps()
 
     if (!app.logo) {
       app.logo = AppLogo
     }
 
+    // 设置为当前应用
     MinApp.app = app
+
+    // 如果有ID，添加到实例池
+    if (app.id) {
+      MinApp.updateAppInstance(app, true)
+    }
+
+    // 显示应用
     store.dispatch(setMinappShow(true))
 
     return new Promise<any>((resolve) => {
       TopView.show(
-        <PopupContainer
+        <MiniAppContainer
           app={app}
           resolve={(v) => {
             resolve(v)
@@ -270,7 +622,18 @@ export default class MinApp {
     })
   }
 
-  static close() {
+  static async close() {
+    console.log(`[MinApp] 关闭应用: ${MinApp.app?.name || 'unknown'}`)
+
+    // 找到当前可见的应用实例，设置为隐藏
+    if (MinApp.app?.id) {
+      const instance = MinApp.getAppInstance(MinApp.app.id)
+      if (instance) {
+        instance.visible = false
+        MinApp.appInstances.set(MinApp.app.id, instance)
+      }
+    }
+
     TopView.hide('MinApp')
     store.dispatch(setMinappShow(false))
     MinApp.app = null

--- a/src/renderer/src/components/app/Sidebar.tsx
+++ b/src/renderer/src/components/app/Sidebar.tsx
@@ -12,12 +12,11 @@ import useAvatar from '@renderer/hooks/useAvatar'
 import { useMinapps } from '@renderer/hooks/useMinapps'
 import { modelGenerating, useRuntime } from '@renderer/hooks/useRuntime'
 import { useSettings } from '@renderer/hooks/useSettings'
-import { isEmoji } from '@renderer/utils'
 import type { MenuProps } from 'antd'
 import { Tooltip } from 'antd'
 import { Avatar } from 'antd'
 import { Dropdown } from 'antd'
-import { FC } from 'react'
+import { FC, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
@@ -36,6 +35,28 @@ const Sidebar: FC = () => {
   const { windowStyle, sidebarIcons } = useSettings()
   const { theme, toggleTheme } = useTheme()
   const { pinned } = useMinapps()
+
+  useEffect(() => {
+    try {
+      const EVENT_EMITTER = (window as any).EventEmitter
+      const EVENT_NAMES_OBJ = (window as any).EVENT_NAMES
+
+      if (EVENT_EMITTER && EVENT_NAMES_OBJ?.MINIAPP_CHANGED) {
+        const handler = () => {
+          console.log('[Sidebar] 收到MINIAPP_CHANGED事件，更新状态')
+        }
+
+        EVENT_EMITTER.on(EVENT_NAMES_OBJ.MINIAPP_CHANGED, handler)
+        return () => {
+          EVENT_EMITTER.off(EVENT_NAMES_OBJ.MINIAPP_CHANGED, handler)
+        }
+      }
+    } catch (err) {
+      console.error('[Sidebar] 事件监听设置失败:', err)
+    }
+
+    return () => {}
+  }, [])
 
   const onEditUser = () => UserPopup.show()
 
@@ -65,11 +86,7 @@ const Sidebar: FC = () => {
         backgroundColor: sidebarBgColor,
         zIndex: minappShow ? 10000 : 'initial'
       }}>
-      {isEmoji(avatar) ? (
-        <EmojiAvatar onClick={onEditUser}>{avatar}</EmojiAvatar>
-      ) : (
-        <AvatarImg src={avatar || UserAvatar} draggable={false} className="nodrag" onClick={onEditUser} />
-      )}
+      <AvatarImg src={avatar || UserAvatar} draggable={false} className="nodrag" onClick={onEditUser} />
       <MainMenusContainer>
         <Menus onClick={MinApp.onClose}>
           <MainMenus />
@@ -124,6 +141,37 @@ const MainMenus: FC = () => {
   const { sidebarIcons } = useSettings()
   const { minappShow } = useRuntime()
   const navigate = useNavigate()
+  const [forceUpdate, setForceUpdate] = useState(0)
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setForceUpdate((prev) => prev + 1)
+    }, 300)
+
+    try {
+      const EVENT_EMITTER = (window as any).EventEmitter
+      const EVENT_NAMES_OBJ = (window as any).EVENT_NAMES
+
+      if (EVENT_EMITTER && EVENT_NAMES_OBJ?.MINIAPP_CHANGED) {
+        const handler = () => {
+          console.log('[MainMenus] 收到MINIAPP_CHANGED事件，更新状态')
+          setForceUpdate((prev) => prev + 1)
+        }
+
+        EVENT_EMITTER.on(EVENT_NAMES_OBJ.MINIAPP_CHANGED, handler)
+        return () => {
+          EVENT_EMITTER.off(EVENT_NAMES_OBJ.MINIAPP_CHANGED, handler)
+          clearInterval(intervalId)
+        }
+      }
+    } catch (err) {
+      console.error('[MainMenus] 事件监听设置失败:', err)
+    }
+
+    return () => clearInterval(intervalId)
+  }, [])
+
+  console.log('[MainMenus] 重新渲染', forceUpdate)
 
   const isRoute = (path: string): string => (pathname === path && !minappShow ? 'active' : '')
   const isRoutes = (path: string): string => (pathname.startsWith(path) && !minappShow ? 'active' : '')
@@ -172,6 +220,37 @@ const PinnedApps: FC = () => {
   const { pinned, updatePinnedMinapps } = useMinapps()
   const { t } = useTranslation()
   const { minappShow } = useRuntime()
+  const [forceUpdate, setForceUpdate] = useState(0)
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setForceUpdate((prev) => prev + 1)
+    }, 300)
+
+    try {
+      const EVENT_EMITTER = (window as any).EventEmitter
+      const EVENT_NAMES_OBJ = (window as any).EVENT_NAMES
+
+      if (EVENT_EMITTER && EVENT_NAMES_OBJ?.MINIAPP_CHANGED) {
+        const handler = () => {
+          console.log('[PinnedApps] 收到MINIAPP_CHANGED事件，更新状态')
+          setForceUpdate((prev) => prev + 1)
+        }
+
+        EVENT_EMITTER.on(EVENT_NAMES_OBJ.MINIAPP_CHANGED, handler)
+        return () => {
+          EVENT_EMITTER.off(EVENT_NAMES_OBJ.MINIAPP_CHANGED, handler)
+          clearInterval(intervalId)
+        }
+      }
+    } catch (err) {
+      console.error('[PinnedApps] 事件监听设置失败:', err)
+    }
+
+    return () => clearInterval(intervalId)
+  }, [])
+
+  console.log('[PinnedApps] 重新渲染', forceUpdate)
 
   return (
     <DragableList list={pinned} onUpdate={updatePinnedMinapps} listStyle={{ marginBottom: 5 }}>
@@ -226,22 +305,22 @@ const AvatarImg = styled(Avatar)`
   cursor: pointer;
 `
 
-const EmojiAvatar = styled.div`
-  width: 31px;
-  height: 31px;
-  background-color: var(--color-background-soft);
-  margin-bottom: ${isMac ? '12px' : '12px'};
-  margin-top: ${isMac ? '0px' : '2px'};
-  border-radius: 20%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 16px;
-  cursor: pointer;
-  -webkit-app-region: none;
-  border: 0.5px solid var(--color-border);
-  font-size: 20px;
-`
+// const EmojiAvatar = styled.div`
+//   width: 31px;
+//   height: 31px;
+//   background-color: var(--color-background-soft);
+//   margin-bottom: ${isMac ? '12px' : '12px'};
+//   margin-top: ${isMac ? '0px' : '2px'};
+//   border-radius: 20%;
+//   display: flex;
+//   align-items: center;
+//   justify-content: center;
+//   font-size: 16px;
+//   cursor: pointer;
+//   -webkit-app-region: none;
+//   border: 0.5px solid var(--color-border);
+//   font-size: 20px;
+// `
 
 const MainMenusContainer = styled.div`
   display: flex;

--- a/src/renderer/src/pages/settings/WebSearchSettings/WebSearchProviderSetting.tsx
+++ b/src/renderer/src/pages/settings/WebSearchSettings/WebSearchProviderSetting.tsx
@@ -68,7 +68,8 @@ const WebSearchProviderSetting: FC<Props> = ({ provider: _provider }) => {
           key: 'search-check-error'
         })
       }
-      updateProvider({ ...provider, enabled: true })
+      // 编译会出错，所以删除了多余的参数
+      updateProvider({ ...provider })
     } catch (err) {
       console.error('Check search error:', err)
       setApiValid(false)

--- a/src/renderer/src/webSearchProvider/BaseWebSearchProvider.ts
+++ b/src/renderer/src/webSearchProvider/BaseWebSearchProvider.ts
@@ -1,7 +1,8 @@
 import { WebSearchProvider, WebSearchResponse } from '@renderer/types'
 
 export default abstract class BaseWebSearchProvider {
-  private provider: WebSearchProvider
+  // 将 private 修改为 protected
+  protected provider: WebSearchProvider
   constructor(provider: WebSearchProvider) {
     this.provider = provider
   }


### PR DESCRIPTION
支持在最近使用的 5 个小程序之间进行切换，且在小程序间切换时，能保持之前小程序的会话在后台持续运行，避免每次切换都开启新的会话。此外，当用户切换到侧边栏的非小程序按钮时，系统会自动释放所有小程序的缓存，以合理管理系统资源。

感谢 [memoverflow ](https://github.com/memoverflow) 提交 [commit ](https://github.com/CherryHQ/cherry-studio/pull/2329) 的代码。