### PR TITLE
fix(sendMessage): optimize message slicing logic

### DIFF
--- a/src/renderer/src/store/messages.ts
+++ b/src/renderer/src/store/messages.ts
@@ -371,14 +371,12 @@ export const sendMessage =
             // 节流
             const throttledDispatch = throttle(handleResponseMessageUpdate, 100, { trailing: true }) // 100ms的节流时间应足够平衡用户体验和性能
 
+            const messageIndex = messages.findIndex((m) => m.id === assistantMessage.id)
             await fetchChatCompletion({
               message: { ...assistantMessage },
               messages: messages
                 .filter((m) => !m.status?.includes('ing'))
-                .slice(
-                  0,
-                  messages.findIndex((m) => m.id === assistantMessage.id)
-                ),
+                .slice(0, messageIndex !== -1 ? messageIndex : undefined),
               assistant: assistantWithModel,
               onResponse: async (msg) => {
                 // 允许在回调外维护一个最新的消息状态，每次都更新这个对象，但只通过节流函数分发到Redux


### PR DESCRIPTION
fix #3048

# 修复聊天历史上下文过滤时的边缘情况

## 问题描述
在聊天上下文处理逻辑中，当无法在消息历史中找到当前助手消息的ID时（`findIndex` 返回 -1），会导致 `slice(0, -1)` 返回空数组，造成AI没有上下文信息进行回复。

## 解决方案
优化了消息过滤逻辑，增加了对 `messageIndex` 为 -1 的情况判断，确保在找不到消息ID时仍然能提供完整的历史消息作为上下文。

## 影响范围
仅修改了消息过滤逻辑，不影响其他功能，确保边缘情况下AI仍能获得正确的上下文信息。