### PR TITLE
Enhance Build and Release Workflow with Artifact-Specific Strategy and Per-commit Build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,40 +1,80 @@
-name: Release
+name: Build and Release
 
 on:
+  push:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag (e.g. v1.0.0)'
+        description: "Release tag (e.g. v1.1.0)"
         required: true
-        default: 'v0.9.18'
-  push:
-    tags:
-      - v*.*.*
+        default: "v1.1.0"
 
 permissions:
   contents: write
 
 jobs:
-  release:
+  build:
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        include:
+          - os: windows-latest
+            platform: win
+            artifacts:
+              - Cherry-Studio-*-portable.exe
+              - Cherry-Studio-*-setup.exe
+              - Cherry-Studio-*-setup.exe.blockmap
+              - latest.yml
+          - os: ubuntu-latest
+            platform: linux
+            artifacts:
+              - Cherry-Studio-*-x86_64.AppImage
+              - Cherry-Studio-*-arm64.AppImage
+              - latest-linux.yml
+              - latest-linux-arm64.yml
+          - os: macos-latest
+            platform: mac
+            artifacts:
+              - Cherry-Studio-*-x64.dmg
+              - Cherry-Studio-*-x64.dmg.blockmap
+              - Cherry-Studio-*-x64.zip
+              - Cherry-Studio-*-x64.zip.blockmap
+              - Cherry-Studio-*-arm64.dmg
+              - Cherry-Studio-*-arm64.dmg.blockmap
+              - Cherry-Studio-*-arm64.zip
+              - Cherry-Studio-*-arm64.zip.blockmap
+              - latest-mac.yml
       fail-fast: false
 
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
 
-      - name: Get release tag
-        id: get-tag
+      - name: Get version
+        id: get-version
         shell: bash
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.tag }}" != "" ]; then
+            VERSION="${{ github.event.inputs.tag }}"
+            VERSION=${VERSION#v}
+            echo "Running workflow dispatch with tag: $VERSION"
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "is_release=true" >> $GITHUB_OUTPUT
             echo "tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
-          else
+          elif [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+            echo "Running on tag: v$VERSION"
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "is_release=true" >> $GITHUB_OUTPUT
             echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          else
+            # For regular commits, use the current timestamp as version
+            VERSION="dev-$(date +'%Y%m%d%H%M%S')"
+            echo "Running on commit: $VERSION"
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "is_release=false" >> $GITHUB_OUTPUT
+            echo "tag=" >> $GITHUB_OUTPUT
           fi
 
       - name: Install Node.js
@@ -96,12 +136,43 @@ jobs:
       - name: Replace spaces in filenames
         run: node scripts/replace-spaces.js
 
-      - name: Release
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-${{ matrix.platform }}
+          path: ${{ matrix.artifacts }}
+
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get release tag
+        id: get-tag
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: all-artifacts
+
+      - name: Prepare release files
+        run: |
+          mkdir -p release
+          find all-artifacts -type f -not -path "*/\.*" -exec cp {} release/ \;
+
+      - name: Create Release
         uses: ncipollo/release-action@v1
         with:
           draft: true
           allowUpdates: true
           makeLatest: false
           tag: ${{ steps.get-tag.outputs.tag }}
-          artifacts: 'dist/*.exe,dist/*.zip,dist/*.dmg,dist/*.AppImage,dist/*.snap,dist/*.deb,dist/*.rpm,dist/*.tar.gz,dist/latest*.yml,dist/*.blockmap'
+          artifacts: "release/*"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to improve its flexibility and specificity in handling builds and releases across multiple platforms. The key goal is to transition from a generic OS-based strategy to one driven by specific artifact filenames, while ensuring builds occur on every commit and releases are limited to tag pushes or workflow dispatches.

#### Key Changes:
- **Build on Every Commit**: The `build` job now triggers on every `push` event (including commits) and `workflow_dispatch`, ensuring continuous integration across all platforms. Artifact filenames are tied to each platform and uploaded using `actions/upload-artifact@v4`.
- **Artifact-Specific Strategy Matrix**: Replaced the previous OS-only matrix with a detailed `strategy.matrix.include` configuration. Each platform (Windows, Ubuntu, macOS) now specifies a list of expected artifact filenames (e.g., `Cherry-Studio-*-portable.exe`, `Cherry-Studio-*-x86_64.AppImage`), aligning with the requirement to use specific filenames instead of wildcards like `*`, omit warnings.
- **Conditional Release**: The `release` job is configured to run only when triggered by a tag push (`refs/tags/*`) or a `workflow_dispatch` event, using the `if` condition `startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'`. This satisfies the requirement to release only on specified tags.
- **Artifact Management**: Artifacts are uploaded per platform in the `build` job and downloaded in the `release` job, then copied to a `release/` directory for the `ncipollo/release-action@v1` to create a draft release.


WIP