### PR TITLE
feat(ChatNavigation): Adjust navigation position based on topic settings

### DIFF
--- a/src/renderer/src/pages/home/Messages/ChatNavigation.tsx
+++ b/src/renderer/src/pages/home/Messages/ChatNavigation.tsx
@@ -1,4 +1,5 @@
 import { DownOutlined, UpOutlined } from '@ant-design/icons'
+import { useSettings } from '@renderer/hooks/useSettings'
 import { Button, Tooltip } from 'antd'
 import { FC, useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -10,8 +11,12 @@ interface ChatNavigationProps {
 
 const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
   const { t } = useTranslation()
+  const { showTopics, topicPosition } = useSettings()
   const [isVisible, setIsVisible] = useState(false)
   const [hideTimer, setHideTimer] = useState<NodeJS.Timeout | null>(null)
+
+  // 计算导航按钮的位置
+  const navigationPosition = showTopics && topicPosition === 'right' ? 'var(--assistants-width)' : '0'
 
   const resetHideTimer = useCallback(() => {
     if (hideTimer) {
@@ -171,8 +176,12 @@ const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
 
   return (
     <>
-      <TriggerArea onMouseEnter={() => setIsVisible(true)} onMouseLeave={() => resetHideTimer()} />
-      <NavigationContainer $isVisible={isVisible}>
+      <TriggerArea
+        onMouseEnter={() => setIsVisible(true)}
+        onMouseLeave={() => resetHideTimer()}
+        $position={navigationPosition}
+      />
+      <NavigationContainer $isVisible={isVisible} $position={navigationPosition}>
         <ButtonGroup>
           <Tooltip title={t('chat.navigation.prev')} placement="left">
             <NavigationButton
@@ -199,9 +208,13 @@ const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
   )
 }
 
-const TriggerArea = styled.div`
+interface PositionProps {
+  $position: string
+}
+
+const TriggerArea = styled.div<PositionProps>`
   position: fixed;
-  right: 0;
+  right: calc(${(props) => props.$position} + 0px);
   top: 40%;
   width: 20px;
   height: 20%;
@@ -209,13 +222,13 @@ const TriggerArea = styled.div`
   background: transparent;
 `
 
-interface NavigationContainerProps {
+interface NavigationContainerProps extends PositionProps {
   $isVisible: boolean
 }
 
 const NavigationContainer = styled.div<NavigationContainerProps>`
   position: fixed;
-  right: 16px;
+  right: calc(${(props) => props.$position} + 16px);
   top: 50%;
   transform: translateY(-50%) translateX(${(props) => (props.$isVisible ? 0 : '100%')});
   z-index: 999;


### PR DESCRIPTION
![PixPin_2025-03-12_13-38-33](https://github.com/user-attachments/assets/bd31a7ca-5ffa-4c1a-a862-b3ef3d29dc68)

修复当话题列表位于右侧时，导航按钮组件位置不正确的问题