### PR TITLE
fix(MCPSettings): MCP server environment variables parsing error

### DIFF
--- a/src/renderer/src/pages/settings/MCPSettings.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings.tsx
@@ -96,7 +96,8 @@ const MCPSettings: FC = () => {
         if (values.env) {
           values.env.split('\n').forEach((line) => {
             if (line.trim()) {
-              const [key, value] = line.split('=')
+              const [key, ...chunks] = line.split('=')
+              const value = chunks.join('=')
               if (key && value) {
                 env[key.trim()] = value.trim()
               }


### PR DESCRIPTION
If there is one or more equal (=) sign in value part, all would be lost

Before:

<img width="563" alt="Clipboard_Screenshot_1741792927" src="https://github.com/user-attachments/assets/a4daf90a-9ea7-487b-8455-39cbbf1d4e54" />


After:

<img width="570" alt="Clipboard_Screenshot_1741792881" src="https://github.com/user-attachments/assets/ce1f081b-e4ed-47b1-93a5-24ead225e6be" />
