### PR TITLE
feat: replace zipfile with zipread in epub

### DIFF
--- a/.yarn/patches/epub-npm-1.3.0-8325494ffe.patch
+++ b/.yarn/patches/epub-npm-1.3.0-8325494ffe.patch
@@ -1,0 +1,53 @@
+diff --git a/epub.js b/epub.js
+index 50efff7678ca4879ed639d3bb70fd37e7477fd16..accbe689cd200bd59475dd20fca596511d0f33e0 100644
+--- a/epub.js
++++ b/epub.js
+@@ -3,9 +3,28 @@ var xml2jsOptions = xml2js.defaults['0.1'];
+ var EventEmitter = require('events').EventEmitter;
+ 
+ try {
+-    // zipfile is an optional dependency:
+-    var ZipFile = require("zipfile").ZipFile;
+-} catch (err) {
++    var zipread = require("zipread");
++    var ZipFile = function(filename) {
++        var zip = zipread(filename);
++        this.zip = zip;
++        var files = zip.files;
++
++        files = Object.values(files).filter((file) => {
++            return !file.dir;
++        }).map((file) => {
++            return file.name;
++        });
++
++        this.names = files;
++        this.count = this.names.length;
++    };
++    ZipFile.prototype.readFile = function(name, cb) {
++        this.zip.readFile(name
++            , function(err, buffer) {
++                return cb(null, buffer);
++            });
++    };
++} catch(err) {
+     // Mock zipfile using pure-JS adm-zip:
+     var AdmZip = require('adm-zip');
+ 
+diff --git a/package.json b/package.json
+index 8c3dccf0caac8913a2edabd7049b25bb9063c905..57bac3b71ddd73916adbdf00b049089181db5bcb 100644
+--- a/package.json
++++ b/package.json
+@@ -40,10 +40,8 @@
+   ],
+   "dependencies": {
+     "adm-zip": "^0.4.11",
+-    "xml2js": "^0.4.23"
+-  },
+-  "optionalDependencies": {
+-    "zipfile": "^0.5.11"
++    "xml2js": "^0.4.23",
++    "zipread": "^1.3.3"
+   },
+   "devDependencies": {
+     "@types/mocha": "^5.2.5",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "electron-store": "^8.2.0",
     "electron-updater": "^6.3.9",
     "electron-window-state": "^5.0.3",
-    "epub": "^1.3.0",
+    "epub": "patch:epub@npm%3A1.3.0#~/.yarn/patches/epub-npm-1.3.0-8325494ffe.patch",
     "fetch-socks": "^1.3.2",
     "fs-extra": "^11.2.0",
     "markdown-it": "^14.1.0",
@@ -85,7 +85,8 @@
     "p-queue": "^8.1.0",
     "tokenx": "^0.4.1",
     "undici": "^7.4.0",
-    "webdav": "4.11.4"
+    "webdav": "4.11.4",
+    "zipread": "^1.3.3"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.38.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3187,7 +3187,7 @@ __metadata:
     electron-window-state: "npm:^5.0.3"
     emittery: "npm:^1.0.3"
     emoji-picker-element: "npm:^1.22.1"
-    epub: "npm:^1.3.0"
+    epub: "patch:epub@npm%3A1.3.0#~/.yarn/patches/epub-npm-1.3.0-8325494ffe.patch"
     eslint: "npm:^8.56.0"
     eslint-plugin-react: "npm:^7.34.3"
     eslint-plugin-react-hooks: "npm:^4.6.2"
@@ -3233,6 +3233,7 @@ __metadata:
     uuid: "npm:^10.0.0"
     vite: "npm:^5.0.12"
     webdav: "npm:4.11.4"
+    zipread: "npm:^1.3.3"
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
@@ -5733,7 +5734,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"epub@npm:^1.3.0":
+"epub@npm:1.3.0":
   version: 1.3.0
   resolution: "epub@npm:1.3.0"
   dependencies:
@@ -5744,6 +5745,20 @@ __metadata:
     zipfile:
       optional: true
   checksum: 10c0/2e8bb70354d13f17224f0fea2f999d1a5537383ed3df7388054eb28b98bd4f91057db19bf58e8bc8618f4f509051ad21fb12f36b6faa029d29bcf647ab13e074
+  languageName: node
+  linkType: hard
+
+"epub@patch:epub@npm%3A1.3.0#~/.yarn/patches/epub-npm-1.3.0-8325494ffe.patch":
+  version: 1.3.0
+  resolution: "epub@patch:epub@npm%3A1.3.0#~/.yarn/patches/epub-npm-1.3.0-8325494ffe.patch::version=1.3.0&hash=3b2b13"
+  dependencies:
+    adm-zip: "npm:^0.4.11"
+    xml2js: "npm:^0.4.23"
+    zipfile: "npm:^0.5.11"
+  dependenciesMeta:
+    zipfile:
+      optional: true
+  checksum: 10c0/02f818a65656666b512eb3477ebdac678a1427a65b32d9741c3e55372faf4a418080c537ccc342b02c3b42a2c94552e65f28c3b9617befe28ab36d2f940ca9f8
   languageName: node
   linkType: hard
 
@@ -15550,6 +15565,13 @@ __metadata:
   bin:
     unzip.js: ./bin/unzip.js
   checksum: 10c0/0813640a8f1b544b3b61f9039a8589f62f5d185c61b8ee282ee5d97115c99d0bf131cadbbe729b86dc1c147ed3196576eaac98175a64893ff4ead039521a5e7f
+  languageName: node
+  linkType: hard
+
+"zipread@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "zipread@npm:1.3.3"
+  checksum: 10c0/e8be7df8ff5188ba2090459f1f54047da376f1fc9175d4531353c82a9a99c323474cb91539677759dccd642c32160b49714c2361800b3666d647a25c9ae19252
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The zipfile(https://github.com/mapbox/node-zipfile) package currently fails to compile on Node.js 12 and above across Mac/Windows/Linux platforms, and doesn't support Mac ARM or Windows ARM architectures. When using the epub library, requiring zipfile fails, defaulting to adm-zip instead.


https://github.com/CherryHQ/cherry-studio/actions/runs/13823838151/job/38674953209
![image](https://github.com/user-attachments/assets/2a0df02c-b0d9-4524-a13f-5426ec8555fa)

https://github.com/CherryHQ/cherry-studio/actions/runs/13823838151/job/38674953218
![image](https://github.com/user-attachments/assets/0b2cdf65-6c1d-4ac8-abd7-29e83a822b9f)

zipread uses Node.js's built-in zlib library, offering similar performance to zipfile without requiring compilation, and supports Mac ARM/Windows ARM architectures. Please consider replacing the zipfile package with this alternative.

https://github.com/szastupov/zipread
zipread is a ZIP file reader designed for speed and memory efficiency. Unlike other modules, it doesn't read the whole file into memory and uses native ZLIB functions for decompression.