### PR TITLE
fix:Resolve bug where clearing context was invalid

### DIFF
--- a/src/renderer/src/providers/OpenAIProvider.ts
+++ b/src/renderer/src/providers/OpenAIProvider.ts
@@ -253,7 +253,7 @@ export default class OpenAIProvider extends BaseProvider {
     const userMessages: ChatCompletionMessageParam[] = []
 
     const _messages = filterUserRoleStartMessages(
-      filterContextMessages(filterEmptyMessages(takeRight(messages, contextCount + 1)))
+      filterEmptyMessages(filterContextMessages(takeRight(messages, contextCount + 1)))
     )
 
     onFilterMessages(_messages)


### PR DESCRIPTION
<img width="671" alt="image" src="https://github.com/user-attachments/assets/b05a3659-dcc5-4207-8bca-9c7ee88d6536" />
这一行把clear消息卡出去了