### PR TITLE
fix(models): Update function_call provider check to exclude embedding models

### DIFF
--- a/src/renderer/src/config/models.ts
+++ b/src/renderer/src/config/models.ts
@@ -185,7 +185,7 @@ export function isFunctionCallingModel(model: Model): boolean {
     return true
   }
 
-  if (['gemini', 'deepseek', 'anthropic'].includes(model.provider)) {
+  if (['gemini', 'deepseek', 'anthropic'].includes(model.provider) && !EMBEDDING_REGEX.test(model.id)) {
     return true
   }
 


### PR DESCRIPTION
在判断是否是函数调用模型时，会把Gemini中的嵌入模型也误认为是函数调用模型