### PR TITLE
fix(MCP): supports openrouter models like gemini flash 2.0

### DIFF
--- a/src/renderer/src/providers/OpenAIProvider.ts
+++ b/src/renderer/src/providers/OpenAIProvider.ts
@@ -365,23 +365,24 @@ export default class OpenAIProvider extends BaseProvider {
 
         if (delta?.tool_calls) {
           const chunkToolCalls = delta.tool_calls
-          if (finishReason !== 'tool_calls') {
-            for (const t of chunkToolCalls) {
-              const { index, id, function: fn, type } = t
-              const args = fn && typeof fn.arguments === 'string' ? fn.arguments : ''
-              if (!(index in final_tool_calls)) {
-                final_tool_calls[index] = {
-                  id,
-                  function: {
-                    name: fn?.name,
-                    arguments: args
-                  },
-                  type
-                } as ChatCompletionMessageToolCall
-              } else {
-                final_tool_calls[index].function.arguments += args
-              }
+          for (const t of chunkToolCalls) {
+            const { index, id, function: fn, type } = t
+            const args = fn && typeof fn.arguments === 'string' ? fn.arguments : ''
+            if (!(index in final_tool_calls)) {
+              final_tool_calls[index] = {
+                id,
+                function: {
+                  name: fn?.name,
+                  arguments: args
+                },
+                type
+              } as ChatCompletionMessageToolCall
+            } else {
+              final_tool_calls[index].function.arguments += args
             }
+          }
+
+          if (finishReason !== 'tool_calls') {
             continue
           }
         }


### PR DESCRIPTION
## Problem

Some models from openrouter like gemini flash 2.0 returns all `tool_calls` and `finish_reason` all at once, in a single chunk, without streaming. In the Previous logic, 
```ts
              final_tool_calls[index] = {
                id,
                function: {
                  name: fn?.name,
                  arguments: args
                },
                type
              } as ChatCompletionMessageToolCall

```
which is inside `if (finishReason !== 'tool_calls')` is just skipped, resulting in an empty tool call.

## Fix

See code

## Test

The MCP functionality is tested to work well with those models based on `OpenAIProvider.ts`:
- Openrouter 
	- Claude models, OpenAI models, Gemini models
- OpenAI
	- GPT-4o, GPT-4o mini

<img width="1674" alt="image" src="https://github.com/user-attachments/assets/f9f1ed0d-f71e-41b4-8cca-0e3c317e42af" />
