### PR TITLE
fix(settings): Change padding to margin in SettingHelpLink styling

### DIFF
--- a/src/renderer/src/pages/settings/index.tsx
+++ b/src/renderer/src/pages/settings/index.tsx
@@ -77,7 +77,7 @@ export const SettingHelpText = styled.div`
 
 export const SettingHelpLink = styled(Link)`
   font-size: 11px;
-  padding: 0 5px;
+  margin: 0 5px;
 `
 
 export const SettingGroup = styled.div<{ theme?: ThemeMode }>`


### PR DESCRIPTION
- After
  <img width="600" alt="image" src="https://github.com/user-attachments/assets/47dfe3b1-c002-4726-8cb1-f9309da2275b" />

- Before
  <img width="600" alt="image" src="https://github.com/user-attachments/assets/0255fee2-076d-41b3-be6f-d1e5133fd8b6" />
