### PR TITLE
fix: 空消息传入知识库和Web搜索

### DIFF
--- a/src/renderer/src/providers/BaseProvider.ts
+++ b/src/renderer/src/providers/BaseProvider.ts
@@ -93,6 +93,10 @@ export default abstract class BaseProvider {
   }
 
   public async getMessageContent(message: Message) {
+    if (isEmpty(message.content)) {
+      return message.content
+    }
+
     const webSearchReferences = await this.getWebSearchReferences(message)
 
     if (!isEmpty(webSearchReferences)) {
@@ -115,6 +119,9 @@ export default abstract class BaseProvider {
   }
 
   private async getWebSearchReferences(message: Message) {
+    if (isEmpty(message.content)) {
+      return []
+    }
     const webSearch: TavilySearchResponse = window.keyv.get(`web-search-${message.id}`)
 
     if (webSearch) {

--- a/src/renderer/src/services/KnowledgeService.ts
+++ b/src/renderer/src/services/KnowledgeService.ts
@@ -117,7 +117,7 @@ export const getKnowledgeBaseReference = async (base: KnowledgeBase, message: Me
 }
 
 export const getKnowledgeBaseReferences = async (message: Message) => {
-  if (isEmpty(message.knowledgeBaseIds)) {
+  if (isEmpty(message.knowledgeBaseIds) || isEmpty(message.content)) {
     return []
   }
 


### PR DESCRIPTION
修复 #3245 等多个issue出现的 `"Error invoking remote method 'knowledge-base:search': Error: 400 The parameter is invalid. Please check again."` 错误，这个错误的原因是添加附件后即可绕开消息为空时不可发送消息的限制，导致搜索传入空值。

Fix #3061