### PR TITLE
refactor: add isNameManuallyEdited flag to topic management

### DIFF
--- a/src/renderer/src/hooks/useTopic.ts
+++ b/src/renderer/src/hooks/useTopic.ts
@@ -61,6 +61,10 @@ export const autoRenameTopic = async (assistant: Assistant, topicId: string) => 
     return
   }
 
+  if (topic.isNameManuallyEdited) {
+    return
+  }
+
   if (!enableTopicNaming) {
     const topicName = topic.messages[0]?.content.substring(0, 50)
     if (topicName) {

--- a/src/renderer/src/pages/home/Tabs/TopicsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/TopicsTab.tsx
@@ -138,7 +138,7 @@ const Topics: FC<Props> = ({ assistant: _assistant, activeTopic, setActiveTopic 
             if (messages.length >= 2) {
               const summaryText = await fetchMessagesSummary({ messages, assistant })
               if (summaryText) {
-                updateTopic({ ...topic, name: summaryText })
+                updateTopic({ ...topic, name: summaryText, isNameManuallyEdited: false })
               }
             }
           }
@@ -154,7 +154,7 @@ const Topics: FC<Props> = ({ assistant: _assistant, activeTopic, setActiveTopic 
               defaultValue: topic?.name || ''
             })
             if (name && topic?.name !== name) {
-              updateTopic({ ...topic, name })
+              updateTopic({ ...topic, name, isNameManuallyEdited: true })
             }
           }
         },

--- a/src/renderer/src/services/AssistantService.ts
+++ b/src/renderer/src/services/AssistantService.ts
@@ -47,7 +47,8 @@ export function getDefaultTopic(assistantId: string): Topic {
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     name: i18n.t('chat.default.topic.name'),
-    messages: []
+    messages: [],
+    isNameManuallyEdited: false
   }
 }
 

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -96,6 +96,7 @@ export type Topic = {
   messages: Message[]
   pinned?: boolean
   prompt?: string
+  isNameManuallyEdited?: boolean
 }
 
 export type User = {


### PR DESCRIPTION
- Resolve #3465

- 当用户手动修改话题名称后，不再自动重命名该话题
- 用户可以通过手动点击"自动重命名"菜单项来重新启用自动重命名功能
- 新创建的话题默认允许自动重命名