### PR TITLE
fix: fix uv and bun install on linux

### DIFF
--- a/resources/scripts/install-bun.js
+++ b/resources/scripts/install-bun.js
@@ -110,7 +110,8 @@ async function downloadBunBinary(platform, arch, version = DEFAULT_BUN_VERSION, 
       const sourcePath = path.join(sourceDir, file)
       const destPath = path.join(binDir, file)
 
-      fs.renameSync(sourcePath, destPath)
+      fs.copyFileSync(sourcePath, destPath)
+      fs.unlinkSync(sourcePath)
 
       // Set executable permissions for non-Windows platforms
       if (platform !== 'win32') {

--- a/resources/scripts/install-uv.js
+++ b/resources/scripts/install-uv.js
@@ -123,7 +123,8 @@ async function downloadUvBinary(platform, arch, version = DEFAULT_UV_VERSION, is
       for (const file of files) {
         const sourcePath = path.join(sourceDir, file)
         const destPath = path.join(binDir, file)
-        fs.renameSync(sourcePath, destPath)
+        fs.copyFileSync(sourcePath, destPath)
+        fs.unlinkSync(sourcePath)
 
         // Set executable permissions for non-Windows platforms
         if (platform !== 'win32') {


### PR DESCRIPTION
修复了下列错误导致的无法在Linux下安装内置uv和bun
![图片](https://github.com/user-attachments/assets/b20af533-a1ea-4326-aedd-e789dc91cfec)
