### PR TITLE
fix: trim() in Translation may result in malformed Markdown output for certain models.

### DIFF
--- a/src/renderer/src/providers/OpenAIProvider.ts
+++ b/src/renderer/src/providers/OpenAIProvider.ts
@@ -679,10 +679,6 @@ export default class OpenAIProvider extends BaseProvider {
     for await (const chunk of response) {
       const deltaContent = chunk.choices[0]?.delta?.content || ''
 
-      if (!deltaContent.trim()) {
-        continue
-      }
-
       if (isReasoning) {
         if (deltaContent.includes('<think>')) {
           isThinking = true


### PR DESCRIPTION
详见 #3521。