### PR TITLE
fix:  too many listeners when setting shortcuts that may cause memory leaks

### DIFF
--- a/src/main/services/ShortcutService.ts
+++ b/src/main/services/ShortcutService.ts
@@ -8,6 +8,9 @@ import { windowService } from './WindowService'
 let showAppAccelerator: string | null = null
 let showMiniWindowAccelerator: string | null = null
 
+// store the focus and blur handlers for each window to unregister them later
+const windowOnHandlers = new Map<BrowserWindow, { onFocusHandler: () => void; onBlurHandler: () => void }>()
+
 function getShortcutHandler(shortcut: Shortcut) {
   switch (shortcut.key) {
     case 'zoom_in':
@@ -112,10 +115,6 @@ const convertShortcutRecordedByKeyboardEventKeyValueToElectronGlobalShortcutForm
 }
 
 export function registerShortcuts(window: BrowserWindow) {
-  window.once('ready-to-show', () => {
-    window.webContents.setZoomFactor(configManager.getZoomFactor())
-  })
-
   const register = () => {
     if (window.isDestroyed()) return
 
@@ -145,9 +144,10 @@ export function registerShortcuts(window: BrowserWindow) {
 
           case 'mini_window':
             //available only when QuickAssistant enabled
-            if (configManager.getEnableQuickAssistant()) {
-              showMiniWindowAccelerator = formatShortcutKey(shortcut.shortcut)
+            if (!configManager.getEnableQuickAssistant()) {
+              return
             }
+            showMiniWindowAccelerator = formatShortcutKey(shortcut.shortcut)
             break
 
           //the following ZOOMs will register shortcuts seperately, so will return
@@ -201,8 +201,12 @@ export function registerShortcuts(window: BrowserWindow) {
     }
   }
 
-  window.on('focus', () => register())
-  window.on('blur', () => unregister())
+  // only register the event handlers once
+  if (undefined === windowOnHandlers.get(window)) {
+    window.on('focus', register)
+    window.on('blur', unregister)
+    windowOnHandlers.set(window, { onFocusHandler: register, onBlurHandler: unregister })
+  }
 
   if (!window.isDestroyed() && window.isFocused()) {
     register()
@@ -213,6 +217,11 @@ export function unregisterAllShortcuts() {
   try {
     showAppAccelerator = null
     showMiniWindowAccelerator = null
+    windowOnHandlers.forEach((handlers, window) => {
+      window.off('focus', handlers.onFocusHandler)
+      window.off('blur', handlers.onBlurHandler)
+    })
+    windowOnHandlers.clear()
     globalShortcut.unregisterAll()
   } catch (error) {
     Logger.error('[ShortcutService] Failed to unregister all shortcuts')

--- a/src/main/services/WindowService.ts
+++ b/src/main/services/WindowService.ts
@@ -145,6 +145,7 @@ export class WindowService {
 
   private setupWindowEvents(mainWindow: BrowserWindow) {
     mainWindow.once('ready-to-show', () => {
+      mainWindow.webContents.setZoomFactor(configManager.getZoomFactor())
       mainWindow.show()
     })
 


### PR DESCRIPTION
fix:  too many listeners when setting shortcuts that may cause memory leaks.
- Everytime a user enable/disable a shortcut, the registerShortcuts will be called. And window.on('blur') & window.on('focus') are set when registerShortcuts called, but listeners haven't been removed when unregisterShortcuts called.
- ready-to-show listener is called also, but it's a wrong place.
- fix code logic related to quickAssistant shortcuts

related logs show:
```
(node:27804) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 focus listeners added to [BrowserWindow]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit

(node:27804) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 blur listeners added to [BrowserWindow]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit

(node:8280) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 ready-to-show listeners added to [BrowserWindow]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit
```