### PR TITLE
fix(GeminiProvider): filterEmptyMessages in Gemini provider

### DIFF
--- a/src/renderer/src/providers/GeminiProvider.ts
+++ b/src/renderer/src/providers/GeminiProvider.ts
@@ -18,7 +18,11 @@ import { getStoreSetting } from '@renderer/hooks/useSettings'
 import i18n from '@renderer/i18n'
 import { getAssistantSettings, getDefaultModel, getTopNamingModel } from '@renderer/services/AssistantService'
 import { EVENT_NAMES } from '@renderer/services/EventService'
-import { filterContextMessages, filterUserRoleStartMessages } from '@renderer/services/MessagesService'
+import {
+  filterContextMessages,
+  filterEmptyMessages,
+  filterUserRoleStartMessages
+} from '@renderer/services/MessagesService'
 import { Assistant, FileType, FileTypes, MCPToolResponse, Message, Model, Provider, Suggestion } from '@renderer/types'
 import { removeSpecialCharactersForTopicName } from '@renderer/utils'
 import {
@@ -180,7 +184,9 @@ export default class GeminiProvider extends BaseProvider {
     const model = assistant.model || defaultModel
     const { contextCount, maxTokens, streamOutput } = getAssistantSettings(assistant)
 
-    const userMessages = filterUserRoleStartMessages(filterContextMessages(takeRight(messages, contextCount + 2)))
+    const userMessages = filterUserRoleStartMessages(
+      filterEmptyMessages(filterContextMessages(takeRight(messages, contextCount + 2)))
+    )
     onFilterMessages(userMessages)
 
     const userLastMessage = userMessages.pop()


### PR DESCRIPTION
Close #3538.

Test after empty message:
<img width="1509" alt="Screenshot 2025-03-19 at 9 45 44 AM" src="https://github.com/user-attachments/assets/ba0c2dbf-025e-4d60-8591-8a572284a899" />

Test after clearing context:
<img width="1509" alt="Screenshot 2025-03-19 at 9 54 44 AM" src="https://github.com/user-attachments/assets/bb507a78-48f0-4c59-a8f2-19889e972d5f" />

