### PR TITLE
fix: ensure active assistant is updated correctly on deletion

### DIFF
--- a/src/renderer/src/pages/home/Tabs/AssistantsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/AssistantsTab.tsx
@@ -31,11 +31,13 @@ const Assistants: FC<AssistantsTabProps> = ({
   const onDelete = useCallback(
     (assistant: Assistant) => {
       const remaining = assistants.filter((a) => a.id !== assistant.id)
-      const newActive = remaining[remaining.length - 1]
-      newActive ? setActiveAssistant(newActive) : onCreateDefaultAssistant()
+      if (assistant.id === activeAssistant?.id) {
+        const newActive = remaining[remaining.length - 1]
+        newActive ? setActiveAssistant(newActive) : onCreateDefaultAssistant()
+      }
       removeAssistant(assistant.id)
     },
-    [assistants, removeAssistant, setActiveAssistant, onCreateDefaultAssistant]
+    [activeAssistant, assistants, removeAssistant, setActiveAssistant, onCreateDefaultAssistant]
   )
 
   return (


### PR DESCRIPTION
修复删除助手时，自动跳到下一个助手的问题
Before：
![PixPin_2025-03-19_15-23-06](https://github.com/user-attachments/assets/f36f0b48-95ef-48e9-a372-ec44648d486e)

After：
![PixPin_2025-03-19_15-22-13](https://github.com/user-attachments/assets/c48d0bd7-19b5-4808-8d54-364ada82489d)
