### PR TITLE
fix: Setting Tabs 的最大上下文提升至 max（20）, 与模型设置保持一致

### DIFF
--- a/src/renderer/src/pages/home/Tabs/SettingsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/SettingsTab.tsx
@@ -177,7 +177,7 @@ const SettingsTab: FC<Props> = (props) => {
           <Col span={24}>
             <Slider
               min={0}
-              max={10}
+              max={20}
               onChange={setContextCount}
               onChangeComplete={onContextCountChange}
               value={typeof contextCount === 'number' ? contextCount : 0}


### PR DESCRIPTION
resolve: https://github.com/CherryHQ/cherry-studio/issues/3654