### PR TITLE
fix(translate): 去除翻译页面中生成的翻译内容开始的空白行

### DIFF
--- a/src/renderer/src/pages/translate/TranslatePage.tsx
+++ b/src/renderer/src/pages/translate/TranslatePage.tsx
@@ -112,8 +112,8 @@ const TranslatePage: FC = () => {
         message,
         assistant,
         onResponse: (text) => {
-          translatedText = text
-          setResult(text)
+          translatedText = text.replace(/^\s*\n+/g, '')
+          setResult(translatedText)
         }
       })
     } catch (error) {


### PR DESCRIPTION
当前版本在翻译页面中翻译内容后, 得到的译文开头有空白行, 如下图, 并且点击复制按钮复制的内容开头也有空白行. 因为使用思考模型后, 返回的内容是 `<think>...</think>` 然后后面空了几行才是真正的内容. 当前实现只是把 think 标签去除了, 但是没有处理后面开头的空白行. 这个 PR 修复.这个问题. 


<img width="685" alt="SCR-20250320-mors" src="https://github.com/user-attachments/assets/9a780fe1-5885-4353-bb33-885b3386784f" />
