### PR TITLE
fix(MessageMenubar): trim leading whitespace from message content  before copying to clipboard

### DIFF
--- a/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
@@ -70,7 +70,7 @@ const MessageMenubar: FC<Props> = (props) => {
   const onCopy = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
-      navigator.clipboard.writeText(removeTrailingDoubleSpaces(message.content))
+      navigator.clipboard.writeText(removeTrailingDoubleSpaces(message.content.trimStart()))
       window.message.success({ content: t('message.copied'), key: 'copy-message' })
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)


### PR DESCRIPTION
修复复制带有思考内容的正式回答时，回答前的换行符未被清除的问题

Before：

![PixPin_2025-03-21_12-52-00](https://github.com/user-attachments/assets/d7c6cee5-3477-4885-9b0d-44925e541807)

After：

![PixPin_2025-03-21_12-53-13](https://github.com/user-attachments/assets/61241bdf-cbaa-4779-b53d-131144d1d142)

