### PR TITLE
fix(MessageMenubar): handle assistant messages from reasoning models when copying and editing content

### DIFF
--- a/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
@@ -16,6 +16,7 @@ import ObsidianExportPopup from '@renderer/components/Popups/ObsidianExportPopup
 import SelectModelPopup from '@renderer/components/Popups/SelectModelPopup'
 import TextEditPopup from '@renderer/components/Popups/TextEditPopup'
 import { TranslateLanguageOptions } from '@renderer/config/translate'
+import { isReasoningModel } from '@renderer/config/models'
 import { useMessageOperations } from '@renderer/hooks/useMessageOperations'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import { getMessageTitle, resetAssistantMessage } from '@renderer/services/MessagesService'
@@ -23,6 +24,7 @@ import { translateText } from '@renderer/services/TranslateService'
 import { Message, Model } from '@renderer/types'
 import { Assistant, Topic } from '@renderer/types'
 import { captureScrollableDivAsBlob, captureScrollableDivAsDataURL, removeTrailingDoubleSpaces } from '@renderer/utils'
+import { withMessageThought } from '@renderer/utils/formats'
 import {
   exportMarkdownToJoplin,
   exportMarkdownToNotion,
@@ -35,6 +37,8 @@ import dayjs from 'dayjs'
 import { FC, memo, useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
+import { clone } from 'lodash'
+
 interface Props {
   message: Message
   assistant: Assistant
@@ -70,12 +74,21 @@ const MessageMenubar: FC<Props> = (props) => {
   const onCopy = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
-      navigator.clipboard.writeText(removeTrailingDoubleSpaces(message.content.trimStart()))
+
+      // 只处理助手消息和来自推理模型的消息
+      if (message.role === 'assistant' && message.model && isReasoningModel(message.model)) {
+        const processedMessage = withMessageThought(clone(message))
+        navigator.clipboard.writeText(removeTrailingDoubleSpaces(processedMessage.content.trimStart()))
+      } else {
+        // 其他情况直接复制原始内容
+        navigator.clipboard.writeText(removeTrailingDoubleSpaces(message.content.trimStart()))
+      }
+
       window.message.success({ content: t('message.copied'), key: 'copy-message' })
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
     },
-    [message.content, t]
+    [message, t]
   )
 
   const onNewBranch = useCallback(async () => {
@@ -96,8 +109,15 @@ const MessageMenubar: FC<Props> = (props) => {
   const onEdit = useCallback(async () => {
     let resendMessage = false
 
+    let textToEdit = message.content
+
+    if (message.role === 'assistant' && message.model && isReasoningModel(message.model)) {
+      const processedMessage = withMessageThought(clone(message))
+      textToEdit = processedMessage.content
+    }
+
     const editedText = await TextEditPopup.show({
-      text: message.content,
+      text: textToEdit,
       children: (props) => {
         const onPress = () => {
           props.onOk?.()
@@ -113,7 +133,7 @@ const MessageMenubar: FC<Props> = (props) => {
       }
     })
 
-    if (editedText && editedText !== message.content) {
+    if (editedText && editedText !== textToEdit) {
       await editMessage(message.id, { content: editedText })
       resendMessage && handleResendUserMessage({ ...message, content: editedText })
     }


### PR DESCRIPTION
- Fix #3660 

将思考内容放在 content 中返回，使用 `<think><\think>` 标签区分思考内容的回答，在复制时会连同思考内容一同复制，这个 PR 解决了这个问题

Before：

![PixPin_2025-03-21_14-57-32](https://github.com/user-attachments/assets/96be7b2d-16ff-4576-8abc-09e2acfff57c)

After：

![PixPin_2025-03-21_14-56-56](https://github.com/user-attachments/assets/b3835bfb-bff9-4885-9333-06d3dba0b42c)


