### PR TITLE
fix(HealthCheck): health checking local models without API keys

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -959,7 +959,7 @@
       "models.check.enabled": "Enabled",
       "models.check.failed": "Failed",
       "models.check.keys_status_count": "Passed: {{count_passed}} keys, failed: {{count_failed}} keys",
-      "models.check.model_status_summary": "{{provider}}: {{count_passed}} models passed all keys, {{count_failed}} models failed all keys, {{count_partial}} models failed some keys",
+      "models.check.model_status_summary": "{{provider}}: {{count_passed}} models passed health checks ({{count_partial}} models had inaccessible keys), {{count_failed}} models completely inaccessible.",
       "models.check.no_api_keys": "No API keys found, please add API keys first.",
       "models.check.passed": "Passed",
       "models.check.select_api_key": "Select the API key to use:",

--- a/src/renderer/src/i18n/locales/ja-jp.json
+++ b/src/renderer/src/i18n/locales/ja-jp.json
@@ -959,7 +959,7 @@
       "models.check.enabled": "開く",
       "models.check.failed": "失敗",
       "models.check.keys_status_count": "合格：{{count_passed}}個のキー、不合格：{{count_failed}}個のキー",
-      "models.check.model_status_summary": "{{provider}}: {{count_passed}}個のモデルが成功しました、{{count_failed}}個のモデルが失敗しました、{{count_partial}}個のモデルが一部成功しました",
+      "models.check.model_status_summary": "{{provider}}: {{count_passed}} 個のモデルが健康チェックを完了しました（{{count_partial}} 個のモデルは一部のキーにアクセスできませんでした）、{{count_failed}} 個のモデルは完全にアクセスできませんでした。",
       "models.check.no_api_keys": "APIキーが見つかりません。まずAPIキーを追加してください。",
       "models.check.passed": "成功",
       "models.check.select_api_key": "使用するAPIキーを選択：",

--- a/src/renderer/src/i18n/locales/ru-ru.json
+++ b/src/renderer/src/i18n/locales/ru-ru.json
@@ -959,7 +959,7 @@
       "models.check.enabled": "Включено",
       "models.check.failed": "Не прошло",
       "models.check.keys_status_count": "Прошло: {{count_passed}} ключей, Не прошло: {{count_failed}} ключей",
-      "models.check.model_status_summary": "{{provider}}: {{count_passed}} модели прошли все ключи, {{count_failed}} модели не прошли все ключи, {{count_partial}} модели не прошли некоторые ключи",
+      "models.check.model_status_summary": "{{provider}}: {{count_passed}} моделей прошли проверку состояния (из них {{count_partial}} моделей недоступны с некоторыми ключами), {{count_failed}} моделей полностью недоступны.",
       "models.check.no_api_keys": "API ключи не найдены, пожалуйста, добавьте API ключи.",
       "models.check.passed": "Прошло",
       "models.check.select_api_key": "Выберите API ключ для использования:",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -959,7 +959,7 @@
       "models.check.enabled": "开启",
       "models.check.failed": "失败",
       "models.check.keys_status_count": "通过：{{count_passed}}个密钥，失败：{{count_failed}}个密钥",
-      "models.check.model_status_summary": "{{provider}}: {{count_passed}}个模型通过所有密钥，{{count_failed}}个模型未通过任何密钥，{{count_partial}}个模型未通过某些密钥",
+      "models.check.model_status_summary": "{{provider}}: {{count_passed}} 个模型完成健康检查（其中 {{count_partial}} 个模型用某些密钥无法访问），{{count_failed}} 个模型完全无法访问。",
       "models.check.no_api_keys": "未找到API密钥，请先添加API密钥。",
       "models.check.passed": "通过",
       "models.check.select_api_key": "选择要使用的API密钥：",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -959,7 +959,7 @@
       "models.check.enabled": "開啟",
       "models.check.failed": "失敗",
       "models.check.keys_status_count": "通過：{{count_passed}}個密鑰，失敗：{{count_failed}}個密鑰",
-      "models.check.model_status_summary": "{{provider}}: {{count_passed}}個模型通過所有密鑰，{{count_failed}}個模型未通過所有密鑰，{{count_partial}}個模型未通過某些密鑰",
+      "models.check.model_status_summary": "{{provider}}: {{count_passed}} 個模型完成健康檢查（其中 {{count_partial}} 個模型用某些密鑰無法訪問），{{count_failed}} 個模型完全無法訪問。",
       "models.check.no_api_keys": "未找到API密鑰，請先添加API密鑰。",
       "models.check.passed": "通過",
       "models.check.select_api_key": "選擇要使用的API密鑰：",

--- a/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
@@ -95,14 +95,10 @@ const ProviderSetting: FC<Props> = ({ provider: _provider }) => {
       .map((k) => k.trim())
       .filter((k) => k)
 
+    // Add an empty key to enable health checks for local models.
+    // Error messages will be shown for each model if a valid key is needed.
     if (keys.length === 0) {
-      window.message.error({
-        key: 'no-api-keys',
-        style: { marginTop: '3vh' },
-        duration: 5,
-        content: t('settings.models.check.no_api_keys')
-      })
-      return
+      keys.push('')
     }
 
     // Show configuration dialog to get health check parameters
@@ -112,7 +108,7 @@ const ProviderSetting: FC<Props> = ({ provider: _provider }) => {
       apiKeys: keys
     })
 
-    if (result.cancelled || result.apiKeys.length === 0) {
+    if (result.cancelled) {
       return
     }
 
@@ -162,9 +158,9 @@ const ProviderSetting: FC<Props> = ({ provider: _provider }) => {
       duration: 10,
       content: t('settings.models.check.model_status_summary', {
         provider: provider.name,
-        count_passed: successModels.length,
-        count_failed: failedModels.length,
-        count_partial: partialModels.length
+        count_passed: successModels.length + partialModels.length,
+        count_partial: partialModels.length,
+        count_failed: failedModels.length
       })
     })
 


### PR DESCRIPTION
fix #3542 

如果用户没有提供 key，健康检查总是会提供一个空的 key。不需要 API key 的模型也可以继续复用 ApiService 中的函数，失败信息总是显示在模型列表中。
