### PR TITLE
增加 Google Drive 和 OneDrive 的备份支持

### DIFF
--- a/docs/icon-usage.md
+++ b/docs/icon-usage.md
@@ -1,0 +1,73 @@
+# Cherry Studio 图标使用指南
+
+## 新增的图标
+
+我们为Cherry Studio添加了以下新图标：
+
+1. Google Drive 图标 - 用于Google Drive备份设置
+   - 使用简洁的三角形设计，符合Google Drive的品牌特征
+   - 保持单色风格，与应用整体设计语言一致
+
+2. OneDrive 图标 - 用于OneDrive备份设置
+   - 使用简化的云形状设计，符合OneDrive的品牌特征
+   - 同样采用单色风格，确保与其他图标视觉统一
+
+这些图标经过精心设计，完全符合Cherry Studio的设计语言，能够无缝融入到现有界面中。
+
+## 如何生成图标字体
+
+要将SVG图标转换为字体文件并更新应用程序，请按照以下步骤操作：
+
+### 安装依赖
+
+```bash
+npm install --save-dev webfonts-generator
+```
+
+### 运行生成脚本
+
+```bash
+npm run generate:iconfont
+```
+
+或者直接运行：
+
+```bash
+node scripts/generate-iconfont.js
+```
+
+这将使用`src/renderer/src/assets/icons`目录中的SVG文件生成新的字体文件，并将其放置在`src/renderer/src/assets/fonts/icon-fonts`目录中。
+
+### 集成到应用程序
+
+生成后的字体文件会自动被应用程序使用，因为我们已经在样式表中引用了它们：
+
+```typescript
+// Google Drive图标组件
+import * as React from 'react'
+
+const GoogleDriveIcon: React.FC = () => {
+  return <i className="iconfont icon-googledrive" />
+}
+
+export default GoogleDriveIcon
+```
+
+## 添加新图标
+
+如果您想添加新图标，请遵循以下步骤：
+
+1. 在`src/renderer/src/assets/icons`目录中添加新的SVG文件。
+2. 文件名应该是图标名称，例如`newicon.svg`。
+3. 在iconfont.css中添加相应的CSS类，例如`.icon-newicon:before { content: '\eXXX'; }`，其中XXX是一个唯一的十六进制代码。
+4. 运行生成脚本以更新字体文件。
+5. 创建一个新的图标组件或在应用程序中直接使用`<i className="iconfont icon-newicon" />`。
+
+## 设计指南
+
+创建新图标时，请遵循以下设计指南：
+
+1. 使用简单的线条和形状。
+2. 保持图标单色，以便可以通过CSS修改颜色。
+3. 确保图标设计与现有图标一致。
+4. 图标应该是24x24像素大小，带有清晰的2像素线条。 

--- a/src/renderer/src/assets/icons/googledrive.svg
+++ b/src/renderer/src/assets/icons/googledrive.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4.3 14.1L9 4.9h5.7l-4.7 9.2H4.3z" />
+  <path d="M14.7 4.9L19.4 14.1 17 19.1 12.3 9.9 14.7 4.9z" />
+  <path d="M4.3 14.1L7 19.1h10l-2.7-5H4.3z" />
+</svg> 

--- a/src/renderer/src/assets/icons/onedrive.svg
+++ b/src/renderer/src/assets/icons/onedrive.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6 13.5C3.5 13.5 1.5 11.5 1.5 9S3.5 4.5 6 4.5c1.9 0 3.5 1.1 4.2 2.8" />
+  <path d="M9.8 8.2C10.2 8.1 10.6 8 11 8c2.5 0 4.5 2 4.5 4.5c0 .3 0 .6-.1.9" />
+  <path d="M10.5 16.5h7c2.8 0 5-2.2 5-5s-2.2-5-5-5c-.6 0-1.1.1-1.7.3" />
+  <path d="M6 13.5c-1.1 0-2.1-.4-2.8-1" />
+  <path d="M14.5 11.5c-.9-1.7-2.7-2.9-4.7-2.9" />
+  <path d="M16.5 6.8c-1.4-.7-3-.7-4.4 0" />
+  <path d="M4.5 16.5h14c1.4 0 2.7-.9 3.3-2.1" />
+</svg> 

--- a/src/renderer/src/components/Icons/GoogleDriveIcon.tsx
+++ b/src/renderer/src/components/Icons/GoogleDriveIcon.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react'
+
+const GoogleDriveIcon: React.FC = () => {
+  return <i className="iconfont icon-googledrive" />
+}
+
+export default GoogleDriveIcon 

--- a/src/renderer/src/components/Icons/OneDriveIcon.tsx
+++ b/src/renderer/src/components/Icons/OneDriveIcon.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react'
+
+const OneDriveIcon: React.FC = () => {
+  return <i className="iconfont icon-onedrive" />
+}
+
+export default OneDriveIcon 


### PR DESCRIPTION
# 📦 添加 Google Drive 和 OneDrive 云备份功能

## 🔍 概述

本PR实现了Cherry Studio连接到Google Drive和OneDrive的功能，使用户能够将聊天记录和应用设置安全地备份到这两大主流云存储服务中。这大大增强了数据安全性，并实现了跨设备的便捷同步。

## ✨ 新增功能

- 🔄 支持Google Drive和OneDrive两大云存储平台
- 🔐 使用OAuth标准协议进行安全授权
- ⏱️ 可配置的自动同步间隔
- 📝 自定义备份文件名
- 📊 查看所有云端备份历史
- 🔄 一键从云端恢复备份
- 📱 自动添加设备标识到备份文件名

## 🧩 技术实现

- 添加了新的服务模块：`BackupService.ts`
- 实现了两个新的设置页面：`GoogleDriveSettings.tsx`和`OneDriveSettings.tsx`
- 创建了专用图标组件：`GoogleDriveIcon.tsx`和`OneDriveIcon.tsx`
- 扩展了应用状态管理，新增云同步状态追踪
- 添加了OAuth流程实现，使用标准授权流程
- 国际化支持：添加所有相关语言的词条

## 🔍 UI/UX变更

- 添加专为网盘服务设计的SVG图标
- 在数据设置页面添加两个新选项卡
- 提供同步状态的实时可视化反馈
- 在备份/恢复过程中显示进度指示

## 📸 截图

![101742625969_ pic](https://github.com/user-attachments/assets/4b213e1d-e542-4f3e-8177-63fa945f4622)


## 📚 相关文档

- 添加了详细的图标使用指南：`docs/icon-usage.md`
- 更新了用户手册中关于数据备份的部分

## 📋 注意事项

- 需要在应用程序中配置Google和Microsoft的OAuth客户端ID
- 备份文件使用标准ZIP格式，包含所有用户数据和设置

## 🔗 相关issue

解决 https://github.com/CherryHQ/cherry-studio/issues/3709

## 问题：**目前缺少 Google 开发者账户认证，无法正常使用完整 OAuth 功能！！！**
![Uploading 91742625966_.pic.jpeg…]()

