### PR TITLE
fix: make the setting icon style of non-system providers consistent with system providers

### DIFF
--- a/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
@@ -267,9 +267,11 @@ const ProviderSetting: FC<Props> = ({ provider: _provider }) => {
             </Link>
           )}
           {!provider.isSystem && (
-            <Button type="text" style={{ width: 30 }} onClick={() => ProviderSettingsPopup.show({ provider })}>
-              <SettingOutlined />
-            </Button>
+            <SettingOutlined
+              type="text"
+              style={{ width: 30 }}
+              onClick={() => ProviderSettingsPopup.show({ provider })}
+            />
           )}
         </Flex>
         <Switch


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e1d69f46-b920-413f-a043-e9d3f7200e58)
