### PR TITLE
feat(SettingTab): add support for reasoning effort model check

### DIFF
--- a/src/renderer/src/config/models.ts
+++ b/src/renderer/src/config/models.ts
@@ -1986,6 +1986,18 @@ export function isOpenAIoSeries(model: Model): boolean {
   return ['o1', 'o1-2024-12-17'].includes(model.id) || model.id.includes('o3')
 }
 
+export function isSupportedResoningEffortModel(model?: Model): boolean {
+  if (!model) {
+    return false
+  }
+
+  if (model.id.includes('claude-3-7-sonnet') || model.id.includes('claude-3.7-sonnet') || isOpenAIoSeries(model)) {
+    return true
+  }
+
+  return false
+}
+
 export function isReasoningModel(model?: Model): boolean {
   if (!model) {
     return false

--- a/src/renderer/src/pages/home/Tabs/SettingsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/SettingsTab.tsx
@@ -8,11 +8,12 @@ import {
   isMac,
   isWindows
 } from '@renderer/config/constant'
-import { isReasoningModel } from '@renderer/config/models'
+import { isSupportedResoningEffortModel } from '@renderer/config/models'
 import { codeThemes } from '@renderer/context/SyntaxHighlighterProvider'
 import { useAssistant } from '@renderer/hooks/useAssistant'
 import { useSettings } from '@renderer/hooks/useSettings'
 import { SettingDivider, SettingRow, SettingRowTitle, SettingSubtitle } from '@renderer/pages/settings'
+import { getDefaultModel } from '@renderer/services/AssistantService'
 import { useAppDispatch } from '@renderer/store'
 import {
   SendMessageShortcut,
@@ -243,7 +244,7 @@ const SettingsTab: FC<Props> = (props) => {
             </Col>
           </Row>
         )}
-        {isReasoningModel(assistant?.model) && (
+        {isSupportedResoningEffortModel(assistant?.model || getDefaultModel()) && (
           <>
             <SettingDivider />
             <Row align="middle">


### PR DESCRIPTION
- fix #3837
- 让“思维链长度”设置只在当前助手模型支持此设置时才出现
- 修复当新建助手时，因为 assistant.model 为 undefined，导致“思维链长度”未能正确显示的问题