### PR TITLE
feat: inchat link to inapp tab

### DIFF
--- a/src/renderer/src/components/app/Sidebar.tsx
+++ b/src/renderer/src/components/app/Sidebar.tsx
@@ -99,7 +99,7 @@ const Sidebar: FC = () => {
         <Tooltip title={t('settings.title')} mouseEnterDelay={0.8} placement="right">
           <StyledLink
             onClick={async () => {
-              minappShow && (await MinApp.close())
+              minappShow && MinApp.close()
               await modelGenerating()
               await to('/settings/provider')
             }}>

--- a/src/renderer/src/hooks/useInAppLinks.ts
+++ b/src/renderer/src/hooks/useInAppLinks.ts
@@ -1,0 +1,27 @@
+import { handleInAppLink } from '@renderer/utils/linkHandler'
+import { RefObject, useEffect } from 'react'
+
+export const useInAppLinks = (contentRef: RefObject<HTMLElement>, dependencies: any[] = []) => {
+  useEffect(() => {
+    if (!contentRef.current) return
+
+    const clickHandler = (event: MouseEvent) => {
+      const target = event.target as HTMLElement
+      const closestAnchor = target.closest('a')
+
+      if (
+        closestAnchor &&
+        closestAnchor.href &&
+        (closestAnchor.href.startsWith('https://') || closestAnchor.href.startsWith('https://'))
+      ) {
+        handleInAppLink(event as any, closestAnchor.href)
+      }
+    }
+
+    contentRef.current.addEventListener('click', clickHandler)
+
+    return () => {
+      contentRef.current?.removeEventListener('click', clickHandler)
+    }
+  }, [contentRef, ...dependencies])
+}

--- a/src/renderer/src/pages/home/Messages/Message.tsx
+++ b/src/renderer/src/pages/home/Messages/Message.tsx
@@ -8,7 +8,7 @@ import { getModelUniqId } from '@renderer/services/ModelService'
 import { Assistant, Message, Topic } from '@renderer/types'
 import { classNames } from '@renderer/utils'
 import { Divider, Dropdown } from 'antd'
-import { Dispatch, FC, memo, SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { Dispatch, FC, memo, SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 

--- a/src/renderer/src/pages/home/Messages/MessageStream.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageStream.tsx
@@ -1,7 +1,7 @@
 import { useAppSelector } from '@renderer/store'
 import { selectStreamMessage } from '@renderer/store/messages'
 import { Assistant, Message, Topic } from '@renderer/types'
-import { memo } from 'react'
+import React, { memo } from 'react'
 import styled from 'styled-components'
 
 import MessageItem from './Message'

--- a/src/renderer/src/pages/home/Messages/Messages.tsx
+++ b/src/renderer/src/pages/home/Messages/Messages.tsx
@@ -19,7 +19,7 @@ import {
   runAsyncFunction
 } from '@renderer/utils'
 import { flatten, last, take } from 'lodash'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import InfiniteScroll from 'react-infinite-scroll-component'
 import BeatLoader from 'react-spinners/BeatLoader'
@@ -151,7 +151,7 @@ const Messages: React.FC<MessagesProps> = ({ assistant, topic, setActiveTopic })
         await db.topics.add({ id: newTopic.id, messages: branchMessages })
         addTopic(newTopic)
         setActiveTopic(newTopic)
-        autoRenameTopic(assistant, newTopic.id)
+        await autoRenameTopic(assistant, newTopic.id)
 
         // 由于复制了消息，消息中附带的文件的总数变了，需要更新
         const filesArr = branchMessages.map((m) => m.files)
@@ -170,7 +170,7 @@ const Messages: React.FC<MessagesProps> = ({ assistant, topic, setActiveTopic })
 
   useEffect(() => {
     runAsyncFunction(async () => {
-      EventEmitter.emit(EVENT_NAMES.ESTIMATED_TOKEN_COUNT, {
+      await EventEmitter.emit(EVENT_NAMES.ESTIMATED_TOKEN_COUNT, {
         tokensCount: await estimateHistoryTokens(assistant, messages),
         contextCount: getContextCount(assistant, messages)
       })

--- a/src/renderer/src/pages/settings/AboutSettings.tsx
+++ b/src/renderer/src/pages/settings/AboutSettings.tsx
@@ -70,7 +70,7 @@ const AboutSettings: FC = () => {
 
   const showLicense = async () => {
     const { appPath } = await window.api.getAppInfo()
-    MinApp.start({
+    await MinApp.start({
       name: t('settings.about.license.title'),
       url: `file://${appPath}/resources/cherry-studio/license.html`,
       logo: AppLogo
@@ -79,7 +79,7 @@ const AboutSettings: FC = () => {
 
   const showReleases = async () => {
     const { appPath } = await window.api.getAppInfo()
-    MinApp.start({
+    await MinApp.start({
       name: t('settings.about.releases.title'),
       url: `file://${appPath}/resources/cherry-studio/releases.html?theme=${theme === ThemeMode.dark ? 'dark' : 'light'}`,
       logo: AppLogo

--- a/src/renderer/src/utils/linkHandler.ts
+++ b/src/renderer/src/utils/linkHandler.ts
@@ -1,0 +1,23 @@
+import MinApp from '@renderer/components/MinApp'
+import { AppLogo } from '@renderer/config/env'
+import { t } from 'i18next'
+import React from 'react'
+
+export const handleInAppLink = (event: React.MouseEvent<HTMLAnchorElement>, url: string) => {
+  event.preventDefault()
+
+  let appName: string
+  try {
+    const urlObj = new URL(url)
+    appName = urlObj.hostname.replace('www.', '')
+  } catch (e) {
+    appName = t('external.link')
+  }
+
+  MinApp.start({
+    id: `web-${Date.now()}`,
+    name: appName,
+    url: url,
+    logo: AppLogo
+  })
+}


### PR DESCRIPTION
点击模型回复中的链接 在minapp tab中打开

主要添加了一个`useInAppLinks`的hook `linkHandler`的工具类
通过点击聊天中的链接 使用Minapp Tab页打开

本地测试大致没有问题 不知道会不会引发其他bug