### PR TITLE
feat(主题): 添加settingTheme字段以增强主题切换功能

### DIFF
--- a/src/renderer/src/components/app/Sidebar.tsx
+++ b/src/renderer/src/components/app/Sidebar.tsx
@@ -35,7 +35,7 @@ const Sidebar: FC = () => {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const { sidebarIcons } = useSettings()
-  const { theme, toggleTheme } = useTheme()
+  const { theme, settingTheme, toggleTheme } = useTheme()
   const { pinned } = useMinapps()
 
   const onEditUser = () => UserPopup.show()
@@ -87,7 +87,10 @@ const Sidebar: FC = () => {
             <QuestionCircleOutlined />
           </Icon>
         </Tooltip>
-        <Tooltip title={t('settings.theme.title')} mouseEnterDelay={0.8} placement="right">
+        <Tooltip
+          title={t('settings.theme.title') + ': ' + t(`settings.theme.${settingTheme}`)}
+          mouseEnterDelay={0.8}
+          placement="right">
           <Icon theme={theme} onClick={() => toggleTheme()}>
             {theme === 'dark' ? (
               <i className="iconfont icon-theme icon-dark1" />

--- a/src/renderer/src/context/ThemeProvider.tsx
+++ b/src/renderer/src/context/ThemeProvider.tsx
@@ -5,11 +5,13 @@ import React, { createContext, PropsWithChildren, useContext, useEffect, useStat
 
 interface ThemeContextType {
   theme: ThemeMode
+  settingTheme: ThemeMode
   toggleTheme: () => void
 }
 
 const ThemeContext = createContext<ThemeContextType>({
   theme: ThemeMode.light,
+  settingTheme: ThemeMode.light,
   toggleTheme: () => {}
 })
 
@@ -55,7 +57,11 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children, defaultT
     }
   })
 
-  return <ThemeContext.Provider value={{ theme: _theme, toggleTheme }}>{children}</ThemeContext.Provider>
+  return (
+    <ThemeContext.Provider value={{ theme: _theme, settingTheme: theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
 }
 
 export const useTheme = () => useContext(ThemeContext)


### PR DESCRIPTION
在ThemeProvider中添加settingTheme字段，用于在Sidebar组件中显示当前主题状态。这样用户可以更直观地了解当前主题设置

在sidebar上展示更详细的主题信息
![图片](https://github.com/user-attachments/assets/a3f07f93-8d33-44a6-88df-644cf79cded0)

因为之前使用的时候注意到，即使开了自动主题，点击这个按钮会切换回单一主题，且只能在两种主题中切换（亮/暗），如果需要换回自动主题还要重新在设置里设置。

这里也想和大佬们商量一下这个功能怎么设置比较合理，我想了两种解决方案：
1. sidebar的按钮可以在三种主题（亮/暗/自动）中切换，也会展示三种文字（亮/暗/自动），sidebar中图标也和设置中保持同步
2. sidebar的按钮保持仅切换亮/暗主题，且展示仅展示实际文字（亮/暗），sidebar图标也只展示两种（亮/暗）。如果设置中为auto，则sidebar按钮仅作展示，点击按钮弹一个toast，提示“已开启自动主题”；如果设置中不为auto，则点击sidebar按钮可直接切换主题

想听下开发团队意见，哪种方式比较合适，我再去做后续开发