### PR TITLE
feat(MessagesService): two or more adjacent messages have the same role as user, then only the last one should be kept

### DIFF
--- a/src/renderer/src/services/MessagesService.ts
+++ b/src/renderer/src/services/MessagesService.ts
@@ -54,7 +54,7 @@ export function filterEmptyMessages(messages: Message[]): Message[] {
 }
 
 export function filterUsefulMessages(messages: Message[]): Message[] {
-  const _messages = [...messages]
+  let _messages = [...messages]
   const groupedMessages = getGroupedMessages(messages)
 
   Object.entries(groupedMessages).forEach(([key, messages]) => {
@@ -77,6 +77,18 @@ export function filterUsefulMessages(messages: Message[]): Message[] {
   while (_messages.length > 0 && _messages[_messages.length - 1].role === 'assistant') {
     _messages.pop()
   }
+
+  // 过滤两条及以上 user 类型消息相邻的情况，只保留最新一条 user 消息
+  _messages = _messages.filter((message, index, origin) => {
+    if (
+      message.role === 'user'
+      && index + 1 < origin.length
+      && origin[index + 1].role === 'user'
+    ) {
+      return false
+    }
+    return true
+  })
 
   return _messages
 }


### PR DESCRIPTION
Network issue or stop generating manually would cause this error

<img width="1170" alt="WeCom20250327-131033@2x" src="https://github.com/user-attachments/assets/32764c9e-3bc0-4ff0-918f-a4714b4de445" />

<img width="961" alt="Clipboard_Screenshot_1743053068" src="https://github.com/user-attachments/assets/74b1d30b-c14f-44ee-88ae-adf623842a58" />

Two or more adjacent messages have the same role as user are sent to LLM. Assistant messages are missing in the message list

<img width="1117" alt="WeCom20250327-131328@2x" src="https://github.com/user-attachments/assets/15c70856-dcb8-462b-8c99-1d524e493ced" />
