### PR TITLE
refactor(mcp settings): enhance NpxSearch component layout and styling

### DIFF
--- a/src/renderer/src/pages/settings/MCPSettings/McpSettings.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/McpSettings.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
-import { SettingContainer, SettingDivider, SettingTitle } from '..'
+import { SettingContainer, SettingDivider, SettingGroup, SettingTitle } from '..'
 
 interface Props {
   server: MCPServer
@@ -163,70 +163,81 @@ const McpSettings: React.FC<Props> = ({ server }) => {
   }
 
   return (
-    <SettingContainer style={{ background: 'transparent' }}>
-      <SettingTitle>
-        <Flex align="center" gap={8}>
+    <SettingContainer>
+      <SettingGroup style={{ marginBottom: 0 }}>
+        <SettingTitle>
           <ServerName>{server?.name}</ServerName>
-        </Flex>
-        <Switch
-          value={server.isActive}
-          key={server.id}
-          loading={loadingServer === server.id}
-          onChange={onToggleActive}
-        />
-      </SettingTitle>
-      <SettingDivider />
-      <Form form={form} layout="vertical" onValuesChange={onFormValuesChange}>
-        <Form.Item name="name" label={t('settings.mcp.name')} rules={[{ required: true, message: '' }]}>
-          <Input placeholder={t('common.name')} />
-        </Form.Item>
-        <Form.Item name="description" label={t('settings.mcp.description')}>
-          <TextArea rows={2} placeholder={t('common.description')} />
-        </Form.Item>
-        <Form.Item name="serverType" label={t('settings.mcp.type')} rules={[{ required: true }]} initialValue="stdio">
-          <Radio.Group
-            onChange={(e) => setServerType(e.target.value)}
-            options={[
-              { label: 'SSE', value: 'sse' },
-              { label: 'STDIO', value: 'stdio' }
-            ]}
-          />
-        </Form.Item>
-        {serverType === 'sse' && (
-          <Form.Item
-            name="baseUrl"
-            label={t('settings.mcp.url')}
-            rules={[{ required: serverType === 'sse', message: '' }]}
-            tooltip={t('settings.mcp.baseUrlTooltip')}>
-            <Input placeholder="http://localhost:3000/sse" />
+          <Flex align="center" gap={16}>
+            <Switch
+              value={server.isActive}
+              key={server.id}
+              loading={loadingServer === server.id}
+              onChange={onToggleActive}
+            />
+            <Button type="primary" size="small" onClick={onSave} loading={loading} disabled={!isFormChanged}>
+              {t('common.save')}
+            </Button>
+          </Flex>
+        </SettingTitle>
+        <SettingDivider />
+        <Form
+          form={form}
+          layout="vertical"
+          onValuesChange={onFormValuesChange}
+          style={{
+            height: 'calc(100vh - var(--navbar-height) - 115px)',
+            overflowY: 'auto',
+            width: 'calc(100% + 10px)',
+            paddingRight: '10px'
+          }}>
+          <Form.Item name="name" label={t('settings.mcp.name')} rules={[{ required: true, message: '' }]}>
+            <Input placeholder={t('common.name')} />
           </Form.Item>
-        )}
-        {serverType === 'stdio' && (
-          <>
+          <Form.Item name="description" label={t('settings.mcp.description')}>
+            <TextArea rows={2} placeholder={t('common.description')} />
+          </Form.Item>
+          <Form.Item name="serverType" label={t('settings.mcp.type')} rules={[{ required: true }]} initialValue="stdio">
+            <Radio.Group
+              onChange={(e) => setServerType(e.target.value)}
+              options={[
+                { label: 'SSE', value: 'sse' },
+                { label: 'STDIO', value: 'stdio' }
+              ]}
+            />
+          </Form.Item>
+          {serverType === 'sse' && (
             <Form.Item
-              name="command"
-              label={t('settings.mcp.command')}
-              rules={[{ required: serverType === 'stdio', message: '' }]}>
-              <Input placeholder="uvx or npx" />
+              name="baseUrl"
+              label={t('settings.mcp.url')}
+              rules={[{ required: serverType === 'sse', message: '' }]}
+              tooltip={t('settings.mcp.baseUrlTooltip')}>
+              <Input placeholder="http://localhost:3000/sse" />
             </Form.Item>
+          )}
+          {serverType === 'stdio' && (
+            <>
+              <Form.Item
+                name="command"
+                label={t('settings.mcp.command')}
+                rules={[{ required: serverType === 'stdio', message: '' }]}>
+                <Input placeholder="uvx or npx" />
+              </Form.Item>
 
-            <Form.Item
-              name="args"
-              label={t('settings.mcp.args')}
-              tooltip={t('settings.mcp.argsTooltip')}
-              rules={[{ required: serverType === 'stdio', message: '' }]}>
-              <TextArea rows={3} placeholder={`arg1\narg2`} style={{ fontFamily: 'monospace' }} />
-            </Form.Item>
+              <Form.Item
+                name="args"
+                label={t('settings.mcp.args')}
+                tooltip={t('settings.mcp.argsTooltip')}
+                rules={[{ required: serverType === 'stdio', message: '' }]}>
+                <TextArea rows={3} placeholder={`arg1\narg2`} style={{ fontFamily: 'monospace' }} />
+              </Form.Item>
 
-            <Form.Item name="env" label={t('settings.mcp.env')} tooltip={t('settings.mcp.envTooltip')}>
-              <TextArea rows={3} placeholder={`KEY1=value1\nKEY2=value2`} style={{ fontFamily: 'monospace' }} />
-            </Form.Item>
-          </>
-        )}
-        <Button type="primary" onClick={onSave} loading={loading} disabled={!isFormChanged}>
-          {t('common.save')}
-        </Button>
-      </Form>
+              <Form.Item name="env" label={t('settings.mcp.env')} tooltip={t('settings.mcp.envTooltip')}>
+                <TextArea rows={3} placeholder={`KEY1=value1\nKEY2=value2`} style={{ fontFamily: 'monospace' }} />
+              </Form.Item>
+            </>
+          )}
+        </Form>
+      </SettingGroup>
     </SettingContainer>
   )
 }

--- a/src/renderer/src/pages/settings/MCPSettings/NpxSearch.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/NpxSearch.tsx
@@ -4,7 +4,7 @@ import { HStack } from '@renderer/components/Layout'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import { useMCPServers } from '@renderer/hooks/useMCPServers'
 import type { MCPServer } from '@renderer/types'
-import { Button, Input, Space, Spin, Table, Tag, Typography } from 'antd'
+import { Button, Card, Flex, Input, Space, Spin, Tag, Typography } from 'antd'
 import { npxFinder } from 'npx-scope-finder'
 import { type FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -128,48 +128,22 @@ const NpxSearch: FC = () => {
             <Spin />
           </div>
         ) : searchResults.length > 0 ? (
-          <Table
-            dataSource={searchResults}
-            columns={[
-              {
-                title: t('settings.mcp.npx_list.package_name'),
-                dataIndex: 'name',
-                key: 'name',
-                width: '200px'
-              },
-              {
-                title: t('settings.mcp.npx_list.description'),
-                key: 'description',
-                ellipsis: true,
-                render: (_, record: SearchResult) => (
-                  <Space direction="vertical" size="small" style={{ width: '100%' }}>
-                    <Text ellipsis={{ tooltip: true }}>{record.description}</Text>
-                    <Text ellipsis={{ tooltip: true }} type="secondary">
-                      {t('settings.mcp.npx_list.usage')}: {record.usage}
-                    </Text>
-                    <Paragraph ellipsis={{ tooltip: true }}>
-                      <Link href={record.npmLink} target="_blank" rel="noopener noreferrer">
-                        {record.npmLink}
-                      </Link>
-                    </Paragraph>
-                  </Space>
-                )
-              },
-              {
-                title: t('settings.mcp.npx_list.version'),
-                dataIndex: 'version',
-                key: 'version',
-                width: '100px',
-                align: 'center'
-              },
-              {
-                title: t('settings.mcp.npx_list.actions'),
-                key: 'actions',
-                width: '80px',
-                align: 'center',
-                render: (_, record: SearchResult) => (
+          searchResults.map((record) => (
+            <Card
+              size="small"
+              key={record.npmLink}
+              title={
+                <Typography.Title level={5} style={{ margin: 0 }}>
+                  {record.name}
+                </Typography.Title>
+              }
+              extra={
+                <Flex>
+                  <Tag bordered={false} color="magenta">
+                    v{record.version}
+                  </Tag>
                   <Button
-                    type="primary"
+                    type="text"
                     icon={<PlusOutlined />}
                     size="small"
                     onClick={() => {
@@ -185,12 +159,21 @@ const NpxSearch: FC = () => {
                       addMCPServer(tempServer)
                     }}
                   />
-                )
-              }
-            ]}
-            pagination={false}
-            bordered
-          />
+                </Flex>
+              }>
+              <Space direction="vertical" size="small">
+                <Text ellipsis={{ tooltip: true }}>{record.description}</Text>
+                <Text ellipsis={{ tooltip: true }} type="secondary">
+                  {t('settings.mcp.npx_list.usage')}: {record.usage}
+                </Text>
+                <Text ellipsis={{ tooltip: true }}>
+                  <Link href={record.npmLink} target="_blank" rel="noopener noreferrer">
+                    {record.npmLink}
+                  </Link>
+                </Text>
+              </Space>
+            </Card>
+          ))
         ) : null}
       </Space>
     </SettingGroup>

--- a/src/renderer/src/pages/settings/MCPSettings/NpxSearch.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/NpxSearch.tsx
@@ -8,6 +8,7 @@ import { Button, Card, Flex, Input, Space, Spin, Tag, Typography } from 'antd'
 import { npxFinder } from 'npx-scope-finder'
 import { type FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import styled, { css } from 'styled-components'
 
 import { SettingDivider, SettingGroup, SettingTitle } from '..'
 
@@ -27,7 +28,7 @@ let _searchResults: SearchResult[] = []
 const NpxSearch: FC = () => {
   const { theme } = useTheme()
   const { t } = useTranslation()
-  const { Paragraph, Text, Link } = Typography
+  const { Text, Link } = Typography
 
   // Add new state variables for npm scope search
   const [npmScope, setNpmScope] = useState('@modelcontextprotocol')
@@ -87,42 +88,44 @@ const NpxSearch: FC = () => {
   }
 
   return (
-    <SettingGroup theme={theme}>
-      <SettingTitle>{t('settings.mcp.npx_list.title')}</SettingTitle>
-      <SettingDivider />
-      <Paragraph type="secondary" style={{ margin: '0 0 10px 0' }}>
-        {t('settings.mcp.npx_list.desc')}
-      </Paragraph>
+    <SettingGroup theme={theme} css={SettingGroupCss}>
+      <div>
+        <SettingTitle>
+          {t('settings.mcp.npx_list.title')} <Text type="secondary">{t('settings.mcp.npx_list.desc')}</Text>
+        </SettingTitle>
+        <SettingDivider />
 
-      <Space direction="vertical" style={{ width: '100%' }}>
-        <Space.Compact style={{ width: '100%', marginBottom: 10 }}>
-          <Input
-            placeholder={t('settings.mcp.npx_list.scope_placeholder')}
-            value={npmScope}
-            onChange={(e) => setNpmScope(e.target.value)}
-            onPressEnter={handleNpmSearch}
-          />
-          <Button icon={<SearchOutlined />} onClick={handleNpmSearch} disabled={searchLoading}>
-            {t('settings.mcp.npx_list.search')}
-          </Button>
-        </Space.Compact>
+        <Space direction="vertical" style={{ width: '100%' }}>
+          <Space.Compact style={{ width: '100%', marginBottom: 10 }}>
+            <Input
+              placeholder={t('settings.mcp.npx_list.scope_placeholder')}
+              value={npmScope}
+              onChange={(e) => setNpmScope(e.target.value)}
+              onPressEnter={handleNpmSearch}
+            />
+            <Button icon={<SearchOutlined />} onClick={handleNpmSearch} disabled={searchLoading}>
+              {t('settings.mcp.npx_list.search')}
+            </Button>
+          </Space.Compact>
+          <HStack alignItems="center" mt="-5px" mb="5px">
+            {npmScopes.map((scope) => (
+              <Tag
+                key={scope}
+                onClick={() => {
+                  if (!searchLoading) {
+                    setNpmScope(scope)
+                    setTimeout(handleNpmSearch, 100)
+                  }
+                }}
+                style={{ cursor: searchLoading ? 'not-allowed' : 'pointer' }}>
+                {scope}
+              </Tag>
+            ))}
+          </HStack>
+        </Space>
+      </div>
 
-        <HStack alignItems="center" mt="-5px" mb="5px">
-          {npmScopes.map((scope) => (
-            <Tag
-              key={scope}
-              onClick={() => {
-                if (!searchLoading) {
-                  setNpmScope(scope)
-                  setTimeout(handleNpmSearch, 100)
-                }
-              }}
-              style={{ cursor: searchLoading ? 'not-allowed' : 'pointer' }}>
-              {scope}
-            </Tag>
-          ))}
-        </HStack>
-
+      <ResultList>
         {searchLoading ? (
           <div style={{ textAlign: 'center', padding: '20px' }}>
             <Spin />
@@ -139,7 +142,7 @@ const NpxSearch: FC = () => {
               }
               extra={
                 <Flex>
-                  <Tag bordered={false} color="magenta">
+                  <Tag bordered={false} color="processing">
                     v{record.version}
                   </Tag>
                   <Button
@@ -162,22 +165,38 @@ const NpxSearch: FC = () => {
                 </Flex>
               }>
               <Space direction="vertical" size="small">
-                <Text ellipsis={{ tooltip: true }}>{record.description}</Text>
-                <Text ellipsis={{ tooltip: true }} type="secondary">
+                <Text>{record.description}</Text>
+                <Text type="secondary">
                   {t('settings.mcp.npx_list.usage')}: {record.usage}
                 </Text>
-                <Text ellipsis={{ tooltip: true }}>
-                  <Link href={record.npmLink} target="_blank" rel="noopener noreferrer">
-                    {record.npmLink}
-                  </Link>
-                </Text>
+                <Link href={record.npmLink} target="_blank" rel="noopener noreferrer">
+                  {record.npmLink}
+                </Link>
               </Space>
             </Card>
           ))
         ) : null}
-      </Space>
+      </ResultList>
     </SettingGroup>
   )
 }
+
+const SettingGroupCss = css`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 0;
+`
+
+const ResultList = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: calc(100% + 10px);
+  padding-right: 4px;
+  overflow-y: scroll;
+`
 
 export default NpxSearch

--- a/src/renderer/src/pages/settings/index.tsx
+++ b/src/renderer/src/pages/settings/index.tsx
@@ -1,7 +1,7 @@
 import { ThemeMode } from '@renderer/types'
 import { Divider } from 'antd'
 import Link from 'antd/es/typography/Link'
-import styled from 'styled-components'
+import styled, { CSSProp } from 'styled-components'
 
 export const SettingContainer = styled.div<{ theme?: ThemeMode }>`
   display: flex;
@@ -80,7 +80,7 @@ export const SettingHelpLink = styled(Link)`
   margin: 0 5px;
 `
 
-export const SettingGroup = styled.div<{ theme?: ThemeMode }>`
+export const SettingGroup = styled.div<{ theme?: ThemeMode; css?: CSSProp }>`
   margin-bottom: 20px;
   border-radius: 8px;
   border: 0.5px solid var(--color-border);


### PR DESCRIPTION
1、固定搜索框；
2、优化卡片内容，自适应换行。

<img width="1130" alt="image" src="https://github.com/user-attachments/assets/2124ad12-f226-4d6a-ba78-1b0d561d2203" />
