### PR TITLE
feat: add webdav synctime show

### DIFF
--- a/src/renderer/src/pages/settings/DataSettings/NutstoreSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/NutstoreSettings.tsx
@@ -207,7 +207,14 @@ const NutstoreSettings: FC = () => {
 
   return (
     <SettingGroup theme={theme}>
-      <SettingTitle>{t('settings.data.nutstore.title')}</SettingTitle>
+      <HStack gap="10px" alignItems="center">
+        <SettingTitle>{t('settings.data.nutstore.title')}</SettingTitle>
+        {isLogin && nutstoreSyncState.lastSyncTime && (
+          <span style={{ color: 'var(--text-secondary)', fontSize: '14px' }}>
+            {t('settings.data.webdav.lastSync')}: {dayjs(nutstoreSyncState.lastSyncTime).format('YYYY-MM-DD HH:mm:ss')}
+          </span>
+        )}
+      </HStack>
       <SettingDivider />
       <SettingRow>
         <SettingRowTitle>

--- a/src/renderer/src/pages/settings/DataSettings/WebDavSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/WebDavSettings.tsx
@@ -103,7 +103,14 @@ const WebDavSettings: FC = () => {
 
   return (
     <SettingGroup theme={theme}>
-      <SettingTitle>{t('settings.data.webdav.title')}</SettingTitle>
+      <HStack gap="10px" alignItems="center">
+        <SettingTitle>{t('settings.data.webdav.title')}</SettingTitle>
+        {webdavSync.lastSyncTime && (
+          <span style={{ color: 'var(--text-secondary)', fontSize: '14px' }}>
+            {t('settings.data.webdav.lastSync')}: {dayjs(webdavSync.lastSyncTime).format('YYYY-MM-DD HH:mm:ss')}
+          </span>
+        )}
+      </HStack>
       <SettingDivider />
       <SettingRow>
         <SettingRowTitle>{t('settings.data.webdav.host')}</SettingRowTitle>


### PR DESCRIPTION
Fix #3993 
在`webdav`以及坚果云标题右侧
增加最近一次的同步时间记录的显示