### PR TITLE
fix: zoomfactor should not change when resize

### DIFF
--- a/src/main/services/WindowService.ts
+++ b/src/main/services/WindowService.ts
@@ -169,10 +169,18 @@ export class WindowService {
     // the zoom factor is reset to cached value when window is resized after routing to other page
     // see: https://github.com/electron/electron/issues/10572
     //
-    // ARCH: as `will-resize` is only for Win & Mac, if linux has the same problem, use `resize` listener also
     mainWindow.on('will-resize', () => {
       mainWindow.webContents.setZoomFactor(configManager.getZoomFactor())
     })
+
+    // ARCH: as `will-resize` is only for Win & Mac,
+    // linux has the same problem, use `resize` listener instead
+    // but `resize` will fliker the ui
+    if (isLinux) {
+      mainWindow.on('resize', () => {
+        mainWindow.webContents.setZoomFactor(configManager.getZoomFactor())
+      })
+    }
 
     // 添加Escape键退出全屏的支持
     mainWindow.webContents.on('before-input-event', (event, input) => {

--- a/src/main/services/WindowService.ts
+++ b/src/main/services/WindowService.ts
@@ -163,6 +163,17 @@ export class WindowService {
       mainWindow.webContents.send('fullscreen-status-changed', false)
     })
 
+    // set the zoom factor again when the window is going to resize
+    //
+    // this is a workaround for the known bug that
+    // the zoom factor is reset to cached value when window is resized after routing to other page
+    // see: https://github.com/electron/electron/issues/10572
+    //
+    // ARCH: as `will-resize` is only for Win & Mac, if linux has the same problem, use `resize` listener also
+    mainWindow.on('will-resize', () => {
+      mainWindow.webContents.setZoomFactor(configManager.getZoomFactor())
+    })
+
     // 添加Escape键退出全屏的支持
     mainWindow.webContents.on('before-input-event', (event, input) => {
       // 当按下Escape键且窗口处于全屏状态时退出全屏


### PR DESCRIPTION
fix: zoomfactor should not change when resize
- the zoom factor is reset to cached value when window has been resized after routing to other page. It's a known bug, see [electron issue](https://github.com/electron/electron/issues/10572) for more details 
- the fix will solve #4146, and solve the zoomfactor problem completely

btw, pr #2253 is not the right way to solve the problem, and could be closed.