### PR TITLE
fix: use server.id as serverKey for better stability

### DIFF
--- a/src/main/services/MCPService.ts
+++ b/src/main/services/MCPService.ts
@@ -17,14 +17,7 @@ class McpService {
   private clients: Map<string, Client> = new Map()
 
   private getServerKey(server: MCPServer): string {
-    return JSON.stringify({
-      baseUrl: server.baseUrl,
-      command: server.command,
-      args: server.args,
-      registryUrl: server.registryUrl,
-      env: server.env,
-      id: server.id
-    })
+    return server.id
   }
 
   constructor() {


### PR DESCRIPTION
Is the logic of generating the serverKey unreasonable? If the parameters are updated and then a restart occurs, the serverKey will be the new key. Certainly, this.clients.get(key) will be null. Therefore, I suggest using return server.id.