### PR TITLE
refactor(MCPService, process): enhance registry URL handling and impr…

### DIFF
--- a/src/main/services/MCPService.ts
+++ b/src/main/services/MCPService.ts
@@ -83,20 +83,16 @@ class McpService {
               args.unshift('x')
             }
           }
-
           if (server.registryUrl) {
-            let registryUrl = server.registryUrl
-
             // if the server name is mcp-auto-install, use the mcp-registry.json file in the bin directory
             if (server.name === 'mcp-auto-install') {
               const binPath = await getBinaryPath()
               makeSureDirExists(binPath)
-              registryUrl = path.join(binPath, 'mcp-registry.json')
+              server.env && (server.env.MCP_REGISTRY_PATH = path.join(binPath, 'mcp-registry.json'))
             }
-
             server.env = {
               ...server.env,
-              NPM_CONFIG_REGISTRY: registryUrl
+              NPM_CONFIG_REGISTRY: server.registryUrl
             }
           }
         } else if (server.command === 'uvx' || server.command === 'uv') {

--- a/src/main/services/MCPService.ts
+++ b/src/main/services/MCPService.ts
@@ -2,6 +2,7 @@ import os from 'node:os'
 import path from 'node:path'
 
 import { isLinux, isMac, isWin } from '@main/constant'
+import { makeSureDirExists } from '@main/utils'
 import { getBinaryName, getBinaryPath } from '@main/utils/process'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
@@ -86,8 +87,10 @@ class McpService {
           if (server.registryUrl) {
             let registryUrl = server.registryUrl
 
+            // if the server name is mcp-auto-install, use the mcp-registry.json file in the bin directory
             if (server.name === 'mcp-auto-install') {
               const binPath = await getBinaryPath()
+              makeSureDirExists(binPath)
               registryUrl = path.join(binPath, 'mcp-registry.json')
             }
 

--- a/src/main/services/MCPService.ts
+++ b/src/main/services/MCPService.ts
@@ -84,15 +84,16 @@ class McpService {
             }
           }
           if (server.registryUrl) {
+            server.env = {
+              ...server.env,
+              NPM_CONFIG_REGISTRY: server.registryUrl
+            }
+
             // if the server name is mcp-auto-install, use the mcp-registry.json file in the bin directory
             if (server.name === 'mcp-auto-install') {
               const binPath = await getBinaryPath()
               makeSureDirExists(binPath)
-              server.env && (server.env.MCP_REGISTRY_PATH = path.join(binPath, 'mcp-registry.json'))
-            }
-            server.env = {
-              ...server.env,
-              NPM_CONFIG_REGISTRY: server.registryUrl
+              server.env.MCP_REGISTRY_PATH = path.join(binPath, 'mcp-registry.json')
             }
           }
         } else if (server.command === 'uvx' || server.command === 'uv') {

--- a/src/main/services/MCPService.ts
+++ b/src/main/services/MCPService.ts
@@ -84,9 +84,16 @@ class McpService {
           }
 
           if (server.registryUrl) {
+            let registryUrl = server.registryUrl
+
+            if (server.name === 'mcp-auto-install') {
+              const binPath = await getBinaryPath()
+              registryUrl = path.join(binPath, 'mcp-registry.json')
+            }
+
             server.env = {
               ...server.env,
-              NPM_CONFIG_REGISTRY: server.registryUrl
+              NPM_CONFIG_REGISTRY: registryUrl
             }
           }
         } else if (server.command === 'uvx' || server.command === 'uv') {

--- a/src/main/utils/index.ts
+++ b/src/main/utils/index.ts
@@ -46,3 +46,9 @@ export function dumpPersistState() {
 export const runAsyncFunction = async (fn: () => void) => {
   await fn()
 }
+
+export function makeSureDirExists(dir: string) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true })
+  }
+}

--- a/src/main/utils/process.ts
+++ b/src/main/utils/process.ts
@@ -42,7 +42,11 @@ export async function getBinaryName(name: string): Promise<string> {
   return name
 }
 
-export async function getBinaryPath(name: string): Promise<string> {
+export async function getBinaryPath(name?: string): Promise<string> {
+  if (!name) {
+    return path.join(os.homedir(), '.cherrystudio', 'bin')
+  }
+
   const binaryName = await getBinaryName(name)
   const binariesDir = path.join(os.homedir(), '.cherrystudio', 'bin')
   const binariesDirExists = await fs.existsSync(binariesDir)


### PR DESCRIPTION
getBinaryPath function

- Updated MCPService to conditionally set the NPM_CONFIG_REGISTRY based on server name, improving flexibility for auto-install scenarios.
- Modified getBinaryPath function to handle optional name parameter, returning a default path when no name is provided, enhancing usability.