### PR TITLE
feat(mcp): add registryUrl to initialState for improved package manag…

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -13,6 +13,7 @@ import TranslateButton from '@renderer/components/TranslateButton'
 import { isFunctionCallingModel, isGenerateImageModel, isVisionModel, isWebSearchModel } from '@renderer/config/models'
 import db from '@renderer/databases'
 import { useAssistant } from '@renderer/hooks/useAssistant'
+import { useMCPServers } from '@renderer/hooks/useMCPServers'
 import { useMessageOperations, useTopicLoading } from '@renderer/hooks/useMessageOperations'
 import { modelGenerating, useRuntime } from '@renderer/hooks/useRuntime'
 import { useMessageStyle, useSettings } from '@renderer/hooks/useSettings'
@@ -101,7 +102,7 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
   const isVision = useMemo(() => isVisionModel(model), [model])
   const supportExts = useMemo(() => [...textExts, ...documentExts, ...(isVision ? imageExts : [])], [isVision])
   const navigate = useNavigate()
-  // const { activedMcpServers } = useMCPServers()
+  const { activedMcpServers } = useMCPServers()
 
   const showKnowledgeIcon = useSidebarIconShow('knowledge')
   const showMCPToolsIcon = isFunctionCallingModel(model)
@@ -181,9 +182,7 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
       }
       if (isFunctionCallingModel(model)) {
         if (!isEmpty(enabledMCPs) && !isEmpty(activedMcpServers)) {
-          userMessage.enabledMCPs = activedMcpServers.filter((server) =>
-            enabledMCPs?.some((s) => s.id === server.id)
-          )
+          userMessage.enabledMCPs = activedMcpServers.filter((server) => enabledMCPs?.some((s) => s.id === server.id))
         }
       }
       userMessage.usage = await estimateMessageUsage(userMessage)

--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -215,7 +215,8 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
     selectedKnowledgeBases,
     text,
     topic,
-    enabledMCPs
+    enabledMCPs,
+    activedMcpServers
   ])
 
   const translate = async () => {

--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -13,7 +13,6 @@ import TranslateButton from '@renderer/components/TranslateButton'
 import { isFunctionCallingModel, isGenerateImageModel, isVisionModel, isWebSearchModel } from '@renderer/config/models'
 import db from '@renderer/databases'
 import { useAssistant } from '@renderer/hooks/useAssistant'
-import { useMCPServers } from '@renderer/hooks/useMCPServers'
 import { useMessageOperations, useTopicLoading } from '@renderer/hooks/useMessageOperations'
 import { modelGenerating, useRuntime } from '@renderer/hooks/useRuntime'
 import { useMessageStyle, useSettings } from '@renderer/hooks/useSettings'
@@ -102,7 +101,7 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
   const isVision = useMemo(() => isVisionModel(model), [model])
   const supportExts = useMemo(() => [...textExts, ...documentExts, ...(isVision ? imageExts : [])], [isVision])
   const navigate = useNavigate()
-  const { activedMcpServers } = useMCPServers()
+  // const { activedMcpServers } = useMCPServers()
 
   const showKnowledgeIcon = useSidebarIconShow('knowledge')
   const showMCPToolsIcon = isFunctionCallingModel(model)
@@ -187,7 +186,6 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
           // }
         }
       }
-      console.log('userMessage', userMessage)
       userMessage.usage = await estimateMessageUsage(userMessage)
       currentMessageId.current = userMessage.id
 
@@ -207,7 +205,6 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
       console.error('Failed to send message:', error)
     }
   }, [
-    activedMcpServers,
     assistant,
     dispatch,
     files,
@@ -218,7 +215,8 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
     resizeTextArea,
     selectedKnowledgeBases,
     text,
-    topic
+    topic,
+    enabledMCPs
   ])
 
   const translate = async () => {

--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -180,15 +180,14 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
       if (mentionModels) {
         userMessage.mentions = mentionModels
       }
-
       if (isFunctionCallingModel(model)) {
-        if (!isEmpty(assistant.mcpServers) && !isEmpty(activedMcpServers)) {
-          userMessage.enabledMCPs = activedMcpServers.filter((server) =>
-            assistant.mcpServers?.some((s) => s.id === server.id)
-          )
+        if (enabledMCPs.length) {
+          // if (!isEmpty(assistant.mcpServers) || !isEmpty(activedMcpServers)) {
+          userMessage.enabledMCPs = [...enabledMCPs]
+          // }
         }
       }
-
+      console.log('userMessage', userMessage)
       userMessage.usage = await estimateMessageUsage(userMessage)
       currentMessageId.current = userMessage.id
 

--- a/src/renderer/src/store/mcp.ts
+++ b/src/renderer/src/store/mcp.ts
@@ -11,6 +11,7 @@ const initialState: MCPConfig = {
       baseUrl: '',
       command: 'npx',
       args: ['-y', '@mcpmarket/mcp-auto-install', 'connect', '--json'],
+      registryUrl: 'https://registry.npmmirror.com',
       env: {},
       isActive: false
     }

--- a/src/renderer/src/utils/mcp-tools.ts
+++ b/src/renderer/src/utils/mcp-tools.ts
@@ -240,6 +240,7 @@ export async function callMCPTool(tool: MCPTool): Promise<any> {
           command: resp.data.command,
           args: resp.data.args,
           env: resp.data.env,
+          registryUrl: '',
           isActive: false
         }
         store.dispatch(addMCPServer(mcpServer))


### PR DESCRIPTION
先fix一下吧 默认淘宝镜像，不然没有registryUrl走不到创建文件的流程。
实现不够优雅。后面可以把mcp-auto-install改成npm包，直接装进项目里，就不用这样配置了