### PR TITLE
feat:add default doubao model to model list

### DIFF
--- a/src/renderer/src/config/models.ts
+++ b/src/renderer/src/config/models.ts
@@ -1231,7 +1231,140 @@ export const SYSTEM_MODELS: Record<string, Model[]> = {
       group: 'Step 1'
     }
   ],
-  doubao: [],
+  doubao: [
+    {
+      id: 'doubao-1-5-vision-pro-32k-250115',
+      provider: 'doubao',
+      name: 'doubao-1.5-vision-pro',
+      group: 'Doubao-1.5-vision-pro'
+    },
+    {
+      id: 'doubao-1-5-pro-32k-250115',
+      provider: 'doubao',
+      name: 'doubao-1.5-pro-32k',
+      group: 'Doubao-1.5-pro'
+    },
+    {
+      id: 'doubao-1-5-pro-32k-character-250228',
+      provider: 'doubao',
+      name: 'doubao-1.5-pro-32k-character',
+      group: 'Doubao-1.5-pro'
+    },
+    {
+      id: 'doubao-1-5-pro-256k-250115',
+      provider: 'doubao',
+      name: 'Doubao-1.5-pro-256k',
+      group: 'Doubao-1.5-pro'
+    },
+    {
+      id: 'deepseek-r1-250120',
+      provider: 'doubao',
+      name: 'DeepSeek-R1',
+      group: 'DeepSeek'
+    },
+    {
+      id: 'deepseek-r1-distill-qwen-32b-250120',
+      provider: 'doubao',
+      name: 'DeepSeek-R1-Distill-Qwen-32B',
+      group: 'DeepSeek'
+    },
+    {
+      id: 'deepseek-r1-distill-qwen-7b-250120',
+      provider: 'doubao',
+      name: 'DeepSeek-R1-Distill-Qwen-7B',
+      group: 'DeepSeek'
+    },
+    {
+      id: 'deepseek-v3-250324',
+      provider: 'doubao',
+      name: 'DeepSeek-V3',
+      group: 'DeepSeek'
+    },
+    {
+      id: 'deepseek-v3-250324',
+      provider: 'doubao',
+      name: 'DeepSeek-V3',
+      group: 'DeepSeek'
+    },
+    {
+      id: 'doubao-pro-32k-241215',
+      provider: 'doubao',
+      name: 'Doubao-pro-32k',
+      group: 'Doubao-pro'
+    },
+    {
+      id: 'doubao-pro-32k-functioncall-241028',
+      provider: 'doubao',
+      name: 'Doubao-pro-32k-functioncall-241028',
+      group: 'Doubao-pro'
+    },
+    {
+      id: 'doubao-pro-32k-character-241215',
+      provider: 'doubao',
+      name: 'Doubao-pro-32k-character-241215',
+      group: 'Doubao-pro'
+    },
+    {
+      id: 'doubao-pro-256k-241115',
+      provider: 'doubao',
+      name: 'Doubao-pro-256k',
+      group: 'Doubao-pro'
+    },
+    {
+      id: 'doubao-lite-4k-character-240828',
+      provider: 'doubao',
+      name: 'Doubao-lite-4k-character-240828',
+      group: 'Doubao-lite'
+    },
+    {
+      id: 'doubao-lite-32k-240828',
+      provider: 'doubao',
+      name: 'Doubao-lite-32k',
+      group: 'Doubao-lite'
+    },
+    {
+      id: 'doubao-lite-32k-character-241015',
+      provider: 'doubao',
+      name: 'Doubao-lite-32k-character-241015',
+      group: 'Doubao-lite'
+    },
+    {
+      id: 'doubao-lite-128k-240828',
+      provider: 'doubao',
+      name: 'Doubao-lite-128k',
+      group: 'Doubao-lite'
+    },
+    {
+      id: 'doubao-1-5-lite-32k-250115',
+      provider: 'doubao',
+      name: 'Doubao-1.5-lite-32k',
+      group: 'Doubao-lite'
+    },
+    {
+      id: 'doubao-embedding-large-text-240915',
+      provider: 'doubao',
+      name: 'Doubao-embedding-large',
+      group: 'Doubao-embedding'
+    },
+    {
+      id: 'doubao-embedding-text-240715',
+      provider: 'doubao',
+      name: 'Doubao-embedding',
+      group: 'Doubao-embedding'
+    },
+    {
+      id: 'doubao-embedding-vision-241215',
+      provider: 'doubao',
+      name: 'Doubao-embedding-vision',
+      group: 'Doubao-embedding'
+    },
+    {
+      id: 'doubao-vision-lite-32k-241015',
+      provider: 'doubao',
+      name: 'Doubao-vision-lite-32k',
+      group: 'Doubao-vision-lite-32k'
+    }
+  ],
   minimax: [
     {
       id: 'abab6.5s-chat',


### PR DESCRIPTION
在添加火山 方舟模型的时候发现 model list是空的,不像其他的模型那样
因此搜索火山方舟上面的模型广场里面的列表,将豆包自家的和deepseek的模型都添加了进来
主要包括:
豆包Pro
豆包Pro 1.5
豆包Lite
豆包embedding
DeepSeek