### PR TITLE
feat: Support Ctrl key for multi-select models when using @ mention

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/MentionModelsInput.tsx
+++ b/src/renderer/src/pages/home/Inputbar/MentionModelsInput.tsx
@@ -21,14 +21,14 @@ const MentionModelsInput: FC<{
   return (
     <Container gap="4px 0" wrap>
       {selectedModels.map((model) => (
-        <Tag
+        <StyledTag
           bordered={false}
           color="processing"
           key={getModelUniqId(model)}
           closable
           onClose={() => onRemoveModel(model)}>
           @{model.name} ({getProviderName(model)})
-        </Tag>
+        </StyledTag>
       ))}
     </Container>
   )
@@ -37,6 +37,27 @@ const MentionModelsInput: FC<{
 const Container = styled(Flex)`
   width: 100%;
   padding: 10px 15px 0;
+`
+
+// Enhance Tag's visual effect to make multi-selected models more prominent
+const StyledTag = styled(Tag)`
+  margin: 2px 4px 2px 0;
+  padding: 2px 8px;
+  border-radius: 4px;
+  transition: all 0.2s;
+  font-weight: 500;
+
+  &:hover {
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    transform: translateY(-1px);
+  }
+
+  .anticon-close {
+    color: rgba(0, 0, 0, 0.45);
+    &:hover {
+      color: rgba(0, 0, 0, 0.85);
+    }
+  }
 `
 
 export default MentionModelsInput


### PR DESCRIPTION
1.使用@弹出模型窗口可以按住ctrl键多选，松开关闭模型窗口
2.增加了模型样式标签效果。

![image](https://github.com/user-attachments/assets/1e469cd2-5bc0-4257-96dc-f6619f9690f8)
![image](https://github.com/user-attachments/assets/3966f1a9-a888-43df-b734-be869ec825e0)
