### PR TITLE
fix(Inputbar): Solve the problem that the initial state of assistant …

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -182,9 +182,9 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
       }
 
       if (isFunctionCallingModel(model)) {
-        if (!isEmpty(assistant.mcpServers) && !isEmpty(activedMcpServers)) {
+        if (!isEmpty(enabledMCPs) && !isEmpty(activedMcpServers)) {
           userMessage.enabledMCPs = activedMcpServers.filter((server) =>
-            assistant.mcpServers?.some((s) => s.id === server.id)
+            enabledMCPs?.some((s) => s.id === server.id)
           )
         }
       }


### PR DESCRIPTION
初始状态下assistant.mcpServers为空，导致无法正常给userMessage.enableMCPs传递当前对话已经启动的MCP Server
，main/src/renderer/src/services/ApiService.ts#L104下无法获取到MCP Server信息，后续MCP Tools没法正常使用