### PR TITLE
fix: 🐛 LRUCache export name error

### DIFF
--- a/src/renderer/src/services/CodeCacheService.ts
+++ b/src/renderer/src/services/CodeCacheService.ts
@@ -1,5 +1,5 @@
 import store from '@renderer/store'
-import { LRUCache } from 'lru-cache'
+import LRUCache from 'lru-cache'
 
 /**
  * FNV-1a哈希函数，用于计算字符串哈希值


### PR DESCRIPTION
BREAKING CHANGE: 🧨 SyntaxError: The requested module '/@fs/Users/bary/code/tools/cherry-studio/node_modules/.vite/deps/lru-cache.js?v=9139ab94' does not provide an export named 'LRUCache' (at
CodeCacheService.ts:2:10)