### PR TITLE
perf: prevent unnecessary reflow

### DIFF
--- a/src/renderer/src/pages/home/Messages/Message.tsx
+++ b/src/renderer/src/pages/home/Messages/Message.tsx
@@ -213,6 +213,8 @@ const MessageContainer = styled.div`
   .menubar {
     opacity: 0;
     transition: opacity 0.2s ease;
+    transform: translateZ(0);
+    will-change: opacity;
     &.show {
       opacity: 1;
     }


### PR DESCRIPTION
节点多的时候非常明显（比如长代码块）， menubar 的 hover 会反复触发 layout，造成卡顿。

## 之前

![image](https://github.com/user-attachments/assets/0a795694-7657-43cf-a990-e6d77d633907)

## 之后

![image](https://github.com/user-attachments/assets/03c7dc6c-0ab8-4885-b6ec-86fef30af5a4)
