### PR TITLE
refactor(reranker): 重构重排序功能以提高可维护性 

### DIFF
--- a/src/main/reranker/BaseReranker.ts
+++ b/src/main/reranker/BaseReranker.ts
@@ -64,7 +64,7 @@ export default abstract class BaseReranker {
     }
   }
 
-  public formatErrorMessage(url: string, error: any, requestBody: any) {
+  protected formatErrorMessage(url: string, error: any, requestBody: any) {
     const errorDetails = {
       url: url,
       message: error.message,

--- a/src/main/reranker/BaseReranker.ts
+++ b/src/main/reranker/BaseReranker.ts
@@ -3,13 +3,59 @@ import { KnowledgeBaseParams } from '@types'
 
 export default abstract class BaseReranker {
   protected base: KnowledgeBaseParams
+
   constructor(base: KnowledgeBaseParams) {
     if (!base.rerankModel) {
       throw new Error('Rerank model is required')
     }
     this.base = base
   }
+
   abstract rerank(query: string, searchResults: ExtractChunkData[]): Promise<ExtractChunkData[]>
+
+  /**
+   * Get Rerank Request Url
+   */
+  protected getRerankUrl() {
+    let baseURL = this.base?.rerankBaseURL?.endsWith('/')
+      ? this.base.rerankBaseURL.slice(0, -1)
+      : this.base.rerankBaseURL
+    // 必须携带/v1，否则会404
+    if (baseURL && !baseURL.endsWith('/v1')) {
+      baseURL = `${baseURL}/v1`
+    }
+
+    return `${baseURL}/rerank`
+  }
+
+  /**
+   * Get Rerank Result
+   * @param searchResults
+   * @param rerankResults
+   * @protected
+   */
+  protected getRerankResult(
+    searchResults: ExtractChunkData[],
+    rerankResults: Array<{
+      index: number
+      relevance_score: number
+    }>
+  ) {
+    const resultMap = new Map(rerankResults.map((result) => [result.index, result.relevance_score || 0]))
+
+    return searchResults
+      .map((doc: ExtractChunkData, index: number) => {
+        const score = resultMap.get(index)
+        if (score === undefined) return undefined
+
+        return {
+          ...doc,
+          score
+        }
+      })
+      .filter((doc): doc is ExtractChunkData => doc !== undefined)
+      .sort((a, b) => b.score - a.score)
+  }
 
   public defaultHeaders() {
     return {

--- a/src/main/reranker/SiliconFlowReranker.ts
+++ b/src/main/reranker/SiliconFlowReranker.ts
@@ -10,16 +10,7 @@ export default class SiliconFlowReranker extends BaseReranker {
   }
 
   public rerank = async (query: string, searchResults: ExtractChunkData[]): Promise<ExtractChunkData[]> => {
-    let baseURL = this.base?.rerankBaseURL?.endsWith('/')
-      ? this.base.rerankBaseURL.slice(0, -1)
-      : this.base.rerankBaseURL
-
-    // 必须携带/v1，否则会404
-    if (baseURL && !baseURL.endsWith('/v1')) {
-      baseURL = `${baseURL}/v1`
-    }
-
-    const url = `${baseURL}/rerank`
+    const url = this.getRerankUrl()
 
     const requestBody = {
       model: this.base.rerankModel,
@@ -34,20 +25,7 @@ export default class SiliconFlowReranker extends BaseReranker {
       const { data } = await axios.post(url, requestBody, { headers: this.defaultHeaders() })
 
       const rerankResults = data.results
-      const resultMap = new Map(rerankResults.map((result: any) => [result.index, result.relevance_score || 0]))
-
-      return searchResults
-        .map((doc: ExtractChunkData, index: number) => {
-          const score = resultMap.get(index)
-          if (score === undefined) return undefined
-
-          return {
-            ...doc,
-            score
-          }
-        })
-        .filter((doc): doc is ExtractChunkData => doc !== undefined)
-        .sort((a, b) => b.score - a.score)
+      return this.getRerankResult(searchResults, rerankResults)
     } catch (error: any) {
       const errorDetails = this.formatErrorMessage(url, error, requestBody)
 


### PR DESCRIPTION
- 将 BaseReranker 类中的公共逻辑提取到受保护的方法中
- 优化了 JinaReranker、SiliconFlowReranker 和 VoyageReranker 的实现
- 新增 getRerankUrl 和 getRerankResult 方法以提高代码复用性 简化了重排序结果的处理逻辑
- 将 formatErrorMessage 方法的访问权限从公共 (public) 改为受保护 (protected)