### PR TITLE
fix: fix main-window fake show up on Linux

### DIFF
--- a/src/main/services/WindowService.ts
+++ b/src/main/services/WindowService.ts
@@ -319,10 +319,18 @@ export class WindowService {
       //[macOS] Known Issue
       // setVisibleOnAllWorkspaces true/false will NOT bring window to current desktop in Mac (works fine with Windows)
       // AppleScript may be a solution, but it's not worth
-      this.mainWindow.setVisibleOnAllWorkspaces(true)
+
+      // [Linux] Known Issue
+      // setVisibleOnAllWorkspaces 在 Linux 环境下（特别是 KDE Wayland）会导致窗口进入"假弹出"状态
+      // 因此在 Linux 环境下不执行这两行代码
+      if (!isLinux) {
+        this.mainWindow.setVisibleOnAllWorkspaces(true)
+      }
       this.mainWindow.show()
       this.mainWindow.focus()
-      this.mainWindow.setVisibleOnAllWorkspaces(false)
+      if (!isLinux) {
+        this.mainWindow.setVisibleOnAllWorkspaces(false)
+      }
     } else {
       this.mainWindow = this.createMainWindow()
     }


### PR DESCRIPTION
之前的重构在Linux环境下引入了这个bug：
> 当按下快捷键或点击托盘图标后，主窗口会进入一个“假弹出”的状态，具体来说，此时系统下方任务栏能看到有窗口，但是屏幕上只是被覆盖了一层透明度很高的东西，根本看不清；而进入这个“假弹出”状态后，再点一次系统托盘图标，则会进入正常的弹出状态

通过判断当前平台修复了这个bug