### PR TITLE
fix: missing ExportMenuOptions in persist leads to useSelector re-render a lot

### DIFF
--- a/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
@@ -41,7 +41,6 @@ import { FC, memo, useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import styled from 'styled-components'
-
 interface Props {
   message: Message
   assistant: Assistant
@@ -70,20 +69,7 @@ const MessageMenubar: FC<Props> = (props) => {
 
   const isUserMessage = message.role === 'user'
 
-  const exportMenuOptions = useSelector(
-    (state: RootState) =>
-      state.settings.exportMenuOptions || {
-        image: true,
-        markdown: true,
-        markdown_reason: true,
-        notion: true,
-        yuque: true,
-        joplin: true,
-        obsidian: true,
-        siyuan: true,
-        docx: true
-      }
-  )
+  const exportMenuOptions = useSelector((state: RootState) => state.settings.exportMenuOptions)
 
   const onCopy = useCallback(
     (e: React.MouseEvent) => {

--- a/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
@@ -41,6 +41,7 @@ import { FC, memo, useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import styled from 'styled-components'
+
 interface Props {
   message: Message
   assistant: Assistant

--- a/src/renderer/src/pages/home/Tabs/TopicsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/TopicsTab.tsx
@@ -156,20 +156,7 @@ const Topics: FC<Props> = ({ assistant: _assistant, activeTopic, setActiveTopic 
     [setActiveTopic]
   )
 
-  const exportMenuOptions = useSelector(
-    (state: RootState) =>
-      state.settings.exportMenuOptions || {
-        image: true,
-        markdown: true,
-        markdown_reason: true,
-        notion: true,
-        yuque: true,
-        joplin: true,
-        obsidian: true,
-        siyuan: true,
-        docx: true
-      }
-  )
+  const exportMenuOptions = useSelector((state: RootState) => state.settings.exportMenuOptions)
 
   const getTopicMenuItems = useCallback(
     (topic: Topic) => {

--- a/src/renderer/src/pages/settings/DataSettings/ExportMenuSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/ExportMenuSettings.tsx
@@ -13,20 +13,7 @@ const ExportMenuOptions: FC = () => {
   const { theme } = useTheme()
   const dispatch = useAppDispatch()
 
-  const exportMenuOptions = useSelector(
-    (state: RootState) =>
-      state.settings.exportMenuOptions || {
-        image: true,
-        markdown: true,
-        markdown_reason: true,
-        notion: true,
-        yuque: true,
-        joplin: true,
-        obsidian: true,
-        siyuan: true,
-        docx: true
-      }
-  )
+  const exportMenuOptions = useSelector((state: RootState) => state.settings.exportMenuOptions)
 
   const handleToggleOption = (option: string, checked: boolean) => {
     dispatch(

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -62,8 +62,6 @@ const store = configureStore({
   devTools: true
 })
 
-console.log('Initial state:', store.getState())
-
 export type RootState = ReturnType<typeof rootReducer>
 export type AppDispatch = typeof store.dispatch
 

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -42,7 +42,7 @@ const persistedReducer = persistReducer(
   {
     key: 'cherry-studio',
     storage,
-    version: 92,
+    version: 93,
     blacklist: ['runtime', 'messages'],
     migrate
   },
@@ -61,6 +61,8 @@ const store = configureStore({
   },
   devTools: true
 })
+
+console.log('Initial state:', store.getState())
 
 export type RootState = ReturnType<typeof rootReducer>
 export type AppDispatch = typeof store.dispatch

--- a/src/renderer/src/store/migrate.ts
+++ b/src/renderer/src/store/migrate.ts
@@ -13,7 +13,7 @@ import { createMigrate } from 'redux-persist'
 import { RootState } from '.'
 import { INITIAL_PROVIDERS, moveProvider } from './llm'
 import { mcpSlice } from './mcp'
-import { DEFAULT_SIDEBAR_ICONS } from './settings'
+import { DEFAULT_SIDEBAR_ICONS, initialState as settingsInitialState } from './settings'
 
 // remove logo base64 data to reduce the size of the state
 function removeMiniAppIconsFromState(state: RootState) {
@@ -1169,6 +1169,17 @@ const migrateConfig = {
     try {
       addMiniApp(state, 'dangbei')
       state.llm.providers = moveProvider(state.llm.providers, 'qiniu', 12)
+      return state
+    } catch (error) {
+      return state
+    }
+  },
+  '93': (state: RootState) => {
+    try {
+      if (!state?.settings?.exportMenuOptions) {
+        state.settings.exportMenuOptions = settingsInitialState.exportMenuOptions
+        return state
+      }
       return state
     } catch (error) {
       return state

--- a/src/renderer/src/store/settings.ts
+++ b/src/renderer/src/store/settings.ts
@@ -125,7 +125,7 @@ export interface SettingsState {
 
 export type MultiModelMessageStyle = 'horizontal' | 'vertical' | 'fold' | 'grid'
 
-const initialState: SettingsState = {
+export const initialState: SettingsState = {
   showAssistants: true,
   showTopics: true,
   sendMessageShortcut: 'Enter',


### PR DESCRIPTION
fix: missing ExportMenuOptions in persist leads to useSelector re-render, which will signally slow down the message streaming
- when fixed, the calling of ExportMenuOptions don't have to set default values hard-coded. and so removed.

***CAUTION***
use migration to reset the default value of ExportMenuOptions