### PR TITLE
fix(Messages): 调整ScrollContainer和Container的样式以减少底部空间

### DIFF
--- a/src/renderer/src/pages/home/Messages/Messages.tsx
+++ b/src/renderer/src/pages/home/Messages/Messages.tsx
@@ -298,6 +298,7 @@ const LoaderContainer = styled.div<LoaderProps>`
 const ScrollContainer = styled.div`
   display: flex;
   flex-direction: column-reverse;
+  margin-bottom: -20px; // 添加负的底部外边距来减少空间
 `
 
 interface ContainerProps {
@@ -307,7 +308,7 @@ interface ContainerProps {
 const Container = styled(Scrollbar)<ContainerProps>`
   display: flex;
   flex-direction: column-reverse;
-  padding: 10px 0 20px;
+  padding: 10px 0 10px;
   overflow-x: hidden;
   background-color: var(--color-background);
   z-index: 1;

--- a/src/renderer/src/pages/home/Messages/NewTopicButton.tsx
+++ b/src/renderer/src/pages/home/Messages/NewTopicButton.tsx
@@ -31,6 +31,8 @@ const Container = styled.div`
   align-items: center;
   margin-bottom: 10px;
   margin-top: -10px;
+  padding: 0;
+  min-height: auto;
 `
 
 const Button = styled(AntdButton)<{ $theme: ThemeMode }>`


### PR DESCRIPTION
减小了ScrollContainer的底部外边距和Container的底部内边距，以解决新话题按钮占用过多垂直空间的问题。这些调整使界面更加紧凑，提高了可用聊天区域的空间利用率。

fix #4703 

pre:
![image](https://github.com/user-attachments/assets/4bcff070-a651-4d03-a0df-c5c550cb97ff)
after:
![image](https://github.com/user-attachments/assets/ab1f730e-3494-4781-9817-599257e6e2b6)
