### PR TITLE
fix(UI): Correct citation tooltip style in light theme

### DIFF
--- a/src/renderer/src/pages/home/Markdown/CitationTooltip.tsx
+++ b/src/renderer/src/pages/home/Markdown/CitationTooltip.tsx
@@ -38,6 +38,8 @@ const CitationTooltip: React.FC<CitationTooltipProps> = ({ children, citation })
       placement="top"
       arrow={false}
       overlayInnerStyle={{
+        backgroundColor: 'var(--color-background-mute)',
+        border: '1px solid var(--color-border)',
         padding: 0,
         borderRadius: '8px'
       }}>


### PR DESCRIPTION
#4667 
![image](https://github.com/user-attachments/assets/1a9e3f22-6cd5-4d29-b441-49b2322c471f)
![image](https://github.com/user-attachments/assets/1df45fa9-369f-4f20-bc7a-d0c361e76338)
