### PR TITLE
feat(model): add ModelCard schema and related types for input/output capabilities

### DIFF
--- a/src/renderer/src/types/model.ts
+++ b/src/renderer/src/types/model.ts
@@ -22,6 +22,7 @@ export const ModelCapability = z.enum([
   'reasoning',
   'streaming',
   'structuredOutput',
+  'textGeneration',
   'translation',
   'transcription',
   'toolUse',
@@ -121,7 +122,7 @@ export const ModelSchema = z
         return false
       }
 
-      // 如果模型有toolUse, Reasoning, streaming, cache, codeExecution, OCR, translation, transcription, webSearch, structuredOutput能力，则必须支持文字的输出
+      // 如果模型有toolUse, Reasoning, streaming, cache, codeExecution, OCR, textGeneration, translation, transcription, webSearch, structuredOutput能力，则必须支持文字的输出
       if (
         (data.capabilities.includes('toolUse') ||
           data.capabilities.includes('reasoning') ||
@@ -129,6 +130,7 @@ export const ModelSchema = z
           data.capabilities.includes('cache') ||
           data.capabilities.includes('codeExecution') ||
           data.capabilities.includes('OCR') ||
+          data.capabilities.includes('textGeneration') ||
           data.capabilities.includes('translation') ||
           data.capabilities.includes('transcription') ||
           data.capabilities.includes('webSearch') ||

--- a/src/renderer/src/types/model.ts
+++ b/src/renderer/src/types/model.ts
@@ -1,0 +1,216 @@
+import { z } from 'zod'
+
+export const InputType = z.enum(['text', 'image', 'audio', 'video', 'document'])
+export type InputType = z.infer<typeof InputType>
+
+export const OutputType = z.enum(['text', 'image', 'audio', 'video', 'vector'])
+export type OutputType = z.infer<typeof OutputType>
+
+export const OutputMode = z.enum(['sync', 'streaming'])
+export type OutputMode = z.infer<typeof OutputMode>
+
+export const ModelCapability = z.enum([
+  'audioGeneration',
+  'cache',
+  'codeExecution',
+  'embedding',
+  'fineTuning',
+  'imageGeneration',
+  'OCR',
+  'realTime',
+  'rerank',
+  'reasoning',
+  'streaming',
+  'structuredOutput',
+  'translation',
+  'transcription',
+  'toolUse',
+  'videoGeneration',
+  'webSearch'
+])
+export type ModelCapability = z.infer<typeof ModelCapability>
+
+export const ModelSchema = z
+  .object({
+    id: z.string(),
+    modelId: z.string(),
+    providerId: z.string(),
+    name: z.string(),
+    group: z.string(),
+    description: z.string().optional(),
+    owned_by: z.string().optional(),
+
+    supportedInputs: z.array(InputType),
+    supportedOutputs: z.array(OutputType),
+    supportedOutputModes: z.array(OutputMode),
+
+    limits: z.object({
+      inputTokenLimit: z.number().optional(),
+      outputTokenLimit: z.number().optional(),
+      contextWindow: z.number().optional()
+    }),
+
+    price: z.object({
+      inputTokenPrice: z.number().optional(),
+      outputTokenPrice: z.number().optional()
+    }),
+
+    capabilities: z.array(ModelCapability)
+  })
+  .refine(
+    (data) => {
+      // 如果模型支持streaming，则必须支持streamingOutputMode
+      if (data.capabilities.includes('streaming') && !data.supportedOutputModes.includes('streaming')) {
+        return false
+      }
+
+      // 如果模型有OCR能力，则必须支持图像输入类型或者文件输入类型
+      if (
+        data.capabilities.includes('OCR') &&
+        !data.supportedInputs.includes('image') &&
+        !data.supportedInputs.includes('document')
+      ) {
+        return false
+      }
+
+      // 如果模型有图像生成能力，则必须支持图像输出
+      if (data.capabilities.includes('imageGeneration') && !data.supportedOutputs.includes('image')) {
+        return false
+      }
+
+      // 如果有音频生成能力，则必须支持音频输出类型
+      if (data.capabilities.includes('audioGeneration') && !data.supportedOutputs.includes('audio')) {
+        return false
+      }
+
+      // 如果有音频识别能力，则必须支持音频输入类型
+      if (
+        (data.capabilities.includes('transcription') || data.capabilities.includes('translation')) &&
+        !data.supportedInputs.includes('audio')
+      ) {
+        return false
+      }
+
+      // 如果有视频生成能力，则必须支持视频输出类型
+      if (data.capabilities.includes('videoGeneration') && !data.supportedOutputs.includes('video')) {
+        return false
+      }
+
+      // 如果模型有embedding能力，则必须支持向量输出类型
+      if (data.capabilities.includes('embedding') && !data.supportedOutputs.includes('vector')) {
+        return false
+      }
+
+      // 如果模型有toolUse, Reasoning, streaming, cache, codeExecution, imageGeneration, audioGeneration, videoGeneration， webSearch能力，则必须支持文字的输入
+      if (
+        (data.capabilities.includes('toolUse') ||
+          data.capabilities.includes('reasoning') ||
+          data.capabilities.includes('streaming') ||
+          data.capabilities.includes('cache') ||
+          data.capabilities.includes('codeExecution') ||
+          data.capabilities.includes('imageGeneration') ||
+          data.capabilities.includes('audioGeneration') ||
+          data.capabilities.includes('videoGeneration') ||
+          data.capabilities.includes('webSearch')) &&
+        !data.supportedInputs.includes('text')
+      ) {
+        return false
+      }
+
+      // 如果模型有toolUse, Reasoning, streaming, cache, codeExecution, OCR, translation, transcription, webSearch, structuredOutput能力，则必须支持文字的输出
+      if (
+        (data.capabilities.includes('toolUse') ||
+          data.capabilities.includes('reasoning') ||
+          data.capabilities.includes('streaming') ||
+          data.capabilities.includes('cache') ||
+          data.capabilities.includes('codeExecution') ||
+          data.capabilities.includes('OCR') ||
+          data.capabilities.includes('translation') ||
+          data.capabilities.includes('transcription') ||
+          data.capabilities.includes('webSearch') ||
+          data.capabilities.includes('structuredOutput')) &&
+        !data.supportedOutputs.includes('text')
+      ) {
+        return false
+      }
+
+      return true
+    },
+    {
+      message: 'ModelCard has inconsistent capabilities and supported input/output type'
+    }
+  )
+
+export type ModelCard = z.infer<typeof ModelSchema>
+
+export function createModelCard(model: ModelCard): ModelCard {
+  return ModelSchema.parse(model)
+}
+
+export function supportesInputType(model: ModelCard, inputType: InputType) {
+  return model.supportedInputs.includes(inputType)
+}
+
+export function supportesOutputType(model: ModelCard, outputType: OutputType) {
+  return model.supportedOutputs.includes(outputType)
+}
+
+export function supportesOutputMode(model: ModelCard, outputMode: OutputMode) {
+  return model.supportedOutputModes.includes(outputMode)
+}
+
+export function supportesCapability(model: ModelCard, capability: ModelCapability) {
+  return model.capabilities.includes(capability)
+}
+
+export function isVisionModel(model: ModelCard) {
+  return supportesInputType(model, 'image')
+}
+
+export function isImageGenerationModel(model: ModelCard) {
+  return isVisionModel(model) && supportesCapability(model, 'imageGeneration')
+}
+
+export function isAudioModel(model: ModelCard) {
+  return supportesInputType(model, 'audio')
+}
+
+export function isAudioGenerationModel(model: ModelCard) {
+  return supportesCapability(model, 'audioGeneration')
+}
+
+export function isVideoModel(model: ModelCard) {
+  return supportesInputType(model, 'video')
+}
+
+export function isEmbedModel(model: ModelCard) {
+  return supportesOutputType(model, 'vector') && supportesCapability(model, 'embedding')
+}
+
+export function isTextEmbeddingModel(model: ModelCard) {
+  return isEmbedModel(model) && supportesInputType(model, 'text') && model.supportedInputs.length === 1
+}
+
+export function isMultiModalEmbeddingModel(model: ModelCard) {
+  return isEmbedModel(model) && model.supportedInputs.length > 1
+}
+
+export function isRerankModel(model: ModelCard) {
+  return supportesCapability(model, 'rerank')
+}
+
+export function isReasoningModel(model: ModelCard) {
+  return supportesCapability(model, 'reasoning')
+}
+
+export function isToolUseModel(model: ModelCard) {
+  return supportesCapability(model, 'toolUse')
+}
+
+export function isOnlyStreamingModel(model: ModelCard) {
+  return (
+    supportesCapability(model, 'streaming') &&
+    supportesOutputMode(model, 'streaming') &&
+    model.supportedOutputModes.length === 1
+  )
+}

--- a/src/renderer/src/types/model.ts
+++ b/src/renderer/src/types/model.ts
@@ -44,16 +44,20 @@ export const ModelSchema = z
     supportedOutputs: z.array(OutputType),
     supportedOutputModes: z.array(OutputMode),
 
-    limits: z.object({
-      inputTokenLimit: z.number().optional(),
-      outputTokenLimit: z.number().optional(),
-      contextWindow: z.number().optional()
-    }),
+    limits: z
+      .object({
+        inputTokenLimit: z.number().optional(),
+        outputTokenLimit: z.number().optional(),
+        contextWindow: z.number().optional()
+      })
+      .optional(),
 
-    price: z.object({
-      inputTokenPrice: z.number().optional(),
-      outputTokenPrice: z.number().optional()
-    }),
+    price: z
+      .object({
+        inputTokenPrice: z.number().optional(),
+        outputTokenPrice: z.number().optional()
+      })
+      .optional(),
 
     capabilities: z.array(ModelCapability)
   })


### PR DESCRIPTION
# Copilot

model.ts 定义了关于模型能力（`ModelCapability`）和模型架构（`ModelSchema`）的类型和校验规则。

### 文件的作用：
1. **定义模型能力（ModelCapability）：**
   - 使用 `z.enum` 定义了一组模型支持的特定功能（如：`reasoning`, `streaming`, `textGeneration` 等）。
   - 这些能力用于表示模型的功能范围，比如是否支持文本生成、翻译或工具使用等。

2. **定义模型架构（ModelSchema）：**
   - 使用 `z`（可能是 [Zod](https://github.com/colinhacks/zod) 库）定义了模型的校验逻辑。
   - 通过校验逻辑限制模型必须满足的条件。例如：
     - 如果模型具有某些特定的能力（如 `toolUse`, `reasoning`, `textGeneration` 等），则模型必须支持文字输出。

### 文件的具体改动：
1. 添加了一个新的模型能力：`textGeneration`（文本生成）。
2. 更新了校验规则，将 `textGeneration` 包含在必须支持文字输出的能力列表中。

### 文件的作用总结：
这个文件主要用于：
- 定义模型的功能能力集合。
- 提供模型数据的校验规则，确保模型配置符合预期的功能逻辑。
- 在整个项目中，可能用于描述和校验不同模型的功能能力及其行为约束。