### PR TITLE
Fix(MCPService): 修复 getSystemPath 因硬编码 Shell 路径导致的兼容性问题

### DIFF
--- a/src/main/services/MCPService.ts
+++ b/src/main/services/MCPService.ts
@@ -514,15 +514,12 @@ class McpService {
 
         // 根据不同的 shell 构建不同的命令
         if (userShell.includes('zsh')) {
-          shell = '/bin/zsh'
           command =
             'source /etc/zshenv 2>/dev/null || true; source ~/.zshenv 2>/dev/null || true; source /etc/zprofile 2>/dev/null || true; source ~/.zprofile 2>/dev/null || true; source /etc/zshrc 2>/dev/null || true; source ~/.zshrc 2>/dev/null || true; source /etc/zlogin 2>/dev/null || true; source ~/.zlogin 2>/dev/null || true; echo $PATH'
         } else if (userShell.includes('bash')) {
-          shell = '/bin/bash'
           command =
             'source /etc/profile 2>/dev/null || true; source ~/.bash_profile 2>/dev/null || true; source ~/.bash_login 2>/dev/null || true; source ~/.profile 2>/dev/null || true; source ~/.bashrc 2>/dev/null || true; echo $PATH'
         } else if (userShell.includes('fish')) {
-          shell = '/bin/fish'
           command =
             'source /etc/fish/config.fish 2>/dev/null || true; source ~/.config/fish/config.fish 2>/dev/null || true; source ~/.config/fish/config.local.fish 2>/dev/null || true; echo $PATH'
         } else {


### PR DESCRIPTION
## 问题:
MCPService 中的 getSystemPath 函数在获取系统 PATH 环境变量时，如果 process.env.SHELL 未设置，会依赖硬编码的 Shell 路径（例如 /bin/zsh, /bin/bash, /bin/fish）。这在某些系统（如 NixOS）上，用户的 Shell 可能安装在非标准位置，导致无法正确找到 Shell 可执行文件，进而无法获取正确的 PATH。

## 解决方案:
本次修改调整了 getSystemPath 函数在非 Windows 系统上确定 Shell 的逻辑：

优先使用 process.env.SHELL: 首先检查 process.env.SHELL 环境变量。如果该变量已设置且指向一个有效的 Shell，则直接使用该 Shell 路径。这是获取用户首选 Shell 的标准方式。
保留硬编码路径作为后备: 仅在 process.env.SHELL 未设置或无效时，才回退到原有的逻辑，即检查 /bin/zsh, /bin/bash, /bin/fish, /bin/sh 是否存在，并使用找到的第一个。

