### PR TITLE
fix: MCP服务器添加server-filesystem时填写参数后启用时报错

### DIFF
--- a/src/renderer/src/pages/settings/MCPSettings/McpSettings.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/McpSettings.tsx
@@ -324,6 +324,12 @@ const McpSettings: React.FC<Props> = ({ server }) => {
   }
 
   const onToggleActive = async (active: boolean) => {
+
+    if (isFormChanged && active) {
+      await onSave()
+      return
+    }
+
     await form.validateFields()
     setLoadingServer(server.id)
     const oldActiveState = server.isActive


### PR DESCRIPTION

以下步骤可复现bug
<img width="1286" alt="image" src="https://github.com/user-attachments/assets/ee0565d1-1e61-40fd-a96c-694d2438ab37" />
<img width="1234" alt="image" src="https://github.com/user-attachments/assets/b21486a0-844e-47b0-8eb1-b37687143aea" />
<img width="1297" alt="image" src="https://github.com/user-attachments/assets/54db7fe4-7c98-4cb7-99d2-2c2d8c593c1e" />
修复思路：在启用函数onToggleActive判断是否更改表单，调用onSave其中逻辑也包含启用，避免报错
