### PR TITLE
fix: 快捷助手发起询问后没有清理掉输入框内的内容

### DIFF
--- a/src/renderer/src/windows/mini/home/HomeWindow.tsx
+++ b/src/renderer/src/windows/mini/home/HomeWindow.tsx
@@ -93,6 +93,7 @@ const HomeWindow: FC = () => {
           if (content) {
             if (route === 'home') {
               featureMenusRef.current?.useFeature()
+              setText('') // 清空输入框
             } else {
               // 目前文本框只在'chat'时可以继续输入，这里相当于 route === 'chat'
               setRoute('chat')


### PR DESCRIPTION
以下步骤可以重现该Bug
1.Ctrl + E启动快捷助手
随便输入一个问题
![image](https://github.com/user-attachments/assets/8b038c85-dc3a-47be-a0c8-043d908fda0a)
按Enter发送
![image](https://github.com/user-attachments/assets/f4bf5c69-89f6-4881-93f7-72fcfa461c54)
成功响应但是Input内的文字没有清除
