### PR TITLE
fix: 快捷助手发起询问后没有清理掉输入框内的内容

### DIFF
--- a/src/renderer/src/windows/mini/home/HomeWindow.tsx
+++ b/src/renderer/src/windows/mini/home/HomeWindow.tsx
@@ -93,6 +93,7 @@ const HomeWindow: FC = () => {
           if (content) {
             if (route === 'home') {
               featureMenusRef.current?.useFeature()
+              setText('') // 清空输入框
             } else {
               // 目前文本框只在'chat'时可以继续输入，这里相当于 route === 'chat'
               setRoute('chat')

--- a/src/renderer/src/windows/mini/home/HomeWindow.tsx
+++ b/src/renderer/src/windows/mini/home/HomeWindow.tsx
@@ -93,13 +93,11 @@ const HomeWindow: FC = () => {
           if (content) {
             if (route === 'home') {
               featureMenusRef.current?.useFeature()
-              setText('') // 清空输入框
             } else {
               // 目前文本框只在'chat'时可以继续输入，这里相当于 route === 'chat'
               setRoute('chat')
               onSendMessage().then()
               focusInput()
-              setTimeout(() => setText(''), 100)
             }
           }
         }
@@ -162,6 +160,7 @@ const HomeWindow: FC = () => {
         }
         EventEmitter.emit(EVENT_NAMES.SEND_MESSAGE, message)
         setIsFirstMessage(false)
+        setText('') // ✅ 清除输入框内容
       }, 0)
     },
     [content, defaultAssistant.id, defaultAssistant.topics]


### PR DESCRIPTION
根据以下步骤重现BUG
1.快捷键(Ctrl + E)启动快捷助手
随便输入什么问题
![433786501-8b038c85-dc3a-47be-a0c8-043d908fda0a](https://github.com/user-attachments/assets/eb7a3492-b367-4aae-a09b-5f99fe6d84b7)
2.按下Enter键
可以发现Input内的内容没有被清理，只有再次Enter才会被清理
![433786711-f4bf5c69-89f6-4881-93f7-72fcfa461c54](https://github.com/user-attachments/assets/47ef1b15-244d-422a-884f-c24d08baf34b)
