### PR TITLE
fix(AssistantSettings): disable transitionName to resolve modal closing issues in production

### DIFF
--- a/src/renderer/src/pages/settings/AssistantSettings/index.tsx
+++ b/src/renderer/src/pages/settings/AssistantSettings/index.tsx
@@ -85,7 +85,28 @@ const AssistantSettingPopupContainer: React.FC<Props> = ({ resolve, tab, ...prop
       afterClose={afterClose}
       footer={null}
       title={assistant.name}
-      transitionName="ant-move-down"
+      /*******************************************
+       * IMPORTANT: The Comment of transitionName is because:
+       *
+       * When in the production mode,
+       * if some of the antd components(like Select or not showing the assistant tab) not loaded beforehand,
+       * the modal will not close properly when using unofficially transitionName(like ant-move-down).
+       *
+       * The resason may be that the antd CSS-in-JS is not loaded the unofficially ant-xxx-xxx motions,
+       * this will cause the modal close process being interrupted.
+       * see antd issue for more details: https://github.com/ant-design/ant-design/issues/29626
+       *
+       * The deeper reason may be that the css/js chunking handle method is different between dev and prod envs
+       * If we want to solve the problem completely, we need to refactor the antd someway.
+       *
+       * The temporary solution is:
+       * 1. not set transitionName (transitionName is no longer supported in antd 5+)
+       * 2. set timeout to execute the modal resolve()
+       * 3. load the other complex antd components(like Select) beforehand
+       *
+       * we take the first solution for now.
+       */
+      // transitionName="ant-move-down"
       styles={{
         content: {
           padding: 0,


### PR DESCRIPTION
solve: #4817


***IMPORTANT***
 
When in the production mode,  if some of the antd components(like Select or not showing the assistant tab) not loaded beforehand, the modal will not close properly when using unofficially transitionName(like ant-move-down).

The resason may be that the antd CSS-in-JS is not loaded the unofficially ant-xxx-xxx motions, this will cause the modal close process being interrupted.  See [antd issue](https://github.com/ant-design/ant-design/issues/29626) for more details.

The deeper reason may be that the css/js chunking handle method is different between dev and prod envs.

If we want to solve the problem completely, we need to refactor the antd someway.

The temporary solution is:
1. Not set transitionName (transitionName is no longer supported in antd 5+)
2. Set timeout to execute the modal resolve()
3. Load the other complex antd components(like Select) beforehand

We take the first solution for now.
