### PR TITLE
fix: 快捷助手发起询问后没有清理掉输入框内的内容 

### DIFF
--- a/src/renderer/src/windows/mini/home/HomeWindow.tsx
+++ b/src/renderer/src/windows/mini/home/HomeWindow.tsx
@@ -93,6 +93,7 @@ const HomeWindow: FC = () => {
           if (content) {
             if (route === 'home') {
               featureMenusRef.current?.useFeature()
+              setText('') // 清空输入框
             } else {
               // 目前文本框只在'chat'时可以继续输入，这里相当于 route === 'chat'
               setRoute('chat')

--- a/src/renderer/src/windows/mini/home/HomeWindow.tsx
+++ b/src/renderer/src/windows/mini/home/HomeWindow.tsx
@@ -93,13 +93,11 @@ const HomeWindow: FC = () => {
           if (content) {
             if (route === 'home') {
               featureMenusRef.current?.useFeature()
-              setText('') // 清空输入框
             } else {
               // 目前文本框只在'chat'时可以继续输入，这里相当于 route === 'chat'
               setRoute('chat')
               onSendMessage().then()
               focusInput()
-              setTimeout(() => setText(''), 100)
             }
           }
         }
@@ -162,6 +160,7 @@ const HomeWindow: FC = () => {
         }
         EventEmitter.emit(EVENT_NAMES.SEND_MESSAGE, message)
         setIsFirstMessage(false)
+        setText('') // ✅ 清除输入框内容
       }, 0)
     },
     [content, defaultAssistant.id, defaultAssistant.topics]


### PR DESCRIPTION
根据以下步骤重现BUG
1.快捷键(Ctrl + E)启动快捷助手
随便输入什么问题
![image](https://github.com/user-attachments/assets/a3823676-1537-408e-abff-f92209c61617)
2.按下Enter键
可以发现Input内的内容没有被清理，只有再次Enter才会被清理
![image](https://github.com/user-attachments/assets/32022544-0a7c-4a4e-a021-963839dc317b)