### PR TITLE
fix: mcp search field redundancy

### DIFF
--- a/src/renderer/src/pages/settings/MCPSettings/NpxSearch.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/NpxSearch.tsx
@@ -209,8 +209,7 @@ const NpxSearch: FC<{
                           args: record.configSample?.args ?? ['-y', record.fullName],
                           env: record.configSample?.env,
                           isActive: false,
-                          type: record.type,
-                          configSample: record.configSample
+                          type: record.type
                         }
 
                         addMCPServer(newServer)


### PR DESCRIPTION
删除mcp配置冗余的configSample字段，消除对mcp JSON配置的影响
![WX20250416-100651@2x](https://github.com/user-attachments/assets/6bacf393-7bf0-4994-8196-561e16712b93)
