### PR TITLE
修复快捷助手在提问后禁用输入框

### DIFF
--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -52,6 +52,8 @@ export async function fetchChatCompletion({
   const webSearchProvider = WebSearchService.getWebSearchProvider()
   const AI = new AiProvider(provider)
 
+  store.dispatch(setGenerating(true))
+
   const searchTheWeb = async () => {
     if (WebSearchService.isWebSearchEnabled() && assistant.enableWebSearch && assistant.model) {
       let query = ''

--- a/src/renderer/src/windows/mini/home/HomeWindow.tsx
+++ b/src/renderer/src/windows/mini/home/HomeWindow.tsx
@@ -13,6 +13,8 @@ import React, { FC, useCallback, useEffect, useRef, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
+import store from '@renderer/store'
+import { setGenerating } from '@renderer/store/runtime'
 
 import ChatWindow from '../chat/ChatWindow'
 import TranslateWindow from '../translate/TranslateWindow'
@@ -177,6 +179,7 @@ const HomeWindow: FC = () => {
     if (route === 'home') {
       onCloseWindow()
     } else {
+      store.dispatch(setGenerating(false))
       setRoute('home')
       setText('')
     }


### PR DESCRIPTION
[https://github.com/CherryHQ/cherry-studio/issues/4876]
根据此问题进行了修复。
原因在于向ai发送消息之后未更改runtime中generating的状态，导致可继续发送消息。
解决：
修改ApiService.ts
结果(图片是手机拍的，截图无法截进去鼠标禁用符)：
![1](https://github.com/user-attachments/assets/640b6d60-00b0-4cd3-bb53-fc64644cea39)

衍生问题：
修复了上个问题后，当我在ai正在回复消息的时候按esc返回快捷助手主页面，发现输入框被禁用。
(图片是手机拍的，截图无法截进去鼠标禁用符)
![2](https://github.com/user-attachments/assets/515de92f-e61f-41ec-b058-fbfcd13f8c23)

原因：
应该是由于ai返回的消息还未处理完成，generating状态还没有被更改未false，导致输入框被禁用。
解决：
修改HomeWindow.tsx 添加修改generating状态
