### PR TITLE
fix(obsidian): update title update logic

### DIFF
--- a/src/renderer/src/components/ObsidianExportDialog.tsx
+++ b/src/renderer/src/components/ObsidianExportDialog.tsx
@@ -131,6 +131,8 @@ const ObsidianExportDialog: React.FC<ObsidianExportDialogProps> = ({
     folder: ''
   })
 
+  // 是否手动编辑过标题
+  const [hasTitleBeenManuallyEdited, setHasTitleBeenManuallyEdited] = useState(false)
   const [vaults, setVaults] = useState<Array<{ path: string; name: string }>>([])
   const [files, setFiles] = useState<FileInfo[]>([])
   const [fileTreeData, setFileTreeData] = useState<any[]>([])
@@ -255,6 +257,12 @@ const ObsidianExportDialog: React.FC<ObsidianExportDialogProps> = ({
     setState((prevState) => ({ ...prevState, [key]: value }))
   }
 
+  // 处理title输入变化
+  const handleTitleInputChange = (newTitle: string) => {
+    handleChange('title', newTitle)
+    setHasTitleBeenManuallyEdited(true)
+  }
+
   const handleVaultChange = (value: string) => {
     setSelectedVault(value)
     // 文件夹会通过useEffect自动获取
@@ -278,11 +286,17 @@ const ObsidianExportDialog: React.FC<ObsidianExportDialogProps> = ({
           const fileName = selectedFile.name
           const titleWithoutExt = fileName.endsWith('.md') ? fileName.substring(0, fileName.length - 3) : fileName
           handleChange('title', titleWithoutExt)
+          // 重置手动编辑标记，因为这是非用户设置的title
+          setHasTitleBeenManuallyEdited(false)
           handleChange('processingMethod', '1')
         } else {
           // 如果是文件夹，自动设置标题为话题名并设置处理方式为3(新建)
           handleChange('processingMethod', '3')
-          handleChange('title', title)
+          // 仅当用户未手动编辑过 title 时，才将其重置为 props.title
+          if (!hasTitleBeenManuallyEdited) {
+            // title 是 props.title
+            handleChange('title', title)
+          }
         }
       }
     }
@@ -309,7 +323,7 @@ const ObsidianExportDialog: React.FC<ObsidianExportDialogProps> = ({
         <Form.Item label={i18n.t('chat.topics.export.obsidian_title')}>
           <Input
             value={state.title}
-            onChange={(e) => handleChange('title', e.target.value)}
+            onChange={(e) => handleTitleInputChange(e.target.value)}
             placeholder={i18n.t('chat.topics.export.obsidian_title_placeholder')}
           />
         </Form.Item>


### PR DESCRIPTION
Fix [[错误]: 导出到Obsidian时，选择路径会导致标题栏重置](https://github.com/CherryHQ/cherry-studio/issues/4998)
## 改动点
- 新增是否手动编辑状态 hasTitleBeenManuallyEdited，用户输入时设为 true，系统更新标题（选择了已有 markdown文件，使用该文件的名称作为 title）时设为 false
- **关键改动点**：当用户手动编辑过时，选择文件夹时，使用已编辑过的 title；否则保持现有逻辑
