### PR TITLE
 feat: support escaping the comma character in the API key.

### DIFF
--- a/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
@@ -206,8 +206,9 @@ const ProviderSetting: FC<Props> = ({ provider: _provider }) => {
 
     if (apiKey.includes(',')) {
       const keys = apiKey
-        .split(',')
+        .split(/(?<!\\),/)
         .map((k) => k.trim())
+        .map(k => k.replace(/\\,/g, ','))
         .filter((k) => k)
 
       const result = await ApiCheckPopup.show({


### PR DESCRIPTION
Solve: #5068
Some special API key may contains the comma, like #5068.

**Feature:**
Add the feature to escape the comma character in the API key. If user's API key contains comma, they can use escaped comma, like `foo\,bar`, then the API key won't be split into two keys.

**Testing:**
The pure comma `,` can split keys, while the escaped comma `\,` is ignored by split and then converted to the original comma when it's used.
![image|600](https://github.com/user-attachments/assets/469fe2a1-8c2a-4351-83af-5b41aa718f2f)

