### PR TITLE
fix(AxiosProxy): windows系统设置为socks5代理问题

### DIFF
--- a/src/main/services/AxiosProxy.ts
+++ b/src/main/services/AxiosProxy.ts
@@ -1,25 +1,27 @@
 import { AxiosInstance, default as axios_ } from 'axios'
+import { ProxyAgent } from 'proxy-agent'
 
 import { proxyManager } from './ProxyManager'
 
 class AxiosProxy {
-  private cacheAxios: AxiosInstance | undefined
-  private proxyURL: string | undefined
+  private cacheAxios: AxiosInstance | null = null
+  private proxyAgent: ProxyAgent | null = null
 
   get axios(): AxiosInstance {
-    const currentProxyURL = proxyManager.getProxyUrl()
-    if (this.proxyURL !== currentProxyURL) {
-      this.proxyURL = currentProxyURL
-      const agent = proxyManager.getProxyAgent()
+    const currentProxyAgent = proxyManager.getProxyAgent()
+
+    // 如果代理发生变化或尚未初始化，则重新创建 axios 实例
+    if (this.cacheAxios === null || (currentProxyAgent !== null && this.proxyAgent !== currentProxyAgent)) {
+      this.proxyAgent = currentProxyAgent
+
+      // 创建带有代理配置的 axios 实例
       this.cacheAxios = axios_.create({
         proxy: false,
-        ...(agent && { httpAgent: agent, httpsAgent: agent })
+        httpAgent: currentProxyAgent || undefined,
+        httpsAgent: currentProxyAgent || undefined
       })
     }
 
-    if (this.cacheAxios === undefined) {
-      this.cacheAxios = axios_.create({ proxy: false })
-    }
     return this.cacheAxios
   }
 }


### PR DESCRIPTION
如果windows系统代理设置为socks5代理，或者macOS上面只设置socks5代理，目前github copilot也是登录不了的。


![image](https://github.com/user-attachments/assets/6f9fa895-08e6-4ac1-8ee4-1a19f1c6ac12)


解决方法：不是用proxyURL来判断，直接使用proxy agent来判断。因为如果是system proxy, proxyURL是空的，proxy agent是有值的，所以可以设置。