### PR TITLE
chore(electron-builder): add StartupWMClass for CherryStudio in liunx desktop configuration

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -74,6 +74,8 @@ linux:
     - target: AppImage
   maintainer: electronjs.org
   category: Utility
+  desktop:
+    StartupWMClass: CherryStudio
 publish:
   provider: generic
   url: https://releases.cherry-ai.com


### PR DESCRIPTION
- fix #2483 
- fix #5148 