### PR TITLE
fix: purify minapp user agent tag

### DIFF
--- a/src/renderer/src/components/MinApp/WebviewContainer.tsx
+++ b/src/renderer/src/components/MinApp/WebviewContainer.tsx
@@ -60,6 +60,9 @@ const WebviewContainer = memo(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [appid, url])
 
+    //remove the tag of CherryStudio and Electron
+    const userAgent = navigator.userAgent.replace(/CherryStudio\/\S+\s/, '').replace(/Electron\/\S+\s/, '')
+
     return (
       <webview
         key={appid}
@@ -67,6 +70,7 @@ const WebviewContainer = memo(
         style={WebviewStyle}
         allowpopups={'true' as any}
         partition="persist:webview"
+        useragent={userAgent}
       />
     )
   }


### PR DESCRIPTION
remove CherryStudio and Electron tag from MinApp webview useragent.
This is a try to avoid Google/OpenAI detecting unsafe browser env.