### PR TITLE
feat(auto-update): improve auto-update toggle functionality

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -102,6 +102,7 @@ export function registerIpc(mainWindow: BrowserWindow, app: Electron.App) {
 
   // auto update
   ipcMain.handle(IpcChannel.App_SetAutoUpdate, (_, isActive: boolean) => {
+    appUpdater.setAutoUpdate(isActive)
     configManager.setAutoUpdate(isActive)
   })
 

--- a/src/main/services/AppUpdater.ts
+++ b/src/main/services/AppUpdater.ts
@@ -55,6 +55,11 @@ export default class AppUpdater {
     this.autoUpdater = autoUpdater
   }
 
+  public setAutoUpdate(isActive: boolean) {
+    autoUpdater.autoDownload = isActive
+    autoUpdater.autoInstallOnAppQuit = isActive
+  }
+
   public async showUpdateDialog(mainWindow: BrowserWindow) {
     if (!this.releaseInfo) {
       return

--- a/src/renderer/src/pages/settings/AboutSettings.tsx
+++ b/src/renderer/src/pages/settings/AboutSettings.tsx
@@ -160,7 +160,7 @@ const AboutSettings: FC = () => {
           <Switch value={autoCheckUpdate} onChange={(v) => setAutoCheckUpdate(v)} />
         </SettingRow>
       </SettingGroup>
-      {hasNewVersion && update.info && autoCheckUpdate && (
+      {autoCheckUpdate && hasNewVersion && update.info && (
         <SettingGroup theme={theme}>
           <SettingRow>
             <SettingRowTitle>

--- a/src/renderer/src/pages/settings/AboutSettings.tsx
+++ b/src/renderer/src/pages/settings/AboutSettings.tsx
@@ -160,7 +160,7 @@ const AboutSettings: FC = () => {
           <Switch value={autoCheckUpdate} onChange={(v) => setAutoCheckUpdate(v)} />
         </SettingRow>
       </SettingGroup>
-      {hasNewVersion && update.info && (
+      {hasNewVersion && update.info && autoCheckUpdate && (
         <SettingGroup theme={theme}>
           <SettingRow>
             <SettingRowTitle>


### PR DESCRIPTION
1. 在关闭auto update后，需要更新electron updater的配置，要不然如果在关闭之前已经下载了新版本的话，app quit后会自动升级，再打开就是新版本，用户会比较困惑，为什么关闭了，还升级了。
2. 关闭auto update了，即使有下载了新版本，建议也是不要显示出新版本的信息。