### PR TITLE
fix(proxy): update os-proxy-config patch to correct proxy URL handling

### DIFF
--- a/.yarn/patches/os-proxy-config-npm-1.1.1-af9c7574cc.patch
+++ b/.yarn/patches/os-proxy-config-npm-1.1.1-af9c7574cc.patch
@@ -1,0 +1,32 @@
+diff --git a/dist/index.js b/dist/index.js
+index 663919ac5bb4f9147c5c1b09bd2e379586266a4b..88ff8873ac5beb5eb293f7e741a92fb15b00960c 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -20,21 +20,21 @@ function getSystemProxy() {
+         else if (process.platform === 'darwin') {
+             const proxySettings = yield mac_system_proxy_1.getMacSystemProxy();
+             const noProxy = proxySettings.ExceptionsList || [];
+-            if (proxySettings.HTTPSEnable && proxySettings.HTTPSProxy && proxySettings.HTTPSPort) {
++            if (proxySettings.HTTPEnable && proxySettings.HTTPProxy && proxySettings.HTTPPort) {
+                 return {
+-                    proxyUrl: `https://${proxySettings.HTTPSProxy}:${proxySettings.HTTPSPort}`,
++                    proxyUrl: `http://${proxySettings.HTTPProxy}:${proxySettings.HTTPPort}`,
+                     noProxy
+                 };
+             }
+-            else if (proxySettings.HTTPEnable && proxySettings.HTTPProxy && proxySettings.HTTPPort) {
++            else if (proxySettings.SOCKSEnable && proxySettings.SOCKSProxy && proxySettings.SOCKSPort) {
+                 return {
+-                    proxyUrl: `http://${proxySettings.HTTPProxy}:${proxySettings.HTTPPort}`,
++                    proxyUrl: `socks://${proxySettings.SOCKSProxy}:${proxySettings.SOCKSPort}`,
+                     noProxy
+                 };
+             }
+-            else if (proxySettings.SOCKSEnable && proxySettings.SOCKSProxy && proxySettings.SOCKSPort) {
++            else if (proxySettings.HTTPSEnable && proxySettings.HTTPSProxy && proxySettings.HTTPSPort) {
+                 return {
+-                    proxyUrl: `socks://${proxySettings.SOCKSProxy}:${proxySettings.SOCKSPort}`,
++                    proxyUrl: `https://${proxySettings.HTTPSProxy}:${proxySettings.HTTPSPort}`,
+                     noProxy
+                 };
+             }

--- a/.yarn/patches/os-proxy-config-npm-1.1.1-af9c7574cc.patch
+++ b/.yarn/patches/os-proxy-config-npm-1.1.1-af9c7574cc.patch
@@ -26,7 +26,7 @@ index 663919ac5bb4f9147c5c1b09bd2e379586266a4b..88ff8873ac5beb5eb293f7e741a92fb1
 +            else if (proxySettings.HTTPSEnable && proxySettings.HTTPSProxy && proxySettings.HTTPSPort) {
                  return {
 -                    proxyUrl: `socks://${proxySettings.SOCKSProxy}:${proxySettings.SOCKSPort}`,
-+                    proxyUrl: `https://${proxySettings.HTTPSProxy}:${proxySettings.HTTPSPort}`,
++                    proxyUrl: `http://${proxySettings.HTTPSProxy}:${proxySettings.HTTPSPort}`,
                      noProxy
                  };
              }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "jsdom": "^26.0.0",
     "markdown-it": "^14.1.0",
     "officeparser": "^4.1.1",
-    "os-proxy-config": "^1.1.1",
+    "os-proxy-config": "patch:os-proxy-config@npm%3A1.1.1#~/.yarn/patches/os-proxy-config-npm-1.1.1-af9c7574cc.patch",
     "proxy-agent": "^6.5.0",
     "tar": "^7.4.3",
     "turndown": "^7.2.0",


### PR DESCRIPTION
fix https://github.com/CherryHQ/cherry-studio/issues/5197.

目前os-proxy-config返回的macOS的代理是自己组装的，比如https代理存在，就直接返回https://127.0.0.1:12345, 但是真实的代理软件的https代理还是 https_proxy=http://127.0.0.1:6152, 导致先用ssl握手了，没有发送connect请求转成tcp直连。

macOS的代理是通过`scutil --proxy`, 输出如下, 没有具体说https代理用的https还是http协议，这个是macOS系统本身的缺陷。
```
<dictionary> {
  ExceptionsList : <array> {
    0 : 192.168.0.0/24
    1 : 10.0.0.0/8
    2 : 172.16.0.0/12
    3 : 127.0.0.1
    4 : localhost
    5 : *.local
  }
  ExcludeSimpleHostnames : 1
  FTPPassive : 1
  HTTPEnable : 1
  HTTPPort : 6152
  HTTPProxy : 127.0.0.1
  HTTPSEnable : 1
  HTTPSPort : 6152
  HTTPSProxy : 127.0.0.1
  ProxyAutoConfigEnable : 0
  ProxyAutoDiscoveryEnable : 0
  SOCKSEnable : 1
  SOCKSPort : 6153
  SOCKSProxy : 127.0.0.1
}
```

**How to Fix**
一般本地很少有https代理，http代理和socks代理更多，所以调整下顺序，将http代理放在第一位，将socks代理放在第二位，将https代理放在最后面，并且返回http://127.0.0.1:xxxx 类似的

上游的PR： https://github.com/httptoolkit/os-proxy-config/pull/1

**How to Test**
在macOS上面设置https代理，然后登录github copilot，看下能不能登录。


