### PR TITLE
fix: mcp sse no headers

### DIFF
--- a/src/main/services/MCPService.ts
+++ b/src/main/services/MCPService.ts
@@ -158,6 +158,9 @@ class McpService {
           return new StreamableHTTPClientTransport(new URL(server.baseUrl!), options)
         } else if (server.type === 'sse') {
           const options: SSEClientTransportOptions = {
+            eventSourceInit: {
+              fetch: (url, init) => fetch(url, { ...init, headers: server.headers || {} }),
+            },
             requestInit: {
               headers: server.headers || {}
             },


### PR DESCRIPTION

This pull request includes a small but important change to the `MCPService` class in `src/main/services/MCPService.ts`. The change adds an `eventSourceInit` property to the `SSEClientTransportOptions` configuration, allowing custom headers to be passed when initializing the `fetch` function for SSE connections.