### PR TITLE
feat(WindowService): add maximize functionality and disable electron-window-state maxmize

### DIFF
--- a/src/main/services/WindowService.ts
+++ b/src/main/services/WindowService.ts
@@ -41,7 +41,8 @@ export class WindowService {
     const mainWindowState = windowStateKeeper({
       defaultWidth: 1080,
       defaultHeight: 670,
-      fullScreen: false
+      fullScreen: false,
+      maximize: false
     })
 
     const theme = configManager.getTheme()
@@ -85,12 +86,24 @@ export class WindowService {
 
   private setupMainWindow(mainWindow: BrowserWindow, mainWindowState: any) {
     mainWindowState.manage(mainWindow)
-
+    
+    this.setupMaximize(mainWindow, mainWindowState.isMaximized)
     this.setupContextMenu(mainWindow)
     this.setupWindowEvents(mainWindow)
     this.setupWebContentsHandlers(mainWindow)
     this.setupWindowLifecycleEvents(mainWindow)
     this.loadMainWindowContent(mainWindow)
+  }
+
+  private setupMaximize(mainWindow: BrowserWindow, isMaximized: boolean) {
+    if (isMaximized) {
+      // 如果是从托盘启动，则需要延迟最大化，否则显示的就不是重启前的最大化窗口了
+      configManager.getLaunchToTray()
+        ? mainWindow.once('show', () => {
+            mainWindow.maximize()
+          })
+        : mainWindow.maximize()
+    }
   }
 
   private setupContextMenu(mainWindow: BrowserWindow) {
@@ -255,40 +268,6 @@ export class WindowService {
 
   private setupWindowLifecycleEvents(mainWindow: BrowserWindow) {
     mainWindow.on('close', (event) => {
-      // 如果已经触发退出，直接退出
-      if (app.isQuitting) {
-        return app.quit()
-      }
-
-      // 托盘及关闭行为设置
-      const isShowTray = configManager.getTray()
-      const isTrayOnClose = configManager.getTrayOnClose()
-
-      // 没有开启托盘，或者开启了托盘，但设置了直接关闭，应执行直接退出
-      if (!isShowTray || (isShowTray && !isTrayOnClose)) {
-        // 如果是Windows或Linux，直接退出
-        // mac按照系统默认行为，不退出
-        if (isWin || isLinux) {
-          return app.quit()
-        }
-      }
-
-      /**
-       * 上述逻辑以下:
-       * win/linux: 是“开启托盘+设置关闭时最小化到托盘”的情况
-       * mac: 任何情况都会到这里，因此需要单独处理mac
-       */
-
-      event.preventDefault()
-
-      mainWindow.hide()
-
-      //for mac users, should hide dock icon if close to tray
-      if (isMac && isTrayOnClose) {
-        app.dock?.hide()
-      }
-    })
-
     mainWindow.on('closed', () => {
       this.mainWindow = null
     })

--- a/src/main/services/WindowService.ts
+++ b/src/main/services/WindowService.ts
@@ -301,6 +301,7 @@ export class WindowService {
         app.dock?.hide()
       }
     })
+
     mainWindow.on('closed', () => {
       this.mainWindow = null
     })


### PR DESCRIPTION
fix https://github.com/CherryHQ/cherry-studio/issues/5256.

https://github.com/mawie81/electron-window-state/blob/2701d9a0f90a44dc8dbf81430538ceb16c9ff27a/index.js#L133-L134

[electron-window-state](https://github.com/mawie81/electron-window-state) manage执行的时候会判断是最大化就会自动最大化，导致启动后show出来了。


**how to fix**

禁用[electron-window-state](https://github.com/mawie81/electron-window-state)的maxmize, 然后自己管理maxmize状态，如果launchToTray是false，则直接显示最大化，如果是true，就要监听一次show，这样用户再去点tray show出来的window也是最大化的。