### PR TITLE
fix #5127

### DIFF
--- a/src/renderer/src/components/TranslateButton.tsx
+++ b/src/renderer/src/components/TranslateButton.tsx
@@ -22,9 +22,12 @@ const TranslateButton: FC<Props> = ({ text, onTranslated, disabled, style, isLoa
   const { t } = useTranslation()
   const { translateModel } = useDefaultModel()
   const [isTranslating, setIsTranslating] = useState(false)
-  const { targetLanguage } = useSettings()
+  const { targetLanguage, showTranslateConfirm } = useSettings()
 
   const translateConfirm = () => {
+    if (!showTranslateConfirm) {
+      return Promise.resolve(true)
+    }
     return window?.modal?.confirm({
       title: t('translate.confirm.title'),
       content: t('translate.confirm.content'),

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -1044,6 +1044,7 @@
       "general.user_name.placeholder": "Enter your name",
       "general.view_webdav_settings": "View WebDAV settings",
       "input.auto_translate_with_space": "Quickly translate with 3 spaces",
+      "input.show_translate_confirm": "Show translation confirmation dialog",
       "input.target_language": "Target language",
       "input.target_language.chinese": "Simplified Chinese",
       "input.target_language.chinese-traditional": "Traditional Chinese",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -1044,6 +1044,7 @@
       "general.user_name.placeholder": "请输入用户名",
       "general.view_webdav_settings": "查看 WebDAV 设置",
       "input.auto_translate_with_space": "快速敲击3次空格翻译",
+      "input.show_translate_confirm": "显示翻译确认对话框",
       "input.target_language": "目标语言",
       "input.target_language.chinese": "简体中文",
       "input.target_language.chinese-traditional": "繁体中文",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -1043,6 +1043,7 @@
       "general.user_name.placeholder": "輸入您的名稱",
       "general.view_webdav_settings": "檢視 WebDAV 設定",
       "input.auto_translate_with_space": "快速敲擊 3 次空格翻譯",
+      "input.show_translate_confirm": "顯示翻譯確認對話框",
       "input.target_language": "目標語言",
       "input.target_language.chinese": "簡體中文",
       "input.target_language.chinese-traditional": "繁體中文",

--- a/src/renderer/src/pages/home/Tabs/SettingsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/SettingsTab.tsx
@@ -40,7 +40,8 @@ import {
   setRenderInputMessageAsMarkdown,
   setShowInputEstimatedTokens,
   setShowMessageDivider,
-  setThoughtAutoCollapse
+  setThoughtAutoCollapse,
+  setShowTranslateConfirm
 } from '@renderer/store/settings'
 import {
   Assistant,
@@ -100,7 +101,8 @@ const SettingsTab: FC<Props> = (props) => {
     thoughtAutoCollapse,
     messageNavigation,
     enableQuickPanelTriggers,
-    enableBackspaceDeleteModel
+    enableBackspaceDeleteModel,
+    showTranslateConfirm
   } = useSettings()
 
   const onUpdateAssistantSettings = (settings: Partial<AssistantSettings>) => {
@@ -609,6 +611,15 @@ const SettingsTab: FC<Props> = (props) => {
             <SettingDivider />
           </>
         )}
+        <SettingRow>
+          <SettingRowTitleSmall>{t('settings.input.show_translate_confirm')}</SettingRowTitleSmall>
+          <Switch
+            size="small"
+            checked={showTranslateConfirm}
+            onChange={(checked) => dispatch(setShowTranslateConfirm(checked))}
+          />
+        </SettingRow>
+        <SettingDivider />
         <SettingRow>
           <SettingRowTitleSmall>{t('settings.messages.input.enable_quick_triggers')}</SettingRowTitleSmall>
           <Switch

--- a/src/renderer/src/store/settings.ts
+++ b/src/renderer/src/store/settings.ts
@@ -75,6 +75,7 @@ export interface SettingsState {
   webdavMaxBackups: number
   translateModelPrompt: string
   autoTranslateWithSpace: boolean
+  showTranslateConfirm: boolean
   enableTopicNaming: boolean
   customCss: string
   topicNamingPrompt: string
@@ -180,6 +181,7 @@ export const initialState: SettingsState = {
   webdavMaxBackups: 0,
   translateModelPrompt: TRANSLATE_PROMPT,
   autoTranslateWithSpace: false,
+  showTranslateConfirm: true,
   enableTopicNaming: true,
   customCss: '',
   topicNamingPrompt: '',
@@ -384,6 +386,9 @@ const settingsSlice = createSlice({
     setAutoTranslateWithSpace: (state, action: PayloadAction<boolean>) => {
       state.autoTranslateWithSpace = action.payload
     },
+    setShowTranslateConfirm: (state, action: PayloadAction<boolean>) => {
+      state.showTranslateConfirm = action.payload
+    },
     setEnableTopicNaming: (state, action: PayloadAction<boolean>) => {
       state.enableTopicNaming = action.payload
     },
@@ -547,6 +552,7 @@ export const {
   setCodeStyle,
   setTranslateModelPrompt,
   setAutoTranslateWithSpace,
+  setShowTranslateConfirm,
   setEnableTopicNaming,
   setPasteLongTextThreshold,
   setCustomCss,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
- Users are always prompted with a confirmation dialog when translating text, with no option to disable this behavior.

After this PR:
- Added a new setting option "Show translation confirmation dialog" in the input settings section.
- Users can now choose to disable the confirmation dialog for translations.
- When disabled, translation happens immediately without showing the confirmation dialog.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

https://github.com/user-attachments/assets/e6425c4f-8e47-4200-a466-31b80ee4dad8



Fixes #

### Why we need it and why it was done in this way

The current implementation requires confirmation for every translation operation, which can be tedious for users who frequently use the translation feature. This PR gives users the flexibility to choose whether they want to see the confirmation dialog.

The following tradeoffs were made:
- Added a boolean setting (`showTranslateConfirm`) in the Redux store to track user preference.
- Modified the `TranslateButton` component to check this setting before showing the confirmation dialog.
- The default value is set to `true` to maintain the original behavior for existing users.

The following alternatives were considered:
- Adding a "Don't show again" checkbox in the confirmation dialog itself, but this would still require at least one confirmation before being disabled.
- Making the setting context-specific (e.g., different for different assistants), but this would add unnecessary complexity.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

The new setting follows the same pattern as other boolean settings in the application. I've added translations for the new setting label in Chinese (Simplified), Chinese (Traditional), and English.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required.

### Release note

release-note
Added a new setting option to disable the translation confirmation dialog for users who prefer immediate translation without confirmation.
