### PR TITLE
feat:add MrDoc export functionality add configuration

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -243,6 +243,7 @@
       "topics.unpinned": "Unpinned Topics",
       "translate": "Translate",
       "topics.export.siyuan": "Export to Siyuan Note",
+      "topics.export.mrdoc": "Export to MrDoc",
       "topics.export.wait_for_title_naming": "Generating title...",
       "topics.export.title_naming_success": "Title generated successfully",
       "topics.export.title_naming_failed": "Failed to generate title, using default title",
@@ -574,7 +575,11 @@
       "error.siyuan.no_config": "Siyuan Note API address or token is not configured",
       "success.siyuan.export": "Successfully exported to Siyuan Note",
       "warn.yuque.exporting": "Exporting to Yuque, please do not request export repeatedly!",
-      "warn.siyuan.exporting": "Exporting to Siyuan Note, please do not request export repeatedly!"
+      "warn.siyuan.exporting": "Exporting to Siyuan Note, please do not request export repeatedly!",
+      "error.mrdoc.export": "Failed to export to MrDoc, please check connection status and configuration according to documentation",
+      "error.mrdoc.no_config": "MrDoc address or token is not configured",
+      "success.mrdoc.export": "Successfully exported to MrDoc",
+      "warn.mrdoc.exporting": "Exporting to MrDoc, please do not request export repeatedly!"
     },
     "minapp": {
       "popup": {
@@ -828,6 +833,7 @@
           "yuque": "Export to Yuque",
           "obsidian": "Export to Obsidian",
           "siyuan": "Export to SiYuan Note",
+          "mrdoc": "Export to MrDoc",
           "joplin": "Export to Joplin",
           "docx": "Export as Word"
         },
@@ -969,6 +975,24 @@
             "success": "Connection successful",
             "fail": "Connection failed, please check API address and token",
             "error": "Connection error, please check network connection"
+          }
+        },
+        "mrdoc": {
+          "title": "MrDoc Configuration",
+          "api_url": "API URL",
+          "api_url_placeholder": "e.g., http://doc.mrdoc.pro",
+          "token": "User Token",
+          "token.help": "Obtain from User Center -> Personal Management -> Token Management",
+          "token_placeholder": "Please enter your MrDoc user token",
+          "box_id": "Project ID",
+          "box_id_placeholder": "Please enter the project ID",
+          "check": {
+            "title": "Connection Check",
+            "button": "Check",
+            "empty_config": "Please fill in the API URL and token",
+            "success": "Connection successful",
+            "fail": "Connection failed, please check the API URL and token",
+            "error": "Connection error, please check your network connection"
           }
         },
         "nutstore": {

--- a/src/renderer/src/i18n/locales/ja-jp.json
+++ b/src/renderer/src/i18n/locales/ja-jp.json
@@ -243,6 +243,7 @@
       "topics.unpinned": "固定解除",
       "translate": "翻訳",
       "topics.export.siyuan": "思源笔记にエクスポート",
+      "topics.export.mrdoc": "觅思文档にエクスポート",
       "topics.export.wait_for_title_naming": "タイトルを生成中...",
       "topics.export.title_naming_success": "タイトルの生成に成功しました",
       "topics.export.title_naming_failed": "タイトルの生成に失敗しました。デフォルトのタイトルを使用します",
@@ -574,7 +575,11 @@
       "success.siyuan.export": "思源ノートへのエクスポートに成功しました",
       "warn.yuque.exporting": "語雀にエクスポート中です。重複してエクスポートしないでください!",
       "warn.siyuan.exporting": "思源ノートにエクスポート中です。重複してエクスポートしないでください!",
-      "error.yuque.no_config": "語雀のAPIアドレスまたはトークンが設定されていません"
+      "error.yuque.no_config": "語雀のAPIアドレスまたはトークンが設定されていません",
+      "error.mrdoc.export": "MrDocへのエクスポートに失敗しました。接続状態を確認し、ドキュメントに従って設定を確認してください",
+      "error.mrdoc.no_config": "MrDoc API URLまたはトークンが設定されていません",
+      "success.mrdoc.export": "MrDocへのエクスポートが成功しました",
+      "warn.mrdoc.exporting": "MrDocへのエクスポート処理中です。重複してエクスポートリクエストを送信しないでください!"
     },
     "minapp": {
       "popup": {
@@ -828,6 +833,7 @@
           "yuque": "語雀にエクスポート",
           "obsidian": "Obsidianにエクスポート",
           "siyuan": "思源ノートにエクスポート",
+          "mrdoc": "MrDocにエクスポート",
           "joplin": "Joplinにエクスポート",
           "docx": "Wordとしてエクスポート"
         },
@@ -969,6 +975,24 @@
             "success": "接続成功",
             "fail": "接続失敗、APIアドレスとトークンを確認してください",
             "error": "接続エラー、ネットワーク接続を確認してください"
+          }
+        },
+        "mrdoc": {
+          "title": "MrDoc設定",
+          "api_url": "API URL",
+          "api_url_placeholder": "例：http://doc.mrdoc.pro",
+          "token": "ユーザートークン",
+          "token.help": "ユーザーセンター -> 個人管理 -> トークン管理で取得",
+          "token_placeholder": "MrDocのユーザートークンを入力してください",
+          "box_id": "プロジェクトID",
+          "box_id_placeholder": "プロジェクトIDを入力してください",
+          "check": {
+            "title": "接続チェック",
+            "button": "チェック",
+            "empty_config": "API URLとトークンを入力してください",
+            "success": "接続成功",
+            "fail": "接続失敗、API URLとトークンを確認してください",
+            "error": "接続異常、ネットワーク接続を確認してください"
           }
         },
         "nutstore": {

--- a/src/renderer/src/i18n/locales/ru-ru.json
+++ b/src/renderer/src/i18n/locales/ru-ru.json
@@ -243,6 +243,7 @@
       "topics.unpinned": "Открепленные темы",
       "translate": "Перевести",
       "topics.export.siyuan": "Экспорт в Siyuan Note",
+      "topics.export.mrdoc": "Экспорт в MrDoc",
       "topics.export.wait_for_title_naming": "Создание заголовка...",
       "topics.export.title_naming_success": "Заголовок успешно создан",
       "topics.export.title_naming_failed": "Не удалось создать заголовок, используется заголовок по умолчанию",
@@ -574,7 +575,11 @@
       "error.siyuan.no_config": "Не настроен API адрес или токен Siyuan",
       "success.siyuan.export": "Успешный экспорт в Siyuan",
       "warn.yuque.exporting": "Экспортируется в Yuque, пожалуйста, не отправляйте повторные запросы!",
-      "warn.siyuan.exporting": "Экспортируется в Siyuan, пожалуйста, не отправляйте повторные запросы!"
+      "warn.siyuan.exporting": "Экспортируется в Siyuan, пожалуйста, не отправляйте повторные запросы!",
+      "error.mrdoc.export": "Не удалось экспортировать в MrDoc. Проверьте состояние соединения и настройки в соответствии с документацией",
+      "error.mrdoc.no_config": "Не настроен URL API MrDoc или токен",
+      "success.mrdoc.export": "Успешно экспортировано в MrDoc",
+      "warn.mrdoc.exporting": "Идет экспорт в MrDoc. Пожалуйста, не отправляйте повторные запросы на экспорт!"
     },
     "minapp": {
       "popup": {
@@ -828,6 +833,7 @@
           "yuque": "Экспорт в Yuque",
           "obsidian": "Экспорт в Obsidian",
           "siyuan": "Экспорт в SiYuan Note",
+          "mrdoc": "Экспорт в MrDoc",
           "joplin": "Экспорт в Joplin",
           "docx": "Экспорт в Word"
         },
@@ -969,6 +975,24 @@
             "success": "Соединение успешно",
             "fail": "Не удалось подключиться, проверьте API адрес и токен",
             "error": "Ошибка соединения, проверьте сетевое подключение"
+          }
+        },
+        "mrdoc": {
+          "title": "Конфигурация MrDoc",
+          "api_url": "API URL",
+          "api_url_placeholder": "например, http://doc.mrdoc.pro",
+          "token": "Пользовательский токен",
+          "token.help": "Получить в Центре пользователя -> Управление профилем -> Управление токенами",
+          "token_placeholder": "Введите ваш пользовательский токен MrDoc",
+          "box_id": "ID проекта",
+          "box_id_placeholder": "Введите ID проекта",
+          "check": {
+            "title": "Проверка соединения",
+            "button": "Проверить",
+            "empty_config": "Пожалуйста, заполните URL API и токен",
+            "success": "Соединение успешно",
+            "fail": "Соединение не удалось, проверьте URL API и токен",
+            "error": "Ошибка соединения, проверьте подключение к сети"
           }
         },
         "nutstore": {

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -245,6 +245,7 @@
       "topics.unpinned": "取消固定",
       "translate": "翻译",
       "topics.export.siyuan": "导出到思源笔记",
+      "topics.export.mrdoc": "导出到觅思文档",
       "topics.export.wait_for_title_naming": "正在生成标题...",
       "topics.export.title_naming_success": "标题生成成功",
       "topics.export.title_naming_failed": "标题生成失败，使用默认标题"
@@ -574,7 +575,11 @@
       "error.siyuan.no_config": "未配置思源笔记API地址或令牌",
       "success.siyuan.export": "导出到思源笔记成功",
       "warn.yuque.exporting": "正在导出语雀, 请勿重复请求导出!",
-      "warn.siyuan.exporting": "正在导出到思源笔记，请勿重复请求导出!"
+      "warn.siyuan.exporting": "正在导出到思源笔记，请勿重复请求导出!",
+      "error.mrdoc.export": "导出觅思文档失败，请检查连接状态并对照文档检查配置",
+      "error.mrdoc.no_config": "未配置觅思文档API地址或令牌",
+      "success.mrdoc.export": "导出到觅思文档成功",
+      "warn.mrdoc.exporting": "正在导出到觅思文档，请勿重复请求导出!"
     },
     "minapp": {
       "popup": {
@@ -828,6 +833,7 @@
           "yuque": "导出到语雀",
           "obsidian": "导出到Obsidian",
           "siyuan": "导出到思源笔记",
+          "mrdoc": "导出到觅思文档",
           "joplin": "导出到Joplin",
           "docx": "导出为Word"
         },
@@ -964,6 +970,24 @@
           "box_id_placeholder": "请输入笔记本ID",
           "root_path": "文档根路径",
           "root_path_placeholder": "例如：/CherryStudio",
+          "check": {
+            "title": "连接检查",
+            "button": "检查",
+            "empty_config": "请填写API地址和令牌",
+            "success": "连接成功",
+            "fail": "连接失败，请检查API地址和令牌",
+            "error": "连接异常，请检查网络连接"
+          }
+        },
+        "mrdoc": {
+          "title": "觅思文档配置",
+          "api_url": "API地址",
+          "api_url_placeholder": "例如：http://doc.mrdoc.pro",
+          "token": "用户Token",
+          "token.help": "在个人中心->个人管理->Token管理中获取",
+          "token_placeholder": "请输入觅思文档的用户Token",
+          "box_id": "文集ID",
+          "box_id_placeholder": "请输入文集ID",
           "check": {
             "title": "连接检查",
             "button": "检查",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -243,6 +243,7 @@
       "topics.unpinned": "取消固定",
       "translate": "翻譯",
       "topics.export.siyuan": "匯出到思源筆記",
+      "topics.export.mrdoc": "匯出到觅思文檔",
       "topics.export.wait_for_title_naming": "正在生成標題...",
       "topics.export.title_naming_success": "標題生成成功",
       "topics.export.title_naming_failed": "標題生成失敗，使用預設標題",
@@ -574,7 +575,11 @@
       "error.siyuan.no_config": "未配置思源筆記API地址或令牌",
       "success.siyuan.export": "導出到思源筆記成功",
       "warn.yuque.exporting": "正在導出語雀，請勿重複請求導出！",
-      "warn.siyuan.exporting": "正在導出到思源筆記，請勿重複請求導出！"
+      "warn.siyuan.exporting": "正在導出到思源筆記，請勿重複請求導出！",
+      "error.mrdoc.export": "導出至覓思文檔失敗，請檢查連接狀態並對照文檔檢查配置",
+      "error.mrdoc.no_config": "未配置覓思文檔API地址或令牌",
+      "success.mrdoc.export": "成功導出至覓思文檔",
+      "warn.mrdoc.exporting": "正在導出至覓思文檔，請勿重複提交導出請求!"
     },
     "minapp": {
       "popup": {
@@ -828,6 +833,7 @@
           "yuque": "匯出到語雀",
           "obsidian": "匯出到Obsidian",
           "siyuan": "匯出到思源筆記",
+          "mrdoc": "匯出到覓思文檔",
           "joplin": "匯出到Joplin",
           "docx": "匯出為Word"
         },
@@ -962,6 +968,24 @@
           "box_id_placeholder": "請輸入筆記本ID",
           "root_path": "文檔根路徑",
           "root_path_placeholder": "例如：/CherryStudio",
+          "check": {
+            "title": "連接檢查",
+            "button": "檢查",
+            "empty_config": "請填寫API地址和令牌",
+            "success": "連接成功",
+            "fail": "連接失敗，請檢查API地址和令牌",
+            "error": "連接異常，請檢查網絡連接"
+          }
+        },
+        "mrdoc": {
+          "title": "覓思文檔配置",
+          "api_url": "API地址",
+          "api_url_placeholder": "例如：http://doc.mrdoc.pro",
+          "token": "用戶Token",
+          "token.help": "在個人中心->個人管理->Token管理中獲取",
+          "token_placeholder": "請輸入覓思文檔的用戶Token",
+          "box_id": "文集ID",
+          "box_id_placeholder": "請輸入專案ID",
           "check": {
             "title": "連接檢查",
             "button": "檢查",

--- a/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
@@ -16,6 +16,7 @@ import {
   exportMarkdownToJoplin,
   exportMarkdownToNotion,
   exportMarkdownToSiyuan,
+  exportMarkdownToMrdoc,
   exportMarkdownToYuque,
   exportMessageAsMarkdown,
   messageToMarkdown
@@ -328,6 +329,15 @@ const MessageMenubar: FC<Props> = (props) => {
               const title = await getMessageTitle(message)
               const markdown = messageToMarkdown(message)
               exportMarkdownToSiyuan(title, markdown)
+            }
+          },
+          exportMenuOptions.mrdoc && {
+            label: t('chat.topics.export.mrdoc'),
+            key: 'mrdoc',
+            onClick: async () => {
+              const title = await getMessageTitle(message)
+              const markdown = messageToMarkdown(message)
+              exportMarkdownToMrdoc(title, markdown)
             }
           }
         ].filter(Boolean)

--- a/src/renderer/src/pages/home/Tabs/TopicsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/TopicsTab.tsx
@@ -29,6 +29,7 @@ import { copyTopicAsMarkdown } from '@renderer/utils/copy'
 import {
   exportMarkdownToJoplin,
   exportMarkdownToSiyuan,
+  exportMarkdownToMrdoc,
   exportMarkdownToYuque,
   exportTopicAsMarkdown,
   exportTopicToNotion,
@@ -320,6 +321,14 @@ const Topics: FC<Props> = ({ assistant: _assistant, activeTopic, setActiveTopic 
               onClick: async () => {
                 const markdown = await topicToMarkdown(topic)
                 exportMarkdownToSiyuan(topic.name, markdown)
+              }
+            },
+            exportMenuOptions.mrdoc !== false && {
+              label: t('chat.topics.export.mrdoc'),
+              key: 'mrdoc',
+              onClick: async () => {
+                const markdown = await topicToMarkdown(topic)
+                exportMarkdownToMrdoc(topic.name, markdown)
               }
             }
           ].filter(Boolean) as ItemType<MenuItemType>[]

--- a/src/renderer/src/pages/settings/DataSettings/DataSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/DataSettings.tsx
@@ -32,6 +32,7 @@ import ObsidianSettings from './ObsidianSettings'
 import SiyuanSettings from './SiyuanSettings'
 import WebDavSettings from './WebDavSettings'
 import YuqueSettings from './YuqueSettings'
+import MrdocSettings from './MrdocSettings'
 
 const DataSettings: FC = () => {
   const { t } = useTranslation()
@@ -60,6 +61,14 @@ const DataSettings: FC = () => {
       <path
         d="M699.52 136.64V136z m-376.96 249.6V136.96s-0.32 50.56 0 249.28zM512 573.76v-127.04zM667.84 672l-6.72 7.36 7.04-7.04c6.72-6.08 7.68-7.36 6.72-7.36zM184 272.96v1.92l2.56-1.92c2.56-1.92 0-2.24 0-2.24a5.44 5.44 0 0 0-2.56 2.24zM141.76 314.88a2.24 2.24 0 0 0 1.92 0v-1.6z m483.2 399.04a71.36 71.36 0 0 0-8.96 10.24 69.76 69.76 0 0 0 10.56-9.6 56 56 0 0 0 8.96-10.24 73.28 73.28 0 0 0-10.56 9.6z m-448 75.52l-3.2 3.2 3.52-2.88 3.52-3.52s-2.56 0-5.44 3.2z m-97.92 96v1.92l2.88-1.92s1.92-2.24 0-2.24a6.72 6.72 0 0 0-4.48 2.88z"
         p-id="2965"></path>
+    </svg>
+  )
+
+  const MrdocIcon = () => (
+    <svg viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="25286" width="16" height="16">
+      <path
+        d="M642.4576 261.5296l-112.64 235.9296 97.0752 1.024 14.1312-28.0576v292.0448h97.8944V261.5296h-96.4608zM479.232 660.48l-96.256-190.0544v292.0448h-97.8944V261.5296h96.4608l110.1824 227.9424 82.3296 171.2128-94.8224-0.2048z"
+        p-id="25287"></path>
     </svg>
   )
 
@@ -101,6 +110,11 @@ const DataSettings: FC = () => {
       key: 'siyuan',
       title: 'settings.data.siyuan.title',
       icon: <SiyuanIcon />
+    },
+    {
+      key: 'mrdoc',
+      title: 'settings.data.mrdoc.title',
+      icon: <MrdocIcon />
     }
   ]
 
@@ -247,6 +261,7 @@ const DataSettings: FC = () => {
         {menu === 'joplin' && <JoplinSettings />}
         {menu === 'obsidian' && <ObsidianSettings />}
         {menu === 'siyuan' && <SiyuanSettings />}
+        {menu === 'mrdoc' && <MrdocSettings />}
       </SettingContainer>
     </Container>
   )

--- a/src/renderer/src/pages/settings/DataSettings/ExportMenuSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/ExportMenuSettings.tsx
@@ -81,6 +81,12 @@ const ExportMenuOptions: FC = () => {
       <SettingDivider />
 
       <SettingRow>
+        <SettingRowTitle>{t('settings.data.export_menu.mrdoc')}</SettingRowTitle>
+        <Switch checked={exportMenuOptions.mrdoc} onChange={(checked) => handleToggleOption('mrdoc', checked)} />
+      </SettingRow>
+      <SettingDivider />
+
+      <SettingRow>
         <SettingRowTitle>{t('settings.data.export_menu.docx')}</SettingRowTitle>
         <Switch checked={exportMenuOptions.docx} onChange={(checked) => handleToggleOption('docx', checked)} />
       </SettingRow>

--- a/src/renderer/src/pages/settings/DataSettings/MrdocSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/MrdocSettings.tsx
@@ -1,0 +1,133 @@
+import { InfoCircleOutlined } from '@ant-design/icons'
+import { HStack } from '@renderer/components/Layout'
+import { useTheme } from '@renderer/context/ThemeProvider'
+import { useMinappPopup } from '@renderer/hooks/useMinappPopup'
+import { RootState, useAppDispatch } from '@renderer/store'
+import { setMrdocApiUrl, setMrdocBoxId, setMrdocToken } from '@renderer/store/settings'
+import { Button, Tooltip } from 'antd'
+import Input from 'antd/es/input/Input'
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
+
+import { SettingDivider, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '..'
+
+const MrdocSettings: FC = () => {
+  const { openMinapp } = useMinappPopup()
+  const { t } = useTranslation()
+  const { theme } = useTheme()
+  const dispatch = useAppDispatch()
+
+  const mrdocApiUrl = useSelector((state: RootState) => state.settings.mrdocApiUrl)
+  const mrdocToken = useSelector((state: RootState) => state.settings.mrdocToken)
+  const mrdocBoxId = useSelector((state: RootState) => state.settings.mrdocBoxId)
+
+  const handleApiUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch(setMrdocApiUrl(e.target.value))
+  }
+
+  const handleTokenChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch(setMrdocToken(e.target.value))
+  }
+
+  const handleBoxIdChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch(setMrdocBoxId(e.target.value))
+  }
+
+  const handleMrdocHelpClick = () => {
+    openMinapp({
+      id: 'mrdoc-help',
+      name: 'Mrdoc Help',
+      url: 'https://docs.cherry-ai.com/advanced-basic/mrdoc'
+    })
+  }
+
+  const handleCheckConnection = async () => {
+    try {
+      if (!mrdocApiUrl || !mrdocToken) {
+        window.message.error(t('settings.data.mrdoc.check.empty_config'))
+        return
+      }
+
+      const response = await fetch(`${mrdocApiUrl}/api/check_token/?token=${mrdocToken}`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      })
+
+      if (!response.ok) {
+        window.message.error(t('settings.data.mrdoc.check.fail'))
+        return
+      }
+
+      const data = await response.json()
+      console.log(data)
+      if (!data.status) {
+        window.message.error(t('settings.data.mrdoc.check.fail'))
+        return
+      }
+
+      window.message.success(t('settings.data.mrdoc.check.success'))
+    } catch (error) {
+      console.error('Check Mrdoc connection failed:', error)
+      window.message.error(t('settings.data.mrdoc.check.error'))
+    }
+  }
+
+  return (
+    <SettingGroup theme={theme}>
+      <SettingTitle>{t('settings.data.mrdoc.title')}</SettingTitle>
+      <SettingDivider />
+      <SettingRow>
+        <SettingRowTitle>{t('settings.data.mrdoc.api_url')}</SettingRowTitle>
+        <HStack alignItems="center" gap="5px" style={{ width: 315 }}>
+          <Input
+            type="text"
+            value={mrdocApiUrl || ''}
+            onChange={handleApiUrlChange}
+            style={{ width: 315 }}
+            placeholder={t('settings.data.mrdoc.api_url_placeholder')}
+          />
+        </HStack>
+      </SettingRow>
+      <SettingDivider />
+      <SettingRow>
+        <SettingRowTitle style={{ display: 'flex', alignItems: 'center' }}>
+          <span>{t('settings.data.mrdoc.token')}</span>
+          <Tooltip title={t('settings.data.mrdoc.token.help')} placement="left">
+            <InfoCircleOutlined
+              style={{ color: 'var(--color-text-2)', cursor: 'pointer', marginLeft: 4 }}
+              onClick={handleMrdocHelpClick}
+            />
+          </Tooltip>
+        </SettingRowTitle>
+        <HStack alignItems="center" gap="5px" style={{ width: 315 }}>
+          <Input
+            type="password"
+            value={mrdocToken || ''}
+            onChange={handleTokenChange}
+            style={{ width: 250 }}
+            placeholder={t('settings.data.mrdoc.token_placeholder')}
+          />
+          <Button onClick={handleCheckConnection}>{t('settings.data.mrdoc.check.button')}</Button>
+        </HStack>
+      </SettingRow>
+      <SettingDivider />
+      <SettingRow>
+        <SettingRowTitle>{t('settings.data.mrdoc.box_id')}</SettingRowTitle>
+        <HStack alignItems="center" gap="5px" style={{ width: 315 }}>
+          <Input
+            type="text"
+            value={mrdocBoxId || ''}
+            onChange={handleBoxIdChange}
+            style={{ width: 315 }}
+            placeholder={t('settings.data.mrdoc.box_id_placeholder')}
+          />
+        </HStack>
+      </SettingRow>
+    </SettingGroup>
+  )
+}
+
+export default MrdocSettings

--- a/src/renderer/src/store/settings.ts
+++ b/src/renderer/src/store/settings.ts
@@ -111,6 +111,10 @@ export interface SettingsState {
   siyuanRootPath: string | null
   maxKeepAliveMinapps: number
   showOpenedMinappsInSidebar: boolean
+  // 觅思文档配置
+  mrdocApiUrl: string | null
+  mrdocToken: string | null
+  mrdocBoxId: string | null
   // 隐私设置
   enableDataCollection: boolean
   enableQuickPanelTriggers: boolean
@@ -124,6 +128,7 @@ export interface SettingsState {
     joplin: boolean
     obsidian: boolean
     siyuan: boolean
+    mrdoc: boolean
     docx: boolean
   }
 }
@@ -211,6 +216,9 @@ export const initialState: SettingsState = {
   siyuanToken: null,
   siyuanBoxId: null,
   siyuanRootPath: null,
+  mrdocApiUrl: null,
+  mrdocToken: null,
+  mrdocBoxId: null,
   maxKeepAliveMinapps: 3,
   showOpenedMinappsInSidebar: true,
   enableDataCollection: false,
@@ -225,6 +233,7 @@ export const initialState: SettingsState = {
     joplin: true,
     obsidian: true,
     siyuan: true,
+    mrdoc: true,
     docx: true
   }
 }
@@ -470,6 +479,15 @@ const settingsSlice = createSlice({
     setSiyuanRootPath: (state, action: PayloadAction<string>) => {
       state.siyuanRootPath = action.payload
     },
+    setMrdocApiUrl: (state, action: PayloadAction<string>) => {
+      state.mrdocApiUrl = action.payload
+    },
+    setMrdocToken: (state, action: PayloadAction<string>) => {
+      state.mrdocToken = action.payload
+    },
+    setMrdocBoxId: (state, action: PayloadAction<string>) => {
+      state.mrdocBoxId = action.payload
+    },
     setMessageNavigation: (state, action: PayloadAction<'none' | 'buttons' | 'anchor'>) => {
       state.messageNavigation = action.payload
     },
@@ -577,6 +595,9 @@ export const {
   setSiyuanToken,
   setSiyuanBoxId,
   setSiyuanRootPath,
+  setMrdocApiUrl,
+  setMrdocToken,
+  setMrdocBoxId,
   setMaxKeepAliveMinapps,
   setShowOpenedMinappsInSidebar,
   setEnableDataCollection,


### PR DESCRIPTION
增加导出到觅思文档（MrDoc）的功能。

MrDoc 是一个开源的在线知识库系统，项目地址为 https://github.com/zmister2016/MrDoc 。

其配置方式和使用方式与「思源笔记」类似，填入觅思文档的URL、用户Token和文集ID即配置完成，导出行为则是通过「用户Token」的 API 接口在觅思文档中新建一篇 Markdown 文档。

## 配置界面

![配置信息如图](https://github.com/user-attachments/assets/f19944f9-7efd-4a80-934d-87c70b4b227a)

## 用户Token的获取

![image](https://github.com/user-attachments/assets/2e2eff42-cd12-4383-9cf1-84099c274906)

## Summary by Sourcery

Add functionality to export content to the MrDoc knowledge base system.

New Features:
- Implement export logic for sending Markdown content to a configured MrDoc instance via its API.
- Add a settings page for configuring the MrDoc API URL, authentication token, and target Box ID.
- Integrate the MrDoc export option into message and topic context menus.
- Add an option in settings to show or hide the MrDoc export menu item.