### PR TITLE
fix: more robust portable data dir setup logic

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -12,7 +12,7 @@ import { CHERRY_STUDIO_PROTOCOL, handleProtocolUrl, registerProtocolClient } fro
 import { registerShortcuts } from './services/ShortcutService'
 import { TrayService } from './services/TrayService'
 import { windowService } from './services/WindowService'
-import { setAppDataDir } from './utils/file'
+import { setUserDataDir } from './utils/file'
 
 // Check for single instance lock
 if (!app.requestSingleInstanceLock()) {
@@ -51,7 +51,7 @@ if (!app.requestSingleInstanceLock()) {
 
     replaceDevtoolsFont(mainWindow)
 
-    setAppDataDir()
+    setUserDataDir()
 
     if (process.env.NODE_ENV === 'development') {
       installExtension([REDUX_DEVTOOLS, REACT_DEVELOPER_TOOLS])

--- a/src/main/utils/file.ts
+++ b/src/main/utils/file.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
-import { isPortable } from '@main/constant'
+import { isMac } from '@main/constant'
 import { audioExts, documentExts, imageExts, textExts, videoExts } from '@shared/config/constant'
 import { FileType, FileTypes } from '@types'
 import { app } from 'electron'
@@ -85,11 +85,11 @@ export function getAppConfigDir(name: string) {
   return path.join(getConfigDir(), name)
 }
 
-export function setAppDataDir() {
-  if (isPortable) {
+export function setUserDataDir() {
+  if (!isMac) {
     const dir = path.join(path.dirname(app.getPath('exe')), 'data')
-    if (fs.existsSync(dir)) {
-      app.setPath('appData', dir)
+    if (fs.existsSync(dir) && fs.statSync(dir).isDirectory()) {
+      app.setPath('userData', dir)
     }
   }
 }


### PR DESCRIPTION
### What this PR does

Before this PR:

- Only Windows is supported to setup portable data dir, but in VSCode, it is [cross-platform](https://github.com/microsoft/vscode/blob/a73a3243c26ae717a466c01e74db532d3010b363/src/bootstrap-node.ts#L135-L148)
- Scoop use [`setup.exe` as downloaded file](https://github.com/ScoopInstaller/Extras/blob/master/bucket/cherry-studio.json), which lead to `isPortable` to `false`
- The target path type is not checked
- Maybe #5332 is caused by `app.setPath('appdata', ...)`

After this PR:

- Allow Linux to setup portable data dir (MacOS?)
- Bypass portable env var check
- Ensure target path type
- `app.setPath('userdata', ...)` (Maybe also setup `appdata`?)

