### PR TITLE
feat: use pagination when loading topic list

### DIFF
--- a/src/renderer/src/pages/home/Tabs/TopicsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/TopicsTab.tsx
@@ -430,7 +430,7 @@ const Topics: FC<Props> = ({ assistant: _assistant, activeTopic, setActiveTopic 
 
   return (
     <Container right={topicPosition === 'right'} className="topics-tab">
-      <div ref={containerRef} onScroll={handleScroll} style={{ height: '100%', overflow: 'auto' }}>
+      <div ref={containerRef} onScroll={handleScroll} style={{ height: '100%', overflow: 'auto', overflowX: 'hidden' }}>
         <DragableList list={displayedTopics} onUpdate={handleDragUpdate}>
           {(topic) => {
             const isActive = topic.id === activeTopic?.id


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR: 当一个助手有较多话题的时候（我的情况是500+），切换到话题列表时，会有明显的卡顿，

After this PR: 使用分页加载话题列表，明显减小了卡顿。

![PixPin_2025-04-25_23-30-49](https://github.com/user-attachments/assets/69d136f9-f93c-4f65-a7d4-b2e0efdbf851)


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes https://github.com/CherryHQ/cherry-studio/issues/5321

但这只是软件卡顿的其中一个场景，还有其他的场景，例如一个话题中有多轮对话时（10+），切换到该话题也会有明显的卡顿。我不确定给对话页面添加分页，会不会影响到其他功能，就暂时没改，只优化了话题列表的加载。之前测试发现出了比较严重的话题丢失bug，应该已经修复了，不确定还有没有其他没发现的bug

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
