### PR TITLE
fix: Fix the image support for the GitHub Copilot models

### DIFF
--- a/src/renderer/src/config/models.ts
+++ b/src/renderer/src/config/models.ts
@@ -2202,9 +2202,10 @@ export function isVisionModel(model: Model): boolean {
   if (!model) {
     return false
   }
-  if (model.provider === 'copilot') {
-    return false
-  }
+  // 新添字段 copilot-vision-request 后可使用 vision 
+  // if (model.provider === 'copilot') {
+  //   return false
+  // }
 
   if (model.provider === 'doubao') {
     return VISION_REGEX.test(model.name) || model.type?.includes('vision') || false

--- a/src/renderer/src/providers/AiProvider/OpenAIProvider.ts
+++ b/src/renderer/src/providers/AiProvider/OpenAIProvider.ts
@@ -70,7 +70,8 @@ export default class OpenAIProvider extends BaseProvider {
       baseURL: this.getBaseURL(),
       defaultHeaders: {
         ...this.defaultHeaders(),
-        ...(this.provider.id === 'copilot' ? { 'editor-version': 'vscode/1.97.2' } : {})
+        ...(this.provider.id === 'copilot' ? { 'editor-version': 'vscode/1.97.2' } : {}),
+        ...(this.provider.id === 'copilot' ? { 'copilot-vision-request': 'true' } : {})
       }
     })
   }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does
### Fixes #2432 
### 修补了 Github Copliot模型不能用解析图片的问题



Before this PR:
1. 因为模型被强行设置为非视觉
<img width="381" alt="image" src="https://github.com/user-attachments/assets/a254dedd-36f2-471a-b3aa-9d53afbedce8" />

2. 手动开启
<img width="381" alt="image" src="https://github.com/user-attachments/assets/97c74289-1843-40d3-911d-6b5995a54a97" />


### After this PR:
<img width="370" alt="image" src="https://github.com/user-attachments/assets/4fdd6e22-d92c-4da0-a899-5f06b037f58c" />

## 如何解决的

简单逆向了一下 发现仅仅少了个`copilot-vision-request`参数 加上去之后就能用了
<img width="500" alt="Screenshot 2025-04-27 at 1 49 54" src="https://github.com/user-attachments/assets/bc60408b-4ad1-4ff1-b477-02e5c4c67a1c" />

解决了之前 https://github.com/CherryHQ/cherry-studio/pull/2432#issuecomment-2691847339 评论中，不知道如何实现的问题。

至于是否是视觉模型，则是直接去掉了硬判断。常用的没问题，但未在`visionExcludedModels`进行进一步修补。
（由于Github Copilot的模型名称各式各样，需要进一步细分。）

<img width="500" alt="image" src="https://github.com/user-attachments/assets/d15d7fca-8bc3-4930-9716-09021fce083d" />



### Checklist
This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```

## Summary by Sourcery

Enable image support for GitHub Copilot models.

Bug Fixes:
- Fix GitHub Copilot models being unable to process images due to being incorrectly classified as non-visual.

Enhancements:
- Remove the hardcoded check preventing Copilot models from being identified as vision-capable.
- Add the 'copilot-vision-request' header to requests for Copilot models to enable vision features.