### PR TITLE
fix(MCPSettings): fix mcp setting state error,fix mcp setting save searchKey lose

### DIFF
--- a/src/renderer/src/pages/settings/MCPSettings/McpSettings.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/McpSettings.tsx
@@ -61,7 +61,11 @@ const parseKeyValueString = (str: string): Record<string, string> => {
 
 const McpSettings: React.FC = () => {
   const { t } = useTranslation()
-  const { server } = useLocation().state as { server: MCPServer }
+  const {
+    server: { id: serverId }
+  } = useLocation().state as { server: MCPServer }
+  const { mcpServers } = useMCPServers()
+  const server = mcpServers.find((it) => it.id === serverId) as MCPServer
   const { deleteMCPServer, updateMCPServer } = useMCPServers()
   const [serverType, setServerType] = useState<MCPServer['type']>('stdio')
   const [form] = Form.useForm<MCPFormValues>()
@@ -214,7 +218,8 @@ const McpSettings: React.FC = () => {
         type: values.serverType || server.type,
         description: values.description,
         isActive: values.isActive,
-        registryUrl: values.registryUrl
+        registryUrl: values.registryUrl,
+        searchKey: server.searchKey
       }
 
       // set stdio or sse server


### PR DESCRIPTION
修复mcp设置页server配置响应式丢失导致的服务启动switch状态错误问题
<img width="1186" alt="image" src="https://github.com/user-attachments/assets/62a2f049-e94f-45dd-8a75-58e03a49d0f1" />
修复mcp设置页保存配置searchKey丢失导致的描述tab丢失问题
<img width="1166" alt="image" src="https://github.com/user-attachments/assets/0a17def4-8f00-43ef-b102-0392567eb0ba" />

## Summary by Sourcery

Fix two bugs in the MCP settings page.

Bug Fixes:
- Ensure the component uses the current server state to prevent display inconsistencies.
- Preserve the `searchKey` when saving MCP server settings.