### PR TITLE
feat(MCPService): add method to find PowerShell executable path

### DIFF
--- a/src/main/services/MCPService.ts
+++ b/src/main/services/MCPService.ts
@@ -567,13 +567,26 @@ class McpService {
     return await cachedGetResource(server, uri)
   }
 
+  private findPowerShellExecutable() {
+    const psPath = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' // Standard WinPS path
+    const pwshPath = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe'
+
+    if (fs.existsSync(psPath)) {
+      return psPath
+    }
+    if (fs.existsSync(pwshPath)) {
+      return pwshPath
+    }
+    return 'powershell.exe'
+  }
+
   private getSystemPath = memoize(async (): Promise<string> => {
     return new Promise((resolve, reject) => {
       let command: string
       let shell: string
 
       if (process.platform === 'win32') {
-        shell = 'powershell.exe'
+        shell = this.findPowerShellExecutable()
         command = '$env:PATH'
       } else {
         // 尝试获取当前用户的默认 shell
@@ -623,6 +636,10 @@ class McpService {
 
       child.stderr.on('data', (data: Buffer) => {
         console.error('Error getting PATH:', data.toString())
+      })
+
+      child.on('error', (error: Error) => {
+        reject(new Error(`Failed to get system PATH, ${error.message}`))
       })
 
       child.on('close', (code: number) => {


### PR DESCRIPTION
- Implemented `findPowerShellExecutable` to determine the correct PowerShell executable path on Windows.
- Updated `getSystemPath` to utilize the new method for improved path retrieval.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
有些电脑上面的powershell不在path里面，找不到，直接报错并且中断程序启动

After this PR:
优先找固定路径，如果找到直接用，最后找不到用powershell.exe，但是在执行的时候加强了error处理，会直接reject出来，外层可以try catch住，不会中断程序启动。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #5331

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
add method to find PowerShell executable path
```

## Summary by Sourcery

Improve PowerShell executable detection and system PATH retrieval on Windows.

New Features:
- Implement a method to search for the PowerShell executable in standard installation directories before relying on the system PATH.

Bug Fixes:
- Prevent application crashes when retrieving the system PATH if the PowerShell executable cannot be found or executed.