### PR TITLE
fix(OpenAIProvider): refine system message handling for specific model IDs

### DIFF
--- a/src/renderer/src/config/models.ts
+++ b/src/renderer/src/config/models.ts
@@ -2168,6 +2168,8 @@ export const GEMINI_SEARCH_MODELS = [
   'gemini-2.5-flash-preview-04-17'
 ]
 
+export const OPENAI_NO_SUPPORT_DEV_ROLE_MODELS = ['o1-preview', 'o1-mini']
+
 export const PERPLEXITY_SEARCH_MODELS = ['sonar-pro', 'sonar', 'sonar-reasoning', 'sonar-reasoning-pro']
 
 export function isTextToImageModel(model: Model): boolean {
@@ -2202,7 +2204,7 @@ export function isVisionModel(model: Model): boolean {
   if (!model) {
     return false
   }
-  // 新添字段 copilot-vision-request 后可使用 vision 
+  // 新添字段 copilot-vision-request 后可使用 vision
   // if (model.provider === 'copilot') {
   //   return false
   // }

--- a/src/renderer/src/providers/AiProvider/OpenAIProvider.ts
+++ b/src/renderer/src/providers/AiProvider/OpenAIProvider.ts
@@ -8,7 +8,8 @@ import {
   isReasoningModel,
   isSupportedModel,
   isVisionModel,
-  isZhipuModel
+  isZhipuModel,
+  OPENAI_NO_SUPPORT_DEV_ROLE_MODELS
 } from '@renderer/config/models'
 import { getStoreSetting } from '@renderer/hooks/useSettings'
 import i18n from '@renderer/i18n'
@@ -317,7 +318,7 @@ export default class OpenAIProvider extends BaseProvider {
     const { contextCount, maxTokens, streamOutput } = getAssistantSettings(assistant)
     messages = addImageFileToContents(messages)
     let systemMessage = { role: 'system', content: assistant.prompt || '' }
-    if (isOpenAIoSeries(model) && !['o1-preview', 'o1-mini'].includes(model.id)) {
+    if (isOpenAIoSeries(model) && !OPENAI_NO_SUPPORT_DEV_ROLE_MODELS.includes(model.id)) {
       systemMessage = {
         role: 'developer',
         content: `Formatting re-enabled${systemMessage ? '\n' + systemMessage.content : ''}`

--- a/src/renderer/src/providers/AiProvider/OpenAIProvider.ts
+++ b/src/renderer/src/providers/AiProvider/OpenAIProvider.ts
@@ -317,7 +317,7 @@ export default class OpenAIProvider extends BaseProvider {
     const { contextCount, maxTokens, streamOutput } = getAssistantSettings(assistant)
     messages = addImageFileToContents(messages)
     let systemMessage = { role: 'system', content: assistant.prompt || '' }
-    if (isOpenAIoSeries(model)) {
+    if (isOpenAIoSeries(model) && !['o1-preview', 'o1-mini'].includes(model.id)) {
       systemMessage = {
         role: 'developer',
         content: `Formatting re-enabled${systemMessage ? '\n' + systemMessage.content : ''}`


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixed the errors in OpenAI o1-mini and o1-preview.

#### Which issue(s) this PR fixes:
<!-- Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->
Fixes #5334

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->

## Summary by Sourcery

Bug Fixes:
- Prevent prepending 'Formatting re-enabled' and using the 'developer' role in system messages for 'o1-preview' and 'o1-mini' models.