### PR TITLE
chore: add grok image alias

### DIFF
--- a/src/renderer/src/config/models.ts
+++ b/src/renderer/src/config/models.ts
@@ -2149,6 +2149,8 @@ export const GENERATE_IMAGE_MODELS = [
   'gemini-2.0-flash-exp-image-generation',
   'gemini-2.0-flash-exp',
   'grok-2-image-1212',
+  'grok-2-image',
+  'grok-2-image-latest',
   'gpt-4o-image',
   'gpt-image-1'
 ]


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Add `grok-2-image` and `grok-2-image-latest` as aliases for the Grok image model.