### PR TITLE
fix: update electron-updater patch and refine content-type regex

### DIFF
--- a/.yarn/patches/electron-updater-npm-6.6.3-9269dbaf84.patch
+++ b/.yarn/patches/electron-updater-npm-6.6.3-9269dbaf84.patch
@@ -36,3 +36,16 @@ index 9829dff7e95aa9baa0bfdf29f52e6f761c9b7243..6ecaade9e294c87c03bb42e77ff5463f
      if (result != null) {
          return result;
      }
+diff --git a/out/differentialDownloader/multipleRangeDownloader.js b/out/differentialDownloader/multipleRangeDownloader.js
+index bf7d3a2982c62b94054fed4ef60455b20b26d622..3a924eddc946ec446654a112a33be4e2cea311d2 100644
+--- a/out/differentialDownloader/multipleRangeDownloader.js
++++ b/out/differentialDownloader/multipleRangeDownloader.js
+@@ -75,7 +75,7 @@ function doExecuteTasks(differentialDownloader, options, out, resolve, reject) {
+             return;
+         }
+         const contentType = (0, builder_util_runtime_1.safeGetHeader)(response, "content-type");
+-        const m = /^multipart\/.+?(?:; boundary=(?:(?:"(.+)")|(?:([^\s]+))))$/i.exec(contentType);
++        const m = /^multipart\/.+?\s*;\s*boundary=(?:"([^"]+)"|([^\s";]+))\s*$/i.exec(contentType);
+         if (m == null) {
+             reject(new Error(`Content-Type "multipart/byteranges" is expected, but got "${contentType}"`));
+             return;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7061,7 +7061,7 @@ __metadata:
 
 "electron-updater@patch:electron-updater@npm%3A6.6.3#~/.yarn/patches/electron-updater-npm-6.6.3-9269dbaf84.patch":
   version: 6.6.3
-  resolution: "electron-updater@patch:electron-updater@npm%3A6.6.3#~/.yarn/patches/electron-updater-npm-6.6.3-9269dbaf84.patch::version=6.6.3&hash=4a31aa"
+  resolution: "electron-updater@patch:electron-updater@npm%3A6.6.3#~/.yarn/patches/electron-updater-npm-6.6.3-9269dbaf84.patch::version=6.6.3&hash=4f329d"
   dependencies:
     builder-util-runtime: "npm:9.3.2"
     fs-extra: "npm:^10.1.0"
@@ -7071,7 +7071,7 @@ __metadata:
     lodash.isequal: "npm:^4.5.0"
     semver: "npm:^7.6.3"
     tiny-typed-emitter: "npm:^2.1.0"
-  checksum: 10c0/6c9540bfaca6a9f4f73ce665f104d5954feb237950c59a73497b8e49b61820735276008c483eb5a7216b0b4c2fc4ca1a5474064645e5b52daa76b43661b3ced1
+  checksum: 10c0/31ca459c2589243e4553531927d9d7c5a99e2395683278b3d4639ebef39963f9fdd0bcf8dda42efecec4d5899dd4e3431473b4b95e72a5813132a1b19fea04e2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
增量更新下载失败，错误信息如下
```
17:13:29.256 > Full: 92,770.98 KB, To download: 19,742.1 KB (21%)
17:13:29.633 > Cannot download differentially, fallback to full download: Error: Content-Type "multipart/byteranges" is expected, but got "multipart/byteranges;boundary=e888c103-165d-4ec1-9b6f-eca722ac9b10"
    at ClientRequest.<anonymous> (C:\Users\payne\AppData\Local\Programs\Cherry Studio\resources\app.asar\node_modules\electron-updater\out\differentialDownloader\multipleRangeDownloader.js:80:20)
    at ClientRequest.emit (node:events:531:35)
    at SimpleURLLoaderWrapper.<anonymous> (node:electron/js2c/browser_init:2:114720)
    at SimpleURLLoaderWrapper.emit (node:events:519:28)
17:13:34.288 > New version 1.2.9 has been downloaded to C:\Users\payne\AppData\Local\cherrystudio-updater\pending\Cherry-Studio-1.2.9-x64-setup.exe
```

After this PR:
增量更新成功，目前从1.2.7升级到1.2.9，只需要下载21%的大小就可以了

```
17:13:29.256 > Full: 92,770.98 KB, To download: 19,742.1 KB (21%)
```
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

上游PR： https://github.com/electron-userland/electron-builder/pull/9064

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist
1. 更新功能是否正常

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
支持增量更新
```
