### PR TITLE
fix(AppUpdater): update condition for checking available updates

### DIFF
--- a/src/main/services/AppUpdater.ts
+++ b/src/main/services/AppUpdater.ts
@@ -71,7 +71,7 @@ export default class AppUpdater {
 
     try {
       const update = await this.autoUpdater.checkForUpdates()
-      if (update?.updateInfo && !this.autoUpdater.autoDownload) {
+      if (update?.isUpdateAvailable && !this.autoUpdater.autoDownload) {
         // 如果 autoDownload 为 false，则需要再调用下面的函数触发下
         // do not use await, because it will block the return of this function
         this.autoUpdater.downloadUpdate()


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
在关闭自动更新，点击检测更新的时候，如果已经是最新版本的时候会报下面的错误
![image](https://github.com/user-attachments/assets/404ae05f-5809-40a4-908c-563548c4e155)

Error logs

```
    at NsisUpdater.downloadUpdate (C:\Users\payne\AppData\Local\Programs\Cherry Studio\resources\app.asar\node_modules\electron-updater\out\AppUpdater.js:428:27)
    at AppUpdater.checkForUpdates (C:\Users\payne\AppData\Local\Programs\Cherry Studio\resources\app.asar\out\main\index.js:15933:26)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async C:\Users\payne\AppData\Local\Programs\Cherry Studio\resources\app.asar\out\main\index.js:121664:5
    at async WebContents.<anonymous> (node:electron/js2c/browser_init:2:83724)
21:23:04.867 > 更新异常 {
  message: 'Please check update first',
  stack: 'Error: Please check update first\n' +
    '    at NsisUpdater.downloadUpdate (C:\\Users\\payne\\AppData\\Local\\Programs\\Cherry Studio\\resources\\app.asar\\node_modules\\electron-updater\\out\\AppUpdater.js:428:27)\n' +
    '    at AppUpdater.checkForUpdates (C:\\Users\\payne\\AppData\\Local\\Programs\\Cherry Studio\\resources\\app.asar\\out\\main\\index.js:15933:26)\n' +
    '    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n' +
    '    at async C:\\Users\\payne\\AppData\\Local\\Programs\\Cherry Studio\\resources\\app.asar\\out\\main\\index.js:121664:5\n' +
    '    at async WebContents.<anonymous> (node:electron/js2c/browser_init:2:83724)',
  time: '2025-04-27T13:23:04.867Z'
}
(node:425672) UnhandledPromiseRejectionWarning: Error: Please check update first
    at NsisUpdater.downloadUpdate (C:\Users\payne\AppData\Local\Programs\Cherry Studio\resources\app.asar\node_modules\electron-updater\out\AppUpdater.js:428:27)
    at AppUpdater.checkForUpdates (C:\Users\payne\AppData\Local\Programs\Cherry Studio\resources\app.asar\out\main\index.js:15933:26)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async C:\Users\payne\AppData\Local\Programs\Cherry Studio\resources\app.asar\out\main\index.js:121664:5
    at async WebContents.<anonymous> (node:electron/js2c/browser_init:2:83724)
(Use `Cherry Studio --trace-warnings ...` to show where the warning was created)
```
After this PR:

在关闭自动更新，点击检测更新的时候，不报错
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
update condition for checking available updates
```

## Summary by Sourcery

Bug Fixes:
- Correct the condition used to determine if an update is available before attempting to download it during manual checks.