### PR TITLE
fix: update tool name and arguments parsing in MCP tools

### DIFF
--- a/src/renderer/src/utils/mcp-tools.ts
+++ b/src/renderer/src/utils/mcp-tools.ts
@@ -354,27 +354,28 @@ export function parseToolUse(content: string, mcpTools: MCPTool[]): MCPToolRespo
   // Find all tool use blocks
   while ((match = toolUsePattern.exec(content)) !== null) {
     // const fullMatch = match[0]
-    const toolName = match[2].trim()
-    const toolArgs = match[4].trim()
+    const toolUseName = match[2].trim()
+    const toolUseArgs = match[4].trim()
 
     // Try to parse the arguments as JSON
     let parsedArgs
     try {
-      parsedArgs = JSON.parse(toolArgs)
+      parsedArgs = JSON.parse(toolUseArgs)
     } catch (error) {
       // If parsing fails, use the string as is
-      parsedArgs = toolArgs
+      parsedArgs = toolUseArgs
     }
-    // console.log(`Parsed arguments for tool "${toolName}":`, parsedArgs)
-    const mcpTool = mcpTools.find((tool) => tool.id === toolName)
+    // console.log(`Parsed arguments for tool "${toolUseName}":`, parsedArgs)
+    const mcpTool = mcpTools.find((tool) => `${tool.serverName}:${tool.name}` == toolUseName)
+
     if (!mcpTool) {
-      console.error(`Tool "${toolName}" not found in MCP tools`)
+      console.error(`Tool "${toolUseName}" not found in MCP tools`)
       continue
     }
 
     // Add to tools array
     tools.push({
-      id: `${toolName}-${idx++}`, // Unique ID for each tool use
+      id: `${toolUseName}-${idx++}`, // Unique ID for each tool use
       tool: {
         ...mcpTool,
         inputSchema: parsedArgs

--- a/src/renderer/src/utils/prompt.ts
+++ b/src/renderer/src/utils/prompt.ts
@@ -133,7 +133,7 @@ export const AvailableTools = (tools: MCPTool[]) => {
     .map((tool) => {
       return `
 <tool>
-  <name>${tool.id}</name>
+  <name>${tool.serverName}:${tool.name}</name>
   <description>${tool.description}</description>
   <arguments>
     ${tool.inputSchema ? JSON.stringify(tool.inputSchema) : ''}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
```
<tool_use>
<name>asja12ghiozxahrwasd-ak1></name>
</tool_use>
```
After this PR:
```
<tool_use>
<name>python:run_python_code></name>
</tool_use>
```
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #5265

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```

## Summary by Sourcery

Bug Fixes:
- Correctly parse tool usage requests by looking up tools using the `serverName:name` format.