### PR TITLE
fix(McpOAuthClientProvider): update redirect URL

### DIFF
--- a/src/main/services/mcp/oauth/callback.ts
+++ b/src/main/services/mcp/oauth/callback.ts
@@ -21,7 +21,7 @@ export class CallBackServer {
       if (req.url?.startsWith(path)) {
         try {
           // Parse the URL to extract the authorization code
-          const url = new URL(req.url, `http://localhost:${port}`)
+          const url = new URL(req.url, `http://127.0.0.1:${port}`)
           const code = url.searchParams.get('code')
           if (code) {
             // Emit the code event

--- a/src/main/services/mcp/oauth/provider.ts
+++ b/src/main/services/mcp/oauth/provider.ts
@@ -27,7 +27,7 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
   }
 
   get redirectUrl(): string {
-    return `http://localhost:${this.config.callbackPort}${this.config.callbackPath}`
+    return `http://127.0.0.1:${this.config.callbackPort}${this.config.callbackPath}`
   }
 
   get clientMetadata() {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR: 

After this PR: 按照RFC8252建议

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #5395 

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

## Summary by Sourcery

Bug Fixes:
- Replace `localhost` with `127.0.0.1` in the OAuth redirect URL and callback URL parsing logic to align with RFC 8252 recommendations.