### PR TITLE
feat: 允许功能键(F1-F19)可以被设置为快捷键而不需要修饰键

### DIFF
--- a/src/renderer/src/pages/settings/ShortcutSettings.tsx
+++ b/src/renderer/src/pages/settings/ShortcutSettings.tsx
@@ -58,8 +58,9 @@ const ShortcutSettings: FC = () => {
   const isValidShortcut = (keys: string[]): boolean => {
     const hasModifier = keys.some((key) => ['Control', 'Ctrl', 'Command', 'Alt', 'Shift'].includes(key))
     const hasNonModifier = keys.some((key) => !['Control', 'Ctrl', 'Command', 'Alt', 'Shift'].includes(key))
+    const hasFnKey = keys.some((key) => /^F\d+$/.test(key))
 
-    return hasModifier && hasNonModifier && keys.length >= 2
+    return (hasModifier && hasNonModifier && keys.length >= 2) || hasFnKey
   }
 
   const isDuplicateShortcut = (newShortcut: string[], currentKey: string): boolean => {


### PR DESCRIPTION
### What this PR does

Before this PR:
快捷键必须是「修饰键+其它按键」

After this PR:
如果快捷键是F1~F19，则可以不需要修饰键

### Why we need it and why it was done in this way

The following tradeoffs were made: 

只改了自己想要的，只支持FN键独立。其实鼠标侧键等按键也可以考虑允许不需要修饰键，但似乎现在软件也不支持鼠标侧键。


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
允许F1-F19键可以不需要修饰键就能作为快捷键使用
```

## Summary by Sourcery

New Features:
- Enable the use of F1 through F19 keys as standalone keyboard shortcuts.