### PR TITLE
refactor(TopicsTab): Use onContextMenu instead of onMouseEnter

### DIFF
--- a/src/renderer/src/pages/home/Tabs/TopicsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/TopicsTab.tsx
@@ -391,7 +391,7 @@ const Topics: FC<Props> = ({ assistant: _assistant, activeTopic, setActiveTopic 
             const fullTopicPrompt = t('common.prompt') + ': ' + topicPrompt
             return (
               <TopicListItem
-                onMouseEnter={() => setTargetTopic(topic)}
+                onContextMenu={() => setTargetTopic(topic)}
                 className={isActive ? 'active' : ''}
                 onClick={() => onSwitchTopic(topic)}
                 style={{ borderRadius }}>


### PR DESCRIPTION
### 修复话题右键菜单问题

onMouseEnter会导致打开菜单后鼠标经过其他item会覆盖掉，现在onContextMenu来解决

## Summary by Sourcery

Bug Fixes:
- Ensure the correct topic is targeted when opening the context menu by triggering on `onContextMenu` instead of `onMouseEnter`.