### PR TITLE
style: optimize mcp arg name display layout when tool or prompt descr…

### DIFF
--- a/src/renderer/src/pages/settings/MCPSettings/McpPrompt.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/McpPrompt.tsx
@@ -23,12 +23,15 @@ const MCPPromptsSection = ({ prompts }: MCPPromptsSectionProps) => {
               key={index}
               label={
                 <Flex vertical gap={4}>
-                  <Typography.Text strong>{arg.name}</Typography.Text>
-                  {arg.required && (
-                    <Tooltip title="Required field">
-                      <Tag color="red">Required</Tag>
-                    </Tooltip>
-                  )}
+                  <Typography.Text strong>
+                    {arg.name}
+                    <br />
+                    {arg.required && (
+                      <Tooltip title="Required field">
+                        <Tag color="red">Required</Tag>
+                      </Tooltip>
+                    )}
+                  </Typography.Text>
                 </Flex>
               }>
               <Flex vertical gap={4}>

--- a/src/renderer/src/pages/settings/MCPSettings/McpPrompt.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/McpPrompt.tsx
@@ -22,16 +22,13 @@ const MCPPromptsSection = ({ prompts }: MCPPromptsSectionProps) => {
             <Descriptions.Item
               key={index}
               label={
-                <Flex vertical gap={4}>
-                  <Typography.Text strong>
-                    {arg.name}
-                    <br />
-                    {arg.required && (
-                      <Tooltip title="Required field">
-                        <Tag color="red">Required</Tag>
-                      </Tooltip>
-                    )}
-                  </Typography.Text>
+                <Flex gap={4}>
+                  <Typography.Text strong>{arg.name}</Typography.Text>
+                  {arg.required && (
+                    <Tooltip title="Required field">
+                      <span style={{ color: '#f5222d' }}>*</span>
+                    </Tooltip>
+                  )}
                 </Flex>
               }>
               <Flex vertical gap={4}>

--- a/src/renderer/src/pages/settings/MCPSettings/McpPrompt.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/McpPrompt.tsx
@@ -1,5 +1,5 @@
 import { MCPPrompt } from '@renderer/types'
-import { Collapse, Descriptions, Empty, Flex, Tag, Tooltip, Typography } from 'antd'
+import { Collapse, Descriptions, Empty, Flex, Tooltip, Typography } from 'antd'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 

--- a/src/renderer/src/pages/settings/MCPSettings/McpTool.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/McpTool.tsx
@@ -51,16 +51,13 @@ const MCPToolsSection = ({ tools, server, onToggleTool }: MCPToolsSectionProps) 
             <Descriptions.Item
               key={key}
               label={
-                <Flex vertical gap={4}>
-                  <Typography.Text strong>
-                    {key}
-                    <br />
-                    {tool.inputSchema.required?.includes(key) && (
-                      <Tooltip title="Required field">
-                        <Tag color="red">Required</Tag>
-                      </Tooltip>
-                    )}
-                  </Typography.Text>
+                <Flex gap={4}>
+                  <Typography.Text strong>{key}</Typography.Text>
+                  {tool.inputSchema.required?.includes(key) && (
+                    <Tooltip title="Required field">
+                      <span style={{ color: '#f5222d' }}>*</span>
+                    </Tooltip>
+                  )}
                 </Flex>
               }>
               <Flex vertical gap={4}>

--- a/src/renderer/src/pages/settings/MCPSettings/McpTool.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/McpTool.tsx
@@ -52,12 +52,15 @@ const MCPToolsSection = ({ tools, server, onToggleTool }: MCPToolsSectionProps) 
               key={key}
               label={
                 <Flex vertical gap={4}>
-                  <Typography.Text strong>{key}</Typography.Text>
-                  {tool.inputSchema.required?.includes(key) && (
-                    <Tooltip title="Required field">
-                      <Tag color="red">Required</Tag>
-                    </Tooltip>
-                  )}
+                  <Typography.Text strong>
+                    {key}
+                    <br />
+                    {tool.inputSchema.required?.includes(key) && (
+                      <Tooltip title="Required field">
+                        <Tag color="red">Required</Tag>
+                      </Tooltip>
+                    )}
+                  </Typography.Text>
                 </Flex>
               }>
               <Flex vertical gap={4}>


### PR DESCRIPTION
…iption is short

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does
上一次优化名称时，只考虑了description比较丰富的情况。当description描述过短时，必填项提示展示会出现异常。
Before this PR:
<img width="772" alt="Screenshot 2025-04-29 at 11 48 19" src="https://github.com/user-attachments/assets/c9b64bbe-82ea-48f5-8630-9224cd7b00e0" />

After this PR:
<img width="792" alt="Screenshot 2025-04-29 at 11 47 21" src="https://github.com/user-attachments/assets/9f24f59d-105d-4e5d-b03b-fbf383e3b1c8" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```

## Summary by Sourcery

Bug Fixes:
- Fix the display of the "Required" tag for prompt and tool arguments to ensure it appears correctly below the argument name, particularly with short descriptions.