### PR TITLE
refactor(MainTextBlock): enhance content processing by ignoring tooluse

### DIFF
--- a/src/renderer/src/pages/home/Messages/Blocks/MainTextBlock.tsx
+++ b/src/renderer/src/pages/home/Messages/Blocks/MainTextBlock.tsx
@@ -31,6 +31,8 @@ interface Props {
   role: Message['role']
 }
 
+const toolUseRegex = /<tool_use>([\s\S]*?)<\/tool_use>/g
+
 const MainTextBlock: React.FC<Props> = ({ block, citationBlockId, role, mentions = [] }) => {
   // Use the passed citationBlockId directly in the selector
   const { renderInputMessageAsMarkdown } = useSettings()
@@ -67,6 +69,10 @@ const MainTextBlock: React.FC<Props> = ({ block, citationBlockId, role, mentions
     return content
   }, [block.content, block.citationReferences, citationBlockId, formattedCitations])
 
+  const ignoreToolUse = useMemo(() => {
+    return processedContent.replace(toolUseRegex, '')
+  }, [processedContent])
+
   return (
     <>
       {/* Render mentions associated with the message */}
@@ -80,7 +86,7 @@ const MainTextBlock: React.FC<Props> = ({ block, citationBlockId, role, mentions
       {role === 'user' && !renderInputMessageAsMarkdown ? (
         <p style={{ marginBottom: 5, whiteSpace: 'pre-wrap' }}>{block.content}</p>
       ) : (
-        <Markdown block={{ ...block, content: processedContent }} />
+        <Markdown block={{ ...block, content: ignoreToolUse }} />
       )}
     </>
   )

--- a/src/renderer/src/providers/AiProvider/OpenAIProvider.ts
+++ b/src/renderer/src/providers/AiProvider/OpenAIProvider.ts
@@ -507,6 +507,7 @@ export default class OpenAIProvider extends BaseProvider {
       // let isThinkingInContent: ThoughtProcessor | undefined = undefined
       // const processThinkingChunk = this.handleThinkingTags()
       let isFirstChunk = true
+      let isFirstThinkingChunk = true
       for await (const chunk of stream) {
         if (window.keyv.get(EVENT_NAMES.CHAT_COMPLETION_PAUSED)) {
           break
@@ -521,12 +522,7 @@ export default class OpenAIProvider extends BaseProvider {
         const reasoningContent = delta?.reasoning_content || delta?.reasoning
         const currentTime = new Date().getTime() // Get current time for each chunk
 
-        if (
-          time_first_token_millsec === 0 &&
-          isEmpty(reasoningContent) &&
-          isEmpty(delta?.content) &&
-          isEmpty(finishReason)
-        ) {
+        if (time_first_token_millsec === 0 && isFirstThinkingChunk && reasoningContent) {
           // 记录第一个token的时间
           time_first_token_millsec = currentTime
           // 记录第一个token的时间差
@@ -542,6 +538,7 @@ export default class OpenAIProvider extends BaseProvider {
               fractionalSecondDigits: 3
             })}`
           )
+          isFirstThinkingChunk = false
         }
         if (reasoningContent) {
           thinkingContent += reasoningContent


### PR DESCRIPTION
…

- Introduced a regex to identify and remove <tool_use> tags from message content.
- correct thinking time display

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

1. 深度思考时间显示有问题
2. tooluse没有过滤

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

<img width="1214" alt="image" src="https://github.com/user-attachments/assets/935607f8-e9fd-4064-b3ec-f607d77ebea7" />


Fixes #5482

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```

## Summary by Sourcery

Improve message display by filtering tool use content and correcting thinking time calculation.

Bug Fixes:
- Correct the calculation for AI thinking time to start upon receiving the first reasoning content.

Enhancements:
- Filter out <tool_use> blocks from the displayed message content.