### PR TITLE
fix: message do not use knowledge

### DIFF
--- a/src/renderer/src/providers/AiProvider/BaseProvider.ts
+++ b/src/renderer/src/providers/AiProvider/BaseProvider.ts
@@ -116,8 +116,9 @@ export default abstract class BaseProvider {
     const allReferences = [...webSearchReferences, ...reindexedKnowledgeReferences]
 
     console.log(`Found ${allReferences.length} references for ID: ${message.id}`, allReferences)
-    if (!isEmpty(webSearchReferences)) {
-      const referenceContent = `\`\`\`json\n${JSON.stringify(webSearchReferences, null, 2)}\n\`\`\``
+
+    if (!isEmpty(allReferences)) {
+      const referenceContent = `\`\`\`json\n${JSON.stringify(allReferences, null, 2)}\n\`\`\``
       return REFERENCE_PROMPT.replace('{question}', content).replace('{references}', referenceContent)
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure knowledge references are used alongside web search references when generating AI responses.