### PR TITLE
perf: <tool_use> display

### DIFF
--- a/src/renderer/src/pages/home/Messages/Blocks/MainTextBlock.tsx
+++ b/src/renderer/src/pages/home/Messages/Blocks/MainTextBlock.tsx
@@ -31,8 +31,6 @@ interface Props {
   role: Message['role']
 }
 
-const toolUseRegex = /<tool_use>([\s\S]*?)<\/tool_use>/g
-
 const MainTextBlock: React.FC<Props> = ({ block, citationBlockId, role, mentions = [] }) => {
   // Use the passed citationBlockId directly in the selector
   const { renderInputMessageAsMarkdown } = useSettings()
@@ -69,10 +67,6 @@ const MainTextBlock: React.FC<Props> = ({ block, citationBlockId, role, mentions
     return content
   }, [block.content, block.citationReferences, citationBlockId, formattedCitations])
 
-  const ignoreToolUse = useMemo(() => {
-    return processedContent.replace(toolUseRegex, '')
-  }, [processedContent])
-
   return (
     <>
       {/* Render mentions associated with the message */}
@@ -86,7 +80,7 @@ const MainTextBlock: React.FC<Props> = ({ block, citationBlockId, role, mentions
       {role === 'user' && !renderInputMessageAsMarkdown ? (
         <p style={{ marginBottom: 5, whiteSpace: 'pre-wrap' }}>{block.content}</p>
       ) : (
-        <Markdown block={{ ...block, content: ignoreToolUse }} />
+        <Markdown block={{ ...block, content: processedContent }} />
       )}
     </>
   )

--- a/src/renderer/src/services/StreamProcessingService.ts
+++ b/src/renderer/src/services/StreamProcessingService.ts
@@ -56,7 +56,8 @@ export function createStreamProcessor(callbacks: StreamProcessorCallbacks = {}) 
         callbacks.onTextChunk(data.text)
       }
       if (data.type === ChunkType.TEXT_COMPLETE && callbacks.onTextComplete) {
-        callbacks.onTextComplete(data.text)
+        // 消除工具使用对信息流的影响
+        callbacks.onTextComplete(data.text.replace(/<tool_use>([\s\S]*?)<\/tool_use>/g, ''))
       }
       if (data.type === ChunkType.THINKING_DELTA && callbacks.onThinkingChunk) {
         callbacks.onThinkingChunk(data.text, data.thinking_millsec)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
原处理逻辑会多次调用正则，会有些性能问题，调整了下标签清除的位置

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
@DeJeune

## Summary by Sourcery

Enhancements:
- Optimize message display performance by stripping `<tool_use>` tags upon completion of the text stream, rather than during rendering.