### PR TITLE
fix: update webSearch type and results structure in upgrade logic

### DIFF
--- a/src/renderer/src/databases/upgrades.ts
+++ b/src/renderer/src/databases/upgrades.ts
@@ -222,7 +222,7 @@ export async function upgradeToV7(tx: Transaction): Promise<void> {
       if (oldMessage.metadata?.webSearch) {
         hasCitationData = true
         citationDataToCreate.response = {
-          results: oldMessage.metadata.webSearch?.results,
+          results: oldMessage.metadata.webSearch,
           source: WebSearchSource.WEBSEARCH
         }
       }

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -87,7 +87,7 @@ export type LegacyMessage = {
     // Zhipu or Hunyuan
     webSearchInfo?: any[]
     // Web search
-    webSearch?: WebSearchResponse
+    webSearch?: WebSearchProviderResponse
     // MCP Tools
     mcpTools?: MCPToolResponse[]
     // Generate Image


### PR DESCRIPTION
fix https://github.com/CherryHQ/cherry-studio/issues/5473#issuecomment-2837656805

## Summary by Sourcery

Update the type and structure of web search metadata in message upgrade logic to fix a compatibility issue with legacy message types

Bug Fixes:
- Corrected the web search results mapping during database upgrade to ensure proper type compatibility

Enhancements:
- Updated type definitions for web search metadata to support legacy message structures