### PR TITLE
feat: support streaming for model health check

### DIFF
--- a/src/renderer/src/providers/AiProvider/BaseProvider.ts
+++ b/src/renderer/src/providers/AiProvider/BaseProvider.ts
@@ -43,7 +43,7 @@ export default abstract class BaseProvider {
   abstract summaryForSearch(messages: Message[], assistant: Assistant): Promise<string | null>
   abstract suggestions(messages: Message[], assistant: Assistant): Promise<Suggestion[]>
   abstract generateText({ prompt, content }: { prompt: string; content: string }): Promise<string>
-  abstract check(model: Model): Promise<{ valid: boolean; error: Error | null }>
+  abstract check(model: Model, stream: boolean): Promise<{ valid: boolean; error: Error | null }>
   abstract models(): Promise<OpenAI.Models.Model[]>
   abstract generateImage(params: GenerateImageParams): Promise<string[]>
   abstract generateImageByChat({ messages, assistant, onChunk, onFilterMessages }: CompletionsParams): Promise<void>

--- a/src/renderer/src/providers/AiProvider/index.ts
+++ b/src/renderer/src/providers/AiProvider/index.ts
@@ -59,8 +59,8 @@ export default class AiProvider {
     return this.sdk.generateText({ prompt, content })
   }
 
-  public async check(model: Model): Promise<{ valid: boolean; error: Error | null }> {
-    return this.sdk.check(model)
+  public async check(model: Model, stream: boolean = false): Promise<{ valid: boolean; error: Error | null }> {
+    return this.sdk.check(model, stream)
   }
 
   public async models(): Promise<OpenAI.Models.Model[]> {

--- a/src/renderer/src/services/ModelService.ts
+++ b/src/renderer/src/services/ModelService.ts
@@ -82,7 +82,14 @@ export async function checkModel(provider: Provider, model: Model) {
     return performModelCheck(
       provider,
       model,
-      (ai, model) => ai.check(model),
+      async (ai, model) => {
+        const result = await ai.check(model, false)
+        if (result.valid && !result.error) {
+          return result
+        }
+        // Try streaming check
+        return ai.check(model, true)
+      },
       ({ valid, error }) => ({ valid, error: error || null })
     )
   }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

无法检查仅支持流式响应的模型。

After this PR:

可以检查。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #5522 

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```

## Summary by Sourcery

Add support for streaming model health checks across different AI providers

New Features:
- Implement streaming-based model validation for Gemini, Anthropic, and OpenAI providers

Enhancements:
- Modify model check method to support both non-streaming and streaming validation
- Update ModelService to attempt streaming check if non-streaming check fails