### PR TITLE
fix: Quick Assistant of mini window mode can't use the latest model settings

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -157,6 +157,22 @@ export function registerIpc(mainWindow: BrowserWindow, app: Electron.App) {
     })
   })
 
+  // Forward model update events to mini window
+  ipcMain.on('model-settings-update', (event, data) => {
+    const senderWindowId = event.sender.id
+    const windows = BrowserWindow.getAllWindows()
+
+    // Log the event
+    log.info('[ipc] Forwarding model-settings-update event', data);
+
+    // Forward to all other windows
+    windows.forEach((win) => {
+      if (win.webContents.id !== senderWindowId) {
+        win.webContents.send('model-settings-update', data)
+      }
+    })
+  })
+
   // clear cache
   ipcMain.handle(IpcChannel.App_ClearCache, async () => {
     const sessions = [session.defaultSession, session.fromPartition('persist:webview')]

--- a/src/renderer/src/hooks/useAssistant.ts
+++ b/src/renderer/src/hooks/useAssistant.ts
@@ -103,7 +103,20 @@ export function useDefaultModel() {
     defaultModel,
     topicNamingModel,
     translateModel,
-    setDefaultModel: (model: Model) => dispatch(setDefaultModel({ model })),
+    setDefaultModel: (model: Model) => {
+      dispatch(setDefaultModel({ model }))
+
+      // Send direct notification to mini window
+      console.log('[useDefaultModel] Sending model-settings-update event:', model)
+      try {
+        window.electron.ipcRenderer.send('model-settings-update', {
+          type: 'defaultModel',
+          model
+        })
+      } catch (error) {
+        console.error('[useDefaultModel] Error sending model update:', error)
+      }
+    },
     setTopicNamingModel: (model: Model) => dispatch(setTopicNamingModel({ model })),
     setTranslateModel: (model: Model) => dispatch(setTranslateModel({ model }))
   }

--- a/src/renderer/src/store/llm.ts
+++ b/src/renderer/src/store/llm.ts
@@ -584,6 +584,12 @@ const llmSlice = createSlice({
     setDefaultModel: (state, action: PayloadAction<{ model: Model }>) => {
       state.defaultModel = action.payload.model
       window.electron.ipcRenderer.send(IpcChannel.MiniWindowReload)
+      // Send a direct model update message that the mini window can listen for
+      console.log('[setDefaultModel] Sending model-settings-update event:', action.payload.model)
+      window.electron.ipcRenderer.send('model-settings-update', {
+        type: 'defaultModel',
+        model: action.payload.model
+      })
     },
     setTopicNamingModel: (state, action: PayloadAction<{ model: Model }>) => {
       state.topicNamingModel = action.payload.model


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

**Before this PR:**  Quick Assistant of mini window mode can't use the latest model settings. It always uses the settings at application start. If you change the Model settings, like API Key, Quick Assistant can't get the updated settings until you restart the application.

**After this PR:** Quick Assistant of mini window mode can use the latest model settings, which perform like the normal chat mode.

Testing:
At first, the API Key is wrong, so all Normal Assistant and Quick Assistant fail to get answer.
<img width="875" alt="image" src="https://github.com/user-attachments/assets/706a1893-c4ff-4901-bdb0-9a961a273261" />
And then, after update the API Key, them all receive the answers, which means Quick Assistant can get the latest Model settings.
<img width="1033" alt="image" src="https://github.com/user-attachments/assets/bc939d60-4de7-4650-bd35-dca83ed29bc3" />


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue (s) when PR gets merged)*: -->

Fixes #5527

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```

## Summary by Sourcery

Improve model settings synchronization for Quick Assistant in mini window mode, ensuring it always uses the latest model configurations without requiring application restart.

New Features:
- Added IPC event to forward model settings updates to all windows

Bug Fixes:
- Fixed Quick Assistant not updating to latest model settings dynamically
- Ensured model settings are synchronized across different application windows

Enhancements:
- Added real-time model settings update mechanism
- Implemented event-based model settings synchronization