### PR TITLE
Remove redundant condition check in MCP service args handling

### DIFF
--- a/src/main/services/MCPService.ts
+++ b/src/main/services/MCPService.ts
@@ -183,7 +183,7 @@ class McpService {
           // add -x to args if args exist
           if (args && args.length > 0) {
             if (!args.includes('-y')) {
-              !args.includes('-y') && args.unshift('-y')
+              args.unshift('-y')
             }
             if (!args.includes('x')) {
               args.unshift('x')


### PR DESCRIPTION
### What this PR does

Simplifies the condition check for -y flag in MCP service by removing redundant check that was already covered by outer if statement.

## Summary by Sourcery

Enhancements:
- Remove redundant condition check when adding '-y' flag to service arguments