### PR TITLE
fix: resolve scrolling issue on files page (#5618)

### DIFF
--- a/src/renderer/src/pages/files/FileList.tsx
+++ b/src/renderer/src/pages/files/FileList.tsx
@@ -28,7 +28,7 @@ interface FileItemProps {
 const FileList: React.FC<FileItemProps> = ({ id, list, files }) => {
   if (id === FileTypes.IMAGE && files?.length && files?.length > 0) {
     return (
-      <div style={{ padding: 16 }}>
+      <div style={{ padding: 16, overflowY: 'auto' }}>
         <Image.PreviewGroup>
           <Row gutter={[16, 16]}>
             {files?.map((file) => (


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Fixes #5618

添加了 overflowY: 'auto' 让文件页面在图片过多时可以被纵向滚动。

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

## Summary by Sourcery

Bug Fixes:
- Fixed scrolling issue for image files when the number of images exceeds the page height