### PR TITLE
fix(messageThunk): enhance reset message logic to include model for s…

### DIFF
--- a/src/renderer/src/store/thunk/messageThunk.ts
+++ b/src/renderer/src/store/thunk/messageThunk.ts
@@ -901,7 +901,8 @@ export const resendMessageThunk =
       for (const originalMsg of assistantMessagesToReset) {
         const blockIdsToDelete = [...(originalMsg.blocks || [])]
         const resetMsg = resetAssistantMessage(originalMsg, {
-          status: AssistantMessageStatus.PENDING
+          status: AssistantMessageStatus.PENDING,
+          ...(assistantMessagesToReset.length === 1 ? { model: assistant.model } : {})
         })
 
         resetDataList.push({ resetMsg })


### PR DESCRIPTION
fix: https://github.com/CherryHQ/cherry-studio/issues/5473#issuecomment-2846823486

单个助手消息，使用顶部model进行重发

## Summary by Sourcery

Bug Fixes:
- Fixed message resend behavior to preserve model when resending a single assistant message