### PR TITLE
Fix/image height

### DIFF
--- a/src/renderer/src/pages/home/Messages/Blocks/index.tsx
+++ b/src/renderer/src/pages/home/Messages/Blocks/index.tsx
@@ -131,6 +131,5 @@ const ImageBlockGroup = styled.div`
   > * {
     flex: 0 0 auto;
     min-width: 200px;
-    max-width: calc(33.33% - 8px);
   }
 `

--- a/src/renderer/src/pages/home/Messages/MessageImage.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageImage.tsx
@@ -99,7 +99,7 @@ const MessageImage: FC<Props> = ({ block }) => {
         <Image
           src={image}
           key={`image-${index}`}
-          height={200}
+          height={300}
           preview={{
             toolbarRender: (
               _,
@@ -131,15 +131,10 @@ const Container = styled.div`
   flex-direction: row;
   gap: 10px;
   margin-top: 8px;
-  width: auto;
 `
 const Image = styled(AntdImage)`
   padding: 5px;
   border-radius: 8px;
-
-  .ant-image-img {
-    width: auto;
-  }
 `
 const ToobarWrapper = styled(Space)`
   padding: 0px 24px;

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -7,7 +7,7 @@
     "src/main/env.d.ts",
     "src/renderer/src/types/*",
     "packages/shared/**/*"
-  ],
+, "src/renderer/src/utils/stream.ts"  ],
   "compilerOptions": {
     "composite": true,
     "types": [

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -7,7 +7,7 @@
     "src/main/env.d.ts",
     "src/renderer/src/types/*",
     "packages/shared/**/*"
-, "src/renderer/src/utils/stream.ts"  ],
+  ],
   "compilerOptions": {
     "composite": true,
     "types": [


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

After this PR:

<img width="761" alt="image" src="https://github.com/user-attachments/assets/757e0956-f9bb-405f-a8be-7284f7938b1b" />


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```

## Summary by Sourcery

Adjust image display styling and dimensions in message image components

Enhancements:
- Increased default image height from 200 to 300 pixels
- Removed max-width constraint on image blocks
- Simplified image container styling