### PR TITLE
fix: openaiprovider timeout is not an integer

### DIFF
--- a/src/renderer/src/providers/AiProvider/OpenAIProvider.ts
+++ b/src/renderer/src/providers/AiProvider/OpenAIProvider.ts
@@ -164,7 +164,7 @@ export default class OpenAIProvider extends BaseProvider {
     if ((model.id.includes('o3') && !model.id.includes('o3-mini')) || model.id.includes('o4-mini')) {
       return 15 * 1000 * 60
     }
-    return undefined
+    return 5 * 1000 * 60
   }
 
   /**


### PR DESCRIPTION
修复 timeout is not an integer #5621 @DeJeune 

## Summary by Sourcery

Bug Fixes:
- Fixed an issue with undefined timeout for certain OpenAI models