### PR TITLE
fix: include thinking_millsec in message block creation

### DIFF
--- a/src/renderer/src/databases/upgrades.ts
+++ b/src/renderer/src/databases/upgrades.ts
@@ -115,6 +115,7 @@ export async function upgradeToV7(tx: Transaction): Promise<void> {
       if (oldMessage.reasoning_content?.trim()) {
         const block = createThinkingBlock(oldMessage.id, oldMessage.reasoning_content, {
           createdAt: oldMessage.createdAt,
+          thinking_millsec: oldMessage?.metrics?.time_thinking_millsec,
           status: MessageBlockStatus.SUCCESS // Thinking block is complete content
         })
         blocksToCreate.push(block)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

<img width="1204" alt="image" src="https://github.com/user-attachments/assets/684f3901-4074-416a-b3d2-cc3943a7156c" />


After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```

## Summary by Sourcery

Bug Fixes:
- Added missing thinking time metric (thinking_millsec) when creating thinking message blocks