### PR TITLE
fix: models such as qwq、qvq do not support thinking token configuration

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -1,7 +1,12 @@
 import { HolderOutlined } from '@ant-design/icons'
 import { QuickPanelListItem, QuickPanelView, useQuickPanel } from '@renderer/components/QuickPanel'
 import TranslateButton from '@renderer/components/TranslateButton'
-import { isGenerateImageModel, isReasoningModel, isVisionModel, isWebSearchModel } from '@renderer/config/models'
+import {
+  isGenerateImageModel,
+  isSupportedThinkingTokenModel,
+  isVisionModel,
+  isWebSearchModel
+} from "@renderer/config/models";
 import db from '@renderer/databases'
 import { useAssistant } from '@renderer/hooks/useAssistant'
 import { useKnowledgeBases } from '@renderer/hooks/useKnowledge'
@@ -920,7 +925,7 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
                 setFiles={setFiles}
                 ToolbarButton={ToolbarButton}
               />
-              {isReasoningModel(model) && (
+              {isSupportedThinkingTokenModel(model) && (
                 <ThinkingButton
                   ref={thinkingButtonRef}
                   model={model}


### PR DESCRIPTION
<img width="1158" alt="image" src="https://github.com/user-attachments/assets/a7859fb9-c8f3-4237-a100-2cbeeae1b55f" />
现有版本qwq会出现关闭thinking模型回复有thinking的情况
<img width="841" alt="image" src="https://github.com/user-attachments/assets/53ab580d-229e-4348-a9e3-f1fd5f2822f5" />
目前qwen系列只有qwen3及衍生版本支持enable_thinking和thinking_budget参数，看到项目内有写好的isSupportedThinkingTokenModel 兼容性判定函数直接用了，酌情合并吧
@DeJeune


## Summary by Sourcery

Bug Fixes:
- Replace isReasoningModel with isSupportedThinkingTokenModel to correctly handle thinking token configuration for different models