### PR TITLE
fix(StoreSyncService): set flag bug when register IPC handler

### DIFF
--- a/src/main/services/StoreSyncService.ts
+++ b/src/main/services/StoreSyncService.ts
@@ -78,6 +78,8 @@ export class StoreSyncService {
       // Broadcast the action to all other windows
       this.broadcastToOtherWindows(sourceWindowId, action)
     })
+
+    this.isIpcHandlerRegistered = true
   }
 
   /**


### PR DESCRIPTION
fix(StoreSyncService): set flag bug when register IPC handler

## Summary by Sourcery

Bug Fixes:
- Correctly set the isIpcHandlerRegistered flag after registering the IPC handler