### PR TITLE
feat(WebSearchButton): add 'Disable Web Search' option

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -268,6 +268,8 @@
       "input.web_search.builtin": "Model Built-in",
       "input.web_search.builtin.enabled_content": "Use the built-in web search function of the model",
       "input.web_search.builtin.disabled_content": "The current model does not support web search",
+      "input.web_search.no_web_search": "Disable Web Search",
+      "input.web_search.no_web_search.description": "Do not enable web search",
       "input.thinking": "Thinking",
       "input.thinking.mode.default": "Default",
       "input.thinking.mode.default.tip": "The model will automatically determine the number of tokens to think",

--- a/src/renderer/src/i18n/locales/ja-jp.json
+++ b/src/renderer/src/i18n/locales/ja-jp.json
@@ -268,6 +268,8 @@
       "input.web_search.builtin": "モデル内蔵",
       "input.web_search.builtin.enabled_content": "モデル内蔵のウェブ検索機能を使用",
       "input.web_search.builtin.disabled_content": "現在のモデルはウェブ検索をサポートしていません",
+      "input.web_search.no_web_search": "ウェブ検索を無効にする",
+      "input.web_search.no_web_search.description": "ウェブ検索を無効にする",
       "input.thinking": "思考",
       "input.thinking.mode.default": "デフォルト",
       "input.thinking.mode.custom": "カスタム",

--- a/src/renderer/src/i18n/locales/ru-ru.json
+++ b/src/renderer/src/i18n/locales/ru-ru.json
@@ -268,6 +268,8 @@
       "input.web_search.builtin": "Модель встроена",
       "input.web_search.builtin.enabled_content": "Используйте встроенную функцию веб-поиска модели",
       "input.web_search.builtin.disabled_content": "Текущая модель не поддерживает веб-поиск",
+      "input.web_search.no_web_search": "Отключить веб-поиск",
+      "input.web_search.no_web_search.description": "Отключить веб-поиск",
       "input.thinking": "Мыслим",
       "input.thinking.mode.default": "По умолчанию",
       "input.thinking.mode.default.tip": "Модель автоматически определяет количество токенов для размышления",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -168,6 +168,8 @@
       "input.web_search.builtin": "模型内置",
       "input.web_search.builtin.enabled_content": "使用模型内置的网络搜索功能",
       "input.web_search.builtin.disabled_content": "当前模型不支持网络搜索功能",
+      "input.web_search.no_web_search": "不使用网络",
+      "input.web_search.no_web_search.description": "不启用网络搜索功能",
       "message.new.branch": "分支",
       "message.new.branch.created": "新分支已创建",
       "message.new.context": "清除上下文",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -267,6 +267,8 @@
       "input.web_search.builtin": "模型內置",
       "input.web_search.builtin.enabled_content": "使用模型內置的網路搜尋功能",
       "input.web_search.builtin.disabled_content": "當前模型不支持網路搜尋功能",
+      "input.web_search.no_web_search": "關閉網路搜尋",
+      "input.web_search.no_web_search.description": "關閉網路搜尋",
       "input.thinking": "思考",
       "input.thinking.mode.default": "預設",
       "input.thinking.mode.default.tip": "模型會自動確定思考的 token 數",

--- a/src/renderer/src/pages/home/Inputbar/WebSearchButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/WebSearchButton.tsx
@@ -29,7 +29,7 @@ const WebSearchButton: FC<Props> = ({ ref, assistant, ToolbarButton }) => {
   const { updateAssistant } = useAssistant(assistant.id)
 
   const updateSelectedWebSearchProvider = useCallback(
-    (providerId: WebSearchProvider['id']) => {
+    (providerId?: WebSearchProvider['id']) => {
       // TODO: updateAssistant有性能问题，会导致关闭快捷面板卡顿
       setTimeout(() => {
         const currentWebSearchProviderId = assistant.webSearchProviderId
@@ -77,6 +77,16 @@ const WebSearchButton: FC<Props> = ({ ref, assistant, ToolbarButton }) => {
       label: '前往设置' + '...',
       icon: <Settings />,
       action: () => navigate('/settings/web-search')
+    })
+
+    items.unshift({
+      label: t('chat.input.web_search.no_web_search'),
+      description: t('chat.input.web_search.no_web_search.description'),
+      icon: <Globe />,
+      isSelected: !assistant.enableWebSearch && !assistant.webSearchProviderId,
+      action: () => {
+        updateSelectedWebSearchProvider(undefined)
+      }
     })
 
     return items


### PR DESCRIPTION
<img width="1177" alt="image" src="https://github.com/user-attachments/assets/a0894542-6979-4268-9e86-5f208e251270" />

## Summary by Sourcery

Add an option to disable web search functionality for an assistant

New Features:
- Introduce a 'Disable Web Search' option in the web search provider selection menu

Enhancements:
- Update web search provider selection to support disabling web search