### PR TITLE
fix: remove useless border and border radius for code block

### DIFF
--- a/src/renderer/src/pages/home/Markdown/CodeBlock.tsx
+++ b/src/renderer/src/pages/home/Markdown/CodeBlock.tsx
@@ -152,9 +152,7 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ children, className }) => {
         isCodeWrappable={codeWrappable}
         // dangerouslySetInnerHTML={{ __html: html }}
         style={{
-          border: '0.5px solid var(--color-code-background)',
-          borderTopLeftRadius: 0,
-          borderTopRightRadius: 0,
+          padding: '1px',
           marginTop: 0,
           fontSize: fontSize - 1,
           maxHeight: codeCollapsible && !isExpanded ? '350px' : 'none',


### PR DESCRIPTION
### What this PR does

目前展示代码块，左下角和右下角有一个非常奇怪的 border。看源码是因为给 CodeBlock 组件加了一个 border 样式， 为了设计我觉得可以去掉这个 border 用 padding 体现层次感。

|  深色 / 浅色模式 | Before | After |
| -------- | ----- | ------ |
| 深色 | ![CleanShot 2025-05-08 at 22 55 37](https://github.com/user-attachments/assets/de1762de-994b-4dcc-9329-a54fd674427e) | ![CleanShot 2025-05-08 at 22 56 56](https://github.com/user-attachments/assets/786698cc-9efb-4e21-a188-ff45627e595d) |
| 浅色 | ![CleanShot 2025-05-08 at 22 55 57](https://github.com/user-attachments/assets/79b3ded2-6a2d-4fa0-8bf1-1c159822d0e9) | ![CleanShot 2025-05-08 at 22 56 30](https://github.com/user-attachments/assets/d203bc7b-3fdf-4aa4-bdaf-9ced6b643672) |


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

