### PR TITLE
fix: SelectModelPopup sticky header

### DIFF
--- a/src/renderer/src/components/Popups/SelectModelPopup.tsx
+++ b/src/renderer/src/components/Popups/SelectModelPopup.tsx
@@ -59,9 +59,11 @@ const PopupContainer: React.FC<PopupContainerProps> = ({ model, resolve }) => {
   const [pinnedModels, setPinnedModels] = useState<string[]>([])
   const [_focusedItemKey, setFocusedItemKey] = useState<string>('')
   const focusedItemKey = useDeferredValue(_focusedItemKey)
-  const [currentStickyGroup, setCurrentStickyGroup] = useState<FlatListItem | null>(null)
+  const [_stickyGroup, setStickyGroup] = useState<FlatListItem | null>(null)
+  const stickyGroup = useDeferredValue(_stickyGroup)
   const firstGroupRef = useRef<FlatListItem | null>(null)
   const scrollTriggerRef = useRef<ScrollTrigger>('initial')
+  const lastScrollOffsetRef = useRef(0)
 
   // 当前选中的模型ID
   const currentModelId = model ? getModelUniqId(model) : ''
@@ -220,6 +222,45 @@ const PopupContainer: React.FC<PopupContainerProps> = ({ model, resolve }) => {
     return items
   }, [providers, getFilteredModels, pinnedModels, searchText, t, createModelItem])
 
+  // 基于滚动位置更新sticky分组标题
+  const updateStickyGroup = useCallback(
+    (scrollOffset?: number) => {
+      if (listItems.length === 0) {
+        setStickyGroup(null)
+        return
+      }
+
+      // 基于滚动位置计算当前可见的第一个项的索引
+      const estimatedIndex = Math.floor((scrollOffset ?? lastScrollOffsetRef.current) / ITEM_HEIGHT)
+
+      // 从该索引向前查找最近的分组标题
+      for (let i = estimatedIndex - 1; i >= 0; i--) {
+        if (i < listItems.length && listItems[i]?.type === 'group') {
+          setStickyGroup(listItems[i])
+          return
+        }
+      }
+
+      // 找不到则使用第一个分组标题
+      setStickyGroup(firstGroupRef.current ?? null)
+    },
+    [listItems]
+  )
+
+  // 在listItems变化时更新sticky group
+  useEffect(() => {
+    updateStickyGroup()
+  }, [listItems, updateStickyGroup])
+
+  // 处理列表滚动事件，更新lastScrollOffset并更新sticky分组
+  const handleScroll = useCallback(
+    ({ scrollOffset }) => {
+      lastScrollOffsetRef.current = scrollOffset
+      updateStickyGroup(scrollOffset)
+    },
+    [updateStickyGroup]
+  )
+
   // 获取可选择的模型项（过滤掉分组标题）
   const modelItems = useMemo(() => {
     return listItems.filter((item) => item.type === 'model')
@@ -362,41 +403,19 @@ const PopupContainer: React.FC<PopupContainerProps> = ({ model, resolve }) => {
     if (!open) return
     setTimeout(() => inputRef.current?.focus(), 0)
     scrollTriggerRef.current = 'initial'
+    lastScrollOffsetRef.current = 0
   }, [open])
-
-  // 初始化sticky分组标题
-  useEffect(() => {
-    if (firstGroupRef.current) {
-      setCurrentStickyGroup(firstGroupRef.current)
-    }
-  }, [listItems])
-
-  const handleItemsRendered = useCallback(
-    ({ visibleStartIndex }: { visibleStartIndex: number; visibleStopIndex: number }) => {
-      // 从可见区域的起始位置向前查找最近的分组标题
-      for (let i = visibleStartIndex - 1; i >= 0; i--) {
-        if (listItems[i]?.type === 'group') {
-          setCurrentStickyGroup(listItems[i])
-          return
-        }
-      }
-
-      // 找不到则使用第一个分组标题
-      setCurrentStickyGroup(firstGroupRef.current ?? null)
-    },
-    [listItems]
-  )
 
   const RowData = useMemo(
     (): VirtualizedRowData => ({
       listItems,
       focusedItemKey,
       setFocusedItemKey,
-      currentStickyGroup,
+      stickyGroup,
       handleItemClick,
       togglePin
     }),
-    [currentStickyGroup, focusedItemKey, handleItemClick, listItems, togglePin]
+    [stickyGroup, focusedItemKey, handleItemClick, listItems, togglePin]
   )
 
   const listHeight = useMemo(() => {
@@ -453,7 +472,7 @@ const PopupContainer: React.FC<PopupContainerProps> = ({ model, resolve }) => {
       {listItems.length > 0 ? (
         <ListContainer onMouseMove={() => setIsMouseOver(true)}>
           {/* Sticky Group Banner，它会替换第一个分组名称 */}
-          <StickyGroupBanner>{currentStickyGroup?.name}</StickyGroupBanner>
+          <StickyGroupBanner>{stickyGroup?.name}</StickyGroupBanner>
           <FixedSizeList
             ref={listRef}
             height={listHeight}
@@ -463,7 +482,7 @@ const PopupContainer: React.FC<PopupContainerProps> = ({ model, resolve }) => {
             itemData={RowData}
             itemKey={(index, data) => data.listItems[index].key}
             overscanCount={4}
-            onItemsRendered={handleItemsRendered}
+            onScroll={handleScroll}
             style={{ pointerEvents: isMouseOver ? 'auto' : 'none' }}>
             {VirtualizedRow}
           </FixedSizeList>
@@ -481,7 +500,7 @@ interface VirtualizedRowData {
   listItems: FlatListItem[]
   focusedItemKey: string
   setFocusedItemKey: (key: string) => void
-  currentStickyGroup: FlatListItem | null
+  stickyGroup: FlatListItem | null
   handleItemClick: (item: FlatListItem) => void
   togglePin: (modelId: string) => void
 }
@@ -491,7 +510,7 @@ interface VirtualizedRowData {
  */
 const VirtualizedRow = React.memo(
   ({ data, index, style }: { data: VirtualizedRowData; index: number; style: React.CSSProperties }) => {
-    const { listItems, focusedItemKey, setFocusedItemKey, handleItemClick, togglePin, currentStickyGroup } = data
+    const { listItems, focusedItemKey, setFocusedItemKey, handleItemClick, togglePin, stickyGroup } = data
 
     const item = listItems[index]
 
@@ -502,7 +521,7 @@ const VirtualizedRow = React.memo(
     return (
       <div style={style}>
         {item.type === 'group' ? (
-          <GroupItem $isSticky={item.key === currentStickyGroup?.key}>{item.name}</GroupItem>
+          <GroupItem $isSticky={item.key === stickyGroup?.key}>{item.name}</GroupItem>
         ) : (
           <ModelItem
             className={classNames({

--- a/src/renderer/src/components/Popups/SelectModelPopup.tsx
+++ b/src/renderer/src/components/Popups/SelectModelPopup.tsx
@@ -257,9 +257,6 @@ const PopupContainer: React.FC<PopupContainerProps> = ({ model, resolve }) => {
     const alignment = scrollTriggerRef.current === 'keyboard' ? 'auto' : 'center'
     listRef.current?.scrollToItem(index, alignment)
 
-    console.log('focusedItemKey', focusedItemKey)
-    console.log('scrollToFocusedItem', index, alignment)
-
     // 滚动后重置触发器
     scrollTriggerRef.current = 'none'
   }, [focusedItemKey, listItems])


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

点击 pin 触发模型置顶的时候不会触发 sticky header 更新，结果“已固定”这个分组名可能不消失或者错误地出现。

After this PR:

改用 react-window 的 onScroll，保存当前位置，手动更新 sticky header

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```

## Summary by Sourcery

Improve sticky header behavior in SelectModelPopup by using react-window's onScroll event and manually tracking scroll position

Bug Fixes:
- Fixed issues with sticky header not updating correctly when pinning models

Enhancements:
- Refactored sticky group header tracking to use scroll offset instead of visible items rendering
- Implemented more robust sticky header update mechanism