### PR TITLE
fix: update input schema reference in MessageTools for accurate tool …

### DIFF
--- a/src/renderer/src/pages/home/Messages/MessageTools.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageTools.tsx
@@ -30,7 +30,7 @@ const MessageTools: FC<Props> = ({ blocks }) => {
     try {
       return JSON.stringify(
         {
-          params: toolResponse?.tool?.inputSchema,
+          params: toolResponse?.arguments,
           response: toolResponse?.response
         },
         null,

--- a/src/renderer/src/pages/settings/MiniappSettings/MiniAppSettings.tsx
+++ b/src/renderer/src/pages/settings/MiniappSettings/MiniAppSettings.tsx
@@ -230,17 +230,4 @@ const BorderedContainer = styled.div`
   background-color: var(--color-bg-1);
 `
 
-// 新增自定义编辑器容器样式
-const CustomEditorContainer = styled.div`
-  margin: 8px 0;
-  padding: 8px;
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  background-color: var(--color-bg-1);
-
-  .ant-input {
-    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
-  }
-`
-
 export default MiniAppSettings

--- a/src/renderer/src/store/messageBlock.ts
+++ b/src/renderer/src/store/messageBlock.ts
@@ -140,7 +140,7 @@ const formatCitationsFromBlock = (block: CitationMessageBlock | undefined): Cita
       case WebSearchSource.ANTHROPIC:
         formattedCitations =
           (block.response.results as Array<WebSearchResultBlock>)?.map((result, index) => {
-            const {url} = result
+            const { url } = result
             let hostname: string | undefined
             try {
               hostname = new URL(url).hostname


### PR DESCRIPTION
…response handling

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR: mcp tool 调用展示参数那里，用的参数错了，不应该是 inputschema

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```

## Summary by Sourcery

Bug Fixes:
- Fixed incorrect parameter reference when displaying tool response, now using tool arguments instead of input schema