### PR TITLE
fix: SelectModelPopup scrolling behaviour

### DIFF
--- a/src/renderer/src/components/Popups/SelectModelPopup.tsx
+++ b/src/renderer/src/components/Popups/SelectModelPopup.tsx
@@ -645,14 +645,26 @@ const PinIconWrapper = styled.div.attrs({ className: 'pin-icon' })<{ $isPinned?:
   }
 `
 
+const TopViewKey = 'SelectModelPopup'
+
 export default class SelectModelPopup {
+  static topviewId = 0
   static hide() {
-    TopView.hide('SelectModelPopup')
+    TopView.hide(TopViewKey)
   }
 
   static show(params: Props) {
     return new Promise<Model | undefined>((resolve) => {
-      TopView.show(<PopupContainer {...params} resolve={resolve} />, 'SelectModelPopup')
+      TopView.show(
+        <PopupContainer
+          {...params}
+          resolve={(v) => {
+            resolve(v)
+            TopView.hide(TopViewKey)
+          }}
+        />,
+        TopViewKey
+      )
     })
   }
 }

--- a/src/renderer/src/components/Popups/SelectModelPopup.tsx
+++ b/src/renderer/src/components/Popups/SelectModelPopup.tsx
@@ -68,6 +68,11 @@ const PopupContainer: React.FC<PopupContainerProps> = ({ model, resolve }) => {
   // 当前选中的模型ID
   const currentModelId = model ? getModelUniqId(model) : ''
 
+  // 搜索文本变化时设置滚动来源
+  useEffect(() => {
+    scrollTriggerRef.current = searchText.trim() ? 'initial' : 'search'
+  }, [searchText])
+
   // 加载置顶模型列表
   useEffect(() => {
     const loadPinnedModels = async () => {
@@ -222,6 +227,11 @@ const PopupContainer: React.FC<PopupContainerProps> = ({ model, resolve }) => {
     return items
   }, [providers, getFilteredModels, pinnedModels, searchText, t, createModelItem])
 
+  // 获取可选择的模型项（过滤掉分组标题）
+  const modelItems = useMemo(() => {
+    return listItems.filter((item) => item.type === 'model')
+  }, [listItems])
+
   // 基于滚动位置更新sticky分组标题
   const updateStickyGroup = useCallback(
     (scrollOffset?: number) => {
@@ -261,29 +271,17 @@ const PopupContainer: React.FC<PopupContainerProps> = ({ model, resolve }) => {
     [updateStickyGroup]
   )
 
-  // 获取可选择的模型项（过滤掉分组标题）
-  const modelItems = useMemo(() => {
-    return listItems.filter((item) => item.type === 'model')
-  }, [listItems])
-
-  // 搜索文本变化时设置滚动来源
-  useEffect(() => {
-    if (searchText.trim() !== '') {
-      scrollTriggerRef.current = 'search'
-      setFocusedItemKey('')
-    }
-  }, [searchText])
-
   // 设置初始聚焦项以触发滚动
   useEffect(() => {
     if (scrollTriggerRef.current === 'initial' || scrollTriggerRef.current === 'search') {
       const selectedItem = modelItems.find((item) => item.isSelected)
       if (selectedItem) {
         setFocusedItemKey(selectedItem.key)
-      } else if (scrollTriggerRef.current === 'initial' && modelItems.length > 0) {
+      } else if (modelItems.length > 0) {
         setFocusedItemKey(modelItems[0].key)
+      } else {
+        setFocusedItemKey('')
       }
-      // 其余情况不设置focusedItemKey
     }
   }, [modelItems])
 
@@ -305,7 +303,7 @@ const PopupContainer: React.FC<PopupContainerProps> = ({ model, resolve }) => {
   const handleItemClick = useCallback(
     (item: FlatListItem) => {
       if (item.type === 'model') {
-        scrollTriggerRef.current = 'none'
+        scrollTriggerRef.current = 'initial'
         resolve(item.model)
         setOpen(false)
       }
@@ -389,12 +387,12 @@ const PopupContainer: React.FC<PopupContainerProps> = ({ model, resolve }) => {
   }, [focusedItemKey, modelItems, handleItemClick, open, resolve])
 
   const onCancel = useCallback(() => {
-    scrollTriggerRef.current = 'none'
+    scrollTriggerRef.current = 'initial'
     setOpen(false)
   }, [])
 
   const onClose = useCallback(async () => {
-    scrollTriggerRef.current = 'none'
+    scrollTriggerRef.current = 'initial'
     resolve(undefined)
     SelectModelPopup.hide()
   }, [resolve])

--- a/src/renderer/src/components/Popups/SelectModelPopup.tsx
+++ b/src/renderer/src/components/Popups/SelectModelPopup.tsx
@@ -53,12 +53,10 @@ const PopupContainer: React.FC<PopupContainerProps> = ({ model, resolve }) => {
   const [open, setOpen] = useState(true)
   const inputRef = useRef<InputRef>(null)
   const listRef = useRef<FixedSizeList>(null)
-  const [_searchText, setSearchText] = useState('')
-  const searchText = useDeferredValue(_searchText)
+  const [searchText, setSearchText] = useState('')
   const [isMouseOver, setIsMouseOver] = useState(false)
   const [pinnedModels, setPinnedModels] = useState<string[]>([])
-  const [_focusedItemKey, setFocusedItemKey] = useState<string>('')
-  const focusedItemKey = useDeferredValue(_focusedItemKey)
+  const [focusedItemKey, setFocusedItemKey] = useState<string>('')
   const [_stickyGroup, setStickyGroup] = useState<FlatListItem | null>(null)
   const stickyGroup = useDeferredValue(_stickyGroup)
   const firstGroupRef = useRef<FlatListItem | null>(null)
@@ -70,7 +68,7 @@ const PopupContainer: React.FC<PopupContainerProps> = ({ model, resolve }) => {
 
   // 搜索文本变化时设置滚动来源
   useEffect(() => {
-    scrollTriggerRef.current = searchText.trim() ? 'initial' : 'search'
+    scrollTriggerRef.current = searchText ? 'initial' : 'search'
   }, [searchText])
 
   // 加载置顶模型列表
@@ -449,7 +447,7 @@ const PopupContainer: React.FC<PopupContainerProps> = ({ model, resolve }) => {
           }
           ref={inputRef}
           placeholder={t('models.search')}
-          value={_searchText} // 使用 _searchText，需要实时更新
+          value={searchText}
           onChange={(e) => setSearchText(e.target.value)}
           allowClear
           autoFocus

--- a/src/renderer/src/components/Popups/SelectModelPopup/hook.ts
+++ b/src/renderer/src/components/Popups/SelectModelPopup/hook.ts
@@ -1,0 +1,41 @@
+import { useMemo, useReducer } from 'react'
+
+import { initialScrollState, scrollReducer } from './reducer'
+import { FlatListItem, ScrollTrigger } from './types'
+
+/**
+ * 管理滚动和焦点状态的 hook
+ */
+export function useScrollState() {
+  const [state, dispatch] = useReducer(scrollReducer, initialScrollState)
+
+  const actions = useMemo(
+    () => ({
+      setFocusedItemKey: (key: string) => dispatch({ type: 'SET_FOCUSED_ITEM_KEY', payload: key }),
+      setScrollTrigger: (trigger: ScrollTrigger) => dispatch({ type: 'SET_SCROLL_TRIGGER', payload: trigger }),
+      setLastScrollOffset: (offset: number) => dispatch({ type: 'SET_LAST_SCROLL_OFFSET', payload: offset }),
+      setStickyGroup: (group: FlatListItem | null) => dispatch({ type: 'SET_STICKY_GROUP', payload: group }),
+      setIsMouseOver: (isOver: boolean) => dispatch({ type: 'SET_IS_MOUSE_OVER', payload: isOver }),
+      focusNextItem: (modelItems: FlatListItem[], step: number) =>
+        dispatch({ type: 'FOCUS_NEXT_ITEM', payload: { modelItems, step } }),
+      focusPage: (modelItems: FlatListItem[], currentIndex: number, step: number) =>
+        dispatch({ type: 'FOCUS_PAGE', payload: { modelItems, currentIndex, step } }),
+      searchChanged: (searchText: string) => dispatch({ type: 'SEARCH_CHANGED', payload: { searchText } }),
+      updateOnListChange: (modelItems: FlatListItem[]) =>
+        dispatch({ type: 'UPDATE_ON_LIST_CHANGE', payload: { modelItems } }),
+      initScroll: () => dispatch({ type: 'INIT_SCROLL' })
+    }),
+    []
+  )
+
+  return {
+    // 状态
+    focusedItemKey: state.focusedItemKey,
+    scrollTrigger: state.scrollTrigger,
+    lastScrollOffset: state.lastScrollOffset,
+    stickyGroup: state.stickyGroup,
+    isMouseOver: state.isMouseOver,
+    // 操作
+    ...actions
+  }
+}

--- a/src/renderer/src/components/Popups/SelectModelPopup/hook.ts
+++ b/src/renderer/src/components/Popups/SelectModelPopup/hook.ts
@@ -15,7 +15,7 @@ export function useScrollState() {
       setScrollTrigger: (trigger: ScrollTrigger) => dispatch({ type: 'SET_SCROLL_TRIGGER', payload: trigger }),
       setLastScrollOffset: (offset: number) => dispatch({ type: 'SET_LAST_SCROLL_OFFSET', payload: offset }),
       setStickyGroup: (group: FlatListItem | null) => dispatch({ type: 'SET_STICKY_GROUP', payload: group }),
-      setIsMouseOver: (isOver: boolean) => dispatch({ type: 'SET_IS_MOUSE_OVER', payload: isOver }),
+      setIsMouseOver: (isMouseOver: boolean) => dispatch({ type: 'SET_IS_MOUSE_OVER', payload: isMouseOver }),
       focusNextItem: (modelItems: FlatListItem[], step: number) =>
         dispatch({ type: 'FOCUS_NEXT_ITEM', payload: { modelItems, step } }),
       focusPage: (modelItems: FlatListItem[], currentIndex: number, step: number) =>

--- a/src/renderer/src/components/Popups/SelectModelPopup/index.ts
+++ b/src/renderer/src/components/Popups/SelectModelPopup/index.ts
@@ -1,0 +1,3 @@
+import { SelectModelPopup } from './popup'
+
+export default SelectModelPopup

--- a/src/renderer/src/components/Popups/SelectModelPopup/popup.tsx
+++ b/src/renderer/src/components/Popups/SelectModelPopup/popup.tsx
@@ -23,8 +23,11 @@ import { FlatListItem } from './types'
 const PAGE_SIZE = 9
 const ITEM_HEIGHT = 36
 
-interface Props {
+interface PopupParams {
   model?: Model
+}
+
+interface Props extends PopupParams {
   resolve: (value: Model | undefined) => void
 }
 
@@ -632,7 +635,7 @@ export class SelectModelPopup {
     TopView.hide(TopViewKey)
   }
 
-  static show(params: Props) {
+  static show(params: PopupParams) {
     return new Promise<Model | undefined>((resolve) => {
       TopView.show(
         <PopupContainer

--- a/src/renderer/src/components/Popups/SelectModelPopup/popup.tsx
+++ b/src/renderer/src/components/Popups/SelectModelPopup/popup.tsx
@@ -34,7 +34,7 @@ interface Props extends PopupParams {
 const PopupContainer: React.FC<Props> = ({ model, resolve }) => {
   const { t } = useTranslation()
   const { providers } = useProviders()
-  const { pinnedModels, togglePinnedModel } = usePinnedModels()
+  const { pinnedModels, togglePinnedModel, loading: loadingPinnedModels } = usePinnedModels()
   const [open, setOpen] = useState(true)
   const inputRef = useRef<InputRef>(null)
   const listRef = useRef<FixedSizeList>(null)
@@ -343,10 +343,10 @@ const PopupContainer: React.FC<Props> = ({ model, resolve }) => {
 
   // 初始化焦点和滚动位置
   useEffect(() => {
-    if (!open) return
+    if (!open || loadingPinnedModels) return
     setTimeout(() => inputRef.current?.focus(), 0)
     initScroll()
-  }, [open, initScroll])
+  }, [open, initScroll, loadingPinnedModels])
 
   const RowData = useMemo(
     (): VirtualizedRowData => ({
@@ -412,7 +412,7 @@ const PopupContainer: React.FC<Props> = ({ model, resolve }) => {
       <Divider style={{ margin: 0, marginTop: 4, borderBlockStartWidth: 0.5 }} />
 
       {listItems.length > 0 ? (
-        <ListContainer onMouseMove={() => setIsMouseOver(true)}>
+        <ListContainer onMouseMove={() => !isMouseOver && setIsMouseOver(true)}>
           {/* Sticky Group Banner，它会替换第一个分组名称 */}
           <StickyGroupBanner>{stickyGroup?.name}</StickyGroupBanner>
           <FixedSizeList

--- a/src/renderer/src/components/Popups/SelectModelPopup/reducer.ts
+++ b/src/renderer/src/components/Popups/SelectModelPopup/reducer.ts
@@ -1,0 +1,100 @@
+import { ScrollAction, ScrollState } from './types'
+
+/**
+ * 初始状态
+ */
+export const initialScrollState: ScrollState = {
+  focusedItemKey: '',
+  scrollTrigger: 'initial',
+  lastScrollOffset: 0,
+  stickyGroup: null,
+  isMouseOver: false
+}
+
+/**
+ * 滚动状态的 reducer，用于避免复杂依赖可能带来的状态更新问题
+ * @param state 当前状态
+ * @param action 动作
+ * @returns 新的状态
+ */
+export const scrollReducer = (state: ScrollState, action: ScrollAction): ScrollState => {
+  switch (action.type) {
+    case 'SET_FOCUSED_ITEM_KEY':
+      return { ...state, focusedItemKey: action.payload }
+
+    case 'SET_SCROLL_TRIGGER':
+      return { ...state, scrollTrigger: action.payload }
+
+    case 'SET_LAST_SCROLL_OFFSET':
+      return { ...state, lastScrollOffset: action.payload }
+
+    case 'SET_STICKY_GROUP':
+      return { ...state, stickyGroup: action.payload }
+
+    case 'SET_IS_MOUSE_OVER':
+      return { ...state, isMouseOver: action.payload }
+
+    case 'FOCUS_NEXT_ITEM': {
+      const { modelItems, step } = action.payload
+      const currentIndex = modelItems.findIndex((item) => item.key === state.focusedItemKey)
+      const nextIndex = (currentIndex < 0 ? 0 : currentIndex + step + modelItems.length) % modelItems.length
+
+      return {
+        ...state,
+        focusedItemKey: modelItems.length > 0 ? modelItems[nextIndex].key : '',
+        scrollTrigger: 'keyboard'
+      }
+    }
+
+    case 'FOCUS_PAGE': {
+      const { modelItems, currentIndex, step } = action.payload
+      const nextIndex = Math.max(0, Math.min(currentIndex + step, modelItems.length - 1))
+
+      return {
+        ...state,
+        focusedItemKey: modelItems.length > 0 ? modelItems[nextIndex].key : '',
+        scrollTrigger: 'keyboard'
+      }
+    }
+
+    case 'SEARCH_CHANGED':
+      return {
+        ...state,
+        scrollTrigger: action.payload.searchText ? 'search' : 'initial'
+      }
+
+    case 'UPDATE_ON_LIST_CHANGE': {
+      const { modelItems } = action.payload
+
+      // 在列表变化时尝试聚焦一个模型：
+      // - 如果是 initial 状态，先尝试聚焦当前选中的模型
+      // - 如果是 search 状态，尝试聚焦第一个模型
+      let newFocusedKey = ''
+      if (state.scrollTrigger === 'initial' || state.scrollTrigger === 'search') {
+        const selectedItem = modelItems.find((item) => item.isSelected)
+        if (selectedItem && state.scrollTrigger === 'initial') {
+          newFocusedKey = selectedItem.key
+        } else if (modelItems.length > 0) {
+          newFocusedKey = modelItems[0].key
+        }
+      } else {
+        newFocusedKey = state.focusedItemKey
+      }
+
+      return {
+        ...state,
+        focusedItemKey: newFocusedKey
+      }
+    }
+
+    case 'INIT_SCROLL':
+      return {
+        ...state,
+        scrollTrigger: 'initial',
+        lastScrollOffset: 0
+      }
+
+    default:
+      return state
+  }
+}

--- a/src/renderer/src/components/Popups/SelectModelPopup/reducer.ts
+++ b/src/renderer/src/components/Popups/SelectModelPopup/reducer.ts
@@ -36,12 +36,21 @@ export const scrollReducer = (state: ScrollState, action: ScrollAction): ScrollS
 
     case 'FOCUS_NEXT_ITEM': {
       const { modelItems, step } = action.payload
+
+      if (modelItems.length === 0) {
+        return {
+          ...state,
+          focusedItemKey: '',
+          scrollTrigger: 'keyboard'
+        }
+      }
+
       const currentIndex = modelItems.findIndex((item) => item.key === state.focusedItemKey)
       const nextIndex = (currentIndex < 0 ? 0 : currentIndex + step + modelItems.length) % modelItems.length
 
       return {
         ...state,
-        focusedItemKey: modelItems.length > 0 ? modelItems[nextIndex].key : '',
+        focusedItemKey: modelItems[nextIndex].key,
         scrollTrigger: 'keyboard'
       }
     }

--- a/src/renderer/src/components/Popups/SelectModelPopup/types.ts
+++ b/src/renderer/src/components/Popups/SelectModelPopup/types.ts
@@ -1,0 +1,42 @@
+import { Model } from '@renderer/types'
+import { ReactNode } from 'react'
+
+// 列表项类型，组名也作为列表项
+export type ListItemType = 'group' | 'model'
+
+// 滚动触发来源类型
+export type ScrollTrigger = 'initial' | 'search' | 'keyboard' | 'none'
+
+// 扁平化列表项接口
+export interface FlatListItem {
+  key: string
+  type: ListItemType
+  icon?: ReactNode
+  name: ReactNode
+  tags?: ReactNode
+  model?: Model
+  isPinned?: boolean
+  isSelected?: boolean
+}
+
+// 滚动和焦点相关的状态类型
+export interface ScrollState {
+  focusedItemKey: string
+  scrollTrigger: ScrollTrigger
+  lastScrollOffset: number
+  stickyGroup: FlatListItem | null
+  isMouseOver: boolean
+}
+
+// 滚动和焦点相关的 action 类型
+export type ScrollAction =
+  | { type: 'SET_FOCUSED_ITEM_KEY'; payload: string }
+  | { type: 'SET_SCROLL_TRIGGER'; payload: ScrollTrigger }
+  | { type: 'SET_LAST_SCROLL_OFFSET'; payload: number }
+  | { type: 'SET_STICKY_GROUP'; payload: FlatListItem | null }
+  | { type: 'SET_IS_MOUSE_OVER'; payload: boolean }
+  | { type: 'FOCUS_NEXT_ITEM'; payload: { modelItems: FlatListItem[]; step: number } }
+  | { type: 'FOCUS_PAGE'; payload: { modelItems: FlatListItem[]; currentIndex: number; step: number } }
+  | { type: 'SEARCH_CHANGED'; payload: { searchText: string } }
+  | { type: 'UPDATE_ON_LIST_CHANGE'; payload: { modelItems: FlatListItem[] } }
+  | { type: 'INIT_SCROLL'; payload?: void }

--- a/src/renderer/src/hooks/usePinnedModels.ts
+++ b/src/renderer/src/hooks/usePinnedModels.ts
@@ -1,0 +1,61 @@
+import db from '@renderer/databases'
+import { getModelUniqId } from '@renderer/services/ModelService'
+import { sortBy } from 'lodash'
+import { useCallback, useEffect, useState } from 'react'
+
+import { useProviders } from './useProvider'
+
+export const usePinnedModels = () => {
+  const [pinnedModels, setPinnedModels] = useState<string[]>([])
+  const { providers } = useProviders()
+
+  useEffect(() => {
+    const loadPinnedModels = async () => {
+      const setting = await db.settings.get('pinned:models')
+      const savedPinnedModels = setting?.value || []
+
+      // Filter out invalid pinned models
+      const allModelIds = providers.flatMap((p) => p.models || []).map((m) => getModelUniqId(m))
+      const validPinnedModels = savedPinnedModels.filter((id) => allModelIds.includes(id))
+
+      // Update storage if there were invalid models
+      if (validPinnedModels.length !== savedPinnedModels.length) {
+        await db.settings.put({ id: 'pinned:models', value: validPinnedModels })
+      }
+
+      setPinnedModels(sortBy(validPinnedModels))
+    }
+
+    try {
+      loadPinnedModels()
+    } catch (error) {
+      console.error('Failed to load pinned models', error)
+      setPinnedModels([])
+    }
+  }, [providers])
+
+  const updatePinnedModels = useCallback(async (models: string[]) => {
+    await db.settings.put({ id: 'pinned:models', value: models })
+    setPinnedModels(sortBy(models))
+  }, [])
+
+  /**
+   * Toggle a single pinned model
+   * @param modelId - The ID string of the model to toggle
+   */
+  const togglePinnedModel = useCallback(
+    async (modelId: string) => {
+      try {
+        const newPinnedModels = pinnedModels.includes(modelId)
+          ? pinnedModels.filter((id) => id !== modelId)
+          : [...pinnedModels, modelId]
+        await updatePinnedModels(newPinnedModels)
+      } catch (error) {
+        console.error('Failed to toggle pinned model', error)
+      }
+    },
+    [pinnedModels, updatePinnedModels]
+  )
+
+  return { pinnedModels, updatePinnedModels, togglePinnedModel }
+}

--- a/src/renderer/src/hooks/usePinnedModels.ts
+++ b/src/renderer/src/hooks/usePinnedModels.ts
@@ -7,10 +7,12 @@ import { useProviders } from './useProvider'
 
 export const usePinnedModels = () => {
   const [pinnedModels, setPinnedModels] = useState<string[]>([])
+  const [loading, setLoading] = useState(true)
   const { providers } = useProviders()
 
   useEffect(() => {
     const loadPinnedModels = async () => {
+      setLoading(true)
       const setting = await db.settings.get('pinned:models')
       const savedPinnedModels = setting?.value || []
 
@@ -24,14 +26,14 @@ export const usePinnedModels = () => {
       }
 
       setPinnedModels(sortBy(validPinnedModels))
+      setLoading(false)
     }
 
-    try {
-      loadPinnedModels()
-    } catch (error) {
+    loadPinnedModels().catch((error) => {
       console.error('Failed to load pinned models', error)
       setPinnedModels([])
-    }
+      setLoading(false)
+    })
   }, [providers])
 
   const updatePinnedModels = useCallback(async (models: string[]) => {
@@ -57,5 +59,5 @@ export const usePinnedModels = () => {
     [pinnedModels, updatePinnedModels]
   )
 
-  return { pinnedModels, updatePinnedModels, togglePinnedModel }
+  return { pinnedModels, updatePinnedModels, togglePinnedModel, loading }
 }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

重构 SelectModelPopup 滚动状态管理，修复滚动行为。

Before this PR:

引入大量独立的 state/ref/useEffect 来管理滚动状态、触发滚动，存在一些问题。
尤其是触发滚动的 useEffect 同时依赖列表和聚焦项的变化，有时导致滚动触发时没有使用最新的值。

After this PR:

集中管理状态：
- 分离出 usePinnedModels hook 专门处理置顶模型。
- 分离出 useScrollState hook 专门集中处理滚动和聚焦，解决滚动没有正确触发的问题（尤其是在输入/删除搜索文本的时候）。

滚动行为：
- 存在搜索文本时，现在总是会尝试聚焦第一个模型。
- 没有搜索文本时，总是尝试聚焦选中的模型。

也许解决了热重载的问题（不确定）

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```

## Summary by Sourcery

Refactor the scroll and focus management in SelectModelPopup to improve state handling and scrolling behavior

Enhancements:
- Centralized scroll and focus state management using a custom hook and reducer
- Separated concerns by extracting pinned models logic into a dedicated hook
- Improved scroll triggering logic for different scenarios

Chores:
- Restructured component file structure
- Extracted complex state logic into separate files

## Summary by Sourcery

Refactor the scroll and focus management in SelectModelPopup to improve state handling and scrolling behavior

New Features:
- Created a dedicated hook for managing pinned models
- Implemented a reducer-based approach for scroll state management

Enhancements:
- Centralized scroll and focus state management using a custom hook and reducer
- Separated concerns by extracting pinned models logic into a dedicated hook
- Improved scroll triggering logic for different scenarios

Chores:
- Restructured component file structure
- Extracted complex state logic into separate files