### PR TITLE
Feat: allow user to define model capabilities

### DIFF
--- a/src/renderer/src/config/models.ts
+++ b/src/renderer/src/config/models.ts
@@ -237,8 +237,8 @@ export const CLAUDE_SUPPORTED_WEBSEARCH_REGEX = new RegExp(
 )
 
 export function isFunctionCallingModel(model: Model): boolean {
-  if (model.type?.includes('function_calling')) {
-    return true
+  if (typeof model.type?.function_calling === 'boolean') {
+    return model.type.function_calling
   }
 
   if (isEmbeddingModel(model)) {
@@ -2189,6 +2189,9 @@ export function isEmbeddingModel(model: Model): boolean {
   if (!model) {
     return false
   }
+  if (typeof model.type?.embedding === 'boolean') {
+    return model.type.embedding
+  }
 
   if (['anthropic'].includes(model?.provider)) {
     return false
@@ -2202,7 +2205,7 @@ export function isEmbeddingModel(model: Model): boolean {
     return false
   }
 
-  return EMBEDDING_REGEX.test(model.id) || model.type?.includes('embedding') || false
+  return EMBEDDING_REGEX.test(model.id) || false
 }
 
 export function isRerankModel(model: Model): boolean {
@@ -2213,16 +2216,20 @@ export function isVisionModel(model: Model): boolean {
   if (!model) {
     return false
   }
+  if (typeof model.type?.vision === 'boolean') {
+    return model.type.vision
+  }
+
   // 新添字段 copilot-vision-request 后可使用 vision
   // if (model.provider === 'copilot') {
   //   return false
   // }
 
   if (model.provider === 'doubao') {
-    return VISION_REGEX.test(model.name) || model.type?.includes('vision') || false
+    return VISION_REGEX.test(model.name) || false
   }
 
-  return VISION_REGEX.test(model.id) || model.type?.includes('vision') || false
+  return VISION_REGEX.test(model.id) || false
 }
 
 export function isOpenAIReasoningModel(model: Model): boolean {
@@ -2356,9 +2363,12 @@ export function isReasoningModel(model?: Model): boolean {
   if (!model) {
     return false
   }
+  if (typeof model.type?.reasoning === 'boolean') {
+    return model.type.reasoning
+  }
 
   if (model.provider === 'doubao') {
-    return REASONING_REGEX.test(model.name) || model.type?.includes('reasoning') || false
+    return REASONING_REGEX.test(model.name) || false
   }
 
   if (
@@ -2372,7 +2382,7 @@ export function isReasoningModel(model?: Model): boolean {
     return true
   }
 
-  return REASONING_REGEX.test(model.id) || model.type?.includes('reasoning') || false
+  return REASONING_REGEX.test(model.id) || false
 }
 
 export function isSupportedModel(model: OpenAI.Models.Model): boolean {
@@ -2387,11 +2397,8 @@ export function isWebSearchModel(model: Model): boolean {
   if (!model) {
     return false
   }
-
-  if (model.type) {
-    if (model.type.includes('web_search')) {
-      return true
-    }
+  if (typeof model.type?.web_search === 'boolean') {
+    return model.type.web_search
   }
 
   const provider = getProviderByModel(model)

--- a/src/renderer/src/pages/settings/ProviderSettings/ModelEditContent.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ModelEditContent.tsx
@@ -164,20 +164,42 @@ interface TypeCheckboxItemProps {
 }
 
 const TypeCheckboxItem: FC<TypeCheckboxItemProps> = ({ model, typeKey, label, checker, onUpdateModel }) => {
+  const { t } = useTranslation()
   const typeValue = model.type?.[typeKey]
   const initialChecked = typeof typeValue === 'boolean' ? typeValue : checker(model)
 
+  const handleChange = (checked: any) => {
+    const isPotentiallyRiskyChange = checked && !checker(model)
+
+    const performUpdate = () => {
+      const newType = {
+        ...(model.type || {}),
+        [typeKey]: checked
+      }
+      onUpdateModel({ ...model, type: newType })
+    }
+
+    if (isPotentiallyRiskyChange) {
+      window.modal.confirm({
+        title: t('settings.moresetting.warn'),
+        content: t('settings.moresetting.check.warn'),
+        okText: t('settings.moresetting.check.confirm'),
+        cancelText: t('common.cancel'),
+        okButtonProps: { danger: true },
+        cancelButtonProps: { type: 'primary' },
+        onOk: () => {
+          performUpdate()
+        },
+        onCancel: () => {},
+        centered: true
+      })
+    } else {
+      performUpdate()
+    }
+  }
+
   return (
-    <Checkbox
-      checked={initialChecked}
-      onChange={(e) => {
-        const checked = e.target.checked
-        const newType = {
-          ...(model.type || {}),
-          [typeKey]: checked
-        }
-        onUpdateModel({ ...model, type: newType })
-      }}>
+    <Checkbox checked={initialChecked} onChange={(e) => handleChange(e.target.checked)}>
       {label}
     </Checkbox>
   )

--- a/src/renderer/src/pages/settings/ProviderSettings/ModelEditContent.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ModelEditContent.tsx
@@ -10,7 +10,7 @@ import {
 import { Model, ModelTypes } from '@renderer/types'
 import { getDefaultGroupName } from '@renderer/utils'
 import { Button, Checkbox, Divider, Flex, Form, Input, message, Modal } from 'antd'
-import { FC, useMemo, useState } from 'react'
+import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 interface ModelEditContentProps {
@@ -164,13 +164,8 @@ interface TypeCheckboxItemProps {
 }
 
 const TypeCheckboxItem: FC<TypeCheckboxItemProps> = ({ model, typeKey, label, checker, onUpdateModel }) => {
-  const initialChecked = useMemo(() => {
-    const typeValue = model.type?.[typeKey]
-    if (typeof typeValue === 'boolean') {
-      return typeValue
-    }
-    return checker(model)
-  }, [model, typeKey, checker])
+  const typeValue = model.type?.[typeKey]
+  const initialChecked = typeof typeValue === 'boolean' ? typeValue : checker(model)
 
   return (
     <Checkbox
@@ -178,7 +173,7 @@ const TypeCheckboxItem: FC<TypeCheckboxItemProps> = ({ model, typeKey, label, ch
       onChange={(e) => {
         const checked = e.target.checked
         const newType = {
-          ...model.type,
+          ...(model.type || {}),
           [typeKey]: checked
         }
         onUpdateModel({ ...model, type: newType })

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -164,8 +164,6 @@ export type Provider = {
 
 export type ProviderType = 'openai' | 'openai-compatible' | 'anthropic' | 'gemini' | 'qwenlm' | 'azure-openai'
 
-export type ModelType = 'text' | 'vision' | 'embedding' | 'reasoning' | 'function_calling' | 'web_search'
-
 export type Model = {
   id: string
   provider: string
@@ -173,7 +171,17 @@ export type Model = {
   group: string
   owned_by?: string
   description?: string
-  type?: ModelType[]
+  type?: ModelTypes
+}
+
+export type ModelType = boolean | undefined
+
+export type ModelTypes = {
+  function_calling?: ModelType
+  vision?: ModelType
+  web_search?: ModelType
+  embedding?: ModelType
+  reasoning?: ModelType
 }
 
 export type Suggestion = {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
被 `isFunctionCallingModel` 判断为支持 tools 的模型，用户无法手动将其配置为不支持 tools

After this PR:
1. 允许用户自行配置模型能力
2. 用户未定义的情况，继续使用`isFunctionCallingModel`等进行判断

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #5809 

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->

```release-note

```
