### PR TITLE
fix: multi-window entry html

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -74,6 +74,14 @@ export default defineConfig({
     },
     optimizeDeps: {
       exclude: []
+    },
+    build: {
+      rollupOptions: {
+        input: {
+          index: resolve(__dirname, 'src/renderer/index.html'),
+          miniWindow: resolve(__dirname, 'src/renderer/miniWindow.html')
+        }
+      }
     }
   }
 })

--- a/src/main/services/WindowService.ts
+++ b/src/main/services/WindowService.ts
@@ -470,7 +470,7 @@ export class WindowService {
     if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
       this.miniWindow.loadURL(process.env['ELECTRON_RENDERER_URL'] + '/src/windows/mini/index.html')
     } else {
-      this.miniWindow.loadFile(join(__dirname, '../renderer/src/windows/mini/index.html'))
+      this.miniWindow.loadFile(join(__dirname, '../renderer/miniWindow.html'))
     }
 
     return this.miniWindow

--- a/src/renderer/miniWindow.html
+++ b/src/renderer/miniWindow.html
@@ -18,7 +18,7 @@
 
 <body>
   <div id="root"></div>
-  <script type="module" src="./entryPoint.tsx"></script>
+  <script type="module" src="/src/windows/mini/entryPoint.tsx"></script>
 </body>
 
 </html>


### PR DESCRIPTION
- Promote the independent entry HTML of multiple windows to the same level as index.html (subsequent multiple windows will maintain this rule)
- Modify vite configuration to support multi-window entry files

## Summary by Sourcery

Promote multi-window HTML entry files to the same directory level as index.html and update build and window loading logic to support this structure.

Enhancements:
- Update Vite configuration to support multiple HTML entry points for different windows.
- Adjust window service logic to load the relocated mini window HTML file.