### PR TITLE
feat(knowledge): adjust default top-n to 10

### DIFF
--- a/src/main/reranker/BaseReranker.ts
+++ b/src/main/reranker/BaseReranker.ts
@@ -38,7 +38,7 @@ export default abstract class BaseReranker {
   protected getRerankRequestBody(query: string, searchResults: ExtractChunkData[]) {
     const provider = this.base.rerankModelProvider
     const documents = searchResults.map((doc) => doc.pageContent)
-    const topN = this.base.topN || 5
+    const topN = this.base.topN || 10
 
     if (provider === 'voyageai') {
       return {

--- a/src/renderer/src/pages/knowledge/components/KnowledgeSettingsPopup.tsx
+++ b/src/renderer/src/pages/knowledge/components/KnowledgeSettingsPopup.tsx
@@ -291,7 +291,7 @@ const PopupContainer: React.FC<Props> = ({ base: _base, resolve }) => {
             rules={[
               {
                 validator(_, value) {
-                  if (value && (value < 0 || value > 10)) {
+                  if (value && (value < 0 || value > 30)) {
                     return Promise.reject(new Error(t('knowledge.topN_too_large_or_small')))
                   }
                   return Promise.resolve()


### PR DESCRIPTION
### What this PR does

Before this PR:

After this PR:
调整rerank默认返回个数为10个，最多为30个。
