### PR TITLE
fix: quickpanel auto-scroll behaviour

### DIFF
--- a/src/renderer/src/components/QuickPanel/types.ts
+++ b/src/renderer/src/components/QuickPanel/types.ts
@@ -65,4 +65,4 @@ export interface QuickPanelContextType {
   readonly afterAction?: (Options: QuickPanelCallBackOptions) => void
 }
 
-export type QuickPanelScrollTrigger = 'initial' | 'keyboard'
+export type QuickPanelScrollTrigger = 'initial' | 'keyboard' | 'none'

--- a/src/renderer/src/components/QuickPanel/types.ts
+++ b/src/renderer/src/components/QuickPanel/types.ts
@@ -64,3 +64,5 @@ export interface QuickPanelContextType {
   readonly beforeAction?: (Options: QuickPanelCallBackOptions) => void
   readonly afterAction?: (Options: QuickPanelCallBackOptions) => void
 }
+
+export type QuickPanelScrollTrigger = 'initial' | 'keyboard'

--- a/src/renderer/src/components/QuickPanel/view.tsx
+++ b/src/renderer/src/components/QuickPanel/view.tsx
@@ -6,13 +6,19 @@ import { theme } from 'antd'
 import Color from 'color'
 import { t } from 'i18next'
 import { Check } from 'lucide-react'
-import React, { use, useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
+import React, { use, useCallback, useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { FixedSizeList } from 'react-window'
 import styled from 'styled-components'
 import * as tinyPinyin from 'tiny-pinyin'
 
 import { QuickPanelContext } from './provider'
-import { QuickPanelCallBackOptions, QuickPanelCloseAction, QuickPanelListItem, QuickPanelOpenOptions } from './types'
+import {
+  QuickPanelCallBackOptions,
+  QuickPanelCloseAction,
+  QuickPanelListItem,
+  QuickPanelOpenOptions,
+  QuickPanelScrollTrigger
+} from './types'
 
 const ITEM_HEIGHT = 31
 
@@ -45,6 +51,7 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
   // 避免上下翻页时，鼠标干扰
   const [isMouseOver, setIsMouseOver] = useState(false)
 
+  const scrollTriggerRef = useRef<QuickPanelScrollTrigger>('initial')
   const [_index, setIndex] = useState(ctx.defaultIndex)
   const index = useDeferredValue(_index)
   const [historyPanel, setHistoryPanel] = useState<QuickPanelOpenOptions[]>([])
@@ -140,6 +147,7 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
     (action?: QuickPanelCloseAction) => {
       ctx.close(action)
       setHistoryPanel([])
+      scrollTriggerRef.current = 'initial'
 
       if (action === 'delete-symbol') {
         const textArea = document.querySelector('.inputbar textarea') as HTMLTextAreaElement
@@ -249,11 +257,14 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ctx.isVisible])
 
-  useEffect(() => {
-    if (index >= 0) {
-      listRef.current?.scrollToItem(index, 'smart')
-    }
-  }, [index])
+  useLayoutEffect(() => {
+    if (!listRef.current || index < 0 || isMouseOver) return
+
+    const alignment = scrollTriggerRef.current === 'keyboard' ? 'auto' : 'smart'
+    listRef.current?.scrollToItem(index, alignment)
+
+    scrollTriggerRef.current = 'initial'
+  }, [index, isMouseOver])
 
   // 处理键盘事件
   useEffect(() => {
@@ -277,6 +288,7 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
 
       switch (e.key) {
         case 'ArrowUp':
+          scrollTriggerRef.current = 'keyboard'
           if (isAssistiveKeyPressed) {
             setIndex((prev) => {
               const newIndex = prev - ctx.pageSize
@@ -289,6 +301,7 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
           break
 
         case 'ArrowDown':
+          scrollTriggerRef.current = 'keyboard'
           if (isAssistiveKeyPressed) {
             setIndex((prev) => {
               const newIndex = prev + ctx.pageSize
@@ -301,6 +314,7 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
           break
 
         case 'PageUp':
+          scrollTriggerRef.current = 'keyboard'
           setIndex((prev) => {
             const newIndex = prev - ctx.pageSize
             return newIndex < 0 ? 0 : newIndex
@@ -308,6 +322,7 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
           break
 
         case 'PageDown':
+          scrollTriggerRef.current = 'keyboard'
           setIndex((prev) => {
             const newIndex = prev + ctx.pageSize
             return newIndex >= list.length ? list.length - 1 : newIndex
@@ -317,6 +332,7 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
         case 'ArrowLeft':
           if (!isAssistiveKeyPressed) return
           if (!historyPanel.length) return
+          scrollTriggerRef.current = 'initial'
           clearSearchText(false)
           if (historyPanel.length > 0) {
             const lastPanel = historyPanel.pop()
@@ -329,6 +345,7 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
         case 'ArrowRight':
           if (!isAssistiveKeyPressed) return
           if (!list?.[index]?.isMenu) return
+          scrollTriggerRef.current = 'initial'
           clearSearchText(false)
           handleItemAction(list[index], 'enter')
           break
@@ -413,7 +430,7 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
       $selectedColor={selectedColor}
       $selectedColorHover={selectedColorHover}
       className={ctx.isVisible ? 'visible' : ''}>
-      <QuickPanelBody ref={bodyRef} onMouseMove={() => setIsMouseOver(true)}>
+      <QuickPanelBody ref={bodyRef} onMouseMove={() => setIsMouseOver((prev) => (prev ? prev : true))}>
         <FixedSizeList
           ref={listRef}
           itemCount={list.length}

--- a/src/renderer/src/components/QuickPanel/view.tsx
+++ b/src/renderer/src/components/QuickPanel/view.tsx
@@ -258,13 +258,13 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
   }, [ctx.isVisible])
 
   useLayoutEffect(() => {
-    if (!listRef.current || index < 0 || isMouseOver) return
+    if (!listRef.current || index < 0 || scrollTriggerRef.current === 'none') return
 
     const alignment = scrollTriggerRef.current === 'keyboard' ? 'auto' : 'smart'
     listRef.current?.scrollToItem(index, alignment)
 
-    scrollTriggerRef.current = 'initial'
-  }, [index, isMouseOver])
+    scrollTriggerRef.current = 'none'
+  }, [index])
 
   // 处理键盘事件
   useEffect(() => {
@@ -430,7 +430,14 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
       $selectedColor={selectedColor}
       $selectedColorHover={selectedColorHover}
       className={ctx.isVisible ? 'visible' : ''}>
-      <QuickPanelBody ref={bodyRef} onMouseMove={() => setIsMouseOver((prev) => (prev ? prev : true))}>
+      <QuickPanelBody
+        ref={bodyRef}
+        onMouseMove={() =>
+          setIsMouseOver((prev) => {
+            scrollTriggerRef.current = 'initial'
+            return prev ? prev : true
+          })
+        }>
         <FixedSizeList
           ref={listRef}
           itemCount={list.length}

--- a/src/renderer/src/components/QuickPanel/view.tsx
+++ b/src/renderer/src/components/QuickPanel/view.tsx
@@ -251,7 +251,7 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
 
   useEffect(() => {
     if (index >= 0) {
-      listRef.current?.scrollToItem(index, 'auto')
+      listRef.current?.scrollToItem(index, 'smart')
     }
   }, [index])
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

启动时没有滚动到第一个

After this PR:

启动和搜索时滚动到第一个
增加 scrollTrigger 来确定采用什么滚动行为

| 类别     | 测试                                                                                                                | 行为                                                                            |
| -------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| 启动     | `/` 启动或者按钮启动                                                                                                | 应该聚焦并且滚动到第一个 item                                                   |
| 上下导航 | 启动 panel<br/>键盘Up/Down导航                                                                                      | 焦点变化<br/>如果下一个 item 可见：不滚动<br/>如果下一个 item 不可见：滚动      |
|          | 启动 panel<br/>`⌘`/`Ctrl`+键盘Up，或者<br/>PageUp                                                                   | 焦点变化<br/>如果第一个 item 可见并且不是当前 item：不滚动<br/>其余情况：滚动   |
|          | 启动 panel<br/>`⌘`/`Ctrl`+键盘Down，或者<br/>PageDown                                                               | 焦点变化<br/>如果最后一个 item 可见并且不是当前 item：不滚动<br/>其余情况：滚动 |
|          | 启动 panel<br/>任意上下导航直到折回列表顶部或底部                                                                   | 如果折回到列表顶部：新焦点位于顶部<br/>如果折回到列表底部：新焦点位于底部<br/>  |
| 左右导航 | 点击网络搜索启动 panel<br/>任意上下导航<br/>点击选择模型切换列表                                                    | 应该聚焦并且滚动到第一个 item                                                   |
|          | `/` 启动 panel<br/>聚焦`选择模型`<br/>`⌘`/`Ctrl`+键盘Right切换列表<br/>键盘Down导航<br/>`⌘`/`Ctrl`+键盘Left切换列表 | 第一次切换：应该聚焦并且滚动到第一个 item<br/>第二次切换：应该聚焦`选择模型`    |
| 搜索     | `/` 启动 panel<br/>输入搜索文本                                                                                     | 应该聚焦并且滚动到第一个                                                        |


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
