### PR TITLE
refactor: update ImageBlockGroup layout to use CSS grid for better re…

### DIFF
--- a/src/renderer/src/pages/home/Messages/Blocks/index.tsx
+++ b/src/renderer/src/pages/home/Messages/Blocks/index.tsx
@@ -162,15 +162,19 @@ const MessageBlockRenderer: React.FC<Props> = ({ blocks, message }) => {
 export default React.memo(MessageBlockRenderer)
 
 const ImageBlockGroup = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-start;
-  align-items: center;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(200px, 1fr));
   gap: 8px;
   width: 100%;
-  margin: 8px 0;
+  max-width: 960px;
   > * {
-    flex: 0 0 auto;
     min-width: 200px;
+  }
+  @media (min-width: 1536px) {
+    grid-template-columns: repeat(4, minmax(250px, 1fr));
+    max-width: 1280px;
+    > * {
+      min-width: 250px;
+    }
   }
 `


### PR DESCRIPTION
…sponsiveness

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
![image](https://github.com/user-attachments/assets/358046cd-532c-42b3-aa21-0e9739022584)
![image](https://github.com/user-attachments/assets/6db9a2ac-827a-4c96-ae23-8fffd22877ee)


After this PR:
![image](https://github.com/user-attachments/assets/1bff1948-d521-4570-90c7-d8bfa2e5cf7f)
![image](https://github.com/user-attachments/assets/6f65cd40-61a7-4f86-ba29-b8f98184f083)
改为grid布局，调整图片大小


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
