### PR TITLE
feat: implement useFullscreen hook and integrate with NavbarRight for dynamic padding

### DIFF
--- a/src/renderer/src/components/app/Navbar.tsx
+++ b/src/renderer/src/components/app/Navbar.tsx
@@ -1,5 +1,6 @@
 import { isLinux, isMac, isWindows } from '@renderer/config/constant'
 import useNavBackgroundColor from '@renderer/hooks/useNavBackgroundColor'
+import { useFullscreen } from '@renderer/hooks/useFullscreen'
 import type { FC, PropsWithChildren } from 'react'
 import type { HTMLAttributes } from 'react'
 import styled from 'styled-components'
@@ -25,7 +26,12 @@ export const NavbarCenter: FC<Props> = ({ children, ...props }) => {
 }
 
 export const NavbarRight: FC<Props> = ({ children, ...props }) => {
-  return <NavbarRightContainer {...props}>{children}</NavbarRightContainer>
+  const isFullscreen = useFullscreen()
+  return (
+    <NavbarRightContainer {...props} $isFullscreen={isFullscreen}>
+      {children}
+    </NavbarRightContainer>
+  )
 }
 
 const NavbarContainer = styled.div`
@@ -58,11 +64,11 @@ const NavbarCenterContainer = styled.div`
   color: var(--color-text-1);
 `
 
-const NavbarRightContainer = styled.div`
+const NavbarRightContainer = styled.div<{ $isFullscreen: boolean }>`
   min-width: var(--topic-list-width);
   display: flex;
   align-items: center;
   padding: 0 12px;
-  padding-right: ${isWindows ? '140px' : isLinux ? '120px' : '12px'};
+  padding-right: ${({ $isFullscreen }) => ($isFullscreen ? '12px' : isWindows ? '140px' : isLinux ? '120px' : '12px')};
   justify-content: flex-end;
 `

--- a/src/renderer/src/components/app/Sidebar.tsx
+++ b/src/renderer/src/components/app/Sidebar.tsx
@@ -325,7 +325,7 @@ const Container = styled.div<{ $isFullscreen: boolean }>`
   padding-bottom: 12px;
   width: var(--sidebar-width);
   min-width: var(--sidebar-width);
-  height: ${isMac ? 'calc(100vh - var(--navbar-height))' : '100vh'};
+  height: ${({ $isFullscreen }) => (isMac && !$isFullscreen ? 'calc(100vh - var(--navbar-height))' : '100vh')};
   -webkit-app-region: drag !important;
   margin-top: ${({ $isFullscreen }) => (isMac && !$isFullscreen ? 'var(--navbar-height)' : 0)};
 

--- a/src/renderer/src/components/app/Sidebar.tsx
+++ b/src/renderer/src/components/app/Sidebar.tsx
@@ -2,6 +2,7 @@ import { isMac } from '@renderer/config/constant'
 import { AppLogo, UserAvatar } from '@renderer/config/env'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import useAvatar from '@renderer/hooks/useAvatar'
+import { useFullscreen } from '@renderer/hooks/useFullscreen'
 import { useMinappPopup } from '@renderer/hooks/useMinappPopup'
 import { useMinapps } from '@renderer/hooks/useMinapps'
 import useNavBackgroundColor from '@renderer/hooks/useNavBackgroundColor'
@@ -67,8 +68,13 @@ const Sidebar: FC = () => {
     })
   }
 
+  const isFullscreen = useFullscreen()
+
   return (
-    <Container id="app-sidebar" style={{ backgroundColor, zIndex: minappShow ? 10000 : 'initial' }}>
+    <Container
+      $isFullscreen={isFullscreen}
+      id="app-sidebar"
+      style={{ backgroundColor, zIndex: minappShow ? 10000 : 'initial' }}>
       {isEmoji(avatar) ? (
         <EmojiAvatar onClick={onEditUser}>{avatar}</EmojiAvatar>
       ) : (
@@ -308,7 +314,7 @@ const PinnedApps: FC = () => {
   )
 }
 
-const Container = styled.div`
+const Container = styled.div<{ $isFullscreen: boolean }>`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -318,7 +324,7 @@ const Container = styled.div`
   min-width: var(--sidebar-width);
   height: ${isMac ? 'calc(100vh - var(--navbar-height))' : '100vh'};
   -webkit-app-region: drag !important;
-  margin-top: ${isMac ? 'var(--navbar-height)' : 0};
+  margin-top: ${({ $isFullscreen }) => (isMac && !$isFullscreen ? 'var(--navbar-height)' : 0)};
 `
 
 const AvatarImg = styled(Avatar)`

--- a/src/renderer/src/hooks/useFullscreen.ts
+++ b/src/renderer/src/hooks/useFullscreen.ts
@@ -1,0 +1,18 @@
+import { IpcChannel } from '@shared/IpcChannel'
+import { useEffect, useState } from 'react'
+
+export function useFullscreen() {
+  const [isFullscreen, setIsFullscreen] = useState(false)
+
+  useEffect(() => {
+    const cleanup = window.electron.ipcRenderer.on(IpcChannel.FullscreenStatusChanged, (_, fullscreen) => {
+      setIsFullscreen(fullscreen)
+    })
+
+    return () => {
+      cleanup()
+    }
+  }, [])
+
+  return isFullscreen
+}

--- a/src/renderer/src/pages/settings/MCPSettings/McpSettingsNavbar.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/McpSettingsNavbar.tsx
@@ -1,6 +1,7 @@
 import { NavbarRight } from '@renderer/components/app/Navbar'
 import { HStack } from '@renderer/components/Layout'
 import { isLinux, isWindows } from '@renderer/config/constant'
+import { useFullscreen } from '@renderer/hooks/useFullscreen'
 import { Button, Dropdown, Menu, type MenuProps } from 'antd'
 import { ChevronDown, Search } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -73,7 +74,7 @@ export const McpSettingsNavbar = () => {
   }))
 
   return (
-    <NavbarRight style={{ paddingRight: isWindows ? 150 : isLinux ? 120 : 12 }}>
+    <NavbarRight style={{ paddingRight: useFullscreen() ? '12px' : isWindows ? 150 : isLinux ? 120 : 12 }}>
       <HStack alignItems="center" gap={5}>
         <Button
           size="small"


### PR DESCRIPTION
优化全屏布局：
窗口化：
![image](https://github.com/user-attachments/assets/f8d27251-f8a0-4429-aa8a-781e3cfa00ba)
全屏状态：
![image](https://github.com/user-attachments/assets/0f6aaa66-898e-4eca-aff7-e2c45a439a38)

包括Windows、Linux、MacOS的优化。

主要涉及MCP设置、聊天主页、app-sidebar的调整。