### PR TITLE
fix: remove undici dependency and clean up ProxyManager code

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "test:renderer": "vitest run",
     "test:renderer:ui": "vitest --ui",
     "test:renderer:coverage": "vitest run --coverage",
-    "test:lint":"eslint . --ext .js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts",
+    "test:lint": "eslint . --ext .js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts",
     "format": "prettier --write .",
     "lint": "eslint . --ext .js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix",
     "postinstall": "electron-builder install-app-deps",
@@ -100,7 +100,6 @@
     "tar": "^7.4.3",
     "turndown": "^7.2.0",
     "turndown-plugin-gfm": "^1.0.2",
-    "undici": "^7.4.0",
     "webdav": "^5.8.0",
     "ws": "^8.18.1",
     "zipread": "^1.3.3"

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "fast-xml-parser": "^5.2.0",
     "fetch-socks": "^1.3.2",
     "fs-extra": "^11.2.0",
-    "go-get-folder-size": "^0.5.5",
     "got-scraping": "^4.1.1",
     "jsdom": "^26.0.0",
     "markdown-it": "^14.1.0",

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -1,8 +1,7 @@
 import { ProxyConfig as _ProxyConfig, session } from 'electron'
-import { socksDispatcher } from 'fetch-socks'
 import { getSystemProxy } from 'os-proxy-config'
 import { ProxyAgent as GeneralProxyAgent } from 'proxy-agent'
-import { ProxyAgent, setGlobalDispatcher } from 'undici'
+// import { ProxyAgent, setGlobalDispatcher } from 'undici'
 
 type ProxyMode = 'system' | 'custom' | 'none'
 
@@ -121,22 +120,22 @@ export class ProxyManager {
     return this.config.url || ''
   }
 
-  setGlobalProxy() {
-    const proxyUrl = this.config.url
-    if (proxyUrl) {
-      const [protocol, address] = proxyUrl.split('://')
-      const [host, port] = address.split(':')
-      if (!protocol.includes('socks')) {
-        setGlobalDispatcher(new ProxyAgent(proxyUrl))
-      } else {
-        global[Symbol.for('undici.globalDispatcher.1')] = socksDispatcher({
-          port: parseInt(port),
-          type: protocol === 'socks5' ? 5 : 4,
-          host: host
-        })
-      }
-    }
-  }
+  // setGlobalProxy() {
+  //   const proxyUrl = this.config.url
+  //   if (proxyUrl) {
+  //     const [protocol, address] = proxyUrl.split('://')
+  //     const [host, port] = address.split(':')
+  //     if (!protocol.includes('socks')) {
+  //       setGlobalDispatcher(new ProxyAgent(proxyUrl))
+  //     } else {
+  //       global[Symbol.for('undici.globalDispatcher.1')] = socksDispatcher({
+  //         port: parseInt(port),
+  //         type: protocol === 'socks5' ? 5 : 4,
+  //         host: host
+  //       })
+  //     }
+  //   }
+  // }
 }
 
 export const proxyManager = new ProxyManager()

--- a/src/main/utils/index.ts
+++ b/src/main/utils/index.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import fsAsync from 'node:fs/promises'
 import path from 'node:path'
 
 import { app } from 'electron'
@@ -51,4 +52,21 @@ export function makeSureDirExists(dir: string) {
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true })
   }
+}
+
+export async function calculateDirectorySize(directoryPath: string): Promise<number> {
+  let totalSize = 0
+  const items = await fsAsync.readdir(directoryPath)
+
+  for (const item of items) {
+    const itemPath = path.join(directoryPath, item)
+    const stats = await fsAsync.stat(itemPath)
+
+    if (stats.isFile()) {
+      totalSize += stats.size
+    } else if (stats.isDirectory()) {
+      totalSize += await calculateDirectorySize(itemPath)
+    }
+  }
+  return totalSize
 }

--- a/src/renderer/src/pages/settings/DataSettings/DataSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/DataSettings.tsx
@@ -240,7 +240,7 @@ const DataSettings: FC = () => {
               <SettingRow>
                 <SettingRowTitle>
                   {t('settings.data.clear_cache.title')}
-                  <CacheText>({cacheSize})</CacheText>
+                  {cacheSize && <CacheText>({cacheSize}MB)</CacheText>}
                 </SettingRowTitle>
                 <HStack gap="5px">
                   <Button onClick={handleClearCache} danger>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4446,7 +4446,6 @@ __metadata:
     fast-xml-parser: "npm:^5.2.0"
     fetch-socks: "npm:^1.3.2"
     fs-extra: "npm:^11.2.0"
-    go-get-folder-size: "npm:^0.5.5"
     got-scraping: "npm:^4.1.1"
     html-to-image: "npm:^1.11.13"
     husky: "npm:^9.1.7"
@@ -8981,17 +8980,6 @@ __metadata:
     merge2: "npm:^1.4.1"
     slash: "npm:^3.0.0"
   checksum: 10c0/b39511b4afe4bd8a7aead3a27c4ade2b9968649abab0a6c28b1a90141b96ca68ca5db1302f7c7bd29eab66bf51e13916b8e0a3d0ac08f75e1e84a39b35691189
-  languageName: node
-  linkType: hard
-
-"go-get-folder-size@npm:^0.5.5":
-  version: 0.5.5
-  resolution: "go-get-folder-size@npm:0.5.5"
-  dependencies:
-    std-env: "npm:^3.7.0"
-  bin:
-    go-get-folder-size: bin/cli.js
-  checksum: 10c0/eb69b686952218cc114dccf65763e0dff5056050fa3e9b2afa6161b933c3978500455503b104f9f28d96aab2fedd64ccb0255d6ea16d699fe020795f431ed7b8
   languageName: node
   linkType: hard
 
@@ -16045,7 +16033,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"std-env@npm:^3.7.0, std-env@npm:^3.8.1":
+"std-env@npm:^3.8.1":
   version: 3.9.0
   resolution: "std-env@npm:3.9.0"
   checksum: 10c0/4a6f9218aef3f41046c3c7ecf1f98df00b30a07f4f35c6d47b28329bc2531eef820828951c7d7b39a1c5eb19ad8a46e3ddfc7deb28f0a2f3ceebee11bab7ba50

--- a/yarn.lock
+++ b/yarn.lock
@@ -4499,7 +4499,6 @@ __metadata:
     turndown: "npm:^7.2.0"
     turndown-plugin-gfm: "npm:^1.0.2"
     typescript: "npm:^5.6.2"
-    undici: "npm:^7.4.0"
     uuid: "npm:^10.0.0"
     vite: "npm:6.2.6"
     vitest: "npm:^3.1.1"
@@ -17002,7 +17001,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:>=6, undici@npm:^7.4.0":
+"undici@npm:>=6":
   version: 7.8.0
   resolution: "undici@npm:7.8.0"
   checksum: 10c0/7141f63ea405208a88120d211d83d77bf21327b16b451d3149fb266c28884fbcf78ec370ac2d3412a0e68ba6132ab85265ba85a2f4fde24cb47dc77f5c5a158c


### PR DESCRIPTION
尝试去掉undici库看看是否还有下面的报错
```
Uncaught Exception:
TypeError: markResourceTiming is not a function
at finalizeAndReportTiming (node:internal/deps/undici/undici:10082:7) at Object.handleFetchDone [as processResponseEndOfBody] (node:internal/ deps/undici/undici: 9997:7)
at node:internal/deps/undici/undici: 10415:46 at node:internal/process/task_queues:140:7
at AsyncResource.runlnAsyncScope (node:async_hooks:206:9)
at AsyncResource.runMicrotask (node:internal/process/task_queues:137:8) at process.processTicksAndRejections (node:internal/process/ task_queues:95:5)
```