### PR TITLE
hotfix: enhance reasoning summary handling in OpenAI response processing

### DIFF
--- a/src/renderer/src/providers/AiProvider/OpenAIResponseProvider.ts
+++ b/src/renderer/src/providers/AiProvider/OpenAIResponseProvider.ts
@@ -543,6 +543,7 @@ export abstract class BaseOpenAIProvider extends BaseProvider {
         return
       }
       let content = ''
+      let thinkContent = ''
 
       const outputItems: OpenAI.Responses.ResponseOutputItem[] = []
 
@@ -552,28 +553,39 @@ export abstract class BaseOpenAIProvider extends BaseProvider {
         }
         switch (chunk.type) {
           case 'response.output_item.added':
-            if (time_first_token_millsec === 0) {
-              time_first_token_millsec = new Date().getTime()
-            }
             if (chunk.item.type === 'function_call') {
               outputItems.push(chunk.item)
             }
             break
-
+          case 'response.reasoning_summary_part.added':
+            if (time_first_token_millsec === 0) {
+              time_first_token_millsec = new Date().getTime()
+            }
+            break
           case 'response.reasoning_summary_text.delta':
             onChunk({
               type: ChunkType.THINKING_DELTA,
               text: chunk.delta,
               thinking_millsec: new Date().getTime() - time_first_token_millsec
             })
+            thinkContent += chunk.delta
             break
-          case 'response.reasoning_summary_text.done':
-            onChunk({
-              type: ChunkType.THINKING_COMPLETE,
-              text: chunk.text,
-              thinking_millsec: new Date().getTime() - time_first_token_millsec
-            })
+          case 'response.output_item.done': {
+            if (thinkContent !== '' && chunk.item.type === 'reasoning') {
+              onChunk({
+                type: ChunkType.THINKING_COMPLETE,
+                text: thinkContent,
+                thinking_millsec: new Date().getTime() - time_first_token_millsec
+              })
+            }
             break
+          }
+          case 'response.content_part.added': {
+            if (time_first_token_millsec === 0) {
+              time_first_token_millsec = new Date().getTime()
+            }
+            break
+          }
           case 'response.output_text.delta': {
             let delta = chunk.delta
             if (isEnabledBuiltinWebSearch) {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

思考块只保存了最后一个contentpart

After this PR:

![test](https://github.com/user-attachments/assets/b6ee1593-b1a4-4b99-bf25-a92f4fc41ced)


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #6033

### Why we need it and why it was done in this way

还是手动用字符串缓存思考内容

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
