### PR TITLE
禁止“自定义CSS”输入框的拼写检查

### DIFF
--- a/src/renderer/src/pages/settings/DisplaySettings/DisplaySettings.tsx
+++ b/src/renderer/src/pages/settings/DisplaySettings/DisplaySettings.tsx
@@ -237,6 +237,7 @@ const DisplaySettings: FC = () => {
             minHeight: 200,
             fontFamily: 'monospace'
           }}
+          spellCheck={false}
         />
       </SettingGroup>
     </SettingContainer>


### PR DESCRIPTION
目前“自定义CSS”输入框里写的很多样式都有红色波浪线，是因为开了拼写检查

### What this PR does

Before this PR:
如图，有很多红色波浪线，其实没必要
![image](https://github.com/user-attachments/assets/dc85da5d-99bc-4de2-942c-dbeb812284bf)

After this PR:
抱歉，没做测试，没有图片。理论上代码是对的。

### Why we need it and why it was done in this way

自定义CSS的Input.TextArea本身就不需要拼写检查，很多样式的拼写都会导致红色波浪线，很难看

### Breaking changes

NONE

### Special notes for your reviewer

我没做测试，所以没有更改后的截图。请review一下code，感谢❤

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
NONE
```
