### PR TITLE
fix(perf): update ThinkingBlock to handle content changes dynamically

### DIFF
--- a/src/renderer/src/pages/home/Messages/Blocks/ThinkingBlock.tsx
+++ b/src/renderer/src/pages/home/Messages/Blocks/ThinkingBlock.tsx
@@ -22,6 +22,8 @@ const ThinkingBlock: React.FC<Props> = ({ block }) => {
   const [activeKey, setActiveKey] = useState<'thought' | ''>(thoughtAutoCollapse ? '' : 'thought')
   const [thinkingTime, setThinkingTime] = useState(block.thinking_millsec || 0)
   const intervalId = useRef<NodeJS.Timeout>(null)
+  const [renderedContent, setRenderedContent] = useState(block.content)
+  const lastContentRef = useRef(block.content)
 
   const isThinking = useMemo(() => block.status === MessageBlockStatus.STREAMING, [block.status])
 
@@ -54,6 +56,13 @@ const ThinkingBlock: React.FC<Props> = ({ block }) => {
         })
     }
   }, [block.content, t])
+
+  useEffect(() => {
+    if (block.content !== lastContentRef.current) {
+      setRenderedContent(block.content)
+      lastContentRef.current = block.content
+    }
+  }, [block.content])
 
   // FIXME: 这里统计的和请求处统计的有一定误差
   useEffect(() => {
@@ -122,12 +131,11 @@ const ThinkingBlock: React.FC<Props> = ({ block }) => {
               )}
             </MessageTitleLabel>
           ),
-          children: (
-            //  FIXME: 临时兼容
+          children: renderedContent ? (
             <div style={{ fontFamily, fontSize }}>
-              <Markdown block={block} />
+              <Markdown block={{ ...block, content: renderedContent }} />
             </div>
-          )
+          ) : null
         }
       ]}
     />


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

将header和content分开渲染，避免思考时间过长时的性能问题

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
