### PR TITLE
refactor(CodeEditor): add more options to props for better customization, fix auto theme

### DIFF
--- a/src/renderer/src/components/CodeEditor/index.tsx
+++ b/src/renderer/src/components/CodeEditor/index.tsx
@@ -26,7 +26,7 @@ interface Props {
   /** 用于覆写编辑器的某些设置 */
   options?: {
     collapsible?: boolean
-    wrapable?: boolean
+    wrappable?: boolean
     keymap?: boolean
   } & BasicSetupOptions
   /** 用于覆写编辑器的样式，会直接传给 CodeMirror 的 style 属性 */
@@ -43,11 +43,11 @@ const CodeEditor = ({ children, language, onSave, onChange, maxHeight, options, 
     fontSize,
     codeShowLineNumbers: _lineNumbers,
     codeCollapsible: _collapsible,
-    codeWrappable: _wrapable,
+    codeWrappable: _wrappable,
     codeEditor
   } = useSettings()
   const collapsible = useMemo(() => options?.collapsible ?? _collapsible, [options?.collapsible, _collapsible])
-  const wrapable = useMemo(() => options?.wrapable ?? _wrapable, [options?.wrapable, _wrapable])
+  const wrappable = useMemo(() => options?.wrappable ?? _wrappable, [options?.wrappable, _wrappable])
   const enableKeymap = useMemo(() => options?.keymap ?? codeEditor.keymap, [options?.keymap, codeEditor.keymap])
 
   // 合并 codeEditor 和 options 的 basicSetup，options 优先
@@ -61,7 +61,7 @@ const CodeEditor = ({ children, language, onSave, onChange, maxHeight, options, 
 
   const { activeCmTheme, languageMap } = useCodeStyle()
   const [isExpanded, setIsExpanded] = useState(!collapsible)
-  const [isUnwrapped, setIsUnwrapped] = useState(!wrapable)
+  const [isUnwrapped, setIsUnwrapped] = useState(!wrappable)
   const initialContent = useRef(children?.trimEnd() ?? '')
   const [langExtension, setLangExtension] = useState<Extension[]>([])
   const [editorReady, setEditorReady] = useState(false)
@@ -113,12 +113,12 @@ const CodeEditor = ({ children, language, onSave, onChange, maxHeight, options, 
       ...TOOL_SPECS.wrap,
       icon: isUnwrapped ? <WrapIcon className="icon" /> : <UnWrapIcon className="icon" />,
       tooltip: isUnwrapped ? t('code_block.wrap.on') : t('code_block.wrap.off'),
-      visible: () => wrapable,
+      visible: () => wrappable,
       onClick: () => setIsUnwrapped((prev) => !prev)
     })
 
     return () => removeTool(TOOL_SPECS.wrap.id)
-  }, [wrapable, isUnwrapped, registerTool, removeTool, t])
+  }, [wrappable, isUnwrapped, registerTool, removeTool, t])
 
   const handleSave = useCallback(() => {
     const currentDoc = editorViewRef.current?.state.doc.toString() ?? ''
@@ -160,8 +160,8 @@ const CodeEditor = ({ children, language, onSave, onChange, maxHeight, options, 
   }, [collapsible])
 
   useEffect(() => {
-    setIsUnwrapped(!wrapable)
-  }, [wrapable])
+    setIsUnwrapped(!wrappable)
+  }, [wrappable])
 
   // 保存功能的快捷键
   const saveKeymap = useMemo(() => {

--- a/src/renderer/src/components/CodeEditor/index.tsx
+++ b/src/renderer/src/components/CodeEditor/index.tsx
@@ -1,7 +1,7 @@
 import { TOOL_SPECS, useCodeToolbar } from '@renderer/components/CodeToolbar'
 import { useCodeStyle } from '@renderer/context/CodeStyleProvider'
 import { useSettings } from '@renderer/hooks/useSettings'
-import CodeMirror, { Annotation, EditorView, Extension, keymap } from '@uiw/react-codemirror'
+import CodeMirror, { Annotation, BasicSetupOptions, EditorView, Extension, keymap } from '@uiw/react-codemirror'
 import diff from 'fast-diff'
 import {
   ChevronsDownUp,
@@ -22,10 +22,15 @@ interface Props {
   language: string
   onSave?: (newContent: string) => void
   onChange?: (newContent: string) => void
-  // options used to override the default behaviour
+  maxHeight?: string
+  /** 用于覆写编辑器的某些设置 */
   options?: {
-    maxHeight?: string
-  }
+    collapsible?: boolean
+    wrapable?: boolean
+    keymap?: boolean
+  } & BasicSetupOptions
+  /** 用于覆写编辑器的样式，会直接传给 CodeMirror 的 style 属性 */
+  style?: React.CSSProperties
 }
 
 /**
@@ -33,11 +38,30 @@ interface Props {
  *
  * 目前必须和 CodeToolbar 配合使用。
  */
-const CodeEditor = ({ children, language, onSave, onChange, options }: Props) => {
-  const { fontSize, codeShowLineNumbers, codeCollapsible, codeWrappable, codeEditor } = useSettings()
+const CodeEditor = ({ children, language, onSave, onChange, maxHeight, options, style }: Props) => {
+  const {
+    fontSize,
+    codeShowLineNumbers: _lineNumbers,
+    codeCollapsible: _collapsible,
+    codeWrappable: _wrapable,
+    codeEditor
+  } = useSettings()
+  const collapsible = useMemo(() => options?.collapsible ?? _collapsible, [options?.collapsible, _collapsible])
+  const wrapable = useMemo(() => options?.wrapable ?? _wrapable, [options?.wrapable, _wrapable])
+  const enableKeymap = useMemo(() => options?.keymap ?? codeEditor.keymap, [options?.keymap, codeEditor.keymap])
+
+  // 合并 codeEditor 和 options 的 basicSetup，options 优先
+  const customBasicSetup = useMemo(() => {
+    return {
+      lineNumbers: _lineNumbers,
+      ...(codeEditor as BasicSetupOptions),
+      ...(options as BasicSetupOptions)
+    }
+  }, [codeEditor, _lineNumbers, options])
+
   const { activeCmTheme, languageMap } = useCodeStyle()
-  const [isExpanded, setIsExpanded] = useState(!codeCollapsible)
-  const [isUnwrapped, setIsUnwrapped] = useState(!codeWrappable)
+  const [isExpanded, setIsExpanded] = useState(!collapsible)
+  const [isUnwrapped, setIsUnwrapped] = useState(!wrapable)
   const initialContent = useRef(children?.trimEnd() ?? '')
   const [langExtension, setLangExtension] = useState<Extension[]>([])
   const [editorReady, setEditorReady] = useState(false)
@@ -75,13 +99,13 @@ const CodeEditor = ({ children, language, onSave, onChange, options }: Props) =>
       tooltip: isExpanded ? t('code_block.collapse') : t('code_block.expand'),
       visible: () => {
         const scrollHeight = editorViewRef?.current?.scrollDOM?.scrollHeight
-        return codeCollapsible && (scrollHeight ?? 0) > 350
+        return collapsible && (scrollHeight ?? 0) > 350
       },
       onClick: () => setIsExpanded((prev) => !prev)
     })
 
     return () => removeTool(TOOL_SPECS.expand.id)
-  }, [codeCollapsible, isExpanded, registerTool, removeTool, t, editorReady])
+  }, [collapsible, isExpanded, registerTool, removeTool, t, editorReady])
 
   // 自动换行工具
   useEffect(() => {
@@ -89,12 +113,12 @@ const CodeEditor = ({ children, language, onSave, onChange, options }: Props) =>
       ...TOOL_SPECS.wrap,
       icon: isUnwrapped ? <WrapIcon className="icon" /> : <UnWrapIcon className="icon" />,
       tooltip: isUnwrapped ? t('code_block.wrap.on') : t('code_block.wrap.off'),
-      visible: () => codeWrappable,
+      visible: () => wrapable,
       onClick: () => setIsUnwrapped((prev) => !prev)
     })
 
     return () => removeTool(TOOL_SPECS.wrap.id)
-  }, [codeWrappable, isUnwrapped, registerTool, removeTool, t])
+  }, [wrapable, isUnwrapped, registerTool, removeTool, t])
 
   const handleSave = useCallback(() => {
     const currentDoc = editorViewRef.current?.state.doc.toString() ?? ''
@@ -132,12 +156,12 @@ const CodeEditor = ({ children, language, onSave, onChange, options }: Props) =>
   }, [children])
 
   useEffect(() => {
-    setIsExpanded(!codeCollapsible)
-  }, [codeCollapsible])
+    setIsExpanded(!collapsible)
+  }, [collapsible])
 
   useEffect(() => {
-    setIsUnwrapped(!codeWrappable)
-  }, [codeWrappable])
+    setIsUnwrapped(!wrapable)
+  }, [wrapable])
 
   // 保存功能的快捷键
   const saveKeymap = useMemo(() => {
@@ -154,19 +178,15 @@ const CodeEditor = ({ children, language, onSave, onChange, options }: Props) =>
   }, [handleSave])
 
   const enabledExtensions = useMemo(() => {
-    return [
-      ...langExtension,
-      ...(isUnwrapped ? [] : [EditorView.lineWrapping]),
-      ...(codeEditor.keymap ? [saveKeymap] : [])
-    ]
-  }, [codeEditor.keymap, langExtension, isUnwrapped, saveKeymap])
+    return [...langExtension, ...(isUnwrapped ? [] : [EditorView.lineWrapping]), ...(enableKeymap ? [saveKeymap] : [])]
+  }, [enableKeymap, langExtension, isUnwrapped, saveKeymap])
 
   return (
     <CodeMirror
       // 维持一个稳定值，避免触发 CodeMirror 重置
       value={initialContent.current}
       width="100%"
-      maxHeight={codeCollapsible && !isExpanded ? (options?.maxHeight ?? '350px') : 'none'}
+      maxHeight={collapsible && !isExpanded ? (maxHeight ?? '350px') : 'none'}
       editable={true}
       // @ts-ignore 强制使用，见 react-codemirror 的 Example.tsx
       theme={activeCmTheme}
@@ -179,32 +199,30 @@ const CodeEditor = ({ children, language, onSave, onChange, options }: Props) =>
         if (onChange && viewUpdate.docChanged) onChange(value)
       }}
       basicSetup={{
-        lineNumbers: codeShowLineNumbers,
-        highlightActiveLineGutter: codeEditor.highlightActiveLine,
-        foldGutter: codeEditor.foldGutter,
         dropCursor: true,
         allowMultipleSelections: true,
         indentOnInput: true,
         bracketMatching: true,
         closeBrackets: true,
-        autocompletion: codeEditor.autocompletion,
         rectangularSelection: true,
         crosshairCursor: true,
-        highlightActiveLine: codeEditor.highlightActiveLine,
+        highlightActiveLineGutter: false,
         highlightSelectionMatches: true,
-        closeBracketsKeymap: codeEditor.keymap,
-        searchKeymap: codeEditor.keymap,
-        foldKeymap: codeEditor.keymap,
-        completionKeymap: codeEditor.keymap,
-        lintKeymap: codeEditor.keymap
+        closeBracketsKeymap: enableKeymap,
+        searchKeymap: enableKeymap,
+        foldKeymap: enableKeymap,
+        completionKeymap: enableKeymap,
+        lintKeymap: enableKeymap,
+        ...customBasicSetup // override basicSetup
       }}
       style={{
         fontSize: `${fontSize - 1}px`,
-        overflow: codeCollapsible && !isExpanded ? 'auto' : 'visible',
+        overflow: collapsible && !isExpanded ? 'auto' : 'visible',
         position: 'relative',
         border: '0.5px solid var(--color-code-background)',
         borderRadius: '5px',
-        marginTop: 0
+        marginTop: 0,
+        ...style
       }}
     />
   )

--- a/src/renderer/src/context/CodeStyleProvider.tsx
+++ b/src/renderer/src/context/CodeStyleProvider.tsx
@@ -1,3 +1,4 @@
+import { useTheme } from '@renderer/context/ThemeProvider'
 import { useMermaid } from '@renderer/hooks/useMermaid'
 import { useSettings } from '@renderer/hooks/useSettings'
 import { HighlightChunkResult, ShikiPreProperties, shikiStreamService } from '@renderer/services/ShikiStreamService'
@@ -29,7 +30,8 @@ const defaultCodeStyleContext: CodeStyleContextType = {
 const CodeStyleContext = createContext<CodeStyleContextType>(defaultCodeStyleContext)
 
 export const CodeStyleProvider: React.FC<PropsWithChildren> = ({ children }) => {
-  const { codeEditor, codePreview, theme } = useSettings()
+  const { codeEditor, codePreview } = useSettings()
+  const { theme } = useTheme()
   const [shikiThemes, setShikiThemes] = useState({})
   useMermaid()
 

--- a/src/renderer/src/pages/settings/MCPSettings/EditMcpJsonPopup.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/EditMcpJsonPopup.tsx
@@ -132,7 +132,7 @@ const PopupContainer: React.FC<Props> = ({ resolve }) => {
               maxHeight="60vh"
               options={{
                 collapsible: true,
-                wrapable: true,
+                wrappable: true,
                 lineNumbers: true,
                 foldGutter: true,
                 highlightActiveLine: true,

--- a/src/renderer/src/pages/settings/MCPSettings/EditMcpJsonPopup.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/EditMcpJsonPopup.tsx
@@ -126,7 +126,18 @@ const PopupContainer: React.FC<Props> = ({ resolve }) => {
       {jsonConfig && (
         <div style={{ marginBottom: '16px' }}>
           <CodeToolbarProvider>
-            <CodeEditor language="json" onChange={handleChange} options={{ maxHeight: '60vh' }}>
+            <CodeEditor
+              language="json"
+              onChange={handleChange}
+              maxHeight="60vh"
+              options={{
+                collapsible: true,
+                wrapable: true,
+                lineNumbers: true,
+                foldGutter: true,
+                highlightActiveLine: true,
+                keymap: true
+              }}>
               {jsonConfig}
             </CodeEditor>
           </CodeToolbarProvider>


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

没有适应自动主题
CodeEditor 设置过于依赖全局设置

After this PR:

适应自动主题
CodeEditor 可以传入更多参数

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
