### PR TITLE
fix: Summary for single message export doesn't work.

### DIFF
--- a/src/renderer/src/services/MessagesService.ts
+++ b/src/renderer/src/services/MessagesService.ts
@@ -215,10 +215,9 @@ export async function getMessageTitle(message: Message, length = 30): Promise<st
     try {
       window.message.loading({ content: t('chat.topics.export.wait_for_title_naming'), key: 'message-title-naming' })
 
-      const tempTextBlock = createMainTextBlock(message.id, content, { status: MessageBlockStatus.SUCCESS })
       const tempMessage = resetMessage(message, {
         status: AssistantMessageStatus.SUCCESS,
-        blocks: [tempTextBlock.id]
+        blocks: message.blocks,
       })
 
       const title = await fetchMessagesSummary({ messages: [tempMessage], assistant: {} as Assistant })


### PR DESCRIPTION
<!-- 来自 https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md? 的模板 -->
<!-- 感谢您发送 pull request！这里有一些给您的提示：
1. 考虑将此 PR 创建为草稿：https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### 这个 PR 做了什么

在这个 PR 之前：在设置当中开启 数据设置 → Markdown 导出 → 使用话题命名模型为导出的消息创建标题，这东西不工作。

![image](https://github.com/user-attachments/assets/9831fd20-70b7-423a-9b43-59ff0a62796e)


在这个 PR 之后：

![image](https://github.com/user-attachments/assets/edd85485-4940-4f96-9afe-b83237d97c38)


### 为什么我们需要它以及为什么以这种方式完成

三周之前似乎有人重构了消息，我没太细究这个 block 和 message 之间的关系，但是可以确定的是：拷贝一个副本之后，再用这个副本的 id 去检索 block，是找不到的。具体的检索失败发生在：

```ts
    const userMessages = takeRight(messages, 5)
      .filter((message) => !message.isPreset)
      .map((message) => ({
        role: message.role,
        content: getMainTextContent(message)     <- Here
      }))
```

### 检查清单

此检查清单并非强制执行，但它可以提醒您每个 PR 可能相关的项目。
审核人应查看此列表。

- [x] PR：PR 描述足够明确，将有助于未来的贡献者
- [x] 代码：[编写人类可以理解的代码](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) 和 [保持简单](https://en.wikipedia.org/wiki/KISS_principle)
- [x] 重构：您已经 [使代码比您发现时更干净（童子军规则）](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] 升级：已考虑此更改对升级流程的影响，并在需要时已解决
- [x] 文档：已考虑 [用户指南更新](https://docs.cherry-ai.com) 并且存在（链接）或不需要。如果它是面向用户的功能，则需要用户指南更新。

### 发行说明

<!-- 编写您的发行说明：
1. 在下面的块中输入您的扩展发行说明。 如果 PR 需要用户切换到新版本时执行其他操作，请包含字符串“action required”。
2. 如果不需要发行说明，只需编写“NONE”。
-->

```release-note
NONE
```
