### PR TITLE
refactor: transparent border for code blocks

### DIFF
--- a/src/renderer/src/components/CodeBlockView/CodePreview.tsx
+++ b/src/renderer/src/components/CodeBlockView/CodePreview.tsx
@@ -228,7 +228,7 @@ const ContentContainer = styled.div<{
   $isCodeWrappable: boolean
 }>`
   position: relative;
-  border: 0.5px solid var(--color-code-background);
+  border: 0.5px solid transparent;
   border-radius: 5px;
   margin-top: 0;
   transition: opacity 0.3s ease;

--- a/src/renderer/src/components/CodeEditor/index.tsx
+++ b/src/renderer/src/components/CodeEditor/index.tsx
@@ -219,7 +219,7 @@ const CodeEditor = ({ children, language, onSave, onChange, maxHeight, options, 
         fontSize: `${fontSize - 1}px`,
         overflow: collapsible && !isExpanded ? 'auto' : 'visible',
         position: 'relative',
-        border: '0.5px solid var(--color-code-background)',
+        border: '0.5px solid transparent',
         borderRadius: '5px',
         marginTop: 0,
         ...style


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

移除代码块内边框颜色

Before this PR:

develop 分支中新的代码块样式和原来不同，内边框有颜色

After this PR:

![屏幕截图 2025-05-18 162446](https://github.com/user-attachments/assets/3647f118-4b33-4c79-ac4e-19517aa22550)
![屏幕截图 2025-05-18 162454](https://github.com/user-attachments/assets/ee1ae018-e006-4322-bbfb-82614cc7cf0e)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
