### PR TITLE
feat: Add debug logging for cloning messages to a new topic in development mode

### DIFF
--- a/src/renderer/src/pages/home/Messages/Messages.tsx
+++ b/src/renderer/src/pages/home/Messages/Messages.tsx
@@ -165,14 +165,6 @@ const Messages: FC<MessagesProps> = ({ assistant, topic, setActiveTopic, onCompo
         newTopic.name = topic.name
         const currentMessages = messagesRef.current
 
-        if (process.env.NODE_ENV === 'development') {
-          console.log(`[NEW_BRANCH] Cloning messages to new topic: ${newTopic.id}`)
-          console.log(`[NEW_BRANCH] Cloning messages from topic: ${topic.id}`)
-          console.log(`[NEW_BRANCH] Cloning messages from index: ${index}`)
-          console.log(`[NEW_BRANCH] Cloning messages count: ${currentMessages.length}`)
-          console.log(`[NEW_BRANCH] Cloning messages:`, currentMessages)
-        }
-
         if (index < 0 || index > currentMessages.length) {
           console.error(`[NEW_BRANCH] Invalid branch index: ${index}`)
           return

--- a/src/renderer/src/pages/home/Messages/Messages.tsx
+++ b/src/renderer/src/pages/home/Messages/Messages.tsx
@@ -165,9 +165,22 @@ const Messages: FC<MessagesProps> = ({ assistant, topic, setActiveTopic, onCompo
         newTopic.name = topic.name
         const currentMessages = messagesRef.current
 
+        if (process.env.NODE_ENV === 'development') {
+          console.log(`[NEW_BRANCH] Cloning messages to new topic: ${newTopic.id}`)
+          console.log(`[NEW_BRANCH] Cloning messages from topic: ${topic.id}`)
+          console.log(`[NEW_BRANCH] Cloning messages from index: ${index}`)
+          console.log(`[NEW_BRANCH] Cloning messages count: ${currentMessages.length}`)
+          console.log(`[NEW_BRANCH] Cloning messages:`, currentMessages)
+        }
+
         if (index < 0 || index > currentMessages.length) {
           console.error(`[NEW_BRANCH] Invalid branch index: ${index}`)
           return
+        }
+
+        // 如果currentMessages[index]是一个助手信息，那么index=index+1，避免多模型输出结果被分割。
+        while (index < currentMessages.length && currentMessages[index].role === 'assistant') {
+          index++
         }
 
         // 1. Add the new topic to Redux store FIRST


### PR DESCRIPTION
Branch的分割点不能单纯用一个index进行描述，如果是多模型输出的中间点击分支按钮的话，就会导致index=中间模型输出的内容。


![image](https://github.com/user-attachments/assets/a6ec925a-9d6f-4ef2-8073-b96ff435e136)


<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
