### PR TITLE
fix: Search results are on the right side

### DIFF
--- a/src/renderer/src/components/ContentSearch.tsx
+++ b/src/renderer/src/components/ContentSearch.tsx
@@ -236,8 +236,8 @@ export const ContentSearch = React.forwardRef<ContentSearchRef, Props>(
             if (shouldScroll) {
               highlightTextNode.scrollIntoView({
                 behavior: 'smooth',
-                block: 'center',
-                inline: 'center'
+                block: 'center'
+                // inline: 'center' 水平方向居中可能会导致 content 页面整体偏右, 使得左半部的内容被遮挡. 因此先注释掉该代码
               })
             }
           }


### PR DESCRIPTION
### What this PR does

Before this PR:

Content Search 进行焦点跳转时会在水平方向上也进行跳转, 当目标搜索结果靠右时, 会让页面整体偏右. 从而导致页面左边的内容被遮挡. 且此时水平方向上无法移动视角. 只能通过切换到其他页面再切换回的方式来恢复视角.
![image](https://github.com/user-attachments/assets/b6510a69-7430-465c-8497-d7faefe594d2)


After this PR:

取消掉 Content Search 在水平方向上的焦点跳转后, 页面跳转变为正常
![image](https://github.com/user-attachments/assets/703eae32-4ccf-4ab6-844a-6dcbdd23d032)

还测试了几个场景
1. 代码块内的水平方向焦点跳转未收到影响
<img width="749" alt="image" src="https://github.com/user-attachments/assets/97009a8d-42d2-4abe-b5b8-231e4a0da33d" />

2. 最大化页面后效果也功能正常
<img width="1393" alt="image" src="https://github.com/user-attachments/assets/2a9d1731-efbb-4983-a82d-8cd5391730f1" />



### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
None
```
