### PR TITLE
fix: optimize startup speed

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -80,6 +80,16 @@ export default defineConfig({
         input: {
           index: resolve(__dirname, 'src/renderer/index.html'),
           miniWindow: resolve(__dirname, 'src/renderer/miniWindow.html')
+        },
+        output: {
+          manualChunks(id: string) {
+            // All node_modules are in the vendor chunk
+            if (id.includes('node_modules')) {
+              return 'vendor'
+            }
+            // Other modules use default chunk splitting strategy
+            return undefined
+          }
         }
       }
     }

--- a/src/renderer/src/pages/settings/MCPSettings/McpDescription.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/McpDescription.tsx
@@ -1,4 +1,5 @@
 import { useTheme } from '@renderer/context/ThemeProvider'
+import { runAsyncFunction } from '@renderer/utils'
 import { getShikiInstance } from '@renderer/utils/shiki'
 import { Card } from 'antd'
 import MarkdownIt from 'markdown-it'
@@ -30,9 +31,11 @@ const MCPDescription = ({ searchKey }: McpDescriptionProps) => {
   }, [md, searchKey])
 
   useEffect(() => {
-    const sk = getShikiInstance(theme)
-    md.current.use(sk)
-    getMcpInfo()
+    runAsyncFunction(async () => {
+      const sk = await getShikiInstance(theme)
+      md.current.use(sk)
+      getMcpInfo()
+    })
   }, [getMcpInfo, theme])
 
   return (

--- a/src/renderer/src/utils/highlighter.ts
+++ b/src/renderer/src/utils/highlighter.ts
@@ -1,0 +1,32 @@
+import { bundledLanguages, bundledThemes, createHighlighter, type Highlighter } from 'shiki'
+
+let highlighterPromise: Promise<Highlighter> | null = null
+
+export async function getHighlighter() {
+  if (!highlighterPromise) {
+    highlighterPromise = createHighlighter({
+      langs: ['javascript', 'typescript', 'python', 'java', 'markdown', 'json'],
+      themes: ['one-light', 'material-theme-darker']
+    })
+  }
+
+  return await highlighterPromise
+}
+
+export async function loadLanguageIfNeeded(highlighter: Highlighter, language: string) {
+  if (!highlighter.getLoadedLanguages().includes(language)) {
+    const languageImportFn = bundledLanguages[language]
+    if (languageImportFn) {
+      await highlighter.loadLanguage(await languageImportFn())
+    }
+  }
+}
+
+export async function loadThemeIfNeeded(highlighter: Highlighter, theme: string) {
+  if (!highlighter.getLoadedThemes().includes(theme)) {
+    const themeImportFn = bundledThemes[theme]
+    if (themeImportFn) {
+      await highlighter.loadTheme(await themeImportFn())
+    }
+  }
+}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

## 优化应用启动速度

1. node_modules 代码合并到 vender.js 单文件内 （不能优化启动速度，可以减少生成文件数量）
2. 移除 await initHighlighter，这个会阻碍 renderer js 代码执行，导致整体执行速度变得很慢
3. 重构 SyntaxHighlighterProvider 和 shiki.ts 代码，共用同一个 highlighter 实例，减少内存占用

* Moved highlighter initialization and loading functions to a new utility file for better organization.
* Simplified theme and language loading in the SyntaxHighlighterProvider using the new utility functions.
* Removed redundant code and improved readability in MessageTools by introducing a new CollapsedContent component for rendering tool responses.
* Updated MCPDescription to use an async function for Shiki instance initialization.

### 优化前

renderer 加载时间 1.9 秒 （MacBook M4 芯片，部分电脑可能高达 5 秒以上）

### 优化后

renderer 加载时间 0.4 秒 （4倍速度提升）


https://github.com/user-attachments/assets/feae7e4d-c719-411c-83d5-ba404f13a830


