### PR TITLE
refactor: serif messageFont & index.scss structure

### DIFF
--- a/src/renderer/src/assets/styles/index.scss
+++ b/src/renderer/src/assets/styles/index.scss
@@ -8,13 +8,6 @@
 @import '../fonts/icon-fonts/iconfont.css';
 @import '../fonts/ubuntu/ubuntu.css';
 
-body {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
 *,
 *::before,
 *::after {
@@ -31,8 +24,18 @@ body {
   -webkit-tap-highlight-color: transparent;
 }
 
-ul {
-  list-style: none;
+html,
+body,
+#root {
+  height: 100%;
+  width: 100%;
+  margin: 0;
+}
+
+#root {
+  display: flex;
+  flex-direction: row;
+  flex: 1;
 }
 
 body {
@@ -44,9 +47,15 @@ body {
   overflow: hidden;
   font-family: var(--font-family);
   text-rendering: optimizeLegibility;
+  transition: background-color 0.3s linear;
+
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  transition: background-color 0.3s linear;
+
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 input,
@@ -67,20 +76,8 @@ a {
   -webkit-user-drag: none;
 }
 
-html,
-body,
-#root {
-  height: 100%;
-  width: 100%;
-  margin: 0;
-}
-
-#root {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: row;
-  flex: 1;
+ul {
+  list-style: none;
 }
 
 .loader {

--- a/src/renderer/src/pages/home/Messages/Blocks/ThinkingBlock.tsx
+++ b/src/renderer/src/pages/home/Messages/Blocks/ThinkingBlock.tsx
@@ -23,12 +23,6 @@ const ThinkingBlock: React.FC<Props> = ({ block }) => {
 
   const isThinking = useMemo(() => block.status === MessageBlockStatus.STREAMING, [block.status])
 
-  const fontFamily = useMemo(() => {
-    return messageFont === 'serif'
-      ? 'serif'
-      : '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans","Helvetica Neue", sans-serif'
-  }, [messageFont])
-
   useEffect(() => {
     if (!isThinking && thoughtAutoCollapse) {
       setActiveKey('')
@@ -98,7 +92,11 @@ const ThinkingBlock: React.FC<Props> = ({ block }) => {
           ),
           children: (
             //  FIXME: 临时兼容
-            <div style={{ fontFamily, fontSize }}>
+            <div
+              style={{
+                fontFamily: messageFont === 'serif' ? 'var(--font-family-serif)' : 'var(--font-family)',
+                fontSize
+              }}>
               <Markdown block={block} />
             </div>
           )

--- a/src/renderer/src/pages/home/Messages/MessageTools.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageTools.tsx
@@ -17,11 +17,6 @@ const MessageTools: FC<Props> = ({ blocks }) => {
   const [expandedResponse, setExpandedResponse] = useState<{ content: string; title: string } | null>(null)
   const { t } = useTranslation()
   const { messageFont, fontSize } = useSettings()
-  const fontFamily = useMemo(() => {
-    return messageFont === 'serif'
-      ? 'serif'
-      : '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans","Helvetica Neue", sans-serif'
-  }, [messageFont])
 
   const toolResponse = blocks.metadata?.rawMcpToolResponse
 
@@ -122,7 +117,11 @@ const MessageTools: FC<Props> = ({ blocks }) => {
         </MessageTitleLabel>
       ),
       children: isDone && result && (
-        <ToolResponseContainer style={{ fontFamily, fontSize: '12px' }}>
+        <ToolResponseContainer
+          style={{
+            fontFamily: messageFont === 'serif' ? 'var(--font-family-serif)' : 'var(--font-family)',
+            fontSize: '12px'
+          }}>
           <div className="markdown" dangerouslySetInnerHTML={{ __html: styledResult }} />
         </ToolResponseContainer>
       )
@@ -173,7 +172,11 @@ const MessageTools: FC<Props> = ({ blocks }) => {
         transitionName="animation-move-down"
         styles={{ body: { maxHeight: '80vh', overflow: 'auto' } }}>
         {expandedResponse && (
-          <ExpandedResponseContainer style={{ fontFamily, fontSize }}>
+          <ExpandedResponseContainer
+            style={{
+              fontFamily: messageFont === 'serif' ? 'var(--font-family-serif)' : 'var(--font-family)',
+              fontSize
+            }}>
             {/* mode swtich tabs */}
             <Tabs
               tabBarExtraContent={


### PR DESCRIPTION
调整了serif messageFont设置的漏网之鱼，改为使用var(--font-family)/var(--font-family-serif)
整理了index.scss的结构