### PR TITLE
refactor: enhance assistant and topic sidebar toggling with force option

### DIFF
--- a/src/renderer/src/pages/home/Navbar.tsx
+++ b/src/renderer/src/pages/home/Navbar.tsx
@@ -67,7 +67,7 @@ const HeaderNavbar: FC<Props> = ({ activeAssistant, setActiveAssistant, activeTo
   }, [showTopics, toggleShowTopics])
 
   useShortcut('toggle_show_assistants', () => {
-    handleToggleShowAssistants()
+    toggleShowAssistants()
     EventEmitter.emit(EVENT_NAMES.SHOW_ASSISTANTS, { force: true })
   })
 

--- a/src/renderer/src/pages/home/Navbar.tsx
+++ b/src/renderer/src/pages/home/Navbar.tsx
@@ -66,13 +66,17 @@ const HeaderNavbar: FC<Props> = ({ activeAssistant, setActiveAssistant, activeTo
     }
   }, [showTopics, toggleShowTopics])
 
-  useShortcut('toggle_show_assistants', handleToggleShowAssistants)
+  useShortcut('toggle_show_assistants', () => {
+    handleToggleShowAssistants()
+    EventEmitter.emit(EVENT_NAMES.SHOW_ASSISTANTS, { force: true })
+  })
 
   useShortcut('toggle_show_topics', () => {
     if (topicPosition === 'right') {
       toggleShowTopics()
     } else {
-      EventEmitter.emit(EVENT_NAMES.SHOW_TOPIC_SIDEBAR)
+      handleToggleShowAssistants()
+      EventEmitter.emit(EVENT_NAMES.SHOW_TOPIC_SIDEBAR, { force: true })
     }
   })
 

--- a/src/renderer/src/pages/home/Tabs/index.tsx
+++ b/src/renderer/src/pages/home/Tabs/index.tsx
@@ -71,14 +71,14 @@ const HomeTabs: FC<Props> = ({
 
   useEffect(() => {
     const unsubscribes = [
-      EventEmitter.on(EVENT_NAMES.SHOW_ASSISTANTS, (): any => {
-        showTab && setTab('assistants')
+      EventEmitter.on(EVENT_NAMES.SHOW_ASSISTANTS, ({ force }: { force: boolean }): any => {
+        if (showTab || force) setTab('assistants')
       }),
-      EventEmitter.on(EVENT_NAMES.SHOW_TOPIC_SIDEBAR, (): any => {
-        showTab && setTab('topic')
+      EventEmitter.on(EVENT_NAMES.SHOW_TOPIC_SIDEBAR, ({ force }: { force: boolean }): any => {
+        if (showTab || force) setTab('topic')
       }),
-      EventEmitter.on(EVENT_NAMES.SHOW_CHAT_SETTINGS, (): any => {
-        showTab && setTab('settings')
+      EventEmitter.on(EVENT_NAMES.SHOW_CHAT_SETTINGS, ({ force }: { force: boolean }): any => {
+        if (showTab || force) setTab('settings')
       }),
       EventEmitter.on(EVENT_NAMES.SWITCH_TOPIC_SIDEBAR, () => {
         showTab && setTab('topic')
@@ -88,7 +88,7 @@ const HomeTabs: FC<Props> = ({
       })
     ]
     return () => unsubscribes.forEach((unsub) => unsub())
-  }, [position, showTab, tab, toggleShowTopics, topicPosition])
+  }, [showTab, position, topicPosition, toggleShowTopics])
 
   useEffect(() => {
     if (position === 'right' && topicPosition === 'right' && tab === 'assistants') {


### PR DESCRIPTION
改进快捷键打开侧边抽屉的逻辑。

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
fix: 改进快捷键打开侧边抽屉的逻辑。
```
