### PR TITLE
feat: add quick assistant settings panel and management functionality

### DIFF
--- a/src/renderer/src/hooks/useAssistant.ts
+++ b/src/renderer/src/hooks/useAssistant.ts
@@ -12,6 +12,7 @@ import {
   updateAssistants,
   updateAssistantSettings,
   updateDefaultAssistant,
+  updateQuickAssistant,
   updateTopic,
   updateTopics
 } from '@renderer/store/assistants'
@@ -115,5 +116,19 @@ export function useDefaultModel() {
     setTopicNamingModel: (model: Model) => dispatch(setTopicNamingModel({ model })),
     setTranslateModel: (model: Model) => dispatch(setTranslateModel({ model })),
     setQuickAssistantModel: (model: Model) => dispatch(setQuickAssistantModel({ model }))
+  }
+}
+
+export function useQuickAssistant() {
+  const quickAssistant = useAppSelector((state) => state.assistants.quickAssistant)
+  const dispatch = useAppDispatch()
+  const { quickAssistantModel } = useDefaultModel()
+
+  return {
+    quickAssistant: {
+      ...quickAssistant,
+      model: quickAssistantModel
+    },
+    updateQuickAssistant: (assistant: Partial<Assistant>) => dispatch(updateQuickAssistant(assistant as Assistant))
   }
 }

--- a/src/renderer/src/pages/settings/ModelSettings/ModelSettings.tsx
+++ b/src/renderer/src/pages/settings/ModelSettings/ModelSettings.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from 'react-i18next'
 
 import { SettingContainer, SettingDescription, SettingGroup, SettingTitle } from '..'
 import DefaultAssistantSettings from './DefaultAssistantSettings'
+import QuickAssistantSettings from './QuickAssistantSettings'
 import TopicNamingModalPopup from './TopicNamingModalPopup'
 
 const ModelSettings: FC = () => {
@@ -179,6 +180,7 @@ const ModelSettings: FC = () => {
             showSearch
             placeholder={t('settings.models.empty')}
           />
+          <Button icon={<Settings2 size={16} />} style={{ marginLeft: 8 }} onClick={QuickAssistantSettings.show} />
         </HStack>
         <SettingDescription>{t('settings.models.quick_assistant_model_description')}</SettingDescription>
       </SettingGroup>

--- a/src/renderer/src/pages/settings/ModelSettings/QuickAssistantSettings.tsx
+++ b/src/renderer/src/pages/settings/ModelSettings/QuickAssistantSettings.tsx
@@ -1,0 +1,303 @@
+import { QuestionCircleOutlined } from '@ant-design/icons'
+import { HStack } from '@renderer/components/Layout'
+import { TopView } from '@renderer/components/TopView'
+import { DEFAULT_CONTEXTCOUNT, DEFAULT_MAX_TOKENS, DEFAULT_TEMPERATURE } from '@renderer/config/constant'
+import { useQuickAssistant } from '@renderer/hooks/useAssistant'
+import { AssistantSettings as AssistantSettingsType } from '@renderer/types'
+import { modalConfirm } from '@renderer/utils'
+import { Button, Col, InputNumber, Modal, Row, Slider, Switch, Tooltip } from 'antd'
+import TextArea from 'antd/es/input/TextArea'
+import { Dispatch, FC, SetStateAction, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+
+import { SettingContainer, SettingSubtitle } from '..'
+
+const QuickAssistantSettings: FC = () => {
+  const { quickAssistant, updateQuickAssistant } = useQuickAssistant()
+  const [temperature, setTemperature] = useState(quickAssistant.settings?.temperature ?? DEFAULT_TEMPERATURE)
+  const [contextCount, setContextCount] = useState(quickAssistant.settings?.contextCount ?? DEFAULT_CONTEXTCOUNT)
+  const [enableMaxTokens, setEnableMaxTokens] = useState(quickAssistant?.settings?.enableMaxTokens ?? false)
+  const [maxTokens, setMaxTokens] = useState(quickAssistant?.settings?.maxTokens ?? DEFAULT_MAX_TOKENS)
+  const [topP, setTopP] = useState(quickAssistant.settings?.topP ?? 1)
+
+  const { t } = useTranslation()
+
+  const onUpdateAssistantSettings = (settings: Partial<AssistantSettingsType>) => {
+    console.log('Updating assistant settings:', {
+      ...quickAssistant.settings,
+      ...settings
+    })
+    updateQuickAssistant({
+      ...quickAssistant,
+      settings: {
+        ...quickAssistant.settings,
+        temperature: settings.temperature ?? temperature,
+        contextCount: settings.contextCount ?? contextCount,
+        enableMaxTokens: settings.enableMaxTokens ?? enableMaxTokens,
+        maxTokens: settings.maxTokens ?? maxTokens,
+        streamOutput: settings.streamOutput ?? true,
+        topP: settings.topP ?? topP
+      }
+    })
+  }
+
+  const handleChange =
+    (setter: Dispatch<SetStateAction<number>>, updater: (value: number) => void) => (value: number | null) => {
+      if (value !== null) {
+        setter(value)
+        updater(value)
+      }
+    }
+  const onTemperatureChange = handleChange(setTemperature, (value) => onUpdateAssistantSettings({ temperature: value }))
+  const onContextCountChange = handleChange(setContextCount, (value) =>
+    onUpdateAssistantSettings({ contextCount: value })
+  )
+  const onMaxTokensChange = handleChange(setMaxTokens, (value) => onUpdateAssistantSettings({ maxTokens: value }))
+  const onTopPChange = handleChange(setTopP, (value) => onUpdateAssistantSettings({ topP: value }))
+
+  const onReset = () => {
+    setTemperature(DEFAULT_TEMPERATURE)
+    setContextCount(DEFAULT_CONTEXTCOUNT)
+    setEnableMaxTokens(false)
+    setMaxTokens(0)
+    setTopP(1)
+    updateQuickAssistant({
+      ...quickAssistant,
+      settings: {
+        ...quickAssistant.settings,
+        temperature: DEFAULT_TEMPERATURE,
+        contextCount: DEFAULT_CONTEXTCOUNT,
+        enableMaxTokens: false,
+        maxTokens: DEFAULT_MAX_TOKENS,
+        streamOutput: true,
+        topP: 1
+      }
+    })
+  }
+
+  return (
+    <SettingContainer style={{ height: 'auto', background: 'transparent', padding: 0 }}>
+      <SettingSubtitle>{t('common.prompt')}</SettingSubtitle>
+      <TextArea
+        rows={4}
+        placeholder={t('common.assistant') + t('common.prompt')}
+        value={quickAssistant.prompt}
+        onChange={(e) => {
+          const newPrompt = e.target.value
+          updateQuickAssistant({
+            ...quickAssistant,
+            prompt: newPrompt
+          })
+        }}
+        style={{ margin: '10px 0' }}
+        spellCheck={false}
+      />
+      <SettingSubtitle
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'space-between'
+        }}>
+        {t('settings.assistant.model_params')}
+        <Button onClick={onReset} style={{ width: 90 }}>
+          {t('chat.settings.reset')}
+        </Button>
+      </SettingSubtitle>
+      <Row align="middle">
+        <Label>{t('chat.settings.temperature')}</Label>
+        <Tooltip title={t('chat.settings.temperature.tip')}>
+          <QuestionIcon />
+        </Tooltip>
+      </Row>
+      <Row align="middle" style={{ marginBottom: 10 }} gutter={20}>
+        <Col span={21}>
+          <Slider
+            min={0}
+            max={2}
+            onChange={setTemperature}
+            onChangeComplete={onTemperatureChange}
+            value={typeof temperature === 'number' ? temperature : 0}
+            marks={{ 0: '0', 0.7: '0.7', 2: '2' }}
+            step={0.01}
+          />
+        </Col>
+        <Col span={3}>
+          <InputNumber
+            min={0}
+            max={2}
+            step={0.01}
+            value={temperature}
+            onChange={onTemperatureChange}
+            style={{ width: '100%' }}
+          />
+        </Col>
+      </Row>
+      <Row align="middle">
+        <Label>{t('chat.settings.top_p')}</Label>
+        <Tooltip title={t('chat.settings.top_p.tip')}>
+          <QuestionIcon />
+        </Tooltip>
+      </Row>
+      <Row align="middle" style={{ marginBottom: 10 }} gutter={20}>
+        <Col span={21}>
+          <Slider
+            min={0}
+            max={1}
+            onChange={setTopP}
+            onChangeComplete={onTopPChange}
+            value={typeof topP === 'number' ? topP : 1}
+            marks={{ 0: '0', 0.5: '0.5', 1: '1' }}
+            step={0.01}
+          />
+        </Col>
+        <Col span={3}>
+          <InputNumber min={0} max={1} step={0.01} value={topP} onChange={onTopPChange} style={{ width: '100%' }} />
+        </Col>
+      </Row>
+      <Row align="middle">
+        <Label>{t('chat.settings.context_count')}</Label>
+        <Tooltip title={t('chat.settings.context_count.tip')}>
+          <QuestionIcon />
+        </Tooltip>
+      </Row>
+      <Row align="middle" style={{ marginBottom: 10 }} gutter={20}>
+        <Col span={21}>
+          <Slider
+            min={0}
+            max={20}
+            marks={{ 0: '0', 5: '5', 10: '10', 15: '15', 20: t('chat.settings.max') }}
+            onChange={setContextCount}
+            onChangeComplete={onContextCountChange}
+            value={typeof contextCount === 'number' ? contextCount : 0}
+            step={1}
+          />
+        </Col>
+        <Col span={3}>
+          <InputNumber
+            min={0}
+            max={20}
+            step={1}
+            value={contextCount}
+            onChange={onContextCountChange}
+            style={{ width: '100%' }}
+          />
+        </Col>
+      </Row>
+      <Row align="middle" style={{ marginBottom: 10 }}>
+        <HStack>
+          <Label>{t('chat.settings.max_tokens')}</Label>
+          <Tooltip title={t('chat.settings.max_tokens.tip')}>
+            <QuestionIcon />
+          </Tooltip>
+        </HStack>
+        <Switch
+          style={{ marginLeft: 10 }}
+          checked={enableMaxTokens}
+          onChange={async (enabled) => {
+            if (enabled) {
+              const confirmed = await modalConfirm({
+                title: t('chat.settings.max_tokens.confirm'),
+                content: t('chat.settings.max_tokens.confirm_content'),
+                okButtonProps: {
+                  danger: true
+                }
+              })
+              if (!confirmed) return
+            }
+            setEnableMaxTokens(enabled)
+            onUpdateAssistantSettings({ enableMaxTokens: enabled })
+          }}
+        />
+      </Row>
+      {enableMaxTokens && (
+        <Row align="middle" gutter={20}>
+          <Col span={24}>
+            <InputNumber
+              disabled={!enableMaxTokens}
+              min={0}
+              max={10000000}
+              step={100}
+              value={maxTokens}
+              changeOnBlur
+              onChange={onMaxTokensChange}
+              style={{ width: '100%' }}
+            />
+          </Col>
+        </Row>
+      )}
+    </SettingContainer>
+  )
+}
+
+interface Props {
+  resolve: (data: any) => void
+}
+
+const PopupContainer = ({ resolve }: Props) => {
+  const { t } = useTranslation()
+
+  const [open, setOpen] = useState(true)
+
+  const onCancel = () => {
+    setOpen(false)
+  }
+
+  const onClose = () => {
+    resolve({})
+  }
+
+  QuickAssistantSettingsPopup.hide = onCancel
+
+  return (
+    <Modal
+      title={t('settings.quickAssistant.title')}
+      open={open}
+      onCancel={onCancel}
+      afterClose={onClose}
+      transitionName="animation-move-down"
+      centered
+      width={800}
+      footer={null}>
+      <QuickAssistantSettings />
+    </Modal>
+  )
+}
+
+const TopViewKey = 'QuickAssistantSettingsPopup'
+
+export default class QuickAssistantSettingsPopup {
+  static topviewId = 0
+
+  static hide() {
+    TopView.hide(TopViewKey)
+  }
+
+  static show() {
+    return new Promise((resolve) => {
+      TopView.show(
+        <PopupContainer
+          resolve={(data) => {
+            TopView.hide(TopViewKey)
+            resolve(data)
+          }}
+        />,
+        TopViewKey
+      )
+    })
+  }
+}
+
+const Label = styled.span`
+  color: var(--color-text);
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 20px;
+  margin-right: 8px;
+`
+
+const QuestionIcon = styled(QuestionCircleOutlined)`
+  color: var(--color-text-secondary);
+  font-size: 14px;
+  cursor: help;
+`

--- a/src/renderer/src/windows/mini/home/HomeWindow.tsx
+++ b/src/renderer/src/windows/mini/home/HomeWindow.tsx
@@ -175,7 +175,9 @@ const HomeWindow: FC = () => {
       store.dispatch(newMessagesActions.addMessage({ topicId, message: userMessage }))
       store.dispatch(upsertManyBlocks(blocks))
 
-      const assistant = getDefaultAssistant()
+      // 如果 quickAssistant 未設定，則使用 defaultAssistant
+      const { quickAssistant } = store.getState().assistants
+      const assistant = quickAssistant || getDefaultAssistant()
       let blockId: string | null = null
       let blockContent: string = ''
 


### PR DESCRIPTION
- Create QuickAssistantSettings component for UI
- Extend useAssistant hook with quick assistant controls
- Add settings button in ModelSettings page
- Implement temperature, context count, max tokens, and other parameters
- Connect settings to store via updateQuickAssistant action

Separate quick assistant preferences from default assistant settings for better customization.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

After this PR:

- 允許使用者自定義快捷助手參數

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
- Create QuickAssistantSettings component for UI
- Extend useAssistant hook with quick assistant controls
- Add settings button in ModelSettings page
- Implement temperature, context count, max tokens, and other parameters
- Connect settings to store via updateQuickAssistant action
```
<img width="300" alt="image" src="https://github.com/user-attachments/assets/73b87bd9-478d-48a0-bad9-5cc7ddce3bbb" />
