### PR TITLE
fix: handle undefined html title

### DIFF
--- a/src/renderer/src/components/CodeBlockView/HtmlArtifacts.tsx
+++ b/src/renderer/src/components/CodeBlockView/HtmlArtifacts.tsx
@@ -13,7 +13,6 @@ interface Props {
 
 const Artifacts: FC<Props> = ({ html }) => {
   const { t } = useTranslation()
-  const title = extractTitle(html) || 'Artifacts ' + t('chat.artifacts.button.preview')
   const { openMinapp } = useMinappPopup()
 
   /**
@@ -23,6 +22,7 @@ const Artifacts: FC<Props> = ({ html }) => {
     const path = await window.api.file.create('artifacts-preview.html')
     await window.api.file.write(path, html)
     const filePath = `file://${path}`
+    const title = extractTitle(html) || 'Artifacts ' + t('chat.artifacts.button.preview')
     openMinapp({
       id: 'artifacts-preview',
       name: title,

--- a/src/renderer/src/utils/__tests__/formats.test.ts
+++ b/src/renderer/src/utils/__tests__/formats.test.ts
@@ -204,6 +204,11 @@ describe('formats', () => {
     it('should handle empty string', () => {
       expect(extractTitle('')).toBeNull()
     })
+
+    it('should handle undefined', () => {
+      // @ts-ignore for testing
+      expect(extractTitle(undefined)).toBeNull()
+    })
   })
 
   describe('removeSvgEmptyLines', () => {

--- a/src/renderer/src/utils/formats.ts
+++ b/src/renderer/src/utils/formats.ts
@@ -54,6 +54,8 @@ $$
 }
 
 export function extractTitle(html: string): string | null {
+  if (!html) return null
+
   // 处理标准闭合的标题标签
   const titleRegex = /<title>(.*?)<\/title>/i
   const match = html.match(titleRegex)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

输出 html 代码块可能报错在 `extractTitle`

After this PR:

不会报错

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
