### PR TITLE
fix:  assistant emoji displaying incorrectly in specific situations

### DIFF
--- a/src/renderer/src/components/EmojiIcon.tsx
+++ b/src/renderer/src/components/EmojiIcon.tsx
@@ -1,4 +1,3 @@
-import { getLeadingEmoji } from '@renderer/utils'
 import { FC } from 'react'
 import styled from 'styled-components'
 

--- a/src/renderer/src/components/EmojiIcon.tsx
+++ b/src/renderer/src/components/EmojiIcon.tsx
@@ -7,13 +7,12 @@ interface EmojiIconProps {
   className?: string
 }
 
-const EmojiIcon: FC<EmojiIconProps> = ({ emoji, className }) => {
-  const _emoji = getLeadingEmoji(emoji || '⭐️') || '⭐️'
+const EmojiIcon: FC<EmojiIconProps> = ({ emoji = '⭐️', className }) => {
 
   return (
     <Container className={className}>
-      <EmojiBackground>{_emoji}</EmojiBackground>
-      {_emoji}
+      <EmojiBackground>{emoji}</EmojiBackground>
+      {emoji}
     </Container>
   )
 }

--- a/src/renderer/src/pages/home/Tabs/components/AssistantItem.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/AssistantItem.tsx
@@ -18,7 +18,7 @@ import AssistantSettingsPopup from '@renderer/pages/settings/AssistantSettings'
 import { getDefaultModel, getDefaultTopic } from '@renderer/services/AssistantService'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import { Assistant } from '@renderer/types'
-import { uuid } from '@renderer/utils'
+import { getLeadingEmoji, uuid } from '@renderer/utils'
 import { hasTopicPendingRequests } from '@renderer/utils/queue'
 import { Dropdown } from 'antd'
 import { ItemType } from 'antd/es/menu/interface'
@@ -217,7 +217,7 @@ const AssistantItem: FC<AssistantItemProps> = ({ assistant, isActive, onSwitch, 
           ) : (
             assistantIconType === 'emoji' && (
               <EmojiIcon
-                emoji={assistant.emoji || assistantName.slice(0, 1)}
+                emoji={assistant.emoji || getLeadingEmoji(assistantName)}
                 className={isPending && !isActive ? 'animation-pulse' : ''}
               />
             )


### PR DESCRIPTION
助手列表和添加助手弹窗中的 emoji 取值逻辑有问题，
导致有些复合 emoji（如带肤色、性别、家庭等组合）其实是多个 Unicode 码点拼成的，这样会被拆开，导致只取到一部分。

![CleanShot 2025-05-21 at 10 01 20@2x](https://github.com/user-attachments/assets/efefaffb-d7d4-4601-85cd-2dc24810ea7f)
