### PR TITLE
feat: Replace translation source language selection with model selection

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -1702,7 +1702,6 @@
       }
     },
     "translate": {
-      "any.language": "Any language",
       "button.translate": "Translate",
       "close": "Close",
       "closed": "Translation closed",

--- a/src/renderer/src/i18n/locales/ja-jp.json
+++ b/src/renderer/src/i18n/locales/ja-jp.json
@@ -1702,7 +1702,6 @@
       }
     },
     "translate": {
-      "any.language": "任意の言語",
       "button.translate": "翻訳",
       "close": "閉じる",
       "closed": "翻訳は閉じられました",

--- a/src/renderer/src/i18n/locales/ru-ru.json
+++ b/src/renderer/src/i18n/locales/ru-ru.json
@@ -1702,7 +1702,6 @@
       "about.debug.open": "Открыть"
     },
     "translate": {
-      "any.language": "Любой язык",
       "button.translate": "Перевести",
       "close": "Закрыть",
       "closed": "Перевод закрыт",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -1702,7 +1702,6 @@
       }
     },
     "translate": {
-      "any.language": "任意语言",
       "button.translate": "翻译",
       "close": "关闭",
       "closed": "翻译已关闭",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -1702,7 +1702,6 @@
       }
     },
     "translate": {
-      "any.language": "任意語言",
       "button.translate": "翻譯",
       "close": "關閉",
       "closed": "翻譯已關閉",

--- a/src/renderer/src/i18n/translate/el-gr.json
+++ b/src/renderer/src/i18n/translate/el-gr.json
@@ -1619,7 +1619,6 @@
       "zoom.title": "Μεγέθυνση σελίδας"
     },
     "translate": {
-      "any.language": " οποιαδήποτε γλώσσα",
       "button.translate": "Μετάφραση",
       "close": "Κλείσιμο",
       "confirm": {

--- a/src/renderer/src/i18n/translate/es-es.json
+++ b/src/renderer/src/i18n/translate/es-es.json
@@ -1618,7 +1618,6 @@
       "zoom.title": "Zoom de página"
     },
     "translate": {
-      "any.language": "cualquier idioma",
       "button.translate": "Traducir",
       "close": "Cerrar",
       "confirm": {

--- a/src/renderer/src/i18n/translate/fr-fr.json
+++ b/src/renderer/src/i18n/translate/fr-fr.json
@@ -1619,7 +1619,6 @@
       "zoom.title": "Zoom de la page"
     },
     "translate": {
-      "any.language": "langue arbitraire",
       "button.translate": "traduire",
       "close": "fermer",
       "confirm": {

--- a/src/renderer/src/i18n/translate/pt-pt.json
+++ b/src/renderer/src/i18n/translate/pt-pt.json
@@ -1621,7 +1621,6 @@
       "zoom.title": "Zoom da página"
     },
     "translate": {
-      "any.language": "qualquer idioma",
       "button.translate": "Traduzir",
       "close": "Fechar",
       "confirm": {


### PR DESCRIPTION
### Replace translation source language selection with model selection. 

I'm not sure if the "source language" selection will be supported in future plans? I removed it and placed a model switching selector in that position.

Before this PR:

![image](https://github.com/user-attachments/assets/28596ecb-36d4-4ce2-96ec-430d38d17d7a)


After this PR:

![image](https://github.com/user-attachments/assets/547cb3b2-5363-4b94-a47c-3902f0c4f6ee)