### PR TITLE
fix: increase the upper limit of issue-management operations-per-run

### DIFF
--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -54,5 +54,5 @@ jobs:
           days-before-pr-close: -1 # Completely disable closing for PRs
 
           # Temporary to reduce the huge issues number
-          operations-per-run: 100
+          operations-per-run: 1000
           debug-only: false


### PR DESCRIPTION
增加工作流关闭issue operation上限的大小