### PR TITLE
fix: shiki does not load language as a fallback & mcp no description page i18n

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -1365,6 +1365,9 @@
           "noToolsAvailable": "No tools available",
           "loadError": "Get tools Error"
         },
+        "descriptions": {
+          "empty": "description not available"
+        },
         "prompts": {
           "availablePrompts": "Available Prompts",
           "noPromptsAvailable": "No prompts available",

--- a/src/renderer/src/i18n/locales/ja-jp.json
+++ b/src/renderer/src/i18n/locales/ja-jp.json
@@ -1362,6 +1362,9 @@
           "noToolsAvailable": "利用可能なツールなし",
           "loadError": "ツール取得エラー"
         },
+        "descriptions": {
+          "empty": "説明はありません"
+        },
         "prompts": {
           "availablePrompts": "利用可能なプロンプト",
           "noPromptsAvailable": "利用可能なプロンプトはありません",

--- a/src/renderer/src/i18n/locales/ru-ru.json
+++ b/src/renderer/src/i18n/locales/ru-ru.json
@@ -1362,6 +1362,9 @@
           "noToolsAvailable": "Нет доступных инструментов",
           "loadError": "Ошибка получения инструментов"
         },
+        "descriptions": {
+          "empty": "Описание недоступно"
+        },
         "prompts": {
           "availablePrompts": "Доступные подсказки",
           "noPromptsAvailable": "Нет доступных подсказок",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -1365,6 +1365,9 @@
           "noToolsAvailable": "无可用工具",
           "loadError": "获取工具失败"
         },
+        "descriptions": {
+          "empty": "暂无描述"
+        },
         "prompts": {
           "availablePrompts": "可用提示",
           "noPromptsAvailable": "无可用提示",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -1365,6 +1365,9 @@
           "noToolsAvailable": "無可用工具",
           "loadError": "獲取工具失敗"
         },
+        "descriptions": {
+          "empty": "暫無描述"
+        },
         "prompts": {
           "availablePrompts": "可用提示",
           "noPromptsAvailable": "無可用提示",

--- a/src/renderer/src/pages/settings/MCPSettings/McpDescription.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/McpDescription.tsx
@@ -6,12 +6,14 @@ import MarkdownIt from 'markdown-it'
 import { npxFinder } from 'npx-scope-finder'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
+import { useTranslation } from 'react-i18next'
 
 interface McpDescriptionProps {
   searchKey: string
 }
 
 const MCPDescription = ({ searchKey }: McpDescriptionProps) => {
+  const { t } = useTranslation()
   const [renderedMarkdown, setRenderedMarkdown] = useState('')
   const [loading, setLoading] = useState(false)
 
@@ -26,7 +28,7 @@ const MCPDescription = ({ searchKey }: McpDescriptionProps) => {
   const getMcpInfo = useCallback(async () => {
     setLoading(true)
     const packages = await npxFinder(searchKey).finally(() => setLoading(false))
-    const readme = packages[0]?.original?.readme ?? '暂无描述'
+    const readme = packages[0]?.original?.readme ?? t('settings.mcp.descriptions.empty')
     setRenderedMarkdown(md.current.render(readme))
   }, [md, searchKey])
 

--- a/src/renderer/src/utils/shiki.ts
+++ b/src/renderer/src/utils/shiki.ts
@@ -1,6 +1,6 @@
 import { useTheme } from '@renderer/context/ThemeProvider'
 import { ThemeMode } from '@renderer/types'
-import { setupMarkdownIt } from '@shikijs/markdown-it'
+import { MarkdownItShikiSetupOptions, setupMarkdownIt } from '@shikijs/markdown-it'
 import MarkdownIt from 'markdown-it'
 import { useEffect, useRef, useState } from 'react'
 import { getTokenStyleObject, ThemedToken } from 'shiki/core'
@@ -38,12 +38,14 @@ export function getReactStyleFromToken(token: ThemedToken): Record<string, strin
   return reactStyle
 }
 
-const defaultOptions = {
+const defaultOptions: MarkdownItShikiSetupOptions = {
   themes: {
     light: 'one-light',
     dark: 'material-theme-darker'
   },
-  defaultColor: 'light'
+  defaultColor: 'light',
+  defaultLanguage: 'json',
+  fallbackLanguage: 'json'
 }
 
 export async function getShikiInstance(theme: ThemeMode) {


### PR DESCRIPTION
1. shiki渲染代码的时候会出现未兼容语言的报错，基础配置加了下兜底语言
![WX20250521-153112@2x](https://github.com/user-attachments/assets/0764dabf-37e5-46c7-a85b-4a0ec9691eb7)
2. mcp描述页补充下多语言的兼容

