### PR TITLE
fix: show x-scrollbar in codeblock if unwrapped, simplify style definitions

### DIFF
--- a/src/renderer/src/assets/styles/markdown.scss
+++ b/src/renderer/src/assets/styles/markdown.scss
@@ -321,7 +321,6 @@ mjx-container {
 
     .cm-lineWrapping * {
       word-wrap: break-word;
-      white-space: pre-wrap;
     }
   }
 }

--- a/src/renderer/src/components/CodeBlockView/CodePreview.tsx
+++ b/src/renderer/src/components/CodeBlockView/CodePreview.tsx
@@ -165,13 +165,11 @@ const CodePreview = ({ children, language }: CodePreviewProps) => {
   return (
     <ContentContainer
       ref={codeContentRef}
-      $isShowLineNumbers={codeShowLineNumbers}
-      $isUnwrapped={isUnwrapped}
-      $isCodeWrappable={codeWrappable}
+      $lineNumbers={codeShowLineNumbers}
+      $wrap={codeWrappable && !isUnwrapped}
       style={{
         fontSize: fontSize - 1,
-        maxHeight: codeCollapsible && !isExpanded ? '350px' : 'none',
-        overflow: codeCollapsible && !isExpanded ? 'auto' : 'visible'
+        maxHeight: codeCollapsible && !isExpanded ? '350px' : 'none'
       }}>
       {tokenLines.length > 0 ? (
         <ShikiTokensRenderer language={language} tokenLines={tokenLines} />
@@ -223,15 +221,21 @@ const ShikiTokensRenderer: React.FC<{ language: string; tokenLines: ThemedToken[
 )
 
 const ContentContainer = styled.div<{
-  $isShowLineNumbers: boolean
-  $isUnwrapped: boolean
-  $isCodeWrappable: boolean
+  $lineNumbers: boolean
+  $wrap: boolean
 }>`
   position: relative;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
   border: 0.5px solid transparent;
   border-radius: 5px;
   margin-top: 0;
   transition: opacity 0.3s ease;
+
+  ::-webkit-scrollbar-thumb {
+    border-radius: 10px;
+  }
 
   .shiki {
     padding: 1em;
@@ -244,13 +248,18 @@ const ContentContainer = styled.div<{
       .line {
         display: block;
         min-height: 1.3rem;
-        padding-left: ${(props) => (props.$isShowLineNumbers ? '2rem' : '0')};
+        padding-left: ${(props) => (props.$lineNumbers ? '2rem' : '0')};
+
+        * {
+          word-wrap: ${(props) => (props.$wrap ? 'break-word' : undefined)};
+          white-space: ${(props) => (props.$wrap ? 'pre-wrap' : 'pre')};
+        }
       }
     }
   }
 
   ${(props) =>
-    props.$isShowLineNumbers &&
+    props.$lineNumbers &&
     `
       code {
         counter-reset: step;
@@ -266,16 +275,6 @@ const ContentContainer = styled.div<{
         left: 0;
         text-align: right;
         opacity: 0.35;
-      }
-    `}
-
-  ${(props) =>
-    props.$isCodeWrappable &&
-    !props.$isUnwrapped &&
-    `
-      code .line * {
-        word-wrap: break-word;
-        white-space: pre-wrap;
       }
     `}
 `

--- a/src/renderer/src/components/CodeBlockView/index.tsx
+++ b/src/renderer/src/components/CodeBlockView/index.tsx
@@ -9,7 +9,7 @@ import dayjs from 'dayjs'
 import { CirclePlay, CodeXml, Copy, Download, Eye, Square, SquarePen, SquareSplitHorizontal } from 'lucide-react'
 import React, { memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
 import CodePreview from './CodePreview'
 import HtmlArtifacts from './HtmlArtifacts'
@@ -258,6 +258,9 @@ const CodeBlockWrapper = styled.div<{ $isInSpecialView: boolean }>`
   position: relative;
 
   .code-toolbar {
+    margin-top: ${(props) => (props.$isInSpecialView ? '20px' : '0')};
+    background-color: ${(props) => (props.$isInSpecialView ? 'transparent' : 'var(--color-background-mute)')};
+    border-radius: ${(props) => (props.$isInSpecialView ? '0' : '4px')};
     opacity: 0;
     transition: opacity 0.2s ease;
     transform: translateZ(0);
@@ -271,23 +274,6 @@ const CodeBlockWrapper = styled.div<{ $isInSpecialView: boolean }>`
       opacity: 1;
     }
   }
-
-  ${(props) =>
-    props.$isInSpecialView &&
-    css`
-      .code-toolbar {
-        margin-top: 20px;
-      }
-    `}
-
-  ${(props) =>
-    !props.$isInSpecialView &&
-    css`
-      .code-toolbar {
-        background-color: var(--color-background-mute);
-        border-radius: 4px;
-      }
-    `}
 `
 
 const CodeHeader = styled.div<{ $isInSpecialView: boolean }>`
@@ -297,16 +283,10 @@ const CodeHeader = styled.div<{ $isInSpecialView: boolean }>`
   color: var(--color-text);
   font-size: 14px;
   font-weight: bold;
-  height: 34px;
   padding: 0 10px;
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
-
-  ${(props) =>
-    props.$isInSpecialView &&
-    css`
-      height: 16px;
-    `}
+  height: ${(props) => (props.$isInSpecialView ? '16px' : '34px')};
 `
 
 const SplitViewWrapper = styled.div`
@@ -315,8 +295,9 @@ const SplitViewWrapper = styled.div`
 
   > * {
     flex: 1 1 0;
+    width: 0;
     min-width: 0;
-    overflow: auto;
+    max-width: 100%;
   }
 `
 

--- a/src/renderer/src/components/CodeEditor/index.tsx
+++ b/src/renderer/src/components/CodeEditor/index.tsx
@@ -223,8 +223,6 @@ const CodeEditor = ({
       }}
       style={{
         fontSize: `${fontSize - 1}px`,
-        overflow: collapsible && !isExpanded ? 'auto' : 'visible',
-        position: 'relative',
         border: '0.5px solid transparent',
         borderRadius: '5px',
         marginTop: 0,

--- a/src/renderer/src/components/CodeToolbar/usePreviewTools.tsx
+++ b/src/renderer/src/components/CodeToolbar/usePreviewTools.tsx
@@ -284,16 +284,6 @@ export const usePreviewTools = ({ handleZoom, handleCopyImage, handleDownload }:
   const { t } = useTranslation()
   const { registerTool, removeTool } = useCodeToolbar()
 
-  const toolIds = useCallback(() => {
-    return {
-      zoomIn: 'preview-zoom-in',
-      zoomOut: 'preview-zoom-out',
-      copyImage: 'preview-copy-image',
-      downloadSvg: 'preview-download-svg',
-      downloadPng: 'preview-download-png'
-    }
-  }, [])
-
   useEffect(() => {
     // 根据提供的功能有选择性地注册工具
     if (handleZoom) {
@@ -356,5 +346,5 @@ export const usePreviewTools = ({ handleZoom, handleCopyImage, handleDownload }:
         removeTool(TOOL_SPECS['download-png'].id)
       }
     }
-  }, [handleCopyImage, handleDownload, handleZoom, registerTool, removeTool, t, toolIds])
+  }, [handleCopyImage, handleDownload, handleZoom, registerTool, removeTool, t])
 }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

修复代码块横向滚动条

Before this PR:

代码块重构之后，unwrap 情况下没有横向滚动条

After this PR:

CodePreview 和 CodeEditor 现在能正确显示横向滚动条

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
