### PR TITLE
refactor: enhance notification handling based on page

### DIFF
--- a/src/renderer/src/context/NotificationProvider.tsx
+++ b/src/renderer/src/context/NotificationProvider.tsx
@@ -39,7 +39,8 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ 
       return new Promise<void>((resolve) => {
         api.open({
           message: notification.title,
-          description: notification.message,
+          description:
+            notification.message.length > 50 ? notification.message.slice(0, 47) + '...' : notification.message,
           duration: 3,
           placement: 'topRight',
           type: typeMap[notification.type] || 'info',

--- a/src/renderer/src/store/thunk/messageThunk.ts
+++ b/src/renderer/src/store/thunk/messageThunk.ts
@@ -36,6 +36,7 @@ import {
 } from '@renderer/utils/messageUtils/create'
 import { getMainTextContent } from '@renderer/utils/messageUtils/find'
 import { getTopicQueue, waitForTopicQueue } from '@renderer/utils/queue'
+import { isOnHomePage } from '@renderer/utils/window'
 import { t } from 'i18next'
 import { throttle } from 'lodash'
 
@@ -589,15 +590,17 @@ const fetchAndProcessAssistantResponseImpl = async (
           status: error.status || error.code,
           requestId: error.request_id
         }
-        await notificationService.send({
-          id: uuid(),
-          type: 'error',
-          title: t('notification.assistant'),
-          message: serializableError.message,
-          silent: false,
-          timestamp: Date.now(),
-          source: 'assistant'
-        })
+        if (!isOnHomePage()) {
+          await notificationService.send({
+            id: uuid(),
+            type: 'error',
+            title: t('notification.assistant'),
+            message: serializableError.message,
+            silent: false,
+            timestamp: Date.now(),
+            source: 'assistant'
+          })
+        }
 
         if (lastBlockId) {
           // 更改上一个block的状态为ERROR
@@ -646,15 +649,17 @@ const fetchAndProcessAssistantResponseImpl = async (
           }
 
           const content = getMainTextContent(finalAssistantMsg)
-          await notificationService.send({
-            id: uuid(),
-            type: 'success',
-            title: t('notification.assistant'),
-            message: content.length > 50 ? content.slice(0, 47) + '...' : content,
-            silent: false,
-            timestamp: Date.now(),
-            source: 'assistant'
-          })
+          if (!isOnHomePage()) {
+            await notificationService.send({
+              id: uuid(),
+              type: 'success',
+              title: t('notification.assistant'),
+              message: content.length > 50 ? content.slice(0, 47) + '...' : content,
+              silent: false,
+              timestamp: Date.now(),
+              source: 'assistant'
+            })
+          }
 
           // 更新topic的name
           autoRenameTopic(assistant, topicId)

--- a/src/renderer/src/utils/window.ts
+++ b/src/renderer/src/utils/window.ts
@@ -1,3 +1,7 @@
 export const isFocused = () => {
   return document.hasFocus()
 }
+
+export const isOnHomePage = () => {
+  return window.location.hash === '#/' || window.location.hash === '#' || window.location.hash === ''
+}


### PR DESCRIPTION
- Updated NotificationProvider to truncate long messages for better display.
- Modified message sending logic in messageThunk to prevent notifications on the home page, improving user experience.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

1. 限制了消息通知的长度
2. 在首页不会推送应用通知

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
