### PR TITLE
fix: shiki does not load language as a fallback & themes error

### DIFF
--- a/src/renderer/src/context/CodeStyleProvider.tsx
+++ b/src/renderer/src/context/CodeStyleProvider.tsx
@@ -136,7 +136,7 @@ export const CodeStyleProvider: React.FC<PropsWithChildren> = ({ children }) => 
   // 使用 Shiki 和 Markdown-it 渲染代码
   const shikiMarkdownIt = useCallback(
     async (code: string) => {
-      const renderer = await getMarkdownIt(activeShikiTheme)
+      const renderer = await getMarkdownIt(activeShikiTheme, code)
       if (!renderer) {
         return code
       }

--- a/src/renderer/src/utils/shiki.ts
+++ b/src/renderer/src/utils/shiki.ts
@@ -1,6 +1,7 @@
 import { getTokenStyleObject, type HighlighterGeneric, SpecialLanguage, ThemedToken } from 'shiki/core'
 
 import { AsyncInitializer } from './asyncInitializer'
+import { BundledLanguage, BundledTheme } from 'shiki/bundle/web'
 
 export const DEFAULT_LANGUAGES = ['javascript', 'typescript', 'python', 'java', 'markdown', 'json']
 export const DEFAULT_THEMES = ['one-light', 'material-theme-darker']
@@ -140,9 +141,11 @@ const mdInitializer = new AsyncInitializer(async () => {
 /**
  * 获取 markdown-it 渲染器
  * @param theme - 主题
+ * @param markdown
  */
-export async function getMarkdownIt(theme: string) {
+export async function getMarkdownIt(theme: string, markdown: string) {
   const highlighter = await getHighlighter()
+  await loadMarkdownLanguage(markdown, highlighter)
   const md = await mdInitializer.get()
   const { fromHighlighter } = await import('@shikijs/markdown-it/core')
 
@@ -159,4 +162,19 @@ export async function getMarkdownIt(theme: string) {
   )
 
   return md
+}
+
+/**
+ * 加载markdown中所有代码块语言类型
+ * @param markdown
+ * @param highlighter
+ */
+async function loadMarkdownLanguage(markdown: string, highlighter: HighlighterGeneric<BundledLanguage, BundledTheme>) {
+  const codeBlockRegex = /```(\w+)?/g
+  let match: string[] | null
+  while ((match = codeBlockRegex.exec(markdown)) !== null) {
+    if (match[1]) {
+      await loadLanguageIfNeeded(highlighter, match[1])
+    }
+  }
 }

--- a/src/renderer/src/utils/shiki.ts
+++ b/src/renderer/src/utils/shiki.ts
@@ -2,7 +2,7 @@ import { getTokenStyleObject, type HighlighterGeneric, SpecialLanguage, ThemedTo
 
 import { AsyncInitializer } from './asyncInitializer'
 
-export const DEFAULT_LANGUAGES = ['javascript', 'typescript', 'python', 'java', 'markdown']
+export const DEFAULT_LANGUAGES = ['javascript', 'typescript', 'python', 'java', 'markdown', 'json']
 export const DEFAULT_THEMES = ['one-light', 'material-theme-darker']
 
 /**
@@ -149,10 +149,12 @@ export async function getMarkdownIt(theme: string) {
   md.use(
     fromHighlighter(highlighter, {
       themes: {
-        light: 'one-light',
-        dark: 'material-theme-darker'
+        'one-light': 'one-light',
+        'material-theme-darker': 'material-theme-darker'
       },
-      defaultColor: theme
+      defaultColor: theme,
+      defaultLanguage: 'json',
+      fallbackLanguage: 'json'
     })
   )
 


### PR DESCRIPTION
1.fix shiki渲染代码的时候会出现未兼容语言的报错，基础配置加了下兜底语言
![WX20250522-093304@2x](https://github.com/user-attachments/assets/ddadd085-0a85-427e-aafb-81636b3f63f5)
2.fix https://github.com/CherryHQ/cherry-studio/pull/6235 修改后导致的主题错误修复
![WX20250522-093411@2x](https://github.com/user-attachments/assets/5ce3f9c0-90c2-471c-8061-b900caff40c4)
