### PR TITLE
Fix: Use effective theme for code style in SettingsTab

### DIFF
--- a/src/renderer/src/pages/home/Tabs/SettingsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/SettingsTab.tsx
@@ -168,18 +168,18 @@ const SettingsTab: FC<Props> = (props) => {
     codeEditor.enabled,
     codeEditor.themeLight,
     codeEditor.themeDark,
-    theme, // This now refers to the theme from useTheme()
+    theme,
     codePreview.themeLight,
     codePreview.themeDark
   ])
 
   const onCodeStyleChange = useCallback(
     (value: CodeStyleVarious) => {
-      const field = theme === ThemeMode.light ? 'themeLight' : 'themeDark' // This now refers to the theme from useTheme()
+      const field = theme === ThemeMode.light ? 'themeLight' : 'themeDark'
       const action = codeEditor.enabled ? setCodeEditor : setCodePreview
       dispatch(action({ [field]: value }))
     },
-    [dispatch, theme, codeEditor.enabled] // theme dependency is updated
+    [dispatch, theme, codeEditor.enabled]
   )
 
   useEffect(() => {

--- a/src/renderer/src/pages/home/Tabs/SettingsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/SettingsTab.tsx
@@ -14,6 +14,7 @@ import {
   isSupportedReasoningEffortOpenAIModel
 } from '@renderer/config/models'
 import { useCodeStyle } from '@renderer/context/CodeStyleProvider'
+import { useTheme } from '@renderer/context/ThemeProvider'
 import { useAssistant } from '@renderer/hooks/useAssistant'
 import { useProvider } from '@renderer/hooks/useProvider'
 import { useSettings } from '@renderer/hooks/useSettings'
@@ -73,7 +74,8 @@ const SettingsTab: FC<Props> = (props) => {
   const { assistant, updateAssistantSettings, updateAssistant } = useAssistant(props.assistant.id)
   const { provider } = useProvider(assistant.model.provider)
 
-  const { messageStyle, fontSize, language, theme } = useSettings()
+  const { messageStyle, fontSize, language } = useSettings()
+  const { theme } = useTheme()
   const { themeNames } = useCodeStyle()
 
   const [temperature, setTemperature] = useState(assistant?.settings?.temperature ?? DEFAULT_TEMPERATURE)
@@ -166,18 +168,18 @@ const SettingsTab: FC<Props> = (props) => {
     codeEditor.enabled,
     codeEditor.themeLight,
     codeEditor.themeDark,
-    theme,
+    theme, // This now refers to the theme from useTheme()
     codePreview.themeLight,
     codePreview.themeDark
   ])
 
   const onCodeStyleChange = useCallback(
     (value: CodeStyleVarious) => {
-      const field = theme === ThemeMode.light ? 'themeLight' : 'themeDark'
+      const field = theme === ThemeMode.light ? 'themeLight' : 'themeDark' // This now refers to the theme from useTheme()
       const action = codeEditor.enabled ? setCodeEditor : setCodePreview
       dispatch(action({ [field]: value }))
     },
-    [dispatch, theme, codeEditor.enabled]
+    [dispatch, theme, codeEditor.enabled] // theme dependency is updated
   )
 
   useEffect(() => {


### PR DESCRIPTION
The SettingsTab component was previously using the theme setting directly from useSettings to determine whether to apply the light or dark code style. This caused an issue when the theme was set to 'auto', as it wouldn't correctly reflect the actual system theme (light or dark).

This commit modifies SettingsTab.tsx to use the `theme` from the `useTheme` hook (which provides the effective theme) for the logic that determines the code editor and preview styles. This ensures that the code style accurately reflects your current effective theme, including when 'auto' theme is selected and the OS theme changes.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
