### PR TITLE
fix: handle empty block content in MessageTranslate component

### DIFF
--- a/src/renderer/src/pages/home/Messages/MessageTranslate.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageTranslate.tsx
@@ -14,16 +14,12 @@ interface Props {
 const MessageTranslate: FC<Props> = ({ block }) => {
   const { t } = useTranslation()
 
-  if (!block.content) {
-    return null
-  }
-
   return (
     <Fragment>
       <Divider style={{ margin: 0, marginBottom: 10 }}>
         <TranslationOutlined />
       </Divider>
-      {block.content === t('translate.processing') ? (
+      {!block.content || block.content === t('translate.processing') ? (
         <SvgSpinners180Ring color="var(--color-text-2)" style={{ marginBottom: 15 }} />
       ) : (
         <Markdown block={block} />


### PR DESCRIPTION
优化消息翻译内容生成时的加载

当content过长时 未显示loading

Before:

https://github.com/user-attachments/assets/f055f84f-35bb-4477-9444-da4831a3c297

After:


https://github.com/user-attachments/assets/32f84ea0-64df-425f-b42f-2261f484a5bc

