### PR TITLE
fix: handle optional usage properties in AnthropicProvider

### DIFF
--- a/src/renderer/src/providers/AiProvider/AnthropicProvider.ts
+++ b/src/renderer/src/providers/AiProvider/AnthropicProvider.ts
@@ -322,7 +322,7 @@ export default class AnthropicProvider extends BaseProvider {
             reasoning_content,
             usage: message.usage as any,
             metrics: {
-              completion_tokens: message.usage.output_tokens,
+              completion_tokens: message.usage?.output_tokens || 0,
               time_completion_millsec,
               time_first_token_millsec: 0
             }
@@ -464,8 +464,8 @@ export default class AnthropicProvider extends BaseProvider {
               }
             }
 
-            finalUsage.prompt_tokens += message.usage.input_tokens
-            finalUsage.completion_tokens += message.usage.output_tokens
+            finalUsage.prompt_tokens += message.usage?.input_tokens || 0
+            finalUsage.completion_tokens += message.usage?.output_tokens || 0
             finalUsage.total_tokens += finalUsage.prompt_tokens + finalUsage.completion_tokens
             finalMetrics.completion_tokens = finalUsage.completion_tokens
             finalMetrics.time_completion_millsec += new Date().getTime() - start_time_millsec


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #5319

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
