### PR TITLE
fix：修复DMXAPI文字生成画bug

### DIFF
--- a/src/renderer/src/pages/paintings/Artboard.tsx
+++ b/src/renderer/src/pages/paintings/Artboard.tsx
@@ -3,7 +3,7 @@ import FileManager from '@renderer/services/FileManager'
 import { Painting } from '@renderer/types'
 import { download } from '@renderer/utils/download'
 import { Button, Dropdown, Spin } from 'antd'
-import { FC } from 'react'
+import React, { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
@@ -17,6 +17,7 @@ interface ArtboardProps {
   onNextImage: () => void
   onCancel: () => void
   retry?: (painting: Painting) => void
+  imageCover?: React.ReactNode
 }
 
 const Artboard: FC<ArtboardProps> = ({
@@ -26,7 +27,8 @@ const Artboard: FC<ArtboardProps> = ({
   onPrevImage,
   onNextImage,
   onCancel,
-  retry
+  retry,
+  imageCover
 }) => {
   const { t } = useTranslation()
 
@@ -108,8 +110,10 @@ const Artboard: FC<ArtboardProps> = ({
                 </div>
               </div>
             ) : (
-              <div>{t('paintings.image_placeholder')}</div>
-            )}
+                imageCover ?
+                  imageCover:
+                  (<div>{t('paintings.image_placeholder')}</div>)
+              )}
           </ImagePlaceholder>
         )}
         {isLoading && (


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #
1. 在DMXAPI文字生成图内容没有输入完成翻译成英文
2. 首次海报加载图片没有loading
3. 取消图片会将之前的图片移除，导致图片加载异常

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->

```release-note

```
