### PR TITLE
fix: update popup content to improve user interaction in MessageGroup

### DIFF
--- a/src/renderer/src/pages/home/Messages/MessageGroup.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageGroup.tsx
@@ -216,7 +216,7 @@ const MessageGroup = ({ messages, topic, hidePresetMessages, registerMessageElem
             trigger={gridPopoverTrigger}
             styles={{ root: { maxWidth: '60vw', minWidth: '550px', overflowY: 'auto', zIndex: 1000 } }}
             getPopupContainer={(triggerNode) => triggerNode.parentNode as HTMLElement}>
-            {wrappedMessage}
+            <div style={{ cursor: 'pointer' }}>{messageContent}</div>
           </Popover>
         )
       }


### PR DESCRIPTION
![屏幕截图 2025-05-25 231542](https://github.com/user-attachments/assets/cdd54703-8c43-41ed-9431-7898a32734cc)

修复多模型回答时 井字排列popup不显示的问题