### PR TITLE
refactor: TrayService & ConfigManager

### DIFF
--- a/packages/shared/IpcChannel.ts
+++ b/packages/shared/IpcChannel.ts
@@ -11,7 +11,6 @@ export enum IpcChannel {
   App_SetLaunchToTray = 'app:set-launch-to-tray',
   App_SetTray = 'app:set-tray',
   App_SetTrayOnClose = 'app:set-tray-on-close',
-  App_RestartTray = 'app:restart-tray',
   App_SetTheme = 'app:set-theme',
   App_SetAutoUpdate = 'app:set-auto-update',
   App_HandleZoomFactor = 'app:handle-zoom-factor',

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -112,8 +112,8 @@ export function registerIpc(mainWindow: BrowserWindow, app: Electron.App) {
     configManager.setAutoUpdate(isActive)
   })
 
-  ipcMain.handle(IpcChannel.Config_Set, (_, key: string, value: any) => {
-    configManager.set(key, value)
+  ipcMain.handle(IpcChannel.Config_Set, (_, key: string, value: any, isNotify: boolean = false) => {
+    configManager.set(key, value, isNotify)
   })
 
   ipcMain.handle(IpcChannel.Config_Get, (_, key: string) => {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -28,7 +28,6 @@ import { searchService } from './services/SearchService'
 import { SelectionService } from './services/SelectionService'
 import { registerShortcuts, unregisterAllShortcuts } from './services/ShortcutService'
 import storeSyncService from './services/StoreSyncService'
-import { TrayService } from './services/TrayService'
 import { setOpenLinkExternal } from './services/WebviewService'
 import { windowService } from './services/WindowService'
 import { calculateDirectorySize, getResourcePath } from './utils'
@@ -112,8 +111,6 @@ export function registerIpc(mainWindow: BrowserWindow, app: Electron.App) {
     appUpdater.setAutoUpdate(isActive)
     configManager.setAutoUpdate(isActive)
   })
-
-  ipcMain.handle(IpcChannel.App_RestartTray, () => TrayService.getInstance().restartTray())
 
   ipcMain.handle(IpcChannel.Config_Set, (_, key: string, value: any) => {
     configManager.set(key, value)

--- a/src/main/services/ConfigManager.ts
+++ b/src/main/services/ConfigManager.ts
@@ -35,8 +35,9 @@ export class ConfigManager {
     return this.get(ConfigKeys.Language, locale) as LanguageVarious
   }
 
-  setLanguage(theme: LanguageVarious) {
-    this.set(ConfigKeys.Language, theme)
+  setLanguage(lang: LanguageVarious) {
+    this.set(ConfigKeys.Language, lang)
+    this.notifySubscribers(ConfigKeys.Language, lang)
   }
 
   getTheme(): ThemeMode {
@@ -131,6 +132,7 @@ export class ConfigManager {
 
   setEnableQuickAssistant(value: boolean) {
     this.set(ConfigKeys.EnableQuickAssistant, value)
+    this.notifySubscribers(ConfigKeys.EnableQuickAssistant, value)
   }
 
   getAutoUpdate(): boolean {
@@ -181,6 +183,7 @@ export class ConfigManager {
 
   set(key: string, value: unknown) {
     this.store.set(key, value)
+    this.notifySubscribers(key, value)
   }
 
   get<T>(key: string, defaultValue?: T) {

--- a/src/main/services/ConfigManager.ts
+++ b/src/main/services/ConfigManager.ts
@@ -36,8 +36,7 @@ export class ConfigManager {
   }
 
   setLanguage(lang: LanguageVarious) {
-    this.set(ConfigKeys.Language, lang)
-    this.notifySubscribers(ConfigKeys.Language, lang)
+    this.setAndNotify(ConfigKeys.Language, lang)
   }
 
   getTheme(): ThemeMode {
@@ -61,8 +60,7 @@ export class ConfigManager {
   }
 
   setTray(value: boolean) {
-    this.set(ConfigKeys.Tray, value)
-    this.notifySubscribers(ConfigKeys.Tray, value)
+    this.setAndNotify(ConfigKeys.Tray, value)
   }
 
   getTrayOnClose(): boolean {
@@ -78,8 +76,7 @@ export class ConfigManager {
   }
 
   setZoomFactor(factor: number) {
-    this.set(ConfigKeys.ZoomFactor, factor)
-    this.notifySubscribers(ConfigKeys.ZoomFactor, factor)
+    this.setAndNotify(ConfigKeys.ZoomFactor, factor)
   }
 
   subscribe<T>(key: string, callback: (newValue: T) => void) {
@@ -111,11 +108,10 @@ export class ConfigManager {
   }
 
   setShortcuts(shortcuts: Shortcut[]) {
-    this.set(
+    this.setAndNotify(
       ConfigKeys.Shortcuts,
       shortcuts.filter((shortcut) => shortcut.system)
     )
-    this.notifySubscribers(ConfigKeys.Shortcuts, shortcuts)
   }
 
   getClickTrayToShowQuickAssistant(): boolean {
@@ -131,8 +127,7 @@ export class ConfigManager {
   }
 
   setEnableQuickAssistant(value: boolean) {
-    this.set(ConfigKeys.EnableQuickAssistant, value)
-    this.notifySubscribers(ConfigKeys.EnableQuickAssistant, value)
+    this.setAndNotify(ConfigKeys.EnableQuickAssistant, value)
   }
 
   getAutoUpdate(): boolean {
@@ -157,8 +152,7 @@ export class ConfigManager {
   }
 
   setSelectionAssistantEnabled(value: boolean) {
-    this.set(ConfigKeys.SelectionAssistantEnabled, value)
-    this.notifySubscribers(ConfigKeys.SelectionAssistantEnabled, value)
+    this.setAndNotify(ConfigKeys.SelectionAssistantEnabled, value)
   }
 
   // Selection Assistant: trigger mode (selected, ctrlkey)
@@ -167,8 +161,7 @@ export class ConfigManager {
   }
 
   setSelectionAssistantTriggerMode(value: string) {
-    this.set(ConfigKeys.SelectionAssistantTriggerMode, value)
-    this.notifySubscribers(ConfigKeys.SelectionAssistantTriggerMode, value)
+    this.setAndNotify(ConfigKeys.SelectionAssistantTriggerMode, value)
   }
 
   // Selection Assistant: if action window position follow toolbar
@@ -177,13 +170,16 @@ export class ConfigManager {
   }
 
   setSelectionAssistantFollowToolbar(value: boolean) {
-    this.set(ConfigKeys.SelectionAssistantFollowToolbar, value)
-    this.notifySubscribers(ConfigKeys.SelectionAssistantFollowToolbar, value)
+    this.setAndNotify(ConfigKeys.SelectionAssistantFollowToolbar, value)
   }
 
-  set(key: string, value: unknown) {
+  setAndNotify(key: string, value: unknown) {
+    this.set(key, value, true)
+  }
+
+  set(key: string, value: unknown, isNotify: boolean = false) {
     this.store.set(key, value)
-    this.notifySubscribers(key, value)
+    isNotify && this.notifySubscribers(key, value)
   }
 
   get<T>(key: string, defaultValue?: T) {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -20,7 +20,6 @@ const api = {
   setLaunchToTray: (isActive: boolean) => ipcRenderer.invoke(IpcChannel.App_SetLaunchToTray, isActive),
   setTray: (isActive: boolean) => ipcRenderer.invoke(IpcChannel.App_SetTray, isActive),
   setTrayOnClose: (isActive: boolean) => ipcRenderer.invoke(IpcChannel.App_SetTrayOnClose, isActive),
-  restartTray: () => ipcRenderer.invoke(IpcChannel.App_RestartTray),
   setTheme: (theme: 'light' | 'dark' | 'auto') => ipcRenderer.invoke(IpcChannel.App_SetTheme, theme),
   handleZoomFactor: (delta: number, reset: boolean = false) =>
     ipcRenderer.invoke(IpcChannel.App_HandleZoomFactor, delta, reset),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -127,7 +127,8 @@ const api = {
     deleteFile: (fileId: string, apiKey: string) => ipcRenderer.invoke(IpcChannel.Gemini_DeleteFile, fileId, apiKey)
   },
   config: {
-    set: (key: string, value: any) => ipcRenderer.invoke(IpcChannel.Config_Set, key, value),
+    set: (key: string, value: any, isNotify: boolean = false) =>
+      ipcRenderer.invoke(IpcChannel.Config_Set, key, value, isNotify),
     get: (key: string) => ipcRenderer.invoke(IpcChannel.Config_Get, key)
   },
   miniWindow: {

--- a/src/renderer/src/pages/settings/QuickAssistantSettings.tsx
+++ b/src/renderer/src/pages/settings/QuickAssistantSettings.tsx
@@ -23,7 +23,7 @@ const QuickAssistantSettings: FC = () => {
 
   const handleEnableQuickAssistant = async (enable: boolean) => {
     dispatch(setEnableQuickAssistant(enable))
-    await window.api.config.set('enableQuickAssistant', enable)
+    await window.api.config.set('enableQuickAssistant', enable, true)
 
     !enable && window.api.miniWindow.close()
 

--- a/src/renderer/src/pages/settings/QuickAssistantSettings.tsx
+++ b/src/renderer/src/pages/settings/QuickAssistantSettings.tsx
@@ -24,9 +24,8 @@ const QuickAssistantSettings: FC = () => {
   const handleEnableQuickAssistant = async (enable: boolean) => {
     dispatch(setEnableQuickAssistant(enable))
     await window.api.config.set('enableQuickAssistant', enable)
-    window.api.restartTray()
-    const disable = !enable
-    disable && window.api.miniWindow.close()
+
+    !enable && window.api.miniWindow.close()
 
     if (enable && !clickTrayToShowQuickAssistant) {
       window.message.info({


### PR DESCRIPTION
- Removed the App_RestartTray channel from IpcChannel and its usage in ipc.ts and preload/index.ts.
- Updated TrayService to handle configuration changes without the need for a restart.
- Enhanced ConfigManager to notify subscribers on language and quick assistant settings changes.
- Updated ConfigManager to consolidate setting and notification logic into a single method, setAndNotify.
- Adjusted QuickAssistantSettings to close the mini window based on the quick assistant's enable state.
- Modified IPC handler to accept an additional parameter for notification control.
