### PR TITLE
feat: 调整分组的效果

### DIFF
--- a/src/renderer/src/hooks/useStore.ts
+++ b/src/renderer/src/hooks/useStore.ts
@@ -1,5 +1,12 @@
 import { useAppDispatch, useAppSelector } from '@renderer/store'
-import { setShowAssistants, setShowTopics, toggleShowAssistants, toggleShowTopics } from '@renderer/store/settings'
+import {
+  setAssistantsTabSortType,
+  setShowAssistants,
+  setShowTopics,
+  toggleShowAssistants,
+  toggleShowTopics
+} from '@renderer/store/settings'
+import { AssistantsSortType } from '@renderer/types'
 
 export function useShowAssistants() {
   const showAssistants = useAppSelector((state) => state.settings.showAssistants)
@@ -20,5 +27,15 @@ export function useShowTopics() {
     showTopics,
     setShowTopics: (show: boolean) => dispatch(setShowTopics(show)),
     toggleShowTopics: () => dispatch(toggleShowTopics())
+  }
+}
+
+export function useAssistantsTabSortType() {
+  const AssistantsTabSortType = useAppSelector((state) => state.settings.assistantsTabSortType)
+  const dispatch = useAppDispatch()
+
+  return {
+    AssistantsTabSortType,
+    setAssistantsTabSortType: (sortType: AssistantsSortType) => dispatch(setAssistantsTabSortType(sortType))
   }
 }

--- a/src/renderer/src/i18n/locales/ja-jp.json
+++ b/src/renderer/src/i18n/locales/ja-jp.json
@@ -105,7 +105,7 @@
         "showByTags": "タグ表示"
       },
       "tags": {
-        "untagged": "未分類タグ",
+        "untagged": "未分類",
         "none": "タグなし",
         "manage": "タグ管理",
         "add": "タグ追加",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -111,7 +111,7 @@
         "none": "暂无标签",
         "manage": "标签管理",
         "add": "添加标签",
-        "untagged": "未分组标签",
+        "untagged": "未分组",
         "modify": "修改标签",
         "delete": "删除标签",
         "settings": {

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -105,7 +105,7 @@
         "showByTags": "標籤展示"
       },
       "tags": {
-        "untagged": "未分組標籤",
+        "untagged": "未分組",
         "none": "暫無標籤",
         "manage": "標籤管理",
         "add": "添加標籤",

--- a/src/renderer/src/pages/home/Tabs/AssistantsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/AssistantsTab.tsx
@@ -3,8 +3,9 @@ import DragableList from '@renderer/components/DragableList'
 import Scrollbar from '@renderer/components/Scrollbar'
 import { useAgents } from '@renderer/hooks/useAgents'
 import { useAssistants } from '@renderer/hooks/useAssistant'
+import { useAssistantsTabSortType } from '@renderer/hooks/useStore'
 import { useTags } from '@renderer/hooks/useTags'
-import { Assistant } from '@renderer/types'
+import { Assistant, AssistantsSortType } from '@renderer/types'
 import { Divider, Tooltip } from 'antd'
 import { FC, useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -12,19 +13,13 @@ import styled from 'styled-components'
 
 import AssistantItem from './components/AssistantItem'
 
-type SortType = '' | 'tags' | 'list'
-
 interface AssistantsTabProps {
-  sortBy: SortType
-  setSortBy: (assistant: SortType) => void
   activeAssistant: Assistant
   setActiveAssistant: (assistant: Assistant) => void
   onCreateAssistant: () => void
   onCreateDefaultAssistant: () => void
 }
 const Assistants: FC<AssistantsTabProps> = ({
-  sortBy,
-  setSortBy,
   activeAssistant,
   setActiveAssistant,
   onCreateAssistant,
@@ -35,6 +30,7 @@ const Assistants: FC<AssistantsTabProps> = ({
   const { addAgent } = useAgents()
   const { t } = useTranslation()
   const { getGroupedAssistants } = useTags()
+  const { AssistantsTabSortType = 'list', setAssistantsTabSortType } = useAssistantsTabSortType()
   const containerRef = useRef<HTMLDivElement>(null)
 
   const onDelete = useCallback(
@@ -50,14 +46,14 @@ const Assistants: FC<AssistantsTabProps> = ({
   )
 
   const handleSortByChange = useCallback(
-    (sortType: SortType) => {
-      setSortBy(sortType)
+    (sortType: AssistantsSortType) => {
+      setAssistantsTabSortType(sortType)
     },
-    [setSortBy]
+    [setAssistantsTabSortType]
   )
   return (
     <Container className="assistants-tab" ref={containerRef}>
-      {sortBy === 'tags' && (
+      {AssistantsTabSortType === 'tags' && (
         <div style={{ marginBottom: '8px' }}>
           {getGroupedAssistants.map((group) => (
             <TagsContainer key={group.tag}>
@@ -72,7 +68,7 @@ const Assistants: FC<AssistantsTabProps> = ({
                   key={assistant.id}
                   assistant={assistant}
                   isActive={assistant.id === activeAssistant.id}
-                  sortBy={sortBy}
+                  sortBy={AssistantsTabSortType}
                   onSwitch={setActiveAssistant}
                   onDelete={onDelete}
                   addAgent={addAgent}
@@ -85,7 +81,7 @@ const Assistants: FC<AssistantsTabProps> = ({
           ))}
         </div>
       )}
-      {sortBy === 'list' && (
+      {AssistantsTabSortType === 'list' && (
         <DragableList
           list={assistants}
           onUpdate={updateAssistants}
@@ -97,7 +93,7 @@ const Assistants: FC<AssistantsTabProps> = ({
               key={assistant.id}
               assistant={assistant}
               isActive={assistant.id === activeAssistant.id}
-              sortBy={sortBy}
+              sortBy={AssistantsTabSortType}
               onSwitch={setActiveAssistant}
               onDelete={onDelete}
               addAgent={addAgent}

--- a/src/renderer/src/pages/home/Tabs/components/AssistantItem.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/AssistantItem.tsx
@@ -21,7 +21,7 @@ import { useTags } from '@renderer/hooks/useTags'
 import AssistantSettingsPopup from '@renderer/pages/settings/AssistantSettings'
 import { getDefaultModel, getDefaultTopic } from '@renderer/services/AssistantService'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
-import { Assistant } from '@renderer/types'
+import { Assistant, AssistantsSortType } from '@renderer/types'
 import { uuid } from '@renderer/utils'
 import { hasTopicPendingRequests } from '@renderer/utils/queue'
 import { Dropdown } from 'antd'
@@ -35,14 +35,14 @@ import * as tinyPinyin from 'tiny-pinyin'
 interface AssistantItemProps {
   assistant: Assistant
   isActive: boolean
-  sortBy: 'tags' | 'list'
+  sortBy: AssistantsSortType
   onSwitch: (assistant: Assistant) => void
   onDelete: (assistant: Assistant) => void
   onCreateDefaultAssistant: () => void
   addAgent: (agent: any) => void
   addAssistant: (assistant: Assistant) => void
   onTagClick?: (tag: string) => void
-  handleSortByChange?: (sortType: '' | 'tags' | 'list') => void
+  handleSortByChange?: (sortType: AssistantsSortType) => void
 }
 
 const AssistantItem: FC<AssistantItemProps> = ({

--- a/src/renderer/src/pages/home/Tabs/index.tsx
+++ b/src/renderer/src/pages/home/Tabs/index.tsx
@@ -25,7 +25,6 @@ interface Props {
 }
 
 type Tab = 'assistants' | 'topic' | 'settings'
-type SortType = '' | 'tags' | 'list'
 
 let _tab: any = ''
 
@@ -39,7 +38,6 @@ const HomeTabs: FC<Props> = ({
   style
 }) => {
   const { addAssistant } = useAssistants()
-  const [sortBy, setSortBy] = useState<SortType>('list')
   const [tab, setTab] = useState<Tab>(position === 'left' ? _tab || 'assistants' : 'topic')
   const { topicPosition } = useSettings()
   const { defaultAssistant } = useDefaultAssistant()
@@ -131,8 +129,6 @@ const HomeTabs: FC<Props> = ({
       <TabContent className="home-tabs-content">
         {tab === 'assistants' && (
           <Assistants
-            setSortBy={setSortBy}
-            sortBy={sortBy}
             activeAssistant={activeAssistant}
             setActiveAssistant={setActiveAssistant}
             onCreateAssistant={onCreateAssistant}

--- a/src/renderer/src/store/settings.ts
+++ b/src/renderer/src/store/settings.ts
@@ -1,6 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { TRANSLATE_PROMPT } from '@renderer/config/prompts'
 import {
+  AssistantsSortType,
   CodeStyleVarious,
   LanguageVarious,
   MathEngine,
@@ -34,6 +35,7 @@ export type AssistantIconType = 'model' | 'emoji' | 'none'
 export interface SettingsState {
   showAssistants: boolean
   showTopics: boolean
+  assistantsTabSortType: AssistantsSortType
   sendMessageShortcut: SendMessageShortcut
   language: LanguageVarious
   targetLanguage: TranslateLanguageVarious
@@ -176,6 +178,7 @@ export type MultiModelMessageStyle = 'horizontal' | 'vertical' | 'fold' | 'grid'
 export const initialState: SettingsState = {
   showAssistants: true,
   showTopics: true,
+  assistantsTabSortType: 'list',
   sendMessageShortcut: 'Enter',
   language: navigator.language as LanguageVarious,
   targetLanguage: 'english' as TranslateLanguageVarious,
@@ -319,6 +322,9 @@ const settingsSlice = createSlice({
     },
     toggleShowTopics: (state) => {
       state.showTopics = !state.showTopics
+    },
+    setAssistantsTabSortType: (state, action: PayloadAction<AssistantsSortType>) => {
+      state.assistantsTabSortType = action.payload
     },
     setSendMessageShortcut: (state, action: PayloadAction<SendMessageShortcut>) => {
       state.sendMessageShortcut = action.payload
@@ -647,6 +653,7 @@ export const {
   toggleShowAssistants,
   setShowTopics,
   toggleShowTopics,
+  setAssistantsTabSortType,
   setSendMessageShortcut,
   setLanguage,
   setTargetLanguage,

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -28,6 +28,8 @@ export type Assistant = {
   tags?: string[] // 助手标签
 }
 
+export type AssistantsSortType = 'tags' | 'list'
+
 export type AssistantMessage = {
   role: 'user' | 'assistant'
   content: string


### PR DESCRIPTION
   

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

此pr是关于pr
https://github.com/CherryHQ/cherry-studio/pull/6065
的补充，鉴于pr已merge了就拉一个新的分支出来merge

1，未分组标签改为未分组
2，列表展示效果持久化
3，增加一个管理列表展示效过的store


1. **Renamed "未分组" label to "未分组" (Uncategorized)**
   - Updated all instances of the ungrouped tag label to maintain consistency
   - Affected components and stores have been modified accordingly

2. **Persistent List Display Configuration**
   - Implemented state persistence for list view settings
   - User preferences for list display (grid/list view, sorting, etc.) are now saved and restored

3. **New Store for Managing List Display Settings**
   - Created a dedicated store (`listDisplayStore`) to



关于问分组之后的助手顺序的问题，这里没有复现。
测试过 未调整助手顺序，按音节升序，按音节降序 都未复现。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
