### PR TITLE
refactor: chat navigation triggering

### DIFF
--- a/src/renderer/src/pages/home/Chat.tsx
+++ b/src/renderer/src/pages/home/Chat.tsx
@@ -115,7 +115,7 @@ const Chat: FC<Props> = (props) => {
           includeUser={filterIncludeUser}
           onIncludeUserChange={userOutlinedItemClickHandler}
         />
-        <MessagesContainer>
+        <MessagesContainer className="messages-container">
           <Messages
             key={props.activeTopic.id}
             assistant={assistant}

--- a/src/renderer/src/pages/home/Messages/ChatNavigation.tsx
+++ b/src/renderer/src/pages/home/Messages/ChatNavigation.tsx
@@ -233,6 +233,8 @@ const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
   // Set up scroll event listener and mouse position tracking
   useEffect(() => {
     const container = document.getElementById(containerId)
+    const messagesContainer = container?.closest('.messages-container') as HTMLElement
+
     if (!container) return
 
     // Handle scroll events on the container
@@ -287,11 +289,21 @@ const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
 
     // Use passive: true for better scroll performance
     container.addEventListener('scroll', handleScroll, { passive: true })
-    window.addEventListener('mousemove', handleMouseMove)
+
+    if (messagesContainer) {
+      // Listen to the messages container (but with global coordinates)
+      messagesContainer.addEventListener('mousemove', handleMouseMove)
+    } else {
+      window.addEventListener('mousemove', handleMouseMove)
+    }
 
     return () => {
       container.removeEventListener('scroll', handleScroll)
-      window.removeEventListener('mousemove', handleMouseMove)
+      if (messagesContainer) {
+        messagesContainer.removeEventListener('mousemove', handleMouseMove)
+      } else {
+        window.removeEventListener('mousemove', handleMouseMove)
+      }
       if (hideTimer) {
         clearTimeout(hideTimer)
       }

--- a/src/renderer/src/pages/home/Messages/ChatNavigation.tsx
+++ b/src/renderer/src/pages/home/Messages/ChatNavigation.tsx
@@ -266,7 +266,7 @@ const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
       }
 
       const rightPosition = window.innerWidth - rightOffset - triggerWidth
-      const topPosition = window.innerHeight * 0.3 // 30% from top
+      const topPosition = window.innerHeight * 0.5 // 50% from top
       const height = window.innerHeight * 0.3 // 30% of window height
 
       const isInTriggerArea =
@@ -394,7 +394,7 @@ interface NavigationContainerProps {
 const NavigationContainer = styled.div<NavigationContainerProps>`
   position: fixed;
   right: 16px;
-  top: 50%;
+  top: 65%;
   transform: translateY(-50%) translateX(${(props) => (props.$isVisible ? 0 : '100%')});
   z-index: 999;
   opacity: ${(props) => (props.$isVisible ? 1 : 0)};

--- a/src/renderer/src/pages/home/Messages/ChatNavigation.tsx
+++ b/src/renderer/src/pages/home/Messages/ChatNavigation.tsx
@@ -323,7 +323,7 @@ const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
     <>
       <NavigationContainer $isVisible={isVisible} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
         <ButtonGroup>
-          <Tooltip title={t('chat.navigation.close')} placement="left">
+          <Tooltip title={t('chat.navigation.close')} placement="left" mouseEnterDelay={0.5}>
             <NavigationButton
               type="text"
               icon={<CloseOutlined />}
@@ -332,7 +332,7 @@ const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
             />
           </Tooltip>
           <Divider />
-          <Tooltip title={t('chat.navigation.top')} placement="left">
+          <Tooltip title={t('chat.navigation.top')} placement="left" mouseEnterDelay={0.5}>
             <NavigationButton
               type="text"
               icon={<VerticalAlignTopOutlined />}
@@ -341,7 +341,7 @@ const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
             />
           </Tooltip>
           <Divider />
-          <Tooltip title={t('chat.navigation.prev')} placement="left">
+          <Tooltip title={t('chat.navigation.prev')} placement="left" mouseEnterDelay={0.5}>
             <NavigationButton
               type="text"
               icon={<ArrowUpOutlined />}
@@ -350,7 +350,7 @@ const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
             />
           </Tooltip>
           <Divider />
-          <Tooltip title={t('chat.navigation.next')} placement="left">
+          <Tooltip title={t('chat.navigation.next')} placement="left" mouseEnterDelay={0.5}>
             <NavigationButton
               type="text"
               icon={<ArrowDownOutlined />}
@@ -359,7 +359,7 @@ const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
             />
           </Tooltip>
           <Divider />
-          <Tooltip title={t('chat.navigation.bottom')} placement="left">
+          <Tooltip title={t('chat.navigation.bottom')} placement="left" mouseEnterDelay={0.5}>
             <NavigationButton
               type="text"
               icon={<VerticalAlignBottomOutlined />}
@@ -368,7 +368,7 @@ const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
             />
           </Tooltip>
           <Divider />
-          <Tooltip title={t('chat.navigation.history')} placement="left">
+          <Tooltip title={t('chat.navigation.history')} placement="left" mouseEnterDelay={0.5}>
             <NavigationButton
               type="text"
               icon={<HistoryOutlined />}

--- a/src/renderer/src/pages/home/Messages/ChatNavigation.tsx
+++ b/src/renderer/src/pages/home/Messages/ChatNavigation.tsx
@@ -17,6 +17,9 @@ import styled from 'styled-components'
 
 import ChatFlowHistory from './ChatFlowHistory'
 
+// Exclude some areas from the navigation
+const EXCLUDED_SELECTORS = ['.MessageFooter', '.code-toolbar', '.ant-collapse-header']
+
 interface ChatNavigationProps {
   containerId: string
 }
@@ -268,10 +271,14 @@ const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
       }
 
       const rightPosition = window.innerWidth - rightOffset - triggerWidth
-      const topPosition = window.innerHeight * 0.5 // 50% from top
+      const topPosition = window.innerHeight * 0.35 // 35% from top
       const height = window.innerHeight * 0.3 // 30% of window height
 
+      const target = e.target as HTMLElement
+      const isInExcludedArea = EXCLUDED_SELECTORS.some((selector) => target.closest(selector))
+
       const isInTriggerArea =
+        !isInExcludedArea &&
         e.clientX > rightPosition &&
         e.clientX < rightPosition + triggerWidth &&
         e.clientY > topPosition &&
@@ -406,7 +413,7 @@ interface NavigationContainerProps {
 const NavigationContainer = styled.div<NavigationContainerProps>`
   position: fixed;
   right: 16px;
-  top: 65%;
+  top: 50%;
   transform: translateY(-50%) translateX(${(props) => (props.$isVisible ? 0 : '100%')});
   z-index: 999;
   opacity: ${(props) => (props.$isVisible ? 1 : 0)};


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

改善右侧导航条的触发体验

**Before this PR**:

- 导航条容易遮挡消息中的按钮
- 只要鼠标在窗口中就可以触发，不管有没有遮挡（比如 inputbar, modals）

https://github.com/user-attachments/assets/ab808b7f-307a-423f-a005-5ddaf22bd72a


**After this PR**:

- 鼠标在工具栏时不触发导航条
- 只能在 MessagesContainer 中触发导航条
- 延迟 Tooltip

https://github.com/user-attachments/assets/28c4bd57-ce7a-46a8-8914-5402eff0d8c4

> 忽略视频中导航条的上下位置，位置调整已经回退了

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

fix #5021 
fix #5181 
fix #5587
fix #6362

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
