### PR TITLE
fix: mcp uv&bun installation status icon in nav bar not updated after…

### DIFF
--- a/src/renderer/src/pages/settings/MCPSettings/InstallNpxUv.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/InstallNpxUv.tsx
@@ -1,5 +1,7 @@
 import { CheckCircleOutlined, QuestionCircleOutlined, WarningOutlined } from '@ant-design/icons'
 import { Center, VStack } from '@renderer/components/Layout'
+import { useAppDispatch, useAppSelector } from '@renderer/store'
+import { setIsBunInstalled, setIsUvInstalled } from '@renderer/store/mcp'
 import { Alert, Button } from 'antd'
 import { FC, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -13,8 +15,10 @@ interface Props {
 }
 
 const InstallNpxUv: FC<Props> = ({ mini = false }) => {
-  const [isUvInstalled, setIsUvInstalled] = useState(true)
-  const [isBunInstalled, setIsBunInstalled] = useState(true)
+  const dispatch = useAppDispatch()
+  const isUvInstalled = useAppSelector((state) => state.mcp.isUvInstalled)
+  const isBunInstalled = useAppSelector((state) => state.mcp.isBunInstalled)
+
   const [isInstallingUv, setIsInstallingUv] = useState(false)
   const [isInstallingBun, setIsInstallingBun] = useState(false)
   const [uvPath, setUvPath] = useState<string | null>(null)
@@ -22,14 +26,13 @@ const InstallNpxUv: FC<Props> = ({ mini = false }) => {
   const [binariesDir, setBinariesDir] = useState<string | null>(null)
   const { t } = useTranslation()
   const navigate = useNavigate()
-
   const checkBinaries = async () => {
     const uvExists = await window.api.isBinaryExist('uv')
     const bunExists = await window.api.isBinaryExist('bun')
     const { uvPath, bunPath, dir } = await window.api.mcp.getInstallInfo()
 
-    setIsUvInstalled(uvExists)
-    setIsBunInstalled(bunExists)
+    dispatch(setIsUvInstalled(uvExists))
+    dispatch(setIsBunInstalled(bunExists))
     setUvPath(uvPath)
     setBunPath(bunPath)
     setBinariesDir(dir)

--- a/src/renderer/src/store/mcp.ts
+++ b/src/renderer/src/store/mcp.ts
@@ -3,7 +3,9 @@ import Logger from '@renderer/config/logger'
 import type { MCPConfig, MCPServer } from '@renderer/types'
 
 export const initialState: MCPConfig = {
-  servers: []
+  servers: [],
+  isUvInstalled: true,
+  isBunInstalled: true
 }
 
 const mcpSlice = createSlice({
@@ -30,6 +32,12 @@ const mcpSlice = createSlice({
       if (index !== -1) {
         state.servers[index].isActive = action.payload.isActive
       }
+    },
+    setIsUvInstalled: (state, action: PayloadAction<boolean>) => {
+      state.isUvInstalled = action.payload
+    },
+    setIsBunInstalled: (state, action: PayloadAction<boolean>) => {
+      state.isBunInstalled = action.payload
     }
   },
   selectors: {
@@ -40,7 +48,15 @@ const mcpSlice = createSlice({
   }
 })
 
-export const { setMCPServers, addMCPServer, updateMCPServer, deleteMCPServer, setMCPServerActive } = mcpSlice.actions
+export const {
+  setMCPServers,
+  addMCPServer,
+  updateMCPServer,
+  deleteMCPServer,
+  setMCPServerActive,
+  setIsBunInstalled,
+  setIsUvInstalled
+} = mcpSlice.actions
 
 // Export the generated selectors from the slice
 export const { getActiveServers, getAllServers } = mcpSlice.selectors

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -600,6 +600,8 @@ export interface GetMCPPromptResponse {
 
 export interface MCPConfig {
   servers: MCPServer[]
+  isUvInstalled: boolean
+  isBunInstalled: boolean
 }
 
 interface BaseToolResponse {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

首次在设置中安装MCP需要的 uv/bun 之后，顶部的状态栏没有响应式的变更为已安装的图标：
![image](https://github.com/user-attachments/assets/555b74ee-730d-49cb-8fb3-21dd0d3cd863)

After this PR:

顶部状态栏的 uv/bun 安装状态总是与详情中同步：
![image](https://github.com/user-attachments/assets/1bbb779d-acba-436a-9150-0fdbfd3d63e9)

### Why we need it and why it was done in this way

原 `<InstallNpxUv />`  组件状态维持在组件作用域内， 顶部图标和安装详情各使用一份，造成状态不一致；现提炼到对应的 redux slice 中。

### Breaking changes

<!-- optional -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
