### PR TITLE
fix: replace franc with franc-min for improved performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "electron-window-state": "^5.0.3",
     "epub": "patch:epub@npm%3A1.3.0#~/.yarn/patches/epub-npm-1.3.0-8325494ffe.patch",
     "fast-xml-parser": "^5.2.0",
-    "franc": "^6.2.0",
+    "franc-min": "^6.2.0",
     "fs-extra": "^11.2.0",
     "jsdom": "^26.0.0",
     "markdown-it": "^14.1.0",

--- a/src/renderer/src/utils/translate.ts
+++ b/src/renderer/src/utils/translate.ts
@@ -1,4 +1,4 @@
-import { franc } from 'franc'
+import { franc } from 'franc-min'
 import React, { MutableRefObject } from 'react'
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -5621,7 +5621,7 @@ __metadata:
     eslint-plugin-unused-imports: "npm:^4.1.4"
     fast-diff: "npm:^1.3.0"
     fast-xml-parser: "npm:^5.2.0"
-    franc: "npm:^6.2.0"
+    franc-min: "npm:^6.2.0"
     fs-extra: "npm:^11.2.0"
     html-to-image: "npm:^1.11.13"
     husky: "npm:^9.1.7"
@@ -9820,12 +9820,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"franc@npm:^6.2.0":
+"franc-min@npm:^6.2.0":
   version: 6.2.0
-  resolution: "franc@npm:6.2.0"
+  resolution: "franc-min@npm:6.2.0"
   dependencies:
     trigram-utils: "npm:^2.0.0"
-  checksum: 10c0/136a08d6e4632f17eae6f0ae93b224b0bf2233dc1d5dbd0b23e479960f6c71c0847bef834d3b6b7c9cefb4f905d5e08fc82b0738bb3ed4a6c83faffcf9fa2a11
+  checksum: 10c0/21c243982b713a7726ffdb185415636c63711e7267be301b6d0607e3533f76771f2396091d9f1ca017f98357e4aa885c0cf4a2c0f90012e138f741cd9cfb5e45
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
替换语言检测库`franc`为`franc-min`以减小打包的体积