### PR TITLE
fix: provider o3 docs not found

### DIFF
--- a/src/renderer/src/config/providers.ts
+++ b/src/renderer/src/config/providers.ts
@@ -124,8 +124,8 @@ export const PROVIDER_CONFIG = {
     websites: {
       official: 'https://o3.fan',
       apiKey: 'https://o3.fan/token',
-      docs: 'https://docs.o3.fan',
-      models: 'https://docs.o3.fan/models'
+      docs: '',
+      models: 'https://o3.fan/info/models/'
     }
   },
   burncloud: {

--- a/src/renderer/src/pages/settings/ProviderSettings/ModelList.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ModelList.tsx
@@ -307,17 +307,21 @@ const ModelList: React.FC<ModelListProps> = ({ providerId, modelStatuses = [], s
             </CustomCollapse>
           </CustomCollapseWrapper>
         ))}
-        {docsWebsite && (
+        {(docsWebsite || modelsWebsite) && (
           <SettingHelpTextRow>
             <SettingHelpText>{t('settings.provider.docs_check')} </SettingHelpText>
-            <SettingHelpLink target="_blank" href={docsWebsite}>
-              {t(`provider.${provider.id}`) + ' '}
-              {t('common.docs')}
-            </SettingHelpLink>
-            <SettingHelpText>{t('common.and')}</SettingHelpText>
-            <SettingHelpLink target="_blank" href={modelsWebsite}>
-              {t('common.models')}
-            </SettingHelpLink>
+            {docsWebsite && (
+              <SettingHelpLink target="_blank" href={docsWebsite}>
+                {t(`provider.${provider.id}`) + ' '}
+                {t('common.docs')}
+              </SettingHelpLink>
+            )}
+            {docsWebsite && modelsWebsite && <SettingHelpText>{t('common.and')}</SettingHelpText>}
+            {modelsWebsite && (
+              <SettingHelpLink target="_blank" href={modelsWebsite}>
+                {t('common.models')}
+              </SettingHelpLink>
+            )}
             <SettingHelpText>{t('settings.provider.docs_more_details')}</SettingHelpText>
           </SettingHelpTextRow>
         )}


### PR DESCRIPTION
### What this PR does

Before this PR: 由于o3的文档已经不再维护，现在点击文档链接会跳转到空页面。

After this PR: 为文档和模型的链接提供了更健壮的显示，现在会灵活判断是否应该显示文档/模型的链接。

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Removed the documentation link for the O3 provider.
```
