### PR TITLE
Refactor: decouple text summarization and topic naming functions and fix qwen3 topic naming problem

### DIFF
--- a/src/renderer/src/hooks/useTopic.ts
+++ b/src/renderer/src/hooks/useTopic.ts
@@ -93,10 +93,10 @@ export const autoRenameTopic = async (assistant: Assistant, topicId: string) => 
     }
 
     if (topic && topic.name === i18n.t('chat.default.topic.name') && topic.messages.length >= 2) {
-      const { fetchMessagesSummary } = await import('@renderer/services/ApiService')
-      const summaryText = await fetchMessagesSummary({ messages: topic.messages, assistant })
-      if (summaryText) {
-        const data = { ...topic, name: summaryText }
+      const { fetchTopicName } = await import('@renderer/services/ApiService')
+      const topicName = await fetchTopicName({ messages: topic.messages, assistant })
+      if (topicName) {
+        const data = { ...topic, name: topicName }
         _setActiveTopic(data)
         store.dispatch(updateTopic({ assistantId: assistant.id, topic: data }))
       }

--- a/src/renderer/src/hooks/useTopic.ts
+++ b/src/renderer/src/hooks/useTopic.ts
@@ -99,6 +99,8 @@ export const autoRenameTopic = async (assistant: Assistant, topicId: string) => 
         const data = { ...topic, name: topicName }
         _setActiveTopic(data)
         store.dispatch(updateTopic({ assistantId: assistant.id, topic: data }))
+      } else {
+        window.message?.error(i18n.t('message.error.fetchTopicName'))
       }
     }
   } finally {

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -627,6 +627,7 @@
       "error.enter.api.key": "Please enter your API key first",
       "error.enter.model": "Please select a model first",
       "error.enter.name": "Please enter the name of the knowledge base",
+      "error.fetchTopicName": "Failed to name the topic",
       "error.get_embedding_dimensions": "Failed to get embedding dimensions",
       "error.invalid.api.host": "Invalid API Host",
       "error.invalid.api.key": "Invalid API Key",
@@ -944,7 +945,6 @@
       "req_error_text": "Operation failed. Please try again. Avoid using 'copyrighted' or 'sensitive' words in your prompt.",
       "auto_create_paint": "Auto-create image",
       "auto_create_paint_tip": "After the image is generated, a new image will be created automatically."
-
     },
     "prompts": {
       "explanation": "Explain this concept to me",

--- a/src/renderer/src/i18n/locales/ja-jp.json
+++ b/src/renderer/src/i18n/locales/ja-jp.json
@@ -627,6 +627,7 @@
       "error.enter.api.key": "APIキーを入力してください",
       "error.enter.model": "モデルを選択してください",
       "error.enter.name": "ナレッジベース名を入力してください",
+      "error.fetchTopicName": "トピックの命名に失敗しました",
       "error.get_embedding_dimensions": "埋込み次元を取得できませんでした",
       "error.invalid.api.host": "無効なAPIアドレスです",
       "error.invalid.api.key": "無効なAPIキーです",

--- a/src/renderer/src/i18n/locales/ru-ru.json
+++ b/src/renderer/src/i18n/locales/ru-ru.json
@@ -627,6 +627,7 @@
       "error.enter.api.key": "Пожалуйста, введите ваш API ключ",
       "error.enter.model": "Пожалуйста, выберите модель",
       "error.enter.name": "Пожалуйста, введите название базы знаний",
+      "error.fetchTopicName": "Не удалось назвать тему",
       "error.get_embedding_dimensions": "Не удалось получить размерность встраивания",
       "error.invalid.api.host": "Неверный API адрес",
       "error.invalid.api.key": "Неверный API ключ",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -627,6 +627,7 @@
       "error.enter.api.key": "请输入您的 API 密钥",
       "error.enter.model": "请选择一个模型",
       "error.enter.name": "请输入知识库名称",
+      "error.fetchTopicName": "话题命名失败",
       "error.get_embedding_dimensions": "获取嵌入维度失败",
       "error.invalid.api.host": "无效的 API 地址",
       "error.invalid.api.key": "无效的 API 密钥",
@@ -941,7 +942,7 @@
         "magic_prompt_option_tip": "智能优化放大提示词"
       },
       "text_desc_required": "请先输入图片描述",
-      "req_error_text" : "运行失败，请重试。提示词避免“版权词”和”敏感词”哦。",
+      "req_error_text": "运行失败，请重试。提示词避免“版权词”和”敏感词”哦。",
       "auto_create_paint": "自动新建图片",
       "auto_create_paint_tip": "在图片生成后，会自动新建图片"
     },

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -627,6 +627,7 @@
       "error.enter.api.key": "請先輸入您的 API 金鑰",
       "error.enter.model": "請先選擇一個模型",
       "error.enter.name": "請先輸入知識庫名稱",
+      "error.fetchTopicName": "話題命名失敗",
       "error.get_embedding_dimensions": "取得嵌入維度失敗",
       "error.invalid.api.host": "無效的 API 位址",
       "error.invalid.api.key": "無效的 API 金鑰",
@@ -941,7 +942,7 @@
       },
       "rendering_speed": "渲染速度",
       "text_desc_required": "請先輸入圖片描述",
-      "req_error_text" : "运行失败，请重试。提示词避免“版权词”和”敏感词”哦。",
+      "req_error_text": "运行失败，请重试。提示词避免“版权词”和”敏感词”哦。",
       "auto_create_paint": "自動新增圖片",
       "auto_create_paint_tip": "圖片生成後，會自動新增圖片"
     },

--- a/src/renderer/src/i18n/translate/el-gr.json
+++ b/src/renderer/src/i18n/translate/el-gr.json
@@ -557,6 +557,7 @@
       "error.enter.api.key": "Παρακαλώ εισάγετε το κλειδί API σας",
       "error.enter.model": "Παρακαλώ επιλέξτε ένα μοντέλο",
       "error.enter.name": "Παρακαλώ εισάγετε ένα όνομα για τη βάση γνώσεων",
+      "error.fetchTopicName": "Αποτυχία ονοματοδοσίας θέματος",
       "error.get_embedding_dimensions": "Απέτυχε η πρόσληψη διαστάσεων ενσωμάτωσης",
       "error.invalid.api.host": "Μη έγκυρη διεύθυνση API",
       "error.invalid.api.key": "Μη έγκυρο κλειδί API",

--- a/src/renderer/src/i18n/translate/es-es.json
+++ b/src/renderer/src/i18n/translate/es-es.json
@@ -558,6 +558,7 @@
       "error.enter.api.key": "Ingrese su clave API",
       "error.enter.model": "Seleccione un modelo",
       "error.enter.name": "Ingrese el nombre de la base de conocimiento",
+      "error.fetchTopicName": "Error al nombrar el tema",
       "error.get_embedding_dimensions": "Fallo al obtener las dimensiones de incrustación",
       "error.invalid.api.host": "Dirección API inválida",
       "error.invalid.api.key": "Clave API inválida",

--- a/src/renderer/src/i18n/translate/fr-fr.json
+++ b/src/renderer/src/i18n/translate/fr-fr.json
@@ -557,6 +557,7 @@
       "error.enter.api.key": "Veuillez entrer votre clé API",
       "error.enter.model": "Veuillez sélectionner un modèle",
       "error.enter.name": "Veuillez entrer le nom de la base de connaissances",
+      "error.fetchTopicName": "Échec de la dénomination du sujet",
       "error.get_embedding_dimensions": "Impossible d'obtenir les dimensions d'encodage",
       "error.invalid.api.host": "Adresse API invalide",
       "error.invalid.api.key": "Clé API invalide",

--- a/src/renderer/src/i18n/translate/pt-pt.json
+++ b/src/renderer/src/i18n/translate/pt-pt.json
@@ -559,6 +559,7 @@
       "error.enter.api.key": "Insira sua chave API",
       "error.enter.model": "Selecione um modelo",
       "error.enter.name": "Insira o nome da base de conhecimento",
+      "error.fetchTopicName": "Falha ao nomear o tópico",
       "error.get_embedding_dimensions": "Falha ao obter dimensões de incorporação",
       "error.invalid.api.host": "Endereço API inválido",
       "error.invalid.api.key": "Chave API inválida",

--- a/src/renderer/src/pages/home/Tabs/TopicsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/TopicsTab.tsx
@@ -175,6 +175,8 @@ const Topics: FC<Props> = ({ assistant: _assistant, activeTopic, setActiveTopic 
             const summaryText = await fetchTopicName({ messages, assistant })
             if (summaryText) {
               updateTopic({ ...topic, name: summaryText, isNameManuallyEdited: false })
+            } else {
+              window.message?.error(t('message.error.fetchTopicName'))
             }
           }
         }

--- a/src/renderer/src/pages/home/Tabs/TopicsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/TopicsTab.tsx
@@ -18,7 +18,7 @@ import { useAssistant, useAssistants } from '@renderer/hooks/useAssistant'
 import { modelGenerating } from '@renderer/hooks/useRuntime'
 import { useSettings } from '@renderer/hooks/useSettings'
 import { TopicManager } from '@renderer/hooks/useTopic'
-import { fetchMessagesSummary } from '@renderer/services/ApiService'
+import { fetchTopicName } from '@renderer/services/ApiService'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import store from '@renderer/store'
 import { RootState } from '@renderer/store'
@@ -172,7 +172,7 @@ const Topics: FC<Props> = ({ assistant: _assistant, activeTopic, setActiveTopic 
         async onClick() {
           const messages = await TopicManager.getTopicMessages(topic.id)
           if (messages.length >= 2) {
-            const summaryText = await fetchMessagesSummary({ messages, assistant })
+            const summaryText = await fetchTopicName({ messages, assistant })
             if (summaryText) {
               updateTopic({ ...topic, name: summaryText, isNameManuallyEdited: false })
             }

--- a/src/renderer/src/providers/AiProvider/AihubmixProvider.ts
+++ b/src/renderer/src/providers/AiProvider/AihubmixProvider.ts
@@ -91,6 +91,10 @@ export default class AihubmixProvider extends BaseProvider {
     return this.getProvider(assistant.model || getDefaultModel()).summaries(messages, assistant)
   }
 
+  public async nameTopic(messages: Message[], assistant: Assistant): Promise<string> {
+    return this.getProvider(assistant.model || getDefaultModel()).nameTopic(messages, assistant)
+  }
+
   public async summaryForSearch(messages: Message[], assistant: Assistant): Promise<string | null> {
     return this.getProvider(assistant.model || getDefaultModel()).summaryForSearch(messages, assistant)
   }

--- a/src/renderer/src/providers/AiProvider/BaseProvider.ts
+++ b/src/renderer/src/providers/AiProvider/BaseProvider.ts
@@ -49,6 +49,7 @@ export default abstract class BaseProvider {
     onResponse?: (text: string, isComplete: boolean) => void
   ): Promise<string>
   abstract summaries(messages: Message[], assistant: Assistant): Promise<string>
+  abstract nameTopic(messages: Message[], assistant: Assistant): Promise<string>
   abstract summaryForSearch(messages: Message[], assistant: Assistant): Promise<string | null>
   abstract suggestions(messages: Message[], assistant: Assistant): Promise<Suggestion[]>
   abstract generateText({ prompt, content }: { prompt: string; content: string }): Promise<string>

--- a/src/renderer/src/providers/AiProvider/OpenAIProvider.ts
+++ b/src/renderer/src/providers/AiProvider/OpenAIProvider.ts
@@ -1068,14 +1068,20 @@ export default class OpenAIProvider extends BaseOpenAIProvider {
 
     await this.checkIsCopilot()
 
-    // @ts-ignore key is not typed
-    const response = await this.sdk.chat.completions.create({
+    const params = {
       model: model.id,
       messages: [systemMessage, userMessage] as ChatCompletionMessageParam[],
       stream: false,
       keep_alive: this.keepAliveTime,
       max_tokens: 64
-    })
+    }
+
+    if (model?.provider === 'dashscope') {
+      params['enable_thinking'] = false
+    }
+
+    // @ts-ignore key is not typed
+    const response = await this.sdk.chat.completions.create(params as ChatCompletionCreateParamsNonStreaming)
 
     // 针对思考类模型的返回，总结仅截取</think>之后的内容
     let content = response.choices[0].message?.content || ''

--- a/src/renderer/src/providers/AiProvider/OpenAIProvider.ts
+++ b/src/renderer/src/providers/AiProvider/OpenAIProvider.ts
@@ -1067,7 +1067,6 @@ export default class OpenAIProvider extends BaseOpenAIProvider {
     }
 
     await this.checkIsCopilot()
-
     const params = {
       model: model.id,
       messages: [systemMessage, userMessage] as ChatCompletionMessageParam[],
@@ -1076,7 +1075,7 @@ export default class OpenAIProvider extends BaseOpenAIProvider {
       max_tokens: 64
     }
 
-    if (model?.provider === 'dashscope') {
+    if (isSupportedThinkingTokenQwenModel(model)) {
       params['enable_thinking'] = false
     }
 

--- a/src/renderer/src/providers/AiProvider/index.ts
+++ b/src/renderer/src/providers/AiProvider/index.ts
@@ -47,6 +47,10 @@ export default class AiProvider {
     return this.sdk.summaries(messages, assistant)
   }
 
+  public async nameTopic(messages: Message[], assistant: Assistant): Promise<string> {
+    return this.sdk.nameTopic(messages, assistant)
+  }
+
   public async summaryForSearch(messages: Message[], assistant: Assistant): Promise<string | null> {
     return this.sdk.summaryForSearch(messages, assistant)
   }

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -343,7 +343,7 @@ export async function fetchTranslate({ content, assistant, onResponse }: FetchTr
 }
 
 export async function fetchMessagesSummary({ messages, assistant }: { messages: Message[]; assistant: Assistant }) {
-  const model = getTopNamingModel() || assistant.model || getDefaultModel()
+  const model = assistant.model || getDefaultModel()
   const provider = getProviderByModel(model)
 
   if (!hasApiKey(provider)) {
@@ -354,6 +354,24 @@ export async function fetchMessagesSummary({ messages, assistant }: { messages: 
 
   try {
     const text = await AI.summaries(filterMessages(messages), assistant)
+    return text?.replace(/["']/g, '') || null
+  } catch (error: any) {
+    return null
+  }
+}
+
+export async function fetchTopicName({ messages, assistant }: { messages: Message[]; assistant: Assistant }) {
+  const model = getTopNamingModel() || assistant.model || getDefaultModel()
+  const provider = getProviderByModel(model)
+
+  if (!hasApiKey(provider)) {
+    return null
+  }
+
+  const AI = new AiProvider(provider)
+
+  try {
+    const text = await AI.nameTopic(filterMessages(messages), assistant)
     return text?.replace(/["']/g, '') || null
   } catch (error: any) {
     return null

--- a/src/renderer/src/services/MessagesService.ts
+++ b/src/renderer/src/services/MessagesService.ts
@@ -229,6 +229,8 @@ export async function getMessageTitle(message: Message, length = 30): Promise<st
       if (title) {
         window.message.success({ content: t('chat.topics.export.title_naming_success'), key: 'message-title-naming' })
         return title
+      } else {
+        window.message?.error(i18n.t('message.error.fetchTopicName'))
       }
     } catch (e) {
       window.message.error({ content: t('chat.topics.export.title_naming_failed'), key: 'message-title-naming' })

--- a/src/renderer/src/services/MessagesService.ts
+++ b/src/renderer/src/services/MessagesService.ts
@@ -2,7 +2,7 @@ import SearchPopup from '@renderer/components/Popups/SearchPopup'
 import { DEFAULT_CONTEXTCOUNT } from '@renderer/config/constant'
 import { getTopicById } from '@renderer/hooks/useTopic'
 import i18n from '@renderer/i18n'
-import { fetchMessagesSummary } from '@renderer/services/ApiService'
+import { fetchTopicName } from '@renderer/services/ApiService'
 import store from '@renderer/store'
 import { messageBlocksSelectors, removeManyBlocks } from '@renderer/store/messageBlock'
 import { selectMessagesForTopic } from '@renderer/store/newMessage'
@@ -220,7 +220,7 @@ export async function getMessageTitle(message: Message, length = 30): Promise<st
         blocks: message.blocks
       })
 
-      const title = await fetchMessagesSummary({ messages: [tempMessage], assistant: {} as Assistant })
+      const title = await fetchTopicName({ messages: [tempMessage], assistant: {} as Assistant })
 
       // store.dispatch(messageBlocksActions.upsertOneBlock(tempTextBlock))
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR: 整个项目的文本总结接口仅用于话题命名，没有用在别的地方。

After this PR: 

1. 保留了原有的文本总结接口的同时，设置了新的话题命名接口；
2. 为每个Provider做了相应实现；
3. 原有的话题命名功能改为使用新的话题命名接口，而不是文本总结接口；
4. 为话题命名接口调小了`max_tokens`；
5. 将原本的文本总结接口的提示词改为了`t('prompts.summarize')`；
6. 在话题命名失败时显示错误提示信息；
7. 修复了 #6716 。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #6716

### Why we need it and why it was done in this way

The following tradeoffs were made: 考虑到单独的文本总结功能仍可能在未来上线，尽管现在文本总结接口没有在任何地方使用，但仍然保留下来。

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
8. If no release note is required, just write "NONE".
-->

```release-note

```
