### PR TITLE
fix: Improve the switching logic in multi-tab state

### DIFF
--- a/src/renderer/src/pages/home/Tabs/components/AssistantItem.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/AssistantItem.tsx
@@ -1,4 +1,5 @@
 import {
+  CheckOutlined,
   DeleteOutlined,
   EditOutlined,
   MinusCircleOutlined,
@@ -185,10 +186,9 @@ const handleTagOperation = (
   updateAssistants: (assistants: Assistant[]) => void
 ) => {
   if (assistant.tags?.includes(tag)) {
-    updateAssistants(assistants.map((a) => (a.id === assistant.id ? { ...a, tags: [] } : a)))
-  } else {
-    updateAssistants(assistants.map((a) => (a.id === assistant.id ? { ...a, tags: [tag] } : a)))
+    return
   }
+  updateAssistants(assistants.map((a) => (a.id === assistant.id ? { ...a, tags: [tag] } : a)))
 }
 
 // 提取创建菜单项的函数
@@ -202,8 +202,7 @@ const createTagMenuItems = (
   const items: MenuProps['items'] = [
     ...allTags.map((tag) => ({
       label: tag,
-      icon: assistant.tags?.includes(tag) ? <DeleteOutlined size={14} /> : <Tag size={12} />,
-      danger: assistant.tags?.includes(tag),
+      icon: assistant.tags?.includes(tag) ? <CheckOutlined size={14} /> : <Tag size={12} />,
       key: `all-tag-${tag}`,
       onClick: () => handleTagOperation(tag, assistant, assistants, updateAssistants)
     }))


### PR DESCRIPTION
完善多标签状态下的切换逻辑

标签管理中对于当前助手的tag显示为删除逻辑 应该为不同tag之间的切换? 删除统一在标签管理中进行

<img src="https://github.com/user-attachments/assets/35d92ed9-d982-4c2f-9405-a28e38b3cd4a" width="400" />
