### PR TITLE
fix: transparent window flashing when show

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -24,9 +24,12 @@ import { setUserDataDir } from './utils/file'
 
 Logger.initialize()
 
-// Disable chromium's window animations
-// main purpose for this is to avoid the transparent window flashing when it is shown
-// (especially on Windows for SelectionAssistant Toolbar)
+/**
+ * Disable chromium's window animations
+ * main purpose for this is to avoid the transparent window flashing when it is shown
+ * (especially on Windows for SelectionAssistant Toolbar)
+ * Know Issue: https://github.com/electron/electron/issues/12130#issuecomment-627198990
+ */
 if (isWin) {
   app.commandLine.appendSwitch('wm-window-animations-disabled')
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,7 +6,7 @@ import { app } from 'electron'
 import installExtension, { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS } from 'electron-devtools-installer'
 import Logger from 'electron-log'
 
-import { isDev } from './constant'
+import { isDev, isWin } from './constant'
 import { registerIpc } from './ipc'
 import { configManager } from './services/ConfigManager'
 import mcpService from './services/MCPService'
@@ -23,6 +23,13 @@ import { windowService } from './services/WindowService'
 import { setUserDataDir } from './utils/file'
 
 Logger.initialize()
+
+// Disable chromium's window animations
+// main purpose for this is to avoid the transparent window flashing when it is shown
+// (especially on Windows for SelectionAssistant Toolbar)
+if (isWin) {
+  app.commandLine.appendSwitch('wm-window-animations-disabled')
+}
 
 // in production mode, handle uncaught exception and unhandled rejection globally
 if (!isDev) {


### PR DESCRIPTION
Electron一个知名[未解决问题](https://github.com/electron/electron/issues/12130#issuecomment-627198990)（源自Chromium和Windows渲染问题）

导致透明窗口在切换显示时会闪烁，这使得划词助手工具栏在出现时会产生闪烁。

该开关在Windows中关闭了Chromium的窗口渲染动画，以解决该问题。