### PR TITLE
feat: codeblock dot language

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,8 @@
     "@vitest/coverage-v8": "^3.1.4",
     "@vitest/ui": "^3.1.4",
     "@vitest/web-worker": "^3.1.4",
+    "@viz-js/lang-dot": "^1.0.4",
+    "@viz-js/viz": "^3.12.0",
     "@xyflow/react": "^12.4.4",
     "antd": "^5.22.5",
     "axios": "^1.7.3",

--- a/src/renderer/src/assets/styles/markdown.scss
+++ b/src/renderer/src/assets/styles/markdown.scss
@@ -123,9 +123,7 @@
     overflow-x: auto;
     font-family: 'Fira Code', 'Courier New', Courier, monospace;
     background-color: var(--color-background-mute);
-    &:has(.mermaid),
-    &:has(.plantuml-preview),
-    &:has(.svg-preview) {
+    &:has(.special-preview) {
       background-color: transparent;
     }
     &:not(pre pre) {

--- a/src/renderer/src/components/CodeBlockView/CodePreview.tsx
+++ b/src/renderer/src/components/CodeBlockView/CodePreview.tsx
@@ -1,4 +1,4 @@
-import { CodeTool, TOOL_SPECS, useCodeTool } from '@renderer/components/CodeToolbar'
+import { TOOL_SPECS, useCodeTool } from '@renderer/components/CodeToolbar'
 import { useCodeStyle } from '@renderer/context/CodeStyleProvider'
 import { useSettings } from '@renderer/hooks/useSettings'
 import { uuid } from '@renderer/utils'
@@ -9,10 +9,10 @@ import { useTranslation } from 'react-i18next'
 import { ThemedToken } from 'shiki/core'
 import styled from 'styled-components'
 
-interface CodePreviewProps {
-  children: string
+import { BasicPreviewProps } from './types'
+
+interface CodePreviewProps extends BasicPreviewProps {
   language: string
-  setTools?: (value: React.SetStateAction<CodeTool[]>) => void
 }
 
 /**

--- a/src/renderer/src/components/CodeBlockView/GraphvizPreview.tsx
+++ b/src/renderer/src/components/CodeBlockView/GraphvizPreview.tsx
@@ -1,0 +1,139 @@
+import { usePreviewToolHandlers, usePreviewTools } from '@renderer/components/CodeToolbar'
+import SvgSpinners180Ring from '@renderer/components/Icons/SvgSpinners180Ring'
+import { Flex, Spin } from 'antd'
+import { debounce } from 'lodash'
+import React, { memo, startTransition, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import styled from 'styled-components'
+
+import { BasicPreviewProps } from './types'
+
+// 懒加载 viz 实例
+let vizInstance: any = null
+let vizLoading = false
+let vizLoadPromise: Promise<any> | null = null
+
+const loadViz = async () => {
+  if (vizInstance) return vizInstance
+  if (vizLoading && vizLoadPromise) return vizLoadPromise
+
+  vizLoading = true
+  vizLoadPromise = import('@viz-js/viz')
+    .then(async (module) => {
+      vizInstance = await module.instance()
+      vizLoading = false
+      return vizInstance
+    })
+    .catch((error) => {
+      vizLoading = false
+      throw error
+    })
+
+  return vizLoadPromise
+}
+
+/** 预览 Graphviz 图表
+ * 通过防抖渲染提供比较统一的体验，减少闪烁。
+ */
+const GraphvizPreview: React.FC<BasicPreviewProps> = ({ children, setTools }) => {
+  const graphvizRef = useRef<HTMLDivElement>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [isLoadingViz, setIsLoadingViz] = useState(false)
+  const [isRendering, setIsRendering] = useState(false)
+
+  // 使用通用图像工具
+  const { handleZoom, handleCopyImage, handleDownload } = usePreviewToolHandlers(graphvizRef, {
+    imgSelector: 'svg',
+    prefix: 'graphviz',
+    enableWheelZoom: true
+  })
+
+  // 使用工具栏
+  usePreviewTools({
+    setTools,
+    handleZoom,
+    handleCopyImage,
+    handleDownload
+  })
+
+  // 实际的渲染函数
+  const renderGraphviz = useCallback(async (content: string) => {
+    if (!content || !graphvizRef.current) return
+
+    try {
+      setIsRendering(true)
+
+      // 首次加载时显示加载状态
+      if (!vizInstance) {
+        setIsLoadingViz(true)
+      }
+
+      const viz = await loadViz()
+      setIsLoadingViz(false)
+
+      const svgElement = viz.renderSVGElement(content)
+
+      // 清空容器并添加新的 SVG
+      graphvizRef.current.innerHTML = ''
+      graphvizRef.current.appendChild(svgElement)
+
+      // 渲染成功，清除错误记录
+      setError(null)
+    } catch (error) {
+      setError((error as Error).message || 'DOT syntax error or rendering failed')
+      setIsLoadingViz(false)
+    } finally {
+      setIsRendering(false)
+    }
+  }, [])
+
+  // debounce 渲染
+  const debouncedRender = useMemo(
+    () =>
+      debounce((content: string) => {
+        startTransition(() => renderGraphviz(content))
+      }, 300),
+    [renderGraphviz]
+  )
+
+  // 触发渲染
+  useEffect(() => {
+    if (children) {
+      setIsRendering(true)
+      debouncedRender(children)
+    } else {
+      debouncedRender.cancel()
+      setIsRendering(false)
+    }
+
+    return () => {
+      debouncedRender.cancel()
+    }
+  }, [children, debouncedRender])
+
+  const isLoading = isLoadingViz || isRendering
+
+  return (
+    <Spin spinning={isLoading} indicator={<SvgSpinners180Ring color="var(--color-text-2)" />}>
+      <Flex vertical style={{ minHeight: isLoading ? '2rem' : 'auto' }}>
+        {error && <StyledError>{error}</StyledError>}
+        <StyledGraphviz ref={graphvizRef} className="graphviz special-preview" />
+      </Flex>
+    </Spin>
+  )
+}
+
+const StyledGraphviz = styled.div`
+  overflow: auto;
+`
+
+const StyledError = styled.div`
+  overflow: auto;
+  padding: 16px;
+  color: #ff4d4f;
+  border: 1px solid #ff4d4f;
+  border-radius: 4px;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+`
+
+export default memo(GraphvizPreview)

--- a/src/renderer/src/components/CodeBlockView/GraphvizPreview.tsx
+++ b/src/renderer/src/components/CodeBlockView/GraphvizPreview.tsx
@@ -5,6 +5,7 @@ import { debounce } from 'lodash'
 import React, { memo, startTransition, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
 
+import PreviewError from './PreviewError'
 import { BasicPreviewProps } from './types'
 
 // 懒加载 viz 实例
@@ -115,7 +116,7 @@ const GraphvizPreview: React.FC<BasicPreviewProps> = ({ children, setTools }) =>
   return (
     <Spin spinning={isLoading} indicator={<SvgSpinners180Ring color="var(--color-text-2)" />}>
       <Flex vertical style={{ minHeight: isLoading ? '2rem' : 'auto' }}>
-        {error && <StyledError>{error}</StyledError>}
+        {error && <PreviewError>{error}</PreviewError>}
         <StyledGraphviz ref={graphvizRef} className="graphviz special-preview" />
       </Flex>
     </Spin>
@@ -124,16 +125,6 @@ const GraphvizPreview: React.FC<BasicPreviewProps> = ({ children, setTools }) =>
 
 const StyledGraphviz = styled.div`
   overflow: auto;
-`
-
-const StyledError = styled.div`
-  overflow: auto;
-  padding: 16px;
-  color: #ff4d4f;
-  border: 1px solid #ff4d4f;
-  border-radius: 4px;
-  word-wrap: break-word;
-  white-space: pre-wrap;
 `
 
 export default memo(GraphvizPreview)

--- a/src/renderer/src/components/CodeBlockView/MermaidPreview.tsx
+++ b/src/renderer/src/components/CodeBlockView/MermaidPreview.tsx
@@ -1,16 +1,13 @@
 import { nanoid } from '@reduxjs/toolkit'
-import { CodeTool, usePreviewToolHandlers, usePreviewTools } from '@renderer/components/CodeToolbar'
+import { usePreviewToolHandlers, usePreviewTools } from '@renderer/components/CodeToolbar'
 import { useMermaid } from '@renderer/hooks/useMermaid'
 import { Flex } from 'antd'
 import React, { memo, startTransition, useCallback, useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 
-interface Props {
-  children: string
-  setTools?: (value: React.SetStateAction<CodeTool[]>) => void
-}
+import { BasicPreviewProps } from './types'
 
-const MermaidPreview: React.FC<Props> = ({ children, setTools }) => {
+const MermaidPreview: React.FC<BasicPreviewProps> = ({ children, setTools }) => {
   const { mermaid, isLoading, error: mermaidError } = useMermaid()
   const mermaidRef = useRef<HTMLDivElement>(null)
   const [error, setError] = useState<string | null>(null)

--- a/src/renderer/src/components/CodeBlockView/MermaidPreview.tsx
+++ b/src/renderer/src/components/CodeBlockView/MermaidPreview.tsx
@@ -5,6 +5,7 @@ import { Flex } from 'antd'
 import React, { memo, startTransition, useCallback, useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 
+import PreviewError from './PreviewError'
 import { BasicPreviewProps } from './types'
 
 const MermaidPreview: React.FC<BasicPreviewProps> = ({ children, setTools }) => {
@@ -75,7 +76,7 @@ const MermaidPreview: React.FC<BasicPreviewProps> = ({ children, setTools }) => 
 
   return (
     <Flex vertical>
-      {(mermaidError || error) && <StyledError>{mermaidError || error}</StyledError>}
+      {(mermaidError || error) && <PreviewError>{mermaidError || error}</PreviewError>}
       <StyledMermaid ref={mermaidRef} className="mermaid" />
     </Flex>
   )
@@ -83,16 +84,6 @@ const MermaidPreview: React.FC<BasicPreviewProps> = ({ children, setTools }) => 
 
 const StyledMermaid = styled.div`
   overflow: auto;
-`
-
-const StyledError = styled.div`
-  overflow: auto;
-  padding: 16px;
-  color: #ff4d4f;
-  border: 1px solid #ff4d4f;
-  border-radius: 4px;
-  word-wrap: break-word;
-  white-space: pre-wrap;
 `
 
 export default memo(MermaidPreview)

--- a/src/renderer/src/components/CodeBlockView/PlantUmlPreview.tsx
+++ b/src/renderer/src/components/CodeBlockView/PlantUmlPreview.tsx
@@ -1,10 +1,12 @@
 import { LoadingOutlined } from '@ant-design/icons'
-import { CodeTool, usePreviewToolHandlers, usePreviewTools } from '@renderer/components/CodeToolbar'
+import { usePreviewToolHandlers, usePreviewTools } from '@renderer/components/CodeToolbar'
 import { Spin } from 'antd'
 import pako from 'pako'
 import React, { memo, useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
+
+import { BasicPreviewProps } from './types'
 
 const PlantUMLServer = 'https://www.plantuml.com/plantuml'
 function encode64(data: Uint8Array) {
@@ -132,12 +134,7 @@ const PlantUMLServerImage: React.FC<PlantUMLServerImageProps> = ({ format, diagr
   )
 }
 
-interface PlantUMLProps {
-  children: string
-  setTools?: (value: React.SetStateAction<CodeTool[]>) => void
-}
-
-const PlantUmlPreview: React.FC<PlantUMLProps> = ({ children, setTools }) => {
+const PlantUmlPreview: React.FC<BasicPreviewProps> = ({ children, setTools }) => {
   const { t } = useTranslation()
   const containerRef = useRef<HTMLDivElement>(null)
 

--- a/src/renderer/src/components/CodeBlockView/PlantUmlPreview.tsx
+++ b/src/renderer/src/components/CodeBlockView/PlantUmlPreview.tsx
@@ -171,7 +171,7 @@ const PlantUmlPreview: React.FC<BasicPreviewProps> = ({ children, setTools }) =>
 
   return (
     <div ref={containerRef}>
-      <PlantUMLServerImage format="svg" diagram={children} className="plantuml-preview" />
+      <PlantUMLServerImage format="svg" diagram={children} className="plantuml-preview special-preview" />
     </div>
   )
 }

--- a/src/renderer/src/components/CodeBlockView/PreviewError.tsx
+++ b/src/renderer/src/components/CodeBlockView/PreviewError.tsx
@@ -1,0 +1,14 @@
+import { memo } from 'react'
+import { styled } from 'styled-components'
+
+const PreviewError = styled.div`
+  overflow: auto;
+  padding: 16px;
+  color: #ff4d4f;
+  border: 1px solid #ff4d4f;
+  border-radius: 4px;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+`
+
+export default memo(PreviewError)

--- a/src/renderer/src/components/CodeBlockView/SvgPreview.tsx
+++ b/src/renderer/src/components/CodeBlockView/SvgPreview.tsx
@@ -1,15 +1,12 @@
-import { CodeTool, usePreviewToolHandlers, usePreviewTools } from '@renderer/components/CodeToolbar'
+import { usePreviewToolHandlers, usePreviewTools } from '@renderer/components/CodeToolbar'
 import { memo, useEffect, useRef } from 'react'
 
-interface Props {
-  children: string
-  setTools?: (value: React.SetStateAction<CodeTool[]>) => void
-}
+import { BasicPreviewProps } from './types'
 
 /**
  * 使用 Shadow DOM 渲染 SVG
  */
-const SvgPreview: React.FC<Props> = ({ children, setTools }) => {
+const SvgPreview: React.FC<BasicPreviewProps> = ({ children, setTools }) => {
   const svgContainerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {

--- a/src/renderer/src/components/CodeBlockView/SvgPreview.tsx
+++ b/src/renderer/src/components/CodeBlockView/SvgPreview.tsx
@@ -55,7 +55,7 @@ const SvgPreview: React.FC<BasicPreviewProps> = ({ children, setTools }) => {
     handleDownload
   })
 
-  return <div ref={svgContainerRef} className="svg-preview" />
+  return <div ref={svgContainerRef} className="svg-preview special-preview" />
 }
 
 export default memo(SvgPreview)

--- a/src/renderer/src/components/CodeBlockView/constants.ts
+++ b/src/renderer/src/components/CodeBlockView/constants.ts
@@ -1,0 +1,17 @@
+import MermaidPreview from './MermaidPreview'
+import PlantUmlPreview from './PlantUmlPreview'
+import SvgPreview from './SvgPreview'
+
+/**
+ * 特殊视图语言列表
+ */
+export const SPECIAL_VIEWS = ['mermaid', 'plantuml', 'svg']
+
+/**
+ * 特殊视图组件映射表
+ */
+export const SPECIAL_VIEW_COMPONENTS = {
+  mermaid: MermaidPreview,
+  plantuml: PlantUmlPreview,
+  svg: SvgPreview
+} as const

--- a/src/renderer/src/components/CodeBlockView/constants.ts
+++ b/src/renderer/src/components/CodeBlockView/constants.ts
@@ -1,3 +1,4 @@
+import GraphvizPreview from './GraphvizPreview'
 import MermaidPreview from './MermaidPreview'
 import PlantUmlPreview from './PlantUmlPreview'
 import SvgPreview from './SvgPreview'
@@ -5,7 +6,7 @@ import SvgPreview from './SvgPreview'
 /**
  * 特殊视图语言列表
  */
-export const SPECIAL_VIEWS = ['mermaid', 'plantuml', 'svg']
+export const SPECIAL_VIEWS = ['mermaid', 'plantuml', 'svg', 'dot', 'graphviz']
 
 /**
  * 特殊视图组件映射表
@@ -13,5 +14,7 @@ export const SPECIAL_VIEWS = ['mermaid', 'plantuml', 'svg']
 export const SPECIAL_VIEW_COMPONENTS = {
   mermaid: MermaidPreview,
   plantuml: PlantUmlPreview,
-  svg: SvgPreview
+  svg: SvgPreview,
+  dot: GraphvizPreview,
+  graphviz: GraphvizPreview
 } as const

--- a/src/renderer/src/components/CodeBlockView/index.ts
+++ b/src/renderer/src/components/CodeBlockView/index.ts
@@ -1,0 +1,2 @@
+export * from './types'
+export * from './view'

--- a/src/renderer/src/components/CodeBlockView/types.ts
+++ b/src/renderer/src/components/CodeBlockView/types.ts
@@ -1,0 +1,14 @@
+import { CodeTool } from '@renderer/components/CodeToolbar'
+
+/**
+ * 预览组件的基本 props
+ */
+export interface BasicPreviewProps {
+  children: string
+  setTools?: (value: React.SetStateAction<CodeTool[]>) => void
+}
+
+/**
+ * 视图模式
+ */
+export type ViewMode = 'source' | 'special' | 'split'

--- a/src/renderer/src/components/CodeBlockView/view.tsx
+++ b/src/renderer/src/components/CodeBlockView/view.tsx
@@ -12,13 +12,10 @@ import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 import CodePreview from './CodePreview'
+import { SPECIAL_VIEW_COMPONENTS, SPECIAL_VIEWS } from './constants'
 import HtmlArtifacts from './HtmlArtifacts'
-import MermaidPreview from './MermaidPreview'
-import PlantUmlPreview from './PlantUmlPreview'
 import StatusBar from './StatusBar'
-import SvgPreview from './SvgPreview'
-
-type ViewMode = 'source' | 'special' | 'split'
+import { ViewMode } from './types'
 
 interface Props {
   children: string
@@ -42,7 +39,7 @@ interface Props {
  * - quick 工具
  * - core 工具
  */
-const CodeBlockView: React.FC<Props> = ({ children, language, onSave }) => {
+export const CodeBlockView: React.FC<Props> = memo(({ children, language, onSave }) => {
   const { t } = useTranslation()
   const { codeEditor, codeExecution } = useSettings()
   const [viewMode, setViewMode] = useState<ViewMode>('special')
@@ -56,7 +53,7 @@ const CodeBlockView: React.FC<Props> = ({ children, language, onSave }) => {
     return codeExecution.enabled && language === 'python'
   }, [codeExecution.enabled, language])
 
-  const hasSpecialView = useMemo(() => ['mermaid', 'plantuml', 'svg'].includes(language), [language])
+  const hasSpecialView = useMemo(() => SPECIAL_VIEWS.includes(language), [language])
 
   const isInSpecialView = useMemo(() => {
     return hasSpecialView && viewMode === 'special'
@@ -202,14 +199,16 @@ const CodeBlockView: React.FC<Props> = ({ children, language, onSave }) => {
 
   // 特殊视图组件映射
   const specialView = useMemo(() => {
-    if (language === 'mermaid') {
-      return <MermaidPreview setTools={setTools}>{children}</MermaidPreview>
-    } else if (language === 'plantuml' && isValidPlantUML(children)) {
-      return <PlantUmlPreview setTools={setTools}>{children}</PlantUmlPreview>
-    } else if (language === 'svg') {
-      return <SvgPreview setTools={setTools}>{children}</SvgPreview>
+    const SpecialView = SPECIAL_VIEW_COMPONENTS[language as keyof typeof SPECIAL_VIEW_COMPONENTS]
+
+    if (!SpecialView) return null
+
+    // PlantUML 语法验证
+    if (language === 'plantuml' && !isValidPlantUML(children)) {
+      return null
     }
-    return null
+
+    return <SpecialView setTools={setTools}>{children}</SpecialView>
   }, [children, language])
 
   const renderHeader = useMemo(() => {
@@ -246,7 +245,7 @@ const CodeBlockView: React.FC<Props> = ({ children, language, onSave }) => {
       {isExecutable && output && <StatusBar>{output}</StatusBar>}
     </CodeBlockWrapper>
   )
-}
+})
 
 const CodeBlockWrapper = styled.div<{ $isInSpecialView: boolean }>`
   /* FIXME: 在 bubble style 中撑开一些宽度*/
@@ -294,5 +293,3 @@ const SplitViewWrapper = styled.div`
     max-width: 100%;
   }
 `
-
-export default memo(CodeBlockView)

--- a/src/renderer/src/components/CodeEditor/hook.ts
+++ b/src/renderer/src/components/CodeEditor/hook.ts
@@ -10,8 +10,10 @@ function importLintPackage() {
   return linterPromise
 }
 
-// 语言对应的 linter 加载器
-const linterLoaders: Record<string, () => Promise<any>> = {
+/**
+ * 语言对应的 linter 加载器
+ */
+const linterLoaders: Record<string, () => Promise<Extension>> = {
   json: async () => {
     const [linter, jsonParseLinter] = await Promise.all([
       importLintPackage(),
@@ -21,45 +23,111 @@ const linterLoaders: Record<string, () => Promise<any>> = {
   }
 }
 
+/**
+ * 特殊语言加载器
+ */
+const specialLanguageLoaders: Record<string, () => Promise<Extension>> = {
+  dot: async () => {
+    const mod = await import('@viz-js/lang-dot')
+    return mod.dot()
+  }
+}
+
+/**
+ * 加载语言扩展
+ */
+async function loadLanguageExtension(language: string, languageMap: Record<string, string>): Promise<Extension | null> {
+  let normalizedLang = languageMap[language as keyof typeof languageMap] || language.toLowerCase()
+
+  // 如果语言名包含 `-`，转换为驼峰命名法
+  if (normalizedLang.includes('-')) {
+    normalizedLang = normalizedLang.replace(/-([a-z])/g, (_, char) => char.toUpperCase())
+  }
+
+  // 尝试加载特殊语言
+  const specialLoader = specialLanguageLoaders[normalizedLang]
+  if (specialLoader) {
+    try {
+      return await specialLoader()
+    } catch (error) {
+      console.debug(`Failed to load language ${normalizedLang}`, error)
+      return null
+    }
+  }
+
+  // 回退到 uiw/codemirror 包含的语言
+  try {
+    const { loadLanguage } = await import('@uiw/codemirror-extensions-langs')
+    const extension = loadLanguage(normalizedLang as any)
+    return extension || null
+  } catch (error) {
+    console.debug(`Failed to load language ${normalizedLang}`, error)
+    return null
+  }
+}
+
+/**
+ * 加载 linter 扩展
+ */
+async function loadLinterExtension(language: string): Promise<Extension | null> {
+  const loader = linterLoaders[language]
+  if (!loader) return null
+
+  try {
+    return await loader()
+  } catch (error) {
+    console.debug(`Failed to load linter for ${language}`, error)
+    return null
+  }
+}
+
+/**
+ * 加载语言相关扩展
+ */
 export const useLanguageExtensions = (language: string, lint?: boolean) => {
   const { languageMap } = useCodeStyle()
   const [extensions, setExtensions] = useState<Extension[]>([])
 
-  // 加载语言
   useEffect(() => {
-    let normalizedLang = languageMap[language as keyof typeof languageMap] || language.toLowerCase()
+    let cancelled = false
 
-    // 如果语言名包含 `-`，转换为驼峰命名法
-    if (normalizedLang.includes('-')) {
-      normalizedLang = normalizedLang.replace(/-([a-z])/g, (_, char) => char.toUpperCase())
-    }
+    const loadAllExtensions = async () => {
+      try {
+        // 加载所有扩展
+        const [languageResult, linterResult] = await Promise.allSettled([
+          loadLanguageExtension(language, languageMap),
+          lint ? loadLinterExtension(language) : Promise.resolve(null)
+        ])
 
-    import('@uiw/codemirror-extensions-langs')
-      .then(({ loadLanguage }) => {
-        const extension = loadLanguage(normalizedLang as any)
-        if (extension) {
-          setExtensions((prev) => [...prev, extension])
+        if (cancelled) return
+
+        const results: Extension[] = []
+
+        // 语言扩展
+        if (languageResult.status === 'fulfilled' && languageResult.value) {
+          results.push(languageResult.value)
         }
-      })
-      .catch((error) => {
-        console.debug(`Failed to load language: ${normalizedLang}`, error)
-      })
-  }, [language, languageMap])
 
-  useEffect(() => {
-    if (!lint) return
+        // linter 扩展
+        if (linterResult.status === 'fulfilled' && linterResult.value) {
+          results.push(linterResult.value)
+        }
 
-    const loader = linterLoaders[language]
-    if (loader) {
-      loader()
-        .then((extension) => {
-          setExtensions((prev) => [...prev, extension])
-        })
-        .catch((error) => {
-          console.error(`Failed to load linter for ${language}`, error)
-        })
+        setExtensions(results)
+      } catch (error) {
+        if (!cancelled) {
+          console.debug('Failed to load language extensions:', error)
+          setExtensions([])
+        }
+      }
     }
-  }, [language, lint])
+
+    loadAllExtensions()
+
+    return () => {
+      cancelled = true
+    }
+  }, [language, lint, languageMap])
 
   return extensions
 }

--- a/src/renderer/src/context/CodeStyleProvider.tsx
+++ b/src/renderer/src/context/CodeStyleProvider.tsx
@@ -89,7 +89,8 @@ export const CodeStyleProvider: React.FC<PropsWithChildren> = ({ children }) => 
       bash: 'shell',
       'objective-c++': 'objective-cpp',
       svg: 'xml',
-      vab: 'vb'
+      vab: 'vb',
+      graphviz: 'dot'
     } as Record<string, string>
   }, [])
 

--- a/src/renderer/src/pages/home/Markdown/CodeBlock.tsx
+++ b/src/renderer/src/pages/home/Markdown/CodeBlock.tsx
@@ -1,4 +1,4 @@
-import CodeBlockView from '@renderer/components/CodeBlockView'
+import { CodeBlockView } from '@renderer/components/CodeBlockView'
 import React, { memo, useCallback } from 'react'
 
 interface Props {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2670,7 +2670,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lezer/common@npm:^1.0.0, @lezer/common@npm:^1.0.2, @lezer/common@npm:^1.1.0, @lezer/common@npm:^1.2.0, @lezer/common@npm:^1.2.1":
+"@lezer/common@npm:^1.0.0, @lezer/common@npm:^1.0.2, @lezer/common@npm:^1.0.3, @lezer/common@npm:^1.1.0, @lezer/common@npm:^1.2.0, @lezer/common@npm:^1.2.1":
   version: 1.2.3
   resolution: "@lezer/common@npm:1.2.3"
   checksum: 10c0/fe9f8e111080ef94037a34ca2af1221c8d01c1763ba5ecf708a286185c76119509a5d19d924c8842172716716ddce22d7834394670c4a9432f0ba9f3b7c0f50d
@@ -2836,7 +2836,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lezer/xml@npm:^1.0.0":
+"@lezer/xml@npm:^1.0.0, @lezer/xml@npm:^1.0.2":
   version: 1.0.6
   resolution: "@lezer/xml@npm:1.0.6"
   dependencies:
@@ -5466,6 +5466,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@viz-js/lang-dot@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "@viz-js/lang-dot@npm:1.0.4"
+  dependencies:
+    "@codemirror/language": "npm:^6.8.0"
+    "@lezer/common": "npm:^1.0.3"
+    "@lezer/highlight": "npm:^1.1.6"
+    "@lezer/xml": "npm:^1.0.2"
+  checksum: 10c0/8d7fb9a2d5c7e02da8e2122db5e4557231b9b353c9aa2db8ada137125a7175ae6df828c6449ba5b7bf48d68211e4b1b73ad42da2e8814da5d2723a0a6b200b49
+  languageName: node
+  linkType: hard
+
+"@viz-js/viz@npm:^3.12.0":
+  version: 3.12.0
+  resolution: "@viz-js/viz@npm:3.12.0"
+  checksum: 10c0/79b8a38b6923ff97e73005a5e9396f969d47d50dfeeeed12271910b07b213f40e40d1efe7f07ea824813f0d3f057ed00a3eb57ae5ae5ddfe38b85b25f0dfef59
+  languageName: node
+  linkType: hard
+
 "@xmldom/xmldom@npm:0.9.8":
   version: 0.9.8
   resolution: "@xmldom/xmldom@npm:0.9.8"
@@ -5591,6 +5610,8 @@ __metadata:
     "@vitest/coverage-v8": "npm:^3.1.4"
     "@vitest/ui": "npm:^3.1.4"
     "@vitest/web-worker": "npm:^3.1.4"
+    "@viz-js/lang-dot": "npm:^1.0.4"
+    "@viz-js/viz": "npm:^3.12.0"
     "@xyflow/react": "npm:^12.4.4"
     antd: "npm:^5.22.5"
     archiver: "npm:^7.0.1"


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

支持 DOT 代码块渲染：
- 使用 `@viz-js/viz` 渲染 DOT
- 代码编辑器支持 DOT 高亮

其他：
- 简化特殊视图样式，提取 `PreviewError`
- 重构 `useLanguageExtensions`，便于增加新的语言扩展

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #6741 

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
