### PR TITLE
fix(ci): Update the nightly-build workflow

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v4
         with:
-          ref: develop
+          ref: main
 
       - name: Install Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
This pull request updates the nightly build workflow to align with the main branch instead of the develop branch after the project default branch changed.

* [`.github/workflows/nightly-build.yml`](diffhunk://#diff-2ee59052448a421cff47b6ee98f786b57f3012d9f9132d37b9bde685a6266166L56-R56): Changed the `ref` parameter in the `actions/checkout` step from `develop` to `main`, ensuring the nightly build uses the latest code from the main branch, to avoid the failure of the CI process due to branch errors.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:  The branch that triggers `nightly-build.yml` is `develop`.

After this PR: The branch that triggers `nightly-build.yml` changes `main`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
