### PR TITLE
fix: sync active topic after rename

### DIFF
--- a/src/renderer/src/pages/home/Tabs/TopicsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/TopicsTab.tsx
@@ -174,7 +174,9 @@ const Topics: FC<Props> = ({ assistant: _assistant, activeTopic, setActiveTopic 
           if (messages.length >= 2) {
             const summaryText = await fetchMessagesSummary({ messages, assistant })
             if (summaryText) {
-              updateTopic({ ...topic, name: summaryText, isNameManuallyEdited: false })
+              const updatedTopic = { ...topic, name: summaryText, isNameManuallyEdited: false }
+              updateTopic(updatedTopic)
+              topic.id === activeTopic.id && setActiveTopic(updatedTopic)
             } else {
               window.message?.error(t('message.error.fetchTopicName'))
             }
@@ -192,7 +194,9 @@ const Topics: FC<Props> = ({ assistant: _assistant, activeTopic, setActiveTopic 
             defaultValue: topic?.name || ''
           })
           if (name && topic?.name !== name) {
-            updateTopic({ ...topic, name, isNameManuallyEdited: true })
+            const updatedTopic = { ...topic, name, isNameManuallyEdited: true }
+            updateTopic(updatedTopic)
+            topic.id === activeTopic.id && setActiveTopic(updatedTopic)
           }
         }
       },


### PR DESCRIPTION
### What this PR does

Before this PR:
- After renaming a topic (auto or manual), the active topic state was not updated.
- Newly created branches could still inherit the old topic name.

After this PR:
- When a topic is renamed through the context menu, the active topic is updated if it matches the renamed topic.

Fixes #6693

### Why we need it and why it was done in this way

The active topic's name controls new branch names. Without updating the active topic, renaming a topic leads to branches created from outdated names.  
We update the active topic directly inside the rename handlers.

The following tradeoffs were made:

None.

The following alternatives were considered:
- Keeping a global synchronization effect in `useTopic.ts` (discarded for simplicity).

### Breaking changes

None.

### Special notes for your reviewer

None.

### Checklist

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: Write code that humans can understand and keep it simple
- [ ] Refactor: Left the code cleaner than it was
- [ ] Upgrade: Considered impact on upgrade flows if required
- [ ] Documentation: Not required for this internal fix

### Release note

```release-note
Fixes branch names after renaming a topic by updating the active topic state.
