### PR TITLE
fix(SelectionAssistant): ignore ctrl pressing when user is zooming in/out

### DIFF
--- a/src/main/services/SelectionService.ts
+++ b/src/main/services/SelectionService.ts
@@ -836,6 +836,8 @@ export class SelectionService {
     //ctrlkey pressed
     if (this.lastCtrlkeyDownTime === 0) {
       this.lastCtrlkeyDownTime = Date.now()
+      //add the mouse-wheel listener, detect if user is zooming in/out
+      this.selectionHook!.on('mouse-wheel', this.handleMouseCtrlkeyMode)
       return
     }
 
@@ -859,7 +861,18 @@ export class SelectionService {
    */
   private handleKeyUpCtrlkeyMode = (data: KeyboardEventData) => {
     if (!this.isCtrlkey(data.vkCode)) return
+    //remove the mouse-wheel listener
+    this.selectionHook!.off('mouse-wheel', this.handleMouseCtrlkeyMode)
     this.lastCtrlkeyDownTime = 0
+  }
+
+  /**
+   * Handle mouse wheel events in ctrlkey trigger mode
+   * ignore CtrlKey pressing when mouse wheel is used
+   * because user is zooming in/out
+   */
+  private handleMouseCtrlkeyMode = () => {
+    this.lastCtrlkeyDownTime = -1
   }
 
   //check if the key is ctrl key

--- a/src/main/services/SelectionService.ts
+++ b/src/main/services/SelectionService.ts
@@ -837,7 +837,7 @@ export class SelectionService {
     if (this.lastCtrlkeyDownTime === 0) {
       this.lastCtrlkeyDownTime = Date.now()
       //add the mouse-wheel listener, detect if user is zooming in/out
-      this.selectionHook!.on('mouse-wheel', this.handleMouseCtrlkeyMode)
+      this.selectionHook!.on('mouse-wheel', this.handleMouseWheelCtrlkeyMode)
       return
     }
 
@@ -862,7 +862,7 @@ export class SelectionService {
   private handleKeyUpCtrlkeyMode = (data: KeyboardEventData) => {
     if (!this.isCtrlkey(data.vkCode)) return
     //remove the mouse-wheel listener
-    this.selectionHook!.off('mouse-wheel', this.handleMouseCtrlkeyMode)
+    this.selectionHook!.off('mouse-wheel', this.handleMouseWheelCtrlkeyMode)
     this.lastCtrlkeyDownTime = 0
   }
 
@@ -871,7 +871,7 @@ export class SelectionService {
    * ignore CtrlKey pressing when mouse wheel is used
    * because user is zooming in/out
    */
-  private handleMouseCtrlkeyMode = () => {
+  private handleMouseWheelCtrlkeyMode = () => {
     this.lastCtrlkeyDownTime = -1
   }
 


### PR DESCRIPTION
当用户使用 ctrl+滚轮 进行放大/缩小时，不进行Ctrl键模式的划词，避免软件冲突