### PR TITLE
fix(SelectionAssistant): support selection when alt key pressed

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "officeparser": "^4.1.1",
     "os-proxy-config": "^1.1.2",
     "proxy-agent": "^6.5.0",
-    "selection-hook": "^0.9.21",
+    "selection-hook": "^0.9.22",
     "tar": "^7.4.3",
     "turndown": "^7.2.0",
     "webdav": "^5.8.0",

--- a/src/main/services/SelectionService.ts
+++ b/src/main/services/SelectionService.ts
@@ -812,8 +812,8 @@ export class SelectionService {
     if (this.triggerMode === TriggerMode.Ctrlkey && this.isCtrlkey(data.vkCode)) {
       return
     }
-    //dont hide toolbar when shiftkey is pressed, because it's used for selection
-    if (this.isShiftkey(data.vkCode)) {
+    //dont hide toolbar when shiftkey or altkey is pressed, because it's used for selection
+    if (this.isShiftkey(data.vkCode) || this.isAltkey(data.vkCode)) {
       return
     }
 
@@ -888,6 +888,11 @@ export class SelectionService {
   //check if the key is shift key
   private isShiftkey(vkCode: number) {
     return vkCode === 160 || vkCode === 161
+  }
+
+  //check if the key is alt key
+  private isAltkey(vkCode: number) {
+    return vkCode === 164 || vkCode === 165
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -5667,7 +5667,7 @@ __metadata:
     remark-math: "npm:^6.0.0"
     rollup-plugin-visualizer: "npm:^5.12.0"
     sass: "npm:^1.88.0"
-    selection-hook: "npm:^0.9.21"
+    selection-hook: "npm:^0.9.22"
     shiki: "npm:^3.4.2"
     string-width: "npm:^7.2.0"
     styled-components: "npm:^6.1.11"
@@ -16384,13 +16384,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"selection-hook@npm:^0.9.21":
-  version: 0.9.21
-  resolution: "selection-hook@npm:0.9.21"
+"selection-hook@npm:^0.9.22":
+  version: 0.9.22
+  resolution: "selection-hook@npm:0.9.22"
   dependencies:
     node-gyp: "npm:latest"
     node-gyp-build: "npm:^4.8.4"
-  checksum: 10c0/e458f8d37c049899e0f9450ca29f882ee01e11b15490f7ee2ddd088843e3e9a201fd5410083faebfbf11e1259a2a74b0b736ff8f1789b626a21ea48ef0ca8705
+  checksum: 10c0/4a202485fc4aed250f4ab863fdca9235240d49e5629549f5cf72dd3087af81ee54d65c28fa7d215d7ca609e25132b125e10540acbab1f6f4a7d8a508e1468ea3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
支持在部分软件中必须按住altkey划词的情况（eg. chrome's link, ides' column selecting)