### PR TITLE
refactor(CodePreview): improve the triggering timing for highlighting

### DIFF
--- a/src/renderer/src/components/CodeBlockView/CodePreview.tsx
+++ b/src/renderer/src/components/CodeBlockView/CodePreview.tsx
@@ -134,26 +134,31 @@ const CodePreview = ({ children, language, setTools }: CodePreviewProps) => {
     return () => cleanupTokenizers(callerId)
   }, [callerId, cleanupTokenizers])
 
-  // 处理第二次开始的代码高亮
+  // 触发代码高亮
+  // - 进入视口后触发第一次高亮
+  // - 内容变化后触发之后的高亮
   useEffect(() => {
-    if (prevCodeLengthRef.current > 0) {
-      setTimeout(highlightCode, 0)
-    }
-  }, [highlightCode])
-
-  // 视口检测逻辑，只处理第一次代码高亮
-  useEffect(() => {
-    const codeElement = codeContentRef.current
-    if (!codeElement || prevCodeLengthRef.current > 0) return
-
     let isMounted = true
 
-    const observer = new IntersectionObserver((entries) => {
-      if (entries[0].isIntersecting && isMounted) {
-        setTimeout(highlightCode, 0)
-        observer.disconnect()
+    if (prevCodeLengthRef.current > 0) {
+      setTimeout(highlightCode, 0)
+      return
+    }
+
+    const codeElement = codeContentRef.current
+    if (!codeElement) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].intersectionRatio > 0 && isMounted) {
+          setTimeout(highlightCode, 0)
+          observer.disconnect()
+        }
+      },
+      {
+        rootMargin: '50px 0px 50px 0px'
       }
-    })
+    )
 
     observer.observe(codeElement)
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

调整 CodePreview 高亮的视口检测逻辑，增大检测范围

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
