### PR TITLE
refactor: unified image viewer with integrated context menu

### DIFF
--- a/src/main/services/FileService.ts
+++ b/src/main/services/FileService.ts
@@ -1,7 +1,9 @@
-import fs from 'node:fs'
+import fs from 'fs/promises'
 
 export default class FileService {
-  public static async readFile(_: Electron.IpcMainInvokeEvent, path: string) {
-    return fs.readFileSync(path, 'utf8')
+  public static async readFile(_: Electron.IpcMainInvokeEvent, pathOrUrl: string, encoding?: BufferEncoding) {
+    const path = pathOrUrl.startsWith('file://') ? new URL(pathOrUrl) : pathOrUrl
+    if (encoding) return fs.readFile(path, { encoding })
+    return fs.readFile(path)
   }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -84,7 +84,7 @@ const api = {
     getPathForFile: (file: File) => webUtils.getPathForFile(file)
   },
   fs: {
-    read: (path: string) => ipcRenderer.invoke(IpcChannel.Fs_Read, path)
+    read: (pathOrUrl: string, encoding?: BufferEncoding) => ipcRenderer.invoke(IpcChannel.Fs_Read, pathOrUrl, encoding)
   },
   export: {
     toWord: (markdown: string, fileName: string) => ipcRenderer.invoke(IpcChannel.Export_Word, markdown, fileName)

--- a/src/renderer/src/components/ImageViewer.tsx
+++ b/src/renderer/src/components/ImageViewer.tsx
@@ -1,0 +1,141 @@
+import {
+  CopyOutlined,
+  DownloadOutlined,
+  FileImageOutlined,
+  RotateLeftOutlined,
+  RotateRightOutlined,
+  SwapOutlined,
+  UndoOutlined,
+  ZoomInOutlined,
+  ZoomOutOutlined
+} from '@ant-design/icons'
+import { download } from '@renderer/utils/download'
+import { Dropdown, Image as AntImage, ImageProps as AntImageProps, Space } from 'antd'
+import { Base64 } from 'js-base64'
+import mime from 'mime'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+
+interface ImageViewerProps extends AntImageProps {
+  src: string
+}
+
+const ImageViewer: React.FC<ImageViewerProps> = ({ src, style, ...props }) => {
+  const { t } = useTranslation()
+
+  // 复制图片到剪贴板
+  const handleCopyImage = async (src: string) => {
+    try {
+      if (src.startsWith('data:')) {
+        // 处理 base64 格式的图片
+        const match = src.match(/^data:(image\/\w+);base64,(.+)$/)
+        if (!match) throw new Error('无效的 base64 图片格式')
+        const mimeType = match[1]
+        const byteArray = Base64.toUint8Array(match[2])
+        const blob = new Blob([byteArray], { type: mimeType })
+        await navigator.clipboard.write([new ClipboardItem({ [mimeType]: blob })])
+      } else if (src.startsWith('file://')) {
+        // 处理本地文件路径
+        const bytes = await window.api.fs.read(src)
+        const mimeType = mime.getType(src) || 'application/octet-stream'
+        const blob = new Blob([bytes], { type: mimeType })
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            [mimeType]: blob
+          })
+        ])
+      } else {
+        // 处理 URL 格式的图片
+        const response = await fetch(src)
+        const blob = await response.blob()
+
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            [blob.type]: blob
+          })
+        ])
+      }
+
+      window.message.success(t('message.copy.success'))
+    } catch (error) {
+      console.error('复制图片失败:', error)
+      window.message.error(t('message.copy.failed'))
+    }
+  }
+
+  const getContextMenuItems = (src: string) => {
+    return [
+      {
+        key: 'copy-url',
+        label: t('common.copy'),
+        icon: <CopyOutlined />,
+        onClick: () => {
+          navigator.clipboard.writeText(src)
+          window.message.success(t('message.copy.success'))
+        }
+      },
+      {
+        key: 'download',
+        label: t('common.download'),
+        icon: <DownloadOutlined />,
+        onClick: () => download(src)
+      },
+      {
+        key: 'copy-image',
+        label: t('code_block.preview.copy.image'),
+        icon: <FileImageOutlined />,
+        onClick: () => handleCopyImage(src)
+      }
+    ]
+  }
+
+  return (
+    <Dropdown menu={{ items: getContextMenuItems(src) }} trigger={['contextMenu']}>
+      <AntImage
+        src={src}
+        style={style}
+        {...props}
+        preview={{
+          mask: typeof props.preview === 'object' ? props.preview.mask : false,
+          toolbarRender: (
+            _,
+            {
+              transform: { scale },
+              actions: { onFlipY, onFlipX, onRotateLeft, onRotateRight, onZoomOut, onZoomIn, onReset }
+            }
+          ) => (
+            <ToolbarWrapper size={12} className="toolbar-wrapper">
+              <SwapOutlined rotate={90} onClick={onFlipY} />
+              <SwapOutlined onClick={onFlipX} />
+              <RotateLeftOutlined onClick={onRotateLeft} />
+              <RotateRightOutlined onClick={onRotateRight} />
+              <ZoomOutOutlined disabled={scale === 1} onClick={onZoomOut} />
+              <ZoomInOutlined disabled={scale === 50} onClick={onZoomIn} />
+              <UndoOutlined onClick={onReset} />
+              <CopyOutlined onClick={() => handleCopyImage(src)} />
+              <DownloadOutlined onClick={() => download(src)} />
+            </ToolbarWrapper>
+          )
+        }}
+      />
+    </Dropdown>
+  )
+}
+
+const ToolbarWrapper = styled(Space)`
+  padding: 0px 24px;
+  color: #fff;
+  font-size: 20px;
+  background-color: rgba(0, 0, 0, 0.1);
+  border-radius: 100px;
+  .anticon {
+    padding: 12px;
+    cursor: pointer;
+  }
+  .anticon:hover {
+    opacity: 0.3;
+  }
+`
+
+export default ImageViewer

--- a/src/renderer/src/pages/agents/index.ts
+++ b/src/renderer/src/pages/agents/index.ts
@@ -45,7 +45,7 @@ export function useSystemAgents() {
 
         // 如果没有远程配置或获取失败，加载本地代理
         if (resourcesPath && _agents.length === 0) {
-          const localAgentsData = await window.api.fs.read(resourcesPath + '/data/agents.json')
+          const localAgentsData = await window.api.fs.read(resourcesPath + '/data/agents.json', 'utf-8')
           _agents = JSON.parse(localAgentsData) as Agent[]
         }
 

--- a/src/renderer/src/pages/home/Markdown/Markdown.tsx
+++ b/src/renderer/src/pages/home/Markdown/Markdown.tsx
@@ -2,6 +2,7 @@ import 'katex/dist/katex.min.css'
 import 'katex/dist/contrib/copy-tex'
 import 'katex/dist/contrib/mhchem'
 
+import ImageViewer from '@renderer/components/ImageViewer'
 import MarkdownShadowDOMRenderer from '@renderer/components/MarkdownShadowDOMRenderer'
 import { useSettings } from '@renderer/hooks/useSettings'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
@@ -22,7 +23,6 @@ import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
 
 import CodeBlock from './CodeBlock'
-import ImagePreview from './ImagePreview'
 import Link from './Link'
 
 const ALLOWED_ELEMENTS =
@@ -83,7 +83,7 @@ const Markdown: FC<Props> = ({ block }) => {
       code: (props: any) => (
         <CodeBlock {...props} id={getCodeBlockId(props?.node?.position?.start)} onSave={onSaveCodeBlock} />
       ),
-      img: ImagePreview,
+      img: (props: any) => <ImageViewer style={{ maxWidth: 500, maxHeight: 500 }} {...props} />,
       pre: (props: any) => <pre style={{ overflow: 'visible' }} {...props} />,
       p: (props) => {
         const hasImage = props?.node?.children?.some((child: any) => child.tagName === 'img')

--- a/src/renderer/src/pages/home/Markdown/Markdown.tsx
+++ b/src/renderer/src/pages/home/Markdown/Markdown.tsx
@@ -84,7 +84,12 @@ const Markdown: FC<Props> = ({ block }) => {
         <CodeBlock {...props} id={getCodeBlockId(props?.node?.position?.start)} onSave={onSaveCodeBlock} />
       ),
       img: ImagePreview,
-      pre: (props: any) => <pre style={{ overflow: 'visible' }} {...props} />
+      pre: (props: any) => <pre style={{ overflow: 'visible' }} {...props} />,
+      p: (props) => {
+        const hasImage = props?.node?.children?.some((child: any) => child.tagName === 'img')
+        if (hasImage) return <div {...props} />
+        return <p {...props} />
+      }
     } as Partial<Components>
   }, [onSaveCodeBlock])
 

--- a/src/renderer/src/pages/home/Messages/Blocks/ImageBlock.tsx
+++ b/src/renderer/src/pages/home/Messages/Blocks/ImageBlock.tsx
@@ -1,15 +1,37 @@
 import SvgSpinners180Ring from '@renderer/components/Icons/SvgSpinners180Ring'
+import ImageViewer from '@renderer/components/ImageViewer'
 import type { ImageMessageBlock } from '@renderer/types/newMessage'
 import React from 'react'
-
-import MessageImage from '../MessageImage'
+import styled from 'styled-components'
 
 interface Props {
   block: ImageMessageBlock
 }
 
 const ImageBlock: React.FC<Props> = ({ block }) => {
-  return block.status === 'success' ? <MessageImage block={block} /> : <SvgSpinners180Ring />
+  if (block.status !== 'success') return <SvgSpinners180Ring />
+  const images = block.metadata?.generateImageResponse?.images?.length
+    ? block.metadata?.generateImageResponse?.images
+    : block?.file?.path
+      ? [`file://${block?.file?.path}`]
+      : []
+  return (
+    <Container style={{ marginBottom: 8 }}>
+      {images.map((src, index) => (
+        <ImageViewer
+          src={src}
+          key={`image-${index}`}
+          style={{ maxWidth: 500, maxHeight: 500, padding: 5, borderRadius: 8 }}
+        />
+      ))}
+    </Container>
+  )
 }
+const Container = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  margin-top: 8px;
+`
 
 export default React.memo(ImageBlock)

--- a/src/renderer/src/pages/paintings/components/Artboard.tsx
+++ b/src/renderer/src/pages/paintings/components/Artboard.tsx
@@ -1,13 +1,10 @@
-import { CopyOutlined, DownloadOutlined } from '@ant-design/icons'
+import ImageViewer from '@renderer/components/ImageViewer'
 import FileManager from '@renderer/services/FileManager'
 import { Painting } from '@renderer/types'
-import { download } from '@renderer/utils/download'
-import { Button, Dropdown, Spin } from 'antd'
+import { Button, Spin } from 'antd'
 import React, { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
-
-import ImagePreview from '../../home/Markdown/ImagePreview'
 
 interface ArtboardProps {
   painting: Painting
@@ -37,29 +34,6 @@ const Artboard: FC<ArtboardProps> = ({
     return currentFile ? FileManager.getFileUrl(currentFile) : ''
   }
 
-  const handleContextMenu = (e: React.MouseEvent) => {
-    e.preventDefault()
-  }
-
-  const getContextMenuItems = () => {
-    return [
-      {
-        key: 'copy',
-        label: t('common.copy'),
-        icon: <CopyOutlined />,
-        onClick: () => {
-          navigator.clipboard.writeText(painting.urls[currentImageIndex])
-        }
-      },
-      {
-        key: 'download',
-        label: t('common.download'),
-        icon: <DownloadOutlined />,
-        onClick: () => download(getCurrentImageUrl())
-      }
-    ]
-  }
-
   return (
     <Container>
       <LoadingContainer spinning={isLoading}>
@@ -70,20 +44,17 @@ const Artboard: FC<ArtboardProps> = ({
                 ←
               </NavigationButton>
             )}
-            <Dropdown menu={{ items: getContextMenuItems() }} trigger={['contextMenu']}>
-              <ImagePreview
-                src={getCurrentImageUrl()}
-                preview={{ mask: false }}
-                onContextMenu={handleContextMenu}
-                style={{
-                  maxWidth: '70vh',
-                  maxHeight: '70vh',
-                  objectFit: 'contain',
-                  backgroundColor: 'var(--color-background-soft)',
-                  cursor: 'pointer'
-                }}
-              />
-            </Dropdown>
+            <ImageViewer
+              src={getCurrentImageUrl()}
+              preview={{ mask: false }}
+              style={{
+                maxWidth: '70vh',
+                maxHeight: '70vh',
+                objectFit: 'contain',
+                backgroundColor: 'var(--color-background-soft)',
+                cursor: 'pointer'
+              }}
+            />
             {painting.files.length > 1 && (
               <NavigationButton onClick={onNextImage} style={{ right: 10 }}>
                 →


### PR DESCRIPTION
**Summary of Changes:**

This PR introduces a unified image viewing experience across the application, improving user convenience by integrating a right-click context menu for images within the chat interface. It also resolves a subtle HTML structural issue related to image rendering.

**Motivation & Problem Solved:**

Currently, users on the dedicated "Images (paintings)" page benefit from a convenient right-click context menu for generated images, allowing quick actions like downloading. In contrast, interacting with images in the chat interface is a little more cumbersome: downloading an image requires clicking it to open a lightbox, then clicking a download button, and finally closing the lightbox. This inconsistency leads to a suboptimal user experience.

This PR aims to address this by bringing the same intuitive right-click context menu functionality to images displayed within the chat interface, streamlining common interactions, especially downloading.

**Technical Details & Implementation:**

1.  **Unified Image Viewer:** We've replaced disparate and similar image rendering components (`Markdown/ImagePreview` and `Messages/MessageImage`) with a single, universal `ImageViewer` component. This new component is now responsible for handling all image display logic and encapsulates the integrated context menu.
2.  **Context Menu Integration:** The `ImageViewer` now includes built-in logic for a context menu, making it available wherever this component is used.
3.  **HTML Structure Fix:** An underlying HTML structural issue has also been resolved. Previously, an `<div>` tag (produced by `AntdImage`) could be nested within a `<p>` tag (due to `ReactMarkdown`'s default paragraph conversion). This led to console errors regarding invalid DOM nesting.

**Release Note:**

```release-note
feat: chat images now support right-click for quick downloads.
```
