### PR TITLE
fix(KnowledgeSettingsPopup): Correct unclickable close button after expanding advanced settings (closes #6883)

### DIFF
--- a/src/renderer/src/pages/knowledge/components/KnowledgeSettingsPopup.tsx
+++ b/src/renderer/src/pages/knowledge/components/KnowledgeSettingsPopup.tsx
@@ -124,7 +124,16 @@ const PopupContainer: React.FC<Props> = ({ base: _base, resolve }) => {
       destroyOnClose
       maskClosable={false}
       transitionName="animation-move-down"
-      centered>
+      centered
+      styles={{
+        body: {
+          maxHeight: '70vh',
+          overflowY: 'auto',
+          boxSizing: 'border-box',
+          paddingRight: '20px',
+          paddingLeft: '8px'
+        }
+      }}>
       <Form form={form} layout="vertical" className="compact-form">
         <Form.Item
           name="name"


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Correct unclickable close button after expanding advanced settings 

Before this PR:
![20250606133743_rec_](https://github.com/user-attachments/assets/cd06a586-f8a9-4c7b-8bd4-0fadfa3af748)

After this PR:

![20250606133851_rec_](https://github.com/user-attachments/assets/34373d70-bd68-4a75-bed9-3a2965d3f1ad)



<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #6883

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
