### PR TITLE
Fix: bubble-style unnecessary menu background (Plan C)

### DIFF
--- a/src/renderer/src/assets/styles/index.scss
+++ b/src/renderer/src/assets/styles/index.scss
@@ -136,15 +136,16 @@ ul {
   }
   .message-user {
     color: var(--chat-text-user);
-    .markdown,
-    .anticon,
-    .iconfont,
-    .lucide,
-    .message-tokens {
+    .message-content-container-user .anticon {
       color: var(--chat-text-user) !important;
     }
-    .message-action-button:hover {
-      background-color: var(--color-white-soft);
+
+    .markdown {
+      color: var(--chat-text-user);
+    }
+
+    .message-tokens {
+      color: var(--color-text-2);
     }
   }
   .group-grid-container.horizontal,

--- a/src/renderer/src/components/ContextMenu/index.tsx
+++ b/src/renderer/src/components/ContextMenu/index.tsx
@@ -7,9 +7,10 @@ import styled from 'styled-components'
 interface ContextMenuProps {
   children: React.ReactNode
   onContextMenu?: (e: React.MouseEvent) => void
+  style?: React.CSSProperties
 }
 
-const ContextMenu: React.FC<ContextMenuProps> = ({ children, onContextMenu }) => {
+const ContextMenu: React.FC<ContextMenuProps> = ({ children, onContextMenu, style }) => {
   const { t } = useTranslation()
   const [contextMenuPosition, setContextMenuPosition] = useState<{ x: number; y: number } | null>(null)
   const [selectedQuoteText, setSelectedQuoteText] = useState<string>('')
@@ -74,7 +75,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ children, onContextMenu }) =>
   ]
 
   return (
-    <ContextContainer onContextMenu={handleContextMenu} className="context-menu-container">
+    <ContextContainer onContextMenu={handleContextMenu} className="context-menu-container" style={style}>
       {contextMenuPosition && (
         <Dropdown
           overlayStyle={{ position: 'fixed', left: contextMenuPosition.x, top: contextMenuPosition.y, zIndex: 1000 }}

--- a/src/renderer/src/pages/home/Messages/Message.tsx
+++ b/src/renderer/src/pages/home/Messages/Message.tsx
@@ -182,8 +182,30 @@ const MessageItem: FC<Props> = ({
           <MessageErrorBoundary>
             <MessageContent message={message} />
           </MessageErrorBoundary>
+          {showMenubar && (!isBubbleStyle || isLastMessage) && (
+            <MessageFooter
+              className="MessageFooter"
+              style={{
+                borderTop: messageBorder,
+                flexDirection: isLastMessage || isBubbleStyle ? 'row-reverse' : undefined
+              }}>
+              <MessageTokens message={message} isLastMessage={isLastMessage} />
+              <MessageMenubar
+                message={message}
+                assistant={assistant}
+                model={model}
+                index={index}
+                topic={topic}
+                isLastMessage={isLastMessage}
+                isAssistantMessage={isAssistantMessage}
+                isGrouped={isGrouped}
+                messageContainerRef={messageContainerRef as React.RefObject<HTMLDivElement>}
+                setModel={setModel}
+              />
+            </MessageFooter>
+          )}
         </MessageContentContainer>
-        {showMenubar && (
+        {showMenubar && isBubbleStyle && !isLastMessage && (
           <MessageFooter
             className="MessageFooter"
             style={{

--- a/src/renderer/src/pages/home/Messages/Message.tsx
+++ b/src/renderer/src/pages/home/Messages/Message.tsx
@@ -182,29 +182,29 @@ const MessageItem: FC<Props> = ({
           <MessageErrorBoundary>
             <MessageContent message={message} />
           </MessageErrorBoundary>
-          {showMenubar && (
-            <MessageFooter
-              className="MessageFooter"
-              style={{
-                border: messageBorder,
-                flexDirection: isLastMessage || isBubbleStyle ? 'row-reverse' : undefined
-              }}>
-              <MessageTokens message={message} isLastMessage={isLastMessage} />
-              <MessageMenubar
-                message={message}
-                assistant={assistant}
-                model={model}
-                index={index}
-                topic={topic}
-                isLastMessage={isLastMessage}
-                isAssistantMessage={isAssistantMessage}
-                isGrouped={isGrouped}
-                messageContainerRef={messageContainerRef as React.RefObject<HTMLDivElement>}
-                setModel={setModel}
-              />
-            </MessageFooter>
-          )}
         </MessageContentContainer>
+        {showMenubar && (
+          <MessageFooter
+            className="MessageFooter"
+            style={{
+              border: messageBorder,
+              flexDirection: isLastMessage || isBubbleStyle ? 'row-reverse' : undefined
+            }}>
+            <MessageTokens message={message} isLastMessage={isLastMessage} />
+            <MessageMenubar
+              message={message}
+              assistant={assistant}
+              model={model}
+              index={index}
+              topic={topic}
+              isLastMessage={isLastMessage}
+              isAssistantMessage={isAssistantMessage}
+              isGrouped={isGrouped}
+              messageContainerRef={messageContainerRef as React.RefObject<HTMLDivElement>}
+              setModel={setModel}
+            />
+          </MessageFooter>
+        )}
       </ContextMenu>
     </MessageContainer>
   )

--- a/src/renderer/src/pages/home/Messages/Message.tsx
+++ b/src/renderer/src/pages/home/Messages/Message.tsx
@@ -52,7 +52,7 @@ const MessageItem: FC<Props> = ({
   const { assistant, setModel } = useAssistant(message.assistantId)
   const model = useModel(getMessageModelId(message), message.model?.provider) || message.model
   const { isBubbleStyle } = useMessageStyle()
-  const { showMessageDivider, messageFont, fontSize, narrowMode, messageStyle, showTokens } = useSettings()
+  const { showMessageDivider, messageFont, fontSize, narrowMode, messageStyle } = useSettings()
   const { editMessageBlocks, resendUserMessageWithEdit, editMessage } = useMessageOperations(topic)
   const messageContainerRef = useRef<HTMLDivElement>(null)
   const { editingMessageId, stopEditing } = useMessageEditing()
@@ -162,7 +162,7 @@ const MessageItem: FC<Props> = ({
       })}
       ref={messageContainerRef}
       style={{ ...style, alignItems: isBubbleStyle ? (isAssistantMessage ? 'start' : 'end') : undefined }}>
-      <ContextMenu>
+      <ContextMenu style={{ display: 'flex', flexDirection: 'column' }}>
         <MessageHeader message={message} assistant={assistant} model={model} key={getModelUniqId(model)} />
         <MessageContentContainer
           className={
@@ -177,11 +177,13 @@ const MessageItem: FC<Props> = ({
             fontSize,
             background: messageBackground,
             overflowY: 'visible',
-            maxWidth: narrowMode ? 760 : undefined
+            maxWidth: narrowMode ? 760 : undefined,
+            alignSelf: isBubbleStyle ? (isAssistantMessage ? 'start' : 'end') : undefined
           }}>
           <MessageErrorBoundary>
             <MessageContent message={message} />
           </MessageErrorBoundary>
+          {/* 内部菜单 */}
           {showMenubar && (!isBubbleStyle || isLastMessage) && (
             <MessageFooter
               className="MessageFooter"
@@ -204,13 +206,8 @@ const MessageItem: FC<Props> = ({
               {(!isBubbleStyle || isLastMessage) && <MessageTokens message={message} isLastMessage={isLastMessage} />}
             </MessageFooter>
           )}
-
-          {!isLastMessage && isBubbleStyle && showTokens && (
-            <MessageTokensContainer style={{ borderTop: messageBorder }}>
-              <MessageTokens message={message} isLastMessage={isLastMessage} />
-            </MessageTokensContainer>
-          )}
         </MessageContentContainer>
+        {/* 外部菜单 */}
         {showMenubar && isBubbleStyle && !isLastMessage && (
           <MessageFooter
             className="MessageFooter"
@@ -290,13 +287,6 @@ const MessageFooter = styled.div`
   padding: 2px 0;
   margin-top: 2px;
   gap: 20px;
-`
-
-const MessageTokensContainer = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  height: 2rem;
 `
 
 const NewContextMessage = styled.div`

--- a/src/renderer/src/pages/home/Messages/Message.tsx
+++ b/src/renderer/src/pages/home/Messages/Message.tsx
@@ -52,7 +52,7 @@ const MessageItem: FC<Props> = ({
   const { assistant, setModel } = useAssistant(message.assistantId)
   const model = useModel(getMessageModelId(message), message.model?.provider) || message.model
   const { isBubbleStyle } = useMessageStyle()
-  const { showMessageDivider, messageFont, fontSize, narrowMode, messageStyle } = useSettings()
+  const { showMessageDivider, messageFont, fontSize, narrowMode, messageStyle, showTokens } = useSettings()
   const { editMessageBlocks, resendUserMessageWithEdit, editMessage } = useMessageOperations(topic)
   const messageContainerRef = useRef<HTMLDivElement>(null)
   const { editingMessageId, stopEditing } = useMessageEditing()
@@ -101,7 +101,7 @@ const MessageItem: FC<Props> = ({
   const isAssistantMessage = message.role === 'assistant'
   const showMenubar = !hideMenuBar && !isStreaming && !message.status.includes('ing') && !isEditing
 
-  const messageBorder = !isBubbleStyle && showMessageDivider ? '1px dotted var(--color-border)' : 'none'
+  const messageBorder = showMessageDivider ? '1px dotted var(--color-border)' : 'none'
   const messageBackground = getMessageBackground(isBubbleStyle, isAssistantMessage)
 
   const messageHighlightHandler = useCallback((highlight: boolean = true) => {
@@ -187,9 +187,8 @@ const MessageItem: FC<Props> = ({
               className="MessageFooter"
               style={{
                 borderTop: messageBorder,
-                flexDirection: isLastMessage ? 'row-reverse' : undefined
+                flexDirection: !isLastMessage ? 'row-reverse' : undefined
               }}>
-              <MessageTokens message={message} isLastMessage={isLastMessage} />
               <MessageMenubar
                 message={message}
                 assistant={assistant}
@@ -202,17 +201,22 @@ const MessageItem: FC<Props> = ({
                 messageContainerRef={messageContainerRef as React.RefObject<HTMLDivElement>}
                 setModel={setModel}
               />
+              {(!isBubbleStyle || isLastMessage) && <MessageTokens message={message} isLastMessage={isLastMessage} />}
             </MessageFooter>
+          )}
+
+          {!isLastMessage && isBubbleStyle && showTokens && (
+            <MessageTokensContainer style={{ borderTop: messageBorder }}>
+              <MessageTokens message={message} isLastMessage={isLastMessage} />
+            </MessageTokensContainer>
           )}
         </MessageContentContainer>
         {showMenubar && isBubbleStyle && !isLastMessage && (
           <MessageFooter
             className="MessageFooter"
             style={{
-              borderTop: messageBorder,
               flexDirection: isLastMessage || !isAssistantMessage ? 'row-reverse' : undefined
             }}>
-            <MessageTokens message={message} isLastMessage={isLastMessage} />
             <MessageMenubar
               message={message}
               assistant={assistant}
@@ -286,6 +290,13 @@ const MessageFooter = styled.div`
   padding: 2px 0;
   margin-top: 2px;
   gap: 20px;
+`
+
+const MessageTokensContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  height: 2rem;
 `
 
 const NewContextMessage = styled.div`

--- a/src/renderer/src/pages/home/Messages/Message.tsx
+++ b/src/renderer/src/pages/home/Messages/Message.tsx
@@ -101,7 +101,7 @@ const MessageItem: FC<Props> = ({
   const isAssistantMessage = message.role === 'assistant'
   const showMenubar = !hideMenuBar && !isStreaming && !message.status.includes('ing') && !isEditing
 
-  const messageBorder = showMessageDivider ? undefined : 'none'
+  const messageBorder = !isBubbleStyle && showMessageDivider ? '1px dotted var(--color-border)' : 'none'
   const messageBackground = getMessageBackground(isBubbleStyle, isAssistantMessage)
 
   const messageHighlightHandler = useCallback((highlight: boolean = true) => {
@@ -187,7 +187,7 @@ const MessageItem: FC<Props> = ({
           <MessageFooter
             className="MessageFooter"
             style={{
-              border: messageBorder,
+              borderTop: messageBorder,
               flexDirection: isLastMessage || isBubbleStyle ? 'row-reverse' : undefined
             }}>
             <MessageTokens message={message} isLastMessage={isLastMessage} />
@@ -263,7 +263,6 @@ const MessageFooter = styled.div`
   align-items: center;
   padding: 2px 0;
   margin-top: 2px;
-  border-top: 1px dotted var(--color-border);
   gap: 20px;
 `
 

--- a/src/renderer/src/pages/home/Messages/Message.tsx
+++ b/src/renderer/src/pages/home/Messages/Message.tsx
@@ -187,7 +187,7 @@ const MessageItem: FC<Props> = ({
               className="MessageFooter"
               style={{
                 borderTop: messageBorder,
-                flexDirection: isLastMessage || isBubbleStyle ? 'row-reverse' : undefined
+                flexDirection: isLastMessage ? 'row-reverse' : undefined
               }}>
               <MessageTokens message={message} isLastMessage={isLastMessage} />
               <MessageMenubar
@@ -210,7 +210,7 @@ const MessageItem: FC<Props> = ({
             className="MessageFooter"
             style={{
               borderTop: messageBorder,
-              flexDirection: isLastMessage || isBubbleStyle ? 'row-reverse' : undefined
+              flexDirection: isLastMessage || !isAssistantMessage ? 'row-reverse' : undefined
             }}>
             <MessageTokens message={message} isLastMessage={isLastMessage} />
             <MessageMenubar

--- a/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
@@ -336,6 +336,8 @@ const MessageMenubar: FC<Props> = (props) => {
     return translationBlocks.length > 0
   }, [message])
 
+  const softHoverBg = isBubbleStyle && !isLastMessage
+
   return (
     <MenusBar className={`menubar ${isLastMessage && 'show'}`}>
       {message.role === 'user' && (
@@ -343,20 +345,20 @@ const MessageMenubar: FC<Props> = (props) => {
           <ActionButton
             className="message-action-button"
             onClick={() => handleResendUserMessage()}
-            $isBubbleStyle={isBubbleStyle}>
+            $softHoverBg={isBubbleStyle}>
             <SyncOutlined />
           </ActionButton>
         </Tooltip>
       )}
       {message.role === 'user' && (
         <Tooltip title={t('common.edit')} mouseEnterDelay={0.8}>
-          <ActionButton className="message-action-button" onClick={onEdit} $isBubbleStyle={isBubbleStyle}>
+          <ActionButton className="message-action-button" onClick={onEdit} $softHoverBg={softHoverBg}>
             <EditOutlined />
           </ActionButton>
         </Tooltip>
       )}
       <Tooltip title={t('common.copy')} mouseEnterDelay={0.8}>
-        <ActionButton className="message-action-button" onClick={onCopy} $isBubbleStyle={isBubbleStyle}>
+        <ActionButton className="message-action-button" onClick={onCopy} $softHoverBg={softHoverBg}>
           {!copied && <Copy size={16} />}
           {copied && <CheckOutlined style={{ color: 'var(--color-primary)' }} />}
         </ActionButton>
@@ -373,7 +375,7 @@ const MessageMenubar: FC<Props> = (props) => {
             mouseEnterDelay={0.8}
             open={showRegenerateTooltip}
             onOpenChange={setShowRegenerateTooltip}>
-            <ActionButton className="message-action-button" $isBubbleStyle={isBubbleStyle}>
+            <ActionButton className="message-action-button" $softHoverBg={softHoverBg}>
               <RefreshCw size={16} />
             </ActionButton>
           </Tooltip>
@@ -381,7 +383,7 @@ const MessageMenubar: FC<Props> = (props) => {
       )}
       {isAssistantMessage && (
         <Tooltip title={t('message.mention.title')} mouseEnterDelay={0.8}>
-          <ActionButton className="message-action-button" onClick={onMentionModel} $isBubbleStyle={isBubbleStyle}>
+          <ActionButton className="message-action-button" onClick={onMentionModel} $softHoverBg={softHoverBg}>
             <AtSign size={16} />
           </ActionButton>
         </Tooltip>
@@ -450,7 +452,7 @@ const MessageMenubar: FC<Props> = (props) => {
             <ActionButton
               className="message-action-button"
               onClick={(e) => e.stopPropagation()}
-              $isBubbleStyle={isBubbleStyle}>
+              $softHoverBg={softHoverBg}>
               <Languages size={16} />
             </ActionButton>
           </Tooltip>
@@ -458,7 +460,7 @@ const MessageMenubar: FC<Props> = (props) => {
       )}
       {isAssistantMessage && isGrouped && (
         <Tooltip title={t('chat.message.useful')} mouseEnterDelay={0.8}>
-          <ActionButton className="message-action-button" onClick={onUseful} $isBubbleStyle={isBubbleStyle}>
+          <ActionButton className="message-action-button" onClick={onUseful} $softHoverBg={softHoverBg}>
             {message.useful ? (
               <ThumbsUp size={17.5} fill="var(--color-primary)" strokeWidth={0} />
             ) : (
@@ -473,10 +475,7 @@ const MessageMenubar: FC<Props> = (props) => {
         icon={<QuestionCircleOutlined style={{ color: 'red' }} />}
         onOpenChange={(open) => open && setShowDeleteTooltip(false)}
         onConfirm={() => deleteMessage(message.id)}>
-        <ActionButton
-          className="message-action-button"
-          onClick={(e) => e.stopPropagation()}
-          $isBubbleStyle={isBubbleStyle}>
+        <ActionButton className="message-action-button" onClick={(e) => e.stopPropagation()} $softHoverBg={softHoverBg}>
           <Tooltip
             title={t('common.delete')}
             mouseEnterDelay={1}
@@ -495,7 +494,7 @@ const MessageMenubar: FC<Props> = (props) => {
           <ActionButton
             className="message-action-button"
             onClick={(e) => e.stopPropagation()}
-            $isBubbleStyle={isBubbleStyle}>
+            $softHoverBg={softHoverBg}>
             <Menu size={19} />
           </ActionButton>
         </Dropdown>
@@ -512,7 +511,7 @@ const MenusBar = styled.div`
   gap: 6px;
 `
 
-const ActionButton = styled.div<{ $isBubbleStyle?: boolean }>`
+const ActionButton = styled.div<{ $softHoverBg?: boolean }>`
   cursor: pointer;
   border-radius: 8px;
   display: flex;
@@ -524,7 +523,7 @@ const ActionButton = styled.div<{ $isBubbleStyle?: boolean }>`
   transition: all 0.2s ease;
   &:hover {
     background-color: ${(props) =>
-      props.$isBubbleStyle ? 'var(--color-background-soft)' : 'var(--color-background-mute)'};
+      props.$softHoverBg ? 'var(--color-background-soft)' : 'var(--color-background-mute)'};
     color: var(--color-text-1);
     .anticon,
     .lucide {

--- a/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
@@ -35,6 +35,8 @@ import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import styled from 'styled-components'
 
+import MessageTokens from './MessageTokens'
+
 interface Props {
   message: Message
   assistant: Assistant
@@ -340,6 +342,8 @@ const MessageMenubar: FC<Props> = (props) => {
 
   return (
     <MenusBar className={`menubar ${isLastMessage && 'show'}`}>
+      {isBubbleStyle && isUserMessage && <MessageTokens message={message} isLastMessage={isLastMessage} />}
+
       {message.role === 'user' && (
         <Tooltip title={t('common.regenerate')} mouseEnterDelay={0.8}>
           <ActionButton
@@ -498,6 +502,9 @@ const MessageMenubar: FC<Props> = (props) => {
             <Menu size={19} />
           </ActionButton>
         </Dropdown>
+      )}
+      {isBubbleStyle && !isLastMessage && !isUserMessage && (
+        <MessageTokens message={message} isLastMessage={isLastMessage} />
       )}
     </MenusBar>
   )

--- a/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
@@ -5,6 +5,7 @@ import { TranslateLanguageOptions } from '@renderer/config/translate'
 import { useMessageEditing } from '@renderer/context/MessageEditingContext'
 import { useChatContext } from '@renderer/hooks/useChatContext'
 import { useMessageOperations, useTopicLoading } from '@renderer/hooks/useMessageOperations'
+import { useMessageStyle } from '@renderer/hooks/useSettings'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import { getMessageTitle } from '@renderer/services/MessagesService'
 import { translateText } from '@renderer/services/TranslateService'
@@ -66,6 +67,9 @@ const MessageMenubar: FC<Props> = (props) => {
     appendAssistantResponse,
     removeMessageBlock
   } = useMessageOperations(topic)
+
+  const { isBubbleStyle } = useMessageStyle()
+
   const loading = useTopicLoading(topic)
 
   const isUserMessage = message.role === 'user'
@@ -336,20 +340,23 @@ const MessageMenubar: FC<Props> = (props) => {
     <MenusBar className={`menubar ${isLastMessage && 'show'}`}>
       {message.role === 'user' && (
         <Tooltip title={t('common.regenerate')} mouseEnterDelay={0.8}>
-          <ActionButton className="message-action-button" onClick={() => handleResendUserMessage()}>
+          <ActionButton
+            className="message-action-button"
+            onClick={() => handleResendUserMessage()}
+            $isBubbleStyle={isBubbleStyle}>
             <SyncOutlined />
           </ActionButton>
         </Tooltip>
       )}
       {message.role === 'user' && (
         <Tooltip title={t('common.edit')} mouseEnterDelay={0.8}>
-          <ActionButton className="message-action-button" onClick={onEdit}>
+          <ActionButton className="message-action-button" onClick={onEdit} $isBubbleStyle={isBubbleStyle}>
             <EditOutlined />
           </ActionButton>
         </Tooltip>
       )}
       <Tooltip title={t('common.copy')} mouseEnterDelay={0.8}>
-        <ActionButton className="message-action-button" onClick={onCopy}>
+        <ActionButton className="message-action-button" onClick={onCopy} $isBubbleStyle={isBubbleStyle}>
           {!copied && <Copy size={16} />}
           {copied && <CheckOutlined style={{ color: 'var(--color-primary)' }} />}
         </ActionButton>
@@ -366,7 +373,7 @@ const MessageMenubar: FC<Props> = (props) => {
             mouseEnterDelay={0.8}
             open={showRegenerateTooltip}
             onOpenChange={setShowRegenerateTooltip}>
-            <ActionButton className="message-action-button">
+            <ActionButton className="message-action-button" $isBubbleStyle={isBubbleStyle}>
               <RefreshCw size={16} />
             </ActionButton>
           </Tooltip>
@@ -374,7 +381,7 @@ const MessageMenubar: FC<Props> = (props) => {
       )}
       {isAssistantMessage && (
         <Tooltip title={t('message.mention.title')} mouseEnterDelay={0.8}>
-          <ActionButton className="message-action-button" onClick={onMentionModel}>
+          <ActionButton className="message-action-button" onClick={onMentionModel} $isBubbleStyle={isBubbleStyle}>
             <AtSign size={16} />
           </ActionButton>
         </Tooltip>
@@ -440,7 +447,10 @@ const MessageMenubar: FC<Props> = (props) => {
           placement="topRight"
           arrow>
           <Tooltip title={t('chat.translate')} mouseEnterDelay={1.2}>
-            <ActionButton className="message-action-button" onClick={(e) => e.stopPropagation()}>
+            <ActionButton
+              className="message-action-button"
+              onClick={(e) => e.stopPropagation()}
+              $isBubbleStyle={isBubbleStyle}>
               <Languages size={16} />
             </ActionButton>
           </Tooltip>
@@ -448,7 +458,7 @@ const MessageMenubar: FC<Props> = (props) => {
       )}
       {isAssistantMessage && isGrouped && (
         <Tooltip title={t('chat.message.useful')} mouseEnterDelay={0.8}>
-          <ActionButton className="message-action-button" onClick={onUseful}>
+          <ActionButton className="message-action-button" onClick={onUseful} $isBubbleStyle={isBubbleStyle}>
             {message.useful ? (
               <ThumbsUp size={17.5} fill="var(--color-primary)" strokeWidth={0} />
             ) : (
@@ -463,7 +473,10 @@ const MessageMenubar: FC<Props> = (props) => {
         icon={<QuestionCircleOutlined style={{ color: 'red' }} />}
         onOpenChange={(open) => open && setShowDeleteTooltip(false)}
         onConfirm={() => deleteMessage(message.id)}>
-        <ActionButton className="message-action-button" onClick={(e) => e.stopPropagation()}>
+        <ActionButton
+          className="message-action-button"
+          onClick={(e) => e.stopPropagation()}
+          $isBubbleStyle={isBubbleStyle}>
           <Tooltip
             title={t('common.delete')}
             mouseEnterDelay={1}
@@ -479,7 +492,10 @@ const MessageMenubar: FC<Props> = (props) => {
           trigger={['click']}
           placement="topRight"
           arrow>
-          <ActionButton className="message-action-button" onClick={(e) => e.stopPropagation()}>
+          <ActionButton
+            className="message-action-button"
+            onClick={(e) => e.stopPropagation()}
+            $isBubbleStyle={isBubbleStyle}>
             <Menu size={19} />
           </ActionButton>
         </Dropdown>
@@ -496,7 +512,7 @@ const MenusBar = styled.div`
   gap: 6px;
 `
 
-const ActionButton = styled.div`
+const ActionButton = styled.div<{ $isBubbleStyle?: boolean }>`
   cursor: pointer;
   border-radius: 8px;
   display: flex;
@@ -507,8 +523,11 @@ const ActionButton = styled.div`
   height: 30px;
   transition: all 0.2s ease;
   &:hover {
-    background-color: var(--color-background-mute);
-    .anticon {
+    background-color: ${(props) =>
+      props.$isBubbleStyle ? 'var(--color-background-soft)' : 'var(--color-background-mute)'};
+    color: var(--color-text-1);
+    .anticon,
+    .lucide {
       color: var(--color-text-1);
     }
   }
@@ -517,9 +536,6 @@ const ActionButton = styled.div`
     cursor: pointer;
     font-size: 14px;
     color: var(--color-icon);
-  }
-  &:hover {
-    color: var(--color-text-1);
   }
   .icon-at {
     font-size: 16px;


### PR DESCRIPTION
### What this PR does

该PR实现 #6871 中的 Plan C.

效果图：
![image](https://github.com/user-attachments/assets/b56cdec7-4a6f-4a47-8477-c922f7218b78)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #6848 

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
