### PR TITLE
fix: unexpected focus when editing assistant prompt

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -810,7 +810,6 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
             }}
             styles={{ textarea: TextareaStyle }}
             onFocus={(e: React.FocusEvent<HTMLTextAreaElement>) => {
-              console.log('Inputbar onFocus', e)
               setInputFocus(true)
               // 记录当前聚焦的组件
               PasteService.setLastFocusedComponent('inputbar')

--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -85,7 +85,7 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
   const [files, setFiles] = useState<FileType[]>(_files)
   const { t } = useTranslation()
   const containerRef = useRef(null)
-  const { searching } = useRuntime()
+  const { searching, isAssistantSettingsOpen } = useRuntime()
   const { isBubbleStyle } = useMessageStyle()
   const { pauseMessages } = useMessageOperations(topic)
   const loading = useTopicLoading(topic)
@@ -654,8 +654,10 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
   }, [addNewTopic, onQuote])
 
   useEffect(() => {
-    textareaRef.current?.focus()
-  }, [assistant, topic])
+    if (!isAssistantSettingsOpen) {
+      textareaRef.current?.focus()
+    }
+  }, [assistant, topic, isAssistantSettingsOpen])
 
   useEffect(() => {
     setTimeout(() => resizeTextArea(), 0)
@@ -808,6 +810,7 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
             }}
             styles={{ textarea: TextareaStyle }}
             onFocus={(e: React.FocusEvent<HTMLTextAreaElement>) => {
+              console.log('Inputbar onFocus', e)
               setInputFocus(true)
               // 记录当前聚焦的组件
               PasteService.setLastFocusedComponent('inputbar')

--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -85,7 +85,7 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
   const [files, setFiles] = useState<FileType[]>(_files)
   const { t } = useTranslation()
   const containerRef = useRef(null)
-  const { searching, isAssistantSettingsOpen } = useRuntime()
+  const { searching } = useRuntime()
   const { isBubbleStyle } = useMessageStyle()
   const { pauseMessages } = useMessageOperations(topic)
   const loading = useTopicLoading(topic)
@@ -654,10 +654,10 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
   }, [addNewTopic, onQuote])
 
   useEffect(() => {
-    if (!isAssistantSettingsOpen) {
+    if (!document.querySelector('.assistant-settings')) {
       textareaRef.current?.focus()
     }
-  }, [assistant, topic, isAssistantSettingsOpen])
+  }, [assistant, topic])
 
   useEffect(() => {
     setTimeout(() => resizeTextArea(), 0)

--- a/src/renderer/src/pages/settings/AssistantSettings/index.tsx
+++ b/src/renderer/src/pages/settings/AssistantSettings/index.tsx
@@ -3,11 +3,9 @@ import { TopView } from '@renderer/components/TopView'
 import { useAgent } from '@renderer/hooks/useAgents'
 import { useAssistant } from '@renderer/hooks/useAssistant'
 import { useSidebarIconShow } from '@renderer/hooks/useSidebarIcon'
-import { useAppDispatch } from '@renderer/store'
-import { setAssistantSettingsOpen } from '@renderer/store/runtime'
 import { Assistant } from '@renderer/types'
 import { Menu, Modal } from 'antd'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
@@ -32,7 +30,6 @@ const AssistantSettingPopupContainer: React.FC<Props> = ({ resolve, tab, ...prop
   const [open, setOpen] = useState(true)
   const { t } = useTranslation()
   const [menu, setMenu] = useState<AssistantSettingPopupTab>(tab || 'prompt')
-  const dispatch = useAppDispatch()
 
   const _useAssistant = useAssistant(props.assistant.id)
   const _useAgent = useAgent(props.assistant.id)
@@ -53,13 +50,8 @@ const AssistantSettingPopupContainer: React.FC<Props> = ({ resolve, tab, ...prop
   }
 
   const afterClose = () => {
-    dispatch(setAssistantSettingsOpen(false))
     resolve(assistant)
   }
-
-  useEffect(() => {
-    dispatch(setAssistantSettingsOpen(true))
-  }, [dispatch])
 
   const items = [
     {
@@ -86,6 +78,7 @@ const AssistantSettingPopupContainer: React.FC<Props> = ({ resolve, tab, ...prop
 
   return (
     <StyledModal
+      className="assistant-settings"
       open={open}
       onOk={onOk}
       onClose={onCancel}

--- a/src/renderer/src/pages/settings/AssistantSettings/index.tsx
+++ b/src/renderer/src/pages/settings/AssistantSettings/index.tsx
@@ -3,9 +3,11 @@ import { TopView } from '@renderer/components/TopView'
 import { useAgent } from '@renderer/hooks/useAgents'
 import { useAssistant } from '@renderer/hooks/useAssistant'
 import { useSidebarIconShow } from '@renderer/hooks/useSidebarIcon'
+import { useAppDispatch } from '@renderer/store'
+import { setAssistantSettingsOpen } from '@renderer/store/runtime'
 import { Assistant } from '@renderer/types'
 import { Menu, Modal } from 'antd'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
@@ -30,6 +32,7 @@ const AssistantSettingPopupContainer: React.FC<Props> = ({ resolve, tab, ...prop
   const [open, setOpen] = useState(true)
   const { t } = useTranslation()
   const [menu, setMenu] = useState<AssistantSettingPopupTab>(tab || 'prompt')
+  const dispatch = useAppDispatch()
 
   const _useAssistant = useAssistant(props.assistant.id)
   const _useAgent = useAgent(props.assistant.id)
@@ -50,8 +53,13 @@ const AssistantSettingPopupContainer: React.FC<Props> = ({ resolve, tab, ...prop
   }
 
   const afterClose = () => {
+    dispatch(setAssistantSettingsOpen(false))
     resolve(assistant)
   }
+
+  useEffect(() => {
+    dispatch(setAssistantSettingsOpen(true))
+  }, [dispatch])
 
   const items = [
     {

--- a/src/renderer/src/store/runtime.ts
+++ b/src/renderer/src/store/runtime.ts
@@ -35,6 +35,7 @@ export interface RuntimeState {
   update: UpdateState
   export: ExportState
   chat: ChatState
+  isAssistantSettingsOpen: boolean
 }
 
 export interface ExportState {
@@ -66,7 +67,8 @@ const initialState: RuntimeState = {
     isMultiSelectMode: false,
     selectedMessageIds: [],
     activeTopic: null
-  }
+  },
+  isAssistantSettingsOpen: false
 }
 
 const runtimeSlice = createSlice({
@@ -118,6 +120,9 @@ const runtimeSlice = createSlice({
     },
     setActiveTopic: (state, action: PayloadAction<Topic>) => {
       state.chat.activeTopic = action.payload
+    },
+    setAssistantSettingsOpen: (state, action: PayloadAction<boolean>) => {
+      state.isAssistantSettingsOpen = action.payload
     }
   }
 })
@@ -137,7 +142,8 @@ export const {
   // Chat related actions
   toggleMultiSelectMode,
   setSelectedMessageIds,
-  setActiveTopic
+  setActiveTopic,
+  setAssistantSettingsOpen
 } = runtimeSlice.actions
 
 export default runtimeSlice.reducer

--- a/src/renderer/src/store/runtime.ts
+++ b/src/renderer/src/store/runtime.ts
@@ -35,7 +35,6 @@ export interface RuntimeState {
   update: UpdateState
   export: ExportState
   chat: ChatState
-  isAssistantSettingsOpen: boolean
 }
 
 export interface ExportState {
@@ -67,8 +66,7 @@ const initialState: RuntimeState = {
     isMultiSelectMode: false,
     selectedMessageIds: [],
     activeTopic: null
-  },
-  isAssistantSettingsOpen: false
+  }
 }
 
 const runtimeSlice = createSlice({
@@ -120,9 +118,6 @@ const runtimeSlice = createSlice({
     },
     setActiveTopic: (state, action: PayloadAction<Topic>) => {
       state.chat.activeTopic = action.payload
-    },
-    setAssistantSettingsOpen: (state, action: PayloadAction<boolean>) => {
-      state.isAssistantSettingsOpen = action.payload
     }
   }
 })
@@ -142,8 +137,7 @@ export const {
   // Chat related actions
   toggleMultiSelectMode,
   setSelectedMessageIds,
-  setActiveTopic,
-  setAssistantSettingsOpen
+  setActiveTopic
 } = runtimeSlice.actions
 
 export default runtimeSlice.reducer


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Fixes #6949

### Why we need it and why it was done in this way

问题在于，每次更新prompt都会触发一次assistant的更新，而assistant更新又会导致inputbar组件重新渲染，触发其自动聚焦的useEffect。

解决方案是添加一个助手设置窗口是否打开的状态，inputbar的自动聚焦只在助手设置窗口未打开时进行。

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
