### PR TITLE
fix: update default translate model to deepseek-v3

### DIFF
--- a/src/renderer/src/store/llm.ts
+++ b/src/renderer/src/store/llm.ts
@@ -493,7 +493,7 @@ export const INITIAL_PROVIDERS: Provider[] = [
 const initialState: LlmState = {
   defaultModel: SYSTEM_MODELS.silicon[1],
   topicNamingModel: SYSTEM_MODELS.silicon[2],
-  translateModel: SYSTEM_MODELS.silicon[3],
+  translateModel: SYSTEM_MODELS.silicon[1],
   quickAssistantModel: SYSTEM_MODELS.silicon[1],
   providers: INITIAL_PROVIDERS,
   settings: {

--- a/src/renderer/src/store/migrate.ts
+++ b/src/renderer/src/store/migrate.ts
@@ -1501,6 +1501,15 @@ const migrateConfig = {
   '111': (state: RootState) => {
     try {
       addSelectionAction(state, 'quote')
+
+      //if user has not set translate model(old default), set it to the new default model(deekseek v3)
+      if (
+        state.llm.translateModel.provider === SYSTEM_MODELS.silicon[3].provider &&
+        state.llm.translateModel.id === SYSTEM_MODELS.silicon[3].id
+      ) {
+        state.llm.translateModel = SYSTEM_MODELS.silicon[1]
+      }
+
       return state
     } catch (error) {
       return state


### PR DESCRIPTION
The old default translate model is no longer available, we change the new default translate model to Silicon's DeepSeek-V3

**Notice**: the migration version has been changed