### PR TITLE
feat: add custom input box icons configuration

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -1281,6 +1281,13 @@
       "display.title": "Display Settings",
       "display.zoom.title": "Zoom Settings",
       "display.topic.title": "Topic Settings",
+      "display.inputbox.title": "Input Box Settings",
+      "display.inputbox.preview": "Input Box Preview",
+      "display.inputbox.icons.title": "Icon Management",
+      "display.inputbox.position.left": "Left",
+      "display.inputbox.position.right": "Right",
+      "display.inputbox.empty.left": "No icons on the left",
+      "display.inputbox.empty.right": "No icons on the right",
       "miniapps": {
         "title": "Mini Apps Settings",
         "custom": {

--- a/src/renderer/src/i18n/locales/ja-jp.json
+++ b/src/renderer/src/i18n/locales/ja-jp.json
@@ -1279,6 +1279,13 @@
       "display.title": "表示設定",
       "display.zoom.title": "ズーム設定",
       "display.topic.title": "トピック設定",
+      "display.inputbox.title": "入力ボックス設定",
+      "display.inputbox.preview": "入力ボックスプレビュー",
+      "display.inputbox.icons.title": "アイコン管理",
+      "display.inputbox.position.left": "左側",
+      "display.inputbox.position.right": "右側",
+      "display.inputbox.empty.left": "左側にアイコンがありません",
+      "display.inputbox.empty.right": "右側にアイコンがありません",
       "miniapps": {
         "title": "ミニアプリ設定",
         "disabled": "非表示のミニアプリ",

--- a/src/renderer/src/i18n/locales/ru-ru.json
+++ b/src/renderer/src/i18n/locales/ru-ru.json
@@ -1279,6 +1279,13 @@
       "display.title": "Настройки отображения",
       "display.zoom.title": "Настройки масштаба",
       "display.topic.title": "Настройки топиков",
+      "display.inputbox.title": "Настройки поля ввода",
+      "display.inputbox.preview": "Предварительный просмотр поля ввода",
+      "display.inputbox.icons.title": "Управление иконками",
+      "display.inputbox.position.left": "Слева",
+      "display.inputbox.position.right": "Справа",
+      "display.inputbox.empty.left": "Нет иконок слева",
+      "display.inputbox.empty.right": "Нет иконок справа",
       "miniapps": {
         "title": "Настройки мини-приложений",
         "disabled": "Скрытые мини-приложения",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -1281,6 +1281,13 @@
       "display.title": "显示设置",
       "display.zoom.title": "缩放设置",
       "display.topic.title": "话题设置",
+      "display.inputbox.title": "输入框设置",
+      "display.inputbox.preview": "输入框预览",
+      "display.inputbox.icons.title": "图标管理",
+      "display.inputbox.position.left": "左侧",
+      "display.inputbox.position.right": "右侧",
+      "display.inputbox.empty.left": "左侧暂无图标",
+      "display.inputbox.empty.right": "右侧暂无图标",
       "miniapps": {
         "title": "小程序设置",
         "disabled": "隐藏的小程序",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -1281,6 +1281,13 @@
       "display.title": "顯示設定",
       "display.zoom.title": "縮放設定",
       "display.topic.title": "話題設定",
+      "display.inputbox.title": "輸入框設定",
+      "display.inputbox.preview": "輸入框預覽",
+      "display.inputbox.icons.title": "圖示管理",
+      "display.inputbox.position.left": "左側",
+      "display.inputbox.position.right": "右側",
+      "display.inputbox.empty.left": "左側暫無圖示",
+      "display.inputbox.empty.right": "右側暫無圖示",
       "miniapps": {
         "title": "小程式設置",
         "disabled": "隱藏的小程式",

--- a/src/renderer/src/pages/settings/DisplaySettings/DisplaySettings.tsx
+++ b/src/renderer/src/pages/settings/DisplaySettings/DisplaySettings.tsx
@@ -11,6 +11,7 @@ import {
   setAssistantIconType,
   setClickAssistantToShowTopic,
   setCustomCss,
+  setInputBoxIconsConfig,
   setPinTopicsToTop,
   setShowTopicTime,
   setSidebarIcons
@@ -23,6 +24,7 @@ import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 import { SettingContainer, SettingDivider, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '..'
+import InputBoxPreview from './InputBoxPreview'
 import SidebarIconsManager from './SidebarIconsManager'
 
 const ColorCircleWrapper = styled.div`
@@ -65,7 +67,8 @@ const DisplaySettings: FC = () => {
     sidebarIcons,
     setTheme,
     assistantIconType,
-    userTheme
+    userTheme,
+    inputBoxIconsConfig
   } = useSettings()
   const { theme, settedTheme } = useTheme()
   const { t } = useTranslation()
@@ -75,6 +78,9 @@ const DisplaySettings: FC = () => {
 
   const [visibleIcons, setVisibleIcons] = useState(sidebarIcons?.visible || DEFAULT_SIDEBAR_ICONS)
   const [disabledIcons, setDisabledIcons] = useState(sidebarIcons?.disabled || [])
+
+  // 输入框图标配置状态
+  const [inputBoxConfig, setInputBoxConfig] = useState(inputBoxIconsConfig || {})
 
   const handleWindowStyleChange = useCallback(
     (checked: boolean) => {
@@ -97,6 +103,11 @@ const DisplaySettings: FC = () => {
     setVisibleIcons([...DEFAULT_SIDEBAR_ICONS])
     setDisabledIcons([])
     dispatch(setSidebarIcons({ visible: DEFAULT_SIDEBAR_ICONS, disabled: [] }))
+  }, [dispatch])
+
+  const handleInputBoxReset = useCallback(() => {
+    setInputBoxConfig({})
+    dispatch(setInputBoxIconsConfig({}))
   }, [dispatch])
 
   const themeOptions = useMemo(
@@ -298,6 +309,17 @@ const DisplaySettings: FC = () => {
           setVisibleIcons={setVisibleIcons}
           setDisabledIcons={setDisabledIcons}
         />
+      </SettingGroup>
+      <SettingGroup theme={theme}>
+        <SettingTitle
+          style={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span>{t('settings.display.inputbox.title')}</span>
+          <ResetButtonWrapper>
+            <Button onClick={handleInputBoxReset}>{t('common.reset')}</Button>
+          </ResetButtonWrapper>
+        </SettingTitle>
+        <SettingDivider />
+        <InputBoxPreview inputBoxConfig={inputBoxConfig} setInputBoxConfig={setInputBoxConfig} />
       </SettingGroup>
       <SettingGroup theme={theme}>
         <SettingTitle>

--- a/src/renderer/src/pages/settings/DisplaySettings/InputBoxIconsManager.tsx
+++ b/src/renderer/src/pages/settings/DisplaySettings/InputBoxIconsManager.tsx
@@ -1,0 +1,343 @@
+import { DragDropContext, Draggable, Droppable, DropResult } from '@hello-pangea/dnd'
+import { Button, Switch } from 'antd'
+import { GripVertical } from 'lucide-react'
+import { FC, useCallback, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+
+import { InputBoxIconInfo } from './inputBoxIconsUtils'
+
+interface Props {
+  icons: InputBoxIconInfo[]
+  inputBoxConfig: Record<string, { visible: boolean; position: 'left' | 'right'; order: number }>
+  setInputBoxConfig: (config: Record<string, { visible: boolean; position: 'left' | 'right'; order: number }>) => void
+}
+
+interface IconConfig {
+  visible: boolean
+  position: 'left' | 'right'
+  order: number
+}
+
+const InputBoxIconsManager: FC<Props> = ({ icons, inputBoxConfig, setInputBoxConfig }) => {
+  const { t } = useTranslation()
+
+  // 本地状态管理 - 使用 useMemo 优化初始化
+  const localConfig = useMemo(() => {
+    const config: Record<string, IconConfig> = {}
+    icons.forEach((icon) => {
+      config[icon.id] = {
+        visible: inputBoxConfig[icon.id]?.visible ?? icon.visible,
+        position: inputBoxConfig[icon.id]?.position ?? icon.position,
+        order: inputBoxConfig[icon.id]?.order ?? icon.order
+      }
+    })
+    return config
+  }, [icons, inputBoxConfig])
+
+  // 获取按位置分组的图标 - 使用 useMemo 缓存结果
+  const { leftIcons, rightIcons } = useMemo(() => {
+    const getIconsByPosition = (position: 'left' | 'right') => {
+      return icons
+        .filter((icon) => (localConfig[icon.id]?.position ?? icon.position) === position)
+        .sort((a, b) => {
+          const orderA = localConfig[a.id]?.order ?? a.order
+          const orderB = localConfig[b.id]?.order ?? b.order
+          return orderA - orderB
+        })
+    }
+
+    return {
+      leftIcons: getIconsByPosition('left'),
+      rightIcons: getIconsByPosition('right')
+    }
+  }, [icons, localConfig])
+
+  // 更新图标配置
+  const updateIconConfig = useCallback(
+    (iconId: string, updates: Partial<IconConfig>) => {
+      // 保护关键图标不能被隐藏
+      if (iconId === 'send_pause' && updates.visible === false) {
+        // 可以添加提示消息
+        return
+      }
+
+      const newConfig = {
+        ...localConfig,
+        [iconId]: {
+          ...localConfig[iconId],
+          ...updates
+        }
+      }
+      setInputBoxConfig(newConfig)
+    },
+    [localConfig, setInputBoxConfig]
+  )
+
+  // 处理拖拽结束
+  const handleDragEnd = useCallback(
+    (result: DropResult) => {
+      if (!result.destination) return
+
+      const { source, destination } = result
+      const sourcePosition = source.droppableId as 'left' | 'right'
+      const destPosition = destination.droppableId as 'left' | 'right'
+
+      const sourceIcons = sourcePosition === 'left' ? leftIcons : rightIcons
+      const destIcons = sourcePosition === destPosition ? sourceIcons : destPosition === 'left' ? leftIcons : rightIcons
+
+      const draggedIcon = sourceIcons[source.index]
+
+      // 重新计算顺序
+      const newConfig = { ...localConfig }
+
+      if (sourcePosition === destPosition) {
+        // 同一位置内重排序
+        const reorderedIcons = Array.from(sourceIcons)
+        const [removed] = reorderedIcons.splice(source.index, 1)
+        reorderedIcons.splice(destination.index, 0, removed)
+
+        reorderedIcons.forEach((icon, index) => {
+          newConfig[icon.id] = {
+            ...newConfig[icon.id],
+            order: index + 1
+          }
+        })
+      } else {
+        // 跨位置移动
+        const newDestIcons = Array.from(destIcons)
+        newDestIcons.splice(destination.index, 0, draggedIcon)
+
+        // 更新目标位置的顺序
+        newDestIcons.forEach((icon, index) => {
+          newConfig[icon.id] = {
+            ...newConfig[icon.id],
+            position: destPosition,
+            order: index + 1
+          }
+        })
+
+        // 更新源位置剩余图标的顺序
+        const remainingSourceIcons = sourceIcons.filter((icon) => icon.id !== draggedIcon.id)
+        remainingSourceIcons.forEach((icon, index) => {
+          newConfig[icon.id] = {
+            ...newConfig[icon.id],
+            order: index + 1
+          }
+        })
+      }
+
+      setInputBoxConfig(newConfig)
+    },
+    [leftIcons, rightIcons, localConfig, setInputBoxConfig]
+  )
+
+  // 重置为默认配置
+  const handleReset = useCallback(() => {
+    setInputBoxConfig({})
+  }, [setInputBoxConfig])
+
+  const renderIconItem = (icon: InputBoxIconInfo, index: number) => {
+    const config = localConfig[icon.id]
+
+    return (
+      <Draggable key={icon.id} draggableId={icon.id} index={index}>
+        {(provided, snapshot) => (
+          <IconItem
+            ref={provided.innerRef}
+            {...provided.draggableProps}
+            {...provided.dragHandleProps}
+            $isDragging={snapshot.isDragging}>
+            <IconInfo>
+              <DragHandle>
+                <GripVertical size={14} />
+              </DragHandle>
+              <IconPreview>{icon.icon}</IconPreview>
+              <IconName>{icon.name}</IconName>
+            </IconInfo>
+            <IconControls onClick={(e) => e.stopPropagation()} onMouseDown={(e) => e.stopPropagation()}>
+              <Switch
+                checked={config?.visible ?? icon.visible}
+                onChange={(visible) => updateIconConfig(icon.id, { visible })}
+                size="small"
+              />
+            </IconControls>
+          </IconItem>
+        )}
+      </Draggable>
+    )
+  }
+
+  return (
+    <Container>
+      <Header>
+        <Title>{t('settings.display.inputbox.icons.title')}</Title>
+        <Button onClick={handleReset} size="small">
+          {t('common.reset')}
+        </Button>
+      </Header>
+
+      <DragDropContext onDragEnd={handleDragEnd}>
+        <PositionsContainer>
+          <PositionSection>
+            <PositionTitle>{t('settings.display.inputbox.position.left')}</PositionTitle>
+            <Droppable droppableId="left">
+              {(provided, snapshot) => (
+                <IconsList ref={provided.innerRef} {...provided.droppableProps} $isDragOver={snapshot.isDraggingOver}>
+                  {leftIcons.length === 0 ? (
+                    <EmptyPlaceholder>{t('settings.display.inputbox.empty.left')}</EmptyPlaceholder>
+                  ) : (
+                    leftIcons.map((icon, index) => renderIconItem(icon, index))
+                  )}
+                  {provided.placeholder}
+                </IconsList>
+              )}
+            </Droppable>
+          </PositionSection>
+
+          <PositionSection>
+            <PositionTitle>{t('settings.display.inputbox.position.right')}</PositionTitle>
+            <Droppable droppableId="right">
+              {(provided, snapshot) => (
+                <IconsList ref={provided.innerRef} {...provided.droppableProps} $isDragOver={snapshot.isDraggingOver}>
+                  {rightIcons.length === 0 ? (
+                    <EmptyPlaceholder>{t('settings.display.inputbox.empty.right')}</EmptyPlaceholder>
+                  ) : (
+                    rightIcons.map((icon, index) => renderIconItem(icon, index))
+                  )}
+                  {provided.placeholder}
+                </IconsList>
+              )}
+            </Droppable>
+          </PositionSection>
+        </PositionsContainer>
+      </DragDropContext>
+    </Container>
+  )
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`
+
+const Title = styled.div`
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-text-1);
+`
+
+const PositionsContainer = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+`
+
+const PositionSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`
+
+const PositionTitle = styled.div`
+  font-size: 12px;
+  color: var(--color-text-2);
+  font-weight: 500;
+`
+
+const IconsList = styled.div<{ $isDragOver?: boolean }>`
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+  padding: 10px;
+  background-color: var(--color-background-soft);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  overflow-y: hidden;
+  transition: all 0.2s;
+
+  ${(props) =>
+    props.$isDragOver &&
+    `
+    border-color: var(--color-primary);
+    background-color: var(--color-primary-bg);
+  `}
+`
+
+const IconItem = styled.div<{ $isDragging?: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  margin-bottom: 8px;
+  background-color: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  cursor: move;
+  transition: all 0.2s;
+  opacity: ${(props) => (props.$isDragging ? 0.9 : 1)};
+  transform: ${(props) => (props.$isDragging ? 'rotate(2deg)' : 'none')};
+
+  &:hover {
+    border-color: var(--color-primary);
+  }
+`
+
+const IconInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+`
+
+const DragHandle = styled.div`
+  color: var(--color-text-3);
+  display: flex;
+  align-items: center;
+  opacity: 0.6;
+  transition: opacity 0.2s;
+
+  ${IconItem}:hover & {
+    opacity: 1;
+  }
+`
+
+const IconPreview = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  color: var(--color-icon);
+`
+
+const IconName = styled.div`
+  font-size: 12px;
+  color: var(--color-text-1);
+`
+
+const IconControls = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`
+
+const EmptyPlaceholder = styled.div`
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-2);
+  text-align: center;
+  padding: 20px;
+  font-size: 14px;
+`
+
+export default InputBoxIconsManager

--- a/src/renderer/src/pages/settings/DisplaySettings/InputBoxPreview.tsx
+++ b/src/renderer/src/pages/settings/DisplaySettings/InputBoxPreview.tsx
@@ -1,0 +1,240 @@
+import { HolderOutlined } from '@ant-design/icons'
+import { useAppDispatch } from '@renderer/store'
+import { setInputBoxIconsConfig } from '@renderer/store/settings'
+import { Input, Tooltip } from 'antd'
+import { FC, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import styled, { CSSProperties } from 'styled-components'
+
+import InputBoxIconsManager from './InputBoxIconsManager'
+import { getInputBoxIcons, getVisibleInputBoxIcons, sortIconsByPosition } from './inputBoxIconsUtils'
+
+const { TextArea } = Input
+
+interface Props {
+  inputBoxConfig: Record<string, { visible: boolean; position: 'left' | 'right'; order: number }>
+  setInputBoxConfig: (config: Record<string, { visible: boolean; position: 'left' | 'right'; order: number }>) => void
+}
+
+const InputBoxPreview: FC<Props> = ({ inputBoxConfig, setInputBoxConfig }) => {
+  const { t } = useTranslation()
+  const dispatch = useAppDispatch()
+  const [isExpanded, setIsExpanded] = useState(false)
+  const [previewText, setPreviewText] = useState('')
+
+  // 获取所有输入框图标 - 使用 useMemo 缓存
+  const allIcons = useMemo(() => getInputBoxIcons(), [])
+
+  // 模拟一些条件状态用于预览
+  const mockConditions = useMemo(
+    () => ({
+      showThinkingButton: true,
+      showKnowledgeIcon: true,
+      hasMcpServers: true,
+      isGenerateImageModel: false,
+      showInputEstimatedTokens: true
+    }),
+    []
+  )
+
+  // 获取可见的图标并应用配置 - 使用 useMemo 优化性能
+  const { leftIcons, rightIcons } = useMemo(() => {
+    // 获取可见的图标
+    const visibleIcons = getVisibleInputBoxIcons(allIcons, mockConditions)
+
+    // 应用用户的自定义配置
+    const configuredIcons = visibleIcons
+      .map((icon) => ({
+        ...icon,
+        visible: inputBoxConfig?.[icon.id]?.visible ?? icon.visible,
+        order: inputBoxConfig?.[icon.id]?.order ?? icon.order,
+        position: inputBoxConfig?.[icon.id]?.position ?? icon.position
+      }))
+      .filter((icon) => icon.visible)
+
+    // 按位置排序
+    return sortIconsByPosition(configuredIcons)
+  }, [allIcons, mockConditions, inputBoxConfig])
+
+  // 更新配置的回调函数
+  const handleConfigUpdate = (
+    newConfig: Record<string, { visible: boolean; position: 'left' | 'right'; order: number }>
+  ) => {
+    setInputBoxConfig(newConfig)
+    dispatch(setInputBoxIconsConfig(newConfig))
+  }
+
+  const textareaRows = isExpanded ? 6 : 3
+
+  const TextareaStyle: CSSProperties = {
+    paddingLeft: 0,
+    padding: '6px 15px 8px'
+  }
+
+  const handleExpandToggle = () => {
+    setIsExpanded(!isExpanded)
+  }
+
+  return (
+    <Container>
+      <PreviewLabel>{t('settings.display.inputbox.preview')}</PreviewLabel>
+      <PreviewContainer>
+        <InputBarContainer className="inputbar-container">
+          <DragHandle>
+            <HolderOutlined />
+          </DragHandle>
+          <Textarea
+            value={previewText}
+            onChange={(e) => setPreviewText(e.target.value)}
+            placeholder={t('chat.input.placeholder')}
+            variant="borderless"
+            spellCheck={false}
+            rows={textareaRows}
+            styles={{ textarea: TextareaStyle }}
+          />
+          <Toolbar>
+            <ToolbarMenu>
+              {leftIcons.map((icon) => (
+                <Tooltip key={icon.id} title={t(icon.tooltip)} placement="top">
+                  <ToolbarButton onClick={icon.id === 'expand_collapse' ? handleExpandToggle : undefined}>
+                    {icon.id === 'expand_collapse' ? (isExpanded ? icon.icon : icon.icon) : icon.icon}
+                  </ToolbarButton>
+                </Tooltip>
+              ))}
+            </ToolbarMenu>
+            <ToolbarMenu>
+              {rightIcons.map((icon) => (
+                <Tooltip key={icon.id} title={t(icon.tooltip)} placement="top">
+                  <ToolbarButton>{icon.icon}</ToolbarButton>
+                </Tooltip>
+              ))}
+            </ToolbarMenu>
+          </Toolbar>
+        </InputBarContainer>
+      </PreviewContainer>
+      <InputBoxIconsManager icons={allIcons} inputBoxConfig={inputBoxConfig} setInputBoxConfig={handleConfigUpdate} />
+    </Container>
+  )
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`
+
+const PreviewLabel = styled.div`
+  font-size: 12px;
+  color: var(--color-text-2);
+  margin-bottom: 8px;
+`
+
+const PreviewContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  z-index: 2;
+  padding: 20px;
+  border: 1px dashed var(--color-border);
+  border-radius: 8px;
+  background-color: var(--color-background-soft);
+  width: 100%;
+`
+
+const InputBarContainer = styled.div`
+  border: 0.5px solid var(--color-border);
+  transition: all 0.2s ease;
+  position: relative;
+  border-radius: 15px;
+  padding-top: 6px;
+  background-color: var(--color-background-opacity);
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+`
+
+const DragHandle = styled.div`
+  position: absolute;
+  top: -3px;
+  left: 0;
+  right: 0;
+  height: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: row-resize;
+  color: var(--color-icon);
+  opacity: 0;
+  transition: opacity 0.2s;
+  z-index: 1;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  .anticon {
+    transform: rotate(90deg);
+    font-size: 14px;
+  }
+`
+
+const Textarea = styled(TextArea)`
+  padding: 0;
+  border-radius: 0;
+  display: flex;
+  flex: 1;
+  font-family: Ubuntu;
+  resize: none !important;
+  overflow: auto;
+  width: 100%;
+  box-sizing: border-box;
+  &.ant-input {
+    line-height: 1.4;
+  }
+`
+
+const Toolbar = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding: 0 8px;
+  padding-bottom: 0;
+  margin-bottom: 4px;
+  height: 36px;
+`
+
+const ToolbarMenu = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 2px;
+`
+
+const ToolbarButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--color-icon);
+  transition: all 0.2s;
+
+  &:hover {
+    background-color: var(--color-background-soft);
+    color: var(--color-text-1);
+  }
+
+  &:active {
+    transform: scale(0.95);
+  }
+
+  .iconfont {
+    font-size: inherit;
+  }
+`
+
+export default InputBoxPreview

--- a/src/renderer/src/pages/settings/DisplaySettings/inputBoxIconsUtils.ts
+++ b/src/renderer/src/pages/settings/DisplaySettings/inputBoxIconsUtils.ts
@@ -1,0 +1,226 @@
+import {
+  Eraser,
+  FileSearch,
+  Globe,
+  Image,
+  Languages,
+  Lightbulb,
+  Maximize,
+  MessageSquareDiff,
+  PaintbrushVertical,
+  Paperclip,
+  SquareTerminal,
+  Zap
+} from 'lucide-react'
+import React from 'react'
+
+// 输入框图标类型定义 - 参考侧边栏的严格类型定义
+export type InputBoxIconType =
+  | 'new_topic'
+  | 'attachment'
+  | 'thinking'
+  | 'web_search'
+  | 'knowledge_base'
+  | 'mcp_tools'
+  | 'generate_image'
+  | 'mention_models'
+  | 'quick_phrases'
+  | 'clear_topic'
+  | 'expand_collapse'
+  | 'new_context'
+  | 'token_count'
+  | 'translate'
+  | 'send_pause'
+
+// 输入框图标的类型定义
+export interface InputBoxIconInfo {
+  id: InputBoxIconType
+  name: string
+  icon: React.ReactNode
+  tooltip: string
+  position: 'left' | 'right'
+  visible: boolean
+  order: number
+  component?: string
+  condition?: string
+}
+
+// 图标配置映射 - 减少重复代码
+interface IconDefinition {
+  icon: any
+  size: number
+  name: string
+  tooltip: string
+  color?: string
+}
+
+const ICON_CONFIGS: Record<string, IconDefinition> = {
+  new_topic: { icon: MessageSquareDiff, size: 19, name: '新话题', tooltip: 'chat.input.new_topic' },
+  attachment: { icon: Paperclip, size: 18, name: '附件', tooltip: 'chat.input.upload' },
+  web_search: { icon: Globe, size: 18, name: '网络搜索', tooltip: 'chat.input.web_search' },
+  knowledge_base: { icon: FileSearch, size: 18, name: '知识库', tooltip: 'chat.input.knowledge_base' },
+  mcp_tools: { icon: SquareTerminal, size: 18, name: 'MCP工具', tooltip: 'settings.mcp.title' },
+  generate_image: { icon: Image, size: 18, name: '生成图片', tooltip: 'chat.input.generate_image' },
+  quick_phrases: { icon: Zap, size: 18, name: '快捷短语', tooltip: 'settings.quickPhrase.title' },
+  clear_topic: { icon: PaintbrushVertical, size: 18, name: '清空话题', tooltip: 'chat.input.clear' },
+  expand_collapse: { icon: Maximize, size: 18, name: '展开/收起', tooltip: 'chat.input.expand' },
+  new_context: { icon: Eraser, size: 18, name: '新上下文', tooltip: 'chat.input.new.context' },
+  translate: { icon: Languages, size: 18, name: '翻译', tooltip: 'chat.input.translate' }
+}
+
+// 创建图标元素的辅助函数
+function createIcon(iconKey: string) {
+  const config = ICON_CONFIGS[iconKey]
+  if (!config) return null
+
+  const props: any = { size: config.size }
+  if (config.color) {
+    props.style = { color: config.color, fontSize: config.size }
+  }
+  return React.createElement(config.icon, props)
+}
+
+// 特殊图标创建函数
+function createSpecialIcons() {
+  return {
+    thinking: React.createElement(Lightbulb, {
+      size: 18,
+      style: { color: 'var(--color-icon)' }
+    }),
+    mention_models: React.createElement('span', { style: { fontSize: 18 } }, '@'),
+    token_count: React.createElement(
+      'div',
+      {
+        style: {
+          fontSize: 11,
+          padding: '3px 10px',
+          border: '0.5px solid var(--color-text-3)',
+          borderRadius: 20,
+          color: 'var(--color-text-2)'
+        }
+      },
+      '0/0'
+    ),
+    send_pause: React.createElement('i', {
+      className: 'iconfont icon-ic_send',
+      style: { fontSize: 22, color: 'var(--color-primary)' }
+    })
+  }
+}
+
+// 定义并返回所有可用的输入框图标信息
+export function getInputBoxIcons(): InputBoxIconInfo[] {
+  const specialIcons = createSpecialIcons()
+
+  // 左侧图标配置
+  const leftIconsConfig = [
+    { id: 'new_topic', order: 1, condition: 'always', visible: true },
+    { id: 'attachment', order: 2, condition: 'always', visible: true },
+    {
+      id: 'thinking',
+      order: 3,
+      condition: 'showThinkingButton',
+      name: '思考模式',
+      tooltip: 'assistants.settings.reasoning_effort',
+      visible: true
+    },
+    { id: 'web_search', order: 4, condition: 'always', visible: true },
+    { id: 'knowledge_base', order: 5, condition: 'showKnowledgeIcon', visible: true },
+    { id: 'mcp_tools', order: 6, condition: 'activedMcpServers.length > 0', visible: true },
+    { id: 'generate_image', order: 7, condition: 'isGenerateImageModel(model)', visible: true },
+    {
+      id: 'mention_models',
+      order: 8,
+      condition: 'always',
+      name: '提及模型',
+      tooltip: 'agents.edit.model.select.title',
+      visible: true
+    },
+    { id: 'quick_phrases', order: 9, condition: 'always', visible: true },
+    { id: 'clear_topic', order: 10, condition: 'always', visible: true },
+    { id: 'expand_collapse', order: 11, condition: 'always', visible: true },
+    { id: 'new_context', order: 12, condition: 'always', visible: true },
+    {
+      id: 'token_count',
+      order: 13,
+      condition: 'showInputEstimatedTokens',
+      name: 'Token计数',
+      tooltip: 'Token计数',
+      visible: true
+    }
+  ]
+
+  // 右侧图标配置
+  const rightIconsConfig = [
+    { id: 'translate', order: 1, condition: 'always', visible: true },
+    { id: 'send_pause', order: 2, condition: 'always', name: '发送/暂停', tooltip: '发送消息或暂停生成', visible: true }
+  ]
+
+  // 生成左侧图标
+  const leftIcons = leftIconsConfig.map((config) => ({
+    id: config.id as InputBoxIconType,
+    name: config.name || ICON_CONFIGS[config.id]?.name || config.id,
+    icon: specialIcons[config.id as keyof typeof specialIcons] || createIcon(config.id),
+    tooltip: config.tooltip || ICON_CONFIGS[config.id]?.tooltip || config.id,
+    position: 'left' as const,
+    visible: config.visible,
+    order: config.order,
+    component: `${config.id}Component`,
+    condition: config.condition
+  }))
+
+  // 生成右侧图标
+  const rightIcons = rightIconsConfig.map((config) => ({
+    id: config.id as InputBoxIconType,
+    name: config.name || ICON_CONFIGS[config.id]?.name || config.id,
+    icon: specialIcons[config.id as keyof typeof specialIcons] || createIcon(config.id),
+    tooltip: config.tooltip || ICON_CONFIGS[config.id]?.tooltip || config.id,
+    position: 'right' as const,
+    visible: config.visible,
+    order: config.order,
+    component: `${config.id}Component`,
+    condition: config.condition
+  }))
+
+  return [...leftIcons, ...rightIcons]
+}
+
+// 根据条件过滤可见的图标
+export function getVisibleInputBoxIcons(
+  icons: InputBoxIconInfo[],
+  conditions: Record<string, boolean> = {}
+): InputBoxIconInfo[] {
+  return icons.filter((icon) => {
+    if (!icon.visible) return false
+
+    // 检查显示条件
+    switch (icon.condition) {
+      case 'always':
+        return true
+      case 'showThinkingButton':
+        return conditions.showThinkingButton ?? true
+      case 'showKnowledgeIcon':
+        return conditions.showKnowledgeIcon ?? true
+      case 'activedMcpServers.length > 0':
+        return conditions.hasMcpServers ?? false
+      case 'isGenerateImageModel(model)':
+        return conditions.isGenerateImageModel ?? false
+      case 'showInputEstimatedTokens':
+        return conditions.showInputEstimatedTokens ?? false
+      default:
+        return true
+    }
+  })
+}
+
+// 按位置和顺序排序图标
+export function sortIconsByPosition(icons: InputBoxIconInfo[]): {
+  leftIcons: InputBoxIconInfo[]
+  rightIcons: InputBoxIconInfo[]
+} {
+  const leftIcons = icons.filter((icon) => icon.position === 'left').sort((a, b) => a.order - b.order)
+
+  const rightIcons = icons.filter((icon) => icon.position === 'right').sort((a, b) => a.order - b.order)
+
+  return { leftIcons, rightIcons }
+}

--- a/src/renderer/src/store/settings.ts
+++ b/src/renderer/src/store/settings.ts
@@ -118,6 +118,11 @@ export interface SettingsState {
     visible: SidebarIcon[]
     disabled: SidebarIcon[]
   }
+  inputBoxIconsConfig: Record<string, {
+    visible: boolean
+    position: 'left' | 'right'
+    order: number
+  }>
   narrowMode: boolean
   // QuickAssistant
   enableQuickAssistant: boolean
@@ -264,6 +269,7 @@ export const initialState: SettingsState = {
     visible: DEFAULT_SIDEBAR_ICONS,
     disabled: []
   },
+  inputBoxIconsConfig: {},
   narrowMode: false,
   enableQuickAssistant: false,
   clickTrayToShowQuickAssistant: false,
@@ -556,6 +562,9 @@ const settingsSlice = createSlice({
         state.sidebarIcons.disabled = action.payload.disabled
       }
     },
+    setInputBoxIconsConfig: (state, action: PayloadAction<Record<string, { visible: boolean; position: 'left' | 'right'; order: number }>>) => {
+      state.inputBoxIconsConfig = action.payload
+    },
     setNarrowMode: (state, action: PayloadAction<boolean>) => {
       state.narrowMode = action.payload
     },
@@ -743,6 +752,7 @@ export const {
   setCustomCss,
   setTopicNamingPrompt,
   setSidebarIcons,
+  setInputBoxIconsConfig,
   setNarrowMode,
   setClickTrayToShowQuickAssistant,
   setEnableQuickAssistant,


### PR DESCRIPTION
feat: 添加自定义输入框图标配置功能

- 在显示设置中添加输入框图标自定义功能
- 支持拖拽重新排序输入框图标
- 支持切换单个图标的显示/隐藏
- 支持设置图标在左侧或右侧显示
- 添加输入框配置的实时预览
- 动态应用用户配置到实际输入框
- 添加 5 种语言翻译 (zh-cn, zh-tw, en-us, ja-jp, ru-ru)
- 导出 ToolbarButton 组件以供复用

新增文件:
- InputBoxIconsManager.tsx: 拖拽图标管理组件
- InputBoxPreview.tsx: 实时预览组件
- inputBoxIconsUtils.ts: 图标工具函数和类型定义

修改文件:
- Inputbar.tsx: 应用动态图标配置
- DisplaySettings.tsx: 添加输入框图标设置区域
- settings.ts: 添加 inputBoxIconsConfig 状态
- i18n 语言文件: 添加新功能的翻译

### 此 PR 的作用

**修改前:**
- 输入框图标布局固定，用户无法自定义
- 所有图标都强制显示，无法隐藏不需要的功能
- 图标顺序固定，无法调整

**修改后:**
- 用户可以自由拖拽调整输入框图标顺序
- 支持隐藏/显示任意图标（发送按钮除外）
- 支持设置图标显示在左侧或右侧
- 提供实时预览，所见即所得
- 配置立即生效，无需重启应用

### 为什么需要这个功能以及实现方式

**需求背景:**
- 用户对输入框的个性化需求不同
- 有些用户不需要某些功能图标，希望能隐藏
- 用户希望能按照自己的使用习惯调整图标顺序
- 提升用户体验和界面整洁度

**技术选择:**
- 使用 `@hello-pangea/dnd` 实现拖拽功能，提供流畅的交互体验
- 采用 Redux 状态管理，确保配置的持久化和全局同步
- 组件化设计，便于维护和扩展
- 动态渲染机制，避免硬编码的图标布局

### 破坏性变更

无破坏性变更。此功能为新增功能，不影响现有用户的使用体验。

### 审查要点

- 请重点关注拖拽交互的流畅性
- 检查实时预览与实际效果的一致性
- 验证多语言翻译的准确性
- 确认配置的持久化是否正常工作

