### PR TITLE
feat: enhance unresponsive renderer handling and crash reporting

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,7 +2,7 @@ import '@main/config'
 
 import { electronApp, optimizer } from '@electron-toolkit/utils'
 import { replaceDevtoolsFont } from '@main/utils/windowUtil'
-import { app, session } from 'electron'
+import { app } from 'electron'
 import installExtension, { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS } from 'electron-devtools-installer'
 import Logger from 'electron-log'
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -34,6 +34,16 @@ if (isWin) {
   app.commandLine.appendSwitch('wm-window-animations-disabled')
 }
 
+// Enable features for unresponsive renderer js call stacks
+app.commandLine.appendSwitch('enable-features', 'DocumentPolicyIncludeJSCallStacksInCrashReports')
+app.on('web-contents-created', (_, webContents) => {
+  webContents.on('unresponsive', async () => {
+    // Interrupt execution and collect call stack from unresponsive renderer
+    const callStack = await webContents.mainFrame.collectJavaScriptCallStack()
+    Logger.error('Renderer unresponsive\n', callStack)
+  })
+})
+
 // in production mode, handle uncaught exception and unhandled rejection globally
 if (!isDev) {
   // handle uncaught exception

--- a/src/main/services/WindowService.ts
+++ b/src/main/services/WindowService.ts
@@ -116,12 +116,6 @@ export class WindowService {
         app.exit(1)
       }
     })
-
-    mainWindow.webContents.on('unresponsive', () => {
-      // 在升级到electron 34后，可以获取具体js stack trace,目前只打个日志监控下
-      // https://www.electronjs.org/blog/electron-34-0#unresponsive-renderer-javascript-call-stacks
-      Logger.error('Renderer process unresponsive')
-    })
   }
 
   private setupMaximize(mainWindow: BrowserWindow, isMaximized: boolean) {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -6,7 +6,6 @@
   <meta name="viewport" content="initial-scale=1, width=device-width" />
   <meta http-equiv="Content-Security-Policy"
     content="default-src 'self'; connect-src blob: *; script-src 'self' 'unsafe-eval' 'unsafe-inline' *; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' *; font-src 'self' data: *; img-src 'self' data: file: * blob:; frame-src * file:" />
-  <meta http-equiv="Document-Policy" content="include-js-call-stacks-in-crash-reports" />
   <title>Cherry Studio</title>
 
   <style>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="initial-scale=1, width=device-width" />
   <meta http-equiv="Content-Security-Policy"
     content="default-src 'self'; connect-src blob: *; script-src 'self' 'unsafe-eval' 'unsafe-inline' *; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' *; font-src 'self' data: *; img-src 'self' data: file: * blob:; frame-src * file:" />
+  <meta http-equiv="Document-Policy" content="include-js-call-stacks-in-crash-reports" />
   <title>Cherry Studio</title>
 
   <style>


### PR DESCRIPTION
* Added support for collecting JavaScript call stacks from unresponsive renderers.
* Updated the Document Policy in the HTML to include JS call stacks in crash reports.
* Removed legacy unresponsive logging from WindowService.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
窗口unresponsive的时候没有办法知道是哪些代码导致的\
参考：
https://github.com/electron/electron/issues/45356
https://www.electronjs.org/blog/electron-34-0#unresponsive-renderer-javascript-call-stacks%20Logger.error('Renderer%20process%20unresponsive'


After this PR:
窗口unresponsive的时候记录下具体的js stack，方便查询问题。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
