### PR TITLE
revert: bubble style tokens break overflow

### DIFF
--- a/src/renderer/src/assets/styles/container.scss
+++ b/src/renderer/src/assets/styles/container.scss
@@ -4,3 +4,13 @@
   border-top-left-radius: 10px;
   border-left: 0.5px solid var(--color-border);
 }
+
+.group-container {
+  .context-menu-container {
+    width: 100%;
+  }
+}
+
+.context-menu-container {
+  max-width: 100%;
+}


### PR DESCRIPTION
#7026 删除的样式破坏了横向溢出行为：
- 长代码块 unwrap
- 横向排列多模型中一些块的横向溢出

@Pleasurecruise @EurFelux 