### PR TITLE
fix(MermaidPreview): re-render mermaid on display change

### DIFF
--- a/src/renderer/src/components/__tests__/MermaidPreview.test.tsx
+++ b/src/renderer/src/components/__tests__/MermaidPreview.test.tsx
@@ -1,0 +1,221 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { act } from 'react'
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
+
+import MermaidPreview from '../CodeBlockView/MermaidPreview'
+
+const mocks = vi.hoisted(() => ({
+  useMermaid: vi.fn(),
+  usePreviewToolHandlers: vi.fn(),
+  usePreviewTools: vi.fn()
+}))
+
+// Mock hooks
+vi.mock('@renderer/hooks/useMermaid', () => ({
+  useMermaid: () => mocks.useMermaid()
+}))
+
+vi.mock('@renderer/components/CodeToolbar', () => ({
+  usePreviewToolHandlers: () => mocks.usePreviewToolHandlers(),
+  usePreviewTools: () => mocks.usePreviewTools()
+}))
+
+// Mock nanoid
+vi.mock('@reduxjs/toolkit', () => ({
+  nanoid: () => 'test-id-123456'
+}))
+
+// Mock lodash debounce
+vi.mock('lodash', async () => {
+  const actual = await import('lodash')
+  return {
+    ...actual,
+    debounce: vi.fn((fn) => {
+      const debounced = (...args: any[]) => fn(...args)
+      debounced.cancel = vi.fn()
+      return debounced
+    })
+  }
+})
+
+// Mock antd components
+vi.mock('antd', () => ({
+  Flex: ({ children, vertical, ...props }: any) => (
+    <div data-testid="flex" data-vertical={vertical} {...props}>
+      {children}
+    </div>
+  ),
+  Spin: ({ children, spinning, indicator }: any) => (
+    <div data-testid="spin" data-spinning={spinning}>
+      {spinning && indicator}
+      {children}
+    </div>
+  )
+}))
+
+describe('MermaidPreview', () => {
+  const mockMermaid = {
+    parse: vi.fn(),
+    render: vi.fn()
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mocks.useMermaid.mockReturnValue({
+      mermaid: mockMermaid,
+      isLoading: false,
+      error: null
+    })
+
+    mocks.usePreviewToolHandlers.mockReturnValue({
+      handleZoom: vi.fn(),
+      handleCopyImage: vi.fn(),
+      handleDownload: vi.fn()
+    })
+
+    mocks.usePreviewTools.mockReturnValue({})
+
+    mockMermaid.parse.mockResolvedValue(true)
+    mockMermaid.render.mockResolvedValue({
+      svg: '<svg class="flowchart" viewBox="0 0 100 100"><g>test diagram</g></svg>'
+    })
+
+    // Mock MutationObserver
+    global.MutationObserver = vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      disconnect: vi.fn(),
+      takeRecords: vi.fn()
+    }))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('visibility detection', () => {
+    it('should not render mermaid when element has display: none', async () => {
+      const mermaidCode = 'graph TD\nA-->B'
+
+      const { container } = render(<MermaidPreview>{mermaidCode}</MermaidPreview>)
+
+      // Mock offsetParent to be null (simulating display: none)
+      const mermaidElement = container.querySelector('.mermaid')
+      if (mermaidElement) {
+        Object.defineProperty(mermaidElement, 'offsetParent', {
+          get: () => null,
+          configurable: true
+        })
+      }
+
+      // Re-render to trigger the effect
+      render(<MermaidPreview>{mermaidCode}</MermaidPreview>)
+
+      // Should not call mermaid render when offsetParent is null
+      expect(mockMermaid.render).not.toHaveBeenCalled()
+
+      const svgElement = mermaidElement?.querySelector('svg.flowchart')
+      expect(svgElement).not.toBeInTheDocument()
+    })
+
+    it('should setup MutationObserver to monitor parent elements', () => {
+      const mermaidCode = 'graph TD\nA-->B'
+
+      render(<MermaidPreview>{mermaidCode}</MermaidPreview>)
+
+      expect(global.MutationObserver).toHaveBeenCalledWith(expect.any(Function))
+    })
+
+    it('should observe parent elements up to fold className', () => {
+      const mermaidCode = 'graph TD\nA-->B'
+
+      // Create a DOM structure that simulates MessageGroup fold layout
+      const foldContainer = document.createElement('div')
+      foldContainer.className = 'fold selected'
+
+      const messageWrapper = document.createElement('div')
+      messageWrapper.className = 'message-wrapper'
+
+      const codeBlock = document.createElement('div')
+      codeBlock.className = 'code-block'
+
+      foldContainer.appendChild(messageWrapper)
+      messageWrapper.appendChild(codeBlock)
+      document.body.appendChild(foldContainer)
+
+      render(<MermaidPreview>{mermaidCode}</MermaidPreview>, {
+        container: codeBlock
+      })
+
+      const observerInstance = (global.MutationObserver as Mock).mock.results[0]?.value
+      expect(observerInstance.observe).toHaveBeenCalled()
+
+      // Cleanup
+      document.body.removeChild(foldContainer)
+    })
+
+    it('should trigger re-render when visibility changes from hidden to visible', async () => {
+      const mermaidCode = 'graph TD\nA-->B'
+
+      const { container, rerender } = render(<MermaidPreview>{mermaidCode}</MermaidPreview>)
+
+      const mermaidElement = container.querySelector('.mermaid')
+
+      // Initially hidden (offsetParent is null)
+      Object.defineProperty(mermaidElement, 'offsetParent', {
+        get: () => null,
+        configurable: true
+      })
+
+      // Clear previous calls
+      mockMermaid.render.mockClear()
+
+      // Re-render with hidden state
+      rerender(<MermaidPreview>{mermaidCode}</MermaidPreview>)
+
+      // Should not render when hidden
+      expect(mockMermaid.render).not.toHaveBeenCalled()
+
+      // Now make it visible
+      Object.defineProperty(mermaidElement, 'offsetParent', {
+        get: () => document.body,
+        configurable: true
+      })
+
+      // Simulate MutationObserver callback
+      const observerCallback = (global.MutationObserver as Mock).mock.calls[0][0]
+      act(() => {
+        observerCallback([])
+      })
+
+      // Re-render to trigger visibility change effect
+      rerender(<MermaidPreview>{mermaidCode}</MermaidPreview>)
+
+      await waitFor(() => {
+        expect(mockMermaid.render).toHaveBeenCalledWith('mermaid-test-id-123456', mermaidCode, expect.any(Object))
+
+        const svgElement = mermaidElement?.querySelector('svg.flowchart')
+        expect(svgElement).toBeInTheDocument()
+        expect(svgElement).toHaveClass('flowchart')
+      })
+    })
+
+    it('should handle mermaid loading state', () => {
+      mocks.useMermaid.mockReturnValue({
+        mermaid: mockMermaid,
+        isLoading: true,
+        error: null
+      })
+
+      const mermaidCode = 'graph TD\nA-->B'
+
+      render(<MermaidPreview>{mermaidCode}</MermaidPreview>)
+
+      // Should not render when mermaid is loading
+      expect(mockMermaid.render).not.toHaveBeenCalled()
+
+      // Should show loading state
+      expect(screen.getByTestId('spin')).toHaveAttribute('data-spinning', 'true')
+    })
+  })
+})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

修复多模型标签样式中被隐藏的 mermaid 无法正确渲染的问题。

Before this PR:

多模型回答中，非当前消息会有 `display: none`，导致 mermaid 无法正确渲染。
这是 mermaid-js 一直就有的问题：https://github.com/mermaid-js/mermaid/issues/1846

After this PR:

在 `display` 变化时触发重新渲染。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #7012

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
