### PR TITLE
fix(SelectionAssistant): shortcut in mac and running handling

### DIFF
--- a/src/main/services/SelectionService.ts
+++ b/src/main/services/SelectionService.ts
@@ -591,7 +591,7 @@ export class SelectionService {
    * it's a public method used by shortcut service
    */
   public processSelectTextByShortcut(): void {
-    if (!this.selectionHook || this.triggerMode !== TriggerMode.Shortcut) return
+    if (!this.selectionHook || !this.started || this.triggerMode !== TriggerMode.Shortcut) return
 
     const selectionData = this.selectionHook.getCurrentSelection()
 
@@ -1189,7 +1189,8 @@ export class SelectionService {
   }
 
   public writeToClipboard(text: string): boolean {
-    return this.selectionHook?.writeToClipboard(text) ?? false
+    if (!this.selectionHook || !this.started) return false
+    return this.selectionHook.writeToClipboard(text)
   }
 
   /**

--- a/src/renderer/src/pages/settings/ShortcutSettings.tsx
+++ b/src/renderer/src/pages/settings/ShortcutSettings.tsx
@@ -22,11 +22,12 @@ const ShortcutSettings: FC = () => {
   const inputRefs = useRef<Record<string, InputRef>>({})
   const [editingKey, setEditingKey] = useState<string | null>(null)
 
-  //TODO: if shortcut is not available on all the platforms, block the shortcut here
+  //if shortcut is not available on all the platforms, block the shortcut here
   let shortcuts = originalShortcuts
   if (!isWindows) {
     //Selection Assistant only available on Windows now
-    shortcuts = shortcuts.filter((s) => s.key !== 'selection_assistant_toggle')
+    const excludedShortcuts = ['selection_assistant_toggle', 'selection_assistant_select_text']
+    shortcuts = shortcuts.filter((s) => !excludedShortcuts.includes(s.key))
   }
 
   const handleClear = (record: Shortcut) => {


### PR DESCRIPTION
- fix mac下显示了划词助手快捷键的问题
- fix 快捷键下selection-hook是否运行的判断