### PR TITLE
feat: Support reasoning control for Doubao models.

### DIFF
--- a/src/renderer/src/config/models.ts
+++ b/src/renderer/src/config/models.ts
@@ -2287,7 +2287,8 @@ export function isSupportedThinkingTokenModel(model?: Model): boolean {
   return (
     isSupportedThinkingTokenGeminiModel(model) ||
     isSupportedThinkingTokenQwenModel(model) ||
-    isSupportedThinkingTokenClaudeModel(model)
+    isSupportedThinkingTokenClaudeModel(model) ||
+    isSupportedThinkingTokenDoubaoModel(model)
   )
 }
 
@@ -2367,6 +2368,16 @@ export function isSupportedThinkingTokenQwenModel(model?: Model): boolean {
       'qwen-turbo-2025-04-28'
     ].includes(model.id.toLowerCase())
   )
+}
+
+export function isSupportedThinkingTokenDoubaoModel(model?: Model): boolean {
+  if (!model) {
+    return false
+  }
+  if (model.id.includes('doubao-seed-1.6')) {
+    return true
+  }
+  return model.name.toLowerCase().includes('doubao') && (model.type?.includes('reasoning') ?? false)
 }
 
 export function isClaudeReasoningModel(model?: Model): boolean {

--- a/src/renderer/src/pages/home/Inputbar/ThinkingButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/ThinkingButton.tsx
@@ -9,7 +9,8 @@ import { useQuickPanel } from '@renderer/components/QuickPanel'
 import {
   isSupportedReasoningEffortGrokModel,
   isSupportedThinkingTokenGeminiModel,
-  isSupportedThinkingTokenQwenModel
+  isSupportedThinkingTokenQwenModel,
+  isSupportedThinkingTokenDoubaoModel
 } from '@renderer/config/models'
 import { useAssistant } from '@renderer/hooks/useAssistant'
 import { Assistant, Model, ReasoningEffortOptions } from '@renderer/types'
@@ -35,7 +36,8 @@ const MODEL_SUPPORTED_OPTIONS: Record<string, ThinkingOption[]> = {
   default: ['off', 'low', 'medium', 'high'],
   grok: ['off', 'low', 'high'],
   gemini: ['off', 'low', 'medium', 'high', 'auto'],
-  qwen: ['off', 'low', 'medium', 'high']
+  qwen: ['off', 'low', 'medium', 'high'],
+  doubao: ['off', 'auto', 'high']
 }
 
 // 选项转换映射表：当选项不支持时使用的替代选项
@@ -55,6 +57,7 @@ const ThinkingButton: FC<Props> = ({ ref, model, assistant, ToolbarButton }): Re
   const isGrokModel = isSupportedReasoningEffortGrokModel(model)
   const isGeminiModel = isSupportedThinkingTokenGeminiModel(model)
   const isQwenModel = isSupportedThinkingTokenQwenModel(model)
+  const isDoubaoModel = isSupportedThinkingTokenDoubaoModel(model)
 
   const currentReasoningEffort = useMemo(() => {
     return assistant.settings?.reasoning_effort || 'off'
@@ -65,6 +68,7 @@ const ThinkingButton: FC<Props> = ({ ref, model, assistant, ToolbarButton }): Re
     if (isGeminiModel) return 'gemini'
     if (isGrokModel) return 'grok'
     if (isQwenModel) return 'qwen'
+    if (isDoubaoModel) return 'doubao'
     return 'default'
   }, [isGeminiModel, isGrokModel, isQwenModel])
 

--- a/src/renderer/src/providers/AiProvider/OpenAIProvider.ts
+++ b/src/renderer/src/providers/AiProvider/OpenAIProvider.ts
@@ -14,6 +14,7 @@ import {
   isSupportedThinkingTokenGeminiModel,
   isSupportedThinkingTokenModel,
   isSupportedThinkingTokenQwenModel,
+  isSupportedThinkingTokenDoubaoModel,
   isVisionModel,
   isWebSearchModel,
   isZhipuModel
@@ -272,6 +273,10 @@ export default class OpenAIProvider extends BaseOpenAIProvider {
         }
       }
 
+      if (isSupportedThinkingTokenDoubaoModel(model)) {
+        return { thinking: { type: 'disabled' } }
+      }
+
       return {}
     }
     const effortRatio = EFFORT_RATIO[reasoningEffort]
@@ -321,6 +326,33 @@ export default class OpenAIProvider extends BaseOpenAIProvider {
           budget_tokens: Math.floor(
             Math.max(1024, Math.min(budgetTokens, (maxTokens || DEFAULT_MAX_TOKENS) * effortRatio))
           )
+        }
+      }
+    }
+
+    // Gemini models
+    if (isSupportedThinkingTokenGeminiModel(model)) {
+      if (effortRatio > 1) {
+        return {}
+      }
+
+      const { max } = findTokenLimit(model.id) || { max: 0 }
+
+      return {
+        thinkingConfig: {
+          thinkingBudget: Math.floor(max * effortRatio),
+          includeThoughts: true
+        }
+      }
+    }
+
+    // Doubao models
+    if (isSupportedThinkingTokenDoubaoModel(model)) {
+      if (assistant.settings?.reasoning_effort === 'high') {
+        return {
+          thinking: {
+            type: 'enabled',
+          }
         }
       }
     }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:（不支持字节跳动豆包系列新模型的推理控制）

After this PR: 将 Reasoning Effort 的开关拓展到豆包系列模型。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->


### Why we need it and why it was done in this way

The following tradeoffs were made:

 - 理论上讲 reasoning_effort 应该是控制 budget 和 CoT 长度的一种手段，但是对于 Doubao 1.6，我们只有控制 all or nothing 的手段。
 - 字节火山平台需要自定义接入点，以至于很多情况下**没法通过 model ID 来判断是否属于豆包系列模型**（火山平台的 DeepSeek 用的人也挺多的）。无奈之下只能先通过 `model.name` + 手动勾选模型推理能力的方式来判断。不知各位佬是否有更好的主意。

Links to places where the discussion took place: #7079



### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

