### PR TITLE
feat:  clean up Windows license files

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -18,7 +18,6 @@ export default defineConfig({
       }
     },
     build: {
-      minify: true,
       rollupOptions: {
         external: ['@libsql/client', 'bufferutil', 'utf-8-validate']
       },
@@ -36,7 +35,6 @@ export default defineConfig({
       }
     },
     build: {
-      minify: true,
       sourcemap: process.env.NODE_ENV === 'development'
     }
   },
@@ -70,7 +68,6 @@ export default defineConfig({
       format: 'es'
     },
     build: {
-      minify: true,
       rollupOptions: {
         input: {
           index: resolve(__dirname, 'src/renderer/index.html'),

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       }
     },
     build: {
+      minify: true,
       rollupOptions: {
         external: ['@libsql/client', 'bufferutil', 'utf-8-validate']
       },
@@ -35,6 +36,7 @@ export default defineConfig({
       }
     },
     build: {
+      minify: true,
       sourcemap: process.env.NODE_ENV === 'development'
     }
   },
@@ -68,6 +70,7 @@ export default defineConfig({
       format: 'es'
     },
     build: {
+      minify: true,
       rollupOptions: {
         input: {
           index: resolve(__dirname, 'src/renderer/index.html'),

--- a/scripts/after-pack.js
+++ b/scripts/after-pack.js
@@ -36,6 +36,11 @@ exports.default = async function (context) {
       keepPackageNodeFiles(node_modules_path, '@libsql', ['win32-x64-msvc'])
     }
   }
+
+  if (platform === 'windows') {
+    fs.rmSync(path.join(context.appOutDir, 'LICENSE.electron.txt'), { force: true })
+    fs.rmSync(path.join(context.appOutDir, 'LICENSES.chromium.html'), { force: true })
+  }
 }
 
 /**


### PR DESCRIPTION


- Added minification option to the build configurations in electron.vite.config.ts to optimize output size.
- Updated after-pack.js to remove unnecessary license files on Windows, improving the packaging process.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
代码没有最小化，会占用一些app size，最小化后加载代码的速度也会变快一点点。

chrome license非常大，在mac上面是默认不包含的。

After this PR:
开启最小化，并且在windows上面删除掉chrome license文件。
![image](https://github.com/user-attachments/assets/306e2532-948c-4afb-8e9c-0ecffbcf52e2)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
