### PR TITLE
refactor(ImageBlock): enhance loading state presentation and improve …

### DIFF
--- a/src/renderer/src/pages/home/Messages/Blocks/ImageBlock.tsx
+++ b/src/renderer/src/pages/home/Messages/Blocks/ImageBlock.tsx
@@ -10,7 +10,11 @@ interface Props {
 
 const ImageBlock: React.FC<Props> = ({ block }) => {
   if (block.status === MessageBlockStatus.STREAMING || block.status === MessageBlockStatus.PROCESSING)
-    return <SvgSpinners180Ring />
+    return (
+      <SpinnerWrapper>
+        <SvgSpinners180Ring />
+      </SpinnerWrapper>
+    )
   if (block.status === MessageBlockStatus.SUCCESS) {
     const images = block.metadata?.generateImageResponse?.images?.length
       ? block.metadata?.generateImageResponse?.images
@@ -37,6 +41,12 @@ const Container = styled.div`
   flex-direction: row;
   gap: 10px;
   margin-top: 8px;
+`
+
+const SpinnerWrapper = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
 `
 
 export default React.memo(ImageBlock)

--- a/src/renderer/src/pages/home/Messages/Blocks/ImageBlock.tsx
+++ b/src/renderer/src/pages/home/Messages/Blocks/ImageBlock.tsx
@@ -1,6 +1,6 @@
-import SvgSpinners180Ring from '@renderer/components/Icons/SvgSpinners180Ring'
 import ImageViewer from '@renderer/components/ImageViewer'
 import { type ImageMessageBlock, MessageBlockStatus } from '@renderer/types/newMessage'
+import { Skeleton } from 'antd'
 import React from 'react'
 import styled from 'styled-components'
 
@@ -10,11 +10,7 @@ interface Props {
 
 const ImageBlock: React.FC<Props> = ({ block }) => {
   if (block.status === MessageBlockStatus.STREAMING || block.status === MessageBlockStatus.PROCESSING)
-    return (
-      <SpinnerWrapper>
-        <SvgSpinners180Ring />
-      </SpinnerWrapper>
-    )
+    return <Skeleton.Image active style={{ width: 200, height: 200 }} />
   if (block.status === MessageBlockStatus.SUCCESS) {
     const images = block.metadata?.generateImageResponse?.images?.length
       ? block.metadata?.generateImageResponse?.images
@@ -32,9 +28,7 @@ const ImageBlock: React.FC<Props> = ({ block }) => {
         ))}
       </Container>
     )
-  } else {
-    return <></>
-  }
+  } else return null
 }
 const Container = styled.div`
   display: flex;
@@ -42,11 +36,4 @@ const Container = styled.div`
   gap: 10px;
   margin-top: 8px;
 `
-
-const SpinnerWrapper = styled.div`
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-`
-
 export default React.memo(ImageBlock)

--- a/src/renderer/src/pages/home/Messages/Blocks/index.tsx
+++ b/src/renderer/src/pages/home/Messages/Blocks/index.tsx
@@ -164,15 +164,14 @@ export default React.memo(MessageBlockRenderer)
 
 const ImageBlockGroup = styled.div`
   display: grid;
-  grid-template-columns: repeat(3, minmax(200px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 8px;
-  width: 100%;
   max-width: 960px;
   > * {
     min-width: 200px;
   }
   @media (min-width: 1536px) {
-    grid-template-columns: repeat(4, minmax(250px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     max-width: 1280px;
     > * {
       min-width: 250px;

--- a/src/renderer/src/pages/home/Messages/Blocks/index.tsx
+++ b/src/renderer/src/pages/home/Messages/Blocks/index.tsx
@@ -167,9 +167,9 @@ const ImageBlockGroup = styled.div`
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 8px;
   max-width: 960px;
-  > * {
+  /* > * {
     min-width: 200px;
-  }
+  } */
   @media (min-width: 1536px) {
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     max-width: 1280px;


### PR DESCRIPTION
…layout responsiveness

- Wrapped the loading spinner in a new SpinnerWrapper for better alignment and presentation during streaming and processing states.
- Updated the ImageBlockGroup to use `repeat(auto-fit, minmax(...))` for more flexible grid layout, improving responsiveness across different screen sizes.

These changes enhance the user experience by providing a clearer loading indication and a more adaptable layout for image blocks.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
<img width="1512" alt="bbae4e6bdf94cb8e4bda3d0b74bc7d5a" src="https://github.com/user-attachments/assets/4bb3a3ba-dd91-440c-b68d-3d77b5580a6e" />

After this PR:
![image](https://github.com/user-attachments/assets/8b80f1f5-48d1-4995-b960-550e1dea48e6)
![image](https://github.com/user-attachments/assets/2951de5f-89b2-4cc4-a51b-f37989557666)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
