### PR TITLE
feat: add prompt variables docs on topic naming modal popup

### DIFF
--- a/src/renderer/src/pages/settings/ModelSettings/TopicNamingModalPopup.tsx
+++ b/src/renderer/src/pages/settings/ModelSettings/TopicNamingModalPopup.tsx
@@ -1,8 +1,9 @@
+import { QuestionCircleOutlined } from '@ant-design/icons'
 import { HStack } from '@renderer/components/Layout'
 import { useSettings } from '@renderer/hooks/useSettings'
 import { useAppDispatch } from '@renderer/store'
 import { setEnableTopicNaming, setTopicNamingPrompt } from '@renderer/store/settings'
-import { Button, Divider, Input, Modal, Switch } from 'antd'
+import { Button, Divider, Flex, Input, Modal, Popover, Switch } from 'antd'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -36,6 +37,8 @@ const PopupContainer: React.FC<Props> = ({ resolve }) => {
 
   TopicNamingModalPopup.hide = onCancel
 
+  const promptVarsContent = <pre>{t('agents.add.prompt.variables.tip.content')}</pre>
+
   return (
     <Modal
       title={t('settings.models.topic_naming_model_setting_title')}
@@ -53,7 +56,12 @@ const PopupContainer: React.FC<Props> = ({ resolve }) => {
       </HStack>
       <Divider style={{ margin: '10px 0' }} />
       <div style={{ marginBottom: 20 }}>
-        <div style={{ marginBottom: 10 }}>{t('settings.models.topic_naming_prompt')}</div>
+        <Flex align="center" style={{ marginBottom: 10, gap: 5 }}>
+          <div>{t('settings.models.topic_naming_prompt')}</div>
+          <Popover title={t('agents.add.prompt.variables.tip.title')} content={promptVarsContent}>
+            <QuestionCircleOutlined size={14} style={{ color: 'var(--color-text-2)' }} />
+          </Popover>
+        </Flex>
         <Input.TextArea
           rows={4}
           value={topicNamingPrompt || t('prompts.title')}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

为话题命名提示词设置添加了提示词变量信息提示。

![image](https://github.com/user-attachments/assets/7d28761a-a7c7-4147-bd86-1e8b2f85c635)


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
