### PR TITLE
fix: Incorrect code file extension

### DIFF
--- a/src/renderer/src/components/CodeBlockView/index.tsx
+++ b/src/renderer/src/components/CodeBlockView/index.tsx
@@ -68,6 +68,31 @@ const CodeBlockView: React.FC<Props> = ({ children, language, onSave }) => {
   }, [children, t])
 
   const handleDownloadSource = useCallback(() => {
+    const languageToSuffix = (language: string) => {
+      switch (language) {
+        case 'python':
+          return 'py'
+        case 'rust':
+          return 'rs'
+        case 'ruby':
+          return 'rb'
+        case 'kotlin':
+          return 'kt'
+        case 'javascript':
+          return 'js'
+        case 'typescript':
+          return 'ts'
+        case 'bash':
+        case 'shell':
+          return 'sh'
+        case 'markdown':
+          return 'md'
+        case 'csharp':
+          return 'cs'
+        default:
+          return language
+      }
+    }
     let fileName = ''
 
     // 尝试提取标题
@@ -80,7 +105,7 @@ const CodeBlockView: React.FC<Props> = ({ children, language, onSave }) => {
 
     // 默认使用日期格式命名
     if (!fileName) {
-      fileName = `${dayjs().format('YYYYMMDDHHmm')}.${language}`
+      fileName = `${dayjs().format('YYYYMMDDHHmm')}.${languageToSuffix(language)}`
     }
 
     window.api.file.save(fileName, children)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

支持常见语言的正确文件后缀名

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #7176 

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
