### PR TITLE
fix: update app-builder-lib patch and adjust minimumSystemVersion handling

### DIFF
--- a/.yarn/patches/app-builder-lib-npm-26.0.15-360e5b0476.patch
+++ b/.yarn/patches/app-builder-lib-npm-26.0.15-360e5b0476.patch
@@ -1,18 +1,70 @@
-diff --git a/out/configuration.d.ts b/out/configuration.d.ts
-index 7ad2646c023e7980021a010fc505aad7d1b52831..60849d54420d2b42e1b0977a4143ca6f598abab1 100644
---- a/out/configuration.d.ts
-+++ b/out/configuration.d.ts
-@@ -173,6 +173,10 @@ export interface CommonConfiguration {
-      * [Experimental] Configuration for concurrent builds.
-      */
-     readonly concurrency?: Concurrency | null;
-+    /**
-+     * The modules to exclude from the rebuild.
-+     */
-+    readonly excludeReBuildModules?: Array<string> | null;
- }
- export interface Configuration extends CommonConfiguration, PlatformSpecificBuildOptions, Hooks {
-     /**
+diff --git a/out/macPackager.js b/out/macPackager.js
+index 852f6c4d16f86a7bb8a78bf1ed5a14647a279aa1..60e7f5f16a844541eb1909b215fcda1811e924b8 100644
+--- a/out/macPackager.js
++++ b/out/macPackager.js
+@@ -423,7 +423,7 @@ class MacPackager extends platformPackager_1.PlatformPackager {
+         }
+         appPlist.CFBundleName = appInfo.productName;
+         appPlist.CFBundleDisplayName = appInfo.productName;
+-        const minimumSystemVersion = this.platformSpecificBuildOptions.minimumSystemVersion;
++        const minimumSystemVersion = this.platformSpecificBuildOptions.LSMinimumSystemVersion;
+         if (minimumSystemVersion != null) {
+             appPlist.LSMinimumSystemVersion = minimumSystemVersion;
+         }
+diff --git a/out/publish/updateInfoBuilder.js b/out/publish/updateInfoBuilder.js
+index 7924c5b47d01f8dfccccb8f46658015fa66da1f7..1a1588923c3939ae1297b87931ba83f0ebc052d8 100644
+--- a/out/publish/updateInfoBuilder.js
++++ b/out/publish/updateInfoBuilder.js
+@@ -133,6 +133,7 @@ async function createUpdateInfo(version, event, releaseInfo) {
+     const customUpdateInfo = event.updateInfo;
+     const url = path.basename(event.file);
+     const sha512 = (customUpdateInfo == null ? null : customUpdateInfo.sha512) || (await (0, hash_1.hashFile)(event.file));
++    const minimumSystemVersion = customUpdateInfo == null ? null : customUpdateInfo.minimumSystemVersion;
+     const files = [{ url, sha512 }];
+     const result = {
+         // @ts-ignore
+@@ -143,9 +144,13 @@ async function createUpdateInfo(version, event, releaseInfo) {
+         path: url /* backward compatibility, electron-updater 1.x - electron-updater 2.15.0 */,
+         // @ts-ignore
+         sha512 /* backward compatibility, electron-updater 1.x - electron-updater 2.15.0 */,
++        minimumSystemVersion,
+         ...releaseInfo,
+     };
+     if (customUpdateInfo != null) {
++        if (customUpdateInfo.minimumSystemVersion) {
++            delete customUpdateInfo.minimumSystemVersion;
++        }
+         // file info or nsis web installer packages info
+         Object.assign("sha512" in customUpdateInfo ? files[0] : result, customUpdateInfo);
+     }
+diff --git a/out/targets/ArchiveTarget.js b/out/targets/ArchiveTarget.js
+index e1f52a5fa86fff6643b2e57eaf2af318d541f865..47cc347f154a24b365e70ae5e1f6d309f3582ed0 100644
+--- a/out/targets/ArchiveTarget.js
++++ b/out/targets/ArchiveTarget.js
+@@ -69,6 +69,9 @@ class ArchiveTarget extends core_1.Target {
+                     }
+                 }
+             }
++            if (updateInfo != null && this.packager.platformSpecificBuildOptions.minimumSystemVersion) {
++                updateInfo.minimumSystemVersion = this.packager.platformSpecificBuildOptions.minimumSystemVersion;
++            }
+             await packager.info.emitArtifactBuildCompleted({
+                 updateInfo,
+                 file: artifactPath,
+diff --git a/out/targets/nsis/NsisTarget.js b/out/targets/nsis/NsisTarget.js
+index e8bd7bb46c8a54b3f55cf3a853ef924195271e01..f956e9f3fe9eb903c78aef3502553b01de4b89b1 100644
+--- a/out/targets/nsis/NsisTarget.js
++++ b/out/targets/nsis/NsisTarget.js
+@@ -305,6 +305,9 @@ class NsisTarget extends core_1.Target {
+             if (updateInfo != null && isPerMachine && (oneClick || options.packElevateHelper)) {
+                 updateInfo.isAdminRightsRequired = true;
+             }
++            if (updateInfo != null && this.packager.platformSpecificBuildOptions.minimumSystemVersion) {
++                updateInfo.minimumSystemVersion = this.packager.platformSpecificBuildOptions.minimumSystemVersion;
++            }
+             await packager.info.emitArtifactBuildCompleted({
+                 file: installerPath,
+                 updateInfo,
 diff --git a/out/util/yarn.js b/out/util/yarn.js
 index 1ee20f8b252a8f28d0c7b103789cf0a9a427aec1..c2878ec54d57da50bf14225e0c70c9c88664eb8a 100644
 --- a/out/util/yarn.js
@@ -26,7 +78,7 @@ index 1ee20f8b252a8f28d0c7b103789cf0a9a427aec1..c2878ec54d57da50bf14225e0c70c9c8
          mode: config.nativeRebuilder || "sequential",
          disablePreGypCopy: true,
 diff --git a/scheme.json b/scheme.json
-index 433e2efc9cef156ff5444f0c4520362ed2ef9ea7..c8827e218f66c45bdaec86b898fb932b9b98764c 100644
+index 433e2efc9cef156ff5444f0c4520362ed2ef9ea7..0167441bf928a92f59b5dbe70b2317a74dda74c9 100644
 --- a/scheme.json
 +++ b/scheme.json
 @@ -1825,6 +1825,20 @@

--- a/yarn.lock
+++ b/yarn.lock
@@ -6036,7 +6036,7 @@ __metadata:
 
 "app-builder-lib@patch:app-builder-lib@npm%3A26.0.15#~/.yarn/patches/app-builder-lib-npm-26.0.15-360e5b0476.patch":
   version: 26.0.15
-  resolution: "app-builder-lib@patch:app-builder-lib@npm%3A26.0.15#~/.yarn/patches/app-builder-lib-npm-26.0.15-360e5b0476.patch::version=26.0.15&hash=1e6426"
+  resolution: "app-builder-lib@patch:app-builder-lib@npm%3A26.0.15#~/.yarn/patches/app-builder-lib-npm-26.0.15-360e5b0476.patch::version=26.0.15&hash=1f4887"
   dependencies:
     "@develar/schema-utils": "npm:~2.6.5"
     "@electron/asar": "npm:3.4.1"
@@ -6074,7 +6074,7 @@ __metadata:
   peerDependencies:
     dmg-builder: 26.0.15
     electron-builder-squirrel-windows: 26.0.15
-  checksum: 10c0/99dab1abe455f964152e5e37fceb08b389858ac5c8c0147887b73100f3bd9f9ebbf3760432b376983ce732e2c42dd866d27010809a3b658d9281501e0f82f343
+  checksum: 10c0/5de2bd593b21e464585ffa3424e053d41f8569b14ba2a00f29f84cb0b83347a7da3653587f9ef8b5d2f6d1e5bfc4081956b9d72f180d65960db49b5ac84b73d4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


- Updated the resolution and checksum for the app-builder-lib patch in yarn.lock.
- Modified macPackager.js and updateInfoBuilder.js to correctly reference LSMinimumSystemVersion.
- Enhanced ArchiveTarget.js and NsisTarget.js to include minimumSystemVersion in updateInfo if specified.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
macOS上面编译的版本运行不了。
After this PR:
macOS上面编译的版本可以正常运行。
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
