### PR TITLE
fix(ImageGenerationMiddleware): correctly process image URLs

### DIFF
--- a/src/renderer/src/aiCore/middleware/feat/ImageGenerationMiddleware.ts
+++ b/src/renderer/src/aiCore/middleware/feat/ImageGenerationMiddleware.ts
@@ -97,11 +97,21 @@ export const ImageGenerationMiddleware: CompletionsMiddleware =
             )
           }
 
-          const b64_json_array = response.data?.map((item) => `data:image/png;base64,${item.b64_json}`) || []
+          let imageType: 'url' | 'base64' = 'base64'
+          const imageList =
+            response.data?.reduce((acc: string[], image) => {
+              if (image.url) {
+                acc.push(image.url)
+                imageType = 'url'
+              } else if (image.b64_json) {
+                acc.push(`data:image/png;base64,${image.b64_json}`)
+              }
+              return acc
+            }, []) || []
 
           enqueue({
             type: ChunkType.IMAGE_COMPLETE,
-            image: { type: 'base64', images: b64_json_array }
+            image: { type: imageType, images: imageList }
           })
 
           const usage = (response as any).usage || { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 }

--- a/src/renderer/src/types/chunk.ts
+++ b/src/renderer/src/types/chunk.ts
@@ -137,7 +137,7 @@ export interface ImageCompleteChunk {
   /**
    * The image content of the chunk
    */
-  image?: { type: 'base64'; images: string[] }
+  image?: { type: 'url' | 'base64'; images: string[] }
 }
 
 export interface ThinkingDeltaChunk {


### PR DESCRIPTION
**Issue:**

The `ImageGenerationMiddleware` instructs models to return images in `b64_json` format. However, some providers do not honor this and respond with an image URL instead. The middleware fails to anticipate this, causing image rendering to fail.

**Example:**

When using the `gpt-image-1` model from [api.bltcy.ai](https://api.bltcy.ai/), which returns a URL, the middleware expects Base64 data. This mismatch results in a broken image, with the `<img>` tag's `src` attribute being set to `data:image/png;base64,undefined`.

**Fix:**

This PR updates the middleware to correctly handle both response formats.

**Future Consideration:**

An alternative solution would be to refactor `GenerateImageResponse`. Instead of defining a single data type for the entire list of images, it could be updated to hold a list of structures, each specifying its own type (e.g., `[{type: 'url', data: '...'}, {type: 'base64', data: '...'}]`).

