### PR TITLE
fix(model): qwen3 model detection

### DIFF
--- a/src/renderer/src/config/models.ts
+++ b/src/renderer/src/config/models.ts
@@ -145,6 +145,7 @@ import YoudaoLogo from '@renderer/assets/images/providers/netease-youdao.svg'
 import NomicLogo from '@renderer/assets/images/providers/nomic.png'
 import { getProviderByModel } from '@renderer/services/AssistantService'
 import { Model } from '@renderer/types'
+import { getBaseModelName } from '@renderer/utils'
 import OpenAI from 'openai'
 
 import { WEB_SEARCH_PROMPT_FOR_OPENROUTER } from './prompts'
@@ -2484,9 +2485,10 @@ export function isSupportedThinkingTokenQwenModel(model?: Model): boolean {
     return false
   }
 
+  const baseName = getBaseModelName(model.id, '/').toLowerCase()
+
   return (
-    model.id.toLowerCase().startsWith('qwen3') ||
-    model.id.toLowerCase().startsWith('qwen/qwen3') ||
+    baseName.startsWith('qwen3') ||
     [
       'qwen-plus-latest',
       'qwen-plus-0428',
@@ -2494,7 +2496,7 @@ export function isSupportedThinkingTokenQwenModel(model?: Model): boolean {
       'qwen-turbo-latest',
       'qwen-turbo-0428',
       'qwen-turbo-2025-04-28'
-    ].includes(model.id.toLowerCase())
+    ].includes(baseName)
   )
 }
 

--- a/src/renderer/src/utils/__tests__/naming.test.ts
+++ b/src/renderer/src/utils/__tests__/naming.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   firstLetter,
   generateColorFromChar,
+  getBaseModelName,
   getBriefInfo,
   getDefaultGroupName,
   getFirstCharacter,
@@ -154,6 +155,38 @@ describe('naming', () => {
         expect(getDefaultGroupName('o3', provider)).toBe('o3')
       })
       expect(getDefaultGroupName('o3', 'openai')).toBe('o3')
+    })
+  })
+
+  describe('getBaseModelName', () => {
+    it('should extract base model name with single delimiter', () => {
+      expect(getBaseModelName('DeepSeek/DeepSeek-R1')).toBe('DeepSeek-R1')
+      expect(getBaseModelName('openai/gpt-4.1')).toBe('gpt-4.1')
+      expect(getBaseModelName('anthropic/claude-3.5-sonnet')).toBe('claude-3.5-sonnet')
+    })
+
+    it('should extract base model name with multiple levels', () => {
+      expect(getBaseModelName('Pro/deepseek-ai/DeepSeek-R1')).toBe('DeepSeek-R1')
+      expect(getBaseModelName('org/team/group/model')).toBe('model')
+    })
+
+    it('should return original id if no delimiter found', () => {
+      expect(getBaseModelName('deepseek-r1')).toBe('deepseek-r1')
+      expect(getBaseModelName('deepseek-r1:free')).toBe('deepseek-r1:free')
+    })
+
+    it('should handle edge cases', () => {
+      // 验证空字符串的情况
+      expect(getBaseModelName('')).toBe('')
+      // 验证以分隔符结尾的字符串
+      expect(getBaseModelName('model/')).toBe('')
+      expect(getBaseModelName('model/name/')).toBe('')
+      // 验证以分隔符开头的字符串
+      expect(getBaseModelName('/model')).toBe('model')
+      expect(getBaseModelName('/path/to/model')).toBe('model')
+      // 验证连续分隔符的情况
+      expect(getBaseModelName('model//name')).toBe('name')
+      expect(getBaseModelName('model///name')).toBe('name')
     })
   })
 

--- a/src/renderer/src/utils/naming.ts
+++ b/src/renderer/src/utils/naming.ts
@@ -47,6 +47,20 @@ export const getDefaultGroupName = (id: string, provider?: string): string => {
 }
 
 /**
+ * 从模型 ID 中提取基础名称。
+ * 例如：
+ * - 'deepseek/deepseek-r1' => 'deepseek-r1'
+ * - 'deepseek-ai/deepseek/deepseek-r1' => 'deepseek-r1'
+ * @param {string} id 模型 ID
+ * @param {string} [delimiter='/'] 分隔符，默认为 '/'
+ * @returns {string} 基础名称
+ */
+export const getBaseModelName = (id: string, delimiter: string = '/'): string => {
+  const parts = id.split(delimiter)
+  return parts[parts.length - 1]
+}
+
+/**
  * 用于获取 avatar 名字的辅助函数，会取出字符串的第一个字符，支持表情符号。
  * @param {string} str 输入字符串
  * @returns {string} 第一个字符，或者返回空字符串


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

调整 qwen3 推理模型的识别。

Before this PR:

自定义前缀的 qwen3 模型无法自动识别，比如 `pro/qwen/qwen3`。

After this PR:

识别 qwen3 时只考虑最后一个 `/` 后面的内容。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
