### PR TITLE
fix: prevent update button from rendering when auto-check for updates…

### DIFF
--- a/src/renderer/src/pages/home/components/UpdateAppButton.tsx
+++ b/src/renderer/src/pages/home/components/UpdateAppButton.tsx
@@ -1,5 +1,6 @@
 import { SyncOutlined } from '@ant-design/icons'
 import { useRuntime } from '@renderer/hooks/useRuntime'
+import { useSettings } from '@renderer/hooks/useSettings'
 import { Button } from 'antd'
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -7,13 +8,14 @@ import styled from 'styled-components'
 
 const UpdateAppButton: FC = () => {
   const { update } = useRuntime()
+  const { autoCheckUpdate } = useSettings()
   const { t } = useTranslation()
 
   if (!update) {
     return null
   }
 
-  if (!update.downloaded) {
+  if (!update.downloaded || !autoCheckUpdate) {
     return null
   }
 


### PR DESCRIPTION
修复自动更新关闭情况下 navbar 依然显示 update available