### PR TITLE
fix: include image files in block retrieval for improved file handling

### DIFF
--- a/src/renderer/src/store/thunk/messageThunk.ts
+++ b/src/renderer/src/store/thunk/messageThunk.ts
@@ -196,7 +196,10 @@ export const cleanupMultipleBlocks = (dispatch: AppDispatch, blockIds: string[])
 
   const getBlocksFiles = async (blockIds: string[]) => {
     const blocks = await db.message_blocks.where('id').anyOf(blockIds).toArray()
-    const files = blocks.filter((block) => block.type === MessageBlockType.FILE).map((block) => block.file)
+    const files = blocks
+      .filter((block) => block.type === MessageBlockType.FILE || block.type === MessageBlockType.IMAGE)
+      .map((block) => block.file)
+      .filter((file): file is FileType => file !== undefined)
     return isEmpty(files) ? [] : files
   }
 


### PR DESCRIPTION
修复清空话题时 图片类型的文件为删除
Fix #7195 
关联comment https://github.com/CherryHQ/cherry-studio/pull/6872#issuecomment-2973527810