### PR TITLE
fix: enhance AppUpdater with IP country detection

### DIFF
--- a/src/main/services/AppUpdater.ts
+++ b/src/main/services/AppUpdater.ts
@@ -64,6 +64,29 @@ export default class AppUpdater {
     this.autoUpdater = autoUpdater
   }
 
+  private async _getIpCountry() {
+    try {
+      // add timeout using AbortController
+      const controller = new AbortController()
+      const timeoutId = setTimeout(() => controller.abort(), 5000)
+
+      const ipinfo = await fetch('https://ipinfo.io/json', {
+        signal: controller.signal,
+        headers: {
+          'User-Agent':
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
+        }
+      })
+
+      clearTimeout(timeoutId)
+      const data = await ipinfo.json()
+      return data.country || 'CN'
+    } catch (error) {
+      logger.error('Failed to get ipinfo:', error)
+      return 'CN'
+    }
+  }
+
   public setAutoUpdate(isActive: boolean) {
     autoUpdater.autoDownload = isActive
     autoUpdater.autoInstallOnAppQuit = isActive
@@ -80,6 +103,11 @@ export default class AppUpdater {
         currentVersion: app.getVersion(),
         updateInfo: null
       }
+    }
+
+    const ipCountry = await this._getIpCountry()
+    if (ipCountry !== 'CN') {
+      this.autoUpdater.setFeedURL(FeedUrl.EARLY_ACCESS)
     }
 
     try {


### PR DESCRIPTION

- Added a new private method `_getIpCountry` in AppUpdater to fetch the user's IP country with a timeout mechanism.
- Updated the `setAutoUpdate` method to adjust the feed URL based on the detected country, improving update handling for users outside of China.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
