### PR TITLE
fix: unified the behavior of SendMessage shortcut

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -183,7 +183,7 @@
       "input.new.context": "Clear Context {{Command}}",
       "input.new_topic": "New Topic {{Command}}",
       "input.pause": "Pause",
-      "input.placeholder": "Type your message here...",
+      "input.placeholder": "Type your message here, press {{key}} to send...",
       "input.send": "Send",
       "input.settings": "Settings",
       "input.topics": " Topics ",

--- a/src/renderer/src/i18n/locales/ja-jp.json
+++ b/src/renderer/src/i18n/locales/ja-jp.json
@@ -183,7 +183,7 @@
       "input.new.context": "コンテキストをクリア {{Command}}",
       "input.new_topic": "新しいトピック {{Command}}",
       "input.pause": "一時停止",
-      "input.placeholder": "ここにメッセージを入力...",
+      "input.placeholder": "ここにメッセージを入力し、{{key}} を押して送信...",
       "input.send": "送信",
       "input.settings": "設定",
       "input.topics": " トピック ",

--- a/src/renderer/src/i18n/locales/ru-ru.json
+++ b/src/renderer/src/i18n/locales/ru-ru.json
@@ -183,7 +183,7 @@
       "input.new.context": "Очистить контекст {{Command}}",
       "input.new_topic": "Новый топик {{Command}}",
       "input.pause": "Остановить",
-      "input.placeholder": "Введите ваше сообщение здесь...",
+      "input.placeholder": "Введите ваше сообщение здесь, нажмите {{key}} для отправки...",
       "input.send": "Отправить",
       "input.settings": "Настройки",
       "input.topics": " Топики ",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -183,7 +183,7 @@
       "input.new.context": "清除上下文 {{Command}}",
       "input.new_topic": "新话题 {{Command}}",
       "input.pause": "暂停",
-      "input.placeholder": "在这里输入消息...",
+      "input.placeholder": "在这里输入消息，按 {{key}} 发送...",
       "input.translating": "翻译中...",
       "input.send": "发送",
       "input.settings": "设置",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -183,7 +183,7 @@
       "input.new.context": "清除上下文 {{Command}}",
       "input.new_topic": "新話題 {{Command}}",
       "input.pause": "暫停",
-      "input.placeholder": "在此輸入您的訊息...",
+      "input.placeholder": "在此輸入您的訊息，按 {{key}} 傳送...",
       "input.send": "傳送",
       "input.settings": "設定",
       "input.topics": " 話題 ",

--- a/src/renderer/src/pages/home/Tabs/SettingsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/SettingsTab.tsx
@@ -1,13 +1,7 @@
 import { CheckOutlined } from '@ant-design/icons'
 import { HStack } from '@renderer/components/Layout'
 import Scrollbar from '@renderer/components/Scrollbar'
-import {
-  DEFAULT_CONTEXTCOUNT,
-  DEFAULT_MAX_TOKENS,
-  DEFAULT_TEMPERATURE,
-  isMac,
-  isWindows
-} from '@renderer/config/constant'
+import { DEFAULT_CONTEXTCOUNT, DEFAULT_MAX_TOKENS, DEFAULT_TEMPERATURE } from '@renderer/config/constant'
 import {
   isOpenAIModel,
   isSupportedFlexServiceTier,
@@ -59,6 +53,7 @@ import {
   TranslateLanguageVarious
 } from '@renderer/types'
 import { modalConfirm } from '@renderer/utils'
+import { getSendMessageShortcutLabel } from '@renderer/utils/input'
 import { Button, Col, InputNumber, Row, Select, Slider, Switch, Tooltip } from 'antd'
 import { CircleHelp, Settings2 } from 'lucide-react'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
@@ -670,10 +665,11 @@ const SettingsTab: FC<Props> = (props) => {
               value={sendMessageShortcut}
               menuItemSelectedIcon={<CheckOutlined />}
               options={[
-                { value: 'Enter', label: 'Enter' },
-                { value: 'Shift+Enter', label: 'Shift + Enter' },
-                { value: 'Ctrl+Enter', label: 'Ctrl + Enter' },
-                { value: 'Command+Enter', label: `${isMac ? '⌘' : isWindows ? 'Win' : 'Super'} + Enter` }
+                { value: 'Enter', label: getSendMessageShortcutLabel('Enter') },
+                { value: 'Ctrl+Enter', label: getSendMessageShortcutLabel('Ctrl+Enter') },
+                { value: 'Alt+Enter', label: getSendMessageShortcutLabel('Alt+Enter') },
+                { value: 'Command+Enter', label: getSendMessageShortcutLabel('Command+Enter') },
+                { value: 'Shift+Enter', label: getSendMessageShortcutLabel('Shift+Enter') }
               ]}
               onChange={(value) => setSendMessageShortcut(value as SendMessageShortcut)}
               style={{ width: 135 }}

--- a/src/renderer/src/store/settings.ts
+++ b/src/renderer/src/store/settings.ts
@@ -14,7 +14,7 @@ import {
 
 import { WebDAVSyncState } from './backup'
 
-export type SendMessageShortcut = 'Enter' | 'Shift+Enter' | 'Ctrl+Enter' | 'Command+Enter'
+export type SendMessageShortcut = 'Enter' | 'Shift+Enter' | 'Ctrl+Enter' | 'Command+Enter' | 'Alt+Enter'
 
 export type SidebarIcon = 'assistants' | 'agents' | 'paintings' | 'translate' | 'minapp' | 'knowledge' | 'files'
 

--- a/src/renderer/src/utils/input.ts
+++ b/src/renderer/src/utils/input.ts
@@ -1,4 +1,6 @@
+import { isMac, isWindows } from '@renderer/config/constant'
 import Logger from '@renderer/config/logger'
+import type { SendMessageShortcut } from '@renderer/store/settings'
 import { FileType } from '@renderer/types'
 
 export const getFilesFromDropEvent = async (e: React.DragEvent<HTMLDivElement>): Promise<FileType[]> => {
@@ -57,4 +59,48 @@ export const getFilesFromDropEvent = async (e: React.DragEvent<HTMLDivElement>):
       }
     })
   }
+}
+
+// convert send message shortcut to human readable label
+export const getSendMessageShortcutLabel = (shortcut: SendMessageShortcut) => {
+  switch (shortcut) {
+    case 'Enter':
+      return 'Enter'
+    case 'Ctrl+Enter':
+      return 'Ctrl + Enter'
+    case 'Alt+Enter':
+      return `${isMac ? '⌥' : 'Alt'} + Enter`
+    case 'Command+Enter':
+      return `${isMac ? '⌘' : isWindows ? 'Win' : 'Super'} + Enter`
+    case 'Shift+Enter':
+      return 'Shift + Enter'
+    default:
+      return shortcut
+  }
+}
+
+// check if the send message key is pressed in textarea
+export const isSendMessageKeyPressed = (
+  event: React.KeyboardEvent<HTMLTextAreaElement>,
+  shortcut: SendMessageShortcut
+) => {
+  let isSendMessageKeyPressed = false
+  switch (shortcut) {
+    case 'Enter':
+      if (!event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) isSendMessageKeyPressed = true
+      break
+    case 'Ctrl+Enter':
+      if (event.ctrlKey && !event.shiftKey && !event.metaKey && !event.altKey) isSendMessageKeyPressed = true
+      break
+    case 'Command+Enter':
+      if (event.metaKey && !event.shiftKey && !event.ctrlKey && !event.altKey) isSendMessageKeyPressed = true
+      break
+    case 'Alt+Enter':
+      if (event.altKey && !event.shiftKey && !event.ctrlKey && !event.metaKey) isSendMessageKeyPressed = true
+      break
+    case 'Shift+Enter':
+      if (event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) isSendMessageKeyPressed = true
+      break
+  }
+  return isSendMessageKeyPressed
 }


### PR DESCRIPTION
- 选中的按键作为发送键，除此之外的Enter组合皆为换行
- 在inputbar的placeholder中加入发送快捷键的提示
- 发送快捷键添加alt+enter
- 同步修改用户消息的编辑发送逻辑，保持统一
- 一些工具方法的整理