### PR TITLE
Fix: Handle embedding dimension retrieval failure when creating knowledge base

### DIFF
--- a/src/renderer/src/aiCore/clients/anthropic/AnthropicAPIClient.ts
+++ b/src/renderer/src/aiCore/clients/anthropic/AnthropicAPIClient.ts
@@ -125,7 +125,7 @@ export class AnthropicAPIClient extends BaseApiClient<
 
   // @ts-ignore sdk未提供
   override async getEmbeddingDimensions(): Promise<number> {
-    return 0
+    throw new Error("Anthropic SDK doesn't support getEmbeddingDimensions method.")
   }
 
   override getTemperature(assistant: Assistant, model: Model): number | undefined {

--- a/src/renderer/src/aiCore/clients/gemini/GeminiAPIClient.ts
+++ b/src/renderer/src/aiCore/clients/gemini/GeminiAPIClient.ts
@@ -147,16 +147,12 @@ export class GeminiAPIClient extends BaseApiClient<
 
   override async getEmbeddingDimensions(model: Model): Promise<number> {
     const sdk = await this.getSdkInstance()
-    try {
-      const data = await sdk.models.embedContent({
-        model: model.id,
-        contents: [{ role: 'user', parts: [{ text: 'hi' }] }]
-      })
-      return data.embeddings?.[0]?.values?.length || 0
-    } catch (e) {
-      console.error('Error getting embedding dimensions:', e)
-      throw e
-    }
+
+    const data = await sdk.models.embedContent({
+      model: model.id,
+      contents: [{ role: 'user', parts: [{ text: 'hi' }] }]
+    })
+    return data.embeddings?.[0]?.values?.length || 0
   }
 
   override async listModels(): Promise<GeminiModel[]> {

--- a/src/renderer/src/aiCore/clients/gemini/GeminiAPIClient.ts
+++ b/src/renderer/src/aiCore/clients/gemini/GeminiAPIClient.ts
@@ -154,7 +154,8 @@ export class GeminiAPIClient extends BaseApiClient<
       })
       return data.embeddings?.[0]?.values?.length || 0
     } catch (e) {
-      return 0
+      console.error('Error getting embedding dimensions:', e)
+      throw e
     }
   }
 

--- a/src/renderer/src/aiCore/clients/openai/OpenAIBaseClient.ts
+++ b/src/renderer/src/aiCore/clients/openai/OpenAIBaseClient.ts
@@ -93,7 +93,8 @@ export abstract class OpenAIBaseClient<
       })
       return data.data[0].embedding.length
     } catch (e) {
-      return 0
+      console.error('Error getting embedding dimensions:', e)
+      throw e
     }
   }
 

--- a/src/renderer/src/aiCore/clients/openai/OpenAIBaseClient.ts
+++ b/src/renderer/src/aiCore/clients/openai/OpenAIBaseClient.ts
@@ -85,17 +85,13 @@ export abstract class OpenAIBaseClient<
 
   override async getEmbeddingDimensions(model: Model): Promise<number> {
     const sdk = await this.getSdkInstance()
-    try {
-      const data = await sdk.embeddings.create({
-        model: model.id,
-        input: model?.provider === 'baidu-cloud' ? ['hi'] : 'hi',
-        encoding_format: 'float'
-      })
-      return data.data[0].embedding.length
-    } catch (e) {
-      console.error('Error getting embedding dimensions:', e)
-      throw e
-    }
+
+    const data = await sdk.embeddings.create({
+      model: model.id,
+      input: model?.provider === 'baidu-cloud' ? ['hi'] : 'hi',
+      encoding_format: 'float'
+    })
+    return data.data[0].embedding.length
   }
 
   override async listModels(): Promise<OpenAI.Models.Model[]> {

--- a/src/renderer/src/aiCore/index.ts
+++ b/src/renderer/src/aiCore/index.ts
@@ -114,7 +114,7 @@ export default class AiProvider {
       return dimensions
     } catch (error) {
       console.error('Error getting embedding dimensions:', error)
-      return 0
+      throw error
     }
   }
 

--- a/src/renderer/src/pages/knowledge/components/AddKnowledgePopup.tsx
+++ b/src/renderer/src/pages/knowledge/components/AddKnowledgePopup.tsx
@@ -115,6 +115,9 @@ const PopupContainer: React.FC<Props> = ({ title, resolve }) => {
           try {
             const aiProvider = new AiProvider(provider)
             values.dimensions = await aiProvider.getEmbeddingDimensions(selectedEmbeddingModel)
+            if (values.dimensions === 0) {
+              throw new Error('')
+            }
           } catch (error) {
             console.error('Error getting embedding dimensions:', error)
             window.message.error(t('message.error.get_embedding_dimensions') + '\n' + getErrorMessage(error))

--- a/src/renderer/src/pages/knowledge/components/AddKnowledgePopup.tsx
+++ b/src/renderer/src/pages/knowledge/components/AddKnowledgePopup.tsx
@@ -115,11 +115,7 @@ const PopupContainer: React.FC<Props> = ({ title, resolve }) => {
           try {
             const aiProvider = new AiProvider(provider)
             values.dimensions = await aiProvider.getEmbeddingDimensions(selectedEmbeddingModel)
-            if (values.dimensions === 0) {
-              throw new Error('')
-            }
           } catch (error) {
-            console.error('Error getting embedding dimensions:', error)
             window.message.error(t('message.error.get_embedding_dimensions') + '\n' + getErrorMessage(error))
             setLoading(false)
             return

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -570,10 +570,7 @@ export async function checkApi(provider: Provider, model: Model): Promise<void> 
   assistant.model = model
   try {
     if (isEmbeddingModel(model)) {
-      const result = await ai.getEmbeddingDimensions(model)
-      if (result === 0) {
-        throw new Error(i18n.t('message.error.enter.model'))
-      }
+      await ai.getEmbeddingDimensions(model)
     } else {
       const params: CompletionsParams = {
         callType: 'check',


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

修复了在新建知识库时，即使自动获取嵌入维度失败也能成功创建知识库的问题。

在这以前，如果嵌入维度获取失败，`dimensions`将被设置为0。目前各个 ApiClient 在实现`getEmbeddingDimensions`方法时，不抛出异常，而是在发生异常时返回0。对于sdk实现而言，传入`dimensions: 0`的非法情况被自动处理，因此没有引起什么问题。不过，这种实现仍然存在潜在的风险，而且得到0作为嵌入维度也很奇怪，所以我修改了`getEmbeddingDimensions`的实现，并且在添加知识库时进行异常处理。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
