### PR TITLE
fix(OpenAI): respect successful stream without finish reason

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -7,7 +7,7 @@ import { handleZoomFactor } from '@main/utils/zoom'
 import { FeedUrl } from '@shared/config/constant'
 import { IpcChannel } from '@shared/IpcChannel'
 import { Shortcut, ThemeMode } from '@types'
-import { dialog, BrowserWindow, ipcMain, session, shell } from 'electron'
+import { BrowserWindow, dialog, ipcMain, session, shell } from 'electron'
 import log from 'electron-log'
 import { Notification } from 'src/renderer/src/types/notification'
 

--- a/src/renderer/src/aiCore/clients/openai/OpenAIApiClient.ts
+++ b/src/renderer/src/aiCore/clients/openai/OpenAIApiClient.ts
@@ -588,9 +588,52 @@ export class OpenAIAPIClient extends OpenAIBaseClient<
 
       return null
     }
+
     const toolCalls: OpenAI.Chat.Completions.ChatCompletionMessageToolCall[] = []
+    let isFinished = false
+    let lastUsageInfo: any = null
+
+    /**
+     * 统一的完成信号发送逻辑
+     * - 有 finish_reason 时
+     * - 无 finish_reason 但是流正常结束时
+     */
+    const emitCompletionSignals = (controller: TransformStreamDefaultController<GenericChunk>) => {
+      if (isFinished) return
+
+      if (toolCalls.length > 0) {
+        controller.enqueue({
+          type: ChunkType.MCP_TOOL_CREATED,
+          tool_calls: toolCalls
+        })
+      }
+
+      const usage = lastUsageInfo || {
+        prompt_tokens: 0,
+        completion_tokens: 0,
+        total_tokens: 0
+      }
+
+      controller.enqueue({
+        type: ChunkType.LLM_RESPONSE_COMPLETE,
+        response: { usage }
+      })
+
+      // 防止重复发送
+      isFinished = true
+    }
+
     return (context: ResponseChunkTransformerContext) => ({
       async transform(chunk: OpenAISdkRawChunk, controller: TransformStreamDefaultController<GenericChunk>) {
+        // 持续更新usage信息
+        if (chunk.usage) {
+          lastUsageInfo = {
+            prompt_tokens: chunk.usage.prompt_tokens || 0,
+            completion_tokens: chunk.usage.completion_tokens || 0,
+            total_tokens: (chunk.usage.prompt_tokens || 0) + (chunk.usage.completion_tokens || 0)
+          }
+        }
+
         // 处理chunk
         if ('choices' in chunk && chunk.choices && chunk.choices.length > 0) {
           const choice = chunk.choices[0]
@@ -655,12 +698,6 @@ export class OpenAIAPIClient extends OpenAIBaseClient<
           // 处理finish_reason，发送流结束信号
           if ('finish_reason' in choice && choice.finish_reason) {
             Logger.debug(`[OpenAIApiClient] Stream finished with reason: ${choice.finish_reason}`)
-            if (toolCalls.length > 0) {
-              controller.enqueue({
-                type: ChunkType.MCP_TOOL_CREATED,
-                tool_calls: toolCalls
-              })
-            }
             const webSearchData = collectWebSearchData(chunk, contentSource, context)
             if (webSearchData) {
               controller.enqueue({
@@ -668,18 +705,17 @@ export class OpenAIAPIClient extends OpenAIBaseClient<
                 llm_web_search: webSearchData
               })
             }
-            controller.enqueue({
-              type: ChunkType.LLM_RESPONSE_COMPLETE,
-              response: {
-                usage: {
-                  prompt_tokens: chunk.usage?.prompt_tokens || 0,
-                  completion_tokens: chunk.usage?.completion_tokens || 0,
-                  total_tokens: (chunk.usage?.prompt_tokens || 0) + (chunk.usage?.completion_tokens || 0)
-                }
-              }
-            })
+            emitCompletionSignals(controller)
           }
         }
+      },
+
+      // 流正常结束时，检查是否需要发送完成信号
+      flush(controller) {
+        if (isFinished) return
+
+        Logger.debug('[OpenAIApiClient] Stream ended without finish_reason, emitting fallback completion signals')
+        emitCompletionSignals(controller)
       }
     })
   }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

OpenAI api client 中，流正常结束时也应该发送完成信号。

Before this PR:

AiHubMix 的 nothink gemini 模型似乎没有 `finish_reason`，但是目前 OpenAI api client 的实现又依赖于这个标记，结果正常结束的流也没有发送完成信号。

After this PR:

确保正常结束的流也发送完成信号。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #5927 

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
