### PR TITLE
fix(AnthropicAPIClient): non stream tooluse

### DIFF
--- a/src/renderer/src/aiCore/clients/anthropic/AnthropicAPIClient.ts
+++ b/src/renderer/src/aiCore/clients/anthropic/AnthropicAPIClient.ts
@@ -372,7 +372,8 @@ export class AnthropicAPIClient extends BaseApiClient<
     listener: RawStreamListener<AnthropicSdkRawChunk>
   ): AnthropicSdkRawOutput {
     console.log(`[AnthropicApiClient] 附加流监听器到原始输出`)
-
+    // 专用的Anthropic事件处理
+    const anthropicListener = listener as AnthropicStreamListener
     // 检查是否为MessageStream
     if (rawOutput instanceof MessageStream) {
       console.log(`[AnthropicApiClient] 检测到 Anthropic MessageStream，附加专用监听器`)
@@ -386,9 +387,6 @@ export class AnthropicAPIClient extends BaseApiClient<
           listener.onChunk!(event)
         })
       }
-
-      // 专用的Anthropic事件处理
-      const anthropicListener = listener as AnthropicStreamListener
 
       if (anthropicListener.onContentBlock) {
         rawOutput.on('contentBlock', anthropicListener.onContentBlock)
@@ -411,6 +409,10 @@ export class AnthropicAPIClient extends BaseApiClient<
       }
 
       return rawOutput
+    }
+
+    if (anthropicListener.onMessage) {
+      anthropicListener.onMessage(rawOutput)
     }
 
     // 对于非MessageStream响应
@@ -518,6 +520,7 @@ export class AnthropicAPIClient extends BaseApiClient<
         async transform(rawChunk: AnthropicSdkRawChunk, controller: TransformStreamDefaultController<GenericChunk>) {
           switch (rawChunk.type) {
             case 'message': {
+              let i = 0
               for (const content of rawChunk.content) {
                 switch (content.type) {
                   case 'text': {
@@ -528,7 +531,8 @@ export class AnthropicAPIClient extends BaseApiClient<
                     break
                   }
                   case 'tool_use': {
-                    toolCalls[0] = content
+                    toolCalls[i] = content
+                    i++
                     break
                   }
                   case 'thinking': {
@@ -550,6 +554,22 @@ export class AnthropicAPIClient extends BaseApiClient<
                   }
                 }
               }
+              if (i > 0) {
+                controller.enqueue({
+                  type: ChunkType.MCP_TOOL_CREATED,
+                  tool_calls: Object.values(toolCalls)
+                } as MCPToolCreatedChunk)
+              }
+              controller.enqueue({
+                type: ChunkType.LLM_RESPONSE_COMPLETE,
+                response: {
+                  usage: {
+                    prompt_tokens: rawChunk.usage.input_tokens || 0,
+                    completion_tokens: rawChunk.usage.output_tokens || 0,
+                    total_tokens: (rawChunk.usage.input_tokens || 0) + (rawChunk.usage.output_tokens || 0)
+                  }
+                }
+              })
               break
             }
             case 'content_block_start': {


### PR DESCRIPTION
- Added debug logging in buildSdkMessages for better traceability.
- Improved handling of tool calls in the transform method to correctly index multiple tool uses.
- Enqueued additional response types to enhance the output structure for better integration with the streaming API.
- Refactored event listener attachment for clarity and maintainability.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

修复了非流情况下 Claude模型的tooluse

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
