### PR TITLE
refactor: remove deprecated MCP server handling and knowledge base ID logic from Inputbar and related services

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -13,7 +13,6 @@ import {
 import db from '@renderer/databases'
 import { useAssistant } from '@renderer/hooks/useAssistant'
 import { useKnowledgeBases } from '@renderer/hooks/useKnowledge'
-import { useMCPServers } from '@renderer/hooks/useMCPServers'
 import { useMessageOperations, useTopicLoading } from '@renderer/hooks/useMessageOperations'
 import { modelGenerating, useRuntime } from '@renderer/hooks/useRuntime'
 import { useMessageStyle, useSettings } from '@renderer/hooks/useSettings'
@@ -105,7 +104,6 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
   const currentMessageId = useRef<string>('')
   const isVision = useMemo(() => isVisionModel(model), [model])
   const supportExts = useMemo(() => [...textExts, ...documentExts, ...(isVision ? imageExts : [])], [isVision])
-  const { activedMcpServers } = useMCPServers()
   const { bases: knowledgeBases } = useKnowledgeBases()
   const isMultiSelectMode = useAppSelector((state) => state.runtime.chat.isMultiSelectMode)
 
@@ -176,20 +174,9 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
       if (uploadedFiles) {
         baseUserMessage.files = uploadedFiles
       }
-      const knowledgeBaseIds = selectedKnowledgeBases?.map((base) => base.id)
-
-      if (knowledgeBaseIds) {
-        baseUserMessage.knowledgeBaseIds = knowledgeBaseIds
-      }
 
       if (mentionModels) {
         baseUserMessage.mentions = mentionModels
-      }
-
-      if (!isEmpty(assistant.mcpServers) && !isEmpty(activedMcpServers)) {
-        baseUserMessage.enabledMCPs = activedMcpServers.filter((server) =>
-          assistant.mcpServers?.some((s) => s.id === server.id)
-        )
       }
 
       const assistantWithTopicPrompt = topic.prompt
@@ -212,19 +199,7 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
     } catch (error) {
       console.error('Failed to send message:', error)
     }
-  }, [
-    activedMcpServers,
-    assistant,
-    dispatch,
-    files,
-    inputEmpty,
-    loading,
-    mentionModels,
-    resizeTextArea,
-    selectedKnowledgeBases,
-    text,
-    topic
-  ])
+  }, [assistant, dispatch, files, inputEmpty, loading, mentionModels, resizeTextArea, text, topic])
 
   const translate = useCallback(async () => {
     if (isTranslating) {

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -33,10 +33,11 @@ import { SdkModel } from '@renderer/types/sdk'
 import { removeSpecialCharactersForTopicName } from '@renderer/utils'
 import { isAbortError } from '@renderer/utils/error'
 import { extractInfoFromXML, ExtractResults } from '@renderer/utils/extract'
-import { findFileBlocks, getKnowledgeBaseIds, getMainTextContent } from '@renderer/utils/messageUtils/find'
+import { findFileBlocks, getMainTextContent } from '@renderer/utils/messageUtils/find'
 import { findLast, isEmpty, takeRight } from 'lodash'
 
 import AiProvider from '../aiCore'
+import store from '../store'
 import {
   getAssistantProvider,
   getAssistantSettings,
@@ -63,7 +64,7 @@ async function fetchExternalTool(
   lastAnswer?: Message
 ): Promise<ExternalToolResult> {
   // 可能会有重复？
-  const knowledgeBaseIds = getKnowledgeBaseIds(lastUserMessage)
+  const knowledgeBaseIds = assistant.knowledge_bases?.map((base) => base.id)
   const hasKnowledgeBase = !isEmpty(knowledgeBaseIds)
   const knowledgeRecognition = assistant.knowledgeRecognition || 'on'
   const webSearchProvider = WebSearchService.getWebSearchProvider(assistant.webSearchProviderId)
@@ -251,7 +252,12 @@ async function fetchExternalTool(
 
     // Get MCP tools (Fix duplicate declaration)
     let mcpTools: MCPTool[] = [] // Initialize as empty array
-    const enabledMCPs = assistant.mcpServers
+    const allMcpServers = store.getState().mcp.servers || []
+    const activedMcpServers = allMcpServers.filter((s) => s.isActive)
+    const assistantMcpServers = assistant.mcpServers || []
+
+    const enabledMCPs = activedMcpServers.filter((server) => assistantMcpServers.some((s) => s.id === server.id))
+
     if (enabledMCPs && enabledMCPs.length > 0) {
       try {
         const toolPromises = enabledMCPs.map(async (mcpServer) => {

--- a/src/renderer/src/services/MessagesService.ts
+++ b/src/renderer/src/services/MessagesService.ts
@@ -6,7 +6,7 @@ import { fetchMessagesSummary } from '@renderer/services/ApiService'
 import store from '@renderer/store'
 import { messageBlocksSelectors, removeManyBlocks } from '@renderer/store/messageBlock'
 import { selectMessagesForTopic } from '@renderer/store/newMessage'
-import type { Assistant, FileType, MCPServer, Model, Topic, Usage } from '@renderer/types'
+import type { Assistant, FileType, Model, Topic, Usage } from '@renderer/types'
 import { FileTypes } from '@renderer/types'
 import type { Message, MessageBlock } from '@renderer/types/newMessage'
 import { AssistantMessageStatus, MessageBlockStatus, MessageBlockType } from '@renderer/types/newMessage'
@@ -108,9 +108,7 @@ export function getUserMessage({
   content,
   files,
   // Keep other potential params if needed by createMessage
-  knowledgeBaseIds,
   mentions,
-  enabledMCPs,
   usage
 }: {
   assistant: Assistant
@@ -120,7 +118,6 @@ export function getUserMessage({
   files?: FileType[]
   knowledgeBaseIds?: string[]
   mentions?: Model[]
-  enabledMCPs?: MCPServer[]
   usage?: Usage
 }): { message: Message; blocks: MessageBlock[] } {
   const defaultModel = getDefaultModel()
@@ -133,8 +130,7 @@ export function getUserMessage({
   if (content !== undefined) {
     // Pass messageId when creating blocks
     const textBlock = createMainTextBlock(messageId, content, {
-      status: MessageBlockStatus.SUCCESS,
-      knowledgeBaseIds
+      status: MessageBlockStatus.SUCCESS
     })
     blocks.push(textBlock)
     blockIds.push(textBlock.id)
@@ -165,7 +161,7 @@ export function getUserMessage({
       blocks: blockIds,
       // 移除knowledgeBaseIds
       mentions,
-      enabledMCPs,
+      // 移除mcp
       type,
       usage
     }
@@ -203,7 +199,6 @@ export function resetAssistantMessage(message: Message, model?: Model): Message 
     useful: undefined,
     askId: undefined,
     mentions: undefined,
-    enabledMCPs: undefined,
     blocks: [],
     createdAt: new Date().toISOString()
   }

--- a/src/renderer/src/types/newMessage.ts
+++ b/src/renderer/src/types/newMessage.ts
@@ -173,6 +173,9 @@ export type Message = {
   useful?: boolean
   askId?: string // 关联的问题消息ID
   mentions?: Model[]
+  /**
+   * @deprecated
+   */
   enabledMCPs?: MCPServer[]
 
   usage?: Usage
@@ -204,8 +207,14 @@ export interface MessageInputBaseParams {
   topic: Topic
   content?: string
   files?: FileType[]
+  /**
+   * @deprecated
+   */
   knowledgeBaseIds?: string[]
   mentions?: Model[]
+  /**
+   * @deprecated
+   */
   enabledMCPs?: MCPServer[]
   usage?: CompletionUsage
 }

--- a/src/renderer/src/utils/messageUtils/find.ts
+++ b/src/renderer/src/utils/messageUtils/find.ts
@@ -141,17 +141,6 @@ export const getCitationContent = (message: Message): string => {
 }
 
 /**
- * Gets the knowledgeBaseIds array from the *first* MainTextMessageBlock of a message.
- * Note: Assumes knowledgeBaseIds are only relevant on the first text block, adjust if needed.
- * @param message - The message object.
- * @returns The knowledgeBaseIds array or undefined if not found.
- */
-export const getKnowledgeBaseIds = (message: Message): string[] | undefined => {
-  const firstTextBlock = findMainTextBlocks(message)
-  return firstTextBlock?.flatMap((block) => block.knowledgeBaseIds).filter((id): id is string => Boolean(id))
-}
-
-/**
  * Gets the file content from all FileMessageBlocks and ImageMessageBlocks of a message.
  * @param message - The message object.
  * @returns The file content or an empty string if no file blocks are found.


### PR DESCRIPTION
- Removed unused MCP server handling from Inputbar and MessagesService.
- Updated ApiService to fetch active MCP servers directly from the store.
- Deprecated knowledgeBaseIds and enabledMCPs in Message types and related functions.
- Cleaned up related utility functions to enhance code clarity and maintainability.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

将mcp和知识库id正确的和助手绑定，而不是使用用户消息中的过时配置
现在输入框中切换mcp的逻辑和网络搜索按钮这些一致了

慢慢向以助手为软件内的基本单位演进

before PR:

如果在输入框切换mcp和知识库，重发消息仍然使用了过时的mcp和知识库

after PR:

助手上下文能正确绑定mcp和知识库

Fixes #7036 #6864 #7280

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
