### PR TITLE
fix: 修复多模型回答的锚点点击无法跳转问题

### DIFF
--- a/src/renderer/src/pages/home/Messages/MessageAnchorLine.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageAnchorLine.tsx
@@ -127,7 +127,6 @@ const MessageAnchorLine: FC<MessageLineProps> = ({ messages }) => {
     (message: Message) => {
       const messageElement = document.getElementById(`message-${message.id}`)
 
-      console.log('🌟TEO🌟 ~ messageElement:', message)
       if (!messageElement) return
 
       const display = messageElement ? window.getComputedStyle(messageElement).display : null

--- a/src/renderer/src/pages/home/Messages/MessageAnchorLine.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageAnchorLine.tsx
@@ -1,4 +1,3 @@
-import { DownOutlined } from '@ant-design/icons'
 import EmojiAvatar from '@renderer/components/Avatar/EmojiAvatar'
 import { APP_NAME, AppLogo, isLocalAi } from '@renderer/config/env'
 import { getModelLogo } from '@renderer/config/models'
@@ -14,6 +13,7 @@ import type { Message } from '@renderer/types/newMessage'
 import { isEmoji, removeLeadingEmoji } from '@renderer/utils'
 import { getMainTextContent } from '@renderer/utils/messageUtils/find'
 import { Avatar } from 'antd'
+import { CircleChevronDown } from 'lucide-react'
 import { type FC, useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -104,14 +104,18 @@ const MessageAnchorLine: FC<MessageLineProps> = ({ messages }) => {
       if (groupMessages.length > 1) {
         for (const m of groupMessages) {
           dispatch(
-            newMessagesActions.updateMessage({ topicId: m.topicId, messageId: m.id, updates: { foldSelected: true } })
+            newMessagesActions.updateMessage({
+              topicId: m.topicId,
+              messageId: m.id,
+              updates: { foldSelected: m.id === message.id }
+            })
           )
         }
 
         setTimeout(() => {
           const messageElement = document.getElementById(`message-${message.id}`)
           if (messageElement) {
-            messageElement.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+            messageElement.scrollIntoView({ behavior: 'auto', block: 'start' })
           }
         }, 100)
       }
@@ -123,6 +127,7 @@ const MessageAnchorLine: FC<MessageLineProps> = ({ messages }) => {
     (message: Message) => {
       const messageElement = document.getElementById(`message-${message.id}`)
 
+      console.log('🌟TEO🌟 ~ messageElement:', message)
       if (!messageElement) return
 
       const display = messageElement ? window.getComputedStyle(messageElement).display : null
@@ -183,16 +188,9 @@ const MessageAnchorLine: FC<MessageLineProps> = ({ messages }) => {
             opacity: mouseY ? 0.5 + calculateValueByDistance('bottom-anchor', 1) : 0.6
           }}
           onClick={scrollToBottom}>
-          <MessageItemContainer
-            style={{ transform: `scale(${1 + calculateValueByDistance('bottom-anchor', 1)})` }}></MessageItemContainer>
-          <Avatar
-            icon={<DownOutlined style={{ color: theme === 'dark' ? 'var(--color-text)' : 'var(--color-primary)' }} />}
+          <CircleChevronDown
             size={10 + calculateValueByDistance('bottom-anchor', 20)}
-            style={{
-              backgroundColor: theme === 'dark' ? 'var(--color-background-soft)' : 'var(--color-primary-light)',
-              border: `1px solid ${theme === 'dark' ? 'var(--color-border-soft)' : 'var(--color-primary-soft)'}`,
-              opacity: 0.9
-            }}
+            style={{ color: theme === 'dark' ? 'var(--color-text)' : 'var(--color-primary)' }}
           />
         </MessageItem>
         {messages.map((message, index) => {
@@ -202,6 +200,8 @@ const MessageAnchorLine: FC<MessageLineProps> = ({ messages }) => {
           const avatarSource = getAvatarSource(isLocalAi, getMessageModelId(message))
           const username = removeLeadingEmoji(getUserName(message))
           const content = getMainTextContent(message)
+
+          if (message.type === 'clear') return null
 
           return (
             <MessageItem
@@ -262,7 +262,6 @@ const MessageItemContainer = styled.div`
   justify-content: space-between;
   text-align: right;
   gap: 4px;
-  text-shadow: 0 0 2px rgba(255, 255, 255, 0.5);
   opacity: 0;
   transform-origin: right center;
 `


### PR DESCRIPTION
### 修复多模型回答的锚点点击无法跳转问题

Before this PR:
当多模型回答的消息为折叠时，点击消息锚点被隐藏的折叠消息无法跳转

After this PR:
正常跳转

 
