### PR TITLE
refactor(Select): provide consistent search experience for antd Select

### DIFF
--- a/src/renderer/src/components/CustomSelect.tsx
+++ b/src/renderer/src/components/CustomSelect.tsx
@@ -1,0 +1,17 @@
+import { includeKeywords } from '@renderer/utils/search'
+import { Select, SelectProps } from 'antd'
+
+/**
+ * 自定义 Select，使用增强的搜索 filter
+ */
+const CustomSelect = ({ ref, ...props }: SelectProps & { ref?: React.RefObject<any | null> }) => {
+  return <Select ref={ref} filterOption={enhancedFilterOption} {...props} />
+}
+
+CustomSelect.displayName = 'CustomSelect'
+
+function enhancedFilterOption(input: string, option: any) {
+  return includeKeywords(option.label, input)
+}
+
+export default CustomSelect

--- a/src/renderer/src/pages/settings/ModelSettings/ModelSettings.tsx
+++ b/src/renderer/src/pages/settings/ModelSettings/ModelSettings.tsx
@@ -1,5 +1,6 @@
 import { RedoOutlined } from '@ant-design/icons'
 import ModelAvatar from '@renderer/components/Avatar/ModelAvatar'
+import CustomSelect from '@renderer/components/CustomSelect'
 import { HStack } from '@renderer/components/Layout'
 import PromptPopup from '@renderer/components/Popups/PromptPopup'
 import { isEmbeddingModel } from '@renderer/config/models'
@@ -96,7 +97,7 @@ const ModelSettings: FC = () => {
           </HStack>
         </SettingTitle>
         <HStack alignItems="center">
-          <Select
+          <CustomSelect
             value={defaultModelValue}
             defaultValue={defaultModelValue}
             style={{ width: 360 }}
@@ -118,7 +119,7 @@ const ModelSettings: FC = () => {
           </HStack>
         </SettingTitle>
         <HStack alignItems="center">
-          <Select
+          <CustomSelect
             value={defaultTopicNamingModel}
             defaultValue={defaultTopicNamingModel}
             style={{ width: 360 }}
@@ -140,7 +141,7 @@ const ModelSettings: FC = () => {
           </HStack>
         </SettingTitle>
         <HStack alignItems="center">
-          <Select
+          <CustomSelect
             value={defaultTranslateModel}
             defaultValue={defaultTranslateModel}
             style={{ width: 360 }}

--- a/src/renderer/src/pages/translate/TranslatePage.tsx
+++ b/src/renderer/src/pages/translate/TranslatePage.tsx
@@ -1,9 +1,10 @@
 import { CheckOutlined, DeleteOutlined, HistoryOutlined, SendOutlined } from '@ant-design/icons'
 import { NavbarCenter, NavbarMain } from '@renderer/components/app/Navbar'
+import CustomSelect from '@renderer/components/CustomSelect'
 import CopyIcon from '@renderer/components/Icons/CopyIcon'
 import { HStack } from '@renderer/components/Layout'
 import { isEmbeddingModel } from '@renderer/config/models'
-import { translateLanguageOptions } from '@renderer/config/translate'
+import { TranslateLanguageOptions } from '@renderer/config/translate'
 import db from '@renderer/databases'
 import { useDefaultModel } from '@renderer/hooks/useAssistant'
 import { useProviders } from '@renderer/hooks/useProvider'
@@ -114,7 +115,7 @@ const TranslateSettings: FC<{
         <div>
           <div style={{ marginBottom: 8, fontWeight: 500 }}>{t('translate.settings.model')}</div>
           <HStack alignItems="center" gap={5}>
-            <Select
+            <CustomSelect
               style={{ width: '100%' }}
               placeholder={t('translate.settings.model_placeholder')}
               value={defaultTranslateModel}
@@ -174,38 +175,38 @@ const TranslateSettings: FC<{
             {isBidirectional && (
               <Flex align="center" justify="space-between" gap={10}>
                 <Select
+                  showSearch
                   style={{ flex: 1 }}
                   value={localPair[0]}
+                  optionFilterProp="label"
                   onChange={(value) => setLocalPair([value, localPair[1]])}
-                  options={translateLanguageOptions().map((lang) => ({
-                    value: lang.value,
-                    label: (
-                      <Space.Compact direction="horizontal" block>
-                        <span role="img" aria-label={lang.emoji} style={{ marginRight: 8 }}>
-                          {lang.emoji}
-                        </span>
-                        <Space.Compact block>{lang.label}</Space.Compact>
-                      </Space.Compact>
-                    )
-                  }))}
+                  options={TranslateLanguageOptions}
+                  optionRender={(option) => (
+                    <Space>
+                      <span role="img" aria-label={(option.data as any).emoji}>
+                        {(option.data as any).emoji}
+                      </span>
+                      {option.label}
+                    </Space>
+                  )}
                   suffixIcon={<ChevronDown strokeWidth={1.5} size={16} color="var(--color-text-3)" />}
                 />
                 <span>⇆</span>
                 <Select
+                  showSearch
                   style={{ flex: 1 }}
                   value={localPair[1]}
+                  optionFilterProp="label"
                   onChange={(value) => setLocalPair([localPair[0], value])}
-                  options={translateLanguageOptions().map((lang) => ({
-                    value: lang.value,
-                    label: (
-                      <Space.Compact direction="horizontal" block>
-                        <span role="img" aria-label={lang.emoji} style={{ marginRight: 8 }}>
-                          {lang.emoji}
-                        </span>
-                        <div style={{ textAlign: 'left', flex: 1 }}>{lang.label}</div>
-                      </Space.Compact>
-                    )
-                  }))}
+                  options={TranslateLanguageOptions}
+                  optionRender={(option) => (
+                    <Space>
+                      <span role="img" aria-label={(option.data as any).emoji}>
+                        {(option.data as any).emoji}
+                      </span>
+                      {option.label}
+                    </Space>
+                  )}
                   suffixIcon={<ChevronDown strokeWidth={1.5} size={16} color="var(--color-text-3)" />}
                 />
               </Flex>
@@ -436,23 +437,23 @@ const TranslatePage: FC = () => {
 
     return (
       <Select
+        showSearch
         style={{ width: 160 }}
         value={targetLanguage}
+        optionFilterProp="label"
         onChange={(value) => {
           setTargetLanguage(value)
           db.settings.put({ id: 'translate:target:language', value })
         }}
-        options={translateLanguageOptions().map((lang) => ({
-          value: lang.value,
-          label: (
-            <Space.Compact direction="horizontal" block>
-              <span role="img" aria-label={lang.emoji} style={{ marginRight: 8 }}>
-                {lang.emoji}
-              </span>
-              <Space.Compact block>{lang.label}</Space.Compact>
-            </Space.Compact>
-          )
-        }))}
+        options={TranslateLanguageOptions}
+        optionRender={(option) => (
+          <Space>
+            <span role="img" aria-label={(option.data as any).emoji}>
+              {(option.data as any).emoji}
+            </span>
+            {option.label}
+          </Space>
+        )}
         suffixIcon={<ChevronDown strokeWidth={1.5} size={16} color="var(--color-text-3)" />}
       />
     )
@@ -538,18 +539,25 @@ const TranslatePage: FC = () => {
                       ? `${t('translate.detected.language')}(${t(`languages.${detectedLanguage.toLowerCase()}`)})`
                       : t('translate.detected.language')
                   },
-                  ...translateLanguageOptions().map((lang) => ({
+                  ...TranslateLanguageOptions.map((lang) => ({
                     value: lang.value,
-                    label: (
-                      <Space.Compact direction="horizontal" block>
-                        <span role="img" aria-label={lang.emoji} style={{ marginRight: 8 }}>
-                          {lang.emoji}
-                        </span>
-                        <Space.Compact block>{lang.label}</Space.Compact>
-                      </Space.Compact>
-                    )
+                    label: lang.label,
+                    emoji: lang.emoji
                   }))
                 ]}
+                optionRender={(option) => {
+                  if (option.value === 'auto') {
+                    return option.label
+                  }
+                  return (
+                    <Space>
+                      <span role="img" aria-label={(option.data as any).emoji}>
+                        {(option.data as any).emoji}
+                      </span>
+                      {option.label}
+                    </Space>
+                  )
+                }}
                 suffixIcon={<ChevronDown strokeWidth={1.5} size={16} color="var(--color-text-3)" />}
               />
               <Button


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

统一 Select 的搜索体验。

**Before this PR**:

- 默认模型设置页面，`Select` 组件只支持精确匹配
- 翻译界面，语言 `Select` 传入的选项无法被搜索

![image](https://github.com/user-attachments/assets/a47ceaf1-a87e-4ef5-a805-0da35677a565)

**After this PR**:

- 模型 `Select` 改用 `CustomSelect`，改善搜索功能
- 修复翻译界面的 `Select` 选项

![image](https://github.com/user-attachments/assets/d0299fff-2c17-4a42-b0fa-1197aae4e4e3)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
