### PR TITLE
fix: re-add newline separator between reasoning_summary parts after openai middleware refactor

### DIFF
--- a/src/renderer/src/aiCore/clients/openai/OpenAIResponseAPIClient.ts
+++ b/src/renderer/src/aiCore/clients/openai/OpenAIResponseAPIClient.ts
@@ -425,6 +425,7 @@ export class OpenAIResponseAPIClient extends OpenAIBaseClient<
     const toolCalls: OpenAIResponseSdkToolCall[] = []
     const outputItems: OpenAI.Responses.ResponseOutputItem[] = []
     let hasBeenCollectedToolCalls = false
+    let hasReasoningSummary = false
     return () => ({
       async transform(chunk: OpenAIResponseSdkRawChunk, controller: TransformStreamDefaultController<GenericChunk>) {
         // 处理chunk
@@ -495,6 +496,16 @@ export class OpenAIResponseAPIClient extends OpenAIBaseClient<
               if (chunk.item.type === 'function_call') {
                 outputItems.push(chunk.item)
               }
+              break
+            case 'response.reasoning_summary_part.added':
+              if (hasReasoningSummary) {
+                const separator = '\n\n'
+                controller.enqueue({
+                  type: ChunkType.THINKING_DELTA,
+                  text: separator
+                })
+              }
+              hasReasoningSummary = true
               break
             case 'response.reasoning_summary_text.delta':
               controller.enqueue({


### PR DESCRIPTION
5f4d73b0 重构中未考虑 5ef88a3 在 `response.reasoning_summary_part.added` 块之间插入空行的逻辑，导致 v1.4.4 起 reasoning summary parts 在前端连在一起。

- 引入 `hasReasoningSummary` 标志来跟踪第一部分
- 后续 `reasoning_summary_part.added` 到达时，在新部分之前发出 '\n\n' 作为 THINKING_DELTA

这恢复了最初在提交 5ef88a3 中实现的换行渲染行为。

![image](https://github.com/user-attachments/assets/1cea6bef-6ab8-4044-b7c5-71ce2578c279)
