### PR TITLE
refactor(middleware): Add error property to CompletionResult and handle errors when checking API

### DIFF
--- a/src/renderer/src/aiCore/middleware/common/ErrorHandlerMiddleware.ts
+++ b/src/renderer/src/aiCore/middleware/common/ErrorHandlerMiddleware.ts
@@ -25,7 +25,7 @@ export const ErrorHandlerMiddleware =
       // 尝试执行下一个中间件
       return await next(ctx, params)
     } catch (error: any) {
-      console.log('ErrorHandlerMiddleware_error', error)
+      console.error('ErrorHandlerMiddleware_error', error)
       // 1. 使用通用的工具函数将错误解析为标准格式
       const errorChunk = createErrorChunk(error)
       // 2. 调用从外部传入的 onError 回调
@@ -50,6 +50,7 @@ export const ErrorHandlerMiddleware =
         rawOutput: undefined,
         stream: errorStream, // 将包含错误的流传递下去
         controller: undefined,
+        error: typeof error?.message === 'string' ? error.message : 'unknown error',
         getText: () => '' // 错误情况下没有文本结果
       }
     }

--- a/src/renderer/src/aiCore/middleware/schemas.ts
+++ b/src/renderer/src/aiCore/middleware/schemas.ts
@@ -62,7 +62,7 @@ export interface CompletionsResult {
   rawOutput?: SdkRawOutput
   stream?: ReadableStream<SdkRawChunk> | ReadableStream<Chunk> | AsyncIterable<Chunk>
   controller?: AbortController
-
+  error?: string
   getText: () => string
 }
 

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -595,6 +595,10 @@ export async function checkApi(provider: Provider, model: Model): Promise<void> 
 
       // Try streaming check first
       const result = await ai.completions(params)
+      console.log('check we got', result)
+      if (result.error) {
+        throw new Error(result.error)
+      }
       if (!result.getText()) {
         throw new Error('No response received')
       }
@@ -608,7 +612,11 @@ export async function checkApi(provider: Provider, model: Model): Promise<void> 
         streamOutput: false
       }
       const result = await ai.completions(params)
+      if (result.error) {
+        throw new Error(result.error)
+      }
       if (!result.getText()) {
+        console.log('Stream check failed')
         throw new Error('No response received')
       }
     } else {

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -595,7 +595,6 @@ export async function checkApi(provider: Provider, model: Model): Promise<void> 
 
       // Try streaming check first
       const result = await ai.completions(params)
-      console.log('check we got', result)
       if (result.error) {
         throw new Error(result.error)
       }
@@ -616,7 +615,6 @@ export async function checkApi(provider: Provider, model: Model): Promise<void> 
         throw new Error(result.error)
       }
       if (!result.getText()) {
-        console.log('Stream check failed')
         throw new Error('No response received')
       }
     } else {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

测试API的时候发现反馈的错误总是空响应，但实际发生的错误在控制台才看得到，甚至是log而不是error。发现`checkApi`函数中使用`getText() === ''`来判断异常，但这样根本不知道发生了什么异常。

此PR为`CompletionResult`添加`error`属性，并且在`ErrorHandlerMiddleware`中为返回结果添加`error`属性，这样只需要判断`result`有没有`error`属性就能完成异常处理。并且，修改了`checkApi`的异常处理逻辑。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

主要问题是，几乎所有的`onChunk`回调都定义在这里：

https://github.com/CherryHQ/cherry-studio/blob/b91ac0de1dd900aae4b476425db6df763ed454d8/src/renderer/src/store/thunk/messageThunk.ts#L411

这种设计假设所有流式completion请求都会经过`messageThunk`执行。然而，在`checkApi`函数中，就有直接通过`AiProvider`的`completions`方法请求，这时并没有定义任何处理chunk的方法，从而所有chunk都没有得到处理。当然，这也包含错误块。

我的解决方案是直接不管流中是否包含错误块，不对块做任何处理，为`CompletionResult`添加额外的`error`属性来标记是否出现错误。否则，其他任何地方再需要做异常处理都需要从流中检查错误块，这有些麻烦。

另一种方案是把每种`onChunk`的回调解耦出去，让其他地方也能复用这部分逻辑。

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
