### PR TITLE
fix: add tag collapse state management for assistants

### DIFF
--- a/src/renderer/src/pages/home/Tabs/AssistantsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/AssistantsTab.tsx
@@ -27,10 +27,9 @@ const Assistants: FC<AssistantsTabProps> = ({
 }) => {
   const { assistants, removeAssistant, addAssistant, updateAssistants } = useAssistants()
   const [dragging, setDragging] = useState(false)
-  const [collapsedTags, setCollapsedTags] = useState<Record<string, boolean>>({})
   const { addAgent } = useAgents()
   const { t } = useTranslation()
-  const { getGroupedAssistants } = useTags()
+  const { getGroupedAssistants, collapsedTags, toggleTagCollapse } = useTags()
   const { assistantsTabSortType = 'list', setAssistantsTabSortType } = useAssistantsTabSortType()
   const containerRef = useRef<HTMLDivElement>(null)
 
@@ -45,13 +44,6 @@ const Assistants: FC<AssistantsTabProps> = ({
     },
     [activeAssistant, assistants, removeAssistant, setActiveAssistant, onCreateDefaultAssistant]
   )
-
-  const toggleTagCollapse = useCallback((tag: string) => {
-    setCollapsedTags((prev) => ({
-      ...prev,
-      [tag]: !prev[tag]
-    }))
-  }, [])
 
   const handleSortByChange = useCallback(
     (sortType: AssistantsSortType) => {
@@ -103,7 +95,6 @@ const Assistants: FC<AssistantsTabProps> = ({
                   <DragableList
                     list={group.assistants}
                     onUpdate={(newList) => handleGroupReorder(group.tag, newList)}
-                    style={{ paddingBottom: dragging ? '34px' : 0 }}
                     onDragStart={() => setDragging(true)}
                     onDragEnd={() => setDragging(false)}>
                     {(assistant) => (
@@ -141,7 +132,6 @@ const Assistants: FC<AssistantsTabProps> = ({
       <DragableList
         list={assistants}
         onUpdate={updateAssistants}
-        style={{ paddingBottom: dragging ? '34px' : 0 }}
         onDragStart={() => setDragging(true)}
         onDragEnd={() => setDragging(false)}>
         {(assistant) => (

--- a/src/renderer/src/store/assistants.ts
+++ b/src/renderer/src/store/assistants.ts
@@ -9,12 +9,14 @@ export interface AssistantsState {
   defaultAssistant: Assistant
   assistants: Assistant[]
   tagsOrder: string[]
+  collapsedTags: Record<string, boolean>
 }
 
 const initialState: AssistantsState = {
   defaultAssistant: getDefaultAssistant(),
   assistants: [getDefaultAssistant()],
-  tagsOrder: []
+  tagsOrder: [],
+  collapsedTags: {}
 }
 
 const assistantsSlice = createSlice({
@@ -56,6 +58,26 @@ const assistantsSlice = createSlice({
             assistant.settings[key] = settings[key]
           }
         }
+      }
+    },
+    setTagsOrder: (state, action: PayloadAction<string[]>) => {
+      const newOrder = action.payload
+      state.tagsOrder = newOrder
+      const prevCollapsed = state.collapsedTags || {}
+      const updatedCollapsed: Record<string, boolean> = { ...prevCollapsed }
+      newOrder.forEach((tag) => {
+        if (!(tag in updatedCollapsed)) {
+          updatedCollapsed[tag] = false
+        }
+      })
+      state.collapsedTags = updatedCollapsed
+    },
+    updateTagCollapse: (state, action: PayloadAction<string>) => {
+      const tag = action.payload
+      const prev = state.collapsedTags || {}
+      state.collapsedTags = {
+        ...prev,
+        [tag]: !prev[tag]
       }
     },
     addTopic: (state, action: PayloadAction<{ assistantId: string; topic: Topic }>) => {
@@ -130,9 +152,6 @@ const assistantsSlice = createSlice({
             }
           : assistant
       )
-    },
-    setTagsOrder: (state, action: PayloadAction<string[]>) => {
-      state.tagsOrder = action.payload
     }
   }
 })
@@ -150,7 +169,8 @@ export const {
   removeAllTopics,
   setModel,
   setTagsOrder,
-  updateAssistantSettings
+  updateAssistantSettings,
+  updateTagCollapse
 } = assistantsSlice.actions
 
 export default assistantsSlice.reducer


### PR DESCRIPTION
Fix #7093 #7427 

Introduces a collapsedTags state to manage the collapsed/expanded state of tag groups in the assistants list. Updates useTags and AssistantsTab to use this state, and adds actions to toggle and initialize tag collapse in the Redux store.