### PR TITLE
fix: use shouldThrow param in checkApi instead of adding error property to CompletionsResult

### DIFF
--- a/src/renderer/src/aiCore/middleware/common/ErrorHandlerMiddleware.ts
+++ b/src/renderer/src/aiCore/middleware/common/ErrorHandlerMiddleware.ts
@@ -25,7 +25,7 @@ export const ErrorHandlerMiddleware =
       // 尝试执行下一个中间件
       return await next(ctx, params)
     } catch (error: any) {
-      console.error('ErrorHandlerMiddleware_error', error)
+      console.log('ErrorHandlerMiddleware_error', error)
       // 1. 使用通用的工具函数将错误解析为标准格式
       const errorChunk = createErrorChunk(error)
       // 2. 调用从外部传入的 onError 回调
@@ -50,7 +50,6 @@ export const ErrorHandlerMiddleware =
         rawOutput: undefined,
         stream: errorStream, // 将包含错误的流传递下去
         controller: undefined,
-        error: typeof error?.message === 'string' ? error.message : 'unknown error',
         getText: () => '' // 错误情况下没有文本结果
       }
     }

--- a/src/renderer/src/aiCore/middleware/schemas.ts
+++ b/src/renderer/src/aiCore/middleware/schemas.ts
@@ -62,7 +62,7 @@ export interface CompletionsResult {
   rawOutput?: SdkRawOutput
   stream?: ReadableStream<SdkRawChunk> | ReadableStream<Chunk> | AsyncIterable<Chunk>
   controller?: AbortController
-  error?: string
+
   getText: () => string
 }
 

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -590,7 +590,8 @@ export async function checkApi(provider: Provider, model: Model): Promise<void> 
         callType: 'check',
         messages: 'hi',
         assistant,
-        streamOutput: true
+        streamOutput: true,
+        shouldThrow: true
       }
 
       // Try streaming check first
@@ -605,7 +606,8 @@ export async function checkApi(provider: Provider, model: Model): Promise<void> 
         callType: 'check',
         messages: 'hi',
         assistant,
-        streamOutput: false
+        streamOutput: false,
+        shouldThrow: true
       }
       const result = await ai.completions(params)
       if (!result.getText()) {

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -595,9 +595,6 @@ export async function checkApi(provider: Provider, model: Model): Promise<void> 
 
       // Try streaming check first
       const result = await ai.completions(params)
-      if (result.error) {
-        throw new Error(result.error)
-      }
       if (!result.getText()) {
         throw new Error('No response received')
       }
@@ -611,9 +608,6 @@ export async function checkApi(provider: Provider, model: Model): Promise<void> 
         streamOutput: false
       }
       const result = await ai.completions(params)
-      if (result.error) {
-        throw new Error(result.error)
-      }
       if (!result.getText()) {
         throw new Error('No response received')
       }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

https://github.com/CherryHQ/cherry-studio/pull/7407#issuecomment-2994064320

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
