### PR TITLE
refactor: data migration modal logic in DataSettings

### DIFF
--- a/src/renderer/src/pages/settings/DataSettings/DataSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/DataSettings.tsx
@@ -458,7 +458,7 @@ const DataSettings: FC = () => {
           newPath,
           occupiedDirs.map((dir) => originalPath + '/' + dir)
         )
-        
+
         // 停止进度更新
         if (progressInterval) {
           clearInterval(progressInterval)


### PR DESCRIPTION
Moved showProgressModal and startMigration functions inside the useEffect hook and added t as a dependency. This improves encapsulation and ensures translation updates are handled correctly.

移动showProgressModal和startMigration到useEffect内部避免重复定义 同时处理依赖数组