### PR TITLE
refactor(GeminiAPIClient): separate model and user message handling to adapt vertex

### DIFF
--- a/src/renderer/src/aiCore/clients/gemini/GeminiAPIClient.ts
+++ b/src/renderer/src/aiCore/clients/gemini/GeminiAPIClient.ts
@@ -683,16 +683,19 @@ export class GeminiAPIClient extends BaseApiClient<
     toolCalls: FunctionCall[]
   ): Content[] {
     const parts: Part[] = []
+    const modelParts: Part[] = []
     if (output) {
-      parts.push({
+      modelParts.push({
         text: output
       })
     }
+
     toolCalls.forEach((toolCall) => {
-      parts.push({
+      modelParts.push({
         functionCall: toolCall
       })
     })
+
     parts.push(
       ...toolResults
         .map((ts) => ts.parts)
@@ -700,10 +703,22 @@ export class GeminiAPIClient extends BaseApiClient<
         .filter((p) => p !== undefined)
     )
 
-    const lastMessage = currentReqMessages[currentReqMessages.length - 1]
-    if (lastMessage) {
-      lastMessage.parts?.push(...parts)
+    const userMessage: Content = {
+      role: 'user',
+      parts: []
     }
+
+    if (modelParts.length > 0) {
+      currentReqMessages.push({
+        role: 'model',
+        parts: modelParts
+      })
+    }
+    if (parts.length > 0) {
+      userMessage.parts?.push(...parts)
+      currentReqMessages.push(userMessage)
+    }
+
     return currentReqMessages
   }
 
@@ -744,7 +759,7 @@ export class GeminiAPIClient extends BaseApiClient<
         }
       })
     }
-    return [messageParam, ...(sdkPayload.history || [])]
+    return [...(sdkPayload.history || []), messageParam]
   }
 
   private async uploadFile(file: FileType): Promise<File> {

--- a/src/renderer/src/aiCore/middleware/core/McpToolChunkMiddleware.ts
+++ b/src/renderer/src/aiCore/middleware/core/McpToolChunkMiddleware.ts
@@ -255,6 +255,10 @@ function buildParamsWithToolResults(
   // 从回复中构建助手消息
   const newReqMessages = apiClient.buildSdkMessages(currentReqMessages, output, toolResults, toolCalls)
 
+  if (output && ctx._internal.toolProcessingState) {
+    ctx._internal.toolProcessingState.output = undefined
+  }
+
   // 估算新增消息的 token 消耗并累加到 usage 中
   if (ctx._internal.observer?.usage && newReqMessages.length > currentReqMessages.length) {
     try {


### PR DESCRIPTION
- Introduced a new modelParts array to manage model-related messages separately from user messages.
- Updated the logic to push model messages to currentReqMessages only if they exist, improving clarity and structure.
- Adjusted the return order of messages in buildSdkMessages to ensure history is appended correctly.
- Enhanced McpToolChunkMiddleware to reset tool processing state output when output is present.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

更新请求的组装形式，适配vertex，上下文更精确

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #7477 

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
