### PR TITLE
feat(TranslatePage): replace ReactMarkdown with Markdown component.

### DIFF
--- a/src/renderer/src/pages/translate/TranslatePage.tsx
+++ b/src/renderer/src/pages/translate/TranslatePage.tsx
@@ -7,10 +7,12 @@ import { translateLanguageOptions } from '@renderer/config/translate'
 import db from '@renderer/databases'
 import { useDefaultModel } from '@renderer/hooks/useAssistant'
 import { useProviders } from '@renderer/hooks/useProvider'
+import Markdown from '@renderer/pages/home/Markdown/Markdown'
 import { fetchTranslate } from '@renderer/services/ApiService'
 import { getDefaultTranslateAssistant } from '@renderer/services/AssistantService'
 import { getModelUniqId, hasModel } from '@renderer/services/ModelService'
 import type { Model, TranslateHistory } from '@renderer/types'
+import type { TranslationMessageBlock } from '@renderer/types/newMessage'
 import { runAsyncFunction, uuid } from '@renderer/utils'
 import {
   createInputScrollHandler,
@@ -26,7 +28,6 @@ import { find, isEmpty, sortBy } from 'lodash'
 import { ChevronDown, HelpCircle, Settings2, TriangleAlert } from 'lucide-react'
 import { FC, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import ReactMarkdown from 'react-markdown'
 import styled from 'styled-components'
 
 let _text = ''
@@ -616,7 +617,14 @@ const TranslatePage: FC = () => {
             {!result ? (
               t('translate.output.placeholder')
             ) : enableMarkdown ? (
-              <ReactMarkdown>{result}</ReactMarkdown>
+              <Markdown
+                block={
+                  {
+                    type: 'translation',
+                    content: result
+                  } as TranslationMessageBlock
+                }
+              />
             ) : (
               result
             )}
@@ -709,6 +717,24 @@ const OutputText = styled.div`
   padding: 5px 16px;
   overflow-y: auto;
   white-space: pre-wrap;
+
+  /* Reset styles for markdown content */
+  .markdown {
+    white-space: normal;
+    
+    /* Ensure proper paragraph spacing for translation content */
+    p {
+      margin: 0.5em 0;
+      
+      &:first-child {
+        margin-top: 0;
+      }
+      
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
 `
 
 const TranslateButton = styled(Button)``


### PR DESCRIPTION


<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

![image](https://github.com/user-attachments/assets/43dad46d-a5a0-40e3-9f86-98a2627d5c11)


After this PR:

![image](https://github.com/user-attachments/assets/091741d0-a30f-454c-a022-96636877ad5d)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # 既然横竖要用 Markdown 了，为什么不用个好的呢。

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->


### Special notes for your reviewer

直接替换掉之后，渲染出来的 Markdown 段间距爆炸大，让 Claude 按照下面这种方式调了一下，不知是否有更好的解决方案。以及其实现有代码的段间距也不小。

