### PR TITLE
fix: rendering issue of \[\] block formulas within Markdown blockquotes

### DIFF
--- a/src/renderer/src/utils/formats.ts
+++ b/src/renderer/src/utils/formats.ts
@@ -54,16 +54,12 @@ export function escapeDollarNumber(text: string) {
 }
 
 export function escapeBrackets(text: string) {
-  const pattern = /(```[\s\S]*?```|`.*?`)|\\\[([\s\S]*?[^\\])\\]|\\\((.*?)\\\)/g
+  const pattern = /(```[\s\S]*?```|`.*?`)|\\\[([\s\S]*?[^\\])\\\]|\\\((.*?)\\\)/g
   return text.replace(pattern, (match, codeBlock, squareBracket, roundBracket) => {
     if (codeBlock) {
       return codeBlock
     } else if (squareBracket) {
-      return `
-$$
-${squareBracket}
-$$
-`
+      return `$$${squareBracket}$$`
     } else if (roundBracket) {
       return `$${roundBracket}$`
     }


### PR DESCRIPTION
### What this PR does

修复正则表达式中方括号字符未正确转义导致的问题：
- 在 escapeBrackets 函数中将 \\\[ 和 \\\] 正则模式修正为 \\\\\[ 和 \\\\\]，从而确保 Markdown blockquote 引用中的数学公式能被正确渲染

Reference: https://github.com/ChatGPTNextWeb/NextChat/blob/673f907ea4e07eda8dbe479213e19b056819550d/app/components/markdown.tsx#L231C1-L248C1

Before this PR:

eg1. (v1.4.5)
```
下面是一个把 `\[\]` 块级公式放在 Markdown 引用里的示例：

> sentence a.
> \[
> \int_{-\infty}^{\infty} e^{-x^{2}} \, dx = \sqrt{\pi}
> \]
> sentence b.
```
<img width="735" alt="image" src="https://github.com/user-attachments/assets/9302e008-40a8-4950-ba60-878d4be9f647" />

eg2. (v1.4.5)
```
下面是一个把 `\[\]` 块级公式放在 Markdown 引用里的示例：

> sentence a.
> $$
> \int_{-\infty}^{\infty} e^{-x^{2}} \, dx = \sqrt{\pi}
> $$
> sentence b.
```
<img width="735" alt="image" src="https://github.com/user-attachments/assets/b915fa05-0293-4a92-bb1d-2eddfec16715" />

After this PR:

eg1.
```
下面是一个把 `\[\]` 块级公式放在 Markdown 引用里的示例：

> sentence a.
> \[
> \int_{-\infty}^{\infty} e^{-x^{2}} \, dx = \sqrt{\pi}
> \]
> sentence b.
```
<img width="735" alt="image" src="https://github.com/user-attachments/assets/ac5b5140-f338-4284-a381-e2f68da95130" />

eg2.
```
下面是一个把 `\[\]` 块级公式放在 Markdown 引用里的示例：

> sentence a.
> $$
> \int_{-\infty}^{\infty} e^{-x^{2}} \, dx = \sqrt{\pi}
> $$
> sentence b.
```
<img width="735" alt="image" src="https://github.com/user-attachments/assets/7bc4b00b-d97a-483a-b241-2ec615b1585c" />

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
