### PR TITLE
fix(Markdown): falsely early return for display `\[\n...\n\]`

### DIFF
--- a/src/renderer/src/utils/__tests__/markdown.test.ts
+++ b/src/renderer/src/utils/__tests__/markdown.test.ts
@@ -465,8 +465,26 @@ describe('markdown', () => {
 
   describe('processLatexBrackets', () => {
     describe('basic LaTeX conversion', () => {
-      it('should convert display math \\[...\\] to $$...$$', () => {
+      it('should convert (inline) display math \\[...\\] to $$...$$', () => {
         expect(processLatexBrackets('The formula is \\[a+b=c\\]')).toBe('The formula is $$a+b=c$$')
+      })
+
+      it('should convert display math \\[...\\] to $$...$$', () => {
+        const input = `
+The formula is
+
+\\[
+a+b=c
+\\]
+`
+        const expected = `
+The formula is
+
+$$
+a+b=c
+$$
+`
+        expect(processLatexBrackets(input)).toBe(expected)
       })
 
       it('should convert inline math \\(...\\) to $...$', () => {
@@ -611,9 +629,13 @@ const func = \\(x\\) => x * 2;
 
 Read more in [Section \\[3.2\\]: Advanced Topics](url) and see inline code \`\\[array\\]\`.
 
-Final thoughts on \\(\\nabla \\cdot \\vec{F} = \\rho\\) and display math:
+Final thoughts on \\(\\nabla \\cdot \\vec{F} = \\rho\\) in inline math and display math:
 
 \\[\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}\\]
+
+\\[
+\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}
+\\]
 `
 
         const expectedOutput = `
@@ -647,9 +669,13 @@ const func = \\(x\\) => x * 2;
 
 Read more in [Section \\[3.2\\]: Advanced Topics](url) and see inline code \`\\[array\\]\`.
 
-Final thoughts on $\\nabla \\cdot \\vec{F} = \\rho$ and display math:
+Final thoughts on $\\nabla \\cdot \\vec{F} = \\rho$ in inline math and display math:
 
 $$\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}$$
+
+$$
+\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}
+$$
 `
 
         expect(processLatexBrackets(complexInput)).toBe(expectedOutput)

--- a/src/renderer/src/utils/markdown.ts
+++ b/src/renderer/src/utils/markdown.ts
@@ -1,5 +1,5 @@
 import { languages } from '@shared/config/languages'
-import balanced from 'balanced-match'
+import { default as balanced } from 'balanced-match'
 import remarkParse from 'remark-parse'
 import remarkStringify from 'remark-stringify'
 import removeMarkdown from 'remove-markdown'
@@ -31,7 +31,7 @@ export const findCitationInChildren = (children: any): string => {
 }
 
 // 检查是否包含潜在的 LaTeX 模式
-const containsLatexRegex = /\\\(.*?\\\)|\\\[.*?\\\]|\$.*?\$|\\begin\{equation\}.*?\\end\{equation\}/
+const containsLatexRegex = /\\\(.*?\\\)|\\\[.*?\\\]|\$.*?\$|\\begin\{equation\}.*?\\end\{equation\}/s
 
 /**
  * 转换 LaTeX 公式括号 `\[\]` 和 `\(\)` 为 Markdown 格式 `$$...$$` 和 `$...$`


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

检测 latex 括号的正则表达式没有匹配换行符，只有行间 `\[\n...\n\]` 的情况下会跳过。
- 修复问题
- 补充测试

Before this PR:

![image](https://github.com/user-attachments/assets/887630bd-eec7-4a4f-9ea5-51dad024cde9)

After this PR:

![image](https://github.com/user-attachments/assets/1cf85b53-e0a0-4eb7-a7a7-f18068a60d37)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
