### PR TITLE
feat(FileStorage): enhance open dialog to handle large files by retur…

### DIFF
--- a/src/main/services/FileStorage.ts
+++ b/src/main/services/FileStorage.ts
@@ -363,7 +363,7 @@ class FileStorage {
   public open = async (
     _: Electron.IpcMainInvokeEvent,
     options: OpenDialogOptions
-  ): Promise<{ fileName: string; filePath: string; content: Buffer } | null> => {
+  ): Promise<{ fileName: string; filePath: string; content?: Buffer; size: number } | null> => {
     try {
       const result: OpenDialogReturnValue = await dialog.showOpenDialog({
         title: '打开文件',
@@ -375,8 +375,16 @@ class FileStorage {
       if (!result.canceled && result.filePaths.length > 0) {
         const filePath = result.filePaths[0]
         const fileName = filePath.split('/').pop() || ''
-        const content = await readFile(filePath)
-        return { fileName, filePath, content }
+        const stats = await fs.promises.stat(filePath)
+
+        // If the file is less than 2GB, read the content
+        if (stats.size < 2 * 1024 * 1024 * 1024) {
+          const content = await readFile(filePath)
+          return { fileName, filePath, content, size: stats.size }
+        }
+
+        // For large files, only return file information, do not read content
+        return { fileName, filePath, size: stats.size }
       }
 
       return null


### PR DESCRIPTION
…ning size without reading content

- Updated the open method to return file size for files larger than 2GB without reading their content.
- Modified return type to include an optional content field and size property for better file handling.

恢复备份的时候选择超过 2GB 文件会报错，导致很多用户无法恢复数据

测试情况：

两个地方使用这个 api
1. 导入 agent json 的地方 ✅
2. 恢复备份 ✅

