### PR TITLE
refactor(CodePreview): line numbers as elements

### DIFF
--- a/src/renderer/src/components/CodeBlockView/CodePreview.tsx
+++ b/src/renderer/src/components/CodeBlockView/CodePreview.tsx
@@ -188,16 +188,18 @@ const CodePreview = ({ children, language, setTools }: CodePreviewProps) => {
   )
 }
 
+interface ShikiTokensRendererProps {
+  language: string
+  tokenLines: ThemedToken[][]
+  showLineNumbers?: boolean
+}
+
 /**
  * 渲染 Shiki 高亮后的 tokens
  *
  * 独立出来，方便将来做 virtual list
  */
-const ShikiTokensRenderer: React.FC<{
-  language: string
-  tokenLines: ThemedToken[][]
-  showLineNumbers: boolean
-}> = memo(({ language, tokenLines, showLineNumbers }) => {
+const ShikiTokensRenderer: React.FC<ShikiTokensRendererProps> = memo(({ language, tokenLines, showLineNumbers }) => {
   const { getShikiPreProperties } = useCodeStyle()
   const rendererRef = useRef<HTMLPreElement>(null)
 

--- a/src/renderer/src/components/CodeBlockView/CodePreview.tsx
+++ b/src/renderer/src/components/CodeBlockView/CodePreview.tsx
@@ -204,7 +204,7 @@ const ShikiTokensRenderer: React.FC<ShikiTokensRendererProps> = memo(({ language
   const rendererRef = useRef<HTMLPreElement>(null)
 
   // 设置 pre 标签属性
-  useEffect(() => {
+  useLayoutEffect(() => {
     getShikiPreProperties(language).then((properties) => {
       const pre = rendererRef.current
       if (pre) {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

放弃用 css counter 实现 CodePreview 的行号，而是直接渲染为元素。

Before this PR:

html-to-image 之类的工具无法处理 counter，结果导出为图片时行号都是 0.

After this PR:

能够正常导出图片。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #7586

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
