### PR TITLE
fix: textarea not resizing back after clearing long input (#7609)

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -788,7 +788,7 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
             variant="borderless"
             spellCheck={enableSpellCheck}
             rows={2}
-            autoSize={{ minRows: 2, maxRows: 20 }}
+            autoSize={textareaHeight ? false : { minRows: 2, maxRows: 20 }}
             ref={textareaRef}
             style={{
               fontSize,

--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -788,6 +788,7 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
             variant="borderless"
             spellCheck={enableSpellCheck}
             rows={2}
+            autoSize={{ minRows: 2, maxRows: 20 }}
             ref={textareaRef}
             style={{
               fontSize,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR: input not resizing after long input clearing or sending out.


https://github.com/user-attachments/assets/9e180039-de71-4ab6-8421-94ed687beefb

After this PR: after clearing the lone text, text area auto resizes back.

https://github.com/user-attachments/assets/382e9c3a-1efb-4141-bd68-bfe9628d6022

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #7609

### Special notes for your reviewer

After adding `autoSize` property, the height of the text area would change after user's content change. Even if the user manually dragged the height. Is this acceptable and as expected?

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
