### PR TITLE
Fix/gemini

### DIFF
--- a/src/renderer/src/aiCore/clients/gemini/GeminiAPIClient.ts
+++ b/src/renderer/src/aiCore/clients/gemini/GeminiAPIClient.ts
@@ -398,12 +398,13 @@ export class GeminiAPIClient extends BaseApiClient<
 
       // 如果thinking_budget是undefined，不思考
       if (reasoningEffort === undefined) {
-        return {
-          thinkingConfig: {
-            includeThoughts: false,
-            ...(GEMINI_FLASH_MODEL_REGEX.test(model.id) ? { thinkingBudget: 0 } : {})
-          } as ThinkingConfig
-        }
+        return GEMINI_FLASH_MODEL_REGEX.test(model.id)
+          ? {
+              thinkingConfig: {
+                thinkingBudget: 0
+              }
+            }
+          : {}
       }
 
       if (reasoningEffort === 'auto') {

--- a/src/renderer/src/aiCore/clients/openai/OpenAIApiClient.ts
+++ b/src/renderer/src/aiCore/clients/openai/OpenAIApiClient.ts
@@ -114,6 +114,9 @@ export class OpenAIAPIClient extends OpenAIBaseClient<
 
     if (!reasoningEffort) {
       if (model.provider === 'openrouter') {
+        if (isSupportedThinkingTokenGeminiModel(model) && !GEMINI_FLASH_MODEL_REGEX.test(model.id)) {
+          return {}
+        }
         return { reasoning: { enabled: false, exclude: true } }
       }
       if (isSupportedThinkingTokenQwenModel(model)) {

--- a/src/renderer/src/aiCore/clients/openai/OpenAIApiClient.ts
+++ b/src/renderer/src/aiCore/clients/openai/OpenAIApiClient.ts
@@ -126,7 +126,15 @@ export class OpenAIAPIClient extends OpenAIBaseClient<
 
       if (isSupportedThinkingTokenGeminiModel(model)) {
         if (GEMINI_FLASH_MODEL_REGEX.test(model.id)) {
-          return { reasoning_effort: 'none' }
+          return {
+            extra_body: {
+              google: {
+                thinking_config: {
+                  thinking_budget: 0
+                }
+              }
+            }
+          }
         }
         return {}
       }
@@ -169,9 +177,34 @@ export class OpenAIAPIClient extends OpenAIBaseClient<
     }
 
     // OpenAI models
-    if (isSupportedReasoningEffortOpenAIModel(model) || isSupportedThinkingTokenGeminiModel(model)) {
+    if (isSupportedReasoningEffortOpenAIModel(model)) {
       return {
         reasoning_effort: reasoningEffort
+      }
+    }
+
+    if (isSupportedThinkingTokenGeminiModel(model)) {
+      if (reasoningEffort === 'auto') {
+        return {
+          extra_body: {
+            google: {
+              thinking_config: {
+                thinking_budget: -1,
+                include_thoughts: true
+              }
+            }
+          }
+        }
+      }
+      return {
+        extra_body: {
+          google: {
+            thinking_config: {
+              thinking_budget: budgetTokens,
+              include_thoughts: true
+            }
+          }
+        }
       }
     }
 

--- a/src/renderer/src/aiCore/middleware/feat/ThinkingTagExtractionMiddleware.ts
+++ b/src/renderer/src/aiCore/middleware/feat/ThinkingTagExtractionMiddleware.ts
@@ -11,11 +11,13 @@ export const MIDDLEWARE_NAME = 'ThinkingTagExtractionMiddleware'
 // 不同模型的思考标签配置
 const reasoningTags: TagConfig[] = [
   { openingTag: '<think>', closingTag: '</think>', separator: '\n' },
+  { openingTag: '<thought>', closingTag: '</thought>', separator: '\n' },
   { openingTag: '###Thinking', closingTag: '###Response', separator: '\n' }
 ]
 
 const getAppropriateTag = (model?: Model): TagConfig => {
   if (model?.id?.includes('qwen3')) return reasoningTags[0]
+  if (model?.id?.includes('gemini-2.5')) return reasoningTags[1]
   // 可以在这里添加更多模型特定的标签配置
   return reasoningTags[0] // 默认使用 <think> 标签
 }

--- a/src/renderer/src/config/models.ts
+++ b/src/renderer/src/config/models.ts
@@ -2479,14 +2479,16 @@ export function isGeminiReasoningModel(model?: Model): boolean {
     return true
   }
 
-  if (model.id.includes('gemini-2.5')) {
+  if (isSupportedThinkingTokenGeminiModel(model)) {
     return true
   }
 
   return false
 }
 
-export const isSupportedThinkingTokenGeminiModel = isGeminiReasoningModel
+export const isSupportedThinkingTokenGeminiModel = (model: Model): boolean => {
+  return model.id.includes('gemini-2.5')
+}
 
 export function isQwenReasoningModel(model?: Model): boolean {
   if (!model) {

--- a/src/renderer/src/pages/home/Inputbar/ThinkingButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/ThinkingButton.tsx
@@ -7,6 +7,7 @@ import {
 } from '@renderer/components/Icons/SVGIcon'
 import { useQuickPanel } from '@renderer/components/QuickPanel'
 import {
+  GEMINI_FLASH_MODEL_REGEX,
   isDoubaoThinkingAutoModel,
   isSupportedReasoningEffortGrokModel,
   isSupportedThinkingTokenDoubaoModel,
@@ -37,13 +38,14 @@ const MODEL_SUPPORTED_OPTIONS: Record<string, ThinkingOption[]> = {
   default: ['off', 'low', 'medium', 'high'],
   grok: ['off', 'low', 'high'],
   gemini: ['off', 'low', 'medium', 'high', 'auto'],
+  gemini_pro: ['low', 'medium', 'high', 'auto'],
   qwen: ['off', 'low', 'medium', 'high'],
   doubao: ['off', 'auto', 'high']
 }
 
 // 选项转换映射表：当选项不支持时使用的替代选项
 const OPTION_FALLBACK: Record<ThinkingOption, ThinkingOption> = {
-  off: 'off',
+  off: 'low', // off -> low (for Gemini Pro models)
   low: 'high',
   medium: 'high', // medium -> high (for Grok models)
   high: 'high',
@@ -57,6 +59,7 @@ const ThinkingButton: FC<Props> = ({ ref, model, assistant, ToolbarButton }): Re
 
   const isGrokModel = isSupportedReasoningEffortGrokModel(model)
   const isGeminiModel = isSupportedThinkingTokenGeminiModel(model)
+  const isGeminiFlashModel = GEMINI_FLASH_MODEL_REGEX.test(model.id)
   const isQwenModel = isSupportedThinkingTokenQwenModel(model)
   const isDoubaoModel = isSupportedThinkingTokenDoubaoModel(model)
 
@@ -66,12 +69,18 @@ const ThinkingButton: FC<Props> = ({ ref, model, assistant, ToolbarButton }): Re
 
   // 确定当前模型支持的选项类型
   const modelType = useMemo(() => {
-    if (isGeminiModel) return 'gemini'
+    if (isGeminiModel) {
+      if (isGeminiFlashModel) {
+        return 'gemini'
+      } else {
+        return 'gemini_pro'
+      }
+    }
     if (isGrokModel) return 'grok'
     if (isQwenModel) return 'qwen'
     if (isDoubaoModel) return 'doubao'
     return 'default'
-  }, [isGeminiModel, isGrokModel, isQwenModel, isDoubaoModel])
+  }, [isGeminiModel, isGrokModel, isQwenModel, isDoubaoModel, isGeminiFlashModel])
 
   // 获取当前模型支持的选项
   const supportedOptions = useMemo(() => {

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -607,6 +607,7 @@ export async function checkApi(provider: Provider, model: Model): Promise<void> 
         messages: 'hi',
         assistant,
         streamOutput: true,
+        enableReasoning: false,
         shouldThrow: true
       }
 

--- a/src/renderer/src/types/sdk.ts
+++ b/src/renderer/src/types/sdk.ts
@@ -53,6 +53,7 @@ export type ReasoningEffortOptionalParams = {
   enable_thinking?: boolean
   thinking_budget?: number
   enable_reasoning?: boolean
+  extra_body?: Record<string, any>
   // Add any other potential reasoning-related keys here if they exist
 }
 


### PR DESCRIPTION
- Simplified the logic for returning thinking configuration when reasoningEffort is undefined in GeminiAPIClient.
- Updated ApiService to include enableReasoning flag for API calls, enhancing control over reasoning capabilities.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

1. 从前端禁止了2.5 pro不思考选项
2. Gemini openai兼容模式现在也能展示思考链
3. 优化了gemini 模型的检测


测试方法：

<img width="941" alt="image" src="https://github.com/user-attachments/assets/1e54d939-e4c7-46ae-8b85-de54d78eb686" />

<img width="941" alt="image" src="https://github.com/user-attachments/assets/fab3ba2f-b8dd-4bd6-b8a6-24b635460858" />


### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
