### PR TITLE
feat(TopicsHistory): add sorting functionality for topics and update UI components

### DIFF
--- a/src/renderer/src/pages/history/components/TopicsHistory.tsx
+++ b/src/renderer/src/pages/history/components/TopicsHistory.tsx
@@ -4,11 +4,14 @@ import { useAssistants } from '@renderer/hooks/useAssistant'
 import useScrollPosition from '@renderer/hooks/useScrollPosition'
 import { getTopicById } from '@renderer/hooks/useTopic'
 import { Topic } from '@renderer/types'
-import { Button, Divider, Empty } from 'antd'
+import { Button, Divider, Empty, Segmented } from 'antd'
 import dayjs from 'dayjs'
 import { groupBy, isEmpty, orderBy } from 'lodash'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
+
+type SortType = 'createdAt' | 'updatedAt'
 
 type Props = {
   keywords: string
@@ -20,15 +23,16 @@ const TopicsHistory: React.FC<Props> = ({ keywords, onClick, onSearch, ...props 
   const { assistants } = useAssistants()
   const { t } = useTranslation()
   const { handleScroll, containerRef } = useScrollPosition('TopicsHistory')
+  const [sortType, setSortType] = useState<SortType>('createdAt')
 
-  const topics = orderBy(assistants.map((assistant) => assistant.topics).flat(), 'createdAt', 'desc')
+  const topics = orderBy(assistants.map((assistant) => assistant.topics).flat(), sortType, 'desc')
 
   const filteredTopics = topics.filter((topic) => {
     return topic.name.toLowerCase().includes(keywords.toLowerCase())
   })
 
   const groupedTopics = groupBy(filteredTopics, (topic) => {
-    return dayjs(topic.createdAt).format('MM/DD')
+    return dayjs(topic[sortType]).format('MM/DD')
   })
 
   if (isEmpty(filteredTopics)) {
@@ -46,6 +50,15 @@ const TopicsHistory: React.FC<Props> = ({ keywords, onClick, onSearch, ...props 
 
   return (
     <ListContainer {...props} ref={containerRef} onScroll={handleScroll}>
+      <Segmented
+        size="small"
+        value={sortType}
+        onChange={setSortType}
+        options={[
+          { label: t('export.created'), value: 'createdAt' },
+          { label: t('export.last_updated'), value: 'updatedAt' }
+        ]}
+      />
       <ContainerWrapper>
         {Object.entries(groupedTopics).map(([date, items]) => (
           <ListItem key={date}>
@@ -91,7 +104,7 @@ const ListContainer = styled.div`
   overflow-y: scroll;
   width: 100%;
   align-items: center;
-  padding-top: 20px;
+  padding-top: 10px;
   padding-bottom: 20px;
 `
 

--- a/src/renderer/src/pages/history/components/TopicsHistory.tsx
+++ b/src/renderer/src/pages/history/components/TopicsHistory.tsx
@@ -51,6 +51,7 @@ const TopicsHistory: React.FC<Props> = ({ keywords, onClick, onSearch, ...props 
   return (
     <ListContainer {...props} ref={containerRef} onScroll={handleScroll}>
       <Segmented
+        shape="round"
         size="small"
         value={sortType}
         onChange={setSortType}
@@ -72,7 +73,7 @@ const TopicsHistory: React.FC<Props> = ({ keywords, onClick, onSearch, ...props 
                   onClick(_topic)
                 }}>
                 <TopicName>{topic.name.substring(0, 50)}</TopicName>
-                <TopicDate>{dayjs(topic.updatedAt).format('HH:mm')}</TopicDate>
+                <TopicDate>{dayjs(topic[sortType]).format('HH:mm')}</TopicDate>
               </TopicItem>
             ))}
           </ListItem>

--- a/src/renderer/src/store/assistants.ts
+++ b/src/renderer/src/store/assistants.ts
@@ -143,6 +143,17 @@ const assistantsSlice = createSlice({
         return assistant
       })
     },
+    updateTopicUpdatedAt: (state, action: PayloadAction<{ topicId: string }>) => {
+      outer: for (const assistant of state.assistants) {
+        for (const topic of assistant.topics) {
+          console.log('updateTopicUpdatedAt', topic.id, topic.id === action.payload.topicId)
+          if (topic.id === action.payload.topicId) {
+            topic.updatedAt = new Date().toISOString()
+            break outer
+          }
+        }
+      }
+    },
     setModel: (state, action: PayloadAction<{ assistantId: string; model: Model }>) => {
       state.assistants = state.assistants.map((assistant) =>
         assistant.id === action.payload.assistantId
@@ -167,6 +178,7 @@ export const {
   updateTopic,
   updateTopics,
   removeAllTopics,
+  updateTopicUpdatedAt,
   setModel,
   setTagsOrder,
   updateAssistantSettings,

--- a/src/renderer/src/store/assistants.ts
+++ b/src/renderer/src/store/assistants.ts
@@ -146,7 +146,6 @@ const assistantsSlice = createSlice({
     updateTopicUpdatedAt: (state, action: PayloadAction<{ topicId: string }>) => {
       outer: for (const assistant of state.assistants) {
         for (const topic of assistant.topics) {
-          console.log('updateTopicUpdatedAt', topic.id, topic.id === action.payload.topicId)
           if (topic.id === action.payload.topicId) {
             topic.updatedAt = new Date().toISOString()
             break outer

--- a/src/renderer/src/store/thunk/messageThunk.ts
+++ b/src/renderer/src/store/thunk/messageThunk.ts
@@ -7,6 +7,7 @@ import { NotificationService } from '@renderer/services/NotificationService'
 import { createStreamProcessor, type StreamProcessorCallbacks } from '@renderer/services/StreamProcessingService'
 import { estimateMessagesUsage } from '@renderer/services/TokenService'
 import store from '@renderer/store'
+import { updateTopicUpdatedAt } from '@renderer/store/assistants'
 import type { Assistant, ExternalToolResult, FileType, MCPToolResponse, Model, Topic } from '@renderer/types'
 import type {
   CitationMessageBlock,
@@ -69,6 +70,7 @@ export const saveMessageAndBlocksToDB = async (message: Message, blocks: Message
         }
       }
       await db.topics.update(message.topicId, { messages: updatedMessages })
+      store.dispatch(updateTopicUpdatedAt({ topicId: message.topicId }))
     } else {
       console.error(`[saveMessageAndBlocksToDB] Topic ${message.topicId} not found.`)
     }
@@ -108,6 +110,8 @@ const updateExistingMessageAndBlocksInDB = async (
               })
             }
           })
+
+        store.dispatch(updateTopicUpdatedAt({ topicId: updatedMessage.topicId }))
       }
     })
   } catch (error) {
@@ -863,6 +867,7 @@ export const sendMessage =
       if (userMessageBlocks.length > 0) {
         dispatch(upsertManyBlocks(userMessageBlocks))
       }
+      dispatch(updateTopicUpdatedAt({ topicId }))
 
       const mentionedModels = userMessage.mentions
       const queue = getTopicQueue(topicId)
@@ -955,6 +960,7 @@ export const deleteSingleMessageThunk =
       if (topic) {
         const finalMessagesToSave = selectMessagesForTopic(getState(), topicId)
         await db.topics.update(topicId, { messages: finalMessagesToSave })
+        dispatch(updateTopicUpdatedAt({ topicId }))
       }
     } catch (error) {
       console.error(`[deleteSingleMessage] Failed to delete message ${messageId}:`, error)
@@ -998,6 +1004,7 @@ export const deleteMessageGroupThunk =
       if (topic) {
         const finalMessagesToSave = selectMessagesForTopic(getState(), topicId)
         await db.topics.update(topicId, { messages: finalMessagesToSave })
+        dispatch(updateTopicUpdatedAt({ topicId }))
       }
     } catch (error) {
       console.error(`[deleteMessageGroup] Failed to delete messages with askId ${askId}:`, error)
@@ -1025,6 +1032,7 @@ export const clearTopicMessagesThunk =
       cleanupMultipleBlocks(dispatch, blockIdsToDelete)
 
       await db.topics.update(topicId, { messages: [] })
+      dispatch(updateTopicUpdatedAt({ topicId }))
       if (blockIdsToDelete.length > 0) {
         await db.message_blocks.bulkDelete(blockIdsToDelete)
       }
@@ -1624,6 +1632,8 @@ export const updateMessageAndBlocksThunk =
           await db.message_blocks.bulkPut(blockUpdatesList)
         }
       })
+
+      dispatch(updateTopicUpdatedAt({ topicId }))
     } catch (error) {
       console.error(`[updateMessageAndBlocksThunk] Failed to process updates for message ${messageId}:`, error)
     }
@@ -1665,6 +1675,8 @@ export const removeBlocksThunk =
           await db.message_blocks.bulkDelete(blockIdsToRemove)
         }
       })
+
+      dispatch(updateTopicUpdatedAt({ topicId }))
 
       return
     } catch (error) {


### PR DESCRIPTION
1、修复话题下message变更时没有更新updateAt问题；
2、添加话题历史搜索的排序功能，支持按创建时间、更新时间来排序；
<img width="1150" alt="image" src="https://github.com/user-attachments/assets/c2b9e8a0-4921-4954-9bf5-6e8c76ac64cd" />
