### PR TITLE
fix: update default timeout configuration across API clients

### DIFF
--- a/packages/shared/config/constant.ts
+++ b/packages/shared/config/constant.ts
@@ -416,6 +416,6 @@ export enum UpgradeChannel {
   BETA = 'beta' // 预览版本
 }
 
-export const defaultTimeout = 5 * 1000 * 60
+export const defaultTimeout = 10 * 1000 * 60
 
 export const occupiedDirs = ['logs', 'Network', 'Partitions/webview/Network']

--- a/src/renderer/src/aiCore/clients/gemini/GeminiAPIClient.ts
+++ b/src/renderer/src/aiCore/clients/gemini/GeminiAPIClient.ts
@@ -60,7 +60,7 @@ import {
 } from '@renderer/utils/mcp-tools'
 import { findFileBlocks, findImageBlocks, getMainTextContent } from '@renderer/utils/messageUtils/find'
 import { buildSystemPrompt } from '@renderer/utils/prompt'
-import { MB } from '@shared/config/constant'
+import { defaultTimeout, MB } from '@shared/config/constant'
 
 import { BaseApiClient } from '../BaseApiClient'
 import { RequestTransformer, ResponseChunkTransformer } from '../types'
@@ -118,7 +118,7 @@ export class GeminiAPIClient extends BaseApiClient<
         aspectRatio: imageSize,
         abortSignal: signal,
         httpOptions: {
-          timeout: 5 * 60 * 1000
+          timeout: defaultTimeout
         }
       }
       const response = await sdk.models.generateImages({

--- a/src/renderer/src/aiCore/middleware/feat/ImageGenerationMiddleware.ts
+++ b/src/renderer/src/aiCore/middleware/feat/ImageGenerationMiddleware.ts
@@ -3,6 +3,7 @@ import { isDedicatedImageGenerationModel } from '@renderer/config/models'
 import FileManager from '@renderer/services/FileManager'
 import { ChunkType } from '@renderer/types/chunk'
 import { findImageBlocks, getMainTextContent } from '@renderer/utils/messageUtils/find'
+import { defaultTimeout } from '@shared/config/constant'
 import OpenAI from 'openai'
 import { toFile } from 'openai/uploads'
 
@@ -74,8 +75,7 @@ export const ImageGenerationMiddleware: CompletionsMiddleware =
 
           const startTime = Date.now()
           let response: OpenAI.Images.ImagesResponse
-
-          const options = { signal, timeout: 300_000 }
+          const options = { signal, timeout: defaultTimeout }
 
           if (imageFiles.length > 0) {
             response = await sdk.images.edit(


### PR DESCRIPTION
- Increased the default timeout value from 5 minutes to 10 minutes in constant.ts.
- Updated GeminiAPIClient and ImageGenerationMiddleware to utilize the new defaultTimeout constant for API call timeouts, ensuring consistent timeout handling across the application.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
