### PR TITLE
refactor: new knowledge base ui layout

### DIFF
--- a/src/renderer/src/pages/knowledge/KnowledgeContent.tsx
+++ b/src/renderer/src/pages/knowledge/KnowledgeContent.tsx
@@ -1,13 +1,12 @@
 import { RedoOutlined } from '@ant-design/icons'
 import CustomTag from '@renderer/components/CustomTag'
 import { HStack } from '@renderer/components/Layout'
-import ListItem from '@renderer/components/ListItem'
 import { useKnowledge } from '@renderer/hooks/useKnowledge'
 import { NavbarIcon } from '@renderer/pages/home/Navbar'
 import { getProviderName } from '@renderer/services/ProviderService'
 import { KnowledgeBase } from '@renderer/types'
-import { Button, Empty, Tag, Tooltip } from 'antd'
-import { Book, Folder, Globe, Link, Notebook, Search, Settings2 } from 'lucide-react'
+import { Button, Empty, Tabs, Tag, Tooltip } from 'antd'
+import { Book, Folder, Globe, Link, Notebook, Search, Settings } from 'lucide-react'
 import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -19,7 +18,6 @@ import KnowledgeFiles from './items/KnowledgeFiles'
 import KnowledgeNotes from './items/KnowledgeNotes'
 import KnowledgeSitemaps from './items/KnowledgeSitemaps'
 import KnowledgeUrls from './items/KnowledgeUrls'
-import { KnowledgeSideNav } from './KnowledgePage'
 
 interface KnowledgeContentProps {
   selectedBase: KnowledgeBase
@@ -36,32 +34,37 @@ const KnowledgeContent: FC<KnowledgeContentProps> = ({ selectedBase }) => {
     {
       key: 'files',
       title: t('files.title'),
-      icon: <Book size={16} />,
-      items: fileItems
+      icon: activeKey === 'files' ? <Book size={16} color="var(--color-primary)" /> : <Book size={16} />,
+      items: fileItems,
+      content: <KnowledgeFiles selectedBase={selectedBase} />
     },
     {
       key: 'notes',
       title: t('knowledge.notes'),
-      icon: <Notebook size={16} />,
-      items: noteItems
+      icon: activeKey === 'notes' ? <Notebook size={16} color="var(--color-primary)" /> : <Notebook size={16} />,
+      items: noteItems,
+      content: <KnowledgeNotes selectedBase={selectedBase} />
     },
     {
       key: 'directories',
       title: t('knowledge.directories'),
-      icon: <Folder size={16} />,
-      items: directoryItems
+      icon: activeKey === 'directories' ? <Folder size={16} color="var(--color-primary)" /> : <Folder size={16} />,
+      items: directoryItems,
+      content: <KnowledgeDirectories selectedBase={selectedBase} />
     },
     {
       key: 'urls',
       title: t('knowledge.urls'),
-      icon: <Link size={16} />,
-      items: urlItems
+      icon: activeKey === 'urls' ? <Link size={16} color="var(--color-primary)" /> : <Link size={16} />,
+      items: urlItems,
+      content: <KnowledgeUrls selectedBase={selectedBase} />
     },
     {
       key: 'sitemaps',
       title: t('knowledge.sitemaps'),
-      icon: <Globe size={16} />,
-      items: sitemapItems
+      icon: activeKey === 'sitemaps' ? <Globe size={16} color="var(--color-primary)" /> : <Globe size={16} />,
+      items: sitemapItems,
+      content: <KnowledgeSitemaps selectedBase={selectedBase} />
     }
   ]
 
@@ -69,13 +72,27 @@ const KnowledgeContent: FC<KnowledgeContentProps> = ({ selectedBase }) => {
     return null
   }
 
+  const tabItems = knowledgeItems.map((item) => ({
+    key: item.key,
+    label: (
+      <TabLabel>
+        {item.icon}
+        <span>{item.title}</span>
+        <CustomTag size={10} color={item.items.length > 0 ? '#00b96b' : '#cccccc'}>
+          {item.items.length}
+        </CustomTag>
+      </TabLabel>
+    ),
+    children: <TabContent>{item.content}</TabContent>
+  }))
+
   return (
     <MainContainer>
       <HeaderContainer>
         <ModelInfo>
           <Button
             type="text"
-            icon={<Settings2 size={18} color="var(--color-icon)" />}
+            icon={<Settings size={18} color="var(--color-icon)" />}
             onClick={() => KnowledgeSettingsPopup.show({ base })}
             size="small"
           />
@@ -98,47 +115,12 @@ const KnowledgeContent: FC<KnowledgeContentProps> = ({ selectedBase }) => {
           </NarrowIcon>
         </HStack>
       </HeaderContainer>
-      <RightContainer>
-        <KnowledgeSideNav style={{ gap: 10 }}>
-          {knowledgeItems.map((item) => (
-            <ListItem
-              key={item.key}
-              title={item.title}
-              icon={item.icon}
-              active={activeKey === item.key}
-              onClick={() => setActiveKey(item.key)}
-              rightContent={
-                <CustomTag size={12} color={item.items.length > 0 ? '#008001' : '#cccccc'}>
-                  {item.items.length}
-                </CustomTag>
-              }
-            />
-          ))}
-        </KnowledgeSideNav>
-        <MainContent>
-          {activeKey === 'files' && <KnowledgeFiles selectedBase={selectedBase} />}
-          {activeKey === 'directories' && <KnowledgeDirectories selectedBase={selectedBase} />}
-          {activeKey === 'urls' && <KnowledgeUrls selectedBase={selectedBase} />}
-          {activeKey === 'sitemaps' && <KnowledgeSitemaps selectedBase={selectedBase} />}
-          {activeKey === 'notes' && <KnowledgeNotes selectedBase={selectedBase} />}
-        </MainContent>
-      </RightContainer>
+      <StyledTabs activeKey={activeKey} onChange={setActiveKey} items={tabItems} type="line" size="small" />
     </MainContainer>
   )
 }
 
-export const CollapseLabel = ({ label, count }: { label: string; count: number }) => {
-  return (
-    <HStack alignItems="center" gap={10}>
-      <label style={{ fontWeight: 600 }}>{label}</label>
-      <CustomTag size={12} color={count ? '#008001' : '#cccccc'}>
-        {count}
-      </CustomTag>
-    </HStack>
-  )
-}
-
-export const KnowledgeEmptyView = () => <Empty style={{ margin: 0 }} styles={{ image: { display: 'none' } }} />
+export const KnowledgeEmptyView = () => <Empty style={{ margin: 20 }} styles={{ image: { display: 'none' } }} />
 
 export const ItemHeaderLabel = ({ label }: { label: string }) => {
   return (
@@ -155,18 +137,55 @@ const MainContainer = styled.div`
   position: relative;
 `
 
-const RightContainer = styled.div`
+const TabLabel = styled.div`
   display: flex;
-  flex-direction: row;
-  flex: 1;
+  align-items: center;
+  gap: 6px;
+  padding: 0 4px;
+  font-size: 14px;
 `
 
-const MainContent = styled.div`
-  display: flex;
-  flex-direction: column;
+const TabContent = styled.div``
+
+const StyledTabs = styled(Tabs)`
   flex: 1;
-  gap: 20px;
-  padding-bottom: 50px;
+
+  .ant-tabs-nav {
+    padding: 0 16px;
+    margin: 0;
+    min-height: 48px;
+  }
+
+  .ant-tabs-tab {
+    padding: 12px 12px;
+    margin-right: 0;
+    font-size: 13px;
+
+    &:hover {
+      color: var(--color-primary);
+    }
+  }
+
+  .ant-tabs-tab-btn {
+    font-size: 13px;
+  }
+
+  .ant-tabs-content {
+    position: initial !important;
+  }
+
+  .ant-tabs-content-holder {
+    overflow: hidden;
+  }
+
+  .ant-tabs-tabpane {
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .ant-tabs-ink-bar {
+    height: 2px;
+  }
 `
 
 const HeaderContainer = styled.div`
@@ -184,7 +203,7 @@ const ModelInfo = styled.div`
   flex-direction: row;
   align-items: center;
   gap: 8px;
-  height: 50px;
+  height: 45px;
 
   .model-header {
     display: flex;
@@ -233,9 +252,10 @@ export const ItemHeader = styled.div`
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  border-bottom: 0.5px solid var(--color-border);
-  padding-bottom: 10px;
-  margin: 10px 15px;
+  position: absolute;
+  top: calc(var(--navbar-height) + 14px);
+  right: 16px;
+  z-index: 1000;
 `
 
 export const StatusIconWrapper = styled.div`

--- a/src/renderer/src/pages/knowledge/KnowledgePage.tsx
+++ b/src/renderer/src/pages/knowledge/KnowledgePage.tsx
@@ -163,7 +163,7 @@ const MainContent = styled(Scrollbar)`
 `
 
 export const KnowledgeSideNav = styled.div`
-  min-width: 240px;
+  min-width: var(--settings-width);
   border-right: 0.5px solid var(--color-border);
   padding: 12px 10px;
   display: flex;

--- a/src/renderer/src/pages/knowledge/items/KnowledgeDirectories.tsx
+++ b/src/renderer/src/pages/knowledge/items/KnowledgeDirectories.tsx
@@ -19,7 +19,6 @@ import {
   FlexAlignCenter,
   ItemContainer,
   ItemHeader,
-  ItemHeaderLabel,
   KnowledgeEmptyView,
   RefreshIcon,
   StatusIconWrapper
@@ -69,9 +68,8 @@ const KnowledgeDirectories: FC<KnowledgeContentProps> = ({ selectedBase }) => {
   return (
     <ItemContainer>
       <ItemHeader>
-        <ItemHeaderLabel label={t('knowledge.directories')} />
         <Button
-          type="text"
+          type="primary"
           icon={<Plus size={16} />}
           onClick={(e) => {
             e.stopPropagation()
@@ -122,9 +120,9 @@ const KnowledgeDirectories: FC<KnowledgeContentProps> = ({ selectedBase }) => {
 const ItemFlexColumn = styled(Scrollbar)`
   display: flex;
   flex-direction: column;
-  gap: 15px;
-  padding: 0 15px;
-  height: calc(100vh - 175px);
+  gap: 10px;
+  padding: 20px 16px;
+  height: calc(100vh - 135px);
 `
 
 export default KnowledgeDirectories

--- a/src/renderer/src/pages/knowledge/items/KnowledgeFiles.tsx
+++ b/src/renderer/src/pages/knowledge/items/KnowledgeFiles.tsx
@@ -21,7 +21,6 @@ import {
   FlexAlignCenter,
   ItemContainer,
   ItemHeader,
-  ItemHeaderLabel,
   KnowledgeEmptyView,
   RefreshIcon,
   StatusIconWrapper
@@ -106,9 +105,8 @@ const KnowledgeFiles: FC<KnowledgeContentProps> = ({ selectedBase }) => {
   return (
     <ItemContainer>
       <ItemHeader>
-        <ItemHeaderLabel label={t('files.title')} />
         <Button
-          type="text"
+          type="primary"
           icon={<Plus size={16} />}
           onClick={(e) => {
             e.stopPropagation()
@@ -124,8 +122,7 @@ const KnowledgeFiles: FC<KnowledgeContentProps> = ({ selectedBase }) => {
           showUploadList={false}
           customRequest={({ file }) => handleDrop([file as File])}
           multiple={true}
-          accept={fileTypes.join(',')}
-          style={{ background: 'transparent' }}>
+          accept={fileTypes.join(',')}>
           <p className="ant-upload-text">{t('knowledge.drag_file')}</p>
           <p className="ant-upload-hint">
             {t('knowledge.file_hint', { file_types: 'TXT, MD, HTML, PDF, DOCX, PPTX, XLSX, EPUB...' })}
@@ -190,8 +187,8 @@ const KnowledgeFiles: FC<KnowledgeContentProps> = ({ selectedBase }) => {
 const ItemFlexColumn = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 15px;
-  padding: 0 15px;
+  padding: 20px 16px;
+  gap: 10px;
 `
 
 export default KnowledgeFiles

--- a/src/renderer/src/pages/knowledge/items/KnowledgeNotes.tsx
+++ b/src/renderer/src/pages/knowledge/items/KnowledgeNotes.tsx
@@ -13,14 +13,7 @@ import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 import StatusIcon from '../components/StatusIcon'
-import {
-  FlexAlignCenter,
-  ItemContainer,
-  ItemHeader,
-  ItemHeaderLabel,
-  KnowledgeEmptyView,
-  StatusIconWrapper
-} from '../KnowledgeContent'
+import { FlexAlignCenter, ItemContainer, ItemHeader, KnowledgeEmptyView, StatusIconWrapper } from '../KnowledgeContent'
 
 interface KnowledgeContentProps {
   selectedBase: KnowledgeBase
@@ -66,9 +59,8 @@ const KnowledgeNotes: FC<KnowledgeContentProps> = ({ selectedBase }) => {
   return (
     <ItemContainer>
       <ItemHeader>
-        <ItemHeaderLabel label={t('knowledge.notes')} />
         <Button
-          type="text"
+          type="primary"
           icon={<Plus size={16} />}
           onClick={(e) => {
             e.stopPropagation()
@@ -107,9 +99,9 @@ const KnowledgeNotes: FC<KnowledgeContentProps> = ({ selectedBase }) => {
 const ItemFlexColumn = styled(Scrollbar)`
   display: flex;
   flex-direction: column;
-  gap: 15px;
-  padding: 0 15px;
-  height: calc(100vh - 175px);
+  gap: 10px;
+  padding: 20px 16px;
+  height: calc(100vh - 135px);
 `
 
 export default KnowledgeNotes

--- a/src/renderer/src/pages/knowledge/items/KnowledgeSitemaps.tsx
+++ b/src/renderer/src/pages/knowledge/items/KnowledgeSitemaps.tsx
@@ -19,7 +19,6 @@ import {
   FlexAlignCenter,
   ItemContainer,
   ItemHeader,
-  ItemHeaderLabel,
   KnowledgeEmptyView,
   RefreshIcon,
   StatusIconWrapper
@@ -80,9 +79,8 @@ const KnowledgeSitemaps: FC<KnowledgeContentProps> = ({ selectedBase }) => {
   return (
     <ItemContainer>
       <ItemHeader>
-        <ItemHeaderLabel label={t('knowledge.sitemaps')} />
         <Button
-          type="text"
+          type="primary"
           icon={<Plus size={16} />}
           onClick={(e) => {
             e.stopPropagation()
@@ -136,9 +134,9 @@ const KnowledgeSitemaps: FC<KnowledgeContentProps> = ({ selectedBase }) => {
 const ItemFlexColumn = styled(Scrollbar)`
   display: flex;
   flex-direction: column;
-  gap: 15px;
-  padding: 0 15px;
-  height: calc(100vh - 175px);
+  gap: 10px;
+  padding: 20px 16px;
+  height: calc(100vh - 135px);
 `
 
 export default KnowledgeSitemaps

--- a/src/renderer/src/pages/knowledge/items/KnowledgeUrls.tsx
+++ b/src/renderer/src/pages/knowledge/items/KnowledgeUrls.tsx
@@ -19,7 +19,6 @@ import {
   FlexAlignCenter,
   ItemContainer,
   ItemHeader,
-  ItemHeaderLabel,
   KnowledgeEmptyView,
   RefreshIcon,
   StatusIconWrapper
@@ -111,9 +110,8 @@ const KnowledgeUrls: FC<KnowledgeContentProps> = ({ selectedBase }) => {
   return (
     <ItemContainer>
       <ItemHeader>
-        <ItemHeaderLabel label={t('knowledge.urls')} />
         <Button
-          type="text"
+          type="primary"
           icon={<Plus size={16} />}
           onClick={(e) => {
             e.stopPropagation()
@@ -184,9 +182,9 @@ const KnowledgeUrls: FC<KnowledgeContentProps> = ({ selectedBase }) => {
 const ItemFlexColumn = styled(Scrollbar)`
   display: flex;
   flex-direction: column;
-  gap: 15px;
-  padding: 0 15px;
-  height: calc(100vh - 175px);
+  gap: 10px;
+  padding: 20px 16px;
+  height: calc(100vh - 135px);
 `
 
 export default KnowledgeUrls


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

新的知识库布局样式

![image](https://github.com/user-attachments/assets/5794caf8-cefc-4306-92c9-5531cf713761)

将原有 KnowledgeContent 组件拆分成多个组件

```
src/renderer/src/pages/knowledge
├── components
│   ├── AddKnowledgePopup.tsx
│   ├── KnowledgeSearchPopup.tsx
│   ├── KnowledgeSettingsPopup.tsx
│   └── StatusIcon.tsx
├── items
│   ├── KnowledgeDirectories.tsx
│   ├── KnowledgeFiles.tsx
│   ├── KnowledgeNotes.tsx
│   ├── KnowledgeSitemaps.tsx
│   └── KnowledgeUrls.tsx
├── KnowledgeContent.tsx
└── KnowledgePage.tsx
```

Before this PR:

界面复杂，难以看清重点，还需要折叠展开查看内容

After this PR:

布局简单，一目了然，保留原有代码逻辑

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

