### PR TITLE
fix: clear cached web search and knowledge references in BaseApiClient

### DIFF
--- a/src/renderer/src/aiCore/clients/BaseApiClient.ts
+++ b/src/renderer/src/aiCore/clients/BaseApiClient.ts
@@ -210,6 +210,7 @@ export abstract class BaseApiClient<
 
   public async getMessageContent(message: Message): Promise<string> {
     const content = getContentWithTools(message)
+
     if (isEmpty(content)) {
       return ''
     }
@@ -273,6 +274,7 @@ export abstract class BaseApiClient<
     const webSearch: WebSearchResponse = window.keyv.get(`web-search-${message.id}`)
 
     if (webSearch) {
+      window.keyv.remove(`web-search-${message.id}`)
       return (webSearch.results as WebSearchProviderResponse).results.map(
         (result, index) =>
           ({
@@ -298,6 +300,7 @@ export abstract class BaseApiClient<
     const knowledgeReferences: KnowledgeReference[] = window.keyv.get(`knowledge-search-${message.id}`)
 
     if (!isEmpty(knowledgeReferences)) {
+      window.keyv.remove(`knowledge-search-${message.id}`)
       // Logger.log(`Found ${knowledgeReferences.length} knowledge base references in cache for ID: ${message.id}`)
       return knowledgeReferences
     }

--- a/src/renderer/src/pages/home/Messages/CitationsList.tsx
+++ b/src/renderer/src/pages/home/Messages/CitationsList.tsx
@@ -87,7 +87,7 @@ const CitationsList: React.FC<CitationsListProps> = ({ citations }) => {
           </div>
         }
         placement="right"
-        trigger="hover"
+        trigger="click"
         styles={{
           body: {
             padding: '0 0 8px 0'
@@ -184,7 +184,6 @@ const KnowledgeCitation: React.FC<{ citation: Citation }> = ({ citation }) => {
           <CitationLink className="text-nowrap" href={citation.url} onClick={(e) => handleLinkClick(citation.url, e)}>
             {citation.title}
           </CitationLink>
-
           <CitationIndex>{citation.number}</CitationIndex>
           {citation.content && <CopyButton content={citation.content} />}
         </WebSearchCardHeader>


### PR DESCRIPTION
### What this PR does

每条消息都会附带知识库搜索结果，导致多轮对话，token 消耗量极大，从而快速达到上下文限制，引起错误

关闭了引用内容 Popover 鼠标浮动显示，改成点击显示，避免误触显示界面

Before this PR:

每个用户消息都附带知识库和网络搜索引用内容

![](https://github.com/user-attachments/assets/86a401c9-2473-481c-8edf-6c94cccd5d00)

After this PR:

最新发送的消息会附带知识库和网络搜索的引用内容，之前的消息只有消息本身

![image](https://github.com/user-attachments/assets/bc6521d2-cbf0-49f7-a6be-be90c6e52e17)
