### PR TITLE
refactor(messageThunk): streamline loading state management for topics

### DIFF
--- a/src/renderer/src/store/thunk/messageThunk.ts
+++ b/src/renderer/src/store/thunk/messageThunk.ts
@@ -888,10 +888,9 @@ export const sendMessage =
       }
     } catch (error) {
       console.error('Error in sendMessage thunk:', error)
+    } finally {
+      handleChangeLoadingOfTopic(topicId)
     }
-    // finally {
-    //   handleChangeLoadingOfTopic(topicId)
-    // }
   }
 
 /**

--- a/src/renderer/src/store/thunk/messageThunk.ts
+++ b/src/renderer/src/store/thunk/messageThunk.ts
@@ -35,6 +35,7 @@ import {
 } from '@renderer/utils/messageUtils/create'
 import { getMainTextContent } from '@renderer/utils/messageUtils/find'
 import { getTopicQueue } from '@renderer/utils/queue'
+import { waitForTopicQueue } from '@renderer/utils/queue'
 import { isOnHomePage } from '@renderer/utils/window'
 import { t } from 'i18next'
 import { isEmpty, throttle } from 'lodash'
@@ -44,10 +45,10 @@ import type { AppDispatch, RootState } from '../index'
 import { removeManyBlocks, updateOneBlock, upsertManyBlocks, upsertOneBlock } from '../messageBlock'
 import { newMessagesActions, selectMessagesForTopic } from '../newMessage'
 
-// const handleChangeLoadingOfTopic = async (topicId: string) => {
-//   await waitForTopicQueue(topicId)
-//   store.dispatch(newMessagesActions.setTopicLoading({ topicId, loading: false }))
-// }
+const handleChangeLoadingOfTopic = async (topicId: string) => {
+  await waitForTopicQueue(topicId)
+  store.dispatch(newMessagesActions.setTopicLoading({ topicId, loading: false }))
+}
 // TODO: 后续可以将db操作移到Listener Middleware中
 export const saveMessageAndBlocksToDB = async (message: Message, blocks: MessageBlock[], messageIndex: number = -1) => {
   try {
@@ -801,7 +802,7 @@ const fetchAndProcessAssistantResponseImpl = async (
             const usage = await estimateMessagesUsage({ assistant, messages: finalContextWithAssistant })
             response.usage = usage
           }
-          dispatch(newMessagesActions.setTopicLoading({ topicId, loading: false }))
+          // dispatch(newMessagesActions.setTopicLoading({ topicId, loading: false }))
         }
         if (response && response.metrics) {
           if (response.metrics.completion_tokens === 0 && response.usage?.completion_tokens) {
@@ -1136,10 +1137,9 @@ export const resendMessageThunk =
       }
     } catch (error) {
       console.error(`[resendMessageThunk] Error resending user message ${userMessageToResend.id}:`, error)
+    } finally {
+      handleChangeLoadingOfTopic(topicId)
     }
-    // finally {
-    //   handleChangeLoadingOfTopic(topicId)
-    // }
   }
 
 /**
@@ -1271,10 +1271,9 @@ export const regenerateAssistantResponseThunk =
         error
       )
       // dispatch(newMessagesActions.setTopicLoading({ topicId, loading: false }))
+    } finally {
+      handleChangeLoadingOfTopic(topicId)
     }
-    //  finally {
-    //   handleChangeLoadingOfTopic(topicId)
-    // }
   }
 
 // --- Thunk to initiate translation and create the initial block ---
@@ -1447,10 +1446,9 @@ export const appendAssistantResponseThunk =
       console.error(`[appendAssistantResponseThunk] Error appending assistant response:`, error)
       // Optionally dispatch an error action or notification
       // Resetting loading state should be handled by the underlying fetchAndProcessAssistantResponseImpl
+    } finally {
+      handleChangeLoadingOfTopic(topicId)
     }
-    // finally {
-    //   handleChangeLoadingOfTopic(topicId)
-    // }
   }
 
 /**


### PR DESCRIPTION
fix:多助手消息回答的情况下,只要有一条消息完毕,按钮状态就更改 #7513

测试模型:
grok3-mini \ grok3-fast

通过测试用例:
- [x] 一对一文本消息
- [x] 一对一mcp调用
- [x] 一对一消息暂停
- [x] 一对多文本消息
- [x] 一对多mcp调用
- [x] 一对多消息暂停
- [x] 以上的用户消息重发
- [x] 以上的助手消息重发