### PR TITLE
fix: move Quick Assistant and Selection Assistant to ToolSettings

### DIFF
--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -8,13 +8,10 @@ import {
   MonitorCog,
   Package,
   PencilRuler,
-  Rocket,
   Settings2,
   SquareTerminal,
-  TextCursorInput,
   Zap
 } from 'lucide-react'
-// 导入useAppSelector
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, Route, Routes, useLocation } from 'react-router-dom'
@@ -27,9 +24,7 @@ import GeneralSettings from './GeneralSettings'
 import MCPSettings from './MCPSettings'
 import { McpSettingsNavbar } from './MCPSettings/McpSettingsNavbar'
 import ProvidersList from './ProviderSettings'
-import QuickAssistantSettings from './QuickAssistantSettings'
 import QuickPhraseSettings from './QuickPhraseSettings'
-import SelectionAssistantSettings from './SelectionAssistantSettings/SelectionAssistantSettings'
 import ShortcutSettings from './ShortcutSettings'
 import ToolSettings from './ToolSettings'
 
@@ -89,18 +84,6 @@ const SettingsPage: FC = () => {
               {t('settings.shortcuts.title')}
             </MenuItem>
           </MenuItemLink>
-          <MenuItemLink to="/settings/quickAssistant">
-            <MenuItem className={isRoute('/settings/quickAssistant')}>
-              <Rocket size={18} />
-              {t('settings.quickAssistant.title')}
-            </MenuItem>
-          </MenuItemLink>
-          <MenuItemLink to="/settings/selectionAssistant">
-            <MenuItem className={isRoute('/settings/selectionAssistant')}>
-              <TextCursorInput size={18} />
-              {t('selection.name')}
-            </MenuItem>
-          </MenuItemLink>
           <MenuItemLink to="/settings/quickPhrase">
             <MenuItem className={isRoute('/settings/quickPhrase')}>
               <Zap size={18} />
@@ -129,8 +112,6 @@ const SettingsPage: FC = () => {
             <Route path="general/*" element={<GeneralSettings />} />
             <Route path="display" element={<DisplaySettings />} />
             <Route path="shortcut" element={<ShortcutSettings />} />
-            <Route path="quickAssistant" element={<QuickAssistantSettings />} />
-            <Route path="selectionAssistant" element={<SelectionAssistantSettings />} />
             <Route path="data" element={<DataSettings />} />
             <Route path="about" element={<AboutSettings />} />
             <Route path="quickPhrase" element={<QuickPhraseSettings />} />

--- a/src/renderer/src/pages/settings/ToolSettings/index.tsx
+++ b/src/renderer/src/pages/settings/ToolSettings/index.tsx
@@ -2,7 +2,9 @@ import { GlobalOutlined } from '@ant-design/icons'
 import OcrIcon from '@renderer/components/Icons/OcrIcon'
 import { HStack } from '@renderer/components/Layout'
 import ListItem from '@renderer/components/ListItem'
-import { FileCode } from 'lucide-react'
+import QuickAssistantSettings from '@renderer/pages/settings/QuickAssistantSettings'
+import SelectionAssistantSettings from '@renderer/pages/settings/SelectionAssistantSettings/SelectionAssistantSettings'
+import { FileCode, Rocket, TextCursorInput } from 'lucide-react'
 import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -16,6 +18,8 @@ const ToolSettings: FC = () => {
   const [menu, setMenu] = useState<string>('web-search')
   const menuItems = [
     { key: 'web-search', title: 'settings.tool.websearch.title', icon: <GlobalOutlined style={{ fontSize: 16 }} /> },
+    { key: 'quick-assistant', title: 'settings.quickAssistant.title', icon: <Rocket size={16} /> },
+    { key: 'selection-assistant', title: 'selection.name', icon: <TextCursorInput size={16} /> },
     { key: 'preprocess', title: 'settings.tool.preprocess.title', icon: <FileCode size={16} /> },
     { key: 'ocr', title: 'settings.tool.ocr.title', icon: <OcrIcon /> }
   ]
@@ -34,6 +38,8 @@ const ToolSettings: FC = () => {
         ))}
       </MenuList>
       {menu == 'web-search' && <WebSearchSettings />}
+      {menu == 'quick-assistant' && <QuickAssistantSettings />}
+      {menu == 'selection-assistant' && <SelectionAssistantSettings />}
       {menu == 'preprocess' && <PreprocessSettings />}
       {menu == 'ocr' && <OcrSettings />}
     </Container>


### PR DESCRIPTION
Quick Assistant and Selection Assistant settings have been relocated from the main settings menu to the ToolSettings section. This streamlines the settings navigation and groups related tool configurations together.

将快捷助手和划词助手路由调整到工具设置中

<img src="https://github.com/user-attachments/assets/d4f8708b-5ee6-464a-9e15-48a327467071" width="500" />
