### PR TITLE
fix(CodePreview): line height rounding

### DIFF
--- a/src/renderer/src/assets/styles/markdown.scss
+++ b/src/renderer/src/assets/styles/markdown.scss
@@ -326,6 +326,8 @@ mjx-container {
 /* Shiki 相关样式 */
 .shiki {
   font-family: var(--code-font-family);
+  // 保持行高为初始值，在 shiki 代码块中处理
+  line-height: initial;
 }
 
 /* CodeMirror 相关样式 */

--- a/src/renderer/src/components/CodeBlockView/CodePreview.tsx
+++ b/src/renderer/src/components/CodeBlockView/CodePreview.tsx
@@ -107,7 +107,8 @@ const CodePreview = ({ children, language, setTools }: CodePreviewProps) => {
   // Virtualizer 配置
   const getScrollElement = useCallback(() => scrollerRef.current, [])
   const getItemKey = useCallback((index: number) => `${callerId}-${index}`, [callerId])
-  const estimateSize = useCallback(() => (fontSize - 1) * 1.6, [fontSize]) // 同步全局样式
+  // `line-height: 1.6` 为全局样式，但是为了避免测量误差在这里取整
+  const estimateSize = useCallback(() => Math.round((fontSize - 1) * 1.6), [fontSize])
 
   // 创建 virtualizer 实例
   const virtualizer = useVirtualizer({
@@ -144,6 +145,7 @@ const CodePreview = ({ children, language, setTools }: CodePreviewProps) => {
         ref={scrollerRef}
         className="shiki-scroller"
         $wrap={shouldWrap}
+        $lineHeight={estimateSize()}
         style={
           {
             '--gutter-width': `${gutterDigits}ch`,
@@ -229,18 +231,19 @@ VirtualizedRow.displayName = 'VirtualizedRow'
 
 const ScrollContainer = styled.div<{
   $wrap?: boolean
+  $lineHeight?: number
 }>`
   display: block;
   overflow: auto;
   position: relative;
   border-radius: inherit;
-  height: auto;
   padding: 0.5em 1em;
 
   .line {
     display: flex;
     align-items: flex-start;
     width: 100%;
+    line-height: ${(props) => props.$lineHeight}px;
 
     .line-number {
       width: var(--gutter-width, 1.2ch);
@@ -250,14 +253,12 @@ const ScrollContainer = styled.div<{
       user-select: none;
       flex-shrink: 0;
       overflow: hidden;
-      line-height: inherit;
       font-family: inherit;
       font-variant-numeric: tabular-nums;
     }
 
     .line-content {
       flex: 1;
-      line-height: inherit;
       * {
         white-space: ${(props) => (props.$wrap ? 'pre-wrap' : 'pre')};
         overflow-wrap: ${(props) => (props.$wrap ? 'break-word' : 'normal')};


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

调整 shiki 代码块的行高，避免小数。

Before this PR:

特定字体下，代码块在展开时出现滚动条或者底部空白。
复现：
- 生成一个 40 行的代码块
- 字体 15
- 展开代码块

> 不同代码行数、不同字体都可以复现，只是明显不明显的区别。

全局样式要求代码块行高 `line-height: 1.6`，似乎会让 react-virtual 测量出现误差，导致虚拟列表元素总高度和外层容器的高度不同（可能多可能少）。在特定字体下会比较明显：
- 右侧出现滚动条，此时元素总高度偏大
- 底部出现一段空白，此时元素总高度偏小

![image](https://github.com/user-attachments/assets/20f667e4-e290-4840-ae8e-c0c190e989d4)

After this PR:

在 `CodePreview` 中用一个舍入后的值来避免误差。

![image](https://github.com/user-attachments/assets/60c43b24-bc11-402f-8d1d-64f3aa27d9cf)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
