### PR TITLE
fix: hide scrollbars on capturing

### DIFF
--- a/src/renderer/src/assets/styles/scrollbar.scss
+++ b/src/renderer/src/assets/styles/scrollbar.scss
@@ -49,3 +49,11 @@ pre:not(.shiki)::-webkit-scrollbar-thumb {
   --color-scrollbar-thumb: var(--color-scrollbar-thumb-light);
   --color-scrollbar-thumb-hover: var(--color-scrollbar-thumb-light-hover);
 }
+
+/* 用于截图时隐藏滚动条
+ * FIXME: 临时方案，因为 html-to-image 没有正确处理伪元素。
+ */
+.hide-scrollbar,
+.hide-scrollbar * {
+  scrollbar-width: none !important;
+}

--- a/src/renderer/src/utils/image.ts
+++ b/src/renderer/src/utils/image.ts
@@ -68,6 +68,9 @@ export const captureScrollableDiv = async (divRef: React.RefObject<HTMLDivElemen
 
       const originalScrollTop = div.scrollTop
 
+      // Hide scrollbars during capture
+      div.classList.add('hide-scrollbar')
+
       // Modify styles to show full content
       div.style.height = 'auto'
       div.style.maxHeight = 'none'
@@ -134,6 +137,9 @@ export const captureScrollableDiv = async (divRef: React.RefObject<HTMLDivElemen
     } catch (error) {
       console.error('Error capturing scrollable div:', error)
       throw error
+    } finally {
+      // Remove scrollbar hiding class
+      divRef.current?.classList.remove('hide-scrollbar')
     }
   }
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

导出为图片时隐藏滚动条

Before this PR:

导出时滚动条样式不对，因为 html-to-image 不支持这些伪元素

After this PR:

暂时隐藏滚动条，代码块不再出现奇怪的滚动条样式

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #7138 

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
