### PR TITLE
fix(MessageMenubar):  use classNames function to handle className

### DIFF
--- a/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
@@ -15,7 +15,7 @@ import { messageBlocksSelectors } from '@renderer/store/messageBlock'
 import { selectMessagesForTopic } from '@renderer/store/newMessage'
 import type { Assistant, Model, Topic } from '@renderer/types'
 import { type Message, MessageBlockType } from '@renderer/types/newMessage'
-import { captureScrollableDivAsBlob, captureScrollableDivAsDataURL } from '@renderer/utils'
+import { captureScrollableDivAsBlob, captureScrollableDivAsDataURL, classNames } from '@renderer/utils'
 import { copyMessageAsPlainText } from '@renderer/utils/copy'
 import {
   exportMarkdownToJoplin,
@@ -399,7 +399,7 @@ const MessageMenubar: FC<Props> = (props) => {
   const softHoverBg = isBubbleStyle && !isLastMessage
 
   return (
-    <MenusBar className={`menubar ${isLastMessage && 'show'}`}>
+    <MenusBar className={classNames({ menubar: true, show: isLastMessage })}>
       {message.role === 'user' && (
         <Tooltip title={t('common.regenerate')} mouseEnterDelay={0.8}>
           <ActionButton


### PR DESCRIPTION


| Before | After |
| ---- | --- |
|  ![CleanShot 2025-07-07 at 08 45 43](https://github.com/user-attachments/assets/eb9312dd-fc99-4309-bd10-89321b489c80) | ![CleanShot 2025-07-07 at 08 45 07](https://github.com/user-attachments/assets/8eccfb13-4ae2-45a3-8d3f-8fbc3589aea0) |
