### PR TITLE
fix(databases): fix upgrade undefined error

### DIFF
--- a/src/renderer/src/databases/upgrades.ts
+++ b/src/renderer/src/databases/upgrades.ts
@@ -357,9 +357,10 @@ export async function upgradeToV8(tx: Transaction): Promise<void> {
   }
 
   Logger.log('originPair: %o', originPair)
-  newPair = [langMap[originPair[0]], langMap[originPair[1]]]
-  if (!newPair[0] || !newPair[1]) {
+  if (!originPair || !originPair[0] || !originPair[1]) {
     newPair = defaultPair
+  } else {
+    newPair = [langMap[originPair[0]], langMap[originPair[1]]]
   }
 
   Logger.log('DB migration to version 8: %o', { newSource, newTarget, newPair })


### PR DESCRIPTION


<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

修复在数据库升级到V8版本时，语言对映射逻辑中未正确处理originPair为空的情况

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
