### PR TITLE
Feat: url context for Gemini models

### DIFF
--- a/src/renderer/src/aiCore/clients/gemini/GeminiAPIClient.ts
+++ b/src/renderer/src/aiCore/clients/gemini/GeminiAPIClient.ts
@@ -443,7 +443,7 @@ export class GeminiAPIClient extends BaseApiClient<
         messages: GeminiSdkMessageParam[]
         metadata: Record<string, any>
       }> => {
-        const { messages, mcpTools, maxTokens, enableWebSearch, enableGenerateImage } = coreRequest
+        const { messages, mcpTools, maxTokens, enableWebSearch, enableUrlContext, enableGenerateImage } = coreRequest
         // 1. 处理系统消息
         let systemInstruction = assistant.prompt
 
@@ -480,6 +480,12 @@ export class GeminiAPIClient extends BaseApiClient<
         if (enableWebSearch) {
           tools.push({
             googleSearch: {}
+          })
+        }
+
+        if (enableUrlContext) {
+          tools.push({
+            urlContext: {}
           })
         }
 

--- a/src/renderer/src/aiCore/clients/gemini/GeminiAPIClient.ts
+++ b/src/renderer/src/aiCore/clients/gemini/GeminiAPIClient.ts
@@ -483,17 +483,10 @@ export class GeminiAPIClient extends BaseApiClient<
           })
         }
 
-        // Force enable urlContext
-        // tools.push({ urlContext: {} })
-        // URL context test passed. Now start solving the enable url context issue.
-
         if (enableUrlContext) {
-          console.log(`URL Context Enabled, adding tools`)
           tools.push({
             urlContext: {}
           })
-        } else {
-          console.log(`URL Context Disabled/ Failed to enable. Please check.`)
         }
 
         if (isGemmaModel(model) && assistant.prompt) {

--- a/src/renderer/src/aiCore/clients/gemini/GeminiAPIClient.ts
+++ b/src/renderer/src/aiCore/clients/gemini/GeminiAPIClient.ts
@@ -483,10 +483,17 @@ export class GeminiAPIClient extends BaseApiClient<
           })
         }
 
+        // Force enable urlContext
+        // tools.push({ urlContext: {} })
+        // URL context test passed. Now start solving the enable url context issue.
+
         if (enableUrlContext) {
+          console.log(`URL Context Enabled, adding tools`)
           tools.push({
             urlContext: {}
           })
+        } else {
+          console.log(`URL Context Disabled/ Failed to enable. Please check.`)
         }
 
         if (isGemmaModel(model) && assistant.prompt) {

--- a/src/renderer/src/aiCore/clients/types.ts
+++ b/src/renderer/src/aiCore/clients/types.ts
@@ -84,6 +84,7 @@ export interface ResponseChunkTransformerContext {
   isStreaming: boolean
   isEnabledToolCalling: boolean
   isEnabledWebSearch: boolean
+  isEnabledUrlContext: boolean
   isEnabledReasoning: boolean
   mcpTools: MCPTool[]
   provider: Provider

--- a/src/renderer/src/aiCore/middleware/core/ResponseTransformMiddleware.ts
+++ b/src/renderer/src/aiCore/middleware/core/ResponseTransformMiddleware.ts
@@ -55,6 +55,7 @@ export const ResponseTransformMiddleware: CompletionsMiddleware =
           isStreaming: params.streamOutput || false,
           isEnabledToolCalling: (params.mcpTools && params.mcpTools.length > 0) || false,
           isEnabledWebSearch: params.enableWebSearch || false,
+          isEnabledUrlContext: params.enableUrlContext || false,
           isEnabledReasoning: params.enableReasoning || false,
           mcpTools: params.mcpTools || [],
           provider: ctx.apiClientInstance?.provider

--- a/src/renderer/src/aiCore/middleware/schemas.ts
+++ b/src/renderer/src/aiCore/middleware/schemas.ts
@@ -49,6 +49,7 @@ export interface CompletionsParams {
   // 功能开关
   streamOutput: boolean
   enableWebSearch?: boolean
+  enableUrlContext?: boolean
   enableReasoning?: boolean
   enableGenerateImage?: boolean
 

--- a/src/renderer/src/config/tools.ts
+++ b/src/renderer/src/config/tools.ts
@@ -39,3 +39,18 @@ export function getWebSearchTools(model: Model): ChatCompletionTool[] {
   }
   return []
 }
+
+export function getUrlContextTools(model: Model): ChatCompletionTool[] {
+  if (model?.id.toLowerCase().includes('gemini')) {
+    return [
+      {
+        type: 'function',
+        function: {
+          name: 'urlContext'
+        }
+      }
+    ]
+  }
+
+  return []
+}

--- a/src/renderer/src/config/tools.ts
+++ b/src/renderer/src/config/tools.ts
@@ -41,7 +41,7 @@ export function getWebSearchTools(model: Model): ChatCompletionTool[] {
 }
 
 export function getUrlContextTools(model: Model): ChatCompletionTool[] {
-  if (model?.id.toLowerCase().includes('gemini')) {
+  if (model.id.includes('gemini')) {
     return [
       {
         type: 'function',

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -210,6 +210,7 @@
       "input.web_search.button.ok": "Go to Settings",
       "input.web_search.enable": "Enable web search",
       "input.web_search.enable_content": "Need to check web search connectivity in settings first",
+      "input.url_context": "URL Context",
       "input.web_search.no_web_search": "Disable Web Search",
       "input.web_search.no_web_search.description": "Do not enable web search",
       "input.web_search.settings": "Web Search Settings",

--- a/src/renderer/src/i18n/locales/ja-jp.json
+++ b/src/renderer/src/i18n/locales/ja-jp.json
@@ -213,6 +213,7 @@
       "input.web_search.no_web_search": "ウェブ検索を無効にする",
       "input.web_search.no_web_search.description": "ウェブ検索を無効にする",
       "input.web_search.settings": "ウェブ検索設定",
+      "input.url_context": "URLコンテキスト",
       "message.new.branch": "新しいブランチ",
       "message.new.branch.created": "新しいブランチが作成されました",
       "message.new.context": "新しいコンテキスト",

--- a/src/renderer/src/i18n/locales/ru-ru.json
+++ b/src/renderer/src/i18n/locales/ru-ru.json
@@ -213,6 +213,7 @@
       "input.web_search.no_web_search": "Отключить веб-поиск",
       "input.web_search.no_web_search.description": "Отключить веб-поиск",
       "input.web_search.settings": "Настройки веб-поиска",
+      "input.url_context": "Контекст страницы",
       "message.new.branch": "Новая ветка",
       "message.new.branch.created": "Новая ветка создана",
       "message.new.context": "Новый контекст",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -213,6 +213,7 @@
       "input.web_search.no_web_search": "不使用网络",
       "input.web_search.no_web_search.description": "不启用网络搜索功能",
       "input.web_search.settings": "网络搜索设置",
+      "input.url_context": "网页上下文",
       "message.new.branch": "分支",
       "message.new.branch.created": "新分支已创建",
       "message.new.context": "清除上下文",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -213,6 +213,7 @@
       "input.web_search.no_web_search": "關閉網路搜尋",
       "input.web_search.no_web_search.description": "關閉網路搜尋",
       "input.web_search.settings": "網路搜尋設定",
+      "input.url_context": "網頁上下文",
       "message.new.branch": "分支",
       "message.new.branch.created": "新分支已建立",
       "message.new.context": "新上下文",

--- a/src/renderer/src/pages/home/Inputbar/InputbarTools.tsx
+++ b/src/renderer/src/pages/home/Inputbar/InputbarTools.tsx
@@ -36,6 +36,7 @@ import MentionModelsButton, { MentionModelsButtonRef } from './MentionModelsButt
 import NewContextButton from './NewContextButton'
 import QuickPhrasesButton, { QuickPhrasesButtonRef } from './QuickPhrasesButton'
 import ThinkingButton, { ThinkingButtonRef } from './ThinkingButton'
+import UrlContextButton from './UrlContextbutton'
 import WebSearchButton, { WebSearchButtonRef } from './WebSearchButton'
 
 export interface InputbarToolsRef {
@@ -59,6 +60,7 @@ export interface InputbarToolsProps {
   extensions: string[]
   showThinkingButton: boolean
   showKnowledgeIcon: boolean
+  showUrlContextIcon: boolean
   selectedKnowledgeBases: KnowledgeBase[]
   handleKnowledgeBaseSelect: (bases?: KnowledgeBase[]) => void
   setText: Dispatch<SetStateAction<string>>
@@ -323,6 +325,12 @@ const InputbarTools = ({
         key: 'web_search',
         label: t('chat.input.web_search'),
         component: <WebSearchButton ref={webSearchButtonRef} assistant={assistant} ToolbarButton={ToolbarButton} />
+      },
+      {
+        key: 'url_context',
+        label: t('chat.input.url_context'),
+        component: <UrlContextButton assistant={assistant} ToolbarButton={ToolbarButton} />,
+        condition: model.id.toLowerCase().includes('gemini')
       },
       {
         key: 'knowledge_base',

--- a/src/renderer/src/pages/home/Inputbar/InputbarTools.tsx
+++ b/src/renderer/src/pages/home/Inputbar/InputbarTools.tsx
@@ -14,6 +14,7 @@ import {
   FileSearch,
   Globe,
   Languages,
+  Link,
   LucideSquareTerminal,
   Maximize,
   MessageSquareDiff,
@@ -36,7 +37,7 @@ import MentionModelsButton, { MentionModelsButtonRef } from './MentionModelsButt
 import NewContextButton from './NewContextButton'
 import QuickPhrasesButton, { QuickPhrasesButtonRef } from './QuickPhrasesButton'
 import ThinkingButton, { ThinkingButtonRef } from './ThinkingButton'
-import UrlContextButton from './UrlContextbutton'
+import UrlContextButton, { UrlContextButtonRef } from './UrlContextbutton'
 import WebSearchButton, { WebSearchButtonRef } from './WebSearchButton'
 
 export interface InputbarToolsRef {
@@ -60,7 +61,6 @@ export interface InputbarToolsProps {
   extensions: string[]
   showThinkingButton: boolean
   showKnowledgeIcon: boolean
-  showUrlContextIcon: boolean
   selectedKnowledgeBases: KnowledgeBase[]
   handleKnowledgeBaseSelect: (bases?: KnowledgeBase[]) => void
   setText: Dispatch<SetStateAction<string>>
@@ -130,6 +130,7 @@ const InputbarTools = ({
   const attachmentButtonRef = useRef<AttachmentButtonRef>(null)
   const webSearchButtonRef = useRef<WebSearchButtonRef | null>(null)
   const thinkingButtonRef = useRef<ThinkingButtonRef | null>(null)
+  const urlContextButtonRef = useRef<UrlContextButtonRef | null>(null)
 
   const toolOrder = useAppSelector((state) => state.inputTools.toolOrder)
   const isCollapse = useAppSelector((state) => state.inputTools.isCollapsed)
@@ -233,6 +234,15 @@ const InputbarTools = ({
         }
       },
       {
+        label: t('chat.input.url_context'),
+        description: '',
+        icon: <Link />,
+        isMenu: true,
+        action: () => {
+          urlContextButtonRef.current?.openQuickPanel()
+        }
+      },
+      {
         label: couldAddImageFile ? t('chat.input.upload') : t('chat.input.upload.document'),
         description: '',
         icon: <Paperclip />,
@@ -329,7 +339,7 @@ const InputbarTools = ({
       {
         key: 'url_context',
         label: t('chat.input.url_context'),
-        component: <UrlContextButton assistant={assistant} ToolbarButton={ToolbarButton} />,
+        component: <UrlContextButton ref={urlContextButtonRef} assistant={assistant} ToolbarButton={ToolbarButton} />,
         condition: model.id.toLowerCase().includes('gemini')
       },
       {

--- a/src/renderer/src/pages/home/Inputbar/UrlContextbutton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/UrlContextbutton.tsx
@@ -24,7 +24,6 @@ const UrlContextButton: FC<Props> = ({ assistant, ToolbarButton }) => {
   const handleToggle = useCallback(() => {
     setTimeout(() => {
       updateAssistant({ ...assistant, enableUrlContext: urlContentNewState })
-      console.log(`URL Context toggle: ${assistant.enableUrlContext}`)
     }, 100)
   }, [assistant, urlContentNewState, updateAssistant])
 
@@ -34,7 +33,7 @@ const UrlContextButton: FC<Props> = ({ assistant, ToolbarButton }) => {
         <Link
           size={18}
           style={{
-            color: urlContentNewState ? 'var(--color-link)' : 'var(--color-icon)'
+            color: assistant.enableUrlContext ? 'var(--color-link)' : 'var(--color-icon)'
           }}
         />
       </ToolbarButton>

--- a/src/renderer/src/pages/home/Inputbar/UrlContextbutton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/UrlContextbutton.tsx
@@ -1,0 +1,39 @@
+import { useAssistant } from '@renderer/hooks/useAssistant'
+import { Assistant } from '@renderer/types'
+import { Tooltip } from 'antd'
+import { Link } from 'lucide-react'
+import { FC, memo, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface Props {
+  assistant: Assistant
+  ToolbarButton: any
+}
+
+const UrlContextButton: FC<Props> = ({ assistant, ToolbarButton }) => {
+  const { t } = useTranslation()
+  const { updateAssistant } = useAssistant(assistant.id)
+
+  const isUrlContextOn = assistant.enableUrlContext === true
+
+  const handleToggle = useCallback(() => {
+    setTimeout(() => {
+      updateAssistant({ ...assistant, enableUrlContext: !isUrlContextOn })
+    }, 100)
+  }, [assistant, isUrlContextOn, updateAssistant])
+
+  return (
+    <Tooltip placement="top" title={t('chat.input.url_context')} arrow>
+      <ToolbarButton type="text" onClick={handleToggle}>
+        <Link
+          size={18}
+          style={{
+            color: isUrlContextOn ? 'var(--color-link)' : 'var(--color-icon)'
+          }}
+        />
+      </ToolbarButton>
+    </Tooltip>
+  )
+}
+
+export default memo(UrlContextButton)

--- a/src/renderer/src/pages/home/Inputbar/UrlContextbutton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/UrlContextbutton.tsx
@@ -5,7 +5,12 @@ import { Link } from 'lucide-react'
 import { FC, memo, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 
+export interface UrlContextButtonRef {
+  openQuickPanel: () => void
+}
+
 interface Props {
+  ref?: React.RefObject<UrlContextButtonRef | null>
   assistant: Assistant
   ToolbarButton: any
 }
@@ -14,13 +19,14 @@ const UrlContextButton: FC<Props> = ({ assistant, ToolbarButton }) => {
   const { t } = useTranslation()
   const { updateAssistant } = useAssistant(assistant.id)
 
-  const isUrlContextOn = assistant.enableUrlContext === true
+  const urlContentNewState = !assistant.enableUrlContext
 
   const handleToggle = useCallback(() => {
     setTimeout(() => {
-      updateAssistant({ ...assistant, enableUrlContext: !isUrlContextOn })
+      updateAssistant({ ...assistant, enableUrlContext: urlContentNewState })
+      console.log(`URL Context toggle: ${assistant.enableUrlContext}`)
     }, 100)
-  }, [assistant, isUrlContextOn, updateAssistant])
+  }, [assistant, urlContentNewState, updateAssistant])
 
   return (
     <Tooltip placement="top" title={t('chat.input.url_context')} arrow>
@@ -28,7 +34,7 @@ const UrlContextButton: FC<Props> = ({ assistant, ToolbarButton }) => {
         <Link
           size={18}
           style={{
-            color: isUrlContextOn ? 'var(--color-link)' : 'var(--color-icon)'
+            color: urlContentNewState ? 'var(--color-link)' : 'var(--color-icon)'
           }}
         />
       </ToolbarButton>

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -354,6 +354,8 @@ export async function fetchChatCompletion({
     model.id.includes('sonar') ||
     false
 
+  const enableUrlContext = assistant.enableUrlContext || false
+
   const enableGenerateImage =
     isGenerateImageModel(model) && (isSupportedDisableGenerationModel(model) ? assistant.enableGenerateImage : true)
 
@@ -370,6 +372,7 @@ export async function fetchChatCompletion({
       streamOutput: assistant.settings?.streamOutput || false,
       enableReasoning,
       enableWebSearch,
+      enableUrlContext,
       enableGenerateImage
     },
     {

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -54,7 +54,7 @@ const persistedReducer = persistReducer(
   {
     key: 'cherry-studio',
     storage,
-    version: 120,
+    version: 121,
     blacklist: ['runtime', 'messages', 'messageBlocks'],
     migrate
   },

--- a/src/renderer/src/store/inputTools.ts
+++ b/src/renderer/src/store/inputTools.ts
@@ -11,6 +11,7 @@ export const DEFAULT_TOOL_ORDER: ToolOrder = {
     'attachment',
     'thinking',
     'web_search',
+    'url_context',
     'knowledge_base',
     'mcp_tools',
     'generate_image',

--- a/src/renderer/src/store/migrate.ts
+++ b/src/renderer/src/store/migrate.ts
@@ -1763,6 +1763,15 @@ const migrateConfig = {
     } catch (error) {
       return state
     }
+  },
+  '121': (state: RootState) => {
+    try {
+      state.inputTools.toolOrder = DEFAULT_TOOL_ORDER
+      state.inputTools.isCollapsed = false
+      return state
+    } catch (error) {
+      return state
+    }
   }
 }
 

--- a/src/renderer/src/store/migrate.ts
+++ b/src/renderer/src/store/migrate.ts
@@ -1766,8 +1766,17 @@ const migrateConfig = {
   },
   '121': (state: RootState) => {
     try {
-      state.inputTools.toolOrder = DEFAULT_TOOL_ORDER
-      state.inputTools.isCollapsed = false
+      const { toolOrder } = state.inputTools
+      const urlContextKey = 'url_context'
+      const webSearchIndex = toolOrder.visible.indexOf('web_search')
+      const knowledgeBaseIndex = toolOrder.visible.indexOf('knowledge_base')
+      if (webSearchIndex !== -1) {
+        toolOrder.visible.splice(webSearchIndex, 0, urlContextKey)
+      } else if (knowledgeBaseIndex !== -1) {
+        toolOrder.visible.splice(knowledgeBaseIndex, 0, urlContextKey)
+      } else {
+        toolOrder.visible.push(urlContextKey)
+      }
       return state
     } catch (error) {
       return state

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -23,6 +23,8 @@ export type Assistant = {
   /** enableWebSearch 代表使用模型内置网络搜索功能 */
   enableWebSearch?: boolean
   webSearchProviderId?: WebSearchProvider['id']
+  // enableUrlContext 是 Gemini 的特有功能
+  enableUrlContext?: boolean
   enableGenerateImage?: boolean
   mcpServers?: MCPServer[]
   knowledgeRecognition?: 'off' | 'on'


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR: Gemini models could not invoke `urlContext` tools

After this PR: be able to do so(not worked so far)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

<!-- Fixes # -->

For now the button is not worked. It would update assistant's config but tools not added to request when user send messages. 😂

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... --> https://github.com/CherryHQ/cherry-studio/discussions/7843


### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
action required. need to write a migration script to refresh buttons list.
```
