### PR TITLE
fix: Improve model filtering and group handling

### DIFF
--- a/src/renderer/src/config/models.ts
+++ b/src/renderer/src/config/models.ts
@@ -208,7 +208,7 @@ export const isDedicatedImageGenerationModel = (model: Model): boolean =>
   DEDICATED_IMAGE_MODELS.filter((m) => model.id.includes(m)).length > 0
 
 // Text to image models
-export const TEXT_TO_IMAGE_REGEX = /flux|diffusion|stabilityai|sd-|dall|cogview|janus/i
+export const TEXT_TO_IMAGE_REGEX = /flux|diffusion|stabilityai|sd-|dall|cogview|janus|midjourney|mj-|image|gpt-image/i
 
 // Reasoning models
 export const REASONING_REGEX =

--- a/src/renderer/src/pages/paintings/NewApiPage.tsx
+++ b/src/renderer/src/pages/paintings/NewApiPage.tsx
@@ -13,12 +13,7 @@ import { useAllProviders } from '@renderer/hooks/useProvider'
 import { useRuntime } from '@renderer/hooks/useRuntime'
 import { useSettings } from '@renderer/hooks/useSettings'
 import PaintingsList from '@renderer/pages/paintings/components/PaintingsList'
-import {
-  DEFAULT_PAINTING,
-  getModelGroup,
-  MODELS,
-  SUPPORTED_MODELS
-} from '@renderer/pages/paintings/config/NewApiConfig'
+import { DEFAULT_PAINTING, MODELS, SUPPORTED_MODELS } from '@renderer/pages/paintings/config/NewApiConfig'
 import FileManager from '@renderer/services/FileManager'
 import { translateText } from '@renderer/services/TranslateService'
 import { useAppDispatch } from '@renderer/store'
@@ -96,7 +91,7 @@ const NewApiPage: FC<{ Options: string[] }> = ({ Options }) => {
         label: m.name,
         value: m.id,
         custom: !SUPPORTED_MODELS.includes(m.id),
-        group: getModelGroup(m.id)
+        group: m.group
       }))
     return [...customModels]
   }, [newApiProvider.models])

--- a/src/renderer/src/pages/paintings/config/NewApiConfig.ts
+++ b/src/renderer/src/pages/paintings/config/NewApiConfig.ts
@@ -30,18 +30,3 @@ export const DEFAULT_PAINTING: GeneratePainting = {
   moderation: 'auto',
   size: 'auto'
 }
-
-export const getModelGroup = (model: string): string => {
-  const modelConfig = MODELS.find((m) => m.name === model)
-  if (modelConfig) {
-    return modelConfig.group
-  }
-  if (model.includes('flux')) {
-    return 'Black Forest Lab'
-  } else if (model.includes('imagen')) {
-    return 'Gemini'
-  } else if (model.includes('dall-e')) {
-    return 'OpenAI'
-  }
-  return 'Custom'
-}

--- a/src/renderer/src/pages/settings/ModelSettings/ModelSettings.tsx
+++ b/src/renderer/src/pages/settings/ModelSettings/ModelSettings.tsx
@@ -2,7 +2,7 @@ import { RedoOutlined } from '@ant-design/icons'
 import ModelAvatar from '@renderer/components/Avatar/ModelAvatar'
 import { HStack } from '@renderer/components/Layout'
 import PromptPopup from '@renderer/components/Popups/PromptPopup'
-import { isEmbeddingModel, isRerankModel } from '@renderer/config/models'
+import { isEmbeddingModel, isRerankModel, isTextToImageModel } from '@renderer/config/models'
 import { TRANSLATE_PROMPT } from '@renderer/config/prompts'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import { useAssistants, useDefaultAssistant, useDefaultModel } from '@renderer/hooks/useAssistant'
@@ -41,16 +41,25 @@ const ModelSettings: FC = () => {
 
   const selectOptions = providers
     .filter((p) => p.models.length > 0)
-    .map((p) => ({
-      label: p.isSystem ? t(`provider.${p.id}`) : p.name,
-      title: p.name,
-      options: sortBy(p.models, 'name')
-        .filter((m) => !isEmbeddingModel(m) && !isRerankModel(m))
+    .flatMap((p) => {
+      const filteredModels = sortBy(p.models, 'name')
+        .filter((m) => !isEmbeddingModel(m) && !isRerankModel(m) && !isTextToImageModel(m))
         .map((m) => ({
           label: `${m.name} | ${p.isSystem ? t(`provider.${p.id}`) : p.name}`,
           value: getModelUniqId(m)
         }))
-    }))
+
+      if (filteredModels.length > 0) {
+        return [
+          {
+            label: p.isSystem ? t(`provider.${p.id}`) : p.name,
+            title: p.name,
+            options: filteredModels
+          }
+        ]
+      }
+      return []
+    })
 
   const defaultModelValue = useMemo(
     () => (hasModel(defaultModel) ? getModelUniqId(defaultModel) : undefined),

--- a/src/renderer/src/pages/translate/TranslatePage.tsx
+++ b/src/renderer/src/pages/translate/TranslatePage.tsx
@@ -2,7 +2,7 @@ import { CheckOutlined, DeleteOutlined, HistoryOutlined, RedoOutlined, SendOutli
 import { Navbar, NavbarCenter } from '@renderer/components/app/Navbar'
 import CopyIcon from '@renderer/components/Icons/CopyIcon'
 import { HStack } from '@renderer/components/Layout'
-import { isEmbeddingModel } from '@renderer/config/models'
+import { isEmbeddingModel, isRerankModel, isTextToImageModel } from '@renderer/config/models'
 import { TRANSLATE_PROMPT } from '@renderer/config/prompts'
 import { LanguagesEnum, translateLanguageOptions } from '@renderer/config/translate'
 import { useCodeStyle } from '@renderer/context/CodeStyleProvider'
@@ -312,16 +312,24 @@ const TranslatePage: FC = () => {
     () =>
       providers
         .filter((p) => p.models.length > 0)
-        .map((p) => ({
-          label: p.isSystem ? t(`provider.${p.id}`) : p.name,
-          title: p.name,
-          options: sortBy(p.models, 'name')
-            .filter((m) => !isEmbeddingModel(m))
+        .flatMap((p) => {
+          const filteredModels = sortBy(p.models, 'name')
+            .filter((m) => !isEmbeddingModel(m) && !isRerankModel(m) && !isTextToImageModel(m))
             .map((m) => ({
               label: `${m.name} | ${p.isSystem ? t(`provider.${p.id}`) : p.name}`,
               value: getModelUniqId(m)
             }))
-        })),
+          if (filteredModels.length > 0) {
+            return [
+              {
+                label: p.isSystem ? t(`provider.${p.id}`) : p.name,
+                title: p.name,
+                options: filteredModels
+              }
+            ]
+          }
+          return []
+        }),
     [providers, t]
   )
 


### PR DESCRIPTION
在模型下拉选择框中排除生图模型

Expanded the text-to-image model regex to include more identifiers. Removed the getModelGroup function and now use the model's group property directly. Updated model selection in ModelSettings and TranslatePage to also filter out rerank and text-to-image models, ensuring only appropriate models are shown in dropdowns.
