### PR TITLE
revert: timing for adding citation references

### DIFF
--- a/src/renderer/src/store/thunk/messageThunk.ts
+++ b/src/renderer/src/store/thunk/messageThunk.ts
@@ -429,6 +429,9 @@ const fetchAndProcessAssistantResponseImpl = async (
         await handleBlockTransition(baseBlock as PlaceholderMessageBlock, MessageBlockType.UNKNOWN)
       },
       onTextChunk: async (text) => {
+        const citationBlockSource = citationBlockId
+          ? (getState().messageBlocks.entities[citationBlockId] as CitationMessageBlock).response?.source
+          : WebSearchSource.WEBSEARCH
         accumulatedContent += text
         if (mainTextBlockId) {
           const blockChanges: Partial<MessageBlock> = {
@@ -441,7 +444,8 @@ const fetchAndProcessAssistantResponseImpl = async (
           const initialChanges: Partial<MessageBlock> = {
             type: MessageBlockType.MAIN_TEXT,
             content: accumulatedContent,
-            status: MessageBlockStatus.STREAMING
+            status: MessageBlockStatus.STREAMING,
+            citationReferences: citationBlockId ? [{ citationBlockId, citationBlockSource }] : []
           }
           mainTextBlockId = initialPlaceholderBlockId
           // 清理占位块
@@ -451,7 +455,8 @@ const fetchAndProcessAssistantResponseImpl = async (
           saveUpdatedBlockToDB(mainTextBlockId, assistantMsgId, topicId, getState)
         } else {
           const newBlock = createMainTextBlock(assistantMsgId, accumulatedContent, {
-            status: MessageBlockStatus.STREAMING
+            status: MessageBlockStatus.STREAMING,
+            citationReferences: citationBlockId ? [{ citationBlockId, citationBlockSource }] : []
           })
           mainTextBlockId = newBlock.id // 立即设置ID，防止竞态条件
           await handleBlockTransition(newBlock, MessageBlockType.MAIN_TEXT)
@@ -459,15 +464,9 @@ const fetchAndProcessAssistantResponseImpl = async (
       },
       onTextComplete: async (finalText) => {
         if (mainTextBlockId) {
-          let citationBlockSource: WebSearchSource | undefined
-          if (citationBlockId) {
-            const citationBlock = getState().messageBlocks.entities[citationBlockId] as CitationMessageBlock
-            citationBlockSource = citationBlock.response?.source
-          }
           const changes = {
             content: finalText,
-            status: MessageBlockStatus.SUCCESS,
-            citationReferences: citationBlockSource ? [{ citationBlockId, citationBlockSource }] : []
+            status: MessageBlockStatus.SUCCESS
           }
           cancelThrottledBlockUpdate(mainTextBlockId)
           dispatch(updateOneBlock({ id: mainTextBlockId, changes }))


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

#7776 调整了引用信息附加到文本块的时机，总是在文本块结束时才附加。
- 回复过程中，看不到引用 tooltip 了
- 如果用户中断回复，所有引用标签都不会被渲染成 tooltip

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
