### PR TITLE
Fix translation key for unlimited backups label

### DIFF
--- a/src/renderer/src/pages/settings/DataSettings/WebDavSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/WebDavSettings.tsx
@@ -202,7 +202,7 @@ const WebDavSettings: FC = () => {
           onChange={onMaxBackupsChange}
           disabled={!webdavHost}
           options={[
-            { label: t('settings.data.webdav.maxBackups.unlimited'), value: 0 },
+            { label: t('settings.data.local.maxBackups.unlimited'), value: 0 },
             { label: '1', value: 1 },
             { label: '3', value: 3 },
             { label: '5', value: 5 },


### PR DESCRIPTION
Fix #7984 
Updated the translation key for the 'unlimited' backups option in WebDavSettings to use the correct namespace.