### PR TITLE
feat(tts): add speak selected text to context menu

### DIFF
--- a/src/renderer/src/components/ContextMenu/index.tsx
+++ b/src/renderer/src/components/ContextMenu/index.tsx
@@ -1,3 +1,4 @@
+import { useTTS } from '@renderer/hooks/useTTS'
 import { Dropdown } from 'antd'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -9,6 +10,7 @@ interface ContextMenuProps {
 const ContextMenu: React.FC<ContextMenuProps> = ({ children }) => {
   const { t } = useTranslation()
   const [selectedText, setSelectedText] = useState<string | undefined>(undefined)
+  const tts = useTTS()
 
   const contextMenuItems = useMemo(() => {
     if (!selectedText) return []
@@ -38,9 +40,18 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ children }) => {
             window.api?.quoteToMainWindow(selectedText)
           }
         }
+      },
+      {
+        key: 'speak',
+        label: t('common.speak', '朗读'), // 添加一个默认值以防万一
+        onClick: () => {
+          if (selectedText) {
+            tts.speak(selectedText)
+          }
+        }
       }
     ]
-  }, [selectedText, t])
+  }, [selectedText, t, tts])
 
   const onOpenChange = (open: boolean) => {
     if (open) {

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -419,6 +419,7 @@
       "reset": "重置",
       "swap": "交换",
       "save": "保存",
+      "speak": "朗读",
       "settings": "设置",
       "search": "搜索",
       "select": "选择",


### PR DESCRIPTION

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

**Before this PR:**
Users could only use the Text-to-Speech (TTS) function to read an entire message. There was no option to have only a specific part of the text read aloud.

**After this PR:**
A "Speak" (朗读) option is now available in the context menu that appears when a user selects text within a message. This allows the TTS engine to read only the highlighted portion of the text.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

This feature enhances the user experience by providing a more granular and flexible way to use the TTS functionality. It improves efficiency and convenience for users who only need to listen to a specific sentence or phrase without hearing the entire message.

The implementation was done by integrating a new "Speak" menu item into the existing context menu component (`ContextMenu/index.tsx`). It utilizes the existing `useTTS` hook to perform the speech synthesis, making the change minimal and consistent with the current architecture. A corresponding translation key was added to the i18n file to support localization.

### Breaking changes

None.

### Special notes for your reviewer

This change is straightforward and self-contained. It adds a new item to the context menu and hooks it up to the TTS service. The new i18n key `common.speak` has been added to `zh-cn.json`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
feat(tts): Add a "Speak" option to the context menu for selected text.
```

---

## 中文摘要

### 本次 PR 的主要变更

**变更前:**
TTS（文本转语音）功能仅支持朗读整条消息，无法对选定的文本片段进行朗读。

**变更后:**
当用户在消息中选中文本时，右键菜单中将出现“朗读”选项，允许 TTS 引擎仅朗读高亮选中的文本内容。

### 背景与实现方式

此项功能为用户提供了更精细、更灵活的 TTS 使用方式，提升了在仅需收听特定片段时的便利性和效率。

实现上，通过在现有的右键菜单组件（`ContextMenu/index.tsx`）中集成一个新的“朗读”菜单项来完成。该功能复用了已有的 `useTTS` 钩子（hook）来处理语音合成，确保了代码的改动量最小化并与现有架构保持一致。同时，在 i18n 配置文件中添加了相应的中文翻译。

### 破坏性变更

无。

### 发布说明

```release-note
功能(tts): 为选中文本的右键菜单添加“朗读”选项。
```

![image](https://github.com/user-attachments/assets/f761febe-dc45-498a-a40f-f8971bdce6fd)
