### PR TITLE
feat(tts): add playback controls to input bar

### DIFF
--- a/src/renderer/src/utils/TTSPlaybackManager.ts
+++ b/src/renderer/src/utils/TTSPlaybackManager.ts
@@ -90,19 +90,21 @@ class TTSPlaybackManager {
   /**
    * 暂停/恢复播放
    */
-  togglePause(messageId: string): { action: 'pause' | 'resume'; newState: PlaybackState } {
-    const isCurrentMessage = this.playbackInfo.currentMessageId === messageId
-
-    if (!isCurrentMessage) {
-      throw new Error('Cannot pause/resume a different message')
+  togglePause(messageId?: string): { action: 'pause' | 'resume'; newState: PlaybackState } {
+    // 如果传入 messageId，则严格校验是否为当前消息
+    if (messageId) {
+      const isCurrentMessage = this.playbackInfo.currentMessageId === messageId
+      if (!isCurrentMessage) {
+        throw new Error('Cannot pause/resume a different message')
+      }
     }
 
     switch (this.playbackInfo.state) {
       case 'playing':
         // 播放中 → 暂停
         this.playbackInfo = {
-          state: 'paused',
-          currentMessageId: messageId
+          ...this.playbackInfo,
+          state: 'paused'
         }
         this.notifyListeners()
         return { action: 'pause', newState: 'paused' }
@@ -110,8 +112,8 @@ class TTSPlaybackManager {
       case 'paused':
         // 暂停中 → 恢复播放
         this.playbackInfo = {
-          state: 'playing',
-          currentMessageId: messageId
+          ...this.playbackInfo,
+          state: 'playing'
         }
         this.notifyListeners()
         return { action: 'resume', newState: 'playing' }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

**Before this PR:**
TTS playback could only be controlled by interacting with the specific message being read. There were no global, always-accessible controls to manage playback.

**After this PR:**
The main input bar now displays global TTS controls (Stop, Play/Pause) whenever audio is playing or is in a paused state. These controls allow the user to manage playback at any time, regardless of which message is active.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

This feature provides a much-needed, centralized, and intuitive way for users to control TTS playback. Previously, stopping or pausing a long message required the user to find the original message and interact with it, which was inconvenient. These global controls are always accessible when needed, significantly improving the user experience.

The implementation adds state management to the `Inputbar` component to track the global playback state. It introduces new buttons that call the `useTTS` hook's `pause`, `resume`, and `stop` methods. The `TTSPlaybackManager` was also slightly refactored to allow `togglePause` to work without a `messageId`, making it suitable for a global control context.

### Breaking changes

None.

### Special notes for your reviewer

This implementation introduces a global state dependency on `TTSPlaybackManager` within the `Inputbar` component. The changes to `TTSPlaybackManager` are backward-compatible but are important for this new global control feature.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required.

### Release note

```release-note
feat(tts): add playback controls to input bar
```

---

## 中文摘要

### 本次 PR 的主要变更

**变更前:**
TTS 播放只能通过操作正在朗读的原始消息来控制，缺少一个全局的、随时可用的控制面板。

**变更后:**
当 TTS 正在播放或暂停时，主输入框会显示一个全局播放控制栏（包含停止、播放/暂停按钮），允许用户随时管理播放状态。

### 背景与实现方式

此功能旨在提供一个集中、便捷的 TTS 控制方式，以优化用户体验，避免了之前需要寻找原消息才能停止或暂停播放的不便。

实现上，在输入框组件（`Inputbar`）中增加了对全局播放状态的监听和管理。同时，对 `TTSPlaybackManager` 进行少量重构，使其支持不指定消息的全局暂停/恢复操作，以适配全局控制栏的需求。

### 破坏性变更

无。

### 发布说明

```release-note
功能(tts): 为输入框添加播放控制栏
```
播放中
![image](https://github.com/user-attachments/assets/2ef132b6-dcac-4098-98d0-c4036b5db353)

播放结束
![image](https://github.com/user-attachments/assets/aa6aee78-7011-41db-bf28-25ffeeac5076)


