### PR TITLE
fix: increase maximum context count to 100 and update slider marks

### DIFF
--- a/src/renderer/src/pages/home/Tabs/SettingsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/SettingsTab.tsx
@@ -161,7 +161,7 @@ const SettingsTab: FC<Props> = (props) => {
   }, [assistant])
 
   const assistantContextCount = assistant?.settings?.contextCount || 20
-  const maxContextCount = assistantContextCount > 20 ? assistantContextCount : 20
+  const maxContextCount = 100
 
   const model = assistant.model || getDefaultModel()
 
@@ -217,6 +217,7 @@ const SettingsTab: FC<Props> = (props) => {
               <Slider
                 min={0}
                 max={maxContextCount}
+                marks={{ 0: '0', 25: '25', 50: '50', 75: '75', 100: <span style={{ fontSize: '18px' }}>∞</span> }}
                 onChange={setContextCount}
                 onChangeComplete={onContextCountChange}
                 value={typeof contextCount === 'number' ? contextCount : 0}

--- a/src/renderer/src/pages/home/Tabs/SettingsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/SettingsTab.tsx
@@ -160,7 +160,6 @@ const SettingsTab: FC<Props> = (props) => {
     setStreamOutput(assistant?.settings?.streamOutput ?? true)
   }, [assistant])
 
-  const assistantContextCount = assistant?.settings?.contextCount || 20
   const maxContextCount = 100
 
   const model = assistant.model || getDefaultModel()

--- a/src/renderer/src/pages/settings/AssistantSettings/AssistantModelSettings.tsx
+++ b/src/renderer/src/pages/settings/AssistantSettings/AssistantModelSettings.tsx
@@ -312,7 +312,7 @@ const AssistantModelSettings: FC<Props> = ({ assistant, updateAssistant, updateA
         <Col span={4}>
           <EditableNumber
             min={0}
-            max={20}
+            max={100}
             step={1}
             value={contextCount}
             changeOnBlur
@@ -334,7 +334,7 @@ const AssistantModelSettings: FC<Props> = ({ assistant, updateAssistant, updateA
             onChange={setContextCount}
             onChangeComplete={onContextCountChange}
             value={typeof contextCount === 'number' ? contextCount : 0}
-            marks={{ 0: '0', 25: '25', 50: '50', 75: '75', 100: t('chat.settings.max') }}
+            marks={{ 0: '0', 25: '25', 50: '50', 75: '75', 100: <span style={{ fontSize: '18px' }}>∞</span> }}
             step={1}
             tooltip={{ formatter: formatSliderTooltip }}
           />

--- a/src/renderer/src/pages/settings/ModelSettings/DefaultAssistantSettings.tsx
+++ b/src/renderer/src/pages/settings/ModelSettings/DefaultAssistantSettings.tsx
@@ -210,8 +210,8 @@ const AssistantSettings: FC = () => {
         <Col span={19}>
           <Slider
             min={0}
-            max={20}
-            marks={{ 0: '0', 5: '5', 10: '10', 15: '15', 20: t('chat.settings.max') }}
+            max={100}
+            marks={{ 0: '0', 25: '25', 50: '50', 75: '75', 100: <span style={{ fontSize: '18px' }}>∞</span> }}
             onChange={setContextCount}
             onChangeComplete={onContextCountChange}
             value={typeof contextCount === 'number' ? contextCount : 0}
@@ -221,7 +221,7 @@ const AssistantSettings: FC = () => {
         <Col span={5}>
           <InputNumber
             min={0}
-            max={20}
+            max={100}
             step={1}
             value={contextCount}
             onChange={onContextCountChange}


### PR DESCRIPTION
This pull request increases the maximum context count for the assistant settings from 20 to 100 and updates the UI to reflect this change. It also introduces a more visually distinct label for the maximum value on sliders.

### Updates to maximum context count:

* Changed the `maxContextCount` value in `SettingsTab` to a fixed value of 100, removing the conditional logic. (`src/renderer/src/pages/home/Tabs/SettingsTab.tsx`)
* Updated the `max` property of sliders and input fields in `AssistantModelSettings` and `DefaultAssistantSettings` components to 100. (`src/renderer/src/pages/settings/AssistantSettings/AssistantModelSettings.tsx`, `src/renderer/src/pages/settings/ModelSettings/DefaultAssistantSettings.tsx`) [[1]](diffhunk://#diff-348b63725ac0de15fe382ef0f1712697671db159553186366f679e32abfb6d80L315-R315) [[2]](diffhunk://#diff-a1abd79e0a6103539137f86d96f72e5bf0c7008ff21e002fabeed61933ff3b87L213-R214) [[3]](diffhunk://#diff-a1abd79e0a6103539137f86d96f72e5bf0c7008ff21e002fabeed61933ff3b87L224-R224)

### UI enhancements:

* Updated slider `marks` to include a styled "∞" symbol for the maximum value (100) to improve visual clarity. (`src/renderer/src/pages/home/Tabs/SettingsTab.tsx`, `src/renderer/src/pages/settings/AssistantSettings/AssistantModelSettings.tsx`, `src/renderer/src/pages/settings/ModelSettings/DefaultAssistantSettings.tsx`) [[1]](diffhunk://#diff-1d5ae08402e9cf842bee4b843295288f47743885766de18eb714ddf6db5671eaR220) [[2]](diffhunk://#diff-348b63725ac0de15fe382ef0f1712697671db159553186366f679e32abfb6d80L337-R337) [[3]](diffhunk://#diff-a1abd79e0a6103539137f86d96f72e5bf0c7008ff21e002fabeed61933ff3b87L213-R214)