### PR TITLE
fix(Doc2xPreprocessProvider):  replace filePath split with path.parse…

### DIFF
--- a/src/main/knowledage/preprocess/Doc2xPreprocessProvider.ts
+++ b/src/main/knowledage/preprocess/Doc2xPreprocessProvider.ts
@@ -217,7 +217,7 @@ export default class Doc2xPreprocessProvider extends BasePreprocessProvider {
    * @param filePath 文件路径
    */
   private async convertFile(uid: string, filePath: string): Promise<void> {
-    const fileName = path.basename(filePath).split('.')[0]
+    const fileName = path.parse(filePath).name
     const config = {
       ...this.createAuthConfig(),
       headers: {


### PR DESCRIPTION
… for clearer filename

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

bugfix: can't get filename while using doc2x if your file has dot (e.g., 1512.03385v1.pdf)

### Why we need it and why it was done in this way

The following alternatives were considered:

use `.split('.').slice(0, -1).join('.')` to keep code style consistent

<!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
