### PR TITLE
feat: add external control service for remote control

### DIFF
--- a/packages/shared/IpcChannel.ts
+++ b/packages/shared/IpcChannel.ts
@@ -159,6 +159,9 @@ export enum IpcChannel {
 
   Shortcuts_Update = 'shortcuts:update',
 
+  ExternalControl_SetServerType = 'external-control:set-server-type',
+  ExternalControl_SetHttpPort = 'external-control:set-http-port',
+
   // backup
   Backup_Backup = 'backup:backup',
   Backup_Restore = 'backup:restore',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -25,6 +25,7 @@ import selectionService, { initSelectionService } from './services/SelectionServ
 import { registerShortcuts } from './services/ShortcutService'
 import { TrayService } from './services/TrayService'
 import { windowService } from './services/WindowService'
+import { externalControlService } from './services/ExternalControlService'
 
 Logger.initialize()
 
@@ -111,6 +112,7 @@ if (!app.requestSingleInstanceLock()) {
     })
 
     registerShortcuts(mainWindow)
+    externalControlService.start()
 
     registerIpc(mainWindow, app)
 
@@ -170,6 +172,9 @@ if (!app.requestSingleInstanceLock()) {
 
   app.on('will-quit', async () => {
     // event.preventDefault()
+
+    await externalControlService.stop()
+
     try {
       await mcpService.cleanup()
     } catch (error) {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -7,7 +7,7 @@ import { getBinaryPath, isBinaryExists, runInstallScript } from '@main/utils/pro
 import { handleZoomFactor } from '@main/utils/zoom'
 import { UpgradeChannel } from '@shared/config/constant'
 import { IpcChannel } from '@shared/IpcChannel'
-import { FileMetadata, Provider, Shortcut, ThemeMode } from '@types'
+import { ExternalControlServerType, FileMetadata, Provider, Shortcut, ThemeMode } from '@types'
 import { BrowserWindow, dialog, ipcMain, session, shell, systemPreferences, webContents } from 'electron'
 import log from 'electron-log'
 import { Notification } from 'src/renderer/src/types/notification'
@@ -441,6 +441,13 @@ export function registerIpc(mainWindow: BrowserWindow, app: Electron.App) {
       unregisterAllShortcuts()
       registerShortcuts(mainWindow)
     }
+  })
+
+  ipcMain.handle(IpcChannel.ExternalControl_SetServerType, (_, serverType: ExternalControlServerType) => {
+    configManager.setExternalControlServerType(serverType)
+  })
+  ipcMain.handle(IpcChannel.ExternalControl_SetHttpPort, (_, port: number | undefined) => {
+    configManager.setExternalControlHttpPort(port)
   })
 
   // knowledge base

--- a/src/main/services/ConfigManager.ts
+++ b/src/main/services/ConfigManager.ts
@@ -1,5 +1,5 @@
 import { defaultLanguage, UpgradeChannel, ZOOM_SHORTCUTS } from '@shared/config/constant'
-import { LanguageVarious, Shortcut, ThemeMode } from '@types'
+import { ExternalControlServerType, LanguageVarious, Shortcut, ThemeMode } from '@types'
 import { app } from 'electron'
 import Store from 'electron-store'
 
@@ -19,6 +19,8 @@ export enum ConfigKeys {
   TestPlan = 'testPlan',
   TestChannel = 'testChannel',
   EnableDataCollection = 'enableDataCollection',
+  ExternalControlServerType = 'externalControlServerType',
+  ExternalControlHttpPort = 'externalControlHttpPort',
   SelectionAssistantEnabled = 'selectionAssistantEnabled',
   SelectionAssistantTriggerMode = 'selectionAssistantTriggerMode',
   SelectionAssistantFollowToolbar = 'selectionAssistantFollowToolbar',
@@ -166,6 +168,23 @@ export class ConfigManager {
 
   setEnableDataCollection(value: boolean) {
     this.set(ConfigKeys.EnableDataCollection, value)
+  }
+
+  getExternalControlServerType(): ExternalControlServerType {
+    return this.get<ExternalControlServerType>(ConfigKeys.ExternalControlServerType, ExternalControlServerType.DISABLE)
+  }
+
+  setExternalControlServerType(value: ExternalControlServerType) {
+    this.setAndNotify(ConfigKeys.ExternalControlServerType, value)
+  }
+
+  getExternalControlHttpPort(): number | undefined {
+    const port = this.get<number | null>(ConfigKeys.ExternalControlHttpPort, undefined)
+    return port === null ? undefined : port
+  }
+
+  setExternalControlHttpPort(value: number | undefined) {
+    this.setAndNotify(ConfigKeys.ExternalControlHttpPort, value === undefined ? null : value)
   }
 
   // Selection Assistant: is enabled the selection assistant

--- a/src/main/services/ExternalControlService.ts
+++ b/src/main/services/ExternalControlService.ts
@@ -1,0 +1,214 @@
+import { isWin } from '@main/constant'
+import { getTempDir } from '@main/utils/file'
+import { ExternalControlServerType } from '@types'
+import Logger from 'electron-log'
+import type { Server as NetServer } from 'net'
+import * as path from 'path'
+
+import { ConfigKeys, configManager } from './ConfigManager'
+import { windowService } from './WindowService'
+
+export class ExternalControlService {
+  private static defaultSocketPath = path.join(getTempDir(), 'cherry-studio.sock')
+
+  private static defaultHttpPort = 9090
+
+  private httpServer: NetServer | null = null
+  private unixDomainSocketServer: NetServer | null = null
+
+  constructor() {
+    this.watchConfigChanges()
+  }
+
+  async start(): Promise<void> {
+    const serverType = configManager.getExternalControlServerType()
+
+    switch (serverType) {
+      case ExternalControlServerType.HTTP: {
+        const httpPort = configManager.getExternalControlHttpPort() ?? ExternalControlService.defaultHttpPort
+        await this.startHttpServer(httpPort)
+        break
+      }
+      case ExternalControlServerType.UNIX_DOMAIN_SOCKET: {
+        if (isWin) {
+          Logger.warn(
+            `[ExternalControl] Unix domain socket server is not supported on Windows. Please use HTTP server instead.`
+          )
+          return
+        }
+        await this.startUnixDomainSocketServer(ExternalControlService.defaultSocketPath)
+        break
+      }
+    }
+  }
+
+  async stop(): Promise<void> {
+    await Promise.all([this.stopHttpServer(), this.stopUnixDomainSocketServer()])
+  }
+
+  async restart(): Promise<void> {
+    await this.stop()
+    await this.start()
+  }
+
+  async startHttpServer(port: number): Promise<void> {
+    Logger.info(`[ExternalControl] Starting HTTP server on port ${port}...`)
+
+    const { createServer } = await import('http')
+    this.httpServer = createServer((req, res) => {
+      req.on('data', (data) => {
+        this.onData(data)
+        res.end()
+      })
+    })
+
+    await new Promise<void>((resolve) => {
+      this.httpServer
+        ?.listen(port, '127.0.0.1', () => {
+          Logger.info(`[ExternalControl] HTTP server started on port ${port}`)
+          resolve()
+        })
+        .on('error', (err) => {
+          Logger.error(`[ExternalControl] Failed to start HTTP server:`, err.message)
+          resolve()
+        })
+    })
+  }
+
+  async stopHttpServer(): Promise<void> {
+    if (!this.httpServer) return
+
+    Logger.info(`[ExternalControl] Stopping HTTP server...`)
+
+    await new Promise<void>((resolve) => {
+      this.httpServer
+        ?.close(() => {
+          Logger.info(`[ExternalControl] HTTP server stopped`)
+          this.httpServer = null
+          resolve()
+        })
+        .on('error', (err) => {
+          Logger.error(`[ExternalControl] Failed to stop HTTP server:`, err.message)
+          resolve()
+        })
+    })
+  }
+
+  async startUnixDomainSocketServer(path: string): Promise<void> {
+    Logger.info(`[ExternalControl] Starting unix domain socket server...`)
+
+    await this.assertSocketNotInUse(path)
+
+    const { createServer } = await import('net')
+    this.unixDomainSocketServer = createServer((socket) => {
+      socket.on('data', (data) => {
+        this.onData(data)
+      })
+    })
+
+    await new Promise<void>((resolve) => {
+      this.unixDomainSocketServer
+        ?.listen(path, () => {
+          Logger.info(`[ExternalControl] Unix domain socket server started at ${path}`)
+          resolve()
+        })
+        .on('error', (err) => {
+          Logger.error(`[ExternalControl] Failed to start unix domain socket server:`, err.message)
+          resolve()
+        })
+    })
+  }
+
+  async stopUnixDomainSocketServer(): Promise<void> {
+    if (!this.unixDomainSocketServer) return
+
+    Logger.info(`[ExternalControl] Stopping unix domain socket server...`)
+
+    await new Promise<void>((resolve) => {
+      this.unixDomainSocketServer
+        ?.close(() => {
+          Logger.info(`[ExternalControl] Unix domain socket server stopped`)
+          this.unixDomainSocketServer = null
+          resolve()
+        })
+        .on('error', (err) => {
+          Logger.error(`[ExternalControl] Failed to stop unix domain socket server:`, err.message)
+          resolve()
+        })
+    })
+  }
+
+  private watchConfigChanges() {
+    configManager.subscribe(ConfigKeys.ExternalControlServerType, () => this.restart())
+    configManager.subscribe(ConfigKeys.ExternalControlHttpPort, () => this.restart())
+  }
+
+  private async assertSocketNotInUse(socketPath: string): Promise<void> {
+    const { stat, mkdir, rm } = await import('fs/promises')
+
+    const dirPath = path.dirname(socketPath)
+
+    let dirExists = false
+    try {
+      await stat(dirPath)
+      dirExists = true
+    } catch {
+      dirExists = false
+    }
+
+    if (!dirExists) {
+      Logger.debug(`[ExternalControl] Socket directory does not exist, creating: ${dirPath}`)
+      await mkdir(dirPath, { recursive: true })
+    }
+
+    await rm(socketPath, { force: true })
+  }
+
+  private onData(data: Buffer): void {
+    Logger.debug(`[ExternalControl] Received data:`, data.toString())
+
+    let json
+    try {
+      json = JSON.parse(data.toString())
+    } catch (error) {
+      Logger.error(`[ExternalControl] Failed to parse data:`, (error as Error).message)
+      return
+    }
+
+    const { cmd, ...args } = json || {}
+    Logger.debug(`[ExternalControl] Command:`, cmd)
+    Logger.debug(`[ExternalControl] Arguments:`, args)
+
+    switch (cmd) {
+      case 'showApplication': {
+        windowService.showMainWindow()
+        break
+      }
+      case 'hideApplication': {
+        break
+      }
+      case 'toggleApplication': {
+        windowService.toggleMainWindow()
+        break
+      }
+      case 'showQuickAssistant': {
+        windowService.showMiniWindow()
+        break
+      }
+      case 'hideQuickAssistant': {
+        windowService.hideMiniWindow()
+        break
+      }
+      case 'toggleQuickAssistant': {
+        windowService.toggleMiniWindow()
+        break
+      }
+      case undefined:
+      default: {
+        Logger.warn(`[ExternalControl] Unknown command:`, cmd)
+      }
+    }
+  }
+}
+
+export const externalControlService = new ExternalControlService()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3,6 +3,7 @@ import { electronAPI } from '@electron-toolkit/preload'
 import { UpgradeChannel } from '@shared/config/constant'
 import { IpcChannel } from '@shared/IpcChannel'
 import {
+  ExternalControlServerType,
   FileListResponse,
   FileMetadata,
   FileUploadResponse,
@@ -159,6 +160,11 @@ const api = {
   openPath: (path: string) => ipcRenderer.invoke(IpcChannel.Open_Path, path),
   shortcuts: {
     update: (shortcuts: Shortcut[]) => ipcRenderer.invoke(IpcChannel.Shortcuts_Update, shortcuts)
+  },
+  externalControl: {
+    setServerType: (serverType: ExternalControlServerType) =>
+      ipcRenderer.invoke(IpcChannel.ExternalControl_SetServerType, serverType),
+    setHttpPort: (httpPort: number | undefined) => ipcRenderer.invoke(IpcChannel.ExternalControl_SetHttpPort, httpPort)
   },
   knowledgeBase: {
     create: (base: KnowledgeBaseParams) => ipcRenderer.invoke(IpcChannel.KnowledgeBase_Create, base),

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -2280,6 +2280,15 @@
         "zoom_out": "Zoom Out",
         "zoom_reset": "Reset Zoom"
       },
+      "externalControl": {
+        "title": "External Control",
+        "server_type": "Server Type",
+        "server_type.disable": "Disable",
+        "server_type.http": "HTTP",
+        "server_type.unix_domain_socket": "Unix Domain Socket",
+        "http.port": "HTTP Port",
+        "http.port.invalid_error": "Invalid HTTP port, must be an integer between 1 and 65535"
+      },
       "theme.color_primary": "Primary Color",
       "theme.dark": "Dark",
       "theme.light": "Light",

--- a/src/renderer/src/i18n/locales/ja-jp.json
+++ b/src/renderer/src/i18n/locales/ja-jp.json
@@ -2280,6 +2280,15 @@
         "zoom_out": "ズームアウト",
         "zoom_reset": "ズームをリセット"
       },
+      "externalControl": {
+        "title": "外部コントロール",
+        "server_type": "サーバータイプ",
+        "server_type.disable": "無効",
+        "server_type.http": "HTTP",
+        "server_type.unix_domain_socket": "Unixドメインソケット",
+        "http.port": "HTTPポート",
+        "http.port.invalid_error": "無効なHTTPポートです，1から65535の間の整数である必要があります"
+      },
       "theme.color_primary": "テーマ色",
       "theme.dark": "ダーク",
       "theme.light": "ライト",

--- a/src/renderer/src/i18n/locales/ru-ru.json
+++ b/src/renderer/src/i18n/locales/ru-ru.json
@@ -2280,6 +2280,15 @@
         "zoom_out": "Уменьшить",
         "zoom_reset": "Сбросить масштаб"
       },
+      "externalControl": {
+        "title": "Внешний контроль",
+        "server_type": "Тип сервера",
+        "server_type.disable": "Отключить",
+        "server_type.http": "HTTP",
+        "server_type.unix_domain_socket": "Unix Domain Socket",
+        "http.port": "HTTP Порт",
+        "http.port.invalid_error": "Неверный HTTP порт, должен быть целым числом от 1 до 65535"
+      },
       "theme.color_primary": "Цвет темы",
       "theme.dark": "Темная",
       "theme.light": "Светлая",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -2280,6 +2280,15 @@
         "zoom_out": "缩小界面",
         "zoom_reset": "重置缩放"
       },
+      "externalControl": {
+        "title": "外部控制",
+        "server_type": "服务器类型",
+        "server_type.disable": "禁用",
+        "server_type.http": "HTTP",
+        "server_type.unix_domain_socket": "Unix 域套接字",
+        "http.port": "HTTP 端口",
+        "http.port.invalid_error": "无效的 HTTP 端口，必须是 1 到 65535 之间的整数"
+      },
       "theme.color_primary": "主题颜色",
       "theme.dark": "深色",
       "theme.light": "浅色",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -2280,6 +2280,15 @@
         "zoom_out": "縮小介面",
         "zoom_reset": "重設縮放"
       },
+      "externalControl": {
+        "title": "外部控制",
+        "server_type": "伺服器類型",
+        "server_type.disable": "禁用",
+        "server_type.http": "HTTP",
+        "server_type.unix_domain_socket": "Unix 域通訊端",
+        "http.port": "HTTP 連接埠",
+        "http.port.invalid_error": "HTTP 連接埠無效，必須是 1 至 65535 之間的整數"
+      },
       "theme.color_primary": "主題顏色",
       "theme.dark": "深色",
       "theme.light": "淺色",

--- a/src/renderer/src/store/externalControl.ts
+++ b/src/renderer/src/store/externalControl.ts
@@ -1,0 +1,29 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { ExternalControlServerType } from '@renderer/types'
+
+export interface ExternalControlState {
+  serverType: ExternalControlServerType
+  httpPort: number | undefined
+}
+
+const initialState: ExternalControlState = {
+  serverType: ExternalControlServerType.DISABLE,
+  httpPort: undefined
+}
+
+const externalControlSlice = createSlice({
+  name: 'externalControl',
+  initialState,
+  reducers: {
+    setServerType: (state, action: PayloadAction<ExternalControlServerType>) => {
+      state.serverType = action.payload
+    },
+    setHttpPort: (state, action: PayloadAction<number | undefined>) => {
+      state.httpPort = action.payload
+    }
+  }
+})
+
+export const { setServerType, setHttpPort } = externalControlSlice.actions
+export default externalControlSlice.reducer
+export { initialState }

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -8,6 +8,7 @@ import agents from './agents'
 import assistants from './assistants'
 import backup from './backup'
 import copilot from './copilot'
+import externalControl from './externalControl'
 import inputToolsReducer from './inputTools'
 import knowledge from './knowledge'
 import llm from './llm'
@@ -37,6 +38,7 @@ const rootReducer = combineReducers({
   runtime,
   ocr,
   shortcuts,
+  externalControl,
   knowledge,
   minapps,
   websearch,

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -772,6 +772,12 @@ export interface StoreSyncAction {
   }
 }
 
+export enum ExternalControlServerType {
+  DISABLE = 'disable',
+  HTTP = 'http',
+  UNIX_DOMAIN_SOCKET = 'unix-domain-socket'
+}
+
 export type OpenAISummaryText = 'auto' | 'concise' | 'detailed' | 'off'
 export type OpenAIServiceTier = 'auto' | 'default' | 'flex'
 


### PR DESCRIPTION
### What this PR does

When running in Wayland environment on Linux, the application's built-in global hotkey binding feature does not work. Adapting to each desktop environment's global hotkey solution is complex and hard to maintain. To address this, this PR introduces an external control service that can be invoked externally, enabling users to assign their own hotkeys to invoke the service, thereby achieving the original global hotkey features.

For consistency across platforms, both an HTTP server (cross-platform) and a UNIX domain socket (Unix-only) are provided.

Fixes #1736

### Why we need it and why it was done in this way

Discussions #2379

### Breaking changes

None. Just a new feature.

### Special notes for your reviewer

My further idea is to allow passing parameters directly in the external invocation, so that specific features inside the application can be triggered directly.

For example, when the external control service is invoked with the following parameters, the application should open the miniwindow and directly navigate to the translation page to translate the given text.

```json
{
  "cmd": "showQuickAssistant",
  "route": "translate",
  "clipboardText": "Hello, world!"
}
```

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

Need to update documentation to explain how to use the external control service, but I don't know how to do it yet. I will update the documentation later.

### Release note

```release-note
Feature: Introduce external control service for invoking application features via external hotkeys.
```
