### PR TITLE
fix: replace Select component with custom Selector in LocalBackupSetting

### DIFF
--- a/src/renderer/src/pages/settings/DataSettings/LocalBackupSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/LocalBackupSettings.tsx
@@ -2,6 +2,7 @@ import { DeleteOutlined, FolderOpenOutlined, SaveOutlined, SyncOutlined, Warning
 import { HStack } from '@renderer/components/Layout'
 import { LocalBackupManager } from '@renderer/components/LocalBackupManager'
 import { LocalBackupModal, useLocalBackupModal } from '@renderer/components/LocalBackupModals'
+import Selector from '@renderer/components/Selector'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import { useSettings } from '@renderer/hooks/useSettings'
 import { startLocalBackupAutoSync, stopLocalBackupAutoSync } from '@renderer/services/BackupService'
@@ -14,7 +15,7 @@ import {
   setLocalBackupSyncInterval as _setLocalBackupSyncInterval
 } from '@renderer/store/settings'
 import { AppInfo } from '@renderer/types'
-import { Button, Input, Select, Switch, Tooltip } from 'antd'
+import { Button, Input, Switch, Tooltip } from 'antd'
 import dayjs from 'dayjs'
 import { FC, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -213,39 +214,43 @@ const LocalBackupSettings: FC = () => {
       <SettingDivider />
       <SettingRow>
         <SettingRowTitle>{t('settings.data.local.autoSync')}</SettingRowTitle>
-        <Select
+        <Selector
+          size={14}
           value={syncInterval}
-          onChange={(value) => onSyncIntervalChange(value as number)}
+          onChange={onSyncIntervalChange}
           disabled={!localBackupDir}
-          style={{ minWidth: 120 }}>
-          <Select.Option value={0}>{t('settings.data.local.autoSync.off')}</Select.Option>
-          <Select.Option value={1}>{t('settings.data.local.minute_interval', { count: 1 })}</Select.Option>
-          <Select.Option value={5}>{t('settings.data.local.minute_interval', { count: 5 })}</Select.Option>
-          <Select.Option value={15}>{t('settings.data.local.minute_interval', { count: 15 })}</Select.Option>
-          <Select.Option value={30}>{t('settings.data.local.minute_interval', { count: 30 })}</Select.Option>
-          <Select.Option value={60}>{t('settings.data.local.hour_interval', { count: 1 })}</Select.Option>
-          <Select.Option value={120}>{t('settings.data.local.hour_interval', { count: 2 })}</Select.Option>
-          <Select.Option value={360}>{t('settings.data.local.hour_interval', { count: 6 })}</Select.Option>
-          <Select.Option value={720}>{t('settings.data.local.hour_interval', { count: 12 })}</Select.Option>
-          <Select.Option value={1440}>{t('settings.data.local.hour_interval', { count: 24 })}</Select.Option>
-        </Select>
+          options={[
+            { label: t('settings.data.local.autoSync.off'), value: 0 },
+            { label: t('settings.data.local.minute_interval', { count: 1 }), value: 1 },
+            { label: t('settings.data.local.minute_interval', { count: 5 }), value: 5 },
+            { label: t('settings.data.local.minute_interval', { count: 15 }), value: 15 },
+            { label: t('settings.data.local.minute_interval', { count: 30 }), value: 30 },
+            { label: t('settings.data.local.hour_interval', { count: 1 }), value: 60 },
+            { label: t('settings.data.local.hour_interval', { count: 2 }), value: 120 },
+            { label: t('settings.data.local.hour_interval', { count: 6 }), value: 360 },
+            { label: t('settings.data.local.hour_interval', { count: 12 }), value: 720 },
+            { label: t('settings.data.local.hour_interval', { count: 24 }), value: 1440 }
+          ]}
+        />
       </SettingRow>
       <SettingDivider />
       <SettingRow>
         <SettingRowTitle>{t('settings.data.local.maxBackups')}</SettingRowTitle>
-        <Select
+        <Selector
+          size={14}
           value={maxBackups}
-          onChange={(value) => onMaxBackupsChange(value as number)}
+          onChange={onMaxBackupsChange}
           disabled={!localBackupDir}
-          style={{ minWidth: 120 }}>
-          <Select.Option value={0}>{t('settings.data.local.maxBackups.unlimited')}</Select.Option>
-          <Select.Option value={1}>1</Select.Option>
-          <Select.Option value={3}>3</Select.Option>
-          <Select.Option value={5}>5</Select.Option>
-          <Select.Option value={10}>10</Select.Option>
-          <Select.Option value={20}>20</Select.Option>
-          <Select.Option value={50}>50</Select.Option>
-        </Select>
+          options={[
+            { label: t('settings.data.local.maxBackups.unlimited'), value: 0 },
+            { label: '1', value: 1 },
+            { label: '3', value: 3 },
+            { label: '5', value: 5 },
+            { label: '10', value: 10 },
+            { label: '20', value: 20 },
+            { label: '50', value: 50 }
+          ]}
+        />
       </SettingRow>
       <SettingDivider />
       <SettingRow>


### PR DESCRIPTION
…ings

- Updated LocalBackupSettings to use a custom Selector component for better styling and functionality.
- Enhanced the options for auto-sync interval and max backups with improved structure and internationalization support.
- Added success notification handling in restoreFromLocalBackup function in BackupService for better user feedback.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
1.local backup 组件不统一
2.local backup不能正常恢复数据

After this PR:

1. 统一组件，和s3/webdav一样
2. 可以正常恢复数据。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->

```release-note

```
