### PR TITLE
fix: 修复从未打开过的话题导出markdown为空的问题

### DIFF
--- a/src/renderer/src/utils/__tests__/export.test.ts
+++ b/src/renderer/src/utils/__tests__/export.test.ts
@@ -416,7 +416,7 @@ describe('export', () => {
     beforeEach(async () => {
       vi.clearAllMocks()
       vi.resetModules()
-      
+
       // Re-mock TopicManager for this test suite
       vi.doMock('@renderer/hooks/useTopic', () => ({
         TopicManager: {
@@ -516,7 +516,7 @@ describe('export', () => {
     beforeEach(async () => {
       vi.clearAllMocks() // Clear mocks before each test in this suite
       vi.resetModules() // Reset module cache
-      
+
       // Re-import and re-mock TopicManager to ensure clean state
       vi.doMock('@renderer/hooks/useTopic', () => ({
         TopicManager: {

--- a/src/renderer/src/utils/__tests__/export.test.ts
+++ b/src/renderer/src/utils/__tests__/export.test.ts
@@ -67,6 +67,13 @@ vi.mock('@renderer/databases', () => ({
   }
 }))
 
+// Mock TopicManager for dynamic import
+vi.mock('@renderer/hooks/useTopic', () => ({
+  TopicManager: {
+    getTopicMessages: vi.fn()
+  }
+}))
+
 vi.mock('@renderer/utils/markdown', async (importOriginal) => {
   const actual = await importOriginal()
   return {
@@ -430,7 +437,9 @@ describe('export', () => {
         createdAt: '',
         updatedAt: ''
       }
-      ;(db.topics.get as any).mockResolvedValue({ messages: [userMsg, assistantMsg] })
+      // Mock TopicManager.getTopicMessages to return the expected messages
+      const { TopicManager } = await import('@renderer/hooks/useTopic')
+      ;(TopicManager.getTopicMessages as any).mockResolvedValue([userMsg, assistantMsg])
       // Specific mock for this test to check formatting
       ;(markdownToPlainText as any).mockImplementation((str: string) => str.replace(/[#*]/g, ''))
 
@@ -549,7 +558,9 @@ describe('export', () => {
         createdAt: '',
         updatedAt: ''
       }
-      ;(db.topics.get as any).mockResolvedValue({ messages: [msgWithEmpty] })
+      // Mock TopicManager.getTopicMessages to return the expected messages
+      const { TopicManager } = await import('@renderer/hooks/useTopic')
+      ;(TopicManager.getTopicMessages as any).mockResolvedValue([msgWithEmpty])
       ;(markdownToPlainText as any).mockImplementation((str: string) => str)
 
       const result = await topicToPlainText(testTopic)
@@ -568,7 +579,9 @@ describe('export', () => {
         createdAt: '',
         updatedAt: ''
       }
-      ;(db.topics.get as any).mockResolvedValue({ messages: [msgWithSpecial] })
+      // Mock TopicManager.getTopicMessages to return the expected messages
+      const { TopicManager } = await import('@renderer/hooks/useTopic')
+      ;(TopicManager.getTopicMessages as any).mockResolvedValue([msgWithSpecial])
       ;(markdownToPlainText as any).mockImplementation((str: string) => str)
 
       const result = await topicToPlainText(testTopic)
@@ -592,11 +605,12 @@ describe('export', () => {
         createdAt: '',
         updatedAt: ''
       }
-      ;(db.topics.get as any).mockResolvedValue({ messages: [msg1, msg2] })
+      // Mock TopicManager.getTopicMessages to return the expected messages
+      const { TopicManager } = await import('@renderer/hooks/useTopic')
+      ;(TopicManager.getTopicMessages as any).mockResolvedValue([msg1, msg2])
       ;(markdownToPlainText as any).mockImplementation((str: string) => str.replace(/[#*_]/g, ''))
 
       const result = await topicToPlainText(testTopic)
-      expect(db.topics.get).toHaveBeenCalledWith('topic1_plain')
       expect(markdownToPlainText).toHaveBeenCalledWith('# Topic One')
       expect(markdownToPlainText).toHaveBeenCalledWith('**Hello**')
       expect(markdownToPlainText).toHaveBeenCalledWith('_World_')
@@ -612,7 +626,9 @@ describe('export', () => {
         createdAt: '',
         updatedAt: ''
       }
-      ;(db.topics.get as any).mockResolvedValue({ messages: [] })
+      // Mock TopicManager.getTopicMessages to return empty array
+      const { TopicManager } = await import('@renderer/hooks/useTopic')
+      ;(TopicManager.getTopicMessages as any).mockResolvedValue([])
       ;(markdownToPlainText as any).mockImplementation((str: string) => str.replace(/[#*_]/g, ''))
 
       const result = await topicToPlainText(testTopic)
@@ -629,10 +645,12 @@ describe('export', () => {
         createdAt: '',
         updatedAt: ''
       }
-      ;(db.topics.get as any).mockResolvedValue(null)
+      // Mock TopicManager.getTopicMessages to return empty array for null case
+      const { TopicManager } = await import('@renderer/hooks/useTopic')
+      ;(TopicManager.getTopicMessages as any).mockResolvedValue([])
 
       const result = await topicToPlainText(testTopic)
-      expect(result).toBe('')
+      expect(result).toBe('Null Messages Topic')
     })
   })
 


### PR DESCRIPTION
- 移除对 db 的直接依赖，改用 TopicManager.getTopicMessages
- 优化导出功能使用 TopicManager 确保消息正确加载
Fixed #8091 
之前导出存在未打开的话题导出为空，需要打开才可以；原有的导出逻辑直接从数据库(db)读取消息，但某些话题的消息可能尚未完全加载到本地缓存中
从直接访问数据库改为使用 TopicManager.getTopicMessages()方法，仿照exportMarkdownToJoplin()

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
<img width="1236" height="1276" alt="image" src="https://github.com/user-attachments/assets/bbb827fe-6e4e-437f-8311-7683cd3b6895" />

After this PR:
<img width="1570" height="1308" alt="image" src="https://github.com/user-attachments/assets/0243dad3-9950-49e1-82a1-102673e30d85" />



### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
