### PR TITLE
fix(Knowledge): pass searchResultCount to embed-js

### DIFF
--- a/src/main/services/KnowledgeService.ts
+++ b/src/main/services/KnowledgeService.ts
@@ -125,7 +125,8 @@ class KnowledgeService {
     apiKey,
     apiVersion,
     baseURL,
-    dimensions
+    dimensions,
+    documentCount
   }: KnowledgeBaseParams): Promise<RAGApplication> => {
     let ragApplication: RAGApplication
     const embeddings = new Embeddings({
@@ -141,6 +142,7 @@ class KnowledgeService {
         .setModel('NO_MODEL')
         .setEmbeddingModel(embeddings)
         .setVectorDatabase(new LibSqlDb({ path: path.join(this.storageDir, id) }))
+        .setSearchResultCount(documentCount || 30)
         .build()
     } catch (e) {
       Logger.error(e)

--- a/src/renderer/src/services/KnowledgeService.ts
+++ b/src/renderer/src/services/KnowledgeService.ts
@@ -51,9 +51,8 @@ export const getKnowledgeBaseParams = (base: KnowledgeBase): KnowledgeBaseParams
     rerankModelProvider: rerankProvider.name.toLowerCase(),
     // topN: base.topN,
     // preprocessing: base.preprocessing,
-    preprocessOrOcrProvider: base.preprocessOrOcrProvider
-
-    // topN: base.topN
+    preprocessOrOcrProvider: base.preprocessOrOcrProvider,
+    documentCount: base.documentCount
   }
 }
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

把 `documentCount` 传给 embed-js 的 `searchResultCount`

Before this PR:

知识库设置中的文档片段数量实际上并不能控制 embed-js 的搜索结果数量。
之前的实现：
- 无论如何设置，embed-js 总是返回[默认的 30 个搜索结果](https://github.com/CherryHQ/embed-js/blob/35bd009a05ca9f3d3c55f1023e78457032e52942/core/embedjs/src/core/rag-application-builder.ts#L24-L38)
- 到了 Cherry Studio 再取前 `documentCount` 个结果

这导致超过 30 的 `documentCount` 不起作用

After this PR:

设置 `searchResultCount`，让用户设置能控制这个数量

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #8110

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
