### PR TITLE
feat: set source language when checking history item

### DIFF
--- a/src/renderer/src/pages/translate/TranslatePage.tsx
+++ b/src/renderer/src/pages/translate/TranslatePage.tsx
@@ -452,6 +452,7 @@ const TranslatePage: FC = () => {
   const onHistoryItemClick = (history: TranslateHistory & { _sourceLanguage: Language; _targetLanguage: Language }) => {
     setText(history.sourceText)
     setResult(history.targetText)
+    setSourceLanguage(history._sourceLanguage)
     setTargetLanguage(history._targetLanguage)
   }
 


### PR DESCRIPTION
在 #8060 遗漏了这个，点击查看历史记录时，这里只设置了 targetLanguage，并没有设置 sourceLanguae