### PR TITLE
feat: improve codeBlock UI

### DIFF
--- a/src/renderer/src/components/CodeBlockView/CodePreview.tsx
+++ b/src/renderer/src/components/CodeBlockView/CodePreview.tsx
@@ -5,7 +5,7 @@ import { useSettings } from '@renderer/hooks/useSettings'
 import { uuid } from '@renderer/utils'
 import { getReactStyleFromToken } from '@renderer/utils/shiki'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { debounce } from 'lodash'
+import { debounce, max } from 'lodash'
 import { ChevronsDownUp, ChevronsUpDown, Text as UnWrapIcon, WrapText as WrapIcon } from 'lucide-react'
 import React, { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -159,7 +159,7 @@ const CodePreview = ({ children, language, setTools }: CodePreviewProps) => {
           className="shiki-list"
           style={{
             height: `${virtualizer.getTotalSize()}px`,
-            width: '100%',
+            width: (max(rawLines.map((line) => line.length * 8)) ?? 0) + 4,
             position: 'relative'
           }}>
           <div

--- a/src/renderer/src/components/CodeBlockView/view.tsx
+++ b/src/renderer/src/components/CodeBlockView/view.tsx
@@ -250,7 +250,6 @@ const CodeBlockWrapper = styled.div<{ $isInSpecialView: boolean }>`
    * 一是 CodePreview 在气泡样式下的用户消息中无法撑开气泡，
    * 二是 代码块内容过少时 toolbar 会和 title 重叠。
    */
-  min-width: 45ch;
 
   .code-toolbar {
     background-color: ${(props) => (props.$isInSpecialView ? 'transparent' : 'var(--color-background-mute)')};

--- a/src/renderer/src/components/CodeToolbar/toolbar.tsx
+++ b/src/renderer/src/components/CodeToolbar/toolbar.tsx
@@ -1,7 +1,7 @@
 import { HStack } from '@renderer/components/Layout'
 import { Tooltip } from 'antd'
 import { EllipsisVertical } from 'lucide-react'
-import React, { memo, useMemo, useState } from 'react'
+import React, { memo, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
@@ -19,8 +19,11 @@ const CodeToolButton: React.FC<CodeToolButtonProps> = memo(({ tool }) => {
   )
 })
 
-export const CodeToolbar: React.FC<{ tools: CodeTool[] }> = memo(({ tools }) => {
-  const [showQuickTools, setShowQuickTools] = useState(false)
+export const CodeToolbar: React.FC<{
+  tools: CodeTool[]
+  showQuickTools: boolean
+  setShowQuickTools: (value: boolean) => void
+}> = memo(({ tools, showQuickTools, setShowQuickTools }) => {
   const { t } = useTranslation()
 
   // 根据条件显示工具
@@ -45,7 +48,7 @@ export const CodeToolbar: React.FC<{ tools: CodeTool[] }> = memo(({ tools }) => 
 
   return (
     <StickyWrapper>
-      <ToolbarWrapper className="code-toolbar">
+      <ToolbarWrapper className="code-toolbar" style={{ position: 'absolute', right: '0.5rem', bottom: '0.3rem' }}>
         {/* 有多个快捷工具时通过 more 按钮展示 */}
         {quickToolButtons}
         {quickTools.length > 1 && (
@@ -65,6 +68,52 @@ export const CodeToolbar: React.FC<{ tools: CodeTool[] }> = memo(({ tools }) => 
   )
 })
 
+const FakeCodeToolButton: React.FC<CodeToolButtonProps> = memo(({ tool }) => {
+  return <ToolWrapper>{tool.icon}</ToolWrapper>
+})
+
+export const FakeCodeToolbar: React.FC<{
+  tools: CodeTool[]
+  showQuickTools: boolean
+}> = memo(({ tools, showQuickTools }) => {
+  // 根据条件显示工具
+  const visibleTools = tools.filter((tool) => !tool.visible || tool.visible())
+
+  // 按类型分组
+  const coreTools = visibleTools.filter((tool) => tool.type === 'core')
+  const quickTools = visibleTools.filter((tool) => tool.type === 'quick')
+
+  // 点击了 more 按钮或者只有一个快捷工具时
+  const quickToolButtons = useMemo(() => {
+    if (quickTools.length === 1 || (quickTools.length > 1 && showQuickTools)) {
+      return quickTools.map((tool) => <FakeCodeToolButton key={tool.id} tool={tool} />)
+    }
+
+    return null
+  }, [quickTools, showQuickTools])
+
+  if (visibleTools.length === 0) {
+    return null
+  }
+
+  return (
+    <ToolbarWrapper className="code-toolbar" style={{ opacity: 0, pointerEvents: 'none' }}>
+      {/* 有多个快捷工具时通过 more 按钮展示 */}
+      {quickToolButtons}
+      {quickTools.length > 1 && (
+        <ToolWrapper className={showQuickTools ? 'active' : ''}>
+          <EllipsisVertical className="icon" />
+        </ToolWrapper>
+      )}
+
+      {/* 始终显示核心工具 */}
+      {coreTools.map((tool) => (
+        <FakeCodeToolButton key={tool.id} tool={tool} />
+      ))}
+    </ToolbarWrapper>
+  )
+})
+
 const StickyWrapper = styled.div`
   position: sticky;
   top: 28px;
@@ -72,10 +121,10 @@ const StickyWrapper = styled.div`
 `
 
 const ToolbarWrapper = styled(HStack)`
-  position: absolute;
+  // position: absolute;
   align-items: center;
-  bottom: 0.3rem;
-  right: 0.5rem;
+  // bottom: 0.3rem;
+  // right: 0.5rem;
   height: 24px;
   gap: 4px;
 `


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
