### PR TITLE
feat: implement BlockManager and associated callbacks for message str…

### DIFF
--- a/src/renderer/src/services/messageStreaming/BlockManager.ts
+++ b/src/renderer/src/services/messageStreaming/BlockManager.ts
@@ -1,0 +1,136 @@
+import type { AppDispatch, RootState } from '@renderer/store'
+import { updateOneBlock, upsertOneBlock } from '@renderer/store/messageBlock'
+import { newMessagesActions } from '@renderer/store/newMessage'
+import { MessageBlock, MessageBlockType } from '@renderer/types/newMessage'
+
+interface ActiveBlockInfo {
+  id: string
+  type: MessageBlockType
+}
+
+interface BlockManagerDependencies {
+  dispatch: AppDispatch
+  getState: () => RootState
+  saveUpdatedBlockToDB: (
+    blockId: string | null,
+    messageId: string,
+    topicId: string,
+    getState: () => RootState
+  ) => Promise<void>
+  saveUpdatesToDB: (
+    messageId: string,
+    topicId: string,
+    messageUpdates: Partial<any>,
+    blocksToUpdate: MessageBlock[]
+  ) => Promise<void>
+  assistantMsgId: string
+  topicId: string
+  // 节流器管理从外部传入
+  throttledBlockUpdate: (id: string, blockUpdate: any) => void
+  cancelThrottledBlockUpdate: (id: string) => void
+}
+
+export class BlockManager {
+  private deps: BlockManagerDependencies
+
+  // 简化后的状态管理
+  private _activeBlockInfo: ActiveBlockInfo | null = null
+  private _lastBlockType: MessageBlockType | null = null // 保留用于错误处理
+
+  constructor(dependencies: BlockManagerDependencies) {
+    this.deps = dependencies
+  }
+
+  // Getters
+  get activeBlockInfo() {
+    return this._activeBlockInfo
+  }
+
+  get lastBlockType() {
+    return this._lastBlockType
+  }
+
+  get hasInitialPlaceholder() {
+    return this._activeBlockInfo?.type === MessageBlockType.UNKNOWN
+  }
+
+  get initialPlaceholderBlockId() {
+    return this.hasInitialPlaceholder ? this._activeBlockInfo?.id || null : null
+  }
+
+  // Setters
+  set lastBlockType(value: MessageBlockType | null) {
+    this._lastBlockType = value
+  }
+
+  set activeBlockInfo(value: ActiveBlockInfo | null) {
+    this._activeBlockInfo = value
+  }
+
+  /**
+   * 智能更新策略：根据块类型连续性自动判断使用节流还是立即更新
+   */
+  smartBlockUpdate(
+    blockId: string,
+    changes: Partial<MessageBlock>,
+    blockType: MessageBlockType,
+    isComplete: boolean = false
+  ) {
+    const isBlockTypeChanged = this._activeBlockInfo !== null && this._activeBlockInfo.type !== blockType
+
+    if (isBlockTypeChanged || isComplete) {
+      // 如果块类型改变，则取消上一个块的节流更新
+      if (isBlockTypeChanged && this._activeBlockInfo) {
+        this.deps.cancelThrottledBlockUpdate(this._activeBlockInfo.id)
+      }
+      // 如果当前块完成，则取消当前块的节流更新
+      if (isComplete) {
+        this.deps.cancelThrottledBlockUpdate(blockId)
+        this._activeBlockInfo = null // 块完成时清空activeBlockInfo
+      } else {
+        this._activeBlockInfo = { id: blockId, type: blockType } // 更新活跃块信息
+      }
+      this.deps.dispatch(updateOneBlock({ id: blockId, changes }))
+      this.deps.saveUpdatedBlockToDB(blockId, this.deps.assistantMsgId, this.deps.topicId, this.deps.getState)
+    } else {
+      this._activeBlockInfo = { id: blockId, type: blockType } // 更新活跃块信息
+      this.deps.throttledBlockUpdate(blockId, changes)
+    }
+  }
+
+  /**
+   * 处理块转换
+   */
+  async handleBlockTransition(newBlock: MessageBlock, newBlockType: MessageBlockType) {
+    this._lastBlockType = newBlockType
+    this._activeBlockInfo = { id: newBlock.id, type: newBlockType } // 设置新的活跃块信息
+
+    this.deps.dispatch(
+      newMessagesActions.updateMessage({
+        topicId: this.deps.topicId,
+        messageId: this.deps.assistantMsgId,
+        updates: { blockInstruction: { id: newBlock.id } }
+      })
+    )
+    this.deps.dispatch(upsertOneBlock(newBlock))
+    this.deps.dispatch(
+      newMessagesActions.upsertBlockReference({
+        messageId: this.deps.assistantMsgId,
+        blockId: newBlock.id,
+        status: newBlock.status
+      })
+    )
+
+    const currentState = this.deps.getState()
+    const updatedMessage = currentState.messages.entities[this.deps.assistantMsgId]
+    if (updatedMessage) {
+      await this.deps.saveUpdatesToDB(this.deps.assistantMsgId, this.deps.topicId, { blocks: updatedMessage.blocks }, [
+        newBlock
+      ])
+    } else {
+      console.error(
+        `[handleBlockTransition] Failed to get updated message ${this.deps.assistantMsgId} from state for DB save.`
+      )
+    }
+  }
+}

--- a/src/renderer/src/services/messageStreaming/callbacks/baseCallbacks.ts
+++ b/src/renderer/src/services/messageStreaming/callbacks/baseCallbacks.ts
@@ -1,0 +1,211 @@
+import { autoRenameTopic } from '@renderer/hooks/useTopic'
+import i18n from '@renderer/i18n'
+import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
+import { NotificationService } from '@renderer/services/NotificationService'
+import { estimateMessagesUsage } from '@renderer/services/TokenService'
+import { selectMessagesForTopic } from '@renderer/store/newMessage'
+import { newMessagesActions } from '@renderer/store/newMessage'
+import type { Assistant } from '@renderer/types'
+import type { Response } from '@renderer/types/newMessage'
+import {
+  AssistantMessageStatus,
+  MessageBlockStatus,
+  MessageBlockType,
+  PlaceholderMessageBlock
+} from '@renderer/types/newMessage'
+import { uuid } from '@renderer/utils'
+import { formatErrorMessage, isAbortError } from '@renderer/utils/error'
+import { createBaseMessageBlock, createErrorBlock } from '@renderer/utils/messageUtils/create'
+import { findAllBlocks, getMainTextContent } from '@renderer/utils/messageUtils/find'
+import { isOnHomePage } from '@renderer/utils/window'
+
+import { BlockManager } from '../BlockManager'
+
+interface BaseCallbacksDependencies {
+  blockManager: BlockManager
+  dispatch: any
+  getState: any
+  topicId: string
+  assistantMsgId: string
+  saveUpdatesToDB: any
+  assistant: Assistant
+}
+
+export const createBaseCallbacks = (deps: BaseCallbacksDependencies) => {
+  const { blockManager, dispatch, getState, topicId, assistantMsgId, saveUpdatesToDB, assistant } = deps
+
+  const startTime = Date.now()
+  const notificationService = NotificationService.getInstance()
+
+  // 通用的 block 查找函数
+  const findBlockIdForCompletion = (message?: any) => {
+    // 优先使用 BlockManager 中的 activeBlockInfo
+    const activeBlockInfo = blockManager.activeBlockInfo
+
+    if (activeBlockInfo) {
+      return activeBlockInfo.id
+    }
+
+    // 如果没有活跃的block，从message中查找最新的block作为备选
+    const targetMessage = message || getState().messages.entities[assistantMsgId]
+    if (targetMessage) {
+      const allBlocks = findAllBlocks(targetMessage)
+      if (allBlocks.length > 0) {
+        return allBlocks[allBlocks.length - 1].id // 返回最新的block
+      }
+    }
+
+    // 最后的备选方案：从 blockManager 获取占位符块ID
+    return blockManager.initialPlaceholderBlockId
+  }
+
+  return {
+    onLLMResponseCreated: async () => {
+      const baseBlock = createBaseMessageBlock(assistantMsgId, MessageBlockType.UNKNOWN, {
+        status: MessageBlockStatus.PROCESSING
+      })
+      await blockManager.handleBlockTransition(baseBlock as PlaceholderMessageBlock, MessageBlockType.UNKNOWN)
+    },
+
+    onError: async (error: any) => {
+      console.dir(error, { depth: null })
+      const isErrorTypeAbort = isAbortError(error)
+      let pauseErrorLanguagePlaceholder = ''
+      if (isErrorTypeAbort) {
+        pauseErrorLanguagePlaceholder = 'pause_placeholder'
+      }
+
+      const serializableError = {
+        name: error.name,
+        message: pauseErrorLanguagePlaceholder || error.message || formatErrorMessage(error),
+        originalMessage: error.message,
+        stack: error.stack,
+        status: error.status || error.code,
+        requestId: error.request_id
+      }
+
+      // 发送错误通知（除了中止错误）
+      if (!isErrorTypeAbort && !isOnHomePage()) {
+        await notificationService.send({
+          id: uuid(),
+          type: 'error',
+          title: i18n.t('notification.assistant'),
+          message: serializableError.message,
+          silent: false,
+          timestamp: Date.now(),
+          source: 'assistant'
+        })
+      }
+
+      const possibleBlockId = findBlockIdForCompletion()
+
+      if (possibleBlockId) {
+        // 更改上一个block的状态为ERROR
+        const changes = {
+          status: isErrorTypeAbort ? MessageBlockStatus.PAUSED : MessageBlockStatus.ERROR
+        }
+        blockManager.smartBlockUpdate(possibleBlockId, changes, blockManager.lastBlockType!, true)
+      }
+
+      const errorBlock = createErrorBlock(assistantMsgId, serializableError, { status: MessageBlockStatus.SUCCESS })
+      await blockManager.handleBlockTransition(errorBlock, MessageBlockType.ERROR)
+
+      // 更新消息状态
+      const messageUpdates = {
+        status: isErrorTypeAbort ? AssistantMessageStatus.PAUSED : AssistantMessageStatus.ERROR
+      }
+      dispatch(
+        newMessagesActions.updateMessage({
+          topicId,
+          messageId: assistantMsgId,
+          updates: messageUpdates
+        })
+      )
+      await saveUpdatesToDB(assistantMsgId, topicId, messageUpdates, [])
+
+      EventEmitter.emit(EVENT_NAMES.MESSAGE_COMPLETE, {
+        id: assistantMsgId,
+        topicId,
+        status: isErrorTypeAbort ? 'pause' : 'error',
+        error: error.message
+      })
+    },
+
+    onComplete: async (status: AssistantMessageStatus, response?: Response) => {
+      const finalStateOnComplete = getState()
+      const finalAssistantMsg = finalStateOnComplete.messages.entities[assistantMsgId]
+
+      if (status === 'success' && finalAssistantMsg) {
+        const userMsgId = finalAssistantMsg.askId
+        const orderedMsgs = selectMessagesForTopic(finalStateOnComplete, topicId)
+        const userMsgIndex = orderedMsgs.findIndex((m) => m.id === userMsgId)
+        const contextForUsage = userMsgIndex !== -1 ? orderedMsgs.slice(0, userMsgIndex + 1) : []
+        const finalContextWithAssistant = [...contextForUsage, finalAssistantMsg]
+
+        const possibleBlockId = findBlockIdForCompletion(finalAssistantMsg)
+
+        if (possibleBlockId) {
+          const changes = {
+            status: MessageBlockStatus.SUCCESS
+          }
+          blockManager.smartBlockUpdate(possibleBlockId, changes, blockManager.lastBlockType!, true)
+        }
+
+        const endTime = Date.now()
+        const duration = endTime - startTime
+        const content = getMainTextContent(finalAssistantMsg)
+
+        // 发送长时间运行消息的成功通知
+        if (!isOnHomePage() && duration > 60 * 1000) {
+          await notificationService.send({
+            id: uuid(),
+            type: 'success',
+            title: i18n.t('notification.assistant'),
+            message: content.length > 50 ? content.slice(0, 47) + '...' : content,
+            silent: false,
+            timestamp: Date.now(),
+            source: 'assistant'
+          })
+        }
+
+        // 更新topic的name
+        autoRenameTopic(assistant, topicId)
+
+        // 处理usage估算
+        if (
+          response &&
+          (response.usage?.total_tokens === 0 ||
+            response?.usage?.prompt_tokens === 0 ||
+            response?.usage?.completion_tokens === 0)
+        ) {
+          const usage = await estimateMessagesUsage({ assistant, messages: finalContextWithAssistant })
+          response.usage = usage
+        }
+      }
+
+      if (response && response.metrics) {
+        if (response.metrics.completion_tokens === 0 && response.usage?.completion_tokens) {
+          response = {
+            ...response,
+            metrics: {
+              ...response.metrics,
+              completion_tokens: response.usage.completion_tokens
+            }
+          }
+        }
+      }
+
+      const messageUpdates = { status, metrics: response?.metrics, usage: response?.usage }
+      dispatch(
+        newMessagesActions.updateMessage({
+          topicId,
+          messageId: assistantMsgId,
+          updates: messageUpdates
+        })
+      )
+      await saveUpdatesToDB(assistantMsgId, topicId, messageUpdates, [])
+
+      EventEmitter.emit(EVENT_NAMES.MESSAGE_COMPLETE, { id: assistantMsgId, topicId, status })
+    }
+  }
+}

--- a/src/renderer/src/services/messageStreaming/callbacks/citationCallbacks.ts
+++ b/src/renderer/src/services/messageStreaming/callbacks/citationCallbacks.ts
@@ -1,0 +1,109 @@
+import type { ExternalToolResult } from '@renderer/types'
+import { CitationMessageBlock, MessageBlockStatus, MessageBlockType } from '@renderer/types/newMessage'
+import { createCitationBlock } from '@renderer/utils/messageUtils/create'
+import { findMainTextBlocks } from '@renderer/utils/messageUtils/find'
+
+import { BlockManager } from '../BlockManager'
+
+interface CitationCallbacksDependencies {
+  blockManager: BlockManager
+  assistantMsgId: string
+  getState: any
+}
+
+export const createCitationCallbacks = (deps: CitationCallbacksDependencies) => {
+  const { blockManager, assistantMsgId, getState } = deps
+
+  // 内部维护的状态
+  let citationBlockId: string | null = null
+
+  return {
+    onExternalToolInProgress: async () => {
+      const citationBlock = createCitationBlock(assistantMsgId, {}, { status: MessageBlockStatus.PROCESSING })
+      citationBlockId = citationBlock.id
+      await blockManager.handleBlockTransition(citationBlock, MessageBlockType.CITATION)
+    },
+
+    onExternalToolComplete: (externalToolResult: ExternalToolResult) => {
+      if (citationBlockId) {
+        const changes: Partial<CitationMessageBlock> = {
+          response: externalToolResult.webSearch,
+          knowledge: externalToolResult.knowledge,
+          status: MessageBlockStatus.SUCCESS
+        }
+        blockManager.smartBlockUpdate(citationBlockId, changes, MessageBlockType.CITATION, true)
+      } else {
+        console.error('[onExternalToolComplete] citationBlockId is null. Cannot update.')
+      }
+    },
+
+    onLLMWebSearchInProgress: async () => {
+      if (blockManager.hasInitialPlaceholder) {
+        blockManager.lastBlockType = MessageBlockType.CITATION
+        citationBlockId = blockManager.initialPlaceholderBlockId!
+        const changes = {
+          type: MessageBlockType.CITATION,
+          status: MessageBlockStatus.PROCESSING
+        }
+        blockManager.smartBlockUpdate(citationBlockId, changes, MessageBlockType.CITATION)
+      } else {
+        const citationBlock = createCitationBlock(assistantMsgId, {}, { status: MessageBlockStatus.PROCESSING })
+        citationBlockId = citationBlock.id
+        await blockManager.handleBlockTransition(citationBlock, MessageBlockType.CITATION)
+      }
+    },
+
+    onLLMWebSearchComplete: async (llmWebSearchResult: any) => {
+      const blockId = citationBlockId || blockManager.initialPlaceholderBlockId
+      if (blockId) {
+        const changes: Partial<CitationMessageBlock> = {
+          type: MessageBlockType.CITATION,
+          response: llmWebSearchResult,
+          status: MessageBlockStatus.SUCCESS
+        }
+        blockManager.smartBlockUpdate(blockId, changes, MessageBlockType.CITATION)
+
+        const state = getState()
+        const existingMainTextBlocks = findMainTextBlocks(state.messages.entities[assistantMsgId])
+        if (existingMainTextBlocks.length > 0) {
+          const existingMainTextBlock = existingMainTextBlocks[0]
+          const currentRefs = existingMainTextBlock.citationReferences || []
+          const mainTextChanges = {
+            citationReferences: [...currentRefs, { blockId, citationBlockSource: llmWebSearchResult.source }]
+          }
+          blockManager.smartBlockUpdate(existingMainTextBlock.id, mainTextChanges, MessageBlockType.MAIN_TEXT, true)
+        }
+
+        if (blockManager.hasInitialPlaceholder) {
+          citationBlockId = blockManager.initialPlaceholderBlockId
+        }
+      } else {
+        const citationBlock = createCitationBlock(
+          assistantMsgId,
+          {
+            response: llmWebSearchResult
+          },
+          {
+            status: MessageBlockStatus.SUCCESS
+          }
+        )
+        citationBlockId = citationBlock.id
+
+        const state = getState()
+        const existingMainTextBlocks = findMainTextBlocks(state.messages.entities[assistantMsgId])
+        if (existingMainTextBlocks.length > 0) {
+          const existingMainTextBlock = existingMainTextBlocks[0]
+          const currentRefs = existingMainTextBlock.citationReferences || []
+          const mainTextChanges = {
+            citationReferences: [...currentRefs, { citationBlockId, citationBlockSource: llmWebSearchResult.source }]
+          }
+          blockManager.smartBlockUpdate(existingMainTextBlock.id, mainTextChanges, MessageBlockType.MAIN_TEXT, true)
+        }
+        await blockManager.handleBlockTransition(citationBlock, MessageBlockType.CITATION)
+      }
+    },
+
+    // 暴露给外部的方法，用于textCallbacks中获取citationBlockId
+    getCitationBlockId: () => citationBlockId
+  }
+}

--- a/src/renderer/src/services/messageStreaming/callbacks/imageCallbacks.ts
+++ b/src/renderer/src/services/messageStreaming/callbacks/imageCallbacks.ts
@@ -1,0 +1,70 @@
+import { ImageMessageBlock, MessageBlockStatus, MessageBlockType } from '@renderer/types/newMessage'
+import { createImageBlock } from '@renderer/utils/messageUtils/create'
+
+import { BlockManager } from '../BlockManager'
+
+interface ImageCallbacksDependencies {
+  blockManager: BlockManager
+  assistantMsgId: string
+}
+
+export const createImageCallbacks = (deps: ImageCallbacksDependencies) => {
+  const { blockManager, assistantMsgId } = deps
+
+  // 内部维护的状态
+  let imageBlockId: string | null = null
+
+  return {
+    onImageCreated: async () => {
+      if (blockManager.hasInitialPlaceholder) {
+        blockManager.lastBlockType = MessageBlockType.IMAGE
+        const initialChanges = {
+          type: MessageBlockType.IMAGE,
+          status: MessageBlockStatus.PENDING
+        }
+        imageBlockId = blockManager.initialPlaceholderBlockId!
+        blockManager.smartBlockUpdate(imageBlockId, initialChanges, MessageBlockType.IMAGE)
+      } else if (!imageBlockId) {
+        const imageBlock = createImageBlock(assistantMsgId, {
+          status: MessageBlockStatus.PENDING
+        })
+        imageBlockId = imageBlock.id
+        await blockManager.handleBlockTransition(imageBlock, MessageBlockType.IMAGE)
+      }
+    },
+
+    onImageDelta: (imageData: any) => {
+      const imageUrl = imageData.images?.[0] || 'placeholder_image_url'
+      if (imageBlockId) {
+        const changes: Partial<ImageMessageBlock> = {
+          url: imageUrl,
+          metadata: { generateImageResponse: imageData },
+          status: MessageBlockStatus.STREAMING
+        }
+        blockManager.smartBlockUpdate(imageBlockId, changes, MessageBlockType.IMAGE, true)
+      }
+    },
+
+    onImageGenerated: (imageData: any) => {
+      if (imageBlockId) {
+        if (!imageData) {
+          const changes: Partial<ImageMessageBlock> = {
+            status: MessageBlockStatus.SUCCESS
+          }
+          blockManager.smartBlockUpdate(imageBlockId, changes, MessageBlockType.IMAGE)
+        } else {
+          const imageUrl = imageData.images?.[0] || 'placeholder_image_url'
+          const changes: Partial<ImageMessageBlock> = {
+            url: imageUrl,
+            metadata: { generateImageResponse: imageData },
+            status: MessageBlockStatus.SUCCESS
+          }
+          blockManager.smartBlockUpdate(imageBlockId, changes, MessageBlockType.IMAGE, true)
+        }
+        imageBlockId = null
+      } else {
+        console.error('[onImageGenerated] Last block was not an Image block or ID is missing.')
+      }
+    }
+  }
+}

--- a/src/renderer/src/services/messageStreaming/callbacks/index.ts
+++ b/src/renderer/src/services/messageStreaming/callbacks/index.ts
@@ -1,0 +1,79 @@
+import type { Assistant } from '@renderer/types'
+
+import { BlockManager } from '../BlockManager'
+import { createBaseCallbacks } from './baseCallbacks'
+import { createCitationCallbacks } from './citationCallbacks'
+import { createImageCallbacks } from './imageCallbacks'
+import { createTextCallbacks } from './textCallbacks'
+import { createThinkingCallbacks } from './thinkingCallbacks'
+import { createToolCallbacks } from './toolCallbacks'
+
+interface CallbacksDependencies {
+  blockManager: BlockManager
+  dispatch: any
+  getState: any
+  topicId: string
+  assistantMsgId: string
+  saveUpdatesToDB: any
+  assistant: Assistant
+}
+
+export const createCallbacks = (deps: CallbacksDependencies) => {
+  const { blockManager, dispatch, getState, topicId, assistantMsgId, saveUpdatesToDB, assistant } = deps
+
+  // 创建基础回调
+  const baseCallbacks = createBaseCallbacks({
+    blockManager,
+    dispatch,
+    getState,
+    topicId,
+    assistantMsgId,
+    saveUpdatesToDB,
+    assistant
+  })
+
+  // 创建各类回调
+  const thinkingCallbacks = createThinkingCallbacks({
+    blockManager,
+    assistantMsgId
+  })
+
+  const toolCallbacks = createToolCallbacks({
+    blockManager,
+    assistantMsgId
+  })
+
+  const imageCallbacks = createImageCallbacks({
+    blockManager,
+    assistantMsgId
+  })
+
+  const citationCallbacks = createCitationCallbacks({
+    blockManager,
+    assistantMsgId,
+    getState
+  })
+
+  // 创建textCallbacks时传入citationCallbacks的getCitationBlockId方法
+  const textCallbacks = createTextCallbacks({
+    blockManager,
+    getState,
+    assistantMsgId,
+    getCitationBlockId: citationCallbacks.getCitationBlockId
+  })
+
+  // 组合所有回调
+  return {
+    ...baseCallbacks,
+    ...textCallbacks,
+    ...thinkingCallbacks,
+    ...toolCallbacks,
+    ...imageCallbacks,
+    ...citationCallbacks,
+    // 清理资源的方法
+    cleanup: () => {
+      // 清理由 messageThunk 中的节流函数管理，这里不需要特别处理
+      // 如果需要，可以调用 blockManager 的相关清理方法
+    }
+  }
+}

--- a/src/renderer/src/services/messageStreaming/callbacks/textCallbacks.ts
+++ b/src/renderer/src/services/messageStreaming/callbacks/textCallbacks.ts
@@ -1,0 +1,75 @@
+import { WebSearchSource } from '@renderer/types'
+import { CitationMessageBlock, MessageBlock, MessageBlockStatus, MessageBlockType } from '@renderer/types/newMessage'
+import { createMainTextBlock } from '@renderer/utils/messageUtils/create'
+
+import { BlockManager } from '../BlockManager'
+
+interface TextCallbacksDependencies {
+  blockManager: BlockManager
+  getState: any
+  assistantMsgId: string
+  getCitationBlockId: () => string | null
+}
+
+export const createTextCallbacks = (deps: TextCallbacksDependencies) => {
+  const { blockManager, getState, assistantMsgId, getCitationBlockId } = deps
+
+  // 内部维护的状态
+  let accumulatedContent = ''
+  let mainTextBlockId: string | null = null
+
+  return {
+    onTextStart: async () => {
+      if (blockManager.hasInitialPlaceholder) {
+        blockManager.lastBlockType = MessageBlockType.MAIN_TEXT
+        const changes = {
+          type: MessageBlockType.MAIN_TEXT,
+          content: accumulatedContent,
+          status: MessageBlockStatus.STREAMING
+        }
+        mainTextBlockId = blockManager.initialPlaceholderBlockId!
+        blockManager.smartBlockUpdate(mainTextBlockId, changes, MessageBlockType.MAIN_TEXT, true)
+      } else if (!mainTextBlockId) {
+        const newBlock = createMainTextBlock(assistantMsgId, accumulatedContent, {
+          status: MessageBlockStatus.STREAMING
+        })
+        mainTextBlockId = newBlock.id
+        await blockManager.handleBlockTransition(newBlock, MessageBlockType.MAIN_TEXT)
+      }
+    },
+
+    onTextChunk: async (text: string) => {
+      const citationBlockId = getCitationBlockId()
+      const citationBlockSource = citationBlockId
+        ? (getState().messageBlocks.entities[citationBlockId] as CitationMessageBlock).response?.source
+        : WebSearchSource.WEBSEARCH
+
+      accumulatedContent += text
+
+      if (mainTextBlockId) {
+        const blockChanges: Partial<MessageBlock> = {
+          content: accumulatedContent,
+          status: MessageBlockStatus.STREAMING,
+          citationReferences: citationBlockId ? [{ citationBlockId, citationBlockSource }] : []
+        }
+        blockManager.smartBlockUpdate(mainTextBlockId, blockChanges, MessageBlockType.MAIN_TEXT)
+      }
+    },
+
+    onTextComplete: async (finalText: string) => {
+      if (mainTextBlockId) {
+        const changes = {
+          content: finalText,
+          status: MessageBlockStatus.SUCCESS
+        }
+        blockManager.smartBlockUpdate(mainTextBlockId, changes, MessageBlockType.MAIN_TEXT, true)
+        mainTextBlockId = null
+        accumulatedContent = ''
+      } else {
+        console.warn(
+          `[onTextComplete] Received text.complete but last block was not MAIN_TEXT (was ${blockManager.lastBlockType}) or lastBlockId is null.`
+        )
+      }
+    }
+  }
+}

--- a/src/renderer/src/services/messageStreaming/callbacks/thinkingCallbacks.ts
+++ b/src/renderer/src/services/messageStreaming/callbacks/thinkingCallbacks.ts
@@ -1,0 +1,71 @@
+import { MessageBlock, MessageBlockStatus, MessageBlockType } from '@renderer/types/newMessage'
+import { createThinkingBlock } from '@renderer/utils/messageUtils/create'
+
+import { BlockManager } from '../BlockManager'
+
+interface ThinkingCallbacksDependencies {
+  blockManager: BlockManager
+  assistantMsgId: string
+}
+
+export const createThinkingCallbacks = (deps: ThinkingCallbacksDependencies) => {
+  const { blockManager, assistantMsgId } = deps
+
+  // 内部维护的状态
+  let accumulatedThinking = ''
+  let thinkingBlockId: string | null = null
+
+  return {
+    onThinkingStart: async () => {
+      if (blockManager.hasInitialPlaceholder) {
+        blockManager.lastBlockType = MessageBlockType.THINKING
+        const changes = {
+          type: MessageBlockType.THINKING,
+          content: accumulatedThinking,
+          status: MessageBlockStatus.STREAMING,
+          thinking_millsec: 0
+        }
+        thinkingBlockId = blockManager.initialPlaceholderBlockId!
+        blockManager.smartBlockUpdate(thinkingBlockId, changes, MessageBlockType.THINKING, true)
+      } else if (!thinkingBlockId) {
+        const newBlock = createThinkingBlock(assistantMsgId, accumulatedThinking, {
+          status: MessageBlockStatus.STREAMING,
+          thinking_millsec: 0
+        })
+        thinkingBlockId = newBlock.id
+        await blockManager.handleBlockTransition(newBlock, MessageBlockType.THINKING)
+      }
+    },
+
+    onThinkingChunk: async (text: string, thinking_millsec?: number) => {
+      accumulatedThinking += text
+
+      if (thinkingBlockId) {
+        const blockChanges: Partial<MessageBlock> = {
+          content: accumulatedThinking,
+          status: MessageBlockStatus.STREAMING,
+          thinking_millsec: thinking_millsec || 0
+        }
+        blockManager.smartBlockUpdate(thinkingBlockId, blockChanges, MessageBlockType.THINKING)
+      }
+    },
+
+    onThinkingComplete: (finalText: string, final_thinking_millsec?: number) => {
+      if (thinkingBlockId) {
+        const changes = {
+          type: MessageBlockType.THINKING,
+          content: finalText,
+          status: MessageBlockStatus.SUCCESS,
+          thinking_millsec: final_thinking_millsec || 0
+        }
+        blockManager.smartBlockUpdate(thinkingBlockId, changes, MessageBlockType.THINKING, true)
+        thinkingBlockId = null
+        accumulatedThinking = ''
+      } else {
+        console.warn(
+          `[onThinkingComplete] Received thinking.complete but last block was not THINKING (was ${blockManager.lastBlockType}) or lastBlockId is null.`
+        )
+      }
+    }
+  }
+}

--- a/src/renderer/src/services/messageStreaming/callbacks/toolCallbacks.ts
+++ b/src/renderer/src/services/messageStreaming/callbacks/toolCallbacks.ts
@@ -1,0 +1,107 @@
+import type { MCPToolResponse } from '@renderer/types'
+import { MessageBlockStatus, MessageBlockType, ToolMessageBlock } from '@renderer/types/newMessage'
+import { createToolBlock } from '@renderer/utils/messageUtils/create'
+
+import { BlockManager } from '../BlockManager'
+
+interface ToolCallbacksDependencies {
+  blockManager: BlockManager
+  assistantMsgId: string
+}
+
+export const createToolCallbacks = (deps: ToolCallbacksDependencies) => {
+  const { blockManager, assistantMsgId } = deps
+
+  // 内部维护的状态
+  const toolCallIdToBlockIdMap = new Map<string, string>()
+  let toolBlockId: string | null = null
+
+  return {
+    onToolCallPending: (toolResponse: MCPToolResponse) => {
+      if (blockManager.hasInitialPlaceholder) {
+        blockManager.lastBlockType = MessageBlockType.TOOL
+        const changes = {
+          type: MessageBlockType.TOOL,
+          status: MessageBlockStatus.PENDING,
+          toolName: toolResponse.tool.name,
+          metadata: { rawMcpToolResponse: toolResponse }
+        }
+        toolBlockId = blockManager.initialPlaceholderBlockId!
+        blockManager.smartBlockUpdate(toolBlockId, changes, MessageBlockType.TOOL)
+        toolCallIdToBlockIdMap.set(toolResponse.id, toolBlockId)
+      } else if (toolResponse.status === 'pending') {
+        const toolBlock = createToolBlock(assistantMsgId, toolResponse.id, {
+          toolName: toolResponse.tool.name,
+          status: MessageBlockStatus.PENDING,
+          metadata: { rawMcpToolResponse: toolResponse }
+        })
+        toolBlockId = toolBlock.id
+        blockManager.handleBlockTransition(toolBlock, MessageBlockType.TOOL)
+        toolCallIdToBlockIdMap.set(toolResponse.id, toolBlock.id)
+      } else {
+        console.warn(
+          `[onToolCallPending] Received unhandled tool status: ${toolResponse.status} for ID: ${toolResponse.id}`
+        )
+      }
+    },
+
+    onToolCallInProgress: (toolResponse: MCPToolResponse) => {
+      // 根据 toolResponse.id 查找对应的块ID
+      const targetBlockId = toolCallIdToBlockIdMap.get(toolResponse.id)
+
+      if (targetBlockId && toolResponse.status === 'invoking') {
+        const changes = {
+          status: MessageBlockStatus.PROCESSING,
+          metadata: { rawMcpToolResponse: toolResponse }
+        }
+        blockManager.smartBlockUpdate(targetBlockId, changes, MessageBlockType.TOOL)
+      } else if (!targetBlockId) {
+        console.warn(
+          `[onToolCallInProgress] No block ID found for tool ID: ${toolResponse.id}. Available mappings:`,
+          Array.from(toolCallIdToBlockIdMap.entries())
+        )
+      } else {
+        console.warn(
+          `[onToolCallInProgress] Received unhandled tool status: ${toolResponse.status} for ID: ${toolResponse.id}`
+        )
+      }
+    },
+
+    onToolCallComplete: (toolResponse: MCPToolResponse) => {
+      const existingBlockId = toolCallIdToBlockIdMap.get(toolResponse.id)
+      toolCallIdToBlockIdMap.delete(toolResponse.id)
+
+      if (toolResponse.status === 'done' || toolResponse.status === 'error' || toolResponse.status === 'cancelled') {
+        if (!existingBlockId) {
+          console.error(
+            `[onToolCallComplete] No existing block found for completed/error tool call ID: ${toolResponse.id}. Cannot update.`
+          )
+          return
+        }
+
+        const finalStatus =
+          toolResponse.status === 'done' || toolResponse.status === 'cancelled'
+            ? MessageBlockStatus.SUCCESS
+            : MessageBlockStatus.ERROR
+
+        const changes: Partial<ToolMessageBlock> = {
+          content: toolResponse.response,
+          status: finalStatus,
+          metadata: { rawMcpToolResponse: toolResponse }
+        }
+
+        if (finalStatus === MessageBlockStatus.ERROR) {
+          changes.error = { message: `Tool execution failed/error`, details: toolResponse.response }
+        }
+
+        blockManager.smartBlockUpdate(existingBlockId, changes, MessageBlockType.TOOL, true)
+      } else {
+        console.warn(
+          `[onToolCallComplete] Received unhandled tool status: ${toolResponse.status} for ID: ${toolResponse.id}`
+        )
+      }
+
+      toolBlockId = null
+    }
+  }
+}

--- a/src/renderer/src/services/messageStreaming/index.ts
+++ b/src/renderer/src/services/messageStreaming/index.ts
@@ -1,0 +1,3 @@
+export { BlockManager } from './BlockManager'
+export type { createCallbacks as CreateCallbacksFunction } from './callbacks'
+export { createCallbacks } from './callbacks'

--- a/src/renderer/src/store/thunk/messageThunk.ts
+++ b/src/renderer/src/store/thunk/messageThunk.ts
@@ -1,50 +1,22 @@
 import db from '@renderer/databases'
-import { autoRenameTopic } from '@renderer/hooks/useTopic'
 import { fetchChatCompletion } from '@renderer/services/ApiService'
-import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import FileManager from '@renderer/services/FileManager'
-import { NotificationService } from '@renderer/services/NotificationService'
+import { BlockManager } from '@renderer/services/messageStreaming/BlockManager'
+import { createCallbacks } from '@renderer/services/messageStreaming/callbacks'
 import { createStreamProcessor, type StreamProcessorCallbacks } from '@renderer/services/StreamProcessingService'
-import { estimateMessagesUsage } from '@renderer/services/TokenService'
 import store from '@renderer/store'
 import { updateTopicUpdatedAt } from '@renderer/store/assistants'
-import {
-  type Assistant,
-  type ExternalToolResult,
-  type FileMetadata,
-  type MCPToolResponse,
-  type Model,
-  type Topic,
-  WebSearchSource
-} from '@renderer/types'
-import type {
-  CitationMessageBlock,
-  FileMessageBlock,
-  ImageMessageBlock,
-  Message,
-  MessageBlock,
-  PlaceholderMessageBlock,
-  ToolMessageBlock
-} from '@renderer/types/newMessage'
-import { AssistantMessageStatus, MessageBlockStatus, MessageBlockType, Response } from '@renderer/types/newMessage'
+import { type Assistant, type FileMetadata, type Model, type Topic } from '@renderer/types'
+import type { FileMessageBlock, ImageMessageBlock, Message, MessageBlock } from '@renderer/types/newMessage'
+import { AssistantMessageStatus, MessageBlockStatus, MessageBlockType } from '@renderer/types/newMessage'
 import { uuid } from '@renderer/utils'
-import { formatErrorMessage, isAbortError } from '@renderer/utils/error'
 import {
   createAssistantMessage,
-  createBaseMessageBlock,
-  createCitationBlock,
-  createErrorBlock,
-  createImageBlock,
-  createMainTextBlock,
-  createThinkingBlock,
-  createToolBlock,
   createTranslationBlock,
   resetAssistantMessage
 } from '@renderer/utils/messageUtils/create'
-import { findMainTextBlocks, getMainTextContent } from '@renderer/utils/messageUtils/find'
 import { getTopicQueue } from '@renderer/utils/queue'
 import { waitForTopicQueue } from '@renderer/utils/queue'
-import { isOnHomePage } from '@renderer/utils/window'
 import { t } from 'i18next'
 import { isEmpty, throttle } from 'lodash'
 import { LRUCache } from 'lru-cache'
@@ -320,25 +292,25 @@ const fetchAndProcessAssistantResponseImpl = async (
   assistantMessage: Message // Pass the prepared assistant message (new or reset)
 ) => {
   const assistantMsgId = assistantMessage.id
-  let callbacks: StreamProcessorCallbacks = {}
+  const callbacks: StreamProcessorCallbacks = {}
   try {
     dispatch(newMessagesActions.setTopicLoading({ topicId, loading: true }))
 
-    let accumulatedContent = ''
-    let accumulatedThinking = ''
-    let lastBlockId: string | null = null
-    let lastBlockType: MessageBlockType | null = null
-    let currentActiveBlockType: MessageBlockType | null = null
-    // 专注于块内部的生命周期处理
-    let initialPlaceholderBlockId: string | null = null
-    let citationBlockId: string | null = null
-    let mainTextBlockId: string | null = null
-    let thinkingBlockId: string | null = null
-    let imageBlockId: string | null = null
-    let toolBlockId: string | null = null
+    // let accumulatedContent = ''
+    // let accumulatedThinking = ''
+    // let lastBlockId: string | null = null
+    // let lastBlockType: MessageBlockType | null = null
+    // let currentActiveBlockType: MessageBlockType | null = null
+    // // 专注于块内部的生命周期处理
+    // let initialPlaceholderBlockId: string | null = null
+    // let citationBlockId: string | null = null
+    // let mainTextBlockId: string | null = null
+    // let thinkingBlockId: string | null = null
+    // let imageBlockId: string | null = null
+    // let toolBlockId: string | null = null
 
-    const toolCallIdToBlockIdMap = new Map<string, string>()
-    const notificationService = NotificationService.getInstance()
+    // const toolCallIdToBlockIdMap = new Map<string, string>()
+    // const notificationService = NotificationService.getInstance()
 
     /**
      * 智能更新策略：根据块类型连续性自动判断使用节流还是立即更新
@@ -349,65 +321,77 @@ const fetchAndProcessAssistantResponseImpl = async (
      * @param blockType 块类型
      * @param isComplete 是否完成，如果完成，则需要保存块更新到redux中
      */
-    const smartBlockUpdate = (
-      blockId: string,
-      changes: Partial<MessageBlock>,
-      blockType: MessageBlockType,
-      isComplete: boolean = false
-    ) => {
-      const isBlockTypeChanged = currentActiveBlockType !== null && currentActiveBlockType !== blockType
-      if (isBlockTypeChanged || isComplete) {
-        // 如果块类型改变，则取消上一个块的节流更新，并保存块更新到redux中（尽管有可能被上一个块本身的oncomplete事件的取消节流已经取消了）
-        if (isBlockTypeChanged && lastBlockId) {
-          cancelThrottledBlockUpdate(lastBlockId)
-        }
-        // 如果当前块完成，则取消当前块的节流更新，并保存块更新到redux中，避免streaming状态覆盖掉完成状态
-        if (isComplete) {
-          cancelThrottledBlockUpdate(blockId)
-        }
-        dispatch(updateOneBlock({ id: blockId, changes }))
-        saveUpdatedBlockToDB(blockId, assistantMsgId, topicId, getState)
-      } else {
-        throttledBlockUpdate(blockId, changes)
-      }
+    // const smartBlockUpdate = (
+    //   blockId: string,
+    //   changes: Partial<MessageBlock>,
+    //   blockType: MessageBlockType,
+    //   isComplete: boolean = false
+    // ) => {
+    //   const isBlockTypeChanged = currentActiveBlockType !== null && currentActiveBlockType !== blockType
+    //   if (isBlockTypeChanged || isComplete) {
+    //     // 如果块类型改变，则取消上一个块的节流更新，并保存块更新到redux中（尽管有可能被上一个块本身的oncomplete事件的取消节流已经取消了）
+    //     if (isBlockTypeChanged && lastBlockId) {
+    //       cancelThrottledBlockUpdate(lastBlockId)
+    //     }
+    //     // 如果当前块完成，则取消当前块的节流更新，并保存块更新到redux中，避免streaming状态覆盖掉完成状态
+    //     if (isComplete) {
+    //       cancelThrottledBlockUpdate(blockId)
+    //     }
+    //     dispatch(updateOneBlock({ id: blockId, changes }))
+    //     saveUpdatedBlockToDB(blockId, assistantMsgId, topicId, getState)
+    //   } else {
+    //     throttledBlockUpdate(blockId, changes)
+    //   }
 
-      // 更新当前活跃块类型
-      currentActiveBlockType = blockType
-    }
+    //   // 更新当前活跃块类型
+    //   currentActiveBlockType = blockType
+    // }
 
-    const handleBlockTransition = async (newBlock: MessageBlock, newBlockType: MessageBlockType) => {
-      lastBlockId = newBlock.id
-      lastBlockType = newBlockType
-      if (newBlockType !== MessageBlockType.MAIN_TEXT) {
-        accumulatedContent = ''
-      }
-      if (newBlockType !== MessageBlockType.THINKING) {
-        accumulatedThinking = ''
-      }
-      dispatch(
-        newMessagesActions.updateMessage({
-          topicId,
-          messageId: assistantMsgId,
-          updates: { blockInstruction: { id: newBlock.id } }
-        })
-      )
-      dispatch(upsertOneBlock(newBlock))
-      dispatch(
-        newMessagesActions.upsertBlockReference({
-          messageId: assistantMsgId,
-          blockId: newBlock.id,
-          status: newBlock.status
-        })
-      )
+    // const handleBlockTransition = async (newBlock: MessageBlock, newBlockType: MessageBlockType) => {
+    //   lastBlockId = newBlock.id
+    //   lastBlockType = newBlockType
+    //   if (newBlockType !== MessageBlockType.MAIN_TEXT) {
+    //     accumulatedContent = ''
+    //   }
+    //   if (newBlockType !== MessageBlockType.THINKING) {
+    //     accumulatedThinking = ''
+    //   }
+    //   dispatch(
+    //     newMessagesActions.updateMessage({
+    //       topicId,
+    //       messageId: assistantMsgId,
+    //       updates: { blockInstruction: { id: newBlock.id } }
+    //     })
+    //   )
+    //   dispatch(upsertOneBlock(newBlock))
+    //   dispatch(
+    //     newMessagesActions.upsertBlockReference({
+    //       messageId: assistantMsgId,
+    //       blockId: newBlock.id,
+    //       status: newBlock.status
+    //     })
+    //   )
 
-      const currentState = getState()
-      const updatedMessage = currentState.messages.entities[assistantMsgId]
-      if (updatedMessage) {
-        await saveUpdatesToDB(assistantMsgId, topicId, { blocks: updatedMessage.blocks }, [newBlock])
-      } else {
-        console.error(`[handleBlockTransition] Failed to get updated message ${assistantMsgId} from state for DB save.`)
-      }
-    }
+    //   const currentState = getState()
+    //   const updatedMessage = currentState.messages.entities[assistantMsgId]
+    //   if (updatedMessage) {
+    //     await saveUpdatesToDB(assistantMsgId, topicId, { blocks: updatedMessage.blocks }, [newBlock])
+    //   } else {
+    //     console.error(`[handleBlockTransition] Failed to get updated message ${assistantMsgId} from state for DB save.`)
+    //   }
+    // }
+
+    // 创建 BlockManager 实例
+    const blockManager = new BlockManager({
+      dispatch,
+      getState,
+      saveUpdatedBlockToDB,
+      saveUpdatesToDB,
+      assistantMsgId,
+      topicId,
+      throttledBlockUpdate,
+      cancelThrottledBlockUpdate
+    })
 
     const allMessagesForTopic = selectMessagesForTopic(getState(), topicId)
 
@@ -430,467 +414,476 @@ const fetchAndProcessAssistantResponseImpl = async (
       messagesForContext = contextSlice.filter((m) => m && !m.status?.includes('ing'))
     }
 
-    callbacks = {
-      onLLMResponseCreated: async () => {
-        const baseBlock = createBaseMessageBlock(assistantMsgId, MessageBlockType.UNKNOWN, {
-          status: MessageBlockStatus.PROCESSING
-        })
-        initialPlaceholderBlockId = baseBlock.id
-        await handleBlockTransition(baseBlock as PlaceholderMessageBlock, MessageBlockType.UNKNOWN)
-      },
-      onTextStart: async () => {
-        if (initialPlaceholderBlockId) {
-          lastBlockType = MessageBlockType.MAIN_TEXT
-          const changes = {
-            type: MessageBlockType.MAIN_TEXT,
-            content: accumulatedContent,
-            status: MessageBlockStatus.STREAMING
-          }
-          smartBlockUpdate(initialPlaceholderBlockId, changes, MessageBlockType.MAIN_TEXT, true)
-          mainTextBlockId = initialPlaceholderBlockId
-          initialPlaceholderBlockId = null
-        } else if (!mainTextBlockId) {
-          const newBlock = createMainTextBlock(assistantMsgId, accumulatedContent, {
-            status: MessageBlockStatus.STREAMING
-          })
-          mainTextBlockId = newBlock.id
-          await handleBlockTransition(newBlock, MessageBlockType.MAIN_TEXT)
-        }
-      },
-      onTextChunk: async (text) => {
-        const citationBlockSource = citationBlockId
-          ? (getState().messageBlocks.entities[citationBlockId] as CitationMessageBlock).response?.source
-          : WebSearchSource.WEBSEARCH
-        accumulatedContent += text
-        if (mainTextBlockId) {
-          const blockChanges: Partial<MessageBlock> = {
-            content: accumulatedContent,
-            status: MessageBlockStatus.STREAMING,
-            citationReferences: citationBlockId ? [{ citationBlockId, citationBlockSource }] : []
-          }
-          smartBlockUpdate(mainTextBlockId, blockChanges, MessageBlockType.MAIN_TEXT)
-        }
-      },
-      onTextComplete: async (finalText) => {
-        if (mainTextBlockId) {
-          const changes = {
-            content: finalText,
-            status: MessageBlockStatus.SUCCESS
-          }
-          smartBlockUpdate(mainTextBlockId, changes, MessageBlockType.MAIN_TEXT, true)
-          mainTextBlockId = null
-        } else {
-          console.warn(
-            `[onTextComplete] Received text.complete but last block was not MAIN_TEXT (was ${lastBlockType}) or lastBlockId  is null.`
-          )
-        }
-      },
-      onThinkingStart: async () => {
-        if (initialPlaceholderBlockId) {
-          lastBlockType = MessageBlockType.THINKING
-          const changes = {
-            type: MessageBlockType.THINKING,
-            content: accumulatedThinking,
-            status: MessageBlockStatus.STREAMING,
-            thinking_millsec: 0
-          }
-          thinkingBlockId = initialPlaceholderBlockId
-          initialPlaceholderBlockId = null
-          smartBlockUpdate(thinkingBlockId, changes, MessageBlockType.THINKING, true)
-        } else if (!thinkingBlockId) {
-          const newBlock = createThinkingBlock(assistantMsgId, accumulatedThinking, {
-            status: MessageBlockStatus.STREAMING,
-            thinking_millsec: 0
-          })
-          thinkingBlockId = newBlock.id
-          await handleBlockTransition(newBlock, MessageBlockType.THINKING)
-        }
-      },
-      onThinkingChunk: async (text, thinking_millsec) => {
-        accumulatedThinking += text
-        if (thinkingBlockId) {
-          const blockChanges: Partial<MessageBlock> = {
-            content: accumulatedThinking,
-            status: MessageBlockStatus.STREAMING,
-            thinking_millsec: thinking_millsec
-          }
-          smartBlockUpdate(thinkingBlockId, blockChanges, MessageBlockType.THINKING)
-        }
-      },
-      onThinkingComplete: (finalText, final_thinking_millsec) => {
-        if (thinkingBlockId) {
-          const changes = {
-            type: MessageBlockType.THINKING,
-            content: finalText,
-            status: MessageBlockStatus.SUCCESS,
-            thinking_millsec: final_thinking_millsec
-          }
-          smartBlockUpdate(thinkingBlockId, changes, MessageBlockType.THINKING, true)
-        } else {
-          console.warn(
-            `[onThinkingComplete] Received thinking.complete but last block was not THINKING (was ${lastBlockType}) or lastBlockId  is null.`
-          )
-        }
-        thinkingBlockId = null
-      },
-      onToolCallPending: (toolResponse: MCPToolResponse) => {
-        if (initialPlaceholderBlockId) {
-          lastBlockType = MessageBlockType.TOOL
-          const changes = {
-            type: MessageBlockType.TOOL,
-            status: MessageBlockStatus.PENDING,
-            toolName: toolResponse.tool.name,
-            metadata: { rawMcpToolResponse: toolResponse }
-          }
-          toolBlockId = initialPlaceholderBlockId
-          initialPlaceholderBlockId = null
-          smartBlockUpdate(toolBlockId, changes, MessageBlockType.TOOL)
-          toolCallIdToBlockIdMap.set(toolResponse.id, toolBlockId)
-        } else if (toolResponse.status === 'pending') {
-          const toolBlock = createToolBlock(assistantMsgId, toolResponse.id, {
-            toolName: toolResponse.tool.name,
-            status: MessageBlockStatus.PENDING,
-            metadata: { rawMcpToolResponse: toolResponse }
-          })
-          toolBlockId = toolBlock.id
-          handleBlockTransition(toolBlock, MessageBlockType.TOOL)
-          toolCallIdToBlockIdMap.set(toolResponse.id, toolBlock.id)
-        } else {
-          console.warn(
-            `[onToolCallPending] Received unhandled tool status: ${toolResponse.status} for ID: ${toolResponse.id}`
-          )
-        }
-      },
-      onToolCallInProgress: (toolResponse: MCPToolResponse) => {
-        // 根据 toolResponse.id 查找对应的块ID
-        const targetBlockId = toolCallIdToBlockIdMap.get(toolResponse.id)
+    // callbacks = {
+    //   onLLMResponseCreated: async () => {
+    //     const baseBlock = createBaseMessageBlock(assistantMsgId, MessageBlockType.UNKNOWN, {
+    //       status: MessageBlockStatus.PROCESSING
+    //     })
+    //     initialPlaceholderBlockId = baseBlock.id
+    //     await handleBlockTransition(baseBlock as PlaceholderMessageBlock, MessageBlockType.UNKNOWN)
+    //   },
+    //   onTextStart: async () => {
+    //     if (initialPlaceholderBlockId) {
+    //       lastBlockType = MessageBlockType.MAIN_TEXT
+    //       const changes = {
+    //         type: MessageBlockType.MAIN_TEXT,
+    //         content: accumulatedContent,
+    //         status: MessageBlockStatus.STREAMING
+    //       }
+    //       smartBlockUpdate(initialPlaceholderBlockId, changes, MessageBlockType.MAIN_TEXT, true)
+    //       mainTextBlockId = initialPlaceholderBlockId
+    //       initialPlaceholderBlockId = null
+    //     } else if (!mainTextBlockId) {
+    //       const newBlock = createMainTextBlock(assistantMsgId, accumulatedContent, {
+    //         status: MessageBlockStatus.STREAMING
+    //       })
+    //       mainTextBlockId = newBlock.id
+    //       await handleBlockTransition(newBlock, MessageBlockType.MAIN_TEXT)
+    //     }
+    //   },
+    //   onTextChunk: async (text) => {
+    //     const citationBlockSource = citationBlockId
+    //       ? (getState().messageBlocks.entities[citationBlockId] as CitationMessageBlock).response?.source
+    //       : WebSearchSource.WEBSEARCH
+    //     accumulatedContent += text
+    //     if (mainTextBlockId) {
+    //       const blockChanges: Partial<MessageBlock> = {
+    //         content: accumulatedContent,
+    //         status: MessageBlockStatus.STREAMING,
+    //         citationReferences: citationBlockId ? [{ citationBlockId, citationBlockSource }] : []
+    //       }
+    //       smartBlockUpdate(mainTextBlockId, blockChanges, MessageBlockType.MAIN_TEXT)
+    //     }
+    //   },
+    //   onTextComplete: async (finalText) => {
+    //     if (mainTextBlockId) {
+    //       const changes = {
+    //         content: finalText,
+    //         status: MessageBlockStatus.SUCCESS
+    //       }
+    //       smartBlockUpdate(mainTextBlockId, changes, MessageBlockType.MAIN_TEXT, true)
+    //       mainTextBlockId = null
+    //     } else {
+    //       console.warn(
+    //         `[onTextComplete] Received text.complete but last block was not MAIN_TEXT (was ${lastBlockType}) or lastBlockId  is null.`
+    //       )
+    //     }
+    //   },
+    //   onThinkingStart: async () => {
+    //     if (initialPlaceholderBlockId) {
+    //       lastBlockType = MessageBlockType.THINKING
+    //       const changes = {
+    //         type: MessageBlockType.THINKING,
+    //         content: accumulatedThinking,
+    //         status: MessageBlockStatus.STREAMING,
+    //         thinking_millsec: 0
+    //       }
+    //       thinkingBlockId = initialPlaceholderBlockId
+    //       initialPlaceholderBlockId = null
+    //       smartBlockUpdate(thinkingBlockId, changes, MessageBlockType.THINKING, true)
+    //     } else if (!thinkingBlockId) {
+    //       const newBlock = createThinkingBlock(assistantMsgId, accumulatedThinking, {
+    //         status: MessageBlockStatus.STREAMING,
+    //         thinking_millsec: 0
+    //       })
+    //       thinkingBlockId = newBlock.id
+    //       await handleBlockTransition(newBlock, MessageBlockType.THINKING)
+    //     }
+    //   },
+    //   onThinkingChunk: async (text, thinking_millsec) => {
+    //     accumulatedThinking += text
+    //     if (thinkingBlockId) {
+    //       const blockChanges: Partial<MessageBlock> = {
+    //         content: accumulatedThinking,
+    //         status: MessageBlockStatus.STREAMING,
+    //         thinking_millsec: thinking_millsec
+    //       }
+    //       smartBlockUpdate(thinkingBlockId, blockChanges, MessageBlockType.THINKING)
+    //     }
+    //   },
+    //   onThinkingComplete: (finalText, final_thinking_millsec) => {
+    //     if (thinkingBlockId) {
+    //       const changes = {
+    //         type: MessageBlockType.THINKING,
+    //         content: finalText,
+    //         status: MessageBlockStatus.SUCCESS,
+    //         thinking_millsec: final_thinking_millsec
+    //       }
+    //       smartBlockUpdate(thinkingBlockId, changes, MessageBlockType.THINKING, true)
+    //     } else {
+    //       console.warn(
+    //         `[onThinkingComplete] Received thinking.complete but last block was not THINKING (was ${lastBlockType}) or lastBlockId  is null.`
+    //       )
+    //     }
+    //     thinkingBlockId = null
+    //   },
+    //   onToolCallPending: (toolResponse: MCPToolResponse) => {
+    //     if (initialPlaceholderBlockId) {
+    //       lastBlockType = MessageBlockType.TOOL
+    //       const changes = {
+    //         type: MessageBlockType.TOOL,
+    //         status: MessageBlockStatus.PENDING,
+    //         toolName: toolResponse.tool.name,
+    //         metadata: { rawMcpToolResponse: toolResponse }
+    //       }
+    //       toolBlockId = initialPlaceholderBlockId
+    //       initialPlaceholderBlockId = null
+    //       smartBlockUpdate(toolBlockId, changes, MessageBlockType.TOOL)
+    //       toolCallIdToBlockIdMap.set(toolResponse.id, toolBlockId)
+    //     } else if (toolResponse.status === 'pending') {
+    //       const toolBlock = createToolBlock(assistantMsgId, toolResponse.id, {
+    //         toolName: toolResponse.tool.name,
+    //         status: MessageBlockStatus.PENDING,
+    //         metadata: { rawMcpToolResponse: toolResponse }
+    //       })
+    //       toolBlockId = toolBlock.id
+    //       handleBlockTransition(toolBlock, MessageBlockType.TOOL)
+    //       toolCallIdToBlockIdMap.set(toolResponse.id, toolBlock.id)
+    //     } else {
+    //       console.warn(
+    //         `[onToolCallPending] Received unhandled tool status: ${toolResponse.status} for ID: ${toolResponse.id}`
+    //       )
+    //     }
+    //   },
+    //   onToolCallInProgress: (toolResponse: MCPToolResponse) => {
+    //     // 根据 toolResponse.id 查找对应的块ID
+    //     const targetBlockId = toolCallIdToBlockIdMap.get(toolResponse.id)
 
-        if (targetBlockId && toolResponse.status === 'invoking') {
-          const changes = {
-            status: MessageBlockStatus.PROCESSING,
-            metadata: { rawMcpToolResponse: toolResponse }
-          }
-          smartBlockUpdate(targetBlockId, changes, MessageBlockType.TOOL)
-        } else if (!targetBlockId) {
-          console.warn(
-            `[onToolCallInProgress] No block ID found for tool ID: ${toolResponse.id}. Available mappings:`,
-            Array.from(toolCallIdToBlockIdMap.entries())
-          )
-        } else {
-          console.warn(
-            `[onToolCallInProgress] Received unhandled tool status: ${toolResponse.status} for ID: ${toolResponse.id}`
-          )
-        }
-      },
-      onToolCallComplete: (toolResponse: MCPToolResponse) => {
-        const existingBlockId = toolCallIdToBlockIdMap.get(toolResponse.id)
-        toolCallIdToBlockIdMap.delete(toolResponse.id)
-        if (toolResponse.status === 'done' || toolResponse.status === 'error' || toolResponse.status === 'cancelled') {
-          if (!existingBlockId) {
-            console.error(
-              `[onToolCallComplete] No existing block found for completed/error tool call ID: ${toolResponse.id}. Cannot update.`
-            )
-            return
-          }
-          const finalStatus =
-            toolResponse.status === 'done' || toolResponse.status === 'cancelled'
-              ? MessageBlockStatus.SUCCESS
-              : MessageBlockStatus.ERROR
-          const changes: Partial<ToolMessageBlock> = {
-            content: toolResponse.response,
-            status: finalStatus,
-            metadata: { rawMcpToolResponse: toolResponse }
-          }
-          if (finalStatus === MessageBlockStatus.ERROR) {
-            changes.error = { message: `Tool execution failed/error`, details: toolResponse.response }
-          }
-          smartBlockUpdate(existingBlockId, changes, MessageBlockType.TOOL, true)
-        } else {
-          console.warn(
-            `[onToolCallComplete] Received unhandled tool status: ${toolResponse.status} for ID: ${toolResponse.id}`
-          )
-        }
-        toolBlockId = null
-      },
-      onExternalToolInProgress: async () => {
-        const citationBlock = createCitationBlock(assistantMsgId, {}, { status: MessageBlockStatus.PROCESSING })
-        citationBlockId = citationBlock.id
-        await handleBlockTransition(citationBlock, MessageBlockType.CITATION)
-        // saveUpdatedBlockToDB(citationBlock.id, assistantMsgId, topicId, getState)
-      },
-      onExternalToolComplete: (externalToolResult: ExternalToolResult) => {
-        if (citationBlockId) {
-          const changes: Partial<CitationMessageBlock> = {
-            response: externalToolResult.webSearch,
-            knowledge: externalToolResult.knowledge,
-            status: MessageBlockStatus.SUCCESS
-          }
-          smartBlockUpdate(citationBlockId, changes, MessageBlockType.CITATION, true)
-        } else {
-          console.error('[onExternalToolComplete] citationBlockId is null. Cannot update.')
-        }
-      },
-      onLLMWebSearchInProgress: async () => {
-        if (initialPlaceholderBlockId) {
-          lastBlockType = MessageBlockType.CITATION
-          citationBlockId = initialPlaceholderBlockId
-          const changes = {
-            type: MessageBlockType.CITATION,
-            status: MessageBlockStatus.PROCESSING
-          }
-          lastBlockType = MessageBlockType.CITATION
-          smartBlockUpdate(initialPlaceholderBlockId, changes, MessageBlockType.CITATION)
-          initialPlaceholderBlockId = null
-        } else {
-          const citationBlock = createCitationBlock(assistantMsgId, {}, { status: MessageBlockStatus.PROCESSING })
-          citationBlockId = citationBlock.id
-          await handleBlockTransition(citationBlock, MessageBlockType.CITATION)
-        }
-      },
-      onLLMWebSearchComplete: async (llmWebSearchResult) => {
-        const blockId = citationBlockId || initialPlaceholderBlockId
-        if (blockId) {
-          const changes: Partial<CitationMessageBlock> = {
-            type: MessageBlockType.CITATION,
-            response: llmWebSearchResult,
-            status: MessageBlockStatus.SUCCESS
-          }
-          smartBlockUpdate(blockId, changes, MessageBlockType.CITATION)
+    //     if (targetBlockId && toolResponse.status === 'invoking') {
+    //       const changes = {
+    //         status: MessageBlockStatus.PROCESSING,
+    //         metadata: { rawMcpToolResponse: toolResponse }
+    //       }
+    //       smartBlockUpdate(targetBlockId, changes, MessageBlockType.TOOL)
+    //     } else if (!targetBlockId) {
+    //       console.warn(
+    //         `[onToolCallInProgress] No block ID found for tool ID: ${toolResponse.id}. Available mappings:`,
+    //         Array.from(toolCallIdToBlockIdMap.entries())
+    //       )
+    //     } else {
+    //       console.warn(
+    //         `[onToolCallInProgress] Received unhandled tool status: ${toolResponse.status} for ID: ${toolResponse.id}`
+    //       )
+    //     }
+    //   },
+    //   onToolCallComplete: (toolResponse: MCPToolResponse) => {
+    //     const existingBlockId = toolCallIdToBlockIdMap.get(toolResponse.id)
+    //     toolCallIdToBlockIdMap.delete(toolResponse.id)
+    //     if (toolResponse.status === 'done' || toolResponse.status === 'error' || toolResponse.status === 'cancelled') {
+    //       if (!existingBlockId) {
+    //         console.error(
+    //           `[onToolCallComplete] No existing block found for completed/error tool call ID: ${toolResponse.id}. Cannot update.`
+    //         )
+    //         return
+    //       }
+    //       const finalStatus =
+    //         toolResponse.status === 'done' || toolResponse.status === 'cancelled'
+    //           ? MessageBlockStatus.SUCCESS
+    //           : MessageBlockStatus.ERROR
+    //       const changes: Partial<ToolMessageBlock> = {
+    //         content: toolResponse.response,
+    //         status: finalStatus,
+    //         metadata: { rawMcpToolResponse: toolResponse }
+    //       }
+    //       if (finalStatus === MessageBlockStatus.ERROR) {
+    //         changes.error = { message: `Tool execution failed/error`, details: toolResponse.response }
+    //       }
+    //       smartBlockUpdate(existingBlockId, changes, MessageBlockType.TOOL, true)
+    //     } else {
+    //       console.warn(
+    //         `[onToolCallComplete] Received unhandled tool status: ${toolResponse.status} for ID: ${toolResponse.id}`
+    //       )
+    //     }
+    //     toolBlockId = null
+    //   },
+    //   onExternalToolInProgress: async () => {
+    //     const citationBlock = createCitationBlock(assistantMsgId, {}, { status: MessageBlockStatus.PROCESSING })
+    //     citationBlockId = citationBlock.id
+    //     await handleBlockTransition(citationBlock, MessageBlockType.CITATION)
+    //     // saveUpdatedBlockToDB(citationBlock.id, assistantMsgId, topicId, getState)
+    //   },
+    //   onExternalToolComplete: (externalToolResult: ExternalToolResult) => {
+    //     if (citationBlockId) {
+    //       const changes: Partial<CitationMessageBlock> = {
+    //         response: externalToolResult.webSearch,
+    //         knowledge: externalToolResult.knowledge,
+    //         status: MessageBlockStatus.SUCCESS
+    //       }
+    //       smartBlockUpdate(citationBlockId, changes, MessageBlockType.CITATION, true)
+    //     } else {
+    //       console.error('[onExternalToolComplete] citationBlockId is null. Cannot update.')
+    //     }
+    //   },
+    //   onLLMWebSearchInProgress: async () => {
+    //     if (initialPlaceholderBlockId) {
+    //       lastBlockType = MessageBlockType.CITATION
+    //       citationBlockId = initialPlaceholderBlockId
+    //       const changes = {
+    //         type: MessageBlockType.CITATION,
+    //         status: MessageBlockStatus.PROCESSING
+    //       }
+    //       lastBlockType = MessageBlockType.CITATION
+    //       smartBlockUpdate(initialPlaceholderBlockId, changes, MessageBlockType.CITATION)
+    //       initialPlaceholderBlockId = null
+    //     } else {
+    //       const citationBlock = createCitationBlock(assistantMsgId, {}, { status: MessageBlockStatus.PROCESSING })
+    //       citationBlockId = citationBlock.id
+    //       await handleBlockTransition(citationBlock, MessageBlockType.CITATION)
+    //     }
+    //   },
+    //   onLLMWebSearchComplete: async (llmWebSearchResult) => {
+    //     const blockId = citationBlockId || initialPlaceholderBlockId
+    //     if (blockId) {
+    //       const changes: Partial<CitationMessageBlock> = {
+    //         type: MessageBlockType.CITATION,
+    //         response: llmWebSearchResult,
+    //         status: MessageBlockStatus.SUCCESS
+    //       }
+    //       smartBlockUpdate(blockId, changes, MessageBlockType.CITATION)
 
-          const state = getState()
-          const existingMainTextBlocks = findMainTextBlocks(state.messages.entities[assistantMsgId])
-          if (existingMainTextBlocks.length > 0) {
-            const existingMainTextBlock = existingMainTextBlocks[0]
-            const currentRefs = existingMainTextBlock.citationReferences || []
-            const mainTextChanges = {
-              citationReferences: [...currentRefs, { blockId, citationBlockSource: llmWebSearchResult.source }]
-            }
-            smartBlockUpdate(existingMainTextBlock.id, mainTextChanges, MessageBlockType.MAIN_TEXT, true)
-          }
+    //       const state = getState()
+    //       const existingMainTextBlocks = findMainTextBlocks(state.messages.entities[assistantMsgId])
+    //       if (existingMainTextBlocks.length > 0) {
+    //         const existingMainTextBlock = existingMainTextBlocks[0]
+    //         const currentRefs = existingMainTextBlock.citationReferences || []
+    //         const mainTextChanges = {
+    //           citationReferences: [...currentRefs, { blockId, citationBlockSource: llmWebSearchResult.source }]
+    //         }
+    //         smartBlockUpdate(existingMainTextBlock.id, mainTextChanges, MessageBlockType.MAIN_TEXT, true)
+    //       }
 
-          if (initialPlaceholderBlockId) {
-            citationBlockId = initialPlaceholderBlockId
-            initialPlaceholderBlockId = null
-          }
-        } else {
-          const citationBlock = createCitationBlock(
-            assistantMsgId,
-            {
-              response: llmWebSearchResult
-            },
-            {
-              status: MessageBlockStatus.SUCCESS
-            }
-          )
-          citationBlockId = citationBlock.id
-          const state = getState()
-          const existingMainTextBlocks = findMainTextBlocks(state.messages.entities[assistantMsgId])
-          if (existingMainTextBlocks.length > 0) {
-            const existingMainTextBlock = existingMainTextBlocks[0]
-            const currentRefs = existingMainTextBlock.citationReferences || []
-            const mainTextChanges = {
-              citationReferences: [...currentRefs, { citationBlockId, citationBlockSource: llmWebSearchResult.source }]
-            }
-            smartBlockUpdate(existingMainTextBlock.id, mainTextChanges, MessageBlockType.MAIN_TEXT, true)
-          }
-          await handleBlockTransition(citationBlock, MessageBlockType.CITATION)
-        }
-      },
-      onImageCreated: async () => {
-        if (initialPlaceholderBlockId) {
-          lastBlockType = MessageBlockType.IMAGE
-          const initialChanges: Partial<MessageBlock> = {
-            type: MessageBlockType.IMAGE,
-            status: MessageBlockStatus.PENDING
-          }
-          lastBlockType = MessageBlockType.IMAGE
-          imageBlockId = initialPlaceholderBlockId
-          initialPlaceholderBlockId = null
-          smartBlockUpdate(imageBlockId, initialChanges, MessageBlockType.IMAGE)
-        } else if (!imageBlockId) {
-          const imageBlock = createImageBlock(assistantMsgId, {
-            status: MessageBlockStatus.PENDING
-          })
-          imageBlockId = imageBlock.id
-          await handleBlockTransition(imageBlock, MessageBlockType.IMAGE)
-        }
-      },
-      onImageDelta: (imageData) => {
-        const imageUrl = imageData.images?.[0] || 'placeholder_image_url'
-        if (imageBlockId) {
-          const changes: Partial<ImageMessageBlock> = {
-            url: imageUrl,
-            metadata: { generateImageResponse: imageData },
-            status: MessageBlockStatus.STREAMING
-          }
-          smartBlockUpdate(imageBlockId, changes, MessageBlockType.IMAGE, true)
-        }
-      },
-      onImageGenerated: (imageData) => {
-        if (imageBlockId) {
-          if (!imageData) {
-            const changes: Partial<ImageMessageBlock> = {
-              status: MessageBlockStatus.SUCCESS
-            }
-            smartBlockUpdate(imageBlockId, changes, MessageBlockType.IMAGE)
-          } else {
-            const imageUrl = imageData.images?.[0] || 'placeholder_image_url'
-            const changes: Partial<ImageMessageBlock> = {
-              url: imageUrl,
-              metadata: { generateImageResponse: imageData },
-              status: MessageBlockStatus.SUCCESS
-            }
-            smartBlockUpdate(imageBlockId, changes, MessageBlockType.IMAGE, true)
-          }
-        } else {
-          console.error('[onImageGenerated] Last block was not an Image block or ID is missing.')
-        }
-        imageBlockId = null
-      },
-      onError: async (error) => {
-        console.dir(error, { depth: null })
-        const isErrorTypeAbort = isAbortError(error)
-        let pauseErrorLanguagePlaceholder = ''
-        if (isErrorTypeAbort) {
-          pauseErrorLanguagePlaceholder = 'pause_placeholder'
-        }
+    //       if (initialPlaceholderBlockId) {
+    //         citationBlockId = initialPlaceholderBlockId
+    //         initialPlaceholderBlockId = null
+    //       }
+    //     } else {
+    //       const citationBlock = createCitationBlock(
+    //         assistantMsgId,
+    //         {
+    //           response: llmWebSearchResult
+    //         },
+    //         {
+    //           status: MessageBlockStatus.SUCCESS
+    //         }
+    //       )
+    //       citationBlockId = citationBlock.id
+    //       const state = getState()
+    //       const existingMainTextBlocks = findMainTextBlocks(state.messages.entities[assistantMsgId])
+    //       if (existingMainTextBlocks.length > 0) {
+    //         const existingMainTextBlock = existingMainTextBlocks[0]
+    //         const currentRefs = existingMainTextBlock.citationReferences || []
+    //         const mainTextChanges = {
+    //           citationReferences: [...currentRefs, { citationBlockId, citationBlockSource: llmWebSearchResult.source }]
+    //         }
+    //         smartBlockUpdate(existingMainTextBlock.id, mainTextChanges, MessageBlockType.MAIN_TEXT, true)
+    //       }
+    //       await handleBlockTransition(citationBlock, MessageBlockType.CITATION)
+    //     }
+    //   },
+    //   onImageCreated: async () => {
+    //     if (initialPlaceholderBlockId) {
+    //       lastBlockType = MessageBlockType.IMAGE
+    //       const initialChanges: Partial<MessageBlock> = {
+    //         type: MessageBlockType.IMAGE,
+    //         status: MessageBlockStatus.PENDING
+    //       }
+    //       lastBlockType = MessageBlockType.IMAGE
+    //       imageBlockId = initialPlaceholderBlockId
+    //       initialPlaceholderBlockId = null
+    //       smartBlockUpdate(imageBlockId, initialChanges, MessageBlockType.IMAGE)
+    //     } else if (!imageBlockId) {
+    //       const imageBlock = createImageBlock(assistantMsgId, {
+    //         status: MessageBlockStatus.PENDING
+    //       })
+    //       imageBlockId = imageBlock.id
+    //       await handleBlockTransition(imageBlock, MessageBlockType.IMAGE)
+    //     }
+    //   },
+    //   onImageDelta: (imageData) => {
+    //     const imageUrl = imageData.images?.[0] || 'placeholder_image_url'
+    //     if (imageBlockId) {
+    //       const changes: Partial<ImageMessageBlock> = {
+    //         url: imageUrl,
+    //         metadata: { generateImageResponse: imageData },
+    //         status: MessageBlockStatus.STREAMING
+    //       }
+    //       smartBlockUpdate(imageBlockId, changes, MessageBlockType.IMAGE, true)
+    //     }
+    //   },
+    //   onImageGenerated: (imageData) => {
+    //     if (imageBlockId) {
+    //       if (!imageData) {
+    //         const changes: Partial<ImageMessageBlock> = {
+    //           status: MessageBlockStatus.SUCCESS
+    //         }
+    //         smartBlockUpdate(imageBlockId, changes, MessageBlockType.IMAGE)
+    //       } else {
+    //         const imageUrl = imageData.images?.[0] || 'placeholder_image_url'
+    //         const changes: Partial<ImageMessageBlock> = {
+    //           url: imageUrl,
+    //           metadata: { generateImageResponse: imageData },
+    //           status: MessageBlockStatus.SUCCESS
+    //         }
+    //         smartBlockUpdate(imageBlockId, changes, MessageBlockType.IMAGE, true)
+    //       }
+    //     } else {
+    //       console.error('[onImageGenerated] Last block was not an Image block or ID is missing.')
+    //     }
+    //     imageBlockId = null
+    //   },
+    //   onError: async (error) => {
+    //     console.dir(error, { depth: null })
+    //     const isErrorTypeAbort = isAbortError(error)
+    //     let pauseErrorLanguagePlaceholder = ''
+    //     if (isErrorTypeAbort) {
+    //       pauseErrorLanguagePlaceholder = 'pause_placeholder'
+    //     }
 
-        const serializableError = {
-          name: error.name,
-          message: pauseErrorLanguagePlaceholder || error.message || formatErrorMessage(error),
-          originalMessage: error.message,
-          stack: error.stack,
-          status: error.status || error.code,
-          requestId: error.request_id
-        }
-        if (!isOnHomePage()) {
-          await notificationService.send({
-            id: uuid(),
-            type: 'error',
-            title: t('notification.assistant'),
-            message: serializableError.message,
-            silent: false,
-            timestamp: Date.now(),
-            source: 'assistant'
-          })
-        }
-        const possibleBlockId =
-          mainTextBlockId ||
-          thinkingBlockId ||
-          toolBlockId ||
-          imageBlockId ||
-          citationBlockId ||
-          initialPlaceholderBlockId ||
-          lastBlockId
+    //     const serializableError = {
+    //       name: error.name,
+    //       message: pauseErrorLanguagePlaceholder || error.message || formatErrorMessage(error),
+    //       originalMessage: error.message,
+    //       stack: error.stack,
+    //       status: error.status || error.code,
+    //       requestId: error.request_id
+    //     }
+    //     if (!isOnHomePage()) {
+    //       await notificationService.send({
+    //         id: uuid(),
+    //         type: 'error',
+    //         title: t('notification.assistant'),
+    //         message: serializableError.message,
+    //         silent: false,
+    //         timestamp: Date.now(),
+    //         source: 'assistant'
+    //       })
+    //     }
+    //     const possibleBlockId =
+    //       mainTextBlockId ||
+    //       thinkingBlockId ||
+    //       toolBlockId ||
+    //       imageBlockId ||
+    //       citationBlockId ||
+    //       initialPlaceholderBlockId ||
+    //       lastBlockId
 
-        if (possibleBlockId) {
-          // 更改上一个block的状态为ERROR
-          const changes: Partial<MessageBlock> = {
-            status: isErrorTypeAbort ? MessageBlockStatus.PAUSED : MessageBlockStatus.ERROR
-          }
-          smartBlockUpdate(possibleBlockId, changes, lastBlockType!, true)
-        }
+    //     if (possibleBlockId) {
+    //       // 更改上一个block的状态为ERROR
+    //       const changes: Partial<MessageBlock> = {
+    //         status: isErrorTypeAbort ? MessageBlockStatus.PAUSED : MessageBlockStatus.ERROR
+    //       }
+    //       smartBlockUpdate(possibleBlockId, changes, lastBlockType!, true)
+    //     }
 
-        const errorBlock = createErrorBlock(assistantMsgId, serializableError, { status: MessageBlockStatus.SUCCESS })
-        await handleBlockTransition(errorBlock, MessageBlockType.ERROR)
-        const messageErrorUpdate = {
-          status: isErrorTypeAbort ? AssistantMessageStatus.SUCCESS : AssistantMessageStatus.ERROR
-        }
-        dispatch(newMessagesActions.updateMessage({ topicId, messageId: assistantMsgId, updates: messageErrorUpdate }))
+    //     const errorBlock = createErrorBlock(assistantMsgId, serializableError, { status: MessageBlockStatus.SUCCESS })
+    //     await handleBlockTransition(errorBlock, MessageBlockType.ERROR)
+    //     const messageErrorUpdate = {
+    //       status: isErrorTypeAbort ? AssistantMessageStatus.SUCCESS : AssistantMessageStatus.ERROR
+    //     }
+    //     dispatch(newMessagesActions.updateMessage({ topicId, messageId: assistantMsgId, updates: messageErrorUpdate }))
 
-        saveUpdatesToDB(assistantMsgId, topicId, messageErrorUpdate, [])
+    //     saveUpdatesToDB(assistantMsgId, topicId, messageErrorUpdate, [])
 
-        EventEmitter.emit(EVENT_NAMES.MESSAGE_COMPLETE, {
-          id: assistantMsgId,
-          topicId,
-          status: isErrorTypeAbort ? 'pause' : 'error',
-          error: error.message
-        })
-      },
-      onComplete: async (status: AssistantMessageStatus, response?: Response) => {
-        const finalStateOnComplete = getState()
-        const finalAssistantMsg = finalStateOnComplete.messages.entities[assistantMsgId]
+    //     EventEmitter.emit(EVENT_NAMES.MESSAGE_COMPLETE, {
+    //       id: assistantMsgId,
+    //       topicId,
+    //       status: isErrorTypeAbort ? 'pause' : 'error',
+    //       error: error.message
+    //     })
+    //   },
+    //   onComplete: async (status: AssistantMessageStatus, response?: Response) => {
+    //     const finalStateOnComplete = getState()
+    //     const finalAssistantMsg = finalStateOnComplete.messages.entities[assistantMsgId]
 
-        if (status === 'success' && finalAssistantMsg) {
-          const userMsgId = finalAssistantMsg.askId
-          const orderedMsgs = selectMessagesForTopic(finalStateOnComplete, topicId)
-          const userMsgIndex = orderedMsgs.findIndex((m) => m.id === userMsgId)
-          const contextForUsage = userMsgIndex !== -1 ? orderedMsgs.slice(0, userMsgIndex + 1) : []
-          const finalContextWithAssistant = [...contextForUsage, finalAssistantMsg]
+    //     if (status === 'success' && finalAssistantMsg) {
+    //       const userMsgId = finalAssistantMsg.askId
+    //       const orderedMsgs = selectMessagesForTopic(finalStateOnComplete, topicId)
+    //       const userMsgIndex = orderedMsgs.findIndex((m) => m.id === userMsgId)
+    //       const contextForUsage = userMsgIndex !== -1 ? orderedMsgs.slice(0, userMsgIndex + 1) : []
+    //       const finalContextWithAssistant = [...contextForUsage, finalAssistantMsg]
 
-          const possibleBlockId =
-            mainTextBlockId ||
-            thinkingBlockId ||
-            toolBlockId ||
-            imageBlockId ||
-            citationBlockId ||
-            initialPlaceholderBlockId ||
-            lastBlockId
-          if (possibleBlockId) {
-            const changes: Partial<MessageBlock> = {
-              status: MessageBlockStatus.SUCCESS
-            }
-            smartBlockUpdate(possibleBlockId, changes, lastBlockType!, true)
-          }
+    //       const possibleBlockId =
+    //         mainTextBlockId ||
+    //         thinkingBlockId ||
+    //         toolBlockId ||
+    //         imageBlockId ||
+    //         citationBlockId ||
+    //         initialPlaceholderBlockId ||
+    //         lastBlockId
+    //       if (possibleBlockId) {
+    //         const changes: Partial<MessageBlock> = {
+    //           status: MessageBlockStatus.SUCCESS
+    //         }
+    //         smartBlockUpdate(possibleBlockId, changes, lastBlockType!, true)
+    //       }
 
-          const endTime = Date.now()
-          const duration = endTime - startTime
-          const content = getMainTextContent(finalAssistantMsg)
-          if (!isOnHomePage() && duration > 60 * 1000) {
-            await notificationService.send({
-              id: uuid(),
-              type: 'success',
-              title: t('notification.assistant'),
-              message: content.length > 50 ? content.slice(0, 47) + '...' : content,
-              silent: false,
-              timestamp: Date.now(),
-              source: 'assistant'
-            })
-          }
+    //       const endTime = Date.now()
+    //       const duration = endTime - startTime
+    //       const content = getMainTextContent(finalAssistantMsg)
+    //       if (!isOnHomePage() && duration > 60 * 1000) {
+    //         await notificationService.send({
+    //           id: uuid(),
+    //           type: 'success',
+    //           title: t('notification.assistant'),
+    //           message: content.length > 50 ? content.slice(0, 47) + '...' : content,
+    //           silent: false,
+    //           timestamp: Date.now(),
+    //           source: 'assistant'
+    //         })
+    //       }
 
-          // 更新topic的name
-          autoRenameTopic(assistant, topicId)
+    //       // 更新topic的name
+    //       autoRenameTopic(assistant, topicId)
 
-          if (
-            response &&
-            (response.usage?.total_tokens === 0 ||
-              response?.usage?.prompt_tokens === 0 ||
-              response?.usage?.completion_tokens === 0)
-          ) {
-            const usage = await estimateMessagesUsage({ assistant, messages: finalContextWithAssistant })
-            response.usage = usage
-          }
-          // dispatch(newMessagesActions.setTopicLoading({ topicId, loading: false }))
-        }
-        if (response && response.metrics) {
-          if (response.metrics.completion_tokens === 0 && response.usage?.completion_tokens) {
-            response = {
-              ...response,
-              metrics: {
-                ...response.metrics,
-                completion_tokens: response.usage.completion_tokens
-              }
-            }
-          }
-        }
+    //       if (
+    //         response &&
+    //         (response.usage?.total_tokens === 0 ||
+    //           response?.usage?.prompt_tokens === 0 ||
+    //           response?.usage?.completion_tokens === 0)
+    //       ) {
+    //         const usage = await estimateMessagesUsage({ assistant, messages: finalContextWithAssistant })
+    //         response.usage = usage
+    //       }
+    //       // dispatch(newMessagesActions.setTopicLoading({ topicId, loading: false }))
+    //     }
+    //     if (response && response.metrics) {
+    //       if (response.metrics.completion_tokens === 0 && response.usage?.completion_tokens) {
+    //         response = {
+    //           ...response,
+    //           metrics: {
+    //             ...response.metrics,
+    //             completion_tokens: response.usage.completion_tokens
+    //           }
+    //         }
+    //       }
+    //     }
 
-        const messageUpdates: Partial<Message> = { status, metrics: response?.metrics, usage: response?.usage }
-        dispatch(
-          newMessagesActions.updateMessage({
-            topicId,
-            messageId: assistantMsgId,
-            updates: messageUpdates
-          })
-        )
-        saveUpdatesToDB(assistantMsgId, topicId, messageUpdates, [])
+    //     const messageUpdates: Partial<Message> = { status, metrics: response?.metrics, usage: response?.usage }
+    //     dispatch(
+    //       newMessagesActions.updateMessage({
+    //         topicId,
+    //         messageId: assistantMsgId,
+    //         updates: messageUpdates
+    //       })
+    //     )
+    //     saveUpdatesToDB(assistantMsgId, topicId, messageUpdates, [])
 
-        EventEmitter.emit(EVENT_NAMES.MESSAGE_COMPLETE, { id: assistantMsgId, topicId, status })
-      }
-    }
+    //     EventEmitter.emit(EVENT_NAMES.MESSAGE_COMPLETE, { id: assistantMsgId, topicId, status })
+    //   }
+    // }
 
+    const callbacks = createCallbacks({
+      blockManager,
+      dispatch,
+      getState,
+      topicId,
+      assistantMsgId,
+      saveUpdatesToDB,
+      assistant
+    })
     const streamProcessorCallbacks = createStreamProcessor(callbacks)
 
-    const startTime = Date.now()
+    // const startTime = Date.now()
     await fetchChatCompletion({
       messages: messagesForContext,
       assistant: assistant,


### PR DESCRIPTION
…eaming

- Introduced BlockManager to manage message blocks with smart update strategies.
- Added various callback handlers for different message types including text, image, citation, and tool responses.
- Enhanced state management for active blocks and transitions between different message types.
- Created utility functions for handling block updates and transitions, improving overall message processing flow.
- Refactored message thunk to utilize BlockManager for better organization and maintainability.

This implementation lays the groundwork for more efficient message streaming and processing in the application.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
- 全部堆积在messageThunk中,难以测试和debug
- 数个xxxBlockId难以管理

After this PR:
- 每个类型的callback独立为一个文件,保持单一职责
- 便于测试,每个文件都可以作为一个测试点

注释了旧逻辑,测试没问题之后删除

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
