### PR TITLE
hotfix: enhance assistant topic validation in useActiveTopic hook

### DIFF
--- a/src/renderer/src/hooks/useTopic.ts
+++ b/src/renderer/src/hooks/useTopic.ts
@@ -34,7 +34,14 @@ export function useActiveTopic(assistantId: string, topic?: Topic) {
 
   useEffect(() => {
     // activeTopic not in assistant.topics
-    if (assistant && assistant.topics.length > 0 && !find(assistant.topics, { id: activeTopic?.id })) {
+    // 确保 assistant 和 assistant.topics 存在，避免在数据未完全加载时访问属性
+    if (
+      assistant &&
+      assistant.topics &&
+      Array.isArray(assistant.topics) &&
+      assistant.topics.length > 0 &&
+      !find(assistant.topics, { id: activeTopic?.id })
+    ) {
       setActiveTopic(assistant.topics[0])
     }
   }, [activeTopic?.id, assistant])


### PR DESCRIPTION
Updated the useActiveTopic hook to ensure that the assistant and its topics are properly validated before accessing properties. This prevents potential errors when data is not fully loaded.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

确保删除当前助手时不会出现空白

Fixes #8116