### PR TITLE
refactor(ActionUtils): streamline message processing logic

### DIFF
--- a/src/renderer/src/store/thunk/messageThunk.ts
+++ b/src/renderer/src/store/thunk/messageThunk.ts
@@ -148,7 +148,7 @@ const getBlockThrottler = (id: string) => {
 /**
  * 更新单个消息块。
  */
-const throttledBlockUpdate = (id: string, blockUpdate: any) => {
+export const throttledBlockUpdate = (id: string, blockUpdate: any) => {
   const throttler = getBlockThrottler(id)
   throttler(blockUpdate)
 }
@@ -156,7 +156,7 @@ const throttledBlockUpdate = (id: string, blockUpdate: any) => {
 /**
  * 取消单个块的节流更新，移除节流器和 RAF。
  */
-const cancelThrottledBlockUpdate = (id: string) => {
+export const cancelThrottledBlockUpdate = (id: string) => {
   const rafId = blockUpdateRafs.get(id)
   if (rafId) {
     cancelAnimationFrame(rafId)

--- a/src/renderer/src/windows/mini/home/HomeWindow.tsx
+++ b/src/renderer/src/windows/mini/home/HomeWindow.tsx
@@ -9,6 +9,7 @@ import { getAssistantMessage, getUserMessage } from '@renderer/services/Messages
 import store, { useAppSelector } from '@renderer/store'
 import { updateOneBlock, upsertManyBlocks, upsertOneBlock } from '@renderer/store/messageBlock'
 import { newMessagesActions, selectMessagesForTopic } from '@renderer/store/newMessage'
+import { cancelThrottledBlockUpdate, throttledBlockUpdate } from '@renderer/store/thunk/messageThunk'
 import { ThemeMode, Topic } from '@renderer/types'
 import { Chunk, ChunkType } from '@renderer/types/chunk'
 import { AssistantMessageStatus, MessageBlockStatus } from '@renderer/types/newMessage'
@@ -243,9 +244,7 @@ const HomeWindow: FC = () => {
           .filter((m) => m && !m.status?.includes('ing'))
 
         let blockId: string | null = null
-        let blockContent: string = ''
         let thinkingBlockId: string | null = null
-        let thinkingBlockContent: string = ''
 
         setIsLoading(true)
         setIsOutputted(false)
@@ -259,14 +258,16 @@ const HomeWindow: FC = () => {
           assistant: { ...currentAssistant, settings: { streamOutput: true } },
           onChunkReceived: (chunk: Chunk) => {
             switch (chunk.type) {
-              case ChunkType.THINKING_DELTA:
+              case ChunkType.THINKING_START:
                 {
-                  thinkingBlockContent += chunk.text
                   setIsOutputted(true)
-                  if (!thinkingBlockId) {
-                    const block = createThinkingBlock(assistantMessage.id, chunk.text, {
-                      status: MessageBlockStatus.STREAMING,
-                      thinking_millsec: chunk.thinking_millsec
+                  if (thinkingBlockId) {
+                    store.dispatch(
+                      updateOneBlock({ id: thinkingBlockId, changes: { status: MessageBlockStatus.STREAMING } })
+                    )
+                  } else {
+                    const block = createThinkingBlock(assistantMessage.id, '', {
+                      status: MessageBlockStatus.STREAMING
                     })
                     thinkingBlockId = block.id
                     store.dispatch(
@@ -277,19 +278,24 @@ const HomeWindow: FC = () => {
                       })
                     )
                     store.dispatch(upsertOneBlock(block))
-                  } else {
-                    store.dispatch(
-                      updateOneBlock({
-                        id: thinkingBlockId,
-                        changes: { content: thinkingBlockContent, thinking_millsec: chunk.thinking_millsec }
-                      })
-                    )
+                  }
+                }
+                break
+              case ChunkType.THINKING_DELTA:
+                {
+                  setIsOutputted(true)
+                  if (thinkingBlockId) {
+                    throttledBlockUpdate(thinkingBlockId, {
+                      content: chunk.text,
+                      thinking_millsec: chunk.thinking_millsec
+                    })
                   }
                 }
                 break
               case ChunkType.THINKING_COMPLETE:
                 {
                   if (thinkingBlockId) {
+                    cancelThrottledBlockUpdate(thinkingBlockId)
                     store.dispatch(
                       updateOneBlock({
                         id: thinkingBlockId,
@@ -299,12 +305,13 @@ const HomeWindow: FC = () => {
                   }
                 }
                 break
-              case ChunkType.TEXT_DELTA:
+              case ChunkType.TEXT_START:
                 {
-                  blockContent += chunk.text
                   setIsOutputted(true)
-                  if (!blockId) {
-                    const block = createMainTextBlock(assistantMessage.id, chunk.text, {
+                  if (blockId) {
+                    store.dispatch(updateOneBlock({ id: blockId, changes: { status: MessageBlockStatus.STREAMING } }))
+                  } else {
+                    const block = createMainTextBlock(assistantMessage.id, '', {
                       status: MessageBlockStatus.STREAMING
                     })
                     blockId = block.id
@@ -316,23 +323,29 @@ const HomeWindow: FC = () => {
                       })
                     )
                     store.dispatch(upsertOneBlock(block))
-                  } else {
-                    store.dispatch(updateOneBlock({ id: blockId, changes: { content: blockContent } }))
+                  }
+                }
+                break
+              case ChunkType.TEXT_DELTA:
+                {
+                  setIsOutputted(true)
+                  if (blockId) {
+                    throttledBlockUpdate(blockId, { content: chunk.text })
                   }
                 }
                 break
 
               case ChunkType.TEXT_COMPLETE:
                 {
-                  blockId &&
-                    store.dispatch(updateOneBlock({ id: blockId, changes: { status: MessageBlockStatus.SUCCESS } }))
-                  store.dispatch(
-                    newMessagesActions.updateMessage({
-                      topicId,
-                      messageId: assistantMessage.id,
-                      updates: { status: AssistantMessageStatus.SUCCESS }
-                    })
-                  )
+                  if (blockId) {
+                    cancelThrottledBlockUpdate(blockId)
+                    store.dispatch(
+                      updateOneBlock({
+                        id: blockId,
+                        changes: { content: chunk.text, status: MessageBlockStatus.SUCCESS }
+                      })
+                    )
+                  }
                 }
                 break
               case ChunkType.ERROR: {
@@ -348,6 +361,15 @@ const HomeWindow: FC = () => {
                       }
                     })
                   )
+                  store.dispatch(
+                    newMessagesActions.updateMessage({
+                      topicId,
+                      messageId: assistantMessage.id,
+                      updates: {
+                        status: isAborted ? AssistantMessageStatus.PAUSED : AssistantMessageStatus.SUCCESS
+                      }
+                    })
+                  )
                 }
                 if (!isAborted) {
                   throw new Error(chunk.error.message)
@@ -358,6 +380,13 @@ const HomeWindow: FC = () => {
                 setIsLoading(false)
                 setIsOutputted(true)
                 currentAskId.current = ''
+                store.dispatch(
+                  newMessagesActions.updateMessage({
+                    topicId,
+                    messageId: assistantMessage.id,
+                    updates: { status: AssistantMessageStatus.SUCCESS }
+                  })
+                )
                 break
             }
           }

--- a/src/renderer/src/windows/selection/action/components/ActionUtils.ts
+++ b/src/renderer/src/windows/selection/action/components/ActionUtils.ts
@@ -62,6 +62,13 @@ export const processMessages = async (
                   status: MessageBlockStatus.STREAMING
                 })
                 thinkingBlockId = block.id
+                store.dispatch(
+                  newMessagesActions.updateMessage({
+                    topicId: topic.id,
+                    messageId: assistantMessage.id,
+                    updates: { blockInstruction: { id: block.id } }
+                  })
+                )
                 store.dispatch(upsertOneBlock(block))
               }
             }

--- a/src/renderer/src/windows/selection/action/components/ActionUtils.ts
+++ b/src/renderer/src/windows/selection/action/components/ActionUtils.ts
@@ -34,6 +34,7 @@ export const processMessages = async (
 
     let textBlockId: string | null = null
     let thinkingBlockId: string | null = null
+    let textBlockContent: string = ''
 
     const assistantMessage = getAssistantMessage({
       assistant,
@@ -127,6 +128,7 @@ export const processMessages = async (
             {
               if (textBlockId) {
                 store.dispatch(updateOneBlock({ id: textBlockId, changes: { content: chunk.text } }))
+                textBlockContent = chunk.text
               }
               onStream()
             }
@@ -153,6 +155,7 @@ export const processMessages = async (
             break
           case ChunkType.BLOCK_COMPLETE:
           case ChunkType.ERROR:
+            onFinish(textBlockContent)
             break
         }
       }

--- a/src/renderer/src/windows/selection/action/components/ActionUtils.ts
+++ b/src/renderer/src/windows/selection/action/components/ActionUtils.ts
@@ -50,7 +50,6 @@ export const processMessages = async (
       messages: [userMessage],
       assistant: { ...assistant, settings: { streamOutput: true } },
       onChunkReceived: (chunk: Chunk) => {
-        console.log('chunk: ', chunk)
         switch (chunk.type) {
           case ChunkType.THINKING_START:
             {

--- a/src/renderer/src/windows/selection/action/components/ActionUtils.ts
+++ b/src/renderer/src/windows/selection/action/components/ActionUtils.ts
@@ -35,7 +35,7 @@ export const processMessages = async (
 
     let textBlockId: string | null = null
     let thinkingBlockId: string | null = null
-    let textBlockContent: string = ''
+    const textBlockContent: string = ''
 
     const assistantMessage = getAssistantMessage({
       assistant,
@@ -127,8 +127,7 @@ export const processMessages = async (
           case ChunkType.TEXT_DELTA:
             {
               if (textBlockId) {
-                throttledBlockUpdate(textBlockContent, { content: chunk.text })
-                textBlockContent = chunk.text
+                throttledBlockUpdate(textBlockId, { content: chunk.text })
               }
               onStream()
             }


### PR DESCRIPTION
- Removed unnecessary content accumulation for thinking and text blocks.
- Updated handling of message chunks to directly use incoming text for updates.
- Improved state management for thinking and text blocks during streaming.
- Enhanced the logic for creating and updating message blocks to ensure proper status and content handling.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
