### PR TITLE
refactor(MiniWindow): separate network request codes into independent hook

### DIFF
--- a/src/renderer/src/hooks/useMiniWindow.ts
+++ b/src/renderer/src/hooks/useMiniWindow.ts
@@ -1,0 +1,251 @@
+import { fetchChatCompletion } from '@renderer/services/ApiService'
+import { getDefaultTopic } from '@renderer/services/AssistantService'
+import { getAssistantMessage, getUserMessage } from '@renderer/services/MessagesService'
+import store from '@renderer/store'
+import { updateOneBlock, upsertManyBlocks, upsertOneBlock } from '@renderer/store/messageBlock'
+import { newMessagesActions, selectMessagesForTopic } from '@renderer/store/newMessage'
+import { cancelThrottledBlockUpdate, throttledBlockUpdate } from '@renderer/store/thunk/messageThunk'
+import { Assistant, Topic } from '@renderer/types'
+import { Chunk, ChunkType } from '@renderer/types/chunk'
+import { AssistantMessageStatus, MessageBlockStatus } from '@renderer/types/newMessage'
+import { abortCompletion } from '@renderer/utils/abortController'
+import { isAbortError } from '@renderer/utils/error'
+import { createMainTextBlock, createThinkingBlock } from '@renderer/utils/messageUtils/create'
+import { RefObject, useCallback, useState } from 'react'
+
+export interface SendMessageOptions {
+  currentAssistant: Assistant
+  currentTopic: RefObject<Topic>
+  currentAskId: RefObject<string>
+}
+
+export const useSendMessage = (options: SendMessageOptions) => {
+  const { currentAssistant, currentTopic, currentAskId } = options
+
+  // Indicator for loading(thinking/streaming)
+  const [isLoading, setIsLoading] = useState(false)
+  // Indicator for whether the first message is outputted
+  const [isOutputted, setIsOutputted] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const sendMessage = useCallback(
+    async (userContent: string, prompt?: string) => {
+      try {
+        const topicId = currentTopic.current.id
+
+        const { message: userMessage, blocks } = getUserMessage({
+          content: [prompt, userContent].filter(Boolean).join('\n\n'),
+          assistant: currentAssistant,
+          topic: currentTopic.current
+        })
+
+        store.dispatch(newMessagesActions.addMessage({ topicId, message: userMessage }))
+        store.dispatch(upsertManyBlocks(blocks))
+
+        const assistantMessage = getAssistantMessage({
+          assistant: currentAssistant,
+          topic: currentTopic.current
+        })
+        assistantMessage.askId = userMessage.id
+        currentAskId.current = userMessage.id
+
+        store.dispatch(newMessagesActions.addMessage({ topicId, message: assistantMessage }))
+
+        const allMessagesForTopic = selectMessagesForTopic(store.getState(), topicId)
+        const userMessageIndex = allMessagesForTopic.findIndex((m) => m?.id === userMessage.id)
+
+        const messagesForContext = allMessagesForTopic
+          .slice(0, userMessageIndex + 1)
+          .filter((m) => m && !m.status?.includes('ing'))
+
+        let blockId: string | null = null
+        let thinkingBlockId: string | null = null
+
+        setIsLoading(true)
+        setIsOutputted(false)
+        setError(null)
+
+        await fetchChatCompletion({
+          messages: messagesForContext,
+          assistant: { ...currentAssistant, settings: { streamOutput: true } },
+          onChunkReceived: (chunk: Chunk) => {
+            switch (chunk.type) {
+              case ChunkType.THINKING_START:
+                {
+                  setIsOutputted(true)
+                  if (thinkingBlockId) {
+                    store.dispatch(
+                      updateOneBlock({ id: thinkingBlockId, changes: { status: MessageBlockStatus.STREAMING } })
+                    )
+                  } else {
+                    const block = createThinkingBlock(assistantMessage.id, '', {
+                      status: MessageBlockStatus.STREAMING
+                    })
+                    thinkingBlockId = block.id
+                    store.dispatch(
+                      newMessagesActions.updateMessage({
+                        topicId,
+                        messageId: assistantMessage.id,
+                        updates: { blockInstruction: { id: block.id } }
+                      })
+                    )
+                    store.dispatch(upsertOneBlock(block))
+                  }
+                }
+                break
+              case ChunkType.THINKING_DELTA:
+                {
+                  setIsOutputted(true)
+                  if (thinkingBlockId) {
+                    throttledBlockUpdate(thinkingBlockId, {
+                      content: chunk.text,
+                      thinking_millsec: chunk.thinking_millsec
+                    })
+                  }
+                }
+                break
+              case ChunkType.THINKING_COMPLETE:
+                {
+                  if (thinkingBlockId) {
+                    cancelThrottledBlockUpdate(thinkingBlockId)
+                    store.dispatch(
+                      updateOneBlock({
+                        id: thinkingBlockId,
+                        changes: { status: MessageBlockStatus.SUCCESS, thinking_millsec: chunk.thinking_millsec }
+                      })
+                    )
+                  }
+                }
+                break
+              case ChunkType.TEXT_START:
+                {
+                  setIsOutputted(true)
+                  if (blockId) {
+                    store.dispatch(updateOneBlock({ id: blockId, changes: { status: MessageBlockStatus.STREAMING } }))
+                  } else {
+                    const block = createMainTextBlock(assistantMessage.id, '', {
+                      status: MessageBlockStatus.STREAMING
+                    })
+                    blockId = block.id
+                    store.dispatch(
+                      newMessagesActions.updateMessage({
+                        topicId,
+                        messageId: assistantMessage.id,
+                        updates: { blockInstruction: { id: block.id } }
+                      })
+                    )
+                    store.dispatch(upsertOneBlock(block))
+                  }
+                }
+                break
+              case ChunkType.TEXT_DELTA:
+                {
+                  setIsOutputted(true)
+                  if (blockId) {
+                    throttledBlockUpdate(blockId, { content: chunk.text })
+                  }
+                }
+                break
+              case ChunkType.TEXT_COMPLETE:
+                {
+                  if (blockId) {
+                    cancelThrottledBlockUpdate(blockId)
+                    store.dispatch(
+                      updateOneBlock({
+                        id: blockId,
+                        changes: { content: chunk.text, status: MessageBlockStatus.SUCCESS }
+                      })
+                    )
+                  }
+                }
+                break
+              case ChunkType.ERROR: {
+                //stop the thinking timer
+                const isAborted = isAbortError(chunk.error)
+                const possibleBlockId = thinkingBlockId || blockId
+                if (possibleBlockId) {
+                  store.dispatch(
+                    updateOneBlock({
+                      id: possibleBlockId,
+                      changes: {
+                        status: isAborted ? MessageBlockStatus.PAUSED : MessageBlockStatus.ERROR
+                      }
+                    })
+                  )
+                  store.dispatch(
+                    newMessagesActions.updateMessage({
+                      topicId,
+                      messageId: assistantMessage.id,
+                      updates: {
+                        status: isAborted ? AssistantMessageStatus.PAUSED : AssistantMessageStatus.SUCCESS
+                      }
+                    })
+                  )
+                }
+                if (!isAborted) {
+                  throw new Error(chunk.error.message)
+                }
+              }
+              //fall through
+              case ChunkType.BLOCK_COMPLETE:
+                setIsLoading(false)
+                setIsOutputted(true)
+                currentAskId.current = ''
+                store.dispatch(
+                  newMessagesActions.updateMessage({
+                    topicId,
+                    messageId: assistantMessage.id,
+                    updates: { status: AssistantMessageStatus.SUCCESS }
+                  })
+                )
+                break
+            }
+          }
+        })
+      } catch (err) {
+        if (isAbortError(err)) return
+
+        setIsLoading(false)
+        setError(err instanceof Error ? err.message : 'An error occurred')
+
+        console.error('Error fetching result:', err)
+      } finally {
+        setIsLoading(false)
+        setIsOutputted(true)
+        currentAskId.current = ''
+      }
+    },
+    [currentAssistant, currentTopic, currentAskId]
+  )
+
+  const pause = useCallback(() => {
+    if (!currentAskId.current) return
+
+    abortCompletion(currentAskId.current)
+    setIsLoading(false)
+    setIsOutputted(true)
+    currentAskId.current = ''
+  }, [currentAskId])
+
+  const reset = useCallback(() => {
+    // Clear the topic messages to reduce memory usage
+    if (currentTopic.current) {
+      store.dispatch(newMessagesActions.clearTopicMessages(currentTopic.current.id))
+    }
+
+    // Reset the topic
+    currentTopic.current = getDefaultTopic(currentAssistant.id)
+
+    setError(null)
+  }, [currentAssistant, currentTopic])
+
+  return {
+    isLoading,
+    isOutputted,
+    error,
+    setError,
+    sendMessage,
+    pause,
+    reset
+  }
+}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

In file `HomeWindow.tsx`, UI state, event callbacks, and network request codes are mixed together, making the component very lengthy. The network request part is relatively independent, and separating it into a separate file will make the logic of each part clearer.

### Why we need it and why it was done in this way

As mentioned above.

### Breaking changes

Nope.

### Special notes for your reviewer

Nope.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
refactor(MiniWindow): separate network request codes into independent hook
```
