### PR TITLE
fix: API call error for Grok reasoning model via OpenRouter

### DIFF
--- a/src/renderer/src/aiCore/clients/openai/OpenAIApiClient.ts
+++ b/src/renderer/src/aiCore/clients/openai/OpenAIApiClient.ts
@@ -5,6 +5,7 @@ import {
   GEMINI_FLASH_MODEL_REGEX,
   getOpenAIWebSearchParams,
   isDoubaoThinkingAutoModel,
+  isGrokReasoningModel,
   isQwenReasoningModel,
   isReasoningModel,
   isSupportedReasoningEffortGrokModel,
@@ -115,11 +116,12 @@ export class OpenAIAPIClient extends OpenAIBaseClient<
 
     if (!reasoningEffort) {
       if (model.provider === 'openrouter') {
-        if (
-          isSupportedThinkingTokenGeminiModel(model) &&
-          !GEMINI_FLASH_MODEL_REGEX.test(model.id) &&
-          model.id.includes('grok-4')
-        ) {
+        // Don't disable reasoning for Gemini models that support thinking tokens
+        if (isSupportedThinkingTokenGeminiModel(model) && !GEMINI_FLASH_MODEL_REGEX.test(model.id)) {
+          return {}
+        }
+        // Don't disable reasoning for models that require it
+        if (isGrokReasoningModel(model)) {
           return {}
         }
         return { reasoning: { enabled: false, exclude: true } }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

如 #8251 所示

<img width="1072" height="255" alt="Image" src="https://github.com/user-attachments/assets/1747db04-3430-432a-b61c-95e7a536555f" />

在没有运行任何推理模型调用之前使用 openrouter 提供的 grok-4 和 grok-3-mini 模型会有 
`Reasoning is mandatory for this endpoint and cannot be disabled` 报错

After this PR:

Fixes #8251

