### PR TITLE
refactor[Logger]: filtering logs with environment variable

### DIFF
--- a/docs/technical/how-to-use-logger-en.md
+++ b/docs/technical/how-to-use-logger-en.md
@@ -135,12 +135,36 @@ If the worker is relatively simple (just one file), you can also use method chai
 const logger = loggerService.initWindowSource('Worker').withContext('LetsWork')
 ```
 
+## Filtering Logs with Environment Variables
+
+In a development environment, you can define environment variables to filter displayed logs by level and module. This helps developers focus on their specific logs and improves development efficiency.
+
+Environment variables can be set in the terminal or defined in the `.env` file in the project's root directory. The available variables are as follows:
+
+| Variable Name    | Description   |
+| ------- | ------- |
+| CSLOGGER_MAIN_LEVEL            | Log level for the `main` process. Logs below this level will not be displayed.                                                                                              |
+| CSLOGGER_MAIN_SHOW_MODULES     | Filters log modules for the `main` process. Use a comma (`,`) to separate modules. The filter is case-sensitive. Only logs from modules in this list will be displayed.     |
+| CSLOGGER_RENDERER_LEVEL        | Log level for the `renderer` process. Logs below this level will not be displayed.                                                                                          |
+| CSLOGGER_RENDERER_SHOW_MODULES | Filters log modules for the `renderer` process. Use a comma (`,`) to separate modules. The filter is case-sensitive. Only logs from modules in this list will be displayed. |
+
+Example:
+
+```bash
+CSLOGGER_MAIN_LEVEL=verbose
+CSLOGGER_MAIN_SHOW_MODULES=MCPService,SelectionService
+```
+
+Note:
+- Environment variables are only effective in the development environment.
+- These variables only affect the logs displayed in the terminal or DevTools. They do not affect file logging or the `logToMain` recording logic.
+
 ## Log Level Usage Guidelines
 
 There are many log levels. The following are the guidelines that should be followed in CherryStudio for when to use each level:
 (Arranged from highest to lowest log level)
 
-| Log Level     | Core Definition & Use Case                                                                                                                                                                          | Example                                                                                                                                                                                                            |
+| Log Level     | Core Definition & Use case | Example  |
 | :------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **`error`**   | **Critical error causing the program to crash or core functionality to become unusable.** <br> This is the highest-priority log, usually requiring immediate reporting or user notification.        | - Main or renderer process crash. <br> - Failure to read/write critical user data files (e.g., database, configuration files), preventing the application from running. <br> - All unhandled exceptions.           |
 | **`warn`**    | **Potential issue or unexpected situation that does not affect the program's core functionality.** <br> The program can recover or use a fallback.                                                  | - Configuration file `settings.json` is missing; started with default settings. <br> - Auto-update check failed, but does not affect the use of the current version. <br> - A non-essential plugin failed to load. |

--- a/docs/technical/how-to-use-logger-zh.md
+++ b/docs/technical/how-to-use-logger-zh.md
@@ -136,6 +136,30 @@ logger.info('message', { logToMain: true })
 const logger = loggerService.initWindowSource('Worker').withContext('LetsWork')
 ```
 
+## 使用环境变量来筛选要显示的日志
+
+在开发环境中，可以通过环境变量的定义，来筛选要显示的日志的级别和module。开发者可以专注于自己的日志，提高开发效率。
+
+环境变量可以在终端中自行设置，或者在开发根目录的`.env`文件中进行定义，可以定义的变量如下：
+
+| 变量名 | 含义 |
+| ----- | ----- |
+| CSLOGGER_MAIN_LEVEL | 用于`main`进程的日志级别，低于该级别的日志将不显示 |
+| CSLOGGER_MAIN_SHOW_MODULES | 用于`main`进程的日志module筛选，用`,`分隔，区分大小写。只有在该列表中的module的日志才会显示 |
+| CSLOGGER_RENDERER_LEVEL | 用于`renderer`进程的日志级别，低于该级别的日志将不显示 |
+| CSLOGGER_RENDERER_SHOW_MODULES |  用于`renderer`进程的日志module筛选，用`,`分隔，区分大小写。只有在该列表中的module的日志才会显示 |
+
+示例：
+
+```bash
+CSLOGGER_MAIN_LEVEL=vebose
+CSLOGGER_MAIN_SHOW_MODULES=MCPService,SelectionService
+```
+
+注意：
+- 环境变量仅在开发环境中生效
+- 该变量仅会改变在终端或在devTools中显示的日志，不会影响文件日志和`logToMain`的记录逻辑
+
 ## 日志级别的使用规范
 
 日志有很多级别，什么时候应该用哪个级别，下面是在CherryStudio中应该遵循的规范：

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "start": "electron-vite preview",
-    "dev": "electron-vite dev",
+    "dev": "dotenv electron-vite dev",
     "debug": "electron-vite -- --inspect --sourcemap --remote-debugging-port=9222",
     "build": "npm run typecheck && electron-vite build",
     "build:check": "yarn typecheck && yarn check:i18n && yarn test",

--- a/packages/shared/config/logger.ts
+++ b/packages/shared/config/logger.ts
@@ -1,0 +1,28 @@
+export type LogSourceWithContext = {
+  process: 'main' | 'renderer'
+  window?: string // only for renderer process
+  module?: string
+  context?: Record<string, any>
+}
+
+export type LogLevel = 'error' | 'warn' | 'info' | 'debug' | 'verbose' | 'silly' | 'none'
+
+export const LEVEL = {
+  ERROR: 'error',
+  WARN: 'warn',
+  INFO: 'info',
+  DEBUG: 'debug',
+  VERBOSE: 'verbose',
+  SILLY: 'silly',
+  NONE: 'none'
+} satisfies Record<string, LogLevel>
+
+export const LEVEL_MAP: Record<LogLevel, number> = {
+  error: 10,
+  warn: 8,
+  info: 6,
+  debug: 4,
+  verbose: 2,
+  silly: 0,
+  none: -1
+}

--- a/packages/shared/config/types.ts
+++ b/packages/shared/config/types.ts
@@ -9,12 +9,3 @@ export type LoaderReturn = {
   message?: string
   messageSource?: 'preprocess' | 'embedding'
 }
-
-export type LogSourceWithContext = {
-  process: 'main' | 'renderer'
-  window?: string // only for renderer process
-  module?: string
-  context?: Record<string, any>
-}
-
-export type LogLevel = 'error' | 'warn' | 'info' | 'debug' | 'verbose' | 'silly'

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,7 +1,7 @@
 import type { ExtractChunkData } from '@cherrystudio/embedjs-interfaces'
 import { electronAPI } from '@electron-toolkit/preload'
 import { UpgradeChannel } from '@shared/config/constant'
-import type { LogLevel, LogSourceWithContext } from '@shared/config/types'
+import type { LogLevel, LogSourceWithContext } from '@shared/config/logger'
 import { IpcChannel } from '@shared/IpcChannel'
 import {
   AddMemoryOptions,


### PR DESCRIPTION
在开发模式中，可以通过环境变量（或`.env`文件），来控制显示的日志（级别及模块），方便开发时调试

详细使用方式，见更新的文档