### PR TITLE
feat: use openrouter's builtin metric

### DIFF
--- a/src/renderer/src/aiCore/clients/openai/OpenAIApiClient.ts
+++ b/src/renderer/src/aiCore/clients/openai/OpenAIApiClient.ts
@@ -536,7 +536,9 @@ export class OpenAIAPIClient extends OpenAIBaseClient<
           ...this.getReasoningEffort(assistant, model),
           ...getOpenAIWebSearchParams(model, enableWebSearch),
           // 只在对话场景下应用自定义参数，避免影响翻译、总结等其他业务逻辑
-          ...(coreRequest.callType === 'chat' ? this.getCustomParameters(assistant) : {})
+          ...(coreRequest.callType === 'chat' ? this.getCustomParameters(assistant) : {}),
+          // OpenRouter usage tracking
+          ...(this.provider.id === 'openrouter' ? { usage: { include: true } } : {})
         }
 
         // Create the appropriate parameters object based on whether streaming is enabled
@@ -656,6 +658,7 @@ export class OpenAIAPIClient extends OpenAIBaseClient<
     const toolCalls: OpenAI.Chat.Completions.ChatCompletionMessageToolCall[] = []
     let isFinished = false
     let lastUsageInfo: any = null
+    let hasFinishReason = false // Track if we've seen a finish_reason
 
     /**
      * 统一的完成信号发送逻辑
@@ -691,14 +694,33 @@ export class OpenAIAPIClient extends OpenAIBaseClient<
     let isFirstTextChunk = true
     return (context: ResponseChunkTransformerContext) => ({
       async transform(chunk: OpenAISdkRawChunk, controller: TransformStreamDefaultController<GenericChunk>) {
+        const isOpenRouter = context.provider?.id === 'openrouter'
+
         // 持续更新usage信息
         logger.silly('chunk', chunk)
         if (chunk.usage) {
+          const usage = chunk.usage as any // OpenRouter may include additional fields like cost
           lastUsageInfo = {
-            prompt_tokens: chunk.usage.prompt_tokens || 0,
-            completion_tokens: chunk.usage.completion_tokens || 0,
-            total_tokens: (chunk.usage.prompt_tokens || 0) + (chunk.usage.completion_tokens || 0)
+            prompt_tokens: usage.prompt_tokens || 0,
+            completion_tokens: usage.completion_tokens || 0,
+            total_tokens: usage.total_tokens || (usage.prompt_tokens || 0) + (usage.completion_tokens || 0),
+            // Handle OpenRouter specific cost fields
+            ...(usage.cost !== undefined ? { cost: usage.cost } : {})
           }
+
+          // For OpenRouter, if we've seen finish_reason and now have usage, emit completion signals
+          if (isOpenRouter && hasFinishReason && !isFinished) {
+            emitCompletionSignals(controller)
+            return
+          }
+        }
+
+        // For OpenRouter, if this chunk only contains usage without choices, emit completion signals
+        if (isOpenRouter && chunk.usage && (!chunk.choices || chunk.choices.length === 0)) {
+          if (!isFinished) {
+            emitCompletionSignals(controller)
+          }
+          return
         }
 
         // 处理chunk
@@ -728,7 +750,18 @@ export class OpenAIAPIClient extends OpenAIBaseClient<
 
             if (!contentSource) {
               if ('finish_reason' in choice && choice.finish_reason) {
-                emitCompletionSignals(controller)
+                // For OpenRouter, don't emit completion signals immediately after finish_reason
+                // Wait for the usage chunk that comes after
+                if (isOpenRouter) {
+                  hasFinishReason = true
+                  // If we already have usage info, emit completion signals now
+                  if (lastUsageInfo && lastUsageInfo.total_tokens > 0) {
+                    emitCompletionSignals(controller)
+                  }
+                } else {
+                  // For other providers, emit completion signals immediately
+                  emitCompletionSignals(controller)
+                }
               }
               continue
             }
@@ -804,7 +837,19 @@ export class OpenAIAPIClient extends OpenAIBaseClient<
                   llm_web_search: webSearchData
                 })
               }
-              emitCompletionSignals(controller)
+
+              // For OpenRouter, don't emit completion signals immediately after finish_reason
+              // Wait for the usage chunk that comes after
+              if (isOpenRouter) {
+                hasFinishReason = true
+                // If we already have usage info, emit completion signals now
+                if (lastUsageInfo && lastUsageInfo.total_tokens > 0) {
+                  emitCompletionSignals(controller)
+                }
+              } else {
+                // For other providers, emit completion signals immediately
+                emitCompletionSignals(controller)
+              }
             }
           }
         }

--- a/src/renderer/src/aiCore/middleware/common/FinalChunkConsumerMiddleware.ts
+++ b/src/renderer/src/aiCore/middleware/common/FinalChunkConsumerMiddleware.ts
@@ -179,6 +179,10 @@ function accumulateUsage(accumulated: Usage, newUsage: Usage): void {
   if (newUsage.thoughts_tokens !== undefined) {
     accumulated.thoughts_tokens = (accumulated.thoughts_tokens || 0) + newUsage.thoughts_tokens
   }
+  // Handle OpenRouter specific cost fields
+  if (newUsage.cost !== undefined) {
+    accumulated.cost = (accumulated.cost || 0) + newUsage.cost
+  }
 }
 
 export default FinalChunkConsumerMiddleware

--- a/src/renderer/src/pages/home/Messages/MessageTokens.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageTokens.tsx
@@ -22,6 +22,12 @@ const MessageTokens: React.FC<MessageTokensProps> = ({ message }) => {
     const inputTokens = message?.usage?.prompt_tokens ?? 0
     const outputTokens = message?.usage?.completion_tokens ?? 0
     const model = message.model
+
+    // For OpenRouter, use the cost directly from usage if available
+    if (model?.provider === 'openrouter' && message?.usage?.cost !== undefined) {
+      return message.usage.cost
+    }
+
     if (!model || model.pricing?.input_per_million_tokens === 0 || model.pricing?.output_per_million_tokens === 0) {
       return 0
     }
@@ -37,8 +43,13 @@ const MessageTokens: React.FC<MessageTokensProps> = ({ message }) => {
     if (price === 0) {
       return ''
     }
+    // For OpenRouter, always show cost even without pricing config
+    const shouldShowCost = message.model?.provider === 'openrouter' || price > 0
+    if (!shouldShowCost) {
+      return ''
+    }
     const currencySymbol = message.model?.pricing?.currencySymbol || '$'
-    return `| ${t('models.price.cost')}: ${currencySymbol}${price}`
+    return `| ${t('models.price.cost')}: ${currencySymbol}${price.toFixed(6)}`
   }
 
   if (!message.usage) {

--- a/src/renderer/src/services/messageStreaming/callbacks/baseCallbacks.ts
+++ b/src/renderer/src/services/messageStreaming/callbacks/baseCallbacks.ts
@@ -177,7 +177,10 @@ export const createBaseCallbacks = (deps: BaseCallbacksDependencies) => {
         autoRenameTopic(assistant, topicId)
 
         // 处理usage估算
+        // For OpenRouter, always use the accurate usage data from API, don't estimate
+        const isOpenRouter = assistant.model?.provider === 'openrouter'
         if (
+          !isOpenRouter &&
           response &&
           (response.usage?.total_tokens === 0 ||
             response?.usage?.prompt_tokens === 0 ||

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -123,6 +123,8 @@ export type LegacyMessage = {
 
 export type Usage = OpenAI.Completions.CompletionUsage & {
   thoughts_tokens?: number
+  // OpenRouter specific fields
+  cost?: number
 }
 
 export type Metrics = {


### PR DESCRIPTION
### What this PR does

Before this PR: 需要手动配置模型价格，并使用本地估计的token数来计量花费

After this PR: 对于Openrouter Provider，直接使用内置的统计功能 （<https://openrouter.ai/docs/use-cases/usage-accounting>）

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.
