### PR TITLE
fix: move winston packages to dependencies to fix build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,9 @@
     "pdfjs-dist": "4.10.38",
     "react-json-view": "^1.21.3",
     "selection-hook": "^1.0.7",
-    "turndown": "7.2.0"
+    "turndown": "7.2.0",
+    "winston": "^3.17.0",
+    "winston-daily-rotate-file": "^5.0.0"
   },
   "devDependencies": {
     "@agentic/exa": "^7.3.3",
@@ -251,8 +253,6 @@
     "vite": "6.2.6",
     "vitest": "^3.1.4",
     "webdav": "^5.8.0",
-    "winston": "^3.17.0",
-    "winston-daily-rotate-file": "^5.0.0",
     "word-extractor": "^1.0.4",
     "zipread": "^1.3.3"
   },


### PR DESCRIPTION
## 概述

### 修复 winston 依赖位置导致的构建错误

###  问题描述

 运行 npm run dev 时报错：
  ERROR [vite]: Rollup failed to resolve import "winston" from "C:/Users/Administrator/Desktop/code/cherry-studio/src/main/services/LoggerService.ts".

###  原因分析

  winston 和 winston-daily-rotate-file 被错误地放在了 devDependencies 中，但它们在主进程运行时被 LoggerService 直接引用，应该作为运行时依赖。

 ### 修改内容

  将以下包从 devDependencies 移至 dependencies：
  - winston: ^3.17.0
  - winston-daily-rotate-file: ^5.0.0

 ### 测试

  - npm run dev 可以正常启动
  - 日志功能正常工作