### PR TITLE
refactor: move initAppDataDir function to a new utils module

### DIFF
--- a/src/main/bootstrap.ts
+++ b/src/main/bootstrap.ts
@@ -3,7 +3,7 @@ import { app } from 'electron'
 import fs from 'fs'
 import path from 'path'
 
-import { initAppDataDir } from './utils/file'
+import { initAppDataDir } from './utils/init'
 
 app.isPackaged && initAppDataDir()
 

--- a/src/main/utils/file.ts
+++ b/src/main/utils/file.ts
@@ -4,7 +4,6 @@ import os from 'node:os'
 import path from 'node:path'
 
 import { loggerService } from '@logger'
-import { isLinux, isPortable, isWin } from '@main/constant'
 import { audioExts, documentExts, imageExts, MB, textExts, videoExts } from '@shared/config/constant'
 import { FileMetadata, FileTypes } from '@types'
 import { app } from 'electron'
@@ -13,20 +12,6 @@ import * as jschardet from 'jschardet'
 import { v4 as uuidv4 } from 'uuid'
 
 const logger = loggerService.withContext('Utils:File')
-
-export function initAppDataDir() {
-  const appDataPath = getAppDataPathFromConfig()
-  if (appDataPath) {
-    app.setPath('userData', appDataPath)
-    return
-  }
-
-  if (isPortable) {
-    const portableDir = process.env.PORTABLE_EXECUTABLE_DIR
-    app.setPath('userData', path.join(portableDir || app.getPath('exe'), 'data'))
-    return
-  }
-}
 
 // 创建文件类型映射表，提高查找效率
 const fileTypeMap = new Map<string, FileTypes>()
@@ -50,94 +35,6 @@ export function hasWritePermission(path: string) {
   } catch (error) {
     return false
   }
-}
-
-function getAppDataPathFromConfig() {
-  try {
-    const configPath = path.join(getConfigDir(), 'config.json')
-    if (!fs.existsSync(configPath)) {
-      return null
-    }
-
-    const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'))
-
-    if (!config.appDataPath) {
-      return null
-    }
-
-    let executablePath = app.getPath('exe')
-    if (isLinux && process.env.APPIMAGE) {
-      // 如果是 AppImage 打包的应用，直接使用 APPIMAGE 环境变量
-      // 这样可以确保获取到正确的可执行文件路径
-      executablePath = path.join(path.dirname(process.env.APPIMAGE), 'cherry-studio.appimage')
-    }
-
-    if (isWin && isPortable) {
-      executablePath = path.join(process.env.PORTABLE_EXECUTABLE_DIR || '', 'cherry-studio-portable.exe')
-    }
-
-    let appDataPath = null
-    // 兼容旧版本
-    if (config.appDataPath && typeof config.appDataPath === 'string') {
-      appDataPath = config.appDataPath
-      // 将旧版本数据迁移到新版本
-      appDataPath && updateAppDataConfig(appDataPath)
-    } else {
-      appDataPath = config.appDataPath.find(
-        (item: { executablePath: string }) => item.executablePath === executablePath
-      )?.dataPath
-    }
-
-    if (appDataPath && fs.existsSync(appDataPath) && hasWritePermission(appDataPath)) {
-      return appDataPath
-    }
-
-    return null
-  } catch (error) {
-    return null
-  }
-}
-
-export function updateAppDataConfig(appDataPath: string) {
-  const configDir = getConfigDir()
-  if (!fs.existsSync(configDir)) {
-    fs.mkdirSync(configDir, { recursive: true })
-  }
-
-  // config.json
-  // appDataPath: [{ executablePath: string, dataPath: string }]
-  const configPath = path.join(getConfigDir(), 'config.json')
-  let executablePath = app.getPath('exe')
-  if (isLinux && process.env.APPIMAGE) {
-    executablePath = path.join(path.dirname(process.env.APPIMAGE), 'cherry-studio.appimage')
-  }
-
-  // 如果是 Windows 可移植版本，则使用 PORTABLE_EXECUTABLE_FILE 环境变量
-  if (isWin && isPortable) {
-    executablePath = path.join(process.env.PORTABLE_EXECUTABLE_DIR || '', 'cherry-studio-portable.exe')
-  }
-
-  if (!fs.existsSync(configPath)) {
-    fs.writeFileSync(configPath, JSON.stringify({ appDataPath: [{ executablePath, dataPath: appDataPath }] }, null, 2))
-    return
-  }
-
-  const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'))
-  if (!config.appDataPath || (config.appDataPath && typeof config.appDataPath !== 'object')) {
-    config.appDataPath = []
-  }
-
-  const existingPath = config.appDataPath.find(
-    (item: { executablePath: string }) => item.executablePath === executablePath
-  )
-
-  if (existingPath) {
-    existingPath.dataPath = appDataPath
-  } else {
-    config.appDataPath.push({ executablePath, dataPath: appDataPath })
-  }
-
-  fs.writeFileSync(configPath, JSON.stringify(config, null, 2))
 }
 
 export function getFileType(ext: string): FileTypes {

--- a/src/main/utils/init.ts
+++ b/src/main/utils/init.ts
@@ -1,0 +1,123 @@
+import * as fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { isLinux, isPortable, isWin } from '@main/constant'
+import { app } from 'electron'
+
+// Please don't import any other modules which is not node/electron built-in modules
+
+function hasWritePermission(path: string) {
+  try {
+    fs.accessSync(path, fs.constants.W_OK)
+    return true
+  } catch (error) {
+    return false
+  }
+}
+
+function getConfigPath() {
+  return path.join(os.homedir(), '.cherrystudio', 'config')
+}
+
+export function initAppDataDir() {
+  const appDataPath = getAppDataPathFromConfig()
+  if (appDataPath) {
+    app.setPath('userData', appDataPath)
+    return
+  }
+
+  if (isPortable) {
+    const portableDir = process.env.PORTABLE_EXECUTABLE_DIR
+    app.setPath('userData', path.join(portableDir || app.getPath('exe'), 'data'))
+    return
+  }
+}
+
+function getAppDataPathFromConfig() {
+  try {
+    const configPath = getConfigPath()
+    if (!fs.existsSync(configPath)) {
+      return null
+    }
+
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'))
+
+    if (!config.appDataPath) {
+      return null
+    }
+
+    let executablePath = app.getPath('exe')
+    if (isLinux && process.env.APPIMAGE) {
+      // 如果是 AppImage 打包的应用，直接使用 APPIMAGE 环境变量
+      // 这样可以确保获取到正确的可执行文件路径
+      executablePath = path.join(path.dirname(process.env.APPIMAGE), 'cherry-studio.appimage')
+    }
+
+    if (isWin && isPortable) {
+      executablePath = path.join(process.env.PORTABLE_EXECUTABLE_DIR || '', 'cherry-studio-portable.exe')
+    }
+
+    let appDataPath = null
+    // 兼容旧版本
+    if (config.appDataPath && typeof config.appDataPath === 'string') {
+      appDataPath = config.appDataPath
+      // 将旧版本数据迁移到新版本
+      appDataPath && updateAppDataConfig(appDataPath)
+    } else {
+      appDataPath = config.appDataPath.find(
+        (item: { executablePath: string }) => item.executablePath === executablePath
+      )?.dataPath
+    }
+
+    if (appDataPath && fs.existsSync(appDataPath) && hasWritePermission(appDataPath)) {
+      return appDataPath
+    }
+
+    return null
+  } catch (error) {
+    return null
+  }
+}
+
+export function updateAppDataConfig(appDataPath: string) {
+  const configDir = getConfigPath()
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir, { recursive: true })
+  }
+
+  // config.json
+  // appDataPath: [{ executablePath: string, dataPath: string }]
+  const configPath = path.join(configDir, 'config.json')
+  let executablePath = app.getPath('exe')
+  if (isLinux && process.env.APPIMAGE) {
+    executablePath = path.join(path.dirname(process.env.APPIMAGE), 'cherry-studio.appimage')
+  }
+
+  // 如果是 Windows 可移植版本，则使用 PORTABLE_EXECUTABLE_FILE 环境变量
+  if (isWin && isPortable) {
+    executablePath = path.join(process.env.PORTABLE_EXECUTABLE_DIR || '', 'cherry-studio-portable.exe')
+  }
+
+  if (!fs.existsSync(configPath)) {
+    fs.writeFileSync(configPath, JSON.stringify({ appDataPath: [{ executablePath, dataPath: appDataPath }] }, null, 2))
+    return
+  }
+
+  const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'))
+  if (!config.appDataPath || (config.appDataPath && typeof config.appDataPath !== 'object')) {
+    config.appDataPath = []
+  }
+
+  const existingPath = config.appDataPath.find(
+    (item: { executablePath: string }) => item.executablePath === executablePath
+  )
+
+  if (existingPath) {
+    existingPath.dataPath = appDataPath
+  } else {
+    config.appDataPath.push({ executablePath, dataPath: appDataPath })
+  }
+
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2))
+}


### PR DESCRIPTION
- Updated the import path for initAppDataDir in bootstrap.ts to reflect its new location in the utils/init module.
- Removed the initAppDataDir function and related code from file.ts to streamline the file and improve organization.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
init app data会import log service，log service里面的app.getData会获取到最原始的，导致日志存放到原始的app data，而不是在用户设置后的data目录。

After this PR:
日志存储在用户设置后的data的目录。
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
