### PR TITLE
fix: update installing status immediately

### DIFF
--- a/src/renderer/src/pages/settings/MCPSettings/InstallNpxUv.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/InstallNpxUv.tsx
@@ -42,8 +42,8 @@ const InstallNpxUv: FC<Props> = ({ mini = false }) => {
     try {
       setIsInstallingUv(true)
       await window.api.installUVBinary()
-      setIsUvInstalled(true)
       setIsInstallingUv(false)
+      dispatch(setIsUvInstalled(true))
     } catch (error: any) {
       window.message.error({ content: `${t('settings.mcp.installError')}: ${error.message}`, key: 'mcp-install-error' })
       setIsInstallingUv(false)
@@ -55,8 +55,8 @@ const InstallNpxUv: FC<Props> = ({ mini = false }) => {
     try {
       setIsInstallingBun(true)
       await window.api.installBunBinary()
-      setIsBunInstalled(true)
       setIsInstallingBun(false)
+      dispatch(setIsBunInstalled(true))
     } catch (error: any) {
       window.message.error({
         content: `${t('settings.mcp.installError')}: ${error.message}`,


### PR DESCRIPTION
Before：安装中 -> 安装 -> 安装完成
After：安装中  -> 安装完成

因为 Before 中的状态改变在 `setTimeout(checkBinaries, 1000)` 中，所以会有一秒延迟。


<table>

<tr>
 <td>

https://github.com/user-attachments/assets/8ae91455-521b-4f20-9c62-a6218697ef9f
 <td>

https://github.com/user-attachments/assets/cb223abc-fa96-4b07-9bb8-4c890ee48a77 
</table>

