### PR TITLE
fix: ensure add button is always visible for empty model providers

### DIFF
--- a/src/renderer/src/components/ModelList/ModelList.tsx
+++ b/src/renderer/src/components/ModelList/ModelList.tsx
@@ -13,7 +13,7 @@ import { useAppDispatch } from '@renderer/store'
 import { setModel } from '@renderer/store/assistants'
 import { Model } from '@renderer/types'
 import { Button, Flex, Tooltip } from 'antd'
-import { groupBy, isEmpty, sortBy, toPairs } from 'lodash'
+import { groupBy, sortBy, toPairs } from 'lodash'
 import { ListCheck, Plus } from 'lucide-react'
 import React, { memo, startTransition, useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -110,31 +110,22 @@ const ModelList: React.FC<ModelListProps> = ({ providerId }) => {
         <HStack alignItems="center" justifyContent="space-between" style={{ width: '100%' }}>
           <HStack alignItems="center" gap={8}>
             <SettingSubtitle style={{ marginTop: 0 }}>{t('common.models')}</SettingSubtitle>
-            {!isEmpty(models) && <CollapsibleSearchBar onSearch={setSearchText} />}
+            <CollapsibleSearchBar onSearch={setSearchText} />
           </HStack>
           <HStack>
-            {!isEmpty(models) && (
-              <Tooltip title={t('button.manage')} mouseLeaveDelay={0}>
-                <Button
-                  type="text"
-                  onClick={onManageModel}
-                  icon={<ListCheck size={16} />}
-                  disabled={isHealthChecking}
-                />
-              </Tooltip>
-            )}
+            <Tooltip title={t('button.manage')} mouseLeaveDelay={0}>
+              <Button type="text" onClick={onManageModel} icon={<ListCheck size={16} />} disabled={isHealthChecking} />
+            </Tooltip>
             <Tooltip title={t('button.add')} mouseLeaveDelay={0}>
               <Button type="text" onClick={onAddModel} icon={<Plus size={16} />} disabled={isHealthChecking} />
             </Tooltip>
-            {!isEmpty(models) && (
-              <Tooltip title={t('settings.models.check.button_caption')} mouseLeaveDelay={0}>
-                <Button
-                  type="text"
-                  onClick={runHealthCheck}
-                  icon={<StreamlineGoodHealthAndWellBeing size={16} isActive={isHealthChecking} />}
-                />
-              </Tooltip>
-            )}
+            <Tooltip title={t('settings.models.check.button_caption')} mouseLeaveDelay={0}>
+              <Button
+                type="text"
+                onClick={runHealthCheck}
+                icon={<StreamlineGoodHealthAndWellBeing size={16} isActive={isHealthChecking} />}
+              />
+            </Tooltip>
           </HStack>
         </HStack>
       </SettingSubtitle>


### PR DESCRIPTION
## 修复: 确保模型列表为空时显示添加按钮

###  问题描述

###  在最新的代码中发现一个严重的UX回归问题：当用户创建自定义模型平台时，如果模型列表为空，"添加"和"管理"按钮都会被隐藏，导致用户无法添加第一个模型。
<img width="767" height="305" alt="截屏2025-07-22 15 03 54" src="https://github.com/user-attachments/assets/fa809ee5-b064-4152-99e1-c95ee48214ec" />


###  影响范围

  - 新创建的自定义Provider无法添加模型
  - 空模型列表的Provider界面缺少关键操作入口
  - 用户体验严重受阻，形成"鸡生蛋蛋生鸡"的问题

###  问题根因

  这是重构中引入的regression bug。重构时将所有按钮包裹在 {!isEmpty(models) && (...)} 条件中，导致空列表时按钮完全消失。

### 解决方案

  遵循合理的UX设计原则，区分不同按钮的显示逻辑：

  | 功能   | 显示逻辑   | 理由              |
  |------|--------|-----------------|
  | 添加按钮 | 始终显示   | 用户的核心入口，必须保证可达性 |
  | 管理按钮 | 有模型时显示 | 没有内容时无法管理       |
  | 健康检查 | 有模型时显示 | 没有模型时无法检查       |
  | 搜索栏  | 有模型时显示 | 没有内容时搜索无意义      |

###  代码变更

```ts
  // 修复前 
  {!isEmpty(models) && (
    <HStack>
      <Button onClick={onManageModel} />  {/* 管理 */}
      <Button onClick={onAddModel} />     {/* 添加 - 被错误隐藏 */}
      <Button onClick={runHealthCheck} /> {/* 健康检查 */}
    </HStack>
  )}

  // 修复后
  <HStack>
    {!isEmpty(models) && <Button onClick={onManageModel} />}  {/* 管理 */}
    <Button onClick={onAddModel} />                          {/* 添加 - 始终可见 */}
    {!isEmpty(models) && <Button onClick={runHealthCheck} />} {/* 健康检查 */}
  </HStack>
```


### 测试


模型列表为空时显示添加按钮，添加模型后显示其与辅助功能按钮


<img width="756" height="284" alt="截屏2025-07-22 15 08 12" src="https://github.com/user-attachments/assets/46fcfbe1-6fbc-4c82-aaac-0ef3e08805c1" />
<img width="765" height="369" alt="截屏2025-07-22 15 09 20" src="https://github.com/user-attachments/assets/ad80994b-0bd8-4364-913f-39e2d22bbf1d" />
