### PR TITLE
fix(MessageTools): improve error handling and logging in message preview rendering

### DIFF
--- a/src/renderer/src/pages/home/Messages/MessageTools.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageTools.tsx
@@ -280,22 +280,37 @@ const MessageTools: FC<Props> = ({ block }) => {
     if (!content) return null
 
     try {
+      logger.debug(`renderPreview: ${content}`)
       const parsedResult = JSON.parse(content)
       switch (parsedResult.content[0]?.type) {
         case 'text':
-          return (
-            <CollapsedContent
-              isExpanded={true}
-              resultString={JSON.stringify(JSON.parse(parsedResult.content[0].text), null, 2)}
-            />
-          )
+          try {
+            return (
+              <CollapsedContent
+                isExpanded={true}
+                resultString={JSON.stringify(JSON.parse(parsedResult.content[0].text), null, 2)}
+              />
+            )
+          } catch (e) {
+            return (
+              <CollapsedContent
+                isExpanded={true}
+                resultString={JSON.stringify(parsedResult.content[0].text, null, 2)}
+              />
+            )
+          }
 
         default:
           return <CollapsedContent isExpanded={true} resultString={JSON.stringify(parsedResult, null, 2)} />
       }
     } catch (e) {
       logger.error('failed to render the preview of mcp results:', e as Error)
-      return <CollapsedContent isExpanded={true} resultString={JSON.stringify(e, null, 2)} />
+      return (
+        <CollapsedContent
+          isExpanded={true}
+          resultString={e instanceof Error ? e.message : JSON.stringify(e, null, 2)}
+        />
+      )
     }
   }
 


### PR DESCRIPTION


- Enhanced the rendering logic for message previews by adding a try-catch block to handle JSON parsing errors more gracefully.
- Updated the error handling to provide clearer error messages in the preview when exceptions occur.
- Added debug logging to track the rendering process of message content.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

`parsedResult.content[0].text`很有可能是字符串，导致`JSON.parse()`报错，预览为空

Before this PR:

https://github.com/CherryHQ/cherry-studio/blob/52c087fd2219928ab3f7e181e2999f0f8ad01156/src/renderer/src/pages/home/Messages/MessageTools.tsx#L286-L300

After this PR:


<img width="2566" height="610" alt="CleanShot 2025-07-24 at 11 15 12@2x" src="https://github.com/user-attachments/assets/d1ecf1fb-cd19-4b75-ac93-b70f2a3c2812" />
