### PR TITLE
fix(modelscopeSyncUtils): update token handling to remove 'ms-' prefix

### DIFF
--- a/src/renderer/src/pages/settings/MCPSettings/SyncServersPopup.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/SyncServersPopup.tsx
@@ -119,28 +119,29 @@ const PopupContainer: React.FC<Props> = ({ resolve, existingServers }) => {
       // Save token if present
       if (token) {
         selectedProvider.saveToken(token)
+        const newToken = selectedProvider.getToken()
         setTokens((prev) => ({
           ...prev,
-          [selectedProvider.tokenFieldName]: token
+          [selectedProvider.tokenFieldName]: newToken!
         }))
-      }
 
-      // Sync servers
-      const result = await selectedProvider.syncServers(token, existingServers)
+        // Sync servers
+        const result = await selectedProvider.syncServers(newToken!, existingServers)
 
-      if (result.success && result.addedServers?.length > 0) {
-        // Add the new servers to the store
-        for (const server of result.addedServers) {
-          addMCPServer(server)
-        }
-        window.message.success(result.message)
-        setOpen(false)
-      } else {
-        // Show message but keep dialog open
-        if (result.success) {
-          window.message.info(result.message)
+        if (result.success && result.addedServers?.length > 0) {
+          // Add the new servers to the store
+          for (const server of result.addedServers) {
+            addMCPServer(server)
+          }
+          window.message.success(result.message)
+          setOpen(false)
         } else {
-          window.message.error(result.message)
+          // Show message but keep dialog open
+          if (result.success) {
+            window.message.info(result.message)
+          } else {
+            window.message.error(result.message)
+          }
         }
       }
     } catch (error: any) {

--- a/src/renderer/src/pages/settings/MCPSettings/modelscopeSyncUtils.ts
+++ b/src/renderer/src/pages/settings/MCPSettings/modelscopeSyncUtils.ts
@@ -9,6 +9,9 @@ const logger = loggerService.withContext('ModelScopeSyncUtils')
 const TOKEN_STORAGE_KEY = 'modelscope_token'
 
 export const saveModelScopeToken = (token: string): void => {
+  if (token.startsWith('ms-')) {
+    token = token.replace('ms-', '')
+  }
   localStorage.setItem(TOKEN_STORAGE_KEY, token)
 }
 


### PR DESCRIPTION
- Added logic to remove the 'ms-' prefix from the token before saving it to local storage, ensuring consistent token format for storage.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

魔搭上游现在请求时不支持ms开头的apikey