### PR TITLE
feat(MCPSettings): enhance JSON loading to inherit all MCPServer fields

### DIFF
--- a/src/renderer/src/pages/settings/MCPSettings/AddMcpServerModal.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/AddMcpServerModal.tsx
@@ -216,19 +216,10 @@ const AddMcpServerModal: FC<AddMcpServerModalProps> = ({
         // 如果成功解析並通過所有檢查，立即加入伺服器（非啟用狀態）並關閉對話框
         const newServer: MCPServer = {
           id: nanoid(),
-          name: serverToAdd!.name!,
-          description: serverToAdd!.description ?? '',
+          ...serverToAdd!,
+          name: serverToAdd!.name || t('settings.mcp.newServer'),
           baseUrl: serverToAdd!.baseUrl ?? serverToAdd!.url ?? '',
-          command: serverToAdd!.command ?? '',
-          args: Array.isArray(serverToAdd!.args) ? serverToAdd!.args : [],
-          env: serverToAdd!.env || {},
-          isActive: false,
-          type: serverToAdd!.type,
-          logoUrl: serverToAdd!.logoUrl,
-          provider: serverToAdd!.provider,
-          providerUrl: serverToAdd!.providerUrl,
-          tags: serverToAdd!.tags,
-          configSample: serverToAdd!.configSample
+          isActive: false // 初始狀態為非啟用
         }
 
         onSuccess(newServer)


### PR DESCRIPTION
Use spread operator to copy all fields from parsed JSON instead of manually mapping specific fields. This ensures all MCPServer properties including headers, timeout, dxtVersion, and other optional fields are preserved during JSON import.

Previously missing fields:
- headers: Record<string, string>
- timeout: number
- dxtVersion: string
- dxtPath: string
- Other optional MCPServer properties

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
