### PR TITLE
chore: Update channel improve

### DIFF
--- a/packages/shared/config/constant.ts
+++ b/packages/shared/config/constant.ts
@@ -194,8 +194,7 @@ export const defaultLanguage = 'en-US'
 
 export enum FeedUrl {
   PRODUCTION = 'https://releases.cherry-ai.com',
-  GITHUB_LATEST = 'https://github.com/CherryHQ/cherry-studio/releases/latest/download',
-  PRERELEASE_LOWEST = 'https://github.com/CherryHQ/cherry-studio/releases/download/v1.4.0'
+  GITHUB_LATEST = 'https://github.com/CherryHQ/cherry-studio/releases/latest/download'
 }
 
 export enum UpgradeChannel {

--- a/src/main/services/AppUpdater.ts
+++ b/src/main/services/AppUpdater.ts
@@ -47,6 +47,12 @@ export default class AppUpdater {
 
     // 检测到不需要更新时
     autoUpdater.on('update-not-available', () => {
+      if (configManager.getTestPlan() && this.autoUpdater.channel !== UpgradeChannel.LATEST) {
+        logger.info('test plan is enabled, but update is not available, do not send update not available event')
+        // will not send update not available event, because will check for updates with latest channel
+        return
+      }
+
       mainWindow.webContents.send(IpcChannel.UpdateNotAvailable)
     })
 
@@ -84,11 +90,11 @@ export default class AppUpdater {
         return item.prerelease && item.tag_name.includes(`-${channel}.`)
       })
 
-      logger.info('release info', release)
-
       if (!release) {
         return null
       }
+
+      logger.info(`prerelease url is ${release.tag_name}, set channel to ${channel}`)
 
       return `https://github.com/CherryHQ/cherry-studio/releases/download/${release.tag_name}`
     } catch (error) {
@@ -152,37 +158,43 @@ export default class AppUpdater {
     return UpgradeChannel.LATEST
   }
 
+  private _setChannel(channel: UpgradeChannel, feedUrl: string) {
+    this.autoUpdater.channel = channel
+    this.autoUpdater.setFeedURL(feedUrl)
+
+    // disable downgrade after change the channel
+    this.autoUpdater.allowDowngrade = false
+    // github and gitcode don't support multiple range download
+    this.autoUpdater.disableDifferentialDownload = true
+  }
+
   private async _setFeedUrl() {
     const testPlan = configManager.getTestPlan()
     if (testPlan) {
       const channel = this._getTestChannel()
 
       if (channel === UpgradeChannel.LATEST) {
-        this.autoUpdater.channel = UpgradeChannel.LATEST
-        this.autoUpdater.setFeedURL(FeedUrl.GITHUB_LATEST)
+        this._setChannel(UpgradeChannel.LATEST, FeedUrl.GITHUB_LATEST)
         return
       }
 
       const preReleaseUrl = await this._getPreReleaseVersionFromGithub(channel)
       if (preReleaseUrl) {
-        this.autoUpdater.setFeedURL(preReleaseUrl)
-        this.autoUpdater.channel = channel
+        logger.info(`prerelease url is ${preReleaseUrl}, set channel to ${channel}`)
+        this._setChannel(channel, preReleaseUrl)
         return
       }
 
-      // if no prerelease url, use lowest prerelease version to avoid error
-      this.autoUpdater.setFeedURL(FeedUrl.PRERELEASE_LOWEST)
-      this.autoUpdater.channel = UpgradeChannel.LATEST
+      // if no prerelease url, use github latest to avoid error
+      this._setChannel(UpgradeChannel.LATEST, FeedUrl.GITHUB_LATEST)
       return
     }
 
-    this.autoUpdater.channel = UpgradeChannel.LATEST
-    this.autoUpdater.setFeedURL(FeedUrl.PRODUCTION)
-
+    this._setChannel(UpgradeChannel.LATEST, FeedUrl.PRODUCTION)
     const ipCountry = await this._getIpCountry()
-    logger.info('ipCountry', ipCountry)
+    logger.info(`ipCountry is ${ipCountry}, set channel to ${UpgradeChannel.LATEST}`)
     if (ipCountry.toLowerCase() !== 'cn') {
-      this.autoUpdater.setFeedURL(FeedUrl.GITHUB_LATEST)
+      this._setChannel(UpgradeChannel.LATEST, FeedUrl.GITHUB_LATEST)
     }
   }
 
@@ -202,16 +214,25 @@ export default class AppUpdater {
       }
     }
 
-    await this._setFeedUrl()
-
-    // disable downgrade after change the channel
-    this.autoUpdater.allowDowngrade = false
-
-    // github and gitcode don't support multiple range download
-    this.autoUpdater.disableDifferentialDownload = true
-
     try {
+      await this._setFeedUrl()
+
       this.updateCheckResult = await this.autoUpdater.checkForUpdates()
+      logger.info(
+        `update check result: ${this.updateCheckResult?.isUpdateAvailable}, channel: ${this.autoUpdater.channel}, currentVersion: ${this.autoUpdater.currentVersion}`
+      )
+
+      // if the update is not available, and the test plan is enabled, set the feed url to the github latest
+      if (
+        !this.updateCheckResult?.isUpdateAvailable &&
+        configManager.getTestPlan() &&
+        this.autoUpdater.channel !== UpgradeChannel.LATEST
+      ) {
+        logger.info('test plan is enabled, but update is not available, set channel to latest')
+        this._setChannel(UpgradeChannel.LATEST, FeedUrl.GITHUB_LATEST)
+        this.updateCheckResult = await this.autoUpdater.checkForUpdates()
+      }
+
       if (this.updateCheckResult?.isUpdateAvailable && !this.autoUpdater.autoDownload) {
         // 如果 autoDownload 为 false，则需要再调用下面的函数触发下
         // do not use await, because it will block the return of this function


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
有latest版本，并且比testplan的版本要高，不会升级

After this PR:
从testplan的版本也能自动升级到最新latest版本。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
