### PR TITLE
fix: set consolelog eslint to error when in prci lint check

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      PRCI: true
 
     steps:
       - name: Check out Git repository

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -56,7 +56,7 @@ export default defineConfig([
     ignores: ['src/**/__tests__/**', 'src/**/__mocks__/**', 'src/**/*.test.*'],
     rules: {
       'no-restricted-syntax': [
-        'warn',
+        process.env.PRCI ? 'error' : 'warn',
         {
           selector: 'CallExpression[callee.object.name="console"]',
           message:


### PR DESCRIPTION
非pr ci状态下，`console.xxx`仍是warn状态
在pr ci状态下，`console.xxx`的使用将是error状态，以防止开发者不看warn而意外将`console.xxx`并入