### PR TITLE
feat(models): add support for new Qwen model and update effort ratio

### DIFF
--- a/src/renderer/src/config/models.ts
+++ b/src/renderer/src/config/models.ts
@@ -2975,6 +2975,7 @@ export const THINKING_TOKEN_MAP: Record<string, { min: number; max: number }> = 
   'gemini-.*-pro.*$': { min: 128, max: 32768 },
 
   // Qwen models
+  'qwen3-235b-a22b-thinking(?:-[\\w-]+)$': { min: 0, max: 81_920 },
   'qwen-plus-.*$': { min: 0, max: 38912 },
   'qwen-turbo-.*$': { min: 0, max: 38912 },
   'qwen3-0\\.6b$': { min: 0, max: 30720 },

--- a/src/renderer/src/pages/home/Inputbar/ThinkingButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/ThinkingButton.tsx
@@ -42,6 +42,7 @@ const MODEL_SUPPORTED_OPTIONS: Record<string, ThinkingOption[]> = {
   gemini: ['off', 'low', 'medium', 'high', 'auto'],
   gemini_pro: ['low', 'medium', 'high', 'auto'],
   qwen: ['off', 'low', 'medium', 'high'],
+  qwen_3235ba22b_thinking: ['low', 'medium', 'high'],
   doubao: ['off', 'auto', 'high'],
   hunyuan: ['off', 'auto']
 }
@@ -64,6 +65,7 @@ const ThinkingButton: FC<Props> = ({ ref, model, assistant, ToolbarButton }): Re
   const isGeminiModel = isSupportedThinkingTokenGeminiModel(model)
   const isGeminiFlashModel = GEMINI_FLASH_MODEL_REGEX.test(model.id)
   const isQwenModel = isSupportedThinkingTokenQwenModel(model)
+  const isQwen3235BA22BThinkingModel = model.id.includes('qwen3-235b-a22b-thinking')
   const isDoubaoModel = isSupportedThinkingTokenDoubaoModel(model)
   const isHunyuanModel = isSupportedThinkingTokenHunyuanModel(model)
 
@@ -81,11 +83,24 @@ const ThinkingButton: FC<Props> = ({ ref, model, assistant, ToolbarButton }): Re
       }
     }
     if (isGrokModel) return 'grok'
-    if (isQwenModel) return 'qwen'
+    if (isQwenModel) {
+      if (isQwen3235BA22BThinkingModel) {
+        return 'qwen_3235ba22b_thinking'
+      }
+      return 'qwen'
+    }
     if (isDoubaoModel) return 'doubao'
     if (isHunyuanModel) return 'hunyuan'
     return 'default'
-  }, [isGeminiModel, isGrokModel, isQwenModel, isDoubaoModel, isGeminiFlashModel, isHunyuanModel])
+  }, [
+    isGeminiModel,
+    isGrokModel,
+    isQwenModel,
+    isDoubaoModel,
+    isHunyuanModel,
+    isGeminiFlashModel,
+    isQwen3235BA22BThinkingModel
+  ])
 
   // 获取当前模型支持的选项
   const supportedOptions = useMemo(() => {
@@ -133,6 +148,7 @@ const ThinkingButton: FC<Props> = ({ ref, model, assistant, ToolbarButton }): Re
   const onThinkingChange = useCallback(
     (option?: ThinkingOption) => {
       const isEnabled = option !== undefined && option !== 'off'
+      console.log('option', option)
       // 然后更新设置
       if (!isEnabled) {
         updateAssistantSettings({

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -51,7 +51,7 @@ export type ReasoningEffortOptions = 'low' | 'medium' | 'high' | 'auto'
 export type EffortRatio = Record<ReasoningEffortOptions, number>
 
 export const EFFORT_RATIO: EffortRatio = {
-  low: 0.2,
+  low: 0.05,
   medium: 0.5,
   high: 0.8,
   auto: 2


### PR DESCRIPTION
- Introduced support for the 'qwen3-235b-a22b-thinking' model with a max token limit of 81,920.
- Updated the model options in ThinkingButton to include 'qwen_3235ba22b_thinking'.
- Adjusted the effort ratio for 'low' from 0.2 to 0.05 for improved performance.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
