### PR TITLE
feat(contentsearch): optimize searchbar UI

### DIFF
--- a/src/renderer/src/components/ContentSearch.tsx
+++ b/src/renderer/src/components/ContentSearch.tsx
@@ -1,3 +1,5 @@
+import { useSettings } from '@renderer/hooks/useSettings'
+import { useShowTopics } from '@renderer/hooks/useStore'
 import { ToolbarButton } from '@renderer/pages/home/Inputbar/Inputbar'
 import NarrowLayout from '@renderer/pages/home/Messages/NarrowLayout'
 import { Tooltip } from 'antd'
@@ -126,6 +128,8 @@ const findRangesInTarget = (
 // eslint-disable-next-line @eslint-react/no-forward-ref
 export const ContentSearch = React.forwardRef<ContentSearchRef, Props>(
   ({ searchTarget, filter, includeUser = false, onIncludeUserChange }, ref) => {
+    const { topicPosition } = useSettings()
+    const { showTopics } = useShowTopics()
     const target: HTMLElement | null = (() => {
       if (searchTarget instanceof HTMLElement) {
         return searchTarget
@@ -333,10 +337,12 @@ export const ContentSearch = React.forwardRef<ContentSearchRef, Props>(
       searchInputFocus()
     }
 
+    const isRightTopicsVisible = topicPosition === 'right' && showTopics
+
     return (
       <Container ref={containerRef} style={enableContentSearch ? {} : { display: 'none' }}>
         <NarrowLayout style={{ width: '100%' }}>
-          <SearchBarContainer>
+          <SearchBarContainer $isRightTopicsVisible={isRightTopicsVisible}>
             <InputWrapper>
               <Input
                 ref={searchInputRef}
@@ -405,14 +411,18 @@ const Container = styled.div`
   z-index: 2;
 `
 
-const SearchBarContainer = styled.div`
+const SearchBarContainer = styled.div<{ $isRightTopicsVisible: boolean }>`
   border: 1px solid var(--color-primary);
   border-radius: 10px;
   transition: all 0.2s ease;
   position: fixed;
-  top: 15px;
-  left: 20px;
-  right: 20px;
+  top: 30px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: ${(props) =>
+    props.$isRightTopicsVisible
+      ? 'min(60%, calc(100vw - 400px))'
+      : 'min(60%, calc(100vw - 140px))'}; /* 容器2/3宽度，并考虑右侧避让 */
   margin-bottom: 5px;
   padding: 5px 15px;
   display: flex;
@@ -448,7 +458,7 @@ const ToolBar = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: tpx;
+  gap: 2px;
 `
 
 const Separator = styled.div`
@@ -463,8 +473,8 @@ const Separator = styled.div`
 const SearchResults = styled.div`
   display: flex;
   justify-content: center;
-  width: 80px;
-  margin: 0 2px;
+  width: 60px;
+  margin: 0 1px;
   flex: 0 0 auto;
   color: var(--color-text-1);
   font-size: 14px;


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

调整优化对话界面的搜索栏UI，使其向下避让代码块按钮。此外调整为居中样式且为UI容器的60%宽度避让对话界面靠右的MCP调用信息相关按钮

Before this PR: 

<img width="1742" height="975" alt="PixPin_2025-07-26_23-01-05" src="https://github.com/user-attachments/assets/fcbc0068-2ee2-438f-ba81-849961720277" />

After this PR:

<img width="1733" height="1171" alt="PixPin_2025-07-26_23-03-46" src="https://github.com/user-attachments/assets/763183c7-6c9e-4cb3-843c-c8434a25f400" />

<img width="1733" height="1171" alt="PixPin_2025-07-26_23-04-29" src="https://github.com/user-attachments/assets/076436cd-5d37-4b62-8d5e-bab49e83c5c2" />

Fixes #8366
