### PR TITLE
refactor(ModelEditContent): enhance model capabilities management and…

### DIFF
--- a/src/renderer/src/components/ModelList/ModelEditContent.tsx
+++ b/src/renderer/src/components/ModelList/ModelEditContent.tsx
@@ -12,6 +12,7 @@ import { useDynamicLabelWidth } from '@renderer/hooks/useDynamicLabelWidth'
 import { Model, ModelCapability, ModelType, Provider } from '@renderer/types'
 import { getDefaultGroupName, getDifference, getUnion, uniqueObjectArray } from '@renderer/utils'
 import { Button, Checkbox, Divider, Flex, Form, Input, InputNumber, message, Modal, Select, Switch } from 'antd'
+import { cloneDeep } from 'lodash'
 import { ChevronDown, ChevronUp } from 'lucide-react'
 import { FC, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -33,6 +34,7 @@ const ModelEditContent: FC<ModelEditContentProps> = ({ provider, model, onUpdate
   const [currencySymbol, setCurrencySymbol] = useState(model.pricing?.currencySymbol || '$')
   const [isCustomCurrency, setIsCustomCurrency] = useState(!symbols.includes(model.pricing?.currencySymbol || '$'))
   const [modelCapabilities, setModelCapabilities] = useState(model.capabilities || [])
+  const originalModelCapabilities = cloneDeep(model.capabilities || [])
   const [supportedTextDelta, setSupportedTextDelta] = useState(model.supported_text_delta)
 
   const labelWidth = useDynamicLabelWidth([t('settings.models.add.endpoint_type.label')])
@@ -99,7 +101,6 @@ const ModelEditContent: FC<ModelEditContentProps> = ({ provider, model, onUpdate
         modelCapabilities?.filter((t) => t.isUserSelected === false),
         (item) => item.type
       )
-
       setModelCapabilities(newModelCapabilities)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -222,7 +223,6 @@ const ModelEditContent: FC<ModelEditContentProps> = ({ provider, model, onUpdate
 
               const isRerankDisabled = selectedTypes.includes('embedding')
               const isEmbeddingDisabled = selectedTypes.includes('rerank')
-
               const showTypeConfirmModal = (newCapability: ModelCapability) => {
                 const onUpdateType = selectedTypes?.find((t) => t === newCapability.type)
                 window.modal.confirm({
@@ -319,7 +319,7 @@ const ModelEditContent: FC<ModelEditContentProps> = ({ provider, model, onUpdate
               }
 
               const handleResetTypes = () => {
-                setModelCapabilities([])
+                setModelCapabilities(originalModelCapabilities)
               }
 
               return (

--- a/src/renderer/src/components/ModelList/ModelEditContent.tsx
+++ b/src/renderer/src/components/ModelList/ModelEditContent.tsx
@@ -36,6 +36,7 @@ const ModelEditContent: FC<ModelEditContentProps> = ({ provider, model, onUpdate
   const [modelCapabilities, setModelCapabilities] = useState(model.capabilities || [])
   const originalModelCapabilities = cloneDeep(model.capabilities || [])
   const [supportedTextDelta, setSupportedTextDelta] = useState(model.supported_text_delta)
+  const [hasUserModified, setHasUserModified] = useState(false)
 
   const labelWidth = useDynamicLabelWidth([t('settings.models.add.endpoint_type.label')])
 
@@ -274,6 +275,7 @@ const ModelEditContent: FC<ModelEditContentProps> = ({ provider, model, onUpdate
               }
 
               const handleTypeChange = (types: string[]) => {
+                setHasUserModified(true) // 标记用户已进行修改
                 const diff = types.length > selectedTypes.length
                 if (diff) {
                   const newCapability = getDifference(types, selectedTypes) // checkbox的特性，确保了newCapability只有一个元素
@@ -320,6 +322,7 @@ const ModelEditContent: FC<ModelEditContentProps> = ({ provider, model, onUpdate
 
               const handleResetTypes = () => {
                 setModelCapabilities(originalModelCapabilities)
+                setHasUserModified(false) // 重置后清除修改标志
               }
 
               return (
@@ -361,9 +364,11 @@ const ModelEditContent: FC<ModelEditContentProps> = ({ provider, model, onUpdate
                         }
                       ]}
                     />
-                    <Button size="small" onClick={handleResetTypes}>
-                      {t('common.reset')}
-                    </Button>
+                    {hasUserModified && (
+                      <Button size="small" onClick={handleResetTypes}>
+                        {t('common.reset')}
+                      </Button>
+                    )}
                   </Flex>
                 </div>
               )

--- a/src/renderer/src/components/ModelList/ModelEditContent.tsx
+++ b/src/renderer/src/components/ModelList/ModelEditContent.tsx
@@ -88,13 +88,17 @@ const ModelEditContent: FC<ModelEditContentProps> = ({ provider, model, onUpdate
 
   useEffect(() => {
     if (showMoreSettings) {
-      const newModelCapabilities = selectedTypes.map((type) => {
-        const existingCapability = modelCapabilities?.find((m) => m.type === type)
-        return {
-          type: type as ModelType,
-          isUserSelected: existingCapability?.isUserSelected ?? undefined
-        }
-      })
+      const newModelCapabilities = getUnion(
+        selectedTypes.map((type) => {
+          const existingCapability = modelCapabilities?.find((m) => m.type === type)
+          return {
+            type: type as ModelType,
+            isUserSelected: existingCapability?.isUserSelected ?? undefined
+          }
+        }),
+        modelCapabilities?.filter((t) => t.isUserSelected === false),
+        (item) => item.type
+      )
 
       setModelCapabilities(newModelCapabilities)
     }
@@ -286,8 +290,9 @@ const ModelEditContent: FC<ModelEditContentProps> = ({ provider, model, onUpdate
                         return { ...t, isUserSelected: false }
                       }
                       if (
-                        (onUpdateType !== t && onUpdateType.type === 'rerank') ||
-                        (onUpdateType.type === 'embedding' && onUpdateType !== t && t.isUserSelected === false)
+                        ((onUpdateType !== t && onUpdateType.type === 'rerank') ||
+                          (onUpdateType.type === 'embedding' && onUpdateType !== t)) &&
+                        t.isUserSelected === false
                       ) {
                         if (changedTypesRef.current.includes(t.type)) {
                           return { ...t, isUserSelected: true }

--- a/src/renderer/src/utils/index.ts
+++ b/src/renderer/src/utils/index.ts
@@ -1,6 +1,7 @@
 import { loggerService } from '@logger'
 import { Language, Model, ModelType, Provider } from '@renderer/types'
 import { ModalFuncProps } from 'antd'
+import { isEqual } from 'lodash'
 import { v4 as uuidv4 } from 'uuid'
 
 const logger = loggerService.withContext('Utils')
@@ -246,6 +247,10 @@ export function mapLanguageToQwenMTModel(language: Language): string {
     return 'Traditional Chinese'
   }
   return language.value
+}
+
+export function uniqueObjectArray<T>(array: T[]): T[] {
+  return array.filter((obj, index, self) => index === self.findIndex((t) => isEqual(t, obj)))
 }
 
 export * from './api'


### PR DESCRIPTION
… introduce uniqueObjectArray utility

- Updated ModelEditContent to improve handling of model capabilities, ensuring user selections are accurately reflected.
- Introduced a new utility function, uniqueObjectArray, to filter out duplicate objects in arrays, enhancing data integrity.
- Refactored logic for updating model capabilities to utilize the new utility, streamlining the process and improving code clarity.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

现在可以同时选择多个类型

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #8529

### Special notes for your reviewer

参照原issue验证即可

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.
