### PR TITLE
feat(inputbar): drop text into inputbar

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -37,7 +37,12 @@ import { Assistant, FileType, FileTypes, KnowledgeBase, KnowledgeItem, Model, To
 import type { MessageInputBaseParams } from '@renderer/types/newMessage'
 import { classNames, delay, formatFileSize, getFileExtension } from '@renderer/utils'
 import { formatQuotedText } from '@renderer/utils/formats'
-import { getFilesFromDropEvent, getSendMessageShortcutLabel, isSendMessageKeyPressed } from '@renderer/utils/input'
+import {
+  getFilesFromDropEvent,
+  getSendMessageShortcutLabel,
+  getTextFromDropEvent,
+  isSendMessageKeyPressed
+} from '@renderer/utils/input'
 import { getLanguageByLangcode } from '@renderer/utils/translate'
 import { documentExts, imageExts, textExts } from '@shared/config/constant'
 import { IpcChannel } from '@shared/IpcChannel'
@@ -567,6 +572,10 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
       e.stopPropagation()
       setIsFileDragging(false)
 
+      const data = await getTextFromDropEvent(e)
+
+      setText(text + data)
+
       const files = await getFilesFromDropEvent(e).catch((err) => {
         logger.error('handleDrop:', err)
         return null
@@ -591,7 +600,7 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
         }
       }
     },
-    [supportedExts, t]
+    [supportedExts, t, text]
   )
 
   const onTranslated = (translatedText: string) => {

--- a/src/renderer/src/utils/input.ts
+++ b/src/renderer/src/utils/input.ts
@@ -5,6 +5,10 @@ import { FileMetadata } from '@renderer/types'
 
 const logger = loggerService.withContext('Utils:Input')
 
+export const getTextFromDropEvent = async (e: React.DragEvent<HTMLDivElement>): Promise<string> => {
+  return e.dataTransfer.getData('text')
+}
+
 export const getFilesFromDropEvent = async (e: React.DragEvent<HTMLDivElement>): Promise<FileMetadata[]> => {
   if (e.dataTransfer.files.length > 0) {
     // 使用新的API获取文件路径


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

现在可以拖拽文本到inputbar中


https://github.com/user-attachments/assets/de83a1e0-fd01-4f34-95d1-9edc57111832



<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
