### PR TITLE
fix: add isPathInside functionality to check path relationships

### DIFF
--- a/packages/shared/IpcChannel.ts
+++ b/packages/shared/IpcChannel.ts
@@ -21,6 +21,7 @@ export enum IpcChannel {
   App_Select = 'app:select',
   App_HasWritePermission = 'app:has-write-permission',
   App_ResolvePath = 'app:resolve-path',
+  App_IsPathInside = 'app:is-path-inside',
   App_Copy = 'app:copy',
   App_SetStopQuitApp = 'app:set-stop-quit-app',
   App_SetAppDataPath = 'app:set-app-data-path',

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -55,7 +55,7 @@ import { setOpenLinkExternal } from './services/WebviewService'
 import { windowService } from './services/WindowService'
 import { calculateDirectorySize, getResourcePath } from './utils'
 import { decrypt, encrypt } from './utils/aes'
-import { getCacheDir, getConfigDir, getFilesDir, hasWritePermission, untildify } from './utils/file'
+import { getCacheDir, getConfigDir, getFilesDir, hasWritePermission, isPathInside, untildify } from './utils/file'
 import { updateAppDataConfig } from './utils/init'
 import { compress, decompress } from './utils/zip'
 
@@ -292,6 +292,11 @@ export function registerIpc(mainWindow: BrowserWindow, app: Electron.App) {
 
   ipcMain.handle(IpcChannel.App_ResolvePath, async (_, filePath: string) => {
     return path.resolve(untildify(filePath))
+  })
+
+  // Check if a path is inside another path (proper parent-child relationship)
+  ipcMain.handle(IpcChannel.App_IsPathInside, async (_, childPath: string, parentPath: string) => {
+    return isPathInside(childPath, parentPath)
   })
 
   // Set app data path

--- a/src/main/utils/__tests__/file.test.ts
+++ b/src/main/utils/__tests__/file.test.ts
@@ -16,8 +16,8 @@ import {
   getFilesDir,
   getFileType,
   getTempDir,
-  untildify,
-  isPathInside
+  isPathInside,
+  untildify
 } from '../file'
 
 // Mock dependencies

--- a/src/main/utils/__tests__/file.test.ts
+++ b/src/main/utils/__tests__/file.test.ts
@@ -9,7 +9,16 @@ import { detectAll as detectEncodingAll } from 'jschardet'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { readTextFileWithAutoEncoding } from '../file'
-import { getAllFiles, getAppConfigDir, getConfigDir, getFilesDir, getFileType, getTempDir, untildify } from '../file'
+import {
+  getAllFiles,
+  getAppConfigDir,
+  getConfigDir,
+  getFilesDir,
+  getFileType,
+  getTempDir,
+  untildify,
+  isPathInside
+} from '../file'
 
 // Mock dependencies
 vi.mock('node:fs')
@@ -341,6 +350,156 @@ describe('file', () => {
       expect(untildify('~/folder with spaces')).toBe('/mock/home/folder with spaces')
       expect(untildify('~/folder-with-dashes')).toBe('/mock/home/folder-with-dashes')
       expect(untildify('~/folder_with_underscores')).toBe('/mock/home/folder_with_underscores')
+    })
+  })
+
+  describe('isPathInside', () => {
+    beforeEach(() => {
+      // Mock path.resolve to simulate path resolution
+      vi.mocked(path.resolve).mockImplementation((...args) => {
+        const joined = args.join('/')
+        return joined.startsWith('/') ? joined : `/${joined}`
+      })
+
+      // Mock path.normalize to simulate path normalization
+      vi.mocked(path.normalize).mockImplementation((p) => p.replace(/\/+/g, '/'))
+
+      // Mock path.relative to calculate relative paths
+      vi.mocked(path.relative).mockImplementation((from, to) => {
+        // Simple mock implementation for testing
+        const fromParts = from.split('/').filter((p) => p)
+        const toParts = to.split('/').filter((p) => p)
+
+        // Find common prefix
+        let i = 0
+        while (i < fromParts.length && i < toParts.length && fromParts[i] === toParts[i]) {
+          i++
+        }
+
+        // Calculate relative path
+        const upLevels = fromParts.length - i
+        const downPath = toParts.slice(i)
+
+        if (upLevels === 0 && downPath.length === 0) {
+          return ''
+        }
+
+        const result = ['..'.repeat(upLevels), ...downPath].filter((p) => p).join('/')
+        return result || '.'
+      })
+
+      // Mock path.isAbsolute
+      vi.mocked(path.isAbsolute).mockImplementation((p) => p.startsWith('/'))
+    })
+
+    describe('basic parent-child relationships', () => {
+      it('should return true when child is inside parent', () => {
+        expect(isPathInside('/root/test/child', '/root/test')).toBe(true)
+        expect(isPathInside('/root/test/deep/child', '/root/test')).toBe(true)
+        expect(isPathInside('child/deep', 'child')).toBe(true)
+      })
+
+      it('should return false when child is not inside parent', () => {
+        expect(isPathInside('/root/test', '/root/test/child')).toBe(false)
+        expect(isPathInside('/root/other', '/root/test')).toBe(false)
+        expect(isPathInside('/different/path', '/root/test')).toBe(false)
+        expect(isPathInside('child', 'child/deep')).toBe(false)
+      })
+
+      it('should return true when paths are the same', () => {
+        expect(isPathInside('/root/test', '/root/test')).toBe(true)
+        expect(isPathInside('child', 'child')).toBe(true)
+      })
+    })
+
+    describe('edge cases that startsWith cannot handle', () => {
+      it('should correctly distinguish similar path names', () => {
+        // The problematic case mentioned by user
+        expect(isPathInside('/root/test aaa', '/root/test')).toBe(false)
+        expect(isPathInside('/root/test', '/root/test aaa')).toBe(false)
+
+        // More similar cases
+        expect(isPathInside('/home/user-data', '/home/user')).toBe(false)
+        expect(isPathInside('/home/user', '/home/user-data')).toBe(false)
+        expect(isPathInside('/var/log-backup', '/var/log')).toBe(false)
+      })
+
+      it('should handle paths with spaces correctly', () => {
+        expect(isPathInside('/path with spaces/child', '/path with spaces')).toBe(true)
+        expect(isPathInside('/path with spaces', '/path with spaces/child')).toBe(false)
+      })
+
+      it('should handle Windows-style paths', () => {
+        // Mock for Windows paths
+        vi.mocked(path.resolve).mockImplementation((...args) => {
+          const joined = args.join('\\').replace(/\//g, '\\')
+          return joined.match(/^[A-Z]:/) ? joined : `C:${joined}`
+        })
+
+        vi.mocked(path.normalize).mockImplementation((p) => p.replace(/\\+/g, '\\'))
+
+        // Mock path.relative for Windows paths
+        vi.mocked(path.relative).mockImplementation((from, to) => {
+          const fromParts = from.split('\\').filter((p) => p && p !== 'C:')
+          const toParts = to.split('\\').filter((p) => p && p !== 'C:')
+
+          // Find common prefix
+          let i = 0
+          while (i < fromParts.length && i < toParts.length && fromParts[i] === toParts[i]) {
+            i++
+          }
+
+          // Calculate relative path
+          const upLevels = fromParts.length - i
+          const downPath = toParts.slice(i)
+
+          if (upLevels === 0 && downPath.length === 0) {
+            return ''
+          }
+
+          const upPath = Array(upLevels).fill('..').join('\\')
+          const result = [upPath, ...downPath].filter((p) => p).join('\\')
+          return result || '.'
+        })
+
+        expect(isPathInside('C:\\Users\\test\\child', 'C:\\Users\\test')).toBe(true)
+        expect(isPathInside('C:\\Users\\test aaa', 'C:\\Users\\test')).toBe(false)
+      })
+    })
+
+    describe('error handling', () => {
+      it('should return false when path operations throw errors', () => {
+        vi.mocked(path.resolve).mockImplementation(() => {
+          throw new Error('Path resolution failed')
+        })
+
+        expect(isPathInside('/any/path', '/any/parent')).toBe(false)
+      })
+    })
+
+    describe('comparison with startsWith behavior', () => {
+      const testCases: [string, string, boolean, boolean][] = [
+        ['/root/test aaa', '/root/test', false, true], // isPathInside vs startsWith
+        ['/root/test', '/root/test aaa', false, false],
+        ['/root/test/child', '/root/test', true, true],
+        ['/home/user-data', '/home/user', false, true]
+      ]
+
+      it.each(testCases)(
+        'should correctly handle %s vs %s',
+        (child: string, parent: string, expectedIsPathInside: boolean, expectedStartsWith: boolean) => {
+          const isPathInsideResult = isPathInside(child, parent)
+          const startsWithResult = child.startsWith(parent)
+
+          expect(isPathInsideResult).toBe(expectedIsPathInside)
+          expect(startsWithResult).toBe(expectedStartsWith)
+
+          // Verify that isPathInside gives different (correct) result in problematic cases
+          if (expectedIsPathInside !== expectedStartsWith) {
+            expect(isPathInsideResult).not.toBe(startsWithResult)
+          }
+        }
+      )
     })
   })
 })

--- a/src/main/utils/file.ts
+++ b/src/main/utils/file.ts
@@ -46,6 +46,42 @@ export async function hasWritePermission(dir: string) {
   }
 }
 
+/**
+ * Check if a path is inside another path (proper parent-child relationship)
+ * This function correctly handles edge cases that string.startsWith() cannot handle,
+ * such as distinguishing between '/root/test' and '/root/test aaa'
+ *
+ * @param childPath - The path that might be inside the parent path
+ * @param parentPath - The path that might contain the child path
+ * @returns true if childPath is inside parentPath, false otherwise
+ */
+export function isPathInside(childPath: string, parentPath: string): boolean {
+  try {
+    const resolvedChild = path.resolve(childPath)
+    const resolvedParent = path.resolve(parentPath)
+
+    // Normalize paths to handle different separators
+    const normalizedChild = path.normalize(resolvedChild)
+    const normalizedParent = path.normalize(resolvedParent)
+
+    // Check if they are the same path
+    if (normalizedChild === normalizedParent) {
+      return true
+    }
+
+    // Get relative path from parent to child
+    const relativePath = path.relative(normalizedParent, normalizedChild)
+
+    // If relative path is empty, they are the same
+    // If relative path starts with '..', child is not inside parent
+    // If relative path is absolute, child is not inside parent
+    return relativePath !== '' && !relativePath.startsWith('..') && !path.isAbsolute(relativePath)
+  } catch (error) {
+    logger.error('Failed to check path relationship:', error as Error)
+    return false
+  }
+}
+
 export function getFileType(ext: string): FileTypes {
   ext = ext.toLowerCase()
   return fileTypeMap.get(ext) || FileTypes.OTHER

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -60,6 +60,8 @@ const api = {
   select: (options: Electron.OpenDialogOptions) => ipcRenderer.invoke(IpcChannel.App_Select, options),
   hasWritePermission: (path: string) => ipcRenderer.invoke(IpcChannel.App_HasWritePermission, path),
   resolvePath: (path: string) => ipcRenderer.invoke(IpcChannel.App_ResolvePath, path),
+  isPathInside: (childPath: string, parentPath: string) =>
+    ipcRenderer.invoke(IpcChannel.App_IsPathInside, childPath, parentPath),
   setAppDataPath: (path: string) => ipcRenderer.invoke(IpcChannel.App_SetAppDataPath, path),
   getDataPathFromArgs: () => ipcRenderer.invoke(IpcChannel.App_GetDataPathFromArgs),
   copy: (oldPath: string, newPath: string, occupiedDirs: string[] = []) =>

--- a/src/renderer/src/pages/settings/DataSettings/DataSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/DataSettings.tsx
@@ -210,13 +210,15 @@ const DataSettings: FC = () => {
     }
 
     // check new app data path is not in old app data path
-    if (newAppDataPath.startsWith(appInfo.appDataPath)) {
+    const isInOldPath = await window.api.isPathInside(newAppDataPath, appInfo.appDataPath)
+    if (isInOldPath) {
       window.message.error(t('settings.data.app_data.select_error_same_path'))
       return
     }
 
     // check new app data path is not in app install path
-    if (newAppDataPath.startsWith(appInfo.installPath)) {
+    const isInInstallPath = await window.api.isPathInside(newAppDataPath, appInfo.installPath)
+    if (isInInstallPath) {
       window.message.error(t('settings.data.app_data.select_error_in_app_path'))
       return
     }

--- a/src/renderer/src/pages/settings/DataSettings/LocalBackupSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/LocalBackupSettings.tsx
@@ -75,14 +75,14 @@ const LocalBackupSettings: React.FC = () => {
 
     // check new local backup dir is not in app data path
     // if is in app data path, show error
-    if (resolvedDir.startsWith(appInfo!.appDataPath)) {
+    if (await window.api.isPathInside(resolvedDir, appInfo!.appDataPath)) {
       window.message.error(t('settings.data.local.directory.select_error_app_data_path'))
       return false
     }
 
     // check new local backup dir is not in app install path
     // if is in app install path, show error
-    if (resolvedDir.startsWith(appInfo!.installPath)) {
+    if (await window.api.isPathInside(resolvedDir, appInfo!.installPath)) {
       window.message.error(t('settings.data.local.directory.select_error_in_app_install_path'))
       return false
     }


### PR DESCRIPTION
- Introduced a new IPC channel for checking if a path is inside another path, enhancing path validation capabilities.
- Implemented the isPathInside function in the file utility, which accurately determines parent-child path relationships, handling edge cases.
- Updated relevant components to utilize the new isPathInside function for validating app data and backup paths, ensuring better user experience and error handling.
- Added comprehensive tests for isPathInside to cover various scenarios, including edge cases and error handling.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
<img width="906" height="705" alt="image" src="https://github.com/user-attachments/assets/9a683149-7d61-4305-8ab7-5fc31fedf5ef" />

直接使用startsWith判断，上面的情况就会判断成子目录了，导致不能修改。

After this PR:
直接使用nodejs fs api来精确判断是不是子目录。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
