### PR TITLE
fix(LocalBackup): streamline local backup relative directory handling 

### DIFF
--- a/packages/shared/IpcChannel.ts
+++ b/packages/shared/IpcChannel.ts
@@ -176,7 +176,6 @@ export enum IpcChannel {
   Backup_RestoreFromLocalBackup = 'backup:restoreFromLocalBackup',
   Backup_ListLocalBackupFiles = 'backup:listLocalBackupFiles',
   Backup_DeleteLocalBackupFile = 'backup:deleteLocalBackupFile',
-  Backup_SetLocalBackupDir = 'backup:setLocalBackupDir',
   Backup_BackupToS3 = 'backup:backupToS3',
   Backup_RestoreFromS3 = 'backup:restoreFromS3',
   Backup_ListS3Files = 'backup:listS3Files',

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -404,7 +404,6 @@ export function registerIpc(mainWindow: BrowserWindow, app: Electron.App) {
   ipcMain.handle(IpcChannel.Backup_RestoreFromLocalBackup, backupManager.restoreFromLocalBackup.bind(backupManager))
   ipcMain.handle(IpcChannel.Backup_ListLocalBackupFiles, backupManager.listLocalBackupFiles.bind(backupManager))
   ipcMain.handle(IpcChannel.Backup_DeleteLocalBackupFile, backupManager.deleteLocalBackupFile.bind(backupManager))
-  ipcMain.handle(IpcChannel.Backup_SetLocalBackupDir, backupManager.setLocalBackupDir.bind(backupManager))
   ipcMain.handle(IpcChannel.Backup_BackupToS3, backupManager.backupToS3.bind(backupManager))
   ipcMain.handle(IpcChannel.Backup_RestoreFromS3, backupManager.restoreFromS3.bind(backupManager))
   ipcMain.handle(IpcChannel.Backup_ListS3Files, backupManager.listS3Files.bind(backupManager))

--- a/src/main/services/BackupManager.ts
+++ b/src/main/services/BackupManager.ts
@@ -33,7 +33,6 @@ class BackupManager {
     this.deleteLocalBackupFile = this.deleteLocalBackupFile.bind(this)
     this.backupToLocalDir = this.backupToLocalDir.bind(this)
     this.restoreFromLocalBackup = this.restoreFromLocalBackup.bind(this)
-    this.setLocalBackupDir = this.setLocalBackupDir.bind(this)
     this.backupToS3 = this.backupToS3.bind(this)
     this.restoreFromS3 = this.restoreFromS3.bind(this)
     this.listS3Files = this.listS3Files.bind(this)
@@ -595,17 +594,6 @@ class BackupManager {
       return true
     } catch (error) {
       logger.error('[BackupManager] Delete local backup file failed:', error as Error)
-      throw error
-    }
-  }
-
-  async setLocalBackupDir(_: Electron.IpcMainInvokeEvent, dirPath: string) {
-    try {
-      // Check if directory exists
-      await fs.ensureDir(dirPath)
-      return true
-    } catch (error) {
-      logger.error('[BackupManager] Set local backup directory failed:', error as Error)
       throw error
     }
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -118,7 +118,6 @@ const api = {
       ipcRenderer.invoke(IpcChannel.Backup_ListLocalBackupFiles, localBackupDir),
     deleteLocalBackupFile: (fileName: string, localBackupDir?: string) =>
       ipcRenderer.invoke(IpcChannel.Backup_DeleteLocalBackupFile, fileName, localBackupDir),
-    setLocalBackupDir: (dirPath: string) => ipcRenderer.invoke(IpcChannel.Backup_SetLocalBackupDir, dirPath),
     checkWebdavConnection: (webdavConfig: WebDavConfig) =>
       ipcRenderer.invoke(IpcChannel.Backup_CheckConnection, webdavConfig),
 

--- a/src/renderer/src/components/LocalBackupManager.tsx
+++ b/src/renderer/src/components/LocalBackupManager.tsx
@@ -31,7 +31,6 @@ export function LocalBackupManager({ visible, onClose, localBackupDir, restoreMe
     pageSize: 5,
     total: 0
   })
-
   const fetchBackupFiles = useCallback(async () => {
     if (!localBackupDir) {
       return

--- a/src/renderer/src/pages/settings/DataSettings/LocalBackupSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/LocalBackupSettings.tsx
@@ -46,13 +46,8 @@ const LocalBackupSettings: React.FC = () => {
   const [appInfo, setAppInfo] = useState<AppInfo>()
 
   useEffect(() => {
-    if (localBackupDir) {
-      window.api.resolvePath(localBackupDir).then(setResolvedLocalBackupDir)
-    }
-  }, [localBackupDir])
-
-  useEffect(() => {
     window.api.getAppInfo().then(setAppInfo)
+    window.api.resolvePath(localBackupDirSetting).then(setResolvedLocalBackupDir)
   }, [])
 
   const { theme } = useTheme()
@@ -117,8 +112,7 @@ const LocalBackupSettings: React.FC = () => {
     if (await checkLocalBackupDirValid(value)) {
       setLocalBackupDir(value)
       dispatch(_setLocalBackupDir(value))
-      // Create directory if it doesn't exist and set it in the backend
-      await window.api.backup.setLocalBackupDir(value)
+      setResolvedLocalBackupDir(await window.api.resolvePath(value))
 
       dispatch(setLocalBackupAutoSync(true))
       startAutoSync(true, 'local')

--- a/src/renderer/src/pages/settings/DataSettings/LocalBackupSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/LocalBackupSettings.tsx
@@ -47,8 +47,13 @@ const LocalBackupSettings: React.FC = () => {
 
   useEffect(() => {
     window.api.getAppInfo().then(setAppInfo)
-    window.api.resolvePath(localBackupDirSetting).then(setResolvedLocalBackupDir)
   }, [])
+
+  useEffect(() => {
+    if (localBackupDirSetting) {
+      window.api.resolvePath(localBackupDirSetting).then(setResolvedLocalBackupDir)
+    }
+  }, [localBackupDirSetting])
 
   const { theme } = useTheme()
 

--- a/src/renderer/src/pages/settings/DataSettings/LocalBackupSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/LocalBackupSettings.tsx
@@ -36,6 +36,7 @@ const LocalBackupSettings: React.FC = () => {
   } = useSettings()
 
   const [localBackupDir, setLocalBackupDir] = useState<string | undefined>(localBackupDirSetting)
+  const [resolvedLocalBackupDir, setResolvedLocalBackupDir] = useState<string | undefined>(undefined)
   const [localBackupSkipBackupFile, setLocalBackupSkipBackupFile] = useState<boolean>(localBackupSkipBackupFileSetting)
   const [backupManagerVisible, setBackupManagerVisible] = useState(false)
 
@@ -43,6 +44,12 @@ const LocalBackupSettings: React.FC = () => {
   const [maxBackups, setMaxBackups] = useState<number>(localBackupMaxBackupsSetting)
 
   const [appInfo, setAppInfo] = useState<AppInfo>()
+
+  useEffect(() => {
+    if (localBackupDir) {
+      window.api.resolvePath(localBackupDir).then(setResolvedLocalBackupDir)
+    }
+  }, [localBackupDir])
 
   useEffect(() => {
     window.api.getAppInfo().then(setAppInfo)
@@ -183,7 +190,7 @@ const LocalBackupSettings: React.FC = () => {
   }
 
   const { isModalVisible, handleBackup, handleCancel, backuping, customFileName, setCustomFileName, showBackupModal } =
-    useLocalBackupModal(localBackupDir)
+    useLocalBackupModal(resolvedLocalBackupDir)
 
   const showBackupManager = () => {
     setBackupManagerVisible(true)
@@ -298,7 +305,7 @@ const LocalBackupSettings: React.FC = () => {
         <LocalBackupManager
           visible={backupManagerVisible}
           onClose={closeBackupManager}
-          localBackupDir={localBackupDir}
+          localBackupDir={resolvedLocalBackupDir}
         />
       </>
     </SettingGroup>

--- a/src/renderer/src/services/BackupService.ts
+++ b/src/renderer/src/services/BackupService.ts
@@ -906,9 +906,6 @@ export async function backupToLocal({
   showMessage?: boolean
   customFileName?: string
   autoBackupProcess?: boolean
-  localBackupDir?: string
-  localBackupMaxBackups?: number
-  localBackupSkipBackupFile?: boolean
 } = {}) {
   const notificationService = NotificationService.getInstance()
   if (isManualBackupRunning) {

--- a/src/renderer/src/services/BackupService.ts
+++ b/src/renderer/src/services/BackupService.ts
@@ -902,7 +902,14 @@ export async function backupToLocal({
   showMessage = false,
   customFileName = '',
   autoBackupProcess = false
-}: { showMessage?: boolean; customFileName?: string; autoBackupProcess?: boolean } = {}) {
+}: {
+  showMessage?: boolean
+  customFileName?: string
+  autoBackupProcess?: boolean
+  localBackupDir?: string
+  localBackupMaxBackups?: number
+  localBackupSkipBackupFile?: boolean
+} = {}) {
   const notificationService = NotificationService.getInstance()
   if (isManualBackupRunning) {
     logger.verbose('Manual backup already in progress')
@@ -917,7 +924,12 @@ export async function backupToLocal({
 
   store.dispatch(setLocalBackupSyncState({ syncing: true, lastSyncError: null }))
 
-  const { localBackupDir, localBackupMaxBackups, localBackupSkipBackupFile } = store.getState().settings
+  const {
+    localBackupDir: localBackupDirSetting,
+    localBackupMaxBackups,
+    localBackupSkipBackupFile
+  } = store.getState().settings
+  const localBackupDir = await window.api.resolvePath(localBackupDirSetting)
   let deviceType = 'unknown'
   let hostname = 'unknown'
   try {
@@ -1039,9 +1051,9 @@ export async function backupToLocal({
 }
 
 export async function restoreFromLocal(fileName: string) {
-  const { localBackupDir } = store.getState().settings
-
   try {
+    const { localBackupDir: localBackupDirSetting } = store.getState().settings
+    const localBackupDir = await window.api.resolvePath(localBackupDirSetting)
     const restoreData = await window.api.backup.restoreFromLocalBackup(fileName, localBackupDir)
     const data = JSON.parse(restoreData)
     await handleData(data)


### PR DESCRIPTION
- Added a new state to manage the resolved local backup directory in LocalBackupSettings.
- Updated the LocalBackupManager component to use the resolved directory instead of the raw input.
- Enhanced the backupToLocal and restoreFromLocal functions to resolve the local backup directory path before use, improving reliability.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
如果路径是相对路径，备份和恢复有问题，不能正常显示

After this PR:

相对路径下，备份和恢复也能正常工作。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
