### PR TITLE
fix: remove compareVersions utility and update version check logic in AboutSettings

### DIFF
--- a/src/renderer/src/pages/settings/AboutSettings.tsx
+++ b/src/renderer/src/pages/settings/AboutSettings.tsx
@@ -10,7 +10,7 @@ import i18n from '@renderer/i18n'
 import { useAppDispatch } from '@renderer/store'
 import { setUpdateState } from '@renderer/store/runtime'
 import { ThemeMode } from '@renderer/types'
-import { compareVersions, runAsyncFunction } from '@renderer/utils'
+import { runAsyncFunction } from '@renderer/utils'
 import { UpgradeChannel } from '@shared/config/constant'
 import { Avatar, Button, Progress, Radio, Row, Switch, Tag, Tooltip } from 'antd'
 import { debounce } from 'lodash'
@@ -96,7 +96,8 @@ const AboutSettings: FC = () => {
     })
   }
 
-  const hasNewVersion = update?.info?.version && version ? compareVersions(update.info.version, version) > 0 : false
+  // don't support downgrade, so we only check if the version is different
+  const hasNewVersion = update?.info?.version && version ? update.info.version !== version : false
 
   const currentChannelByVersion =
     [

--- a/src/renderer/src/utils/__tests__/index.test.ts
+++ b/src/renderer/src/utils/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { runAsyncFunction } from '../index'
-import { compareVersions, hasPath, isFreeModel, isValidProxyUrl, removeQuotes, removeSpecialCharacters } from '../index'
+import { hasPath, isFreeModel, isValidProxyUrl, removeQuotes, removeSpecialCharacters } from '../index'
 
 describe('Unclassified Utils', () => {
   describe('runAsyncFunction', () => {
@@ -108,34 +108,6 @@ describe('Unclassified Utils', () => {
     it('should return false for invalid url', () => {
       expect(hasPath('not a url')).toBe(false)
       expect(hasPath('')).toBe(false)
-    })
-  })
-
-  describe('compareVersions', () => {
-    it('should return 1 if v1 > v2', () => {
-      expect(compareVersions('1.2.3', '1.2.2')).toBe(1)
-      expect(compareVersions('2.0.0', '1.9.9')).toBe(1)
-      expect(compareVersions('1.2.0', '1.1.9')).toBe(1)
-      expect(compareVersions('1.2.3', '1.2')).toBe(1)
-    })
-
-    it('should return -1 if v1 < v2', () => {
-      expect(compareVersions('1.2.2', '1.2.3')).toBe(-1)
-      expect(compareVersions('1.9.9', '2.0.0')).toBe(-1)
-      expect(compareVersions('1.1.9', '1.2.0')).toBe(-1)
-      expect(compareVersions('1.2', '1.2.3')).toBe(-1)
-    })
-
-    it('should return 0 if v1 == v2', () => {
-      expect(compareVersions('1.2.3', '1.2.3')).toBe(0)
-      expect(compareVersions('1.2', '1.2.0')).toBe(0)
-      expect(compareVersions('1.0.0', '1')).toBe(0)
-    })
-
-    it('should handle non-numeric and empty string', () => {
-      expect(compareVersions('', '')).toBe(0)
-      expect(compareVersions('a.b.c', '1.2.3')).toBe(-1)
-      expect(compareVersions('1.2.3', 'a.b.c')).toBe(1)
     })
   })
 })

--- a/src/renderer/src/utils/index.ts
+++ b/src/renderer/src/utils/index.ts
@@ -148,25 +148,6 @@ export function hasPath(url: string): boolean {
 }
 
 /**
- * 比较两个版本号字符串。
- * @param {string} v1 第一个版本号
- * @param {string} v2 第二个版本号
- * @returns {number} 比较结果，1 表示 v1 大于 v2，-1 表示 v1 小于 v2，0 表示相等
- */
-export const compareVersions = (v1: string, v2: string): number => {
-  const v1Parts = v1.split('.').map(Number)
-  const v2Parts = v2.split('.').map(Number)
-
-  for (let i = 0; i < Math.max(v1Parts.length, v2Parts.length); i++) {
-    const v1Part = v1Parts[i] || 0
-    const v2Part = v2Parts[i] || 0
-    if (v1Part > v2Part) return 1
-    if (v1Part < v2Part) return -1
-  }
-  return 0
-}
-
-/**
  * 显示确认模态框。
  * @param {ModalFuncProps} params 模态框参数
  * @returns {Promise<boolean>} 用户确认返回 true，取消返回 false


### PR DESCRIPTION
… AboutSettings

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

test plan有新版本的时候，不会显示出release notes.

因为compareVersions针对1.5.3和1.5.4-rc.1的对比是有问题的

<img width="2039" height="969" alt="image" src="https://github.com/user-attachments/assets/157496b8-6d23-45f1-8138-c24566a74c98" />


After this PR:

删除compareVersions，cs不支持downgrade，所以不需要判断版本大小，只需要判断判断不同就认为有新版本了。

测试结果：
<img width="3369" height="1506" alt="image" src="https://github.com/user-attachments/assets/b61f913b-fc3f-4361-8ec2-70d9b84fe5a1" />


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
