### PR TITLE
fix(AppUpdater): simplify error logging and update version check logic

### DIFF
--- a/src/main/services/AppUpdater.ts
+++ b/src/main/services/AppUpdater.ts
@@ -31,17 +31,12 @@ export default class AppUpdater {
     }
 
     autoUpdater.on('error', (error) => {
-      // 简单记录错误信息和时间戳
-      logger.error('更新异常', {
-        message: error.message,
-        stack: error.stack,
-        time: new Date().toISOString()
-      })
+      logger.error('update error', error as Error)
       mainWindow.webContents.send(IpcChannel.UpdateError, error)
     })
 
     autoUpdater.on('update-available', (releaseInfo: UpdateInfo) => {
-      logger.info('检测到新版本', releaseInfo)
+      logger.info('update available', releaseInfo)
       mainWindow.webContents.send(IpcChannel.UpdateAvailable, releaseInfo)
     })
 
@@ -65,7 +60,7 @@ export default class AppUpdater {
     autoUpdater.on('update-downloaded', (releaseInfo: UpdateInfo) => {
       mainWindow.webContents.send(IpcChannel.UpdateDownloaded, releaseInfo)
       this.releaseInfo = releaseInfo
-      logger.info('下载完成', releaseInfo)
+      logger.info('update downloaded', releaseInfo)
     })
 
     if (isWin) {
@@ -242,7 +237,7 @@ export default class AppUpdater {
 
       return {
         currentVersion: this.autoUpdater.currentVersion,
-        updateInfo: this.updateCheckResult?.updateInfo
+        updateInfo: this.updateCheckResult?.isUpdateAvailable ? this.updateCheckResult?.updateInfo : null
       }
     } catch (error) {
       logger.error('Failed to check for update:', error as Error)

--- a/src/renderer/src/hooks/useAppInit.ts
+++ b/src/renderer/src/hooks/useAppInit.ts
@@ -62,8 +62,8 @@ export function useAppInit() {
       const { isPackaged } = await window.api.getAppInfo()
       if (isPackaged && autoCheckUpdate) {
         await delay(2)
-        const { updateInfo, isUpdateAvailable } = await window.api.checkForUpdate()
-        dispatch(setUpdateState({ info: updateInfo, available: isUpdateAvailable }))
+        const { updateInfo } = await window.api.checkForUpdate()
+        dispatch(setUpdateState({ info: updateInfo }))
       }
     })
   }, [dispatch, autoCheckUpdate])

--- a/src/renderer/src/hooks/useAppInit.ts
+++ b/src/renderer/src/hooks/useAppInit.ts
@@ -62,8 +62,8 @@ export function useAppInit() {
       const { isPackaged } = await window.api.getAppInfo()
       if (isPackaged && autoCheckUpdate) {
         await delay(2)
-        const { updateInfo } = await window.api.checkForUpdate()
-        dispatch(setUpdateState({ info: updateInfo }))
+        const { updateInfo, isUpdateAvailable } = await window.api.checkForUpdate()
+        dispatch(setUpdateState({ info: updateInfo, available: isUpdateAvailable }))
       }
     })
   }, [dispatch, autoCheckUpdate])

--- a/src/renderer/src/pages/settings/AboutSettings.tsx
+++ b/src/renderer/src/pages/settings/AboutSettings.tsx
@@ -96,9 +96,6 @@ const AboutSettings: FC = () => {
     })
   }
 
-  // don't support downgrade, so we only check if the version is different
-  const hasNewVersion = update?.info?.version && version ? update.info.version !== version : false
-
   const currentChannelByVersion =
     [
       { pattern: `-${UpgradeChannel.BETA}.`, channel: UpgradeChannel.BETA },
@@ -267,7 +264,7 @@ const AboutSettings: FC = () => {
           </>
         )}
       </SettingGroup>
-      {hasNewVersion && update.info && (
+      {update.info && update.available && (
         <SettingGroup theme={theme}>
           <SettingRow>
             <SettingRowTitle>


### PR DESCRIPTION
- Updated error logging to use a more concise format.
- Changed logging messages for update events to be more consistent.
- Modified the update check logic to return null when no update is available.
- Enhanced the app initialization hook to include update availability in the state dispatch.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
<img width="2656" height="1824" alt="企业微信截图_33989fb7-622a-46b1-8cb2-eec9b8152db2" src="https://github.com/user-attachments/assets/2f1755a4-3ca4-4f6e-9364-b4f246745cee" />


会显示出低版本的update info，不会降级的。

After this PR:

不显示出低版本的update info。直接使用electron updater 的availabe 信号来显示，而不是render上面自己判断有没有新版本。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
