### PR TITLE
feat(database): enable strict transaction durability for CherryStudio database

### DIFF
--- a/src/renderer/src/databases/index.ts
+++ b/src/renderer/src/databases/index.ts
@@ -6,7 +6,9 @@ import { Dexie, type EntityTable } from 'dexie'
 import { upgradeToV5, upgradeToV7, upgradeToV8 } from './upgrades'
 
 // Database declaration (move this to its own module also)
-export const db = new Dexie('CherryStudio') as Dexie & {
+export const db = new Dexie('CherryStudio', {
+  chromeTransactionDurability: 'strict'
+}) as Dexie & {
   files: EntityTable<FileMetadata, 'id'>
   topics: EntityTable<{ id: string; messages: NewMessage[] }, 'id'> // Correct type for topics
   settings: EntityTable<{ id: string; value: any }, 'id'>


### PR DESCRIPTION
Fix https://github.com/CherryHQ/cherry-studio/issues/8734

The default durability mode in IndexedDB is changing from strict to relaxed from Chrome 121. This adjustment is to enhance performance and to align with other major browsers like Firefox and Safari. 

[IndexedDB](https://developer.mozilla.org/docs/Web/API/IndexedDB_API), a powerful web API for storing large amounts of structured data, offers two [durability](https://developer.mozilla.org/docs/Web/API/IDBDatabase/transaction#durability) modes for readwrite transactions:

strict: this mode explicitly instructs the OS to flush changes to disk before issuing the [complete](https://developer.mozilla.org/docs/Web/API/IDBTransaction/complete_event) event.
relaxed this mode relies on default OS flushing behavior and issues the complete event after changes make it to the OS buffer, which is typically flushed every couple seconds.
It's important to note that strict does not ensure that changes are actually written immediately to disk. After a site calls [put()](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/put), there's still some finite amount of time during which a power failure could cause the change to not make it to disk and therefore be missing the next time the app runs.

When it comes to guarantees with strict durability, the IndexedDB transaction complete event is not fired until after the data is actually written, whereas with relaxed durability, the data is still in the process of being written when the complete event fires. (For more details about the full process, [check this explainer](https://wicg.github.io/storage-buckets/explainer.html#durability-guarantees)).

So strict is really only for operations where you absolutely need to know it was written before you do the next thing. Data migration is an example where strict durability is required. When moving from one backing store to another, you don't want to delete the old format until the new one is written. This way, strict durability facilitates a migration routine that could recover from a failure halfway through.