### PR TITLE
fix: conditional auto-focus based on last focused component

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -704,7 +704,10 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
 
   useEffect(() => {
     if (!document.querySelector('.topview-fullscreen-container')) {
-      textareaRef.current?.focus()
+      const lastFocusedComponent = PasteService.getLastFocusedComponent()
+      if (lastFocusedComponent === 'inputbar') {
+        textareaRef.current?.focus()
+      }
     }
   }, [assistant, topic])
 


### PR DESCRIPTION
Close: #8706 

After：如果上一个聚焦的不是输入框，信息输出完成的时候我们不会再次聚焦到输入框。


https://github.com/user-attachments/assets/52e84613-83bc-4eaf-8ff6-45a37b10268a

