### PR TITLE
feat: add smooth transition animation to narrow mode toggle

### DIFF
--- a/src/renderer/src/pages/home/Messages/NarrowLayout.tsx
+++ b/src/renderer/src/pages/home/Messages/NarrowLayout.tsx
@@ -9,22 +9,23 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
 const NarrowLayout: FC<Props> = ({ children, ...props }) => {
   const { narrowMode } = useSettings()
 
-  if (narrowMode) {
-    return (
-      <Container className="narrow-mode" {...props}>
-        {children}
-      </Container>
-    )
-  }
-
-  return children
+  return (
+    <Container className={`narrow-mode ${narrowMode ? 'active' : ''}`} {...props}>
+      {children}
+    </Container>
+  )
 }
 
 const Container = styled.div`
-  max-width: 800px;
+  max-width: 100%;
   width: 100%;
   margin: 0 auto;
   position: relative;
+  transition: max-width 0.3s ease-in-out;
+
+  &.active {
+    max-width: 800px;
+  }
 `
 
 export default NarrowLayout


### PR DESCRIPTION
1. 点击伸缩模式，会有卡顿，看下面这段代码应该似乎是重新渲染了一次，但是这里应该只要修改样式而不是重新渲染。

```tsx
 if (narrowMode) {
    return (
      <Container className="narrow-mode" {...props}>
        {children}
      </Container>
    )
  }

 return children
```

2. 添加了伸缩的过渡效果


<table>

<tr>

<td>

Before

<td>

After

<tr>

<td>

https://github.com/user-attachments/assets/fa8bc4ce-359d-4d72-92e3-667f0ae730fd


<td>

https://github.com/user-attachments/assets/4d937d93-f152-442b-8155-5a03094cec8d


</table>


