### PR TITLE
perf: improve model list loading

### DIFF
--- a/src/renderer/src/components/Icons/SvgSpinners180Ring.tsx
+++ b/src/renderer/src/components/Icons/SvgSpinners180Ring.tsx
@@ -1,20 +1,41 @@
 import { SVGProps } from 'react'
 
 export function SvgSpinners180Ring(props: SVGProps<SVGSVGElement>) {
+  // 避免与全局样式冲突
+  const animationClassName = 'svg-spinner-anim-180-ring'
+
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" {...props}>
-      {/* Icon from SVG Spinners by Utkarsh Verma - https://github.com/n3r4zzurr0/svg-spinners/blob/main/LICENSE */}
-      <path
-        fill="currentColor"
-        d="M12,4a8,8,0,0,1,7.89,6.7A1.53,1.53,0,0,0,21.38,12h0a1.5,1.5,0,0,0,1.48-1.75,11,11,0,0,0-21.72,0A1.5,1.5,0,0,0,2.62,12h0a1.53,1.53,0,0,0,1.49-1.3A8,8,0,0,1,12,4Z">
-        <animateTransform
-          attributeName="transform"
-          dur="0.75s"
-          repeatCount="indefinite"
-          type="rotate"
-          values="0 12 12;360 12 12"></animateTransform>
-      </path>
-    </svg>
+    <>
+      {/*  CSS transform 硬件加速 */}
+      <style>
+        {`
+          @keyframes svg-spinner-rotate-180-ring {
+            from {
+              transform: rotate(0deg);
+            }
+            to {
+              transform: rotate(360deg);
+            }
+          }
+          .${animationClassName} {
+            transform-origin: center;
+            animation: svg-spinner-rotate-180-ring 0.75s linear infinite;
+          }
+        `}
+      </style>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="1em"
+        height="1em"
+        viewBox="0 0 24 24"
+        {...props}
+        className={`${animationClassName} ${props.className || ''}`.trim()}>
+        {/* Icon from SVG Spinners by Utkarsh Verma - https://github.com/n3r4zzurr0/svg-spinners/blob/main/LICENSE */}
+        <path
+          fill="currentColor"
+          d="M12,4a8,8,0,0,1,7.89,6.7A1.53,1.53,0,0,0,21.38,12h0a1.5,1.5,0,0,0,1.48-1.75,11,11,0,0,0-21.72,0A1.5,1.5,0,0,0,2.62,12h0a1.53,1.53,0,0,0,1.49-1.3A8,8,0,0,1,12,4Z"></path>
+      </svg>
+    </>
   )
 }
 export default SvgSpinners180Ring

--- a/src/renderer/src/components/ModelList/ModelList.tsx
+++ b/src/renderer/src/components/ModelList/ModelList.tsx
@@ -16,8 +16,8 @@ import { useAppDispatch } from '@renderer/store'
 import { setModel } from '@renderer/store/assistants'
 import { Model } from '@renderer/types'
 import { filterModelsByKeywords } from '@renderer/utils'
-import { Button, Flex, Spin, Tooltip } from 'antd'
-import { groupBy, sortBy, toPairs } from 'lodash'
+import { Button, Empty, Flex, Spin, Tooltip } from 'antd'
+import { groupBy, isEmpty, sortBy, toPairs } from 'lodash'
 import { ListCheck, Plus } from 'lucide-react'
 import React, { memo, startTransition, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -134,6 +134,8 @@ const ModelList: React.FC<ModelListProps> = ({ providerId }) => {
     [provider, onUpdateModel]
   )
 
+  const isLoading = useMemo(() => displayedModelGroups === null, [displayedModelGroups])
+
   return (
     <>
       <SettingSubtitle style={{ marginBottom: 5 }}>
@@ -158,54 +160,60 @@ const ModelList: React.FC<ModelListProps> = ({ providerId }) => {
           </HStack>
         </HStack>
       </SettingSubtitle>
-      {displayedModelGroups === null ? (
-        <Flex align="center" justify="center" style={{ minHeight: '8rem' }}>
-          <Spin indicator={<SvgSpinners180Ring color="var(--color-text-2)" />} />
+      <Spin spinning={isLoading} indicator={<SvgSpinners180Ring color="var(--color-text-2)" />}>
+        {displayedModelGroups && !isEmpty(displayedModelGroups) ? (
+          <Flex gap={12} vertical>
+            {Object.keys(displayedModelGroups).map((group, i) => (
+              <ModelListGroup
+                key={group}
+                groupName={group}
+                models={displayedModelGroups[group]}
+                modelStatuses={modelStatuses}
+                defaultOpen={i <= 5}
+                disabled={isHealthChecking}
+                onEditModel={onEditModel}
+                onRemoveModel={removeModel}
+                onRemoveGroup={() => displayedModelGroups[group].forEach((model) => removeModel(model))}
+              />
+            ))}
+          </Flex>
+        ) : (
+          <Empty
+            image={Empty.PRESENTED_IMAGE_SIMPLE}
+            description={t('settings.models.empty')}
+            style={{ visibility: isLoading ? 'hidden' : 'visible' }}
+          />
+        )}
+      </Spin>
+      <Flex justify="space-between" align="center">
+        {docsWebsite || modelsWebsite ? (
+          <SettingHelpTextRow>
+            <SettingHelpText>{t('settings.provider.docs_check')} </SettingHelpText>
+            {docsWebsite && (
+              <SettingHelpLink target="_blank" href={docsWebsite}>
+                {getProviderLabel(provider.id) + ' '}
+                {t('common.docs')}
+              </SettingHelpLink>
+            )}
+            {docsWebsite && modelsWebsite && <SettingHelpText>{t('common.and')}</SettingHelpText>}
+            {modelsWebsite && (
+              <SettingHelpLink target="_blank" href={modelsWebsite}>
+                {t('common.models')}
+              </SettingHelpLink>
+            )}
+            <SettingHelpText>{t('settings.provider.docs_more_details')}</SettingHelpText>
+          </SettingHelpTextRow>
+        ) : (
+          <div style={{ height: 5 }} />
+        )}
+        <Flex gap={10} style={{ marginTop: 12 }}>
+          <Button type="primary" onClick={onManageModel} icon={<ListCheck size={16} />} disabled={isHealthChecking}>
+            {t('button.manage')}
+          </Button>
+          <Button type="default" onClick={onAddModel} icon={<Plus size={16} />} disabled={isHealthChecking}>
+            {t('button.add')}
+          </Button>
         </Flex>
-      ) : (
-        <Flex gap={12} vertical>
-          {Object.keys(displayedModelGroups).map((group, i) => (
-            <ModelListGroup
-              key={group}
-              groupName={group}
-              models={displayedModelGroups[group]}
-              modelStatuses={modelStatuses}
-              defaultOpen={i <= 5}
-              disabled={isHealthChecking}
-              onEditModel={onEditModel}
-              onRemoveModel={removeModel}
-              onRemoveGroup={() => displayedModelGroups[group].forEach((model) => removeModel(model))}
-            />
-          ))}
-          {docsWebsite || modelsWebsite ? (
-            <SettingHelpTextRow>
-              <SettingHelpText>{t('settings.provider.docs_check')} </SettingHelpText>
-              {docsWebsite && (
-                <SettingHelpLink target="_blank" href={docsWebsite}>
-                  {getProviderLabel(provider.id) + ' '}
-                  {t('common.docs')}
-                </SettingHelpLink>
-              )}
-              {docsWebsite && modelsWebsite && <SettingHelpText>{t('common.and')}</SettingHelpText>}
-              {modelsWebsite && (
-                <SettingHelpLink target="_blank" href={modelsWebsite}>
-                  {t('common.models')}
-                </SettingHelpLink>
-              )}
-              <SettingHelpText>{t('settings.provider.docs_more_details')}</SettingHelpText>
-            </SettingHelpTextRow>
-          ) : (
-            <div style={{ height: 5 }} />
-          )}
-        </Flex>
-      )}
-      <Flex gap={10} style={{ marginTop: 10 }}>
-        <Button type="primary" onClick={onManageModel} icon={<ListCheck size={16} />} disabled={isHealthChecking}>
-          {t('button.manage')}
-        </Button>
-        <Button type="default" onClick={onAddModel} icon={<Plus size={16} />} disabled={isHealthChecking}>
-          {t('button.add')}
-        </Button>
       </Flex>
     </>
   )


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

- 改善 SvgSpinners180Ring 性能
- 模型列表出现时启用淡入动画
- 没有模型时显示占位符

Before this PR:

SvgSpinners180Ring 一直没有用 transform，所以看起来很卡。

https://github.com/user-attachments/assets/67eb2334-ab80-4af7-9551-fefdd1d2de44

After this PR:

https://github.com/user-attachments/assets/c346c9e8-bd27-4692-9044-4bf3e438c29f

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
