### PR TITLE
fix: implement data save confirmation on window close to prevent data loss

### DIFF
--- a/packages/shared/IpcChannel.ts
+++ b/packages/shared/IpcChannel.ts
@@ -35,6 +35,7 @@ export enum IpcChannel {
   App_InstallBunBinary = 'app:install-bun-binary',
   App_LogToMain = 'app:log-to-main',
   App_SaveData = 'app:save-data',
+  App_SaveDataComplete = 'app:save-data-complete',
 
   App_MacIsProcessTrusted = 'app:mac-is-process-trusted',
   App_MacRequestProcessTrust = 'app:mac-request-process-trust',

--- a/src/renderer/src/hooks/useAppInit.ts
+++ b/src/renderer/src/hooks/useAppInit.ts
@@ -54,6 +54,8 @@ export function useAppInit() {
   useEffect(() => {
     window.electron.ipcRenderer.on(IpcChannel.App_SaveData, async () => {
       await handleSaveData()
+      // 发送保存完成确认
+      window.electron.ipcRenderer.send(IpcChannel.App_SaveDataComplete)
     })
   }, [])
 


### PR DESCRIPTION
## 修复：解决窗口关闭时的数据丢失问题

###  问题描述

  项目目前存在严重的数据丢失问题：当用户通过任务栏右键关闭、Alt+F4 或断电、死机等关闭等方式退出应用时，有可能丢失全部用户数据 #8637


###  问题成因分析


我的分析是当任务栏右键关闭时，Windows 强制终止进程，导致异步数据写入中断，再次启动时 Chromium 检测到存储不完整，清空"损坏"的 localStorage 和 IndexedDB 导致除文件外（不经过 Chromium 存储管理）的所有数据归零。

###  本次紧急修复方案

  1. 拦截窗口关闭事件
  mainWindow.on('close', (event) => {
    event.preventDefault()  // 阻止立即关闭
    // 等待数据保存完成后再关闭
  })
  2. 实现保存确认机制
    - 新增 App_SaveDataComplete IPC 通道
    - 渲染进程保存完成后发送确认消息
    - 主进程收到确认后才真正退出
  3. 增强数据保存流程
    - 取消所有节流的消息更新，强制立即保存
    - 等待 IndexedDB 操作完成
    - 设置 5 秒超时保护，防止应用卡死

 ### 修复效果

  - 解决了正常关闭场景下的数据丢失
  - 包括：任务栏关闭、Alt+F4、窗口关闭按钮等
  - 断电、系统崩溃、强制结束进程等异常场景仍然未解决，这是一个不完美的紧急修复

###  后续改进计划


考虑全部使用文件存储或者迁移到 SQLite 
 