### PR TITLE
fix: auto-close panel when no commands match (#7824)

### DIFF
--- a/src/renderer/src/components/QuickPanel/view.tsx
+++ b/src/renderer/src/components/QuickPanel/view.tsx
@@ -495,15 +495,6 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
     return () => window.removeEventListener('resize', handleResize)
   }, [ctx.isVisible])
 
-  // 组件卸载时清理定时器
-  useEffect(() => {
-    return () => {
-      if (noMatchTimeoutRef.current) {
-        clearTimeout(noMatchTimeoutRef.current)
-        noMatchTimeoutRef.current = null
-      }
-    }
-  }, [])
 
   const listHeight = useMemo(() => {
     return Math.min(ctx.pageSize, list.length) * ITEM_HEIGHT

--- a/src/renderer/src/components/QuickPanel/view.tsx
+++ b/src/renderer/src/components/QuickPanel/view.tsx
@@ -166,6 +166,7 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
         noMatchTimeoutRef.current = null
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- ctx对象引用不稳定，使用具体属性避免过度重渲染
   }, [ctx.isVisible, searchText, list.length, ctx.close])
 
   const clearSearchText = useCallback(

--- a/src/renderer/src/components/QuickPanel/view.tsx
+++ b/src/renderer/src/components/QuickPanel/view.tsx
@@ -141,10 +141,15 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
   useEffect(() => {
     const _searchText = searchText.replace(/^[/@]/, '')
     
-    // 清除之前的定时器
+    // 清除之前的定时器（无论面板是否可见都要清理）
     if (noMatchTimeoutRef.current) {
       clearTimeout(noMatchTimeoutRef.current)
       noMatchTimeoutRef.current = null
+    }
+    
+    // 面板不可见时不设置新定时器
+    if (!ctx.isVisible) {
+      return
     }
     
     // 只有在有搜索文本但无匹配项时才设置延迟关闭
@@ -161,7 +166,7 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
         noMatchTimeoutRef.current = null
       }
     }
-  }, [searchText, list.length, ctx])
+  }, [ctx.isVisible, searchText, list.length, ctx.close])
 
   const clearSearchText = useCallback(
     (includeSymbol = false) => {

--- a/src/renderer/src/components/QuickPanel/view.tsx
+++ b/src/renderer/src/components/QuickPanel/view.tsx
@@ -131,7 +131,7 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
     prevSymbolRef.current = ctx.symbol
 
     return newList
-  }, [ctx, searchText])
+  }, [ctx.isVisible, ctx.symbol, ctx.list, searchText])
 
   const canForwardAndBackward = useMemo(() => {
     return list.some((item) => item.isMenu) || historyPanel.length > 0
@@ -140,25 +140,25 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
   // 智能关闭逻辑：当有搜索文本但无匹配项时，延迟关闭面板
   useEffect(() => {
     const _searchText = searchText.replace(/^[/@]/, '')
-    
+
     // 清除之前的定时器（无论面板是否可见都要清理）
     if (noMatchTimeoutRef.current) {
       clearTimeout(noMatchTimeoutRef.current)
       noMatchTimeoutRef.current = null
     }
-    
+
     // 面板不可见时不设置新定时器
     if (!ctx.isVisible) {
       return
     }
-    
+
     // 只有在有搜索文本但无匹配项时才设置延迟关闭
     if (_searchText && _searchText.length > 0 && list.length === 0) {
       noMatchTimeoutRef.current = setTimeout(() => {
         ctx.close('no-matches')
       }, 300)
     }
-    
+
     // 清理函数
     return () => {
       if (noMatchTimeoutRef.current) {
@@ -499,7 +499,6 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
     window.addEventListener('resize', handleResize)
     return () => window.removeEventListener('resize', handleResize)
   }, [ctx.isVisible])
-
 
   const listHeight = useMemo(() => {
     return Math.min(ctx.pageSize, list.length) * ITEM_HEIGHT

--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -527,68 +527,6 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
       if (enableQuickPanelTriggers && !quickPanel.isVisible && lastSymbol === '@') {
         inputbarToolsRef.current?.openMentionModelsPanel()
       }
-
-      // 删除过程中的智能重新打开逻辑：只有在有匹配项时才重新打开面板
-      if (enableQuickPanelTriggers && !quickPanel.isVisible && lastSymbol !== '/' && lastSymbol !== '@') {
-        const textBeforeCursor = newText.slice(0, cursorPosition)
-        const lastSlashIndex = textBeforeCursor.lastIndexOf('/')
-        const lastAtIndex = textBeforeCursor.lastIndexOf('@')
-        const lastSymbolIndex = Math.max(lastSlashIndex, lastAtIndex)
-
-        if (lastSymbolIndex !== -1) {
-          const symbolType = lastSlashIndex > lastAtIndex ? '/' : '@'
-          const searchText = textBeforeCursor.slice(lastSymbolIndex)
-
-          if (symbolType === '/') {
-            const _searchText = searchText.replace(/^\//, '')
-            // 优化：只在搜索文本长度 > 0 且 <= 10 时执行匹配检查，避免过长搜索文本的性能问题
-            if (_searchText.length > 0 && _searchText.length <= 10) {
-              const quickPanelMenu =
-                inputbarToolsRef.current?.getQuickPanelMenu({
-                  t,
-                  files,
-                  couldAddImageFile,
-                  text: newText,
-                  openSelectFileMenu,
-                  translate
-                }) || []
-
-              // 优化：简化匹配逻辑，只做基础字符串匹配，避免复杂正则运算
-              const hasMatches = quickPanelMenu.some((item) => {
-                let filterText = item.filterText || ''
-                if (typeof item.label === 'string') {
-                  filterText += item.label
-                }
-                if (typeof item.description === 'string') {
-                  filterText += item.description
-                }
-                return filterText.toLowerCase().includes(_searchText.toLowerCase())
-              })
-
-              // 只有在确实有匹配项时才重新打开面板
-              if (hasMatches) {
-                quickPanel.open({
-                  title: t('settings.quickPanel.title'),
-                  list: quickPanelMenu,
-                  symbol: '/'
-                })
-
-                // 立即触发输入事件，让QuickPanel同步最新的搜索文本进行过滤
-                setTimeout(() => {
-                  const inputEvent = new Event('input', { bubbles: true })
-                  textArea?.dispatchEvent(inputEvent)
-                }, 0)
-              }
-            }
-          } else if (symbolType === '@') {
-            // 对于@符号，重新打开模型选择面板（模型面板通常都有内容）
-            const _searchText = searchText.replace(/^@/, '')
-            if (_searchText.length > 0 && _searchText.length <= 10) {
-              inputbarToolsRef.current?.openMentionModelsPanel()
-            }
-          }
-        }
-      }
     },
     [enableQuickPanelTriggers, quickPanel, t, files, couldAddImageFile, openSelectFileMenu, translate]
   )

--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -527,6 +527,68 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
       if (enableQuickPanelTriggers && !quickPanel.isVisible && lastSymbol === '@') {
         inputbarToolsRef.current?.openMentionModelsPanel()
       }
+
+      // 删除过程中的智能重新打开逻辑：只有在有匹配项时才重新打开面板
+      if (enableQuickPanelTriggers && !quickPanel.isVisible && lastSymbol !== '/' && lastSymbol !== '@') {
+        const textBeforeCursor = newText.slice(0, cursorPosition)
+        const lastSlashIndex = textBeforeCursor.lastIndexOf('/')
+        const lastAtIndex = textBeforeCursor.lastIndexOf('@')
+        const lastSymbolIndex = Math.max(lastSlashIndex, lastAtIndex)
+
+        if (lastSymbolIndex !== -1) {
+          const symbolType = lastSlashIndex > lastAtIndex ? '/' : '@'
+          const searchText = textBeforeCursor.slice(lastSymbolIndex)
+
+          if (symbolType === '/') {
+            const _searchText = searchText.replace(/^\//, '')
+            // 优化：只在搜索文本长度 > 0 且 <= 10 时执行匹配检查，避免过长搜索文本的性能问题
+            if (_searchText.length > 0 && _searchText.length <= 10) {
+              const quickPanelMenu =
+                inputbarToolsRef.current?.getQuickPanelMenu({
+                  t,
+                  files,
+                  couldAddImageFile,
+                  text: newText,
+                  openSelectFileMenu,
+                  translate
+                }) || []
+
+              // 优化：简化匹配逻辑，只做基础字符串匹配，避免复杂正则运算
+              const hasMatches = quickPanelMenu.some((item) => {
+                let filterText = item.filterText || ''
+                if (typeof item.label === 'string') {
+                  filterText += item.label
+                }
+                if (typeof item.description === 'string') {
+                  filterText += item.description
+                }
+                return filterText.toLowerCase().includes(_searchText.toLowerCase())
+              })
+
+              // 只有在确实有匹配项时才重新打开面板
+              if (hasMatches) {
+                quickPanel.open({
+                  title: t('settings.quickPanel.title'),
+                  list: quickPanelMenu,
+                  symbol: '/'
+                })
+
+                // 立即触发输入事件，让QuickPanel同步最新的搜索文本进行过滤
+                setTimeout(() => {
+                  const inputEvent = new Event('input', { bubbles: true })
+                  textArea?.dispatchEvent(inputEvent)
+                }, 0)
+              }
+            }
+          } else if (symbolType === '@') {
+            // 对于@符号，重新打开模型选择面板（模型面板通常都有内容）
+            const _searchText = searchText.replace(/^@/, '')
+            if (_searchText.length > 0 && _searchText.length <= 10) {
+              inputbarToolsRef.current?.openMentionModelsPanel()
+            }
+          }
+        }
+      }
     },
     [enableQuickPanelTriggers, quickPanel, t, files, couldAddImageFile, openSelectFileMenu, translate]
   )

--- a/src/renderer/src/pages/home/Inputbar/InputbarTools.tsx
+++ b/src/renderer/src/pages/home/Inputbar/InputbarTools.tsx
@@ -397,6 +397,7 @@ const InputbarTools = ({
             ToolbarButton={ToolbarButton}
             couldMentionNotVisionModel={couldMentionNotVisionModel}
             files={files}
+            setText={setText}
           />
         )
       },


### PR DESCRIPTION
 ### 问题描述
  当用户输入无效的斜杠命令（如 `/etc`）时，QuickPanel 会一直显示在界面上， 用户在输入框中输入"@"符号调出模型选择面板后，无论是否选择了模型，按ESC或Backspace关闭面板时"@"字符总是保留在输入框中，影响用户体验。

  ### 解决方案
  添加智能延迟关闭机制，当搜索无匹配结果时，面板会在 300ms 后自动关闭。智能处理"@"字符：当用户选择了模型后关闭面板：自动删除"@"字符，当用户未选择任何模型关闭面板：保留"@"字符。

  ### 主要修改
  - 新增无匹配项自动关闭逻辑
  - 组件卸载时清理定时器
  - 保持原有的 `/` 和 `@` 触发行为不变
  - 使用useRef跟踪用户的模型选择动作，避免React状态更新时序问题
  - 模型选择面板支持ESC键和Backspace键两种关闭方式
  - 通过React的setText函数更新状态，避免直接DOM操作
  - 在组件接口中添加setText属性，实现父子组件间的状态同步


 ### 修复 #7824