### PR TITLE
feat(miniapp): add banner attribute to google login tip

### DIFF
--- a/src/renderer/src/components/MinApp/MinappPopupContainer.tsx
+++ b/src/renderer/src/components/MinApp/MinappPopupContainer.tsx
@@ -125,6 +125,7 @@ const GoogleLoginTip = ({
       type="warning"
       showIcon
       closable
+      banner
       onClose={handleClose}
       action={
         <Button type="primary" size="small" onClick={openGoogleMinApp}>


### PR DESCRIPTION
https://ant.design/components/alert-cn#alert-demo-banner

加了一个 banner 属性， 这样提示的样式感觉更好。

Before:

<img width="3300" height="284" alt="CleanShot 2025-08-04 at 10 52 49" src="https://github.com/user-attachments/assets/bbb9f5f4-5ca3-4de3-a332-2a1f756146c7" />

After:

<img width="3298" height="270" alt="CleanShot 2025-08-04 at 10 52 22" src="https://github.com/user-attachments/assets/4f94ca10-fe37-43dc-8643-e8cfd7d4e4b5" />
