### PR TITLE
feat: enable additional GPU channel features and improve crash reportdetails in renderer

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -56,8 +56,14 @@ if (isLinux && process.env.XDG_SESSION_TYPE === 'wayland') {
   app.commandLine.appendSwitch('enable-features', 'GlobalShortcutsPortal')
 }
 
-// Enable features for unresponsive renderer js call stacks
-app.commandLine.appendSwitch('enable-features', 'DocumentPolicyIncludeJSCallStacksInCrashReports')
+// DocumentPolicyIncludeJSCallStacksInCrashReports: Enable features for unresponsive renderer js call stacks
+// EarlyEstablishGpuChannel,EstablishGpuChannelAsync: Enable features for early establish gpu channel
+// speed up the startup time
+// https://github.com/microsoft/vscode/pull/241640/files
+app.commandLine.appendSwitch(
+  'enable-features',
+  'DocumentPolicyIncludeJSCallStacksInCrashReports,EarlyEstablishGpuChannel,EstablishGpuChannelAsync'
+)
 app.on('web-contents-created', (_, webContents) => {
   webContents.session.webRequest.onHeadersReceived((details, callback) => {
     callback({


### PR DESCRIPTION
参考https://github.com/microsoft/vscode/pull/241640/files， 在electron34之后打开窗口速度变慢，可以通过开启EarlyEstablishGpuChannel,EstablishGpuChannelAsync feature加快窗口的打开。