### PR TITLE
fix(s3): add volces.com to virtual host suffix whitelist

### DIFF
--- a/src/main/services/S3Storage.ts
+++ b/src/main/services/S3Storage.ts
@@ -26,7 +26,7 @@ function streamToBuffer(stream: Readable): Promise<Buffer> {
 }
 
 // 需要使用 Virtual Host-Style 的服务商域名后缀白名单
-const VIRTUAL_HOST_SUFFIXES = ['aliyuncs.com', 'myqcloud.com']
+const VIRTUAL_HOST_SUFFIXES = ['aliyuncs.com', 'myqcloud.com', 'volces.com']
 
 /**
  * 使用 AWS SDK v3 的简单 S3 封装，兼容之前 RemoteStorage 的最常用接口。


### PR DESCRIPTION
### What this PR does

修复火山引擎对象存储 TOS VirtualHost处理不正确的问题

Before this PR: 火山TOS 备份失败

After this PR: 火山TOS 备份正常进行

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #8820


