### PR TITLE
fix(ProxyManager): handle optional currentProxy in system proxy check and log changes

### DIFF
--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -87,10 +87,11 @@ export class ProxyManager {
     // Set new interval
     this.systemProxyInterval = setInterval(async () => {
       const currentProxy = await getSystemProxy()
-      if (currentProxy && currentProxy.proxyUrl.toLowerCase() === this.config?.proxyRules) {
+      if (currentProxy?.proxyUrl.toLowerCase() === this.config?.proxyRules) {
         return
       }
 
+      logger.info(`system proxy changed: ${currentProxy?.proxyUrl}, this.config.proxyRules: ${this.config.proxyRules}`)
       await this.configureProxy({
         mode: 'system',
         proxyRules: currentProxy?.proxyUrl.toLowerCase(),


### PR DESCRIPTION

### What this PR does

Before this PR:
当用户把系统的代理关闭后，会一直打日志

After this PR:

1. 不会打日志
2. 当系统的代理关闭后，只在第一次做一次configure proxy， 后面就不会再重复做了，只有当用户再打开system proxy，才会切换。


