### PR TITLE
refactor(ProxyManager): don't filter proxy in system proxy

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -94,15 +94,12 @@ export function registerIpc(mainWindow: BrowserWindow, app: Electron.App) {
     let proxyConfig: ProxyConfig
 
     if (proxy === 'system') {
+      // system proxy will use the system filter by themselves
       proxyConfig = { mode: 'system' }
     } else if (proxy) {
-      proxyConfig = { mode: 'fixed_servers', proxyRules: proxy }
+      proxyConfig = { mode: 'fixed_servers', proxyRules: proxy, proxyBypassRules: bypassRules }
     } else {
       proxyConfig = { mode: 'direct' }
-    }
-
-    if (bypassRules) {
-      proxyConfig.proxyBypassRules = bypassRules
     }
 
     await proxyManager.configureProxy(proxyConfig)

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -1,5 +1,4 @@
 import { loggerService } from '@logger'
-import { defaultByPassRules } from '@shared/config/constant'
 import axios from 'axios'
 import { app, ProxyConfig, session } from 'electron'
 import { socksDispatcher } from 'fetch-socks'
@@ -10,9 +9,13 @@ import { ProxyAgent } from 'proxy-agent'
 import { Dispatcher, EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } from 'undici'
 
 const logger = loggerService.withContext('ProxyManager')
-let byPassRules = defaultByPassRules.split(',')
+let byPassRules: string[] = []
 
 const isByPass = (hostname: string) => {
+  if (byPassRules.length === 0) {
+    return false
+  }
+
   return byPassRules.includes(hostname)
 }
 
@@ -98,7 +101,7 @@ export class ProxyManager {
       await this.configureProxy({
         mode: 'system',
         proxyRules: currentProxy?.proxyUrl.toLowerCase(),
-        proxyBypassRules: this.config.proxyBypassRules
+        proxyBypassRules: undefined
       })
     }, 1000 * 60)
   }
@@ -131,7 +134,7 @@ export class ProxyManager {
         this.monitorSystemProxy()
       }
 
-      byPassRules = config.proxyBypassRules?.split(',') || defaultByPassRules.split(',')
+      byPassRules = config.proxyBypassRules?.split(',') || []
       this.setGlobalProxy(this.config)
     } catch (error) {
       logger.error('Failed to config proxy:', error as Error)

--- a/src/renderer/src/pages/settings/GeneralSettings.tsx
+++ b/src/renderer/src/pages/settings/GeneralSettings.tsx
@@ -229,7 +229,7 @@ const GeneralSettings: FC = () => {
             </SettingRow>
           </>
         )}
-        {(storeProxyMode === 'custom' || storeProxyMode === 'system') && (
+        {storeProxyMode === 'custom' && (
           <>
             <SettingDivider />
             <SettingRow>


### PR DESCRIPTION


### What this PR does

Before this PR:
如果系统代理是http代理，过滤localhost和127.0.0.1，就会导致访问一些域名异常。

After this PR:
系统代理不要有过滤规则，直接使用系统代理的过滤规则就行，不需要app本身再搞一个。

只有自定义代理的，会显示过滤规则，可以自定义。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #https://github.com/CherryHQ/cherry-studio/issues/8916

