### PR TITLE
fix: 切换 assistant 时能看到旧数据到新数据的过程

### DIFF
--- a/src/renderer/src/pages/home/Tabs/index.tsx
+++ b/src/renderer/src/pages/home/Tabs/index.tsx
@@ -128,23 +128,26 @@ const HomeTabs: FC<Props> = ({
       )}
 
       <TabContent className="home-tabs-content">
-        {tab === 'assistants' && (
+        <TabContentPane className={tab === 'assistants' ? 'active' : ''}>
           <Assistants
             activeAssistant={activeAssistant}
             setActiveAssistant={setActiveAssistant}
             onCreateAssistant={onCreateAssistant}
             onCreateDefaultAssistant={onCreateDefaultAssistant}
           />
-        )}
-        {tab === 'topic' && (
+        </TabContentPane>
+        <TabContentPane className={tab === 'topic' ? 'active' : ''}>
           <Topics
+            key={activeAssistant.id}
             assistant={activeAssistant}
             activeTopic={activeTopic}
             setActiveTopic={setActiveTopic}
             position={position}
           />
-        )}
-        {tab === 'settings' && <Settings assistant={activeAssistant} />}
+        </TabContentPane>
+        <TabContentPane className={tab === 'settings' ? 'active' : ''}>
+          <Settings assistant={activeAssistant} />
+        </TabContentPane>
       </TabContent>
     </Container>
   )
@@ -234,6 +237,13 @@ const TabItem = styled.button<{ active: boolean }>`
   &:hover::after {
     width: ${(props) => (props.active ? '30px' : '16px')};
     background: ${(props) => (props.active ? 'var(--color-primary)' : 'var(--color-primary-soft)')};
+  }
+`
+
+const TabContentPane = styled.div`
+  display: none;
+  &.active {
+    display: block;
   }
 `
 


### PR DESCRIPTION
设置了自动切换话题时，点击切换 assistant，能观察到 旧数据 到 新数据的一个过程
<table>
<tr>
 <td>
Before
 <td>
After
<tr>
 <td>

https://github.com/user-attachments/assets/4474fadf-b052-42f1-b2fd-b921a253fed5


 <td>

https://github.com/user-attachments/assets/f1aee1f3-3ade-4758-97fa-d8364b38d0c8


</table>


