### PR TITLE
Fix/translate selection

### DIFF
--- a/src/renderer/src/components/Popups/TextEditPopup.tsx
+++ b/src/renderer/src/components/Popups/TextEditPopup.tsx
@@ -1,9 +1,7 @@
 import { LoadingOutlined } from '@ant-design/icons'
 import { loggerService } from '@logger'
-import { useDefaultModel } from '@renderer/hooks/useAssistant'
 import { useSettings } from '@renderer/hooks/useSettings'
-import { fetchTranslate } from '@renderer/services/ApiService'
-import { getDefaultTranslateAssistant } from '@renderer/services/AssistantService'
+import { translateText } from '@renderer/services/TranslateService'
 import { getLanguageByLangcode } from '@renderer/utils/translate'
 import { Modal, ModalProps } from 'antd'
 import TextArea from 'antd/es/input/TextArea'
@@ -43,7 +41,6 @@ const PopupContainer: React.FC<Props> = ({
   const [textValue, setTextValue] = useState(text)
   const [isTranslating, setIsTranslating] = useState(false)
   const textareaRef = useRef<TextAreaRef>(null)
-  const { translateModel } = useDefaultModel()
   const { targetLanguage, showTranslateConfirm } = useSettings()
   const isMounted = useRef(true)
 
@@ -103,21 +100,12 @@ const PopupContainer: React.FC<Props> = ({
       if (!confirmed) return
     }
 
-    if (!translateModel) {
-      window.message.error({
-        content: t('translate.error.not_configured'),
-        key: 'translate-message'
-      })
-      return
-    }
-
     if (isMounted.current) {
       setIsTranslating(true)
     }
 
     try {
-      const assistant = getDefaultTranslateAssistant(getLanguageByLangcode(targetLanguage), textValue)
-      const translatedText = await fetchTranslate({ content: textValue, assistant })
+      const translatedText = await translateText(textValue, getLanguageByLangcode(targetLanguage))
       if (isMounted.current) {
         setTextValue(translatedText)
       }

--- a/src/renderer/src/components/TranslateButton.tsx
+++ b/src/renderer/src/components/TranslateButton.tsx
@@ -1,9 +1,7 @@
 import { LoadingOutlined } from '@ant-design/icons'
 import { loggerService } from '@logger'
-import { useDefaultModel } from '@renderer/hooks/useAssistant'
 import { useSettings } from '@renderer/hooks/useSettings'
-import { fetchTranslate } from '@renderer/services/ApiService'
-import { getDefaultTranslateAssistant } from '@renderer/services/AssistantService'
+import { translateText } from '@renderer/services/TranslateService'
 import { getLanguageByLangcode } from '@renderer/utils/translate'
 import { Button, Tooltip } from 'antd'
 import { Languages } from 'lucide-react'
@@ -23,7 +21,6 @@ const logger = loggerService.withContext('TranslateButton')
 
 const TranslateButton: FC<Props> = ({ text, onTranslated, disabled, style, isLoading }) => {
   const { t } = useTranslation()
-  const { translateModel } = useDefaultModel()
   const [isTranslating, setIsTranslating] = useState(false)
   const { targetLanguage, showTranslateConfirm } = useSettings()
 
@@ -45,21 +42,12 @@ const TranslateButton: FC<Props> = ({ text, onTranslated, disabled, style, isLoa
       return
     }
 
-    if (!translateModel) {
-      window.message.error({
-        content: t('translate.error.not_configured'),
-        key: 'translate-message'
-      })
-      return
-    }
-
     // 先复制原文到剪贴板
     await navigator.clipboard.writeText(text)
 
     setIsTranslating(true)
     try {
-      const assistant = getDefaultTranslateAssistant(getLanguageByLangcode(targetLanguage), text)
-      const translatedText = await fetchTranslate({ content: text, assistant })
+      const translatedText = await translateText(text, getLanguageByLangcode(targetLanguage))
       onTranslated(translatedText)
     } catch (error) {
       logger.error('Translation failed:', error as Error)

--- a/src/renderer/src/hooks/useTranslate.ts
+++ b/src/renderer/src/hooks/useTranslate.ts
@@ -1,11 +1,10 @@
 import db from '@renderer/databases'
-import { fetchTranslate } from '@renderer/services/ApiService'
-import { getDefaultTranslateAssistant } from '@renderer/services/AssistantService'
 import { loggerService } from '@renderer/services/LoggerService'
+import { translateText } from '@renderer/services/TranslateService'
 import store, { useAppDispatch, useAppSelector } from '@renderer/store'
 import { setTranslating as _setTranslating } from '@renderer/store/runtime'
 import { setTranslatedContent as _setTranslatedContent } from '@renderer/store/translate'
-import { Language, LanguageCode, TranslateAssistant, TranslateHistory } from '@renderer/types'
+import { Language, LanguageCode, TranslateHistory } from '@renderer/types'
 import { uuid } from '@renderer/utils'
 import { t } from 'i18next'
 import { throttle } from 'lodash'
@@ -55,24 +54,8 @@ export default function useTranslate() {
 
       setTranslating(true)
 
-      let assistant: TranslateAssistant
       try {
-        assistant = getDefaultTranslateAssistant(actualTargetLanguage, text)
-      } catch (e) {
-        if (e instanceof Error) {
-          window.message.error(e.message)
-          return
-        } else {
-          throw e
-        }
-      }
-
-      try {
-        await fetchTranslate({
-          content: text,
-          assistant,
-          onResponse: throttle(setTranslatedContent, 100)
-        })
+        await translateText(text, actualTargetLanguage, throttle(setTranslatedContent, 100))
       } catch (e) {
         logger.error('Failed to translate text', e as Error)
         window.message.error(t('translate.error.failed'))

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -30,7 +30,6 @@ import {
   MemoryItem,
   Model,
   Provider,
-  TranslateAssistant,
   WebSearchResponse,
   WebSearchSource
 } from '@renderer/types'
@@ -62,8 +61,7 @@ import {
   getDefaultAssistant,
   getDefaultModel,
   getProviderByModel,
-  getTopNamingModel,
-  getTranslateModel
+  getTopNamingModel
 } from './AssistantService'
 import { processKnowledgeSearch } from './KnowledgeService'
 import { MemoryProcessor } from './MemoryProcessor'
@@ -608,56 +606,6 @@ async function processConversationMemory(messages: Message[], assistant: Assista
   }
 }
 
-interface FetchTranslateProps {
-  content: string
-  assistant: TranslateAssistant
-  onResponse?: (text: string, isComplete: boolean) => void
-}
-
-export async function fetchTranslate({ content, assistant, onResponse }: FetchTranslateProps) {
-  const model = getTranslateModel() || assistant.model || getDefaultModel()
-
-  if (!model) {
-    throw new Error(i18n.t('error.provider_disabled'))
-  }
-
-  const provider = getProviderByModel(model)
-
-  if (!hasApiKey(provider)) {
-    throw new Error(i18n.t('error.no_api_key'))
-  }
-
-  const isSupportedStreamOutput = () => {
-    if (!onResponse) {
-      return false
-    }
-    return true
-  }
-
-  const stream = isSupportedStreamOutput()
-  const enableReasoning =
-    ((isSupportedThinkingTokenModel(model) || isSupportedReasoningEffortModel(model)) &&
-      assistant.settings?.reasoning_effort !== undefined) ||
-    (isReasoningModel(model) && (!isSupportedThinkingTokenModel(model) || !isSupportedReasoningEffortModel(model)))
-
-  const params: CompletionsParams = {
-    callType: 'translate',
-    messages: content,
-    assistant: { ...assistant, model },
-    streamOutput: stream,
-    enableReasoning,
-    onResponse
-  }
-
-  const AI = new AiProvider(provider)
-
-  try {
-    return (await AI.completions(params)).getText() || ''
-  } catch (error: any) {
-    return ''
-  }
-}
-
 export async function fetchMessagesSummary({ messages, assistant }: { messages: Message[]; assistant: Assistant }) {
   let prompt = (getStoreSetting('topicNamingPrompt') as string) || i18n.t('prompts.title')
   const model = getTopNamingModel() || assistant.model || getDefaultModel()
@@ -791,7 +739,7 @@ export async function fetchGenerate({
   }
 }
 
-function hasApiKey(provider: Provider) {
+export function hasApiKey(provider: Provider) {
   if (!provider) return false
   if (provider.id === 'ollama' || provider.id === 'lmstudio' || provider.type === 'vertexai') return true
   return !isEmpty(provider.apiKey)

--- a/src/renderer/src/services/TranslateService.ts
+++ b/src/renderer/src/services/TranslateService.ts
@@ -1,10 +1,80 @@
+import AiProvider from '@renderer/aiCore'
+import { CompletionsParams } from '@renderer/aiCore/middleware/schemas'
+import {
+  isReasoningModel,
+  isSupportedReasoningEffortModel,
+  isSupportedThinkingTokenModel
+} from '@renderer/config/models'
 import i18n from '@renderer/i18n'
 import store from '@renderer/store'
-import { Language } from '@renderer/types'
+import { Language, TranslateAssistant } from '@renderer/types'
 
-import { fetchTranslate } from './ApiService'
-import { getDefaultTranslateAssistant } from './AssistantService'
+import { hasApiKey } from './ApiService'
+import {
+  getDefaultModel,
+  getDefaultTranslateAssistant,
+  getProviderByModel,
+  getTranslateModel
+} from './AssistantService'
 
+interface FetchTranslateProps {
+  content: string
+  assistant: TranslateAssistant
+  onResponse?: (text: string, isComplete: boolean) => void
+}
+
+async function fetchTranslate({ content, assistant, onResponse }: FetchTranslateProps) {
+  const model = getTranslateModel() || assistant.model || getDefaultModel()
+
+  if (!model) {
+    throw new Error(i18n.t('error.provider_disabled'))
+  }
+
+  const provider = getProviderByModel(model)
+
+  if (!hasApiKey(provider)) {
+    throw new Error(i18n.t('error.no_api_key'))
+  }
+
+  const isSupportedStreamOutput = () => {
+    if (!onResponse) {
+      return false
+    }
+    return true
+  }
+
+  const stream = isSupportedStreamOutput()
+  const enableReasoning =
+    ((isSupportedThinkingTokenModel(model) || isSupportedReasoningEffortModel(model)) &&
+      assistant.settings?.reasoning_effort !== undefined) ||
+    (isReasoningModel(model) && (!isSupportedThinkingTokenModel(model) || !isSupportedReasoningEffortModel(model)))
+
+  const params: CompletionsParams = {
+    callType: 'translate',
+    messages: content,
+    assistant: { ...assistant, model },
+    streamOutput: stream,
+    enableReasoning,
+    onResponse
+  }
+
+  const AI = new AiProvider(provider)
+
+  try {
+    return (await AI.completions(params)).getText() || ''
+  } catch (error: any) {
+    return ''
+  }
+}
+
+/**
+ * 翻译文本到目标语言
+ * @param text - 需要翻译的文本内容
+ * @param targetLanguage - 目标语言
+ * @param onResponse - 流式输出的回调函数，用于实时获取翻译结果
+ * @returns 返回翻译后的文本
+ * @throws {Error} 当翻译模型未配置或翻译失败时抛出错误
+ */
 export const translateText = async (
   text: string,
   targetLanguage: Language,

--- a/src/renderer/src/services/TranslateService.ts
+++ b/src/renderer/src/services/TranslateService.ts
@@ -29,7 +29,7 @@ async function fetchTranslate({ content, assistant, onResponse }: FetchTranslate
   const model = getTranslateModel() || assistant.model || getDefaultModel()
 
   if (!model) {
-    throw new Error(i18n.t('error.provider_disabled'))
+    throw new Error(i18n.t('translate.error.not_configured'))
   }
 
   const provider = getProviderByModel(model)

--- a/src/renderer/src/windows/mini/translate/TranslateWindow.tsx
+++ b/src/renderer/src/windows/mini/translate/TranslateWindow.tsx
@@ -4,9 +4,8 @@ import Scrollbar from '@renderer/components/Scrollbar'
 import { LanguagesEnum, translateLanguageOptions } from '@renderer/config/translate'
 import db from '@renderer/databases'
 import { useDefaultModel } from '@renderer/hooks/useAssistant'
-import { fetchTranslate } from '@renderer/services/ApiService'
-import { getDefaultTranslateAssistant } from '@renderer/services/AssistantService'
-import { Assistant, Language } from '@renderer/types'
+import { translateText } from '@renderer/services/TranslateService'
+import { Language } from '@renderer/types'
 import { runAsyncFunction } from '@renderer/utils'
 import { getLanguageByLangcode } from '@renderer/utils/translate'
 import { Select } from 'antd'
@@ -41,20 +40,7 @@ const Translate: FC<Props> = ({ text }) => {
     try {
       translatingRef.current = true
 
-      const assistant: Assistant = getDefaultTranslateAssistant(targetLanguage, text)
-      // const message: Message = {
-      //   id: uuid(),
-      //   role: 'user',
-      //   content: '',
-      //   assistantId: assistant.id,
-      //   topicId: uuid(),
-      //   model: translateModel,
-      //   createdAt: new Date().toISOString(),
-      //   type: 'text',
-      //   status: 'sending'
-      // }
-
-      await fetchTranslate({ content: text, assistant, onResponse: setResult })
+      await translateText(text, targetLanguage, setResult)
 
       translatingRef.current = false
     } catch (error) {

--- a/src/renderer/src/windows/selection/action/components/ActionUtils.ts
+++ b/src/renderer/src/windows/selection/action/components/ActionUtils.ts
@@ -51,10 +51,15 @@ export const processMessages = async (
       })
     )
 
+    let finished = false
+
     await fetchChatCompletion({
       messages: [userMessage],
       assistant: { ...assistant, settings: { streamOutput: true } },
       onChunkReceived: (chunk: Chunk) => {
+        if (finished) {
+          return
+        }
         switch (chunk.type) {
           case ChunkType.THINKING_START:
             {
@@ -162,6 +167,9 @@ export const processMessages = async (
                 })
               )
             }
+            break
+          case ChunkType.LLM_RESPONSE_COMPLETE:
+            finished = true
             break
           case ChunkType.ERROR:
             {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

- 重构翻译接口，将`fetchTranslate`迁移到`TranslateService`并不再导出，外部统一使用导出的`translateText`函数。
- 修复了划词翻译处理了多余块的问题。QwenMT会输出两个`finish_reason: stop`的块，没处理好。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #8924

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
