### PR TITLE
feat(package): add patch for windows-system-proxy to improve http proxy

### DIFF
--- a/.yarn/patches/windows-system-proxy-npm-1.0.0-ff2a828eec.patch
+++ b/.yarn/patches/windows-system-proxy-npm-1.0.0-ff2a828eec.patch
@@ -1,0 +1,23 @@
+diff --git a/dist/index.js b/dist/index.js
+index b54962b2d332c1a3affadbdb37d39fdf90ab9f82..7906b4ea3bf9dffe60d74c279e9cfe885489c9f9 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -36,12 +36,12 @@ async function getWindowsSystemProxy() {
+         const proxies = Object.fromEntries(proxyConfigString
+             .split(';')
+             .map((proxyPair) => proxyPair.split('=')));
+-        const proxyUrl = proxies['https']
+-            ? `https://${proxies['https']}`
+-            : proxies['http']
+-                ? `http://${proxies['http']}`
+-                : proxies['socks']
+-                    ? `socks://${proxies['socks']}`
++        const proxyUrl = proxies['http']
++            ? `http://${proxies['http']}`
++            : proxies['socks']
++                ? `socks://${proxies['socks']}`
++                : proxies['https']
++                    ? `https://${proxies['https']}`
+                     : undefined;
+         if (!proxyUrl) {
+             throw new Error(`Could not get usable proxy URL from ${proxyConfigString}`);

--- a/package.json
+++ b/package.json
@@ -284,7 +284,8 @@
     "undici": "6.21.2",
     "vite": "npm:rolldown-vite@latest",
     "atomically@npm:^1.7.0": "patch:atomically@npm%3A1.7.0#~/.yarn/patches/atomically-npm-1.7.0-e742e5293b.patch",
-    "file-stream-rotator@npm:^0.6.1": "patch:file-stream-rotator@npm%3A0.6.1#~/.yarn/patches/file-stream-rotator-npm-0.6.1-eab45fb13d.patch"
+    "file-stream-rotator@npm:^0.6.1": "patch:file-stream-rotator@npm%3A0.6.1#~/.yarn/patches/file-stream-rotator-npm-0.6.1-eab45fb13d.patch",
+    "windows-system-proxy@npm:^1.0.0": "patch:windows-system-proxy@npm%3A1.0.0#~/.yarn/patches/windows-system-proxy-npm-1.0.0-ff2a828eec.patch"
   },
   "packageManager": "yarn@4.9.1",
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -21468,12 +21468,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"windows-system-proxy@npm:^1.0.0":
+"windows-system-proxy@npm:1.0.0":
   version: 1.0.0
   resolution: "windows-system-proxy@npm:1.0.0"
   dependencies:
     registry-js: "npm:^1.15.1"
   checksum: 10c0/f3712938ce0786c359f171c40cc40df37448e06feeaaddd056312dcc93caff02c1eac9df6f0fac162ec99ac1f23dffb70bf19fe08fac097fed3c32b7ae95f6aa
+  languageName: node
+  linkType: hard
+
+"windows-system-proxy@patch:windows-system-proxy@npm%3A1.0.0#~/.yarn/patches/windows-system-proxy-npm-1.0.0-ff2a828eec.patch":
+  version: 1.0.0
+  resolution: "windows-system-proxy@patch:windows-system-proxy@npm%3A1.0.0#~/.yarn/patches/windows-system-proxy-npm-1.0.0-ff2a828eec.patch::version=1.0.0&hash=bc3cd7"
+  dependencies:
+    registry-js: "npm:^1.15.1"
+  checksum: 10c0/4941a22109ced18bece1aa7eacb828a1b4364d031c8528fc76a0a76509ef431f70886574d8629d5086ef7dbfb9595815996489acaa9468c63b337551847761fd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
<img width="458" height="550" alt="image" src="https://github.com/user-attachments/assets/eb15e81f-0a4b-4c70-8e22-93a326384af3" />

用户将http代理设置到https代理，获取到的就是https代理，会导致tls握手失败，从而代理失败。

After this PR:

上游patch（https://github.com/httptoolkit/windows-system-proxy/pull/1 ），默认优先返回http代理，再返回socks代理，最后返回https代理。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #https://github.com/CherryHQ/cherry-studio/issues/8916


