### PR TITLE
feat: add language filter to local web search queries

### DIFF
--- a/src/renderer/src/providers/WebSearchProvider/LocalSearchProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/LocalSearchProvider.ts
@@ -1,5 +1,6 @@
 import { loggerService } from '@logger'
 import { nanoid } from '@reduxjs/toolkit'
+import store from '@renderer/store'
 import { WebSearchState } from '@renderer/store/websearch'
 import { WebSearchProvider, WebSearchProviderResponse, WebSearchProviderResult } from '@renderer/types'
 import { createAbortPromise } from '@renderer/utils/abortController'
@@ -29,6 +30,7 @@ export default class LocalSearchProvider extends BaseWebSearchProvider {
     httpOptions?: RequestInit
   ): Promise<WebSearchProviderResponse> {
     const uid = nanoid()
+    const language = store.getState().settings.language
     try {
       if (!query.trim()) {
         throw new Error('Search query cannot be empty')
@@ -38,7 +40,8 @@ export default class LocalSearchProvider extends BaseWebSearchProvider {
       }
 
       const cleanedQuery = query.split('\r\n')[1] ?? query
-      const url = this.provider.url.replace('%s', encodeURIComponent(cleanedQuery))
+      const queryWithLanguage = language ? this.applyLanguageFilter(cleanedQuery, language) : cleanedQuery
+      const url = this.provider.url.replace('%s', encodeURIComponent(queryWithLanguage))
       let content: string = ''
       const promisesToRace: [Promise<string>] = [window.api.searchService.openUrlInSearchWindow(uid, url)]
       if (httpOptions?.signal) {
@@ -76,6 +79,22 @@ export default class LocalSearchProvider extends BaseWebSearchProvider {
       throw new Error(`Search failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
     } finally {
       await window.api.searchService.closeSearchWindow(uid)
+    }
+  }
+
+  /**
+   * 根据提供的语言为查询添加语言过滤器
+   * @param query 原始查询
+   * @param language 语言代码 (例如: 'zh-CN', 'en-US')
+   * @returns 带有语言过滤的查询
+   */
+  protected applyLanguageFilter(query: string, language: string): string {
+    if (this.provider.name?.toLowerCase().includes('google')) {
+      return `${query} lang:${language.split('-')[0]}`
+    } else if (this.provider.name?.toLowerCase().includes('bing')) {
+      return `${query} language:${language}`
+    } else {
+      return `${query} language:${language}`
     }
   }
 


### PR DESCRIPTION
对于local web search增加语言过滤 可能使用ip地语言导致和应用内语言不符

Integrates user's language setting into search queries by applying a language filter based on the provider (Google, Bing, or others). This improves search relevance for localized results.