### PR TITLE
feat: add max backups for NutStore

### DIFF
--- a/src/renderer/src/pages/settings/DataSettings/NutstoreSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/NutstoreSettings.tsx
@@ -56,7 +56,6 @@ const NutstoreSettings: FC = () => {
   const [nsConnected, setNsConnected] = useState<boolean>(false)
 
   const [syncInterval, setSyncInterval] = useState<number>(nutstoreSyncInterval)
-  const [maxBackups, setMaxBackups] = useState<number>(nutstoreMaxBackups)
 
   const [nutSkipBackupFile, setNutSkipBackupFile] = useState<boolean>(nutstoreSkipBackupFile)
 
@@ -147,7 +146,6 @@ const NutstoreSettings: FC = () => {
   }
 
   const onMaxBackupsChange = (value: number) => {
-    setMaxBackups(value)
     dispatch(setNutstoreMaxBackups(value))
   }
 
@@ -320,7 +318,7 @@ const NutstoreSettings: FC = () => {
             <SettingRowTitle>{t('settings.data.webdav.maxBackups')}</SettingRowTitle>
             <Selector
               size={14}
-              value={maxBackups}
+              value={nutstoreMaxBackups}
               onChange={onMaxBackupsChange}
               disabled={!nutstoreToken}
               options={[

--- a/src/renderer/src/pages/settings/DataSettings/NutstoreSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/NutstoreSettings.tsx
@@ -17,6 +17,7 @@ import {
 import { useAppDispatch, useAppSelector } from '@renderer/store'
 import {
   setNutstoreAutoSync,
+  setNutstoreMaxBackups,
   setNutstorePath,
   setNutstoreSkipBackupFile,
   setNutstoreSyncInterval,
@@ -41,7 +42,8 @@ const NutstoreSettings: FC = () => {
     nutstoreSyncInterval,
     nutstoreAutoSync,
     nutstoreSyncState,
-    nutstoreSkipBackupFile
+    nutstoreSkipBackupFile,
+    nutstoreMaxBackups
   } = useAppSelector((state) => state.nutstore)
 
   const dispatch = useAppDispatch()
@@ -54,6 +56,7 @@ const NutstoreSettings: FC = () => {
   const [nsConnected, setNsConnected] = useState<boolean>(false)
 
   const [syncInterval, setSyncInterval] = useState<number>(nutstoreSyncInterval)
+  const [maxBackups, setMaxBackups] = useState<number>(nutstoreMaxBackups)
 
   const [nutSkipBackupFile, setNutSkipBackupFile] = useState<boolean>(nutstoreSkipBackupFile)
 
@@ -141,6 +144,11 @@ const NutstoreSettings: FC = () => {
   const onSkipBackupFilesChange = (value: boolean) => {
     setNutSkipBackupFile(value)
     dispatch(setNutstoreSkipBackupFile(value))
+  }
+
+  const onMaxBackupsChange = (value: number) => {
+    setMaxBackups(value)
+    dispatch(setNutstoreMaxBackups(value))
   }
 
   const handleClickPathChange = async () => {
@@ -307,6 +315,25 @@ const NutstoreSettings: FC = () => {
               </SettingRow>
             </>
           )}
+          <SettingDivider />
+          <SettingRow>
+            <SettingRowTitle>{t('settings.data.webdav.maxBackups')}</SettingRowTitle>
+            <Selector
+              size={14}
+              value={maxBackups}
+              onChange={onMaxBackupsChange}
+              disabled={!nutstoreToken}
+              options={[
+                { label: t('settings.data.local.maxBackups.unlimited'), value: 0 },
+                { label: '1', value: 1 },
+                { label: '3', value: 3 },
+                { label: '5', value: 5 },
+                { label: '10', value: 10 },
+                { label: '20', value: 20 },
+                { label: '50', value: 50 }
+              ]}
+            />
+          </SettingRow>
           <SettingDivider />
           <SettingRow>
             <SettingRowTitle>{t('settings.data.backup.skip_file_data_title')}</SettingRowTitle>

--- a/src/renderer/src/store/migrate.ts
+++ b/src/renderer/src/store/migrate.ts
@@ -2080,19 +2080,11 @@ const migrateConfig = {
       return state
     }
   },
-    '130': (state: RootState) => {
+  '130': (state: RootState) => {
     try {
       if (state.settings && state.settings.openAI && !state.settings.openAI.verbosity) {
         state.settings.openAI.verbosity = 'medium'
       }
-      return state
-    } catch (error) {
-      logger.error('migrate 130 error', error as Error)
-      return state
-    }
-  },
-  '130': (state: RootState) => {
-    try {
       // 为 nutstore 添加备份数量限制的默认值
       if (state.nutstore && state.nutstore.nutstoreMaxBackups === undefined) {
         state.nutstore.nutstoreMaxBackups = 0

--- a/src/renderer/src/store/migrate.ts
+++ b/src/renderer/src/store/migrate.ts
@@ -2090,6 +2090,18 @@ const migrateConfig = {
       logger.error('migrate 130 error', error as Error)
       return state
     }
+  },
+  '130': (state: RootState) => {
+    try {
+      // 为 nutstore 添加备份数量限制的默认值
+      if (state.nutstore && state.nutstore.nutstoreMaxBackups === undefined) {
+        state.nutstore.nutstoreMaxBackups = 0
+      }
+      return state
+    } catch (error) {
+      logger.error('migrate 130 error', error as Error)
+      return state
+    }
   }
 }
 

--- a/src/renderer/src/store/nutstore.ts
+++ b/src/renderer/src/store/nutstore.ts
@@ -11,6 +11,7 @@ export interface NutstoreState {
   nutstoreSyncInterval: number
   nutstoreSyncState: NutstoreSyncState
   nutstoreSkipBackupFile: boolean
+  nutstoreMaxBackups: number
 }
 
 const initialState: NutstoreState = {
@@ -23,7 +24,8 @@ const initialState: NutstoreState = {
     syncing: false,
     lastSyncError: null
   },
-  nutstoreSkipBackupFile: false
+  nutstoreSkipBackupFile: false,
+  nutstoreMaxBackups: 0
 }
 
 const nutstoreSlice = createSlice({
@@ -47,6 +49,9 @@ const nutstoreSlice = createSlice({
     },
     setNutstoreSkipBackupFile: (state, action: PayloadAction<boolean>) => {
       state.nutstoreSkipBackupFile = action.payload
+    },
+    setNutstoreMaxBackups: (state, action: PayloadAction<number>) => {
+      state.nutstoreMaxBackups = action.payload
     }
   }
 })
@@ -57,7 +62,8 @@ export const {
   setNutstoreAutoSync,
   setNutstoreSyncInterval,
   setNutstoreSyncState,
-  setNutstoreSkipBackupFile
+  setNutstoreSkipBackupFile,
+  setNutstoreMaxBackups
 } = nutstoreSlice.actions
 
 export default nutstoreSlice.reducer


### PR DESCRIPTION
### What this PR does

Before this:
- 坚果云没有备份数量限制，旧备份会无限累积。​

After this PR:
- 为坚果云添加最大备份数量设置。
- 实现清理逻辑，在超过限制时自动删除旧备份。

Fixes # 

### Release note

```release-note
Add configurable max backups for NutStore and automatic cleanup of old backups when the limit is exceeded.
```