### PR TITLE
feat: add RPM target support for Linux builds

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -93,6 +93,7 @@ jobs:
       - name: Build Linux
         if: matrix.os == 'ubuntu-latest'
         run: |
+          sudo apt-get install -y rpm
           yarn build:npm linux
           yarn build:linux
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
       - name: Build Linux
         if: matrix.os == 'ubuntu-latest'
         run: |
+          sudo apt-get install -y rpm
           yarn build:npm linux
           yarn build:linux
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -98,6 +98,7 @@ linux:
   target:
     - target: AppImage
     - target: deb
+    - target: rpm
   maintainer: electronjs.org
   category: Utility
   desktop:


### PR DESCRIPTION
* Updated electron-builder configuration to include RPM as a target for Linux builds.
* Modified GitHub workflows to install RPM dependencies during the build process for both nightly and release workflows.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
不支持rpm包

After this PR:
支持rpm包

fix https://github.com/CherryHQ/cherry-studio/discussions/8961


