### PR TITLE
refactor: extract message-menu-bar's logic into custom hooks

### DIFF
--- a/src/renderer/src/hooks/useExportsActions.ts
+++ b/src/renderer/src/hooks/useExportsActions.ts
@@ -1,0 +1,140 @@
+import ObsidianExportPopup from '@renderer/components/Popups/ObsidianExportPopup'
+import { getMessageTitle } from '@renderer/services/MessagesService'
+import { RootState } from '@renderer/store'
+import { Message, Topic } from '@renderer/types'
+import { captureScrollableDivAsBlob, captureScrollableDivAsDataURL } from '@renderer/utils'
+import { copyMessageAsPlainText } from '@renderer/utils/copy'
+import {
+  exportMarkdownToJoplin,
+  exportMarkdownToSiyuan,
+  exportMarkdownToYuque,
+  exportMessageAsMarkdown,
+  exportMessageToNotion,
+  messageToMarkdown
+} from '@renderer/utils/export'
+import { t } from 'i18next'
+import { useMemo } from 'react'
+import { useSelector } from 'react-redux'
+
+export const useExportActions = (
+  message: Message,
+  topic: Topic,
+  messageContainerRef: React.RefObject<HTMLDivElement>
+) => {
+  const exportMenuOptions = useSelector((state: RootState) => state.settings.exportMenuOptions)
+
+  const exportActions = useMemo(
+    () => ({
+      copyPlainText: () => copyMessageAsPlainText(message),
+      copyImage: async () => {
+        await captureScrollableDivAsBlob(messageContainerRef, async (blob) => {
+          if (blob) {
+            await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })])
+          }
+        })
+      },
+      exportImage: async () => {
+        const imageData = await captureScrollableDivAsDataURL(messageContainerRef)
+        const title = await getMessageTitle(message)
+        if (title && imageData) {
+          window.api.file.saveImage(title, imageData)
+        }
+      },
+      exportMarkdown: () => exportMessageAsMarkdown(message),
+      exportMarkdownWithReasoning: () => exportMessageAsMarkdown(message, true),
+      exportWord: async () => {
+        const markdown = messageToMarkdown(message)
+        const title = await getMessageTitle(message)
+        window.api.export.toWord(markdown, title)
+      },
+      exportNotion: async () => {
+        const title = await getMessageTitle(message)
+        const markdown = messageToMarkdown(message)
+        exportMessageToNotion(title, markdown, message)
+      },
+      exportYuque: async () => {
+        const title = await getMessageTitle(message)
+        const markdown = messageToMarkdown(message)
+        exportMarkdownToYuque(title, markdown)
+      },
+      exportObsidian: async () => {
+        const title = topic.name?.replace(/\//g, '_') || 'Untitled'
+        await ObsidianExportPopup.show({ title, message, processingMethod: '1' })
+      },
+      exportJoplin: async () => {
+        const title = await getMessageTitle(message)
+        exportMarkdownToJoplin(title, message)
+      },
+      exportSiyuan: async () => {
+        const title = await getMessageTitle(message)
+        const markdown = messageToMarkdown(message)
+        exportMarkdownToSiyuan(title, markdown)
+      }
+    }),
+    [message, topic]
+  )
+
+  const exportMenuItems = useMemo(
+    () =>
+      [
+        exportMenuOptions.plain_text && {
+          label: t('chat.topics.copy.plain_text'),
+          key: 'copy_message_plain_text',
+          onClick: exportActions.copyPlainText
+        },
+        exportMenuOptions.image && {
+          label: t('chat.topics.copy.image'),
+          key: 'img',
+          onClick: exportActions.copyImage
+        },
+        exportMenuOptions.image && {
+          label: t('chat.topics.export.image'),
+          key: 'image',
+          onClick: exportActions.exportImage
+        },
+        exportMenuOptions.markdown && {
+          label: t('chat.topics.export.md.label'),
+          key: 'markdown',
+          onClick: exportActions.exportMarkdown
+        },
+        exportMenuOptions.markdown_reason && {
+          label: t('chat.topics.export.md.reason'),
+          key: 'markdown_reason',
+          onClick: exportActions.exportMarkdownWithReasoning
+        },
+        exportMenuOptions.docx && {
+          label: t('chat.topics.export.word'),
+          key: 'word',
+          onClick: exportActions.exportWord
+        },
+        exportMenuOptions.notion && {
+          label: t('chat.topics.export.notion'),
+          key: 'notion',
+          onClick: exportActions.exportNotion
+        },
+        exportMenuOptions.yuque && {
+          label: t('chat.topics.export.yuque'),
+          key: 'yuque',
+          onClick: exportActions.exportYuque
+        },
+        exportMenuOptions.obsidian && {
+          label: t('chat.topics.export.obsidian'),
+          key: 'obsidian',
+          onClick: exportActions.exportObsidian
+        },
+        exportMenuOptions.joplin && {
+          label: t('chat.topics.export.joplin'),
+          key: 'joplin',
+          onClick: exportActions.exportJoplin
+        },
+        exportMenuOptions.siyuan && {
+          label: t('chat.topics.export.siyuan'),
+          key: 'siyuan',
+          onClick: exportActions.exportSiyuan
+        }
+      ].filter(Boolean),
+    [exportActions]
+  )
+
+  return { exportMenuItems }
+}

--- a/src/renderer/src/hooks/useMessageActions.ts
+++ b/src/renderer/src/hooks/useMessageActions.ts
@@ -1,0 +1,155 @@
+import SelectModelPopup from '@renderer/components/Popups/SelectModelPopup'
+import { isVisionModel } from '@renderer/config/models'
+import { useMessageEditing } from '@renderer/context/MessageEditingContext'
+import store from '@renderer/store'
+import { messageBlocksSelectors } from '@renderer/store/messageBlock'
+import { selectMessagesForTopic } from '@renderer/store/newMessage'
+import type { Assistant, Model, Topic } from '@renderer/types'
+import { type Message, MessageBlockType } from '@renderer/types/newMessage'
+import { removeTrailingDoubleSpaces } from '@renderer/utils/markdown'
+import { getMainTextContent } from '@renderer/utils/messageUtils/find'
+import { t } from 'i18next'
+import { useCallback, useMemo, useState } from 'react'
+
+import { useMessageOperations, useTopicLoading } from './useMessageOperations'
+
+export const useMessageActions = (message: Message, topic: Topic, assistant: Assistant) => {
+  const { resendMessage, regenerateAssistantMessage, deleteMessage, appendAssistantResponse } =
+    useMessageOperations(topic)
+
+  const [copied, setCopied] = useState(false)
+  const { startEditing } = useMessageEditing()
+  const loading = useTopicLoading(topic)
+
+  const isAssistantMessage = message.role === 'assistant'
+
+  const handleCopy = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+
+      const currentMessageId = message.id // from props
+      const latestMessageEntity = store.getState().messages.entities[currentMessageId]
+
+      let contentToCopy = ''
+      if (latestMessageEntity) {
+        contentToCopy = getMainTextContent(latestMessageEntity as Message)
+      } else {
+        contentToCopy = getMainTextContent(message)
+      }
+
+      navigator.clipboard.writeText(removeTrailingDoubleSpaces(contentToCopy.trimStart()))
+
+      window.message.success({ content: t('message.copied'), key: 'copy-message' })
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    },
+    [message, t]
+  )
+
+  const handleEdit = useCallback(() => {
+    startEditing(message.id)
+  }, [message.id, startEditing])
+
+  const handleRegenerate = useCallback(
+    async (messageUpdate?: Message) => {
+      if (!loading) {
+        const assistantWithTopicPrompt = topic.prompt
+          ? { ...assistant, prompt: `${assistant.prompt}\n${topic.prompt}` }
+          : assistant
+        await resendMessage(messageUpdate ?? message, assistantWithTopicPrompt)
+      }
+    },
+    [assistant, loading, message, resendMessage, topic.prompt]
+  )
+
+  const handleAssistantRegenerate = useCallback(
+    async (e: React.MouseEvent | undefined) => {
+      e?.stopPropagation?.()
+      if (loading) return
+      // No need to reset or edit the message anymore
+      // const selectedModel = isGrouped ? model : assistantModel
+      // const _message = resetAssistantMessage(message, selectedModel)
+      // editMessage(message.id, { ..._message }) // REMOVED
+
+      const assistantWithTopicPrompt = topic.prompt
+        ? { ...assistant, prompt: `${assistant.prompt}\n${topic.prompt}` }
+        : assistant
+
+      // Call the function from the hook
+      regenerateAssistantMessage(message, assistantWithTopicPrompt)
+    },
+    [assistant, loading, message, regenerateAssistantMessage, topic.prompt]
+  )
+
+  const handleDeleteMessage = useCallback(
+    (e: React.MouseEvent | undefined) => {
+      e?.stopPropagation?.()
+      deleteMessage(message.id, message.traceId, message.model?.name)
+    },
+    [deleteMessage, message.id, message.traceId, message.model?.name]
+  )
+
+  const handleTraceUserMessage = useCallback(() => {
+    if (message.traceId) {
+      window.api.trace.openWindow(
+        message.topicId,
+        message.traceId,
+        true,
+        message.role === 'user' ? undefined : message.model?.name
+      )
+    }
+  }, [message])
+
+  // 按条件筛选能够提及的模型，该函数仅在isAssistantMessage时会用到
+  const mentionModelFilter = useMemo(() => {
+    if (!isAssistantMessage) {
+      return () => true
+    }
+    const state = store.getState()
+    const topicMessages: Message[] = selectMessagesForTopic(state, topic.id)
+    // 理论上助手消息只会关联一条用户消息
+    const relatedUserMessage = topicMessages.find((msg) => {
+      return msg.role === 'user' && message.askId === msg.id
+    })
+    // 无关联用户消息时，默认返回所有模型
+    if (!relatedUserMessage) {
+      return () => true
+    }
+
+    const relatedUserMessageBlocks = relatedUserMessage.blocks.map((msgBlockId) =>
+      messageBlocksSelectors.selectById(store.getState(), msgBlockId)
+    )
+
+    if (!relatedUserMessageBlocks) {
+      return () => true
+    }
+
+    if (relatedUserMessageBlocks.some((block) => block && block.type === MessageBlockType.IMAGE)) {
+      return (m: Model) => isVisionModel(m)
+    } else {
+      return () => true
+    }
+  }, [isAssistantMessage, message.askId, topic.id])
+
+  const handleMentionModel = useCallback(
+    async (e: React.MouseEvent, model?: Model) => {
+      e.stopPropagation()
+      if (loading) return
+      const selectedModel = await SelectModelPopup.show({ model, modelFilter: mentionModelFilter })
+      if (!selectedModel) return
+      appendAssistantResponse(message, selectedModel, { ...assistant, model: selectedModel })
+    },
+    [appendAssistantResponse, assistant, loading, mentionModelFilter, message]
+  )
+
+  return {
+    copied,
+    handleCopy,
+    handleEdit,
+    handleRegenerate,
+    handleAssistantRegenerate,
+    handleDeleteMessage,
+    handleTraceUserMessage,
+    handleMentionModel
+  }
+}

--- a/src/renderer/src/hooks/useTranslationActions.ts
+++ b/src/renderer/src/hooks/useTranslationActions.ts
@@ -1,0 +1,77 @@
+import { loggerService } from '@logger'
+import { translateText } from '@renderer/services/TranslateService'
+import { useAppDispatch } from '@renderer/store'
+import { removeOneBlock } from '@renderer/store/messageBlock'
+import { Message, Topic, TranslateLanguage } from '@renderer/types'
+import { findTranslationBlocks, findTranslationBlocksById, getMainTextContent } from '@renderer/utils/messageUtils/find'
+import { t } from 'i18next'
+import { useCallback, useMemo, useState } from 'react'
+
+import { useMessageOperations } from './useMessageOperations'
+import useTranslate from './useTranslate'
+
+const logger = loggerService.withContext('MessageMenubar')
+
+export const useTranslationActions = (message: Message, topic: Topic) => {
+  const { getTranslationUpdater } = useMessageOperations(topic)
+  const [isTranslating, setIsTranslating] = useState(false)
+  const { translateLanguages } = useTranslate()
+  const dispatch = useAppDispatch()
+
+  const hasTranslationBlocks = useMemo(() => {
+    const translationBlocks = findTranslationBlocks(message)
+    return translationBlocks.length > 0
+  }, [message])
+
+  const mainTextContent = useMemo(() => {
+    // 只处理助手消息和来自推理模型的消息
+    // if (message.role === 'assistant' && message.model && isReasoningModel(message.model)) {
+    // return getMainTextContent(withMessageThought(message))
+    // }
+    return getMainTextContent(message)
+  }, [message])
+
+  const handleTranslate = useCallback(
+    async (language: TranslateLanguage) => {
+      if (isTranslating) return
+
+      setIsTranslating(true)
+      const messageId = message.id
+      const translationUpdater = await getTranslationUpdater(messageId, language.langCode)
+      if (!translationUpdater) return
+      try {
+        await translateText(mainTextContent, language, translationUpdater)
+      } catch (error) {
+        // console.error('Translation failed:', error)
+        window.message.error({ content: t('translate.error.failed'), key: 'translate-message' })
+        // 理应只有一个
+        const translationBlocks = findTranslationBlocksById(message.id)
+        logger.silly(`there are ${translationBlocks.length} translation blocks`)
+        if (translationBlocks.length > 0) {
+          const block = translationBlocks[0]
+          logger.silly(`block`, block)
+          if (!block.content) {
+            dispatch(removeOneBlock(block.id))
+          }
+        }
+
+        // clearStreamMessage(message.id)
+      } finally {
+        setIsTranslating(false)
+      }
+    },
+    [isTranslating, message, getTranslationUpdater, mainTextContent, t, dispatch]
+  )
+
+  const translationMenuItems = useMemo(() => {
+    // 生成翻译菜单项
+  }, [translateLanguages, hasTranslationBlocks])
+
+  return {
+    isTranslating,
+    mainTextContent,
+    hasTranslationBlocks,
+    translationMenuItems,
+    handleTranslate
+  }
+}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

`MessageMenuBar` 这个组件看着太重了，所以将大部分的逻辑抽离到了不同的 hook 里面，减轻了文件的体积，利于维护

<table>
<tr>

 <td>
useMessageActions
 <td>


https://github.com/user-attachments/assets/7c237589-effb-4099-baa3-1e78e99b0acf



<tr>

 <td>
useTranslationActions
 <td>

https://github.com/user-attachments/assets/b5fe0235-87bb-40b2-8d2a-456f12829cdd

<tr>
 <td>
useExportActions

 <td>
 

https://github.com/user-attachments/assets/6cf3ccc7-68af-4ddf-a5dc-62dceb3aa724


 
</table>

