### PR TITLE
style(ProviderSettings): remove ant splitter panel scrollbar

### DIFF
--- a/src/renderer/src/pages/settings/ProviderSettings/index.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/index.tsx
@@ -456,7 +456,7 @@ const ProvidersList: FC = () => {
   return (
     <Container className="selectable">
       <Splitter>
-        <Splitter.Panel min={250} defaultSize={250}>
+        <Splitter.Panel min={250} defaultSize={250} style={{ overflow: 'auto', scrollbarWidth: 'none' }}>
           <ProviderListContainer>
             <AddButtonWrapper>
               <Input
@@ -522,7 +522,7 @@ const ProvidersList: FC = () => {
           </ProviderListContainer>
         </Splitter.Panel>
 
-        <Splitter.Panel min={'50%'}>
+        <Splitter.Panel min={'50%'} style={{ overflow: 'auto', scrollbarWidth: 'none' }}>
           <ProviderSetting providerId={selectedProvider.id} key={selectedProvider.id} />
         </Splitter.Panel>
       </Splitter>


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does
移除 AntDesign Splitter panel 组件原生滚动条，在暗色模式下滚动条十分难看。

Before this PR:
<img width="1678" height="965" alt="image" src="https://github.com/user-attachments/assets/f80040f8-9fb2-46ce-8284-03832384d558" />

After this PR:
<img width="1816" height="750" alt="image" src="https://github.com/user-attachments/assets/95c66881-2708-4995-a3c5-cc8097799110" />



<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #9070

