### PR TITLE
refactor(proxy): update proxy handling logic in useAppInit and GeneralSettings

### DIFF
--- a/src/renderer/src/hooks/useAppInit.ts
+++ b/src/renderer/src/hooks/useAppInit.ts
@@ -86,11 +86,12 @@ export function useAppInit() {
 
   useEffect(() => {
     if (proxyMode === 'system') {
-      window.api.setProxy('system', proxyBypassRules)
+      window.api.setProxy('system', undefined)
     } else if (proxyMode === 'custom') {
       proxyUrl && window.api.setProxy(proxyUrl, proxyBypassRules)
     } else {
-      window.api.setProxy('')
+      // set proxy to none for direct mode
+      window.api.setProxy('', undefined)
     }
   }, [proxyUrl, proxyMode, proxyBypassRules])
 

--- a/src/renderer/src/pages/settings/GeneralSettings.tsx
+++ b/src/renderer/src/pages/settings/GeneralSettings.tsx
@@ -113,12 +113,6 @@ const GeneralSettings: FC = () => {
 
   const onProxyModeChange = (mode: 'system' | 'custom' | 'none') => {
     dispatch(setProxyMode(mode))
-    if (mode === 'system') {
-      dispatch(_setProxyUrl(undefined))
-    } else if (mode === 'none') {
-      dispatch(_setProxyUrl(undefined))
-      dispatch(_setProxyBypassRules(undefined))
-    }
   }
 
   const languagesOptions: { value: LanguageVarious; label: string; flag: string }[] = [


### PR DESCRIPTION

- Simplified proxy setting logic by removing unnecessary dispatches for 'system' and 'none' modes.
- Updated useAppInit to set proxy to undefined for 'system' mode and clarified direct mode handling with comments.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
切换代理，再切换到其它配置，再切加来切换代理，custom proxy url就会空掉了，还有就是重启app后也会没有了。

After this PR:
proxyURL专门来保存custom proxy url，只要用户没有修改就一直在。底层主要是根据proxy mode来切换的，这个proxyURL有没有值不会影响底层的，

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #https://github.com/CherryHQ/cherry-studio/issues/9064

