### PR TITLE
refactor(AppUpdater): remove mainWindow dependency and utilize windowService

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -70,7 +70,7 @@ const memoryService = MemoryService.getInstance()
 const dxtService = new DxtService()
 
 export function registerIpc(mainWindow: BrowserWindow, app: Electron.App) {
-  const appUpdater = new AppUpdater(mainWindow)
+  const appUpdater = new AppUpdater()
   const notificationService = new NotificationService(mainWindow)
 
   // Initialize Python service with main window

--- a/src/main/services/AppUpdater.ts
+++ b/src/main/services/AppUpdater.ts
@@ -9,6 +9,7 @@ import { CancellationToken, UpdateInfo } from 'builder-util-runtime'
 import { app, BrowserWindow, dialog } from 'electron'
 import { AppUpdater as _AppUpdater, autoUpdater, Logger, NsisUpdater, UpdateCheckResult } from 'electron-updater'
 import path from 'path'
+import { windowService } from './WindowService'
 
 import icon from '../../../build/icon.png?asset'
 import { configManager } from './ConfigManager'
@@ -21,7 +22,7 @@ export default class AppUpdater {
   private cancellationToken: CancellationToken = new CancellationToken()
   private updateCheckResult: UpdateCheckResult | null = null
 
-  constructor(mainWindow: BrowserWindow) {
+  constructor() {
     autoUpdater.logger = logger as Logger
     autoUpdater.forceDevUpdateConfig = !app.isPackaged
     autoUpdater.autoDownload = configManager.getAutoUpdate()
@@ -33,12 +34,12 @@ export default class AppUpdater {
 
     autoUpdater.on('error', (error) => {
       logger.error('update error', error as Error)
-      mainWindow.webContents.send(IpcChannel.UpdateError, error)
+      windowService.getMainWindow()?.webContents.send(IpcChannel.UpdateError, error)
     })
 
     autoUpdater.on('update-available', (releaseInfo: UpdateInfo) => {
       logger.info('update available', releaseInfo)
-      mainWindow.webContents.send(IpcChannel.UpdateAvailable, releaseInfo)
+      windowService.getMainWindow()?.webContents.send(IpcChannel.UpdateAvailable, releaseInfo)
     })
 
     // 检测到不需要更新时
@@ -49,17 +50,17 @@ export default class AppUpdater {
         return
       }
 
-      mainWindow.webContents.send(IpcChannel.UpdateNotAvailable)
+      windowService.getMainWindow()?.webContents.send(IpcChannel.UpdateNotAvailable)
     })
 
     // 更新下载进度
     autoUpdater.on('download-progress', (progress) => {
-      mainWindow.webContents.send(IpcChannel.DownloadProgress, progress)
+      windowService.getMainWindow()?.webContents.send(IpcChannel.DownloadProgress, progress)
     })
 
     // 当需要更新的内容下载完成后
     autoUpdater.on('update-downloaded', (releaseInfo: UpdateInfo) => {
-      mainWindow.webContents.send(IpcChannel.UpdateDownloaded, releaseInfo)
+      windowService.getMainWindow()?.webContents.send(IpcChannel.UpdateDownloaded, releaseInfo)
       this.releaseInfo = releaseInfo
       logger.info('update downloaded', releaseInfo)
     })


### PR DESCRIPTION
…Service

- Updated AppUpdater to eliminate the mainWindow parameter from the constructor.
- Replaced direct mainWindow references with windowService calls to retrieve the main window, improving modularity and decoupling.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
有一定概率检测更新会报下面的错误
```
{"level":"error","message":"Error: TypeError: Object has been destroyed\n    at MacUpdater.<anonymous> (/Applications/Cherry Studio.app/Contents/Resources/app.asar/out/main/index.js:69138:15)\n    at MacUpdater.emit (node:events:518:28)\n    at MacUpdater.doCheckForUpdates (/Applications/Cherry Studio.app/Contents/Resources/app.asar/out/main/index.js:67869:10)\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at async AppUpdater.checkForUpdates (/Applications/Cherry Studio.app/Contents/Resources/app.asar/out/main/index.js:69251:30)\n    at async /Applications/Cherry Studio.app/Contents/Resources/app.asar/out/main/index.js:604309:10\n    at async Session.<anonymous> (node:electron/js2c/browser_init:2:107024)","module":"AppUpdater","process":"main","timestamp":"2025-08-11 17:20:51"}
{"level":"error","message":"update error Object has been destroyed","stack":"TypeError: Object has been destroyed\n    at MacUpdater.<anonymous> (/Applications/Cherry Studio.app/Contents/Resources/app.asar/out/main/index.js:69138:15)\n    at MacUpdater.emit (node:events:518:28)\n    at MacUpdater.doCheckForUpdates (/Applications/Cherry Studio.app/Contents/Resources/app.asar/out/main/index.js:67869:10)\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at async AppUpdater.checkForUpdates (/Applications/Cherry Studio.app/Contents/Resources/app.asar/out/main/index.js:69251:30)\n    at async /Applications/Cherry Studio.app/Contents/Resources/app.asar/out/main/index.js:604309:10\n    at async Session.<anonymous> (node:electron/js2c/browser_init:2:107024)","timestamp":"2025-08-11 17:20:51"}
{"level":"error","message":"Failed to check for update: Object has been destroyed","stack":"TypeError: Object has been destroyed\n    at MacUpdater.<anonymous> (/Applications/Cherry Studio.app/Contents/Resources/app.asar/out/main/index.js:69127:15)\n    at MacUpdater.emit (node:events:530:35)\n    at /Applications/Cherry Studio.app/Contents/Resources/app.asar/out/main/index.js:67761:10\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at async AppUpdater.checkForUpdates (/Applications/Cherry Studio.app/Contents/Resources/app.asar/out/main/index.js:69251:30)\n    at async /Applications/Cherry Studio.app/Contents/Resources/app.asar/out/main/index.js:604309:10\n    at async Session.<anonymous> (node:electron/js2c/browser_init:2:107024)","timestamp":"2025-08-11 17:20:51"}
```

constructor里面的mainWindow.webcontens 是desctroyed， 但是windows本身是没有是没有问题的，应该是中途有重建过windows了

After this PR:

实时获取mainWindow，而不是将mainWindow保存起来。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
