### PR TITLE
fix: web search button memory leak

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/InputbarTools.tsx
+++ b/src/renderer/src/pages/home/Inputbar/InputbarTools.tsx
@@ -501,7 +501,7 @@ const InputbarTools = ({
     return hiddenTools.filter((tool) => tool.condition ?? true).length > 0
   }, [hiddenTools])
 
-  const getMenuItems = useMemo(() => {
+  const menuItems = useMemo(() => {
     const baseItems: ItemType[] = [...visibleTools, ...hiddenTools].map((tool) => ({
       label: tool.label,
       key: tool.key,
@@ -533,7 +533,7 @@ const InputbarTools = ({
   }, [hiddenTools, t, targetTool, toggleToolVisibility, visibleTools])
 
   return (
-    <Dropdown menu={{ items: getMenuItems }} trigger={['contextMenu']}>
+    <Dropdown menu={{ items: menuItems }} trigger={['contextMenu']}>
       <ToolsContainer
         onContextMenu={(e) => {
           const target = e.target as HTMLElement

--- a/src/renderer/src/pages/home/Inputbar/InputbarTools.tsx
+++ b/src/renderer/src/pages/home/Inputbar/InputbarTools.tsx
@@ -501,7 +501,7 @@ const InputbarTools = ({
     return hiddenTools.filter((tool) => tool.condition ?? true).length > 0
   }, [hiddenTools])
 
-  const menuItems = useMemo(() => {
+  const getMenuItems = useMemo(() => {
     const baseItems: ItemType[] = [...visibleTools, ...hiddenTools].map((tool) => ({
       label: tool.label,
       key: tool.key,
@@ -533,7 +533,7 @@ const InputbarTools = ({
   }, [hiddenTools, t, targetTool, toggleToolVisibility, visibleTools])
 
   return (
-    <Dropdown menu={{ items: menuItems }} trigger={['contextMenu']}>
+    <Dropdown menu={{ items: getMenuItems }} trigger={['contextMenu']}>
       <ToolsContainer
         onContextMenu={(e) => {
           const target = e.target as HTMLElement

--- a/src/renderer/src/pages/home/Inputbar/WebSearchButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/WebSearchButton.tsx
@@ -7,7 +7,7 @@ import { Assistant, WebSearchProvider } from '@renderer/types'
 import { hasObjectKey } from '@renderer/utils'
 import { Tooltip } from 'antd'
 import { Globe } from 'lucide-react'
-import { FC, memo, useCallback, useImperativeHandle, useMemo } from 'react'
+import { FC, memo, startTransition, useCallback, useImperativeHandle, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 export interface WebSearchButtonRef {
@@ -28,26 +28,23 @@ const WebSearchButton: FC<Props> = ({ ref, assistant, ToolbarButton }) => {
 
   const enableWebSearch = assistant?.webSearchProviderId || assistant.enableWebSearch
 
-  // FIXME: 内存泄露风险
   const updateSelectedWebSearchProvider = useCallback(
-    (providerId?: WebSearchProvider['id']) => {
+    async (providerId?: WebSearchProvider['id']) => {
       // TODO: updateAssistant有性能问题，会导致关闭快捷面板卡顿
-      // NOTE: 也许可以用startTransition优化卡顿问题
-      setTimeout(() => {
-        const currentWebSearchProviderId = assistant.webSearchProviderId
-        const newWebSearchProviderId = currentWebSearchProviderId === providerId ? undefined : providerId
+      const currentWebSearchProviderId = assistant.webSearchProviderId
+      const newWebSearchProviderId = currentWebSearchProviderId === providerId ? undefined : providerId
+      startTransition(() => {
         updateAssistant({ ...assistant, webSearchProviderId: newWebSearchProviderId, enableWebSearch: false })
-      }, 200)
+      })
     },
     [assistant, updateAssistant]
   )
 
-  // FIXME: 内存泄露风险
-  const updateSelectedWebSearchBuiltin = useCallback(() => {
+  const updateSelectedWebSearchBuiltin = useCallback(async () => {
     // TODO: updateAssistant有性能问题，会导致关闭快捷面板卡顿
-    setTimeout(() => {
+    startTransition(() => {
       updateAssistant({ ...assistant, webSearchProviderId: undefined, enableWebSearch: !assistant.enableWebSearch })
-    }, 200)
+    })
   }, [assistant, updateAssistant])
 
   const providerItems = useMemo<QuickPanelListItem[]>(() => {
@@ -94,11 +91,13 @@ const WebSearchButton: FC<Props> = ({ ref, assistant, ToolbarButton }) => {
 
   const openQuickPanel = useCallback(() => {
     if (assistant.webSearchProviderId) {
-      return updateSelectedWebSearchProvider(undefined)
+      updateSelectedWebSearchProvider(undefined)
+      return
     }
 
     if (assistant.enableWebSearch) {
-      return updateSelectedWebSearchBuiltin()
+      updateSelectedWebSearchBuiltin()
+      return
     }
 
     quickPanel.open({

--- a/src/renderer/src/pages/home/Inputbar/WebSearchButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/WebSearchButton.tsx
@@ -28,6 +28,7 @@ const WebSearchButton: FC<Props> = ({ ref, assistant, ToolbarButton }) => {
 
   const enableWebSearch = assistant?.webSearchProviderId || assistant.enableWebSearch
 
+  // FIXME: 内存泄露风险
   const updateSelectedWebSearchProvider = useCallback(
     (providerId?: WebSearchProvider['id']) => {
       // TODO: updateAssistant有性能问题，会导致关闭快捷面板卡顿
@@ -41,6 +42,7 @@ const WebSearchButton: FC<Props> = ({ ref, assistant, ToolbarButton }) => {
     [assistant, updateAssistant]
   )
 
+  // FIXME: 内存泄露风险
   const updateSelectedWebSearchBuiltin = useCallback(() => {
     // TODO: updateAssistant有性能问题，会导致关闭快捷面板卡顿
     setTimeout(() => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

网络搜索按钮使用的函数中设置了未管理的定时器，有内存泄露风险，尤其是该组件会经常用到。

尝试使用`startTransition`避免UI阻塞，同时不再使用可能导致内存泄露的定时器。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
