### PR TITLE
chore: use destroyOnHidden instead of deprecated destroyOnClose

### DIFF
--- a/src/renderer/src/components/CodeBlockView/HtmlArtifactsPopup.tsx
+++ b/src/renderer/src/components/CodeBlockView/HtmlArtifactsPopup.tsx
@@ -133,7 +133,7 @@ const HtmlArtifactsPopup: React.FC<HtmlArtifactsPopupProps> = ({ open, title, ht
       open={open}
       afterClose={onClose}
       centered={!isFullscreen}
-      destroyOnClose
+      destroyOnHidden
       mask={!isFullscreen}
       maskClosable={false}
       width={isFullscreen ? '100vw' : '90vw'}

--- a/src/renderer/src/components/MinApp/MinappPopupContainer.tsx
+++ b/src/renderer/src/components/MinApp/MinappPopupContainer.tsx
@@ -499,7 +499,7 @@ const MinappPopupContainer: React.FC = () => {
       placement="bottom"
       onClose={handlePopupMinimize}
       open={isPopupShow}
-      destroyOnClose={false}
+      destroyOnHidden={false}
       mask={false}
       rootClassName="minapp-drawer"
       maskClassName="minapp-mask"

--- a/src/renderer/src/components/Popups/SaveToKnowledgePopup.tsx
+++ b/src/renderer/src/components/Popups/SaveToKnowledgePopup.tsx
@@ -349,7 +349,7 @@ const PopupContainer: React.FC<Props> = ({ source, title, resolve }) => {
       onOk={onOk}
       onCancel={onCancel}
       afterClose={onClose}
-      destroyOnClose
+      destroyOnHidden
       centered
       width={500}
       okText={t('common.save')}

--- a/src/renderer/src/pages/home/Messages/ChatNavigation.tsx
+++ b/src/renderer/src/pages/home/Messages/ChatNavigation.tsx
@@ -403,7 +403,7 @@ const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
         onClose={handleDrawerClose}
         open={showChatHistory}
         width={680}
-        destroyOnClose
+        destroyOnHidden
         styles={{
           header: { border: 'none' },
           body: {

--- a/src/renderer/src/pages/knowledge/components/KnowledgeSettings/KnowledgeBaseFormModal.tsx
+++ b/src/renderer/src/pages/knowledge/components/KnowledgeSettings/KnowledgeBaseFormModal.tsx
@@ -21,7 +21,7 @@ const KnowledgeBaseFormModal: React.FC<KnowledgeBaseFormModalProps> = ({ panels,
 
   return (
     <StyledModal
-      destroyOnClose
+      destroyOnHidden
       maskClosable={false}
       centered
       transitionName="animation-move-down"

--- a/src/renderer/src/pages/settings/MCPSettings/AddMcpServerModal.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/AddMcpServerModal.tsx
@@ -274,7 +274,7 @@ const AddMcpServerModal: FC<AddMcpServerModalProps> = ({
         onClose()
       }}
       confirmLoading={loading}
-      destroyOnClose
+      destroyOnHidden
       centered
       transitionName="animation-move-down"
       width={600}>

--- a/src/renderer/src/pages/settings/SelectionAssistantSettings/components/MacProcessTrustHintModal.tsx
+++ b/src/renderer/src/pages/settings/SelectionAssistantSettings/components/MacProcessTrustHintModal.tsx
@@ -39,7 +39,7 @@ const MacProcessTrustHintModal: FC<MacProcessTrustHintModalProps> = ({ open, onC
         </div>
       }
       centered
-      destroyOnClose>
+      destroyOnHidden>
       <ContentContainer>
         <Paragraph>
           <Text>

--- a/src/renderer/src/pages/settings/SelectionAssistantSettings/components/SelectionActionSearchModal.tsx
+++ b/src/renderer/src/pages/settings/SelectionAssistantSettings/components/SelectionActionSearchModal.tsx
@@ -149,7 +149,7 @@ const SelectionActionSearchModal: FC<SelectionActionSearchModalProps> = ({
       open={isModalOpen}
       onOk={handleOk}
       onCancel={handleCancel}
-      destroyOnClose
+      destroyOnHidden
       centered>
       <Form
         form={form}

--- a/src/renderer/src/pages/settings/SelectionAssistantSettings/components/SelectionFilterListModal.tsx
+++ b/src/renderer/src/pages/settings/SelectionAssistantSettings/components/SelectionFilterListModal.tsx
@@ -46,7 +46,7 @@ const SelectionFilterListModal: FC<SelectionFilterListModalProps> = ({ open, onC
       onCancel={onClose}
       maskClosable={false}
       keyboard={true}
-      destroyOnClose={true}
+      destroyOnHidden={true}
       footer={[
         <Button key="modal-cancel" onClick={onClose}>
           {t('common.cancel')}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

antd 5.25.0 开始使用 `destroyOnHidden` 代替 `destroyOnClose`

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
