### PR TITLE
Update label.ts

### DIFF
--- a/src/renderer/src/i18n/label.ts
+++ b/src/renderer/src/i18n/label.ts
@@ -293,7 +293,7 @@ export const getFileFieldLabel = (key: string): string => {
 
 const builtInMcpDescriptionKeyMap = {
   '@cherry/mcp-auto-install': 'settings.mcp.builtinServersDescriptions.mcp_auto_install',
-  '@cherry/memory': 'settings.mcp.builtinServersDescriptions.mcp_auto_install',
+  '@cherry/memory': 'settings.mcp.builtinServersDescriptions.memory',
   '@cherry/sequentialthinking': 'settings.mcp.builtinServersDescriptions.sequentialthinking',
   '@cherry/brave-search': 'settings.mcp.builtinServersDescriptions.brave_search',
   '@cherry/fetch': 'settings.mcp.builtinServersDescriptions.fetch',


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
`@cherry/memory` 模块的内置服务器描述键错误地指向了 `settings.mcp.builtInServersDescriptions.mcp_auto_install`。

After this PR:
`@cherry/memory` 模块的内置服务器描述键已更正为指向 `settings.mcp.builtInServersDescriptions.memory`，确保了正确的国际化（i18n）标签映射。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

需要此更改是为了修正 `@cherry/memory` 模块的 i18n 键映射错误。原始配置中 `@cherry/memory` 的描述键错误地使用了 `@cherry/mcp-auto-install` 的键，导致在显示相关标签时可能出现错误或不一致。通过将其更正为 `settings.mcp.builtInServersDescriptions.memory`，我们确保了 UI 中 `@cherry/memory` 功能的描述能够正确加载和显示。

The following tradeoffs were made:
无显著权衡。这是一个直接的错误修正。

The following alternatives were considered:
无替代方案，这是一个必要的修正。

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

此 PR 未引入任何破坏性更改。它只是修正了一个现有的配置错误。

### Special notes for your reviewer

<!-- optional -->
请注意，此更改位于 `src/renderer/src/i18n/label.ts` 文件中，并修正了 `builtInMcpDescriptionKeyMap` 对象中 `@cherry/memory` 键的值。请验证更改后的键是否与预期的 i18n 路径匹配。

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
    * （此为 i18n 键修正，通常不影响升级流程，除非旧版本依赖于此错误值）
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.
    * （此为内部配置修正，不涉及新的用户功能，因此无需更新用户指南。）

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
修正了 `@cherry/memory` 模块的国际化（i18n）描述键映射，确保了 UI 中相关标签的正确显示。此更改修复了一个配置错误，无需用户采取任何操作。
