### PR TITLE
fix: websearch

### DIFF
--- a/src/renderer/src/providers/WebSearchProvider/LocalSearchProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/LocalSearchProvider.ts
@@ -89,14 +89,8 @@ export default class LocalSearchProvider extends BaseWebSearchProvider {
    * @returns 带有语言过滤的查询
    */
   protected applyLanguageFilter(query: string, language: string): string {
-    if (this.provider.id.includes('local-google')) {
+    if (this.provider.id.includes('local-google') || this.provider.id.includes('local-bing')) {
       return `${query} lang:${language.split('-')[0]}`
-    }
-    if (this.provider.id.includes('local-bing')) {
-      return `${query} language:${language}`
-    }
-    if (this.provider.id.includes('local-baidu')) {
-      return `${query} language:${language.split('-')[0]}`
     }
     return query
   }


### PR DESCRIPTION
Fix #9019
Fix #9208
bing搜索 语言过滤标签为 `lang: en`
百度搜搜语言过滤标签无用