### PR TITLE
fix: Update KnowledgeBase form and service to handle preprocess provider correctly

### DIFF
--- a/src/renderer/src/hooks/useKnowledgeBaseForm.ts
+++ b/src/renderer/src/hooks/useKnowledgeBaseForm.ts
@@ -2,7 +2,7 @@ import { getEmbeddingMaxContext } from '@renderer/config/embedings'
 import { usePreprocessProviders } from '@renderer/hooks/usePreprocess'
 import { useProviders } from '@renderer/hooks/useProvider'
 import { getModelUniqId } from '@renderer/services/ModelService'
-import { KnowledgeBase } from '@renderer/types'
+import { KnowledgeBase, PreprocessProviderId } from '@renderer/types'
 import { nanoid } from 'nanoid'
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -90,8 +90,10 @@ export const useKnowledgeBaseForm = (base?: KnowledgeBase) => {
       }
       setNewBase((prev) => ({
         ...prev,
+
         preprocessProvider: {
           type: 'preprocess',
+          providerId: value as PreprocessProviderId,
           provider
         }
       }))

--- a/src/renderer/src/services/KnowledgeService.ts
+++ b/src/renderer/src/services/KnowledgeService.ts
@@ -21,6 +21,17 @@ export const getKnowledgeBaseParams = (base: KnowledgeBase): KnowledgeBaseParams
   const aiProvider = new AiProvider(provider)
   const rerankAiProvider = new AiProvider(rerankProvider)
 
+  // get preprocess provider from store instead of base.preprocessProvider
+  const preprocessProvider = store
+    .getState()
+    .preprocess.providers.find((p) => p.id === base.preprocessProvider?.provider.id)
+  base.preprocessProvider = preprocessProvider
+    ? {
+        type: 'preprocess',
+        provider: preprocessProvider
+      }
+    : base.preprocessProvider
+
   let host = aiProvider.getBaseURL()
   const rerankHost = rerankAiProvider.getBaseURL()
   if (provider.type === 'gemini') {


### PR DESCRIPTION
…der correctly

- Enhanced useKnowledgeBaseForm hook to set preprocessProvider with the correct providerId type.
- Modified getKnowledgeBaseParams function to retrieve preprocess provider from the store instead of the base, ensuring accurate provider assignment.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
