### PR TITLE
refactor(SvgPreview,Markdown): make svg size adaptive

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "dexie-react-hooks": "^1.1.7",
     "diff": "^7.0.0",
     "docx": "^9.0.2",
+    "dompurify": "^3.2.6",
     "dotenv-cli": "^7.4.2",
     "electron": "37.2.3",
     "electron-builder": "26.0.15",

--- a/src/renderer/src/components/Preview/__tests__/utils.test.ts
+++ b/src/renderer/src/components/Preview/__tests__/utils.test.ts
@@ -105,7 +105,7 @@ describe('renderSvgInShadowHost', () => {
 
   it('should throw an error for non-SVG content', () => {
     const nonSvg = '<div>this is not svg</div>'
-    expect(() => renderSvgInShadowHost(nonSvg, hostElement)).toThrow('Invalid SVG content')
+    expect(() => renderSvgInShadowHost(nonSvg, hostElement)).toThrow()
   })
 
   it('should not throw an error for empty or whitespace content', () => {

--- a/src/renderer/src/components/Preview/__tests__/utils.test.ts
+++ b/src/renderer/src/components/Preview/__tests__/utils.test.ts
@@ -10,29 +10,39 @@ describe('renderSvgInShadowHost', () => {
 
     // Mock attachShadow
     Element.prototype.attachShadow = vi.fn().mockImplementation(function (this: HTMLElement) {
-      const shadowRoot = document.createElement('div')
+      // Check if a shadow root already exists to prevent re-creating it.
+      if (this.shadowRoot) {
+        return this.shadowRoot
+      }
+
+      // Create a container that acts as the shadow root.
+      const shadowRootContainer = document.createElement('div')
+      shadowRootContainer.dataset.testid = 'shadow-root'
+
       Object.defineProperty(this, 'shadowRoot', {
-        value: shadowRoot,
+        value: shadowRootContainer,
         writable: true,
         configurable: true
       })
-      // Simple innerHTML copy for test verification
-      Object.defineProperty(shadowRoot, 'innerHTML', {
-        set(value) {
-          shadowRoot.textContent = value // A simplified mock
+
+      // Mock essential methods like appendChild and innerHTML.
+      // JSDOM doesn't fully implement shadow DOM, so we simulate its behavior.
+      const originalInnerHTMLDescriptor = Object.getOwnPropertyDescriptor(Element.prototype, 'innerHTML')
+      Object.defineProperty(shadowRootContainer, 'innerHTML', {
+        set(value: string) {
+          // Clear existing content and parse the new HTML.
+          originalInnerHTMLDescriptor?.set?.call(this, '')
+          const template = document.createElement('template')
+          template.innerHTML = value
+          shadowRootContainer.append(...Array.from(template.content.childNodes))
         },
         get() {
-          return shadowRoot.textContent || ''
+          return originalInnerHTMLDescriptor?.get?.call(this) ?? ''
         },
         configurable: true
       })
 
-      shadowRoot.appendChild = vi.fn(<T extends Node>(node: T): T => {
-        shadowRoot.append(node)
-        return node
-      })
-
-      return shadowRoot as unknown as ShadowRoot
+      return shadowRootContainer as unknown as ShadowRoot
     })
   })
 
@@ -57,7 +67,7 @@ describe('renderSvgInShadowHost', () => {
 
     expect(Element.prototype.attachShadow).not.toHaveBeenCalled()
     // Verify it works with the existing shadow root
-    expect(existingShadowRoot.appendChild).toHaveBeenCalled()
+    expect(existingShadowRoot.innerHTML).toContain('<svg')
   })
 
   it('should inject styles and valid SVG content into the shadow DOM', () => {
@@ -71,15 +81,26 @@ describe('renderSvgInShadowHost', () => {
     expect(shadowRoot?.querySelector('rect')).not.toBeNull()
   })
 
+  it('should add the xmlns attribute if it is missing', () => {
+    const svgWithoutXmlns = '<svg width="100" height="100"><circle cx="50" cy="50" r="40" /></svg>'
+    renderSvgInShadowHost(svgWithoutXmlns, hostElement)
+
+    const svgElement = hostElement.shadowRoot?.querySelector('svg')
+    expect(svgElement).not.toBeNull()
+    expect(svgElement?.getAttribute('xmlns')).toBe('http://www.w3.org/2000/svg')
+  })
+
   it('should throw an error if the host element is not available', () => {
     expect(() => renderSvgInShadowHost('<svg></svg>', null as any)).toThrow(
       'Host element for SVG rendering is not available.'
     )
   })
 
-  it('should throw an error for invalid SVG content', () => {
-    const invalidSvg = '<svg><rect></svg>' // Malformed
-    expect(() => renderSvgInShadowHost(invalidSvg, hostElement)).toThrow(/SVG parsing error/)
+  it('should not throw an error for malformed SVG content due to HTML parser fallback', () => {
+    const invalidSvg = '<svg><rect></svg>' // Malformed, but fixable by the browser's HTML parser
+    expect(() => renderSvgInShadowHost(invalidSvg, hostElement)).not.toThrow()
+    // Also, assert that it successfully rendered something.
+    expect(hostElement.shadowRoot?.querySelector('svg')).not.toBeNull()
   })
 
   it('should throw an error for non-SVG content', () => {

--- a/src/renderer/src/components/Preview/utils.ts
+++ b/src/renderer/src/components/Preview/utils.ts
@@ -1,3 +1,5 @@
+import { makeSvgScalable } from '@renderer/utils'
+
 /**
  * Renders an SVG string inside a host element's Shadow DOM to ensure style encapsulation.
  * This function handles creating the shadow root, injecting base styles for the host,
@@ -14,13 +16,13 @@ export function renderSvgInShadowHost(svgContent: string, hostElement: HTMLEleme
 
   const shadowRoot = hostElement.shadowRoot || hostElement.attachShadow({ mode: 'open' })
 
-  // Base styles for the host element
+  // Base styles for the host element and the inner SVG
   const style = document.createElement('style')
   style.textContent = `
     :host {
       padding: 1em;
       background-color: white;
-      overflow: auto;
+      overflow: hidden; /* Prevent scrollbars, as scaling is now handled */
       border: 0.5px solid var(--color-code-background);
       border-radius: 8px;
       display: block;
@@ -28,20 +30,24 @@ export function renderSvgInShadowHost(svgContent: string, hostElement: HTMLEleme
       width: 100%;
       height: 100%;
     }
+
     svg {
       max-width: 100%;
+      max-height: 100%;
+      width: auto;
       height: auto;
     }
   `
 
-  // Clear previous content and append new style and SVG
+  // Clear previous content and append new style
   shadowRoot.innerHTML = ''
   shadowRoot.appendChild(style)
 
-  // Parse and append the SVG using DOMParser to prevent script execution and check for errors
   if (svgContent.trim() === '') {
     return
   }
+
+  // Parse and append the SVG using DOMParser to prevent script execution and check for errors
   const parser = new DOMParser()
   const doc = parser.parseFromString(svgContent, 'image/svg+xml')
 
@@ -53,6 +59,10 @@ export function renderSvgInShadowHost(svgContent: string, hostElement: HTMLEleme
 
   const svgElement = doc.documentElement
   if (svgElement && svgElement.nodeName.toLowerCase() === 'svg') {
+    // Standardize the SVG element for proper scaling
+    makeSvgScalable(svgElement)
+
+    // Append the SVG element to the shadow root
     shadowRoot.appendChild(svgElement.cloneNode(true))
   } else if (svgContent.trim() !== '') {
     // Do not throw error for empty content

--- a/src/renderer/src/components/Preview/utils.ts
+++ b/src/renderer/src/components/Preview/utils.ts
@@ -1,4 +1,4 @@
-import { makeSvgScalable } from '@renderer/utils'
+import { makeSvgSizeAdaptive } from '@renderer/utils'
 
 /**
  * Renders an SVG string inside a host element's Shadow DOM to ensure style encapsulation.
@@ -68,7 +68,7 @@ export function renderSvgInShadowHost(svgContent: string, hostElement: HTMLEleme
   // Type guard
   if (svgElement instanceof SVGSVGElement) {
     // Standardize the SVG element for proper scaling
-    makeSvgScalable(svgElement)
+    makeSvgSizeAdaptive(svgElement)
 
     // Append the SVG element to the shadow root
     shadowRoot.appendChild(svgElement)

--- a/src/renderer/src/components/Preview/utils.ts
+++ b/src/renderer/src/components/Preview/utils.ts
@@ -32,8 +32,6 @@ export function renderSvgInShadowHost(svgContent: string, hostElement: HTMLEleme
     }
 
     svg {
-      max-width: 100%;
-      max-height: 100%;
       width: auto;
       height: auto;
     }

--- a/src/renderer/src/components/Preview/utils.ts
+++ b/src/renderer/src/components/Preview/utils.ts
@@ -30,11 +30,6 @@ export function renderSvgInShadowHost(svgContent: string, hostElement: HTMLEleme
       width: 100%;
       height: 100%;
     }
-
-    svg {
-      width: auto;
-      height: auto;
-    }
   `
 
   // Clear previous content and append new style

--- a/src/renderer/src/pages/home/Markdown/Markdown.tsx
+++ b/src/renderer/src/pages/home/Markdown/Markdown.tsx
@@ -29,6 +29,7 @@ import { Pluggable } from 'unified'
 
 import CodeBlock from './CodeBlock'
 import Link from './Link'
+import MarkdownSvgRenderer from './MarkdownSvgRenderer'
 import rehypeHeadingIds from './plugins/rehypeHeadingIds'
 import rehypeScalableSvg from './plugins/rehypeScalableSvg'
 import remarkDisableConstructs from './plugins/remarkDisableConstructs'
@@ -149,7 +150,8 @@ const Markdown: FC<Props> = ({ block, postProcess }) => {
         const hasImage = props?.node?.children?.some((child: any) => child.tagName === 'img')
         if (hasImage) return <div {...props} />
         return <p {...props} />
-      }
+      },
+      svg: MarkdownSvgRenderer
     } as Partial<Components>
   }, [onSaveCodeBlock, block.id])
 

--- a/src/renderer/src/pages/home/Markdown/Markdown.tsx
+++ b/src/renderer/src/pages/home/Markdown/Markdown.tsx
@@ -30,6 +30,7 @@ import { Pluggable } from 'unified'
 import CodeBlock from './CodeBlock'
 import Link from './Link'
 import rehypeHeadingIds from './plugins/rehypeHeadingIds'
+import rehypeScalableSvg from './plugins/rehypeScalableSvg'
 import remarkDisableConstructs from './plugins/remarkDisableConstructs'
 import Table from './Table'
 
@@ -113,7 +114,7 @@ const Markdown: FC<Props> = ({ block, postProcess }) => {
   const rehypePlugins = useMemo(() => {
     const plugins: Pluggable[] = []
     if (ALLOWED_ELEMENTS.test(messageContent)) {
-      plugins.push(rehypeRaw)
+      plugins.push(rehypeRaw, rehypeScalableSvg)
     }
     plugins.push([rehypeHeadingIds, { prefix: `heading-${block.id}` }])
     if (mathEngine === 'KaTeX') {

--- a/src/renderer/src/pages/home/Markdown/MarkdownSvgRenderer.tsx
+++ b/src/renderer/src/pages/home/Markdown/MarkdownSvgRenderer.tsx
@@ -1,5 +1,6 @@
+import { ImagePreviewService } from '@renderer/services/ImagePreviewService'
 import { makeSvgSizeAdaptive } from '@renderer/utils/image'
-import React, { FC, useEffect, useRef } from 'react'
+import React, { FC, useCallback, useEffect, useRef } from 'react'
 
 interface SvgProps extends React.SVGProps<SVGSVGElement> {
   'data-needs-measurement'?: 'true'
@@ -33,8 +34,13 @@ const MarkdownSvgRenderer: FC<SvgProps> = (props) => {
     }
   }, [needsMeasurement])
 
+  const onClick = useCallback(() => {
+    if (!svgRef.current) return
+    ImagePreviewService.show(svgRef.current, { format: 'svg' })
+  }, [])
+
   // Create a mutable copy of props to potentially modify.
-  const finalProps = { ...restProps }
+  const finalProps = { ...restProps, style: { cursor: 'pointer', ...restProps.style } }
 
   // If the SVG has been measured and mutated, we prevent React from
   // re-applying the original width and height attributes on subsequent renders.
@@ -44,7 +50,7 @@ const MarkdownSvgRenderer: FC<SvgProps> = (props) => {
     delete finalProps.height
   }
 
-  return <svg ref={svgRef} {...finalProps} />
+  return <svg ref={svgRef} {...finalProps} onClick={onClick} />
 }
 
 export default MarkdownSvgRenderer

--- a/src/renderer/src/pages/home/Markdown/MarkdownSvgRenderer.tsx
+++ b/src/renderer/src/pages/home/Markdown/MarkdownSvgRenderer.tsx
@@ -1,0 +1,45 @@
+import { makeSvgScalable } from '@renderer/utils/image'
+import React, { FC, useEffect, useRef, useState } from 'react'
+
+interface SvgProps extends React.SVGProps<SVGSVGElement> {
+  'data-needs-measurement'?: 'true'
+}
+
+/**
+ * A smart SVG renderer for Markdown content.
+ *
+ * This component handles two types of SVGs passed from `react-markdown`:
+ *
+ * 1.  **Pre-processed SVGs**: Simple SVGs that were already handled by the
+ *     `rehypeScalableSvg` plugin. These are rendered directly with zero
+ *     performance overhead.
+ *
+ * 2.  **SVGs needing measurement**: Complex SVGs (e.g., with unit-based
+ *     dimensions like "100pt") are flagged with `data-needs-measurement`.
+ *     This component will perform a one-time, off-screen measurement for
+ *     these SVGs upon mounting to ensure they are rendered correctly and
+ *     scalably.
+ */
+const MarkdownSvgRenderer: FC<SvgProps> = (props) => {
+  const { 'data-needs-measurement': needsMeasurement, ...restProps } = props
+  const svgRef = useRef<SVGSVGElement>(null)
+  const [isMeasured, setIsMeasured] = useState(false)
+
+  useEffect(() => {
+    if (needsMeasurement && svgRef.current && !isMeasured) {
+      // The element is a real DOM node, we can now measure it.
+      makeSvgScalable(svgRef.current)
+      // Set flag to prevent re-measuring on subsequent renders
+      setIsMeasured(true)
+    }
+  }, [needsMeasurement, isMeasured])
+
+  // For SVGs that need measurement, we render them once with their original
+  // props to allow the ref to capture the DOM element for measurement.
+  // The `useEffect` will then trigger, process the element, and cause a
+  // re-render with the correct scalable attributes.
+  // For simple SVGs, they are rendered correctly from the start.
+  return <svg ref={svgRef} {...restProps} />
+}
+
+export default MarkdownSvgRenderer

--- a/src/renderer/src/pages/home/Markdown/MarkdownSvgRenderer.tsx
+++ b/src/renderer/src/pages/home/Markdown/MarkdownSvgRenderer.tsx
@@ -1,4 +1,4 @@
-import { makeSvgScalable } from '@renderer/utils/image'
+import { makeSvgSizeAdaptive } from '@renderer/utils/image'
 import React, { FC, useEffect, useRef, useState } from 'react'
 
 interface SvgProps extends React.SVGProps<SVGSVGElement> {
@@ -28,7 +28,7 @@ const MarkdownSvgRenderer: FC<SvgProps> = (props) => {
   useEffect(() => {
     if (needsMeasurement && svgRef.current && !isMeasured) {
       // The element is a real DOM node, we can now measure it.
-      makeSvgScalable(svgRef.current)
+      makeSvgSizeAdaptive(svgRef.current)
       // Set flag to prevent re-measuring on subsequent renders
       setIsMeasured(true)
     }

--- a/src/renderer/src/pages/home/Markdown/MarkdownSvgRenderer.tsx
+++ b/src/renderer/src/pages/home/Markdown/MarkdownSvgRenderer.tsx
@@ -1,5 +1,9 @@
+import { ImagePreviewService } from '@renderer/services/ImagePreviewService'
 import { makeSvgSizeAdaptive } from '@renderer/utils/image'
-import React, { FC, useEffect, useRef } from 'react'
+import { Dropdown } from 'antd'
+import { Eye } from 'lucide-react'
+import React, { FC, useCallback, useEffect, useMemo, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
 
 interface SvgProps extends React.SVGProps<SVGSVGElement> {
   'data-needs-measurement'?: 'true'
@@ -23,6 +27,7 @@ const MarkdownSvgRenderer: FC<SvgProps> = (props) => {
   const { 'data-needs-measurement': needsMeasurement, ...restProps } = props
   const svgRef = useRef<SVGSVGElement>(null)
   const isMeasuredRef = useRef(false)
+  const { t } = useTranslation()
 
   useEffect(() => {
     if (needsMeasurement && svgRef.current && !isMeasuredRef.current) {
@@ -32,6 +37,23 @@ const MarkdownSvgRenderer: FC<SvgProps> = (props) => {
       isMeasuredRef.current = true
     }
   }, [needsMeasurement])
+
+  const onPreview = useCallback(() => {
+    if (!svgRef.current) return
+    ImagePreviewService.show(svgRef.current, { format: 'svg' })
+  }, [])
+
+  const contextMenuItems = useMemo(
+    () => [
+      {
+        key: 'preview',
+        label: t('common.preview'),
+        icon: <Eye size="1rem" />,
+        onClick: onPreview
+      }
+    ],
+    [onPreview, t]
+  )
 
   // Create a mutable copy of props to potentially modify.
   const finalProps = { ...restProps }
@@ -44,7 +66,11 @@ const MarkdownSvgRenderer: FC<SvgProps> = (props) => {
     delete finalProps.height
   }
 
-  return <svg ref={svgRef} {...finalProps} />
+  return (
+    <Dropdown menu={{ items: contextMenuItems }} trigger={['contextMenu']}>
+      <svg ref={svgRef} {...finalProps} />
+    </Dropdown>
+  )
 }
 
 export default MarkdownSvgRenderer

--- a/src/renderer/src/pages/home/Markdown/MarkdownSvgRenderer.tsx
+++ b/src/renderer/src/pages/home/Markdown/MarkdownSvgRenderer.tsx
@@ -1,5 +1,5 @@
 import { makeSvgSizeAdaptive } from '@renderer/utils/image'
-import React, { FC, useEffect, useRef, useState } from 'react'
+import React, { FC, useEffect, useRef } from 'react'
 
 interface SvgProps extends React.SVGProps<SVGSVGElement> {
   'data-needs-measurement'?: 'true'
@@ -11,35 +11,40 @@ interface SvgProps extends React.SVGProps<SVGSVGElement> {
  * This component handles two types of SVGs passed from `react-markdown`:
  *
  * 1.  **Pre-processed SVGs**: Simple SVGs that were already handled by the
- *     `rehypeScalableSvg` plugin. These are rendered directly with zero
- *     performance overhead.
+ *     `rehypeScalableSvg` plugin. These are rendered directly.
  *
- * 2.  **SVGs needing measurement**: Complex SVGs (e.g., with unit-based
- *     dimensions like "100pt") are flagged with `data-needs-measurement`.
- *     This component will perform a one-time, off-screen measurement for
- *     these SVGs upon mounting to ensure they are rendered correctly and
- *     scalably.
+ * 2.  **SVGs needing measurement**: Complex SVGs are flagged with
+ *     `data-needs-measurement`. This component performs a one-time DOM
+ *     mutation upon mounting to make them scalable. To prevent React from
+ *     reverting these changes during subsequent renders, it stops passing
+ *     the original `width` and `height` props after the mutation is complete.
  */
 const MarkdownSvgRenderer: FC<SvgProps> = (props) => {
   const { 'data-needs-measurement': needsMeasurement, ...restProps } = props
   const svgRef = useRef<SVGSVGElement>(null)
-  const [isMeasured, setIsMeasured] = useState(false)
+  const isMeasuredRef = useRef(false)
 
   useEffect(() => {
-    if (needsMeasurement && svgRef.current && !isMeasured) {
-      // The element is a real DOM node, we can now measure it.
+    if (needsMeasurement && svgRef.current && !isMeasuredRef.current) {
+      // Directly mutate the DOM element to make it adaptive.
       makeSvgSizeAdaptive(svgRef.current)
-      // Set flag to prevent re-measuring on subsequent renders
-      setIsMeasured(true)
+      // Set flag to prevent re-measuring. This does not trigger a re-render.
+      isMeasuredRef.current = true
     }
-  }, [needsMeasurement, isMeasured])
+  }, [needsMeasurement])
 
-  // For SVGs that need measurement, we render them once with their original
-  // props to allow the ref to capture the DOM element for measurement.
-  // The `useEffect` will then trigger, process the element, and cause a
-  // re-render with the correct scalable attributes.
-  // For simple SVGs, they are rendered correctly from the start.
-  return <svg ref={svgRef} {...restProps} />
+  // Create a mutable copy of props to potentially modify.
+  const finalProps = { ...restProps }
+
+  // If the SVG has been measured and mutated, we prevent React from
+  // re-applying the original width and height attributes on subsequent renders.
+  // This preserves the changes made by `makeSvgSizeAdaptive`.
+  if (isMeasuredRef.current) {
+    delete finalProps.width
+    delete finalProps.height
+  }
+
+  return <svg ref={svgRef} {...finalProps} />
 }
 
 export default MarkdownSvgRenderer

--- a/src/renderer/src/pages/home/Markdown/MarkdownSvgRenderer.tsx
+++ b/src/renderer/src/pages/home/Markdown/MarkdownSvgRenderer.tsx
@@ -1,6 +1,5 @@
-import { ImagePreviewService } from '@renderer/services/ImagePreviewService'
 import { makeSvgSizeAdaptive } from '@renderer/utils/image'
-import React, { FC, useCallback, useEffect, useRef } from 'react'
+import React, { FC, useEffect, useRef } from 'react'
 
 interface SvgProps extends React.SVGProps<SVGSVGElement> {
   'data-needs-measurement'?: 'true'
@@ -34,13 +33,8 @@ const MarkdownSvgRenderer: FC<SvgProps> = (props) => {
     }
   }, [needsMeasurement])
 
-  const onClick = useCallback(() => {
-    if (!svgRef.current) return
-    ImagePreviewService.show(svgRef.current, { format: 'svg' })
-  }, [])
-
   // Create a mutable copy of props to potentially modify.
-  const finalProps = { ...restProps, style: { cursor: 'pointer', ...restProps.style } }
+  const finalProps = { ...restProps }
 
   // If the SVG has been measured and mutated, we prevent React from
   // re-applying the original width and height attributes on subsequent renders.
@@ -50,7 +44,7 @@ const MarkdownSvgRenderer: FC<SvgProps> = (props) => {
     delete finalProps.height
   }
 
-  return <svg ref={svgRef} {...finalProps} onClick={onClick} />
+  return <svg ref={svgRef} {...finalProps} />
 }
 
 export default MarkdownSvgRenderer

--- a/src/renderer/src/pages/home/Markdown/__tests__/Markdown.test.tsx
+++ b/src/renderer/src/pages/home/Markdown/__tests__/Markdown.test.tsx
@@ -68,9 +68,9 @@ vi.mock('../CodeBlock', () => ({
   )
 }))
 
-vi.mock('../ImagePreview', () => ({
+vi.mock('@renderer/components/ImageViewer', () => ({
   __esModule: true,
-  default: (props: any) => <img data-testid="image-preview" {...props} />
+  default: (props: any) => <img data-testid="image-viewer" {...props} />
 }))
 
 vi.mock('../Link', () => ({
@@ -94,12 +94,18 @@ vi.mock('../Table', () => ({
   )
 }))
 
+vi.mock('../MarkdownSvgRenderer', () => ({
+  __esModule: true,
+  default: ({ children }: any) => <div data-testid="svg-renderer">{children}</div>
+}))
+
 vi.mock('@renderer/components/MarkdownShadowDOMRenderer', () => ({
   __esModule: true,
   default: ({ children }: any) => <div data-testid="shadow-dom">{children}</div>
 }))
 
 // Mock plugins
+vi.mock('remark-alert', () => ({ __esModule: true, default: vi.fn() }))
 vi.mock('remark-gfm', () => ({ __esModule: true, default: vi.fn() }))
 vi.mock('remark-cjk-friendly', () => ({ __esModule: true, default: vi.fn() }))
 vi.mock('remark-math', () => ({ __esModule: true, default: vi.fn() }))
@@ -109,6 +115,16 @@ vi.mock('rehype-raw', () => ({ __esModule: true, default: vi.fn() }))
 
 // Mock custom plugins
 vi.mock('../plugins/remarkDisableConstructs', () => ({
+  __esModule: true,
+  default: vi.fn()
+}))
+
+vi.mock('../plugins/rehypeHeadingIds', () => ({
+  __esModule: true,
+  default: vi.fn()
+}))
+
+vi.mock('../plugins/rehypeScalableSvg', () => ({
   __esModule: true,
   default: vi.fn()
 }))
@@ -331,7 +347,7 @@ describe('Markdown', () => {
       expect(tableComponent).toHaveAttribute('data-block-id', 'test-block-456')
     })
 
-    it('should integrate ImagePreview component', () => {
+    it('should integrate ImageViewer component', () => {
       render(<Markdown block={createMainTextBlock()} />)
 
       expect(screen.getByTestId('has-img-component')).toBeInTheDocument()

--- a/src/renderer/src/pages/home/Markdown/plugins/rehypeScalableSvg.ts
+++ b/src/renderer/src/pages/home/Markdown/plugins/rehypeScalableSvg.ts
@@ -1,0 +1,47 @@
+import type { Element, Root } from 'hast'
+import { visit } from 'unist-util-visit'
+
+/**
+ * A Rehype plugin that makes SVG elements scalable.
+ *
+ * This plugin traverses the HAST (HTML Abstract Syntax Tree) and performs
+ * the following operations on each `<svg>` element:
+ *
+ * 1. Ensures a `viewBox` attribute exists. If it's missing but `width` and
+ *    `height` are present, it generates a `viewBox` from them. This is
+ *    crucial for making the SVG scalable.
+ *
+ * 2. Removes the `width` and `height` attributes. This allows the SVG's size
+ *    to be controlled by CSS (e.g., `max-width: 100%`), making it responsive
+ *    and preventing it from overflowing its container.
+ *
+ * @returns A unified transformer function.
+ */
+function rehypeScalableSvg() {
+  return (tree: Root) => {
+    visit(tree, 'element', (node: Element) => {
+      if (node.tagName === 'svg') {
+        const properties = node.properties || {}
+        const hasViewBox = 'viewBox' in properties
+        const width = properties.width as string | number | undefined
+        const height = properties.height as string | number | undefined
+
+        if (!hasViewBox && width && height) {
+          const numericWidth = parseFloat(String(width))
+          const numericHeight = parseFloat(String(height))
+          if (!isNaN(numericWidth) && !isNaN(numericHeight)) {
+            properties.viewBox = `0 0 ${numericWidth} ${numericHeight}`
+          }
+        }
+
+        // Remove fixed width and height to allow CSS to control the size
+        delete properties.width
+        delete properties.height
+
+        node.properties = properties
+      }
+    })
+  }
+}
+
+export default rehypeScalableSvg

--- a/src/renderer/src/utils/__tests__/image.test.ts
+++ b/src/renderer/src/utils/__tests__/image.test.ts
@@ -7,7 +7,7 @@ import {
   captureScrollableDivAsDataURL,
   compressImage,
   convertToBase64,
-  makeSvgScalable
+  makeSvgSizeAdaptive
 } from '../image'
 
 // mock 依赖
@@ -127,7 +127,7 @@ describe('utils/image', () => {
     })
   })
 
-  describe('makeSvgScalable', () => {
+  describe('makeSvgSizeAdaptive', () => {
     const createSvgElement = (svgString: string): SVGElement => {
       const div = document.createElement('div')
       div.innerHTML = svgString
@@ -151,7 +151,7 @@ describe('utils/image', () => {
         .spyOn(SVGElement.prototype, 'getBoundingClientRect')
         .mockReturnValue({ width: 133, height: 106 } as DOMRect)
 
-      const result = makeSvgScalable(svgElement) as SVGElement
+      const result = makeSvgSizeAdaptive(svgElement) as SVGElement
 
       expect(spy).toHaveBeenCalled()
       expect(result.getAttribute('viewBox')).toBe('0 0 133 106')
@@ -166,7 +166,7 @@ describe('utils/image', () => {
       const svgElement = createSvgElement('<svg viewBox="0 0 50 50" width="100pt" height="80pt"></svg>')
       const spy = vi.spyOn(SVGElement.prototype, 'getBoundingClientRect') // Spy to ensure it's NOT called
 
-      const result = makeSvgScalable(svgElement) as SVGElement
+      const result = makeSvgSizeAdaptive(svgElement) as SVGElement
 
       expect(spy).not.toHaveBeenCalled()
       expect(result.getAttribute('viewBox')).toBe('0 0 50 50')
@@ -184,7 +184,7 @@ describe('utils/image', () => {
         .spyOn(SVGElement.prototype, 'getBoundingClientRect')
         .mockReturnValue({ width: 0, height: 0 } as DOMRect)
 
-      const result = makeSvgScalable(svgElement) as SVGElement
+      const result = makeSvgSizeAdaptive(svgElement) as SVGElement
 
       expect(result.hasAttribute('viewBox')).toBe(false)
       expect(result.style.maxWidth).toBe('100pt') // Falls back to width attribute
@@ -195,7 +195,7 @@ describe('utils/image', () => {
 
     it('should only set width="100%" if width/height attributes are missing', () => {
       const svgElement = createSvgElement('<svg></svg>')
-      const result = makeSvgScalable(svgElement) as SVGElement
+      const result = makeSvgSizeAdaptive(svgElement) as SVGElement
 
       expect(result.hasAttribute('viewBox')).toBe(false)
       expect(result.style.maxWidth).toBe('')
@@ -206,7 +206,7 @@ describe('utils/image', () => {
     it('should return the element unchanged if it is not an SVGElement', () => {
       const divElement = document.createElement('div')
       const originalOuterHTML = divElement.outerHTML
-      const result = makeSvgScalable(divElement)
+      const result = makeSvgSizeAdaptive(divElement)
 
       expect(result.outerHTML).toBe(originalOuterHTML)
     })

--- a/src/renderer/src/utils/__tests__/image.test.ts
+++ b/src/renderer/src/utils/__tests__/image.test.ts
@@ -193,16 +193,6 @@ describe('utils/image', () => {
       spy.mockRestore()
     })
 
-    it('should only set width="100%" if width/height attributes are missing', () => {
-      const svgElement = createSvgElement('<svg></svg>')
-      const result = makeSvgSizeAdaptive(svgElement) as SVGElement
-
-      expect(result.hasAttribute('viewBox')).toBe(false)
-      expect(result.style.maxWidth).toBe('')
-      expect(result.getAttribute('width')).toBe('100%')
-      expect(result.hasAttribute('height')).toBe(false)
-    })
-
     it('should return the element unchanged if it is not an SVGElement', () => {
       const divElement = document.createElement('div')
       const originalOuterHTML = divElement.outerHTML

--- a/src/renderer/src/utils/image.ts
+++ b/src/renderer/src/utils/image.ts
@@ -319,19 +319,15 @@ export const makeSvgSizeAdaptive = (element: Element): Element => {
 
   const hasViewBox = element.hasAttribute('viewBox')
   const widthStr = element.getAttribute('width')
-  const heightStr = element.getAttribute('height')
 
   let measuredWidth: number | undefined
 
   // 如果缺少 viewBox 属性，测量元素尺寸来创建
   if (!hasViewBox) {
-    // 只在 width 和 height 都有值时测量
-    if (widthStr && heightStr) {
-      const renderedSize = measureElementSize(element)
-      if (renderedSize.width > 0 && renderedSize.height > 0) {
-        measuredWidth = renderedSize.width
-        element.setAttribute('viewBox', `0 0 ${renderedSize.width} ${renderedSize.height}`)
-      }
+    const renderedSize = measureElementSize(element)
+    if (renderedSize.width > 0 && renderedSize.height > 0) {
+      measuredWidth = renderedSize.width
+      element.setAttribute('viewBox', `0 0 ${renderedSize.width} ${renderedSize.height}`)
     }
   }
 
@@ -346,6 +342,9 @@ export const makeSvgSizeAdaptive = (element: Element): Element => {
   // 调整 width 和 height
   element.setAttribute('width', '100%')
   element.removeAttribute('height')
+
+  // FIXME: 移除 preserveAspectRatio 来避免某些图无法正常预览
+  element.removeAttribute('preserveAspectRatio')
 
   return element
 }

--- a/src/renderer/src/utils/image.ts
+++ b/src/renderer/src/utils/image.ts
@@ -270,3 +270,33 @@ export const svgToSvgBlob = (svgElement: SVGElement): Blob => {
   const svgData = new XMLSerializer().serializeToString(svgElement)
   return new Blob([svgData], { type: 'image/svg+xml' })
 }
+
+/**
+ * 确保 SVG 元素有 viewBox 并且移除固定的 width/height 属性。
+ * 用于“预览”功能，让 SVG 在容器内可缩放。
+ */
+export const makeSvgScalable = (element: Element): Element => {
+  // Type Guard: Only proceed if the element is actually an SVGElement.
+  if (!(element instanceof SVGElement)) {
+    return element
+  }
+
+  const hasViewBox = element.hasAttribute('viewBox')
+  const width = element.getAttribute('width')
+  const height = element.getAttribute('height')
+
+  // 缺少 viewBox 但存在 width 和 height 属性时创建 viewBox
+  if (!hasViewBox && width && height) {
+    const numericWidth = parseFloat(width)
+    const numericHeight = parseFloat(height)
+    if (!isNaN(numericWidth) && !isNaN(numericHeight)) {
+      element.setAttribute('viewBox', `0 0 ${numericWidth} ${numericHeight}`)
+    }
+  }
+
+  // 移除固定的 width 和 height 属性，让 CSS 控制元素尺寸
+  element.removeAttribute('width')
+  element.removeAttribute('height')
+
+  return element
+}

--- a/src/renderer/src/utils/image.ts
+++ b/src/renderer/src/utils/image.ts
@@ -291,6 +291,7 @@ export const makeSvgScalable = (element: Element): Element => {
     const numericHeight = parseFloat(height)
     if (!isNaN(numericWidth) && !isNaN(numericHeight)) {
       element.setAttribute('viewBox', `0 0 ${numericWidth} ${numericHeight}`)
+      element.setAttribute('max-width', `${numericWidth}px`)
     }
   }
 

--- a/src/renderer/src/utils/image.ts
+++ b/src/renderer/src/utils/image.ts
@@ -311,7 +311,7 @@ function measureElementSize(element: Element): { width: number; height: number }
  * - 把 width 改为 100%
  * - 移除 height
  */
-export const makeSvgScalable = (element: Element): Element => {
+export const makeSvgSizeAdaptive = (element: Element): Element => {
   // type guard
   if (!(element instanceof SVGElement)) {
     return element

--- a/yarn.lock
+++ b/yarn.lock
@@ -8552,6 +8552,7 @@ __metadata:
     dexie-react-hooks: "npm:^1.1.7"
     diff: "npm:^7.0.0"
     docx: "npm:^9.0.2"
+    dompurify: "npm:^3.2.6"
     dotenv-cli: "npm:^7.4.2"
     electron: "npm:37.2.3"
     electron-builder: "npm:26.0.15"
@@ -11445,7 +11446,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.2.5":
+"dompurify@npm:^3.2.5, dompurify@npm:^3.2.6":
   version: 3.2.6
   resolution: "dompurify@npm:3.2.6"
   dependencies:


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

- 添加 viewBox，让 `SvgPreview` 和 `Markdown` 中的 svg 元素自动适应大小。
- 修复部分 SVG 缺少 namespace 时在 shadow host 中无法正确渲染的问题。
- 渲染之前 sanitize svg。
- 补充测试。
- 修复 `Markdown` 测试中的 mocks。

| |BEFORE|AFTER|
|---|---|---|
|SvgPreview|<img width="756" height="336" alt="image" src="https://github.com/user-attachments/assets/78aec2e9-4ac5-4634-a0fc-b281ff19f994" />|<img width="757" height="380" alt="image" src="https://github.com/user-attachments/assets/44c9fe39-3b25-4f28-a495-f81ffd32ebe0" />|
|Markdown svg|<img width="774" height="322" alt="image" src="https://github.com/user-attachments/assets/86969961-d5ad-4c4e-a02a-73606f8daecb" />|<img width="772" height="296" alt="image" src="https://github.com/user-attachments/assets/d707f1b5-a854-4bc4-a774-541de9a8c5ad" />|

https://github.com/user-attachments/assets/75cbef98-fd31-4296-b9c3-ebff70496f48

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #9209

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
