### PR TITLE
ci(PR-CI): grant only read permission for contents in CI

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,5 +1,8 @@
 name: Pull Request CI
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
### What this PR does

Before this PR:
- PR-CI Action 缺少权限控制

 this PR:
- PR-CI 工作流现在仅被授予对仓库内容的读取权限。