### PR TITLE
feat(FileSystemService): 添加文件类型检查

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@libsql/win32-x64-msvc": "^0.4.7",
     "@strongtz/win32-arm64-msvc": "^0.4.7",
     "graceful-fs": "^4.2.11",
+    "istextorbinary": "^9.5.0",
     "jsdom": "26.1.0",
     "node-stream-zip": "^1.15.0",
     "officeparser": "^4.2.0",

--- a/packages/shared/IpcChannel.ts
+++ b/packages/shared/IpcChannel.ts
@@ -155,6 +155,8 @@ export enum IpcChannel {
   File_Base64File = 'file:base64File',
   File_GetPdfInfo = 'file:getPdfInfo',
   Fs_Read = 'fs:read',
+  Fs_IsTextFile = 'fs:isTextFile',
+  Fs_IsTextContent = 'fs:isTextContent',
   File_OpenWithRelativePath = 'file:openWithRelativePath',
 
   // file service

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -464,6 +464,8 @@ export function registerIpc(mainWindow: BrowserWindow, app: Electron.App) {
 
   // fs
   ipcMain.handle(IpcChannel.Fs_Read, FileService.readFile.bind(FileService))
+  ipcMain.handle(IpcChannel.Fs_IsTextFile, FileService.isTextFile.bind(FileService))
+  ipcMain.handle(IpcChannel.Fs_IsTextContent, FileService.isTextContent.bind(FileService))
 
   // export
   ipcMain.handle(IpcChannel.Export_Word, exportService.exportToWord.bind(exportService))

--- a/src/main/services/FileSystemService.ts
+++ b/src/main/services/FileSystemService.ts
@@ -1,5 +1,10 @@
 import { TraceMethod } from '@mcp-trace/trace-core'
 import fs from 'fs/promises'
+import { isText } from 'istextorbinary'
+
+import { loggerService } from './LoggerService'
+
+const logger = loggerService.withContext('FileService')
 
 export default class FileService {
   @TraceMethod({ spanName: 'readFile', tag: 'FileService' })
@@ -7,5 +12,53 @@ export default class FileService {
     const path = pathOrUrl.startsWith('file://') ? new URL(pathOrUrl) : pathOrUrl
     if (encoding) return fs.readFile(path, { encoding })
     return fs.readFile(path)
+  }
+
+  /**
+   * 检测文件是否为文本文件
+   * @param _ IPC event
+   * @param filePath 文件路径
+   * @returns Promise<boolean> 是否为文本文件
+   */
+  @TraceMethod({ spanName: 'isTextFile', tag: 'FileService' })
+  public static async isTextFile(_: Electron.IpcMainInvokeEvent, filePath: string): Promise<boolean> {
+    try {
+      // 读取文件的前 8KB 用于检测（istextorbinary 建议的大小）
+      const buffer = await fs.readFile(filePath, { flag: 'r' })
+      const sampleSize = Math.min(8192, buffer.length)
+      const sampleBuffer = buffer.subarray(0, sampleSize)
+
+      // 使用 istextorbinary 检测文件内容
+      return isText(filePath, sampleBuffer) === true
+    } catch (error) {
+      logger.error('Error detecting file content type:', error as Error)
+      return false
+    }
+  }
+
+  /**
+   * 检测文件内容是否为文本（使用 Buffer 数据）
+   * @param _ IPC event
+   * @param fileName 文件名
+   * @param fileBuffer 文件内容 Buffer
+   * @returns Promise<boolean> 是否为文本文件
+   */
+  @TraceMethod({ spanName: 'isTextContent', tag: 'FileService' })
+  public static async isTextContent(
+    _: Electron.IpcMainInvokeEvent,
+    fileName: string,
+    fileBuffer: ArrayBuffer
+  ): Promise<boolean> {
+    try {
+      const buffer = Buffer.from(fileBuffer)
+      const sampleSize = Math.min(8192, buffer.length)
+      const sampleBuffer = buffer.subarray(0, sampleSize)
+
+      // 使用 istextorbinary 检测文件内容
+      return isText(fileName, sampleBuffer) === true
+    } catch (error) {
+      logger.error('Error detecting file content type:', error as Error)
+      return false
+    }
   }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -172,7 +172,10 @@ const api = {
     openFileWithRelativePath: (file: FileMetadata) => ipcRenderer.invoke(IpcChannel.File_OpenWithRelativePath, file)
   },
   fs: {
-    read: (pathOrUrl: string, encoding?: BufferEncoding) => ipcRenderer.invoke(IpcChannel.Fs_Read, pathOrUrl, encoding)
+    read: (pathOrUrl: string, encoding?: BufferEncoding) => ipcRenderer.invoke(IpcChannel.Fs_Read, pathOrUrl, encoding),
+    isTextFile: (filePath: string) => ipcRenderer.invoke(IpcChannel.Fs_IsTextFile, filePath),
+    isTextContent: (fileName: string, fileBuffer: ArrayBuffer) =>
+      ipcRenderer.invoke(IpcChannel.Fs_IsTextContent, fileName, fileBuffer)
   },
   export: {
     toWord: (markdown: string, fileName: string) => ipcRenderer.invoke(IpcChannel.Export_Word, markdown, fileName)

--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -36,7 +36,7 @@ import { sendMessage as _sendMessage } from '@renderer/store/thunk/messageThunk'
 import { Assistant, FileType, FileTypes, KnowledgeBase, KnowledgeItem, Model, Topic } from '@renderer/types'
 import type { MessageInputBaseParams } from '@renderer/types/newMessage'
 import { classNames, delay, formatFileSize } from '@renderer/utils'
-import { getSupportedExtensions } from '@renderer/utils/fileValidation'
+import { getSupportedExtensions, validateFileMetadata } from '@renderer/utils/fileValidation'
 import { formatQuotedText } from '@renderer/utils/formats'
 import {
   getFilesFromDropEvent,
@@ -609,14 +609,7 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
         if (couldAddTextFile && unsupportedFiles.length > 0) {
           for (const fileMetadata of unsupportedFiles) {
             try {
-              // 获取文件路径并读取内容
-              const filePath = fileMetadata.path || fileMetadata.id + fileMetadata.ext
-              const fileContent = await window.api.file.get(filePath)
-              const file = new File([fileContent], fileMetadata.origin_name)
-
-              // 使用内容检测判断是否为文本文件
-              const { validateFileUpload } = await import('@renderer/utils/fileValidation')
-              const validation = await validateFileUpload(file, false) // 不允许图片，只检测文本
+              const validation = await validateFileMetadata(fileMetadata, false) // 不允许图片，只检测文本
 
               if (validation.allowed) {
                 setFiles((prevFiles) => [...prevFiles, fileMetadata])

--- a/src/renderer/src/pages/home/Messages/MessageEditor.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageEditor.tsx
@@ -11,7 +11,7 @@ import { selectMessagesForTopic } from '@renderer/store/newMessage'
 import { FileMetadata, FileTypes } from '@renderer/types'
 import { Message, MessageBlock, MessageBlockStatus, MessageBlockType } from '@renderer/types/newMessage'
 import { classNames } from '@renderer/utils'
-import { getSupportedExtensions } from '@renderer/utils/fileValidation'
+import { getSupportedExtensions, validateFileMetadata } from '@renderer/utils/fileValidation'
 import { getFilesFromDropEvent, isSendMessageKeyPressed } from '@renderer/utils/input'
 import { createFileBlock, createImageBlock } from '@renderer/utils/messageUtils/create'
 import { findAllBlocks } from '@renderer/utils/messageUtils/find'
@@ -189,14 +189,7 @@ const MessageBlockEditor: FC<Props> = ({ message, topicId, onSave, onResend, onC
       if (couldAddTextFile && unsupportedFiles.length > 0) {
         for (const fileMetadata of unsupportedFiles) {
           try {
-            // 获取文件路径并读取内容
-            const filePath = fileMetadata.path || fileMetadata.id + fileMetadata.ext
-            const fileContent = await window.api.file.get(filePath)
-            const file = new File([fileContent], fileMetadata.origin_name)
-
-            // 使用内容检测判断是否为文本文件
-            const { validateFileUpload } = await import('@renderer/utils/fileValidation')
-            const validation = await validateFileUpload(file, false) // 不允许图片，只检测文本
+            const validation = await validateFileMetadata(fileMetadata, false) // 不允许图片，只检测文本
 
             if (validation.allowed) {
               setFiles((prevFiles) => [...prevFiles, fileMetadata])

--- a/src/renderer/src/pages/home/Messages/MessageEditor.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageEditor.tsx
@@ -11,10 +11,11 @@ import { selectMessagesForTopic } from '@renderer/store/newMessage'
 import { FileMetadata, FileTypes } from '@renderer/types'
 import { Message, MessageBlock, MessageBlockStatus, MessageBlockType } from '@renderer/types/newMessage'
 import { classNames } from '@renderer/utils'
+import { getSupportedExtensions } from '@renderer/utils/fileValidation'
 import { getFilesFromDropEvent, isSendMessageKeyPressed } from '@renderer/utils/input'
 import { createFileBlock, createImageBlock } from '@renderer/utils/messageUtils/create'
 import { findAllBlocks } from '@renderer/utils/messageUtils/find'
-import { documentExts, imageExts, textExts } from '@shared/config/constant'
+import { imageExts } from '@shared/config/constant'
 import { Space, Tooltip } from 'antd'
 import TextArea, { TextAreaRef } from 'antd/es/input/TextArea'
 import { Save, Send, X } from 'lucide-react'
@@ -86,11 +87,11 @@ const MessageBlockEditor: FC<Props> = ({ message, topicId, onSave, onResend, onC
 
   const extensions = useMemo(() => {
     if (couldAddImageFile && couldAddTextFile) {
-      return [...imageExts, ...documentExts, ...textExts]
+      return getSupportedExtensions(true)
     } else if (couldAddImageFile) {
       return [...imageExts]
     } else if (couldAddTextFile) {
-      return [...documentExts, ...textExts]
+      return getSupportedExtensions(false)
     } else {
       return []
     }
@@ -167,17 +168,45 @@ const MessageBlockEditor: FC<Props> = ({ message, topicId, onSave, onResend, onC
     setIsFileDragging(false)
 
     const files = await getFilesFromDropEvent(e).catch((err) => {
-      logger.error('[src/renderer/src/pages/home/Inputbar/Inputbar.tsx] handleDrop:', err)
+      logger.error('[MessageEditor] handleDrop:', err)
       return null
     })
     if (files) {
       let supportedFiles = 0
+      const unsupportedFiles: typeof files = []
+
+      // 首先使用原有的扩展名检查
       files.forEach((file) => {
         if (extensions.includes(file.ext)) {
           setFiles((prevFiles) => [...prevFiles, file])
           supportedFiles++
+        } else {
+          unsupportedFiles.push(file)
         }
       })
+
+      // 对于不支持的扩展名，尝试内容检测（仅当允许文本文件时）
+      if (couldAddTextFile && unsupportedFiles.length > 0) {
+        for (const fileMetadata of unsupportedFiles) {
+          try {
+            // 获取文件路径并读取内容
+            const filePath = fileMetadata.path || fileMetadata.id + fileMetadata.ext
+            const fileContent = await window.api.file.get(filePath)
+            const file = new File([fileContent], fileMetadata.origin_name)
+
+            // 使用内容检测判断是否为文本文件
+            const { validateFileUpload } = await import('@renderer/utils/fileValidation')
+            const validation = await validateFileUpload(file, false) // 不允许图片，只检测文本
+
+            if (validation.allowed) {
+              setFiles((prevFiles) => [...prevFiles, fileMetadata])
+              supportedFiles++
+            }
+          } catch (error) {
+            logger.error('Error detecting file content:', error as Error)
+          }
+        }
+      }
 
       // 如果有文件，但都不支持
       if (files.length > 0 && supportedFiles === 0) {

--- a/src/renderer/src/utils/__tests__/fileValidation.audio-video.test.ts
+++ b/src/renderer/src/utils/__tests__/fileValidation.audio-video.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'vitest'
+
+import { isAudioVideoExtension, validateFileUpload } from '../fileValidation'
+
+describe('Audio Video File Validation', () => {
+  describe('isAudioVideoExtension', () => {
+    test('should identify audio file extensions', () => {
+      expect(isAudioVideoExtension('.mp3')).toBe(true)
+      expect(isAudioVideoExtension('.MP3')).toBe(true)
+      expect(isAudioVideoExtension('.wav')).toBe(true)
+      expect(isAudioVideoExtension('.ogg')).toBe(true)
+      expect(isAudioVideoExtension('.flac')).toBe(true)
+      expect(isAudioVideoExtension('.aac')).toBe(true)
+    })
+
+    test('should identify video file extensions', () => {
+      expect(isAudioVideoExtension('.mp4')).toBe(true)
+      expect(isAudioVideoExtension('.MP4')).toBe(true)
+      expect(isAudioVideoExtension('.avi')).toBe(true)
+      expect(isAudioVideoExtension('.mov')).toBe(true)
+      expect(isAudioVideoExtension('.wmv')).toBe(true)
+      expect(isAudioVideoExtension('.flv')).toBe(true)
+      expect(isAudioVideoExtension('.mkv')).toBe(true)
+    })
+
+    test('should not identify non-audio-video extensions', () => {
+      expect(isAudioVideoExtension('.txt')).toBe(false)
+      expect(isAudioVideoExtension('.js')).toBe(false)
+      expect(isAudioVideoExtension('.png')).toBe(false)
+      expect(isAudioVideoExtension('.pdf')).toBe(false)
+    })
+  })
+
+  describe('validateFileUpload - Audio/Video Blocking', () => {
+    test('should reject audio files', async () => {
+      const audioFile = new File(['fake audio content'], 'test.mp3', { type: 'audio/mpeg' })
+      const result = await validateFileUpload(audioFile, true)
+
+      expect(result.allowed).toBe(false)
+      expect(result.reason).toContain('Audio and video files are not supported')
+    })
+
+    test('should reject video files', async () => {
+      const videoFile = new File(['fake video content'], 'test.mp4', { type: 'video/mp4' })
+      const result = await validateFileUpload(videoFile, true)
+
+      expect(result.allowed).toBe(false)
+      expect(result.reason).toContain('Audio and video files are not supported')
+    })
+
+    test('should reject audio files with uppercase extensions', async () => {
+      const audioFile = new File(['fake audio content'], 'TEST.MP3', { type: 'audio/mpeg' })
+      const result = await validateFileUpload(audioFile, true)
+
+      expect(result.allowed).toBe(false)
+      expect(result.reason).toContain('Audio and video files are not supported')
+    })
+
+    test('should reject video files with uppercase extensions', async () => {
+      const videoFile = new File(['fake video content'], 'TEST.MP4', { type: 'video/mp4' })
+      const result = await validateFileUpload(videoFile, true)
+
+      expect(result.allowed).toBe(false)
+      expect(result.reason).toContain('Audio and video files are not supported')
+    })
+  })
+})

--- a/src/renderer/src/utils/__tests__/fileValidation.test.ts
+++ b/src/renderer/src/utils/__tests__/fileValidation.test.ts
@@ -1,38 +1,220 @@
-import { getSupportedExtensions, validateFileUpload } from '../fileValidation'
+import { describe, expect, test, vi } from 'vitest'
 
-/**
- * 测试文件验证功能
- */
+import { getSupportedExtensions, validateFileMetadata, validateFileUpload } from '../fileValidation'
 
-// 测试扩展名支持
-console.log('=== 测试扩展名支持 ===')
-console.log('支持图片的扩展名:', getSupportedExtensions(true).slice(0, 10)) // 显示前10个
-console.log('不支持图片的扩展名:', getSupportedExtensions(false).slice(0, 10)) // 显示前10个
-
-// 测试文件验证
-const testValidation = async () => {
-  console.log('\n=== 测试文件验证 ===')
-
-  // 测试已知文本文件
-  const textContent = 'This is a test text file content.'
-  const textFile = new File([textContent], 'test.unknown', { type: 'text/plain' })
-
-  const validation = await validateFileUpload(textFile, true)
-  console.log('未知扩展名的文本文件验证结果:', validation)
-
-  // 测试已知扩展名文件
-  const jsFile = new File([textContent], 'test.js', { type: 'text/javascript' })
-  const jsValidation = await validateFileUpload(jsFile, false)
-  console.log('JavaScript文件验证结果:', jsValidation)
-
-  // 测试二进制文件
-  const binaryData = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]) // JPEG header
-  const imageFile = new File([binaryData], 'test.unknown', { type: 'image/jpeg' })
-  const imageValidation = await validateFileUpload(imageFile, true)
-  console.log('未知扩展名的图片文件验证结果:', imageValidation)
+// Mock window.api for testing
+const mockApi = {
+  fs: {
+    isTextContent: vi.fn()
+  },
+  file: {
+    get: vi.fn()
+  }
 }
 
-// 运行测试（如果在浏览器环境中）
-if (typeof window !== 'undefined') {
-  testValidation().catch(console.error)
+// @ts-ignore - Mock global window.api
+global.window = {
+  api: mockApi
+} as any
+
+// Create a custom File mock that has arrayBuffer method
+class MockFile {
+  name: string
+  type: string
+  size: number
+  private data: any
+
+  constructor(data: any, name: string, options: { type?: string } = {}) {
+    this.data = data
+    this.name = name
+    this.type = options.type || ''
+    this.size = Array.isArray(data) ? data.length : data.byteLength || 0
+  }
+
+  async arrayBuffer(): Promise<ArrayBuffer> {
+    if (this.data instanceof ArrayBuffer) {
+      return this.data
+    }
+    if (this.data instanceof Uint8Array) {
+      // Create a new ArrayBuffer and copy the data
+      const buffer = new ArrayBuffer(this.data.length)
+      const view = new Uint8Array(buffer)
+      view.set(this.data)
+      return buffer
+    }
+    // Convert string to ArrayBuffer
+    const encoder = new TextEncoder()
+    const uint8Array = encoder.encode(String(this.data))
+    const buffer = new ArrayBuffer(uint8Array.length)
+    const view = new Uint8Array(buffer)
+    view.set(uint8Array)
+    return buffer
+  }
 }
+
+// Replace global File with our mock for testing
+global.File = MockFile as any
+
+describe('File Validation', () => {
+  describe('getSupportedExtensions', () => {
+    test('should return extensions with images when allowImages is true', () => {
+      const extensions = getSupportedExtensions(true)
+      expect(extensions).toContain('.png')
+      expect(extensions).toContain('.jpg')
+      expect(extensions).toContain('.txt')
+      expect(extensions).toContain('.pdf')
+    })
+
+    test('should return extensions without images when allowImages is false', () => {
+      const extensions = getSupportedExtensions(false)
+      expect(extensions).not.toContain('.png')
+      expect(extensions).not.toContain('.jpg')
+      expect(extensions).toContain('.txt')
+      expect(extensions).toContain('.pdf')
+    })
+  })
+
+  describe('validateFileUpload', () => {
+    test('should allow supported file extensions', async () => {
+      const jsFile = new File(['console.log("test")'], 'test.js', { type: 'text/javascript' })
+      const result = await validateFileUpload(jsFile, false)
+
+      expect(result.allowed).toBe(true)
+    })
+
+    test('should use content detection for unknown extensions', async () => {
+      mockApi.fs.isTextContent.mockResolvedValue(true)
+
+      const unknownFile = new File(['This is text content'], 'test.unknown', { type: 'text/plain' })
+      const result = await validateFileUpload(unknownFile, false)
+
+      expect(result.allowed).toBe(true)
+      expect(result.reason).toContain('text content via content analysis')
+      expect(mockApi.fs.isTextContent).toHaveBeenCalledWith('test.unknown', expect.any(ArrayBuffer))
+    })
+
+    test('should reject unsupported file types', async () => {
+      mockApi.fs.isTextContent.mockResolvedValue(false)
+
+      const unknownFile = new File([new Uint8Array([0xff, 0xd8, 0xff])], 'test.unknown', {
+        type: 'application/octet-stream'
+      })
+      const result = await validateFileUpload(unknownFile, false)
+
+      expect(result.allowed).toBe(false)
+      expect(result.reason).toContain('File type not supported')
+    })
+  })
+
+  describe('validateFileMetadata', () => {
+    test('should validate file metadata successfully', async () => {
+      mockApi.file.get.mockResolvedValue('This is test content')
+      mockApi.fs.isTextContent.mockResolvedValue(true)
+
+      const fileMetadata = {
+        id: 'test-id',
+        ext: '.unknown',
+        origin_name: 'test.unknown',
+        path: '/path/to/test.unknown'
+      }
+
+      const result = await validateFileMetadata(fileMetadata, false)
+
+      expect(result.allowed).toBe(true)
+      expect(result.reason).toContain('text content via content analysis')
+      expect(mockApi.file.get).toHaveBeenCalledWith('/path/to/test.unknown')
+    })
+
+    test('should handle file read errors gracefully', async () => {
+      mockApi.file.get.mockRejectedValue(new Error('File not found'))
+
+      const fileMetadata = {
+        id: 'test-id',
+        ext: '.txt',
+        origin_name: 'test.txt'
+      }
+
+      const result = await validateFileMetadata(fileMetadata, false)
+
+      expect(result.allowed).toBe(false)
+      expect(result.reason).toContain('Failed to read file: File not found')
+    })
+
+    test('should use id + ext as fallback path', async () => {
+      mockApi.file.get.mockResolvedValue('Text content')
+      mockApi.fs.isTextContent.mockResolvedValue(false)
+
+      const fileMetadata = {
+        id: 'test-id',
+        ext: '.unknown',
+        origin_name: 'test.unknown'
+        // no path provided
+      }
+
+      const result = await validateFileMetadata(fileMetadata, false)
+
+      expect(mockApi.file.get).toHaveBeenCalledWith('test-id.unknown')
+      expect(result.allowed).toBe(false)
+    })
+
+    test('should handle invalid file metadata gracefully', async () => {
+      const fileMetadata = {
+        id: '',
+        ext: '.txt',
+        origin_name: 'test.txt'
+      }
+
+      const result = await validateFileMetadata(fileMetadata, false)
+
+      expect(result.allowed).toBe(false)
+      expect(result.reason).toBe('Invalid file metadata: missing file identifier')
+    })
+
+    test('should handle invalid file paths', async () => {
+      const fileMetadata = {
+        id: 'test<>:|"?*',
+        ext: '.txt',
+        origin_name: 'test.txt'
+      }
+
+      const result = await validateFileMetadata(fileMetadata, false)
+
+      expect(result.allowed).toBe(false)
+      expect(result.reason).toBe('Invalid file path format')
+    })
+
+    test('should handle path length limit', async () => {
+      const longId = 'a'.repeat(300) // Exceeds 260 char limit
+      const fileMetadata = {
+        id: longId,
+        ext: '.txt',
+        origin_name: 'test.txt'
+      }
+
+      const result = await validateFileMetadata(fileMetadata, false)
+
+      expect(result.allowed).toBe(false)
+      expect(result.reason).toBe('Invalid file path format')
+    })
+
+    test('should normalize extension correctly', async () => {
+      // Clear previous mock calls
+      mockApi.file.get.mockClear()
+      mockApi.fs.isTextContent.mockClear()
+
+      mockApi.file.get.mockResolvedValue('Text content')
+      mockApi.fs.isTextContent.mockResolvedValue(true)
+
+      const fileMetadata = {
+        id: 'test-file',
+        ext: 'txt', // without leading dot
+        origin_name: 'test.txt'
+      }
+
+      const result = await validateFileMetadata(fileMetadata, false)
+
+      expect(mockApi.file.get).toHaveBeenCalledWith('test-file.txt')
+      expect(result.allowed).toBe(true)
+    })
+  })
+})

--- a/src/renderer/src/utils/__tests__/fileValidation.test.ts
+++ b/src/renderer/src/utils/__tests__/fileValidation.test.ts
@@ -1,0 +1,38 @@
+import { getSupportedExtensions, validateFileUpload } from '../fileValidation'
+
+/**
+ * 测试文件验证功能
+ */
+
+// 测试扩展名支持
+console.log('=== 测试扩展名支持 ===')
+console.log('支持图片的扩展名:', getSupportedExtensions(true).slice(0, 10)) // 显示前10个
+console.log('不支持图片的扩展名:', getSupportedExtensions(false).slice(0, 10)) // 显示前10个
+
+// 测试文件验证
+const testValidation = async () => {
+  console.log('\n=== 测试文件验证 ===')
+
+  // 测试已知文本文件
+  const textContent = 'This is a test text file content.'
+  const textFile = new File([textContent], 'test.unknown', { type: 'text/plain' })
+
+  const validation = await validateFileUpload(textFile, true)
+  console.log('未知扩展名的文本文件验证结果:', validation)
+
+  // 测试已知扩展名文件
+  const jsFile = new File([textContent], 'test.js', { type: 'text/javascript' })
+  const jsValidation = await validateFileUpload(jsFile, false)
+  console.log('JavaScript文件验证结果:', jsValidation)
+
+  // 测试二进制文件
+  const binaryData = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]) // JPEG header
+  const imageFile = new File([binaryData], 'test.unknown', { type: 'image/jpeg' })
+  const imageValidation = await validateFileUpload(imageFile, true)
+  console.log('未知扩展名的图片文件验证结果:', imageValidation)
+}
+
+// 运行测试（如果在浏览器环境中）
+if (typeof window !== 'undefined') {
+  testValidation().catch(console.error)
+}

--- a/src/renderer/src/utils/fileValidation.ts
+++ b/src/renderer/src/utils/fileValidation.ts
@@ -1,0 +1,111 @@
+import { loggerService } from '@logger'
+import { documentExts, imageExts, textExts } from '@shared/config/constant'
+
+const logger = loggerService.withContext('Utils:FileValidation')
+
+/**
+ * 文件上传验证工具
+ * 结合扩展名检查和内容检测，提供更准确的文件类型判断
+ */
+
+/**
+ * 获取支持的文件扩展名列表
+ * @param allowImages 是否允许图片文件
+ * @returns 支持的扩展名数组
+ */
+export function getSupportedExtensions(allowImages: boolean = true): string[] {
+  if (allowImages) {
+    return [...imageExts, ...documentExts, ...textExts]
+  }
+  return [...documentExts, ...textExts]
+}
+
+/**
+ * 基于扩展名检查文件是否被支持
+ * @param fileExtension 文件扩展名（包含点号，如 '.txt'）
+ * @param allowImages 是否允许图片文件
+ * @returns 是否被支持
+ */
+export function isExtensionSupported(fileExtension: string, allowImages: boolean = true): boolean {
+  const supportedExts = getSupportedExtensions(allowImages)
+  return supportedExts.includes(fileExtension.toLowerCase())
+}
+
+/**
+ * 基于文件内容检测文件是否为文本文件
+ * 使用 IPC 调用 main 进程中的 istextorbinary 库
+ * @param file File 对象
+ * @returns Promise<boolean> 是否为文本文件
+ */
+export async function isTextFile(file: File): Promise<boolean> {
+  try {
+    // 读取文件内容并通过 IPC 发送到 main 进程进行检测
+    const buffer = await file.arrayBuffer()
+
+    // 调用 main 进程的文件检测服务
+    return await window.api.fs.isTextContent(file.name, buffer)
+  } catch (error) {
+    logger.error('Error detecting file content type:', error as Error)
+    return false
+  }
+}
+
+/**
+ * 综合验证文件是否可以上传
+ * 优先使用扩展名检查，如果扩展名不在支持列表中，则使用内容检测
+ * @param file File 对象
+ * @param allowImages 是否允许图片文件
+ * @returns Promise<{ allowed: boolean; reason?: string }> 验证结果
+ */
+export async function validateFileUpload(
+  file: File,
+  allowImages: boolean = true
+): Promise<{ allowed: boolean; reason?: string }> {
+  const fileExtension = '.' + file.name.split('.').pop()?.toLowerCase() || ''
+
+  // 1. 首先检查扩展名是否在支持列表中
+  if (isExtensionSupported(fileExtension, allowImages)) {
+    return { allowed: true }
+  }
+
+  // 2. 如果扩展名不在支持列表中，但可能是文本文件，使用内容检测
+  const isTextContent = await isTextFile(file)
+
+  if (isTextContent) {
+    return {
+      allowed: true,
+      reason: 'File detected as text content via content analysis'
+    }
+  }
+
+  // 3. 既不在扩展名列表中，内容也不是文本
+  const supportedExts = getSupportedExtensions(allowImages)
+  return {
+    allowed: false,
+    reason: `File type not supported. Supported extensions: ${supportedExts.join(', ')}`
+  }
+}
+
+/**
+ * 批量验证多个文件
+ * @param files File 对象数组
+ * @param allowImages 是否允许图片文件
+ * @returns Promise<Array<{ file: File; allowed: boolean; reason?: string }>> 验证结果数组
+ */
+export async function validateMultipleFiles(
+  files: File[],
+  allowImages: boolean = true
+): Promise<Array<{ file: File; allowed: boolean; reason?: string }>> {
+  const results = await Promise.all(
+    files.map(async (file) => {
+      const validation = await validateFileUpload(file, allowImages)
+      return {
+        file,
+        allowed: validation.allowed,
+        reason: validation.reason
+      }
+    })
+  )
+
+  return results
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8578,6 +8578,7 @@ __metadata:
     husky: "npm:^9.1.7"
     i18next: "npm:^23.11.5"
     iconv-lite: "npm:^0.6.3"
+    istextorbinary: "npm:^9.5.0"
     jaison: "npm:^2.0.2"
     jest-styled-components: "npm:^7.2.0"
     jsdom: "npm:26.1.0"
@@ -9332,6 +9333,15 @@ __metadata:
   version: 2.3.0
   resolution: "binary-extensions@npm:2.3.0"
   checksum: 10c0/75a59cafc10fb12a11d510e77110c6c7ae3f4ca22463d52487709ca7f18f69d886aa387557cc9864fbdb10153d0bdb4caacabf11541f55e89ed6e18d12ece2b5
+  languageName: node
+  linkType: hard
+
+"binaryextensions@npm:^6.11.0":
+  version: 6.11.0
+  resolution: "binaryextensions@npm:6.11.0"
+  dependencies:
+    editions: "npm:^6.21.0"
+  checksum: 10c0/7cd07215d2ba9722cc2c378de554e294e2577ee8b53e8e3715abf1f3e0f23db75851c9820dc34c117a3d44a778360cc28d4800e4802cdb9bc20774b71f3f5202
   languageName: node
   linkType: hard
 
@@ -11547,6 +11557,15 @@ __metadata:
   dependencies:
     safe-buffer: "npm:^5.0.1"
   checksum: 10c0/ebfbf19d4b8be938f4dd4a83b8788385da353d63307ede301a9252f9f7f88672e76f2191618fd8edfc2f24679236064176fab0b78131b161ee73daa37125408c
+  languageName: node
+  linkType: hard
+
+"editions@npm:^6.21.0":
+  version: 6.22.0
+  resolution: "editions@npm:6.22.0"
+  dependencies:
+    version-range: "npm:^4.15.0"
+  checksum: 10c0/566edfdea81c5b9e9e366e4ceea7d0911095cc7689640e31113c49530762daaa39df4c60b2811ba05c769c485051592bf136325da019e1642bbead7d60bb7c1a
   languageName: node
   linkType: hard
 
@@ -14520,6 +14539,17 @@ __metadata:
     html-escaper: "npm:^2.0.0"
     istanbul-lib-report: "npm:^3.0.0"
   checksum: 10c0/a379fadf9cf8dc5dfe25568115721d4a7eb82fbd50b005a6672aff9c6989b20cc9312d7865814e0859cd8df58cbf664482e1d3604be0afde1f7fc3ccc1394a51
+  languageName: node
+  linkType: hard
+
+"istextorbinary@npm:^9.5.0":
+  version: 9.5.0
+  resolution: "istextorbinary@npm:9.5.0"
+  dependencies:
+    binaryextensions: "npm:^6.11.0"
+    editions: "npm:^6.21.0"
+    textextensions: "npm:^6.11.0"
+  checksum: 10c0/76ed0355b48ceb351301ade26824f136be9436a1a31432b37191e591e868a081d6953fb7b5faa964681a24cad0435863635618354c5d440c79b65b75a9d788c5
   languageName: node
   linkType: hard
 
@@ -21001,6 +21031,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"textextensions@npm:^6.11.0":
+  version: 6.11.0
+  resolution: "textextensions@npm:6.11.0"
+  dependencies:
+    editions: "npm:^6.21.0"
+  checksum: 10c0/6077ca91af65d8067007973635d9e22c712c08cc06004cf2fa91f221239f0a833ededa18bf977131b45649be4a34fe44a7d1cb7b3f6c6c49d5677a197a10b0e0
+  languageName: node
+  linkType: hard
+
 "throttle-debounce@npm:^2.1.0":
   version: 2.3.0
   resolution: "throttle-debounce@npm:2.3.0"
@@ -21877,6 +21916,13 @@ __metadata:
     core-util-is: "npm:1.0.2"
     extsprintf: "npm:^1.2.0"
   checksum: 10c0/293fb060a4c9b07965569a0c3e45efa954127818707995a8a4311f691b5d6687be99f972c759838ba6eecae717f9af28e3c49d2afc7bbdf5f0b675238f1426e8
+  languageName: node
+  linkType: hard
+
+"version-range@npm:^4.15.0":
+  version: 4.15.0
+  resolution: "version-range@npm:4.15.0"
+  checksum: 10c0/ab40c6f1399e0ad5b5de7f295bb93f79f80a7cda919324d4682e388d937f1e50d6127d8cd6aa46c38bb185f4905e53bdad4cdc36ec5c14ec730e5954422f06ab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What this PR does

Before this PR:

- 对于文本类型的判断依赖拓展名白名单列表，部分纯文本的文件无法上传

After this PR:

- 引入istextorbinary进行文本文件的fallback判断，支持上传更多文本类型文件

Fixes #

### Special notes for your reviewer

添加[istextorbinary](https://www.npmjs.com/package/istextorbinary)