### PR TITLE
refactor: remove rc-virtual-list from DraggableList

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,7 +225,6 @@
     "prettier": "^3.5.3",
     "prettier-plugin-sort-json": "^4.1.1",
     "proxy-agent": "^6.5.0",
-    "rc-virtual-list": "^3.18.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hotkeys-hook": "^4.6.1",

--- a/src/renderer/src/components/DraggableList/__tests__/DraggableList.test.tsx
+++ b/src/renderer/src/components/DraggableList/__tests__/DraggableList.test.tsx
@@ -29,14 +29,14 @@ vi.mock('@hello-pangea/dnd', () => {
   }
 })
 
-// mock VirtualList 只做简单渲染
-vi.mock('rc-virtual-list', () => ({
+// mock antd list 只做简单渲染
+vi.mock('antd', () => ({
   __esModule: true,
-  default: ({ data, itemKey, children }: any) => (
+  List: ({ dataSource, renderItem }: any) => (
     <div data-testid="virtual-list">
-      {data.map((item: any, idx: number) => (
-        <div key={item[itemKey] || item} data-testid="virtual-list-item">
-          {children(item, idx)}
+      {dataSource.map((item: any, idx: number) => (
+        <div key={item.id || item} data-testid="virtual-list-item">
+          {renderItem(item, idx)}
         </div>
       ))}
     </div>

--- a/src/renderer/src/components/DraggableList/__tests__/DraggableVirtualList.test.tsx
+++ b/src/renderer/src/components/DraggableList/__tests__/DraggableVirtualList.test.tsx
@@ -1,5 +1,3 @@
-/// <reference types="@vitest/browser/context" />
-
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -45,11 +43,6 @@ vi.mock('@tanstack/react-virtual', () => ({
     getTotalSize: () => count * 50,
     measureElement: vi.fn()
   })
-}))
-
-vi.mock('react-virtualized-auto-sizer', () => ({
-  __esModule: true,
-  default: ({ children }) => <div data-testid="auto-sizer">{children({ height: 500, width: 300 })}</div>
 }))
 
 vi.mock('@renderer/components/Scrollbar', () => ({

--- a/src/renderer/src/components/DraggableList/list.tsx
+++ b/src/renderer/src/components/DraggableList/list.tsx
@@ -9,7 +9,7 @@ import {
   ResponderProvided
 } from '@hello-pangea/dnd'
 import { droppableReorder } from '@renderer/utils'
-import VirtualList from 'rc-virtual-list'
+import { List } from 'antd'
 import { FC } from 'react'
 
 interface Props<T> {
@@ -48,8 +48,9 @@ const DraggableList: FC<Props<any>> = ({
       <Droppable droppableId="droppable" {...droppableProps}>
         {(provided) => (
           <div {...provided.droppableProps} ref={provided.innerRef} style={style}>
-            <VirtualList data={list} itemKey="id">
-              {(item, index) => {
+            <List
+              dataSource={list}
+              renderItem={(item, index) => {
                 const id = item.id || item
                 return (
                   <Draggable key={`draggable_${id}_${index}`} draggableId={id} index={index}>
@@ -69,7 +70,7 @@ const DraggableList: FC<Props<any>> = ({
                   </Draggable>
                 )
               }}
-            </VirtualList>
+            />
             {provided.placeholder}
           </div>
         )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8603,7 +8603,6 @@ __metadata:
     prettier: "npm:^3.5.3"
     prettier-plugin-sort-json: "npm:^4.1.1"
     proxy-agent: "npm:^6.5.0"
-    rc-virtual-list: "npm:^3.18.6"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
     react-hotkeys-hook: "npm:^4.6.1"
@@ -19042,7 +19041,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-virtual-list@npm:^3.14.2, rc-virtual-list@npm:^3.18.6, rc-virtual-list@npm:^3.5.1, rc-virtual-list@npm:^3.5.2":
+"rc-virtual-list@npm:^3.14.2, rc-virtual-list@npm:^3.5.1, rc-virtual-list@npm:^3.5.2":
   version: 3.18.6
   resolution: "rc-virtual-list@npm:3.18.6"
   dependencies:


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

DraggableList 中的 rc-virtual-list 并没有启用虚拟滚动（启用了会失去平滑滚动功能），可以移除。
需要虚拟滚动可以用 DraggableVirtualList。
移除不必要的 mock

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
