### PR TITLE
fix(Artboard): update dimensions to use CSS variables for better layout control

### DIFF
--- a/src/renderer/src/pages/paintings/components/Artboard.tsx
+++ b/src/renderer/src/pages/paintings/components/Artboard.tsx
@@ -50,8 +50,8 @@ const Artboard: FC<ArtboardProps> = ({
               src={getCurrentImageUrl()}
               preview={{ mask: false }}
               style={{
-                maxWidth: '70vh',
-                maxHeight: '70vh',
+                maxWidth: 'var(--artboard-max)',
+                maxHeight: 'var(--artboard-max)',
                 objectFit: 'contain',
                 backgroundColor: 'var(--color-background-soft)',
                 cursor: 'pointer'
@@ -109,12 +109,14 @@ const Container = styled.div`
   flex-direction: row;
   justify-content: center;
   align-items: center;
+
+  --artboard-max: calc(100vh - 256px);
 `
 
 const ImagePlaceholder = styled.div`
   display: flex;
-  width: 70vh;
-  height: 70vh;
+  width: var(--artboard-max);
+  height: var(--artboard-max);
   background-color: var(--color-background-soft);
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
### What this PR does

Before this PR:
<img width="1192" height="712" alt="图片" src="https://github.com/user-attachments/assets/af84fb0f-4b62-4e49-b218-76078d963ecc" />
<img width="2160" height="1167" alt="图片" src="https://github.com/user-attachments/assets/0cf68379-f1e1-404a-936d-7961097212c0" />

After this PR:
<img width="1192" height="712" alt="图片" src="https://github.com/user-attachments/assets/6c80b930-8be3-485a-848a-99392848a75d" />
<img width="2160" height="1166" alt="图片" src="https://github.com/user-attachments/assets/5f9494c5-3493-462c-8afa-4d4f8964231a" />

### Why we need it and why it was done in this way

The following tradeoffs were made:
- The use of a CSS variable (--artboard-max: calc(100vh - 256px)) instead of a fixed 70vh value allows the artboard to remain responsive to different viewport heights. This approach **solves layout issues such as content overflow, overly small spacing, and element compression in smaller windows, as well as excessive spacing in larger windows**. The adjustment is made using the vh unit to preserve compatibility with existing components and avoid side effects elsewhere in the layout.

The following alternatives were considered:
- The ideal solution would be to refactor the layout using flexbox for more robust and natural space distribution. However, this would likely require changes to the ImageViewer component and could introduce breaking changes across the codebase, so it was not chosen for this fix.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
NONE
```
