### PR TITLE
fix: web search references missing caused by early reset

### DIFF
--- a/src/renderer/src/services/messageStreaming/callbacks/citationCallbacks.ts
+++ b/src/renderer/src/services/messageStreaming/callbacks/citationCallbacks.ts
@@ -40,7 +40,6 @@ export const createCitationCallbacks = (deps: CitationCallbacksDependencies) => 
           status: MessageBlockStatus.SUCCESS
         }
         blockManager.smartBlockUpdate(citationBlockId, changes, MessageBlockType.CITATION, true)
-        citationBlockId = null
       } else {
         logger.error('[onExternalToolComplete] citationBlockId is null. Cannot update.')
       }
@@ -121,6 +120,9 @@ export const createCitationCallbacks = (deps: CitationCallbacksDependencies) => 
     },
 
     // 暴露给外部的方法，用于textCallbacks中获取citationBlockId
-    getCitationBlockId: () => citationBlockId
+    getCitationBlockId: () => citationBlockId,
+    setCitationBlockId: (id: string | null) => {
+      citationBlockId = id
+    }
   }
 }

--- a/src/renderer/src/services/messageStreaming/callbacks/index.ts
+++ b/src/renderer/src/services/messageStreaming/callbacks/index.ts
@@ -59,7 +59,8 @@ export const createCallbacks = (deps: CallbacksDependencies) => {
     blockManager,
     getState,
     assistantMsgId,
-    getCitationBlockId: citationCallbacks.getCitationBlockId
+    getCitationBlockId: citationCallbacks.getCitationBlockId,
+    setCitationBlockId: citationCallbacks.setCitationBlockId
   })
 
   // 组合所有回调

--- a/src/renderer/src/services/messageStreaming/callbacks/textCallbacks.ts
+++ b/src/renderer/src/services/messageStreaming/callbacks/textCallbacks.ts
@@ -12,10 +12,11 @@ interface TextCallbacksDependencies {
   getState: any
   assistantMsgId: string
   getCitationBlockId: () => string | null
+  setCitationBlockId: (id: string | null) => void
 }
 
 export const createTextCallbacks = (deps: TextCallbacksDependencies) => {
-  const { blockManager, getState, assistantMsgId, getCitationBlockId } = deps
+  const { blockManager, getState, assistantMsgId, getCitationBlockId, setCitationBlockId } = deps
 
   // 内部维护的状态
   let mainTextBlockId: string | null = null
@@ -62,6 +63,7 @@ export const createTextCallbacks = (deps: TextCallbacksDependencies) => {
         }
         blockManager.smartBlockUpdate(mainTextBlockId, changes, MessageBlockType.MAIN_TEXT, true)
         mainTextBlockId = null
+        setCitationBlockId(null)
       } else {
         logger.warn(
           `[onTextComplete] Received text.complete but last block was not MAIN_TEXT (was ${blockManager.lastBlockType}) or lastBlockId is null.`


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

在 citationCallbacks 中清空 block id 之后，main text block 总是获取到 null，导致渲染不出任何卡片来。
尝试把重置时机延后到 main text complete。

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #9306

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
