### PR TITLE
fix: sidebar code icon reset bug (#9307)

### DIFF
--- a/src/renderer/src/config/sidebar.ts
+++ b/src/renderer/src/config/sidebar.ts
@@ -1,0 +1,23 @@
+import { SidebarIcon } from '@renderer/types'
+
+/**
+ * 默认显示的侧边栏图标
+ * 这些图标会在侧边栏中默认显示
+ */
+export const DEFAULT_SIDEBAR_ICONS: SidebarIcon[] = [
+  'assistants',
+  'agents',
+  'paintings',
+  'translate',
+  'minapp',
+  'knowledge',
+  'files',
+  'code_tools'
+]
+
+/**
+ * 必须显示的侧边栏图标（不能被隐藏）
+ * 这些图标必须始终在侧边栏中可见
+ * 抽取为参数方便未来扩展
+ */
+export const REQUIRED_SIDEBAR_ICONS: SidebarIcon[] = ['assistants']

--- a/src/renderer/src/pages/settings/DisplaySettings/DisplaySettings.tsx
+++ b/src/renderer/src/pages/settings/DisplaySettings/DisplaySettings.tsx
@@ -3,13 +3,13 @@ import { ResetIcon } from '@renderer/components/Icons'
 import { HStack } from '@renderer/components/Layout'
 import TextBadge from '@renderer/components/TextBadge'
 import { isMac, THEME_COLOR_PRESETS } from '@renderer/config/constant'
+import { DEFAULT_SIDEBAR_ICONS } from '@renderer/config/sidebar'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import { useNavbarPosition, useSettings } from '@renderer/hooks/useSettings'
 import useUserTheme from '@renderer/hooks/useUserTheme'
 import { useAppDispatch } from '@renderer/store'
 import {
   AssistantIconType,
-  DEFAULT_SIDEBAR_ICONS,
   setAssistantIconType,
   setClickAssistantToShowTopic,
   setCustomCss,

--- a/src/renderer/src/pages/settings/DisplaySettings/SidebarIconsManager.tsx
+++ b/src/renderer/src/pages/settings/DisplaySettings/SidebarIconsManager.tsx
@@ -10,13 +10,12 @@ import {
 import { getSidebarIconLabel } from '@renderer/i18n/label'
 import { useAppDispatch } from '@renderer/store'
 import { setSidebarIcons } from '@renderer/store/settings'
+import { SidebarIcon } from '@renderer/types'
 import { message } from 'antd'
 import { Code, FileSearch, Folder, Languages, LayoutGrid, MessageSquareQuote, Palette, Sparkle } from 'lucide-react'
 import { FC, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
-
-import { SidebarIcon } from '../../../store/settings'
 
 interface SidebarIconsManagerProps {
   visibleIcons: SidebarIcon[]

--- a/src/renderer/src/store/migrate.ts
+++ b/src/renderer/src/store/migrate.ts
@@ -4,6 +4,7 @@ import { DEFAULT_CONTEXTCOUNT, DEFAULT_TEMPERATURE, isMac } from '@renderer/conf
 import { DEFAULT_MIN_APPS } from '@renderer/config/minapps'
 import { isFunctionCallingModel, isNotSupportedTextDelta, SYSTEM_MODELS } from '@renderer/config/models'
 import { TRANSLATE_PROMPT } from '@renderer/config/prompts'
+import { DEFAULT_SIDEBAR_ICONS } from '@renderer/config/sidebar'
 import {
   isSupportArrayContentProvider,
   isSupportDeveloperRoleProvider,
@@ -32,7 +33,7 @@ import { DEFAULT_TOOL_ORDER } from './inputTools'
 import { initialState as llmInitialState, moveProvider } from './llm'
 import { mcpSlice } from './mcp'
 import { defaultActionItems } from './selectionStore'
-import { DEFAULT_SIDEBAR_ICONS, initialState as settingsInitialState } from './settings'
+import { initialState as settingsInitialState } from './settings'
 import { initialState as shortcutsInitialState } from './shortcuts'
 import { defaultWebSearchProviders } from './websearch'
 

--- a/src/renderer/src/store/minapps.ts
+++ b/src/renderer/src/store/minapps.ts
@@ -1,16 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { DEFAULT_MIN_APPS } from '@renderer/config/minapps'
-import { MinAppType, SidebarIcon } from '@renderer/types'
-
-export const DEFAULT_SIDEBAR_ICONS: SidebarIcon[] = [
-  'assistants',
-  'agents',
-  'paintings',
-  'translate',
-  'minapp',
-  'knowledge',
-  'files'
-]
+import { MinAppType } from '@renderer/types'
 
 export interface MinAppsState {
   enabled: MinAppType[]

--- a/src/renderer/src/store/settings.ts
+++ b/src/renderer/src/store/settings.ts
@@ -10,6 +10,7 @@ import {
   OpenAISummaryText,
   PaintingProvider,
   S3Config,
+  SidebarIcon,
   ThemeMode,
   TranslateLanguageCode
 } from '@renderer/types'
@@ -20,16 +21,6 @@ import { OpenAIVerbosity } from '@types'
 import { RemoteSyncState } from './backup'
 
 export type SendMessageShortcut = 'Enter' | 'Shift+Enter' | 'Ctrl+Enter' | 'Command+Enter' | 'Alt+Enter'
-
-export type SidebarIcon =
-  | 'assistants'
-  | 'agents'
-  | 'paintings'
-  | 'translate'
-  | 'minapp'
-  | 'knowledge'
-  | 'files'
-  | 'code_tools'
 
 export const DEFAULT_SIDEBAR_ICONS: SidebarIcon[] = [
   'assistants',

--- a/src/renderer/src/store/settings.ts
+++ b/src/renderer/src/store/settings.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { TRANSLATE_PROMPT } from '@renderer/config/prompts'
+import { DEFAULT_SIDEBAR_ICONS } from '@renderer/config/sidebar'
 import {
   ApiServerConfig,
   AssistantsSortType,
@@ -22,16 +23,8 @@ import { RemoteSyncState } from './backup'
 
 export type SendMessageShortcut = 'Enter' | 'Shift+Enter' | 'Ctrl+Enter' | 'Command+Enter' | 'Alt+Enter'
 
-export const DEFAULT_SIDEBAR_ICONS: SidebarIcon[] = [
-  'assistants',
-  'agents',
-  'paintings',
-  'translate',
-  'minapp',
-  'knowledge',
-  'files',
-  'code_tools'
-]
+// Re-export for backward compatibility
+export { DEFAULT_SIDEBAR_ICONS }
 
 export interface NutstoreSyncRuntime extends RemoteSyncState {}
 

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -692,7 +692,7 @@ export const isAutoDetectionMethod = (method: string): method is AutoDetectionMe
   return Object.hasOwn(AutoDetectionMethods, method)
 }
 
-export type SidebarIcon = 'assistants' | 'agents' | 'paintings' | 'translate' | 'minapp' | 'knowledge' | 'files'
+export type SidebarIcon = 'assistants' | 'agents' | 'paintings' | 'translate' | 'minapp' | 'knowledge' | 'files' | 'code_tools'
 
 export type ExternalToolResult = {
   mcpTools?: MCPTool[]


### PR DESCRIPTION
### 问题原因：
- src/renderer/src/types/index.ts 中 SidebarIcon 未包含 'code_tools'，而其他处（如 settings.ts）有本地重复定义且包含 'code_tools'，造成类型/常量多处定义不一致。
- src/renderer/src/store/minapps.ts 里还存在一份重复的 DEFAULT_SIDEBAR_ICONS，易引发默认值漂移。

### 修复内容：
- 在 types/index.ts 的 SidebarIcon 类型中添加 'code_tools'
- 删除 minapps.ts 中重复的 DEFAULT_SIDEBAR_ICONS 常量
- 删除 settings.ts 中重复的 SidebarIcon 类型定义
- 统一从 @renderer/types 导入 SidebarIcon 类型

这确保了在导航栏设置为左侧时，点击侧边栏设置的重置按钮后，Code 图标能够正确显示。

修复 #9307