### PR TITLE
feat: reasoning effort cache

### DIFF
--- a/src/renderer/src/hooks/useAssistant.ts
+++ b/src/renderer/src/hooks/useAssistant.ts
@@ -3,7 +3,8 @@ import {
   getThinkModelType,
   isSupportedReasoningEffortModel,
   isSupportedThinkingTokenModel,
-  MODEL_SUPPORTED_OPTIONS
+  MODEL_SUPPORTED_OPTIONS,
+  MODEL_SUPPORTED_REASONING_EFFORT
 } from '@renderer/config/models'
 import { db } from '@renderer/databases'
 import { getDefaultTopic } from '@renderer/services/AssistantService'
@@ -113,9 +114,12 @@ export function useAssistant(id: string) {
           if (cache && supportedOptions.includes(cache)) {
             fallbackOption = cache
           } else {
-            // 回退到第一个支持的值
+            // 灵活回退到支持的值
             // 注意：这里假设可用的options不会为空
-            fallbackOption = MODEL_SUPPORTED_OPTIONS[modelType][0]
+            const enableThinking = currentReasoningEffort !== undefined
+            fallbackOption = enableThinking
+              ? MODEL_SUPPORTED_REASONING_EFFORT[modelType][0]
+              : MODEL_SUPPORTED_OPTIONS[modelType][0]
           }
 
           updateAssistantSettings({

--- a/src/renderer/src/hooks/useAssistant.ts
+++ b/src/renderer/src/hooks/useAssistant.ts
@@ -123,6 +123,8 @@ export function useAssistant(id: string) {
             reasoning_effort_cache: fallbackOption === 'off' ? undefined : fallbackOption,
             qwenThinkMode: fallbackOption === 'off' ? undefined : true
           })
+        } else {
+          // 对于支持的选项, 不再更新 cache.
         }
       } else {
         // 切换到非思考模型时保留cache

--- a/src/renderer/src/pages/home/Inputbar/ThinkingButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/ThinkingButton.tsx
@@ -77,12 +77,14 @@ const ThinkingButton: FC<Props> = ({ ref, model, assistant, ToolbarButton }): Re
       if (!isEnabled) {
         updateAssistantSettings({
           reasoning_effort: undefined,
+          reasoning_effort_cache: undefined,
           qwenThinkMode: false
         })
         return
       }
       updateAssistantSettings({
         reasoning_effort: option,
+        reasoning_effort_cache: option,
         qwenThinkMode: true
       })
       return

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -99,7 +99,12 @@ export type AssistantSettings = {
   defaultModel?: Model
   customParameters?: AssistantSettingCustomParameters[]
   reasoning_effort?: ReasoningEffortOption
-  /** 保留上一次使用思考模型时的 reasoning effort, 在从非思考模型切换到思考模型时恢复. */
+  /** 保留上一次使用思考模型时的 reasoning effort, 在从非思考模型切换到思考模型时恢复.
+   *
+   * TODO: 目前 reasoning_effort === undefined 有两个语义，有的场景是显式关闭思考，有的场景是不传参。
+   * 未来应该重构思考控制，将启用/关闭思考和思考选项分离，这样就不用依赖 cache 了。
+   *
+   */
   reasoning_effort_cache?: ReasoningEffortOption
   qwenThinkMode?: boolean
   toolUseMode: 'function' | 'prompt'

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -99,6 +99,8 @@ export type AssistantSettings = {
   defaultModel?: Model
   customParameters?: AssistantSettingCustomParameters[]
   reasoning_effort?: ReasoningEffortOption
+  /** 保留上一次使用思考模型时的 reasoning effort, 在从非思考模型切换到思考模型时恢复. */
+  reasoning_effort_cache?: ReasoningEffortOption
   qwenThinkMode?: boolean
   toolUseMode: 'function' | 'prompt'
 }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

- 现在每个助手会记忆上一次使用思考模型时选择的选项，同时也保证当前的 `reasoning_effort` 对于 `model` 合法。
- 保证在开启思考时切换到其他思考模型不会回退到`off`

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #9335

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
