### PR TITLE
feat(utils): show weekday in date and datetime prompt variables

### DIFF
--- a/src/renderer/src/utils/__tests__/prompt.test.ts
+++ b/src/renderer/src/utils/__tests__/prompt.test.ts
@@ -133,7 +133,15 @@ describe('prompt', () => {
       const result = await replacePromptVariables(userPrompt, assistant.model?.name)
       const expectedPrompt = `
 以下是一些辅助信息:
-  - 日期和时间: ${mockDate.toLocaleString()};
+  - 日期和时间: ${mockDate.toLocaleString(undefined, {
+    weekday: 'short',
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric'
+  })};
   - 操作系统: macOS;
   - 中央处理器架构: darwin64;
   - 语言: zh-CN;
@@ -176,7 +184,12 @@ describe('prompt', () => {
       basePrompt = await replacePromptVariables(initialPrompt, assistant.model?.name)
       expectedBasePrompt = `
         System Information:
-        - Date: ${mockDate.toLocaleDateString()}
+        - Date: ${mockDate.toLocaleDateString(undefined, {
+          weekday: 'short',
+          year: 'numeric',
+          month: 'numeric',
+          day: 'numeric'
+        })}
         - User: MockUser
 
         Instructions: Be helpful.
@@ -239,7 +252,12 @@ describe('prompt', () => {
       const basePrompt = await replacePromptVariables(initialPrompt, assistant.model?.name)
       const expectedBasePrompt = `
         System Information:
-        - Date: ${mockDate.toLocaleDateString()}
+        - Date: ${mockDate.toLocaleDateString(undefined, {
+          weekday: 'short',
+          year: 'numeric',
+          month: 'numeric',
+          day: 'numeric'
+        })}
         - User: MockUser
 
         Instructions: Be helpful.

--- a/src/renderer/src/utils/prompt.ts
+++ b/src/renderer/src/utils/prompt.ts
@@ -176,7 +176,12 @@ export const replacePromptVariables = async (userSystemPrompt: string, modelName
 
   const now = new Date()
   if (userSystemPrompt.includes('{{date}}')) {
-    const date = now.toLocaleDateString()
+    const date = now.toLocaleDateString(undefined, {
+      weekday: 'short',
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric'
+    })
     userSystemPrompt = userSystemPrompt.replace(/{{date}}/g, date)
   }
 
@@ -186,7 +191,15 @@ export const replacePromptVariables = async (userSystemPrompt: string, modelName
   }
 
   if (userSystemPrompt.includes('{{datetime}}')) {
-    const datetime = now.toLocaleString()
+    const datetime = now.toLocaleString(undefined, {
+      weekday: 'short',
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric'
+    })
     userSystemPrompt = userSystemPrompt.replace(/{{datetime}}/g, datetime)
   }
 


### PR DESCRIPTION


<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

为 {{date}} 和 {{datetime}} 变量替换添加星期信息

<img width="1184" height="146" alt="image" src="https://github.com/user-attachments/assets/452a3c9d-7333-4621-a9b0-493de1461adf" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #9359

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
