### PR TITLE
fix(translate): improve auto translate language detection

### DIFF
--- a/src/renderer/src/utils/translate.ts
+++ b/src/renderer/src/utils/translate.ts
@@ -29,7 +29,15 @@ export const detectLanguage = async (inputText: string): Promise<TranslateLangua
   switch (method) {
     case 'auto':
       // hard encoded threshold
-      result = estimateTextTokens(text) < 50 ? await detectLanguageByLLM(text) : detectLanguageByFranc(text)
+      if (estimateTextTokens(text) < 100) {
+        result = await detectLanguageByLLM(text)
+      } else {
+        result = detectLanguageByFranc(text)
+        // fallback to llm when franc fails
+        if (result === UNKNOWN.langCode) {
+          result = await detectLanguageByLLM(text)
+        }
+      }
       break
     case 'franc':
       result = detectLanguageByFranc(text)
@@ -48,7 +56,7 @@ const detectLanguageByLLM = async (inputText: string): Promise<TranslateLanguage
   logger.info('Detect langugage by llm')
   let detectedLang = ''
   await fetchLanguageDetection({
-    text: sliceByTokens(inputText, 0, 50),
+    text: sliceByTokens(inputText, 0, 100),
     onResponse: (text) => {
       detectedLang = text.replace(/^\s*\n+/g, '')
     }


### PR DESCRIPTION


<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

`tokenx` 预估token的方式有点微妙，和主流llm分词器的处理方式差挺多，导致实际短文本的token量被过大估计。从而，auto模式下，对短文本还是会使用franc检测，然后得到错误结果。

After this PR:

- 调整阈值到 100
- 在franc检测失败时 fallback 到 llm

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
