### PR TITLE
fix(AttachmentButton): 添加选择状态防止重复触发文件选择

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/AttachmentButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/AttachmentButton.tsx
@@ -2,7 +2,7 @@ import { FileMetadata, FileType } from '@renderer/types'
 import { filterSupportedFiles } from '@renderer/utils/file'
 import { Tooltip } from 'antd'
 import { Paperclip } from 'lucide-react'
-import { FC, useCallback, useImperativeHandle } from 'react'
+import { FC, useCallback, useImperativeHandle, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 export interface AttachmentButtonRef {
@@ -29,11 +29,16 @@ const AttachmentButton: FC<Props> = ({
   disabled
 }) => {
   const { t } = useTranslation()
+  const [selecting, setSelecting] = useState<boolean>(false)
 
   const onSelectFile = useCallback(async () => {
+    if (selecting) {
+      return
+    }
     // when the number of extensions is greater than 20, use *.* to avoid selecting window lag
     const useAllFiles = extensions.length > 20
 
+    setSelecting(true)
     const _files: FileMetadata[] = await window.api.file.select({
       properties: ['openFile', 'multiSelections'],
       filters: [
@@ -43,6 +48,7 @@ const AttachmentButton: FC<Props> = ({
         }
       ]
     })
+    setSelecting(false)
 
     if (_files) {
       if (!useAllFiles) {
@@ -63,7 +69,7 @@ const AttachmentButton: FC<Props> = ({
         })
       }
     }
-  }, [extensions, files, setFiles, t])
+  }, [extensions, files, selecting, setFiles, t])
 
   const openQuickPanel = useCallback(() => {
     onSelectFile()


### PR DESCRIPTION

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

添加 selecting 状态变量以防止在文件选择过程中重复触发选择操作

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #9095

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
