### PR TITLE
fix: incorrect default avatar casing in custom provider

### DIFF
--- a/src/renderer/src/pages/settings/ProviderSettings/AddProviderPopup.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/AddProviderPopup.tsx
@@ -3,7 +3,7 @@ import { Center, VStack } from '@renderer/components/Layout'
 import { TopView } from '@renderer/components/TopView'
 import ImageStorage from '@renderer/services/ImageStorage'
 import { Provider, ProviderType } from '@renderer/types'
-import { compressImage } from '@renderer/utils'
+import { compressImage, generateColorFromChar } from '@renderer/utils'
 import { Divider, Dropdown, Form, Input, Modal, Select, Upload } from 'antd'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -171,7 +171,13 @@ const PopupContainer: React.FC<Props> = ({ provider, resolve }) => {
             onOpenChange={(visible) => {
               setDropdownOpen(visible)
             }}>
-            {logo ? <ProviderLogo src={logo} /> : <ProviderInitialsLogo>{getInitials()}</ProviderInitialsLogo>}
+            {logo ? (
+              <ProviderLogo src={logo} />
+            ) : (
+              <ProviderInitialsLogo style={{ backgroundColor: generateColorFromChar(name) }}>
+                {getInitials()}
+              </ProviderInitialsLogo>
+            )}
           </Dropdown>
         </VStack>
       </Center>

--- a/src/renderer/src/pages/settings/ProviderSettings/AddProviderPopup.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/AddProviderPopup.tsx
@@ -174,7 +174,8 @@ const PopupContainer: React.FC<Props> = ({ provider, resolve }) => {
             {logo ? (
               <ProviderLogo src={logo} />
             ) : (
-              <ProviderInitialsLogo style={{ backgroundColor: generateColorFromChar(name) }}>
+              <ProviderInitialsLogo
+                style={name ? { backgroundColor: generateColorFromChar(name) } : { color: 'black' }}>
                 {getInitials()}
               </ProviderInitialsLogo>
             )}

--- a/src/renderer/src/pages/settings/ProviderSettings/AddProviderPopup.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/AddProviderPopup.tsx
@@ -242,6 +242,7 @@ const ProviderInitialsLogo = styled.div`
   transition: opacity 0.3s ease;
   background-color: var(--color-background-soft);
   border: 0.5px solid var(--color-border);
+  color: white;
   &:hover {
     opacity: 0.8;
   }

--- a/src/renderer/src/pages/settings/ProviderSettings/AddProviderPopup.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/AddProviderPopup.tsx
@@ -78,7 +78,7 @@ const PopupContainer: React.FC<Props> = ({ provider, resolve }) => {
   }
 
   const getInitials = () => {
-    return name.charAt(0).toUpperCase() || 'P'
+    return name.charAt(0) || 'P'
   }
 
   const items = [


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does
编辑自定义提供商时默认头像取首字母后不再强制大写
Before this PR:
<img width="714" height="667" alt="PixPin_2025-08-21_15-46-07" src="https://github.com/user-attachments/assets/5df69b97-d033-4081-97c0-a2d2dcaed70a" />

编辑提供商时头像大写，模型列表显示头像小写
After this PR:
<img width="703" height="666" alt="PixPin_2025-08-21_15-53-22" src="https://github.com/user-attachments/assets/565bedc4-d3b3-4d51-be38-f674b2060315" />

编辑提供商时头像小写，模型列表显示头像小写
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:
编辑提供商时的头像和模型列表显示头像大小写不一致，编辑提供商时AddProviderPopup.tsx文件的函数getInitials会转换成大写，而模型列表显示时index.tsx文件用到的函数getFirstCharacter不会强制大写
The following alternatives were considered:
1.全部采取转换大写
2.全部取消转换大写
Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
