### PR TITLE
fix(translate): fix translating state management

### DIFF
--- a/src/renderer/src/pages/translate/TranslatePage.tsx
+++ b/src/renderer/src/pages/translate/TranslatePage.tsx
@@ -122,8 +122,6 @@ const TranslatePage: FC = () => {
           return
         }
 
-        setTranslating(true)
-
         let translated: string
         try {
           translated = await translateText(text, actualTargetLanguage, throttle(setTranslatedContent, 100))
@@ -145,8 +143,6 @@ const TranslatePage: FC = () => {
       } catch (e) {
         logger.error('Failed to translate', e as Error)
         window.message.error(t('translate.error.unknown') + ': ' + (e as Error).message)
-      } finally {
-        setTranslating(false)
       }
     },
     [setTranslatedContent, setTranslating, t, translating]
@@ -162,6 +158,8 @@ const TranslatePage: FC = () => {
       })
       return
     }
+
+    setTranslating(true)
 
     try {
       // 确定源语言：如果用户选择了特定语言，使用用户选择的；如果选择'auto'，则自动检测
@@ -202,6 +200,8 @@ const TranslatePage: FC = () => {
         key: 'translate-message'
       })
       return
+    } finally {
+      setTranslating(false)
     }
   }, [
     bidirectionalPair,

--- a/src/renderer/src/pages/translate/TranslatePage.tsx
+++ b/src/renderer/src/pages/translate/TranslatePage.tsx
@@ -207,6 +207,7 @@ const TranslatePage: FC = () => {
     bidirectionalPair,
     getLanguageByLangcode,
     isBidirectional,
+    setTranslating,
     sourceLanguage,
     t,
     targetLanguage,

--- a/src/renderer/src/utils/translate.ts
+++ b/src/renderer/src/utils/translate.ts
@@ -49,7 +49,7 @@ export const detectLanguage = async (inputText: string): Promise<TranslateLangua
       throw new Error('Invalid detection method.')
   }
   logger.info(`Detected Language: ${result}`)
-  return result
+  return result.trim()
 }
 
 const detectLanguageByLLM = async (inputText: string): Promise<TranslateLanguageCode> => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

修改管理 translating 状态的位置。

由于 LLM 检测语言会发起网络请求，应该在检测开始前就阻塞按钮。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
