### PR TITLE
fix: throw error when translate language detection failed

### DIFF
--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -620,7 +620,7 @@ interface FetchLanguageDetectionProps {
  * @param params - 参数对象
  * @param {string} params.text - 需要检测语言的文本内容
  * @param {function} [params.onResponse] - 流式响应回调函数,用于实时获取检测结果
- * @returns {Promise<string>} 返回检测到的语言代码,如果检测失败返回空字符串
+ * @returns {Promise<string>} 返回检测到的语言代码,如果检测失败会抛出错误
  * @throws {Error}
  */
 export async function fetchLanguageDetection({ text, onResponse }: FetchLanguageDetectionProps) {

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -615,6 +615,14 @@ interface FetchLanguageDetectionProps {
   onResponse?: (text: string, isComplete: boolean) => void
 }
 
+/**
+ * 检测文本语言
+ * @param params - 参数对象
+ * @param {string} params.text - 需要检测语言的文本内容
+ * @param {function} [params.onResponse] - 流式响应回调函数,用于实时获取检测结果
+ * @returns {Promise<string>} 返回检测到的语言代码,如果检测失败返回空字符串
+ * @throws {Error}
+ */
 export async function fetchLanguageDetection({ text, onResponse }: FetchLanguageDetectionProps) {
   const translateLanguageOptions = await getTranslateOptions()
   const listLang = translateLanguageOptions.map((item) => item.langCode)
@@ -661,16 +669,13 @@ export async function fetchLanguageDetection({ text, onResponse }: FetchLanguage
     assistant,
     streamOutput: stream,
     enableReasoning: false,
+    shouldThrow: true,
     onResponse
   }
 
   const AI = new AiProvider(provider)
 
-  try {
-    return (await AI.completions(params)).getText() || ''
-  } catch (error: any) {
-    return ''
-  }
+  return (await AI.completions(params)).getText() || ''
 }
 
 export async function fetchMessagesSummary({ messages, assistant }: { messages: Message[]; assistant: Assistant }) {

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -675,7 +675,7 @@ export async function fetchLanguageDetection({ text, onResponse }: FetchLanguage
 
   const AI = new AiProvider(provider)
 
-  return (await AI.completions(params)).getText() || ''
+  return (await AI.completions(params)).getText()
 }
 
 export async function fetchMessagesSummary({ messages, assistant }: { messages: Message[]; assistant: Assistant }) {

--- a/src/renderer/src/windows/selection/action/components/ActionTranslate.tsx
+++ b/src/renderer/src/windows/selection/action/components/ActionTranslate.tsx
@@ -9,7 +9,7 @@ import { useSettings } from '@renderer/hooks/useSettings'
 import useTranslate from '@renderer/hooks/useTranslate'
 import MessageContent from '@renderer/pages/home/Messages/MessageContent'
 import { getDefaultTopic, getDefaultTranslateAssistant } from '@renderer/services/AssistantService'
-import { Assistant, Topic, TranslateLanguage } from '@renderer/types'
+import { Assistant, Topic, TranslateLanguage, TranslateLanguageCode } from '@renderer/types'
 import type { ActionItem } from '@renderer/types/selectionTypes'
 import { runAsyncFunction } from '@renderer/utils'
 import { abortCompletion } from '@renderer/utils/abortController'
@@ -114,7 +114,15 @@ const ActionTranslate: FC<Props> = ({ action, scrollToBottom }) => {
 
     setIsLoading(true)
 
-    const sourceLanguageCode = await detectLanguage(action.selectedText)
+    let sourceLanguageCode: TranslateLanguageCode
+
+    try {
+      sourceLanguageCode = await detectLanguage(action.selectedText)
+    } catch (err) {
+      onError(err instanceof Error ? err : new Error('An error occurred'))
+      logger.error('Error detecting language:', err as Error)
+      return
+    }
 
     let translateLang: TranslateLanguage
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

不再静默错误

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
