### PR TITLE
fix(Markdown): hide programmed style in MarkdownShadowDOMRenderer

### DIFF
--- a/src/renderer/src/components/MarkdownShadowDOMRenderer.tsx
+++ b/src/renderer/src/components/MarkdownShadowDOMRenderer.tsx
@@ -47,7 +47,7 @@ const ShadowDOMRenderer: React.FC<Props> = ({ children }) => {
   }
 
   return (
-    <div ref={hostRef}>
+    <div ref={hostRef} style={{ display: 'none', position: 'absolute' }}>
       {createPortal(
         <StyleSheetManager target={shadowRoot}>
           <StyleProvider container={shadowRoot} layer>

--- a/src/renderer/src/components/MarkdownShadowDOMRenderer.tsx
+++ b/src/renderer/src/components/MarkdownShadowDOMRenderer.tsx
@@ -47,7 +47,7 @@ const ShadowDOMRenderer: React.FC<Props> = ({ children }) => {
   }
 
   return (
-    <div ref={hostRef} style={{ display: 'none', position: 'absolute' }}>
+    <div ref={hostRef} style={{ display: 'none' }}>
       {createPortal(
         <StyleSheetManager target={shadowRoot}>
           <StyleProvider container={shadowRoot} layer>


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

MarkdownShadowDOMRenderer 用于隔离 `<style>`，但是 mathjax 会自己添加 style，结果内容全变成普通文本显示出来了，但是这些内容不应该显示。

|BEFORE|AFTER|
|---|---|
|<img width="760" height="613" alt="image" src="https://github.com/user-attachments/assets/585ffcf0-595e-401f-b47e-178fdd652070" />|<img width="223" height="138" alt="image" src="https://github.com/user-attachments/assets/ce1995fa-efc1-4df4-9d33-9fc9ef1c3b74" />|

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
