### PR TITLE
fix(CodeTool): Code页面显示不全

### DIFF
--- a/src/renderer/src/pages/code/CodeToolsPage.tsx
+++ b/src/renderer/src/pages/code/CodeToolsPage.tsx
@@ -346,11 +346,14 @@ const Container = styled.div`
 const ContentContainer = styled.div`
   display: flex;
   flex: 1;
+  overflow-y: auto;
+  padding: 20px 0;
 `
 
 const MainContent = styled.div`
   width: 600px;
   margin: auto;
+  min-height: fit-content;
 `
 
 const Title = styled.h1`


### PR DESCRIPTION
### What this PR does

Before this PR:
- 主窗口纵向高度不足时Code页面内容显示不全
<img width="1733" height="963" alt="PixPin_2025-08-24_23-22-04" src="https://github.com/user-attachments/assets/53fc9319-0c4c-49a4-ad55-afc2440e3c2a" />


After this PR:
- 纵向高度不足时Code页面可正常显示
<img width="1733" height="963" alt="PixPin_2025-08-24_23-23-17" src="https://github.com/user-attachments/assets/c9af1346-5b54-4d59-bae6-c7361d15e588" />


Fixes #9475