### PR TITLE
feat: add seed-36b <seed:think></seed:think> parser support

### DIFF
--- a/src/renderer/src/aiCore/middleware/feat/ThinkingTagExtractionMiddleware.ts
+++ b/src/renderer/src/aiCore/middleware/feat/ThinkingTagExtractionMiddleware.ts
@@ -30,7 +30,7 @@ const getAppropriateTag = (model?: Model): TagConfig => {
   if (model?.id?.includes('qwen3')) return reasoningTags[0]
   if (model?.id?.includes('gemini-2.5')) return reasoningTags[1]
   if (model?.id?.includes('kimi-vl-a3b-thinking')) return reasoningTags[3]
-  if (model?.id?.includes('seed-oss-36b')) return reasoningTags[5]
+  if (model?.id?.toLowerCase().includes('seed-oss-36b')) return reasoningTags[5]
   // 可以在这里添加更多模型特定的标签配置
   return reasoningTags[0] // 默认使用 <think> 标签
 }

--- a/src/renderer/src/aiCore/middleware/feat/ThinkingTagExtractionMiddleware.ts
+++ b/src/renderer/src/aiCore/middleware/feat/ThinkingTagExtractionMiddleware.ts
@@ -30,8 +30,7 @@ const getAppropriateTag = (model?: Model): TagConfig => {
   if (model?.id?.includes('qwen3')) return reasoningTags[0]
   if (model?.id?.includes('gemini-2.5')) return reasoningTags[1]
   if (model?.id?.includes('kimi-vl-a3b-thinking')) return reasoningTags[3]
-  if (model?.id?.includes('seed-oss-36b')) return reasoningTags[5]
-  // 可以在这里添加更多模型特定的标签配置
+  if (model?.id?.includes('Seed-OSS-36B')) return reasoningTags[5]
   return reasoningTags[0] // 默认使用 <think> 标签
 }
 

--- a/src/renderer/src/aiCore/middleware/feat/ThinkingTagExtractionMiddleware.ts
+++ b/src/renderer/src/aiCore/middleware/feat/ThinkingTagExtractionMiddleware.ts
@@ -30,7 +30,8 @@ const getAppropriateTag = (model?: Model): TagConfig => {
   if (model?.id?.includes('qwen3')) return reasoningTags[0]
   if (model?.id?.includes('gemini-2.5')) return reasoningTags[1]
   if (model?.id?.includes('kimi-vl-a3b-thinking')) return reasoningTags[3]
-  if (model?.id?.includes('Seed-OSS-36B')) return reasoningTags[5]
+  if (model?.id?.includes('seed-oss-36b')) return reasoningTags[5]
+  // 可以在这里添加更多模型特定的标签配置
   return reasoningTags[0] // 默认使用 <think> 标签
 }
 

--- a/src/renderer/src/aiCore/middleware/feat/ThinkingTagExtractionMiddleware.ts
+++ b/src/renderer/src/aiCore/middleware/feat/ThinkingTagExtractionMiddleware.ts
@@ -7,6 +7,7 @@ import {
   ThinkingDeltaChunk,
   ThinkingStartChunk
 } from '@renderer/types/chunk'
+import { getLowerBaseModelName } from '@renderer/utils'
 import { TagConfig, TagExtractor } from '@renderer/utils/tagExtraction'
 
 import { CompletionsParams, CompletionsResult, GenericChunk } from '../schemas'
@@ -27,10 +28,11 @@ const reasoningTags: TagConfig[] = [
 ]
 
 const getAppropriateTag = (model?: Model): TagConfig => {
-  if (model?.id?.includes('qwen3')) return reasoningTags[0]
-  if (model?.id?.includes('gemini-2.5')) return reasoningTags[1]
-  if (model?.id?.includes('kimi-vl-a3b-thinking')) return reasoningTags[3]
-  if (model?.id?.toLowerCase().includes('seed-oss-36b')) return reasoningTags[5]
+  const modelId = model?.id ? getLowerBaseModelName(model.id) : undefined
+  if (modelId?.includes('qwen3')) return reasoningTags[0]
+  if (modelId?.includes('gemini-2.5')) return reasoningTags[1]
+  if (modelId?.includes('kimi-vl-a3b-thinking')) return reasoningTags[3]
+  if (modelId?.includes('seed-oss-36b')) return reasoningTags[5]
   // 可以在这里添加更多模型特定的标签配置
   return reasoningTags[0] // 默认使用 <think> 标签
 }

--- a/src/renderer/src/aiCore/middleware/feat/ThinkingTagExtractionMiddleware.ts
+++ b/src/renderer/src/aiCore/middleware/feat/ThinkingTagExtractionMiddleware.ts
@@ -22,13 +22,15 @@ const reasoningTags: TagConfig[] = [
   { openingTag: '<thought>', closingTag: '</thought>', separator: '\n' },
   { openingTag: '###Thinking', closingTag: '###Response', separator: '\n' },
   { openingTag: '◁think▷', closingTag: '◁/think▷', separator: '\n' },
-  { openingTag: '<thinking>', closingTag: '</thinking>', separator: '\n' }
+  { openingTag: '<thinking>', closingTag: '</thinking>', separator: '\n' },
+  { openingTag: '<seed:think>', closingTag: '</seed:think>', separator: '\n' }
 ]
 
 const getAppropriateTag = (model?: Model): TagConfig => {
   if (model?.id?.includes('qwen3')) return reasoningTags[0]
   if (model?.id?.includes('gemini-2.5')) return reasoningTags[1]
   if (model?.id?.includes('kimi-vl-a3b-thinking')) return reasoningTags[3]
+  if (model?.id?.includes('seed-oss-36b')) return reasoningTags[5]
   // 可以在这里添加更多模型特定的标签配置
   return reasoningTags[0] // 默认使用 <think> 标签
 }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

**Before this PR:** Seed-OSS-36B models use unique \<seed:think\> tags that are not parsed by cherry-studio and get dumped into normal assistant responses.

**After this PR:** Seed-OSS-36B models will have \<seed:think\> parsed correctly into the normal "Thinking deeply..." section and the main response is parsed into the assistant response field, bringing it line with other reasoning models.


### Why we need it and why it was done in this way

The model is becoming popular on western social media and it is important that the program be updated to support it's novel reasoning tag output style.

**The following tradeoffs were made:** None.

**The following alternatives were considered:** None.

### Breaking changes:

None.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
- Add <seed:think> and </seed:think> tags to reasoningTags array.
- Update getAppropriateTag function to detect Seed-OSS-36B model IDs.
- Ensure proper thinking tag parsing for ByteDance Seed-36B model.
```