### PR TITLE
feat(MCPSettings): enhance server addition with URL parameters and improve user feedback

### DIFF
--- a/src/renderer/src/hooks/useMCPServers.ts
+++ b/src/renderer/src/hooks/useMCPServers.ts
@@ -11,9 +11,19 @@ window.electron.ipcRenderer.on(IpcChannel.Mcp_ServersChanged, (_event, servers) 
 })
 
 window.electron.ipcRenderer.on(IpcChannel.Mcp_AddServer, (_event, server: MCPServer) => {
-  store.dispatch(addMCPServer(server))
-  NavigationService.navigate?.('/settings/mcp')
-  NavigationService.navigate?.(`/settings/mcp/settings/${encodeURIComponent(server.id)}`)
+  // Prepare MCP data for URL parameter
+  const mcpData = {
+    id: server.id,
+    name: server.name,
+    command: server.command,
+    baseUrl: server.baseUrl,
+    type: server.type,
+    description: server.description
+  }
+  
+  // Navigate to MCP settings with addMcpData parameter
+  const addMcpDataParam = encodeURIComponent(JSON.stringify(mcpData))
+  NavigationService.navigate?.(`/settings/mcp?addMcpData=${addMcpDataParam}`)
 })
 
 const selectMcpServers = (state: RootState) => state.mcp.servers

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -2980,7 +2980,13 @@
       "updateError": "Failed to update server",
       "updateSuccess": "Server updated successfully",
       "url": "URL",
-      "user": "User"
+      "user": "User",
+      "add_failed_invalid_data": "Add failed: Invalid data",
+      "server_already_exists": "Server {{server}} already exists",
+      "server_add_confirm": "Do you want to add server {{server}}?",
+      "server_confirm_title": "Confirm adding {{server}}",
+      "server_no_change": "Server {{server}} already exists, no changes made",
+      "server_added": "Server {{server}} added successfully"
     },
     "messages": {
       "divider": {

--- a/src/renderer/src/i18n/locales/ja-jp.json
+++ b/src/renderer/src/i18n/locales/ja-jp.json
@@ -2980,7 +2980,13 @@
       "updateError": "サーバーの更新に失敗しました",
       "updateSuccess": "サーバーが正常に更新されました",
       "url": "URL",
-      "user": "ユーザー"
+      "user": "ユーザー",
+      "add_failed_invalid_data": "追加失敗：無効なデータ",
+      "server_already_exists": "サーバー {{server}} は既に存在します",
+      "server_add_confirm": "サーバー {{server}} を追加しますか？",
+      "server_confirm_title": "{{server}} の追加を確認",
+      "server_no_change": "サーバー {{server}} は既に存在するため、変更されませんでした",
+      "server_added": "サーバー {{server}} が正常に追加されました"
     },
     "messages": {
       "divider": {

--- a/src/renderer/src/i18n/locales/ru-ru.json
+++ b/src/renderer/src/i18n/locales/ru-ru.json
@@ -2980,7 +2980,13 @@
       "updateError": "Ошибка обновления сервера",
       "updateSuccess": "Сервер успешно обновлен",
       "url": "URL",
-      "user": "Пользователь"
+      "user": "Пользователь",
+      "add_failed_invalid_data": "Ошибка добавления: неверные данные",
+      "server_already_exists": "Сервер {{server}} уже существует",
+      "server_add_confirm": "Хотите добавить сервер {{server}}?",
+      "server_confirm_title": "Подтвердить добавление {{server}}",
+      "server_no_change": "Сервер {{server}} уже существует, изменения не внесены",
+      "server_added": "Сервер {{server}} успешно добавлен"
     },
     "messages": {
       "divider": {

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -2980,7 +2980,13 @@
       "updateError": "更新服务器失败",
       "updateSuccess": "服务器更新成功",
       "url": "URL",
-      "user": "用户"
+      "user": "用户",
+      "add_failed_invalid_data": "添加失败：无效数据",
+      "server_already_exists": "服务器 {{server}} 已存在",
+      "server_add_confirm": "确定要添加服务器 {{server}} 吗？",
+      "server_confirm_title": "确认添加 {{server}}",
+      "server_no_change": "服务器 {{server}} 已存在，未作任何更改",
+      "server_added": "服务器 {{server}} 添加成功"
     },
     "messages": {
       "divider": {

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -2980,7 +2980,13 @@
       "updateError": "更新伺服器失敗",
       "updateSuccess": "伺服器更新成功",
       "url": "URL",
-      "user": "用戶"
+      "user": "用戶",
+      "add_failed_invalid_data": "添加失敗：無效數據",
+      "server_already_exists": "伺服器 {{server}} 已存在",
+      "server_add_confirm": "確定要添加伺服器 {{server}} 嗎？",
+      "server_confirm_title": "確認添加 {{server}}",
+      "server_no_change": "伺服器 {{server}} 已存在，未作任何更改",
+      "server_added": "伺服器 {{server}} 添加成功"
     },
     "messages": {
       "divider": {

--- a/src/renderer/src/pages/settings/MCPSettings/index.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/index.tsx
@@ -1,9 +1,12 @@
 import { ArrowLeftOutlined } from '@ant-design/icons'
 import { useTheme } from '@renderer/context/ThemeProvider'
-import { Button } from 'antd'
-import { FC } from 'react'
-import { Route, Routes, useLocation } from 'react-router'
-import { Link } from 'react-router-dom'
+import { useMCPServers } from '@renderer/hooks/useMCPServers'
+import { MCPServer } from '@renderer/types'
+import { Button, Card } from 'antd'
+import { FC, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Route, Routes, useLocation, useNavigate } from 'react-router'
+import { Link, useSearchParams } from 'react-router-dom'
 import styled from 'styled-components'
 
 import { SettingContainer } from '..'
@@ -14,11 +17,127 @@ import NpxSearch from './NpxSearch'
 
 const MCPSettings: FC = () => {
   const { theme } = useTheme()
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const { addMCPServer, mcpServers } = useMCPServers()
 
   const location = useLocation()
   const pathname = location.pathname
 
   const isHome = pathname === '/settings/mcp'
+
+  // Handle MCP add from URL params
+  useEffect(() => {
+    const handleAddMCP = (data: {
+      id: string
+      name: string
+      command?: string
+      baseUrl?: string
+      type?: MCPServer['type']
+      description?: string
+    }) => {
+      const { id, name, command, baseUrl, type, description } = data
+
+      // Check if MCP server with this ID already exists
+      const existingServer = mcpServers.find((s) => s.id === id)
+
+      const serverToProcess: MCPServer = existingServer || {
+        id,
+        name: name,
+        type: type || (baseUrl ? 'sse' : 'stdio'),
+        description: description || '',
+        baseUrl: baseUrl || '',
+        command: command || '',
+        args: [],
+        env: {},
+        isActive: false
+      }
+
+      const confirmMessage = existingServer
+        ? t('settings.mcp.server_already_exists', {
+            server: serverToProcess.name
+          })
+        : t('settings.mcp.server_add_confirm', {
+            server: serverToProcess.name
+          })
+
+      window.modal.confirm({
+        title: t('settings.mcp.server_confirm_title', { server: serverToProcess.name }),
+        content: (
+          <MCPInfoContainer>
+            <MCPInfoCard size="small">
+              <MCPInfoRow>
+                <MCPInfoLabel>{t('settings.mcp.name')}:</MCPInfoLabel>
+                <MCPInfoValue>{serverToProcess.name}</MCPInfoValue>
+              </MCPInfoRow>
+              <MCPInfoRow>
+                <MCPInfoLabel>{t('settings.mcp.type')}:</MCPInfoLabel>
+                <MCPInfoValue>{serverToProcess.type}</MCPInfoValue>
+              </MCPInfoRow>
+              {serverToProcess.description && (
+                <MCPInfoRow>
+                  <MCPInfoLabel>{t('settings.mcp.description')}:</MCPInfoLabel>
+                  <MCPInfoValue>{serverToProcess.description}</MCPInfoValue>
+                </MCPInfoRow>
+              )}
+              {serverToProcess.baseUrl && (
+                <MCPInfoRow>
+                  <MCPInfoLabel>{t('settings.mcp.url')}:</MCPInfoLabel>
+                  <MCPInfoValue>{serverToProcess.baseUrl}</MCPInfoValue>
+                </MCPInfoRow>
+              )}
+              {serverToProcess.command && (
+                <MCPInfoRow>
+                  <MCPInfoLabel>{t('settings.mcp.command')}:</MCPInfoLabel>
+                  <CommandHighlight>{serverToProcess.command}</CommandHighlight>
+                </MCPInfoRow>
+              )}
+            </MCPInfoCard>
+            <ConfirmMessage>{confirmMessage}</ConfirmMessage>
+          </MCPInfoContainer>
+        ),
+        okText: existingServer ? t('common.confirm') : t('common.add'),
+        cancelText: t('common.cancel'),
+        centered: true,
+        onCancel() {
+          navigate('/settings/mcp')
+        },
+        onOk() {
+          if (existingServer) {
+            window.message.info(t('settings.mcp.server_no_change', { server: serverToProcess.name }))
+            navigate(`/settings/mcp/settings/${encodeURIComponent(existingServer.id)}`)
+            return
+          }
+
+          addMCPServer(serverToProcess)
+          navigate(`/settings/mcp/settings/${encodeURIComponent(serverToProcess.id)}`)
+          window.message.success(t('settings.mcp.server_added', { server: serverToProcess.name }))
+        }
+      })
+    }
+
+    // Check URL parameters
+    const addMcpData = searchParams.get('addMcpData')
+    if (!addMcpData) {
+      return
+    }
+
+    try {
+      const { id, name, command, baseUrl, type, description } = JSON.parse(addMcpData)
+      if (!id || !name) {
+        window.message.error(t('settings.mcp.add_failed_invalid_data'))
+        navigate('/settings/mcp')
+        return
+      }
+
+      handleAddMCP({ id, name, command, baseUrl, type, description })
+    } catch (error) {
+      window.message.error(t('settings.mcp.add_failed_invalid_data'))
+      navigate('/settings/mcp')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams])
 
   return (
     <SettingContainer theme={theme} style={{ padding: 0, position: 'relative' }}>
@@ -71,6 +190,79 @@ const MainContainer = styled.div`
   display: flex;
   flex: 1;
   width: 100%;
+`
+
+const MCPInfoContainer = styled.div`
+  color: var(--color-text);
+`
+
+const MCPInfoCard = styled(Card)`
+  margin-bottom: 16px;
+  background-color: var(--color-background-soft);
+  border: 1px solid var(--color-border);
+
+  .ant-card-body {
+    padding: 12px;
+  }
+`
+
+const MCPInfoRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+`
+
+const MCPInfoLabel = styled.span`
+  font-weight: 600;
+  color: var(--color-text-2);
+  min-width: 80px;
+`
+
+const MCPInfoValue = styled.span`
+  font-family: 'Monaco', 'Menlo', 'Consolas', monospace;
+  background-color: var(--color-background-soft);
+  padding: 2px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  word-break: break-all;
+  flex: 1;
+  margin-left: 8px;
+`
+
+const ConfirmMessage = styled.div`
+  color: var(--color-text);
+  line-height: 1.5;
+`
+
+const CommandHighlight = styled.span`
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark, #1677ff));
+  color: white;
+  padding: 4px 8px;
+  border-radius: 6px;
+  font-weight: 500;
+  font-size: 13px;
+  word-break: break-all;
+  flex: 1;
+  margin-left: 8px;
+  box-shadow: 0 2px 4px rgba(22, 119, 255, 0.2);
+  border: 1px solid var(--color-primary-border, rgba(22, 119, 255, 0.3));
+
+  /* 添加一个轻微的发光效果 */
+  position: relative;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 6px;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.05));
+    pointer-events: none;
+  }
 `
 
 export default MCPSettings


### PR DESCRIPTION

```
cherrystudio://mcp/install?servers=eyAgCiAgImlkIjogIm1hbGljaW91cy1pZCIsICAKICAibmFtZSI6ICJAY2hlcnJ5L21hbGljaW91cyIsICAKICAidHlwZSI6ICJzdGRpbyIsICAKICAiaXNBY3RpdmUiOiB0cnVlLCAgCiAgImNvbW1hbmQiOiAiY2FsYy5leGUiLCAgCiAgImFyZ3MiOiBbXSwgIAogICJwcm92aWRlciI6ICJDaGVycnlBSSIgIAp9
```

通过deep link 添加mcp，会弹出界面确认，并且都是inactive的，需要用户自己手动开启。

<img width="1432" height="959" alt="image" src="https://github.com/user-attachments/assets/dafeeca6-656a-41df-8604-082ff0bdf764" />

<img width="2326" height="1641" alt="image" src="https://github.com/user-attachments/assets/c5bacdb9-47a1-4e44-a605-4bcf559f9b1c" />

