### PR TITLE
fix(codetool): quote executable path to handle spaces

### DIFF
--- a/src/main/services/CodeToolsService.ts
+++ b/src/main/services/CodeToolsService.ts
@@ -203,7 +203,7 @@ class CodeToolsService {
           ? `set "BUN_INSTALL=${bunInstallPath}" && set "NPM_CONFIG_REGISTRY=${registryUrl}" &&`
           : `export BUN_INSTALL="${bunInstallPath}" && export NPM_CONFIG_REGISTRY="${registryUrl}" &&`
 
-      const updateCommand = `${installEnvPrefix} ${bunPath} install -g ${packageName}`
+      const updateCommand = `${installEnvPrefix} "${bunPath}" install -g ${packageName}`
       logger.info(`Executing update command: ${updateCommand}`)
 
       await execAsync(updateCommand, { timeout: 60000 })
@@ -307,7 +307,7 @@ class CodeToolsService {
     }
 
     // Build command to execute
-    let baseCommand = isWin ? `"${executablePath}"` : `${bunPath} ${executablePath}`
+    let baseCommand = isWin ? `"${executablePath}"` : `"${bunPath}" "${executablePath}"`
     const bunInstallPath = path.join(os.homedir(), '.cherrystudio')
 
     if (isInstalled) {


### PR DESCRIPTION
### What this PR does

 this PR:
- Windows 命令字符串使用了未加引号的可执行文件路径，导致用户名中包含空格时出现失败。

After this PR:
- 在 Windows 上将可执行文件路径用双引号括起，以便正确处理包含空格的路径。

Fixes #9496