### PR TITLE
fix: not using system default terminal on deepin

### DIFF
--- a/src/main/services/CodeToolsService.ts
+++ b/src/main/services/CodeToolsService.ts
@@ -420,7 +420,7 @@ end tell`
         const envPrefix = buildEnvPrefix(false)
         const command = envPrefix ? `${envPrefix} && ${baseCommand}` : baseCommand
 
-        const linuxTerminals = ['gnome-terminal', 'konsole', 'xterm', 'x-terminal-emulator']
+        const linuxTerminals = ['gnome-terminal', 'konsole', 'deepin-terminal', 'xterm', 'x-terminal-emulator']
         let foundTerminal = 'xterm' // Default to xterm
 
         for (const terminal of linuxTerminals) {


### PR DESCRIPTION
deepin-terminal is not in the `linuxTerminals` list, that will cause xterm picked as the terminal to run code tool, which has compatibility with Chinese charaters.

see: https://bbs.deepin.org.cn/post/290948

### What this PR does

Before this PR:

<img width="1309" height="843" alt="image" src="https://github.com/user-attachments/assets/8211de21-15fb-44a9-94c5-3d3bcac358eb" />


After this PR:

deepin-terminal will be used and no character visual problems.

### Why we need it and why it was done in this way

The following tradeoffs were made:

NO.

The following alternatives were considered:

NO.

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
NONE
```
