### PR TITLE
refactor(DraggableList): remove antd List component

### DIFF
--- a/src/renderer/src/components/DraggableList/__tests__/DraggableList.test.tsx
+++ b/src/renderer/src/components/DraggableList/__tests__/DraggableList.test.tsx
@@ -29,20 +29,6 @@ vi.mock('@hello-pangea/dnd', () => {
   }
 })
 
-// mock antd list 只做简单渲染
-vi.mock('antd', () => ({
-  __esModule: true,
-  List: ({ dataSource, renderItem }: any) => (
-    <div data-testid="virtual-list">
-      {dataSource.map((item: any, idx: number) => (
-        <div key={item.id || item} data-testid="virtual-list-item">
-          {renderItem(item, idx)}
-        </div>
-      ))}
-    </div>
-  )
-}))
-
 declare global {
   interface Window {
     triggerOnDragEnd: (result?: any, provided?: any) => void
@@ -73,14 +59,14 @@ describe('DraggableList', () => {
       const list = [{ id: 'a', name: 'A' }]
       const style = { background: 'red' }
       const listStyle = { color: 'blue' }
-      render(
+      const { container } = render(
         <DraggableList list={list} style={style} listStyle={listStyle} onUpdate={() => {}}>
           {(item) => <div data-testid="item">{item.name}</div>}
         </DraggableList>
       )
       // 检查 style 是否传递到外层容器
-      const virtualList = screen.getByTestId('virtual-list')
-      expect(virtualList.parentElement).toHaveStyle({ background: 'red' })
+      const listContainer = container.querySelector('.draggable-list-container')
+      expect(listContainer.parentElement).toHaveStyle({ background: 'red' })
     })
 
     it('should render nothing when list is empty', () => {

--- a/src/renderer/src/components/DraggableList/__tests__/DraggableList.test.tsx
+++ b/src/renderer/src/components/DraggableList/__tests__/DraggableList.test.tsx
@@ -66,7 +66,8 @@ describe('DraggableList', () => {
       )
       // 检查 style 是否传递到外层容器
       const listContainer = container.querySelector('.draggable-list-container')
-      expect(listContainer.parentElement).toHaveStyle({ background: 'red' })
+      expect(listContainer).not.toBeNull()
+      expect(listContainer?.parentElement).toHaveStyle({ background: 'red' })
     })
 
     it('should render nothing when list is empty', () => {

--- a/src/renderer/src/components/DraggableList/__tests__/__snapshots__/DraggableList.test.tsx.snap
+++ b/src/renderer/src/components/DraggableList/__tests__/__snapshots__/DraggableList.test.tsx.snap
@@ -10,56 +10,44 @@ exports[`DraggableList > snapshot > should match snapshot 1`] = `
     >
       <div>
         <div
-          data-testid="virtual-list"
+          class="draggable-list-container"
         >
           <div
-            data-testid="virtual-list-item"
+            data-testid="draggable-a-0"
           >
             <div
-              data-testid="draggable-a-0"
+              style="margin-bottom: 8px;"
             >
               <div
-                style="margin-bottom: 8px;"
+                data-testid="item"
               >
-                <div
-                  data-testid="item"
-                >
-                  A
-                </div>
+                A
               </div>
             </div>
           </div>
           <div
-            data-testid="virtual-list-item"
+            data-testid="draggable-b-1"
           >
             <div
-              data-testid="draggable-b-1"
+              style="margin-bottom: 8px;"
             >
               <div
-                style="margin-bottom: 8px;"
+                data-testid="item"
               >
-                <div
-                  data-testid="item"
-                >
-                  B
-                </div>
+                B
               </div>
             </div>
           </div>
           <div
-            data-testid="virtual-list-item"
+            data-testid="draggable-c-2"
           >
             <div
-              data-testid="draggable-c-2"
+              style="margin-bottom: 8px;"
             >
               <div
-                style="margin-bottom: 8px;"
+                data-testid="item"
               >
-                <div
-                  data-testid="item"
-                >
-                  C
-                </div>
+                C
               </div>
             </div>
           </div>

--- a/src/renderer/src/components/DraggableList/list.tsx
+++ b/src/renderer/src/components/DraggableList/list.tsx
@@ -9,14 +9,13 @@ import {
   ResponderProvided
 } from '@hello-pangea/dnd'
 import { droppableReorder } from '@renderer/utils'
-import { List, ListProps } from 'antd'
-import { FC } from 'react'
+import { FC, HTMLAttributes } from 'react'
 
 interface Props<T> {
   list: T[]
   style?: React.CSSProperties
   listStyle?: React.CSSProperties
-  listProps?: ListProps<T>
+  listProps?: HTMLAttributes<HTMLDivElement>
   children: (item: T, index: number) => React.ReactNode
   onUpdate: (list: T[]) => void
   onDragStart?: OnDragStartResponder
@@ -52,10 +51,8 @@ const DraggableList: FC<Props<any>> = ({
       <Droppable droppableId="droppable" {...droppableProps}>
         {(provided) => (
           <div {...provided.droppableProps} ref={provided.innerRef} style={style}>
-            <List
-              {...listProps}
-              dataSource={list}
-              renderItem={(item, index) => {
+            <div {...listProps} className="draggable-list-container">
+              {list.map((item, index) => {
                 const id = item.id || item
                 return (
                   <Draggable key={`draggable_${id}_${index}`} draggableId={id} index={index}>
@@ -74,8 +71,8 @@ const DraggableList: FC<Props<any>> = ({
                     )}
                   </Draggable>
                 )
-              }}
-            />
+              })}
+            </div>
             {provided.placeholder}
           </div>
         )}


### PR DESCRIPTION
The DraggableList component was unnecessarily wrapped in an antd List component. This change removes the antd List and replaces it with a standard div.

A `className` has been added to the new div for testing purposes. The `listProps` prop is preserved and its type is updated to `React.HTMLAttributes<HTMLDivElement>`.

The tests have been updated to reflect the new DOM structure, using a class selector instead of a data-testid. The antd mock has been removed, and the snapshot has been updated.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

DraggableList 不需要 antd list，避免空列表时显示占位符

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
