### PR TITLE
fix: move topic prompt handling to message thunk and fix prompt logic

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -241,16 +241,12 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
         baseUserMessage.mentions = mentionedModels
       }
 
-      const assistantWithTopicPrompt = topic.prompt
-        ? { ...assistant, prompt: `${assistant.prompt}\n${topic.prompt}` }
-        : assistant
-
       baseUserMessage.usage = await estimateUserPromptUsage(baseUserMessage)
 
       const { message, blocks } = getUserMessage(baseUserMessage)
       message.traceId = parent?.spanContext().traceId
 
-      dispatch(_sendMessage(message, blocks, assistantWithTopicPrompt, topic.id))
+      dispatch(_sendMessage(message, blocks, assistant, topic.id))
 
       // Clear input
       setText('')

--- a/src/renderer/src/pages/home/Messages/Message.tsx
+++ b/src/renderer/src/pages/home/Messages/Message.tsx
@@ -100,11 +100,8 @@ const MessageItem: FC<Props> = ({
 
   const handleEditResend = useCallback(
     async (blocks: MessageBlock[]) => {
-      const assistantWithTopicPrompt = topic.prompt
-        ? { ...assistant, prompt: `${assistant.prompt}\n${topic.prompt}` }
-        : assistant
       try {
-        await resendUserMessageWithEdit(message, blocks, assistantWithTopicPrompt)
+        await resendUserMessageWithEdit(message, blocks, assistant)
         stopEditing()
       } catch (error) {
         logger.error('Failed to resend message:', error as Error)

--- a/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
@@ -150,10 +150,7 @@ const MessageMenubar: FC<Props> = (props) => {
   const handleResendUserMessage = useCallback(
     async (messageUpdate?: Message) => {
       if (!loading) {
-        const assistantWithTopicPrompt = topic.prompt
-          ? { ...assistant, prompt: `${assistant.prompt}\n${topic.prompt}` }
-          : assistant
-        await resendMessage(messageUpdate ?? message, assistantWithTopicPrompt)
+        await resendMessage(messageUpdate ?? message, assistant)
       }
     },
     [assistant, loading, message, resendMessage, topic.prompt]
@@ -379,12 +376,8 @@ const MessageMenubar: FC<Props> = (props) => {
     // const _message = resetAssistantMessage(message, selectedModel)
     // editMessage(message.id, { ..._message }) // REMOVED
 
-    const assistantWithTopicPrompt = topic.prompt
-      ? { ...assistant, prompt: `${assistant.prompt}\n${topic.prompt}` }
-      : assistant
-
     // Call the function from the hook
-    regenerateAssistantMessage(message, assistantWithTopicPrompt)
+    regenerateAssistantMessage(message, assistant)
   }
 
   // 按条件筛选能够提及的模型，该函数仅在isAssistantMessage时会用到

--- a/src/renderer/src/store/thunk/messageThunk.ts
+++ b/src/renderer/src/store/thunk/messageThunk.ts
@@ -288,14 +288,18 @@ const dispatchMultiModelResponses = async (
 }
 
 // --- End Helper Function ---
-
+// 发送和处理助手响应的实现函数，话题提示词在此拼接
 const fetchAndProcessAssistantResponseImpl = async (
   dispatch: AppDispatch,
   getState: () => RootState,
   topicId: string,
-  assistant: Assistant,
+  origAssistant: Assistant,
   assistantMessage: Message // Pass the prepared assistant message (new or reset)
 ) => {
+  const topic = origAssistant.topics.find((t) => t.id === topicId)
+  const assistant = topic?.prompt
+    ? { ...origAssistant, prompt: `${origAssistant.prompt}\n${topic.prompt}` }
+    : origAssistant
   const assistantMsgId = assistantMessage.id
   let callbacks: StreamProcessorCallbacks = {}
   try {


### PR DESCRIPTION
## 核心变更
将topic prompt的处理逻辑从多个UI组件中移除，集中到 messageThunk.ts 中统一处理。

## 具体修改
### 1. 移除了UI组件中的topic prompt处理逻辑
- Inputbar/Inputbar.tsx : 移除了将topic prompt附加到assistant prompt的逻辑
- Messages/Message.tsx : 移除了在消息重新发送时处理topic prompt的代码
- Messages/MessageMenubar.tsx : 移除了两处topic prompt处理逻辑（消息重新发送和重新生成）
### 2. 在messageThunk.ts中添加了统一的topic prompt处理
- 添加了查找当前topic的prompt的逻辑：
  ```
  const thisTopicPrompt = assistant.topics?.find
  ((t) => t.id === topicId)?.prompt
  ```
- 添加了组合prompt的逻辑：
  ```
  const finalPrompt = (thisTopicPrompt ? `$
  {assistant.prompt}\n${thisTopicPrompt}` : 
  assistant.prompt).trim()
  ```
- 修改了buildSystemPrompt的调用，使用处理后的finalPrompt：
  ```
  assistant.prompt = await buildSystemPrompt
  (finalPrompt || '', assistant)
  ```
## 优势
1. 1.
   代码集中管理 ：将topic prompt处理逻辑统一放在messageThunk中，避免了在多个UI组件中重复实现
2. 2.
   维护性提升 ：当需要修改topic prompt处理逻辑时，只需修改一个地方
3. 3.
   一致性保证 ：确保所有消息处理路径都使用相同的topic prompt处理逻辑