### PR TITLE
fix: decode Bing redirect URLs in LocalBingProvider

### DIFF
--- a/src/main/services/SearchService.ts
+++ b/src/main/services/SearchService.ts
@@ -1,5 +1,8 @@
 import { is } from '@electron-toolkit/utils'
+import { loggerService } from '@logger'
 import { BrowserWindow } from 'electron'
+
+const logger = loggerService.withContext('SearchService')
 
 export class SearchService {
   private static instance: SearchService | null = null
@@ -55,6 +58,7 @@ export class SearchService {
 
   public async openUrlInSearchWindow(uid: string, url: string): Promise<any> {
     let window = this.searchWindows[uid]
+    logger.debug(`Searching with URL: ${url}`)
     if (window) {
       await window.loadURL(url)
     } else {

--- a/src/renderer/src/providers/WebSearchProvider/LocalBingProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/LocalBingProvider.ts
@@ -17,9 +17,10 @@ export default class LocalBingProvider extends LocalSearchProvider {
       items.forEach((item) => {
         const node = item.querySelector('a')
         if (node) {
+          const decodedUrl = this.decodeBingUrl(node.href)
           results.push({
             title: node.textContent || '',
-            url: node.href
+            url: decodedUrl
           })
         }
       })
@@ -27,5 +28,35 @@ export default class LocalBingProvider extends LocalSearchProvider {
       logger.error('Failed to parse Bing search HTML:', error as Error)
     }
     return results
+  }
+
+  /**
+   * Decode Bing redirect URL to get the actual URL
+   * Bing URLs are in format: https://www.bing.com/ck/a?...&u=a1aHR0cHM6Ly93d3cudG91dGlhby5jb20...
+   * The 'u' parameter contains Base64 encoded URL with 'a1' prefix
+   */
+  private decodeBingUrl(bingUrl: string): string {
+    try {
+      const url = new URL(bingUrl)
+      const encodedUrl = url.searchParams.get('u')
+
+      if (!encodedUrl) {
+        return bingUrl // Return original if no 'u' parameter
+      }
+
+      // Remove the 'a1' prefix and decode Base64
+      const base64Part = encodedUrl.substring(2)
+      const decodedUrl = atob(base64Part)
+
+      // Validate the decoded URL
+      if (decodedUrl.startsWith('http')) {
+        return decodedUrl
+      }
+
+      return bingUrl // Return original if decoded URL is invalid
+    } catch (error) {
+      logger.warn('Failed to decode Bing URL:', error as Error)
+      return bingUrl // Return original URL if decoding fails
+    }
   }
 }


### PR DESCRIPTION
修复Bing搜索无法使用

https://github.com/CherryHQ/cherry-studio/issues/9208#issuecomment-3216767158

Added logic to extract and decode the actual target URL from Bing redirect links in LocalBingProvider. Also introduced debug logging in SearchService to log search URLs.