### PR TITLE
fix(CodeToolsService): open new terminal tab for command execution

### DIFF
--- a/src/main/services/CodeToolsService.ts
+++ b/src/main/services/CodeToolsService.ts
@@ -337,8 +337,9 @@ class CodeToolsService {
         terminalArgs = [
           '-e',
           `tell application "Terminal"
+  set newTab to do script "cd '${directory.replace(/'/g, "\\'")}' && clear"
   activate
-  do script "cd '${directory.replace(/'/g, "\\'")}' && clear && ${command.replace(/"/g, '\\"')}"
+  do script "${command.replace(/"/g, '\\"')}" in newTab
 end tell`
         ]
         break


### PR DESCRIPTION
Updated the terminal command execution logic to open a new tab in the Terminal application for running commands. This change enhances user experience by keeping the original tab available while executing commands in a separate tab.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

没有终端启动，点击启动code tool，会先启动一个空白的terminal，再启动第二terminal来运行代码。

After this PR:

先启动一个空白terminal并且cd到工具目录，再执行下面花费比较久的安装或者code命令。不会出现两个terminal

