### PR TITLE
fix: filter inline base64 image in messages summary

### DIFF
--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -42,6 +42,7 @@ import { removeSpecialCharactersForTopicName, uuid } from '@renderer/utils'
 import { abortCompletion } from '@renderer/utils/abortController'
 import { isAbortError } from '@renderer/utils/error'
 import { extractInfoFromXML, ExtractResults } from '@renderer/utils/extract'
+import { purifyMarkdownImages } from '@renderer/utils/markdown'
 import { filterAdjacentUserMessaegs, filterLastAssistantMessage } from '@renderer/utils/messageUtils/filters'
 import { findFileBlocks, getMainTextContent } from '@renderer/utils/messageUtils/find'
 import {
@@ -699,7 +700,7 @@ export async function fetchMessagesSummary({ messages, assistant }: { messages: 
   const structredMessages = contextMessages.map((message) => {
     const structredMessage = {
       role: message.role,
-      mainText: getMainTextContent(message)
+      mainText: purifyMarkdownImages(getMainTextContent(message))
     }
 
     // 让LLM知道消息中包含的文件，但只提供文件名

--- a/src/renderer/src/utils/markdown.ts
+++ b/src/renderer/src/utils/markdown.ts
@@ -312,3 +312,27 @@ export const markdownToPlainText = (markdown: string): string => {
   // 直接用 remove-markdown 库，使用默认的 removeMarkdown 参数
   return removeMarkdown(markdown)
 }
+
+/**
+ * 清理 Markdown 中的 base64 图片链接
+ *
+ * 将 Markdown 中的 base64 格式图片链接替换为普通链接格式。
+ * 例如:
+ * - 输入: ![image](data:image/png;base64,iVBORw0...)
+ * - 输出: [image](image_url)
+ *
+ * @param {string} markdown - 包含图片链接的 Markdown 文本
+ * @returns {string} 处理后的 Markdown 文本，所有 base64 图片链接都被替换为普通链接
+ *
+ * @example
+ * ```ts
+ * const md = '![test](data:image/png;base64,iVBORw0...)'
+ * purifyMarkdownImages(md) // 返回 '[test](image_url)'
+ * ```
+ */
+export const purifyMarkdownImages = (markdown: string): string => {
+  return markdown.replace(
+    /(!\[[^\]]*\]\()\s*data:image\/[\w+.-]+;base64\s*,[\w+/=]+(?:\s*[\w+/=]+)*\s*\)/gi,
+    '$1image_url)'
+  )
+}

--- a/src/renderer/src/utils/markdown.ts
+++ b/src/renderer/src/utils/markdown.ts
@@ -317,18 +317,12 @@ export const markdownToPlainText = (markdown: string): string => {
  * 清理 Markdown 中的 base64 图片链接
  *
  * 将 Markdown 中的 base64 格式图片链接替换为普通链接格式。
- * 例如:
- * - 输入: ![image](data:image/png;base64,iVBORw0...)
- * - 输出: [image](image_url)
  *
  * @param {string} markdown - 包含图片链接的 Markdown 文本
  * @returns {string} 处理后的 Markdown 文本，所有 base64 图片链接都被替换为普通链接
- *
  * @example
- * ```ts
- * const md = '![test](data:image/png;base64,iVBORw0...)'
- * purifyMarkdownImages(md) // 返回 '[test](image_url)'
- * ```
+ * - 输入: `![image](data:image/png;base64,iVBORw0...)`
+ * - 输出: `![image](image_url)`
  */
 export const purifyMarkdownImages = (markdown: string): string => {
   return markdown.replace(


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

内联生图会导致话题总结token爆掉

https://github.com/CherryHQ/cherry-studio/issues/9670#issuecomment-3238049975

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
