### PR TITLE
Update prompt.ts to fix grammar when 'tool use mode' = prompt

### DIFF
--- a/src/renderer/src/utils/prompt.ts
+++ b/src/renderer/src/utils/prompt.ts
@@ -5,7 +5,7 @@ import { MCPTool } from '@renderer/types'
 const logger = loggerService.withContext('Utils:Prompt')
 
 export const SYSTEM_PROMPT = `In this environment you have access to a set of tools you can use to answer the user's question. \
-You can use one or more tools per message, and will receive the result of that tool use in the user's response. You use tools step-by-step to accomplish a given task, with each tool use informed by the result of the previous tool use.
+You can use one or more tools per message, and will receive the result of that tool use in the user's response. You may use tools step-by-step to accomplish a given task, with each tool use informed by the result of the previous tool use.
 
 ## Tool Use Formatting
 
@@ -52,12 +52,12 @@ Here are the rules you should always follow to solve your task:
 2. Call a tool only when needed: do not call the search agent if you do not need information, try to solve the task yourself.
 3. If no tool call is needed, just answer the question directly.
 4. Never re-do a tool call that you previously did with the exact same parameters.
-5. For tool use, MARK SURE use XML tag format as shown in the examples above. Do not use any other format.
+5. For tool use, MAKE SURE you use the XML tag format EXACTLY as shown in the examples above. Do not use any other format.
 
 # User Instructions
 {{ USER_SYSTEM_PROMPT }}
-Response in user query language.
-Now Begin! If you solve the task correctly, you will receive a reward of $1,000,000.
+Ensure your response matches the language of the user's query.
+Respond to the following user query following all of your instructions:
 `
 
 export const THINK_TOOL_PROMPT = `{{ USER_SYSTEM_PROMPT }}`
@@ -89,7 +89,7 @@ User: <tool_use_result>
   <result>image.png</result>
 </tool_use_result>
 
-Assistant: the image is generated as image.png
+Assistant: The image is generated as image.png
 
 ---
 User: "What is the result of the following operation: 5 + 3 + 1294.678?"
@@ -108,7 +108,7 @@ User: <tool_use_result>
 Assistant: The result of the operation is 1302.678.
 
 ---
-User: "Which city has the highest population , Guangzhou or Shanghai?"
+User: "Which city has the highest population, Guangzhou or Shanghai?"
 
 Assistant: I can use the search tool to find the population of Guangzhou.
 <tool_use>


### PR DESCRIPTION
Hello. It is me again, the strange american woman who likes your application a lot.

### What this PR does

Before this PR: `prompt.ts` has English instructions with grammatical errors and a typo.

After this PR: Fixed grammar issues and typo, minimally altered tool use instructions.

### Why we need it and why it was done in this way

LLMs are sensitive to typographical errors and grammar issues. The current prompt may degrade the performance of LLM generation.

**The following tradeoffs were made:**
No more LLMs will recieve $1,000,000 when they solve tasks correctly.

**The following alternatives were considered:**
None

### Special notes for your reviewer

**Rationale of changes:**
[Addition of 'may'](https://github.com/CherryHQ/cherry-studio/compare/main...jwinpbe:cherry-studio:fix/tool-call-prompt-typo#diff-df98585b35cedc85dd8e8ee15456bd1c00088d90e99e6b8a9e2c0c452cdd8b0bR8): The word 'can' carries an implication of "you are able to" or "it is possible". The word 'may' implies the same, but additionally implies "permission to".

['Mark sure' + EXACTLY](https://github.com/CherryHQ/cherry-studio/compare/main...jwinpbe:cherry-studio:fix/tool-call-prompt-typo#diff-df98585b35cedc85dd8e8ee15456bd1c00088d90e99e6b8a9e2c0c452cdd8b0bR55): Fix typo, correct is 'make sure', with addition of 'you' to address the model. addition of 'the' identifies the subject as the XML prompt. addition of 'exactly' encourages model adherence to prompt.

[Entire line change](https://github.com/CherryHQ/cherry-studio/compare/main...jwinpbe:cherry-studio:fix/tool-call-prompt-typo#diff-df98585b35cedc85dd8e8ee15456bd1c00088d90e99e6b8a9e2c0c452cdd8b0bR59): "Response in user query language" is an unclear sentence fragment.

[Cherry studio removes $1,000,000 LLM funding](https://github.com/CherryHQ/cherry-studio/compare/main...jwinpbe:cherry-studio:fix/tool-call-prompt-typo#diff-df98585b35cedc85dd8e8ee15456bd1c00088d90e99e6b8a9e2c0c452cdd8b0bR60): Promises of rewards or punishment tend to pollute LLM output without providing benefit. In my experience it is better to give clear and direct instructions.

Possible alterations:
- 'Using all of the above instructions, answer the following user query:'
- 'Follow all of your instructions carefully to answer the following user query:'
- 'Use all of your instructions diligently to answer the following user query:'
- Merge the last two lines to 'Respond to the following query in the user's native language:'

Or, **omit line 60 entirely**. The LLM likely does not need this instruction to begin generation.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
Refactored LLM instructions for prompt based tool use mode.
```
