### PR TITLE
refactor(CodeEditor): support file extensions explicitly

### DIFF
--- a/src/renderer/src/components/CodeEditor/__tests__/utils.test.ts
+++ b/src/renderer/src/components/CodeEditor/__tests__/utils.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getNormalizedExtension } from '../utils'
+
+const mocks = vi.hoisted(() => ({
+  getExtensionByLanguage: vi.fn()
+}))
+
+vi.mock('@renderer/utils/code-language', () => ({
+  getExtensionByLanguage: mocks.getExtensionByLanguage
+}))
+
+describe('getNormalizedExtension', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return custom mapping for custom language', async () => {
+    mocks.getExtensionByLanguage.mockReturnValue(undefined)
+    await expect(getNormalizedExtension('svg')).resolves.toBe('xml')
+    await expect(getNormalizedExtension('SVG')).resolves.toBe('xml')
+  })
+
+  it('should prefer custom mapping when both custom and linguist exist', async () => {
+    mocks.getExtensionByLanguage.mockReturnValue('.svg')
+    await expect(getNormalizedExtension('svg')).resolves.toBe('xml')
+  })
+
+  it('should return linguist mapping when available (strip leading dot)', async () => {
+    mocks.getExtensionByLanguage.mockReturnValue('.ts')
+    await expect(getNormalizedExtension('TypeScript')).resolves.toBe('ts')
+  })
+
+  it('should return extension when input already looks like extension (leading dot)', async () => {
+    mocks.getExtensionByLanguage.mockReturnValue(undefined)
+    await expect(getNormalizedExtension('.json')).resolves.toBe('json')
+  })
+
+  it('should return language as-is when no rules matched', async () => {
+    mocks.getExtensionByLanguage.mockReturnValue(undefined)
+    await expect(getNormalizedExtension('unknownLanguage')).resolves.toBe('unknownLanguage')
+  })
+})

--- a/src/renderer/src/components/CodeEditor/hooks.ts
+++ b/src/renderer/src/components/CodeEditor/hooks.ts
@@ -8,7 +8,9 @@ import { getNormalizedExtension } from './utils'
 
 const logger = loggerService.withContext('CodeEditorHooks')
 
-// 语言对应的 linter 加载器
+/** 语言对应的 linter 加载器
+ * key: 语言文件扩展名（不包含 `.`）
+ */
 const linterLoaders: Record<string, () => Promise<any>> = {
   json: async () => {
     const jsonParseLinter = await import('@codemirror/lang-json').then((mod) => mod.jsonParseLinter)
@@ -64,13 +66,15 @@ async function loadLanguageExtension(language: string): Promise<Extension | null
  * 加载 linter 扩展
  */
 async function loadLinterExtension(language: string): Promise<Extension | null> {
-  const loader = linterLoaders[language]
+  const fileExt = await getNormalizedExtension(language)
+
+  const loader = linterLoaders[fileExt]
   if (!loader) return null
 
   try {
     return await loader()
   } catch (error) {
-    logger.debug(`Failed to load linter for ${language}`, error as Error)
+    logger.debug(`Failed to load linter for ${language} (${fileExt})`, error as Error)
     return null
   }
 }

--- a/src/renderer/src/components/CodeEditor/index.tsx
+++ b/src/renderer/src/components/CodeEditor/index.tsx
@@ -20,7 +20,13 @@ export interface CodeEditorProps {
   value: string
   /** Placeholder when the editor content is empty. */
   placeholder?: string | HTMLElement
-  /** Code language, supports aliases. */
+  /**
+   * Code language string.
+   * - Case-insensitive.
+   * - Supports common names: javascript, json, python, etc.
+   * - Supports aliases: c#/csharp, objective-c++/obj-c++/objc++, etc.
+   * - Supports file extensions: .cpp/cpp, .js/js, .py/py, etc.
+   */
   language: string
   /** Fired when ref.save() is called or the save shortcut is triggered. */
   onSave?: (newContent: string) => void

--- a/src/renderer/src/components/CodeEditor/utils.ts
+++ b/src/renderer/src/components/CodeEditor/utils.ts
@@ -13,6 +13,7 @@ const _customLanguageExtensions: Record<string, string> = {
  * 获取语言的扩展名，用于 @uiw/codemirror-extensions-langs
  * - 先搜索自定义扩展名
  * - 再搜索 github linguist 扩展名
+ * - 最后假定名称已经是扩展名
  * @param language 语言名称
  * @returns 扩展名（不包含 `.`）
  */
@@ -27,6 +28,11 @@ export async function getNormalizedExtension(language: string) {
   const linguistExt = getExtensionByLanguage(language)
   if (linguistExt) {
     return linguistExt.slice(1)
+  }
+
+  // 如果语言名称像扩展名
+  if (language.startsWith('.') && language.length > 1) {
+    return language.slice(1)
   }
 
   // 回退到语言名称


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

CodeEditor 的 language 参数显式支持文件扩展名，例如 `js`、`.js`

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
