### PR TITLE
fix: initialize notes path on app startup to resolve missing default directory

### DIFF
--- a/src/renderer/src/pages/settings/NotesSettings.tsx
+++ b/src/renderer/src/pages/settings/NotesSettings.tsx
@@ -31,10 +31,10 @@ const NotesSettings: FC = () => {
 
   // Update tempPath when notesPath changes (e.g., after initialization)
   useEffect(() => {
-    if (notesPath && tempPath !== notesPath) {
+    if (notesPath) {
       setTempPath(notesPath)
     }
-  }, [notesPath, tempPath])
+  }, [notesPath])
 
   const handleSelectWorkDirectory = async () => {
     try {

--- a/src/renderer/src/pages/settings/NotesSettings.tsx
+++ b/src/renderer/src/pages/settings/NotesSettings.tsx
@@ -6,7 +6,7 @@ import { initWorkSpace } from '@renderer/services/NotesService'
 import { EditorView } from '@renderer/types'
 import { Button, Input, message, Switch } from 'antd'
 import { FolderOpen } from 'lucide-react'
-import { FC, useState } from 'react'
+import { FC, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
@@ -28,6 +28,13 @@ const NotesSettings: FC = () => {
   const { settings, updateSettings, notesPath, updateNotesPath } = useNotesSettings()
   const [tempPath, setTempPath] = useState<string>(notesPath || '')
   const [isSelecting, setIsSelecting] = useState(false)
+
+  // Update tempPath when notesPath changes (e.g., after initialization)
+  useEffect(() => {
+    if (notesPath && tempPath !== notesPath) {
+      setTempPath(notesPath)
+    }
+  }, [notesPath, tempPath])
 
   const handleSelectWorkDirectory = async () => {
     try {


### PR DESCRIPTION
- Add notes path initialization in store persistStore callback after rehydration
- Update NotesSettings to sync tempPath when notesPath changes from initialization
- Ensure notes directory is set even when user doesn't visit NotesPage first
- Fixes issue where notes path was empty after data reset until NotesPage visit