### PR TITLE
fix(ProviderSettings): click padding won't trigger onClick

### DIFF
--- a/src/renderer/src/assets/styles/ant.scss
+++ b/src/renderer/src/assets/styles/ant.scss
@@ -232,7 +232,3 @@
     }
   }
 }
-
-.add-provider-popup .ant-dropdown-menu .ant-dropdown-menu-item {
-  padding: 0;
-}

--- a/src/renderer/src/assets/styles/ant.scss
+++ b/src/renderer/src/assets/styles/ant.scss
@@ -232,3 +232,7 @@
     }
   }
 }
+
+.add-provider-popup .ant-dropdown-menu .ant-dropdown-menu-item {
+  padding: 0;
+}

--- a/src/renderer/src/pages/settings/ProviderSettings/AddProviderPopup.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/AddProviderPopup.tsx
@@ -7,7 +7,8 @@ import ImageStorage from '@renderer/services/ImageStorage'
 import { Provider, ProviderType } from '@renderer/types'
 import { compressImage, generateColorFromChar, getForegroundColor } from '@renderer/utils'
 import { Divider, Dropdown, Form, Input, Modal, Popover, Select, Upload } from 'antd'
-import React, { useEffect, useState } from 'react'
+import { ItemType } from 'antd/es/menu/interface'
+import React, { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
@@ -26,6 +27,7 @@ const PopupContainer: React.FC<Props> = ({ provider, resolve }) => {
   const [logoPickerOpen, setLogoPickerOpen] = useState(false)
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const { t } = useTranslation()
+  const uploadRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     if (provider?.id) {
@@ -147,36 +149,27 @@ const PopupContainer: React.FC<Props> = ({ provider, resolve }) => {
               window.message.error(error.message)
             }
           }}>
-          <MenuItem>{t('settings.general.image_upload')}</MenuItem>
+          <MenuItem ref={uploadRef}>{t('settings.general.image_upload')}</MenuItem>
         </Upload>
-      )
+      ),
+      onClick: () => {
+        uploadRef.current?.click()
+      }
     },
     {
       key: 'builtin',
-      label: (
-        <MenuItem
-          onClick={(e) => {
-            e.stopPropagation()
-            setDropdownOpen(false)
-            setLogoPickerOpen(true)
-          }}>
-          {t('settings.general.avatar.builtin')}
-        </MenuItem>
-      )
+      label: <MenuItem>{t('settings.general.avatar.builtin')}</MenuItem>,
+      onClick: () => {
+        setDropdownOpen(false)
+        setLogoPickerOpen(true)
+      }
     },
     {
       key: 'reset',
-      label: (
-        <MenuItem
-          onClick={(e) => {
-            e.stopPropagation()
-            handleReset()
-          }}>
-          {t('settings.general.avatar.reset')}
-        </MenuItem>
-      )
+      label: <MenuItem>{t('settings.general.avatar.reset')}</MenuItem>,
+      onClick: handleReset
     }
-  ]
+  ] satisfies ItemType[]
 
   // for logo
   const backgroundColor = generateColorFromChar(name)
@@ -204,7 +197,6 @@ const PopupContainer: React.FC<Props> = ({ provider, resolve }) => {
             open={dropdownOpen}
             align={{ offset: [0, 4] }}
             placement="bottom"
-            overlayClassName="add-provider-popup" // FIXME: 避免点击边缘无法触发点击回调，但没有找到比类名控制控制更好的方式，可以的话尽量不想把局部样式加到外部文件里
             onOpenChange={(visible) => {
               setDropdownOpen(visible)
               if (visible) {
@@ -300,7 +292,6 @@ const ProviderInitialsLogo = styled.div`
 `
 
 const MenuItem = styled.div`
-  padding: 5px 8px;
   width: 100%;
   text-align: center;
 `

--- a/src/renderer/src/pages/settings/ProviderSettings/AddProviderPopup.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/AddProviderPopup.tsx
@@ -107,77 +107,73 @@ const PopupContainer: React.FC<Props> = ({ provider, resolve }) => {
     {
       key: 'upload',
       label: (
-        <div style={{ width: '100%', textAlign: 'center' }}>
-          <Upload
-            customRequest={() => {}}
-            accept="image/png, image/jpeg, image/gif"
-            itemRender={() => null}
-            maxCount={1}
-            onChange={async ({ file }) => {
-              try {
-                const _file = file.originFileObj as File
-                let logoData: string | Blob
+        <Upload
+          customRequest={() => {}}
+          accept="image/png, image/jpeg, image/gif"
+          itemRender={() => null}
+          maxCount={1}
+          onChange={async ({ file }) => {
+            try {
+              const _file = file.originFileObj as File
+              let logoData: string | Blob
 
-                if (_file.type === 'image/gif') {
-                  logoData = _file
-                } else {
-                  logoData = await compressImage(_file)
-                }
-
-                if (provider?.id) {
-                  if (logoData instanceof Blob && !(logoData instanceof File)) {
-                    const fileFromBlob = new File([logoData], 'logo.png', { type: logoData.type })
-                    await ImageStorage.set(`provider-${provider.id}`, fileFromBlob)
-                  } else {
-                    await ImageStorage.set(`provider-${provider.id}`, logoData)
-                  }
-                  const savedLogo = await ImageStorage.get(`provider-${provider.id}`)
-                  setLogo(savedLogo)
-                } else {
-                  // 临时保存在内存中，等创建 provider 后会在调用方保存
-                  const tempUrl = await new Promise<string>((resolve) => {
-                    const reader = new FileReader()
-                    reader.onload = () => resolve(reader.result as string)
-                    reader.readAsDataURL(logoData)
-                  })
-                  setLogo(tempUrl)
-                }
-
-                setDropdownOpen(false)
-              } catch (error: any) {
-                window.message.error(error.message)
+              if (_file.type === 'image/gif') {
+                logoData = _file
+              } else {
+                logoData = await compressImage(_file)
               }
-            }}>
-            {t('settings.general.image_upload')}
-          </Upload>
-        </div>
+
+              if (provider?.id) {
+                if (logoData instanceof Blob && !(logoData instanceof File)) {
+                  const fileFromBlob = new File([logoData], 'logo.png', { type: logoData.type })
+                  await ImageStorage.set(`provider-${provider.id}`, fileFromBlob)
+                } else {
+                  await ImageStorage.set(`provider-${provider.id}`, logoData)
+                }
+                const savedLogo = await ImageStorage.get(`provider-${provider.id}`)
+                setLogo(savedLogo)
+              } else {
+                // 临时保存在内存中，等创建 provider 后会在调用方保存
+                const tempUrl = await new Promise<string>((resolve) => {
+                  const reader = new FileReader()
+                  reader.onload = () => resolve(reader.result as string)
+                  reader.readAsDataURL(logoData)
+                })
+                setLogo(tempUrl)
+              }
+
+              setDropdownOpen(false)
+            } catch (error: any) {
+              window.message.error(error.message)
+            }
+          }}>
+          <MenuItem>{t('settings.general.image_upload')}</MenuItem>
+        </Upload>
       )
     },
     {
       key: 'builtin',
       label: (
-        <div
-          style={{ width: '100%', textAlign: 'center' }}
+        <MenuItem
           onClick={(e) => {
             e.stopPropagation()
             setDropdownOpen(false)
             setLogoPickerOpen(true)
           }}>
           {t('settings.general.avatar.builtin')}
-        </div>
+        </MenuItem>
       )
     },
     {
       key: 'reset',
       label: (
-        <div
-          style={{ width: '100%', textAlign: 'center' }}
+        <MenuItem
           onClick={(e) => {
             e.stopPropagation()
             handleReset()
           }}>
           {t('settings.general.avatar.reset')}
-        </div>
+        </MenuItem>
       )
     }
   ]
@@ -208,6 +204,7 @@ const PopupContainer: React.FC<Props> = ({ provider, resolve }) => {
             open={dropdownOpen}
             align={{ offset: [0, 4] }}
             placement="bottom"
+            overlayClassName="add-provider-popup" // FIXME: 避免点击边缘无法触发点击回调，但没有找到比类名控制控制更好的方式，可以的话尽量不想把局部样式加到外部文件里
             onOpenChange={(visible) => {
               setDropdownOpen(visible)
               if (visible) {
@@ -300,6 +297,12 @@ const ProviderInitialsLogo = styled.div`
   &:hover {
     opacity: 0.8;
   }
+`
+
+const MenuItem = styled.div`
+  padding: 5px 8px;
+  width: 100%;
+  text-align: center;
 `
 
 export default class AddProviderPopup {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

dropdown的onClick逻辑是放在label里的，如果点击menu item外部的padding就触发不了。

现在把点击逻辑放在配置项onclick属性中，点击边缘padding也可以触发回调。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
