### PR TITLE
fix: tabs 高度不足导致 border 样式不能占满父元素

### DIFF
--- a/src/renderer/src/pages/home/Tabs/index.tsx
+++ b/src/renderer/src/pages/home/Tabs/index.tsx
@@ -155,9 +155,8 @@ const Container = styled.div`
   flex-direction: column;
   max-width: var(--assistants-width);
   min-width: var(--assistants-width);
-  &.right {
-    height: calc(100vh - var(--navbar-height));
-  }
+  height: calc(100vh - var(--navbar-height));
+
   [navbar-position='left'] & {
     background-color: var(--color-background);
   }


### PR DESCRIPTION



<table>
<tr>
 <td>
 Before
 <td>
 
<img width="738" height="1058" alt="CleanShot 2025-09-02 at 10 56 27@2x" src="https://github.com/user-attachments/assets/bc12bf05-cad0-4caa-a6f7-b90b5587ae34" />

 <td>
<tr>
 <td>

After
 <td>

<img width="3942" height="2702" alt="CleanShot 2025-09-02 at 11 03 52@2x" src="https://github.com/user-attachments/assets/fb6a7b35-fcdd-45f4-977e-254c9d0893e0" />
 <td>
<img width="3942" height="2702" alt="CleanShot 2025-09-02 at 11 03 30@2x" src="https://github.com/user-attachments/assets/a1a8f3bf-f067-48ae-a493-e1fdfdabbd67" />

</table>