### PR TITLE
QuickPanel/Inputbar: refine Enter handling with collapsed panel

### DIFF
--- a/src/renderer/src/components/QuickPanel/view.tsx
+++ b/src/renderer/src/components/QuickPanel/view.tsx
@@ -343,11 +343,12 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
     scrollTriggerRef.current = 'none'
   }, [index])
 
-  // 处理键盘事件（折叠时不拦截全局键盘）
+  // 处理键盘事件：
+  // - 可见且未折叠时：拦截 Enter 及其组合键（纯 Enter 选择项；带修饰键仅拦截不处理）。
+  // - 软隐藏/折叠时：不拦截 Enter，允许输入框处理（用于发送消息等）。
+  // - 不可见时：不拦截，输入框按常规处理。
   useEffect(() => {
-    const hasSearchTextFlag = searchText.replace(/^[/@]/, '').length > 0
-    const isCollapsed = hasSearchTextFlag && list.length === 0
-    if (!ctx.isVisible || isCollapsed) return
+    if (!ctx.isVisible) return
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (isMac ? e.metaKey : e.ctrlKey) {
@@ -440,8 +441,23 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
           break
 
         case 'Enter':
-        case 'NumpadEnter':
+        case 'NumpadEnter': {
           if (isComposing.current) return
+
+          // 折叠/软隐藏时不拦截，让输入框处理（用于发送消息）
+          const hasSearch = searchText.replace(/^[/@]/, '').length > 0
+          const nonPinnedCount = list.filter((i) => !i.alwaysVisible).length
+          const isCollapsed = hasSearch && nonPinnedCount === 0
+          if (isCollapsed) return
+
+          // 面板可见且未折叠时：拦截所有 Enter 变体；
+          // 纯 Enter 选择项，带修饰键仅拦截不处理
+          if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) {
+            e.preventDefault()
+            e.stopPropagation()
+            setIsMouseOver(false)
+            break
+          }
 
           if (list?.[index]) {
             e.preventDefault()
@@ -453,6 +469,7 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
             handleClose('enter_empty')
           }
           break
+        }
         case 'Escape':
           e.stopPropagation()
           handleClose('esc')

--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -404,37 +404,40 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
     //other keys should be ignored
     const isEnterPressed = event.key === 'Enter' && !event.nativeEvent.isComposing
     if (isEnterPressed) {
-      if (quickPanel.isVisible) return event.preventDefault()
-
+      // 1) 优先判断是否为“发送”（当前仅支持纯 Enter 发送；其余 Enter 组合键均换行）
       if (isSendMessageKeyPressed(event, sendMessageShortcut)) {
         sendMessage()
         return event.preventDefault()
-      } else {
-        //shift+enter's default behavior is to add a new line, ignore it
-        if (!event.shiftKey) {
-          event.preventDefault()
+      }
 
-          const textArea = textareaRef.current?.resizableTextArea?.textArea
-          if (textArea) {
-            const start = textArea.selectionStart
-            const end = textArea.selectionEnd
-            const text = textArea.value
-            const newText = text.substring(0, start) + '\n' + text.substring(end)
+      // 2) 不再基于 quickPanel.isVisible 主动拦截。
+      //    纯 Enter 的处理权交由 QuickPanel 的全局捕获（其只在纯 Enter 时拦截），
+      //    其它带修饰键的 Enter 则由输入框处理为换行。
 
-            // update text by setState, not directly modify textarea.value
-            setText(newText)
+      if (event.shiftKey) {
+        return
+      }
 
-            // set cursor position in the next render cycle
-            setTimeoutTimer(
-              'handleKeyDown',
-              () => {
-                textArea.selectionStart = textArea.selectionEnd = start + 1
-                onInput() // trigger resizeTextArea
-              },
-              0
-            )
-          }
-        }
+      event.preventDefault()
+      const textArea = textareaRef.current?.resizableTextArea?.textArea
+      if (textArea) {
+        const start = textArea.selectionStart
+        const end = textArea.selectionEnd
+        const text = textArea.value
+        const newText = text.substring(0, start) + '\n' + text.substring(end)
+
+        // update text by setState, not directly modify textarea.value
+        setText(newText)
+
+        // set cursor position in the next render cycle
+        setTimeoutTimer(
+          'handleKeyDown',
+          () => {
+            textArea.selectionStart = textArea.selectionEnd = start + 1
+            onInput() // trigger resizeTextArea
+          },
+          0
+        )
       }
     }
 


### PR DESCRIPTION
fix https://github.com/CherryHQ/cherry-studio/pull/9371#issuecomment-3242034473

fixes #9926

问题复现

- 触发面板：在输入框中输入 @ 或 / 呼出快捷面板。
- 输入搜索词：使列表无匹配项，仅剩（或不显示）固定项，面板进入折叠/软隐藏态（max-height: 0、pointer-events: none）。
- 按 Enter：预期应发送消息；实际被拦截，输入框无法发送。


问题原因

- 捕获阶段拦截：QuickPanel 使用 window.addEventListener('keydown', ..., true) 捕获按键，优先于输入框处理。
- 软隐藏≠不可见：折叠/软隐藏时 ctx.isVisible 仍为 true，原逻辑在“可见”即拦截 Enter（含组合键），导致输入框拿不到 Enter。
- 结果：面板虽然视觉上隐藏，但键盘层仍被面板截走，Enter 无法发送。

修复方案

- QuickPanel（核心修复）
    - 文件：src/renderer/src/components/QuickPanel/view.tsx
    - 变更：在 keydown 的 Enter/NumpadEnter 分支内，计算“是否折叠”后再决定是否拦截：
    - 折叠判定：`isCollapsed = hasSearch && nonPinnedCount === 0`
      - `hasSearch = searchText 去除首字符(/或@)后的长度 > 0`
      - `nonPinnedCount = list.filter(i => !i.alwaysVisible).length`
    - 若折叠：不拦截 Enter（不调用 `preventDefault/stopPropagation`），让事件回落到输入框处理（从而可发送）。
    - 若未折叠：维持原行为（纯 Enter 选择高亮项；带修饰键的 Enter 仅拦截不处理）。
- 更新“处理键盘事件”的注释，明确折叠时放行 Enter 的行为。
- Inputbar（配套梳理）
    - 文件：src/renderer/src/pages/home/Inputbar/Inputbar.tsx
    - 变更：在 handleKeyDown 中
    - 优先判断发送快捷键：调用 `isSendMessageKeyPressed(event, sendMessageShortcut)`，满足则发送并 `preventDefault`。
    - 移除基于 `quickPanel.isVisible` 的前置拦截逻辑，避免“可见但已折叠”仍被误拦。
- 目的：保证当面板折叠时，Enter 能正确回落到输入框，按用户设置发送或换行。


备注

- 采用局部重算折叠态（不新增状态），最小化侵入；同时修正文档注释，降低后续维护误解。

效果

https://github.com/user-attachments/assets/91d24246-47d1-4a9a-b5ad-2746046d37b9

