### PR TITLE
fix: auto-enable image generation button for Gemini 2.5 Flash  Image model

### DIFF
--- a/src/renderer/src/config/models.ts
+++ b/src/renderer/src/config/models.ts
@@ -739,6 +739,12 @@ export const SYSTEM_MODELS: Record<SystemProviderId | 'defaultModel', Model[]> =
       provider: 'gemini',
       name: 'Gemini 2.0 Flash',
       group: 'Gemini 2.0'
+    },
+    {
+      id: 'gemini-2.5-flash-image-preview',
+      provider: 'gemini',
+      name: 'Gemini 2.5 Flash Image',
+      group: 'Gemini 2.5'
     }
   ],
   anthropic: [
@@ -1564,6 +1570,12 @@ export const SYSTEM_MODELS: Record<SystemProviderId | 'defaultModel', Model[]> =
     }
   ],
   openrouter: [
+    {
+      id: 'google/gemini-2.5-flash-image-preview',
+      provider: 'openrouter',
+      name: 'Google: Gemini 2.5 Flash Image',
+      group: 'google'
+    },
     {
       id: 'google/gemini-2.5-flash-preview',
       provider: 'openrouter',

--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -783,7 +783,9 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
     if (!isGenerateImageModel(model) && assistant.enableGenerateImage) {
       updateAssistant({ ...assistant, enableGenerateImage: false })
     }
-    if (isDedicatedImageGenerationModel(model) && !assistant.enableGenerateImage) {
+    const shouldAutoEnableImageGen =
+      isDedicatedImageGenerationModel(model) || (model && model.id.toLowerCase().includes('gemini-2.5-flash-image'))
+    if (shouldAutoEnableImageGen && !assistant.enableGenerateImage) {
       updateAssistant({ ...assistant, enableGenerateImage: true })
     }
   }, [assistant, model, updateAssistant])


### PR DESCRIPTION
auto-enable image generation button for Gemini 2.5 Flash  Image model
because nano doesn't support the `/images/generations` API, `DEDICATED_IMAGE_MODELS` is not used.