### PR TITLE
feat: integrate file selection and upload functionality in KnowledgeFiles component

### DIFF
--- a/src/renderer/src/pages/knowledge/items/KnowledgeFiles.tsx
+++ b/src/renderer/src/pages/knowledge/items/KnowledgeFiles.tsx
@@ -1,5 +1,6 @@
 import { loggerService } from '@logger'
 import Ellipsis from '@renderer/components/Ellipsis'
+import { useFiles } from '@renderer/hooks/useFiles'
 import { useKnowledge } from '@renderer/hooks/useKnowledge'
 import FileItem from '@renderer/pages/files/FileItem'
 import StatusIcon from '@renderer/pages/knowledge/components/StatusIcon'
@@ -48,6 +49,7 @@ const getDisplayTime = (item: KnowledgeItem) => {
 const KnowledgeFiles: FC<KnowledgeContentProps> = ({ selectedBase, progressMap, preprocessMap }) => {
   const { t } = useTranslation()
   const [windowHeight, setWindowHeight] = useState(window.innerHeight)
+  const { onSelectFile, selecting } = useFiles({ extensions: fileTypes })
 
   const { base, fileItems, addFiles, refreshItem, removeItem, getProcessingStatus } = useKnowledge(
     selectedBase.id || ''
@@ -71,19 +73,16 @@ const KnowledgeFiles: FC<KnowledgeContentProps> = ({ selectedBase, progressMap, 
     return null
   }
 
-  const handleAddFile = () => {
-    if (disabled) {
+  const handleAddFile = async () => {
+    if (disabled || selecting) {
       return
     }
-    const input = document.createElement('input')
-    input.type = 'file'
-    input.multiple = true
-    input.accept = fileTypes.join(',')
-    input.onchange = (e) => {
-      const files = (e.target as HTMLInputElement).files
-      files && handleDrop(Array.from(files))
+    const selectedFiles = await onSelectFile({ multipleSelections: true })
+    if (selectedFiles.length > 0) {
+      const uploadedFiles = await FileManager.uploadFiles(selectedFiles)
+      logger.debug('uploadedFiles', uploadedFiles)
+      addFiles(uploadedFiles)
     }
-    input.click()
   }
 
   const handleDrop = async (files: File[]) => {

--- a/src/renderer/src/pages/knowledge/items/KnowledgeFiles.tsx
+++ b/src/renderer/src/pages/knowledge/items/KnowledgeFiles.tsx
@@ -78,11 +78,7 @@ const KnowledgeFiles: FC<KnowledgeContentProps> = ({ selectedBase, progressMap, 
       return
     }
     const selectedFiles = await onSelectFile({ multipleSelections: true })
-    if (selectedFiles.length > 0) {
-      const uploadedFiles = await FileManager.uploadFiles(selectedFiles)
-      logger.debug('uploadedFiles', uploadedFiles)
-      addFiles(uploadedFiles)
-    }
+    processFiles(selectedFiles)
   }
 
   const handleDrop = async (files: File[]) => {
@@ -117,8 +113,14 @@ const KnowledgeFiles: FC<KnowledgeContentProps> = ({ selectedBase, progressMap, 
           }
         })
         .filter(({ ext }) => fileTypes.includes(ext))
-      const uploadedFiles = await FileManager.uploadFiles(_files)
-      logger.debug('uploadedFiles', uploadedFiles)
+      processFiles(_files)
+    }
+  }
+
+  const processFiles = async (files: FileMetadata[]) => {
+    logger.debug('processFiles', files)
+    if (files.length > 0) {
+      const uploadedFiles = await FileManager.uploadFiles(files)
       addFiles(uploadedFiles)
     }
   }

--- a/src/renderer/src/pages/knowledge/items/KnowledgeFiles.tsx
+++ b/src/renderer/src/pages/knowledge/items/KnowledgeFiles.tsx
@@ -149,16 +149,23 @@ const KnowledgeFiles: FC<KnowledgeContentProps> = ({ selectedBase, progressMap, 
       </ItemHeader>
 
       <ItemFlexColumn>
-        <Dragger
-          showUploadList={false}
-          customRequest={({ file }) => handleDrop([file as File])}
-          multiple={true}
-          accept={fileTypes.join(',')}>
-          <p className="ant-upload-text">{t('knowledge.drag_file')}</p>
-          <p className="ant-upload-hint">
-            {t('knowledge.file_hint', { file_types: 'TXT, MD, HTML, PDF, DOCX, PPTX, XLSX, EPUB...' })}
-          </p>
-        </Dragger>
+        <div
+          onClick={(e) => {
+            e.stopPropagation()
+            handleAddFile()
+          }}>
+          <Dragger
+            showUploadList={false}
+            customRequest={({ file }) => handleDrop([file as File])}
+            multiple={true}
+            accept={fileTypes.join(',')}
+            openFileDialogOnClick={false}>
+            <p className="ant-upload-text">{t('knowledge.drag_file')}</p>
+            <p className="ant-upload-hint">
+              {t('knowledge.file_hint', { file_types: 'TXT, MD, HTML, PDF, DOCX, PPTX, XLSX, EPUB...' })}
+            </p>
+          </Dragger>
+        </div>
         {fileItems.length === 0 ? (
           <KnowledgeEmptyView />
         ) : (


### PR DESCRIPTION
…iles component

- Added useFiles hook to manage file selection.
- Updated handleAddFile to utilize the new file selection logic, allowing multiple file uploads.
- Improved user experience by handling file uploads asynchronously and logging the results.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

所有类型都显示到选择文件窗口，非常卡

After this PR:
不显示，到文件上传后再判断，和dropFile一样，这样可以非常快

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
