### PR TITLE
feat: enhance RichEditor with logging and improve NotesPage editor synchronization

### DIFF
--- a/src/renderer/src/components/RichEditor/index.tsx
+++ b/src/renderer/src/components/RichEditor/index.tsx
@@ -1,3 +1,4 @@
+import { loggerService } from '@logger'
 import { ContentSearch, type ContentSearchRef } from '@renderer/components/ContentSearch'
 import DragHandle from '@tiptap/extension-drag-handle-react'
 import { EditorContent } from '@tiptap/react'
@@ -26,6 +27,7 @@ import { ToC } from './TableOfContent'
 import { Toolbar } from './toolbar'
 import type { FormattingCommand, RichEditorProps, RichEditorRef } from './types'
 import { useRichEditor } from './useRichEditor'
+const logger = loggerService.withContext('RichEditor')
 
 const RichEditor = ({
   ref,
@@ -290,6 +292,7 @@ const RichEditor = ({
                   const end = $from.end()
                   editor.chain().focus().setTextSelection({ from: start, to: end }).setEnhancedLink({ href: url }).run()
                 } catch (error) {
+                  logger.warn('Failed to set enhanced link:', error as Error)
                   editor.chain().focus().toggleEnhancedLink({ href: '' }).run()
                 }
               } else {

--- a/src/renderer/src/pages/notes/NotesPage.tsx
+++ b/src/renderer/src/pages/notes/NotesPage.tsx
@@ -51,7 +51,6 @@ const NotesPage: FC = () => {
   const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null)
   const watcherRef = useRef<(() => void) | null>(null)
   const isSyncingTreeRef = useRef(false)
-  const isEditorInitialized = useRef(false)
   const lastContentRef = useRef<string>('')
   const lastFilePathRef = useRef<string | undefined>(undefined)
   const isInitialSortApplied = useRef(false)
@@ -85,7 +84,7 @@ const NotesPage: FC = () => {
   const saveCurrentNote = useCallback(
     async (content: string, filePath?: string) => {
       const targetPath = filePath || activeFilePath
-      if (!targetPath || content === currentContent) return
+      if (!targetPath || content.trim() === currentContent.trim()) return
 
       try {
         await window.api.file.write(targetPath, content)
@@ -284,26 +283,35 @@ const NotesPage: FC = () => {
   ])
 
   useEffect(() => {
-    if (currentContent && editorRef.current) {
-      editorRef.current.setMarkdown(currentContent)
-      // 标记编辑器已初始化
-      isEditorInitialized.current = true
+    const editor = editorRef.current
+    if (!editor || !currentContent) return
+    // 获取编辑器当前内容
+    const editorMarkdown = editor.getMarkdown()
+
+    // 只有当编辑器内容与期望内容不一致时才更新
+    // 这样既能处理初始化，也能处理后续的内容同步，还能避免光标跳动
+    if (editorMarkdown !== currentContent) {
+      editor.setMarkdown(currentContent)
     }
   }, [currentContent, activeFilePath])
 
-  // 切换文件时重置编辑器初始化状态并兜底保存
+  // 切换文件时的清理工作
   useEffect(() => {
-    if (lastContentRef.current && lastContentRef.current !== currentContent && lastFilePathRef.current) {
-      saveCurrentNote(lastContentRef.current, lastFilePathRef.current).catch((error) => {
-        logger.error('Emergency save before file switch failed:', error as Error)
-      })
-    }
+    return () => {
+      // 保存之前文件的内容
+      if (lastContentRef.current && lastFilePathRef.current) {
+        saveCurrentNote(lastContentRef.current, lastFilePathRef.current).catch((error) => {
+          logger.error('Emergency save before file switch failed:', error as Error)
+        })
+      }
 
-    // 重置状态
-    isEditorInitialized.current = false
-    lastContentRef.current = ''
-    lastFilePathRef.current = undefined
-  }, [activeFilePath, currentContent, saveCurrentNote])
+      // 取消防抖保存并清理状态
+      debouncedSave.cancel()
+      lastContentRef.current = ''
+      lastFilePathRef.current = undefined
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeFilePath])
 
   // 获取目标文件夹路径（选中文件夹或根目录）
   const getTargetFolderPath = useCallback(() => {

--- a/src/renderer/src/pages/settings/AssistantSettings/AssistantPromptSettings.tsx
+++ b/src/renderer/src/pages/settings/AssistantSettings/AssistantPromptSettings.tsx
@@ -122,7 +122,12 @@ const AssistantPromptSettings: React.FC<Props> = ({ assistant, updateAssistant }
       <TextAreaContainer>
         <RichEditorContainer>
           {showPreview ? (
-            <MarkdownContainer>
+            <MarkdownContainer
+              onDoubleClick={() => {
+                const currentScrollTop = editorRef.current?.getScrollTop?.() || 0
+                setShowPreview(false)
+                requestAnimationFrame(() => editorRef.current?.setScrollTop?.(currentScrollTop))
+              }}>
               <ReactMarkdown>{processedPrompt || prompt}</ReactMarkdown>
             </MarkdownContainer>
           ) : (

--- a/src/renderer/src/utils/__tests__/markdownConverter.test.ts
+++ b/src/renderer/src/utils/__tests__/markdownConverter.test.ts
@@ -313,6 +313,26 @@ describe('markdownConverter', () => {
       expect(backToMarkdown).toBe(originalMarkdown)
     })
 
+    it('should maintain task list structure through html → markdown → html conversion', () => {
+      const originalHtml =
+        '<ul data-type="taskList" class="task-list"><li data-type="taskItem" class="task-list-item" data-checked="false"><label><input type="checkbox" disabled></label><div><p></p></div></li></ul>'
+      const markdown = htmlToMarkdown(originalHtml)
+      const html = markdownToHtml(markdown)
+
+      expect(html).toBe(
+        '<ul data-type="taskList" class="task-list">\n<li data-type="taskItem" class="task-list-item" data-checked="false"><label><input type="checkbox" disabled></label><div><p></p></div></li>\n</ul>\n'
+      )
+    })
+
+    it('should maintain task list structure through html → markdown → html conversion2', () => {
+      const originalHtml =
+        '<ul data-type="taskList" class="task-list">\n<li data-type="taskItem" class="task-list-item" data-checked="false">\n<label><input type="checkbox" disabled></label><div><p>123</p></div>\n</li>\n<li data-type="taskItem" class="task-list-item" data-checked="false">\n<label><input type="checkbox" disabled></label><div><p></p></div>\n</li>\n</ul>\n'
+      const markdown = htmlToMarkdown(originalHtml)
+      const html = markdownToHtml(markdown)
+
+      expect(html).toBe(originalHtml)
+    })
+
     it('should handle complex task lists with multiple items', () => {
       const originalMarkdown =
         '- [ ] First unchecked task\n\n- [x] First checked task\n\n- [ ] Second unchecked task\n\n- [x] Second checked task'


### PR DESCRIPTION
- Added logging for enhanced link setting failures in RichEditor.
- Improved content synchronization logic in NotesPage to prevent unnecessary updates and ensure cleaner state management during file switches.
- Updated markdown conversion to handle task list structures more robustly, including support for div formats in task items.
- Added tests to verify task list structure preservation during HTML to Markdown conversions.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #9790 #9816

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

快速输入一段文字，快速摁回车，看光标是否弹回
