### PR TITLE
fix: 对齐模型设置中 avatar 的样式

### DIFF
--- a/src/renderer/src/components/ProviderLogoPicker/index.tsx
+++ b/src/renderer/src/components/ProviderLogoPicker/index.tsx
@@ -1,6 +1,7 @@
 import { SearchOutlined } from '@ant-design/icons'
 import { PROVIDER_LOGO_MAP } from '@renderer/config/providers'
 import { getProviderLabel } from '@renderer/i18n/label'
+import { getProviderAvatar } from '@renderer/pages/settings/ProviderSettings/AddProviderPopup'
 import { Input, Tooltip } from 'antd'
 import { FC, useMemo, useState } from 'react'
 import styled from 'styled-components'
@@ -48,10 +49,10 @@ const ProviderLogoPicker: FC<Props> = ({ onProviderClick }) => {
         />
       </SearchContainer>
       <LogoGrid>
-        {filteredProviders.map(({ id, logo, name }) => (
+        {filteredProviders.map(({ id, name, logo }) => (
           <Tooltip key={id} title={name} placement="top" mouseLeaveDelay={0}>
             <LogoItem onClick={(e) => handleProviderClick(e, id)}>
-              <img src={logo} alt={name} draggable={false} />
+              {getProviderAvatar({ providerId: id, providerName: name, logoSrc: logo })}
             </LogoItem>
           </Tooltip>
         ))}
@@ -86,11 +87,12 @@ const LogoGrid = styled.div`
 const LogoItem = styled.div`
   width: 52px;
   height: 52px;
+  border-radius: 100%;
+  overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  border-radius: 8px;
   transition: all 0.2s ease;
   background: var(--color-background-soft);
   border: 0.5px solid var(--color-border);
@@ -102,8 +104,8 @@ const LogoItem = styled.div`
   }
 
   img {
-    width: 32px;
-    height: 32px;
+    width: 100%;
+    height: 100%;
     object-fit: contain;
     user-select: none;
     -webkit-user-drag: none;

--- a/src/renderer/src/config/providers.ts
+++ b/src/renderer/src/config/providers.ts
@@ -661,7 +661,7 @@ export const PROVIDER_LOGO_MAP: AtLeast<SystemProviderId, string> = {
   vertexai: VertexAIProviderLogo,
   'new-api': NewAPIProviderLogo,
   'aws-bedrock': AwsProviderLogo,
-  poe: 'svg' // use svg icon component
+  poe: 'poe' // use svg icon component
 } as const
 
 export function getProviderLogo(providerId: string) {

--- a/src/renderer/src/pages/settings/ProviderSettings/AddProviderPopup.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/AddProviderPopup.tsx
@@ -1,4 +1,5 @@
 import { loggerService } from '@logger'
+import { PoeLogo } from '@renderer/components/Icons'
 import { Center, VStack } from '@renderer/components/Layout'
 import ProviderLogoPicker from '@renderer/components/ProviderLogoPicker'
 import { TopView } from '@renderer/components/TopView'
@@ -17,6 +18,21 @@ const logger = loggerService.withContext('AddProviderPopup')
 interface Props {
   provider?: Provider
   resolve: (result: { name: string; type: ProviderType; logo?: string; logoFile?: File }) => void
+}
+
+interface ProviderAvatarProps {
+  providerId: string
+  providerName: string
+  logoSrc: string
+}
+
+export const getProviderAvatar = ({ providerId, providerName, logoSrc }: ProviderAvatarProps, size: number = 32) => {
+  switch (providerId) {
+    case 'poe':
+      return <PoeLogo fontSize={size} />
+  }
+
+  return <img src={logoSrc} alt={providerName} draggable={false} />
 }
 
 const PopupContainer: React.FC<Props> = ({ provider, resolve }) => {
@@ -215,7 +231,13 @@ const PopupContainer: React.FC<Props> = ({ provider, resolve }) => {
               }}
               placement="bottom">
               {logo ? (
-                <ProviderLogo src={logo} />
+                <ProviderLogo>
+                  {getProviderAvatar({
+                    providerId: logo,
+                    providerName: name,
+                    logoSrc: logo
+                  })}
+                </ProviderLogo>
               ) : (
                 <ProviderInitialsLogo style={name ? { backgroundColor, color } : undefined}>
                   {getInitials()}
@@ -258,12 +280,17 @@ const PopupContainer: React.FC<Props> = ({ provider, resolve }) => {
   )
 }
 
-const ProviderLogo = styled.img`
+const ProviderLogo = styled.div`
   cursor: pointer;
   width: 60px;
   height: 60px;
-  border-radius: 12px;
+  border-radius: 100%;
   object-fit: contain;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
   transition: opacity 0.3s ease;
   background-color: var(--color-background-soft);
   padding: 5px;
@@ -271,13 +298,19 @@ const ProviderLogo = styled.img`
   &:hover {
     opacity: 0.8;
   }
+
+  > img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
 `
 
 const ProviderInitialsLogo = styled.div`
   cursor: pointer;
   width: 60px;
   height: 60px;
-  border-radius: 12px;
+  border-radius: 100%;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/renderer/src/pages/settings/ProviderSettings/ProviderList.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ProviderList.tsx
@@ -285,7 +285,11 @@ const ProviderList: FC = () => {
     if (isSystemProvider(provider)) {
       switch (provider.id) {
         case 'poe':
-          return <PoeLogo fontSize={size} />
+          return (
+            <ProviderSvgLogo size={size}>
+              <PoeLogo />
+            </ProviderSvgLogo>
+          )
       }
     }
 
@@ -296,7 +300,15 @@ const ProviderList: FC = () => {
 
     const customLogo = providerLogos[provider.id]
     if (customLogo) {
-      return <ProviderLogo draggable="false" shape="square" src={customLogo} size={size} />
+      // Poe 这类使用 svg 格式的 provider，需要特殊处理一下
+      if (customLogo === 'poe') {
+        return (
+          <ProviderSvgLogo size={size}>
+            <PoeLogo />
+          </ProviderSvgLogo>
+        )
+      }
+      return <ProviderLogo draggable="false" shape="circle" src={customLogo} size={size} />
     }
 
     // generate color for custom provider
@@ -304,7 +316,7 @@ const ProviderList: FC = () => {
     const color = provider.name ? getForegroundColor(backgroundColor) : 'white'
 
     return (
-      <ProviderLogo size={size} shape="square" style={{ backgroundColor, color, minWidth: size }}>
+      <ProviderLogo size={size} shape="circle" style={{ backgroundColor, color, minWidth: size }}>
         {getFirstCharacter(provider.name)}
       </ProviderLogo>
     )
@@ -468,6 +480,16 @@ const DragHandle = styled.div`
 
 const ProviderLogo = styled(Avatar)`
   border: 0.5px solid var(--color-border);
+`
+
+const ProviderSvgLogo = styled.div<{ size: number }>`
+  width: ${({ size }) => size}px;
+  height: ${({ size }) => size}px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 0.5px solid var(--color-border);
+  border-radius: 100%;
 `
 
 const ProviderItemName = styled.div`


### PR DESCRIPTION
Fix: #9813 

<table>
<tr>
 <td>
After
 <td>

<tr>
 <td>
<img width="920" height="1084" alt="CleanShot 2025-09-03 at 11 20 13@2x" src="https://github.com/user-attachments/assets/ddd2d1fa-4627-4acb-8c2c-01766d73b280" />

 <td>
<img width="576" height="956" alt="CleanShot 2025-09-03 at 11 20 01@2x" src="https://github.com/user-attachments/assets/b003479f-c7fb-4f2a-8bfd-f297e92c6082" />

<tr>


 <td>
Before
 <td>


<tr>
 <td>

<img width="968" height="1054" alt="CleanShot 2025-09-03 at 11 23 16@2x" src="https://github.com/user-attachments/assets/66fd0365-f7f3-423c-bc35-d2de5d32c600" />

 <td>

<img width="608" height="654" alt="CleanShot 2025-09-03 at 11 23 22@2x" src="https://github.com/user-attachments/assets/0d1edd19-7c28-4d7f-9f37-c11b6c84adae" />


</table>