### PR TITLE
fix: correct provider URL formatting in syncModelScopeServers function

### DIFF
--- a/src/renderer/src/pages/settings/MCPSettings/providers/modelscope.ts
+++ b/src/renderer/src/pages/settings/MCPSettings/providers/modelscope.ts
@@ -116,7 +116,7 @@ export const syncModelScopeServers = async (
           env: {},
           isActive: true,
           provider: 'ModelScope',
-          providerUrl: `${MODELSCOPE_HOST}/mcp/servers/@${server.id}`,
+          providerUrl: `${MODELSCOPE_HOST}/mcp/servers/${server.id}`,
           logoUrl: server.logo_url || '',
           tags: server.tags || []
         }


### PR DESCRIPTION
## Summary
- Fixed ModelScope MCP server URL formatting issue where provider URLs were being concatenated incorrectly
- Ensures proper URL format for ModelScope servers in the MCP synchronization process

Before: https://www.modelscope.cn/mcp/servers/@@modelcontextprotocol/sequentialthinking
After: https://www.modelscope.cn/mcp/servers/@modelcontextprotocol/sequentialthinking

Fixes #9840