### PR TITLE
fix(Link): 修复点击本地文件的引用链接时无法正常打开的问题。

### DIFF
--- a/src/renderer/src/pages/home/Markdown/Link.tsx
+++ b/src/renderer/src/pages/home/Markdown/Link.tsx
@@ -11,15 +11,29 @@ interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   node?: Omit<Node, 'type'>
 }
 
+function isLocalFilePath(path: string): boolean {
+  if (/^https?:\/\//i.test(path)) return false
+  if (path.startsWith('/')) return true
+  if (/^[a-zA-Z]:\\/.test(path) || path.startsWith('\\\\')) return true
+  return false
+}
+
 const Link: React.FC<LinkProps> = (props) => {
   const citationData = useMemo(() => {
     const raw = parseJSON(findCitationInChildren(props.children))
+    if (isLocalFilePath(raw.url)) {
+      raw.url = "file://" + raw.url
+    }
     const parsed = CitationSchema.safeParse(raw)
     return parsed.success ? parsed.data : null
   }, [props.children])
 
+  const href = useMemo(() => {
+    return citationData?.url || props.href
+  }, [citationData, props.href])
+
   // 处理内部链接
-  if (props.href?.startsWith('#')) {
+  if (href?.startsWith('#')) {
     return <span className="link">{props.children}</span>
   }
 
@@ -37,7 +51,7 @@ const Link: React.FC<LinkProps> = (props) => {
       <CitationTooltip citation={citationData}>
         <a
           {...omit(props, ['node', 'citationData'])}
-          href={isEmpty(props.href) ? undefined : props.href}
+          href={isEmpty(href) ? undefined : href}
           target="_blank"
           rel="noreferrer"
           onClick={(e) => e.stopPropagation()}
@@ -48,7 +62,7 @@ const Link: React.FC<LinkProps> = (props) => {
 
   // 普通链接
   return (
-    <Hyperlink href={props.href || ''}>
+    <Hyperlink href={href || ''}>
       <a
         {...omit(props, ['node', 'citationData'])}
         target="_blank"


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR: 

- Citation links from the knowledge base that pointed to local files were missing the file:// scheme, which caused CitationSchema.safeParse to fail.
- In CitationTooltip, <a> tags used props.href directly, but for local file citations props.href was null, resulting in broken links.

After this PR: 

- Local file paths are automatically prefixed with file://, so they can be parsed correctly by CitationSchema.safeParse and opened as expected.
- In CitationTooltip, <a> tag hrefs are unified to citationData?.url || props.href, ensuring that local file citations resolve correctly (using citationData.url when available, falling back to props.href).

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #9904 

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
