### PR TITLE
fix(miniapp): title container background style align with sidebar

### DIFF
--- a/src/renderer/src/components/MinApp/MinappPopupContainer.tsx
+++ b/src/renderer/src/components/MinApp/MinappPopupContainer.tsx
@@ -537,7 +537,9 @@ const MinappPopupContainer: React.FC = () => {
         wrapper: {
           position: 'fixed',
           marginLeft: isLeftNavbar ? 'var(--sidebar-width)' : 0,
-          marginTop: isTopNavbar ? 'var(--navbar-height)' : 0,
+          marginTop: isTopNavbar ? 'var(--navbar-height)' : 0
+        },
+        content: {
           backgroundColor: window.root.style.background
         }
       }}>


### PR DESCRIPTION
<table>
<tr>
 <td>
Before
 <td>
After
<tr>
 <td>
<img width="2038" height="1068" alt="CleanShot 2025-09-05 at 09 30 26@2x" src="https://github.com/user-attachments/assets/cc0c57e5-c3ae-412d-bfd2-0bdfdb9dc563" />
 <td>

<img width="2336" height="1306" alt="CleanShot 2025-09-05 at 09 30 12@2x" src="https://github.com/user-attachments/assets/a44a64f0-e98a-4c99-8d2c-87576cfd8792" />

</table>

