### PR TITLE
fix(settings): prevent undefined array errors in settings pages

### DIFF
--- a/src/renderer/src/pages/settings/AssistantSettings/AssistantMCPSettings.tsx
+++ b/src/renderer/src/pages/settings/AssistantSettings/AssistantMCPSettings.tsx
@@ -68,7 +68,7 @@ const AssistantMCPSettings: React.FC<Props> = ({ assistant, updateAssistant }) =
       {allMcpServers.length > 0 ? (
         <ServerList>
           {allMcpServers.map((server) => {
-            const isEnabled = assistant.mcpServers?.some((s) => s.id === server.id) || false
+            const isEnabled = (assistant.mcpServers || []).some((s) => s.id === server.id) || false
 
             return (
               <ServerItem key={server.id} isEnabled={isEnabled}>

--- a/src/renderer/src/pages/settings/DisplaySettings/SidebarIconsManager.tsx
+++ b/src/renderer/src/pages/settings/DisplaySettings/SidebarIconsManager.tsx
@@ -51,29 +51,29 @@ const SidebarIconsManager: FC<SidebarIconsManagerProps> = ({
       const { source, destination } = result
 
       // 如果是chat图标且目标是disabled区域,则不允许移动并提示
-      const draggedItem = source.droppableId === 'visible' ? visibleIcons[source.index] : disabledIcons[source.index]
+      const draggedItem = source.droppableId === 'visible' ? (visibleIcons || [])[source.index] : (disabledIcons || [])[source.index]
       if (draggedItem === 'assistants' && destination.droppableId === 'disabled') {
         message.warning(t('settings.display.sidebar.chat.hiddenMessage'))
         return
       }
 
       if (source.droppableId === destination.droppableId) {
-        const list = source.droppableId === 'visible' ? [...visibleIcons] : [...disabledIcons]
+        const list = source.droppableId === 'visible' ? [...(visibleIcons || [])] : [...(disabledIcons || [])]
         const [removed] = list.splice(source.index, 1)
         list.splice(destination.index, 0, removed)
 
         if (source.droppableId === 'visible') {
           setVisibleIcons(list)
-          dispatch(setSidebarIcons({ visible: list, disabled: disabledIcons }))
+          dispatch(setSidebarIcons({ visible: list, disabled: disabledIcons || [] }))
         } else {
           setDisabledIcons(list)
-          dispatch(setSidebarIcons({ visible: visibleIcons, disabled: list }))
+          dispatch(setSidebarIcons({ visible: visibleIcons || [], disabled: list }))
         }
         return
       }
 
-      const sourceList = source.droppableId === 'visible' ? [...visibleIcons] : [...disabledIcons]
-      const destList = destination.droppableId === 'visible' ? [...visibleIcons] : [...disabledIcons]
+      const sourceList = source.droppableId === 'visible' ? [...(visibleIcons || [])] : [...(disabledIcons || [])]
+      const destList = destination.droppableId === 'visible' ? [...(visibleIcons || [])] : [...(disabledIcons || [])]
 
       const [removed] = sourceList.splice(source.index, 1)
       const targetList = destList.filter((icon) => icon !== removed)
@@ -98,15 +98,15 @@ const SidebarIconsManager: FC<SidebarIconsManagerProps> = ({
       }
 
       if (fromList === 'visible') {
-        const newVisibleIcons = visibleIcons.filter((i) => i !== icon)
-        const newDisabledIcons = disabledIcons.some((i) => i === icon) ? disabledIcons : [...disabledIcons, icon]
+        const newVisibleIcons = (visibleIcons || []).filter((i) => i !== icon)
+        const newDisabledIcons = (disabledIcons || []).some((i) => i === icon) ? disabledIcons : [...(disabledIcons || []), icon]
 
         setVisibleIcons(newVisibleIcons)
         setDisabledIcons(newDisabledIcons)
         dispatch(setSidebarIcons({ visible: newVisibleIcons, disabled: newDisabledIcons }))
       } else {
-        const newDisabledIcons = disabledIcons.filter((i) => i !== icon)
-        const newVisibleIcons = visibleIcons.some((i) => i === icon) ? visibleIcons : [...visibleIcons, icon]
+        const newDisabledIcons = (disabledIcons || []).filter((i) => i !== icon)
+        const newVisibleIcons = (visibleIcons || []).some((i) => i === icon) ? visibleIcons : [...(visibleIcons || []), icon]
 
         setDisabledIcons(newDisabledIcons)
         setVisibleIcons(newVisibleIcons)
@@ -142,7 +142,7 @@ const SidebarIconsManager: FC<SidebarIconsManagerProps> = ({
           <Droppable droppableId="visible">
             {(provided: DroppableProvided) => (
               <IconList ref={provided.innerRef} {...provided.droppableProps}>
-                {visibleIcons.map((icon, index) => (
+                {(visibleIcons || []).map((icon, index) => (
                   <Draggable key={icon} draggableId={icon} index={index}>
                     {(provided: DraggableProvided) => (
                       <IconItem ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
@@ -169,10 +169,10 @@ const SidebarIconsManager: FC<SidebarIconsManagerProps> = ({
           <Droppable droppableId="disabled">
             {(provided: DroppableProvided) => (
               <IconList ref={provided.innerRef} {...provided.droppableProps}>
-                {disabledIcons.length === 0 ? (
+                {(disabledIcons || []).length === 0 ? (
                   <EmptyPlaceholder>{t('settings.display.sidebar.empty')}</EmptyPlaceholder>
                 ) : (
-                  disabledIcons.map((icon, index) => (
+                  (disabledIcons || []).map((icon, index) => (
                     <Draggable key={icon} draggableId={icon} index={index}>
                       {(provided: DraggableProvided) => (
                         <IconItem ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>

--- a/src/renderer/src/pages/settings/MCPSettings/BuiltinMCPServerList.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/BuiltinMCPServerList.tsx
@@ -18,7 +18,7 @@ const BuiltinMCPServerList: FC = () => {
       <SettingTitle style={{ gap: 3 }}>{t('settings.mcp.builtinServers')}</SettingTitle>
       <ServersGrid>
         {builtinMCPServers.map((server) => {
-          const isInstalled = mcpServers.some((existingServer) => existingServer.name === server.name)
+          const isInstalled = (mcpServers || []).some((existingServer) => existingServer.name === server.name)
 
           return (
             <ServerCard key={server.id}>

--- a/src/renderer/src/pages/settings/MCPSettings/NpxSearch.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/NpxSearch.tsx
@@ -146,7 +146,7 @@ const NpxSearch: FC = () => {
       {!searchLoading && (
         <ResultList>
           {searchResults?.map((record) => {
-            const isInstalled = mcpServers.some((server) => server.name === record.name)
+            const isInstalled = (mcpServers || []).some((server) => server.name === record.name)
             return (
               <Card
                 size="small"

--- a/src/renderer/src/pages/settings/ProviderSettings/ModelList/utils.ts
+++ b/src/renderer/src/pages/settings/ProviderSettings/ModelList/utils.ts
@@ -2,7 +2,7 @@ import { Model, Provider } from '@renderer/types'
 
 // Check if the model exists in the provider's model list
 export const isModelInProvider = (provider: Provider, modelId: string): boolean => {
-  return provider.models.some((m) => m.id === modelId)
+  return (provider.models || []).some((m) => m.id === modelId)
 }
 
 export const isValidNewApiModel = (model: Model): boolean => {

--- a/src/renderer/src/pages/settings/ProviderSettings/ProviderList.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ProviderList.tsx
@@ -275,7 +275,7 @@ const ProviderList: FC = () => {
   const filteredProviders = providers.filter((provider) => {
     const keywords = searchText.toLowerCase().split(/\s+/).filter(Boolean)
     const isProviderMatch = matchKeywordsInProvider(keywords, provider)
-    const isModelMatch = provider.models.some((model) => matchKeywordsInModel(keywords, model))
+    const isModelMatch = (provider.models || []).some((model) => matchKeywordsInModel(keywords, model))
     return isProviderMatch || isModelMatch
   })
 

--- a/src/renderer/src/pages/settings/ShortcutSettings.tsx
+++ b/src/renderer/src/pages/settings/ShortcutSettings.tsx
@@ -85,7 +85,7 @@ const ShortcutSettings: FC = () => {
   }
 
   const isDuplicateShortcut = (newShortcut: string[], currentKey: string): boolean => {
-    return shortcuts.some(
+    return (shortcuts || []).some(
       (s) => s.key !== currentKey && s.shortcut.length > 0 && s.shortcut.join('+') === newShortcut.join('+')
     )
   }


### PR DESCRIPTION
Fixed "Cannot read properties of undefined (reading 'some')" errors that occurred when accessing settings pages. Added defensive null/undefined checks for all array operations using the .some() method.

Changes:
- SidebarIconsManager: Added safety checks for visibleIcons/disabledIcons
- AssistantMCPSettings: Protected mcpServers array access
- BuiltinMCPServerList: Added mcpServers null check
- NpxSearch: Protected mcpServers access
- ProviderList: Added provider.models safety check
- ModelList/utils: Protected provider.models access
- ShortcutSettings: Added shortcuts array protection

All changes use (array || []).some() pattern to ensure safe array access.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

