### PR TITLE
fix(mcp): enhance progress event structure to include callId for specific tool tracking

### DIFF
--- a/packages/shared/IpcChannel.ts
+++ b/packages/shared/IpcChannel.ts
@@ -83,7 +83,7 @@ export enum IpcChannel {
   Mcp_UploadDxt = 'mcp:upload-dxt',
   Mcp_AbortTool = 'mcp:abort-tool',
   Mcp_GetServerVersion = 'mcp:get-server-version',
-
+  Mcp_Progress = 'mcp:progress',
   // Python
   Python_Execute = 'python:execute',
 

--- a/packages/shared/config/types.ts
+++ b/packages/shared/config/types.ts
@@ -17,3 +17,8 @@ export type FileChangeEvent = {
   filePath: string
   watchPath: string
 }
+
+export type MCPProgressEvent = {
+  callId: string
+  progress: number // 0-1 range
+}

--- a/src/main/services/MCPService.ts
+++ b/src/main/services/MCPService.ts
@@ -27,6 +27,8 @@ import {
   ToolListChangedNotificationSchema
 } from '@modelcontextprotocol/sdk/types.js'
 import { nanoid } from '@reduxjs/toolkit'
+import { MCPProgressEvent } from '@shared/config/types'
+import { IpcChannel } from '@shared/IpcChannel'
 import {
   BuiltinMCPServerNames,
   type GetResourceResponse,
@@ -689,10 +691,10 @@ class McpService {
             })
             const mainWindow = windowService.getMainWindow()
             if (mainWindow) {
-              mainWindow.webContents.send('mcp-progress', {
+              mainWindow.webContents.send(IpcChannel.Mcp_Progress, {
                 callId: toolCallId,
                 progress: process.progress / (process.total || 1)
-              })
+              } as MCPProgressEvent)
             }
           },
           timeout: server.timeout ? server.timeout * 1000 : 60000, // Default timeout of 1 minute,

--- a/src/main/services/MCPService.ts
+++ b/src/main/services/MCPService.ts
@@ -689,7 +689,10 @@ class McpService {
             })
             const mainWindow = windowService.getMainWindow()
             if (mainWindow) {
-              mainWindow.webContents.send('mcp-progress', process.progress / (process.total || 1))
+              mainWindow.webContents.send('mcp-progress', {
+                callId: toolCallId,
+                progress: process.progress / (process.total || 1)
+              })
             }
           },
           timeout: server.timeout ? server.timeout * 1000 : 60000, // Default timeout of 1 minute,

--- a/src/renderer/src/pages/home/Messages/Tools/MessageMcpTool.tsx
+++ b/src/renderer/src/pages/home/Messages/Tools/MessageMcpTool.tsx
@@ -86,15 +86,18 @@ const MessageMcpTool: FC<Props> = ({ block }) => {
   useEffect(() => {
     const removeListener = window.electron.ipcRenderer.on(
       'mcp-progress',
-      (_event: Electron.IpcRendererEvent, value: number) => {
-        setProgress(value)
+      (_event: Electron.IpcRendererEvent, data: { callId: string; progress: number }) => {
+        // Only update progress if this event is for our specific tool call
+        if (data.callId === id) {
+          setProgress(data.progress)
+        }
       }
     )
     return () => {
       setProgress(0)
       removeListener()
     }
-  }, [])
+  }, [id])
 
   const cancelCountdown = () => {
     if (timer.current) {

--- a/src/renderer/src/pages/home/Messages/Tools/MessageMcpTool.tsx
+++ b/src/renderer/src/pages/home/Messages/Tools/MessageMcpTool.tsx
@@ -7,6 +7,8 @@ import { useTimer } from '@renderer/hooks/useTimer'
 import type { ToolMessageBlock } from '@renderer/types/newMessage'
 import { isToolAutoApproved } from '@renderer/utils/mcp-tools'
 import { cancelToolAction, confirmToolAction } from '@renderer/utils/userConfirmation'
+import { MCPProgressEvent } from '@shared/config/types'
+import { IpcChannel } from '@shared/IpcChannel'
 import {
   Button,
   Collapse,
@@ -85,8 +87,8 @@ const MessageMcpTool: FC<Props> = ({ block }) => {
 
   useEffect(() => {
     const removeListener = window.electron.ipcRenderer.on(
-      'mcp-progress',
-      (_event: Electron.IpcRendererEvent, data: { callId: string; progress: number }) => {
+      IpcChannel.Mcp_Progress,
+      (_event: Electron.IpcRendererEvent, data: MCPProgressEvent) => {
         // Only update progress if this event is for our specific tool call
         if (data.callId === id) {
           setProgress(data.progress)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #9856

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
