### PR TITLE
fix: improve note sorting behavior for drag and drop operations

### DIFF
--- a/src/renderer/src/pages/notes/NotesPage.tsx
+++ b/src/renderer/src/pages/notes/NotesPage.tsx
@@ -563,8 +563,11 @@ const NotesPage: FC = () => {
   const handleMoveNode = useCallback(
     async (sourceNodeId: string, targetNodeId: string, position: 'before' | 'after' | 'inside') => {
       try {
-        await moveNode(sourceNodeId, targetNodeId, position)
-        await sortAllLevels(sortType)
+        const result = await moveNode(sourceNodeId, targetNodeId, position)
+        // 如果不是手动排序（同级拖动），则执行自动排序
+        if (result !== 'manual_reorder') {
+          await sortAllLevels(sortType)
+        }
       } catch (error) {
         logger.error('Failed to move nodes:', error as Error)
       }


### PR DESCRIPTION
- Skip automatic sorting when performing same-level drag reordering
- Preserve treePath during same-level moves to maintain manual ordering
- Return special indicator for manual reorder operations to prevent conflicts

修复笔记侧边栏同级下拖动排序的问题