### PR TITLE
fix: workaround for electron build issue on rpm package

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -113,7 +113,7 @@ linux:
 rpm:
   # Workaround for electron build issue on rpm package:
   # https://github.com/electron/forge/issues/3594
-  fpm: ["--rpm-rpmbuild-define=_build_id_links none"]
+  fpm: ['--rpm-rpmbuild-define=_build_id_links none']
 publish:
   provider: generic
   url: https://releases.cherry-ai.com


### PR DESCRIPTION
### What this PR does

On Fedora, installing the rpm package (https://github.com/CherryHQ/cherry-studio/releases/tag/v1.5.9) fails with a /usr/lib/.build-id/… conflict against other electron packages.
```bash
➜  Downloads sudo rpm -i ./Cherry-Studio-1.6.0-beta.6-x86_64.rpm                                 
[sudo] password for zhang: 
	file /usr/lib/.build-id/c9/57ecc373e560d9bb51a63cf32078f702187a63 from install of CherryStudio-1.6.0~beta.6-1.x86_64 conflicts with file from package mihomo-party-1.8.4-1.x86_64
```
This happens because both packages contain an identical build-id file (for debug?), it's an unresolved electron build bug: https://github.com/electron/forge/issues/3594

Since this file is unnecessary, we can simply exclude it from the RPM package.I've built and installed the modified rpm on my own Fedora system,no more conflicts.