### PR TITLE
fix(parameter-builder): avoid enabling built-in web search when external provider is configured

### DIFF
--- a/src/renderer/src/aiCore/prepareParams/parameterBuilder.ts
+++ b/src/renderer/src/aiCore/prepareParams/parameterBuilder.ts
@@ -67,11 +67,14 @@ export async function buildStreamTextParams(
       assistant.settings?.reasoning_effort !== undefined) ||
     (isReasoningModel(model) && (!isSupportedThinkingTokenModel(model) || !isSupportedReasoningEffortModel(model)))
 
+  // 判断是否使用内置搜索
+  // 条件：没有外部搜索提供商 && (用户开启了内置搜索 || 模型强制使用内置搜索)
+  const hasExternalSearch = !!options.webSearchProviderId
   const enableWebSearch =
-    (assistant.enableWebSearch && isWebSearchModel(model)) ||
-    isOpenRouterBuiltInWebSearchModel(model) ||
-    model.id.includes('sonar') ||
-    false
+    !hasExternalSearch &&
+    ((assistant.enableWebSearch && isWebSearchModel(model)) ||
+      isOpenRouterBuiltInWebSearchModel(model) ||
+      model.id.includes('sonar'))
 
   const enableUrlContext = assistant.enableUrlContext || false
 


### PR DESCRIPTION
### What this PR does

Before this PR:
- Built-in web search could be enabled even when an external search provider was configured. Especially when provider is openrouter

After this PR:
- Prevents enabling the built-in web search when an external provider is configured.

Fixes #9851