### PR TITLE
fix(translate): state management is passed when early return

### DIFF
--- a/src/renderer/src/pages/translate/TranslatePage.tsx
+++ b/src/renderer/src/pages/translate/TranslatePage.tsx
@@ -568,34 +568,37 @@ const TranslatePage: FC = () => {
     async (e: React.DragEvent<HTMLDivElement>) => {
       setIsProcessing(true)
       setIsDragging(false)
-      // const supportedFiles = await filterSupportedFiles(_files, extensions)
-      const data = await getTextFromDropEvent(e).catch((err) => {
-        logger.error('getTextFromDropEvent', err)
-        window.message.error({
-          key: 'file_error',
-          content: t('translate.files.error.unknown')
+      const process = async () => {
+        // const supportedFiles = await filterSupportedFiles(_files, extensions)
+        const data = await getTextFromDropEvent(e).catch((err) => {
+          logger.error('getTextFromDropEvent', err)
+          window.message.error({
+            key: 'file_error',
+            content: t('translate.files.error.unknown')
+          })
+          return null
         })
-        return null
-      })
-      if (data === null) {
-        return
-      }
-      setText(text + data)
+        if (data === null) {
+          return
+        }
+        setText(text + data)
 
-      const droppedFiles = await getFilesFromDropEvent(e).catch((err) => {
-        logger.error('handleDrop:', err)
-        window.message.error({
-          key: 'file_error',
-          content: t('translate.files.error.unknown')
+        const droppedFiles = await getFilesFromDropEvent(e).catch((err) => {
+          logger.error('handleDrop:', err)
+          window.message.error({
+            key: 'file_error',
+            content: t('translate.files.error.unknown')
+          })
+          return null
         })
-        return null
-      })
 
-      if (droppedFiles) {
-        const file = getSingleFile(droppedFiles) as FileMetadata
-        if (!file) return
-        processFile(file)
+        if (droppedFiles) {
+          const file = getSingleFile(droppedFiles) as FileMetadata
+          if (!file) return
+          processFile(file)
+        }
       }
+      await process()
       setIsProcessing(false)
     },
     [getSingleFile, processFile, setIsDragging, setText, t, text]


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #10019 

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
