### PR TITLE
style: remove heroui default background setting

### DIFF
--- a/src/renderer/src/assets/styles/tailwind.css
+++ b/src/renderer/src/assets/styles/tailwind.css
@@ -1,9 +1,9 @@
+@import 'tailwindcss' source('../../../../renderer');
+@import 'tw-animate-css';
+
 /* heroui */
 @plugin '../../hero.ts';
 @source '../../../../../node_modules/@heroui/theme/dist/**/*.{js,ts,jsx,tsx}';
-
-@import 'tailwindcss' source('../../../../renderer');
-@import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));
 

--- a/src/renderer/src/assets/styles/tailwind.css
+++ b/src/renderer/src/assets/styles/tailwind.css
@@ -155,8 +155,6 @@
   }
 }
 
-@layer components {
-  :root {
-    background-color: unset;
-  }
+:root {
+  background-color: unset;
 }

--- a/src/renderer/src/assets/styles/tailwind.css
+++ b/src/renderer/src/assets/styles/tailwind.css
@@ -1,9 +1,9 @@
-@import 'tailwindcss' source('../../../../renderer');
-@import 'tw-animate-css';
-
 /* heroui */
 @plugin '../../hero.ts';
 @source '../../../../../node_modules/@heroui/theme/dist/**/*.{js,ts,jsx,tsx}';
+
+@import 'tailwindcss' source('../../../../renderer');
+@import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));
 
@@ -152,5 +152,11 @@
   }
   body {
     @apply bg-background text-foreground;
+  }
+}
+
+@layer components {
+  :root {
+    background-color: unset;
   }
 }

--- a/src/renderer/src/context/ThemeProvider.tsx
+++ b/src/renderer/src/context/ThemeProvider.tsx
@@ -69,7 +69,10 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
   }, [actualTheme, initUserTheme, navbarPosition, setSettedTheme, settedTheme])
 
   useEffect(() => {
-    tailwindThemeChange(settedTheme)
+    tailwindThemeChange(actualTheme)
+  }, [actualTheme])
+
+  useEffect(() => {
     window.api.setTheme(settedTheme)
   }, [settedTheme])
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

<img width="3216" height="2088" alt="Screenshot-gXRV1uIP@2x" src="https://github.com/user-attachments/assets/12c80965-05e5-45a7-854c-78d8525d6224" />
<img width="3216" height="2088" alt="Screenshot-9tETOqiE@2x" src="https://github.com/user-attachments/assets/e579bead-3170-4876-998b-b41e9f3b3a5c" />

背景颜色被 heroui 默认样式覆盖，且无法正确设置暗黑模式

After this PR:

<img width="3216" height="2088" alt="Screenshot-xJlIqplf@2x" src="https://github.com/user-attachments/assets/c7287c59-3e42-4794-a877-f1ac57f8ae36" />
<img width="3216" height="2088" alt="Screenshot-7BvLcR96@2x" src="https://github.com/user-attachments/assets/832ed40e-580a-4ef6-8e57-3aad1f7997b9" />

恢复以背景往样式

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```

