### PR TITLE
fix(codetool): incorrect codetool workdir on macOS

### DIFF
--- a/src/main/services/CodeToolsService.ts
+++ b/src/main/services/CodeToolsService.ts
@@ -332,14 +332,15 @@ class CodeToolsService {
         // macOS - Use osascript to launch terminal and execute command directly, without showing startup command
         const envPrefix = buildEnvPrefix(false)
         const command = envPrefix ? `${envPrefix} && ${baseCommand}` : baseCommand
+        // Combine directory change with the main command to ensure they execute in the same shell session
+        const fullCommand = `cd '${directory.replace(/'/g, "\\'")}' && clear && ${command}`
 
         terminalCommand = 'osascript'
         terminalArgs = [
           '-e',
           `tell application "Terminal"
-  set newTab to do script "cd '${directory.replace(/'/g, "\\'")}' && clear"
+  do script "${fullCommand.replace(/"/g, '\\"')}"
   activate
-  do script "${command.replace(/"/g, '\\"')}" in newTab
 end tell`
         ]
         break


### PR DESCRIPTION
### What this PR does

Before this PR:
- codetool separate shells for running and changing directories macOS, causing incorrect working behavior.

After PR:
- Ensure the is run and cd occur in the same shell on macOS so the codool uses the correct workdir.

Fixes #9990

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Implemented same-shell execution on macOS to preserve expected shell state; no other platforms changed.

The following alternatives were considered:
- Leaving current behavior (caused incorrect workdir)
- More complex cross-platform shell handling (deemed unnecessary)

Links to places where the discussion took place: <!-- optional -->

### Breaking changes

- None anticipated.

### Special notes for your reviewer

- Verify macOS behavior: commands should run in the intended working directory.

### Checklist

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: Write code that humans can understand and Keep it simple
- [ ] Refactor: Left the code cleaner than you found it
- [ ] Upgrade: Impact on upgrade flows was considered
- [ ] Documentation: User-guide update not required

### Release note

```release-note

```