### PR TITLE
refactor(Navbar): improve WindowControls visibility and clean up event listener management

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -455,9 +455,10 @@ const api = {
     isMaximized: (): Promise<boolean> => ipcRenderer.invoke(IpcChannel.Windows_IsMaximized),
     onMaximizedChange: (callback: (isMaximized: boolean) => void): (() => void) => {
       const channel = IpcChannel.Windows_MaximizedChanged
-      ipcRenderer.on(channel, (_, isMaximized: boolean) => callback(isMaximized))
+      const listener = (_: Electron.IpcRendererEvent, isMaximized: boolean) => callback(isMaximized)
+      ipcRenderer.on(channel, listener)
       return () => {
-        ipcRenderer.removeAllListeners(channel)
+        ipcRenderer.removeListener(channel, listener)
       }
     }
   }

--- a/src/renderer/src/components/app/Navbar.tsx
+++ b/src/renderer/src/components/app/Navbar.tsx
@@ -1,6 +1,7 @@
 import { isLinux, isMac, isWin } from '@renderer/config/constant'
 import { useFullscreen } from '@renderer/hooks/useFullscreen'
 import useNavBackgroundColor from '@renderer/hooks/useNavBackgroundColor'
+import { useRuntime } from '@renderer/hooks/useRuntime'
 import { useNavbarPosition } from '@renderer/hooks/useSettings'
 import type { FC, PropsWithChildren } from 'react'
 import type { HTMLAttributes } from 'react'
@@ -13,6 +14,7 @@ type Props = PropsWithChildren & HTMLAttributes<HTMLDivElement>
 export const Navbar: FC<Props> = ({ children, ...props }) => {
   const backgroundColor = useNavBackgroundColor()
   const { isTopNavbar } = useNavbarPosition()
+  const { minappShow } = useRuntime()
 
   if (isTopNavbar) {
     return null
@@ -23,7 +25,7 @@ export const Navbar: FC<Props> = ({ children, ...props }) => {
       <NavbarContainer {...props} style={{ backgroundColor }}>
         {children}
       </NavbarContainer>
-      {(isWin || isLinux) && <WindowControls />}
+      {!isTopNavbar && !minappShow && <WindowControls />}
     </>
   )
 }

--- a/src/renderer/src/pages/minapps/MinAppsPage.tsx
+++ b/src/renderer/src/pages/minapps/MinAppsPage.tsx
@@ -1,7 +1,6 @@
-import { Navbar, NavbarMain, NavbarRight } from '@renderer/components/app/Navbar'
+import { Navbar, NavbarMain } from '@renderer/components/app/Navbar'
 import App from '@renderer/components/MinApp/MinApp'
 import Scrollbar from '@renderer/components/Scrollbar'
-import { isLinux, isWin } from '@renderer/config/constant'
 import { useMinapps } from '@renderer/hooks/useMinapps'
 import { useNavbarPosition } from '@renderer/hooks/useSettings'
 import { Button, Input } from 'antd'
@@ -58,21 +57,13 @@ const AppsPage: FC = () => {
             value={search}
             onChange={(e) => setSearch(e.target.value)}
           />
-        </NavbarMain>
-        <NavbarRight
-          style={{
-            justifyContent: 'flex-end',
-            flex: 1,
-            position: 'relative',
-            paddingRight: isWin || isLinux ? '144px' : '6px'
-          }}>
           <Button
             type="text"
             className="nodrag"
             icon={<SettingsIcon size={18} color="var(--color-text-2)" />}
             onClick={MinappSettingsPopup.show}
           />
-        </NavbarRight>
+        </NavbarMain>
       </Navbar>
       <ContentContainer id="content-container">
         <MainContainer>


### PR DESCRIPTION
old ui的情况下，mini app pop up界面是一个antd drawer会覆盖整个界面，把custom title bar都覆盖了，导致点不了。现在的做法是在drawer上面加载一个windowControls，然后在navbar的里面判断下要不要再次加载windowControls。

还有一个就是windowControls不加载的时候，就删除对应channel callback，不要全部删除，全部删除会导致restore/max显示异常。

