### PR TITLE
QuickPanel: Adjustable height + persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ stats.html
 
 # Local
 local
+.codex/
 .aider*
 .cursorrules
 .cursor/*

--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ stats.html
 
 # Local
 local
-.codex/
 .aider*
 .cursorrules
 .cursor/*

--- a/src/renderer/src/components/QuickPanel/provider.tsx
+++ b/src/renderer/src/components/QuickPanel/provider.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import db from '@renderer/databases'
 
 import {
   QuickPanelCallBackOptions,
@@ -54,6 +55,23 @@ export const QuickPanelProvider: React.FC<React.PropsWithChildren> = ({ children
     setAfterAction(() => options.afterAction)
 
     setIsVisible(true)
+  }, [])
+
+  // Load persisted rows (pageSize) on mount
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const setting = await db.settings.get('ui:quickpanel:rows')
+        const rows = typeof setting?.value === 'number' ? setting.value : undefined
+        if (!cancelled && typeof rows === 'number') {
+          setPageSize(rows)
+        }
+      } catch {}
+    })()
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   const close = useCallback(

--- a/src/renderer/src/components/QuickPanel/provider.tsx
+++ b/src/renderer/src/components/QuickPanel/provider.tsx
@@ -41,7 +41,10 @@ export const QuickPanelProvider: React.FC<React.PropsWithChildren> = ({ children
     setTitle(options.title)
     setList(options.list)
     setDefaultIndex(options.defaultIndex ?? 0)
-    setPageSize(options.pageSize ?? 7)
+    // 仅当显式传入时才更新行数，否则沿用用户最近一次调整值
+    if (typeof options.pageSize === 'number') {
+      setPageSize(options.pageSize)
+    }
     setMultiple(options.multiple ?? false)
     setSymbol(options.symbol)
     setTriggerInfo(options.triggerInfo)
@@ -85,6 +88,7 @@ export const QuickPanelProvider: React.FC<React.PropsWithChildren> = ({ children
       open,
       close,
       updateItemSelection,
+      setPageSize,
 
       isVisible,
       symbol,
@@ -103,6 +107,7 @@ export const QuickPanelProvider: React.FC<React.PropsWithChildren> = ({ children
       open,
       close,
       updateItemSelection,
+      setPageSize,
       isVisible,
       symbol,
       list,

--- a/src/renderer/src/components/QuickPanel/types.ts
+++ b/src/renderer/src/components/QuickPanel/types.ts
@@ -68,6 +68,8 @@ export interface QuickPanelContextType {
   readonly open: (options: QuickPanelOpenOptions) => void
   readonly close: (action?: QuickPanelCloseAction, searchText?: string) => void
   readonly updateItemSelection: (targetItem: QuickPanelListItem, isSelected: boolean) => void
+  /** 更新可视行数（原 pageSize） */
+  readonly setPageSize: (size: number) => void
   readonly isVisible: boolean
   readonly symbol: string
   readonly list: QuickPanelListItem[]

--- a/src/renderer/src/components/QuickPanel/view.tsx
+++ b/src/renderer/src/components/QuickPanel/view.tsx
@@ -9,6 +9,7 @@ import { t } from 'i18next'
 import { debounce } from 'lodash'
 import { Check } from 'lucide-react'
 import React, { use, useCallback, useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import db from '@renderer/databases'
 import styled from 'styled-components'
 import * as tinyPinyin from 'tiny-pinyin'
 
@@ -552,6 +553,10 @@ export const QuickPanelView: React.FC<Props> = ({ setInputText }) => {
     window.removeEventListener('mousemove', onResizeMouseMove)
     window.removeEventListener('mouseup', onResizeMouseUp)
     document.body.style.cursor = ''
+    // 持久化当前行数
+    try {
+      void db.settings.put({ id: 'ui:quickpanel:rows', value: ctx.pageSize })
+    } catch {}
   }, [onResizeMouseMove])
 
   const onResizeMouseDown = useCallback(


### PR DESCRIPTION
This PR adds adjustable QuickPanel height with a draggable top handle, session-safe behavior, and Dexie-backed persistence.



https://github.com/user-attachments/assets/d85e51f9-d179-4bb8-b5f3-6f4a6ea02245



Summary

- Draggable resize handle at the top; drag up increases rows, down decreases.
- Live height updates: list size = rows * ITEM_HEIGHT.
- Clamp rows to [3, 16].
- Ignore outside-click while resizing to prevent accidental close.\n- Keep focused row visible after resize.
- Persistence: save rows to db.settings['ui:quickpanel:rows'] on resize end; load on mount.

Code Changes
- src/renderer/src/components/QuickPanel/types.ts: expose setPageSize in context.
- src/renderer/src/components/QuickPanel/provider.tsx: read rows on mount; don't override unless provided in open().
- src/renderer/src/components/QuickPanel/view.tsx: top handle + resize logic + persistence write + outside-click guard.

Testing
- Open QuickPanel (@ models). Drag handle at top to resize.
- Confirm panel stays open after drag and remains usable.
- Close and reopen: height persists.
- Restart app: height persists across sessions.

