### PR TITLE
fix(toolUsePlugin): handle empty tools case in prompt generation

### DIFF
--- a/packages/aiCore/src/core/plugins/built-in/toolUsePlugin/promptToolUsePlugin.ts
+++ b/packages/aiCore/src/core/plugins/built-in/toolUsePlugin/promptToolUsePlugin.ts
@@ -156,8 +156,10 @@ Assistant: The population of Shanghai is 26 million, while Guangzhou has a popul
 /**
  * 构建可用工具部分（提取自 Cherry Studio）
  */
-function buildAvailableTools(tools: ToolSet): string {
+function buildAvailableTools(tools: ToolSet): string | null {
   const availableTools = Object.keys(tools)
+  if (availableTools.length === 0) return null
+  const result = availableTools
     .map((toolName: string) => {
       const tool = tools[toolName]
       return `
@@ -172,7 +174,7 @@ function buildAvailableTools(tools: ToolSet): string {
     })
     .join('\n')
   return `<tools>
-${availableTools}
+${result}
 </tools>`
 }
 
@@ -181,6 +183,7 @@ ${availableTools}
  */
 function defaultBuildSystemPrompt(userSystemPrompt: string, tools: ToolSet): string {
   const availableTools = buildAvailableTools(tools)
+  if (availableTools === null) return userSystemPrompt
 
   const fullPrompt = DEFAULT_SYSTEM_PROMPT.replace('{{ TOOL_USE_EXAMPLES }}', DEFAULT_TOOL_USE_EXAMPLES)
     .replace('{{ AVAILABLE_TOOLS }}', availableTools)


### PR DESCRIPTION
Return null when no tools are available and skip tool section in system prompt

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #10110

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
