### PR TITLE
style(MinApp): responsive layout for MinAppPage

### DIFF
--- a/src/renderer/src/components/MinApp/MinApp.tsx
+++ b/src/renderer/src/components/MinApp/MinApp.tsx
@@ -135,6 +135,7 @@ const Container = styled.div`
   align-items: center;
   cursor: pointer;
   overflow: hidden;
+  min-height: 85px;
 `
 
 const IconContainer = styled.div`

--- a/src/renderer/src/pages/minapps/MinAppsPage.tsx
+++ b/src/renderer/src/pages/minapps/MinAppsPage.tsx
@@ -46,10 +46,7 @@ const AppsPage: FC = () => {
             style={{
               width: '30%',
               height: 28,
-              borderRadius: 15,
-              position: 'absolute',
-              left: '50vw',
-              transform: 'translateX(-50%)'
+              borderRadius: 15
             }}
             size="small"
             variant="filled"
@@ -107,6 +104,7 @@ const Container = styled.div`
   flex: 1;
   flex-direction: column;
   height: 100%;
+  overflow: hidden;
 `
 
 const ContentContainer = styled.div`
@@ -132,11 +130,13 @@ const MainContainer = styled.div`
   flex: 1;
   flex-direction: row;
   height: calc(100vh - var(--navbar-height));
+  width: 100%;
 `
 
 const RightContainer = styled(Scrollbar)`
   display: flex;
-  flex: 1;
+  flex: 1 1 0%;
+  min-width: 0;
   flex-direction: column;
   height: 100%;
   align-items: center;
@@ -150,6 +150,7 @@ const AppsContainerWrapper = styled(Scrollbar)`
   justify-content: center;
   padding: 50px 0;
   width: 100%;
+  margin-bottom: 20px;
   [navbar-position='top'] & {
     padding: 20px 0;
   }
@@ -159,6 +160,7 @@ const AppsContainer = styled.div`
   display: grid;
   min-width: 0;
   max-width: 930px;
+  margin: 0 20px;
   width: 100%;
   grid-template-columns: repeat(auto-fill, 90px);
   gap: 25px;


### PR DESCRIPTION
- Add min-height to MinApp container
- Remove absolute positioning from search bar
- Improve flex and overflow handling in containers
- Adjust margins and widths for better spacing

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

看情况是最小窗口宽度对于显示器本身宽度较小的情况不适用。现在小程序页面可以自适应宽度变化。

| Before | After |
| --- | --- |
| <img width="500" height="862" alt="image" src="https://github.com/user-attachments/assets/bed5e2dd-1a31-4bf5-adff-74c27be525d3" /> | <img width="500" height="862" alt="image" src="https://github.com/user-attachments/assets/86e3c72f-995a-4e7b-8831-f5cde620ca7d" /> |
| <img width="500" height="862" alt="image" src="https://github.com/user-attachments/assets/004c80a4-5fa0-4e5e-bf43-c8b82c1756e6" /> | <img width="500" height="862" alt="image" src="https://github.com/user-attachments/assets/7e7affc5-e854-455b-abd9-1d020478abd2" /> |



<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
