### PR TITLE
fix: make autostart config persistant, and auto flush in start

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -13,6 +13,7 @@ import installExtension, { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS } from 'electro
 
 import { isDev, isLinux, isWin } from './constant'
 import { registerIpc } from './ipc'
+import appService from './services/AppService'
 import { configManager } from './services/ConfigManager'
 import mcpService from './services/MCPService'
 import { nodeTraceService } from './services/NodeTraceService'
@@ -114,6 +115,10 @@ if (!app.requestSingleInstanceLock()) {
     if (isLaunchToTray) {
       app.dock?.hide()
     }
+
+    // Apply launch on boot settings from configuration
+    const isLaunchOnBoot = configManager.getLaunchOnBoot()
+    await appService.setAppLaunchOnBoot(isLaunchOnBoot)
 
     const mainWindow = windowService.createMainWindow()
     new TrayService()

--- a/src/main/services/AppService.ts
+++ b/src/main/services/AppService.ts
@@ -1,5 +1,6 @@
 import { loggerService } from '@logger'
 import { isDev, isLinux, isMac, isWin } from '@main/constant'
+import { configManager } from '@main/services/ConfigManager'
 import { app } from 'electron'
 import fs from 'fs'
 import os from 'os'
@@ -22,6 +23,9 @@ export class AppService {
   }
 
   public async setAppLaunchOnBoot(isLaunchOnBoot: boolean): Promise<void> {
+    // Save configuration
+    configManager.setLaunchOnBoot(isLaunchOnBoot)
+
     // Set login item settings for windows and mac
     // linux is not supported because it requires more file operations
     if (isWin || isMac) {

--- a/src/main/services/ConfigManager.ts
+++ b/src/main/services/ConfigManager.ts
@@ -9,6 +9,7 @@ export enum ConfigKeys {
   Language = 'language',
   Theme = 'theme',
   LaunchToTray = 'launchToTray',
+  LaunchOnBoot = 'launchOnBoot',
   Tray = 'tray',
   TrayOnClose = 'trayOnClose',
   ZoomFactor = 'ZoomFactor',
@@ -61,6 +62,14 @@ export class ConfigManager {
 
   setLaunchToTray(value: boolean) {
     this.set(ConfigKeys.LaunchToTray, value)
+  }
+
+  getLaunchOnBoot(): boolean {
+    return !!this.get(ConfigKeys.LaunchOnBoot, false)
+  }
+
+  setLaunchOnBoot(value: boolean) {
+    this.set(ConfigKeys.LaunchOnBoot, value)
   }
 
   getTray(): boolean {


### PR DESCRIPTION
### What this PR does

Before this PR: 开机自启配置只存储于前端进程，且在多版本混用、AppImage版本更新等场景下，不会自动更新启动路径

After this PR: 开机自启配置会同步到后端的配置存储里，并且启动时会根据配置重新施加当前的开机自启策略

### Why we need it and why it was done in this way
是否开机自启作为一个核心配置，应该进入ConfigManager，借用现有的配置执行机制避免重复编写代码


### Breaking changes

之前如果设置了开机自启，需要关闭并重新打开

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
之前如果设置了开机自启，需要关闭并重新打开
```
