### PR TITLE
refactor: migrate all antd Tooltip components to HeroUI Tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@strongtz/win32-arm64-msvc": "^0.4.7",
     "express": "^5.1.0",
     "faiss-node": "^0.5.1",
+    "font-list": "^2.0.0",
     "graceful-fs": "^4.2.11",
     "jsdom": "26.1.0",
     "node-stream-zip": "^1.15.0",

--- a/packages/shared/IpcChannel.ts
+++ b/packages/shared/IpcChannel.ts
@@ -38,6 +38,7 @@ export enum IpcChannel {
   App_GetDiskInfo = 'app:get-disk-info',
   App_SetFullScreen = 'app:set-full-screen',
   App_IsFullScreen = 'app:is-full-screen',
+  App_GetSystemFonts = 'app:get-system-fonts',
 
   App_MacIsProcessTrusted = 'app:mac-is-process-trusted',
   App_MacRequestProcessTrust = 'app:mac-request-process-trust',

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -14,6 +14,7 @@ import { IpcChannel } from '@shared/IpcChannel'
 import { FileMetadata, Provider, Shortcut, ThemeMode } from '@types'
 import checkDiskSpace from 'check-disk-space'
 import { BrowserWindow, dialog, ipcMain, ProxyConfig, session, shell, systemPreferences, webContents } from 'electron'
+import fontList from 'font-list'
 import { Notification } from 'src/renderer/src/types/notification'
 
 import { apiServerService } from './services/ApiServerService'
@@ -217,6 +218,17 @@ export function registerIpc(mainWindow: BrowserWindow, app: Electron.App) {
 
   ipcMain.handle(IpcChannel.App_IsFullScreen, (): boolean => {
     return mainWindow.isFullScreen()
+  })
+
+  // Get System Fonts
+  ipcMain.handle(IpcChannel.App_GetSystemFonts, async () => {
+    try {
+      const fonts = await fontList.getFonts()
+      return fonts.map((font: string) => font.replace(/^"(.*)"$/, '$1')).filter((font: string) => font.length > 0)
+    } catch (error) {
+      logger.error('Failed to get system fonts:', error as Error)
+      return []
+    }
   })
 
   ipcMain.handle(IpcChannel.Config_Set, (_, key: string, value: any, isNotify: boolean = false) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -84,6 +84,7 @@ const api = {
     ipcRenderer.invoke(IpcChannel.App_LogToMain, source, level, message, data),
   setFullScreen: (value: boolean): Promise<void> => ipcRenderer.invoke(IpcChannel.App_SetFullScreen, value),
   isFullScreen: (): Promise<boolean> => ipcRenderer.invoke(IpcChannel.App_IsFullScreen),
+  getSystemFonts: (): Promise<string[]> => ipcRenderer.invoke(IpcChannel.App_GetSystemFonts),
   mac: {
     isProcessTrusted: (): Promise<boolean> => ipcRenderer.invoke(IpcChannel.App_MacIsProcessTrusted),
     requestProcessTrust: (): Promise<boolean> => ipcRenderer.invoke(IpcChannel.App_MacRequestProcessTrust)

--- a/src/renderer/src/assets/styles/font.css
+++ b/src/renderer/src/assets/styles/font.css
@@ -1,23 +1,24 @@
 :root {
   --font-family:
-    Ubuntu, -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, Roboto, Oxygen, Cantarell, 'Open Sans',
-    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
-    'Noto Color Emoji';
+    var(--user-font-family), Ubuntu, -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, Roboto, Oxygen,
+    Cantarell, 'Open Sans', 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
 
   --font-family-serif:
     serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, Ubuntu, Roboto, Oxygen, Cantarell, 'Open Sans',
     'Helvetica Neue', Arial, 'Noto Sans', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 
-  --code-font-family: 'Cascadia Code', 'Fira Code', 'Consolas', Menlo, Courier, monospace;
+  --code-font-family: var(--user-code-font-family), 'Cascadia Code', 'Fira Code', 'Consolas', Menlo, Courier, monospace;
 }
 
 /* Windows系统专用字体配置 */
 body[os='windows'] {
   --font-family:
-    'Twemoji Country Flags', Ubuntu, -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, Roboto, Oxygen,
-    Cantarell, 'Open Sans', 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-    'Segoe UI Symbol', 'Noto Color Emoji';
+    var(--user-font-family), 'Twemoji Country Flags', Ubuntu, -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui,
+    Roboto, Oxygen, Cantarell, 'Open Sans', 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 
   --code-font-family:
-    'Cascadia Code', 'Fira Code', 'Consolas', 'Sarasa Mono SC', 'Microsoft YaHei UI', Courier, monospace;
+    var(--user-code-font-family), 'Cascadia Code', 'Fira Code', 'Consolas', 'Sarasa Mono SC', 'Microsoft YaHei UI',
+    Courier, monospace;
 }

--- a/src/renderer/src/components/CodeBlockView/HtmlArtifactsPopup.tsx
+++ b/src/renderer/src/components/CodeBlockView/HtmlArtifactsPopup.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import CodeEditor, { CodeEditorHandles } from '@renderer/components/CodeEditor'
 import { CopyIcon, FilePngIcon } from '@renderer/components/Icons'
 import { isMac } from '@renderer/config/constant'
@@ -5,7 +6,7 @@ import { useTemporaryValue } from '@renderer/hooks/useTemporaryValue'
 import { classNames } from '@renderer/utils'
 import { extractHtmlTitle, getFileNameFromHtmlTitle } from '@renderer/utils/formats'
 import { captureScrollableIframeAsBlob, captureScrollableIframeAsDataURL } from '@renderer/utils/image'
-import { Button, Dropdown, Modal, Splitter, Tooltip, Typography } from 'antd'
+import { Button, Dropdown, Modal, Splitter, Typography } from 'antd'
 import { Camera, Check, Code, Eye, Maximize2, Minimize2, SaveIcon, SquareSplitHorizontal, X } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -121,7 +122,7 @@ const HtmlArtifactsPopup: React.FC<HtmlArtifactsPopupProps> = ({ open, title, ht
               }
             ]
           }}>
-          <Tooltip title={t('html_artifacts.capture.label')} mouseLeaveDelay={0}>
+          <Tooltip content={t('html_artifacts.capture.label')} closeDelay={0} showArrow={true}>
             <Button type="text" icon={<Camera size={16} />} className="nodrag" />
           </Tooltip>
         </Dropdown>
@@ -156,7 +157,7 @@ const HtmlArtifactsPopup: React.FC<HtmlArtifactsPopupProps> = ({ open, title, ht
           }}
         />
         <ToolbarWrapper>
-          <Tooltip title={t('code_block.edit.save.label')} mouseLeaveDelay={0}>
+          <Tooltip content={t('code_block.edit.save.label')} closeDelay={0} showArrow={true}>
             <ToolbarButton
               shape="circle"
               size="large"

--- a/src/renderer/src/components/CodeToolbar/button.tsx
+++ b/src/renderer/src/components/CodeToolbar/button.tsx
@@ -1,5 +1,6 @@
+import { Tooltip } from '@heroui/react'
 import { ActionTool } from '@renderer/components/ActionTools'
-import { Dropdown, Tooltip } from 'antd'
+import { Dropdown } from 'antd'
 import { memo, useMemo } from 'react'
 
 import { ToolWrapper } from './styles'
@@ -11,7 +12,7 @@ interface CodeToolButtonProps {
 const CodeToolButton = ({ tool }: CodeToolButtonProps) => {
   const mainTool = useMemo(
     () => (
-      <Tooltip key={tool.id} title={tool.tooltip} mouseEnterDelay={0.5} mouseLeaveDelay={0}>
+      <Tooltip key={tool.id} content={tool.tooltip} closeDelay={500} showArrow={true}>
         <ToolWrapper onClick={tool.onClick}>{tool.icon}</ToolWrapper>
       </Tooltip>
     ),

--- a/src/renderer/src/components/CodeToolbar/toolbar.tsx
+++ b/src/renderer/src/components/CodeToolbar/toolbar.tsx
@@ -1,6 +1,6 @@
+import { Tooltip } from '@heroui/react'
 import { ActionTool } from '@renderer/components/ActionTools'
 import { HStack } from '@renderer/components/Layout'
-import { Tooltip } from 'antd'
 import { EllipsisVertical } from 'lucide-react'
 import { memo, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -39,7 +39,7 @@ const CodeToolbar = ({ tools }: { tools: ActionTool[] }) => {
         {/* 有多个快捷工具时通过 more 按钮展示 */}
         {quickToolButtons}
         {quickTools.length > 1 && (
-          <Tooltip title={t('code_block.more')} mouseEnterDelay={0.5}>
+          <Tooltip content={t('code_block.more')} closeDelay={500} showArrow={true}>
             <ToolWrapper onClick={() => setShowQuickTools(!showQuickTools)} className={showQuickTools ? 'active' : ''}>
               <EllipsisVertical className="tool-icon" />
             </ToolWrapper>

--- a/src/renderer/src/components/CollapsibleSearchBar.tsx
+++ b/src/renderer/src/components/CollapsibleSearchBar.tsx
@@ -1,5 +1,6 @@
+import { Tooltip } from '@heroui/react'
 import i18n from '@renderer/i18n'
-import { Input, InputRef, Tooltip } from 'antd'
+import { Input, InputRef } from 'antd'
 import { Search } from 'lucide-react'
 import { motion } from 'motion/react'
 import React, { memo, useCallback, useEffect, useRef, useState } from 'react'
@@ -92,7 +93,7 @@ const CollapsibleSearchBar = ({
         }}
         style={{ cursor: 'pointer', display: 'flex' }}
         onClick={() => setSearchVisible(true)}>
-        <Tooltip title={tooltip} mouseEnterDelay={0.5} mouseLeaveDelay={0}>
+        <Tooltip content={tooltip} closeDelay={500} showArrow={true}>
           {icon}
         </Tooltip>
       </motion.div>

--- a/src/renderer/src/components/ContentSearch.tsx
+++ b/src/renderer/src/components/ContentSearch.tsx
@@ -1,6 +1,6 @@
+import { Tooltip } from '@heroui/react'
 import { ToolbarButton } from '@renderer/pages/home/Inputbar/Inputbar'
 import NarrowLayout from '@renderer/pages/home/Messages/NarrowLayout'
-import { Tooltip } from 'antd'
 import { debounce } from 'lodash'
 import { CaseSensitive, ChevronDown, ChevronUp, User, WholeWord, X } from 'lucide-react'
 import React, { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
@@ -363,13 +363,17 @@ export const ContentSearch = React.forwardRef<ContentSearchRef, Props>(
               />
               <ToolBar>
                 {showUserToggle && (
-                  <Tooltip title={t('button.includes_user_questions')} mouseEnterDelay={0.8} placement="bottom">
+                  <Tooltip
+                    content={t('button.includes_user_questions')}
+                    closeDelay={800}
+                    placement="bottom"
+                    showArrow={true}>
                     <ToolbarButton type="text" onClick={userOutlinedButtonOnClick}>
                       <User size={18} style={{ color: includeUser ? 'var(--color-link)' : 'var(--color-icon)' }} />
                     </ToolbarButton>
                   </Tooltip>
                 )}
-                <Tooltip title={t('button.case_sensitive')} mouseEnterDelay={0.8} placement="bottom">
+                <Tooltip content={t('button.case_sensitive')} closeDelay={800} placement="bottom" showArrow={true}>
                   <ToolbarButton type="text" onClick={caseSensitiveButtonOnClick}>
                     <CaseSensitive
                       size={18}
@@ -377,7 +381,7 @@ export const ContentSearch = React.forwardRef<ContentSearchRef, Props>(
                     />
                   </ToolbarButton>
                 </Tooltip>
-                <Tooltip title={t('button.whole_word')} mouseEnterDelay={0.8} placement="bottom">
+                <Tooltip content={t('button.whole_word')} closeDelay={800} placement="bottom" showArrow={true}>
                   <ToolbarButton type="text" onClick={wholeWordButtonOnClick}>
                     <WholeWord size={18} style={{ color: isWholeWord ? 'var(--color-link)' : 'var(--color-icon)' }} />
                   </ToolbarButton>

--- a/src/renderer/src/components/CopyButton.tsx
+++ b/src/renderer/src/components/CopyButton.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from 'antd'
+import { Tooltip } from '@heroui/react'
 import { Copy } from 'lucide-react'
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -47,7 +47,11 @@ const CopyButton: FC<CopyButtonProps> = ({
   )
 
   if (tooltip) {
-    return <Tooltip title={tooltip}>{button}</Tooltip>
+    return (
+      <Tooltip content={tooltip} showArrow={true}>
+        {button}
+      </Tooltip>
+    )
   }
 
   return button

--- a/src/renderer/src/components/HealthStatusIndicator/indicator.tsx
+++ b/src/renderer/src/components/HealthStatusIndicator/indicator.tsx
@@ -1,5 +1,6 @@
 import { CheckCircleFilled, CloseCircleFilled, ExclamationCircleFilled, LoadingOutlined } from '@ant-design/icons'
-import { Flex, Tooltip, Typography } from 'antd'
+import { Tooltip } from '@heroui/react'
+import { Flex, Typography } from 'antd'
 import React, { memo } from 'react'
 import styled from 'styled-components'
 
@@ -50,7 +51,7 @@ const HealthStatusIndicator: React.FC<HealthStatusIndicatorProps> = ({
   return (
     <Flex align="center" gap={6}>
       {latencyText && <LatencyText type="secondary">{latencyText}</LatencyText>}
-      <Tooltip title={tooltip} styles={{ body: { userSelect: 'text' } }}>
+      <Tooltip content={tooltip} classNames={{ content: 'user-select-text' }} showArrow={true}>
         <IndicatorWrapper $type={overallStatus}>{icon}</IndicatorWrapper>
       </Tooltip>
     </Flex>

--- a/src/renderer/src/components/Icons/ReasoningIcon.tsx
+++ b/src/renderer/src/components/Icons/ReasoningIcon.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from 'antd'
+import { Tooltip } from '@heroui/react'
 import React, { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -8,7 +8,7 @@ const ReasoningIcon: FC<React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement
 
   return (
     <Container>
-      <Tooltip title={t('models.type.reasoning')} placement="top">
+      <Tooltip content={t('models.type.reasoning')} placement="top" showArrow={true}>
         <Icon className="iconfont icon-thinking" {...(props as any)} />
       </Tooltip>
     </Container>

--- a/src/renderer/src/components/Icons/ToolsCallingIcon.tsx
+++ b/src/renderer/src/components/Icons/ToolsCallingIcon.tsx
@@ -1,5 +1,5 @@
 import { ToolOutlined } from '@ant-design/icons'
-import { Tooltip } from 'antd'
+import { Tooltip } from '@heroui/react'
 import React, { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -9,7 +9,7 @@ const ToolsCallingIcon: FC<React.DetailedHTMLProps<React.HTMLAttributes<HTMLElem
 
   return (
     <Container>
-      <Tooltip title={t('models.function_calling')} placement="top">
+      <Tooltip content={t('models.function_calling')} placement="top" showArrow={true}>
         <Icon {...(props as any)} />
       </Tooltip>
     </Container>

--- a/src/renderer/src/components/Icons/VisionIcon.tsx
+++ b/src/renderer/src/components/Icons/VisionIcon.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from 'antd'
+import { Tooltip } from '@heroui/react'
 import { ImageIcon } from 'lucide-react'
 import React, { FC } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -9,7 +9,7 @@ const VisionIcon: FC<React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, 
 
   return (
     <Container>
-      <Tooltip title={t('models.type.vision')} placement="top">
+      <Tooltip content={t('models.type.vision')} placement="top" showArrow={true}>
         <Icon size={15} {...(props as any)} />
       </Tooltip>
     </Container>

--- a/src/renderer/src/components/Icons/WebSearchIcon.tsx
+++ b/src/renderer/src/components/Icons/WebSearchIcon.tsx
@@ -1,5 +1,5 @@
 import { GlobalOutlined } from '@ant-design/icons'
-import { Tooltip } from 'antd'
+import { Tooltip } from '@heroui/react'
 import React, { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -9,7 +9,7 @@ const WebSearchIcon: FC<React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement
 
   return (
     <Container>
-      <Tooltip title={t('models.type.websearch')} placement="top">
+      <Tooltip content={t('models.type.websearch')} placement="top" showArrow={true}>
         <Icon {...(props as any)} />
       </Tooltip>
     </Container>

--- a/src/renderer/src/components/InputEmbeddingDimension.tsx
+++ b/src/renderer/src/components/InputEmbeddingDimension.tsx
@@ -1,10 +1,11 @@
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import AiProvider from '@renderer/aiCore'
 import { RefreshIcon } from '@renderer/components/Icons'
 import { useProvider } from '@renderer/hooks/useProvider'
 import { Model } from '@renderer/types'
 import { getErrorMessage } from '@renderer/utils'
-import { Button, InputNumber, Space, Tooltip } from 'antd'
+import { Button, InputNumber, Space } from 'antd'
 import { memo, useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -73,7 +74,7 @@ const InputEmbeddingDimension = ({
         onChange={onChange}
         disabled={disabled}
       />
-      <Tooltip title={t('knowledge.dimensions_auto_set')}>
+      <Tooltip content={t('knowledge.dimensions_auto_set')} showArrow={true}>
         <Button
           role="button"
           aria-label="Get embedding dimension"

--- a/src/renderer/src/components/LocalBackupManager.tsx
+++ b/src/renderer/src/components/LocalBackupManager.tsx
@@ -1,7 +1,8 @@
 import { DeleteOutlined, ExclamationCircleOutlined, ReloadOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { restoreFromLocal } from '@renderer/services/BackupService'
 import { formatFileSize } from '@renderer/utils'
-import { Button, message, Modal, Table, Tooltip } from 'antd'
+import { Button, message, Modal, Table } from 'antd'
 import dayjs from 'dayjs'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -167,7 +168,7 @@ export function LocalBackupManager({ visible, onClose, localBackupDir, restoreMe
         showTitle: false
       },
       render: (fileName: string) => (
-        <Tooltip placement="topLeft" title={fileName}>
+        <Tooltip placement="top-start" content={fileName} showArrow={true}>
           {fileName}
         </Tooltip>
       )

--- a/src/renderer/src/components/MinApp/MinappPopupContainer.tsx
+++ b/src/renderer/src/components/MinApp/MinappPopupContainer.tsx
@@ -10,6 +10,7 @@ import {
   PushpinOutlined,
   ReloadOutlined
 } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import WindowControls from '@renderer/components/WindowControls'
 import { isLinux, isMac, isWin } from '@renderer/config/constant'
@@ -26,7 +27,7 @@ import { setMinappsOpenLinkExternal } from '@renderer/store/settings'
 import { MinAppType } from '@renderer/types'
 import { delay } from '@renderer/utils'
 import { clearWebviewState, getWebviewLoaded, setWebviewLoaded } from '@renderer/utils/webviewStateManager'
-import { Alert, Avatar, Button, Drawer, Tooltip } from 'antd'
+import { Alert, Avatar, Button, Drawer } from 'antd'
 import { WebviewTag } from 'electron'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -404,24 +405,23 @@ const MinappPopupContainer: React.FC = () => {
     return (
       <TitleContainer style={{ backgroundColor: backgroundColor }}>
         <Tooltip
-          title={
+          content={
             <TitleTextTooltip>
               {url ?? appInfo.url} <br />
               <CopyOutlined className="icon-copy" />
               {t('minapp.popup.rightclick_copyurl')}
             </TitleTextTooltip>
           }
-          mouseEnterDelay={0.8}
-          placement="rightBottom"
-          styles={{
-            root: {
-              maxWidth: '400px'
-            }
+          closeDelay={800}
+          placement="right-end"
+          showArrow={true}
+          classNames={{
+            content: 'max-w-md'
           }}>
           <TitleText onContextMenu={(e) => handleCopyUrl(e, url ?? appInfo.url)}>{appInfo.name}</TitleText>
         </Tooltip>
         {appInfo.canOpenExternalLink && (
-          <Tooltip title={t('minapp.popup.openExternal')} mouseEnterDelay={0.8} placement="bottom">
+          <Tooltip content={t('minapp.popup.openExternal')} closeDelay={800} placement="bottom" showArrow={true}>
             <TitleButton onClick={() => handleOpenLink(url ?? appInfo.url)}>
               <ExportOutlined />
             </TitleButton>
@@ -432,24 +432,24 @@ const MinappPopupContainer: React.FC = () => {
           className={isWin || isLinux ? 'windows' : ''}
           style={{ marginRight: isWin || isLinux ? '140px' : 0 }}
           isTopNavbar={isTopNavbar}>
-          <Tooltip title={t('minapp.popup.goBack')} mouseEnterDelay={0.8} placement="bottom">
+          <Tooltip content={t('minapp.popup.goBack')} closeDelay={800} placement="bottom" showArrow={true}>
             <TitleButton onClick={() => handleGoBack(appInfo.id)}>
               <ArrowLeftOutlined />
             </TitleButton>
           </Tooltip>
-          <Tooltip title={t('minapp.popup.goForward')} mouseEnterDelay={0.8} placement="bottom">
+          <Tooltip content={t('minapp.popup.goForward')} closeDelay={800} placement="bottom" showArrow={true}>
             <TitleButton onClick={() => handleGoForward(appInfo.id)}>
               <ArrowRightOutlined />
             </TitleButton>
           </Tooltip>
-          <Tooltip title={t('minapp.popup.refresh')} mouseEnterDelay={0.8} placement="bottom">
+          <Tooltip content={t('minapp.popup.refresh')} closeDelay={800} placement="bottom" showArrow={true}>
             <TitleButton onClick={() => handleReload(appInfo.id)}>
               <ReloadOutlined />
             </TitleButton>
           </Tooltip>
           {appInfo.canPinned && (
             <Tooltip
-              title={
+              content={
                 appInfo.isPinned
                   ? isTopNavbar
                     ? t('minapp.remove_from_launchpad')
@@ -458,40 +458,42 @@ const MinappPopupContainer: React.FC = () => {
                     ? t('minapp.add_to_launchpad')
                     : t('minapp.add_to_sidebar')
               }
-              mouseEnterDelay={0.8}
-              placement="bottom">
+              closeDelay={800}
+              placement="bottom"
+              showArrow={true}>
               <TitleButton onClick={() => handleTogglePin(appInfo.id)} className={appInfo.isPinned ? 'pinned' : ''}>
                 <PushpinOutlined style={{ fontSize: 16 }} />
               </TitleButton>
             </Tooltip>
           )}
           <Tooltip
-            title={
+            content={
               minappsOpenLinkExternal
                 ? t('minapp.popup.open_link_external_on')
                 : t('minapp.popup.open_link_external_off')
             }
-            mouseEnterDelay={0.8}
-            placement="bottom">
+            closeDelay={800}
+            placement="bottom"
+            showArrow={true}>
             <TitleButton onClick={handleToggleOpenExternal} className={minappsOpenLinkExternal ? 'open-external' : ''}>
               <LinkOutlined />
             </TitleButton>
           </Tooltip>
           {isInDevelopment && (
-            <Tooltip title={t('minapp.popup.devtools')} mouseEnterDelay={0.8} placement="bottom">
+            <Tooltip content={t('minapp.popup.devtools')} closeDelay={800} placement="bottom" showArrow={true}>
               <TitleButton onClick={() => handleOpenDevTools(appInfo.id)}>
                 <CodeOutlined />
               </TitleButton>
             </Tooltip>
           )}
           {canMinimize && (
-            <Tooltip title={t('minapp.popup.minimize')} mouseEnterDelay={0.8} placement="bottom">
+            <Tooltip content={t('minapp.popup.minimize')} closeDelay={800} placement="bottom" showArrow={true}>
               <TitleButton onClick={() => handlePopupMinimize()}>
                 <MinusOutlined />
               </TitleButton>
             </Tooltip>
           )}
-          <Tooltip title={t('minapp.popup.close')} mouseEnterDelay={0.8} placement="bottom">
+          <Tooltip content={t('minapp.popup.close')} closeDelay={800} placement="bottom" showArrow={true}>
             <TitleButton onClick={() => handlePopupClose(appInfo.id)}>
               <CloseOutlined />
             </TitleButton>

--- a/src/renderer/src/components/ModelIdWithTags.tsx
+++ b/src/renderer/src/components/ModelIdWithTags.tsx
@@ -1,5 +1,6 @@
+import { Tooltip } from '@heroui/react'
+import CopyButton from '@renderer/components/CopyButton'
 import { Model } from '@renderer/types'
-import { Tooltip, Typography } from 'antd'
 import { memo } from 'react'
 import styled from 'styled-components'
 
@@ -20,20 +21,18 @@ const ModelIdWithTags = ({
   return (
     <ListItemName ref={ref} $fontSize={fontSize} style={style}>
       <Tooltip
-        styles={{
-          root: {
-            width: 'auto',
-            maxWidth: '500px'
-          }
+        classNames={{
+          content: 'w-auto max-w-lg'
         }}
-        destroyOnHidden
-        title={
-          <Typography.Text style={{ color: 'white' }} copyable={{ text: model.id }}>
-            {model.id}
-          </Typography.Text>
+        content={
+          <div style={{ color: 'white', display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <span>{model.id}</span>
+            <CopyButton textToCopy={model.id} size={12} />
+          </div>
         }
-        mouseEnterDelay={0.5}
-        placement="top">
+        closeDelay={500}
+        placement="top"
+        showArrow={true}>
         <NameSpan>{model.name}</NameSpan>
       </Tooltip>
       <ModelTagsWithLabel model={model} size={11} style={{ flexShrink: 0 }} />

--- a/src/renderer/src/components/ModelSelectButton.tsx
+++ b/src/renderer/src/components/ModelSelectButton.tsx
@@ -1,5 +1,6 @@
+import { Tooltip } from '@heroui/react'
 import { Model } from '@renderer/types'
-import { Button, Tooltip, TooltipProps } from 'antd'
+import { Button } from 'antd'
 import { useCallback, useMemo } from 'react'
 
 import ModelAvatar from './Avatar/ModelAvatar'
@@ -10,7 +11,7 @@ type Props = {
   onSelectModel: (model: Model) => void
   modelFilter?: (model: Model) => boolean
   noTooltip?: boolean
-  tooltipProps?: TooltipProps
+  tooltipProps?: any
 }
 
 const ModelSelectButton = ({ model, onSelectModel, modelFilter, noTooltip, tooltipProps }: Props) => {
@@ -29,7 +30,7 @@ const ModelSelectButton = ({ model, onSelectModel, modelFilter, noTooltip, toolt
     return button
   } else {
     return (
-      <Tooltip title={model.name} {...tooltipProps}>
+      <Tooltip content={model.name} showArrow={true} {...tooltipProps}>
         {button}
       </Tooltip>
     )

--- a/src/renderer/src/components/Popups/ApiKeyListPopup/item.tsx
+++ b/src/renderer/src/components/Popups/ApiKeyListPopup/item.tsx
@@ -1,9 +1,10 @@
+import { Tooltip } from '@heroui/react'
 import { type HealthResult, HealthStatusIndicator } from '@renderer/components/HealthStatusIndicator'
 import { EditIcon } from '@renderer/components/Icons'
 import { StreamlineGoodHealthAndWellBeing } from '@renderer/components/Icons/SVGIcon'
 import { ApiKeyWithStatus } from '@renderer/types/healthCheck'
 import { maskApiKey } from '@renderer/utils/api'
-import { Button, Flex, Input, InputRef, List, Popconfirm, Tooltip, Typography } from 'antd'
+import { Button, Flex, Input, InputRef, List, Popconfirm, Typography } from 'antd'
 import { Check, Minus, X } from 'lucide-react'
 import { FC, memo, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -103,7 +104,7 @@ const ApiKeyItem: FC<ApiKeyItemProps> = ({
             disabled={disabled}
           />
           <Flex gap={0} align="center">
-            <Tooltip title={t('common.save')}>
+            <Tooltip content={t('common.save')} showArrow={true}>
               <Button
                 type={hasUnsavedChanges ? 'primary' : 'text'}
                 icon={<Check size={16} />}
@@ -111,7 +112,7 @@ const ApiKeyItem: FC<ApiKeyItemProps> = ({
                 disabled={disabled}
               />
             </Tooltip>
-            <Tooltip title={t('common.cancel')}>
+            <Tooltip content={t('common.cancel')} showArrow={true}>
               <Button type="text" icon={<X size={16} />} onClick={handleCancelEdit} disabled={disabled} />
             </Tooltip>
           </Flex>
@@ -119,15 +120,14 @@ const ApiKeyItem: FC<ApiKeyItemProps> = ({
       ) : (
         <ItemInnerContainer style={{ gap: '10px' }}>
           <Tooltip
-            title={
+            content={
               <Typography.Text style={{ color: 'white' }} copyable={{ text: keyStatus.key }}>
                 {keyStatus.key}
               </Typography.Text>
             }
-            mouseEnterDelay={0.5}
+            closeDelay={500}
             placement="top"
-            // 确保不留下明文
-            destroyOnHidden>
+            showArrow={true}>
             <span style={{ cursor: 'help' }}>{maskApiKey(keyStatus.key)}</span>
           </Tooltip>
 
@@ -136,7 +136,7 @@ const ApiKeyItem: FC<ApiKeyItemProps> = ({
 
             <Flex gap={0} align="center">
               {showHealthCheck && (
-                <Tooltip title={t('settings.provider.check')} mouseLeaveDelay={0}>
+                <Tooltip content={t('settings.provider.check')} closeDelay={0} showArrow={true}>
                   <Button
                     type="text"
                     icon={<StreamlineGoodHealthAndWellBeing size={18} isActive={keyStatus.checking} />}
@@ -145,7 +145,7 @@ const ApiKeyItem: FC<ApiKeyItemProps> = ({
                   />
                 </Tooltip>
               )}
-              <Tooltip title={t('common.edit')} mouseLeaveDelay={0}>
+              <Tooltip content={t('common.edit')} closeDelay={0} showArrow={true}>
                 <Button type="text" icon={<EditIcon size={16} />} onClick={handleEdit} disabled={disabled} />
               </Tooltip>
               <Popconfirm
@@ -155,7 +155,7 @@ const ApiKeyItem: FC<ApiKeyItemProps> = ({
                 okText={t('common.confirm')}
                 cancelText={t('common.cancel')}
                 okButtonProps={{ danger: true }}>
-                <Tooltip title={t('common.delete')} mouseLeaveDelay={0}>
+                <Tooltip content={t('common.delete')} closeDelay={0} showArrow={true}>
                   <Button type="text" icon={<Minus size={16} />} disabled={disabled} />
                 </Tooltip>
               </Popconfirm>

--- a/src/renderer/src/components/Popups/ApiKeyListPopup/list.tsx
+++ b/src/renderer/src/components/Popups/ApiKeyListPopup/list.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import { DeleteIcon } from '@renderer/components/Icons'
 import { StreamlineGoodHealthAndWellBeing } from '@renderer/components/Icons/SVGIcon'
 import Scrollbar from '@renderer/components/Scrollbar'
@@ -8,7 +9,7 @@ import { SettingHelpText } from '@renderer/pages/settings'
 import { isProviderSupportAuth } from '@renderer/services/ProviderService'
 import { PreprocessProviderId, WebSearchProviderId } from '@renderer/types'
 import { ApiKeyWithStatus, HealthStatus } from '@renderer/types/healthCheck'
-import { Button, Card, Flex, List, Popconfirm, Space, Tooltip, Typography } from 'antd'
+import { Button, Card, Flex, List, Popconfirm, Space, Typography } from 'antd'
 import { Plus } from 'lucide-react'
 import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -139,7 +140,11 @@ export const ApiKeyList: FC<ApiKeyListProps> = ({ provider, updateProvider, show
                 okText={t('common.confirm')}
                 cancelText={t('common.cancel')}
                 okButtonProps={{ danger: true }}>
-                <Tooltip title={t('settings.provider.remove_invalid_keys')} placement="top" mouseLeaveDelay={0}>
+                <Tooltip
+                  content={t('settings.provider.remove_invalid_keys')}
+                  placement="top"
+                  closeDelay={0}
+                  showArrow={true}>
                   <Button
                     type="text"
                     icon={<DeleteIcon size={16} className="lucide-custom" />}
@@ -150,7 +155,7 @@ export const ApiKeyList: FC<ApiKeyListProps> = ({ provider, updateProvider, show
               </Popconfirm>
 
               {/* 批量检查 */}
-              <Tooltip title={t('settings.provider.check_all_keys')} placement="top" mouseLeaveDelay={0}>
+              <Tooltip content={t('settings.provider.check_all_keys')} placement="top" closeDelay={0} showArrow={true}>
                 <Button
                   type="text"
                   icon={<StreamlineGoodHealthAndWellBeing size={'1.2em'} />}

--- a/src/renderer/src/components/Popups/MultiSelectionPopup.tsx
+++ b/src/renderer/src/components/Popups/MultiSelectionPopup.tsx
@@ -1,7 +1,8 @@
+import { Tooltip } from '@heroui/react'
 import { CopyIcon, DeleteIcon } from '@renderer/components/Icons'
 import { useChatContext } from '@renderer/hooks/useChatContext'
 import { Topic } from '@renderer/types'
-import { Button, Tooltip } from 'antd'
+import { Button } from 'antd'
 import { Save, X } from 'lucide-react'
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -35,7 +36,7 @@ const MultiSelectActionPopup: FC<Props> = ({ topic }) => {
       <ActionBar>
         <SelectionCount>{t('common.selectedMessages', { count: selectedMessageIds.length })}</SelectionCount>
         <ActionButtons>
-          <Tooltip title={t('common.save')}>
+          <Tooltip content={t('common.save')} showArrow={true}>
             <Button
               shape="circle"
               color="default"
@@ -45,7 +46,7 @@ const MultiSelectActionPopup: FC<Props> = ({ topic }) => {
               onClick={() => handleAction('save')}
             />
           </Tooltip>
-          <Tooltip title={t('common.copy')}>
+          <Tooltip content={t('common.copy')} showArrow={true}>
             <Button
               shape="circle"
               color="default"
@@ -55,7 +56,7 @@ const MultiSelectActionPopup: FC<Props> = ({ topic }) => {
               onClick={() => handleAction('copy')}
             />
           </Tooltip>
-          <Tooltip title={t('common.delete')}>
+          <Tooltip content={t('common.delete')} showArrow={true}>
             <Button
               shape="circle"
               color="danger"
@@ -66,7 +67,7 @@ const MultiSelectActionPopup: FC<Props> = ({ topic }) => {
             />
           </Tooltip>
         </ActionButtons>
-        <Tooltip title={t('chat.navigation.close')}>
+        <Tooltip content={t('chat.navigation.close')} showArrow={true}>
           <Button shape="circle" color="default" variant="text" icon={<X size={16} />} onClick={handleClose} />
         </Tooltip>
       </ActionBar>

--- a/src/renderer/src/components/Popups/SaveToKnowledgePopup.tsx
+++ b/src/renderer/src/components/Popups/SaveToKnowledgePopup.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import CustomTag from '@renderer/components/Tags/CustomTag'
 import { TopView } from '@renderer/components/TopView'
@@ -15,7 +16,7 @@ import {
   processTopicContent,
   TopicContentStats
 } from '@renderer/utils/knowledge'
-import { Flex, Form, Modal, Select, Tooltip, Typography } from 'antd'
+import { Flex, Form, Modal, Select, Typography } from 'antd'
 import { Check, CircleHelp } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -334,7 +335,7 @@ const PopupContainer: React.FC<Props> = ({ source, title, resolve }) => {
                       {option.count}
                     </CustomTag>
                     <span>{option.label}</span>
-                    <Tooltip title={option.description} mouseLeaveDelay={0}>
+                    <Tooltip content={option.description} closeDelay={0} showArrow={true}>
                       <CircleHelp size={16} style={{ cursor: 'help' }} />
                     </Tooltip>
                   </Flex>

--- a/src/renderer/src/components/Popups/SelectModelPopup/popup.tsx
+++ b/src/renderer/src/components/Popups/SelectModelPopup/popup.tsx
@@ -1,4 +1,5 @@
 import { PushpinOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { FreeTrialModelTag } from '@renderer/components/FreeTrialModelTag'
 import ModelTagsWithLabel from '@renderer/components/ModelTagsWithLabel'
 import { TopView } from '@renderer/components/TopView'
@@ -10,7 +11,7 @@ import { getModelUniqId } from '@renderer/services/ModelService'
 import { Model, ModelType, objectEntries, Provider } from '@renderer/types'
 import { classNames, filterModelsByKeywords, getFancyProviderName } from '@renderer/utils'
 import { getModelTags } from '@renderer/utils/model'
-import { Avatar, Divider, Empty, Modal, Tooltip } from 'antd'
+import { Avatar, Divider, Empty, Modal } from 'antd'
 import { first, sortBy } from 'lodash'
 import { Settings2 } from 'lucide-react'
 import React, {
@@ -178,7 +179,7 @@ const PopupContainer: React.FC<Props> = ({ model, filter: baseFilter, showTagFil
         type: 'group',
         name: getFancyProviderName(p),
         actions: (
-          <Tooltip title={t('navigate.provider_settings')} mouseEnterDelay={0.5} mouseLeaveDelay={0}>
+          <Tooltip content={t('navigate.provider_settings')} closeDelay={500} showArrow={true}>
             <Settings2
               size={12}
               color="var(--color-text)"

--- a/src/renderer/src/components/Preview/ImageToolButton.tsx
+++ b/src/renderer/src/components/Preview/ImageToolButton.tsx
@@ -1,4 +1,5 @@
-import { Button, Tooltip } from 'antd'
+import { Tooltip } from '@heroui/react'
+import { Button } from 'antd'
 import { memo } from 'react'
 
 interface ImageToolButtonProps {
@@ -9,7 +10,7 @@ interface ImageToolButtonProps {
 
 const ImageToolButton = ({ tooltip, icon, onClick }: ImageToolButtonProps) => {
   return (
-    <Tooltip title={tooltip} mouseEnterDelay={0.5} mouseLeaveDelay={0}>
+    <Tooltip content={tooltip} closeDelay={500} showArrow={true}>
       <Button shape="circle" icon={icon} onClick={onClick} role="button" aria-label={tooltip} />
     </Tooltip>
   )

--- a/src/renderer/src/components/ProviderLogoPicker/index.tsx
+++ b/src/renderer/src/components/ProviderLogoPicker/index.tsx
@@ -1,8 +1,9 @@
 import { SearchOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { ProviderAvatarPrimitive } from '@renderer/components/ProviderAvatar'
 import { PROVIDER_LOGO_MAP } from '@renderer/config/providers'
 import { getProviderLabel } from '@renderer/i18n/label'
-import { Input, Tooltip } from 'antd'
+import { Input } from 'antd'
 import { FC, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
@@ -50,7 +51,7 @@ const ProviderLogoPicker: FC<Props> = ({ onProviderClick }) => {
       </SearchContainer>
       <LogoGrid>
         {filteredProviders.map(({ id, name, logo }) => (
-          <Tooltip key={id} title={name} placement="top" mouseLeaveDelay={0}>
+          <Tooltip key={id} content={name} placement="top" closeDelay={0} showArrow={true}>
             <LogoItem onClick={(e) => handleProviderClick(e, id)}>
               <ProviderAvatarPrimitive providerId={id} size={52} providerName={name} logoSrc={logo} />
             </LogoItem>

--- a/src/renderer/src/components/RichEditor/extensions/code-block-shiki/CodeBlockNodeView.tsx
+++ b/src/renderer/src/components/RichEditor/extensions/code-block-shiki/CodeBlockNodeView.tsx
@@ -1,7 +1,8 @@
 import { CopyOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { DEFAULT_LANGUAGES, getHighlighter, getShiki } from '@renderer/utils/shiki'
 import { NodeViewContent, NodeViewWrapper, type ReactNodeViewProps, ReactNodeViewRenderer } from '@tiptap/react'
-import { Button, Select, Tooltip } from 'antd'
+import { Button, Select } from 'antd'
 import { FC, useCallback, useEffect, useState } from 'react'
 
 const CodeBlockNodeView: FC<ReactNodeViewProps> = (props) => {
@@ -64,7 +65,7 @@ const CodeBlockNodeView: FC<ReactNodeViewProps> = (props) => {
           options={languageOptions.map((lang) => ({ value: lang, label: lang }))}
           style={{ minWidth: 90 }}
         />
-        <Tooltip title="Copy">
+        <Tooltip content="Copy" showArrow={true}>
           <Button
             size="small"
             type="text"

--- a/src/renderer/src/components/RichEditor/index.tsx
+++ b/src/renderer/src/components/RichEditor/index.tsx
@@ -1,8 +1,8 @@
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import { ContentSearch, type ContentSearchRef } from '@renderer/components/ContentSearch'
 import DragHandle from '@tiptap/extension-drag-handle-react'
 import { EditorContent } from '@tiptap/react'
-import { Tooltip } from 'antd'
 import { t } from 'i18next'
 import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, GripVertical, Plus, Trash2 } from 'lucide-react'
 import React, { useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react'
@@ -402,12 +402,12 @@ const RichEditor = ({
       <Scrollbar ref={scrollContainerRef} style={{ flex: 1, display: 'flex' }}>
         <StyledEditorContent>
           <PlusButton editor={editor} onElementClick={handlePlusButtonClick}>
-            <Tooltip title={t('richEditor.plusButton')}>
+            <Tooltip content={t('richEditor.plusButton')} showArrow={true}>
               <Plus />
             </Tooltip>
           </PlusButton>
           <DragHandle editor={editor} onElementDragEnd={handleDragEnd}>
-            <Tooltip title={t('richEditor.dragHandle')}>
+            <Tooltip content={t('richEditor.dragHandle')} showArrow={true}>
               <GripVertical />
             </Tooltip>
           </DragHandle>

--- a/src/renderer/src/components/RichEditor/toolbar.tsx
+++ b/src/renderer/src/components/RichEditor/toolbar.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from 'antd'
+import { Tooltip } from '@heroui/react'
 import type { TFunction } from 'i18next'
 import { LucideProps } from 'lucide-react'
 import React, { ForwardRefExoticComponent, RefAttributes, useEffect, useState } from 'react'
@@ -176,7 +176,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({ editor, formattingState, onCom
         )
 
         return (
-          <Tooltip key={item.id} title={tooltipText} placement="top">
+          <Tooltip key={item.id} content={tooltipText} placement="top" showArrow={true}>
             {buttonElement}
           </Tooltip>
         )

--- a/src/renderer/src/components/S3BackupManager.tsx
+++ b/src/renderer/src/components/S3BackupManager.tsx
@@ -1,8 +1,9 @@
 import { DeleteOutlined, ExclamationCircleOutlined, ReloadOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { restoreFromS3 } from '@renderer/services/BackupService'
 import type { S3Config } from '@renderer/types'
 import { formatFileSize } from '@renderer/utils'
-import { Button, Modal, Table, Tooltip } from 'antd'
+import { Button, Modal, Table } from 'antd'
 import dayjs from 'dayjs'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -206,7 +207,7 @@ export function S3BackupManager({ visible, onClose, s3Config, restoreMethod }: S
         showTitle: false
       },
       render: (fileName: string) => (
-        <Tooltip placement="topLeft" title={fileName}>
+        <Tooltip placement="top-start" content={fileName} showArrow={true}>
           {fileName}
         </Tooltip>
       )

--- a/src/renderer/src/components/Tab/TabContainer.tsx
+++ b/src/renderer/src/components/Tab/TabContainer.tsx
@@ -1,4 +1,5 @@
 import { PlusOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { Sortable, useDndReorder } from '@renderer/components/dnd'
 import HorizontalScrollContainer from '@renderer/components/HorizontalScrollContainer'
 import { isMac } from '@renderer/config/constant'
@@ -14,7 +15,6 @@ import type { Tab } from '@renderer/store/tabs'
 import { addTab, removeTab, setActiveTab, setTabs } from '@renderer/store/tabs'
 import { ThemeMode } from '@renderer/types'
 import { classNames } from '@renderer/utils'
-import { Tooltip } from 'antd'
 import {
   FileSearch,
   Folder,
@@ -219,9 +219,10 @@ const TabsContainer: React.FC<TabsContainerProps> = ({ children }) => {
         </HorizontalScrollContainer>
         <RightButtonsContainer>
           <Tooltip
-            title={t('settings.theme.title') + ': ' + getThemeModeLabel(settedTheme)}
-            mouseEnterDelay={0.8}
-            placement="bottom">
+            content={t('settings.theme.title') + ': ' + getThemeModeLabel(settedTheme)}
+            closeDelay={800}
+            placement="bottom"
+            showArrow={true}>
             <ThemeButton onClick={toggleTheme}>
               {settedTheme === ThemeMode.dark ? (
                 <Moon size={16} />

--- a/src/renderer/src/components/Tags/CustomTag.tsx
+++ b/src/renderer/src/components/Tags/CustomTag.tsx
@@ -1,5 +1,5 @@
 import { CloseOutlined } from '@ant-design/icons'
-import { Tooltip } from 'antd'
+import { Tooltip } from '@heroui/react'
 import { CSSProperties, FC, memo, MouseEventHandler, useMemo } from 'react'
 import styled from 'styled-components'
 
@@ -60,7 +60,7 @@ const CustomTag: FC<CustomTagProps> = ({
   )
 
   return tooltip ? (
-    <Tooltip title={tooltip} placement="top" mouseEnterDelay={0.3}>
+    <Tooltip content={tooltip} placement="top" closeDelay={300} showArrow={true}>
       {tagContent}
     </Tooltip>
   ) : (

--- a/src/renderer/src/components/TooltipIcons/HelpTooltip.tsx
+++ b/src/renderer/src/components/TooltipIcons/HelpTooltip.tsx
@@ -1,4 +1,4 @@
-import { Tooltip, TooltipProps } from 'antd'
+import { Tooltip, TooltipProps } from '@heroui/react'
 import { HelpCircle } from 'lucide-react'
 
 type InheritedTooltipProps = Omit<TooltipProps, 'children'>
@@ -11,7 +11,7 @@ interface HelpTooltipProps extends InheritedTooltipProps {
 
 const HelpTooltip = ({ iconColor = 'var(--color-text-2)', iconSize = 14, iconStyle, ...rest }: HelpTooltipProps) => {
   return (
-    <Tooltip {...rest}>
+    <Tooltip showArrow={true} {...rest}>
       <HelpCircle size={iconSize} color={iconColor} style={{ ...iconStyle }} role="img" aria-label="Help" />
     </Tooltip>
   )

--- a/src/renderer/src/components/TooltipIcons/InfoTooltip.tsx
+++ b/src/renderer/src/components/TooltipIcons/InfoTooltip.tsx
@@ -1,4 +1,4 @@
-import { Tooltip, TooltipProps } from 'antd'
+import { Tooltip, TooltipProps } from '@heroui/react'
 import { Info } from 'lucide-react'
 
 type InheritedTooltipProps = Omit<TooltipProps, 'children'>
@@ -11,7 +11,7 @@ interface InfoTooltipProps extends InheritedTooltipProps {
 
 const InfoTooltip = ({ iconColor = 'var(--color-text-2)', iconSize = 14, iconStyle, ...rest }: InfoTooltipProps) => {
   return (
-    <Tooltip {...rest}>
+    <Tooltip showArrow={true} {...rest}>
       <Info size={iconSize} color={iconColor} style={{ ...iconStyle }} role="img" aria-label="Information" />
     </Tooltip>
   )

--- a/src/renderer/src/components/TooltipIcons/WarnTooltip.tsx
+++ b/src/renderer/src/components/TooltipIcons/WarnTooltip.tsx
@@ -1,4 +1,4 @@
-import { Tooltip, TooltipProps } from 'antd'
+import { Tooltip, TooltipProps } from '@heroui/react'
 import { AlertTriangle } from 'lucide-react'
 
 type InheritedTooltipProps = Omit<TooltipProps, 'children'>
@@ -16,7 +16,7 @@ const WarnTooltip = ({
   ...rest
 }: WarnTooltipProps) => {
   return (
-    <Tooltip {...rest}>
+    <Tooltip showArrow={true} {...rest}>
       <AlertTriangle size={iconSize} color={iconColor} style={{ ...iconStyle }} role="img" aria-label="Information" />
     </Tooltip>
   )

--- a/src/renderer/src/components/TranslateButton.tsx
+++ b/src/renderer/src/components/TranslateButton.tsx
@@ -1,9 +1,10 @@
 import { LoadingOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import { useSettings } from '@renderer/hooks/useSettings'
 import useTranslate from '@renderer/hooks/useTranslate'
 import { translateText } from '@renderer/services/TranslateService'
-import { Button, Tooltip } from 'antd'
+import { Button } from 'antd'
 import { Languages } from 'lucide-react'
 import { FC, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -65,9 +66,9 @@ const TranslateButton: FC<Props> = ({ text, onTranslated, disabled, style, isLoa
   return (
     <Tooltip
       placement="top"
-      title={t('chat.input.translate', { target_language: getLanguageByLangcode(targetLanguage).label() })}
-      mouseLeaveDelay={0}
-      arrow>
+      content={t('chat.input.translate', { target_language: getLanguageByLangcode(targetLanguage).label() })}
+      closeDelay={0}
+      showArrow={true}>
       <ToolbarButton onClick={handleTranslate} disabled={disabled || isTranslating} style={style} type="text">
         {isTranslating ? <LoadingOutlined spin /> : <Languages size={18} />}
       </ToolbarButton>

--- a/src/renderer/src/components/WebdavBackupManager.tsx
+++ b/src/renderer/src/components/WebdavBackupManager.tsx
@@ -1,7 +1,8 @@
 import { DeleteOutlined, ExclamationCircleOutlined, ReloadOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { restoreFromWebdav } from '@renderer/services/BackupService'
 import { formatFileSize } from '@renderer/utils'
-import { Button, message, Modal, Table, Tooltip } from 'antd'
+import { Button, message, Modal, Table } from 'antd'
 import dayjs from 'dayjs'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -213,7 +214,7 @@ export function WebdavBackupManager({
         showTitle: false
       },
       render: (fileName: string) => (
-        <Tooltip placement="topLeft" title={fileName}>
+        <Tooltip placement="top-start" content={fileName} showArrow={true}>
           {fileName}
         </Tooltip>
       )

--- a/src/renderer/src/components/WindowControls/index.tsx
+++ b/src/renderer/src/components/WindowControls/index.tsx
@@ -1,5 +1,5 @@
+import { Tooltip } from '@heroui/react'
 import { isLinux, isWin } from '@renderer/config/constant'
-import { Tooltip } from 'antd'
 import { Minus, Square, X } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { SVGProps } from 'react'
@@ -85,20 +85,21 @@ const WindowControls: React.FC = () => {
 
   return (
     <WindowControlsContainer>
-      <Tooltip title={t('navbar.window.minimize')} placement="bottom" mouseEnterDelay={DEFAULT_DELAY}>
+      <Tooltip content={t('navbar.window.minimize')} placement="bottom" delay={DEFAULT_DELAY} showArrow={true}>
         <ControlButton onClick={handleMinimize} aria-label="Minimize">
           <Minus size={14} />
         </ControlButton>
       </Tooltip>
       <Tooltip
-        title={isMaximized ? t('navbar.window.restore') : t('navbar.window.maximize')}
+        content={isMaximized ? t('navbar.window.restore') : t('navbar.window.maximize')}
         placement="bottom"
-        mouseEnterDelay={DEFAULT_DELAY}>
+        delay={DEFAULT_DELAY}
+        showArrow={true}>
         <ControlButton onClick={handleMaximize} aria-label={isMaximized ? 'Restore' : 'Maximize'}>
           {isMaximized ? <WindowRestoreIcon size={14} /> : <Square size={14} />}
         </ControlButton>
       </Tooltip>
-      <Tooltip title={t('navbar.window.close')} placement="bottom" mouseEnterDelay={DEFAULT_DELAY}>
+      <Tooltip content={t('navbar.window.close')} placement="bottom" delay={DEFAULT_DELAY} showArrow={true}>
         <ControlButton $isClose onClick={handleClose} aria-label="Close">
           <X size={17} />
         </ControlButton>

--- a/src/renderer/src/components/app/PinnedMinapps.tsx
+++ b/src/renderer/src/components/app/PinnedMinapps.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import { useMinappPopup } from '@renderer/hooks/useMinappPopup'
 import { useMinapps } from '@renderer/hooks/useMinapps'
@@ -5,7 +6,7 @@ import { useRuntime } from '@renderer/hooks/useRuntime'
 import { useNavbarPosition, useSettings } from '@renderer/hooks/useSettings'
 import { MinAppType } from '@renderer/types'
 import type { MenuProps } from 'antd'
-import { Dropdown, Tooltip } from 'antd'
+import { Dropdown } from 'antd'
 import { FC, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -85,7 +86,7 @@ export const SidebarOpenedMinappTabs: FC = () => {
             const isActive = minappShow && currentMinappId === app.id
 
             return (
-              <Tooltip key={app.id} title={app.name} mouseEnterDelay={0.8} placement="right">
+              <Tooltip key={app.id} content={app.name} closeDelay={800} placement="right" showArrow={true}>
                 <Dropdown menu={{ items: menuItems }} trigger={['contextMenu']} overlayStyle={{ zIndex: 10000 }}>
                   <Icon
                     theme={theme}
@@ -126,7 +127,7 @@ export const SidebarPinnedApps: FC = () => {
         ]
         const isActive = minappShow && currentMinappId === app.id
         return (
-          <Tooltip key={app.id} title={app.name} mouseEnterDelay={0.8} placement="right">
+          <Tooltip key={app.id} content={app.name} closeDelay={800} placement="right" showArrow={true}>
             <Dropdown menu={{ items: menuItems }} trigger={['contextMenu']} overlayStyle={{ zIndex: 10000 }}>
               <Icon
                 theme={theme}

--- a/src/renderer/src/components/app/Sidebar.tsx
+++ b/src/renderer/src/components/app/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import EmojiAvatar from '@renderer/components/Avatar/EmojiAvatar'
 import { isMac } from '@renderer/config/constant'
 import { UserAvatar } from '@renderer/config/env'
@@ -12,7 +13,7 @@ import { useSettings } from '@renderer/hooks/useSettings'
 import { getSidebarIconLabel, getThemeModeLabel } from '@renderer/i18n/label'
 import { ThemeMode } from '@renderer/types'
 import { isEmoji } from '@renderer/utils'
-import { Avatar, Tooltip } from 'antd'
+import { Avatar } from 'antd'
 import {
   Code,
   FileSearch,
@@ -90,9 +91,10 @@ const Sidebar: FC = () => {
       </MainMenusContainer>
       <Menus>
         <Tooltip
-          title={t('settings.theme.title') + ': ' + getThemeModeLabel(settedTheme)}
-          mouseEnterDelay={0.8}
-          placement="right">
+          content={t('settings.theme.title') + ': ' + getThemeModeLabel(settedTheme)}
+          closeDelay={800}
+          placement="right"
+          showArrow={true}>
           <Icon theme={theme} onClick={toggleTheme}>
             {settedTheme === ThemeMode.dark ? (
               <Moon size={20} className="icon" />
@@ -103,7 +105,7 @@ const Sidebar: FC = () => {
             )}
           </Icon>
         </Tooltip>
-        <Tooltip title={t('settings.title')} mouseEnterDelay={0.8} placement="right">
+        <Tooltip content={t('settings.title')} closeDelay={800} placement="right" showArrow={true}>
           <StyledLink
             onClick={async () => {
               hideMinappPopup()
@@ -159,7 +161,7 @@ const MainMenus: FC = () => {
     const isActive = path === '/' ? isRoute(path) : isRoutes(path)
 
     return (
-      <Tooltip key={icon} title={getSidebarIconLabel(icon)} mouseEnterDelay={0.8} placement="right">
+      <Tooltip key={icon} content={getSidebarIconLabel(icon)} closeDelay={800} placement="right" showArrow={true}>
         <StyledLink
           onClick={async () => {
             hideMinappPopup()

--- a/src/renderer/src/hooks/useUserTheme.ts
+++ b/src/renderer/src/hooks/useUserTheme.ts
@@ -15,6 +15,10 @@ export default function useUserTheme() {
     document.body.style.setProperty('--primary', colorPrimary.toString())
     document.body.style.setProperty('--color-primary-soft', colorPrimary.alpha(0.6).toString())
     document.body.style.setProperty('--color-primary-mute', colorPrimary.alpha(0.3).toString())
+
+    // Set font family CSS variables
+    document.documentElement.style.setProperty('--user-font-family', `'${theme.userFontFamily}'`)
+    document.documentElement.style.setProperty('--user-code-font-family', `'${theme.userCodeFontFamily}'`)
   }
 
   return {

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -3116,6 +3116,13 @@
           "placeholder": "/* Put custom CSS here */"
         }
       },
+      "font": {
+        "code": "Code Font",
+        "default": "Default",
+        "global": "Global Font",
+        "select": "Select Font",
+        "title": "Font Settings"
+      },
       "navbar": {
         "position": {
           "label": "Navbar Position",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -3117,6 +3117,13 @@
           "placeholder": "/* 这里写自定义 CSS */"
         }
       },
+      "font": {
+        "code": "代码字体",
+        "default": "默认",
+        "global": "全局字体",
+        "select": "选择字体",
+        "title": "字体设置"
+      },
       "navbar": {
         "position": {
           "label": "导航栏位置",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -3116,6 +3116,13 @@
           "placeholder": "/* 這裡寫自訂 CSS */"
         }
       },
+      "font": {
+        "code": "[to be translated]:代码字体",
+        "default": "[to be translated]:默认",
+        "global": "[to be translated]:全局字体",
+        "select": "[to be translated]:选择字体",
+        "title": "[to be translated]:字体设置"
+      },
       "navbar": {
         "position": {
           "label": "導航欄位置",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -3117,11 +3117,11 @@
         }
       },
       "font": {
-        "code": "[to be translated]:代码字体",
-        "default": "[to be translated]:默认",
-        "global": "[to be translated]:全局字体",
-        "select": "[to be translated]:选择字体",
-        "title": "[to be translated]:字体设置"
+        "code": "程式碼字型",
+        "default": "預設",
+        "global": "全域字型",
+        "select": "選擇字體",
+        "title": "字型設定"
       },
       "navbar": {
         "position": {

--- a/src/renderer/src/i18n/translate/el-gr.json
+++ b/src/renderer/src/i18n/translate/el-gr.json
@@ -3117,11 +3117,11 @@
         }
       },
       "font": {
-        "code": "[to be translated]:代码字体",
-        "default": "[to be translated]:默认",
-        "global": "[to be translated]:全局字体",
-        "select": "[to be translated]:选择字体",
-        "title": "[to be translated]:字体设置"
+        "code": "γραμματοσειρά κώδικα",
+        "default": "προεπιλογή",
+        "global": "Γενική γραμματοσειρά",
+        "select": "Επιλέξτε γραμματοσειρά",
+        "title": "Ρύθμιση γραμματοσειράς"
       },
       "navbar": {
         "position": {

--- a/src/renderer/src/i18n/translate/el-gr.json
+++ b/src/renderer/src/i18n/translate/el-gr.json
@@ -3116,6 +3116,13 @@
           "placeholder": "/* Γράψτε εδώ την προσαρμοστική CSS */"
         }
       },
+      "font": {
+        "code": "[to be translated]:代码字体",
+        "default": "[to be translated]:默认",
+        "global": "[to be translated]:全局字体",
+        "select": "[to be translated]:选择字体",
+        "title": "[to be translated]:字体设置"
+      },
       "navbar": {
         "position": {
           "label": "Θέση Γραμμής Πλοήγησης",

--- a/src/renderer/src/i18n/translate/es-es.json
+++ b/src/renderer/src/i18n/translate/es-es.json
@@ -3116,6 +3116,13 @@
           "placeholder": "/* Escribe tu CSS personalizado aquí */"
         }
       },
+      "font": {
+        "code": "[to be translated]:代码字体",
+        "default": "[to be translated]:默认",
+        "global": "[to be translated]:全局字体",
+        "select": "[to be translated]:选择字体",
+        "title": "[to be translated]:字体设置"
+      },
       "navbar": {
         "position": {
           "label": "Posición de la barra de navegación",

--- a/src/renderer/src/i18n/translate/es-es.json
+++ b/src/renderer/src/i18n/translate/es-es.json
@@ -3117,11 +3117,11 @@
         }
       },
       "font": {
-        "code": "[to be translated]:代码字体",
-        "default": "[to be translated]:默认",
-        "global": "[to be translated]:全局字体",
-        "select": "[to be translated]:选择字体",
-        "title": "[to be translated]:字体设置"
+        "code": "fuente de código",
+        "default": "predeterminado",
+        "global": "Fuente global",
+        "select": "Seleccionar fuente",
+        "title": "Configuración de fuente"
       },
       "navbar": {
         "position": {

--- a/src/renderer/src/i18n/translate/fr-fr.json
+++ b/src/renderer/src/i18n/translate/fr-fr.json
@@ -3116,6 +3116,13 @@
           "placeholder": "/* Écrire votre CSS personnalisé ici */"
         }
       },
+      "font": {
+        "code": "[to be translated]:代码字体",
+        "default": "[to be translated]:默认",
+        "global": "[to be translated]:全局字体",
+        "select": "[to be translated]:选择字体",
+        "title": "[to be translated]:字体设置"
+      },
       "navbar": {
         "position": {
           "label": "Position de la barre de navigation",

--- a/src/renderer/src/i18n/translate/fr-fr.json
+++ b/src/renderer/src/i18n/translate/fr-fr.json
@@ -3117,11 +3117,11 @@
         }
       },
       "font": {
-        "code": "[to be translated]:代码字体",
-        "default": "[to be translated]:默认",
-        "global": "[to be translated]:全局字体",
-        "select": "[to be translated]:选择字体",
-        "title": "[to be translated]:字体设置"
+        "code": "police de code",
+        "default": "Par défaut",
+        "global": "Police de caractère globale",
+        "select": "Sélectionner la police",
+        "title": "Paramètres de police"
       },
       "navbar": {
         "position": {

--- a/src/renderer/src/i18n/translate/ja-jp.json
+++ b/src/renderer/src/i18n/translate/ja-jp.json
@@ -3116,6 +3116,13 @@
           "placeholder": "/* ここにカスタムCSSを入力 */"
         }
       },
+      "font": {
+        "code": "[to be translated]:代码字体",
+        "default": "[to be translated]:默认",
+        "global": "[to be translated]:全局字体",
+        "select": "[to be translated]:选择字体",
+        "title": "[to be translated]:字体设置"
+      },
       "navbar": {
         "position": {
           "label": "ナビゲーションバー位置",

--- a/src/renderer/src/i18n/translate/ja-jp.json
+++ b/src/renderer/src/i18n/translate/ja-jp.json
@@ -3117,11 +3117,11 @@
         }
       },
       "font": {
-        "code": "[to be translated]:代码字体",
-        "default": "[to be translated]:默认",
-        "global": "[to be translated]:全局字体",
-        "select": "[to be translated]:选择字体",
-        "title": "[to be translated]:字体设置"
+        "code": "コードフォント",
+        "default": "デフォルト",
+        "global": "グローバルフォント",
+        "select": "フォントを選択",
+        "title": "フォント設定"
       },
       "navbar": {
         "position": {

--- a/src/renderer/src/i18n/translate/pt-pt.json
+++ b/src/renderer/src/i18n/translate/pt-pt.json
@@ -3117,11 +3117,11 @@
         }
       },
       "font": {
-        "code": "[to be translated]:代码字体",
-        "default": "[to be translated]:默认",
-        "global": "[to be translated]:全局字体",
-        "select": "[to be translated]:选择字体",
-        "title": "[to be translated]:字体设置"
+        "code": "fonte de código",
+        "default": "padrão",
+        "global": "Fonte global",
+        "select": "Selecionar fonte",
+        "title": "Configuração de fonte"
       },
       "navbar": {
         "position": {

--- a/src/renderer/src/i18n/translate/pt-pt.json
+++ b/src/renderer/src/i18n/translate/pt-pt.json
@@ -3116,6 +3116,13 @@
           "placeholder": "/* Escreva seu CSS personalizado aqui */"
         }
       },
+      "font": {
+        "code": "[to be translated]:代码字体",
+        "default": "[to be translated]:默认",
+        "global": "[to be translated]:全局字体",
+        "select": "[to be translated]:选择字体",
+        "title": "[to be translated]:字体设置"
+      },
       "navbar": {
         "position": {
           "label": "Posição da Barra de Navegação",

--- a/src/renderer/src/i18n/translate/ru-ru.json
+++ b/src/renderer/src/i18n/translate/ru-ru.json
@@ -3117,11 +3117,11 @@
         }
       },
       "font": {
-        "code": "[to be translated]:代码字体",
-        "default": "[to be translated]:默认",
-        "global": "[to be translated]:全局字体",
-        "select": "[to be translated]:选择字体",
-        "title": "[to be translated]:字体设置"
+        "code": "шрифт кода",
+        "default": "по умолчанию",
+        "global": "Глобальный шрифт",
+        "select": "Выбрать шрифт",
+        "title": "Настройки шрифта"
       },
       "navbar": {
         "position": {

--- a/src/renderer/src/i18n/translate/ru-ru.json
+++ b/src/renderer/src/i18n/translate/ru-ru.json
@@ -3116,6 +3116,13 @@
           "placeholder": "/* Здесь введите пользовательский CSS */"
         }
       },
+      "font": {
+        "code": "[to be translated]:代码字体",
+        "default": "[to be translated]:默认",
+        "global": "[to be translated]:全局字体",
+        "select": "[to be translated]:选择字体",
+        "title": "[to be translated]:字体设置"
+      },
       "navbar": {
         "position": {
           "label": "Положение навигации",

--- a/src/renderer/src/pages/home/ChatNavbar.tsx
+++ b/src/renderer/src/pages/home/ChatNavbar.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import { NavbarHeader } from '@renderer/components/app/Navbar'
 import { HStack } from '@renderer/components/Layout'
 import SearchPopup from '@renderer/components/Popups/SearchPopup'
@@ -10,7 +11,6 @@ import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import { useAppDispatch } from '@renderer/store'
 import { setNarrowMode } from '@renderer/store/settings'
 import { Assistant, Topic } from '@renderer/types'
-import { Tooltip } from 'antd'
 import { t } from 'i18next'
 import { Menu, PanelLeftClose, PanelRightClose, Search } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
@@ -68,14 +68,14 @@ const HeaderNavbar: FC<Props> = ({ activeAssistant, setActiveAssistant, activeTo
     <NavbarHeader className="home-navbar">
       <HStack alignItems="center">
         {showAssistants && (
-          <Tooltip title={t('navbar.hide_sidebar')} mouseEnterDelay={0.8}>
+          <Tooltip content={t('navbar.hide_sidebar')} closeDelay={800} showArrow={true}>
             <NavbarIcon onClick={toggleShowAssistants}>
               <PanelLeftClose size={18} />
             </NavbarIcon>
           </Tooltip>
         )}
         {!showAssistants && (
-          <Tooltip title={t('navbar.show_sidebar')} mouseEnterDelay={0.8}>
+          <Tooltip content={t('navbar.show_sidebar')} closeDelay={800} showArrow={true}>
             <NavbarIcon onClick={() => toggleShowAssistants()} style={{ marginRight: 8 }}>
               <PanelRightClose size={18} />
             </NavbarIcon>
@@ -98,25 +98,25 @@ const HeaderNavbar: FC<Props> = ({ activeAssistant, setActiveAssistant, activeTo
       </HStack>
       <HStack alignItems="center" gap={8}>
         <UpdateAppButton />
-        <Tooltip title={t('navbar.expand')} mouseEnterDelay={0.8}>
+        <Tooltip content={t('navbar.expand')} closeDelay={800} showArrow={true}>
           <NarrowIcon onClick={handleNarrowModeToggle}>
             <i className="iconfont icon-icon-adaptive-width"></i>
           </NarrowIcon>
         </Tooltip>
-        <Tooltip title={t('chat.assistant.search.placeholder')} mouseEnterDelay={0.8}>
+        <Tooltip content={t('chat.assistant.search.placeholder')} closeDelay={800} showArrow={true}>
           <NavbarIcon onClick={() => SearchPopup.show()}>
             <Search size={18} />
           </NavbarIcon>
         </Tooltip>
         {topicPosition === 'right' && !showTopics && (
-          <Tooltip title={t('navbar.show_sidebar')} mouseEnterDelay={2}>
+          <Tooltip content={t('navbar.show_sidebar')} closeDelay={2000} showArrow={true}>
             <NavbarIcon onClick={toggleShowTopics}>
               <PanelLeftClose size={18} />
             </NavbarIcon>
           </Tooltip>
         )}
         {topicPosition === 'right' && showTopics && (
-          <Tooltip title={t('navbar.hide_sidebar')} mouseEnterDelay={2}>
+          <Tooltip content={t('navbar.hide_sidebar')} closeDelay={2000} showArrow={true}>
             <NavbarIcon onClick={toggleShowTopics}>
               <PanelRightClose size={18} />
             </NavbarIcon>

--- a/src/renderer/src/pages/home/Inputbar/AttachmentButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/AttachmentButton.tsx
@@ -1,6 +1,6 @@
+import { Tooltip } from '@heroui/react'
 import { FileType } from '@renderer/types'
 import { filterSupportedFiles } from '@renderer/utils/file'
-import { Tooltip } from 'antd'
 import { Paperclip } from 'lucide-react'
 import { FC, useCallback, useImperativeHandle, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -81,9 +81,9 @@ const AttachmentButton: FC<Props> = ({
   return (
     <Tooltip
       placement="top"
-      title={couldAddImageFile ? t('chat.input.upload.label') : t('chat.input.upload.document')}
-      mouseLeaveDelay={0}
-      arrow>
+      content={couldAddImageFile ? t('chat.input.upload.label') : t('chat.input.upload.document')}
+      closeDelay={0}
+      showArrow={true}>
       <ToolbarButton type="text" onClick={onSelectFile} disabled={disabled}>
         <Paperclip size={18} style={{ color: files.length ? 'var(--color-primary)' : 'var(--color-icon)' }} />
       </ToolbarButton>

--- a/src/renderer/src/pages/home/Inputbar/AttachmentPreview.tsx
+++ b/src/renderer/src/pages/home/Inputbar/AttachmentPreview.tsx
@@ -12,12 +12,13 @@ import {
   GlobalOutlined,
   LinkOutlined
 } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import CustomTag from '@renderer/components/Tags/CustomTag'
 import { useAttachment } from '@renderer/hooks/useAttachment'
 import FileManager from '@renderer/services/FileManager'
 import { FileMetadata } from '@renderer/types'
 import { formatFileSize } from '@renderer/utils'
-import { Flex, Image, Tooltip } from 'antd'
+import { Flex, Image } from 'antd'
 import { isEmpty } from 'lodash'
 import { FC, useState } from 'react'
 import styled from 'styled-components'
@@ -93,13 +94,8 @@ export const FileNameRender: FC<{ file: FileMetadata }> = ({ file }) => {
 
   return (
     <Tooltip
-      styles={{
-        body: {
-          padding: 5
-        }
-      }}
-      fresh
-      title={
+      showArrow={true}
+      content={
         <Flex vertical gap={2} align="center">
           {isImage(file.ext) && (
             <Image

--- a/src/renderer/src/pages/home/Inputbar/GenerateImageButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/GenerateImageButton.tsx
@@ -1,6 +1,6 @@
+import { Tooltip } from '@heroui/react'
 import { isGenerateImageModel } from '@renderer/config/models'
 import { Assistant, Model } from '@renderer/types'
-import { Tooltip } from 'antd'
 import { Image } from 'lucide-react'
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -18,11 +18,11 @@ const GenerateImageButton: FC<Props> = ({ model, ToolbarButton, assistant, onEna
   return (
     <Tooltip
       placement="top"
-      title={
+      content={
         isGenerateImageModel(model) ? t('chat.input.generate_image') : t('chat.input.generate_image_not_supported')
       }
-      mouseLeaveDelay={0}
-      arrow>
+      closeDelay={0}
+      showArrow={true}>
       <ToolbarButton type="text" disabled={!isGenerateImageModel(model)} onClick={onEnableGenerateImage}>
         <Image size={18} color={assistant.enableGenerateImage ? 'var(--color-primary)' : 'var(--color-icon)'} />
       </ToolbarButton>

--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -1,4 +1,5 @@
 import { HolderOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import { QuickPanelView, useQuickPanel } from '@renderer/components/QuickPanel'
 import TranslateButton from '@renderer/components/TranslateButton'
@@ -49,7 +50,7 @@ import {
 import { isPromptToolUse, isSupportedToolUse } from '@renderer/utils/mcp-tools'
 import { documentExts, imageExts, textExts } from '@shared/config/constant'
 import { IpcChannel } from '@shared/IpcChannel'
-import { Button, Tooltip } from 'antd'
+import { Button } from 'antd'
 import TextArea, { TextAreaRef } from 'antd/es/input/TextArea'
 import dayjs from 'dayjs'
 import { debounce, isEmpty } from 'lodash'
@@ -955,7 +956,7 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
               <TranslateButton text={text} onTranslated={onTranslated} isLoading={isTranslating} />
               <SendMessageButton sendMessage={sendMessage} disabled={inputEmpty} />
               {loading && (
-                <Tooltip placement="top" title={t('chat.input.pause')} mouseLeaveDelay={0} arrow>
+                <Tooltip placement="top" content={t('chat.input.pause')} closeDelay={0} showArrow={true}>
                   <ToolbarButton type="text" onClick={onPause} style={{ marginRight: -2 }}>
                     <CirclePause size={20} color="var(--color-error)" />
                   </ToolbarButton>

--- a/src/renderer/src/pages/home/Inputbar/InputbarTools.tsx
+++ b/src/renderer/src/pages/home/Inputbar/InputbarTools.tsx
@@ -1,4 +1,5 @@
 import { DragDropContext, Draggable, Droppable, DropResult } from '@hello-pangea/dnd'
+import { Tooltip } from '@heroui/react'
 import { QuickPanelListItem } from '@renderer/components/QuickPanel'
 import { isGeminiModel, isGenerateImageModel, isMandatoryWebSearchModel } from '@renderer/config/models'
 import { isSupportUrlContextProvider } from '@renderer/config/providers'
@@ -7,7 +8,7 @@ import { useAppDispatch, useAppSelector } from '@renderer/store'
 import { setIsCollapsed, setToolOrder } from '@renderer/store/inputTools'
 import { Assistant, FileType, KnowledgeBase, Model } from '@renderer/types'
 import { classNames } from '@renderer/utils'
-import { Divider, Dropdown, Tooltip } from 'antd'
+import { Divider, Dropdown } from 'antd'
 import { ItemType } from 'antd/es/menu/interface'
 import {
   AtSign,
@@ -310,9 +311,9 @@ const InputbarTools = ({
         component: (
           <Tooltip
             placement="top"
-            title={t('chat.input.new_topic', { Command: newTopicShortcut })}
-            mouseLeaveDelay={0}
-            arrow>
+            content={t('chat.input.new_topic', { Command: newTopicShortcut })}
+            closeDelay={0}
+            showArrow={true}>
             <ToolbarButton type="text" onClick={addNewTopic}>
               <MessageSquareDiff size={19} />
             </ToolbarButton>
@@ -429,9 +430,9 @@ const InputbarTools = ({
         component: (
           <Tooltip
             placement="top"
-            title={t('chat.input.clear.label', { Command: cleanTopicShortcut })}
-            mouseLeaveDelay={0}
-            arrow>
+            content={t('chat.input.clear.label', { Command: cleanTopicShortcut })}
+            closeDelay={0}
+            showArrow={true}>
             <ToolbarButton type="text" onClick={clearTopic}>
               <PaintbrushVertical size={18} />
             </ToolbarButton>
@@ -444,9 +445,9 @@ const InputbarTools = ({
         component: (
           <Tooltip
             placement="top"
-            title={isExpended ? t('chat.input.collapse') : t('chat.input.expand')}
-            mouseLeaveDelay={0}
-            arrow>
+            content={isExpended ? t('chat.input.collapse') : t('chat.input.expand')}
+            closeDelay={0}
+            showArrow={true}>
             <ToolbarButton type="text" onClick={onToggleExpended}>
               {isExpended ? <Minimize size={18} /> : <Maximize size={18} />}
             </ToolbarButton>
@@ -626,8 +627,8 @@ const InputbarTools = ({
         {showCollapseButton && (
           <Tooltip
             placement="top"
-            title={isCollapse ? t('chat.input.tools.expand') : t('chat.input.tools.collapse')}
-            arrow>
+            content={isCollapse ? t('chat.input.tools.expand') : t('chat.input.tools.collapse')}
+            showArrow={true}>
             <ToolbarButton type="text" onClick={() => dispatch(setIsCollapsed(!isCollapse))}>
               <CircleChevronRight
                 size={18}

--- a/src/renderer/src/pages/home/Inputbar/KnowledgeBaseButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/KnowledgeBaseButton.tsx
@@ -1,7 +1,7 @@
+import { Tooltip } from '@heroui/react'
 import { QuickPanelListItem, useQuickPanel } from '@renderer/components/QuickPanel'
 import { useAppSelector } from '@renderer/store'
 import { KnowledgeBase } from '@renderer/types'
-import { Tooltip } from 'antd'
 import { CircleX, FileSearch, Plus } from 'lucide-react'
 import { FC, memo, useCallback, useEffect, useImperativeHandle, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -106,7 +106,7 @@ const KnowledgeBaseButton: FC<Props> = ({ ref, selectedBases, onSelect, disabled
   }))
 
   return (
-    <Tooltip placement="top" title={t('chat.input.knowledge_base')} mouseLeaveDelay={0} arrow>
+    <Tooltip placement="top" content={t('chat.input.knowledge_base')} closeDelay={0} showArrow={true}>
       <ToolbarButton type="text" onClick={handleOpenQuickPanel} disabled={disabled}>
         <FileSearch
           size={18}

--- a/src/renderer/src/pages/home/Inputbar/MCPToolsButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/MCPToolsButton.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import { QuickPanelListItem, useQuickPanel } from '@renderer/components/QuickPanel'
 import { isGeminiModel } from '@renderer/config/models'
 import { isGeminiWebSearchProvider, isSupportUrlContextProvider } from '@renderer/config/providers'
@@ -8,7 +9,7 @@ import { getProviderByModel } from '@renderer/services/AssistantService'
 import { EventEmitter } from '@renderer/services/EventService'
 import { Assistant, MCPPrompt, MCPResource, MCPServer } from '@renderer/types'
 import { isToolUseModeFunction } from '@renderer/utils/assistant'
-import { Form, Input, Tooltip } from 'antd'
+import { Form, Input } from 'antd'
 import { CircleX, Hammer, Plus } from 'lucide-react'
 import React, { FC, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -485,7 +486,7 @@ const MCPToolsButton: FC<Props> = ({ ref, setInputValue, resizeTextArea, Toolbar
   }))
 
   return (
-    <Tooltip placement="top" title={t('settings.mcp.title')} mouseLeaveDelay={0} arrow>
+    <Tooltip placement="top" content={t('settings.mcp.title')} closeDelay={0} showArrow={true}>
       <ToolbarButton type="text" onClick={handleOpenQuickPanel}>
         <Hammer
           size={18}

--- a/src/renderer/src/pages/home/Inputbar/MentionModelsButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/MentionModelsButton.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import ModelTagsWithLabel from '@renderer/components/ModelTagsWithLabel'
 import { useQuickPanel } from '@renderer/components/QuickPanel'
 import { QuickPanelListItem } from '@renderer/components/QuickPanel/types'
@@ -7,7 +8,7 @@ import { useProviders } from '@renderer/hooks/useProvider'
 import { getModelUniqId } from '@renderer/services/ModelService'
 import { FileType, Model } from '@renderer/types'
 import { getFancyProviderName } from '@renderer/utils'
-import { Avatar, Tooltip } from 'antd'
+import { Avatar } from 'antd'
 import { useLiveQuery } from 'dexie-react-hooks'
 import { first, sortBy } from 'lodash'
 import { AtSign, CircleX, Plus } from 'lucide-react'
@@ -306,7 +307,7 @@ const MentionModelsButton: FC<Props> = ({
   }))
 
   return (
-    <Tooltip placement="top" title={t('agents.edit.model.select.title')} mouseLeaveDelay={0} arrow>
+    <Tooltip placement="top" content={t('agents.edit.model.select.title')} closeDelay={0} showArrow={true}>
       <ToolbarButton type="text" onClick={handleOpenQuickPanel}>
         <AtSign size={18} color={mentionedModels.length > 0 ? 'var(--color-primary)' : 'var(--color-icon)'} />
       </ToolbarButton>

--- a/src/renderer/src/pages/home/Inputbar/NewContextButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/NewContextButton.tsx
@@ -1,5 +1,5 @@
+import { Tooltip } from '@heroui/react'
 import { useShortcut, useShortcutDisplay } from '@renderer/hooks/useShortcuts'
-import { Tooltip } from 'antd'
 import { Eraser } from 'lucide-react'
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -18,9 +18,9 @@ const NewContextButton: FC<Props> = ({ onNewContext, ToolbarButton }) => {
   return (
     <Tooltip
       placement="top"
-      title={t('chat.input.new.context', { Command: newContextShortcut })}
-      mouseLeaveDelay={0}
-      arrow>
+      content={t('chat.input.new.context', { Command: newContextShortcut })}
+      closeDelay={0}
+      showArrow={true}>
       <ToolbarButton type="text" onClick={onNewContext}>
         <Eraser size={18} />
       </ToolbarButton>

--- a/src/renderer/src/pages/home/Inputbar/QuickPhrasesButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/QuickPhrasesButton.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import { useQuickPanel } from '@renderer/components/QuickPanel'
 import { QuickPanelListItem, QuickPanelOpenOptions } from '@renderer/components/QuickPanel/types'
 import { useAssistant } from '@renderer/hooks/useAssistant'
@@ -6,7 +7,7 @@ import QuickPhraseService from '@renderer/services/QuickPhraseService'
 import { useAppSelector } from '@renderer/store'
 import { QuickPhrase } from '@renderer/types'
 import { Assistant } from '@renderer/types'
-import { Input, Modal, Radio, Space, Tooltip } from 'antd'
+import { Input, Modal, Radio, Space } from 'antd'
 import { BotMessageSquare, Plus, Zap } from 'lucide-react'
 import { memo, useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -158,7 +159,7 @@ const QuickPhrasesButton = ({ ref, setInputValue, resizeTextArea, ToolbarButton,
 
   return (
     <>
-      <Tooltip placement="top" title={t('settings.quickPhrase.title')} mouseLeaveDelay={0} arrow>
+      <Tooltip placement="top" content={t('settings.quickPhrase.title')} closeDelay={0} showArrow={true}>
         <ToolbarButton type="text" onClick={handleOpenQuickPanel}>
           <Zap size={18} />
         </ToolbarButton>

--- a/src/renderer/src/pages/home/Inputbar/ThinkingButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/ThinkingButton.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import {
   MdiLightbulbAutoOutline,
   MdiLightbulbOffOutline,
@@ -11,7 +12,6 @@ import { getThinkModelType, isDoubaoThinkingAutoModel, MODEL_SUPPORTED_OPTIONS }
 import { useAssistant } from '@renderer/hooks/useAssistant'
 import { getReasoningEffortOptionsLabel } from '@renderer/i18n/label'
 import { Assistant, Model, ThinkingOption } from '@renderer/types'
-import { Tooltip } from 'antd'
 import { FC, ReactElement, useCallback, useImperativeHandle, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -144,13 +144,13 @@ const ThinkingButton: FC<Props> = ({ ref, model, assistant, ToolbarButton }): Re
   return (
     <Tooltip
       placement="top"
-      title={
+      content={
         isThinkingEnabled && supportedOptions.includes('off')
           ? t('common.close')
           : t('assistants.settings.reasoning_effort.label')
       }
-      mouseLeaveDelay={0}
-      arrow>
+      closeDelay={0}
+      showArrow={true}>
       <ToolbarButton type="text" onClick={handleOpenQuickPanel}>
         {getThinkingIcon()}
       </ToolbarButton>

--- a/src/renderer/src/pages/home/Inputbar/UrlContextbutton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/UrlContextbutton.tsx
@@ -1,8 +1,8 @@
+import { Tooltip } from '@heroui/react'
 import { useAssistant } from '@renderer/hooks/useAssistant'
 import { useTimer } from '@renderer/hooks/useTimer'
 import { Assistant } from '@renderer/types'
 import { isToolUseModeFunction } from '@renderer/utils/assistant'
-import { Tooltip } from 'antd'
 import { Link } from 'lucide-react'
 import { FC, memo, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -47,7 +47,7 @@ const UrlContextButton: FC<Props> = ({ assistant, ToolbarButton }) => {
   }, [setTimeoutTimer, assistant, urlContentNewState, updateAssistant, t])
 
   return (
-    <Tooltip placement="top" title={t('chat.input.url_context')} arrow>
+    <Tooltip placement="top" content={t('chat.input.url_context')} showArrow={true}>
       <ToolbarButton type="text" onClick={handleToggle}>
         <Link
           size={18}

--- a/src/renderer/src/pages/home/Inputbar/WebSearchButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/WebSearchButton.tsx
@@ -1,4 +1,5 @@
 import { BaiduOutlined, GoogleOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import { BingLogo, BochaLogo, ExaLogo, SearXNGLogo, TavilyLogo, ZhipuLogo } from '@renderer/components/Icons'
 import { QuickPanelListItem, useQuickPanel } from '@renderer/components/QuickPanel'
@@ -12,7 +13,6 @@ import WebSearchService from '@renderer/services/WebSearchService'
 import { Assistant, WebSearchProvider, WebSearchProviderId } from '@renderer/types'
 import { hasObjectKey } from '@renderer/utils'
 import { isToolUseModeFunction } from '@renderer/utils/assistant'
-import { Tooltip } from 'antd'
 import { Globe } from 'lucide-react'
 import { FC, memo, useCallback, useImperativeHandle, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -195,9 +195,9 @@ const WebSearchButton: FC<Props> = ({ ref, assistant, ToolbarButton }) => {
   return (
     <Tooltip
       placement="top"
-      title={enableWebSearch ? t('common.close') : t('chat.input.web_search.label')}
-      mouseLeaveDelay={0}
-      arrow>
+      content={enableWebSearch ? t('common.close') : t('chat.input.web_search.label')}
+      closeDelay={0}
+      showArrow={true}>
       <ToolbarButton type="text" onClick={onClick}>
         <WebSearchIcon color={color} pid={assistant.webSearchProviderId} />
       </ToolbarButton>

--- a/src/renderer/src/pages/home/Markdown/CitationTooltip.tsx
+++ b/src/renderer/src/pages/home/Markdown/CitationTooltip.tsx
@@ -1,8 +1,18 @@
+import { Tooltip } from '@heroui/react'
 import Favicon from '@renderer/components/Icons/FallbackFavicon'
-import { Tooltip } from 'antd'
 import React, { memo, useCallback, useMemo } from 'react'
-import styled from 'styled-components'
+import styled, { createGlobalStyle } from 'styled-components'
 import { z } from 'zod'
+
+const CitationTooltipStyles = createGlobalStyle`
+  .citation-tooltip-content {
+    background: var(--color-background) !important;
+    border: 1px solid var(--color-border) !important;
+    padding: 12px !important;
+    border-radius: 8px !important;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15) !important;
+  }
+`
 
 export const CitationSchema = z.object({
   url: z.url(),
@@ -56,20 +66,18 @@ const CitationTooltip: React.FC<CitationTooltipProps> = ({ children, citation })
   )
 
   return (
-    <Tooltip
-      arrow={false}
-      overlay={tooltipContent}
-      placement="top"
-      color="var(--color-background)"
-      styles={{
-        body: {
-          border: '1px solid var(--color-border)',
-          padding: '12px',
-          borderRadius: '8px'
-        }
-      }}>
-      {children}
-    </Tooltip>
+    <>
+      <CitationTooltipStyles />
+      <Tooltip
+        showArrow={false}
+        content={tooltipContent}
+        placement="top"
+        classNames={{
+          content: 'citation-tooltip-content'
+        }}>
+        {children}
+      </Tooltip>
+    </>
   )
 }
 

--- a/src/renderer/src/pages/home/Markdown/Table.tsx
+++ b/src/renderer/src/pages/home/Markdown/Table.tsx
@@ -1,8 +1,8 @@
+import { Tooltip } from '@heroui/react'
 import { CopyIcon } from '@renderer/components/Icons'
 import { useTemporaryValue } from '@renderer/hooks/useTemporaryValue'
 import store from '@renderer/store'
 import { messageBlocksSelectors } from '@renderer/store/messageBlock'
-import { Tooltip } from 'antd'
 import { Check } from 'lucide-react'
 import React, { memo, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -40,7 +40,7 @@ const Table: React.FC<Props> = ({ children, node, blockId }) => {
     <TableWrapper className="table-wrapper">
       <table>{children}</table>
       <ToolbarWrapper className="table-toolbar">
-        <Tooltip title={t('common.copy')} mouseEnterDelay={0.8}>
+        <Tooltip content={t('common.copy')} closeDelay={800} showArrow={true}>
           <ToolButton role="button" aria-label={t('common.copy')} onClick={handleCopyTable}>
             {copied ? <Check size={14} color="var(--color-primary)" /> : <CopyIcon size={14} />}
           </ToolButton>

--- a/src/renderer/src/pages/home/Messages/Blocks/ThinkingBlock.tsx
+++ b/src/renderer/src/pages/home/Messages/Blocks/ThinkingBlock.tsx
@@ -1,10 +1,11 @@
 import { CheckOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import ThinkingEffect from '@renderer/components/ThinkingEffect'
 import { useSettings } from '@renderer/hooks/useSettings'
 import { useTemporaryValue } from '@renderer/hooks/useTemporaryValue'
 import { MessageBlockStatus, type ThinkingMessageBlock } from '@renderer/types/newMessage'
-import { Collapse, message as antdMessage, Tooltip } from 'antd'
+import { Collapse, message as antdMessage } from 'antd'
 import { memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -79,7 +80,7 @@ const ThinkingBlock: React.FC<Props> = ({ block }) => {
                 fontSize
               }}>
               {!isThinking && (
-                <Tooltip title={t('common.copy')} mouseEnterDelay={0.8}>
+                <Tooltip content={t('common.copy')} closeDelay={0.8} showArrow={true}>
                   <ActionButton
                     className="message-action-button"
                     onClick={(e) => {

--- a/src/renderer/src/pages/home/Messages/ChatFlowHistory.tsx
+++ b/src/renderer/src/pages/home/Messages/ChatFlowHistory.tsx
@@ -1,6 +1,7 @@
 import '@xyflow/react/dist/style.css'
 
 import { RobotOutlined, UserOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import EmojiAvatar from '@renderer/components/Avatar/EmojiAvatar'
 import ModelAvatar from '@renderer/components/Avatar/ModelAvatar'
 import { getModelLogo } from '@renderer/config/models'
@@ -16,7 +17,7 @@ import { isEmoji } from '@renderer/utils'
 import { getMainTextContent } from '@renderer/utils/messageUtils/find'
 import { Controls, Handle, MiniMap, ReactFlow, ReactFlowProvider } from '@xyflow/react'
 import { Edge, Node, NodeTypes, Position, useEdgesState, useNodesState } from '@xyflow/react'
-import { Avatar, Spin, Tooltip } from 'antd'
+import { Avatar, Spin } from 'antd'
 import { isEqual } from 'lodash'
 import { FC, memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -138,7 +139,7 @@ const CustomNode: FC<{ data: any }> = ({ data }) => {
 
   return (
     <Tooltip
-      title={
+      content={
         <TooltipContent>
           <TooltipTitle>{title}</TooltipTitle>
           <TooltipBody>{data.content}</TooltipBody>
@@ -146,10 +147,8 @@ const CustomNode: FC<{ data: any }> = ({ data }) => {
         </TooltipContent>
       }
       placement="top"
-      color="rgba(0, 0, 0, 0.85)"
-      mouseEnterDelay={0.3}
-      mouseLeaveDelay={0.1}
-      destroyOnHidden>
+      closeDelay={0.3}
+      showArrow={true}>
       <CustomNodeContainer
         style={{
           borderColor,

--- a/src/renderer/src/pages/home/Messages/ChatNavigation.tsx
+++ b/src/renderer/src/pages/home/Messages/ChatNavigation.tsx
@@ -6,10 +6,11 @@ import {
   VerticalAlignBottomOutlined,
   VerticalAlignTopOutlined
 } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { useSettings } from '@renderer/hooks/useSettings'
 import { RootState } from '@renderer/store'
 // import { selectCurrentTopicId } from '@renderer/store/newMessage'
-import { Button, Drawer, Tooltip } from 'antd'
+import { Button, Drawer } from 'antd'
 import { FC, useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
@@ -334,7 +335,7 @@ const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
     <>
       <NavigationContainer $isVisible={isVisible} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
         <ButtonGroup>
-          <Tooltip title={t('chat.navigation.close')} placement="left" mouseEnterDelay={0.5}>
+          <Tooltip content={t('chat.navigation.close')} placement="left" closeDelay={0.5} showArrow={true}>
             <NavigationButton
               type="text"
               icon={<CloseOutlined />}
@@ -343,7 +344,7 @@ const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
             />
           </Tooltip>
           <Divider />
-          <Tooltip title={t('chat.navigation.top')} placement="left" mouseEnterDelay={0.5}>
+          <Tooltip content={t('chat.navigation.top')} placement="left" closeDelay={0.5} showArrow={true}>
             <NavigationButton
               type="text"
               icon={<VerticalAlignTopOutlined />}
@@ -352,7 +353,7 @@ const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
             />
           </Tooltip>
           <Divider />
-          <Tooltip title={t('chat.navigation.prev')} placement="left" mouseEnterDelay={0.5}>
+          <Tooltip content={t('chat.navigation.prev')} placement="left" closeDelay={0.5} showArrow={true}>
             <NavigationButton
               type="text"
               icon={<ArrowUpOutlined />}
@@ -361,7 +362,7 @@ const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
             />
           </Tooltip>
           <Divider />
-          <Tooltip title={t('chat.navigation.next')} placement="left" mouseEnterDelay={0.5}>
+          <Tooltip content={t('chat.navigation.next')} placement="left" closeDelay={0.5} showArrow={true}>
             <NavigationButton
               type="text"
               icon={<ArrowDownOutlined />}
@@ -370,7 +371,7 @@ const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
             />
           </Tooltip>
           <Divider />
-          <Tooltip title={t('chat.navigation.bottom')} placement="left" mouseEnterDelay={0.5}>
+          <Tooltip content={t('chat.navigation.bottom')} placement="left" closeDelay={0.5} showArrow={true}>
             <NavigationButton
               type="text"
               icon={<VerticalAlignBottomOutlined />}
@@ -379,7 +380,7 @@ const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
             />
           </Tooltip>
           <Divider />
-          <Tooltip title={t('chat.navigation.history')} placement="left" mouseEnterDelay={0.5}>
+          <Tooltip content={t('chat.navigation.history')} placement="left" closeDelay={0.5} showArrow={true}>
             <NavigationButton
               type="text"
               icon={<HistoryOutlined />}

--- a/src/renderer/src/pages/home/Messages/MessageEditor.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageEditor.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import CustomTag from '@renderer/components/Tags/CustomTag'
 import TranslateButton from '@renderer/components/TranslateButton'
@@ -16,7 +17,7 @@ import { getFilesFromDropEvent, isSendMessageKeyPressed } from '@renderer/utils/
 import { createFileBlock, createImageBlock } from '@renderer/utils/messageUtils/create'
 import { findAllBlocks } from '@renderer/utils/messageUtils/find'
 import { documentExts, imageExts, textExts } from '@shared/config/constant'
-import { Space, Tooltip } from 'antd'
+import { Space } from 'antd'
 import TextArea, { TextAreaRef } from 'antd/es/input/TextArea'
 import { Save, Send, X } from 'lucide-react'
 import { FC, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -352,18 +353,18 @@ const MessageBlockEditor: FC<Props> = ({ message, topicId, onSave, onResend, onC
         </ActionBarLeft>
         <ActionBarMiddle />
         <ActionBarRight>
-          <Tooltip title={t('common.cancel')}>
+          <Tooltip content={t('common.cancel')} showArrow={true}>
             <ToolbarButton type="text" onClick={onCancel}>
               <X size={16} />
             </ToolbarButton>
           </Tooltip>
-          <Tooltip title={t('common.save')}>
+          <Tooltip content={t('common.save')} showArrow={true}>
             <ToolbarButton type="text" onClick={handleSave}>
               <Save size={16} />
             </ToolbarButton>
           </Tooltip>
           {message.role === 'user' && (
-            <Tooltip title={t('chat.resend')}>
+            <Tooltip content={t('chat.resend')} showArrow={true}>
               <ToolbarButton type="text" onClick={handleResend}>
                 <Send size={16} />
               </ToolbarButton>

--- a/src/renderer/src/pages/home/Messages/MessageGroupMenuBar.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageGroupMenuBar.tsx
@@ -6,6 +6,7 @@ import {
   NumberOutlined,
   ReloadOutlined
 } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { HStack } from '@renderer/components/Layout'
 import { useAssistant } from '@renderer/hooks/useAssistant'
 import { useMessageOperations } from '@renderer/hooks/useMessageOperations'
@@ -14,7 +15,7 @@ import type { Topic } from '@renderer/types'
 import type { Message } from '@renderer/types/newMessage'
 import { AssistantMessageStatus } from '@renderer/types/newMessage'
 import { getMainTextContent } from '@renderer/utils/messageUtils/find'
-import { Button, Tooltip } from 'antd'
+import { Button } from 'antd'
 import { FC, memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -105,9 +106,10 @@ const MessageGroupMenuBar: FC<Props> = ({
         <LayoutContainer>
           {(['fold', 'vertical', 'horizontal', 'grid'] as const).map((layout) => (
             <Tooltip
-              mouseEnterDelay={0.5}
+              closeDelay={0.5}
               key={layout}
-              title={t('message.message.multi_model_style.label') + ': ' + multiModelMessageStyleTextByLayout[layout]}>
+              content={t('message.message.multi_model_style.label') + ': ' + multiModelMessageStyleTextByLayout[layout]}
+              showArrow={true}>
               <LayoutOption
                 $active={multiModelMessageStyle === layout}
                 onClick={() => setMultiModelMessageStyle(layout)}>
@@ -134,7 +136,7 @@ const MessageGroupMenuBar: FC<Props> = ({
         {multiModelMessageStyle === 'grid' && <MessageGroupSettings />}
       </HStack>
       {hasFailedMessages && (
-        <Tooltip title={t('message.group.retry_failed')} mouseEnterDelay={0.6}>
+        <Tooltip content={t('message.group.retry_failed')} closeDelay={0.6} showArrow={true}>
           <Button
             type="text"
             size="small"

--- a/src/renderer/src/pages/home/Messages/MessageGroupModelList.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageGroupModelList.tsx
@@ -1,4 +1,5 @@
 import { ArrowsAltOutlined, ShrinkOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import ModelAvatar from '@renderer/components/Avatar/ModelAvatar'
 import { HStack } from '@renderer/components/Layout'
 import Scrollbar from '@renderer/components/Scrollbar'
@@ -8,7 +9,7 @@ import { setFoldDisplayMode } from '@renderer/store/settings'
 import type { Model } from '@renderer/types'
 import { AssistantMessageStatus, type Message } from '@renderer/types/newMessage'
 import { lightbulbSoftVariants } from '@renderer/utils/motionVariants'
-import { Avatar, Segmented as AntdSegmented, Tooltip } from 'antd'
+import { Avatar, Segmented as AntdSegmented } from 'antd'
 import { motion } from 'motion/react'
 import { FC, memo, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -43,7 +44,7 @@ const MessageGroupModelList: FC<MessageGroupModelListProps> = ({ messages, selec
 
       if (isCompact) {
         return (
-          <Tooltip key={message.id} title={modelTip} mouseEnterDelay={0.5} mouseLeaveDelay={0}>
+          <Tooltip key={message.id} content={modelTip} closeDelay={0.5} showArrow={true}>
             <AvatarWrapper
               className="avatar-wrapper"
               $isSelected={message.id === selectMessageId}
@@ -70,14 +71,14 @@ const MessageGroupModelList: FC<MessageGroupModelListProps> = ({ messages, selec
   return (
     <Container>
       <Tooltip
-        title={
+        content={
           isCompact
             ? t('message.message.multi_model_style.fold.expand')
             : t('message.message.multi_model_style.fold.compress')
         }
         placement="top"
-        mouseEnterDelay={0.5}
-        mouseLeaveDelay={0}>
+        closeDelay={0.5}
+        showArrow={true}>
         <DisplayModeToggle
           displayMode={foldDisplayMode}
           onClick={() => dispatch(setFoldDisplayMode(isCompact ? 'expanded' : 'compact'))}>

--- a/src/renderer/src/pages/home/Messages/MessageHeader.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageHeader.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import EmojiAvatar from '@renderer/components/Avatar/EmojiAvatar'
 import { HStack } from '@renderer/components/Layout'
 import UserPopup from '@renderer/components/Popups/UserPopup'
@@ -13,7 +14,7 @@ import { getModelName } from '@renderer/services/ModelService'
 import type { Assistant, Model, Topic } from '@renderer/types'
 import type { Message } from '@renderer/types/newMessage'
 import { firstLetter, isEmoji, removeLeadingEmoji } from '@renderer/utils'
-import { Avatar, Checkbox, Tooltip } from 'antd'
+import { Avatar, Checkbox } from 'antd'
 import dayjs from 'dayjs'
 import { Sparkle } from 'lucide-react'
 import { FC, memo, useCallback, useMemo } from 'react'
@@ -115,7 +116,7 @@ const MessageHeader: FC<Props> = memo(({ assistant, model, message, topic, isGro
             {username}
           </UserName>
           {isGroupContextMessage && (
-            <Tooltip title={t('chat.message.useful.tip')}>
+            <Tooltip content={t('chat.message.useful.tip')} showArrow={true}>
               <Sparkle fill="var(--color-primary)" strokeWidth={0} size={18} />
             </Tooltip>
           )}

--- a/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
@@ -1,4 +1,5 @@
 // import { InfoCircleOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import { CopyIcon, DeleteIcon, EditIcon, RefreshIcon } from '@renderer/components/Icons'
 import ObsidianExportPopup from '@renderer/components/Popups/ObsidianExportPopup'
@@ -40,7 +41,7 @@ import {
   findTranslationBlocksById,
   getMainTextContent
 } from '@renderer/utils/messageUtils/find'
-import { Dropdown, Popconfirm, Tooltip } from 'antd'
+import { Dropdown, Popconfirm } from 'antd'
 import dayjs from 'dayjs'
 import {
   AtSign,
@@ -473,7 +474,7 @@ const MessageMenubar: FC<Props> = (props) => {
               okButtonProps={{ danger: true }}
               onConfirm={() => handleResendUserMessage()}
               onOpenChange={(open) => open && setShowDeleteTooltip(false)}>
-              <Tooltip title={t('common.regenerate')} mouseEnterDelay={0.8}>
+              <Tooltip content={t('common.regenerate')} closeDelay={0.8} showArrow={true}>
                 <ActionButton
                   className="message-action-button"
                   onClick={(e) => e.stopPropagation()}
@@ -483,7 +484,7 @@ const MessageMenubar: FC<Props> = (props) => {
               </Tooltip>
             </Popconfirm>
           ) : (
-            <Tooltip title={t('common.regenerate')} mouseEnterDelay={0.8}>
+            <Tooltip content={t('common.regenerate')} closeDelay={0.8} showArrow={true}>
               <ActionButton
                 className="message-action-button"
                 onClick={() => handleResendUserMessage()}
@@ -493,13 +494,13 @@ const MessageMenubar: FC<Props> = (props) => {
             </Tooltip>
           ))}
         {message.role === 'user' && (
-          <Tooltip title={t('common.edit')} mouseEnterDelay={0.8}>
+          <Tooltip content={t('common.edit')} closeDelay={0.8} showArrow={true}>
             <ActionButton className="message-action-button" onClick={onEdit} $softHoverBg={softHoverBg}>
               <EditIcon size={15} />
             </ActionButton>
           </Tooltip>
         )}
-        <Tooltip title={t('common.copy')} mouseEnterDelay={0.8}>
+        <Tooltip content={t('common.copy')} closeDelay={0.8} showArrow={true}>
           <ActionButton className="message-action-button" onClick={onCopy} $softHoverBg={softHoverBg}>
             {!copied && <CopyIcon size={15} />}
             {copied && <Check size={15} color="var(--color-primary)" />}
@@ -512,7 +513,7 @@ const MessageMenubar: FC<Props> = (props) => {
               okButtonProps={{ danger: true }}
               onConfirm={onRegenerate}
               onOpenChange={(open) => open && setShowDeleteTooltip(false)}>
-              <Tooltip title={t('common.regenerate')} mouseEnterDelay={0.8}>
+              <Tooltip content={t('common.regenerate')} closeDelay={0.8} showArrow={true}>
                 <ActionButton
                   className="message-action-button"
                   onClick={(e) => e.stopPropagation()}
@@ -522,14 +523,14 @@ const MessageMenubar: FC<Props> = (props) => {
               </Tooltip>
             </Popconfirm>
           ) : (
-            <Tooltip title={t('common.regenerate')} mouseEnterDelay={0.8}>
+            <Tooltip content={t('common.regenerate')} closeDelay={0.8} showArrow={true}>
               <ActionButton className="message-action-button" onClick={onRegenerate} $softHoverBg={softHoverBg}>
                 <RefreshIcon size={15} />
               </ActionButton>
             </Tooltip>
           ))}
         {isAssistantMessage && (
-          <Tooltip title={t('message.mention.title')} mouseEnterDelay={0.8}>
+          <Tooltip content={t('message.mention.title')} closeDelay={0.8} showArrow={true}>
             <ActionButton className="message-action-button" onClick={onMentionModel} $softHoverBg={softHoverBg}>
               <AtSign size={15} />
             </ActionButton>
@@ -600,7 +601,7 @@ const MessageMenubar: FC<Props> = (props) => {
             trigger={['click']}
             placement="top"
             arrow>
-            <Tooltip title={t('chat.translate')} mouseEnterDelay={1.2}>
+            <Tooltip content={t('chat.translate')} closeDelay={1.2} showArrow={true}>
               <ActionButton
                 className="message-action-button"
                 onClick={(e) => e.stopPropagation()}
@@ -611,7 +612,7 @@ const MessageMenubar: FC<Props> = (props) => {
           </Dropdown>
         )}
         {isAssistantMessage && isGrouped && (
-          <Tooltip title={t('chat.message.useful.label')} mouseEnterDelay={0.8}>
+          <Tooltip content={t('chat.message.useful.label')} closeDelay={0.8} showArrow={true}>
             <ActionButton className="message-action-button" onClick={onUseful} $softHoverBg={softHoverBg}>
               {message.useful ? (
                 <ThumbsUp size={17.5} fill="var(--color-primary)" strokeWidth={0} />
@@ -622,7 +623,7 @@ const MessageMenubar: FC<Props> = (props) => {
           </Tooltip>
         )}
         {isAssistantMessage && (
-          <Tooltip title={t('notes.save')} mouseEnterDelay={0.8}>
+          <Tooltip content={t('notes.save')} closeDelay={0.8} showArrow={true}>
             <ActionButton
               className="message-action-button"
               onClick={async (e) => {
@@ -647,10 +648,11 @@ const MessageMenubar: FC<Props> = (props) => {
               onClick={(e) => e.stopPropagation()}
               $softHoverBg={softHoverBg}>
               <Tooltip
-                title={t('common.delete')}
-                mouseEnterDelay={1}
-                open={showDeleteTooltip}
-                onOpenChange={setShowDeleteTooltip}>
+                content={t('common.delete')}
+                closeDelay={1}
+                isOpen={showDeleteTooltip}
+                onOpenChange={setShowDeleteTooltip}
+                showArrow={true}>
                 <DeleteIcon size={15} />
               </Tooltip>
             </ActionButton>
@@ -664,16 +666,17 @@ const MessageMenubar: FC<Props> = (props) => {
             }}
             $softHoverBg={softHoverBg}>
             <Tooltip
-              title={t('common.delete')}
-              mouseEnterDelay={1}
-              open={showDeleteTooltip}
-              onOpenChange={setShowDeleteTooltip}>
+              content={t('common.delete')}
+              closeDelay={1}
+              isOpen={showDeleteTooltip}
+              onOpenChange={setShowDeleteTooltip}
+              showArrow={true}>
               <DeleteIcon size={15} />
             </Tooltip>
           </ActionButton>
         )}
         {enableDeveloperMode && message.traceId && (
-          <Tooltip title={t('trace.label')} mouseEnterDelay={0.8}>
+          <Tooltip content={t('trace.label')} closeDelay={0.8} showArrow={true}>
             <ActionButton className="message-action-button" onClick={() => handleTraceUserMessage()}>
               <TraceIcon size={16} className={'lucide lucide-trash'} />
             </ActionButton>

--- a/src/renderer/src/pages/home/Navbar.tsx
+++ b/src/renderer/src/pages/home/Navbar.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import { Navbar, NavbarLeft, NavbarRight } from '@renderer/components/app/Navbar'
 import { HStack } from '@renderer/components/Layout'
 import SearchPopup from '@renderer/components/Popups/SearchPopup'
@@ -11,7 +12,6 @@ import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import { useAppDispatch } from '@renderer/store'
 import { setNarrowMode } from '@renderer/store/settings'
 import { Assistant, Topic } from '@renderer/types'
-import { Tooltip } from 'antd'
 import { t } from 'i18next'
 import { Menu, PanelLeftClose, PanelRightClose, Search } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
@@ -76,7 +76,7 @@ const HeaderNavbar: FC<Props> = ({ activeAssistant, setActiveAssistant, activeTo
             transition={{ duration: 0.3, ease: 'easeInOut' }}
             style={{ overflow: 'hidden', display: 'flex', flexDirection: 'row' }}>
             <NavbarLeft style={{ justifyContent: 'space-between', borderRight: 'none', padding: 0 }}>
-              <Tooltip title={t('navbar.hide_sidebar')} mouseEnterDelay={0.8}>
+              <Tooltip content={t('navbar.hide_sidebar')} closeDelay={800} showArrow={true}>
                 <NavbarIcon onClick={toggleShowAssistants}>
                   <PanelLeftClose size={18} />
                 </NavbarIcon>
@@ -87,7 +87,7 @@ const HeaderNavbar: FC<Props> = ({ activeAssistant, setActiveAssistant, activeTo
       </AnimatePresence>
       {!showAssistants && (
         <NavbarLeft style={{ justifyContent: 'flex-start', borderRight: 'none', padding: '0 10px', minWidth: 'auto' }}>
-          <Tooltip title={t('navbar.show_sidebar')} mouseEnterDelay={0.8}>
+          <Tooltip content={t('navbar.show_sidebar')} closeDelay={800} showArrow={true}>
             <NavbarIcon onClick={() => toggleShowAssistants()}>
               <PanelRightClose size={18} />
             </NavbarIcon>
@@ -118,26 +118,26 @@ const HeaderNavbar: FC<Props> = ({ activeAssistant, setActiveAssistant, activeTo
         }}
         className="home-navbar-right">
         <HStack alignItems="center" gap={6}>
-          <Tooltip title={t('chat.assistant.search.placeholder')} mouseEnterDelay={0.8}>
+          <Tooltip content={t('chat.assistant.search.placeholder')} closeDelay={800} showArrow={true}>
             <NarrowIcon onClick={() => SearchPopup.show()}>
               <Search size={18} />
             </NarrowIcon>
           </Tooltip>
-          <Tooltip title={t('navbar.expand')} mouseEnterDelay={0.8}>
+          <Tooltip content={t('navbar.expand')} closeDelay={800} showArrow={true}>
             <NarrowIcon onClick={handleNarrowModeToggle}>
               <i className="iconfont icon-icon-adaptive-width"></i>
             </NarrowIcon>
           </Tooltip>
           <UpdateAppButton />
           {topicPosition === 'right' && !showTopics && (
-            <Tooltip title={t('navbar.show_sidebar')} mouseEnterDelay={2}>
+            <Tooltip content={t('navbar.show_sidebar')} closeDelay={2000} showArrow={true}>
               <NavbarIcon onClick={toggleShowTopics}>
                 <PanelLeftClose size={18} />
               </NavbarIcon>
             </Tooltip>
           )}
           {topicPosition === 'right' && showTopics && (
-            <Tooltip title={t('navbar.hide_sidebar')} mouseEnterDelay={2}>
+            <Tooltip content={t('navbar.hide_sidebar')} closeDelay={2000} showArrow={true}>
               <NavbarIcon onClick={toggleShowTopics}>
                 <PanelRightClose size={18} />
               </NavbarIcon>

--- a/src/renderer/src/pages/home/Tabs/AssistantsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/AssistantsTab.tsx
@@ -1,4 +1,5 @@
 import { DownOutlined, RightOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { DraggableList } from '@renderer/components/DraggableList'
 import Scrollbar from '@renderer/components/Scrollbar'
 import { useAgents } from '@renderer/hooks/useAgents'
@@ -6,7 +7,7 @@ import { useAssistants } from '@renderer/hooks/useAssistant'
 import { useAssistantsTabSortType } from '@renderer/hooks/useStore'
 import { useTags } from '@renderer/hooks/useTags'
 import { Assistant, AssistantsSortType } from '@renderer/types'
-import { Tooltip, Typography } from 'antd'
+import { Typography } from 'antd'
 import { Plus } from 'lucide-react'
 import { FC, useCallback, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -91,7 +92,7 @@ const Assistants: FC<AssistantsTabProps> = ({
             <TagsContainer key={group.tag}>
               {group.tag !== t('assistants.tags.untagged') && (
                 <GroupTitle onClick={() => toggleTagCollapse(group.tag)}>
-                  <Tooltip title={group.tag}>
+                  <Tooltip content={group.tag} showArrow={true}>
                     <GroupTitleName>
                       {collapsedTags[group.tag] ? (
                         <RightOutlined style={{ fontSize: '10px', marginRight: '5px' }} />

--- a/src/renderer/src/pages/home/Tabs/TopicsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/TopicsTab.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import { DraggableVirtualList } from '@renderer/components/DraggableList'
 import { CopyIcon, DeleteIcon, EditIcon } from '@renderer/components/Icons'
 import ObsidianExportPopup from '@renderer/components/Popups/ObsidianExportPopup'
@@ -28,7 +29,7 @@ import {
   exportTopicToNotion,
   topicToMarkdown
 } from '@renderer/utils/export'
-import { Dropdown, MenuProps, Tooltip } from 'antd'
+import { Dropdown, MenuProps } from 'antd'
 import { ItemType, MenuItemType } from 'antd/es/menu/interface'
 import dayjs from 'dayjs'
 import { findIndex } from 'lodash'
@@ -246,7 +247,7 @@ const Topics: FC<Props> = ({ assistant: _assistant, activeTopic, setActiveTopic,
         key: 'topic-prompt',
         icon: <PackagePlus size={14} />,
         extra: (
-          <Tooltip title={t('chat.topics.prompt.tips')}>
+          <Tooltip content={t('chat.topics.prompt.tips')} showArrow={true}>
             <HelpCircle size={14} />
           </Tooltip>
         ),
@@ -554,13 +555,14 @@ const Topics: FC<Props> = ({ assistant: _assistant, activeTopic, setActiveTopic,
                 {!topic.pinned && (
                   <Tooltip
                     placement="bottom"
-                    mouseEnterDelay={0.7}
-                    mouseLeaveDelay={0}
-                    title={
+                    delay={700}
+                    closeDelay={0}
+                    content={
                       <div style={{ fontSize: '12px', opacity: 0.8, fontStyle: 'italic' }}>
                         {t('chat.topics.delete.shortcut', { key: isMac ? '⌘' : 'Ctrl' })}
                       </div>
-                    }>
+                    }
+                    showArrow={true}>
                     <MenuButton
                       className="menu"
                       onClick={(e) => {

--- a/src/renderer/src/pages/home/Tabs/components/OpenAISettingsGroup.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/OpenAISettingsGroup.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import Selector from '@renderer/components/Selector'
 import {
   isSupportedReasoningEffortOpenAIModel,
@@ -20,7 +21,6 @@ import {
   SystemProviderIds
 } from '@renderer/types'
 import { OpenAIVerbosity } from '@types'
-import { Tooltip } from 'antd'
 import { CircleHelp } from 'lucide-react'
 import { FC, useCallback, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -172,7 +172,7 @@ const OpenAISettingsGroup: FC<Props> = ({ model, providerId, SettingGroup, Setti
             <SettingRow>
               <SettingRowTitleSmall>
                 {t('settings.openai.service_tier.title')}{' '}
-                <Tooltip title={t('settings.openai.service_tier.tip')}>
+                <Tooltip content={t('settings.openai.service_tier.tip')} showArrow={true}>
                   <CircleHelp size={14} style={{ marginLeft: 4 }} color="var(--color-text-2)" />
                 </Tooltip>
               </SettingRowTitleSmall>
@@ -193,7 +193,7 @@ const OpenAISettingsGroup: FC<Props> = ({ model, providerId, SettingGroup, Setti
             <SettingRow>
               <SettingRowTitleSmall>
                 {t('settings.openai.summary_text_mode.title')}{' '}
-                <Tooltip title={t('settings.openai.summary_text_mode.tip')}>
+                <Tooltip content={t('settings.openai.summary_text_mode.tip')} showArrow={true}>
                   <CircleHelp size={14} style={{ marginLeft: 4 }} color="var(--color-text-2)" />
                 </Tooltip>
               </SettingRowTitleSmall>
@@ -212,7 +212,7 @@ const OpenAISettingsGroup: FC<Props> = ({ model, providerId, SettingGroup, Setti
           <SettingRow>
             <SettingRowTitleSmall>
               {t('settings.openai.verbosity.title')}{' '}
-              <Tooltip title={t('settings.openai.verbosity.tip')}>
+              <Tooltip content={t('settings.openai.verbosity.tip')} showArrow={true}>
                 <CircleHelp size={14} style={{ marginLeft: 4 }} color="var(--color-text-2)" />
               </Tooltip>
             </SettingRowTitleSmall>

--- a/src/renderer/src/pages/knowledge/KnowledgeContent.tsx
+++ b/src/renderer/src/pages/knowledge/KnowledgeContent.tsx
@@ -1,4 +1,5 @@
 import { RedoOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import { HStack } from '@renderer/components/Layout'
 import CustomTag from '@renderer/components/Tags/CustomTag'
@@ -6,7 +7,7 @@ import { useKnowledge } from '@renderer/hooks/useKnowledge'
 import { NavbarIcon } from '@renderer/pages/home/ChatNavbar'
 import { getProviderName } from '@renderer/services/ProviderService'
 import { KnowledgeBase } from '@renderer/types'
-import { Button, Empty, Tabs, Tag, Tooltip } from 'antd'
+import { Button, Empty, Tabs, Tag } from 'antd'
 import { Book, Folder, Globe, Link, Notebook, Search, Settings, Video } from 'lucide-react'
 import { FC, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -153,7 +154,7 @@ const KnowledgeContent: FC<KnowledgeContentProps> = ({ selectedBase }) => {
             <div className="label-column">
               <label>{t('models.embedding_model')}</label>
             </div>
-            <Tooltip title={providerName} placement="bottom">
+            <Tooltip content={providerName} placement="bottom" showArrow={true}>
               <div className="tag-column">
                 <Tag style={{ borderRadius: 20, margin: 0 }}>{base.model.name}</Tag>
               </div>

--- a/src/renderer/src/pages/knowledge/components/KnowledgeSearchItem/components.tsx
+++ b/src/renderer/src/pages/knowledge/components/KnowledgeSearchItem/components.tsx
@@ -1,6 +1,7 @@
 import { CopyOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { FileMetadata, KnowledgeSearchResult } from '@renderer/types'
-import { Tooltip, Typography } from 'antd'
+import { Typography } from 'antd'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -44,7 +45,7 @@ export const CopyButtonContainer: React.FC<CopyButtonContainerProps> = ({ textTo
 
   return (
     <TagContainer>
-      <Tooltip title={tooltipTitle}>
+      <Tooltip content={tooltipTitle} showArrow={true}>
         <CopyButton onClick={() => handleCopy(textToCopy)}>
           <CopyOutlined />
         </CopyButton>

--- a/src/renderer/src/pages/knowledge/components/StatusIcon.tsx
+++ b/src/renderer/src/pages/knowledge/components/StatusIcon.tsx
@@ -1,7 +1,8 @@
 import { CheckCircleOutlined, CloseCircleOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import { KnowledgeBase, ProcessingStatus } from '@renderer/types'
-import { Progress, Tooltip } from 'antd'
+import { Progress } from 'antd'
 import React, { FC, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -35,19 +36,19 @@ const StatusIcon: FC<StatusIconProps> = ({
       if (item?.uniqueId) {
         if (isPreprocessed && item.type === 'file') {
           return (
-            <Tooltip title={t('knowledge.status_preprocess_completed')} placement="left">
+            <Tooltip content={t('knowledge.status_preprocess_completed')} placement="left" showArrow={true}>
               <CheckCircleOutlined style={{ color: '#52c41a' }} />
             </Tooltip>
           )
         }
         return (
-          <Tooltip title={t('knowledge.status_embedding_completed')} placement="left">
+          <Tooltip content={t('knowledge.status_embedding_completed')} placement="left" showArrow={true}>
             <CheckCircleOutlined style={{ color: '#52c41a' }} />
           </Tooltip>
         )
       }
       return (
-        <Tooltip title={t('knowledge.status_new')} placement="left">
+        <Tooltip content={t('knowledge.status_new')} placement="left" showArrow={true}>
           <StatusDot $status="new" />
         </Tooltip>
       )
@@ -56,7 +57,7 @@ const StatusIcon: FC<StatusIconProps> = ({
     switch (status) {
       case 'pending':
         return (
-          <Tooltip title={t('knowledge.status_pending')} placement="left">
+          <Tooltip content={t('knowledge.status_pending')} placement="left" showArrow={true}>
             <StatusDot $status="pending" />
           </Tooltip>
         )
@@ -65,20 +66,20 @@ const StatusIcon: FC<StatusIconProps> = ({
         return type === 'directory' || type === 'file' ? (
           <Progress type="circle" size={14} percent={Number(progress?.toFixed(0))} />
         ) : (
-          <Tooltip title={t('knowledge.status_processing')} placement="left">
+          <Tooltip content={t('knowledge.status_processing')} placement="left" showArrow={true}>
             <StatusDot $status="processing" />
           </Tooltip>
         )
       }
       case 'completed':
         return (
-          <Tooltip title={t('knowledge.status_completed')} placement="left">
+          <Tooltip content={t('knowledge.status_completed')} placement="left" showArrow={true}>
             <CheckCircleOutlined style={{ color: '#52c41a' }} />
           </Tooltip>
         )
       case 'failed':
         return (
-          <Tooltip title={errorText || t('knowledge.status_failed')} placement="left">
+          <Tooltip content={errorText || t('knowledge.status_failed')} placement="left" showArrow={true}>
             <CloseCircleOutlined style={{ color: '#ff4d4f' }} />
           </Tooltip>
         )

--- a/src/renderer/src/pages/knowledge/items/KnowledgeDirectories.tsx
+++ b/src/renderer/src/pages/knowledge/items/KnowledgeDirectories.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import Ellipsis from '@renderer/components/Ellipsis'
 import { DeleteIcon } from '@renderer/components/Icons'
@@ -6,7 +7,7 @@ import { useKnowledge } from '@renderer/hooks/useKnowledge'
 import FileItem from '@renderer/pages/files/FileItem'
 import { getProviderName } from '@renderer/services/ProviderService'
 import { KnowledgeBase, KnowledgeItem } from '@renderer/types'
-import { Button, Tooltip } from 'antd'
+import { Button } from 'antd'
 import dayjs from 'dayjs'
 import { PlusIcon } from 'lucide-react'
 import { FC, useCallback, useMemo } from 'react'
@@ -94,7 +95,9 @@ const KnowledgeDirectories: FC<KnowledgeContentProps> = ({ selectedBase, progres
                 name: (
                   <ClickableSpan onClick={() => window.api.file.openPath(item.content as string)}>
                     <Ellipsis>
-                      <Tooltip title={item.content as string}>{item.content as string}</Tooltip>
+                      <Tooltip content={item.content as string} showArrow={true}>
+                        {item.content as string}
+                      </Tooltip>
                     </Ellipsis>
                   </ClickableSpan>
                 ),

--- a/src/renderer/src/pages/knowledge/items/KnowledgeFiles.tsx
+++ b/src/renderer/src/pages/knowledge/items/KnowledgeFiles.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import Ellipsis from '@renderer/components/Ellipsis'
 import { useFiles } from '@renderer/hooks/useFiles'
@@ -9,7 +10,7 @@ import { getProviderName } from '@renderer/services/ProviderService'
 import { FileMetadata, FileTypes, isKnowledgeFileItem, KnowledgeBase, KnowledgeItem } from '@renderer/types'
 import { formatFileSize, uuid } from '@renderer/utils'
 import { bookExts, documentExts, textExts, thirdPartyApplicationExts } from '@shared/config/constant'
-import { Button, Tooltip, Upload } from 'antd'
+import { Button, Upload } from 'antd'
 import dayjs from 'dayjs'
 import { FC, useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -191,7 +192,9 @@ const KnowledgeFiles: FC<KnowledgeContentProps> = ({ selectedBase, progressMap, 
                       name: (
                         <ClickableSpan onClick={() => window.api.file.openFileWithRelativePath(file)}>
                           <Ellipsis>
-                            <Tooltip title={file.origin_name}>{file.origin_name}</Tooltip>
+                            <Tooltip content={file.origin_name} showArrow={true}>
+                              {file.origin_name}
+                            </Tooltip>
                           </Ellipsis>
                         </ClickableSpan>
                       ),

--- a/src/renderer/src/pages/knowledge/items/KnowledgeSitemaps.tsx
+++ b/src/renderer/src/pages/knowledge/items/KnowledgeSitemaps.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import Ellipsis from '@renderer/components/Ellipsis'
 import { DeleteIcon } from '@renderer/components/Icons'
@@ -7,7 +8,7 @@ import { useKnowledge } from '@renderer/hooks/useKnowledge'
 import FileItem from '@renderer/pages/files/FileItem'
 import { getProviderName } from '@renderer/services/ProviderService'
 import { KnowledgeBase, KnowledgeItem } from '@renderer/types'
-import { Button, message, Tooltip } from 'antd'
+import { Button, message } from 'antd'
 import dayjs from 'dayjs'
 import { PlusIcon } from 'lucide-react'
 import { FC, useCallback, useMemo } from 'react'
@@ -112,7 +113,7 @@ const KnowledgeSitemaps: FC<KnowledgeContentProps> = ({ selectedBase }) => {
               fileInfo={{
                 name: (
                   <ClickableSpan>
-                    <Tooltip title={item.content as string}>
+                    <Tooltip content={item.content as string} showArrow={true}>
                       <Ellipsis>
                         <a href={item.content as string} target="_blank" rel="noopener noreferrer">
                           {item.content as string}

--- a/src/renderer/src/pages/knowledge/items/KnowledgeUrls.tsx
+++ b/src/renderer/src/pages/knowledge/items/KnowledgeUrls.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import Ellipsis from '@renderer/components/Ellipsis'
 import { CopyIcon, DeleteIcon, EditIcon } from '@renderer/components/Icons'
 import PromptPopup from '@renderer/components/Popups/PromptPopup'
@@ -6,7 +7,7 @@ import { useKnowledge } from '@renderer/hooks/useKnowledge'
 import FileItem from '@renderer/pages/files/FileItem'
 import { getProviderName } from '@renderer/services/ProviderService'
 import { KnowledgeBase, KnowledgeItem } from '@renderer/types'
-import { Button, Dropdown, Tooltip } from 'antd'
+import { Button, Dropdown } from 'antd'
 import dayjs from 'dayjs'
 import { PlusIcon } from 'lucide-react'
 import { FC, useCallback, useMemo } from 'react'
@@ -161,7 +162,7 @@ const KnowledgeUrls: FC<KnowledgeContentProps> = ({ selectedBase }) => {
                     }}
                     trigger={['contextMenu']}>
                     <ClickableSpan>
-                      <Tooltip title={item.content as string}>
+                      <Tooltip content={item.content as string} showArrow={true}>
                         <Ellipsis>
                           <a href={item.content as string} target="_blank" rel="noopener noreferrer">
                             {item.remark || (item.content as string)}

--- a/src/renderer/src/pages/knowledge/items/KnowledgeVideos.tsx
+++ b/src/renderer/src/pages/knowledge/items/KnowledgeVideos.tsx
@@ -1,4 +1,5 @@
 import { DeleteOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import Ellipsis from '@renderer/components/Ellipsis'
 import VideoPopup from '@renderer/components/Popups/VideoPopup'
@@ -6,7 +7,7 @@ import Scrollbar from '@renderer/components/Scrollbar'
 import { useKnowledge } from '@renderer/hooks/useKnowledge'
 import { getProviderName } from '@renderer/services/ProviderService'
 import { FileTypes, isKnowledgeVideoItem, KnowledgeBase, KnowledgeItem } from '@renderer/types'
-import { Button, Tooltip } from 'antd'
+import { Button } from 'antd'
 import dayjs from 'dayjs'
 import { Plus } from 'lucide-react'
 import VirtualList from 'rc-virtual-list'
@@ -128,7 +129,9 @@ const KnowledgeVideos: FC<KnowledgeContentProps> = ({ selectedBase }) => {
                       name: (
                         <ClickableSpan onClick={() => window.api.file.openFileWithRelativePath(videoFile)}>
                           <Ellipsis>
-                            <Tooltip title={videoFile.origin_name}>{videoFile.origin_name}</Tooltip>
+                            <Tooltip content={videoFile.origin_name} showArrow={true}>
+                              {videoFile.origin_name}
+                            </Tooltip>
                           </Ellipsis>
                         </ClickableSpan>
                       ),

--- a/src/renderer/src/pages/minapps/MiniappSettings/MiniAppSettings.tsx
+++ b/src/renderer/src/pages/minapps/MiniappSettings/MiniAppSettings.tsx
@@ -1,4 +1,5 @@
 import { UndoOutlined } from '@ant-design/icons' // 导入重置图标
+import { Tooltip } from '@heroui/react'
 import { DEFAULT_MIN_APPS } from '@renderer/config/minapps'
 import { useMinapps } from '@renderer/hooks/useMinapps'
 import { useSettings } from '@renderer/hooks/useSettings'
@@ -9,7 +10,7 @@ import {
   setMinappsOpenLinkExternal,
   setShowOpenedMinappsInSidebar
 } from '@renderer/store/settings'
-import { Button, message, Slider, Switch, Tooltip } from 'antd'
+import { Button, message, Slider, Switch } from 'antd'
 import { FC, useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -111,7 +112,7 @@ const MiniAppSettings: FC = () => {
         </SettingLabelGroup>
         <CacheSettingControls>
           <SliderWithResetContainer>
-            <Tooltip title={t('settings.miniapps.reset_tooltip')} placement="top">
+            <Tooltip content={t('settings.miniapps.reset_tooltip')} placement="top" showArrow={true}>
               <ResetButton onClick={handleResetCacheLimit}>
                 <UndoOutlined />
               </ResetButton>

--- a/src/renderer/src/pages/minapps/components/MinimalToolbar.tsx
+++ b/src/renderer/src/pages/minapps/components/MinimalToolbar.tsx
@@ -8,13 +8,13 @@ import {
   PushpinOutlined,
   ReloadOutlined
 } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { DEFAULT_MIN_APPS } from '@renderer/config/minapps'
 import { useMinapps } from '@renderer/hooks/useMinapps'
 import { useSettings } from '@renderer/hooks/useSettings'
 import { useAppDispatch } from '@renderer/store'
 import { setMinappsOpenLinkExternal } from '@renderer/store/settings'
 import { MinAppType } from '@renderer/types'
-import { Tooltip } from 'antd'
 import { WebviewTag } from 'electron'
 import { FC, useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -87,19 +87,19 @@ const MinimalToolbar: FC<Props> = ({ app, webviewRef, currentUrl, onReload, onOp
     <ToolbarContainer>
       <LeftSection>
         <ButtonGroup>
-          <Tooltip title={t('minapp.popup.goBack')} placement="bottom">
+          <Tooltip content={t('minapp.popup.goBack')} placement="bottom" showArrow={true}>
             <ToolbarButton onClick={handleGoBack} $disabled={!canGoBack}>
               <ArrowLeftOutlined />
             </ToolbarButton>
           </Tooltip>
 
-          <Tooltip title={t('minapp.popup.goForward')} placement="bottom">
+          <Tooltip content={t('minapp.popup.goForward')} placement="bottom" showArrow={true}>
             <ToolbarButton onClick={handleGoForward} $disabled={!canGoForward}>
               <ArrowRightOutlined />
             </ToolbarButton>
           </Tooltip>
 
-          <Tooltip title={t('minapp.popup.refresh')} placement="bottom">
+          <Tooltip content={t('minapp.popup.refresh')} placement="bottom" showArrow={true}>
             <ToolbarButton onClick={onReload}>
               <ReloadOutlined />
             </ToolbarButton>
@@ -110,7 +110,7 @@ const MinimalToolbar: FC<Props> = ({ app, webviewRef, currentUrl, onReload, onOp
       <RightSection>
         <ButtonGroup>
           {canOpenExternalLink && (
-            <Tooltip title={t('minapp.popup.openExternal')} placement="bottom">
+            <Tooltip content={t('minapp.popup.openExternal')} placement="bottom" showArrow={true}>
               <ToolbarButton onClick={handleOpenLink}>
                 <ExportOutlined />
               </ToolbarButton>
@@ -119,8 +119,9 @@ const MinimalToolbar: FC<Props> = ({ app, webviewRef, currentUrl, onReload, onOp
 
           {canPinned && (
             <Tooltip
-              title={isPinned ? t('minapp.remove_from_launchpad') : t('minapp.add_to_launchpad')}
-              placement="bottom">
+              content={isPinned ? t('minapp.remove_from_launchpad') : t('minapp.add_to_launchpad')}
+              placement="bottom"
+              showArrow={true}>
               <ToolbarButton onClick={handleTogglePin} $active={isPinned}>
                 <PushpinOutlined />
               </ToolbarButton>
@@ -128,26 +129,27 @@ const MinimalToolbar: FC<Props> = ({ app, webviewRef, currentUrl, onReload, onOp
           )}
 
           <Tooltip
-            title={
+            content={
               minappsOpenLinkExternal
                 ? t('minapp.popup.open_link_external_on')
                 : t('minapp.popup.open_link_external_off')
             }
-            placement="bottom">
+            placement="bottom"
+            showArrow={true}>
             <ToolbarButton onClick={handleToggleOpenExternal} $active={minappsOpenLinkExternal}>
               <LinkOutlined />
             </ToolbarButton>
           </Tooltip>
 
           {isInDevelopment && (
-            <Tooltip title={t('minapp.popup.devtools')} placement="bottom">
+            <Tooltip content={t('minapp.popup.devtools')} placement="bottom" showArrow={true}>
               <ToolbarButton onClick={onOpenDevTools}>
                 <CodeOutlined />
               </ToolbarButton>
             </Tooltip>
           )}
 
-          <Tooltip title={t('minapp.popup.minimize')} placement="bottom">
+          <Tooltip content={t('minapp.popup.minimize')} placement="bottom" showArrow={true}>
             <ToolbarButton onClick={handleMinimize}>
               <MinusOutlined />
             </ToolbarButton>

--- a/src/renderer/src/pages/notes/HeaderNavbar.tsx
+++ b/src/renderer/src/pages/notes/HeaderNavbar.tsx
@@ -1,4 +1,5 @@
 import { BreadcrumbItem, Breadcrumbs } from '@heroui/react'
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import { NavbarCenter, NavbarHeader, NavbarRight } from '@renderer/components/app/Navbar'
 import { HStack } from '@renderer/components/Layout'
@@ -7,7 +8,7 @@ import { useNotesSettings } from '@renderer/hooks/useNotesSettings'
 import { useShowWorkspace } from '@renderer/hooks/useShowWorkspace'
 import { findNodeByPath, findNodeInTree, updateNodeInTree } from '@renderer/services/NotesTreeService'
 import { NotesTreeNode } from '@types'
-import { Dropdown, Tooltip } from 'antd'
+import { Dropdown } from 'antd'
 import { t } from 'i18next'
 import { MoreHorizontal, PanelLeftClose, PanelRightClose, Star } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
@@ -163,14 +164,14 @@ const HeaderNavbar = ({ notesTree, getCurrentNoteContent, onToggleStar }) => {
       style={{ justifyContent: 'flex-start', borderBottom: '0.5px solid var(--color-border)' }}>
       <HStack alignItems="center" flex="0 0 auto">
         {showWorkspace && (
-          <Tooltip title={t('navbar.hide_sidebar')} mouseEnterDelay={0.8}>
+          <Tooltip content={t('navbar.hide_sidebar')} closeDelay={800} showArrow={true}>
             <NavbarIcon onClick={handleToggleShowWorkspace}>
               <PanelLeftClose size={18} />
             </NavbarIcon>
           </Tooltip>
         )}
         {!showWorkspace && (
-          <Tooltip title={t('navbar.show_sidebar')} mouseEnterDelay={0.8}>
+          <Tooltip content={t('navbar.show_sidebar')} closeDelay={800} showArrow={true}>
             <NavbarIcon onClick={handleToggleShowWorkspace}>
               <PanelRightClose size={18} />
             </NavbarIcon>
@@ -194,7 +195,10 @@ const HeaderNavbar = ({ notesTree, getCurrentNoteContent, onToggleStar }) => {
       </NavbarCenter>
       <NavbarRight style={{ paddingRight: 0 }}>
         {canShowStarButton && (
-          <Tooltip title={activeNode.isStarred ? t('notes.unstar') : t('notes.star')} mouseEnterDelay={0.8}>
+          <Tooltip
+            content={activeNode.isStarred ? t('notes.unstar') : t('notes.star')}
+            closeDelay={800}
+            showArrow={true}>
             <StarButton onClick={handleToggleStarred}>
               {activeNode.isStarred ? (
                 <Star size={18} fill="var(--color-status-warning)" stroke="var(--color-status-warning)" />
@@ -204,7 +208,7 @@ const HeaderNavbar = ({ notesTree, getCurrentNoteContent, onToggleStar }) => {
             </StarButton>
           </Tooltip>
         )}
-        <Tooltip title={t('notes.settings.title')} mouseEnterDelay={0.8}>
+        <Tooltip content={t('notes.settings.title')} closeDelay={800} showArrow={true}>
           <Dropdown
             menu={{ items: menuItems.map(buildMenuItem) }}
             trigger={['click']}

--- a/src/renderer/src/pages/notes/NotesSidebarHeader.tsx
+++ b/src/renderer/src/pages/notes/NotesSidebarHeader.tsx
@@ -1,6 +1,7 @@
 import { CheckOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { NotesSortType } from '@renderer/types/note'
-import { Dropdown, Input, MenuProps, Tooltip } from 'antd'
+import { Dropdown, Input, MenuProps } from 'antd'
 import { ArrowLeft, ArrowUpNarrowWide, FilePlus2, FolderPlus, Search, Star } from 'lucide-react'
 import { FC, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -69,13 +70,13 @@ const NotesSidebarHeader: FC<NotesSidebarHeaderProps> = ({
       <HeaderActions>
         {!isShowStarred && !isShowSearch && (
           <>
-            <Tooltip title={t('notes.new_note')} mouseEnterDelay={0.8}>
+            <Tooltip content={t('notes.new_note')} closeDelay={800} showArrow={true}>
               <ActionButton onClick={onCreateNote}>
                 <FilePlus2 size={18} />
               </ActionButton>
             </Tooltip>
 
-            <Tooltip title={t('notes.new_folder')} mouseEnterDelay={0.8}>
+            <Tooltip content={t('notes.new_folder')} closeDelay={800} showArrow={true}>
               <ActionButton onClick={onCreateFolder}>
                 <FolderPlus size={18} />
               </ActionButton>
@@ -87,20 +88,20 @@ const NotesSidebarHeader: FC<NotesSidebarHeaderProps> = ({
                 onClick: handleSortMenuClick
               }}
               trigger={['click']}>
-              <Tooltip title={t('agents.sorting.title')} mouseEnterDelay={0.8}>
+              <Tooltip content={t('agents.sorting.title')} closeDelay={800} showArrow={true}>
                 <ActionButton>
                   <ArrowUpNarrowWide size={18} />
                 </ActionButton>
               </Tooltip>
             </Dropdown>
 
-            <Tooltip title={t('notes.show_starred')} mouseEnterDelay={0.8}>
+            <Tooltip content={t('notes.show_starred')} closeDelay={800} showArrow={true}>
               <ActionButton onClick={onToggleStarredView}>
                 <Star size={18} />
               </ActionButton>
             </Tooltip>
 
-            <Tooltip title={t('common.search')} mouseEnterDelay={0.8}>
+            <Tooltip content={t('common.search')} closeDelay={800} showArrow={true}>
               <ActionButton onClick={onToggleSearchView}>
                 <Search size={18} />
               </ActionButton>
@@ -108,7 +109,7 @@ const NotesSidebarHeader: FC<NotesSidebarHeaderProps> = ({
           </>
         )}
         {isShowStarred && (
-          <Tooltip title={t('common.back')} mouseEnterDelay={0.8}>
+          <Tooltip content={t('common.back')} closeDelay={800} showArrow={true}>
             <ActionButton onClick={onToggleStarredView}>
               <ArrowLeft size={18} />
             </ActionButton>
@@ -116,7 +117,7 @@ const NotesSidebarHeader: FC<NotesSidebarHeaderProps> = ({
         )}
         {isShowSearch && (
           <>
-            <Tooltip title={t('common.back')} mouseEnterDelay={0.8}>
+            <Tooltip content={t('common.back')} closeDelay={800} showArrow={true}>
               <ActionButton onClick={onToggleSearchView}>
                 <ArrowLeft size={18} />
               </ActionButton>

--- a/src/renderer/src/pages/paintings/AihubmixPage.tsx
+++ b/src/renderer/src/pages/paintings/AihubmixPage.tsx
@@ -1,4 +1,5 @@
 import { PlusOutlined, RedoOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import AiProvider from '@renderer/aiCore'
 import IcImageUp from '@renderer/assets/images/paintings/ic_ImageUp.svg'
@@ -22,7 +23,7 @@ import { setGenerating } from '@renderer/store/runtime'
 import type { FileMetadata } from '@renderer/types'
 import type { PaintingAction, PaintingsState } from '@renderer/types'
 import { getErrorMessage, uuid } from '@renderer/utils'
-import { Avatar, Button, Input, InputNumber, Radio, Segmented, Select, Slider, Switch, Tooltip, Upload } from 'antd'
+import { Avatar, Button, Input, InputNumber, Radio, Segmented, Select, Slider, Switch, Upload } from 'antd'
 import TextArea from 'antd/es/input/TextArea'
 import { Info } from 'lucide-react'
 import type { FC } from 'react'
@@ -790,7 +791,7 @@ const AihubmixPage: FC<{ Options: string[] }> = ({ Options }) => {
         <SettingTitle style={{ marginBottom: 5, marginTop: 15 }}>
           {t(item.title!)}
           {item.tooltip && (
-            <Tooltip title={t(item.tooltip)}>
+            <Tooltip content={t(item.tooltip)} showArrow={true}>
               <InfoIcon />
             </Tooltip>
           )}

--- a/src/renderer/src/pages/paintings/DmxapiPage.tsx
+++ b/src/renderer/src/pages/paintings/DmxapiPage.tsx
@@ -1,4 +1,5 @@
 import { PlusOutlined, RedoOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import DMXAPIToImg from '@renderer/assets/images/providers/DMXAPI-to-img.webp'
 import { Navbar, NavbarCenter, NavbarRight } from '@renderer/components/app/Navbar'
 import { HStack } from '@renderer/components/Layout'
@@ -15,7 +16,7 @@ import { setGenerating } from '@renderer/store/runtime'
 import type { FileMetadata } from '@renderer/types'
 import { convertToBase64, uuid } from '@renderer/utils'
 import { DmxapiPainting } from '@types'
-import { Avatar, Button, Input, InputNumber, Segmented, Select, Switch, Tooltip } from 'antd'
+import { Avatar, Button, Input, InputNumber, Segmented, Select, Switch } from 'antd'
 import TextArea from 'antd/es/input/TextArea'
 import { Info } from 'lucide-react'
 import React, { FC, useEffect, useRef, useState } from 'react'
@@ -923,7 +924,7 @@ const DmxapiPage: FC<{ Options: string[] }> = ({ Options }) => {
             <>
               <SettingTitle style={{ marginBottom: 5, marginTop: 15 }}>
                 {t('paintings.seed')}
-                <Tooltip title={t('paintings.seed_desc_tip')}>
+                <Tooltip content={t('paintings.seed_desc_tip')} showArrow={true}>
                   <InfoIcon />
                 </Tooltip>
               </SettingTitle>
@@ -957,7 +958,7 @@ const DmxapiPage: FC<{ Options: string[] }> = ({ Options }) => {
 
           <SettingTitle style={{ marginBottom: 5, marginTop: 15 }}>
             {t('paintings.auto_create_paint')}
-            <Tooltip title={t('paintings.auto_create_paint_tip')}>
+            <Tooltip content={t('paintings.auto_create_paint_tip')} showArrow={true}>
               <InfoIcon />
             </Tooltip>
           </SettingTitle>

--- a/src/renderer/src/pages/paintings/SiliconPage.tsx
+++ b/src/renderer/src/pages/paintings/SiliconPage.tsx
@@ -1,4 +1,5 @@
 import { PlusOutlined, RedoOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import AiProvider from '@renderer/aiCore'
 import ImageSize1_1 from '@renderer/assets/images/paintings/image-size-1-1.svg'
@@ -26,7 +27,7 @@ import { useAppDispatch } from '@renderer/store'
 import { setGenerating } from '@renderer/store/runtime'
 import type { FileMetadata, Painting } from '@renderer/types'
 import { getErrorMessage, uuid } from '@renderer/utils'
-import { Button, Input, InputNumber, Radio, Select, Slider, Switch, Tooltip } from 'antd'
+import { Button, Input, InputNumber, Radio, Select, Slider, Switch } from 'antd'
 import TextArea from 'antd/es/input/TextArea'
 import { Info } from 'lucide-react'
 import type { FC } from 'react'
@@ -402,7 +403,7 @@ const SiliconPage: FC<{ Options: string[] }> = ({ Options }) => {
 
           <SettingTitle style={{ marginBottom: 5, marginTop: 15 }}>
             {t('paintings.number_images')}
-            <Tooltip title={t('paintings.number_images_tip')}>
+            <Tooltip content={t('paintings.number_images_tip')} showArrow={true}>
               <InfoIcon />
             </Tooltip>
           </SettingTitle>
@@ -415,7 +416,7 @@ const SiliconPage: FC<{ Options: string[] }> = ({ Options }) => {
 
           <SettingTitle style={{ marginBottom: 5, marginTop: 15 }}>
             {t('paintings.seed')}
-            <Tooltip title={t('paintings.seed_tip')}>
+            <Tooltip content={t('paintings.seed_tip')} showArrow={true}>
               <InfoIcon />
             </Tooltip>
           </SettingTitle>
@@ -432,7 +433,7 @@ const SiliconPage: FC<{ Options: string[] }> = ({ Options }) => {
 
           <SettingTitle style={{ marginBottom: 5, marginTop: 15 }}>
             {t('paintings.inference_steps')}
-            <Tooltip title={t('paintings.inference_steps_tip')}>
+            <Tooltip content={t('paintings.inference_steps_tip')} showArrow={true}>
               <InfoIcon />
             </Tooltip>
           </SettingTitle>
@@ -448,7 +449,7 @@ const SiliconPage: FC<{ Options: string[] }> = ({ Options }) => {
 
           <SettingTitle style={{ marginBottom: 5, marginTop: 15 }}>
             {t('paintings.guidance_scale')}
-            <Tooltip title={t('paintings.guidance_scale_tip')}>
+            <Tooltip content={t('paintings.guidance_scale_tip')} showArrow={true}>
               <InfoIcon />
             </Tooltip>
           </SettingTitle>
@@ -470,7 +471,7 @@ const SiliconPage: FC<{ Options: string[] }> = ({ Options }) => {
           </SliderContainer>
           <SettingTitle style={{ marginBottom: 5, marginTop: 15 }}>
             {t('paintings.negative_prompt')}
-            <Tooltip title={t('paintings.negative_prompt_tip')}>
+            <Tooltip content={t('paintings.negative_prompt_tip')} showArrow={true}>
               <InfoIcon />
             </Tooltip>
           </SettingTitle>
@@ -482,7 +483,7 @@ const SiliconPage: FC<{ Options: string[] }> = ({ Options }) => {
           />
           <SettingTitle style={{ marginBottom: 5, marginTop: 15 }}>
             {t('paintings.prompt_enhancement')}
-            <Tooltip title={t('paintings.prompt_enhancement_tip')}>
+            <Tooltip content={t('paintings.prompt_enhancement_tip')} showArrow={true}>
               <InfoIcon />
             </Tooltip>
           </SettingTitle>

--- a/src/renderer/src/pages/paintings/TokenFluxPage.tsx
+++ b/src/renderer/src/pages/paintings/TokenFluxPage.tsx
@@ -1,4 +1,5 @@
 import { PlusOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import { Navbar, NavbarCenter, NavbarRight } from '@renderer/components/app/Navbar'
 import Scrollbar from '@renderer/components/Scrollbar'
@@ -17,7 +18,7 @@ import { useAppDispatch } from '@renderer/store'
 import { setGenerating } from '@renderer/store/runtime'
 import type { TokenFluxPainting } from '@renderer/types'
 import { getErrorMessage, uuid } from '@renderer/utils'
-import { Avatar, Button, Select, Tooltip } from 'antd'
+import { Avatar, Button, Select } from 'antd'
 import TextArea from 'antd/es/input/TextArea'
 import { Info } from 'lucide-react'
 import type { FC } from 'react'
@@ -435,7 +436,7 @@ const TokenFluxPage: FC<{ Options: string[] }> = ({ Options }) => {
               <Select.OptGroup key={provider} label={provider}>
                 {providerModels.map((model) => (
                   <Select.Option key={model.id} value={model.id}>
-                    <Tooltip title={model.description} placement="right">
+                    <Tooltip content={model.description} placement="right" showArrow={true}>
                       <ModelOptionContainer>
                         <ModelName>{model.name}</ModelName>
                       </ModelOptionContainer>
@@ -464,7 +465,7 @@ const TokenFluxPage: FC<{ Options: string[] }> = ({ Options }) => {
                           {isRequired && <RequiredIndicator> *</RequiredIndicator>}
                         </ParameterName>
                         {property.description && (
-                          <Tooltip title={readI18nContext(property, 'description')}>
+                          <Tooltip content={readI18nContext(property, 'description')} showArrow={true}>
                             <InfoIcon />
                           </Tooltip>
                         )}

--- a/src/renderer/src/pages/settings/AboutSettings.tsx
+++ b/src/renderer/src/pages/settings/AboutSettings.tsx
@@ -1,4 +1,5 @@
 import { GithubOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import IndicatorLight from '@renderer/components/IndicatorLight'
 import { HStack } from '@renderer/components/Layout'
 import { APP_NAME, AppLogo } from '@renderer/config/env'
@@ -12,7 +13,7 @@ import { setUpdateState } from '@renderer/store/runtime'
 import { ThemeMode } from '@renderer/types'
 import { runAsyncFunction } from '@renderer/utils'
 import { UpgradeChannel } from '@shared/config/constant'
-import { Avatar, Button, Progress, Radio, Row, Switch, Tag, Tooltip } from 'antd'
+import { Avatar, Button, Progress, Radio, Row, Switch, Tag } from 'antd'
 import { debounce } from 'lodash'
 import { Bug, FileCheck, Github, Globe, Mail, Rss } from 'lucide-react'
 import { BadgeQuestionMark } from 'lucide-react'
@@ -239,7 +240,7 @@ const AboutSettings: FC = () => {
             <SettingDivider />
             <SettingRow>
               <SettingRowTitle>{t('settings.general.test_plan.title')}</SettingRowTitle>
-              <Tooltip title={t('settings.general.test_plan.tooltip')} trigger={['hover', 'focus']}>
+              <Tooltip content={t('settings.general.test_plan.tooltip')} showArrow={true}>
                 <Switch value={testPlan} onChange={(v) => handleSetTestPlan(v)} />
               </Tooltip>
             </SettingRow>
@@ -254,7 +255,7 @@ const AboutSettings: FC = () => {
                     value={getTestChannel()}
                     onChange={(e) => handleTestChannelChange(e.target.value)}>
                     {getAvailableTestChannels().map((option) => (
-                      <Tooltip key={option.value} title={option.tooltip}>
+                      <Tooltip key={option.value} content={option.tooltip} showArrow={true}>
                         <Radio.Button value={option.value}>{option.label}</Radio.Button>
                       </Tooltip>
                     ))}

--- a/src/renderer/src/pages/settings/AssistantSettings/AssistantKnowledgeBaseSettings.tsx
+++ b/src/renderer/src/pages/settings/AssistantSettings/AssistantKnowledgeBaseSettings.tsx
@@ -1,8 +1,9 @@
 import { CheckOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { Box } from '@renderer/components/Layout'
 import { useAppSelector } from '@renderer/store'
 import { Assistant, AssistantSettings } from '@renderer/types'
-import { Row, Segmented, Select, SelectProps, Tooltip } from 'antd'
+import { Row, Segmented, Select, SelectProps } from 'antd'
 import { CircleHelp } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -59,7 +60,7 @@ const AssistantKnowledgeBaseSettings: React.FC<Props> = ({ assistant, updateAssi
               label: (
                 <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
                   {t('assistants.settings.knowledge_base.recognition.on')}
-                  <Tooltip title={t('assistants.settings.knowledge_base.recognition.tip')}>
+                  <Tooltip content={t('assistants.settings.knowledge_base.recognition.tip')} showArrow={true}>
                     <QuestionIcon size={15} />
                   </Tooltip>
                 </div>

--- a/src/renderer/src/pages/settings/AssistantSettings/AssistantMCPSettings.tsx
+++ b/src/renderer/src/pages/settings/AssistantSettings/AssistantMCPSettings.tsx
@@ -1,8 +1,9 @@
 import { InfoCircleOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { Box } from '@renderer/components/Layout'
 import { useMCPServers } from '@renderer/hooks/useMCPServers'
 import { Assistant, AssistantSettings } from '@renderer/types'
-import { Empty, Switch, Tooltip } from 'antd'
+import { Empty, Switch } from 'antd'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
@@ -54,7 +55,9 @@ const AssistantMCPSettings: React.FC<Props> = ({ assistant, updateAssistant }) =
       <HeaderContainer>
         <Box style={{ fontWeight: 'bold', fontSize: '14px' }}>
           {t('assistants.settings.mcp.title')}
-          <Tooltip title={t('assistants.settings.mcp.description', 'Select MCP servers to use with this assistant')}>
+          <Tooltip
+            content={t('assistants.settings.mcp.description', 'Select MCP servers to use with this assistant')}
+            showArrow={true}>
             <InfoIcon />
           </Tooltip>
         </Box>
@@ -78,11 +81,12 @@ const AssistantMCPSettings: React.FC<Props> = ({ assistant, updateAssistant }) =
                   {server.baseUrl && <ServerUrl>{server.baseUrl}</ServerUrl>}
                 </ServerInfo>
                 <Tooltip
-                  title={
+                  content={
                     !server.isActive
                       ? t('assistants.settings.mcp.enableFirst', 'Enable this server in MCP settings first')
                       : undefined
-                  }>
+                  }
+                  showArrow={true}>
                   <Switch
                     checked={isEnabled}
                     disabled={!server.isActive}

--- a/src/renderer/src/pages/settings/AssistantSettings/AssistantMemorySettings.tsx
+++ b/src/renderer/src/pages/settings/AssistantSettings/AssistantMemorySettings.tsx
@@ -1,11 +1,12 @@
 import { InfoCircleOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import { Box } from '@renderer/components/Layout'
 import MemoriesSettingsModal from '@renderer/pages/memory/settings-modal'
 import MemoryService from '@renderer/services/MemoryService'
 import { selectGlobalMemoryEnabled, selectMemoryConfig } from '@renderer/store/memory'
 import { Assistant, AssistantSettings } from '@renderer/types'
-import { Alert, Button, Card, Space, Switch, Tooltip, Typography } from 'antd'
+import { Alert, Button, Card, Space, Switch, Typography } from 'antd'
 import { useForm } from 'antd/es/form/Form'
 import { Settings2 } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
@@ -76,20 +77,21 @@ const AssistantMemorySettings: React.FC<Props> = ({ assistant, updateAssistant, 
       <HeaderContainer>
         <Box style={{ fontWeight: 'bold', fontSize: '14px' }}>
           {t('memory.title')}
-          <Tooltip title={t('memory.description')}>
+          <Tooltip content={t('memory.description')} showArrow={true}>
             <InfoIcon />
           </Tooltip>
         </Box>
         <Space>
           <Button type="text" icon={<Settings2 size={15} />} onClick={handleNavigateToMemory} />
           <Tooltip
-            title={
+            content={
               !globalMemoryEnabled
                 ? t('memory.enable_global_memory_first')
                 : !isMemoryConfigured
                   ? t('memory.configure_memory_first')
                   : ''
-            }>
+            }
+            showArrow={true}>
             <Switch
               checked={assistant.enableMemory || false}
               onChange={handleMemoryToggle}

--- a/src/renderer/src/pages/settings/AssistantSettings/AssistantModelSettings.tsx
+++ b/src/renderer/src/pages/settings/AssistantSettings/AssistantModelSettings.tsx
@@ -1,4 +1,5 @@
 import { QuestionCircleOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import ModelAvatar from '@renderer/components/Avatar/ModelAvatar'
 import EditableNumber from '@renderer/components/EditableNumber'
 import { DeleteIcon, ResetIcon } from '@renderer/components/Icons'
@@ -11,7 +12,7 @@ import { useTimer } from '@renderer/hooks/useTimer'
 import { SettingRow } from '@renderer/pages/settings'
 import { Assistant, AssistantSettingCustomParameters, AssistantSettings, Model } from '@renderer/types'
 import { modalConfirm } from '@renderer/utils'
-import { Button, Col, Divider, Input, InputNumber, Row, Select, Slider, Switch, Tooltip } from 'antd'
+import { Button, Col, Divider, Input, InputNumber, Row, Select, Slider, Switch } from 'antd'
 import { isNull } from 'lodash'
 import { PlusIcon } from 'lucide-react'
 import { FC, useCallback, useEffect, useRef, useState } from 'react'
@@ -243,7 +244,7 @@ const AssistantModelSettings: FC<Props> = ({ assistant, updateAssistant, updateA
         <HStack alignItems="center">
           <Label>
             {t('chat.settings.temperature.label')}
-            <Tooltip title={t('chat.settings.temperature.tip')}>
+            <Tooltip content={t('chat.settings.temperature.tip')} showArrow={true}>
               <QuestionIcon />
             </Tooltip>
           </Label>
@@ -292,7 +293,7 @@ const AssistantModelSettings: FC<Props> = ({ assistant, updateAssistant, updateA
       <SettingRow style={{ minHeight: 30 }}>
         <HStack alignItems="center">
           <Label>{t('chat.settings.top_p.label')}</Label>
-          <Tooltip title={t('chat.settings.top_p.tip')}>
+          <Tooltip content={t('chat.settings.top_p.tip')} showArrow={true}>
             <QuestionIcon />
           </Tooltip>
         </HStack>
@@ -341,7 +342,7 @@ const AssistantModelSettings: FC<Props> = ({ assistant, updateAssistant, updateA
         <Col span={20}>
           <Label>
             {t('chat.settings.context_count.label')}{' '}
-            <Tooltip title={t('chat.settings.context_count.tip')}>
+            <Tooltip content={t('chat.settings.context_count.tip')} showArrow={true}>
               <QuestionIcon />
             </Tooltip>
           </Label>
@@ -381,7 +382,7 @@ const AssistantModelSettings: FC<Props> = ({ assistant, updateAssistant, updateA
       <SettingRow style={{ minHeight: 30 }}>
         <HStack alignItems="center">
           <Label>{t('chat.settings.max_tokens.label')}</Label>
-          <Tooltip title={t('chat.settings.max_tokens.tip')}>
+          <Tooltip content={t('chat.settings.max_tokens.tip')} showArrow={true}>
             <QuestionIcon />
           </Tooltip>
         </HStack>

--- a/src/renderer/src/pages/settings/DataSettings/JoplinSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/JoplinSettings.tsx
@@ -1,10 +1,11 @@
 import { InfoCircleOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { HStack } from '@renderer/components/Layout'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import { useMinappPopup } from '@renderer/hooks/useMinappPopup'
 import { RootState, useAppDispatch } from '@renderer/store'
 import { setJoplinExportReasoning, setJoplinToken, setJoplinUrl } from '@renderer/store/settings'
-import { Button, Space, Switch, Tooltip } from 'antd'
+import { Button, Space, Switch } from 'antd'
 import { Input } from 'antd'
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -98,7 +99,7 @@ const JoplinSettings: FC = () => {
       <SettingRow>
         <SettingRowTitle style={{ display: 'flex', alignItems: 'center' }}>
           <span>{t('settings.data.joplin.token')}</span>
-          <Tooltip title={t('settings.data.joplin.help')} placement="left">
+          <Tooltip content={t('settings.data.joplin.help')} placement="left" showArrow={true}>
             <InfoCircleOutlined
               style={{ color: 'var(--color-text-2)', cursor: 'pointer', marginLeft: 4 }}
               onClick={handleJoplinHelpClick}

--- a/src/renderer/src/pages/settings/DataSettings/LocalBackupSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/LocalBackupSettings.tsx
@@ -1,4 +1,5 @@
 import { DeleteOutlined, FolderOpenOutlined, SaveOutlined, SyncOutlined, WarningOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import { HStack } from '@renderer/components/Layout'
 import { LocalBackupManager } from '@renderer/components/LocalBackupManager'
@@ -16,7 +17,7 @@ import {
   setLocalBackupSyncInterval as _setLocalBackupSyncInterval
 } from '@renderer/store/settings'
 import { AppInfo } from '@renderer/types'
-import { Button, Input, Switch, Tooltip } from 'antd'
+import { Button, Input, Switch } from 'antd'
 import dayjs from 'dayjs'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -175,7 +176,7 @@ const LocalBackupSettings: React.FC = () => {
       <HStack gap="5px" alignItems="center">
         {localBackupSync.syncing && <SyncOutlined spin />}
         {!localBackupSync.syncing && localBackupSync.lastSyncError && (
-          <Tooltip title={`${t('settings.data.local.syncError')}: ${localBackupSync.lastSyncError}`}>
+          <Tooltip content={`${t('settings.data.local.syncError')}: ${localBackupSync.lastSyncError}`} showArrow={true}>
             <WarningOutlined style={{ color: 'red' }} />
           </Tooltip>
         )}

--- a/src/renderer/src/pages/settings/DataSettings/NotionSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/NotionSettings.tsx
@@ -1,4 +1,5 @@
 import { InfoCircleOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { Client } from '@notionhq/client'
 import { HStack } from '@renderer/components/Layout'
 import { useTheme } from '@renderer/context/ThemeProvider'
@@ -10,7 +11,7 @@ import {
   setNotionExportReasoning,
   setNotionPageNameKey
 } from '@renderer/store/settings'
-import { Button, Space, Switch, Tooltip } from 'antd'
+import { Button, Space, Switch } from 'antd'
 import { Input } from 'antd'
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -82,7 +83,7 @@ const NotionSettings: FC = () => {
     <SettingGroup theme={theme}>
       <SettingTitle style={{ justifyContent: 'flex-start', gap: 10 }}>
         {t('settings.data.notion.title')}
-        <Tooltip title={t('settings.data.notion.help')} placement="right">
+        <Tooltip content={t('settings.data.notion.help')} placement="right" showArrow={true}>
           <InfoCircleOutlined
             style={{ color: 'var(--color-text-2)', cursor: 'pointer' }}
             onClick={handleNotionTitleClick}

--- a/src/renderer/src/pages/settings/DataSettings/NutstoreSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/NutstoreSettings.tsx
@@ -1,4 +1,5 @@
 import { CheckOutlined, FolderOutlined, LoadingOutlined, SyncOutlined, WarningOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { HStack } from '@renderer/components/Layout'
 import NutstorePathPopup from '@renderer/components/Popups/NutsorePathPopup'
 import Selector from '@renderer/components/Selector'
@@ -26,7 +27,7 @@ import {
 } from '@renderer/store/nutstore'
 import { modalConfirm } from '@renderer/utils'
 import { NUTSTORE_HOST } from '@shared/config/nutstore'
-import { Button, Input, Switch, Tooltip, Typography } from 'antd'
+import { Button, Input, Switch, Typography } from 'antd'
 import dayjs from 'dayjs'
 import { FC, useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -187,7 +188,9 @@ const NutstoreSettings: FC = () => {
       <HStack gap="5px" alignItems="center">
         {nutstoreSyncState.syncing && <SyncOutlined spin />}
         {!nutstoreSyncState.syncing && nutstoreSyncState.lastSyncError && (
-          <Tooltip title={`${t('settings.data.webdav.syncError')}: ${nutstoreSyncState.lastSyncError}`}>
+          <Tooltip
+            content={`${t('settings.data.webdav.syncError')}: ${nutstoreSyncState.lastSyncError}`}
+            showArrow={true}>
             <WarningOutlined style={{ color: 'red' }} />
           </Tooltip>
         )}

--- a/src/renderer/src/pages/settings/DataSettings/S3Settings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/S3Settings.tsx
@@ -1,4 +1,5 @@
 import { FolderOpenOutlined, InfoCircleOutlined, SaveOutlined, SyncOutlined, WarningOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { HStack } from '@renderer/components/Layout'
 import { S3BackupManager } from '@renderer/components/S3BackupManager'
 import { S3BackupModal, useS3BackupModal } from '@renderer/components/S3Modals'
@@ -10,7 +11,7 @@ import { startAutoSync, stopAutoSync } from '@renderer/services/BackupService'
 import { useAppDispatch, useAppSelector } from '@renderer/store'
 import { setS3Partial } from '@renderer/store/settings'
 import { S3Config } from '@renderer/types'
-import { Button, Input, Switch, Tooltip } from 'antd'
+import { Button, Input, Switch } from 'antd'
 import dayjs from 'dayjs'
 import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -90,7 +91,7 @@ const S3Settings: FC = () => {
       <HStack gap="5px" alignItems="center">
         {s3Sync?.syncing && <SyncOutlined spin />}
         {!s3Sync?.syncing && s3Sync?.lastSyncError && (
-          <Tooltip title={t('settings.data.s3.syncStatus.error', { message: s3Sync.lastSyncError })}>
+          <Tooltip content={t('settings.data.s3.syncStatus.error', { message: s3Sync.lastSyncError })} showArrow={true}>
             <WarningOutlined style={{ color: 'red' }} />
           </Tooltip>
         )}
@@ -118,7 +119,7 @@ const S3Settings: FC = () => {
     <SettingGroup theme={theme}>
       <SettingTitle style={{ justifyContent: 'flex-start', gap: 10 }}>
         {t('settings.data.s3.title.label')}
-        <Tooltip title={t('settings.data.s3.title.tooltip')} placement="right">
+        <Tooltip content={t('settings.data.s3.title.tooltip')} placement="right" showArrow={true}>
           <InfoCircleOutlined style={{ color: 'var(--color-text-2)', cursor: 'pointer' }} onClick={handleTitleClick} />
         </Tooltip>
       </SettingTitle>

--- a/src/renderer/src/pages/settings/DataSettings/SiyuanSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/SiyuanSettings.tsx
@@ -1,11 +1,12 @@
 import { InfoCircleOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import { HStack } from '@renderer/components/Layout'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import { useMinappPopup } from '@renderer/hooks/useMinappPopup'
 import { RootState, useAppDispatch } from '@renderer/store'
 import { setSiyuanApiUrl, setSiyuanBoxId, setSiyuanRootPath, setSiyuanToken } from '@renderer/store/settings'
-import { Button, Space, Tooltip } from 'antd'
+import { Button, Space } from 'antd'
 import { Input } from 'antd'
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -103,7 +104,7 @@ const SiyuanSettings: FC = () => {
       <SettingRow>
         <SettingRowTitle style={{ display: 'flex', alignItems: 'center' }}>
           <span>{t('settings.data.siyuan.token.label')}</span>
-          <Tooltip title={t('settings.data.siyuan.token.help')} placement="left">
+          <Tooltip content={t('settings.data.siyuan.token.help')} placement="left" showArrow={true}>
             <InfoCircleOutlined
               style={{ color: 'var(--color-text-2)', cursor: 'pointer', marginLeft: 4 }}
               onClick={handleSiyuanHelpClick}

--- a/src/renderer/src/pages/settings/DataSettings/WebDavSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/WebDavSettings.tsx
@@ -1,4 +1,5 @@
 import { FolderOpenOutlined, SaveOutlined, SyncOutlined, WarningOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { HStack } from '@renderer/components/Layout'
 import Selector from '@renderer/components/Selector'
 import { WebdavBackupManager } from '@renderer/components/WebdavBackupManager'
@@ -18,7 +19,7 @@ import {
   setWebdavSyncInterval as _setWebdavSyncInterval,
   setWebdavUser as _setWebdavUser
 } from '@renderer/store/settings'
-import { Button, Input, Switch, Tooltip } from 'antd'
+import { Button, Input, Switch } from 'antd'
 import dayjs from 'dayjs'
 import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -95,7 +96,7 @@ const WebDavSettings: FC = () => {
       <HStack gap="5px" alignItems="center">
         {webdavSync.syncing && <SyncOutlined spin />}
         {!webdavSync.syncing && webdavSync.lastSyncError && (
-          <Tooltip title={`${t('settings.data.webdav.syncError')}: ${webdavSync.lastSyncError}`}>
+          <Tooltip content={`${t('settings.data.webdav.syncError')}: ${webdavSync.lastSyncError}`} showArrow={true}>
             <WarningOutlined style={{ color: 'red' }} />
           </Tooltip>
         )}

--- a/src/renderer/src/pages/settings/DataSettings/YuqueSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/YuqueSettings.tsx
@@ -1,10 +1,11 @@
 import { InfoCircleOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { HStack } from '@renderer/components/Layout'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import { useMinappPopup } from '@renderer/hooks/useMinappPopup'
 import { RootState, useAppDispatch } from '@renderer/store'
 import { setYuqueRepoId, setYuqueToken, setYuqueUrl } from '@renderer/store/settings'
-import { Button, Space, Tooltip } from 'antd'
+import { Button, Space } from 'antd'
 import { Input } from 'antd'
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -92,7 +93,7 @@ const YuqueSettings: FC = () => {
       <SettingRow>
         <SettingRowTitle>
           {t('settings.data.yuque.token')}
-          <Tooltip title={t('settings.data.yuque.help')} placement="left">
+          <Tooltip content={t('settings.data.yuque.help')} placement="left" showArrow={true}>
             <InfoCircleOutlined
               style={{ color: 'var(--color-text-2)', cursor: 'pointer', marginLeft: 4 }}
               onClick={handleYuqueHelpClick}

--- a/src/renderer/src/pages/settings/DisplaySettings/DisplaySettings.tsx
+++ b/src/renderer/src/pages/settings/DisplaySettings/DisplaySettings.tsx
@@ -18,7 +18,7 @@ import {
   setSidebarIcons
 } from '@renderer/store/settings'
 import { ThemeMode } from '@renderer/types'
-import { Button, ColorPicker, Segmented, Switch } from 'antd'
+import { Button, ColorPicker, Segmented, Select, Switch } from 'antd'
 import { Minus, Monitor, Moon, Plus, Sun } from 'lucide-react'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -78,6 +78,7 @@ const DisplaySettings: FC = () => {
 
   const [visibleIcons, setVisibleIcons] = useState(sidebarIcons?.visible || DEFAULT_SIDEBAR_ICONS)
   const [disabledIcons, setDisabledIcons] = useState(sidebarIcons?.disabled || [])
+  const [fontList, setFontList] = useState<string[]>([])
 
   const handleWindowStyleChange = useCallback(
     (checked: boolean) => {
@@ -136,6 +137,11 @@ const DisplaySettings: FC = () => {
   )
 
   useEffect(() => {
+    // 初始化获取所有系统字体
+    window.api.getSystemFonts().then((fonts: string[]) => {
+      setFontList(fonts)
+    })
+
     // 初始化获取当前缩放值
     window.api.handleZoomFactor(0).then((factor) => {
       setCurrentZoom(factor)
@@ -159,6 +165,26 @@ const DisplaySettings: FC = () => {
     const zoomFactor = await window.api.handleZoomFactor(delta, reset)
     setCurrentZoom(zoomFactor)
   }
+
+  const handleUserFontChange = useCallback(
+    (value: string) => {
+      setUserTheme({
+        ...userTheme,
+        userFontFamily: value
+      })
+    },
+    [setUserTheme, userTheme]
+  )
+
+  const handleUserCodeFontChange = useCallback(
+    (value: string) => {
+      setUserTheme({
+        ...userTheme,
+        userCodeFontFamily: value
+      })
+    },
+    [setUserTheme, userTheme]
+  )
 
   const assistantIconTypeOptions = useMemo(
     () => [
@@ -194,6 +220,7 @@ const DisplaySettings: FC = () => {
               ))}
             </HStack>
             <ColorPicker
+              style={{ fontFamily: 'inherit' }}
               className="color-picker"
               value={userTheme.colorPrimary}
               onChange={(color) => handleColorPrimaryChange(color.toHexString())}
@@ -253,6 +280,75 @@ const DisplaySettings: FC = () => {
               variant="text"
             />
           </ZoomButtonGroup>
+        </SettingRow>
+      </SettingGroup>
+      <SettingGroup theme={theme}>
+        <SettingTitle style={{ justifyContent: 'flex-start', gap: 5 }}>
+          {t('settings.display.font.title')} <TextBadge text="New" />
+        </SettingTitle>
+        <SettingDivider />
+        <SettingRow>
+          <SettingRowTitle>{t('settings.display.font.global')}</SettingRowTitle>
+          <SelectRow>
+            <Select
+              style={{ width: 200 }}
+              placeholder={t('settings.display.font.select')}
+              options={[
+                {
+                  label: (
+                    <span style={{ fontFamily: 'Ubuntu, -apple-system, system-ui, Arial, sans-serif' }}>
+                      {t('settings.display.font.default')}
+                    </span>
+                  ),
+                  value: ''
+                },
+                ...fontList.map((font) => ({ label: <span style={{ fontFamily: font }}>{font}</span>, value: font }))
+              ]}
+              value={userTheme.userFontFamily || ''}
+              onChange={(font) => handleUserFontChange(font)}
+              showSearch
+              getPopupContainer={(triggerNode) => triggerNode.parentElement || document.body}
+            />
+            <Button
+              onClick={() => handleUserFontChange('')}
+              style={{ marginLeft: 8 }}
+              icon={<ResetIcon size="14" />}
+              color="default"
+              variant="text"
+            />
+          </SelectRow>
+        </SettingRow>
+        <SettingDivider />
+        <SettingRow>
+          <SettingRowTitle>{t('settings.display.font.code')}</SettingRowTitle>
+          <SelectRow>
+            <Select
+              style={{ width: 200 }}
+              placeholder={t('settings.display.font.select')}
+              options={[
+                {
+                  label: (
+                    <span style={{ fontFamily: 'Ubuntu, -apple-system, system-ui, Arial, sans-serif' }}>
+                      {t('settings.display.font.default')}
+                    </span>
+                  ),
+                  value: ''
+                },
+                ...fontList.map((font) => ({ label: <span style={{ fontFamily: font }}>{font}</span>, value: font }))
+              ]}
+              value={userTheme.userCodeFontFamily || ''}
+              onChange={(font) => handleUserCodeFontChange(font)}
+              showSearch
+              getPopupContainer={(triggerNode) => triggerNode.parentElement || document.body}
+            />
+            <Button
+              onClick={() => handleUserCodeFontChange('')}
+              style={{ marginLeft: 8 }}
+              icon={<ResetIcon size="14" />}
+              color="default"
+              variant="text"
+            />
+          </SelectRow>
         </SettingRow>
       </SettingGroup>
       <SettingGroup theme={theme}>
@@ -377,6 +473,13 @@ const ZoomValue = styled.span`
   width: 40px;
   text-align: center;
   margin: 0 5px;
+`
+
+const SelectRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  width: 300px;
 `
 
 export default DisplaySettings

--- a/src/renderer/src/pages/settings/DocProcessSettings/PreprocessProviderSettings.tsx
+++ b/src/renderer/src/pages/settings/DocProcessSettings/PreprocessProviderSettings.tsx
@@ -1,10 +1,11 @@
 import { ExportOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { ApiKeyListPopup } from '@renderer/components/Popups/ApiKeyListPopup'
 import { getPreprocessProviderLogo, PREPROCESS_PROVIDER_CONFIG } from '@renderer/config/preprocessProviders'
 import { usePreprocessProvider } from '@renderer/hooks/usePreprocess'
 import { PreprocessProvider } from '@renderer/types'
 import { formatApiKeys, hasObjectKey } from '@renderer/utils'
-import { Avatar, Button, Divider, Flex, Input, Tooltip } from 'antd'
+import { Avatar, Button, Divider, Flex, Input } from 'antd'
 import Link from 'antd/es/typography/Link'
 import { List } from 'lucide-react'
 import { FC, useEffect, useState } from 'react'
@@ -92,7 +93,7 @@ const PreprocessProviderSettings: FC<Props> = ({ provider: _provider }) => {
               justifyContent: 'space-between'
             }}>
             {t('settings.provider.api_key.label')}
-            <Tooltip title={t('settings.provider.api.key.list.open')} mouseEnterDelay={0.5}>
+            <Tooltip content={t('settings.provider.api.key.list.open')} delay={500} showArrow={true}>
               <Button type="text" size="small" onClick={openApiKeyList} icon={<List size={14} />} />
             </Tooltip>
           </SettingSubtitle>

--- a/src/renderer/src/pages/settings/GeneralSettings.tsx
+++ b/src/renderer/src/pages/settings/GeneralSettings.tsx
@@ -1,4 +1,5 @@
 import { InfoCircleOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { HStack } from '@renderer/components/Layout'
 import Selector from '@renderer/components/Selector'
 import { InfoTooltip } from '@renderer/components/TooltipIcons'
@@ -22,7 +23,7 @@ import { NotificationSource } from '@renderer/types/notification'
 import { isValidProxyUrl } from '@renderer/utils'
 import { formatErrorMessage } from '@renderer/utils/error'
 import { defaultByPassRules, defaultLanguage } from '@shared/config/constant'
-import { Flex, Input, Switch, Tooltip } from 'antd'
+import { Flex, Input, Switch } from 'antd'
 import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
@@ -283,7 +284,7 @@ const GeneralSettings: FC = () => {
         <SettingRow>
           <SettingRowTitle style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
             <span>{t('settings.notification.assistant')}</span>
-            <Tooltip title={t('notification.tip')} placement="right">
+            <Tooltip content={t('notification.tip')} placement="right" showArrow={true}>
               <InfoCircleOutlined style={{ cursor: 'pointer' }} />
             </Tooltip>
           </SettingRowTitle>

--- a/src/renderer/src/pages/settings/MCPSettings/McpPrompt.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/McpPrompt.tsx
@@ -1,5 +1,6 @@
+import { Tooltip } from '@heroui/react'
 import { MCPPrompt } from '@renderer/types'
-import { Collapse, Descriptions, Empty, Flex, Tooltip, Typography } from 'antd'
+import { Collapse, Descriptions, Empty, Flex, Typography } from 'antd'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
@@ -25,7 +26,7 @@ const MCPPromptsSection = ({ prompts }: MCPPromptsSectionProps) => {
                 <Flex gap={4}>
                   <Typography.Text strong>{arg.name}</Typography.Text>
                   {arg.required && (
-                    <Tooltip title="Required field">
+                    <Tooltip content="Required field" showArrow={true}>
                       <span style={{ color: '#f5222d' }}>*</span>
                     </Tooltip>
                   )}

--- a/src/renderer/src/pages/settings/MCPSettings/McpServerCard.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/McpServerCard.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import { ErrorBoundary } from '@renderer/components/ErrorBoundary'
 import { DeleteIcon } from '@renderer/components/Icons'
 import GeneralPopup from '@renderer/components/Popups/GeneralPopup'
@@ -5,7 +6,7 @@ import Scrollbar from '@renderer/components/Scrollbar'
 import { getMcpTypeLabel } from '@renderer/i18n/label'
 import { MCPServer } from '@renderer/types'
 import { formatErrorMessage } from '@renderer/utils/error'
-import { Alert, Button, Space, Switch, Tag, Tooltip, Typography } from 'antd'
+import { Alert, Button, Space, Switch, Tag, Typography } from 'antd'
 import { CircleXIcon, Settings2, SquareArrowOutUpRight } from 'lucide-react'
 import { FC, useCallback } from 'react'
 import { FallbackProps } from 'react-error-boundary'
@@ -82,7 +83,7 @@ const McpServerCard: FC<McpServerCardProps> = ({
                 danger
                 type="text"
                 icon={
-                  <Tooltip title={t('error.boundary.details')}>
+                  <Tooltip content={t('error.boundary.details')} showArrow={true}>
                     <CircleXIcon size={16} />
                   </Tooltip>
                 }
@@ -93,7 +94,7 @@ const McpServerCard: FC<McpServerCardProps> = ({
                 danger
                 type="text"
                 icon={
-                  <Tooltip title={t('common.delete')}>
+                  <Tooltip content={t('common.delete')} showArrow={true}>
                     <DeleteIcon size={16} />
                   </Tooltip>
                 }

--- a/src/renderer/src/pages/settings/MCPSettings/McpTool.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/McpTool.tsx
@@ -1,6 +1,7 @@
+import { Tooltip } from '@heroui/react'
 import { MCPServer, MCPTool } from '@renderer/types'
 import { isToolAutoApproved } from '@renderer/utils/mcp-tools'
-import { Badge, Descriptions, Empty, Flex, Switch, Table, Tag, Tooltip, Typography } from 'antd'
+import { Badge, Descriptions, Empty, Flex, Switch, Table, Tag, Typography } from 'antd'
 import { ColumnsType } from 'antd/es/table'
 import { Hammer, Info, Zap } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -61,7 +62,7 @@ const MCPToolsSection = ({ tools, server, onToggleTool, onToggleAutoApprove }: M
               <Flex gap={4}>
                 <Typography.Text strong>{key}</Typography.Text>
                 {tool.inputSchema.required?.includes(key) && (
-                  <Tooltip title="Required field">
+                  <Tooltip content="Required field" showArrow={true}>
                     <span style={{ color: '#f5222d' }}>*</span>
                   </Tooltip>
                 )}
@@ -118,7 +119,7 @@ const MCPToolsSection = ({ tools, server, onToggleTool, onToggleAutoApprove }: M
             <Typography.Text strong ellipsis={{ tooltip: tool.name }}>
               {tool.name}
             </Typography.Text>
-            <Tooltip title={`ID: ${tool.id}`} mouseEnterDelay={0}>
+            <Tooltip content={`ID: ${tool.id}`} closeDelay={0} showArrow={true}>
               <Info size={14} />
             </Tooltip>
           </Flex>
@@ -159,14 +160,15 @@ const MCPToolsSection = ({ tools, server, onToggleTool, onToggleAutoApprove }: M
       align: 'center',
       render: (_, tool) => (
         <Tooltip
-          title={
+          content={
             !isToolEnabled(tool)
               ? t('settings.mcp.tools.autoApprove.tooltip.howToEnable')
               : isToolAutoApproved(tool, server)
                 ? t('settings.mcp.tools.autoApprove.tooltip.enabled')
                 : t('settings.mcp.tools.autoApprove.tooltip.disabled')
           }
-          placement="top">
+          placement="top"
+          showArrow={true}>
           <Switch
             checked={isToolAutoApproved(tool, server)}
             disabled={!isToolEnabled(tool)}

--- a/src/renderer/src/pages/settings/MemorySettings/UserSelector.tsx
+++ b/src/renderer/src/pages/settings/MemorySettings/UserSelector.tsx
@@ -1,5 +1,6 @@
+import { Tooltip } from '@heroui/react'
 import { HStack } from '@renderer/components/Layout'
-import { Avatar, Button, Select, Space, Tooltip } from 'antd'
+import { Avatar, Button, Select, Space } from 'antd'
 import { UserRoundPlus } from 'lucide-react'
 import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -53,7 +54,7 @@ const UserSelector: React.FC<UserSelectorProps> = ({ currentUser, uniqueUsers, o
   return (
     <Space.Compact>
       <Select value={currentUser} onChange={onUserSwitch} style={{ width: 200 }} options={options} />
-      <Tooltip title={t('memory.add_new_user')}>
+      <Tooltip content={t('memory.add_new_user')} showArrow={true}>
         <Button type="default" onClick={onAddUser} icon={<UserRoundPlus size={16} />} />
       </Tooltip>
     </Space.Compact>

--- a/src/renderer/src/pages/settings/ModelSettings/DefaultAssistantSettings.tsx
+++ b/src/renderer/src/pages/settings/ModelSettings/DefaultAssistantSettings.tsx
@@ -1,4 +1,5 @@
 import { CloseCircleFilled, QuestionCircleOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import EmojiPicker from '@renderer/components/EmojiPicker'
 import { ResetIcon } from '@renderer/components/Icons'
 import { HStack } from '@renderer/components/Layout'
@@ -8,7 +9,7 @@ import { useTheme } from '@renderer/context/ThemeProvider'
 import { useDefaultAssistant } from '@renderer/hooks/useAssistant'
 import { AssistantSettings as AssistantSettingsType } from '@renderer/types'
 import { getLeadingEmoji, modalConfirm } from '@renderer/utils'
-import { Button, Col, Flex, Input, InputNumber, Modal, Popover, Row, Slider, Switch, Tooltip } from 'antd'
+import { Button, Col, Flex, Input, InputNumber, Modal, Popover, Row, Slider, Switch } from 'antd'
 import TextArea from 'antd/es/input/TextArea'
 import { Dispatch, FC, SetStateAction, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -156,14 +157,14 @@ const AssistantSettings: FC = () => {
           marginTop: 0
         }}>
         {t('settings.assistant.model_params')}
-        <Tooltip title={t('common.reset')} mouseLeaveDelay={0}>
+        <Tooltip content={t('common.reset')} closeDelay={0} showArrow={true}>
           <Button type="text" onClick={onReset} icon={<ResetIcon size={16} />} />
         </Tooltip>
       </SettingSubtitle>
       <SettingRow>
         <HStack alignItems="center">
           <Label>{t('chat.settings.temperature.label')}</Label>
-          <Tooltip title={t('chat.settings.temperature.tip')}>
+          <Tooltip content={t('chat.settings.temperature.tip')} showArrow={true}>
             <QuestionIcon />
           </Tooltip>
         </HStack>
@@ -204,7 +205,7 @@ const AssistantSettings: FC = () => {
       <SettingRow>
         <HStack alignItems="center">
           <Label>{t('chat.settings.top_p.label')}</Label>
-          <Tooltip title={t('chat.settings.top_p.tip')}>
+          <Tooltip content={t('chat.settings.top_p.tip')} showArrow={true}>
             <QuestionIcon />
           </Tooltip>
         </HStack>
@@ -237,7 +238,7 @@ const AssistantSettings: FC = () => {
       )}
       <Row align="middle">
         <Label>{t('chat.settings.context_count.label')}</Label>
-        <Tooltip title={t('chat.settings.context_count.tip')}>
+        <Tooltip content={t('chat.settings.context_count.tip')} showArrow={true}>
           <QuestionIcon />
         </Tooltip>
       </Row>
@@ -267,7 +268,7 @@ const AssistantSettings: FC = () => {
       <Flex justify="space-between" align="center">
         <HStack alignItems="center">
           <Label>{t('chat.settings.max_tokens.label')}</Label>
-          <Tooltip title={t('chat.settings.max_tokens.tip')}>
+          <Tooltip content={t('chat.settings.max_tokens.tip')} showArrow={true}>
             <QuestionIcon />
           </Tooltip>
         </HStack>

--- a/src/renderer/src/pages/settings/ModelSettings/ModelSettings.tsx
+++ b/src/renderer/src/pages/settings/ModelSettings/ModelSettings.tsx
@@ -1,4 +1,5 @@
 import { RedoOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { HStack } from '@renderer/components/Layout'
 import ModelSelector from '@renderer/components/ModelSelector'
 import { InfoTooltip } from '@renderer/components/TooltipIcons'
@@ -12,7 +13,7 @@ import { getModelUniqId, hasModel } from '@renderer/services/ModelService'
 import { useAppDispatch } from '@renderer/store'
 import { setTranslateModelPrompt } from '@renderer/store/settings'
 import { Model } from '@renderer/types'
-import { Button, Tooltip } from 'antd'
+import { Button } from 'antd'
 import { find } from 'lodash'
 import { Languages, MessageSquareMore, Rocket, Settings2 } from 'lucide-react'
 import { FC, useCallback, useMemo } from 'react'
@@ -123,7 +124,7 @@ const ModelSettings: FC = () => {
             onClick={() => TranslateSettingsPopup.show()}
           />
           {translateModelPrompt !== TRANSLATE_PROMPT && (
-            <Tooltip title={t('common.reset')}>
+            <Tooltip content={t('common.reset')} showArrow={true}>
               <Button icon={<RedoOutlined />} style={{ marginLeft: 8 }} onClick={onResetTranslatePrompt}></Button>
             </Tooltip>
           )}

--- a/src/renderer/src/pages/settings/ProviderSettings/GithubCopilotSettings.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/GithubCopilotSettings.tsx
@@ -1,8 +1,9 @@
 import { CheckCircleOutlined, CopyOutlined, ExclamationCircleOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import { useCopilot } from '@renderer/hooks/useCopilot'
 import { useProvider } from '@renderer/hooks/useProvider'
-import { Alert, Button, Input, Slider, Steps, Tooltip, Typography } from 'antd'
+import { Alert, Button, Input, Slider, Steps, Typography } from 'antd'
 import { FC, useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -287,7 +288,8 @@ const GithubCopilotSettings: FC<GithubCopilotSettingsProps> = ({ providerId }) =
                     </div>
                   </StepHeader>
                   <Tooltip
-                    title={!verificationPageOpened ? t('settings.provider.copilot.open_verification_first') : ''}>
+                    content={!verificationPageOpened ? t('settings.provider.copilot.open_verification_first') : ''}
+                    showArrow={true}>
                     <Button
                       type="primary"
                       loading={loading}

--- a/src/renderer/src/pages/settings/ProviderSettings/ModelList/ManageModelsList.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ModelList/ManageModelsList.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import ExpandableText from '@renderer/components/ExpandableText'
 import ModelIdWithTags from '@renderer/components/ModelIdWithTags'
 import CustomTag from '@renderer/components/Tags/CustomTag'
@@ -6,7 +7,7 @@ import { getModelLogo } from '@renderer/config/models'
 import FileItem from '@renderer/pages/files/FileItem'
 import NewApiBatchAddModelPopup from '@renderer/pages/settings/ProviderSettings/ModelList/NewApiBatchAddModelPopup'
 import { Model, Provider } from '@renderer/types'
-import { Button, Flex, Tooltip } from 'antd'
+import { Button, Flex } from 'antd'
 import { Avatar } from 'antd'
 import { ChevronRight, Minus, Plus } from 'lucide-react'
 import React, { memo, useCallback, useMemo, useState } from 'react'
@@ -109,14 +110,14 @@ const ManageModelsList: React.FC<ManageModelsListProps> = ({ modelGroups, provid
 
       return (
         <Tooltip
-          destroyOnHidden
-          title={
+          content={
             isAllInProvider
               ? t('settings.models.manage.remove_whole_group')
               : t('settings.models.manage.add_whole_group')
           }
-          mouseLeaveDelay={0}
-          placement="top">
+          closeDelay={0}
+          placement="top"
+          showArrow={true}>
           <Button
             type="text"
             icon={isAllInProvider ? <Minus size={16} /> : <Plus size={16} />}

--- a/src/renderer/src/pages/settings/ProviderSettings/ModelList/ManageModelsPopup.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ModelList/ManageModelsPopup.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import { LoadingIcon } from '@renderer/components/Icons'
 import { HStack } from '@renderer/components/Layout'
@@ -20,7 +21,7 @@ import { fetchModels } from '@renderer/services/ApiService'
 import { Model, Provider } from '@renderer/types'
 import { filterModelsByKeywords, getDefaultGroupName, getFancyProviderName } from '@renderer/utils'
 import { isFreeModel } from '@renderer/utils/model'
-import { Button, Empty, Flex, Modal, Spin, Tabs, Tooltip } from 'antd'
+import { Button, Empty, Flex, Modal, Spin, Tabs } from 'antd'
 import Input from 'antd/es/input/Input'
 import { groupBy, isEmpty, uniqBy } from 'lodash'
 import { debounce } from 'lodash'
@@ -243,12 +244,13 @@ const PopupContainer: React.FC<Props> = ({ providerId, resolve }) => {
     return (
       <HStack gap={8}>
         <Tooltip
-          title={
+          content={
             isAllFilteredInProvider
               ? t('settings.models.manage.remove_listed')
               : t('settings.models.manage.add_listed.label')
           }
-          mouseLeaveDelay={0}>
+          closeDelay={0}
+          showArrow={true}>
           <Button
             type="default"
             icon={isAllFilteredInProvider ? <ListMinus size={18} /> : <ListPlus size={18} />}
@@ -260,7 +262,7 @@ const PopupContainer: React.FC<Props> = ({ providerId, resolve }) => {
             disabled={loadingModels || list.length === 0}
           />
         </Tooltip>
-        <Tooltip title={t('settings.models.manage.refetch_list')} mouseLeaveDelay={0}>
+        <Tooltip content={t('settings.models.manage.refetch_list')} closeDelay={0} showArrow={true}>
           <Button
             type="default"
             icon={<RefreshCcw size={16} />}

--- a/src/renderer/src/pages/settings/ProviderSettings/ModelList/ModelList.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ModelList/ModelList.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import CollapsibleSearchBar from '@renderer/components/CollapsibleSearchBar'
 import { LoadingIcon, StreamlineGoodHealthAndWellBeing } from '@renderer/components/Icons'
 import { HStack } from '@renderer/components/Layout'
@@ -12,7 +13,7 @@ import ManageModelsPopup from '@renderer/pages/settings/ProviderSettings/ModelLi
 import NewApiAddModelPopup from '@renderer/pages/settings/ProviderSettings/ModelList/NewApiAddModelPopup'
 import { Model } from '@renderer/types'
 import { filterModelsByKeywords } from '@renderer/utils'
-import { Button, Flex, Spin, Tooltip } from 'antd'
+import { Button, Flex, Spin } from 'antd'
 import { groupBy, isEmpty, sortBy, toPairs } from 'lodash'
 import { ListCheck, Plus } from 'lucide-react'
 import React, { memo, startTransition, useCallback, useEffect, useMemo, useState } from 'react'
@@ -115,7 +116,7 @@ const ModelList: React.FC<ModelListProps> = ({ providerId }) => {
           </HStack>
           {editable && (
             <HStack>
-              <Tooltip title={t('settings.models.check.button_caption')} mouseLeaveDelay={0}>
+              <Tooltip content={t('settings.models.check.button_caption')} closeDelay={0} showArrow={true}>
                 <Button
                   type="text"
                   onClick={runHealthCheck}

--- a/src/renderer/src/pages/settings/ProviderSettings/ModelList/ModelListGroup.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ModelList/ModelListGroup.tsx
@@ -1,8 +1,9 @@
+import { Tooltip } from '@heroui/react'
 import CustomCollapse from '@renderer/components/CustomCollapse'
 import { DynamicVirtualList, type DynamicVirtualListRef } from '@renderer/components/VirtualList'
 import { Model } from '@renderer/types'
 import { ModelWithStatus } from '@renderer/types/healthCheck'
-import { Button, Flex, Tooltip } from 'antd'
+import { Button, Flex } from 'antd'
 import { Minus } from 'lucide-react'
 import React, { memo, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -55,7 +56,7 @@ const ModelListGroup: React.FC<ModelListGroupProps> = ({
           </Flex>
         }
         extra={
-          <Tooltip title={t('settings.models.manage.remove_whole_group')} mouseLeaveDelay={0}>
+          <Tooltip content={t('settings.models.manage.remove_whole_group')} closeDelay={0} showArrow={true}>
             <Button
               type="text"
               className="toolbar-item"

--- a/src/renderer/src/pages/settings/ProviderSettings/ModelList/ModelListItem.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ModelList/ModelListItem.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import { FreeTrialModelTag } from '@renderer/components/FreeTrialModelTag'
 import { type HealthResult, HealthStatusIndicator } from '@renderer/components/HealthStatusIndicator'
 import { HStack } from '@renderer/components/Layout'
@@ -6,7 +7,7 @@ import { getModelLogo } from '@renderer/config/models'
 import { Model } from '@renderer/types'
 import { ModelWithStatus } from '@renderer/types/healthCheck'
 import { maskApiKey } from '@renderer/utils/api'
-import { Avatar, Button, Tooltip } from 'antd'
+import { Avatar, Button } from 'antd'
 import { Bolt, Minus } from 'lucide-react'
 import React, { memo } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -52,10 +53,10 @@ const ModelListItem: React.FC<ModelListItemProps> = ({ ref, model, modelStatus, 
       <HStack alignItems="center" gap={6}>
         <HealthStatusIndicator results={healthResults} loading={isChecking} showLatency />
         <HStack alignItems="center" gap={0}>
-          <Tooltip title={t('models.edit')} mouseLeaveDelay={0}>
+          <Tooltip content={t('models.edit')} closeDelay={0} showArrow={true}>
             <Button type="text" onClick={() => onEdit(model)} disabled={disabled} icon={<Bolt size={14} />} />
           </Tooltip>
-          <Tooltip title={t('settings.models.manage.remove_model')} mouseLeaveDelay={0}>
+          <Tooltip content={t('settings.models.manage.remove_model')} closeDelay={0} showArrow={true}>
             <Button type="text" onClick={() => onRemove(model)} disabled={disabled} icon={<Minus size={14} />} />
           </Tooltip>
         </HStack>

--- a/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import OpenAIAlert from '@renderer/components/Alert/OpenAIAlert'
 import { LoadingIcon } from '@renderer/components/Icons'
 import { HStack } from '@renderer/components/Layout'
@@ -18,7 +19,7 @@ import { isSystemProvider } from '@renderer/types'
 import { ApiKeyConnectivity, HealthStatus } from '@renderer/types/healthCheck'
 import { formatApiHost, formatApiKeys, getFancyProviderName, isOpenAIProvider } from '@renderer/utils'
 import { formatErrorMessage } from '@renderer/utils/error'
-import { Button, Divider, Flex, Input, Select, Space, Switch, Tooltip } from 'antd'
+import { Button, Divider, Flex, Input, Select, Space, Switch } from 'antd'
 import Link from 'antd/es/typography/Link'
 import { debounce, isEmpty } from 'lodash'
 import { Bolt, Check, Settings2, SquareArrowOutUpRight, TriangleAlert } from 'lucide-react'
@@ -222,7 +223,7 @@ const ProviderSetting: FC<Props> = ({ providerId }) => {
     }
 
     return (
-      <Tooltip title={<ErrorOverlay>{apiKeyConnectivity.error}</ErrorOverlay>}>
+      <Tooltip content={<ErrorOverlay>{apiKeyConnectivity.error}</ErrorOverlay>} showArrow={true}>
         <TriangleAlert size={16} color="var(--color-status-warning)" />
       </Tooltip>
     )
@@ -248,7 +249,7 @@ const ProviderSetting: FC<Props> = ({ providerId }) => {
             </Link>
           )}
           {!isSystemProvider(provider) && (
-            <Tooltip title={t('settings.provider.api.options.label')}>
+            <Tooltip content={t('settings.provider.api.options.label')} showArrow={true}>
               <Button
                 type="text"
                 icon={<Bolt size={14} />}
@@ -299,7 +300,7 @@ const ProviderSetting: FC<Props> = ({ providerId }) => {
             }}>
             {t('settings.provider.api_key.label')}
             {provider.id !== 'copilot' && (
-              <Tooltip title={t('settings.provider.api.key.list.open')} mouseEnterDelay={0.5}>
+              <Tooltip content={t('settings.provider.api.key.list.open')} closeDelay={0.5} showArrow={true}>
                 <Button type="text" onClick={openApiKeyList} icon={<Settings2 size={16} />} />
               </Tooltip>
             )}

--- a/src/renderer/src/pages/settings/QuickAssistantSettings.tsx
+++ b/src/renderer/src/pages/settings/QuickAssistantSettings.tsx
@@ -1,4 +1,5 @@
 import { InfoCircleOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import ModelAvatar from '@renderer/components/Avatar/ModelAvatar'
 import { HStack } from '@renderer/components/Layout'
 import { useTheme } from '@renderer/context/ThemeProvider'
@@ -12,7 +13,7 @@ import {
   setReadClipboardAtStartup
 } from '@renderer/store/settings'
 import HomeWindow from '@renderer/windows/mini/home/HomeWindow'
-import { Button, Select, Switch, Tooltip } from 'antd'
+import { Button, Select, Switch } from 'antd'
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -68,7 +69,7 @@ const QuickAssistantSettings: FC = () => {
         <SettingRow>
           <SettingRowTitle style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
             <span>{t('settings.quickAssistant.enable_quick_assistant')}</span>
-            <Tooltip title={t('settings.quickAssistant.use_shortcut_to_show')} placement="right">
+            <Tooltip content={t('settings.quickAssistant.use_shortcut_to_show')} placement="right" showArrow={true}>
               <InfoCircleOutlined style={{ cursor: 'pointer' }} />
             </Tooltip>
           </SettingRowTitle>
@@ -98,7 +99,7 @@ const QuickAssistantSettings: FC = () => {
           <HStack alignItems="center" justifyContent="space-between">
             <HStack alignItems="center" gap={10}>
               {t('settings.models.quick_assistant_model')}
-              <Tooltip title={t('selection.settings.user_modal.model.tooltip')} arrow>
+              <Tooltip content={t('selection.settings.user_modal.model.tooltip')} showArrow={true}>
                 <InfoCircleOutlined style={{ cursor: 'pointer' }} />
               </Tooltip>
               <Spacer />

--- a/src/renderer/src/pages/settings/SelectionAssistantSettings/SelectionAssistantSettings.tsx
+++ b/src/renderer/src/pages/settings/SelectionAssistantSettings/SelectionAssistantSettings.tsx
@@ -1,10 +1,11 @@
+import { Tooltip } from '@heroui/react'
 import { isMac, isWin } from '@renderer/config/constant'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import { useSelectionAssistant } from '@renderer/hooks/useSelectionAssistant'
 import { getSelectionDescriptionLabel } from '@renderer/i18n/label'
 import { FilterMode, TriggerMode } from '@renderer/types/selectionTypes'
 import SelectionToolbar from '@renderer/windows/selection/toolbar/SelectionToolbar'
-import { Button, Radio, Row, Slider, Switch, Tooltip } from 'antd'
+import { Button, Radio, Row, Slider, Switch } from 'antd'
 import { CircleHelp, Edit2 } from 'lucide-react'
 import { FC, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -132,7 +133,10 @@ const SelectionAssistantSettings: FC = () => {
                 <SettingRowTitle>
                   <div style={{ marginRight: '4px' }}>{t('selection.settings.toolbar.trigger_mode.title')}</div>
                   {/* FIXME: 没有考虑Linux？ */}
-                  <Tooltip placement="top" title={getSelectionDescriptionLabel(isWin ? 'windows' : 'mac')} arrow>
+                  <Tooltip
+                    placement="top"
+                    content={getSelectionDescriptionLabel(isWin ? 'windows' : 'mac')}
+                    showArrow={true}>
                     <QuestionIcon size={14} />
                   </Tooltip>
                 </SettingRowTitle>
@@ -142,17 +146,23 @@ const SelectionAssistantSettings: FC = () => {
                 value={triggerMode}
                 onChange={(e) => setTriggerMode(e.target.value as TriggerMode)}
                 buttonStyle="solid">
-                <Tooltip placement="top" title={t('selection.settings.toolbar.trigger_mode.selected_note')} arrow>
+                <Tooltip
+                  placement="top"
+                  content={t('selection.settings.toolbar.trigger_mode.selected_note')}
+                  showArrow={true}>
                   <Radio.Button value="selected">{t('selection.settings.toolbar.trigger_mode.selected')}</Radio.Button>
                 </Tooltip>
                 {isWin && (
-                  <Tooltip placement="top" title={t('selection.settings.toolbar.trigger_mode.ctrlkey_note')} arrow>
+                  <Tooltip
+                    placement="top"
+                    content={t('selection.settings.toolbar.trigger_mode.ctrlkey_note')}
+                    showArrow={true}>
                     <Radio.Button value="ctrlkey">{t('selection.settings.toolbar.trigger_mode.ctrlkey')}</Radio.Button>
                   </Tooltip>
                 )}
                 <Tooltip
-                  placement="topRight"
-                  title={
+                  placement="top-end"
+                  content={
                     <div>
                       {t('selection.settings.toolbar.trigger_mode.shortcut_note')}
                       <Link to="/settings/shortcut" style={{ color: 'var(--color-primary)' }}>
@@ -160,7 +170,7 @@ const SelectionAssistantSettings: FC = () => {
                       </Link>
                     </div>
                   }
-                  arrow>
+                  showArrow={true}>
                   <Radio.Button value="shortcut">{t('selection.settings.toolbar.trigger_mode.shortcut')}</Radio.Button>
                 </Tooltip>
               </Radio.Group>

--- a/src/renderer/src/pages/settings/SelectionAssistantSettings/components/SelectionActionUserModal.tsx
+++ b/src/renderer/src/pages/settings/SelectionAssistantSettings/components/SelectionActionUserModal.tsx
@@ -1,9 +1,10 @@
+import { Tooltip } from '@heroui/react'
 import ModelAvatar from '@renderer/components/Avatar/ModelAvatar'
 import CopyButton from '@renderer/components/CopyButton'
 import { useAssistants, useDefaultAssistant } from '@renderer/hooks/useAssistant'
 import { getDefaultModel } from '@renderer/services/AssistantService'
 import type { ActionItem } from '@renderer/types/selectionTypes'
-import { Col, Input, Modal, Radio, Row, Select, Space, Tooltip } from 'antd'
+import { Col, Input, Modal, Radio, Row, Select, Space } from 'antd'
 import { CircleHelp, Dices, OctagonX } from 'lucide-react'
 import { DynamicIcon, iconNames } from 'lucide-react/dynamic'
 import { FC, useEffect, useState } from 'react'
@@ -115,7 +116,7 @@ const SelectionActionUserModal: FC<SelectionActionUserModalProps> = ({
             <Col>
               <ModalSectionTitle>
                 <ModalSectionTitleLabel>{t('selection.settings.user_modal.icon.label')}</ModalSectionTitleLabel>
-                <Tooltip placement="top" title={t('selection.settings.user_modal.icon.tooltip')} arrow>
+                <Tooltip placement="top" content={t('selection.settings.user_modal.icon.tooltip')} showArrow={true}>
                   <QuestionIcon size={14} />
                 </Tooltip>
                 <Spacer />
@@ -126,7 +127,7 @@ const SelectionActionUserModal: FC<SelectionActionUserModalProps> = ({
                   style={{ fontSize: '12px', color: 'var(--color-primary)' }}>
                   {t('selection.settings.user_modal.icon.view_all')}
                 </a>
-                <Tooltip title={t('selection.settings.user_modal.icon.random')}>
+                <Tooltip content={t('selection.settings.user_modal.icon.random')} showArrow={true}>
                   <DiceButton
                     onClick={() => {
                       const randomIcon = iconNames[Math.floor(Math.random() * iconNames.length)]
@@ -162,7 +163,7 @@ const SelectionActionUserModal: FC<SelectionActionUserModalProps> = ({
             <Col flex="auto" style={{ paddingRight: '16px' }}>
               <ModalSectionTitle>
                 <ModalSectionTitleLabel>{t('selection.settings.user_modal.model.label')}</ModalSectionTitleLabel>
-                <Tooltip placement="top" title={t('selection.settings.user_modal.model.tooltip')} arrow>
+                <Tooltip placement="top" content={t('selection.settings.user_modal.model.tooltip')} showArrow={true}>
                   <QuestionIcon size={14} />
                 </Tooltip>
               </ModalSectionTitle>
@@ -214,7 +215,7 @@ const SelectionActionUserModal: FC<SelectionActionUserModalProps> = ({
         <ModalSection>
           <ModalSectionTitle>
             <ModalSectionTitleLabel>{t('selection.settings.user_modal.prompt.label')}</ModalSectionTitleLabel>
-            <Tooltip placement="top" title={t('selection.settings.user_modal.prompt.tooltip')} arrow>
+            <Tooltip placement="top" content={t('selection.settings.user_modal.prompt.tooltip')} showArrow={true}>
               <QuestionIcon size={14} />
             </Tooltip>
             <Spacer />

--- a/src/renderer/src/pages/settings/SelectionAssistantSettings/components/SettingsActionsListHeader.tsx
+++ b/src/renderer/src/pages/settings/SelectionAssistantSettings/components/SettingsActionsListHeader.tsx
@@ -1,4 +1,5 @@
-import { Button, Row, Tooltip } from 'antd'
+import { Tooltip } from '@heroui/react'
+import { Button, Row } from 'antd'
 import { Plus } from 'lucide-react'
 import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -21,17 +22,18 @@ const SettingsActionsListHeader = memo(({ customItemsCount, maxCustomItems, onRe
     <Row>
       <SettingTitle>{t('selection.settings.actions.title')}</SettingTitle>
       <Spacer />
-      <Tooltip title={t('selection.settings.actions.reset.tooltip')}>
+      <Tooltip content={t('selection.settings.actions.reset.tooltip')} showArrow={true}>
         <ResetButton type="text" onClick={onReset}>
           {t('selection.settings.actions.reset.button')}
         </ResetButton>
       </Tooltip>
       <Tooltip
-        title={
+        content={
           isCustomItemLimitReached
             ? t('selection.settings.actions.add_tooltip.disabled', { max: maxCustomItems })
             : t('selection.settings.actions.add_tooltip.enabled')
-        }>
+        }
+        showArrow={true}>
         <Button
           type="primary"
           icon={<Plus size={16} />}

--- a/src/renderer/src/pages/settings/ShortcutSettings.tsx
+++ b/src/renderer/src/pages/settings/ShortcutSettings.tsx
@@ -1,4 +1,5 @@
 import { ClearOutlined, UndoOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { HStack } from '@renderer/components/Layout'
 import { isMac, isWin } from '@renderer/config/constant'
 import { useTheme } from '@renderer/context/ThemeProvider'
@@ -8,7 +9,7 @@ import { getShortcutLabel } from '@renderer/i18n/label'
 import { useAppDispatch } from '@renderer/store'
 import { initialState, resetShortcuts, toggleShortcut, updateShortcut } from '@renderer/store/shortcuts'
 import { Shortcut } from '@renderer/types'
-import { Button, Input, InputRef, Switch, Table as AntTable, Tooltip } from 'antd'
+import { Button, Input, InputRef, Switch, Table as AntTable } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import React, { FC, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -368,7 +369,7 @@ const ShortcutSettings: FC = () => {
       width: '70px',
       render: (record: Shortcut) => (
         <HStack style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end', alignItems: 'center' }}>
-          <Tooltip title={t('settings.shortcuts.reset_to_default')}>
+          <Tooltip content={t('settings.shortcuts.reset_to_default')} showArrow={true}>
             <Button
               icon={<UndoOutlined />}
               size="small"
@@ -377,7 +378,7 @@ const ShortcutSettings: FC = () => {
               disabled={!isShortcutModified(record)}
             />
           </Tooltip>
-          <Tooltip title={t('settings.shortcuts.clear_shortcut')}>
+          <Tooltip content={t('settings.shortcuts.clear_shortcut')} showArrow={true}>
             <Button
               icon={<ClearOutlined />}
               size="small"

--- a/src/renderer/src/pages/settings/ToolSettings/ApiServerSettings/ApiServerSettings.tsx
+++ b/src/renderer/src/pages/settings/ToolSettings/ApiServerSettings/ApiServerSettings.tsx
@@ -1,11 +1,12 @@
 // TODO: Refactor this component to use HeroUI
+import { Tooltip } from '@heroui/react'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import { loggerService } from '@renderer/services/LoggerService'
 import { RootState, useAppDispatch } from '@renderer/store'
 import { setApiServerApiKey, setApiServerEnabled, setApiServerPort } from '@renderer/store/settings'
 import { formatErrorMessage } from '@renderer/utils/error'
 import { IpcChannel } from '@shared/IpcChannel'
-import { Button, Input, InputNumber, Tooltip, Typography } from 'antd'
+import { Button, Input, InputNumber, Typography } from 'antd'
 import { Copy, ExternalLink, Play, RotateCcw, Square } from 'lucide-react'
 import { FC, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -145,7 +146,7 @@ const ApiServerSettings: FC = () => {
 
         <ControlSection>
           {apiServerRunning && (
-            <Tooltip title={t('apiServer.actions.restart.tooltip')}>
+            <Tooltip content={t('apiServer.actions.restart.tooltip')} showArrow={true}>
               <RestartButton
                 $loading={apiServerLoading}
                 onClick={apiServerLoading ? undefined : handleApiServerRestart}>
@@ -168,7 +169,9 @@ const ApiServerSettings: FC = () => {
             />
           )}
 
-          <Tooltip title={apiServerRunning ? t('apiServer.actions.stop') : t('apiServer.actions.start')}>
+          <Tooltip
+            content={apiServerRunning ? t('apiServer.actions.stop') : t('apiServer.actions.start')}
+            showArrow={true}>
             {apiServerRunning ? (
               <StopButton
                 $loading={apiServerLoading}
@@ -203,7 +206,7 @@ const ApiServerSettings: FC = () => {
                   {t('apiServer.actions.regenerate')}
                 </RegenerateButton>
               )}
-              <Tooltip title={t('apiServer.fields.apiKey.copyTooltip')}>
+              <Tooltip content={t('apiServer.fields.apiKey.copyTooltip')} showArrow={true}>
                 <InputButton icon={<Copy size={14} />} onClick={copyApiKey} disabled={!apiServerConfig.apiKey} />
               </Tooltip>
             </InputButtonContainer>

--- a/src/renderer/src/pages/settings/TranslateSettingsPopup/TranslatePromptSettings.tsx
+++ b/src/renderer/src/pages/settings/TranslateSettingsPopup/TranslatePromptSettings.tsx
@@ -1,11 +1,12 @@
 import { RedoOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { HStack } from '@renderer/components/Layout'
 import { TRANSLATE_PROMPT } from '@renderer/config/prompts'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import { useSettings } from '@renderer/hooks/useSettings'
 import { useAppDispatch } from '@renderer/store'
 import { setTranslateModelPrompt } from '@renderer/store/settings'
-import { Input, Tooltip } from 'antd'
+import { Input } from 'antd'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -32,7 +33,7 @@ const TranslatePromptSettings = () => {
         <HStack alignItems="center" gap={10} height={30}>
           {t('settings.translate.prompt')}
           {localPrompt !== TRANSLATE_PROMPT && (
-            <Tooltip title={t('common.reset')}>
+            <Tooltip content={t('common.reset')} showArrow={true}>
               <ResetButton type="reset" onClick={onResetTranslatePrompt}>
                 <RedoOutlined size={16} />
               </ResetButton>

--- a/src/renderer/src/pages/settings/WebSearchSettings/BasicSettings.tsx
+++ b/src/renderer/src/pages/settings/WebSearchSettings/BasicSettings.tsx
@@ -1,8 +1,9 @@
+import { Tooltip } from '@heroui/react'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import { useWebSearchSettings } from '@renderer/hooks/useWebSearchProviders'
 import { useAppDispatch } from '@renderer/store'
 import { setMaxResult, setSearchWithTime } from '@renderer/store/websearch'
-import { Slider, Switch, Tooltip } from 'antd'
+import { Slider, Switch } from 'antd'
 import { t } from 'i18next'
 import { Info } from 'lucide-react'
 import { FC } from 'react'
@@ -29,7 +30,10 @@ const BasicSettings: FC = () => {
           <SettingRowTitle style={{ minWidth: 120 }}>
             {t('settings.tool.websearch.search_max_result.label')}
             {maxResults > 20 && compressionConfig?.method === 'none' && (
-              <Tooltip title={t('settings.tool.websearch.search_max_result.tooltip')} placement="top">
+              <Tooltip
+                content={t('settings.tool.websearch.search_max_result.tooltip')}
+                placement="top"
+                showArrow={true}>
                 <Info size={16} color="var(--color-icon)" style={{ marginLeft: 5, cursor: 'pointer' }} />
               </Tooltip>
             )}

--- a/src/renderer/src/pages/settings/WebSearchSettings/CompressionSettings/CutoffSettings.tsx
+++ b/src/renderer/src/pages/settings/WebSearchSettings/CompressionSettings/CutoffSettings.tsx
@@ -1,6 +1,7 @@
+import { Tooltip } from '@heroui/react'
 import { useWebSearchSettings } from '@renderer/hooks/useWebSearchProviders'
 import { SettingRow, SettingRowTitle } from '@renderer/pages/settings'
-import { Input, Select, Space, Tooltip } from 'antd'
+import { Input, Select, Space } from 'antd'
 import { ChevronDown, Info } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
@@ -27,7 +28,10 @@ const CutoffSettings = () => {
     <SettingRow>
       <SettingRowTitle>
         {t('settings.tool.websearch.compression.cutoff.limit.label')}
-        <Tooltip title={t('settings.tool.websearch.compression.cutoff.limit.tooltip')} placement="right">
+        <Tooltip
+          content={t('settings.tool.websearch.compression.cutoff.limit.tooltip')}
+          placement="right"
+          showArrow={true}>
           <Info size={16} color="var(--color-icon)" style={{ marginLeft: 5, cursor: 'pointer' }} />
         </Tooltip>
       </SettingRowTitle>

--- a/src/renderer/src/pages/settings/WebSearchSettings/CompressionSettings/RagSettings.tsx
+++ b/src/renderer/src/pages/settings/WebSearchSettings/CompressionSettings/RagSettings.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import InputEmbeddingDimension from '@renderer/components/InputEmbeddingDimension'
 import ModelSelector from '@renderer/components/ModelSelector'
 import { DEFAULT_WEBSEARCH_RAG_DOCUMENT_COUNT } from '@renderer/config/constant'
@@ -8,7 +9,7 @@ import { useWebSearchSettings } from '@renderer/hooks/useWebSearchProviders'
 import { SettingDivider, SettingRow, SettingRowTitle } from '@renderer/pages/settings'
 import { getModelUniqId } from '@renderer/services/ModelService'
 import { Model } from '@renderer/types'
-import { Slider, Tooltip } from 'antd'
+import { Slider } from 'antd'
 import { find } from 'lodash'
 import { Info } from 'lucide-react'
 import { useMemo } from 'react'
@@ -70,7 +71,7 @@ const RagSettings = () => {
       <SettingRow>
         <SettingRowTitle>
           {t('models.embedding_dimensions')}
-          <Tooltip title={t('knowledge.dimensions_size_tooltip')}>
+          <Tooltip content={t('knowledge.dimensions_size_tooltip')} showArrow={true}>
             <Info size={16} color="var(--color-icon)" style={{ marginLeft: 5, cursor: 'pointer' }} />
           </Tooltip>
         </SettingRowTitle>
@@ -101,7 +102,10 @@ const RagSettings = () => {
       <SettingRow>
         <SettingRowTitle>
           {t('settings.tool.websearch.compression.rag.document_count.label')}
-          <Tooltip title={t('settings.tool.websearch.compression.rag.document_count.tooltip')} placement="top">
+          <Tooltip
+            content={t('settings.tool.websearch.compression.rag.document_count.tooltip')}
+            placement="top"
+            showArrow={true}>
             <Info size={16} color="var(--color-icon)" style={{ marginLeft: 5, cursor: 'pointer' }} />
           </Tooltip>
         </SettingRowTitle>

--- a/src/renderer/src/pages/settings/WebSearchSettings/WebSearchProviderSetting.tsx
+++ b/src/renderer/src/pages/settings/WebSearchSettings/WebSearchProviderSetting.tsx
@@ -1,4 +1,5 @@
 import { CheckOutlined, ExportOutlined, LoadingOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import BochaLogo from '@renderer/assets/images/search/bocha.webp'
 import ExaLogo from '@renderer/assets/images/search/exa.png'
@@ -13,7 +14,7 @@ import { useWebSearchProvider } from '@renderer/hooks/useWebSearchProviders'
 import WebSearchService from '@renderer/services/WebSearchService'
 import { WebSearchProviderId } from '@renderer/types'
 import { formatApiKeys, hasObjectKey } from '@renderer/utils'
-import { Button, Divider, Flex, Form, Input, Space, Tooltip } from 'antd'
+import { Button, Divider, Flex, Form, Input, Space } from 'antd'
 import Link from 'antd/es/typography/Link'
 import { Info, List } from 'lucide-react'
 import { FC, useEffect, useState } from 'react'
@@ -177,7 +178,7 @@ const WebSearchProviderSetting: FC<Props> = ({ providerId }) => {
               justifyContent: 'space-between'
             }}>
             {t('settings.provider.api_key.label')}
-            <Tooltip title={t('settings.provider.api.key.list.open')} mouseEnterDelay={0.5}>
+            <Tooltip content={t('settings.provider.api.key.list.open')} delay={500} showArrow={true}>
               <Button type="text" size="small" onClick={openApiKeyList} icon={<List size={14} />} />
             </Tooltip>
           </SettingSubtitle>
@@ -237,7 +238,7 @@ const WebSearchProviderSetting: FC<Props> = ({ providerId }) => {
           <SettingDivider style={{ marginTop: 12, marginBottom: 12 }} />
           <SettingSubtitle style={{ marginTop: 5, marginBottom: 10 }}>
             {t('settings.provider.basic_auth.label')}
-            <Tooltip title={t('settings.provider.basic_auth.tip')} placement="right">
+            <Tooltip content={t('settings.provider.basic_auth.tip')} placement="right" showArrow={true}>
               <Info size={16} color="var(--color-icon)" style={{ marginLeft: 5, cursor: 'pointer' }} />
             </Tooltip>
           </SettingSubtitle>

--- a/src/renderer/src/pages/translate/TranslatePage.tsx
+++ b/src/renderer/src/pages/translate/TranslatePage.tsx
@@ -1,4 +1,5 @@
 import { PlusOutlined, SendOutlined, SwapOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import { Navbar, NavbarCenter } from '@renderer/components/app/Navbar'
 import { CopyIcon } from '@renderer/components/Icons'
@@ -41,7 +42,7 @@ import {
   determineTargetLanguage
 } from '@renderer/utils/translate'
 import { imageExts, MB, textExts } from '@shared/config/constant'
-import { Button, Flex, FloatButton, Popover, Tooltip, Typography } from 'antd'
+import { Button, Flex, FloatButton, Popover, Typography } from 'antd'
 import TextArea, { TextAreaRef } from 'antd/es/input/TextArea'
 import { isEmpty, throttle } from 'lodash'
 import { Check, CirclePause, FolderClock, Settings2, UploadIcon } from 'lucide-react'
@@ -713,7 +714,7 @@ const TranslatePage: FC = () => {
                 }
               ]}
             />
-            <Tooltip title={t('translate.exchange.label')} placement="bottom">
+            <Tooltip content={t('translate.exchange.label')} placement="bottom" showArrow={true}>
               <Button
                 type="text"
                 icon={<SwapOutlined />}
@@ -970,10 +971,10 @@ const TranslateButton = ({
   const { t } = useTranslation()
   return (
     <Tooltip
-      mouseEnterDelay={0.5}
+      closeDelay={500}
       placement="bottom"
-      styles={{ body: { fontSize: '12px' } }}
-      title={
+      showArrow={true}
+      content={
         <div style={{ textAlign: 'center' }}>
           Enter: {t('translate.button.translate')}
           <br />

--- a/src/renderer/src/pages/translate/TranslateSettings.tsx
+++ b/src/renderer/src/pages/translate/TranslateSettings.tsx
@@ -1,10 +1,11 @@
 import { Switch } from '@heroui/react'
+import { Tooltip } from '@heroui/react'
 import LanguageSelect from '@renderer/components/LanguageSelect'
 import { HStack } from '@renderer/components/Layout'
 import db from '@renderer/databases'
 import useTranslate from '@renderer/hooks/useTranslate'
 import { AutoDetectionMethod, Model, TranslateLanguage } from '@renderer/types'
-import { Button, Flex, Modal, Radio, Space, Tooltip } from 'antd'
+import { Button, Flex, Modal, Radio, Space } from 'antd'
 import { HelpCircle } from 'lucide-react'
 import { FC, memo, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -107,7 +108,7 @@ const TranslateSettings: FC<{
         <HStack style={{ justifyContent: 'space-between' }}>
           <div style={{ marginBottom: 8, fontWeight: 500, display: 'flex', alignItems: 'center' }}>
             {t('translate.detect.method.label')}
-            <Tooltip title={t('translate.detect.method.tip')}>
+            <Tooltip content={t('translate.detect.method.tip')} showArrow={true}>
               <span style={{ marginLeft: 4, display: 'flex', alignItems: 'center' }}>
                 <HelpCircle size={14} style={{ color: 'var(--color-text-3)' }} />
               </span>
@@ -122,13 +123,13 @@ const TranslateSettings: FC<{
               onChange={(e) => {
                 setAutoDetectionMethod(e.target.value)
               }}>
-              <Tooltip title={t('translate.detect.method.auto.tip')}>
+              <Tooltip content={t('translate.detect.method.auto.tip')} showArrow={true}>
                 <Radio.Button value="auto">{t('translate.detect.method.auto.label')}</Radio.Button>
               </Tooltip>
-              <Tooltip title={t('translate.detect.method.algo.tip')}>
+              <Tooltip content={t('translate.detect.method.algo.tip')} showArrow={true}>
                 <Radio.Button value="franc">{t('translate.detect.method.algo.label')}</Radio.Button>
               </Tooltip>
-              <Tooltip title={t('translate.detect.method.llm.tip')}>
+              <Tooltip content={t('translate.detect.method.llm.tip')} showArrow={true}>
                 <Radio.Button value="llm">LLM</Radio.Button>
               </Tooltip>
             </Radio.Group>
@@ -140,7 +141,7 @@ const TranslateSettings: FC<{
             <div style={{ fontWeight: 500 }}>
               <HStack alignItems="center" gap={5}>
                 {t('translate.settings.bidirectional')}
-                <Tooltip title={t('translate.settings.bidirectional_tip')}>
+                <Tooltip content={t('translate.settings.bidirectional_tip')} showArrow={true}>
                   <span style={{ display: 'flex', alignItems: 'center' }}>
                     <HelpCircle size={14} style={{ color: 'var(--color-text-3)' }} />
                   </span>

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -67,7 +67,7 @@ const persistedReducer = persistReducer(
   {
     key: 'cherry-studio',
     storage,
-    version: 153,
+    version: 154,
     blacklist: ['runtime', 'messages', 'messageBlocks', 'tabs'],
     migrate
   },

--- a/src/renderer/src/store/migrate.ts
+++ b/src/renderer/src/store/migrate.ts
@@ -2451,6 +2451,18 @@ const migrateConfig = {
       logger.error('migrate 153 error', error as Error)
       return state
     }
+  },
+  '154': (state: RootState) => {
+    try {
+      if (state.settings.userTheme) {
+        state.settings.userTheme.userFontFamily = settingsInitialState.userTheme.userFontFamily
+        state.settings.userTheme.userCodeFontFamily = settingsInitialState.userTheme.userCodeFontFamily
+      }
+      return state
+    } catch (error) {
+      logger.error('migrate 154 error', error as Error)
+      return state
+    }
   }
 }
 

--- a/src/renderer/src/store/settings.ts
+++ b/src/renderer/src/store/settings.ts
@@ -33,6 +33,8 @@ export type AssistantIconType = 'model' | 'emoji' | 'none'
 
 export type UserTheme = {
   colorPrimary: string
+  userFontFamily: string
+  userCodeFontFamily: string
 }
 
 export interface SettingsState {
@@ -242,7 +244,9 @@ export const initialState: SettingsState = {
   tray: true,
   theme: ThemeMode.system,
   userTheme: {
-    colorPrimary: '#00b96b'
+    colorPrimary: '#00b96b',
+    userFontFamily: '',
+    userCodeFontFamily: ''
   },
   windowStyle: isMac ? 'transparent' : 'opaque',
   fontSize: 14,

--- a/src/renderer/src/windows/mini/home/components/Footer.tsx
+++ b/src/renderer/src/windows/mini/home/components/Footer.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeftOutlined, LoadingOutlined } from '@ant-design/icons'
-import { Tag as AntdTag, Tooltip } from 'antd'
+import { Tooltip } from '@heroui/react'
+import { Tag as AntdTag } from 'antd'
 import { CircleArrowLeft, Copy, Pin } from 'lucide-react'
 import { FC } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
@@ -86,7 +87,7 @@ const Footer: FC<FooterProps> = ({
         )}
       </FooterText>
       <PinButtonArea onClick={() => setIsPinned(!isPinned)} className="nodrag">
-        <Tooltip title={t('miniwindow.tooltip.pin')} mouseEnterDelay={0.8} placement="left">
+        <Tooltip content={t('miniwindow.tooltip.pin')} closeDelay={800} placement="left" showArrow={true}>
           <Pin
             size={14}
             stroke={isPinned ? 'var(--color-primary)' : 'var(--color-text)'}

--- a/src/renderer/src/windows/selection/action/SelectionActionApp.tsx
+++ b/src/renderer/src/windows/selection/action/SelectionActionApp.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@heroui/react'
 import { isMac } from '@renderer/config/constant'
 import { useSelectionAssistant } from '@renderer/hooks/useSelectionAssistant'
 import { useSettings } from '@renderer/hooks/useSettings'
@@ -5,7 +6,7 @@ import i18n from '@renderer/i18n'
 import type { ActionItem } from '@renderer/types/selectionTypes'
 import { defaultLanguage } from '@shared/config/constant'
 import { IpcChannel } from '@shared/IpcChannel'
-import { Button, Slider, Tooltip } from 'antd'
+import { Button, Slider } from 'antd'
 import { Droplet, Minus, Pin, X } from 'lucide-react'
 import { DynamicIcon } from 'lucide-react/dynamic'
 import { FC, useCallback, useEffect, useRef, useState } from 'react'
@@ -203,8 +204,9 @@ const SelectionActionApp: FC = () => {
         <TitleBarCaption>{action.isBuiltIn ? t(action.name) : action.name}</TitleBarCaption>
         <TitleBarButtons>
           <Tooltip
-            title={isPinned ? t('selection.action.window.pinned') : t('selection.action.window.pin')}
-            placement="bottom">
+            content={isPinned ? t('selection.action.window.pinned') : t('selection.action.window.pin')}
+            placement="bottom"
+            showArrow={true}>
             <WinButton
               type="text"
               icon={<Pin size={14} className={isPinned ? 'pinned' : ''} />}
@@ -213,9 +215,10 @@ const SelectionActionApp: FC = () => {
             />
           </Tooltip>
           <Tooltip
-            title={t('selection.action.window.opacity')}
+            content={t('selection.action.window.opacity')}
             placement="bottom"
-            {...(showOpacitySlider ? { open: false } : {})}>
+            showArrow={true}
+            {...(showOpacitySlider ? { isOpen: false } : {})}>
             <WinButton
               type="text"
               icon={<Droplet size={14} />}

--- a/src/renderer/src/windows/selection/action/components/ActionTranslate.tsx
+++ b/src/renderer/src/windows/selection/action/components/ActionTranslate.tsx
@@ -1,4 +1,5 @@
 import { LoadingOutlined } from '@ant-design/icons'
+import { Tooltip } from '@heroui/react'
 import { loggerService } from '@logger'
 import CopyButton from '@renderer/components/CopyButton'
 import LanguageSelect from '@renderer/components/LanguageSelect'
@@ -14,7 +15,6 @@ import type { ActionItem } from '@renderer/types/selectionTypes'
 import { runAsyncFunction } from '@renderer/utils'
 import { abortCompletion } from '@renderer/utils/abortController'
 import { detectLanguage } from '@renderer/utils/translate'
-import { Tooltip } from 'antd'
 import { ArrowRightFromLine, ArrowRightToLine, ChevronDown, CircleHelp, Globe } from 'lucide-react'
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -178,11 +178,11 @@ const ActionTranslate: FC<Props> = ({ action, scrollToBottom }) => {
     <>
       <Container>
         <MenuContainer>
-          <Tooltip placement="bottom" title={t('translate.any.language')} arrow>
+          <Tooltip placement="bottom" content={t('translate.any.language')} showArrow={true}>
             <Globe size={16} style={{ flexShrink: 0 }} />
           </Tooltip>
           <ArrowRightToLine size={16} color="var(--color-text-3)" style={{ margin: '0 2px' }} />
-          <Tooltip placement="bottom" title={t('translate.target_language')} arrow>
+          <Tooltip placement="bottom" content={t('translate.target_language')} showArrow={true}>
             <LanguageSelect
               value={targetLanguage.langCode}
               style={{ minWidth: 80, maxWidth: 200, flex: 'auto' }}
@@ -194,7 +194,7 @@ const ActionTranslate: FC<Props> = ({ action, scrollToBottom }) => {
             />
           </Tooltip>
           <ArrowRightFromLine size={16} color="var(--color-text-3)" style={{ margin: '0 2px' }} />
-          <Tooltip placement="bottom" title={t('translate.alter_language')} arrow>
+          <Tooltip placement="bottom" content={t('translate.alter_language')} showArrow={true}>
             <LanguageSelect
               value={alterLanguage.langCode}
               style={{ minWidth: 80, maxWidth: 200, flex: 'auto' }}
@@ -205,7 +205,7 @@ const ActionTranslate: FC<Props> = ({ action, scrollToBottom }) => {
               disabled={isLoading}
             />
           </Tooltip>
-          <Tooltip placement="bottom" title={t('selection.action.translate.smart_translate_tips')} arrow>
+          <Tooltip placement="bottom" content={t('selection.action.translate.smart_translate_tips')} showArrow={true}>
             <QuestionIcon size={14} style={{ marginLeft: 4 }} />
           </Tooltip>
           <Spacer />

--- a/yarn.lock
+++ b/yarn.lock
@@ -13198,6 +13198,7 @@ __metadata:
     fast-diff: "npm:^1.3.0"
     fast-xml-parser: "npm:^5.2.0"
     fetch-socks: "npm:1.3.2"
+    font-list: "npm:^2.0.0"
     framer-motion: "npm:^12.23.12"
     franc-min: "npm:^6.2.0"
     fs-extra: "npm:^11.2.0"
@@ -18040,6 +18041,13 @@ __metadata:
     debug:
       optional: true
   checksum: 10c0/5829165bd112c3c0e82be6c15b1a58fa9dcfaede3b3c54697a82fe4a62dd5ae5e8222956b448d2f98e331525f05d00404aba7d696de9e761ef6e42fdc780244f
+  languageName: node
+  linkType: hard
+
+"font-list@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "font-list@npm:2.0.0"
+  checksum: 10c0/9fc8600fa40a5d079982505ea101e49b21260a36f33167ac993fd7b26cec8372a16017c00d6fb404e259600ce8d588830167c9141c2df7dedb0fedd5953905f6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Replace all antd Tooltip imports with HeroUI Tooltip across 125 files
- Update prop mappings: title → content, arrow → showArrow, mouseLeaveDelay → closeDelay
- Add showArrow={true} to all Tooltip components for consistent visual experience
- Remove unsupported props like destroyTooltipOnHide for HeroUI compatibility
- Maintain all existing functionality while adopting HeroUI design system
