### PR TITLE
feat(components): add semantic component to replace styled-components

### DIFF
--- a/src/renderer/src/components/semantic.tsx
+++ b/src/renderer/src/components/semantic.tsx
@@ -1,22 +1,26 @@
 import React from "react"
 
-type DistributiveOmit<T, K extends keyof T> = T extends any ? Omit<T, K> : never;
-
-type IntrinsicProps<Tag extends keyof React.JSX.IntrinsicElements> =
-  DistributiveOmit<React.JSX.IntrinsicElements[Tag], 'ref'>
-
 type NoStyleProps<Tag extends keyof React.JSX.IntrinsicElements> =
-  Omit<IntrinsicProps<Tag>, 'style'>
+  Omit<React.ComponentPropsWithoutRef<Tag>, 'style'>;
 
 function intrinsicFactory<Tag extends keyof React.JSX.IntrinsicElements>(tag: Tag) {
   return React.forwardRef<
     React.ComponentRef<Tag>,
-    NoStyleProps<Tag> & { children?: React.ReactNode }
-  >((props, ref) => React.createElement(tag, { ...props, ref } as any));
+    NoStyleProps<Tag>
+  >((props, ref) => React.createElement(tag, { ...props, ref }));
 }
 
-export const semantic = {
-  div: intrinsicFactory('div'),
-  span: intrinsicFactory('span')
-} as const
+const createSemantic = () => {
+  function semantic<T extends React.FC>(component: T) {
+    return React.forwardRef<
+      React.ComponentRef<T>,
+      React.ComponentProps<T>
+    >((props, ref) => React.createElement(component, { ...props, ref }))
+  }
+  // add more native html element here
+  semantic.div = intrinsicFactory('div')
+  semantic.span = intrinsicFactory('span')
+  return semantic
+}
 
+export const semantic = createSemantic()

--- a/src/renderer/src/components/semantic.tsx
+++ b/src/renderer/src/components/semantic.tsx
@@ -1,21 +1,16 @@
-import React from "react"
+import React from 'react'
 
-type NoStyleProps<Tag extends keyof React.JSX.IntrinsicElements> =
-  Omit<React.ComponentPropsWithoutRef<Tag>, 'style'>;
+type NoStyleProps<Tag extends keyof React.JSX.IntrinsicElements> = Omit<React.ComponentPropsWithoutRef<Tag>, 'style'>
 
 function intrinsicFactory<Tag extends keyof React.JSX.IntrinsicElements>(tag: Tag) {
-  return React.forwardRef<
-    React.ComponentRef<Tag>,
-    NoStyleProps<Tag>
-  >((props, ref) => React.createElement(tag, { ...props, ref }));
+  return ({ ref, ...props }: NoStyleProps<Tag> & { ref?: React.RefObject<React.ComponentRef<Tag> | null> }) =>
+    React.createElement(tag, { ...props, ref })
 }
 
 const createSemantic = () => {
   function semantic<T extends React.FC<any>>(component: T) {
-    return React.forwardRef<
-      React.ComponentRef<T>,
-      React.ComponentProps<T>
-    >((props, ref) => React.createElement(component, { ...props, ref }))
+    return ({ ref, ...props }: React.ComponentProps<T> & { ref?: React.RefObject<React.ComponentRef<T> | null> }) =>
+      React.createElement(component, { ...props, ref })
   }
   // add more native html element here
   semantic.div = intrinsicFactory('div')

--- a/src/renderer/src/components/semantic.tsx
+++ b/src/renderer/src/components/semantic.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+
+type DistributiveOmit<T, K extends keyof T> = T extends any ? Omit<T, K> : never;
+
+type IntrinsicProps<Tag extends keyof React.JSX.IntrinsicElements> =
+  DistributiveOmit<React.JSX.IntrinsicElements[Tag], 'ref'>
+
+type NoStyleProps<Tag extends keyof React.JSX.IntrinsicElements> =
+  Omit<IntrinsicProps<Tag>, 'style'>
+
+function intrinsicFactory<Tag extends keyof React.JSX.IntrinsicElements>(tag: Tag) {
+  return React.forwardRef<
+    React.ComponentRef<Tag>,
+    NoStyleProps<Tag> & { children?: React.ReactNode }
+  >((props, ref) => React.createElement(tag, { ...props, ref } as any));
+}
+
+export const semantic = {
+  div: intrinsicFactory('div'),
+  span: intrinsicFactory('span')
+} as const
+

--- a/src/renderer/src/components/semantic.tsx
+++ b/src/renderer/src/components/semantic.tsx
@@ -11,7 +11,7 @@ function intrinsicFactory<Tag extends keyof React.JSX.IntrinsicElements>(tag: Ta
 }
 
 const createSemantic = () => {
-  function semantic<T extends React.FC>(component: T) {
+  function semantic<T extends React.FC<any>>(component: T) {
     return React.forwardRef<
       React.ComponentRef<T>,
       React.ComponentProps<T>


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

This PR adds a `semantic` object, which in usage is similar to `styled` from `styled-components`, but does not allow custom CSS or inline styles. Instead, it restricts callers to using Tailwind CSS utility classes for styling adjustments.

The motivation behind adding this function is to serve as a potential replacement for `styled-components` in the future, offering semantically meaningful native HTML components, as well as the ability to create arbitrarily named custom components.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
