### PR TITLE
feat(Inputbar): cache mentioned models state between renders

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -71,6 +71,7 @@ interface Props {
 
 let _text = ''
 let _files: FileType[] = []
+let _mentionedModelsCache: Model[] = []
 
 const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) => {
   const [text, setText] = useState(_text)
@@ -103,7 +104,8 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
   const spaceClickTimer = useRef<NodeJS.Timeout>(null)
   const [isTranslating, setIsTranslating] = useState(false)
   const [selectedKnowledgeBases, setSelectedKnowledgeBases] = useState<KnowledgeBase[]>([])
-  const [mentionedModels, setMentionedModels] = useState<Model[]>([])
+  const [mentionedModels, setMentionedModels] = useState<Model[]>(_mentionedModelsCache)
+  const mentionedModelsRef = useRef(mentionedModels)
   const [isDragging, setIsDragging] = useState(false)
   const [isFileDragging, setIsFileDragging] = useState(false)
   const [textareaHeight, setTextareaHeight] = useState<number>()
@@ -113,6 +115,10 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
   const isVisionAssistant = useMemo(() => isVisionModel(model), [model])
   const isGenerateImageAssistant = useMemo(() => isGenerateImageModel(model), [model])
   const { setTimeoutTimer } = useTimer()
+
+  useEffect(() => {
+    mentionedModelsRef.current = mentionedModels
+  }, [mentionedModels])
 
   const isVisionSupported = useMemo(
     () =>
@@ -178,6 +184,13 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
 
   _text = text
   _files = files
+
+  useEffect(() => {
+    // 利用useEffect清理函数在卸载组件时更新状态缓存
+    return () => {
+      _mentionedModelsCache = mentionedModelsRef.current
+    }
+  }, [])
 
   const focusTextarea = useCallback(() => {
     textareaRef.current?.focus()


### PR DESCRIPTION
### What this PR does

Use a ref to track mentioned models state and cache it in a module-level variable when component unmounts to preserve state between renders

Fixes #8944