### PR TITLE
fix(note&knowledge): failed to add external notes to knowledge

### DIFF
--- a/src/renderer/src/components/Popups/SaveToKnowledgePopup.tsx
+++ b/src/renderer/src/components/Popups/SaveToKnowledgePopup.tsx
@@ -255,7 +255,9 @@ const PopupContainer: React.FC<Props> = ({ source, title, resolve }) => {
     try {
       if (isNoteMode) {
         const note = source.data as NotesTreeNode
-        const content = note.externalPath ? await window.api.file.readExternal(note.externalPath) : await window.api.file.read(note.id + '.md')
+        const content = note.externalPath
+          ? await window.api.file.readExternal(note.externalPath)
+          : await window.api.file.read(note.id + '.md')
         logger.debug('Note content:', content)
         await addNote(content)
         savedCount = 1

--- a/src/renderer/src/components/Popups/SaveToKnowledgePopup.tsx
+++ b/src/renderer/src/components/Popups/SaveToKnowledgePopup.tsx
@@ -255,7 +255,7 @@ const PopupContainer: React.FC<Props> = ({ source, title, resolve }) => {
     try {
       if (isNoteMode) {
         const note = source.data as NotesTreeNode
-        const content = await window.api.file.read(note.id + '.md')
+        const content = note.externalPath ? await window.api.file.readExternal(note.externalPath) : await window.api.file.read(note.id + '.md')
         logger.debug('Note content:', content)
         await addNote(content)
         savedCount = 1

--- a/src/renderer/src/hooks/useKnowledge.ts
+++ b/src/renderer/src/hooks/useKnowledge.ts
@@ -67,7 +67,8 @@ export const useKnowledge = (baseId: string) => {
   // 添加笔记
   const addNote = async (content: string) => {
     await dispatch(addNoteThunk(baseId, content))
-    checkAllBases()
+    // 确保数据库写入完成后再触发队列检查
+    setTimeout(() => KnowledgeQueue.checkAllBases(), 100)
   }
 
   // 添加URL


### PR DESCRIPTION
### What this PR

Before this PR- Adding external notes to knowledge could fail.
- The queue failed to start after adding notes.

After this PR:
- Fixes failure when adding external notes to the knowledge store.
- Ensures the processing queue starts properly after notes are added.

Fixes #9849

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Focused fixes on note ingestion and queue startup to restore reliability; broader refactors deferred.

The following alternatives were considered:
- Reworking the entire queue system, but opted for targeted fixes to minimize risk.

### Release note

```release-note
Fixed failing external note ingestion and ensured queue starts after adding notes.
```