### PR TITLE
Skip header modification for main window requests

### DIFF
--- a/src/main/services/WebviewService.ts
+++ b/src/main/services/WebviewService.ts
@@ -1,5 +1,7 @@
 import { session, shell, webContents } from 'electron'
 
+import { windowService } from './WindowService'
+
 /**
  * init the useragent of the webview session
  * remove the CherryStudio and Electron from the useragent
@@ -11,6 +13,13 @@ export function initSessionUserAgent() {
 
   wvSession.setUserAgent(newUA)
   wvSession.webRequest.onBeforeSendHeaders((details, cb) => {
+    // Skip header modification for main window requests
+    const mainWindow = windowService.getMainWindow()
+    if (mainWindow && details.webContentsId === mainWindow.webContents.id) {
+      cb({ requestHeaders: details.requestHeaders })
+      return
+    }
+
     const headers = {
       ...details.requestHeaders,
       'User-Agent': details.url.includes('google.com') ? originUA : newUA


### PR DESCRIPTION
- Add import for WindowService to access main window
- Check if request originates from main window and bypass header changes
- Maintain existing user-agent logic for all other webview requests

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Fixes: #10209 
