### PR TITLE
fix: Add AWS Bedrock reasoning extraction middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@aws-sdk/client-bedrock-runtime": "^3.840.0",
     "@aws-sdk/client-s3": "^3.840.0",
     "@biomejs/biome": "2.2.4",
-    "@cherrystudio/ai-core": "workspace:^1.0.0-alpha.17",
+    "@cherrystudio/ai-core": "workspace:^1.0.0-alpha.18",
     "@cherrystudio/embedjs": "^0.1.31",
     "@cherrystudio/embedjs-libsql": "^0.1.31",
     "@cherrystudio/embedjs-loader-csv": "^0.1.31",

--- a/packages/aiCore/package.json
+++ b/packages/aiCore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cherrystudio/ai-core",
-  "version": "1.0.0-alpha.17",
+  "version": "1.0.0-alpha.18",
   "description": "Cherry Studio AI Core - Unified AI Provider Interface Based on Vercel AI SDK",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/aiCore/src/core/providers/schemas.ts
+++ b/packages/aiCore/src/core/providers/schemas.ts
@@ -9,7 +9,9 @@ import { createDeepSeek } from '@ai-sdk/deepseek'
 import { createGoogleGenerativeAI } from '@ai-sdk/google'
 import { createOpenAI, type OpenAIProviderSettings } from '@ai-sdk/openai'
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
+import { LanguageModelV2 } from '@ai-sdk/provider'
 import { createXai } from '@ai-sdk/xai'
+import { createOpenRouter } from '@openrouter/ai-sdk-provider'
 import { customProvider, Provider } from 'ai'
 import { z } from 'zod'
 
@@ -46,7 +48,7 @@ export const isBaseProvider = (id: ProviderId): id is BaseProviderId => {
 type BaseProvider = {
   id: BaseProviderId
   name: string
-  creator: (options: any) => Provider
+  creator: (options: any) => Provider | LanguageModelV2
   supportsImageGeneration: boolean
 }
 
@@ -124,6 +126,12 @@ export const baseProviders = [
     name: 'DeepSeek',
     creator: createDeepSeek,
     supportsImageGeneration: false
+  },
+  {
+    id: 'openrouter',
+    name: 'OpenRouter',
+    creator: createOpenRouter,
+    supportsImageGeneration: true
   }
 ] as const satisfies BaseProvider[]
 

--- a/src/renderer/src/aiCore/middleware/AiSdkMiddlewareBuilder.ts
+++ b/src/renderer/src/aiCore/middleware/AiSdkMiddlewareBuilder.ts
@@ -140,7 +140,7 @@ export function buildAiSdkMiddlewares(config: AiSdkMiddlewareConfig): LanguageMo
   return builder.build()
 }
 
-const tagNameArray = ['think', 'thought']
+const tagNameArray = ['think', 'thought', 'reasoning']
 
 /**
  * 添加provider特定的中间件
@@ -167,6 +167,16 @@ function addProviderSpecificMiddlewares(builder: AiSdkMiddlewareBuilder, config:
     case 'gemini':
       // Gemini特定中间件
       break
+    case 'aws-bedrock': {
+      if (config.model?.id.includes('gpt-oss')) {
+        const tagName = tagNameArray[2]
+        builder.add({
+          name: 'thinking-tag-extraction',
+          middleware: extractReasoningMiddleware({ tagName })
+        })
+      }
+      break
+    }
     default:
       // 其他provider的通用处理
       break

--- a/src/renderer/src/aiCore/provider/factory.ts
+++ b/src/renderer/src/aiCore/provider/factory.ts
@@ -69,6 +69,9 @@ export function getAiSdkProviderId(provider: Provider): ProviderId | 'openai-com
       return resolvedFromType
     }
   }
+  if (provider.apiHost.includes('api.openai.com')) {
+    return 'openai-chat'
+  }
   // 3. 最后的fallback（通常会成为openai-compatible）
   return provider.id as ProviderId
 }

--- a/src/renderer/src/aiCore/utils/options.ts
+++ b/src/renderer/src/aiCore/utils/options.ts
@@ -82,6 +82,7 @@ export function buildProviderOptions(
     // 应该覆盖所有类型
     switch (baseProviderId) {
       case 'openai':
+      case 'openai-chat':
       case 'azure':
         providerSpecificOptions = {
           ...buildOpenAIProviderOptions(assistant, model, capabilities),
@@ -101,13 +102,15 @@ export function buildProviderOptions(
         providerSpecificOptions = buildXAIProviderOptions(assistant, model, capabilities)
         break
       case 'deepseek':
-      case 'openai-compatible':
+      case 'openrouter':
+      case 'openai-compatible': {
         // 对于其他 provider，使用通用的构建逻辑
         providerSpecificOptions = {
           ...buildGenericProviderOptions(assistant, model, capabilities),
           serviceTier: serviceTierSetting
         }
         break
+      }
       default:
         throw new Error(`Unsupported base provider ${baseProviderId}`)
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2309,7 +2309,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cherrystudio/ai-core@workspace:^1.0.0-alpha.17, @cherrystudio/ai-core@workspace:packages/aiCore":
+"@cherrystudio/ai-core@workspace:^1.0.0-alpha.18, @cherrystudio/ai-core@workspace:packages/aiCore":
   version: 0.0.0-use.local
   resolution: "@cherrystudio/ai-core@workspace:packages/aiCore"
   dependencies:
@@ -13195,7 +13195,7 @@ __metadata:
     "@aws-sdk/client-bedrock-runtime": "npm:^3.840.0"
     "@aws-sdk/client-s3": "npm:^3.840.0"
     "@biomejs/biome": "npm:2.2.4"
-    "@cherrystudio/ai-core": "workspace:^1.0.0-alpha.17"
+    "@cherrystudio/ai-core": "workspace:^1.0.0-alpha.18"
     "@cherrystudio/embedjs": "npm:^0.1.31"
     "@cherrystudio/embedjs-libsql": "npm:^0.1.31"
     "@cherrystudio/embedjs-loader-csv": "npm:^0.1.31"


### PR DESCRIPTION
- Add 'reasoning' tag to tagNameArray for broader reasoning support
- Add AWS Bedrock case with gpt-oss model-specific reasoning extraction
- Add openai-chat and openrouter cases to provider options switch
- Remove unused zod import

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

fixes: #10225