### PR TITLE
fix: Remove maxTokens check from Anthropic thinking budget

### DIFF
--- a/src/renderer/src/aiCore/utils/reasoning.ts
+++ b/src/renderer/src/aiCore/utils/reasoning.ts
@@ -312,7 +312,7 @@ export function getOpenAIReasoningParams(assistant: Assistant, model: Model): Re
 
 export function getAnthropicThinkingBudget(assistant: Assistant, model: Model): number {
   const { maxTokens, reasoning_effort: reasoningEffort } = getAssistantSettings(assistant)
-  if (maxTokens === undefined || reasoningEffort === undefined) {
+  if (reasoningEffort === undefined) {
     return 0
   }
   const effortRatio = EFFORT_RATIO[reasoningEffort]


### PR DESCRIPTION
Fixes: #10219 
maxToken默认值是undefined