### PR TITLE
fix(s3): make region optional

### DIFF
--- a/src/main/services/BackupManager.ts
+++ b/src/main/services/BackupManager.ts
@@ -28,7 +28,7 @@ class BackupManager {
   // 缓存核心连接配置，用于检测连接配置是否变更
   private cachedS3ConnectionConfig: {
     endpoint: string
-    region: string
+    region?: string
     bucket: string
     accessKeyId: string
     secretAccessKey: string

--- a/src/main/services/S3Storage.ts
+++ b/src/main/services/S3Storage.ts
@@ -58,7 +58,7 @@ export default class S3Storage {
     })()
 
     this.client = new S3Client({
-      region,
+      ...(region && { region }), // Only include region if it's not empty
       endpoint: endpoint || undefined,
       credentials: {
         accessKeyId: accessKeyId,

--- a/src/renderer/src/pages/settings/DataSettings/S3Settings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/S3Settings.tsx
@@ -198,13 +198,13 @@ const S3Settings: FC = () => {
             onClick={showBackupModal}
             icon={<SaveOutlined />}
             loading={backuping}
-            disabled={!endpoint || !region || !bucket || !accessKeyId || !secretAccessKey}>
+            disabled={!endpoint || !bucket || !accessKeyId || !secretAccessKey}>
             {t('settings.data.s3.backup.button')}
           </Button>
           <Button
             onClick={showBackupManager}
             icon={<FolderOpenOutlined />}
-            disabled={!endpoint || !region || !bucket || !accessKeyId || !secretAccessKey}>
+            disabled={!endpoint || !bucket || !accessKeyId || !secretAccessKey}>
             {t('settings.data.s3.backup.manager.button')}
           </Button>
         </HStack>

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -1009,7 +1009,7 @@ export function isServiceTier(tier: string): tier is ServiceTier {
 
 export type S3Config = {
   endpoint: string
-  region: string
+  region?: string // Some S3-compatible storage services don't require region
   bucket: string
   accessKeyId: string
   secretAccessKey: string


### PR DESCRIPTION
### What this PR does

Before this PR:
- Region was required for S3-compatible stores, causing configuration failures for stores that not provide or need a region.

After this PR:
- Region is optional for S3-compatible stores, allowing configurations without a region to work correctly.

Fixes #10196