### PR TITLE
fix: prevent backspace from deleting files when text contains whitespace

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -377,7 +377,7 @@ const Inputbar: FC<Props> = ({ assistant: _assistant, setActiveTopic, topic }) =
       }
     }
 
-    if (event.key === 'Backspace' && text.trim() === '' && files.length > 0) {
+    if (event.key === 'Backspace' && text.length === 0 && files.length > 0) {
       setFiles((prev) => prev.slice(0, -1))
       return event.preventDefault()
     }


### PR DESCRIPTION
### What this PR does
Fixes the issue where pressing Backspace deletes attached files incorrectly when the input text only contains whitespace characters (spaces, tabs, newlines).

Before this PR:  
Pressing Backspace would delete attached files if the input text was trimmed to an empty string (e.g., text with only spaces), even though the text still had actual length.

After this PR:  
File deletion via Backspace only triggers when the input text has **zero length** (truly empty), allowing users to delete whitespace characters without accidentally removing attached files.

Fixes # https://github.com/CherryHQ/cherry-studio/issues/9604

---

### Why we need it and why it was done in this way
- **Need**: The original logic (using `text.trim() === ''`) misjudged "empty text" by ignoring whitespace characters. This led to frustrating user experiences where accidental spaces caused attached files to be deleted when pressing Backspace.
- **Implementation Reason**: Changing the condition to `text.length === 0` directly checks if the text is truly empty (no characters, including whitespace), which aligns with user expectations of "deleting files only when there’s no text at all".

The following tradeoffs were made:
- No major tradeoffs; the change is a targeted fix that only adjusts the condition for Backspace-triggered file deletion, without affecting other functionalities.
- Maintains full compatibility with existing correct behaviors (e.g., file deletion still works when text is truly empty).

The following alternatives were considered:
- Alternative 1: Checking for "whitespace-only" text and preventing file deletion, then allowing Backspace to delete whitespace first. This was more complex than the chosen approach and unnecessary, as `text.length === 0` directly solves the root issue.
- Alternative 2: Adding a separate check for whitespace characters. This would introduce redundant logic compared to the simpler `text.length` check.

Links to places where the discussion took place: <!-- 若有相关讨论链接（如Slack、Issue评论区）可补充，无则留空 -->

---

### Breaking changes
None. This fix only adjusts the trigger condition for Backspace-induced file deletion and does not modify any other user-facing features or API behaviors.

---

### Special notes for your reviewer
- Focus on the condition change in the Backspace event handler (`text.trim() === ''` → `text.length === 0`) in `Inputbar.tsx`.
- Test scenarios to verify:
  1. Input text with only spaces/tabs/newlines + attached files → Press Backspace should delete whitespace, not files.
  2. Input text is completely empty + attached files → Press Backspace should delete the last file (existing correct behavior).
  3. Input text has actual content (non-whitespace) + attached files → Press Backspace should delete text, not files (existing correct behavior).

---

### Checklist
This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature. 

---

### Release note
```release-note
Fixed an issue where pressing Backspace would incorrectly delete attached files when the input text only contained whitespace characters (e.g., spaces, tabs). Now, file deletion via Backspace only occurs when the input text is completely empty (has zero length).
```

