### PR TITLE
fix: use translate assistant's content instead of select text

### DIFF
--- a/src/renderer/src/windows/selection/action/components/ActionTranslate.tsx
+++ b/src/renderer/src/windows/selection/action/components/ActionTranslate.tsx
@@ -138,8 +138,9 @@ const ActionTranslate: FC<Props> = ({ action, scrollToBottom }) => {
       }
     }
 
-    assistantRef.current = getDefaultTranslateAssistant(translateLang, action.selectedText)
-    processMessages(assistantRef.current, topicRef.current, action.selectedText, setAskId, onStream, onFinish, onError)
+    const assistant = getDefaultTranslateAssistant(translateLang, action.selectedText)
+    assistantRef.current = assistant
+    processMessages(assistant, topicRef.current, assistant.content, setAskId, onStream, onFinish, onError)
   }, [action, targetLanguage, alterLanguage, scrollToBottom])
 
   useEffect(() => {


### PR DESCRIPTION
使用translate assistant's content来发送请求，可以减少发送一次select text，并且保持和翻译界面一样的content。


fix  #10256