### PR TITLE
fix(providerConfig): add includeUsage option to provider configuration

### DIFF
--- a/src/renderer/src/aiCore/provider/providerConfig.ts
+++ b/src/renderer/src/aiCore/provider/providerConfig.ts
@@ -213,7 +213,8 @@ export function providerToAiSdkConfig(
     options: {
       ...options,
       name: actualProvider.id,
-      ...extraOptions
+      ...extraOptions,
+      includeUsage: true
     }
   }
 }


### PR DESCRIPTION
Added the includeUsage option to the provider configuration to enhance functionality and provide better usage tracking for providers.

before：
Currently, third-party providers do not have usage tracking, relying entirely on local calculations. 
Trace also lacks token usage

<img width="1150" height="392" alt="image" src="https://github.com/user-attachments/assets/fe4b6d16-4d9b-4a52-9570-5b05d8eac9ec" />

after：
ai-sdk returns directly, which is more accurate.
<img width="1200" height="1600" alt="image" src="https://github.com/user-attachments/assets/0f15f188-a012-43a9-b579-2bf855917b17" />
