### PR TITLE
Fix slash newline

### DIFF
--- a/src/renderer/src/components/RichEditor/CommandListPopover.tsx
+++ b/src/renderer/src/components/RichEditor/CommandListPopover.tsx
@@ -87,6 +87,9 @@ const CommandListPopover = ({
           return true
 
         case 'Enter':
+          if (event.shiftKey) {
+            return false
+          }
           event.preventDefault()
           if (items[internalSelectedIndex]) {
             selectItem(internalSelectedIndex)

--- a/src/renderer/src/components/RichEditor/__tests__/commandSuggestion.test.ts
+++ b/src/renderer/src/components/RichEditor/__tests__/commandSuggestion.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { commandSuggestion } from '../command'
+
+const createEditorMock = () => {
+  const run = vi.fn()
+  const insertContent = vi.fn(() => ({ run }))
+  const focus = vi.fn(() => ({ insertContent }))
+  const chain = vi.fn(() => ({ focus }))
+
+  return {
+    editor: {
+      chain
+    },
+    spies: { chain, focus, insertContent, run }
+  }
+}
+
+describe('commandSuggestion.onKeyDown', () => {
+  it('inserts newline when Shift+Enter is pressed', () => {
+    const { editor, spies } = createEditorMock()
+    const preventDefault = vi.fn()
+
+    const handled = commandSuggestion.onKeyDown?.({
+      event: {
+        key: 'Enter',
+        shiftKey: true,
+        preventDefault
+      },
+      editor
+    } as any) ?? false
+
+    expect(handled).toBe(true)
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(spies.chain).toHaveBeenCalledTimes(1)
+    expect(spies.focus).toHaveBeenCalledTimes(1)
+    expect(spies.insertContent).toHaveBeenCalledWith('\n')
+    expect(spies.run).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores other keys', () => {
+    const { editor, spies } = createEditorMock()
+    const preventDefault = vi.fn()
+
+    const handled = commandSuggestion.onKeyDown?.({
+      event: {
+        key: 'Enter',
+        shiftKey: false,
+        preventDefault
+      },
+      editor
+    } as any) ?? false
+
+    expect(handled).toBe(false)
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(spies.chain).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/RichEditor/command.ts
+++ b/src/renderer/src/components/RichEditor/command.ts
@@ -579,6 +579,16 @@ export const commandSuggestion: Omit<SuggestionOptions<Command, MentionNodeAttrs
     }
   },
 
+  onKeyDown: ({ event, editor }) => {
+    if (event.key === 'Enter' && event.shiftKey) {
+      event.preventDefault()
+      editor.chain().focus().insertContent('\n').run()
+      return true
+    }
+
+    return false
+  },
+
   render: () => {
     let component: ReactRenderer<any, any>
     let cleanup: (() => void) | undefined


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
  - When the slash command menu was open, pressing Shift+Enter was intercepted, so no newline was inserted in the editor.
After this PR:
  - The menu now only consumes plain Enter. With Shift+Enter, the event falls back to TipTap, a newline is inserted, and a dedicated unit test verifies the behavior.
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes https://github.com/CherryHQ/cherry-studio/issues/10301

### Why we need it and why it was done in this way
  - This matches the expected UX for rich-text editors: Shift+Enter should always insert a newline.
  - We ignore modified Enter keys in the CommandListPopover handler and add an onKeyDown hook to commandSuggestion that calls TipTap’s chain to insert \n, keeping menu and editor states in sync.
  - Added a Vitest unit test so future changes don’t reintroduce the regression.
  
The following tradeoffs were made:
 - None; the change is scoped to slash-menu handling and its tests.

The following alternatives were considered:
- Handling it only in the popover was insufficient because the suggestion plugin itself still intercepts Enter.

Links to places where the discussion took place: 
 - N/A

### Breaking changes
- None

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- The new test runs with yarn vitest run src/renderer/src/components/RichEditor/__tests__/commandSuggestion.test.ts.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
fix: allow Shift+Enter to insert a newline while the slash command menu is open
```
