### PR TITLE
Show loading icon when chat is in streaming

### DIFF
--- a/src/renderer/src/pages/home/Messages/Blocks/PlaceholderBlock.tsx
+++ b/src/renderer/src/pages/home/Messages/Blocks/PlaceholderBlock.tsx
@@ -10,10 +10,7 @@ const PlaceholderBlock: React.FC<PlaceholderBlockProps> = ({ block }) => {
   if (block.status === MessageBlockStatus.PROCESSING && block.type === MessageBlockType.UNKNOWN) {
     return (
       <MessageContentLoading>
-        <Spinner
-          color="current"
-          variant="dots"
-        />
+        <Spinner color="current" variant="dots" />
       </MessageContentLoading>
     )
   }

--- a/src/renderer/src/pages/home/Messages/Blocks/PlaceholderBlock.tsx
+++ b/src/renderer/src/pages/home/Messages/Blocks/PlaceholderBlock.tsx
@@ -1,4 +1,4 @@
-import { LoadingIcon } from '@renderer/components/Icons'
+import { Spinner } from '@heroui/react'
 import { MessageBlockStatus, MessageBlockType, type PlaceholderMessageBlock } from '@renderer/types/newMessage'
 import React from 'react'
 import styled from 'styled-components'
@@ -10,7 +10,10 @@ const PlaceholderBlock: React.FC<PlaceholderBlockProps> = ({ block }) => {
   if (block.status === MessageBlockStatus.PROCESSING && block.type === MessageBlockType.UNKNOWN) {
     return (
       <MessageContentLoading>
-        <LoadingIcon />
+        <Spinner
+          color="current"
+          variant="dots"
+        />
       </MessageContentLoading>
     )
   }

--- a/src/renderer/src/pages/home/Messages/Blocks/index.tsx
+++ b/src/renderer/src/pages/home/Messages/Blocks/index.tsx
@@ -110,15 +110,6 @@ const MessageBlockRenderer: React.FC<Props> = ({ blocks, message }) => {
   // Check if message is still processing
   const isProcessing = isMessageProcessing(message)
 
-  // Check if there's already a placeholder block being shown
-  const hasPlaceholderBlock = useMemo(() =>
-    groupedBlocks.some(block =>
-      !Array.isArray(block) &&
-      block.type === MessageBlockType.UNKNOWN &&
-      block.status === MessageBlockStatus.PROCESSING
-    ), [groupedBlocks]
-  )
-
   return (
     <AnimatePresence mode="sync">
       {groupedBlocks.map((block) => {
@@ -163,9 +154,6 @@ const MessageBlockRenderer: React.FC<Props> = ({ blocks, message }) => {
 
         switch (block.type) {
           case MessageBlockType.UNKNOWN:
-            if (block.status === MessageBlockStatus.PROCESSING) {
-              blockComponent = <PlaceholderBlock key={block.id} block={block} />
-            }
             break
           case MessageBlockType.MAIN_TEXT:
           case MessageBlockType.CODE: {
@@ -225,7 +213,7 @@ const MessageBlockRenderer: React.FC<Props> = ({ blocks, message }) => {
           </AnimatedBlockWrapper>
         )
       })}
-      {isProcessing && !hasPlaceholderBlock && (
+      {isProcessing && (
         <AnimatedBlockWrapper key="message-loading-placeholder" enableAnimation={true}>
           <PlaceholderBlock
             block={{


### PR DESCRIPTION
> [!NOTE]
> This issue was translated by Claude.

before:
<img width="786" height="506" alt="image" src="https://github.com/user-attachments/assets/3e4430c1-94f7-467c-8a0d-02f0407109b0" />

after:
<img width="787" height="463" alt="image" src="https://github.com/user-attachments/assets/9eb76ddb-13d5-4311-a05a-df641aab64cf" />

Before the modification, loading is not displayed during the message stream process. After the modification, loading will be displayed continuously until the conversation ends. This improves the user experience when streaming is relatively slow.

---
<details>
<summary>Original Content</summary>

before:
<img width="786" height="506" alt="image" src="https://github.com/user-attachments/assets/3e4430c1-94f7-467c-8a0d-02f0407109b0" />

after:
<img width="787" height="463" alt="image" src="https://github.com/user-attachments/assets/9eb76ddb-13d5-4311-a05a-df641aab64cf" />

修改前在message stream的过程中不会显示loading，修改后会一直显示loading直到对话结束。这样会在提升streaming比较慢时的用户体验。
</details>