### PR TITLE
fix(assistant): enforce id requirement when updating assistant

### DIFF
--- a/src/renderer/src/hooks/useAssistant.ts
+++ b/src/renderer/src/hooks/useAssistant.ts
@@ -173,8 +173,8 @@ export function useAssistant(id: string) {
       [assistant, dispatch]
     ),
     updateAssistant: useCallback(
-      (update: Partial<Assistant> & { id: string }) => dispatch(updateAssistant(update)),
-      [dispatch]
+      (update: Partial<Omit<Assistant, 'id'>>) => dispatch(updateAssistant({ id, ...update })),
+      [dispatch, id]
     ),
     updateAssistantSettings
   }

--- a/src/renderer/src/hooks/useAssistant.ts
+++ b/src/renderer/src/hooks/useAssistant.ts
@@ -172,7 +172,10 @@ export function useAssistant(id: string) {
       (model: Model) => assistant && dispatch(setModel({ assistantId: assistant?.id, model })),
       [assistant, dispatch]
     ),
-    updateAssistant: useCallback((assistant: Partial<Assistant>) => dispatch(updateAssistant(assistant)), [dispatch]),
+    updateAssistant: useCallback(
+      (update: Partial<Assistant> & { id: string }) => dispatch(updateAssistant(update)),
+      [dispatch]
+    ),
     updateAssistantSettings
   }
 }

--- a/src/renderer/src/pages/home/Inputbar/InputbarTools.tsx
+++ b/src/renderer/src/pages/home/Inputbar/InputbarTools.tsx
@@ -147,10 +147,10 @@ const InputbarTools = ({
 
   const handleKnowledgeBaseSelect = useCallback(
     (bases?: KnowledgeBase[]) => {
-      updateAssistant({ id: assistant.id, knowledge_bases: bases })
+      updateAssistant({ knowledge_bases: bases })
       setSelectedKnowledgeBases(bases ?? [])
     },
-    [assistant.id, setSelectedKnowledgeBases, updateAssistant]
+    [setSelectedKnowledgeBases, updateAssistant]
   )
 
   // 仅允许在不含图片文件时mention非视觉模型
@@ -177,8 +177,8 @@ const InputbarTools = ({
   const onClearMentionModels = useCallback(() => setMentionedModels([]), [setMentionedModels])
 
   const onEnableGenerateImage = useCallback(() => {
-    updateAssistant({ id: assistant.id, enableGenerateImage: !assistant.enableGenerateImage })
-  }, [assistant.enableGenerateImage, assistant.id, updateAssistant])
+    updateAssistant({ enableGenerateImage: !assistant.enableGenerateImage })
+  }, [assistant.enableGenerateImage, updateAssistant])
 
   const newTopicShortcut = useShortcutDisplay('new_topic')
   const clearTopicShortcut = useShortcutDisplay('clear_topic')

--- a/src/renderer/src/pages/home/Inputbar/InputbarTools.tsx
+++ b/src/renderer/src/pages/home/Inputbar/InputbarTools.tsx
@@ -147,10 +147,10 @@ const InputbarTools = ({
 
   const handleKnowledgeBaseSelect = useCallback(
     (bases?: KnowledgeBase[]) => {
-      updateAssistant({ knowledge_bases: bases })
+      updateAssistant({ id: assistant.id, knowledge_bases: bases })
       setSelectedKnowledgeBases(bases ?? [])
     },
-    [setSelectedKnowledgeBases, updateAssistant]
+    [assistant.id, setSelectedKnowledgeBases, updateAssistant]
   )
 
   // 仅允许在不含图片文件时mention非视觉模型
@@ -177,8 +177,8 @@ const InputbarTools = ({
   const onClearMentionModels = useCallback(() => setMentionedModels([]), [setMentionedModels])
 
   const onEnableGenerateImage = useCallback(() => {
-    updateAssistant({ enableGenerateImage: !assistant.enableGenerateImage })
-  }, [assistant.enableGenerateImage, updateAssistant])
+    updateAssistant({ id: assistant.id, enableGenerateImage: !assistant.enableGenerateImage })
+  }, [assistant.enableGenerateImage, assistant.id, updateAssistant])
 
   const newTopicShortcut = useShortcutDisplay('new_topic')
   const clearTopicShortcut = useShortcutDisplay('clear_topic')

--- a/src/renderer/src/store/assistants.ts
+++ b/src/renderer/src/store/assistants.ts
@@ -46,8 +46,9 @@ const assistantsSlice = createSlice({
     removeAssistant: (state, action: PayloadAction<{ id: string }>) => {
       state.assistants = state.assistants.filter((c) => c.id !== action.payload.id)
     },
-    updateAssistant: (state, action: PayloadAction<Partial<Assistant>>) => {
-      state.assistants = state.assistants.map((c) => (c.id === action.payload.id ? { ...c, ...action.payload } : c))
+    updateAssistant: (state, action: PayloadAction<Partial<Assistant> & { id: string }>) => {
+      const { id, ...update } = action.payload
+      state.assistants = state.assistants.map((c) => (c.id === id ? { ...c, ...update } : c))
     },
     updateAssistantSettings: (
       state,


### PR DESCRIPTION
Ensure assistant id is always provided when updating assistant properties by making it a required field in the update payload. This prevents potential bugs where updates might be applied to wrong assistants.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
