### PR TITLE
fix(openai-client): honor literal apiHost when it ends with '#'

### DIFF
--- a/src/renderer/src/aiCore/legacy/clients/openai/OpenAIResponseAPIClient.ts
+++ b/src/renderer/src/aiCore/legacy/clients/openai/OpenAIResponseAPIClient.ts
@@ -70,6 +70,10 @@ export class OpenAIResponseAPIClient extends OpenAIBaseClient<
 
   private formatApiHost() {
     const host = this.provider.apiHost
+    // 支持以 # 结尾时强制使用输入地址（去掉 #，不自动追加 /openai/v1）
+    if (host.endsWith('#')) {
+      return host.slice(0, -1)
+    }
     if (host.endsWith('/openai/v1')) {
       return host
     } else {


### PR DESCRIPTION
### What this PR does

Before this PR:
- apiHost values ending with '#' were treated as needing normalization/stripping, causing incorrect host handling.

After this PR:
- Honor literal apiHost values that end with '#' and preserve them as provided.

Fixes #10340