### PR TITLE
fix(translate): remove unused effect for clearing translation contenton mount

### DIFF
--- a/src/renderer/src/pages/translate/TranslatePage.tsx
+++ b/src/renderer/src/pages/translate/TranslatePage.tsx
@@ -335,7 +335,6 @@ const TranslatePage: FC = () => {
     setTargetLanguage(source)
   }, [couldExchangeAuto, detectedLanguage, sourceLanguage, t, targetLanguage])
 
-
   useEffect(() => {
     isEmpty(text) && setTranslatedContent('')
   }, [setTranslatedContent, text])

--- a/src/renderer/src/pages/translate/TranslatePage.tsx
+++ b/src/renderer/src/pages/translate/TranslatePage.tsx
@@ -335,11 +335,6 @@ const TranslatePage: FC = () => {
     setTargetLanguage(source)
   }, [couldExchangeAuto, detectedLanguage, sourceLanguage, t, targetLanguage])
 
-  // Clear translation content when component mounts
-  useEffect(() => {
-    setText('')
-    setTranslatedContent('')
-  }, [])
 
   useEffect(() => {
     isEmpty(text) && setTranslatedContent('')


### PR DESCRIPTION


### What this PR does

Before this PR:

在翻译界面写了一堆字，然后切到笔记去复制一段文字过来，之前写的字都没有了，这个体验有点差了，因为经常要到到聊天或者笔记复制一些东西来翻译界面。

After this PR:

翻译界面缓存住之前的输入内容。


