### PR TITLE
feat: enhance multi-language support in release notes processing

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -125,6 +125,7 @@ afterSign: scripts/notarize.js
 artifactBuildCompleted: scripts/artifact-build-completed.js
 releaseInfo:
   releaseNotes: |
+    <!--LANG:en-->
     🚀 New Features:
     - Refactored AI core engine for more efficient and stable content generation
     - Added support for multiple AI model providers: CherryIN, AiOnly
@@ -151,4 +152,32 @@ releaseInfo:
     - Improved scrollbar component with horizontal scrolling support
     - Fixed multiple translation issues: paste handling, file processing, state management
     - Various UI optimizations and bug fixes
+    <!--LANG:zh-CN-->
+    🚀 新功能：
+    - 重构 AI 核心引擎，提供更高效稳定的内容生成
+    - 新增多个 AI 模型提供商支持：CherryIN、AiOnly
+    - 新增 API 服务器功能，支持外部应用集成
+    - 新增 PaddleOCR 文档识别，增强文档处理能力
+    - 新增 Anthropic OAuth 认证支持
+    - 新增数据存储空间限制提醒
+    - 新增字体设置，支持全局字体和代码字体自定义
+    - 新增翻译完成后自动复制功能
+    - 新增键盘快捷键：重命名主题、编辑最后一条消息等
+    - 新增文本附件预览，可查看消息中的文件内容
+    - 新增自定义窗口控制按钮（最小化、最大化、关闭）
+    - 支持通义千问长文本（qwen-long）和文档分析（qwen-doc）模型，原生文件上传
+    - 支持通义千问图像识别模型（Qwen-Image）
+    - 新增 iFlow CLI 支持
+    - 知识库和网页搜索转换为工具调用方式，提升灵活性
+
+    🎨 界面改进与问题修复：
+    - 集成 HeroUI 和 Tailwind CSS 框架
+    - 优化消息通知样式，统一 toast 组件
+    - 免费模型移至底部固定位置，便于访问
+    - 重构快捷面板和输入栏工具，操作更流畅
+    - 优化导航栏和侧边栏响应式设计
+    - 改进滚动条组件，支持水平滚动
+    - 修复多个翻译问题：粘贴处理、文件处理、状态管理
+    - 各种界面优化和问题修复
+    <!--LANG:END-->
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
不支持英文的release notes

After this PR:

支持英文的release notes

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
