### PR TITLE
style: update UpdateNotesWrapper to use markdown class for improved formatting

### DIFF
--- a/src/renderer/src/pages/settings/AboutSettings.tsx
+++ b/src/renderer/src/pages/settings/AboutSettings.tsx
@@ -273,7 +273,7 @@ const AboutSettings: FC = () => {
               <IndicatorLight color="green" />
             </SettingRowTitle>
           </SettingRow>
-          <UpdateNotesWrapper>
+          <UpdateNotesWrapper className="markdown">
             <Markdown>
               {typeof update.info.releaseNotes === 'string'
                 ? update.info.releaseNotes.replace(/\n/g, '\n\n')


### PR DESCRIPTION


### What this PR does

Before this PR:

<img width="2724" height="1700" alt="image (6)" src="https://github.com/user-attachments/assets/f1c155f8-8f13-47dc-bc76-8d03b6c29ade" />

release info 显示有问题，都显示到最左边了。格式应该是

release info
- feat1
- feat2

After this PR:
<img width="2108" height="1623" alt="image" src="https://github.com/user-attachments/assets/41cc1cff-7e64-42b5-a370-8dc84916c24e" />


