### PR TITLE
fix(websearch): handle blocked domains conditionally in web search 

### DIFF
--- a/src/renderer/src/aiCore/prepareParams/parameterBuilder.ts
+++ b/src/renderer/src/aiCore/prepareParams/parameterBuilder.ts
@@ -134,9 +134,10 @@ export async function buildStreamTextParams(
     if (aiSdkProviderId === 'google-vertex') {
       tools.google_search = vertex.tools.googleSearch({}) as ProviderDefinedTool
     } else if (aiSdkProviderId === 'google-vertex-anthropic') {
+      const blockedDomains = mapRegexToPatterns(webSearchConfig.excludeDomains)
       tools.web_search = vertexAnthropic.tools.webSearch_20250305({
         maxUses: webSearchConfig.maxResults,
-        blockedDomains: mapRegexToPatterns(webSearchConfig.excludeDomains)
+        blockedDomains: blockedDomains.length > 0 ? blockedDomains : undefined
       }) as ProviderDefinedTool
     }
   }

--- a/src/renderer/src/aiCore/utils/websearch.ts
+++ b/src/renderer/src/aiCore/utils/websearch.ts
@@ -61,9 +61,10 @@ export function buildProviderBuiltinWebSearchConfig(
       }
     }
     case 'anthropic': {
+      const blockedDomains = mapRegexToPatterns(webSearchConfig.excludeDomains)
       const anthropicSearchOptions: AnthropicSearchConfig = {
         maxUses: webSearchConfig.maxResults,
-        blockedDomains: mapRegexToPatterns(webSearchConfig.excludeDomains)
+        blockedDomains: blockedDomains.length > 0 ? blockedDomains : undefined
       }
       return {
         anthropic: anthropicSearchOptions


### PR DESCRIPTION
fix: `blockedDomains:[]`
Error Message:
```
"tools.0.web_search_20250305.blocked_domains: 
Empty list of domains is ambiguous. Provide at least one domain or null.\"
```