### PR TITLE
fix: clear @ and other input text when exiting model selection menu w…

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/MentionModelsButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/MentionModelsButton.tsx
@@ -250,21 +250,23 @@ const MentionModelsButton: FC<Props> = ({
           // ESC关闭时的处理：删除 @ 和搜索文本
           if (action === 'esc') {
             // 只有在输入触发且有模型选择动作时才删除@字符和搜索文本
+            const triggerInfo = ctx?.triggerInfo ?? triggerInfoRef.current
             if (
               hasModelActionRef.current &&
-              ctx.triggerInfo?.type === 'input' &&
-              ctx.triggerInfo?.position !== undefined
+              triggerInfo?.type === 'input' &&
+              triggerInfo?.position !== undefined
             ) {
               // 基于当前光标 + 搜索词精确定位并删除，position 仅作兜底
               setText((currentText) => {
                 const textArea = document.querySelector('.inputbar textarea') as HTMLTextAreaElement | null
                 const caret = textArea ? (textArea.selectionStart ?? currentText.length) : currentText.length
-                return removeAtSymbolAndText(currentText, caret, searchText || '', ctx.triggerInfo?.position!)
+                return removeAtSymbolAndText(currentText, caret, searchText || '', triggerInfo.position!)
               })
             }
           }
           // Backspace删除@的情况（delete-symbol）：
           // @ 已经被Backspace自然删除，面板关闭，不需要额外操作
+          triggerInfoRef.current = undefined
         }
       })
     },


### PR DESCRIPTION
…ith Esc

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR: 老版本当中按下 Esc 以退出 @ 模型选单时应该清除 @ 以及输入的文本，但是在最新的版本当中失去响应。

After this PR: 恢复了之前的行为。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

代码由 OpenAI CodeX 生成。如果有问题十一假期我会来修的，最近已经快被导师烤糊了。

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
