### PR TITLE
fix: AI_APICallError for Gemini via proxy #10366

### DIFF
--- a/src/renderer/src/aiCore/provider/providerConfig.ts
+++ b/src/renderer/src/aiCore/provider/providerConfig.ts
@@ -18,7 +18,7 @@ import { loggerService } from '@renderer/services/LoggerService'
 import store from '@renderer/store'
 import { isSystemProvider, type Model, type Provider } from '@renderer/types'
 import { formatApiHost } from '@renderer/utils/api'
-import { cloneDeep, isEmpty } from 'lodash'
+import { cloneDeep, trim } from 'lodash'
 
 import { aihubmixProviderCreator, newApiResolverCreator, vertexAnthropicProviderCreator } from './config'
 import { getAiSdkProviderId } from './factory'
@@ -120,7 +120,7 @@ export function providerToAiSdkConfig(
 
   // 构建基础配置
   const baseConfig = {
-    baseURL: actualProvider.apiHost,
+    baseURL: trim(actualProvider.apiHost),
     apiKey: getRotatedApiKey(actualProvider)
   }
   // 处理OpenAI模式
@@ -195,7 +195,10 @@ export function providerToAiSdkConfig(
     } else if (baseConfig.baseURL.endsWith('/v1')) {
       baseConfig.baseURL = baseConfig.baseURL.slice(0, -3)
     }
-    baseConfig.baseURL = isEmpty(baseConfig.baseURL) ? '' : baseConfig.baseURL
+
+    if (baseConfig.baseURL && !baseConfig.baseURL.includes('publishers/google')) {
+      baseConfig.baseURL = `${baseConfig.baseURL}/v1/projects/${project}/locations/${location}/publishers/google`
+    }
   }
 
   // 如果AI SDK支持该provider，使用原生配置


### PR DESCRIPTION

### What this PR does

Fix VertexAI request error (via proxy)

When sending requests to Gemini via proxy, the system returns: "模型不存在或者请求路径错误".

Before this PR:

Users need to fill in the complete URL path

After this PR:

Users only need to fill in the baseURL

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fix: https://github.com/CherryHQ/cherry-studio/issues/10366
