### PR TITLE
chore: bump version to 1.6.3 and add migration for missing providers …

### DIFF
--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -67,7 +67,7 @@ const persistedReducer = persistReducer(
   {
     key: 'cherry-studio',
     storage,
-    version: 158,
+    version: 159,
     blacklist: ['runtime', 'messages', 'messageBlocks', 'tabs'],
     migrate
   },

--- a/src/renderer/src/store/migrate.ts
+++ b/src/renderer/src/store/migrate.ts
@@ -85,6 +85,15 @@ function addProvider(state: RootState, id: string) {
   }
 }
 
+// Fix missing provider
+function fixMissingProvider(state: RootState) {
+  SYSTEM_PROVIDERS.forEach((p) => {
+    if (!state.llm.providers.find((provider) => provider.id === p.id)) {
+      state.llm.providers.push(p)
+    }
+  })
+}
+
 // add ocr provider
 function addOcrProvider(state: RootState, provider: BuiltinOcrProvider) {
   if (!state.ocr.providers.find((p) => p.id === provider.id)) {
@@ -2553,6 +2562,7 @@ const migrateConfig = {
   '159': (state: RootState) => {
     try {
       addProvider(state, 'ovms')
+      fixMissingProvider(state)
       return state
     } catch (error) {
       logger.error('migrate 159 error', error as Error)


### PR DESCRIPTION
fix: #10425

- Updated the version from 158 to 159 in the persisted reducer configuration.
- Implemented a migration function to ensure missing system providers are added to the state during the migration to version 159, enhancing state consistency.
