### PR TITLE
feat(models): update Gemini regex

### DIFF
--- a/src/renderer/src/config/models/reasoning.ts
+++ b/src/renderer/src/config/models/reasoning.ts
@@ -178,9 +178,13 @@ export function isGeminiReasoningModel(model?: Model): boolean {
   return false
 }
 
+// Gemini 支持思考模式的模型正则
+export const GEMINI_THINKING_MODEL_REGEX =
+  /gemini-(?:2\.5.*(?:-latest)?|flash-latest|pro-latest|flash-lite-latest)(?:-[\w-]+)*$/i
+
 export const isSupportedThinkingTokenGeminiModel = (model: Model): boolean => {
   const modelId = getLowerBaseModelName(model.id, '/')
-  if (modelId.includes('gemini-2.5')) {
+  if (GEMINI_THINKING_MODEL_REGEX.test(modelId)) {
     if (modelId.includes('image') || modelId.includes('tts')) {
       return false
     }

--- a/src/renderer/src/config/models/vision.ts
+++ b/src/renderer/src/config/models/vision.ts
@@ -12,6 +12,7 @@ const visionAllowedModels = [
   'gemini-1\\.5',
   'gemini-2\\.0',
   'gemini-2\\.5',
+  'gemini-(flash|pro|flash-lite)-latest',
   'gemini-exp',
   'claude-3',
   'claude-sonnet-4',

--- a/src/renderer/src/config/models/websearch.ts
+++ b/src/renderer/src/config/models/websearch.ts
@@ -11,9 +11,9 @@ export const CLAUDE_SUPPORTED_WEBSEARCH_REGEX = new RegExp(
   'i'
 )
 
-export const GEMINI_FLASH_MODEL_REGEX = new RegExp('gemini-.*-flash.*$')
+export const GEMINI_FLASH_MODEL_REGEX = new RegExp('gemini.*-flash.*$')
 
-export const GEMINI_SEARCH_REGEX = new RegExp('gemini-2\\..*', 'i')
+export const GEMINI_SEARCH_REGEX = new RegExp('gemini-(?:2.*(?:-latest)?|flash-latest|pro-latest|flash-lite-latest)(?:-[\w-]+)*$', 'i')
 
 export const PERPLEXITY_SEARCH_MODELS = [
   'sonar-pro',

--- a/src/renderer/src/config/models/websearch.ts
+++ b/src/renderer/src/config/models/websearch.ts
@@ -13,7 +13,7 @@ export const CLAUDE_SUPPORTED_WEBSEARCH_REGEX = new RegExp(
 
 export const GEMINI_FLASH_MODEL_REGEX = new RegExp('gemini.*-flash.*$')
 
-export const GEMINI_SEARCH_REGEX = new RegExp('gemini-(?:2.*(?:-latest)?|flash-latest|pro-latest|flash-lite-latest)(?:-[\w-]+)*$', 'i')
+export const GEMINI_SEARCH_REGEX = new RegExp('gemini-(?:2.*(?:-latest)?|flash-latest|pro-latest|flash-lite-latest)(?:-[\\w-]+)*$', 'i')
 
 export const PERPLEXITY_SEARCH_MODELS = [
   'sonar-pro',

--- a/src/renderer/src/config/models/websearch.ts
+++ b/src/renderer/src/config/models/websearch.ts
@@ -13,7 +13,10 @@ export const CLAUDE_SUPPORTED_WEBSEARCH_REGEX = new RegExp(
 
 export const GEMINI_FLASH_MODEL_REGEX = new RegExp('gemini.*-flash.*$')
 
-export const GEMINI_SEARCH_REGEX = new RegExp('gemini-(?:2.*(?:-latest)?|flash-latest|pro-latest|flash-lite-latest)(?:-[\\w-]+)*$', 'i')
+export const GEMINI_SEARCH_REGEX = new RegExp(
+  'gemini-(?:2.*(?:-latest)?|flash-latest|pro-latest|flash-lite-latest)(?:-[\\w-]+)*$',
+  'i'
+)
 
 export const PERPLEXITY_SEARCH_MODELS = [
   'sonar-pro',


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

After this PR:
Gemini 新增了几个 alias，更新正则

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #
#10458 

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
