### PR TITLE
Fix(backup): Ensure local backup file is fully written to disk before return (Issue #10476)

### DIFF
--- a/src/main/services/BackupManager.ts
+++ b/src/main/services/BackupManager.ts
@@ -354,7 +354,6 @@ class BackupManager {
         await new Promise((res) => setTimeout(res, 500))
       }
 
-
       logger.debug('Backup completed successfully')
       return backupedFilePath
     } catch (error) {


### PR DESCRIPTION
Adds explicit fsync call after zip file creation to prevent I/O race conditions where the consuming function attempts to read the file before it is fully flushed from the OS cache, causing "Backup file format error".