### PR TITLE
fix: correct Groq API base URL to include /v1 path (issue #10496)

### DIFF
--- a/src/renderer/src/config/providers.ts
+++ b/src/renderer/src/config/providers.ts
@@ -460,7 +460,7 @@ export const SYSTEM_PROVIDERS_CONFIG: Record<SystemProviderId, SystemProvider> =
     name: 'Groq',
     type: 'openai',
     apiKey: '',
-    apiHost: 'https://api.groq.com/openai',
+    apiHost: 'https://api.groq.com/openai/v1',
     models: SYSTEM_MODELS.groq,
     isSystem: true,
     enabled: false
@@ -1037,7 +1037,7 @@ export const PROVIDER_URLS: Record<SystemProviderId, ProviderUrls> = {
   },
   groq: {
     api: {
-      url: 'https://api.groq.com/openai'
+      url: 'https://api.groq.com/openai/v1'
     },
     websites: {
       official: 'https://groq.com/',


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
  <!--  Thanks for sending a pull request!  Here are some tips for you:
  1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
  -->

  ### What this PR does

  Before this PR:
  - Groq provider's API base URL was configured as `https://api.groq.com/openai`
  - API service requests to Groq were failing with 404 errors: `Unknown request URL: POST /openai/chat/completions`
  - Users had to manually override the base URL to `https://api.groq.com/openai/v1` as a workaround

  After this PR:
  - Groq provider's API base URL is correctly configured as `https://api.groq.com/openai/v1`
  - API service requests to Groq work correctly, calling `/openai/v1/chat/completions`
  - Users can use Groq provider through the API service without manual configuration

  <!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets
  merged)*: -->

  Fixes #10496

  ### Why we need it and why it was done in this way

  **Problem**: The OpenAI SDK (used by the API service) automatically appends `/chat/completions` to the provided 
  `baseURL`. With the old configuration (`https://api.groq.com/openai`), the final request URL became
  `https://api.groq.com/openai/chat/completions`, which doesn't match Groq's actual API endpoint.

  **Solution**: Updated the Groq provider configuration to include the `/v1` path segment in the base URL. This ensures 
  the final URL matches Groq's API specification: `https://api.groq.com/openai/v1/chat/completions`.

  The following tradeoffs were made:
  - None. This is a straightforward bug fix with no tradeoffs.

  The following alternatives were considered:
  - Modifying the API service code to handle special cases for different providers - rejected as it would add 
  unnecessary complexity
  - Documenting the workaround for users - rejected as it's better to fix the root cause

  Links to places where the discussion took place:
  - Issue: https://github.com/CherryHQ/cherry-studio/issues/10496

  ### Breaking changes

  None. This fix makes the existing Groq provider configuration work as intended. Users who were using the manual 
  workaround (setting base URL to `https://api.groq.com/openai/v1`) will continue to work without any changes.

  ### Special notes for your reviewer

  This is a minimal two-line change affecting only the Groq provider configuration:
  1. Line 463: Updated `apiHost` in `SYSTEM_PROVIDERS_CONFIG`
  2. Line 1040: Updated `api.url` in `PROVIDER_URLS` for consistency

  The fix aligns the configuration with Groq's official API documentation.

  ### Checklist

  This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
  Approvers are expected to review this list.

  - [x] PR: The PR description is expressive enough and will help future contributors
  - [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and 
  [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
  - [x] Refactor: You have [left the code cleaner than you found it (Boy Scout 
  Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
  - [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
  - [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not 
  required. You want a user-guide update if it's a user facing feature.

  ### Release note

  <!--  Write your release note:
  1. Enter your extended release note in the below block. If the PR requires additional action from users switching to 
  the new release, include the string "action required".
  2. If no release note is required, just write "NONE".
  -->

  ```release-note
  Fix Groq provider API base URL to correctly include /v1 path, resolving 404 errors when using Groq through the API 
  service.