### PR TITLE
feat(CodeEditor): add a prop to enable the readOnly extension

### DIFF
--- a/src/renderer/src/components/CodeEditor/index.tsx
+++ b/src/renderer/src/components/CodeEditor/index.tsx
@@ -75,12 +75,12 @@ export interface CodeEditorProps {
   /** CSS class name appended to the default `code-editor` class. */
   className?: string
   /**
-   * Whether the editor is editable.
+   * Whether the editor view is editable.
    * @default true
    */
   editable?: boolean
   /**
-   * Whether the editor is read only.
+   * Set the editor state to read only but keep some user interactions, e.g., keymaps.
    * @default false
    */
   readOnly?: boolean

--- a/src/renderer/src/components/CodeEditor/index.tsx
+++ b/src/renderer/src/components/CodeEditor/index.tsx
@@ -80,6 +80,11 @@ export interface CodeEditorProps {
    */
   editable?: boolean
   /**
+   * Whether the editor is read only.
+   * @default false
+   */
+  readOnly?: boolean
+  /**
    * Whether the editor is expanded.
    * If true, the height and maxHeight props are ignored.
    * @default true
@@ -114,6 +119,7 @@ const CodeEditor = ({
   style,
   className,
   editable = true,
+  readOnly = false,
   expanded = true,
   wrapped = true
 }: CodeEditorProps) => {
@@ -189,6 +195,7 @@ const CodeEditor = ({
       maxHeight={expanded ? undefined : maxHeight}
       minHeight={minHeight}
       editable={editable}
+      readOnly={readOnly}
       // @ts-ignore 强制使用，见 react-codemirror 的 Example.tsx
       theme={activeCmTheme}
       extensions={customExtensions}

--- a/src/renderer/src/components/Popups/TextFilePreview.tsx
+++ b/src/renderer/src/components/Popups/TextFilePreview.tsx
@@ -61,6 +61,9 @@ const PopupContainer: React.FC<Props> = ({ text, title, extension, resolve }) =>
           style={{ height: '100%' }}
           value={text}
           language={extension}
+          options={{
+            keymap: true
+          }}
         />
       ) : (
         <Text>{text}</Text>

--- a/src/renderer/src/components/Popups/TextFilePreview.tsx
+++ b/src/renderer/src/components/Popups/TextFilePreview.tsx
@@ -1,4 +1,3 @@
-import { EditorState } from '@codemirror/state'
 import { Modal } from 'antd'
 import { useState } from 'react'
 import styled from 'styled-components'
@@ -56,12 +55,12 @@ const PopupContainer: React.FC<Props> = ({ text, title, extension, resolve }) =>
       footer={null}>
       {extension !== undefined ? (
         <Editor
+          readOnly={true}
           expanded={false}
           height="100%"
           style={{ height: '100%' }}
           value={text}
           language={extension}
-          extensions={[EditorState.readOnly.of(true)]}
         />
       ) : (
         <Text>{text}</Text>


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Enable `readOnly` for `CodeEditor`.

Related to #10499

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
