### PR TITLE
feat(CodeEditor): enable readOnly for CodeEditor (v2)

### DIFF
--- a/packages/ui/src/components/interactive/CodeEditor/CodeEditor.tsx
+++ b/packages/ui/src/components/interactive/CodeEditor/CodeEditor.tsx
@@ -31,6 +31,7 @@ const CodeEditor = ({
   style,
   className,
   editable = true,
+  readOnly = false,
   expanded = true,
   wrapped = true
 }: CodeEditorProps) => {
@@ -111,6 +112,7 @@ const CodeEditor = ({
       maxHeight={expanded ? undefined : maxHeight}
       minHeight={minHeight}
       editable={editable}
+      readOnly={readOnly}
       theme={theme}
       extensions={customExtensions}
       onCreateEditor={(view: EditorView) => {

--- a/packages/ui/src/components/interactive/CodeEditor/types.ts
+++ b/packages/ui/src/components/interactive/CodeEditor/types.ts
@@ -91,12 +91,12 @@ export interface CodeEditorProps {
   /** CSS class name appended to the default `code-editor` class. */
   className?: string
   /**
-   * Whether the editor is editable.
+   * Whether the editor view is editable.
    * @default true
    */
   editable?: boolean
   /**
-   * Whether the editor is read only.
+   * Set the editor state to read only but keep some user interactions, e.g., keymaps.
    * @default false
    */
   readOnly?: boolean

--- a/packages/ui/src/components/interactive/CodeEditor/types.ts
+++ b/packages/ui/src/components/interactive/CodeEditor/types.ts
@@ -96,6 +96,11 @@ export interface CodeEditorProps {
    */
   editable?: boolean
   /**
+   * Whether the editor is read only.
+   * @default false
+   */
+  readOnly?: boolean
+  /**
    * Whether the editor is expanded.
    * If true, the height and maxHeight props are ignored.
    * @default true

--- a/packages/ui/stories/components/interactive/CodeEditor.stories.tsx
+++ b/packages/ui/stories/components/interactive/CodeEditor.stories.tsx
@@ -66,6 +66,7 @@ const meta: Meta<typeof CodeEditor> = {
     },
     fontSize: { control: { type: 'range', min: 12, max: 22, step: 1 } },
     editable: { control: 'boolean' },
+    readOnly: { control: 'boolean' },
     expanded: { control: 'boolean' },
     wrapped: { control: 'boolean' },
     height: { control: 'text' },
@@ -89,6 +90,7 @@ export const Default: Story = {
     value: `function greet(name: string) {\n  return 'Hello ' + name\n}`,
     fontSize: 16,
     editable: true,
+    readOnly: false,
     expanded: true,
     wrapped: true
   },
@@ -101,6 +103,7 @@ export const Default: Story = {
         theme={getCmThemeByName((args as any).theme || 'light')}
         fontSize={args.fontSize as number}
         editable={args.editable as boolean}
+        readOnly={args.readOnly as boolean}
         expanded={args.expanded as boolean}
         wrapped={args.wrapped as boolean}
         height={args.height as string | undefined}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Enable `readOnly` for `CodeEditor`.

The prop `editable` is similar to `!disabled`, but `readOnly` retains some user interactions, such as keymaps, brace matching.

See #10516

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
