### PR TITLE
chore(build): 更新 electron 版本

### DIFF
--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
     "docx": "^9.0.2",
     "dompurify": "^3.2.6",
     "dotenv-cli": "^7.4.2",
-    "electron": "37.4.0",
+    "electron": "37.6.0",
     "electron-builder": "26.0.15",
     "electron-devtools-installer": "^3.2.0",
     "electron-store": "^8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16809,16 +16809,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:37.4.0":
-  version: 37.4.0
-  resolution: "electron@npm:37.4.0"
+"electron@npm:37.6.0":
+  version: 37.6.0
+  resolution: "electron@npm:37.6.0"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^22.7.7"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10c0/92a0c41190e234d302bc612af6cce9af08cd07f6699c1ff21a9365297e73dc9d88c6c4c25ddabf352447e3e555878d2ab0f2f31a14e210dda6de74d2787ff323
+  checksum: 10c0/d67b7f0ff902f9184c2a7445507746343f8b39f3616d9d26128e7515e0184252cfc8ac97a3f1458f9ea9b4af6ab5b3208282014e8d91c0e1505ff21f5fa57ce6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What this PR does

[https://github.com/electron/electron/issues/48311](https://github.com/electron/electron/issues/48311)
中提到旧版本的electron会导致WindowServer异常占用，因此将electron从37.4.0升级到37.6.0，解决旧版本导致macOS 26卡顿问题