### PR TITLE
feat: Add long text paste as attachment to prevent input lag / feat: 新增粘贴长文本为附件功能，避免输入卡顿

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -337,6 +337,11 @@
       "placeholder_without_triggers": "Type your message here, press {{key}} to send",
       "send": "Send",
       "settings": "Settings",
+      "text_attachment": {
+        "label": "Text Attachment",
+        "preview": "Preview text content",
+        "remove": "Remove text attachment"
+      },
       "thinking": {
         "budget_exceeds_max": "Thinking budget exceeds the maximum token number",
         "label": "Thinking",
@@ -3537,8 +3542,9 @@
         "confirm_delete_message": "Confirm before deleting messages",
         "confirm_regenerate_message": "Confirm before regenerating messages",
         "enable_quick_triggers": "Enable / and @ triggers",
-        "paste_long_text_as_file": "Paste long text as file",
-        "paste_long_text_threshold": "Paste long text length",
+        "paste_long_text_as_file": "Show Long Pasted Text as Attachment",
+        "paste_long_text_as_file_description": "When pasted text exceeds the set character count, it will automatically be converted to an attachment displayed next to the input box, but will still be merged with the input text when sent",
+        "paste_long_text_threshold": "Long text threshold (characters)",
         "send_shortcuts": "Send shortcuts",
         "show_estimated_tokens": "Show estimated tokens",
         "title": "Input Settings"

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -339,6 +339,7 @@
       "settings": "Settings",
       "text_attachment": {
         "label": "Text Attachment",
+        "pasted_text_name": "Pasted Text ({{count}} characters)",
         "preview": "Preview text content",
         "remove": "Remove text attachment"
       },

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -337,6 +337,11 @@
       "placeholder_without_triggers": "在这里输入消息，按 {{key}} 发送",
       "send": "发送",
       "settings": "设置",
+      "text_attachment": {
+        "label": "文本附件",
+        "preview": "预览文本内容",
+        "remove": "移除文本附件"
+      },
       "thinking": {
         "budget_exceeds_max": "思考预算超过最大 Token 数",
         "label": "思考",
@@ -3537,8 +3542,9 @@
         "confirm_delete_message": "删除消息前确认",
         "confirm_regenerate_message": "重新生成消息前确认",
         "enable_quick_triggers": "启用 / 和 @ 触发快捷菜单",
-        "paste_long_text_as_file": "长文本粘贴为文件",
-        "paste_long_text_threshold": "长文本长度",
+        "paste_long_text_as_file": "粘贴长文本为附件",
+        "paste_long_text_as_file_description": "当粘贴文本超过设定字符数时，将自动转换为附件显示在输入框旁边，发送时仍会与输入框文本合并。",
+        "paste_long_text_threshold": "长文本阈值（字符数）",
         "send_shortcuts": "发送快捷键",
         "show_estimated_tokens": "显示预估 Token 数",
         "title": "输入设置"

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -339,6 +339,7 @@
       "settings": "设置",
       "text_attachment": {
         "label": "文本附件",
+        "pasted_text_name": "粘贴的文本 ({{count}} 字符)",
         "preview": "预览文本内容",
         "remove": "移除文本附件"
       },

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -339,6 +339,7 @@
       "settings": "設定",
       "text_attachment": {
         "label": "[to be translated]:文本附件",
+        "pasted_text_name": "[to be translated]:粘贴的文本 ({{count}} 字符)",
         "preview": "[to be translated]:预览文本内容",
         "remove": "[to be translated]:移除文本附件"
       },

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -337,6 +337,11 @@
       "placeholder_without_triggers": "在此輸入您的訊息，按 {{key}} 傳送",
       "send": "傳送",
       "settings": "設定",
+      "text_attachment": {
+        "label": "[to be translated]:文本附件",
+        "preview": "[to be translated]:预览文本内容",
+        "remove": "[to be translated]:移除文本附件"
+      },
       "thinking": {
         "budget_exceeds_max": "思考預算超過最大 Token 數",
         "label": "思考",
@@ -3538,6 +3543,7 @@
         "confirm_regenerate_message": "重新生成訊息前確認",
         "enable_quick_triggers": "啟用 / 和 @ 觸發快捷選單",
         "paste_long_text_as_file": "將長文字貼上為檔案",
+        "paste_long_text_as_file_description": "[to be translated]:当粘贴文本超过设定字符数时，将自动转换为附件显示在输入框旁边，发送时仍会与输入框文本合并",
         "paste_long_text_threshold": "長文字長度",
         "send_shortcuts": "傳送快捷鍵",
         "show_estimated_tokens": "顯示預估 Token 數",

--- a/src/renderer/src/i18n/translate/el-gr.json
+++ b/src/renderer/src/i18n/translate/el-gr.json
@@ -339,6 +339,7 @@
       "settings": "Ρυθμίσεις",
       "text_attachment": {
         "label": "[to be translated]:文本附件",
+        "pasted_text_name": "[to be translated]:粘贴的文本 ({{count}} 字符)",
         "preview": "[to be translated]:预览文本内容",
         "remove": "[to be translated]:移除文本附件"
       },

--- a/src/renderer/src/i18n/translate/el-gr.json
+++ b/src/renderer/src/i18n/translate/el-gr.json
@@ -334,8 +334,14 @@
       "new_topic": "Νέο θέμα {{Command}}",
       "pause": "Παύση",
       "placeholder": "Εισάγετε μήνυμα εδώ...",
+      "placeholder_without_triggers": "[to be translated]:在这里输入消息，按 {{key}} 发送",
       "send": "Αποστολή",
       "settings": "Ρυθμίσεις",
+      "text_attachment": {
+        "label": "[to be translated]:文本附件",
+        "preview": "[to be translated]:预览文本内容",
+        "remove": "[to be translated]:移除文本附件"
+      },
       "thinking": {
         "budget_exceeds_max": "Ο προϋπολογισμός σκέψης υπερβαίνει τον μέγιστο αριθμό token",
         "label": "Σκέψη",
@@ -1696,6 +1702,12 @@
     "provider_settings": "Μετάβαση στις ρυθμίσεις παρόχου"
   },
   "notes": {
+    "auto_rename": {
+      "empty_note": "[to be translated]:笔记为空，无法生成名称",
+      "failed": "[to be translated]:生成笔记名称失败",
+      "label": "[to be translated]:生成笔记名称",
+      "success": "[to be translated]:笔记名称生成成功"
+    },
     "characters": "χαρακτήρας",
     "collapse": "σύμπτυξη",
     "content_placeholder": "Παρακαλώ εισαγάγετε το περιεχόμενο των σημειώσεων...",
@@ -3531,6 +3543,7 @@
         "confirm_regenerate_message": "Επιβεβαίωση πριν από την επαναδημιουργία του μηνύματος",
         "enable_quick_triggers": "Ενεργοποίηση των '/' και '@' για γρήγορη πρόσβαση σε μενού",
         "paste_long_text_as_file": "Επικόλληση μεγάλου κειμένου ως αρχείο",
+        "paste_long_text_as_file_description": "[to be translated]:当粘贴文本超过设定字符数时，将自动转换为附件显示在输入框旁边，发送时仍会与输入框文本合并",
         "paste_long_text_threshold": "Όριο μεγάλου κειμένου",
         "send_shortcuts": "Συντάγματα αποστολής",
         "show_estimated_tokens": "Εμφάνιση εκτιμώμενου αριθμού token",

--- a/src/renderer/src/i18n/translate/es-es.json
+++ b/src/renderer/src/i18n/translate/es-es.json
@@ -334,8 +334,14 @@
       "new_topic": "Nuevo tema {{Command}}",
       "pause": "Pausar",
       "placeholder": "Escribe aquí tu mensaje...",
+      "placeholder_without_triggers": "[to be translated]:在这里输入消息，按 {{key}} 发送",
       "send": "Enviar",
       "settings": "Configuración",
+      "text_attachment": {
+        "label": "[to be translated]:文本附件",
+        "preview": "[to be translated]:预览文本内容",
+        "remove": "[to be translated]:移除文本附件"
+      },
       "thinking": {
         "budget_exceeds_max": "El presupuesto de pensamiento excede el número máximo de tokens",
         "label": "Pensando",
@@ -1696,6 +1702,12 @@
     "provider_settings": "Ir a la configuración del proveedor"
   },
   "notes": {
+    "auto_rename": {
+      "empty_note": "[to be translated]:笔记为空，无法生成名称",
+      "failed": "[to be translated]:生成笔记名称失败",
+      "label": "[to be translated]:生成笔记名称",
+      "success": "[to be translated]:笔记名称生成成功"
+    },
     "characters": "carácter",
     "collapse": "ocultar",
     "content_placeholder": "Introduzca el contenido de la nota...",
@@ -3531,6 +3543,7 @@
         "confirm_regenerate_message": "confirmar antes de regenerar el mensaje",
         "enable_quick_triggers": "Habilitar menú rápido con '/' y '@'",
         "paste_long_text_as_file": "Pegar texto largo como archivo",
+        "paste_long_text_as_file_description": "[to be translated]:当粘贴文本超过设定字符数时，将自动转换为附件显示在输入框旁边，发送时仍会与输入框文本合并",
         "paste_long_text_threshold": "Límite de longitud de texto largo",
         "send_shortcuts": "Atajos de teclado para enviar",
         "show_estimated_tokens": "Mostrar número estimado de tokens",

--- a/src/renderer/src/i18n/translate/es-es.json
+++ b/src/renderer/src/i18n/translate/es-es.json
@@ -339,6 +339,7 @@
       "settings": "Configuración",
       "text_attachment": {
         "label": "[to be translated]:文本附件",
+        "pasted_text_name": "[to be translated]:粘贴的文本 ({{count}} 字符)",
         "preview": "[to be translated]:预览文本内容",
         "remove": "[to be translated]:移除文本附件"
       },

--- a/src/renderer/src/i18n/translate/fr-fr.json
+++ b/src/renderer/src/i18n/translate/fr-fr.json
@@ -339,6 +339,7 @@
       "settings": "Paramètres",
       "text_attachment": {
         "label": "[to be translated]:文本附件",
+        "pasted_text_name": "[to be translated]:粘贴的文本 ({{count}} 字符)",
         "preview": "[to be translated]:预览文本内容",
         "remove": "[to be translated]:移除文本附件"
       },

--- a/src/renderer/src/i18n/translate/fr-fr.json
+++ b/src/renderer/src/i18n/translate/fr-fr.json
@@ -334,8 +334,14 @@
       "new_topic": "Nouveau sujet {{Command}}",
       "pause": "Pause",
       "placeholder": "Entrez votre message ici...",
+      "placeholder_without_triggers": "[to be translated]:在这里输入消息，按 {{key}} 发送",
       "send": "Envoyer",
       "settings": "Paramètres",
+      "text_attachment": {
+        "label": "[to be translated]:文本附件",
+        "preview": "[to be translated]:预览文本内容",
+        "remove": "[to be translated]:移除文本附件"
+      },
       "thinking": {
         "budget_exceeds_max": "Le budget de réflexion dépasse le nombre maximum de tokens",
         "label": "Pensée",
@@ -1696,6 +1702,12 @@
     "provider_settings": "Aller aux paramètres du fournisseur"
   },
   "notes": {
+    "auto_rename": {
+      "empty_note": "[to be translated]:笔记为空，无法生成名称",
+      "failed": "[to be translated]:生成笔记名称失败",
+      "label": "[to be translated]:生成笔记名称",
+      "success": "[to be translated]:笔记名称生成成功"
+    },
     "characters": "caractère",
     "collapse": "réduire",
     "content_placeholder": "Veuillez saisir le contenu de la note...",
@@ -3531,6 +3543,7 @@
         "confirm_regenerate_message": "Confirmer avant de régénérer le message",
         "enable_quick_triggers": "Activer les menus rapides avec '/' et '@'",
         "paste_long_text_as_file": "Coller le texte long sous forme de fichier",
+        "paste_long_text_as_file_description": "[to be translated]:当粘贴文本超过设定字符数时，将自动转换为附件显示在输入框旁边，发送时仍会与输入框文本合并",
         "paste_long_text_threshold": "Seuil de longueur de texte",
         "send_shortcuts": "Raccourcis d'envoi",
         "show_estimated_tokens": "Afficher le nombre estimatif de tokens",

--- a/src/renderer/src/i18n/translate/ja-jp.json
+++ b/src/renderer/src/i18n/translate/ja-jp.json
@@ -339,6 +339,7 @@
       "settings": "設定",
       "text_attachment": {
         "label": "[to be translated]:文本附件",
+        "pasted_text_name": "[to be translated]:粘贴的文本 ({{count}} 字符)",
         "preview": "[to be translated]:预览文本内容",
         "remove": "[to be translated]:移除文本附件"
       },

--- a/src/renderer/src/i18n/translate/ja-jp.json
+++ b/src/renderer/src/i18n/translate/ja-jp.json
@@ -334,8 +334,14 @@
       "new_topic": "新しいトピック {{Command}}",
       "pause": "一時停止",
       "placeholder": "ここにメッセージを入力し、{{key}} を押して送信...",
+      "placeholder_without_triggers": "[to be translated]:在这里输入消息，按 {{key}} 发送",
       "send": "送信",
       "settings": "設定",
+      "text_attachment": {
+        "label": "[to be translated]:文本附件",
+        "preview": "[to be translated]:预览文本内容",
+        "remove": "[to be translated]:移除文本附件"
+      },
       "thinking": {
         "budget_exceeds_max": "思考予算が最大トークン数を超えました",
         "label": "思考",
@@ -1696,6 +1702,12 @@
     "provider_settings": "プロバイダー設定に移動"
   },
   "notes": {
+    "auto_rename": {
+      "empty_note": "[to be translated]:笔记为空，无法生成名称",
+      "failed": "[to be translated]:生成笔记名称失败",
+      "label": "[to be translated]:生成笔记名称",
+      "success": "[to be translated]:笔记名称生成成功"
+    },
     "characters": "文字",
     "collapse": "閉じる",
     "content_placeholder": "メモの内容を入力してください...",
@@ -3531,6 +3543,7 @@
         "confirm_regenerate_message": "メッセージ再生成前に確認",
         "enable_quick_triggers": "/ と @ を有効にしてクイックメニューを表示します。",
         "paste_long_text_as_file": "長いテキストをファイルとして貼り付け",
+        "paste_long_text_as_file_description": "[to be translated]:当粘贴文本超过设定字符数时，将自动转换为附件显示在输入框旁边，发送时仍会与输入框文本合并",
         "paste_long_text_threshold": "長いテキストの長さ",
         "send_shortcuts": "送信ショートカット",
         "show_estimated_tokens": "推定トークン数を表示",

--- a/src/renderer/src/i18n/translate/pt-pt.json
+++ b/src/renderer/src/i18n/translate/pt-pt.json
@@ -339,6 +339,7 @@
       "settings": "Configurações",
       "text_attachment": {
         "label": "[to be translated]:文本附件",
+        "pasted_text_name": "[to be translated]:粘贴的文本 ({{count}} 字符)",
         "preview": "[to be translated]:预览文本内容",
         "remove": "[to be translated]:移除文本附件"
       },

--- a/src/renderer/src/i18n/translate/pt-pt.json
+++ b/src/renderer/src/i18n/translate/pt-pt.json
@@ -334,8 +334,14 @@
       "new_topic": "Novo tópico {{Command}}",
       "pause": "Pausar",
       "placeholder": "Digite sua mensagem aqui...",
+      "placeholder_without_triggers": "[to be translated]:在这里输入消息，按 {{key}} 发送",
       "send": "Enviar",
       "settings": "Configurações",
+      "text_attachment": {
+        "label": "[to be translated]:文本附件",
+        "preview": "[to be translated]:预览文本内容",
+        "remove": "[to be translated]:移除文本附件"
+      },
       "thinking": {
         "budget_exceeds_max": "Orçamento de pensamento excede o número máximo de tokens",
         "label": "Pensando",
@@ -1696,6 +1702,12 @@
     "provider_settings": "Ir para as configurações do provedor"
   },
   "notes": {
+    "auto_rename": {
+      "empty_note": "[to be translated]:笔记为空，无法生成名称",
+      "failed": "[to be translated]:生成笔记名称失败",
+      "label": "[to be translated]:生成笔记名称",
+      "success": "[to be translated]:笔记名称生成成功"
+    },
     "characters": "caractere",
     "collapse": "[minimizar]",
     "content_placeholder": "Introduza o conteúdo da nota...",
@@ -3531,6 +3543,7 @@
         "confirm_regenerate_message": "Confirmar antes de regenerar a mensagem",
         "enable_quick_triggers": "Ativar menu rápido com '/' e '@'",
         "paste_long_text_as_file": "Colar texto longo como arquivo",
+        "paste_long_text_as_file_description": "[to be translated]:当粘贴文本超过设定字符数时，将自动转换为附件显示在输入框旁边，发送时仍会与输入框文本合并",
         "paste_long_text_threshold": "Limite de texto longo",
         "send_shortcuts": "Atalhos de envio",
         "show_estimated_tokens": "Mostrar número estimado de tokens",

--- a/src/renderer/src/i18n/translate/ru-ru.json
+++ b/src/renderer/src/i18n/translate/ru-ru.json
@@ -334,8 +334,14 @@
       "new_topic": "Новый топик {{Command}}",
       "pause": "Остановить",
       "placeholder": "Введите ваше сообщение здесь, нажмите {{key}} для отправки...",
+      "placeholder_without_triggers": "[to be translated]:在这里输入消息，按 {{key}} 发送",
       "send": "Отправить",
       "settings": "Настройки",
+      "text_attachment": {
+        "label": "[to be translated]:文本附件",
+        "preview": "[to be translated]:预览文本内容",
+        "remove": "[to be translated]:移除文本附件"
+      },
       "thinking": {
         "budget_exceeds_max": "Бюджет размышления превышает максимальное количество токенов",
         "label": "Мыслим",
@@ -1696,6 +1702,12 @@
     "provider_settings": "Перейти к настройкам поставщика"
   },
   "notes": {
+    "auto_rename": {
+      "empty_note": "[to be translated]:笔记为空，无法生成名称",
+      "failed": "[to be translated]:生成笔记名称失败",
+      "label": "[to be translated]:生成笔记名称",
+      "success": "[to be translated]:笔记名称生成成功"
+    },
     "characters": "Символы",
     "collapse": "Свернуть",
     "content_placeholder": "Введите содержимое заметки...",
@@ -3531,6 +3543,7 @@
         "confirm_regenerate_message": "Подтверждать перед пересозданием сообщений",
         "enable_quick_triggers": "Включите / и @, чтобы вызвать быстрое меню.",
         "paste_long_text_as_file": "Вставлять длинный текст как файл",
+        "paste_long_text_as_file_description": "[to be translated]:当粘贴文本超过设定字符数时，将自动转换为附件显示在输入框旁边，发送时仍会与输入框文本合并",
         "paste_long_text_threshold": "Длина вставки длинного текста",
         "send_shortcuts": "Горячие клавиши для отправки",
         "show_estimated_tokens": "Показывать затраты токенов",

--- a/src/renderer/src/i18n/translate/ru-ru.json
+++ b/src/renderer/src/i18n/translate/ru-ru.json
@@ -339,6 +339,7 @@
       "settings": "Настройки",
       "text_attachment": {
         "label": "[to be translated]:文本附件",
+        "pasted_text_name": "[to be translated]:粘贴的文本 ({{count}} 字符)",
         "preview": "[to be translated]:预览文本内容",
         "remove": "[to be translated]:移除文本附件"
       },

--- a/src/renderer/src/pages/home/Tabs/SettingsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/SettingsTab.tsx
@@ -12,7 +12,7 @@ import { useAssistant } from '@renderer/hooks/useAssistant'
 import { useProvider } from '@renderer/hooks/useProvider'
 import { useSettings } from '@renderer/hooks/useSettings'
 import useTranslate from '@renderer/hooks/useTranslate'
-import { SettingDivider, SettingRow, SettingRowTitle } from '@renderer/pages/settings'
+import { SettingDivider, SettingHelpText, SettingRow, SettingRowTitle } from '@renderer/pages/settings'
 import AssistantSettingsPopup from '@renderer/pages/settings/AssistantSettings'
 import { CollapsibleSettingGroup } from '@renderer/pages/settings/SettingGroup'
 import { getDefaultModel } from '@renderer/services/AssistantService'
@@ -602,6 +602,7 @@ const SettingsTab: FC<Props> = (props) => {
               onChange={(checked) => dispatch(setPasteLongTextAsFile(checked))}
             />
           </SettingRow>
+          <SettingHelpText>{t('settings.messages.input.paste_long_text_as_file_description')}</SettingHelpText>
           {pasteLongTextAsFile && (
             <>
               <SettingDivider />
@@ -609,11 +610,11 @@ const SettingsTab: FC<Props> = (props) => {
                 <SettingRowTitleSmall>{t('settings.messages.input.paste_long_text_threshold')}</SettingRowTitleSmall>
                 <EditableNumber
                   size="small"
-                  min={500}
-                  max={10000}
-                  step={100}
+                  min={1000}
+                  max={20000}
+                  step={500}
                   value={pasteLongTextThreshold}
-                  onChange={(value) => dispatch(setPasteLongTextThreshold(value ?? 500))}
+                  onChange={(value) => dispatch(setPasteLongTextThreshold(value ?? 8000))}
                   style={{ width: 80 }}
                 />
               </SettingRow>

--- a/src/renderer/src/services/PasteService.ts
+++ b/src/renderer/src/services/PasteService.ts
@@ -1,6 +1,7 @@
 import { loggerService } from '@logger'
 import { FileMetadata, FileTypes } from '@renderer/types'
 import { getFileExtension, isSupportedFile } from '@renderer/utils'
+import type { TFunction } from 'i18next'
 
 const logger = loggerService.withContext('PasteService')
 
@@ -33,7 +34,7 @@ export const handlePaste = async (
   pasteLongTextThreshold?: number,
   text?: string,
   resizeTextArea?: () => void,
-  t?: (key: string) => string
+  t?: TFunction
 ): Promise<boolean> => {
   try {
     // 优先处理文本粘贴
@@ -48,7 +49,7 @@ export const handlePaste = async (
         const textAttachment = {
           id: `text_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
           name: `pasted_text_${new Date().toISOString().slice(0, 19).replace(/[:-]/g, '')}.txt`,
-          origin_name: `粘贴的文本 (${clipboardText.length} 字符)`,
+          origin_name: t ? t('chat.input.text_attachment.pasted_text_name', { count: clipboardText.length }) : 'Pasted Text',
           path: '', // 文本附件不需要实际路径
           size: new Blob([clipboardText]).size,
           ext: '.txt',

--- a/src/renderer/src/store/settings.ts
+++ b/src/renderer/src/store/settings.ts
@@ -255,7 +255,7 @@ export const initialState: SettingsState = {
   pinTopicsToTop: false,
   assistantIconType: 'emoji',
   pasteLongTextAsFile: false,
-  pasteLongTextThreshold: 1500,
+  pasteLongTextThreshold: 8000,
   clickAssistantToShowTopic: true,
   autoCheckUpdate: true,
   testPlan: false,

--- a/src/renderer/src/types/file.ts
+++ b/src/renderer/src/types/file.ts
@@ -110,6 +110,14 @@ export interface FileMetadata {
    * 该文件的用途
    */
   purpose?: OpenAI.FilePurpose
+  /**
+   * 是否为粘贴的文本附件
+   */
+  isPastedText?: boolean
+  /**
+   * 粘贴的文本内容（仅当 isPastedText 为 true 时有效）
+   */
+  pastedTextContent?: string
 }
 
 export interface FileType extends FileMetadata {}


### PR DESCRIPTION
### What this PR does

Before this PR:
- Pasting very long text directly into the input box caused UI lag and degraded user experience.
- There was no mechanism to handle pasted long text as a lightweight attachment while keeping send semantics unchanged.

After this PR:
- Introduces "Paste long text as attachment" feature. When pasted text exceeds a configurable character threshold it is shown as a text attachment next to the input box rather than rendered inside the input area, preserving input responsiveness. On send, the attachment content is merged with the input text and sent as before.

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/5d61d4c6-107c-455e-8035-0fb6813d12c0" />

<img width="1708" height="377" alt="image" src="https://github.com/user-attachments/assets/3b27e9a6-ab00-4183-8c3a-a0c6e2cbc9a1" />

<img width="1177" height="437" alt="image" src="https://github.com/user-attachments/assets/41dbfbc8-b64e-4cfb-b9b6-8ac2831c6d24" />

* Upon sending, the attachment content is merged with the input text on the client-side and sent as a single, complete message. The recipient sees the full text as if it were sent normally. The merge logic follows the format user's query + newline + pasted content, ensuring the user's original query is always placed at the beginning. *

*点击发送后，文本附件的内容会与输入框中的文本在前端合并，然后作为一个整体发送。用户的接收方看到的是一条完整的长消息，体验与之前完全一致。合并时会遵循 用户输入内容 + 换行符 + 粘贴的附件内容 的格式，确保用户输入的上下文始终位于最前面。*


Fixes #

### Why we need it and why it was done in this way

Problems addressed:
- Performance: Avoids input box freezes when pasting very large text blobs.
- UX: Keeps the input responsive and editable while still allowing large text to be included in messages.

Tradeoffs and rationale:
- Showing pasted long text as an attachment keeps the UI lightweight while still preserving content semantics on send.
- Default threshold (8000 chars) balances typical usage and performance; the threshold is configurable (1000–20000).
- Implementation reuses existing attachment preview UI to minimize new surface area and maintenance cost.

Alternatives considered:
- Streaming or chunked rendering inside the input: more complex and fragile.
- Truncating pasted text automatically: could cause data loss and surprising behavior.

Links to discussion: none (internal design inspired by Claude Web behavior)

### Breaking changes

- None. The feature is disabled by default and the send behavior is kept consistent (attachments are merged into message payload rather than being uploaded as separate files).

### Special notes for your reviewer

- Focus review on:
  - Paste handling logic in PasteService.ts
  - Attachment rendering and UX in AttachmentPreview.tsx
  - Send merging logic in Inputbar.tsx
  - Settings tab and i18n keys and defaults
- The change aims to be minimal and backwards-compatible; please test edge cases (multiple attachments, delete/restore behavior, copy/paste variations).

### Checklist

- [x] PR: The PR description is expressive and should help future contributors
- [x] Code: Code written to be human-readable and follows KISS
- [x] Refactor: Left the code cleaner than found (focused reuse of attachment component)
- [x] Upgrade: No upgrade flow required; feature is opt-in
- [x] Documentation: i18n strings and settings added; user-guide update recommended (not included in this PR)

### Release note

```release-note
Add optional "Paste long text as attachment" feature: when pasting text longer than a configurable threshold (default 8000 characters), the text will be shown as a lightweight text attachment instead of being inserted into the input box. On send, attachment content is merged with the input text. Feature disabled by default.
```

Files changed (high level)
- src/renderer/src/types/file.ts — extend FileMetadata: isPastedText, pastedTextContent
- src/renderer/src/services/PasteService.ts — paste handling logic: convert long pasted text to text attachment
- src/renderer/src/pages/home/Inputbar/AttachmentPreview.tsx — render text attachments (green tag, icon, hover preview, click-to-view, delete)
- src/renderer/src/pages/home/Inputbar/Inputbar.tsx — send logic: merge pasted text attachments with input text; ensure previous file-upload behavior unchanged
- src/renderer/src/pages/home/Tabs/SettingsTab.tsx — settings UI for enabling feature and threshold
- src/renderer/src/store/settings.ts — default config values
- src/renderer/src/i18n/locales/en-us.json — new English translations
- src/renderer/src/i18n/locales/zh-cn.json — new Chinese translations
- *Other i18n files are only synchronized and not translated.*

Core technical notes
- Added typed properties: isPastedText: boolean and pastedTextContent: string on FileMetadata to identify and carry text attachments.
- Reused existing attachment preview component to display text attachments with a green label and icon.
- Hover shows first 200 characters; clicking opens full view modal.
- Delete removes the attachment and preserves remaining input.
- Threshold is configurable in settings (1000–20000). Default = 8000.
- Only plain text attachments are handled as in-memory text; normal file attachments are uploaded as before.

Testing and quality
- Lint: passed (0 warnings, 0 errors)
- TypeScript checks: passed
- Basic integration tests and manual verification completed (attachment add/remove, hover preview, send merging, disabling feature)
- i18n keys added:
  - settings.messages.input.paste_long_text_as_file_description
  - chat.input.text_attachment.label
  - chat.input.text_attachment.preview
  - chat.input.text_attachment.remove

Usage
1. Settings > General Settings
2. Enable "Paste long text as attachment"
3. Set desired character threshold (recommended 8000)
4. Paste long text that exceeds the threshold: it will show as a text attachment
5. Send: attachment content is merged with the input text and sent

Backward compatibility
- Feature is opt-in and off by default. Existing flows and file-attachments unchanged.

---

### 本次 PR 做了什么

Before（修改前）：
- 在输入框直接粘贴大量文本会导致界面卡顿，体验差。
- 没有对粘贴长文本的处理机制。

After（修改后）：
- 增加“粘贴长文本显示为附件”功能：当粘贴文本超过可配置字符阈值时，文本将作为附件显示在输入框旁，而不是直接渲染在输入框内，从而保持输入框流畅。发送时，附件内容会与输入框文本合并并发送，行为与之前一致。

Fixes #

### 为什么需要以及为何这么实现

要解决的问题：
- 性能：避免在输入框内渲染超大文本导致卡顿。
- 用户体验：保持输入可编辑且响应迅速。

折衷与理由：
- 将长文本显示为附件可减少渲染压力且不丢失内容。
- 默认阈值 8000 字符在常见场景下兼顾性能与便利；用户可配置（1000–20000）。
- 复用已有附件预览组件，减小改动面与维护成本。

考虑过的替代方案：
- 在输入框内分块/流式渲染：实现复杂，易出问题。
- 自动截断：会造成数据丢失，不友好。

讨论链接：无（设计参考 Claude Web）

### 破坏性变更

- 无。功能默认关闭，发送语义保持不变（文本附件在本地合并后发送，而非变更为文件上传行为）。

### 给审阅者的特别提示

- 请重点审查：
  - PasteService.ts 的粘贴处理逻辑
  - AttachmentPreview.tsx 的显示与交互细节
  - Inputbar.tsx 的发送合并逻辑
  - 设置页面与 i18n 字符串
- 请测试边界场景（多个附件、删除/恢复、不同粘贴来源等）。

### 清单

- [x] PR 描述清晰，便于未来贡献者理解
- [x] 代码可读且符合 KISS 原则
- [x] 重构后代码更整洁（复用附件组件）
- [x] 升级路径：无需特别升级，功能为可选
- [x] 文档：添加了 i18n 与设置交互说明，建议同步用户指南

### Release note（发布说明）

```release-note
新增可选“粘贴长文本显示为附件”功能：当粘贴文本超过可配置阈值（默认 8000 字符）时，文本将以轻量文本附件显示在输入框旁。发送时附件内容会与输入框文本合并发送。该功能默认关闭。
```

修改文件（概览）
- src/renderer/src/types/file.ts — 扩展 FileMetadata：isPastedText、pastedTextContent
- src/renderer/src/services/PasteService.ts — 粘贴处理，超过阈值转换为文本附件
- src/renderer/src/pages/home/Inputbar/AttachmentPreview.tsx — 文本附件渲染（绿色标签、图标、悬停预览、点击查看、删除）
- src/renderer/src/pages/home/Inputbar/Inputbar.tsx — 发送时合并文本附件与输入框文本；保留原有文件上传行为
- src/renderer/src/pages/home/Tabs/SettingsTab.tsx — 设置界面（启用开关 + 阈值）
- src/renderer/src/store/settings.ts — 默认配置
- src/renderer/src/i18n/locales/en-us.json — 英文翻译项
- src/renderer/src/i18n/locales/zh-cn.json — 中文翻译项
- *其他国际化文件仅同步但未翻译*

核心技术要点
- 在类型中新增 isPastedText: boolean 和 pastedTextContent: string，标识并携带文本附件内容。
- 复用现有附件预览组件以显示文本附件（绿色标签 + 文本图标）。
- 悬停显示前 200 字符，点击可打开完整查看模态框。
- 删除操作支持移除附件并保留输入状态。
- 阈值可在 1000–20000 范围内配置，默认 8000。
- 仅对纯文本做内存级处理，普通文件附件仍走上传流程。

测试与质量保证
- Lint：通过（0 warnings, 0 errors）
- TypeScript 类型检查：通过
- 基本集成与手动验证完成（添加/删除附件、悬停预览、发送合并、禁用功能）
- 新增 i18n 键：
  - settings.messages.input.paste_long_text_as_file_description
  - chat.input.text_attachment.label
  - chat.input.text_attachment.preview
  - chat.input.text_attachment.remove

使用方法
1. 进入 设置 > 常规设置
2. 启用 “粘贴长文本显示为附件”
3. 设置字符阈值（推荐 8000）
4. 粘贴超过阈值的长文本时，会自动显示为附件
5. 发送时附件内容会自动合并并随消息发送

向后兼容性
- 完全向后兼容，默认关闭；不影响现有文件附件功能。