### PR TITLE
fix: use correct publisher for Claude models on Vertex AI

### DIFF
--- a/src/renderer/src/aiCore/provider/providerConfig.ts
+++ b/src/renderer/src/aiCore/provider/providerConfig.ts
@@ -196,8 +196,10 @@ export function providerToAiSdkConfig(
       baseConfig.baseURL = baseConfig.baseURL.slice(0, -3)
     }
 
-    if (baseConfig.baseURL && !baseConfig.baseURL.includes('publishers/google')) {
-      baseConfig.baseURL = `${baseConfig.baseURL}/v1/projects/${project}/locations/${location}/publishers/google`
+    if (baseConfig.baseURL && !baseConfig.baseURL.includes('publishers/')) {
+      // Vertex AI supports multiple publishers: 'google' for Gemini, 'anthropic' for Claude
+      const publisher = aiSdkProviderId === 'google-vertex-anthropic' ? 'anthropic' : 'google'
+      baseConfig.baseURL = `${baseConfig.baseURL}/v1/projects/${project}/locations/${location}/publishers/${publisher}/models`
     }
   }
 


### PR DESCRIPTION
### What this PR does

**Before this PR:**
- Vertex AI Claude models (e.g., `claude-sonnet-4-5@20250929`) returned 404 errors when attempting to connect
- The URL builder hardcoded `publishers/google` for all Vertex AI models
- The `/models` path segment was missing from the constructed URL

**After this PR:**
- Vertex AI Claude models connect successfully without 404 errors
- URL construction dynamically selects the correct publisher based on model type:
  - `publishers/anthropic` for Claude models
  - `publishers/google` for Gemini models
- The complete URL path includes the required `/models` segment

Fixes #10493

### Why we need it and why it was done in this way

**Problem:** @luosc reported that Claude models on Vertex AI were failing with 404 errors. The root cause was that Cherry Studio was hardcoding `publishers/google` in the Vertex AI URL construction, when Claude models actually require `publishers/anthropic`.

**Solution:** Modified `src/renderer/src/aiCore/provider/providerConfig.ts` (lines 199-202) to:
1. Detect Claude models via the existing `aiSdkProviderId === 'google-vertex-anthropic'` check (already implemented in the codebase)
2. Dynamically select the publisher based on model type
3. Include the `/models` path segment to match Vertex AI's API specification

**The following tradeoffs were made:**
- None. This change uses existing model detection logic already present in the codebase.

**The following alternatives were considered:**
1. **Adding a UI field for publisher selection** - Rejected because it adds complexity for users and the model type already determines the publisher
2. **Creating separate provider types** - Rejected because the existing architecture already handles this distinction via `vertexAnthropicProviderCreator`

**Links to places where the discussion took place:**
- Original issue: https://github.com/CherryHQ/cherry-studio/issues/10493
- Vertex AI documentation: 
    - Model Garden: https://console.cloud.google.com/vertex-ai/publishers/anthropic/model-garden/claude-sonnet-4-5
    - REST API docs: https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/use-claude

### Breaking changes

None. This change is fully backward compatible:
- Existing Gemini models continue to work exactly as before
- Users don't need to modify their configurations
- The change only affects the internal URL construction logic

### Special notes for your reviewer

**Testing performed with real Vertex AI credentials:**
- ✅ Tested with `global` location using Gemini models
- ✅ Tested with `global` location using Claude models (claude-sonnet-4.5-v2)
- ✅ Tested with regional location (`us-east5`) using both Gemini and Claude models
- ✅ Verified backward compatibility with existing Gemini configurations
- ✅ Confirmed the fix works with empty baseURL (recommended) and custom baseURL (for reverse proxy users)

**Technical details:**
The fix leverages the existing `vertexAnthropicProviderCreator` function which already sets `aiSdkProviderId` to `google-vertex-anthropic` for Claude models (detected via model name starting with 'claude'). No changes were needed to model detection logic.

**Expected URL format after fix:**
```
https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/publishers/{publisher}/models/{model}:streamRawPredict
```
Where `{publisher}` is `anthropic` for Claude models and `google` for Gemini models.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required (internal URL construction change)

### Release note

```release-note
Fix Vertex AI Claude models failing with 404 errors by correctly setting the publisher in URL construction. Claude models now use publishers/anthropic while Gemini models continue using publishers/google. Users with existing Vertex AI configurations do not need to make any changes.
```