### PR TITLE
fix: adding multiple keys to the zhipu model service is not detected properly

### DIFF
--- a/src/renderer/src/components/Popups/ApiKeyListPopup/popup.tsx
+++ b/src/renderer/src/components/Popups/ApiKeyListPopup/popup.tsx
@@ -10,6 +10,7 @@ interface ShowParams {
   providerId: string
   title?: string
   showHealthCheck?: boolean
+  providerType?: 'llm' | 'webSearch' | 'preprocess'
 }
 
 interface Props extends ShowParams {
@@ -19,7 +20,7 @@ interface Props extends ShowParams {
 /**
  * API Key 列表弹窗容器组件
  */
-const PopupContainer: React.FC<Props> = ({ providerId, title, resolve, showHealthCheck = true }) => {
+const PopupContainer: React.FC<Props> = ({ providerId, title, resolve, showHealthCheck = true, providerType }) => {
   const [open, setOpen] = useState(true)
   const { t } = useTranslation()
 
@@ -32,14 +33,20 @@ const PopupContainer: React.FC<Props> = ({ providerId, title, resolve, showHealt
   }
 
   const ListComponent = useMemo(() => {
-    if (isWebSearchProviderId(providerId)) {
-      return <WebSearchApiKeyList providerId={providerId} showHealthCheck={showHealthCheck} />
+    const type =
+      providerType ||
+      (isWebSearchProviderId(providerId) ? 'webSearch' : isPreprocessProviderId(providerId) ? 'preprocess' : 'llm')
+
+    switch (type) {
+      case 'webSearch':
+        return <WebSearchApiKeyList providerId={providerId as any} showHealthCheck={showHealthCheck} />
+      case 'preprocess':
+        return <DocPreprocessApiKeyList providerId={providerId as any} showHealthCheck={showHealthCheck} />
+      case 'llm':
+      default:
+        return <LlmApiKeyList providerId={providerId} showHealthCheck={showHealthCheck} />
     }
-    if (isPreprocessProviderId(providerId)) {
-      return <DocPreprocessApiKeyList providerId={providerId} showHealthCheck={showHealthCheck} />
-    }
-    return <LlmApiKeyList providerId={providerId} showHealthCheck={showHealthCheck} />
-  }, [providerId, showHealthCheck])
+  }, [providerId, showHealthCheck, providerType])
 
   return (
     <Modal

--- a/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
@@ -172,15 +172,22 @@ const ProviderSetting: FC<Props> = ({ providerId }) => {
   const onUpdateApiVersion = () => updateProvider({ apiVersion })
 
   const openApiKeyList = async () => {
+    if (localApiKey !== provider.apiKey) {
+      updateProvider({ apiKey: formatApiKeys(localApiKey) })
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+
     await ApiKeyListPopup.show({
       providerId: provider.id,
-      title: `${fancyProviderName} ${t('settings.provider.api.key.list.title')}`
+      title: `${fancyProviderName} ${t('settings.provider.api.key.list.title')}`,
+      providerType: 'llm'
     })
   }
 
   const onCheckApi = async () => {
+    const formattedLocalKey = formatApiKeys(localApiKey)
     // 如果存在多个密钥，直接打开管理窗口
-    if (provider.apiKey.includes(',')) {
+    if (formattedLocalKey.includes(',')) {
       await openApiKeyList()
       return
     }
@@ -204,7 +211,7 @@ const ProviderSetting: FC<Props> = ({ providerId }) => {
 
     try {
       setApiKeyConnectivity((prev) => ({ ...prev, checking: true, status: HealthStatus.NOT_CHECKED }))
-      await checkApi({ ...provider, apiHost }, model)
+      await checkApi({ ...provider, apiHost, apiKey: formattedLocalKey }, model)
 
       window.toast.success({
         timeout: 2000,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Fixes #10576

智谱API同时作为llm provider和web search provider，且id相同，导致渲染的是`WebSearchApiKeyList`而不是`LlmApiKeyList`，添加了`providerType`参数来明确api key类型