### PR TITLE
fix: claude-translator.yml

### DIFF
--- a/.github/workflows/claude-translator.yml
+++ b/.github/workflows/claude-translator.yml
@@ -21,10 +21,7 @@ jobs:
       || (
         (github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment')
         && github.event.sender.type != 'Bot'
-        && (
-          github.event.pull_request == null
-          || github.event.pull_request.head.repo.fork == false
-        )
+        && github.event.pull_request.head.repo.fork == false
       )
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
skipped CI temporarily because forked repositories cannot obtain OIDC tokens
related issue anthropics/claude-code-action/issues/542