### PR TITLE
fix: use users default system prompt

### DIFF
--- a/src/renderer/src/utils/prompt.ts
+++ b/src/renderer/src/utils/prompt.ts
@@ -4,60 +4,8 @@ import { MCPTool } from '@renderer/types'
 
 const logger = loggerService.withContext('Utils:Prompt')
 
-export const SYSTEM_PROMPT = `In this environment you have access to a set of tools you can use to answer the user's question. \
-You can use one or more tools per message, and will receive the result of that tool use in the user's response. You use tools step-by-step to accomplish a given task, with each tool use informed by the result of the previous tool use.
-
-## Tool Use Formatting
-
-Tool use is formatted using XML-style tags. The tool name is enclosed in opening and closing tags, and each parameter is similarly enclosed within its own set of tags. Here's the structure:
-
-<tool_use>
-  <name>{tool_name}</name>
-  <arguments>{json_arguments}</arguments>
-</tool_use>
-
-The tool name should be the exact name of the tool you are using, and the arguments should be a JSON object containing the parameters required by that tool. For example:
-<tool_use>
-  <name>python_interpreter</name>
-  <arguments>{"code": "5 + 3 + 1294.678"}</arguments>
-</tool_use>
-
-The user will respond with the result of the tool use, which should be formatted as follows:
-
-<tool_use_result>
-  <name>{tool_name}</name>
-  <result>{result}</result>
-</tool_use_result>
-
-The result should be a string, which can represent a file or any other output type. You can use this result as input for the next action.
-For example, if the result of the tool use is an image file, you can use it in the next action like this:
-
-<tool_use>
-  <name>image_transformer</name>
-  <arguments>{"image": "image_1.jpg"}</arguments>
-</tool_use>
-
-Always adhere to this format for the tool use to ensure proper parsing and execution.
-
-## Tool Use Examples
-{{ TOOL_USE_EXAMPLES }}
-
-## Tool Use Available Tools
-Above example were using notional tools that might not exist for you. You only have access to these tools:
-{{ AVAILABLE_TOOLS }}
-
-## Tool Use Rules
-Here are the rules you should always follow to solve your task:
-1. Always use the right arguments for the tools. Never use variable names as the action arguments, use the value instead.
-2. Call a tool only when needed: do not call the search agent if you do not need information, try to solve the task yourself.
-3. If no tool call is needed, just answer the question directly.
-4. Never re-do a tool call that you previously did with the exact same parameters.
-5. For tool use, MARK SURE use XML tag format as shown in the examples above. Do not use any other format.
-
-# User Instructions
+export const SYSTEM_PROMPT = `
 {{ USER_SYSTEM_PROMPT }}
-Response in user query language.
-Now Begin! If you solve the task correctly, you will receive a reward of $1,000,000.
 `
 
 export const THINK_TOOL_PROMPT = `{{ USER_SYSTEM_PROMPT }}`


### PR DESCRIPTION
Updated the SYSTEM_PROMPT to include user instructions and removed detailed tool use formatting.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

User's system prompt will be wrapped with a weird "reward" of $10000

After this PR:

User's system prompt is the user's system prompt.

Fixes #10599 

### Why we need it and why it was done in this way

The tool calling capability should not be activated in this way.

### Breaking changes

None

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Feedback welcome!

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
