### PR TITLE
fix: add safety checks and confirmation for MCP server install

### DIFF
--- a/src/main/services/ProtocolClient.ts
+++ b/src/main/services/ProtocolClient.ts
@@ -24,7 +24,7 @@ export function registerProtocolClient(app: Electron.App) {
   app.setAsDefaultProtocolClient(CHERRY_STUDIO_PROTOCOL)
 }
 
-export async function handleProtocolUrl(url: string) {
+export function handleProtocolUrl(url: string) {
   if (!url) return
   // Process the URL that was used to open the app
   // The url will be in the format: cherrystudio://data?param1=value1&param2=value2
@@ -35,7 +35,7 @@ export async function handleProtocolUrl(url: string) {
 
   switch (urlObj.hostname.toLowerCase()) {
     case 'mcp':
-      await handleMcpProtocolUrl(urlObj)
+      handleMcpProtocolUrl(urlObj)
       return
     case 'providers':
       handleProvidersProtocolUrl(urlObj)

--- a/src/main/utils/mcp.ts
+++ b/src/main/utils/mcp.ts
@@ -1,3 +1,28 @@
+export const ALLOWED_MCP_SERVER_COMMANDS = ['npx', 'uvx', 'uv', 'bunx', 'bun'] as const
+
+const MCP_COMMAND_EXTENSION_REGEX = /\.(exe|cmd|bat|com)$/i
+
+const normalizeCommand = (command: string): string => {
+  const trimmed = command.trim().toLowerCase()
+  if (!trimmed) {
+    return trimmed
+  }
+  return trimmed.replace(MCP_COMMAND_EXTENSION_REGEX, '')
+}
+
+export const normalizeMcpCommand = (command: string): string => normalizeCommand(command)
+
+export const isAllowedMcpCommand = (command?: string | null): boolean => {
+  if (!command) {
+    return false
+  }
+  const normalized = normalizeCommand(command)
+  if (!normalized) {
+    return false
+  }
+  return ALLOWED_MCP_SERVER_COMMANDS.includes(normalized as (typeof ALLOWED_MCP_SERVER_COMMANDS)[number])
+}
+
 export function buildFunctionCallToolName(serverName: string, toolName: string) {
   const sanitizedServer = serverName.trim().replace(/-/g, '_')
   const sanitizedTool = toolName.trim().replace(/-/g, '_')


### PR DESCRIPTION
Fix https://github.com/CherryHQ/cherry-studio/security/advisories/GHSA-hh6w-rmjc-26f6
Fix #10681 

Introduces a whitelist of allowed commands for MCP server installation via protocol URLs and blocks installation if an unsafe command is detected. Adds a user confirmation dialog displaying server details before proceeding with installation, enhancing security and user awareness.
