### PR TITLE
feat: new middleware to add 'no_think'

### DIFF
--- a/src/renderer/src/aiCore/middleware/AiSdkMiddlewareBuilder.ts
+++ b/src/renderer/src/aiCore/middleware/AiSdkMiddlewareBuilder.ts
@@ -189,7 +189,7 @@ function addProviderSpecificMiddlewares(builder: AiSdkMiddlewareBuilder, config:
       break
   }
 
-  // OVMS+MCP 的特定中间件
+  // OVMS+MCP's specific middleware
   if (config.provider.id === 'ovms' && config.mcpTools && config.mcpTools.length > 0) {
     builder.add({
       name: 'no-think',

--- a/src/renderer/src/aiCore/middleware/noThinkMiddleware.ts
+++ b/src/renderer/src/aiCore/middleware/noThinkMiddleware.ts
@@ -4,9 +4,9 @@ import { LanguageModelMiddleware } from 'ai'
 const logger = loggerService.withContext('noThinkMiddleware')
 
 /**
- * No Think 中间件
- * 为 provider 的用户消息自动在最后添加 ' /no_think' 字符串
- * 这可以防止模型生成不必要的思考过程，直接返回结果
+ * No Think Middleware
+ * Automatically appends ' /no_think' string to the end of user messages for the provider
+ * This prevents the model from generating unnecessary thinking process and returns results directly
  * @returns LanguageModelMiddleware
  */
 export function noThinkMiddleware(): LanguageModelMiddleware {
@@ -15,17 +15,17 @@ export function noThinkMiddleware(): LanguageModelMiddleware {
 
     transformParams: async ({ params }) => {
       const transformedParams = { ...params }
-      // 处理 prompt 中的消息
+      // Process messages in prompt
       if (transformedParams.prompt && Array.isArray(transformedParams.prompt)) {
         transformedParams.prompt = transformedParams.prompt.map((message) => {
-          // 只处理用户消息
+          // Only process user messages
           if (message.role === 'user') {
-            // 处理 content 数组
+            // Process content array
             if (Array.isArray(message.content)) {
               const lastContent = message.content[message.content.length - 1]
-              // 如果最后一个内容是文本类型，追加 ' /no_think'
+              // If the last content is text type, append ' /no_think'
               if (lastContent && lastContent.type === 'text' && typeof lastContent.text === 'string') {
-                // 避免重复添加
+                // Avoid duplicate additions
                 if (!lastContent.text.endsWith('/no_think')) {
                   logger.debug('Adding /no_think to user message')
                   return {


### PR DESCRIPTION
### What this PR does

Before this PR:

After this PR:

Added a new middleware "src\renderer\src\aiCore\middleware\noThinkMiddleware.ts".
This middleware appends " /no_think" on user prompts automatically.

When using MCP on local OVMS, this flag is needed to indicate the model to accelerate processing without thinking and avoid getting stuck in a thinking loop.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note
```release-note
new middleware: noThinkMiddleware
```
