### PR TITLE
fix: up-down button does not hide properly in some cases

### DIFF
--- a/src/renderer/src/pages/home/Messages/ChatNavigation.tsx
+++ b/src/renderer/src/pages/home/Messages/ChatNavigation.tsx
@@ -7,6 +7,7 @@ import {
   VerticalAlignTopOutlined
 } from '@ant-design/icons'
 import { useSettings } from '@renderer/hooks/useSettings'
+import { useTimer } from '@renderer/hooks/useTimer'
 import { RootState } from '@renderer/store'
 // import { selectCurrentTopicId } from '@renderer/store/newMessage'
 import { Button, Drawer, Tooltip } from 'antd'
@@ -38,7 +39,8 @@ interface ChatNavigationProps {
 const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
   const { t } = useTranslation()
   const [isVisible, setIsVisible] = useState(false)
-  const hideTimerRef = useRef<NodeJS.Timeout>(undefined)
+  const timerKey = 'hide'
+  const { setTimeoutTimer, clearTimeoutTimer } = useTimer()
   const [showChatHistory, setShowChatHistory] = useState(false)
   const [manuallyClosedUntil, setManuallyClosedUntil] = useState<number | null>(null)
   const currentTopicId = useSelector((state: RootState) => state.messages.currentTopicId)
@@ -49,17 +51,20 @@ const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
   const showRightTopics = topicPosition === 'right' && showTopics
 
   const clearHideTimer = useCallback(() => {
-    clearTimeout(hideTimerRef.current)
-  }, [])
+    clearTimeoutTimer(timerKey)
+  }, [clearTimeoutTimer])
 
   const scheduleHide = useCallback(
     (delay: number) => {
-      clearHideTimer()
-      hideTimerRef.current = setTimeout(() => {
-        setIsVisible(false)
-      }, delay)
+      setTimeoutTimer(
+        timerKey,
+        () => {
+          setIsVisible(false)
+        },
+        delay
+      )
     },
-    [clearHideTimer]
+    [setTimeoutTimer]
   )
 
   const showNavigation = useCallback(() => {
@@ -322,9 +327,9 @@ const ChatNavigation: FC<ChatNavigationProps> = ({ containerId }) => {
       container.removeEventListener('scroll', handleScroll)
       window.removeEventListener('mousemove', handleMouseMove)
       messagesContainer?.removeEventListener('mouseleave', handleMessagesMouseLeave)
-      clearTimeout(hideTimerRef.current)
+      clearHideTimer()
     }
-  }, [containerId, showRightTopics, manuallyClosedUntil, scheduleHide, showNavigation])
+  }, [containerId, showRightTopics, manuallyClosedUntil, scheduleHide, showNavigation, clearHideTimer])
 
   return (
     <>


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR: 如果只是鼠标滑过目标区域，而没有和上下按钮产生“有意义的交互”（包括暂停以展示 ToolTip），那么这排按钮有大概率卡住，永远不消失。

> - `handleMouseMove`（src/renderer/src/pages/home/Messages/ChatNavigation.tsx:259）是唯一能在指针离开触发条但从未接触按钮时将 `isNearButtons` 重置为 false 的路径。该监听器附加在 `.messages-container` 元素上（或在容器缺失时仅附加在 window 上）。
> - 若从聊天面板进入触发条，监听器会通过 `handleMouseEnter` 将 `isNearButtons` 设为 true。但如果随后将光标直接移至 UI 的其他部分（标题栏、侧边面板等）而未进行“有效交互”，则 `.messages-container` 不会再接收到后续的 mousemove 事件，导致 `!isInTriggerArea && isNearButtons` 分支永远不会执行。因此，`handleMouseLeave`（src/renderer/src/pages/home/Messages/ChatNavigation.tsx:77）不会触发，`isNearButtons` 保持为 true，且 `handleMouseLeave` 和 `resetHideTimer`（src/renderer/src/pages/home/Messages/ChatNavigation.tsx:50）中的隐藏计时器均不会被激活。工具栏会无限期保持可见状态。
> - 当悬停按钮时，无论后续移至何处，组件自身的 `onMouseLeave` 都会触发，因此 500 ms 隐藏计时器会启动，一切表现符合预期。


After this PR: 基本上能做到“除非有意识地把鼠标放在按钮上，否则离开之后总能稳定触发自动折叠”。顺便调整了一下动画。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->


### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

NONE
