### PR TITLE
fix: preserve spaces in API keys; update i18n tips to use commas or newlines

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -4073,7 +4073,7 @@
       "api_host_tooltip": "Override only when your provider requires a custom OpenAI-compatible endpoint.",
       "api_key": {
         "label": "API Key",
-        "tip": "Multiple keys separated by commas or spaces"
+        "tip": "Use commas to separate multiple keys"
       },
       "api_version": "API Version",
       "aws-bedrock": {

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -4073,7 +4073,7 @@
       "api_host_tooltip": "仅在服务商需要自定义的 OpenAI 兼容地址时覆盖。",
       "api_key": {
         "label": "API 密钥",
-        "tip": "多个密钥使用逗号或空格分隔"
+        "tip": "多个密钥使用逗号分隔"
       },
       "api_version": "API 版本",
       "aws-bedrock": {

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -4073,7 +4073,7 @@
       "api_host_tooltip": "僅在服務商需要自訂的 OpenAI 相容端點時才覆蓋。",
       "api_key": {
         "label": "API 金鑰",
-        "tip": "多個金鑰使用逗號或空格分隔"
+        "tip": "多個金鑰使用逗號分隔"
       },
       "api_version": "API 版本",
       "aws-bedrock": {

--- a/src/renderer/src/utils/api.ts
+++ b/src/renderer/src/utils/api.ts
@@ -5,7 +5,7 @@
  * @returns {string} 格式化后的 API key 字符串。
  */
 export function formatApiKeys(value: string): string {
-  return value.replaceAll('，', ',').replaceAll(' ', ',').replaceAll('\n', ',')
+  return value.replaceAll('，', ',').replaceAll('\n', ',')
 }
 
 /**


### PR DESCRIPTION
This PR prevents splitting API keys containing spaces by removing space-to-comma normalization in formatApiKeys, and updates UI hints to recommend separating multiple keys with English commas or newlines.
Fixes CherryHQ/cherry-studio#10692
Refs CherryHQ/cherry-studio#10678