### PR TITLE
fix: Fix knowledge base recognition mode default value inconsistency

### DIFF
--- a/src/renderer/src/aiCore/plugins/searchOrchestrationPlugin.ts
+++ b/src/renderer/src/aiCore/plugins/searchOrchestrationPlugin.ts
@@ -265,7 +265,7 @@ export const searchOrchestrationPlugin = (assistant: Assistant, topicId: string)
         // 判断是否需要各种搜索
         const knowledgeBaseIds = assistant.knowledge_bases?.map((base) => base.id)
         const hasKnowledgeBase = !isEmpty(knowledgeBaseIds)
-        const knowledgeRecognition = assistant.knowledgeRecognition || 'on'
+        const knowledgeRecognition = assistant.knowledgeRecognition || 'off'
         const globalMemoryEnabled = selectGlobalMemoryEnabled(store.getState())
         const shouldWebSearch = !!assistant.webSearchProviderId
         const shouldKnowledgeSearch = hasKnowledgeBase && knowledgeRecognition === 'on'
@@ -329,7 +329,7 @@ export const searchOrchestrationPlugin = (assistant: Assistant, topicId: string)
         // 📚 知识库搜索工具配置
         const knowledgeBaseIds = assistant.knowledge_bases?.map((base) => base.id)
         const hasKnowledgeBase = !isEmpty(knowledgeBaseIds)
-        const knowledgeRecognition = assistant.knowledgeRecognition || 'on'
+        const knowledgeRecognition = assistant.knowledgeRecognition || 'off'
 
         if (hasKnowledgeBase) {
           if (knowledgeRecognition === 'off') {


### PR DESCRIPTION
Fix the inconsistency between UI display and actual behavior of knowledge base recognition mode:

- UI defaults to 'off' (forced retrieval)
- Code logic defaults to 'on' (intent recognition)

### What this PR does

**Before this PR:**

- The UI displays knowledge base recognition mode with a default of 'off' (forced retrieval)
- However, the actual code logic defaults to 'on' (intent recognition)
- When users don't explicitly configure this option, the system uses intent recognition mode
- AI may determine that knowledge base search is not needed and skip retrieval, resulting in "no file provided" error messages

**After this PR:**

- Code logic now defaults to 'off' (forced retrieval), matching the UI display
- When users select a knowledge base without explicitly configuring the recognition mode, the system will always perform retrieval
- Eliminates the confusion caused by UI/behavior mismatch

Fixes #10677

### Why we need it and why it was done in this way

**The problem:** Users reported that after selecting a knowledge base in the chat interface, when requesting AI to read/summarize files, the AI responds indicating no file was provided. This occurs because:

1. The UI component (`AssistantKnowledgeBaseSettings.tsx`) shows the default as 'off' via `assistant.knowledgeRecognition ?? 'off'`
2. The orchestration plugin logic defaults to 'on' via `assistant.knowledgeRecognition || 'on'`
3. In 'on' mode, the system performs AI-based intent analysis which may decide not to search the knowledge base for certain queries
4. This creates a confusing user experience where selecting a knowledge base doesn't guarantee it will be used

**Why this approach:**

- Changing the default to 'off' ensures predictable behavior: if a user selects a knowledge base, it will always be searched
- This matches user expectations and the UI display
- 'Forced retrieval' is a safer default that guarantees knowledge base usage
- Users who want intent-based recognition can explicitly enable it

**The following tradeoffs were made:**

- Some users might prefer intelligent intent recognition by default, but consistency and predictability are more important for a better user experience
- In 'off' mode, all queries will trigger knowledge base search even when it might not be necessary, potentially consuming more tokens, but this ensures reliability

**The following alternatives were considered:**

1. Change the UI default to 'on' instead: Rejected because forced retrieval is the safer, more predictable default
2. Add explicit initialization logic: Rejected as unnecessarily complex; fixing the default value is simpler and clearer

### Breaking changes

None. This fix makes the actual behavior match what the UI already displays, so it should improve rather than break user experience.

### Special notes for your reviewer

- The fix involves changing two instances of the default value in `searchOrchestrationPlugin.ts` (lines 268 and 332)
- Both locations handle the same logic but at different stages of the plugin execution
- Please verify that the behavior now matches the UI expectations in both code paths

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required (this is a bug fix that makes behavior match existing documentation)

### Release note

```release-note
fix: Fixed knowledge base recognition mode default value inconsistency. The system now defaults
to 'forced retrieval' mode, matching the UI display. This ensures that when users select a
knowledge base, it will always be searched, eliminating the "no file provided" error when the
default mode was not explicitly configured.
```
