### PR TITLE
fix: update session model when changing agent model in top navbar

### DIFF
--- a/src/renderer/src/hooks/agents/useUpdateAgent.ts
+++ b/src/renderer/src/hooks/agents/useUpdateAgent.ts
@@ -36,7 +36,7 @@ export const useUpdateAgent = () => {
 
   const updateModel = useCallback(
     async (agentId: string, modelId: string, options?: UpdateAgentOptions) => {
-      updateAgent({ id: agentId, model: modelId }, options)
+      return updateAgent({ id: agentId, model: modelId }, options)
     },
     [updateAgent]
   )

--- a/src/renderer/src/pages/home/ChatNavbar.tsx
+++ b/src/renderer/src/pages/home/ChatNavbar.tsx
@@ -84,12 +84,16 @@ const HeaderNavbar: FC<Props> = ({ activeAssistant, setActiveAssistant, activeTo
     async (model: ApiModel) => {
       if (!agent) return
 
-      // Update agent model
-      await updateModel(agent.id, model.id, { showSuccessToast: false })
+      try {
+        // Update agent model
+        await updateModel(agent.id, model.id, { showSuccessToast: false })
 
-      // Update current session model if there's an active session
-      if (sessionId && session) {
-        await updateSession({ id: sessionId, model: model.id })
+        // Update current session model if there's an active session
+        if (sessionId && session) {
+          await updateSession({ id: sessionId, model: model.id })
+        }
+      } catch (error) {
+        window.toast.error(formatErrorMessageWithPrefix(error, t('agent.update.error.failed')))
       }
     },
     [agent, sessionId, session, updateModel, updateSession]


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

Session model not updating after model change in top nav.

After this PR:

After changing the model via top navbar, the code now updates both the agent configuration and the active session model (if any).
Requests from the active session will use the new model id.


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #10764 

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
