### PR TITLE
fix: add array checks for knowledge and memories in citations

### DIFF
--- a/src/renderer/src/store/messageBlock.ts
+++ b/src/renderer/src/store/messageBlock.ts
@@ -242,7 +242,7 @@ export const formatCitationsFromBlock = (block: CitationMessageBlock | undefined
     }
   }
   // 3. Handle Knowledge Base References
-  if (block.knowledge && block.knowledge.length > 0) {
+  if (block.knowledge && Array.isArray(block.knowledge) && block.knowledge.length > 0) {
     formattedCitations.push(
       ...block.knowledge.map((result, index) => {
         const filePattern = /\[(.*?)]\(http:\/\/file\/(.*?)\)/
@@ -270,7 +270,7 @@ export const formatCitationsFromBlock = (block: CitationMessageBlock | undefined
     )
   }
 
-  if (block.memories && block.memories.length > 0) {
+  if (block.memories && Array.isArray(block.memories) && block.memories.length > 0) {
     // 5. Handle Memory References
     formattedCitations.push(
       ...block.memories.map((memory, index) => ({


### PR DESCRIPTION
Fix #10777

Updated formatCitationsFromBlock to verify that 'knowledge' and 'memories' are arrays before accessing their length and mapping over them. This prevents potential runtime errors if these properties are not arrays.