### PR TITLE
fix: prevent default behavior for Cmd/Ctrl+F in WebviewService

### DIFF
--- a/src/main/services/WebviewService.ts
+++ b/src/main/services/WebviewService.ts
@@ -60,15 +60,20 @@ const attachKeyboardHandler = (contents: Electron.WebContents) => {
     if (!isFindShortcut && !isEscape && !isEnter) {
       return
     }
-    // Prevent default to override the guest page's native find dialog
-    // and keep shortcuts routed to our custom search overlay
-    event.preventDefault()
 
     const host = contents.hostWebContents
     if (!host || host.isDestroyed()) {
       return
     }
 
+    // Always prevent Cmd/Ctrl+F to override the guest page's native find dialog
+    if (isFindShortcut) {
+      event.preventDefault()
+    }
+
+    // Send the hotkey event to the renderer
+    // The renderer will decide whether to preventDefault for Escape and Enter
+    // based on whether the search bar is visible
     host.send(IpcChannel.Webview_SearchHotkey, {
       webviewId: contents.id,
       key,


### PR DESCRIPTION
Updated the keyboard handler in WebviewService to always prevent the default action for the Cmd/Ctrl+F shortcut, ensuring it overrides the guest page's native find dialog. This change allows the renderer to manage the behavior of Escape and Enter keys based on the visibility of the search bar.

Fix #10770