### PR TITLE
 Fix(renderer): "Export as image" captures full content in side-by-side/grid layouts

### DIFF
--- a/src/renderer/src/utils/image.ts
+++ b/src/renderer/src/utils/image.ts
@@ -73,7 +73,10 @@ export const captureScrollable = async (elRef: React.RefObject<HTMLElement | nul
 
       // Track nested elements we temporarily modify
       type SavedStyle = Partial<
-        Pick<CSSStyleDeclaration, 'overflow' | 'overflowX' | 'overflowY' | 'height' | 'maxHeight' | 'width' | 'minWidth'>
+        Pick<
+          CSSStyleDeclaration,
+          'overflow' | 'overflowX' | 'overflowY' | 'height' | 'maxHeight' | 'width' | 'minWidth'
+        >
       >
       const savedStyles = new Map<HTMLElement, SavedStyle>()
       const modifiedNodes: HTMLElement[] = []
@@ -135,10 +138,7 @@ export const captureScrollable = async (elRef: React.RefObject<HTMLElement | nul
           }
 
           // Special case: message content containers in horizontal layout
-          if (
-            node.classList.contains('message-content-container') &&
-            node.scrollHeight > node.clientHeight
-          ) {
+          if (node.classList.contains('message-content-container') && node.scrollHeight > node.clientHeight) {
             save(node, ['maxHeight', 'overflow', 'overflowY', 'height'])
             node.style.maxHeight = 'none'
             node.style.overflow = 'visible'
@@ -190,7 +190,10 @@ export const captureScrollable = async (elRef: React.RefObject<HTMLElement | nul
       }
       // Cap pixelRatio to avoid exceeding browser canvas limits
       const maxLogical = Math.max(totalWidth, totalHeight)
-      const maxAllowedPR = Math.max(0.1, Math.min(window.devicePixelRatio, MAX_ALLOWED_DIMENSION / Math.max(1, maxLogical)))
+      const maxAllowedPR = Math.max(
+        0.1,
+        Math.min(window.devicePixelRatio, MAX_ALLOWED_DIMENSION / Math.max(1, maxLogical))
+      )
 
       const canvas = await new Promise<HTMLCanvasElement>((resolve, reject) => {
         htmlToImage

--- a/src/renderer/src/utils/image.ts
+++ b/src/renderer/src/utils/image.ts
@@ -89,8 +89,6 @@ export const captureScrollable = async (elRef: React.RefObject<HTMLElement | nul
         }
         for (const f of fields) {
           if (saved[f] === undefined) {
-            // Record inline style only once
-            // @ts-expect-error index signature
             saved[f] = node.style[f]
           }
         }


### PR DESCRIPTION
## What this PR does

- Fixes exporting chat content as image capturing only the visible viewport when the message group layout is side-by-side (horizontal) or grid
- Changes html-to-image options to use width/height instead of canvasWidth/canvasHeight
- Temporarily expands nested scrollable containers (including .message-content-container) to remove max-height/overflow clipping during capture, then restores them after
- Keeps safety guard against extremely large canvases (max dimension 32767 px)

### Before this PR:
- Exported image included only the visible portion of the chat
- In side-by-side or grid layouts, columns were truncated; long replies were clipped by inner scroll areas

### After this PR:
- Exports contain the full content width and height, including all horizontal columns and long replies
- Scrollbars are hidden during capture and original styles/scroll positions are restored afterward

Fixes #10870

## Why we need it and why it was done in this way

- html-to-image respects width/height for output size; previously passing canvasWidth/canvasHeight resulted in viewport-only rendering
- Horizontal and grid layouts introduce nested scrollable containers; temporarily unsetting overflow/max-height ensures full DOM is rendered to canvas
- Scope-limited change: no new dependencies, minimal risk, focused on the capture path

### The following tradeoffs were made:
- Potential higher memory use and longer render time for very large chats
- Temporary style overrides could cause a brief layout reflow, mitigated by restoring styles immediately after capture
- Still enforces a hard dimension cap (32767) to avoid browser canvas limits

### The following alternatives were considered:
- Chunked capture and stitching: added complexity and seams
- Switching to different libraries (html2canvas/dom-to-image-more): larger change surface and new dependencies
- Virtualized capture per message: heavy refactor and UX differences

## Code changes

### Core fix:
- src/renderer/src/utils/image.ts (captureScrollable)
  - Use width/height with style sizing instead of canvasWidth/canvasHeight
  - Expand only actually clipped nested scrollables; skip hidden nodes
  - Use minWidth for horizontal scroll regions to avoid layout breakage
  - Aggregate inline styles via Map and restore in reverse order
  - Wait one frame (rAF) before measuring; cap pixelRatio;restore scroll positio

### Affected flows triggering capture:
- src/renderer/src/pages/home/Messages/Messages.tsx — topic “Copy as Image” / “Export as Image”
- src/renderer/src/utils/export.ts — notes export: “copyImage” /“exportImage”
- src/renderer/src/pages/home/Messages/MessageMenubar.tsx — per‑message “Copy/Export as Image”

## Breaking changes

- None

## Special notes for your reviewer

- Verify export in:
  - Message group "Side by side" and "Grid" layouts
  - Topic menu: Export → Image
  - Message menubar: Export → Image, Copy as Image
- Very large chats should gracefully error with the dimension-too-large toast
- Retina/HiDPI machines: confirm pixel ratio rendering looks crisp

## Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR. Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

## Release note

```release-note
Fix: "Export as image" captured only the visible portion in side-by-side/grid layouts. 
Now expands nested scrollables and uses correct width/height so the full content is exported, 
with styles restored after capture.
```
