### PR TITLE
feat: add cherryin in provider type options

### DIFF
--- a/src/renderer/src/pages/settings/ProviderSettings/AddProviderPopup.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/AddProviderPopup.tsx
@@ -24,6 +24,7 @@ const PopupContainer: React.FC<Props> = ({ provider, resolve }) => {
   const [open, setOpen] = useState(true)
   const [name, setName] = useState(provider?.name || '')
   const [type, setType] = useState<ProviderType>(provider?.type || 'openai')
+  const [displayType, setDisplayType] = useState<string>(provider?.type || 'openai')
   const [logo, setLogo] = useState<string | null>(null)
   const [logoPickerOpen, setLogoPickerOpen] = useState(false)
   const [dropdownOpen, setDropdownOpen] = useState(false)
@@ -245,15 +246,20 @@ const PopupContainer: React.FC<Props> = ({ provider, resolve }) => {
         </Form.Item>
         <Form.Item label={t('settings.provider.add.type')} style={{ marginBottom: 0 }}>
           <Select
-            value={type}
-            onChange={setType}
+            value={displayType}
+            onChange={(value: string) => {
+              setDisplayType(value)
+              // special case for cherryin-type, map to new-api internally
+              setType(value === 'cherryin-type' ? 'new-api' : (value as ProviderType))
+            }}
             options={[
               { label: 'OpenAI', value: 'openai' },
               { label: 'OpenAI-Response', value: 'openai-response' },
               { label: 'Gemini', value: 'gemini' },
               { label: 'Anthropic', value: 'anthropic' },
               { label: 'Azure OpenAI', value: 'azure-openai' },
-              { label: 'New API', value: 'new-api' }
+              { label: 'New API', value: 'new-api' },
+              { label: 'CherryIN', value: 'cherryin-type' }
             ]}
           />
         </Form.Item>


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does
Add cherryin as displayed provider type option.
related issue: #10880

| Before this PR: | After this PR: |
| --- | --- |
| <img width="766" height="704" alt="image" src="https://github.com/user-attachments/assets/9d8f310d-25af-4184-8524-c631f073d67a" /> | <img width="716" height="672" alt="image" src="https://github.com/user-attachments/assets/85cfa74f-0d3b-4baf-a55a-34a09815aa73" /> |






<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
