### PR TITLE
fix: align and unify LocalBackupManager footer layout

### DIFF
--- a/src/renderer/src/components/LocalBackupManager.tsx
+++ b/src/renderer/src/components/LocalBackupManager.tsx
@@ -226,7 +226,7 @@ export function LocalBackupManager({ visible, onClose, localBackupDir, restoreMe
         onClick={handleDeleteSelected}
         disabled={selectedRowKeys.length === 0 || deleting}
         loading={deleting}>
-        {t('settings.data.local.backup.manager.delete.selected', { count: selectedRowKeys.length })}
+        {t('settings.data.local.backup.manager.delete.selected')} ({selectedRowKeys.length})
       </Button>
       <Button key="close" onClick={onClose}>
         {t('common.close')}


### PR DESCRIPTION
### What this PR does

Before this PR:

- LocalBackupManager's footer buttons were defined as an array, inconsistent with S3BackupManager
- Delete button text used hardcoded concatenation with count: {t('...')} ({selectedRowKeys.length})

After this PR:

- LocalBackupManager's footer buttons are now wrapped with Space component, consistent with S3BackupManager
- Delete button text uses i18n count parameter: {t('...', { count: selectedRowKeys.length })}

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Chose Space component over array-based footer for better layout consistency and maintainability across backup manager components

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

None. This is a non-breaking UI improvement.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

This change aligns LocalBackupManager with S3BackupManager's implementation pattern, making the codebase more consistent and maintainable.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
NONE
```
