### PR TITLE
fix: update GlobTool to count lines instead of files in output

### DIFF
--- a/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/GlobTool.tsx
+++ b/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/GlobTool.tsx
@@ -6,7 +6,7 @@ import type { GlobToolInput as GlobToolInputType, GlobToolOutput as GlobToolOutp
 
 export function GlobTool({ input, output }: { input: GlobToolInputType; output?: GlobToolOutputType }) {
   // 如果有输出，计算文件数量
-  const fileCount = output ? output.split('\n').filter((line) => line.trim()).length : 0
+  const lineCount = output ? output.split('\n').filter((line) => line.trim()).length : 0
 
   return (
     <AccordionItem
@@ -17,7 +17,7 @@ export function GlobTool({ input, output }: { input: GlobToolInputType; output?:
           icon={<FolderSearch className="h-4 w-4" />}
           label="Glob"
           params={input.pattern}
-          stats={output ? `${fileCount} found` : undefined}
+          stats={output ? `${lineCount} of output` : undefined}
         />
       }>
       <div>{output}</div>


### PR DESCRIPTION
fix: https://github.com/CherryHQ/cherry-studio/issues/11015
change:`of output`
<img width="1466" height="534" alt="image" src="https://github.com/user-attachments/assets/c1d7823e-8198-4699-adb6-7e8af9b20d95" />

claude code vscode plugin also has bug ⬇️
<img width="1818" height="994" alt="image" src="https://github.com/user-attachments/assets/27b03fc0-bc09-4bdb-b7c9-3001d4234fa0" />
