### PR TITLE
🐛 fix: agent OAuth support and fast model settings

### DIFF
--- a/src/main/apiServer/services/messages.ts
+++ b/src/main/apiServer/services/messages.ts
@@ -7,15 +7,7 @@ import { Provider } from '@types'
 import { Response } from 'express'
 
 const logger = loggerService.withContext('MessagesService')
-const EXCLUDED_FORWARD_HEADERS: ReadonlySet<string> = new Set([
-  'host',
-  'x-api-key',
-  'authorization',
-  'sentry-trace',
-  'baggage',
-  'content-length',
-  'connection'
-])
+const EXCLUDED_FORWARD_HEADERS: ReadonlySet<string> = new Set(['host', 'x-api-key', 'authorization'])
 
 export interface ValidationResult {
   isValid: boolean

--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -98,14 +98,17 @@ class ClaudeCodeService implements AgentServiceInterface {
     const env = {
       ...loginShellEnvWithoutProxies,
       // TODO: fix the proxy api server
-      // ANTHROPIC_API_KEY: apiConfig.apiKey,
-      // ANTHROPIC_AUTH_TOKEN: apiConfig.apiKey,
-      // ANTHROPIC_BASE_URL: `http://${apiConfig.host}:${apiConfig.port}/${modelInfo.provider.id}`,
-      ANTHROPIC_API_KEY: modelInfo.provider.apiKey,
-      ANTHROPIC_AUTH_TOKEN: modelInfo.provider.apiKey,
-      ANTHROPIC_BASE_URL: modelInfo.provider.anthropicApiHost?.trim() || modelInfo.provider.apiHost,
+      ANTHROPIC_API_KEY: apiConfig.apiKey,
+      ANTHROPIC_AUTH_TOKEN: apiConfig.apiKey,
+      ANTHROPIC_BASE_URL: `http://${apiConfig.host}:${apiConfig.port}/${modelInfo.provider.id}`,
+      // ANTHROPIC_API_KEY: modelInfo.provider.apiKey,
+      // ANTHROPIC_AUTH_TOKEN: modelInfo.provider.apiKey,
+      // ANTHROPIC_BASE_URL: modelInfo.provider.anthropicApiHost?.trim() || modelInfo.provider.apiHost,
       ANTHROPIC_MODEL: modelInfo.modelId,
-      ANTHROPIC_SMALL_FAST_MODEL: modelInfo.modelId,
+      ANTHROPIC_DEFAULT_OPUS_MODEL: modelInfo.modelId,
+      ANTHROPIC_DEFAULT_SONNET_MODEL: modelInfo.modelId,
+      // TODO: support set small model in UI
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: modelInfo.modelId,
       ELECTRON_RUN_AS_NODE: '1',
       ELECTRON_NO_ATTACH_CONSOLE: '1'
     }


### PR DESCRIPTION
## Summary

This PR fixes two issues with Claude Code agent configuration:

1. **OAuth Support (#10785)**: Agents now properly support Anthropic OAuth authentication by routing requests through the proxy API server, allowing users with Anthropic Pro subscriptions to use OAuth instead of being forced to use API keys.

2. **Fast Model Settings (#11014)**: Updated environment variable configuration to match the official Claude Code documentation, using `ANTHROPIC_DEFAULT_OPUS_MODEL`, `ANTHROPIC_DEFAULT_SONNET_MODEL`, and `ANTHROPIC_DEFAULT_HAIKU_MODEL` instead of the incorrect `ANTHROPIC_SMALL_FAST_MODEL`.

## Changes

- Route agent requests through proxy API server to support OAuth and other authentication methods
- Fix model environment variables according to [official Claude Code docs](https://docs.claude.com/en/docs/claude-code/model-config#environment-variables)
- Allow forwarding of additional HTTP headers needed for proper request routing

## Test Plan

- [ ] Test agent creation with Anthropic OAuth authentication
- [ ] Test agent creation with API key authentication
- [ ] Verify fast model selection works correctly
- [ ] Test existing agents still work after changes

## Related Issues

Fixes #10785
Fixes #11014