### PR TITLE
fix: cancel debounced save on file path update

### DIFF
--- a/src/renderer/src/pages/notes/NotesPage.tsx
+++ b/src/renderer/src/pages/notes/NotesPage.tsx
@@ -716,10 +716,17 @@ const NotesPage: FC = () => {
         const normalizedActivePath = activeFilePath ? normalizePathValue(activeFilePath) : undefined
         if (normalizedActivePath) {
           if (normalizedActivePath === sourceNode.externalPath) {
+            // Cancel debounced save to prevent saving to old path
+            debouncedSaveRef.current?.cancel()
+            lastFilePathRef.current = destinationPath
             dispatch(setActiveFilePath(destinationPath))
           } else if (sourceNode.type === 'folder' && normalizedActivePath.startsWith(`${sourceNode.externalPath}/`)) {
             const suffix = normalizedActivePath.slice(sourceNode.externalPath.length)
-            dispatch(setActiveFilePath(`${destinationPath}${suffix}`))
+            const newActivePath = `${destinationPath}${suffix}`
+            // Cancel debounced save to prevent saving to old path
+            debouncedSaveRef.current?.cancel()
+            lastFilePathRef.current = newActivePath
+            dispatch(setActiveFilePath(newActivePath))
           }
         }
 


### PR DESCRIPTION
Fix #11068 it will trigger when modifying both the note content and title and then moving them.

Adds cancellation of the debounced save when the active file path is updated after moving a file or folder. This prevents saving to the old path and ensures lastFilePathRef is updated accordingly.