### PR TITLE
WIP: Feat: Add Code Execution button for gemini only

### DIFF
--- a/src/renderer/src/aiCore/legacy/middleware/schemas.ts
+++ b/src/renderer/src/aiCore/legacy/middleware/schemas.ts
@@ -52,6 +52,7 @@ export interface CompletionsParams {
   streamOutput: boolean
   enableWebSearch?: boolean
   enableUrlContext?: boolean
+  enableCodeExecution?: boolean
   enableReasoning?: boolean
   enableGenerateImage?: boolean
 

--- a/src/renderer/src/aiCore/middleware/AiSdkMiddlewareBuilder.ts
+++ b/src/renderer/src/aiCore/middleware/AiSdkMiddlewareBuilder.ts
@@ -37,6 +37,7 @@ export interface AiSdkMiddlewareConfig {
   enableWebSearch: boolean
   enableGenerateImage: boolean
   enableUrlContext: boolean
+  enableCodeExecution: boolean
   mcpTools?: MCPTool[]
   uiMessages?: Message[]
   // 内置搜索配置

--- a/src/renderer/src/config/providers.ts
+++ b/src/renderer/src/config/providers.ts
@@ -66,6 +66,7 @@ import type {
   SystemProviderId
 } from '@renderer/types'
 import { isSystemProvider, OpenAIServiceTiers } from '@renderer/types'
+import { Provider } from 'react-redux'
 
 import { TOKENFLUX_HOST } from './constant'
 import { glm45FlashModel, qwen38bModel, SYSTEM_MODELS } from './models'
@@ -1473,6 +1474,17 @@ const SUPPORT_URL_CONTEXT_PROVIDER_TYPES = [
 
 export const isSupportUrlContextProvider = (provider: Provider) => {
   return SUPPORT_URL_CONTEXT_PROVIDER_TYPES.some((type) => type === provider.type)
+}
+
+const SUPPORT_CODE_EXECUTION_PROVIDER_TYPES = [
+  'gemini',
+  'vertexai',
+  'anthropic',
+  'new-api'
+] as const satisfies ProviderType[]
+
+export const isSupportCodeExecutionProvider = (provider: Provider) => {
+  return SUPPORT_CODE_EXECUTION_PROVIDER_TYPES.some((type) => type === provider.type)
 }
 
 const SUPPORT_GEMINI_NATIVE_WEB_SEARCH_PROVIDERS = ['gemini', 'vertexai'] as const satisfies SystemProviderId[]

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -602,6 +602,7 @@
         "label": "Clear {{Command}}",
         "title": "Clear all messages?"
       },
+      "code_execution": "Code Execution",
       "collapse": "Collapse",
       "context_count": {
         "tip": "Context / Max Context"
@@ -683,7 +684,8 @@
         "parse_tool_call": "Unable to convert to a valid tool call format: {{toolCall}}"
       },
       "warning": {
-        "gemini_web_search": "Gemini does not support using native web search tools and function calling simultaneously",
+        "gemini_code_execution": "Gemini does not support using native code execution tools and function calls at the same time",
+        "gemini_web_search": "Gemini does not support using native network search tools and function calls at the same time",
         "multiple_tools": "Multiple matching MCP tools exist, {{tool}} has been selected",
         "no_tool": "No matching MCP tool found for {{tool}}",
         "url_context": "Gemini does not support using url context and function calling simultaneously"

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -602,6 +602,7 @@
         "label": "清空消息 {{Command}}",
         "title": "清空消息"
       },
+      "code_execution": "代码执行",
       "collapse": "收起",
       "context_count": {
         "tip": "上下文数 / 最大上下文数"
@@ -683,6 +684,7 @@
         "parse_tool_call": "无法转换为有效的工具调用格式：{{toolCall}}"
       },
       "warning": {
+        "gemini_code_execution": "Gemini 不支持同时使用原生代码执行工具与函数调用",
         "gemini_web_search": "Gemini 不支持同时使用原生网络搜索工具与函数调用",
         "multiple_tools": "存在多个匹配的MCP工具，已选择 {{tool}}",
         "no_tool": "未匹配到所需的MCP工具 {{tool}}",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -602,6 +602,7 @@
         "label": "清除 {{Command}}",
         "title": "清除所有訊息？"
       },
+      "code_execution": "代碼執行",
       "collapse": "折疊",
       "context_count": {
         "tip": "上下文數 / 最大上下文數"
@@ -683,6 +684,7 @@
         "parse_tool_call": "無法轉換為有效的工具呼叫格式：{{toolCall}}"
       },
       "warning": {
+        "gemini_code_execution": "Gemini 不支持同時使用原生代碼執行工具與函數調用",
         "gemini_web_search": "Gemini 不支援同時使用原生網路搜尋工具與函數呼叫",
         "multiple_tools": "存在多個匹配的MCP工具，已選擇 {{tool}}",
         "no_tool": "未匹配到所需的MCP工具 {{tool}}",

--- a/src/renderer/src/pages/home/Inputbar/CodeExecutionButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/CodeExecutionButton.tsx
@@ -1,0 +1,58 @@
+import { ActionIconButton } from '@renderer/components/Buttons'
+import { useAssistant } from '@renderer/hooks/useAssistant'
+import { useTimer } from '@renderer/hooks/useTimer'
+import { isToolUseModeFunction } from '@renderer/utils/assistant'
+import { Tooltip } from 'antd'
+import { Code } from 'lucide-react'
+import type { FC } from 'react'
+import { memo, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+
+export interface CodeExecutionButtonRef {
+  openQuickPanel: () => void
+}
+
+interface Props {
+  ref?: React.RefObject<CodeExecutionButtonRef | null>
+  assistantId: string
+}
+
+const UrlContextButton: FC<Props> = ({ assistantId }) => {
+  const { t } = useTranslation()
+  const { assistant, updateAssistant } = useAssistant(assistantId)
+  const { setTimeoutTimer } = useTimer()
+
+  const codeExecutionNewState = !assistant.enableCodeExecution
+
+  const handleToggle = useCallback(() => {
+    setTimeoutTimer(
+      'handleToggle',
+      () => {
+        const update = { ...assistant }
+        if (
+          assistant.mcpServers &&
+          assistant.mcpServers.length > 0 &&
+          codeExecutionNewState === true &&
+          isToolUseModeFunction(assistant)
+        ) {
+          update.enableCodeExecution = false
+          window.toast.warning(t('chat.mcp.warning.gemini_code_execution'))
+        } else {
+          update.enableCodeExecution = codeExecutionNewState
+        }
+        updateAssistant(update)
+      },
+      100
+    )
+  }, [setTimeoutTimer, assistant, codeExecutionNewState, updateAssistant, t])
+
+  return (
+    <Tooltip placement="top" title={t('chat.input.code_execution')} arrow>
+      <ActionIconButton onClick={handleToggle} active={assistant.enableCodeExecution}>
+        <Code size={18} />
+      </ActionIconButton>
+    </Tooltip>
+  )
+}
+
+export default memo(UrlContextButton)

--- a/src/renderer/src/pages/home/Inputbar/InputbarTools.tsx
+++ b/src/renderer/src/pages/home/Inputbar/InputbarTools.tsx
@@ -13,7 +13,7 @@ import {
   isSupportedThinkingTokenModel,
   isVisionModel
 } from '@renderer/config/models'
-import { isSupportUrlContextProvider } from '@renderer/config/providers'
+import { isSupportCodeExecutionProvider, isSupportUrlContextProvider } from '@renderer/config/providers'
 import { useAssistant } from '@renderer/hooks/useAssistant'
 import { useShortcutDisplay } from '@renderer/hooks/useShortcuts'
 import { useSidebarIconShow } from '@renderer/hooks/useSidebarIcon'
@@ -32,6 +32,7 @@ import {
   AtSign,
   Check,
   CircleChevronRight,
+  Code,
   FileSearch,
   Globe,
   Hammer,
@@ -52,6 +53,8 @@ import styled from 'styled-components'
 
 import type { AttachmentButtonRef } from './AttachmentButton'
 import AttachmentButton from './AttachmentButton'
+import type { CodeExecutionButtonRef } from './codeExecutionButton'
+import CodeExecutionButton from './codeExecutionButton'
 import GenerateImageButton from './GenerateImageButton'
 import type { KnowledgeBaseButtonRef } from './KnowledgeBaseButton'
 import KnowledgeBaseButton from './KnowledgeBaseButton'
@@ -143,6 +146,7 @@ const InputbarTools = ({
   const webSearchButtonRef = useRef<WebSearchButtonRef | null>(null)
   const thinkingButtonRef = useRef<ThinkingButtonRef | null>(null)
   const urlContextButtonRef = useRef<UrlContextButtonRef | null>(null)
+  const codeExecutionButtonRef = useRef<CodeExecutionButtonRef | null>(null)
 
   const toolOrder = useAppSelector((state) => state.inputTools.toolOrder)
   const isCollapse = useAppSelector((state) => state.inputTools.isCollapsed)
@@ -306,6 +310,15 @@ const InputbarTools = ({
         }
       },
       {
+        label: t('chat.input.code_execution'),
+        description: '',
+        icon: <Code />,
+        isMenu: true,
+        action: () => {
+          codeExecutionButtonRef.current?.openQuickPanel()
+        }
+      },
+      {
         label: couldAddImageFile ? t('chat.input.upload.attachment') : t('chat.input.upload.document'),
         description: '',
         icon: <Paperclip />,
@@ -410,6 +423,14 @@ const InputbarTools = ({
         condition:
           (isGeminiModel(model) || isAnthropicModel(model)) &&
           (isSupportUrlContextProvider(getProviderByModel(model)) || model.endpoint_type === 'gemini')
+      },
+      {
+        key: 'code_execution',
+        label: t('chat.input.code_execution'),
+        component: <CodeExecutionButton ref={codeExecutionButtonRef} assistantId={assistant.id} />,
+        condition:
+          (isGeminiModel(model) || isAnthropicModel(model)) &&
+          (isSupportCodeExecutionProvider(getProviderByModel(model)) || model.endpoint_type === 'gemini')
       },
       {
         key: 'knowledge_base',

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -138,6 +138,7 @@ export async function fetchChatCompletion({
     enableWebSearch: capabilities.enableWebSearch,
     enableGenerateImage: capabilities.enableGenerateImage,
     enableUrlContext: capabilities.enableUrlContext,
+    enableCodeExecution: capabilities.enableCodeExecution,
     mcpTools,
     uiMessages,
     knowledgeRecognition: assistant.knowledgeRecognition
@@ -228,6 +229,7 @@ export async function fetchMessagesSummary({ messages, assistant }: { messages: 
     enableWebSearch: false,
     enableGenerateImage: false,
     enableUrlContext: false,
+    enableCodeExecution: false,
     mcpTools: []
   }
   try {
@@ -299,6 +301,7 @@ export async function fetchNoteSummary({ content, assistant }: { content: string
     enableWebSearch: false,
     enableGenerateImage: false,
     enableUrlContext: false,
+    enableCodeExecution: false,
     mcpTools: []
   }
 
@@ -377,7 +380,8 @@ export async function fetchGenerate({
     isImageGenerationEndpoint: false,
     enableWebSearch: false,
     enableGenerateImage: false,
-    enableUrlContext: false
+    enableUrlContext: false,
+    enableCodeExecution: false
   }
 
   try {
@@ -487,6 +491,7 @@ export async function checkApi(provider: Provider, model: Model, timeout = 15000
         enableGenerateImage: false,
         isPromptToolUse: false,
         enableUrlContext: false,
+        enableCodeExecution: false,
         assistant,
         callType: 'check',
         onChunk: (chunk: Chunk) => {

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -67,7 +67,11 @@ const persistedReducer = persistReducer(
   {
     key: 'cherry-studio',
     storage,
+<<<<<<< HEAD
     version: 171,
+=======
+    version: 170,
+>>>>>>> e891adfc0 (Feat: Add Code Execution button for gemini only)
     blacklist: ['runtime', 'messages', 'messageBlocks', 'tabs', 'toolPermissions'],
     migrate
   },

--- a/src/renderer/src/store/inputTools.ts
+++ b/src/renderer/src/store/inputTools.ts
@@ -14,6 +14,7 @@ export const DEFAULT_TOOL_ORDER: ToolOrder = {
     'thinking',
     'web_search',
     'url_context',
+    'code_execution',
     'knowledge_base',
     'mcp_tools',
     'generate_image',

--- a/src/renderer/src/store/migrate.ts
+++ b/src/renderer/src/store/migrate.ts
@@ -2786,14 +2786,42 @@ const migrateConfig = {
   },
   '170': (state: RootState) => {
     try {
+<<<<<<< HEAD
       addProvider(state, 'sophnet')
       state.llm.providers = moveProvider(state.llm.providers, 'sophnet', 17)
       state.settings.defaultPaintingProvider = 'cherryin'
+=======
+      const { toolOrder } = state.inputTools
+      const codeExecutionKey = 'code_execution'
+      if (!toolOrder.visible.includes(codeExecutionKey)) {
+        const urlContextIndex = toolOrder.visible.indexOf('url_context')
+        const knowledgeBaseIndex = toolOrder.visible.indexOf('knowledge_base')
+        if (urlContextIndex !== -1) {
+          toolOrder.visible.splice(urlContextIndex, 0, codeExecutionKey)
+        } else if (knowledgeBaseIndex !== -1) {
+          toolOrder.visible.splice(knowledgeBaseIndex, 0, codeExecutionKey)
+        } else {
+          toolOrder.visible.push(codeExecutionKey)
+        }
+      }
+
+      for (const assistant of state.assistants.assistants) {
+        if (assistant.settings?.toolUseMode === 'prompt' && isFunctionCallingModel(assistant.model)) {
+          assistant.settings.toolUseMode = 'function'
+        }
+      }
+
+      if (state.settings && typeof state.settings.webdavDisableStream === 'undefined') {
+        state.settings.webdavDisableStream = false
+      }
+
+>>>>>>> e891adfc0 (Feat: Add Code Execution button for gemini only)
       return state
     } catch (error) {
       logger.error('migrate 170 error', error as Error)
       return state
     }
+<<<<<<< HEAD
   },
   '171': (state: RootState) => {
     try {
@@ -2805,6 +2833,8 @@ const migrateConfig = {
       logger.error('migrate 171 error', error as Error)
       return state
     }
+=======
+>>>>>>> e891adfc0 (Feat: Add Code Execution button for gemini only)
   }
 }
 

--- a/src/renderer/src/types/chat.ts
+++ b/src/renderer/src/types/chat.ts
@@ -6,6 +6,7 @@ export type InputBarToolType =
   | 'thinking'
   | 'web_search'
   | 'url_context'
+  | 'code_execution'
   | 'knowledge_base'
   | 'mcp_tools'
   | 'generate_image'

--- a/src/renderer/src/types/chunk.ts
+++ b/src/renderer/src/types/chunk.ts
@@ -48,7 +48,19 @@ export enum ChunkType {
   SEARCH_COMPLETE_UNION = 'search_complete_union',
   VIDEO_SEARCHED = 'video.searched',
   IMAGE_SEARCHED = 'image.searched',
-  RAW = 'raw'
+  RAW = 'raw',
+  CODE_EXECUTION_REQUEST = 'code_execution_request', // 模型将要执行的代码
+  CODE_EXECUTION_OUTPUT = 'code_execution_output' // 代码执行后的输出
+}
+
+export interface CodeExecutionRequestChunk {
+  type: ChunkType.CODE_EXECUTION_REQUEST
+  code: string | undefined
+}
+
+export interface CodeExecutionOutputChunk {
+  type: ChunkType.CODE_EXECUTION_OUTPUT
+  output: string | undefined
 }
 
 export interface LLMResponseCreatedChunk {
@@ -463,3 +475,5 @@ export type Chunk =
   | VideoSearchedChunk // 知识库检索视频
   | ImageSearchedChunk // 知识库检索图片
   | RawChunk
+  | CodeExecutionRequestChunk // 代码执行请求
+  | CodeExecutionOutputChunk // 代码执行结果

--- a/src/renderer/src/types/newMessage.ts
+++ b/src/renderer/src/types/newMessage.ts
@@ -27,6 +27,7 @@ export enum MessageBlockType {
   TRANSLATION = 'translation', // Re-added
   IMAGE = 'image', // 图片内容
   CODE = 'code', // 代码块
+  CODE_EXECUTION_OUTPUT = 'code_execution_result',
   TOOL = 'tool', // Added unified tool block type
   FILE = 'file', // 文件内容
   ERROR = 'error', // 错误信息
@@ -96,6 +97,14 @@ export interface CodeMessageBlock extends BaseMessageBlock {
   language: string // 代码语言
 }
 
+// 代码输出块
+export interface CodeExecutionResultMessageBlock extends BaseMessageBlock {
+  type: MessageBlockType.CODE_EXECUTION_OUTPUT
+  content: string // 用于存放代码的输出
+  // 可选：为了更好的关联，可以添加一个字段指向对应的代码块ID
+  codeBlockId?: string
+}
+
 export interface ImageMessageBlock extends BaseMessageBlock {
   type: MessageBlockType.IMAGE
   url?: string // For generated images or direct links
@@ -152,6 +161,7 @@ export type MessageBlock =
   | ThinkingMessageBlock
   | TranslationMessageBlock
   | CodeMessageBlock
+  | CodeExecutionResultMessageBlock
   | ImageMessageBlock
   | ToolMessageBlock
   | FileMessageBlock


### PR DESCRIPTION
also `Fix: defaultPaintingProvider type error in migrate 170 and 171`

Documentation from Google: https://ai.google.dev/gemini-api/docs/code-execution#enable-code-execution
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

⚠️ Important: Redux/IndexedDB Data-Changing Feature PRs Temporarily On Hold ⚠️

Please note: For our current development cycle, we are not accepting feature Pull Requests that introduce changes to Redux data models or IndexedDB schemas.

While we value your contributions, PRs of this nature will be blocked without merge. We welcome all other contributions (bug fixes, perf enhancements, docs, etc.). Thank you!

Once version 2.0.0 is released, we will resume reviewing feature PRs.

-->

### What this PR does

Before this PR: cannot use Gemini's codeExecution tool.

After this PR: can use Gemini's codeExecution tool. 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made: I have to make a new chunk block type specifically for rendering `part.executableCode.code` and `part.codeExecutionResult.output`

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

1. Users would have found a new button when using Gemini models in `inputBarTool`.
2. New chunk type introduced and may have some glich(specifically, repeat request) while alpha testing.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->

```release-note

```
