### PR TITLE
🐛 fix(mcp): resolve OAuth callback page hanging and add i18n support

### DIFF
--- a/src/main/services/mcp/oauth/callback.ts
+++ b/src/main/services/mcp/oauth/callback.ts
@@ -1,4 +1,6 @@
 import { loggerService } from '@logger'
+import { configManager } from '@main/services/ConfigManager'
+import { locales } from '@main/utils/locales'
 import type EventEmitter from 'events'
 import http from 'http'
 import { URL } from 'url'
@@ -6,6 +8,36 @@ import { URL } from 'url'
 import type { OAuthCallbackServerOptions } from './types'
 
 const logger = loggerService.withContext('MCP:OAuthCallbackServer')
+
+function getTranslation(key: string): string {
+  const language = configManager.getLanguage()
+  const localeData = locales[language]
+
+  if (!localeData) {
+    logger.warn(`No locale data found for language: ${language}`)
+    return key
+  }
+
+  const translations = localeData.translation as any
+  if (!translations) {
+    logger.warn(`No translations found for language: ${language}`)
+    return key
+  }
+
+  const keys = key.split('.')
+  let value = translations
+
+  for (const k of keys) {
+    if (value && typeof value === 'object' && k in value) {
+      value = value[k]
+    } else {
+      logger.warn(`Translation key not found: ${key} (failed at: ${k})`)
+      return key // fallback to key if translation not found
+    }
+  }
+
+  return typeof value === 'string' ? value : key
+}
 
 export class CallBackServer {
   private server: Promise<http.Server>
@@ -28,6 +60,55 @@ export class CallBackServer {
           if (code) {
             // Emit the code event
             this.events.emit('auth-code-received', code)
+            // Send success response to browser
+            const title = getTranslation('settings.mcp.oauth.callback.title')
+            const message = getTranslation('settings.mcp.oauth.callback.message')
+
+            res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+            res.end(`
+              <!DOCTYPE html>
+              <html>
+                <head>
+                  <meta charset="utf-8">
+                  <title>${title}</title>
+                  <style>
+                    body {
+                      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+                      display: flex;
+                      justify-content: center;
+                      align-items: center;
+                      height: 100vh;
+                      margin: 0;
+                      background: #ffffff;
+                    }
+                    .container {
+                      text-align: center;
+                      padding: 2rem;
+                    }
+                    h1 {
+                      color: #2d3748;
+                      margin: 0 0 0.5rem 0;
+                      font-size: 24px;
+                      font-weight: 600;
+                    }
+                    p {
+                      color: #718096;
+                      margin: 0;
+                      font-size: 14px;
+                    }
+                  </style>
+                </head>
+                <body>
+                  <div class="container">
+                    <h1>${title}</h1>
+                    <p>${message}</p>
+                  </div>
+                </body>
+              </html>
+            `)
+          } else {
+            res.writeHead(400, { 'Content-Type': 'text/plain' })
+            res.end('Missing authorization code')
           }
         } catch (error) {
           logger.error('Error processing OAuth callback:', error as Error)

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -3863,6 +3863,12 @@
         "usage": "Usage",
         "version": "Version"
       },
+      "oauth": {
+        "callback": {
+          "message": "You can close this page and return to Cherry Studio",
+          "title": "Authentication Successful"
+        }
+      },
       "prompts": {
         "arguments": "Arguments",
         "availablePrompts": "Available Prompts",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -3863,6 +3863,12 @@
         "usage": "用法",
         "version": "版本"
       },
+      "oauth": {
+        "callback": {
+          "message": "您可以关闭此页面并返回 Cherry Studio",
+          "title": "认证成功"
+        }
+      },
       "prompts": {
         "arguments": "参数",
         "availablePrompts": "可用提示",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -3863,6 +3863,12 @@
         "usage": "用法",
         "version": "版本"
       },
+      "oauth": {
+        "callback": {
+          "message": "您可以關閉此頁面並返回 Cherry Studio",
+          "title": "認證成功"
+        }
+      },
       "prompts": {
         "arguments": "參數",
         "availablePrompts": "可用提示",

--- a/src/renderer/src/i18n/translate/de-de.json
+++ b/src/renderer/src/i18n/translate/de-de.json
@@ -3863,6 +3863,12 @@
         "usage": "Verwendung",
         "version": "Version"
       },
+      "oauth": {
+        "callback": {
+          "message": "Sie können diese Seite schließen und zu Cherry Studio zurückkehren",
+          "title": "Authentifizierung erfolgreich"
+        }
+      },
       "prompts": {
         "arguments": "Parameter",
         "availablePrompts": "Verfügbare Prompts",

--- a/src/renderer/src/i18n/translate/el-gr.json
+++ b/src/renderer/src/i18n/translate/el-gr.json
@@ -3863,6 +3863,12 @@
         "usage": "Χρήση",
         "version": "Έκδοση"
       },
+      "oauth": {
+        "callback": {
+          "message": "Μπορείτε να κλείσετε αυτήν τη σελίδα και να επιστρέψετε στο Cherry Studio",
+          "title": "Επιτυχής Ταυτοποίηση"
+        }
+      },
       "prompts": {
         "arguments": "Ορίσματα",
         "availablePrompts": "Διαθέσιμες Υποδείξεις",

--- a/src/renderer/src/i18n/translate/es-es.json
+++ b/src/renderer/src/i18n/translate/es-es.json
@@ -3863,6 +3863,12 @@
         "usage": "Uso",
         "version": "Versión"
       },
+      "oauth": {
+        "callback": {
+          "message": "Puede cerrar esta página y volver a Cherry Studio",
+          "title": "Autenticación Exitosa"
+        }
+      },
       "prompts": {
         "arguments": "Argumentos",
         "availablePrompts": "Indicaciones disponibles",

--- a/src/renderer/src/i18n/translate/fr-fr.json
+++ b/src/renderer/src/i18n/translate/fr-fr.json
@@ -3863,6 +3863,12 @@
         "usage": "Utilisation",
         "version": "Version"
       },
+      "oauth": {
+        "callback": {
+          "message": "Vous pouvez fermer cette page et retourner à Cherry Studio",
+          "title": "Authentification Réussie"
+        }
+      },
       "prompts": {
         "arguments": "Arguments",
         "availablePrompts": "Invites disponibles",

--- a/src/renderer/src/i18n/translate/ja-jp.json
+++ b/src/renderer/src/i18n/translate/ja-jp.json
@@ -3863,6 +3863,12 @@
         "usage": "使用法",
         "version": "バージョン"
       },
+      "oauth": {
+        "callback": {
+          "message": "このページを閉じてCherry Studioに戻ることができます",
+          "title": "認証成功"
+        }
+      },
       "prompts": {
         "arguments": "引数",
         "availablePrompts": "利用可能なプロンプト",

--- a/src/renderer/src/i18n/translate/pt-pt.json
+++ b/src/renderer/src/i18n/translate/pt-pt.json
@@ -3863,6 +3863,12 @@
         "usage": "Uso",
         "version": "Versão"
       },
+      "oauth": {
+        "callback": {
+          "message": "Você pode fechar esta página e retornar ao Cherry Studio",
+          "title": "Autenticação Bem-Sucedida"
+        }
+      },
       "prompts": {
         "arguments": "Argumentos",
         "availablePrompts": "Dicas disponíveis",

--- a/src/renderer/src/i18n/translate/ru-ru.json
+++ b/src/renderer/src/i18n/translate/ru-ru.json
@@ -3863,6 +3863,12 @@
         "usage": "Использование",
         "version": "Версия"
       },
+      "oauth": {
+        "callback": {
+          "message": "Вы можете закрыть эту страницу и вернуться в Cherry Studio",
+          "title": "Аутентификация Успешна"
+        }
+      },
       "prompts": {
         "arguments": "Аргументы",
         "availablePrompts": "Доступные подсказки",


### PR DESCRIPTION
 ### What this PR does

  Before this PR:
  - When MCP OAuth authentication completes, the callback page hangs indefinitely without responding to the browser

  After this PR:
  - Browser receives immediate HTTP response with a clean success page
  - Success page supports 10 languages based on user's language settings
  - Simplified design with white background and centered text for better user experience

  ### Why we need it and why it was done in this way

  **Problem**:
  The OAuth callback server was emitting the auth code event but not sending an HTTP response to the browser, causing the browser to hang waiting for a response.

  **Solution**:
  1. Added HTTP 200 response with internationalized HTML success page
  2. Implemented translation lookup using user's configured language
  3. Simplified page design for cleaner UX

  The following tradeoffs were made:
  - Used inline HTML/CSS instead of external files for simplicity and to avoid additional resource loading
  - Translations are fetched from existing i18n files to maintain consistency

  The following alternatives were considered:
  - Close browser tab automatically: Rejected because users may want to verify the success message
  - Use external CSS file: Rejected to keep the callback simple and self-contained

  ### Breaking changes

  None. This is a bug fix and enhancement that maintains backward compatibility.

  ### Special notes for your reviewer

  **Testing**:
  - Tested OAuth flow with MCP servers requiring authentication
  - Verified all 10 language translations display correctly
  - Confirmed page renders properly across different browsers

  **Files changed**:
  - `src/main/services/mcp/oauth/callback.ts`: Fixed HTTP response handling and added i18n support
  - `src/renderer/src/i18n/locales/*.json`: Added OAuth callback translations
  - `src/renderer/src/i18n/translate/*.json`: Added translations for all supported languages

  ### Checklist

  - [x] PR: The PR description is expressive enough and will help future contributors
  - [x] Code: Write code that humans can understand and Keep it simple
  - [x] Refactor: Left the code cleaner than found (removed unnecessary emoji, simplified design)
  - [x] Upgrade: No upgrade impact - backward compatible bug fix
  - [x] Documentation: No user-guide update required (internal improvement)

  ### Release note

  ```release-note
  Fix MCP OAuth callback page hanging issue and add internationalization support for the success page. The callback page now properly responds to browsers and displays localized messages in the user's configured language.