### PR TITLE
fix(agents): inherit allowed_tools from Agent when creating Session

### DIFF
--- a/src/main/services/agents/services/SessionService.ts
+++ b/src/main/services/agents/services/SessionService.ts
@@ -78,6 +78,7 @@ export class SessionService extends BaseService {
       plan_model: serializedData.plan_model || null,
       small_model: serializedData.small_model || null,
       mcps: serializedData.mcps || null,
+      allowed_tools: serializedData.allowed_tools || null,
       configuration: serializedData.configuration || null,
       created_at: now,
       updated_at: now


### PR DESCRIPTION
## Summary
- Fixed Session creation to inherit `allowed_tools` configuration from parent Agent
- Previously, the `allowed_tools` parameter was missing from the Session creation API call, causing inconsistency between Agent and Session configurations

## Changes
- Added `allowed_tools: serializedData.allowed_tools || null` parameter in SessionService.ts when creating a new Session

## Test Plan
- Verify that when creating a Session under an Agent, the Session now correctly inherits the Agent's `allowed_tools` configuration
- Confirm that Sessions created with this fix have consistent `allowed_tools` values with their parent Agent

Generated with [Claude Code](https://claude.com/claude-code)