### PR TITLE
feat(agent): add permission mode display component for empty session state

### DIFF
--- a/src/renderer/src/pages/home/Messages/AgentSessionMessages.tsx
+++ b/src/renderer/src/pages/home/Messages/AgentSessionMessages.tsx
@@ -5,11 +5,13 @@ import { useTopicMessages } from '@renderer/hooks/useMessageOperations'
 import { getGroupedMessages } from '@renderer/services/MessagesService'
 import { type Topic, TopicType } from '@renderer/types'
 import { buildAgentSessionTopicId } from '@renderer/utils/agentSession'
+import { Spin } from 'antd'
 import { memo, useMemo } from 'react'
 import styled from 'styled-components'
 
 import MessageGroup from './MessageGroup'
 import NarrowLayout from './NarrowLayout'
+import PermissionModeDisplay from './PermissionModeDisplay'
 import { MessagesContainer, ScrollContainer } from './shared'
 
 const logger = loggerService.withContext('AgentSessionMessages')
@@ -67,8 +69,12 @@ const AgentSessionMessages: React.FC<Props> = ({ agentId, sessionId }) => {
               groupedMessages.map(([key, groupMessages]) => (
                 <MessageGroup key={key} messages={groupMessages} topic={derivedTopic} />
               ))
+            ) : session ? (
+              <PermissionModeDisplay session={session} agentId={agentId} />
             ) : (
-              <EmptyState>{session ? 'No messages yet.' : 'Loading session...'}</EmptyState>
+              <LoadingState>
+                <Spin size="small" />
+              </LoadingState>
             )}
           </ScrollContainer>
         </ContextMenu>
@@ -77,10 +83,10 @@ const AgentSessionMessages: React.FC<Props> = ({ agentId, sessionId }) => {
   )
 }
 
-const EmptyState = styled.div`
-  color: var(--color-text-3);
-  font-size: 12px;
-  text-align: center;
+const LoadingState = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
   padding: 20px 0;
 `
 

--- a/src/renderer/src/pages/home/Messages/PermissionModeDisplay.tsx
+++ b/src/renderer/src/pages/home/Messages/PermissionModeDisplay.tsx
@@ -1,0 +1,82 @@
+import { permissionModeCards } from '@renderer/config/agent'
+import SessionSettingsPopup from '@renderer/pages/settings/AgentSettings/SessionSettingsPopup'
+import type { GetAgentSessionResponse, PermissionMode } from '@renderer/types'
+import { FileEdit, Lightbulb, Shield, ShieldOff } from 'lucide-react'
+import type { FC } from 'react'
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface Props {
+  session: GetAgentSessionResponse
+  agentId: string
+}
+
+const getPermissionModeConfig = (mode: PermissionMode) => {
+  switch (mode) {
+    case 'default':
+      return {
+        icon: <Shield size={18} color="var(--color-primary)" />
+      }
+    case 'plan':
+      return {
+        icon: <Lightbulb size={18} color="#faad14" />
+      }
+    case 'acceptEdits':
+      return {
+        icon: <FileEdit size={18} color="#52c41a" />
+      }
+    case 'bypassPermissions':
+      return {
+        icon: <ShieldOff size={18} color="var(--color-error)" />
+      }
+    default:
+      return {
+        icon: <Shield size={18} color="var(--color-primary)" />
+      }
+  }
+}
+
+const PermissionModeDisplay: FC<Props> = ({ session, agentId }) => {
+  const { t } = useTranslation()
+
+  const permissionMode = session?.configuration?.permission_mode ?? 'default'
+
+  const modeCard = useMemo(() => {
+    return permissionModeCards.find((card) => card.mode === permissionMode)
+  }, [permissionMode])
+
+  const modeConfig = useMemo(() => getPermissionModeConfig(permissionMode), [permissionMode])
+
+  const handleClick = () => {
+    SessionSettingsPopup.show({
+      agentId,
+      sessionId: session.id,
+      tab: 'tooling'
+    })
+  }
+
+  if (!modeCard) {
+    return null
+  }
+
+  return (
+    <div
+      onClick={handleClick}
+      className="mx-2 cursor-pointer rounded-lg border-[0.5px] border-[var(--color-border)] px-3 py-2">
+      <div className="flex items-center gap-2.5">
+        <div className="flex shrink-0 items-center justify-center">{modeConfig.icon}</div>
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <div className="overflow-hidden text-ellipsis whitespace-nowrap font-semibold text-[var(--color-text-1)] text-xs">
+            {t(modeCard.titleKey, modeCard.titleFallback)}
+          </div>
+          <div className="overflow-hidden text-ellipsis whitespace-nowrap text-[11px] text-[var(--color-text-2)] leading-[1.4]">
+            {t(modeCard.descriptionKey, modeCard.descriptionFallback)}{' '}
+            {t(modeCard.behaviorKey, modeCard.behaviorFallback)}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default PermissionModeDisplay


### PR DESCRIPTION
## Summary
Replace the empty state text in agent sessions with a visual permission mode display component that provides better UX and navigation to settings.

## Motivation

Consistent with the behavior displayed by the Assistant Prompt component

<img width="1041" height="139" alt="image" src="https://github.com/user-attachments/assets/3e439703-d195-499b-af4c-054be42f8de8" />

## Changes
- Created new `PermissionModeDisplay` component to show current permission mode
- Each permission mode has a unique icon and color:
  - **Default**: Shield icon with primary color
  - **Plan**: Lightbulb icon with warning color
  - **Accept Edits**: FileEdit icon with success color
  - **Bypass Permissions**: ShieldOff icon with error color
- Displays permission mode title and description in a compact card layout
- Clickable to navigate directly to the tooling settings tab
- Replaced loading text with Ant Design Spin component

<img width="1399" height="1018" alt="image" src="https://github.com/user-attachments/assets/224e2dc0-4e3b-461c-8a74-a47565ab17d6" />

<img width="864" height="84" alt="image" src="https://github.com/user-attachments/assets/7241abfb-2552-4503-aa5f-3c9417059df3" />

<img width="862" height="83" alt="image" src="https://github.com/user-attachments/assets/fcea7b38-dfbf-4297-879c-8c79553e83c5" />

<img width="863" height="83" alt="image" src="https://github.com/user-attachments/assets/a6ef44ac-1ef4-4f70-8b73-20843733e4ed" />


## Test plan
- [x] Run `yarn build:check` - All tests passed
- [x] Verify empty session state displays permission mode card
- [x] Click on permission mode card navigates to tooling settings
- [x] Verify all 4 permission modes display with correct icons and colors
- [x] Verify loading state shows spinner instead of text