### PR TITLE
style(ui): center plugin browser tabs

### DIFF
--- a/src/renderer/src/pages/settings/AgentSettings/components/PluginBrowser.tsx
+++ b/src/renderer/src/pages/settings/AgentSettings/components/PluginBrowser.tsx
@@ -263,6 +263,7 @@ export const PluginBrowser: FC<PluginBrowserProps> = ({
           items={pluginTypeTabItems}
           className="w-full"
           size="small"
+          centered
         />
       </div>
 


### PR DESCRIPTION
## Summary
- Center the tab items in the plugin browser component for better visual alignment

## Changes
- Added `centered` prop to the Tabs component in PluginBrowser

Before:

<img width="572" height="684" alt="image" src="https://github.com/user-attachments/assets/c390a4f4-ac4b-4ec7-96c0-6d3786f64abd" />

After:

<img width="570" height="675" alt="image" src="https://github.com/user-attachments/assets/4026f617-bb23-4c8b-9777-815d955cef5e" />


## Test plan
- [x] Verify tabs are centered in the plugin browser
- [x] Verify UI layout is not broken
- [x] Test responsiveness on different screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)