### PR TITLE
fix(ui): resolve sidebar tooltip overlap with window controls on macOS

### DIFF
--- a/src/renderer/src/pages/home/ChatNavbar.tsx
+++ b/src/renderer/src/pages/home/ChatNavbar.tsx
@@ -84,7 +84,7 @@ const HeaderNavbar: FC<Props> = ({ activeAssistant, setActiveAssistant, activeTo
           </Tooltip>
         )}
         {isTopNavbar && !showAssistants && (
-          <Tooltip title={t('navbar.show_sidebar')} mouseEnterDelay={0.8}>
+          <Tooltip title={t('navbar.show_sidebar')} mouseEnterDelay={0.8} placement="right">
             <NavbarIcon onClick={() => toggleShowAssistants()} style={{ marginRight: 8 }}>
               <PanelRightClose size={18} />
             </NavbarIcon>

--- a/src/renderer/src/pages/home/Navbar.tsx
+++ b/src/renderer/src/pages/home/Navbar.tsx
@@ -98,7 +98,7 @@ const HeaderNavbar: FC<Props> = ({
             paddingRight: 0,
             minWidth: 'auto'
           }}>
-          <Tooltip title={t('navbar.show_sidebar')} mouseEnterDelay={0.8}>
+          <Tooltip title={t('navbar.show_sidebar')} mouseEnterDelay={0.8} placement="right">
             <NavbarIcon onClick={() => toggleShowAssistants()}>
               <PanelRightClose size={18} />
             </NavbarIcon>

--- a/src/renderer/src/pages/notes/HeaderNavbar.tsx
+++ b/src/renderer/src/pages/notes/HeaderNavbar.tsx
@@ -181,7 +181,7 @@ const HeaderNavbar = ({ notesTree, getCurrentNoteContent, onToggleStar, onExpand
           </Tooltip>
         )}
         {!showWorkspace && (
-          <Tooltip title={t('navbar.show_sidebar')} mouseEnterDelay={0.8}>
+          <Tooltip title={t('navbar.show_sidebar')} mouseEnterDelay={0.8} placement="right">
             <NavbarIcon onClick={handleToggleShowWorkspace}>
               <PanelRightClose size={18} />
             </NavbarIcon>


### PR DESCRIPTION
## Summary

Fixes #11125

This PR resolves the tooltip overlap issue on macOS where sidebar toggle tooltips would overlap with the native window control buttons (minimize, maximize, close) in the top-left corner.

## Changes

Added `placement="right"` to all sidebar toggle tooltips in:
- `src/renderer/src/pages/home/ChatNavbar.tsx`
- `src/renderer/src/pages/home/Navbar.tsx` 
- `src/renderer/src/pages/notes/HeaderNavbar.tsx`

Before:

<img width="634" height="301" alt="image" src="https://github.com/user-attachments/assets/c5f1048d-f113-45ba-83bb-d75b1e6eae0b" />

After:

<img width="711" height="312" alt="image" src="https://github.com/user-attachments/assets/02e944b0-b03f-41a5-9573-92d569fe07e5" />

## Impact

- Tooltips now appear to the right of toggle buttons
- Prevents overlap with macOS window controls
- Consistent behavior across all navbar components

## Testing

Tested on macOS by:
1. Hiding the sidebar in conversation interface
2. Hovering over the sidebar toggle button
3. Verifying tooltip appears on the right without overlapping window controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>