### PR TITLE
fix: remove explicit Content-Type header in file upload

### DIFF
--- a/src/main/knowledge/preprocess/MineruPreprocessProvider.ts
+++ b/src/main/knowledge/preprocess/MineruPreprocessProvider.ts
@@ -275,15 +275,10 @@ export default class MineruPreprocessProvider extends BasePreprocessProvider {
     try {
       const fileBuffer = await fs.promises.readFile(filePath)
 
+      // https://mineru.net/apiManage/docs
       const response = await net.fetch(uploadUrl, {
         method: 'PUT',
-        body: fileBuffer,
-        headers: {
-          'Content-Type': 'application/pdf'
-        }
-        // headers: {
-        //   'Content-Length': fileBuffer.length.toString()
-        // }
+        body: fileBuffer
       })
 
       if (!response.ok) {


### PR DESCRIPTION
Fix: #11229 

The Content-Type header was removed from the fetch request when uploading files. This change may allow the server to infer the correct content type or handle uploads more flexibly.