### PR TITLE
fix: ensure the user can select any image in NewApiPage

### DIFF
--- a/src/renderer/src/pages/paintings/NewApiPage.tsx
+++ b/src/renderer/src/pages/paintings/NewApiPage.tsx
@@ -472,9 +472,15 @@ const NewApiPage: FC<{ Options: string[] }> = ({ Options }) => {
       addPainting(mode, newPainting)
       setPainting(newPainting)
     } else {
-      setPainting(filteredPaintings[0])
+      // 如果当前 painting 存在于 filteredPaintings 中，则优先显示当前 painting
+      const found = filteredPaintings.find((p) => p.id === painting.id)
+      if (found) {
+        setPainting(found)
+      } else {
+        setPainting(filteredPaintings[0])
+      }
     }
-  }, [filteredPaintings, mode, addPainting, getNewPainting])
+  }, [filteredPaintings, mode, addPainting, getNewPainting, painting.id])
 
   useEffect(() => {
     const timer = spaceClickTimer.current


### PR DESCRIPTION
NewApiPage always show the first image in filteredPaintings. As a result, the user is unable to select other images. This issue was introduced in commit 0502ff4.

### What this PR does

Before this PR:
      The first image in filteredPaintings is always shown, hence the user can't select other images in NewApiPage.
      
After this PR:
      The user can switch to any previously generated image.

