### PR TITLE
fix: cannot use send shortcut after quick translation

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/components/InputbarCore.tsx
+++ b/src/renderer/src/pages/home/Inputbar/components/InputbarCore.tsx
@@ -144,6 +144,7 @@ export const InputbarCore: FC<InputbarCoreProps> = ({
   const startDragY = useRef<number>(0)
   const startHeight = useRef<number>(0)
   const { setTimeoutTimer } = useTimer()
+  const wasTranslatingRef = useRef(false)
 
   // 全局 QuickPanel Hook (用于控制面板显示状态)
   const quickPanel = useQuickPanel()
@@ -567,6 +568,15 @@ export const InputbarCore: FC<InputbarCoreProps> = ({
     },
     [focusTextarea, resizeTextArea, setText, setTimeoutTimer]
   )
+
+  useEffect(() => {
+    if (wasTranslatingRef.current && !isTranslating) {
+      setTimeoutTimer('translate_refocus', () => {
+        focusTextarea()
+      }, 0)
+    }
+    wasTranslatingRef.current = isTranslating
+  }, [focusTextarea, isTranslating, setTimeoutTimer])
 
   useEffect(() => {
     const quoteListener = window.electron?.ipcRenderer.on(IpcChannel.App_QuoteToMain, (_, selectedText: string) =>


### PR DESCRIPTION


### What this PR does

Before this PR: 重构之后的 InputBar 会在翻译期间禁用文本框，导致焦点丢失，发送快捷键无法正常使用。

After this PR: 让文本框在自动翻译完成之后重新获取焦点。

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made: （由 OpenAI CodeX 编写）第一次尝试时直接单纯地调用一下 `focusTextarea()` 似乎没什么用。

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

还是那句话，我不怎么懂 TypeScript，提出这个 PR 更多的是为了尽早引起注意，以及免得到时候 upstream 更新我又要手动 resolve conflict……请各位 collaborator 雅正。

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
