### PR TITLE
fix: resolve "no such file" error when processing non-English filenames in open-mineru

### DIFF
--- a/src/main/knowledge/preprocess/OpenMineruPreprocessProvider.ts
+++ b/src/main/knowledge/preprocess/OpenMineruPreprocessProvider.ts
@@ -72,8 +72,8 @@ export default class OpenMineruPreprocessProvider extends BasePreprocessProvider
     // Find the main file after extraction
     let finalPath = ''
     let finalName = file.origin_name.replace('.pdf', '.md')
-    // Find the corresponding folder by file name
-    outputPath = path.join(outputPath, `${file.origin_name.replace('.pdf', '')}`)
+    // Find the corresponding folder by file id
+    outputPath = path.join(outputPath, file.id)
     try {
       const files = fs.readdirSync(outputPath)
 
@@ -125,7 +125,7 @@ export default class OpenMineruPreprocessProvider extends BasePreprocessProvider
     formData.append('return_md', 'true')
     formData.append('response_format_zip', 'true')
     formData.append('files', fileBuffer, {
-      filename: file.origin_name
+      filename: file.name
     })
 
     while (retries < maxRetries) {


### PR DESCRIPTION
**Due to encoding reasons, in some cases, non English PDF file names may result in ENOENT: no such file or directory errors**

> <img width="500" alt="image" src="https://github.com/user-attachments/assets/ee6612d4-1887-48bf-b47f-c2ad96cdc8a7" />
> <img width="500" alt="image" src="https://github.com/user-attachments/assets/5e80bb8b-b8e5-4dd5-a430-7de4eecd17a5" />
> <img width="500" alt="image" src="https://github.com/user-attachments/assets/e019c1f8-653e-4d8e-9157-b8c68f54be74" />
