### PR TITLE
refactor: namespace tool call ids with session id to prevent conflicts

### DIFF
--- a/src/main/services/agents/services/claudecode/__tests__/transform.test.ts
+++ b/src/main/services/agents/services/claudecode/__tests__/transform.test.ts
@@ -25,7 +25,7 @@ describe('stripLocalCommandTags', () => {
 
 describe('Claude → AiSDK transform', () => {
   it('handles tool call streaming lifecycle', () => {
-    const state = new ClaudeStreamState()
+    const state = new ClaudeStreamState({ agentSessionId: baseStreamMetadata.session_id })
     const parts: ReturnType<typeof transformSDKMessageToStreamParts>[number][] = []
 
     const messages: SDKMessage[] = [
@@ -182,14 +182,14 @@ describe('Claude → AiSDK transform', () => {
       (typeof parts)[number],
       { type: 'tool-result' }
     >
-    expect(toolResult.toolCallId).toBe('tool-1')
+    expect(toolResult.toolCallId).toBe('session-123:tool-1')
     expect(toolResult.toolName).toBe('Bash')
     expect(toolResult.input).toEqual({ command: 'ls' })
     expect(toolResult.output).toBe('ok')
   })
 
   it('handles streaming text completion', () => {
-    const state = new ClaudeStreamState()
+    const state = new ClaudeStreamState({ agentSessionId: baseStreamMetadata.session_id })
     const parts: ReturnType<typeof transformSDKMessageToStreamParts>[number][] = []
 
     const messages: SDKMessage[] = [

--- a/src/main/services/agents/services/claudecode/claude-stream-state.ts
+++ b/src/main/services/agents/services/claudecode/claude-stream-state.ts
@@ -10,7 +10,20 @@
  * Every Claude turn gets its own instance. `resetStep` should be invoked once the finish event has
  * been emitted to avoid leaking state into the next turn.
  */
+import { loggerService } from '@logger'
 import type { FinishReason, LanguageModelUsage, ProviderMetadata } from 'ai'
+
+/**
+ * Builds a namespaced tool call ID by combining session ID with raw tool call ID.
+ * This ensures tool calls from different sessions don't conflict even if they have
+ * the same raw ID from the SDK.
+ *
+ * @param sessionId - The agent session ID
+ * @param rawToolCallId - The raw tool call ID from SDK (e.g., "WebFetch_0")
+ */
+export function buildNamespacedToolCallId(sessionId: string, rawToolCallId: string): string {
+  return `${sessionId}:${rawToolCallId}`
+}
 
 /**
  * Shared fields for every block that Claude can stream (text, reasoning, tool).
@@ -34,6 +47,7 @@ type ReasoningBlockState = BaseBlockState & {
 type ToolBlockState = BaseBlockState & {
   kind: 'tool'
   toolCallId: string
+  rawToolCallId: string
   toolName: string
   inputBuffer: string
   providerMetadata?: ProviderMetadata
@@ -48,10 +62,15 @@ type PendingUsageState = {
 }
 
 type PendingToolCall = {
+  rawToolCallId: string
   toolCallId: string
   toolName: string
   input: unknown
   providerMetadata?: ProviderMetadata
+}
+
+type ClaudeStreamStateOptions = {
+  agentSessionId: string
 }
 
 /**
@@ -61,11 +80,19 @@ type PendingToolCall = {
  * usage/finish metadata once Anthropic closes a message.
  */
 export class ClaudeStreamState {
+  private logger
+  private readonly agentSessionId: string
   private blocksByIndex = new Map<number, BlockState>()
-  private toolIndexById = new Map<string, number>()
+  private toolIndexByNamespacedId = new Map<string, number>()
   private pendingUsage: PendingUsageState = {}
   private pendingToolCalls = new Map<string, PendingToolCall>()
   private stepActive = false
+
+  constructor(options: ClaudeStreamStateOptions) {
+    this.logger = loggerService.withContext('ClaudeStreamState')
+    this.agentSessionId = options.agentSessionId
+    this.logger.silly('ClaudeStreamState', options)
+  }
 
   /** Marks the beginning of a new AiSDK step. */
   beginStep(): void {
@@ -104,19 +131,21 @@ export class ClaudeStreamState {
   /** Caches tool metadata so subsequent input deltas and results can find it. */
   openToolBlock(
     index: number,
-    params: { toolCallId: string; toolName: string; providerMetadata?: ProviderMetadata }
+    params: { rawToolCallId: string; toolName: string; providerMetadata?: ProviderMetadata }
   ): ToolBlockState {
+    const toolCallId = buildNamespacedToolCallId(this.agentSessionId, params.rawToolCallId)
     const block: ToolBlockState = {
       kind: 'tool',
-      id: params.toolCallId,
+      id: toolCallId,
       index,
-      toolCallId: params.toolCallId,
+      toolCallId,
+      rawToolCallId: params.rawToolCallId,
       toolName: params.toolName,
       inputBuffer: '',
       providerMetadata: params.providerMetadata
     }
     this.blocksByIndex.set(index, block)
-    this.toolIndexById.set(params.toolCallId, index)
+    this.toolIndexByNamespacedId.set(toolCallId, index)
     return block
   }
 
@@ -125,11 +154,15 @@ export class ClaudeStreamState {
   }
 
   getToolBlockById(toolCallId: string): ToolBlockState | undefined {
-    const index = this.toolIndexById.get(toolCallId)
+    const index = this.toolIndexByNamespacedId.get(toolCallId)
     if (index === undefined) return undefined
     const block = this.blocksByIndex.get(index)
     if (!block || block.kind !== 'tool') return undefined
     return block
+  }
+
+  getToolBlockByRawId(rawToolCallId: string): ToolBlockState | undefined {
+    return this.getToolBlockById(buildNamespacedToolCallId(this.agentSessionId, rawToolCallId))
   }
 
   /** Appends streamed text to a text block, returning the updated state when present. */
@@ -158,10 +191,12 @@ export class ClaudeStreamState {
 
   /** Records a tool call to be consumed once its result arrives from the user. */
   registerToolCall(
-    toolCallId: string,
+    rawToolCallId: string,
     payload: { toolName: string; input: unknown; providerMetadata?: ProviderMetadata }
   ): void {
-    this.pendingToolCalls.set(toolCallId, {
+    const toolCallId = buildNamespacedToolCallId(this.agentSessionId, rawToolCallId)
+    this.pendingToolCalls.set(rawToolCallId, {
+      rawToolCallId,
       toolCallId,
       toolName: payload.toolName,
       input: payload.input,
@@ -170,10 +205,10 @@ export class ClaudeStreamState {
   }
 
   /** Retrieves and clears the buffered tool call metadata for the given id. */
-  consumePendingToolCall(toolCallId: string): PendingToolCall | undefined {
-    const entry = this.pendingToolCalls.get(toolCallId)
+  consumePendingToolCall(rawToolCallId: string): PendingToolCall | undefined {
+    const entry = this.pendingToolCalls.get(rawToolCallId)
     if (entry) {
-      this.pendingToolCalls.delete(toolCallId)
+      this.pendingToolCalls.delete(rawToolCallId)
     }
     return entry
   }
@@ -183,12 +218,12 @@ export class ClaudeStreamState {
    * completion so that downstream tool results can reference the original call.
    */
   completeToolBlock(toolCallId: string, input: unknown, providerMetadata?: ProviderMetadata): void {
+    const block = this.getToolBlockByRawId(toolCallId)
     this.registerToolCall(toolCallId, {
-      toolName: this.getToolBlockById(toolCallId)?.toolName ?? 'unknown',
+      toolName: block?.toolName ?? 'unknown',
       input,
       providerMetadata
     })
-    const block = this.getToolBlockById(toolCallId)
     if (block) {
       block.resolvedInput = input
     }
@@ -200,7 +235,7 @@ export class ClaudeStreamState {
     if (!block) return undefined
     this.blocksByIndex.delete(index)
     if (block.kind === 'tool') {
-      this.toolIndexById.delete(block.toolCallId)
+      this.toolIndexByNamespacedId.delete(block.toolCallId)
     }
     return block
   }
@@ -227,7 +262,7 @@ export class ClaudeStreamState {
   /** Drops cached block metadata for the currently active message. */
   resetBlocks(): void {
     this.blocksByIndex.clear()
-    this.toolIndexById.clear()
+    this.toolIndexByNamespacedId.clear()
   }
 
   /** Resets the entire step lifecycle after emitting a terminal frame. */
@@ -235,6 +270,10 @@ export class ClaudeStreamState {
     this.resetBlocks()
     this.resetPendingUsage()
     this.stepActive = false
+  }
+
+  getNamespacedToolCallId(rawToolCallId: string): string {
+    return buildNamespacedToolCallId(this.agentSessionId, rawToolCallId)
   }
 }
 

--- a/src/main/services/agents/services/claudecode/transform.ts
+++ b/src/main/services/agents/services/claudecode/transform.ts
@@ -243,9 +243,10 @@ function handleAssistantToolUse(
   state: ClaudeStreamState,
   chunks: AgentStreamPart[]
 ): void {
+  const toolCallId = state.getNamespacedToolCallId(block.id)
   chunks.push({
     type: 'tool-call',
-    toolCallId: block.id,
+    toolCallId,
     toolName: block.name,
     input: block.input,
     providerExecuted: true,
@@ -331,10 +332,11 @@ function handleUserMessage(
     if (block.type === 'tool_result') {
       const toolResult = block as ToolResultContent
       const pendingCall = state.consumePendingToolCall(toolResult.tool_use_id)
+      const toolCallId = pendingCall?.toolCallId ?? state.getNamespacedToolCallId(toolResult.tool_use_id)
       if (toolResult.is_error) {
         chunks.push({
           type: 'tool-error',
-          toolCallId: toolResult.tool_use_id,
+          toolCallId,
           toolName: pendingCall?.toolName ?? 'unknown',
           input: pendingCall?.input,
           error: toolResult.content,
@@ -343,7 +345,7 @@ function handleUserMessage(
       } else {
         chunks.push({
           type: 'tool-result',
-          toolCallId: toolResult.tool_use_id,
+          toolCallId,
           toolName: pendingCall?.toolName ?? 'unknown',
           input: pendingCall?.input,
           output: toolResult.content,
@@ -514,7 +516,7 @@ function handleContentBlockStart(
     }
     case 'tool_use': {
       const block = state.openToolBlock(index, {
-        toolCallId: contentBlock.id,
+        rawToolCallId: contentBlock.id,
         toolName: contentBlock.name,
         providerMetadata
       })

--- a/src/renderer/src/pages/home/Messages/Tools/ToolPermissionRequestCard.tsx
+++ b/src/renderer/src/pages/home/Messages/Tools/ToolPermissionRequestCard.tsx
@@ -1,7 +1,7 @@
 import type { PermissionUpdate } from '@anthropic-ai/claude-agent-sdk'
 import { loggerService } from '@logger'
 import { useAppDispatch, useAppSelector } from '@renderer/store'
-import { selectPendingPermissionByToolName, toolPermissionsActions } from '@renderer/store/toolPermissions'
+import { selectPendingPermission, toolPermissionsActions } from '@renderer/store/toolPermissions'
 import type { NormalToolResponse } from '@renderer/types'
 import { Button } from 'antd'
 import { ChevronDown, CirclePlay, CircleX } from 'lucide-react'
@@ -17,9 +17,7 @@ interface Props {
 export function ToolPermissionRequestCard({ toolResponse }: Props) {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
-  const request = useAppSelector((state) =>
-    selectPendingPermissionByToolName(state.toolPermissions, toolResponse.tool.name)
-  )
+  const request = useAppSelector((state) => selectPendingPermission(state.toolPermissions, toolResponse.toolCallId))
   const [now, setNow] = useState(() => Date.now())
   const [showDetails, setShowDetails] = useState(false)
 

--- a/src/renderer/src/store/toolPermissions.ts
+++ b/src/renderer/src/store/toolPermissions.ts
@@ -6,6 +6,7 @@ export type ToolPermissionRequestPayload = {
   requestId: string
   toolName: string
   toolId: string
+  toolCallId: string
   description?: string
   requiresPermissions: boolean
   input: Record<string, unknown>
@@ -82,12 +83,12 @@ export const selectActiveToolPermission = (state: ToolPermissionsState): ToolPer
   return activeEntries[0]
 }
 
-export const selectPendingPermissionByToolName = (
+export const selectPendingPermission = (
   state: ToolPermissionsState,
-  toolName: string
+  toolCallId: string
 ): ToolPermissionEntry | undefined => {
   const activeEntries = Object.values(state.requests)
-    .filter((entry) => entry.toolName === toolName)
+    .filter((entry) => entry.toolCallId === toolCallId)
     .filter(
       (entry) => entry.status === 'pending' || entry.status === 'submitting-allow' || entry.status === 'submitting-deny'
     )


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

⚠️ Important: Redux/IndexedDB Data-Changing Feature PRs Temporarily On Hold ⚠️

Please note: For our current development cycle, we are not accepting feature Pull Requests that introduce changes to Redux data models or IndexedDB schemas.

While we value your contributions, PRs of this nature will be blocked without merge. We welcome all other contributions (bug fixes, perf enhancements, docs, etc.). Thank you!

Once version 2.0.0 is released, we will resume reviewing feature PRs.

-->

### What this PR does
This PR introduces session-scoped namespacing for tool call IDs to prevent conflicts when multiple agent sessions run concurrently. Tool call IDs now follow the format `${sessionId}:${rawToolCallId}` instead of just raw IDs, fixing issues where tool results and permission requests could be incorrectly matched across different sessions.

Before this PR:
  - Tool call IDs could conflict across different agent sessions
  - Tool results were matched by raw ID, causing results to be delivered to wrong sessions
  - Permission requests were matched by `toolName`, which could lead to incorrect tool call matching
  - Tool call ID format was simple like `WebFetch_0`, `WebFetch_1`, etc. Which leads to result

After this PR:
  - Tool call IDs are namespaced with session ID, format: `${sessionId}:${rawToolCallId}`
  - Tool results are correctly matched to their originating session
  - Permission requests use precise `toolCallId` for matching, avoiding confusion

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

### Special notes for your reviewer

**How to Test This Change**
1. Open two agent sessions (preferably using the default permission mode).
1. In both sessions, invoke the same tool at roughly the same time.
    - It’s best to use a long-running command such as WebFetch.
    - Example prompt: `Use WebFetch to explain this repository: https://github.com/CherryHQ/cherry-studio`
1. In one session allow the tool call, and in the other deny it.
1. Observe whether the subsequent responses in each session behave as expected.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->

```release-note

```
