### PR TITLE
fix(i18n): add input placeholder translations for multiple languages

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -27,6 +27,9 @@
         "null_id": "Agent ID is null."
       }
     },
+    "input": {
+      "placeholder": "Enter your message here, send with {{key}} - @ select path, / select command"
+    },
     "list": {
       "error": {
         "failed": "Failed to list agents."

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -27,6 +27,9 @@
         "null_id": "智能体 ID 为空。"
       }
     },
+    "input": {
+      "placeholder": "在这里输入消息，按 {{key}} 发送 - @ 选择路径， / 选择命令"
+    },
     "list": {
       "error": {
         "failed": "获取智能体列表失败"

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -27,6 +27,9 @@
         "null_id": "代理程式 ID 為空。"
       }
     },
+    "input": {
+      "placeholder": "[to be translated]:Enter your message here, send with {{key}} - @ select path, / select command"
+    },
     "list": {
       "error": {
         "failed": "無法列出代理程式。"

--- a/src/renderer/src/i18n/translate/de-de.json
+++ b/src/renderer/src/i18n/translate/de-de.json
@@ -27,6 +27,9 @@
         "null_id": "Agent ID ist leer."
       }
     },
+    "input": {
+      "placeholder": "[to be translated]:Enter your message here, send with {{key}} - @ select path, / select command"
+    },
     "list": {
       "error": {
         "failed": "Agent-Liste abrufen fehlgeschlagen"

--- a/src/renderer/src/i18n/translate/el-gr.json
+++ b/src/renderer/src/i18n/translate/el-gr.json
@@ -27,6 +27,9 @@
         "null_id": "Το ID του πράκτορα είναι null."
       }
     },
+    "input": {
+      "placeholder": "[to be translated]:Enter your message here, send with {{key}} - @ select path, / select command"
+    },
     "list": {
       "error": {
         "failed": "Αποτυχία καταχώρησης πρακτόρων."

--- a/src/renderer/src/i18n/translate/es-es.json
+++ b/src/renderer/src/i18n/translate/es-es.json
@@ -27,6 +27,9 @@
         "null_id": "El ID del agente es nulo."
       }
     },
+    "input": {
+      "placeholder": "[to be translated]:Enter your message here, send with {{key}} - @ select path, / select command"
+    },
     "list": {
       "error": {
         "failed": "Error al listar agentes."

--- a/src/renderer/src/i18n/translate/fr-fr.json
+++ b/src/renderer/src/i18n/translate/fr-fr.json
@@ -27,6 +27,9 @@
         "null_id": "L'ID de l'agent est nul."
       }
     },
+    "input": {
+      "placeholder": "[to be translated]:Enter your message here, send with {{key}} - @ select path, / select command"
+    },
     "list": {
       "error": {
         "failed": "Échec de la liste des agents."

--- a/src/renderer/src/i18n/translate/ja-jp.json
+++ b/src/renderer/src/i18n/translate/ja-jp.json
@@ -27,6 +27,9 @@
         "null_id": "エージェント ID が null です。"
       }
     },
+    "input": {
+      "placeholder": "[to be translated]:Enter your message here, send with {{key}} - @ select path, / select command"
+    },
     "list": {
       "error": {
         "failed": "エージェントの一覧取得に失敗しました。"

--- a/src/renderer/src/i18n/translate/pt-pt.json
+++ b/src/renderer/src/i18n/translate/pt-pt.json
@@ -27,6 +27,9 @@
         "null_id": "O ID do agente é nulo."
       }
     },
+    "input": {
+      "placeholder": "[to be translated]:Enter your message here, send with {{key}} - @ select path, / select command"
+    },
     "list": {
       "error": {
         "failed": "Falha ao listar agentes."

--- a/src/renderer/src/i18n/translate/ru-ru.json
+++ b/src/renderer/src/i18n/translate/ru-ru.json
@@ -27,6 +27,9 @@
         "null_id": "ID агента равен null."
       }
     },
+    "input": {
+      "placeholder": "[to be translated]:Enter your message here, send with {{key}} - @ select path, / select command"
+    },
     "list": {
       "error": {
         "failed": "Не удалось получить список агентов."

--- a/src/renderer/src/pages/home/Inputbar/AgentSessionInputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/AgentSessionInputbar.tsx
@@ -470,7 +470,7 @@ const AgentSessionInputbarInner: FC<InnerProps> = ({ assistant, agentId, session
   )
   const placeholderText = useMemo(
     () =>
-      t('chat.input.placeholder', {
+      t('agent.input.placeholder', {
         key: getSendMessageShortcutLabel(sendMessageShortcut)
       }),
     [sendMessageShortcut, t]


### PR DESCRIPTION
bug:

<img width="768" height="194" alt="image" src="https://github.com/user-attachments/assets/ffd07fd5-aa13-4b3f-8b98-98cfff711ffb" />




fixed:

<img width="577" height="148" alt="image" src="https://github.com/user-attachments/assets/5749fa5c-d1c3-488b-baf1-7c08f750a147" />
