### PR TITLE
fix: fix api-host for vercel ai-gateway provider

### DIFF
--- a/src/renderer/src/config/providers.ts
+++ b/src/renderer/src/config/providers.ts
@@ -684,7 +684,7 @@ export const SYSTEM_PROVIDERS_CONFIG: Record<SystemProviderId, SystemProvider> =
     name: 'AI Gateway',
     type: 'ai-gateway',
     apiKey: '',
-    apiHost: 'https://ai-gateway.vercel.sh/v1',
+    apiHost: 'https://ai-gateway.vercel.sh/v1/ai',
     models: [],
     isSystem: true,
     enabled: false


### PR DESCRIPTION
according to the doc for 'ai-gateaway' provider of ai-sdk. the baseURL should be: https://ai-gateway.vercel.sh/v1/ai

https://ai-sdk.dev/providers/ai-sdk-providers/ai-gateway