### PR TITLE
fix(conversation): set context length to 1 for gemini-2.5-flash-image model

### DIFF
--- a/src/renderer/src/aiCore/utils/image.ts
+++ b/src/renderer/src/aiCore/utils/image.ts
@@ -14,3 +14,7 @@ export function isOpenRouterGeminiGenerateImageModel(model: Model, provider: Pro
     provider.id === SystemProviderIds.openrouter
   )
 }
+
+export function isGeminiGenerateImageModel(model: Model): boolean {
+  return model.id.includes('gemini-2.5-flash-image')
+}


### PR DESCRIPTION
## Summary

- Fixed continuous conversation failures for the gemini-2.5-flash-image (Nano Banana) model by setting its context length to 1
- Added `isGeminiGenerateImageModel` utility function to identify Nano Banana models
- This ensures the model only receives the most recent message, preventing context-related errors

## Changes

- Added new utility function `isGeminiGenerateImageModel` in [image.ts](src/renderer/src/aiCore/utils/image.ts#L18)
- Modified `ConversationService.prepareMessages` to override `contextCount` to 1 for gemini-2.5-flash-image models in [ConversationService.ts](src/renderer/src/services/ConversationService.ts#L25-L27)
- Removed the previous `+2` offset from the final `takeRight` call to align with the new contextCount handling

## Test Plan

- [ ] Test continuous conversations with gemini-2.5-flash-image model
- [ ] Verify that conversations no longer fail after the first message
- [ ] Confirm that other models are not affected by this change
- [ ] Run `yarn build:check` to ensure no lint/type errors