### PR TITLE
feat(options): enhance provider key handling for cherryin in buildPro…

### DIFF
--- a/src/renderer/src/aiCore/utils/options.ts
+++ b/src/renderer/src/aiCore/utils/options.ts
@@ -162,12 +162,16 @@ export function buildProviderOptions(
     ...getCustomParameters(assistant)
   }
 
-  const rawProviderKey =
+  let rawProviderKey =
     {
       'google-vertex': 'google',
       'google-vertex-anthropic': 'anthropic',
       'ai-gateway': 'gateway'
     }[rawProviderId] || rawProviderId
+
+  if (rawProviderKey === 'cherryin') {
+    rawProviderKey = { gemini: 'google' }[actualProvider.type] || actualProvider.type
+  }
 
   // 返回 AI Core SDK 要求的格式：{ 'providerId': providerOptions }
   return {


### PR DESCRIPTION
before:
```js
providerOptions:{
  cherryin:{
    xxx:xxx
  }
}
```
无法正确的传递参数

**after:** 
```js
providerOptions:{
 [openai | google | anthropic]:{
    xxx:xxx
  }
}
```