### PR TITLE
refactor: simplify agent creation form

### DIFF
--- a/src/renderer/src/components/Popups/agent/AgentModal.tsx
+++ b/src/renderer/src/components/Popups/agent/AgentModal.tsx
@@ -97,12 +97,12 @@ const PopupContainer: React.FC<Props> = ({ agent, afterSubmit, resolve }) => {
     }))
   }, [])
 
-  const onDescChange = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
-    setForm((prev) => ({
-      ...prev,
-      description: e.target.value
-    }))
-  }, [])
+  // const onDescChange = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
+  //   setForm((prev) => ({
+  //     ...prev,
+  //     description: e.target.value
+  //   }))
+  // }, [])
 
   const onInstChange = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
     setForm((prev) => ({
@@ -369,10 +369,10 @@ const PopupContainer: React.FC<Props> = ({ agent, afterSubmit, resolve }) => {
               <TextArea rows={3} value={form.instructions ?? ''} onChange={onInstChange} />
             </FormItem>
 
-            <FormItem>
+            {/* <FormItem>
               <Label>{t('common.description')}</Label>
               <TextArea rows={1} value={form.description ?? ''} onChange={onDescChange} />
-            </FormItem>
+            </FormItem> */}
           </FormContent>
 
           <FormFooter>

--- a/src/renderer/src/pages/settings/AgentSettings/EssentialSettings.tsx
+++ b/src/renderer/src/pages/settings/AgentSettings/EssentialSettings.tsx
@@ -1,21 +1,13 @@
-import { getAgentTypeAvatar } from '@renderer/config/agent'
 import type { useUpdateAgent } from '@renderer/hooks/agents/useUpdateAgent'
 import type { useUpdateSession } from '@renderer/hooks/agents/useUpdateSession'
-import { getAgentTypeLabel } from '@renderer/i18n/label'
 import type { GetAgentResponse, GetAgentSessionResponse } from '@renderer/types'
-import { isAgentEntity } from '@renderer/types'
-import { Avatar } from 'antd'
 import type { FC } from 'react'
-import { useTranslation } from 'react-i18next'
 
 import { AccessibleDirsSetting } from './AccessibleDirsSetting'
-import { AvatarSetting } from './AvatarSetting'
 import { DescriptionSetting } from './DescriptionSetting'
 import { ModelSetting } from './ModelSetting'
 import { NameSetting } from './NameSetting'
-import { SettingsContainer, SettingsItem, SettingsTitle } from './shared'
-
-// const logger = loggerService.withContext('AgentEssentialSettings')
+import { SettingsContainer } from './shared'
 
 type EssentialSettingsProps =
   | {
@@ -30,26 +22,10 @@ type EssentialSettingsProps =
     }
 
 const EssentialSettings: FC<EssentialSettingsProps> = ({ agentBase, update, showModelSetting = true }) => {
-  const { t } = useTranslation()
-
   if (!agentBase) return null
-
-  const isAgent = isAgentEntity(agentBase)
 
   return (
     <SettingsContainer>
-      {isAgent && (
-        <SettingsItem inline>
-          <SettingsTitle>{t('agent.type.label')}</SettingsTitle>
-          <div className="flex items-center gap-2">
-            <Avatar size={24} src={getAgentTypeAvatar(agentBase.type)} className="h-6 w-6 text-lg" />
-            <span>{(agentBase?.name ?? agentBase?.type) ? getAgentTypeLabel(agentBase.type) : ''}</span>
-          </div>
-        </SettingsItem>
-      )}
-      {isAgent && (
-        <AvatarSetting agent={agentBase} update={update as ReturnType<typeof useUpdateAgent>['updateAgent']} />
-      )}
       <NameSetting base={agentBase} update={update} />
       {showModelSetting && <ModelSetting base={agentBase} update={update} />}
       <AccessibleDirsSetting base={agentBase} update={update} />

--- a/src/renderer/src/pages/settings/AgentSettings/NameSetting.tsx
+++ b/src/renderer/src/pages/settings/AgentSettings/NameSetting.tsx
@@ -1,6 +1,8 @@
+import { EmojiAvatarWithPicker } from '@renderer/components/Avatar/EmojiAvatarWithPicker'
 import type { AgentBaseWithId, UpdateAgentBaseForm, UpdateAgentFunctionUnion } from '@renderer/types'
+import { AgentConfigurationSchema, isAgentEntity, isAgentType } from '@renderer/types'
 import { Input } from 'antd'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { SettingsItem, SettingsTitle } from './shared'
@@ -13,26 +15,61 @@ export interface NameSettingsProps {
 export const NameSetting = ({ base, update }: NameSettingsProps) => {
   const { t } = useTranslation()
   const [name, setName] = useState<string | undefined>(base?.name?.trim())
+
   const updateName = async (name: UpdateAgentBaseForm['name']) => {
     if (!base) return
     return update({ id: base.id, name: name?.trim() })
   }
+
+  // Avatar logic
+  const isAgent = isAgentEntity(base)
+  const isDefault = isAgent ? isAgentType(base.configuration?.avatar) : false
+  const [emoji, setEmoji] = useState(isAgent && !isDefault ? (base.configuration?.avatar ?? '⭐️') : '⭐️')
+
+  const updateAvatar = useCallback(
+    (avatar: string) => {
+      if (!isAgent || !base) return
+      const parsedConfiguration = AgentConfigurationSchema.parse(base.configuration ?? {})
+      const payload = {
+        id: base.id,
+        configuration: {
+          ...parsedConfiguration,
+          avatar
+        }
+      }
+      update(payload)
+    },
+    [base, update, isAgent]
+  )
+
   if (!base) return null
 
   return (
     <SettingsItem inline>
       <SettingsTitle>{t('common.name')}</SettingsTitle>
-      <Input
-        placeholder={t('common.agent_one') + t('common.name')}
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        onBlur={() => {
-          if (name !== base.name) {
-            updateName(name)
-          }
-        }}
-        className="max-w-70 flex-1"
-      />
+      <div className="flex max-w-70 flex-1 items-center gap-1">
+        {isAgent && (
+          <EmojiAvatarWithPicker
+            emoji={emoji}
+            onPick={(emoji: string) => {
+              setEmoji(emoji)
+              if (isAgent && emoji === base?.configuration?.avatar) return
+              updateAvatar(emoji)
+            }}
+          />
+        )}
+        <Input
+          placeholder={t('common.agent_one') + t('common.name')}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onBlur={() => {
+            if (name !== base.name) {
+              updateName(name)
+            }
+          }}
+          className="flex-1"
+        />
+      </div>
     </SettingsItem>
   )
 }


### PR DESCRIPTION
## Summary
- Simplify agent creation form and settings interface for better UX

## Changes
- **Agent Creation Form**: 
  - Removed agent type selector (defaulting to 'claude-code')
  - Description field no longer shown by default in creation form
  - Simplified form layout and styling

- **Agent Settings Interface**:
  - Avatar and name input now displayed on the same row for a more compact layout
  - Removed agent type display (no longer showing "Claude Code" label)
  - Streamlined settings UI

<img width="550" height="596" alt="image" src="https://github.com/user-attachments/assets/6da7ad65-8845-4925-9d24-bd7d923907dc" />

## Test Plan
- [x] Test agent creation with simplified form
- [x] Test agent settings UI with combined avatar/name row
- [x] Verify session creation works correctly
- [x] Test existing agents still work after migration