### PR TITLE
fix: remove light background from MCP NpxUv install alerts

### DIFF
--- a/src/renderer/src/pages/settings/MCPSettings/InstallNpxUv.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/InstallNpxUv.tsx
@@ -109,7 +109,6 @@ const InstallNpxUv: FC<Props> = ({ mini = false }) => {
     <Container>
       <Alert
         type={isUvInstalled ? 'success' : 'warning'}
-        banner
         style={{ borderRadius: 'var(--list-item-border-radius)' }}
         description={
           <VStack>
@@ -140,7 +139,6 @@ const InstallNpxUv: FC<Props> = ({ mini = false }) => {
       />
       <Alert
         type={isBunInstalled ? 'success' : 'warning'}
-        banner
         style={{ borderRadius: 'var(--list-item-border-radius)' }}
         description={
           <VStack>

--- a/src/renderer/src/pages/settings/MCPSettings/index.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/index.tsx
@@ -140,7 +140,7 @@ const MCPSettings: FC = () => {
             <Route
               path="mcp-install"
               element={
-                <SettingContainer theme={theme}>
+                <SettingContainer style={{ backgroundColor: 'inherit' }}>
                   <InstallNpxUv />
                 </SettingContainer>
               }


### PR DESCRIPTION
## Summary
- Remove 'banner' prop from Alert components in InstallNpxUv to fix light background issue
- Set SettingContainer background to 'inherit' in MCP settings route
- Resolves the visual inconsistency where NpxUv interface had an unwanted light background

Before:

<img width="1376" height="1019" alt="image" src="https://github.com/user-attachments/assets/87fe4726-a950-4bfe-ad93-d8fe8b27b805" />

After:

<img width="1376" height="1019" alt="image" src="https://github.com/user-attachments/assets/e14ca0c1-4e1d-45b2-be04-c4ff8ad656d8" />


## Test plan
- [x] Run the app in development mode
- [x] Navigate to Settings > MCP > Install tab
- [x] Verify that the NpxUv install alerts no longer have a light background
- [x] Verify that the alerts maintain proper styling and readability
- [x] Test in both light and dark themes