### PR TITLE
fix: prevent EventEmitter memory leak in useApiServer hook

### DIFF
--- a/src/renderer/src/hooks/useApiServer.ts
+++ b/src/renderer/src/hooks/useApiServer.ts
@@ -1,10 +1,30 @@
 import { loggerService } from '@logger'
 import { useAppDispatch, useAppSelector } from '@renderer/store'
 import { setApiServerEnabled as setApiServerEnabledAction } from '@renderer/store/settings'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 const logger = loggerService.withContext('useApiServer')
+
+// Module-level single instance subscription to prevent EventEmitter memory leak
+// Only one IPC listener will be registered regardless of how many components use this hook
+const onReadyCallbacks = new Set<() => void>()
+let removeIpcListener: (() => void) | null = null
+
+const ensureIpcSubscribed = () => {
+  if (!removeIpcListener) {
+    removeIpcListener = window.api.apiServer.onReady(() => {
+      onReadyCallbacks.forEach((cb) => cb())
+    })
+  }
+}
+
+const cleanupIpcIfEmpty = () => {
+  if (onReadyCallbacks.size === 0 && removeIpcListener) {
+    removeIpcListener()
+    removeIpcListener = null
+  }
+}
 
 export const useApiServer = () => {
   const { t } = useTranslation()
@@ -102,15 +122,28 @@ export const useApiServer = () => {
     checkApiServerStatus()
   }, [checkApiServerStatus])
 
-  // Listen for API server ready event
+  // Use ref to keep the latest checkApiServerStatus without causing re-subscription
+  const checkStatusRef = useRef(checkApiServerStatus)
   useEffect(() => {
-    const cleanup = window.api.apiServer.onReady(() => {
-      logger.info('API server ready event received, checking status')
-      checkApiServerStatus()
-    })
+    checkStatusRef.current = checkApiServerStatus
+  })
 
-    return cleanup
-  }, [checkApiServerStatus])
+  // Create stable callback for the single instance subscription
+  const handleReady = useCallback(() => {
+    logger.info('API server ready event received, checking status')
+    checkStatusRef.current()
+  }, [])
+
+  // Listen for API server ready event using single instance subscription
+  useEffect(() => {
+    ensureIpcSubscribed()
+    onReadyCallbacks.add(handleReady)
+
+    return () => {
+      onReadyCallbacks.delete(handleReady)
+      cleanupIpcIfEmpty()
+    }
+  }, [handleReady])
 
   return {
     apiServerConfig,


### PR DESCRIPTION
## Summary
- Fixes MaxListenersExceededWarning caused by multiple IPC listener registrations
- Implements single instance subscription pattern to keep listener count at 1
- Maintains existing behavior while preventing memory leak warnings

## Problem
Previously, each component using `useApiServer` hook would register a separate `api-server:ready` IPC listener. With 5+ components using this hook plus React strict mode double rendering, the listener count quickly exceeded the default limit of 10, triggering:
```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 
11 api-server:ready listeners added to [IpcRenderer]. MaxListeners is 10.
```

## Solution
Implemented a module-level subscription manager that:
- Registers only one IPC listener regardless of how many components use the hook
- Uses a `Set<() => void>` to track all component callbacks
- Automatically subscribes/unsubscribes the IPC listener based on active components
- Uses `useRef` to maintain stable callback references without causing re-subscriptions

## Changes
- Added module-level `onReadyCallbacks` Set and `removeIpcListener` state
- Added `ensureIpcSubscribed()` and `cleanupIpcIfEmpty()` helper functions
- Modified `useEffect` to use single instance subscription pattern
- Used `useRef` to keep latest `checkApiServerStatus` reference

## Test plan
- [ ] Start the application and verify no MaxListenersExceededWarning appears
- [ ] Open multiple views that use useApiServer hook (Settings, Assistants Tab, etc.)
- [ ] Verify API server status updates correctly across all components
- [ ] Test start/stop/restart API server functionality
- [ ] Verify cleanup works correctly when components unmount

🤖 Generated with [Claude Code](https://claude.com/claude-code)