### PR TITLE
fix: [macOS] hide from dock when displaying in tray

### DIFF
--- a/src/main/services/WindowService.ts
+++ b/src/main/services/WindowService.ts
@@ -378,12 +378,6 @@ export class WindowService {
       //for mac users, should hide dock icon if close to tray
       if (isMac && isTrayOnClose) {
         app.dock?.hide()
-
-        mainWindow.once('show', () => {
-          //restore the window can hide by cmd+h when the window is shown again
-          // https://github.com/electron/electron/pull/47970
-          app.dock?.show()
-        })
       }
     })
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

⚠️ Important: Redux/IndexedDB Data-Changing Feature PRs Temporarily On Hold ⚠️

Please note: For our current development cycle, we are not accepting feature Pull Requests that introduce changes to Redux data models or IndexedDB schemas.

While we value your contributions, PRs of this nature will be blocked without merge. We welcome all other contributions (bug fixes, perf enhancements, docs, etc.). Thank you!

Once version 2.0.0 is released, we will resume reviewing feature PRs.

-->

### What this PR does

Before this PR: On macOS, when the application window was closed (minimised to the tray), the Dock icon remained visible, cluttering the Dock even when the app was running in the background.

After this PR: On macOS, when the application window is closed to the tray, the Dock icon is automatically hidden. It reappears immediately when the main window is shown again. 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

There is a "start to the tray" option that hides the application icon from the dock. However, in every other scenario, the icon remains visible in the dock. Moreover, it’s unclear why the application needs to appear in the dock at all when it is already present in the tray. (Guess it can be a bug?)

The following tradeoffs were made: It is just a UX issue.

The following alternatives were considered: Unsure. Seems none.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

None.

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
fix: [macOS] App icon now automatically hides from the Dock when the window is closed to the tray.
```
