### PR TITLE
fix: respect enableMaxTokens setting when maxTokens is not configured

### DIFF
--- a/src/renderer/src/aiCore/prepareParams/modelParameters.ts
+++ b/src/renderer/src/aiCore/prepareParams/modelParameters.ts
@@ -73,11 +73,12 @@ export function getTimeout(model: Model): number {
 export function getMaxTokens(assistant: Assistant, model: Model): number | undefined {
   // NOTE: ai-sdk会把maxToken和budgetToken加起来
   const assistantSettings = getAssistantSettings(assistant)
+  const enabledMaxTokens = assistantSettings.enableMaxTokens ?? false
   let maxTokens = assistantSettings.maxTokens
 
   // If user hasn't enabled enableMaxTokens, return undefined to let the API use its default value.
   // Note: Anthropic API requires max_tokens, but that's handled by the Anthropic client with a fallback.
-  if (maxTokens === undefined) {
+  if (!enabledMaxTokens || maxTokens === undefined) {
     return undefined
   }
 


### PR DESCRIPTION
## Summary

- Fix regression where all conversations were limited to 4096 tokens even when `enableMaxTokens` was disabled
- Return `undefined` from `getMaxTokens()` when user hasn't enabled the setting, allowing APIs to use their own defaults

## Problem

After upgrading to v1.7.0-rc.2, users reported that conversations were being limited to 4096 tokens by default, even when they hadn't configured any `max_tokens` setting. This behavior differs from previous versions.

### Root Cause

The issue was introduced in commit `49903a156` (Test/ai-core #11307) which added the `getMaxTokens()` function in `modelParameters.ts`:

```typescript
export function getMaxTokens(assistant: Assistant, model: Model): number | undefined {
  let { maxTokens = DEFAULT_MAX_TOKENS } = getAssistantSettings(assistant)
  // ...
  return maxTokens
}
```

When `enableMaxTokens` is `false`, `getAssistantSettings()` correctly returns `maxTokens: undefined`. However, the destructuring assignment with a default value (`= DEFAULT_MAX_TOKENS`) converts this `undefined` to `4096`, causing all API requests to include `max_tokens: 4096`.

### Expected Behavior (Previous Versions)

In `AssistantService.ts`, the `getAssistantSettings()` function handles this correctly:
- When `enableMaxTokens: false` → returns `undefined` → API uses its own default
- When `enableMaxTokens: true` → returns user-configured value or fallback

Different API providers handle `undefined` appropriately:
- **OpenAI**: Passes `undefined`, letting the API decide the default
- **Anthropic**: Uses `maxTokens || DEFAULT_MAX_TOKENS` as a fallback (since Anthropic API requires `max_tokens`)

## Solution

Modified `getMaxTokens()` to return `undefined` when the user hasn't enabled `enableMaxTokens`, preserving the original behavior where each API provider can handle the default value appropriately.

```typescript
export function getMaxTokens(assistant: Assistant, model: Model): number | undefined {
  const assistantSettings = getAssistantSettings(assistant)
  let maxTokens = assistantSettings.maxTokens

  // If user hasn't enabled enableMaxTokens, return undefined to let the API use its default value.
  if (maxTokens === undefined) {
    return undefined
  }
  // ... rest of the function
}
```

## Test plan

- [ ] Verify that conversations without `enableMaxTokens` enabled no longer force 4096 tokens
- [ ] Verify that OpenAI models use the API's default max_tokens when not configured
- [ ] Verify that Anthropic models still work correctly (they require max_tokens, handled by client fallback)
- [ ] Verify that explicitly configured max_tokens values are still respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)