### PR TITLE
fix: correct updateAssistantPreset reducer to properly update preset

### DIFF
--- a/src/renderer/src/store/assistants.ts
+++ b/src/renderer/src/store/assistants.ts
@@ -202,11 +202,10 @@ const assistantsSlice = createSlice({
     },
     updateAssistantPreset: (state, action: PayloadAction<AssistantPreset>) => {
       const preset = action.payload
-      state.presets.forEach((a) => {
-        if (a.id === preset.id) {
-          a = preset
-        }
-      })
+      const index = state.presets.findIndex((a) => a.id === preset.id)
+      if (index !== -1) {
+        state.presets[index] = preset
+      }
     },
     updateAssistantPresetSettings: (
       state,


### PR DESCRIPTION
## Summary
- Fixed `updateAssistantPreset` reducer in `src/renderer/src/store/assistants.ts` that was not actually updating the preset
- The bug: using `a = preset` inside `forEach` only reassigns the local variable, not the array element
- The fix: use `findIndex` + direct array index assignment to properly update the preset

## Root Cause
```typescript
// Before (broken)
state.presets.forEach((a) => {
  if (a.id === preset.id) {
    a = preset  // ❌ Only reassigns local variable
  }
})

// After (fixed)
const index = state.presets.findIndex((a) => a.id === preset.id)
if (index !== -1) {
  state.presets[index] = preset  // ✅ Actually updates the array
}
```

## Test plan
- [ ] Verify model settings changes persist after updating an assistant preset

Fixes #11451

🤖 Generated with [Claude Code](https://claude.com/claude-code)