### PR TITLE
docs: enhance CLAUDE.md with quality guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ This file provides guidance to AI coding assistants when working with code in th
 - **Always propose before executing**: Before making any changes, clearly explain your planned approach and wait for explicit user approval to ensure alignment and prevent unwanted modifications.
 - **Lint, test, and format before completion**: Coding tasks are only complete after running `yarn lint`, `yarn test`, and `yarn format` successfully.
 - **Write conventional commits**: Commit small, focused changes using Conventional Commit messages (e.g., `feat:`, `fix:`, `refactor:`, `docs:`).
+- **Follow PR template**: When submitting pull requests, follow the template in `.github/pull_request_template.md` to ensure complete context and documentation.
 
 ## Development Commands
 


### PR DESCRIPTION
### What this PR does

Before this PR:
- CLAUDE.md lacked explicit guidance on code quality checks before task completion
- No reminder about following PR template when submitting changes

After this PR:
- Added principle requiring `yarn lint`, `yarn test`, and `yarn format` to pass before coding tasks are complete
- Added principle to follow `.github/pull_request_template.md` when submitting PRs
- Ensures consistent code quality and complete PR documentation

Fixes #

### Why we need it and why it was done in this way

These additions improve the AI assistant's behavior by:
1. Enforcing quality gates (lint/test/format) before completing tasks
2. Ensuring PRs provide complete context via the template

The following tradeoffs were made:
- None - these are additive guidelines that improve quality

The following alternatives were considered:
- Could have added these to a separate checklist file, but CLAUDE.md is the central guidance document

Links to places where the discussion took place: N/A

### Breaking changes

None - this only adds documentation guidance.

### Special notes for your reviewer

This PR only modifies documentation (CLAUDE.md) and does not change any code behavior directly. It will influence how AI assistants interact with the codebase going forward.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present or not required

### Release note

```release-note
NONE
```