### PR TITLE
fix(i18n): clean up translation tags and untranslated strings

### DIFF
--- a/src/renderer/src/i18n/translate/ja-jp.json
+++ b/src/renderer/src/i18n/translate/ja-jp.json
@@ -893,7 +893,7 @@
         "title": "コード実行"
       },
       "code_fancy_block": {
-        "label": "<translate_input>\n装飾的なコードブロック\n</translate_input>",
+        "label": "装飾的なコードブロック",
         "tip": "より見栄えの良いコードブロックスタイルを使用する、例えばHTMLカード"
       },
       "code_image_tools": {
@@ -1297,7 +1297,7 @@
     "statusCode": "ステータスコード",
     "statusText": "状態テキスト",
     "text": "テキスト",
-    "toolInput": "<translate_input>\nツール入力\n</translate_input>",
+    "toolInput": "ツール入力",
     "toolName": "ツール名",
     "unknown": "不明なエラー",
     "usage": "用量",

--- a/src/renderer/src/i18n/translate/ru-ru.json
+++ b/src/renderer/src/i18n/translate/ru-ru.json
@@ -1514,7 +1514,7 @@
       "preprocessing_tooltip": "Предварительная обработка документов",
       "title": "Настройки базы знаний"
     },
-    "sitemap_added": "添加成功",
+    "sitemap_added": "Карта сайта добавлена",
     "sitemap_placeholder": "Введите URL карты сайта",
     "sitemaps": "Сайты",
     "source": "Источник",
@@ -2174,12 +2174,12 @@
         "font_size": "Размер шрифта",
         "font_size_description": "Отрегулируйте размер шрифта для лучшего чтения (10–30 пикселей)",
         "font_size_large": "Большой",
-        "font_size_medium": "中",
-        "font_size_small": "<translate_input>\nмаленький\n</translate_input>",
+        "font_size_medium": "Средний",
+        "font_size_small": "маленький",
         "font_title": "Настройки шрифта",
         "serif_font": "Serif Font",
         "show_table_of_contents": "Показать оглавление",
-        "show_table_of_contents_description": "显示目录大纲侧边栏，方便文档内导航",
+        "show_table_of_contents_description": "Показать боковую панель оглавления для удобной навигации по документу",
         "title": "показывать"
       },
       "editor": {
@@ -4775,7 +4775,7 @@
         }
       },
       "prompt": "Следуйте системному запросу",
-      "title": "翻译设置"
+      "title": "Настройки перевода"
     },
     "tray": {
       "onclose": "Свернуть в трей при закрытии",


### PR DESCRIPTION
## Summary
- Remove `<translate_input>` tags from ja-jp.json translation strings
- Fix untranslated Chinese strings in ru-ru.json
- Improve translation quality for Japanese and Russian locales

## Changes
### Japanese (ja-jp.json)
- Cleaned up `<translate_input>` tags in:
  - Code fancy block label
  - Tool input error message

### Russian (ru-ru.json)
- Translated remaining Chinese strings:
  - "添加成功" → "Карта сайта добавлена" (sitemap added)
  - "中" → "Средний" (medium font size)
  - Font size small label
  - Table of contents description
  - Translation settings title

## Test plan
- [x] Verified translation strings are properly formatted
- [x] Checked that no `<translate_input>` tags remain in affected files
- [x] Ensured all Chinese strings in ru-ru.json are translated

🤖 Generated with [Claude Code](https://claude.com/claude-code)