### PR TITLE
fix: silicon provider code list

### DIFF
--- a/src/renderer/src/pages/code/index.ts
+++ b/src/renderer/src/pages/code/index.ts
@@ -33,9 +33,8 @@ export const CLAUDE_OFFICIAL_SUPPORTED_PROVIDERS = [
   'modelscope',
   'minimax',
   'longcat',
-  SystemProviderIds.qiniu
-  // If silicon is in this list, the fallback logic above will return true for all silicon models,
-  // potentially bypassing the specific model filtering you added above.
+  SystemProviderIds.qiniu,
+  SystemProviderIds.silicon
 ]
 export const CLAUDE_SUPPORTED_PROVIDERS = [
   'aihubmix',


### PR DESCRIPTION
CLAUDE_OFFICIAL_SUPPORTED_PROVIDERS 用来展示list的，和前面的model predicate无关


<img width="800" height="632" alt="image" src="https://github.com/user-attachments/assets/f2087516-696f-4c16-b883-db4510273a42" />
