### PR TITLE
fix: inconsistent text color in release notes last line

### DIFF
--- a/src/renderer/src/pages/settings/AboutSettings.tsx
+++ b/src/renderer/src/pages/settings/AboutSettings.tsx
@@ -404,11 +404,11 @@ const UpdateNotesWrapper = styled.div`
   margin: 8px 0;
   background-color: var(--color-bg-2);
   border-radius: 6px;
+  color: var(--color-text-2);
+  font-size: 14px;
 
   p {
     margin: 0;
-    color: var(--color-text-2);
-    font-size: 14px;
   }
 `
 


### PR DESCRIPTION
## Summary

- Fix the last line of release notes displaying with a darker color than other lines in the About settings page
- Move `color` and `font-size` styles from `p` selector to container level in `UpdateNotesWrapper`

<img width="500" height="558" alt="image" src="https://github.com/user-attachments/assets/96f68779-a9a5-4061-8483-ce7ce675420f" />

## Root Cause

The `.replace(/\n/g, '\n\n')` transformation creates a "loose list" in Markdown. In loose lists, most list items get wrapped in `<p>` tags, but the last item (without a trailing newline) may not be wrapped. This caused it to inherit a different color from the parent `.markdown` class instead of using the `var(--color-text-2)` defined only for `p` elements.

## Solution

Apply `color` and `font-size` at the container level so all child elements (both `<p>` and `<li>`) inherit the same styling.

## Test Plan

- [x] Check the About settings page when a new version is available
- [x] Verify all lines in release notes have consistent text color

🤖 Generated with [Claude Code](https://claude.com/claude-code)