### PR TITLE
fix(code-tools): support Chinese paths and validate directory existence

### DIFF
--- a/src/main/services/CodeToolsService.ts
+++ b/src/main/services/CodeToolsService.ts
@@ -548,6 +548,17 @@ class CodeToolsService {
     logger.debug(`Environment variables:`, Object.keys(env))
     logger.debug(`Options:`, options)
 
+    // Validate directory exists before proceeding
+    if (!directory || !fs.existsSync(directory)) {
+      const errorMessage = `Directory does not exist: ${directory}`
+      logger.error(errorMessage)
+      return {
+        success: false,
+        message: errorMessage,
+        command: ''
+      }
+    }
+
     const packageName = await this.getPackageName(cliTool)
     const bunPath = await this.getBunPath()
     const executableName = await this.getCliExecutableName(cliTool)
@@ -709,6 +720,7 @@ class CodeToolsService {
         // Build bat file content, including debug information
         const batContent = [
           '@echo off',
+          'chcp 65001 >nul 2>&1', // Switch to UTF-8 code page for international path support
           `title ${cliTool} - Cherry Studio`, // Set window title in bat file
           'echo ================================================',
           'echo Cherry Studio CLI Tool Launcher',


### PR DESCRIPTION
## Summary
- Add `chcp 65001` to Windows batch file to switch CMD.exe to UTF-8 code page, fixing CLI tool launch failure when working directory contains Chinese or other non-ASCII characters
- Add directory existence validation before launching terminal to provide immediate error feedback instead of delayed failure

## Root Cause
Windows CMD.exe uses the system code page (e.g., CP936 for Chinese Windows) by default, not UTF-8. When the batch file is saved as UTF-8 and contains Chinese characters in the `cd /d "${directory}"` command, CMD.exe misinterprets them, causing the directory change to fail.

## Changes
1. **UTF-8 Code Page**: Added `chcp 65001 >nul 2>&1` at the beginning of the batch file to switch CMD.exe to UTF-8 mode
2. **Directory Validation**: Added `fs.existsSync(directory)` check at the start of `run()` method for immediate error feedback

## Test Plan
- [ ] Test with Chinese path: `C:\Users\Test\我的项目\代码`
- [ ] Test with Japanese path: `C:\Users\Test\プロジェクト`
- [ ] Test with non-existent directory (should show error immediately)
- [ ] Test with normal ASCII path (regression test)
- [ ] Test with path containing spaces

Closes #11483

🤖 Generated with [Claude Code](https://claude.com/claude-code)