### PR TITLE
fix: resolve readonly property error in assistant preset settings

### DIFF
--- a/src/renderer/src/store/assistants.ts
+++ b/src/renderer/src/store/assistants.ts
@@ -216,7 +216,7 @@ const assistantsSlice = createSlice({
         if (agent.id === action.payload.assistantId) {
           for (const key in settings) {
             if (!agent.settings) {
-              agent.settings = DEFAULT_ASSISTANT_SETTINGS
+              agent.settings = { ...DEFAULT_ASSISTANT_SETTINGS }
             }
             agent.settings[key] = settings[key]
           }


### PR DESCRIPTION
### What this PR does

Before this PR:
When editing assistant presets in the assistant library and switching between settings tabs (e.g., from "Model Settings" back to "Prompt Settings"), the software would become unresponsive with a gray/white screen. This was caused by a `TypeError: Cannot assign to read only property 'customParameters'` error.

After this PR:
Users can edit assistant presets and switch between settings tabs without the application freezing.

Fixes #11490

### Why we need it and why it was done in this way

**Root Cause:**
`DEFAULT_ASSISTANT_SETTINGS` is defined with `as const`, making it a readonly object. When `updateAssistantPresetSettings` was called and `agent.settings` was undefined, it was assigned a direct reference to this readonly object. Subsequent attempts to modify properties on `agent.settings` would fail with a TypeError.

**Solution:**
Create a shallow copy of `DEFAULT_ASSISTANT_SETTINGS` using the spread operator (`{ ...DEFAULT_ASSISTANT_SETTINGS }`) instead of referencing it directly. This ensures the new object is mutable.

The following alternatives were considered:
- Removing `as const` from `DEFAULT_ASSISTANT_SETTINGS`: Not recommended as it would reduce type safety across the codebase.

### Breaking changes

None.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)

### Release note

```release-note
fix: resolve software freeze when editing assistant presets in assistant library
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)