### PR TITLE
feat: Quick Assistant add 'Open Main Window' button; IPC App_ShowMain…

### DIFF
--- a/packages/shared/IpcChannel.ts
+++ b/packages/shared/IpcChannel.ts
@@ -47,6 +47,7 @@ export enum IpcChannel {
   App_MacRequestProcessTrust = 'app:mac-request-process-trust',
 
   App_QuoteToMain = 'app:quote-to-main',
+  App_ShowMainWindow = 'app:show-main-window',
   App_SetDisableHardwareAcceleration = 'app:set-disable-hardware-acceleration',
 
   Notification_Send = 'notification:send',

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -865,6 +865,7 @@ export function registerIpc(mainWindow: BrowserWindow, app: Electron.App) {
   SelectionService.registerIpcHandler()
 
   ipcMain.handle(IpcChannel.App_QuoteToMain, (_, text: string) => windowService.quoteToMainWindow(text))
+  ipcMain.handle(IpcChannel.App_ShowMainWindow, () => windowService.showMainWindow())
 
   ipcMain.handle(IpcChannel.App_SetDisableHardwareAcceleration, (_, isDisable: boolean) => {
     configManager.setDisableHardwareAcceleration(isDisable)

--- a/src/main/services/WindowService.ts
+++ b/src/main/services/WindowService.ts
@@ -375,15 +375,15 @@ export class WindowService {
 
       mainWindow.hide()
 
-      //for mac users, should hide dock icon if close to tray
       if (isMac && isTrayOnClose) {
-        app.dock?.hide()
+        const quickAssistantEnabled = configManager.getEnableQuickAssistant()
+        if (!quickAssistantEnabled) {
+          app.dock?.hide()
 
-        mainWindow.once('show', () => {
-          //restore the window can hide by cmd+h when the window is shown again
-          // https://github.com/electron/electron/pull/47970
-          app.dock?.show()
-        })
+          mainWindow.once('show', () => {
+            app.dock?.show()
+          })
+        }
       }
     })
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -464,6 +464,7 @@ const api = {
     }) => ipcRenderer.invoke(IpcChannel.AgentToolPermission_Response, payload)
   },
   quoteToMainWindow: (text: string) => ipcRenderer.invoke(IpcChannel.App_QuoteToMain, text),
+  openMainWindow: () => ipcRenderer.invoke(IpcChannel.App_ShowMainWindow),
   setDisableHardwareAcceleration: (isDisable: boolean) =>
     ipcRenderer.invoke(IpcChannel.App_SetDisableHardwareAcceleration, isDisable),
   trace: {

--- a/src/renderer/src/windows/mini/home/components/Footer.tsx
+++ b/src/renderer/src/windows/mini/home/components/Footer.tsx
@@ -64,6 +64,16 @@ const Footer: FC<FooterProps> = ({
                 : t('miniwindow.footer.esc_back')
           })}
         </Tag>
+        <Tag
+          bordered={false}
+          style={{ cursor: 'pointer' }}
+          className="nodrag"
+          onClick={() => {
+            window.api.openMainWindow()
+            window.api.miniWindow.hide()
+          }}>
+          打开主窗口
+        </Tag>
         {route === 'home' && !canUseBackspace && (
           <Tag
             bordered={false}

--- a/src/renderer/src/windows/selection/action/components/WindowFooter.tsx
+++ b/src/renderer/src/windows/selection/action/components/WindowFooter.tsx
@@ -183,6 +183,10 @@ const WindowFooter: FC<FooterProps> = ({
             </>
           )}
         </OpButton>
+        <OpButton onClick={() => window.api?.openMainWindow?.()} $isWindowFocus={isWindowFocus}>
+          <CircleX size={14} className="btn-icon" />
+          打开主窗口
+        </OpButton>
         {onRegenerate && (
           <OpButton onClick={handleRegenerate} $isWindowFocus={isWindowFocus} data-hovered={isRegenerateHovered}>
             <RefreshIcon size={14} className="btn-icon" />


### PR DESCRIPTION
…Window; keep Quick Assistant available on mac when closing main window

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

⚠️ Important: Redux/IndexedDB Data-Changing Feature PRs Temporarily On Hold ⚠️

Please note: For our current development cycle, we are not accepting feature Pull Requests that introduce changes to Redux data models or IndexedDB schemas.

While we value your contributions, PRs of this nature will be blocked without merge. We welcome all other contributions (bug fixes, perf enhancements, docs, etc.). Thank you!

Once version 2.0.0 is released, we will resume reviewing feature PRs.

-->

### What this PR does

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
