### PR TITLE
fix: store JSON custom parameters as strings instead of objects (#11501)

### DIFF
--- a/src/renderer/src/aiCore/legacy/clients/BaseApiClient.ts
+++ b/src/renderer/src/aiCore/legacy/clients/BaseApiClient.ts
@@ -405,6 +405,9 @@ export abstract class BaseApiClient<
         if (!param.name?.trim()) {
           return acc
         }
+        // Parse JSON type parameters (Legacy API clients)
+        // Related: src/renderer/src/pages/settings/AssistantSettings/AssistantModelSettings.tsx:133-148
+        // The UI stores JSON type params as strings, this function parses them before sending to API
         if (param.type === 'json') {
           const value = param.value as string
           if (value === 'undefined') {

--- a/src/renderer/src/aiCore/utils/reasoning.ts
+++ b/src/renderer/src/aiCore/utils/reasoning.ts
@@ -684,6 +684,10 @@ export function getCustomParameters(assistant: Assistant): Record<string, any> {
       if (!param.name?.trim()) {
         return acc
       }
+      // Parse JSON type parameters
+      // Related: src/renderer/src/pages/settings/AssistantSettings/AssistantModelSettings.tsx:133-148
+      // The UI stores JSON type params as strings (e.g., '{"key":"value"}')
+      // This function parses them into objects before sending to the API
       if (param.type === 'json') {
         const value = param.value as string
         if (value === 'undefined') {

--- a/src/renderer/src/pages/settings/AssistantSettings/AssistantModelSettings.tsx
+++ b/src/renderer/src/pages/settings/AssistantSettings/AssistantModelSettings.tsx
@@ -135,12 +135,18 @@ const AssistantModelSettings: FC<Props> = ({ assistant, updateAssistant, updateA
           <Input
             value={typeof param.value === 'string' ? param.value : JSON.stringify(param.value, null, 2)}
             onChange={(e) => {
-              try {
-                const jsonValue = JSON.parse(e.target.value)
-                onUpdateCustomParameter(index, 'value', jsonValue)
-              } catch {
-                onUpdateCustomParameter(index, 'value', e.target.value)
-              }
+              // For JSON type parameters, always store the value as a STRING
+              //
+              // Data Flow:
+              // 1. UI stores: { name: "config", value: '{"key":"value"}', type: "json" } ← STRING format
+              // 2. API parses: getCustomParameters() in src/renderer/src/aiCore/utils/reasoning.ts:687-696
+              //                calls JSON.parse() to convert string to object
+              // 3. Request sends: The parsed object is sent to the AI provider
+              //
+              // Previously this code was parsing JSON here and storing
+              // the object directly, which caused getCustomParameters() to fail when trying
+              // to JSON.parse() an already-parsed object.
+              onUpdateCustomParameter(index, 'value', e.target.value)
             }}
           />
         )


### PR DESCRIPTION
### What this PR does

Before this PR:
- JSON-type custom parameters were incorrectly parsed and stored as JavaScript objects in the UI layer
- When sending API requests, `getCustomParameters()` attempted to `JSON.parse()` an already-parsed object
- This caused API requests to fail or send malformed parameters

After this PR:
- JSON-type custom parameters are now correctly stored as strings in the UI layer
- The string values are parsed to objects only when constructing API requests
- JSON custom parameters are properly sent to AI providers in the correct format

Fixes #11501

### Why we need it and done in this way

**The Problem:**
In `AssistantModelSettings.tsx`, when users entered JSON values for custom parameters, the `onChange` handler was parsing the JSON string and storing the resulting object. However, the type definition and API layer expected JSON-type parameters to be stored as strings, which would then be parsed when needed.

**The Solution:**
Store JSON-type custom parameters as strings throughout the UI layer, and only parse them when constructing API requests in `getCustomParameters()`.

The following tradeoffs were made:
- **Validation**: We removed immediate JSON validation in the UI layer. Invalid JSON will now be caught when the API request is made. This is acceptable because the try-catch in `getCustomParameters()` handles parse errors gracefully.

The following alternatives were considered:
- Changing the type definition to allow objects: This would require updating all API clients and could introduce breaking changes.
- Adding a separate `parsedValue` field: This would add unnecessary complexity and potential for state inconsistency.

Links to places where the discussion took place:
- Issue: https://github.com/CherryHQ/cherry-studio/issues/11501

### Breaking changes

None. This is a bug fix that corrects the behavior to match the intended design.

### Special notes for your reviewer

- The fix is minimal and focused on the root cause
- Added detailed comments in three key locations to prevent similar issues in the future
- Existing tests in `reasoning.test.ts` already validate the correct behavior (JSON strings being parsed)

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
Fix JSON-type custom parameters being sent as text instead of proper JSON format in API requests
