### PR TITLE
fix(anthropic): comment out CONTEXT_100M_HEADER to handle via user preferences

### DIFF
--- a/src/renderer/src/aiCore/prepareParams/header.ts
+++ b/src/renderer/src/aiCore/prepareParams/header.ts
@@ -7,7 +7,7 @@ import { isAwsBedrockProvider, isVertexProvider } from '@renderer/utils/provider
 // https://docs.claude.com/en/docs/build-with-claude/extended-thinking#interleaved-thinking
 const INTERLEAVED_THINKING_HEADER = 'interleaved-thinking-2025-05-14'
 // https://docs.claude.com/en/docs/build-with-claude/context-windows#1m-token-context-window
-const CONTEXT_100M_HEADER = 'context-1m-2025-08-07'
+// const CONTEXT_100M_HEADER = 'context-1m-2025-08-07'
 // https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/web-search
 const WEBSEARCH_HEADER = 'web-search-2025-03-05'
 
@@ -25,7 +25,9 @@ export function addAnthropicHeaders(assistant: Assistant, model: Model): string[
     if (isVertexProvider(provider) && assistant.enableWebSearch) {
       anthropicHeaders.push(WEBSEARCH_HEADER)
     }
-    anthropicHeaders.push(CONTEXT_100M_HEADER)
+    // We may add it by user preference in assistant.settings instead of always adding it.
+    // See #11540, #11397
+    // anthropicHeaders.push(CONTEXT_100M_HEADER)
   }
   return anthropicHeaders
 }


### PR DESCRIPTION
### What this PR does

Before this PR:
- The `CONTEXT_100M_HEADER` was automatically added for all Anthropic Claude 4 models
- Users had no control over whether to use the 1M context window feature

After this PR:
- The `CONTEXT_100M_HEADER` is commented out from automatic inclusion
- Sets up the code to allow this to be handled via user preferences in assistant settings

Fixes #11540
Related to #11397

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Removed automatic header inclusion to prevent forcing all users to use the 1M context window
- This is a temporary measure; the proper solution will be to add a user preference setting in assistant configuration

The following alternatives were considered:
- Adding the preference setting immediately: Decided to do a quick fix first to unblock users, with the proper setting to follow
- Removing the constant entirely: Kept it commented to document the feature and make it easier to implement the preference setting later

Links to places where the discussion took place:
- Issue #11540: Users reporting issues with automatic 1M context
- Issue #11397: Original discussion about context window handling

### Breaking changes

No breaking changes. This removes a recently added automatic behavior, returning to the previous default.

### Special notes for your reviewer

This is a quick fix to address user-reported issues. The code includes comments explaining why the header is commented out and references the relevant issues for future implementation of a proper preference setting.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
fix: Removed automatic 1M context window header for Anthropic models to allow for future user preference control
```