### PR TITLE
fix: separate undefined vs none reasoning effort

### DIFF
--- a/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
+++ b/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
@@ -144,7 +144,7 @@ describe('reasoning utils', () => {
       expect(result).toEqual({})
     })
 
-    it('should disable reasoning for OpenRouter when no reasoning effort set', async () => {
+    it('should not override reasoning for OpenRouter when reasoning effort undefined', async () => {
       const { isReasoningModel } = await import('@renderer/config/models')
 
       vi.mocked(isReasoningModel).mockReturnValue(true)
@@ -159,6 +159,29 @@ describe('reasoning utils', () => {
         id: 'test',
         name: 'Test',
         settings: {}
+      } as Assistant
+
+      const result = getReasoningEffort(assistant, model)
+      expect(result).toEqual({})
+    })
+
+    it('should disable reasoning for OpenRouter when reasoning effort explicitly none', async () => {
+      const { isReasoningModel } = await import('@renderer/config/models')
+
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+
+      const model: Model = {
+        id: 'anthropic/claude-sonnet-4',
+        name: 'Claude Sonnet 4',
+        provider: SystemProviderIds.openrouter
+      } as Model
+
+      const assistant: Assistant = {
+        id: 'test',
+        name: 'Test',
+        settings: {
+          reasoning_effort: 'none'
+        }
       } as Assistant
 
       const result = getReasoningEffort(assistant, model)
@@ -269,7 +292,9 @@ describe('reasoning utils', () => {
       const assistant: Assistant = {
         id: 'test',
         name: 'Test',
-        settings: {}
+        settings: {
+          reasoning_effort: 'none'
+        }
       } as Assistant
 
       const result = getReasoningEffort(assistant, model)


### PR DESCRIPTION
### What this PR does

Before this PR:
- OpenRouter reasoning models (e.g. Kimi K2 Thinking from #11561) received `{ reasoning: { enabled: false, exclude: true } }` whenever `assistant.settings.reasoning_effort` was unset, so the model always started with thinking disabled even though the UI had never toggled it off.
- The existing unit tests enforced that old behavior, so they would fail if we tried to align the runtime logic with the desired defaults.

After this PR:
- `getReasoningEffort` treats `undefined` as "no override" and only sends the opt-out payload when the user explicitly chooses `none`, keeping Kimi and other OpenRouter models thinking by default.
- The reasoning unit tests now distinguish between the implicit default and the explicit opt-out, so CI reflects the new behavior.

Fixes #11561

### Why we need it and why it was done in this way

Issue #11561 reports that Kimi K2 Thinking "cannot think" because the app forces reasoning off even when the user does nothing. The right fix is to stop sending any reasoning payload in that case and keep the disable logic only for an explicit `none`. Updating the tests ensures we won't regress this contract again.

The following tradeoffs were made:
- Limited scope to reasoning logic/tests so we do not touch unrelated providers while stabilizing this regression.

The following alternatives were considered:
- Reverting to the old behavior was rejected because it contradicts user expectations captured in #11561.

Links to places where the discussion took place: #11561.

### Breaking changes

None.

### Special notes for your reviewer

- Manual verification: OpenRouter `gemini-2.5-pro`, `grok-4`, `qwen/qwen3-235b-a22b-thinking-2507`, `minimax-m2`, `claude-haiku-4.5`, `kimi-k2-thinking`; OpenAI-compatible `claude-haiku-4.5`.
- Automated checks: `yarn lint`, `yarn test`, `yarn format`.

### Checklist

- [x] PR description explains the regression and the fix
- [x] Code keeps the logic simple and matches existing style
- [x] Left tests/code cleaner than before
- [x] No upgrade impact
- [x] Docs not required for this behavior-only change

### Release note

```release-note
fix: keep OpenRouter reasoning enabled when no explicit effort is set
```
