### PR TITLE
fix: correct trace token usage

### DIFF
--- a/src/renderer/src/aiCore/trace/AiSdkSpanAdapter.ts
+++ b/src/renderer/src/aiCore/trace/AiSdkSpanAdapter.ts
@@ -245,8 +245,8 @@ export class AiSdkSpanAdapter {
       'gen_ai.usage.output_tokens'
     ]
 
-    const completionTokens = attributes[inputsTokenKeys.find((key) => attributes[key]) || '']
-    const promptTokens = attributes[outputTokenKeys.find((key) => attributes[key]) || '']
+    const promptTokens = attributes[inputsTokenKeys.find((key) => attributes[key]) || '']
+    const completionTokens = attributes[outputTokenKeys.find((key) => attributes[key]) || '']
 
     if (completionTokens !== undefined || promptTokens !== undefined) {
       const usage: TokenUsage = {

--- a/src/renderer/src/aiCore/trace/__tests__/AiSdkSpanAdapter.test.ts
+++ b/src/renderer/src/aiCore/trace/__tests__/AiSdkSpanAdapter.test.ts
@@ -1,0 +1,53 @@
+import type { Span } from '@opentelemetry/api'
+import { SpanKind, SpanStatusCode } from '@opentelemetry/api'
+import { describe, expect, it, vi } from 'vitest'
+
+import { AiSdkSpanAdapter } from '../AiSdkSpanAdapter'
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn()
+    })
+  }
+}))
+
+describe('AiSdkSpanAdapter', () => {
+  const createMockSpan = (attributes: Record<string, unknown>): Span => {
+    const span = {
+      spanContext: () => ({
+        traceId: 'trace-id',
+        spanId: 'span-id'
+      }),
+      _attributes: attributes,
+      _events: [],
+      name: 'test span',
+      status: { code: SpanStatusCode.OK },
+      kind: SpanKind.CLIENT,
+      startTime: [0, 0] as [number, number],
+      endTime: [0, 1] as [number, number],
+      ended: true,
+      parentSpanId: '',
+      links: []
+    }
+    return span as unknown as Span
+  }
+
+  it('maps prompt and completion usage tokens to the correct fields', () => {
+    const attributes = {
+      'ai.usage.promptTokens': 321,
+      'ai.usage.completionTokens': 654
+    }
+
+    const span = createMockSpan(attributes)
+    const result = AiSdkSpanAdapter.convertToSpanEntity({ span })
+
+    expect(result.usage).toBeDefined()
+    expect(result.usage?.prompt_tokens).toBe(321)
+    expect(result.usage?.completion_tokens).toBe(654)
+    expect(result.usage?.total_tokens).toBe(975)
+  })
+})


### PR DESCRIPTION
### What this PR does

Before this PR:
- As reported in #11568, token usage shown in the trace call chain had the input/output icons and values reversed because the AI SDK span adapter swapped prompt/completion counts when saving usage.

After this PR:
- AiSdkSpanAdapter now maps prompt and completion usage tokens correctly and a regression test covers the conversion logic, so SpanDetail displays the same usage numbers as MessageTokens.

Fixes #11568

### Why we need it and why it was done in this way
The AI SDK adapter had the wrong mapping when extracting usage attributes (input tokens were treated as completions and vice versa). Fixing the adapter keeps data consistent across the app and the regression test protects against future swaps.

The following tradeoffs were made:
- None.

The following alternatives were considered:
- Swapping the display logic in SpanDetail, but that would only mask the underlying data issue and leave other consumers incorrect.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
- N/A

### Breaking changes
- None

### Special notes for your reviewer
- Verified via `yarn lint`, `yarn test`, and `yarn format`.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
Fix span trace token usage showing reversed prompt/completion counts.
```
