### PR TITLE
fix: remove stale anthropic-beta header for oauth

### DIFF
--- a/src/renderer/src/aiCore/provider/providerConfig.ts
+++ b/src/renderer/src/aiCore/provider/providerConfig.ts
@@ -314,7 +314,6 @@ export async function prepareSpecialProviderConfig(
             ...(config.options.headers ? config.options.headers : {}),
             'Content-Type': 'application/json',
             'anthropic-version': '2023-06-01',
-            'anthropic-beta': 'oauth-2025-04-20',
             Authorization: `Bearer ${oauthToken}`
           },
           baseURL: 'https://api.anthropic.com/v1',


### PR DESCRIPTION
### What this PR does

Before this PR:
- OAuth requests to Anthropic API included a stale `anthropic-beta: oauth-2025-04-20` header that was no longer needed

After this PR:
- Removed the outdated `anthropic-beta` header from OAuth configuration while keeping other required headers

Fixes #11597

### Why we need it and why it was done in this way

The `anthropic-beta: oauth-2025-04-20` header was part of an early OAuth implementation that is no longer required by the Anthropic API. Including stale headers can cause confusion and may potentially lead to API request issues in the future if the API server becomes stricter about header validation.

The following tradeoffs were made:
- Minimal change: Only removed the specific stale header without touching any other functionality
- No behavioral change: This is purely a cleanup that maintains existing OAuth functionality

The following alternatives were considered:
- Adding conditional logic to include the header based on API version - deemed unnecessary since the header is deprecated
- Complete OAuth configuration refactor - excessive for this simple header removal

### Breaking changes

None. This is a cleanup change that removes an unnecessary header without affecting functionality.

### Special notes for your reviewer

This is a straightforward cleanup of a stale header. The OAuth functionality remains unchanged.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
NONE
```