### PR TITLE
fix: properly handle thinking mode switching in qwenThinkingMiddleware

### DIFF
--- a/src/renderer/src/aiCore/middleware/qwenThinkingMiddleware.ts
+++ b/src/renderer/src/aiCore/middleware/qwenThinkingMiddleware.ts
@@ -23,8 +23,10 @@ export function qwenThinkingMiddleware(enableThinking: boolean): LanguageModelMi
             // Process content array
             if (Array.isArray(message.content)) {
               for (const part of message.content) {
-                if (part.type === 'text' && !part.text.endsWith('/think') && !part.text.endsWith('/no_think')) {
-                  part.text += suffix
+                if (part.type === 'text') {
+                  // Remove any existing thinking suffixes first, then add the correct one
+                  const cleanText = part.text.replace(/\s*\/think\s*$/, '').replace(/\s*\/no_think\s*$/, '')
+                  part.text = cleanText + suffix
                 }
               }
             }


### PR DESCRIPTION
### What this PR does

Before this PR:
- Users could enable thinking mode for Qwen models on Ollama, but couldn't properly switch back to non-thinking mode
- Once `/think` was appended to a message, the middleware would never update it to `/no_think`
- This caused thinking mode to persist indefinitely, even when users explicitly disabled it

After this PR:
- Users can now properly switch between thinking and non-thinking modes for Qwen models on Ollama
- The middleware correctly removes existing thinking suffixes and applies the appropriate one based on current settings
- Thinking mode toggles work as expected in both directions

Fixes #11612

### Why we need it and why it was done in this way

The issue was in the `qwenThinkingMiddleware.ts` where the condition `!part.text.endsWith('/think') && !part.text.endsWith('/no_think')` prevented any message with existing thinking suffixes from being processed. This meant once a message had `/think`, it would never be changed to `/no_think`.

The solution cleans all existing thinking suffixes first, then applies the correct one based on the current `reasoning_effort` setting. This approach:
- Ensures consistency between UI state and API calls
- Maintains backward compatibility 
- Fixes the root cause without adding complexity
- Follows the existing middleware pattern

The following tradeoffs were made:
- Minimal code changes to reduce risk of introducing new bugs
- Regex-based suffix removal for robustness against whitespace variations
- No changes to the public API or middleware interface

The following alternatives were considered:
1. Track state per message and only update when needed - rejected due to complexity
2. Add a separate middleware for suffix cleanup - rejected as overengineering
3. Modify the condition logic only - rejected as it wouldn't handle existing suffixes properly

Links to places where the discussion took place:
- Original issue: #11612

### Breaking changes

No breaking changes. The middleware maintains the same interface and behavior for all other use cases.

### Special notes for your reviewer

The fix is minimal and focused:
- Only modifies the suffix handling logic in `qwenThinkingMiddleware`
- No changes to configuration, types, or other components
- Maintains existing logging and error handling patterns
- Follows the established code style and formatting

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
Fix thinking mode toggle for Qwen models on Ollama. Users can now properly switch between thinking and non-thinking modes without getting stuck in thinking mode.
```