### PR TITLE
fix: avoid sending empty anthropic-beta header

### DIFF
--- a/src/renderer/src/aiCore/prepareParams/parameterBuilder.ts
+++ b/src/renderer/src/aiCore/prepareParams/parameterBuilder.ts
@@ -177,8 +177,12 @@ export async function buildStreamTextParams(
   let headers: Record<string, string | undefined> = options.requestOptions?.headers ?? {}
 
   if (isAnthropicModel(model) && !isAwsBedrockProvider(provider)) {
-    const newBetaHeaders = { 'anthropic-beta': addAnthropicHeaders(assistant, model).join(',') }
-    headers = combineHeaders(headers, newBetaHeaders)
+    const betaHeaders = addAnthropicHeaders(assistant, model)
+    // Only add the anthropic-beta header if there are actual beta headers to include
+    if (betaHeaders.length > 0) {
+      const newBetaHeaders = { 'anthropic-beta': betaHeaders.join(',') }
+      headers = combineHeaders(headers, newBetaHeaders)
+    }
   }
 
   // 构建基础参数


### PR DESCRIPTION
### What this PR does

Before this PR:
- When building request headers for Anthropic API calls, the code joined the array returned by `addAnthropicHeaders()` with `.join(',')` and always set the `anthropic-beta` header.
- If `addAnthropicHeaders()` returned an empty array, this produced an empty string (`anthropic-beta: ""`), which caused Anthropic to return HTTP 400 with: "Unexpected value(s) `` for the `anthropic-beta` header."
- Some request scenarios failed as a result.

After this PR:
- We check the array returned by `addAnthropicHeaders()` and only set the `anthropic-beta` header when the array is non-empty.
- Requests no longer send an empty `anthropic-beta` header and therefore avoid the 400 error.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Closes #11597

### Why we need it and why it was done in this way

- Root cause: `addAnthropicHeaders()` can legitimately return an empty array. Joining an empty array results in an empty string which the Anthropic API rejects for the `anthropic-beta` header.
- This change is minimal and low-risk: add a defensive check at the point of header composition to avoid sending empty header values while preserving existing header behavior when values are present.
- Implementing the check where headers are assembled keeps the fix small and avoids broad refactors.

The following tradeoffs were made:
- Pros: Small change, easy to review, low chance of regressions, quick to roll out.
- Cons: Header management remains decentralized (the alternative of centralizing header handling in the SDK client was considered but would be a larger refactor).

The following alternatives were considered:
- Centralize management of `anthropic-beta` headers in SDK client construction (remove header handling from request assembly sites). Rejected due to larger scope, higher risk and longer review cycle for this urgent bugfix.

Links to places where the discussion took place:
- Related issue: https://github.com/CherryHQ/cherry-studio/issues/11597

### Breaking changes

- None. This is a small defensive change that only prevents sending an empty header; it does not change header values when they exist.

### Special notes for your reviewer

- This is a focused bugfix that does not modify Redux/IndexedDB schemas.
- Please ensure commits include a sign-off (see CONTRIBUTING). Example:
  git commit --signoff -m "fix: avoid sending empty `anthropic-beta` header"

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Code is simple and readable
- [x] Refactor: Code leaves the codebase in a cleaner or safer state (defensive guard)
- [x] Upgrade: Not applicable (no upgrade flow changes)
- [x] Documentation: Not required (no user-facing change)

### Release note

```release-note
fix: avoid sending empty `anthropic-beta` header which caused 400 errors for some Anthropic requests (Closes #11597)
```