### PR TITLE
fix: sync Upload UI with editImageFiles in NewApiPage

### DIFF
--- a/src/renderer/src/pages/paintings/NewApiPage.tsx
+++ b/src/renderer/src/pages/paintings/NewApiPage.tsx
@@ -31,6 +31,8 @@ import { getErrorMessage, uuid } from '@renderer/utils'
 import { isNewApiProvider } from '@renderer/utils/provider'
 import { Avatar, Button, Empty, InputNumber, Segmented, Select, Upload } from 'antd'
 import TextArea from 'antd/es/input/TextArea'
+import type { RcFile } from 'antd/es/upload'
+import type { UploadFile } from 'antd/es/upload/interface'
 import type { FC } from 'react'
 import React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -553,7 +555,31 @@ const NewApiPage: FC<{ Options: string[] }> = ({ Options }) => {
                     maxCount={16}
                     showUploadList={true}
                     listType="picture"
-                    beforeUpload={handleImageUpload}>
+                    beforeUpload={handleImageUpload}
+                    fileList={editImageFiles.map((file, idx): UploadFile<any> => {
+                      const rcFile: RcFile = {
+                        ...file,
+                        uid: String(idx),
+                        lastModifiedDate: file.lastModified ? new Date(file.lastModified) : new Date()
+                      }
+                      return {
+                        uid: rcFile.uid,
+                        name: rcFile.name || `image_${idx + 1}.png`,
+                        status: 'done',
+                        url: URL.createObjectURL(file),
+                        originFileObj: rcFile,
+                        lastModifiedDate: rcFile.lastModifiedDate
+                      }
+                    })}
+                    onRemove={(file) => {
+                      setEditImageFiles((prev) =>
+                        prev.filter((f) => {
+                          const idx = prev.indexOf(f)
+                          return String(idx) !== file.uid
+                        })
+                      )
+                      return true
+                    }}>
                     <ImagePlaceholder>
                       <ImageSizeImage src={IcImageUp} theme={theme} />
                     </ImagePlaceholder>


### PR DESCRIPTION
Resolved issue where Upload component UI was not synchronized with editImageFiles state in NewApiPage. Switched to controlled fileList and handled file removal via onRemove to ensure consistent UI updates.

### What this PR does

Before this PR: 
An image file was removed from the Upload UI however this image file was still in use because it was not removed from editImageFiles

After this PR:
Upload component UI is synchronized with editImageFiles state, so user is able to use the right image for image editing. 


