### PR TITLE
feat(settings): add Slovak language support for spell check

### DIFF
--- a/src/renderer/src/pages/settings/GeneralSettings.tsx
+++ b/src/renderer/src/pages/settings/GeneralSettings.tsx
@@ -2,6 +2,7 @@ import { InfoCircleOutlined } from '@ant-design/icons'
 import { HStack } from '@renderer/components/Layout'
 import Selector from '@renderer/components/Selector'
 import { InfoTooltip } from '@renderer/components/TooltipIcons'
+import { isMac } from '@renderer/config/constant'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import { useEnableDeveloperMode, useSettings } from '@renderer/hooks/useSettings'
 import { useTimer } from '@renderer/hooks/useTimer'
@@ -260,7 +261,7 @@ const GeneralSettings: FC = () => {
         <SettingRow>
           <HStack justifyContent="space-between" alignItems="center" style={{ flex: 1, marginRight: 16 }}>
             <SettingRowTitle>{t('settings.general.spell_check.label')}</SettingRowTitle>
-            {enableSpellCheck && (
+            {enableSpellCheck && !isMac && (
               <Selector<string>
                 size={14}
                 multiple


### PR DESCRIPTION
### What this PR does

Before this PR:
- Spell check only supported 10 languages (English, Spanish, French, German, Italian, Portuguese, Russian, Dutch, Polish, Greek)
- Users requesting Slovak language support had no option available
- On macOS, the spell check language selector was shown but non-functional (macOS uses system-level spell check settings)

After this PR:
- Added Slovak (Slovenčina) as a spell check language option
- Improved type safety by defining SpellCheckOption type
- Moved spell check language options to constants for better code organization
- Fixed macOS behavior: the language selector is now hidden on macOS since it's not supported on that platform

Fixes #11618

### Why we need it and why it was done in this way

This PR addresses the feature request in #11618 to add more spell check languages, specifically Slovak. It also fixes a platform-specific issue where the language selector was shown on macOS despite being non-functional.

The following tradeoffs were made:
- Maintained the current hardcoded language list approach instead of implementing a fully customizable language architecture. This keeps the change minimal and focused while ensuring only commonly supported languages are available.
- The hardcoded approach prevents users from selecting unsupported languages that might cause issues with Electron's spell checker.
- On macOS, we hide the language selector entirely rather than showing a disabled state, as users should use system preferences for spell check configuration.

The following alternatives were considered:
- A fully customizable spell check language system where users can add any language code. This was deferred for future refactoring as it requires more architectural changes and validation logic.
- Showing a disabled selector on macOS with a tooltip explaining the limitation. However, hiding it completely provides a cleaner UX and avoids confusion.

### Breaking changes

None. This is a backward-compatible feature addition with improved platform-specific behavior.

### Special notes for your reviewer

- Added Slovak language with code 'sk', native name 'Slovenčina', and flag emoji 🇸🇰
- Also improved code structure by extracting spell check options to a const and adding TypeScript type
- The language selector is now hidden on macOS (using `isMac` constant) since macOS uses system-level spell check settings
- On Windows and Linux, users can now select Slovak as a spell check language
- The change only affects the UI options list; the underlying Electron spell checker natively supports Slovak

**I am unable to test whether Slovak spell checking works on macOS. If possible, please test it using Windows or Linux.**

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
feat: Add Slovak (Slovenčina) language support for spell check in General Settings
fix: Hide spell check language selector on macOS (uses system preferences instead)
```