### PR TITLE
fix: Text selection assistant popup window can no longer be resized

### DIFF
--- a/src/main/services/SelectionService.ts
+++ b/src/main/services/SelectionService.ts
@@ -404,7 +404,7 @@ export class SelectionService {
       height: toolbarHeight,
       show: false,
       frame: false,
-      transparent: true,
+      transparent: isWin ? false : true,
       alwaysOnTop: true,
       skipTaskbar: true,
       autoHideMenuBar: true,
@@ -1111,7 +1111,7 @@ export class SelectionService {
       minHeight: 200,
       resizable: true,
       frame: false,
-      transparent: true,
+      transparent: isWin ? false : true,
       autoHideMenuBar: true,
       titleBarStyle: 'hidden', // [macOS]
       trafficLightPosition: { x: 12, y: 9 }, // [macOS]

--- a/src/renderer/src/windows/selection/action/SelectionActionApp.tsx
+++ b/src/renderer/src/windows/selection/action/SelectionActionApp.tsx
@@ -260,9 +260,9 @@ const WindowFrame = styled.div<{ $opacity: number }>`
   position: relative;
   display: flex;
   flex-direction: column;
-  width: calc(100% - 6px);
-  height: calc(100% - 6px);
-  margin: 2px;
+  width: 100%;
+  height: 100%;
+  margin: 0;
   background-color: var(--color-background);
   border: 1px solid var(--color-border);
   box-shadow: 0px 0px 2px var(--color-text-3);


### PR DESCRIPTION
## What this PR does

Restores the ability to resize the **Selection Assistant action window** on Windows.

### Key changes

  * **Main (action window)**
      * Add `resizable: true` to the action window `BrowserWindow`
      * On Windows, set `thickFrame: true` so OS edge hit-testing works for resizing
      * On Windows, set `transparent: false` for the action window to ensure stable OS resize behavior
  * **Main (toolbar window)**
      * On Windows, set `transparent: false` for consistency and to avoid hit-testing quirks
  * **Renderer (action window)**
      * Make the inner window frame fill the whole window (`width/height: 100%`, remove the 2px margin) to avoid any background seams when the window is not transparent

### Files touched

  * `src/main/services/SelectionService.ts`
  * `src/renderer/src/windows/selection/action/SelectionActionApp.tsx`

Fixes \#11647

### Before this PR:

  * On Windows, the Selection Assistant “action” popup could not be resized. The `frameless + transparent` window without a thick frame no longer exposed OS resize handles after recent Electron upgrades.

### After this PR:

  * On Windows, the action popup is resizable again from edges and corners.
  * “Remember Window Size” continues to work as expected.
  * macOS behavior unchanged.

-----

## Why we need it and why it was done in this way

On Windows, Electron’s frameless transparent windows can lose the OS resize grab areas depending on Chromium/Electron versions. Enabling a **thick frame** and **disabling window transparency** for the action window reliably restores native resize handles without changing our custom UI or introducing complex hit-testing.

### The following tradeoffs were made:

  * Windows action window transparency is disabled to regain reliable OS-level edge resizing. The inner UI fills the window to keep visuals consistent and avoid visible seams.
  * Toolbar window on Windows also uses non-transparent for consistency and to avoid corner cases with edge hit-testing.

### The following alternatives were considered:

  * **Keep transparency and implement custom resize handles in the renderer.** This adds complexity and more edge cases across DPI/scales.
  * **Use `frame: true` (native title bar) on Windows.** This breaks the custom window chrome design.
  * **Only set `resizable: true` while keeping `thickFrame: false` and `transparent: true`.** This does not consistently restore OS hit-testing on recent Electron versions.

### Links to places where the discussion took place:

  * Issue: [https://github.com/CherryHQ/cherry-studio/issues/11647](https://github.com/CherryHQ/cherry-studio/issues/11647)

-----

## Breaking changes

None. Behavior change is limited to the action window (and toolbar transparency) on Windows. macOS remains the same.

-----

## Special notes for your reviewer

  * **Verify on Windows 10/11:**
      * Trigger Selection Assistant and open the action window (e.g., Translate/Explain/Summary).
      * Resize from edges/corners.
      * Toggle “Remember Window Size” and confirm the size persists.
  * macOS should be unaffected.

-----

## Checklist

  * [ ] **PR:** The PR description is expressive enough and will help future contributors
  * [ ] **Code:** [[Write code that humans can understand](https://www.google.com/search?q=https://en.wikiquote.org/wiki/Martin_Fowler%23code-for-humans)](https://www.google.com/search?q=https://en.wikiquote.org/wiki/Martin_Fowler%23code-for-humans) and [[Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)](https://en.wikipedia.org/wiki/KISS_principle)
  * [ ] **Refactor:** You have [[left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
  * [ ] **Upgrade:** Impact of this change on upgrade flows was considered and addressed if required
  * [ ] **Documentation:** A [[user-guide update](https://docs.cherry-ai.com/)](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

-----

## Release note

```release-note
Fix: Restore resizing for Selection Assistant action window on Windows. The action window now sets resizable + thick frame and uses a non-transparent window on Windows to regain OS edge resizing. macOS is unaffected.
```