### PR TITLE
fix(inputbar): block enter send while generating

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/components/InputbarCore.tsx
+++ b/src/renderer/src/pages/home/Inputbar/components/InputbarCore.tsx
@@ -180,6 +180,8 @@ export const InputbarCore: FC<InputbarCoreProps> = ({
   })
   // 判断是否可以发送：文本不为空或有文件
   const cannotSend = isEmpty && files.length === 0
+  // 发送入口统一禁用条件：空内容、正在生成、全局搜索态
+  const isSendDisabled = cannotSend || isLoading || searching
 
   useEffect(() => {
     setExtensions(supportedExts)
@@ -310,7 +312,7 @@ export const InputbarCore: FC<InputbarCoreProps> = ({
 
       const isEnterPressed = event.key === 'Enter' && !event.nativeEvent.isComposing
       if (isEnterPressed) {
-        if (isSendMessageKeyPressed(event, sendMessageShortcut) && !cannotSend) {
+        if (isSendMessageKeyPressed(event, sendMessageShortcut) && !isSendDisabled) {
           handleSendMessage()
           event.preventDefault()
           return
@@ -357,6 +359,7 @@ export const InputbarCore: FC<InputbarCoreProps> = ({
       handleToggleExpanded,
       sendMessageShortcut,
       cannotSend,
+      isSendDisabled,
       handleSendMessage,
       setText,
       setTimeoutTimer,
@@ -617,7 +620,7 @@ export const InputbarCore: FC<InputbarCoreProps> = ({
   const rightSectionExtras = useMemo(() => {
     const extras: React.ReactNode[] = []
     extras.push(<TranslateButton key="translate" text={text} onTranslated={onTranslated} isLoading={isTranslating} />)
-    extras.push(<SendMessageButton sendMessage={handleSendMessage} disabled={cannotSend || isLoading || searching} />)
+    extras.push(<SendMessageButton sendMessage={handleSendMessage} disabled={isSendDisabled} />)
 
     if (isLoading) {
       extras.push(
@@ -630,7 +633,7 @@ export const InputbarCore: FC<InputbarCoreProps> = ({
     }
 
     return <>{extras}</>
-  }, [text, onTranslated, isTranslating, handleSendMessage, cannotSend, isLoading, searching, t, onPause])
+  }, [text, onTranslated, isTranslating, handleSendMessage, isSendDisabled, isLoading, t, onPause])
 
   const quickPanelElement = config.enableQuickPanel ? <QuickPanelView setInputText={setText} /> : null
 


### PR DESCRIPTION
- reuse unified send disable state for keyboard and button
  - prevent enter sending when loading or searching