### PR TITLE
fix(inputbar): block enter send while generating

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/components/InputbarCore.tsx
+++ b/src/renderer/src/pages/home/Inputbar/components/InputbarCore.tsx
@@ -178,10 +178,10 @@ export const InputbarCore: FC<InputbarCoreProps> = ({
     enabled: config.enableDragDrop,
     t
   })
-  // 判断是否可以发送：文本不为空或有文件
-  const cannotSend = isEmpty && files.length === 0
+  // 判断是否有内容：文本不为空或有文件
+  const noContent = isEmpty && files.length === 0
   // 发送入口统一禁用条件：空内容、正在生成、全局搜索态
-  const isSendDisabled = cannotSend || isLoading || searching
+  const isSendDisabled = noContent || isLoading || searching
 
   useEffect(() => {
     setExtensions(supportedExts)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

⚠️ Important: Redux/IndexedDB Data-Changing Feature PRs Temporarily On Hold ⚠️

Please note: For our current development cycle, we are not accepting feature Pull Requests that introduce changes to Redux data models or IndexedDB schemas.

While we value your contributions, PRs of this nature will be blocked without merge. We welcome all other contributions (bug fixes, perf enhancements, docs, etc.). Thank you!

Once version 2.0.0 is released, we will resume reviewing feature PRs.

-->

### What this PR does

Before this PR:

During model response generation, pressing Enter in the input field incorrectly sends a new message instead of being properly disabled

![Cherry Studio 2025-12-03 16-41-39](https://pictures.kazoottt.top/2025/12/20251203-ad85d8442f896a2947e64ab28fe5b6de.gif)

After this PR:

- Send button and Enter shortcut share unified disabled state
- During loading or searching, pressing Enter won't trigger sending, avoiding interruption of generation process

![](https://pictures.kazoottt.top/2025/12/20251203-8224f5b3abf7b78c2761885d4244e80d.mp4)

### Why we need it and why it was done in this way

- Avoid accidental Enter key presses during model replies that cause parallel requests, improving user experience and reducing backend pressure
- Reuse existing disable conditions (empty input/loading/search) with unified control at the entry layer, minimal changes and easy maintenance

The following tradeoffs were made:

NONE

### Breaking changes

<!-- optional -->

NONE

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

NONE
