### PR TITLE
fix(aiCore): correct provider adaptation with model parameter

### DIFF
--- a/src/renderer/src/aiCore/index_new.ts
+++ b/src/renderer/src/aiCore/index_new.ts
@@ -91,7 +91,9 @@ export default class ModernAiProvider {
     if (this.isModel(modelOrProvider)) {
       // 传入的是 Model
       this.model = modelOrProvider
-      this.actualProvider = provider ? adaptProvider({ provider }) : getActualProvider(modelOrProvider)
+      this.actualProvider = provider
+        ? adaptProvider({ provider, model: modelOrProvider })
+        : getActualProvider(modelOrProvider)
       // 只保存配置，不预先创建executor
       this.config = providerToAiSdkConfig(this.actualProvider, modelOrProvider)
     } else {


### PR DESCRIPTION
### What this PR does

Before this PR:
When a `Model` and an optional `Provider` are passed to the `ModernAiProvider` constructor, the `adaptProvider` function was called without the `model` parameter. This caused the special provider handling logic in `handleSpecialProviders` (line 130-132 in providerConfig.ts) to be skipped, resulting in incorrect route selection for providers like New-API, aihubmix, vertexai, and Azure OpenAI.

After this PR:
The `model` parameter is now correctly passed to `adaptProvider` when a provider is specified, ensuring that model-specific provider transformations are applied before API host formatting. This fixes routing issues for providers that require model-aware configuration.

Fixes #

### Why we need it and why it was done in this way

The `adaptProvider` function applies transformations in a specific order:
1. Model-specific provider handling (requires model parameter)
2. API host formatting

Without passing the model, the first transformation step was skipped, causing providers to use incorrect endpoints. The fix ensures the full transformation pipeline is executed.

The following tradeoffs were made:
- None. This is a straightforward bug fix that aligns the code with its documented behavior.

The following alternatives were considered:
- Making model required in adaptProvider: Rejected because some operations (like fetchModels) don't need a model.
- Duplicating the logic: Rejected to maintain DRY principles.

Links to places where the discussion took place:
N/A

### Breaking changes

None. This is a bug fix that corrects existing behavior.

### Special notes for your reviewer

The fix is a single-line change that ensures consistency between two code paths:
- Line 95-96: When model + optional provider is passed (now fixed)
- Line 101: When only provider is passed (already correct, but model is optional there)

Please verify that the model parameter flows correctly through the transformation pipeline.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
fix: Correct provider routing for model-specific configurations (New-API, aihubmix, vertexai, Azure OpenAI)
```