### PR TITLE
fix(models): include model name as fallback for id field

### DIFF
--- a/src/renderer/src/services/models/ModelAdapter.ts
+++ b/src/renderer/src/services/models/ModelAdapter.ts
@@ -45,7 +45,7 @@ function normalizeModels<T>(models: T[], transformer: (entry: T) => Model | null
 }
 
 function adaptSdkModel(provider: Provider, model: SdkModel): Model | null {
-  const id = pickPreferredString([(model as any)?.id, (model as any)?.modelId])
+  const id = pickPreferredString([(model as any)?.id, (model as any)?.modelId, (model as any)?.name])
   const name = pickPreferredString([
     (model as any)?.display_name,
     (model as any)?.displayName,


### PR DESCRIPTION
### What this PR does

Before this PR:
- Gemini provider's model list retrieval failed because the model adapter only checked for `id` and `modelId` fields when adapting SDK models
- Gemini API returns models with only a `name` field, causing the adapter to skip these models

After this PR:
- Model adapter now includes `name` as a third fallback option when extracting model IDs
- Gemini provider successfully retrieves and displays its model list

Fixes #11759

### Why we need it and why it was done in this way

The issue occurred because different AI provider APIs use different field names for model identifiers. The `pickPreferredString` function checks fields in order of preference, returning the first non-empty value.

The following tradeoffs were made:
- Adding `name` as a fallback maintains backward compatibility while supporting providers that only provide a `name` field
- Placed `name` after `id` and `modelId` to prefer more specific identifiers when available

The following alternatives were considered:
- Provider-specific adapters: Would add unnecessary complexity for a simple field mapping issue
- Required field validation: Would break other providers that may have different field structures

### Breaking changes

None. This is a purely additive change that adds support for an additional field fallback.

### Special notes for your reviewer

This is a minimal one-line fix that resolves the Gemini model list issue. The change is safe because:
- It only adds an additional fallback option
- The `pickPreferredString` function already handles null/undefined values gracefully
- Existing providers using `id` or `modelId` are unaffected

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
fix(models): Gemini provider can now successfully retrieve model list by including model name as fallback identifier
```