### PR TITLE
fix(windows): add manual window resize for SelectionAction window

### DIFF
--- a/packages/shared/IpcChannel.ts
+++ b/packages/shared/IpcChannel.ts
@@ -293,6 +293,8 @@ export enum IpcChannel {
   Selection_ActionWindowClose = 'selection:action-window-close',
   Selection_ActionWindowMinimize = 'selection:action-window-minimize',
   Selection_ActionWindowPin = 'selection:action-window-pin',
+  // [Windows only] Electron bug workaround - can be removed once https://github.com/electron/electron/issues/48554 is fixed
+  Selection_ActionWindowResize = 'selection:action-window-resize',
   Selection_ProcessAction = 'selection:process-action',
   Selection_UpdateActionData = 'selection:update-action-data',
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -456,7 +456,10 @@ const api = {
       ipcRenderer.invoke(IpcChannel.Selection_ProcessAction, actionItem, isFullScreen),
     closeActionWindow: () => ipcRenderer.invoke(IpcChannel.Selection_ActionWindowClose),
     minimizeActionWindow: () => ipcRenderer.invoke(IpcChannel.Selection_ActionWindowMinimize),
-    pinActionWindow: (isPinned: boolean) => ipcRenderer.invoke(IpcChannel.Selection_ActionWindowPin, isPinned)
+    pinActionWindow: (isPinned: boolean) => ipcRenderer.invoke(IpcChannel.Selection_ActionWindowPin, isPinned),
+    // [Windows only] Electron bug workaround - can be removed once https://github.com/electron/electron/issues/48554 is fixed
+    resizeActionWindow: (deltaX: number, deltaY: number, direction: string) =>
+      ipcRenderer.invoke(IpcChannel.Selection_ActionWindowResize, deltaX, deltaY, direction)
   },
   agentTools: {
     respondToPermission: (payload: {

--- a/src/renderer/src/windows/selection/action/SelectionActionApp.tsx
+++ b/src/renderer/src/windows/selection/action/SelectionActionApp.tsx
@@ -1,4 +1,4 @@
-import { isMac } from '@renderer/config/constant'
+import { isMac, isWin } from '@renderer/config/constant'
 import { useSelectionAssistant } from '@renderer/hooks/useSelectionAssistant'
 import { useSettings } from '@renderer/hooks/useSettings'
 import i18n from '@renderer/i18n'
@@ -8,10 +8,13 @@ import { IpcChannel } from '@shared/IpcChannel'
 import { Button, Slider, Tooltip } from 'antd'
 import { Droplet, Minus, Pin, X } from 'lucide-react'
 import { DynamicIcon } from 'lucide-react/dynamic'
-import type { FC } from 'react'
+import type { FC, MouseEvent as ReactMouseEvent } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
+
+// [Windows only] Electron bug workaround type - can be removed once https://github.com/electron/electron/issues/48554 is fixed
+type ResizeDirection = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw'
 
 import ActionGeneral from './components/ActionGeneral'
 import ActionTranslate from './components/ActionTranslate'
@@ -185,11 +188,62 @@ const SelectionActionApp: FC = () => {
     }
   }
 
+  /**
+   * [Windows only] Manual window resize handler
+   *
+   * ELECTRON BUG WORKAROUND:
+   * In Electron, when using `frame: false` + `transparent: true`, the native window
+   * resize functionality is broken on Windows. This is a known Electron bug.
+   * See: https://github.com/electron/electron/issues/48554
+   *
+   * This custom resize implementation can be removed once the Electron bug is fixed.
+   */
+  const handleResizeStart = useCallback((e: ReactMouseEvent, direction: ResizeDirection) => {
+    e.preventDefault()
+    e.stopPropagation()
+
+    let lastX = e.screenX
+    let lastY = e.screenY
+
+    const handleMouseMove = (moveEvent: MouseEvent) => {
+      const deltaX = moveEvent.screenX - lastX
+      const deltaY = moveEvent.screenY - lastY
+
+      if (deltaX !== 0 || deltaY !== 0) {
+        window.api.selection.resizeActionWindow(deltaX, deltaY, direction)
+        lastX = moveEvent.screenX
+        lastY = moveEvent.screenY
+      }
+    }
+
+    const handleMouseUp = () => {
+      window.removeEventListener('mousemove', handleMouseMove)
+      window.removeEventListener('mouseup', handleMouseUp)
+    }
+
+    window.addEventListener('mousemove', handleMouseMove)
+    window.addEventListener('mouseup', handleMouseUp)
+  }, [])
+
   //we don't need to render the component if action is not set
   if (!action) return null
 
   return (
     <WindowFrame $opacity={opacity / 100}>
+      {/* [Windows only] Custom resize handles - Electron bug workaround, can be removed once fixed */}
+      {isWin && (
+        <>
+          <ResizeHandle $direction="n" onMouseDown={(e) => handleResizeStart(e, 'n')} />
+          <ResizeHandle $direction="s" onMouseDown={(e) => handleResizeStart(e, 's')} />
+          <ResizeHandle $direction="e" onMouseDown={(e) => handleResizeStart(e, 'e')} />
+          <ResizeHandle $direction="w" onMouseDown={(e) => handleResizeStart(e, 'w')} />
+          <ResizeHandle $direction="ne" onMouseDown={(e) => handleResizeStart(e, 'ne')} />
+          <ResizeHandle $direction="nw" onMouseDown={(e) => handleResizeStart(e, 'nw')} />
+          <ResizeHandle $direction="se" onMouseDown={(e) => handleResizeStart(e, 'se')} />
+          <ResizeHandle $direction="sw" onMouseDown={(e) => handleResizeStart(e, 'sw')} />
+        </>
+      )}
+
       <TitleBar $isWindowFocus={isWindowFocus} style={isMac ? { paddingLeft: '70px' } : {}}>
         {action.icon && (
           <TitleBarIcon>
@@ -429,6 +483,92 @@ const OpacitySlider = styled.div`
       box-shadow: 0 0 0 2px var(--color-primary-mute);
     }
   }
+`
+
+/**
+ * [Windows only] Custom resize handle styled component
+ *
+ * ELECTRON BUG WORKAROUND:
+ * This component can be removed once https://github.com/electron/electron/issues/48554 is fixed.
+ */
+const ResizeHandle = styled.div<{ $direction: ResizeDirection }>`
+  position: absolute;
+  -webkit-app-region: no-drag;
+  z-index: 10;
+
+  ${({ $direction }) => {
+    const edgeSize = '6px'
+    const cornerSize = '12px'
+
+    switch ($direction) {
+      case 'n':
+        return `
+          top: 0;
+          left: ${cornerSize};
+          right: ${cornerSize};
+          height: ${edgeSize};
+          cursor: ns-resize;
+        `
+      case 's':
+        return `
+          bottom: 0;
+          left: ${cornerSize};
+          right: ${cornerSize};
+          height: ${edgeSize};
+          cursor: ns-resize;
+        `
+      case 'e':
+        return `
+          right: 0;
+          top: ${cornerSize};
+          bottom: ${cornerSize};
+          width: ${edgeSize};
+          cursor: ew-resize;
+        `
+      case 'w':
+        return `
+          left: 0;
+          top: ${cornerSize};
+          bottom: ${cornerSize};
+          width: ${edgeSize};
+          cursor: ew-resize;
+        `
+      case 'ne':
+        return `
+          top: 0;
+          right: 0;
+          width: ${cornerSize};
+          height: ${cornerSize};
+          cursor: nesw-resize;
+        `
+      case 'nw':
+        return `
+          top: 0;
+          left: 0;
+          width: ${cornerSize};
+          height: ${cornerSize};
+          cursor: nwse-resize;
+        `
+      case 'se':
+        return `
+          bottom: 0;
+          right: 0;
+          width: ${cornerSize};
+          height: ${cornerSize};
+          cursor: nwse-resize;
+        `
+      case 'sw':
+        return `
+          bottom: 0;
+          left: 0;
+          width: ${cornerSize};
+          height: ${cornerSize};
+          cursor: nesw-resize;
+        `
+      default:
+        return ''
+    }
+  }}
 `
 
 export default SelectionActionApp


### PR DESCRIPTION
### What this PR does

Before this PR:
- On Windows, the SelectionAction window cannot be resized by dragging edges/corners due to an Electron bug with `frame: false` + `transparent: true` configuration.

After this PR:
- Users can resize the SelectionAction window by dragging edges and corners on Windows.
- The implementation uses custom resize handles with CSS positioning and IPC calls to the main process.
- On macOS and Linux, the native resize functionality is preserved (no changes needed).

Fixes: #11762 #11647 

### Why we need it and why it was done in this way

**The following tradeoffs were made:**
- Added 8 invisible resize handles (4 edges + 4 corners) around the window frame
- Each handle triggers IPC calls to resize the window via `setBounds()`
- This adds some code complexity but provides a seamless user experience

**The following alternatives were considered:**
- Waiting for Electron to fix the bug - not feasible as the timeline is unknown
- Using a different window configuration - not possible due to design requirements (transparency, frameless)

**Links to places where the discussion took place:**
- Electron bug: https://github.com/electron/electron/issues/48554 

### Breaking changes

None. This change only affects Windows platform behavior and adds new functionality.

### Special notes for your reviewer

- All workaround code is clearly documented with `[Windows only]` markers and links to the Electron issue
- The code can be safely removed once Electron fixes the underlying bug
- The implementation respects minimum window size constraints (300x200)

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: Code is clean and well-documented with removal instructions
- [x] Upgrade: No impact on upgrade flows
- [ ] Documentation: Not required (internal implementation detail)

### Release note

```release-note
fix(windows): SelectionAction window can now be resized by dragging edges and corners on Windows
```