### PR TITLE
feat: add CherryIN API host selection settings

### DIFF
--- a/src/renderer/src/aiCore/provider/providerConfig.ts
+++ b/src/renderer/src/aiCore/provider/providerConfig.ts
@@ -9,6 +9,7 @@ import {
 } from '@renderer/hooks/useAwsBedrock'
 import { createVertexProvider, isVertexAIConfigured } from '@renderer/hooks/useVertexAI'
 import { getProviderByModel } from '@renderer/services/AssistantService'
+import { getProviderById } from '@renderer/services/ProviderService'
 import store from '@renderer/store'
 import { isSystemProvider, type Model, type Provider, SystemProviderIds } from '@renderer/types'
 import type { OpenAICompletionsStreamOptions } from '@renderer/types/aiCoreTypes'
@@ -247,6 +248,12 @@ export function providerToAiSdkConfig(actualProvider: Provider, model: Model): A
   if (aiSdkProviderId === 'cherryin') {
     if (model.endpoint_type) {
       extraOptions.endpointType = model.endpoint_type
+    }
+    // CherryIN API Host
+    const cherryinProvider = getProviderById(SystemProviderIds.cherryin)
+    if (cherryinProvider) {
+      extraOptions.anthropicBaseURL = cherryinProvider.anthropicApiHost
+      extraOptions.geminiBaseURL = cherryinProvider.apiHost + '/gemini/v1beta'
     }
   }
 

--- a/src/renderer/src/pages/settings/ProviderSettings/CherryINSettings.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/CherryINSettings.tsx
@@ -1,0 +1,74 @@
+import { useProvider } from '@renderer/hooks/useProvider'
+import { Select } from 'antd'
+import type { FC } from 'react'
+import { useCallback, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface CherryINSettingsProps {
+  providerId: string
+  apiHost: string
+  setApiHost: (host: string) => void
+}
+
+const API_HOST_OPTIONS = [
+  {
+    value: 'https://open.cherryin.cc',
+    labelKey: '加速域名',
+    description: 'open.cherryin.cc'
+  },
+  {
+    value: 'https://open.cherryin.net',
+    labelKey: '国际域名',
+    description: 'open.cherryin.net'
+  },
+  {
+    value: 'https://open.cherryin.ai',
+    labelKey: '备用域名',
+    description: 'open.cherryin.ai'
+  }
+]
+
+const CherryINSettings: FC<CherryINSettingsProps> = ({ providerId, apiHost, setApiHost }) => {
+  const { updateProvider } = useProvider(providerId)
+  const { t } = useTranslation()
+
+  const getCurrentHost = useMemo(() => {
+    const matchedOption = API_HOST_OPTIONS.find((option) => apiHost?.includes(option.value.replace('https://', '')))
+    return matchedOption?.value ?? API_HOST_OPTIONS[0].value
+  }, [apiHost])
+
+  const handleHostChange = useCallback(
+    (value: string) => {
+      setApiHost(value)
+      updateProvider({ apiHost: value, anthropicApiHost: value })
+    },
+    [setApiHost, updateProvider]
+  )
+
+  const options = useMemo(
+    () =>
+      API_HOST_OPTIONS.map((option) => ({
+        value: option.value,
+        label: (
+          <div className="flex flex-col gap-0.5">
+            <span>{t(option.labelKey)}</span>
+            <span className="text-[var(--color-text-3)] text-xs">{t(option.description)}</span>
+          </div>
+        )
+      })),
+    [t]
+  )
+
+  return (
+    <Select
+      value={getCurrentHost}
+      onChange={handleHostChange}
+      options={options}
+      style={{ width: '100%', marginTop: 5 }}
+      optionLabelProp="label"
+      labelRender={(option) => option.value}
+    />
+  )
+}
+
+export default CherryINSettings

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -67,7 +67,7 @@ const persistedReducer = persistReducer(
   {
     key: 'cherry-studio',
     storage,
-    version: 182,
+    version: 183,
     blacklist: ['runtime', 'messages', 'messageBlocks', 'tabs', 'toolPermissions'],
     migrate
   },

--- a/src/renderer/src/store/migrate.ts
+++ b/src/renderer/src/store/migrate.ts
@@ -2976,6 +2976,22 @@ const migrateConfig = {
       logger.error('migrate 182 error', error as Error)
       return state
     }
+  },
+  '183': (state: RootState) => {
+    try {
+      state.llm.providers.forEach((provider) => {
+        if (provider.id === SystemProviderIds.cherryin) {
+          provider.apiHost = 'https://open.cherryin.cc'
+          provider.anthropicApiHost = 'https://open.cherryin.cc'
+        }
+      })
+      state.llm.providers = moveProvider(state.llm.providers, SystemProviderIds.poe, 10)
+      logger.info('migrate 183 success')
+      return state
+    } catch (error) {
+      logger.error('migrate 183 error', error as Error)
+      return state
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Add CherryINSettings component for domestic/international API host selection
- Implement dropdown selector for API host options (open.cherryin.cc vs open.cherryin.net)
- Add multi-language support for CherryIN settings UI
- Update provider configuration to handle CherryIN-specific API hosts
- Add store migration (v183) for default CherryIN API host initialization

<img width="761" height="366" alt="image" src="https://github.com/user-attachments/assets/0a8096c4-1e69-4174-8edf-c8ff4c396b18" />

## Description
Before this PR:
- CherryIN provider used fixed API host configuration
- No user interface for selecting between domestic and international API hosts
- Anthropic API host could be manually configured for CherryIN

After this PR:
- Users can select between domestic (open.cherryin.cc) and international (open.cherryin.net) API hosts through a dropdown interface
- CherryIN-specific configuration handles both API host and Anthropic API host automatically
- Custom Anthropic host input is disabled for CherryIN provider to prevent conflicts
- Multi-language support for CherryIN settings across all supported languages

## Test plan
- [x] Test CherryIN API host selection dropdown functionality
- [x] Verify both domestic and international options work correctly
- [x] Test provider configuration updates when switching hosts
- [x] Verify store migration properly initializes default CherryIN settings
- [x] Test multi-language display of CherryIN settings
- [x] Verify custom Anthropic host input is disabled for CherryIN provider
- [x] Run integration tests to ensure CherryIN functionality works with both hosts

## Checklist
- [ ] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

## Release note
```release-note
Add CherryIN API host selection settings allowing users to choose between domestic and international API endpoints through a user-friendly dropdown interface.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a CherryIN-specific API host dropdown (CN-only), wires provider config for Anthropic/Gemini bases, and migrates defaults to open.cherryin.cc (v183).
> 
> - **Settings UI**:
>   - Add `CherryINSettings` with dropdown to select CherryIN API host (`open.cherryin.cc/.net/.ai`) for Chinese locale users in `ProviderSetting.tsx`.
>   - Auto-syncs both `apiHost` and `anthropicApiHost` on selection; disables custom Anthropic host field for `cherryin`.
> - **Provider config** (`aiCore/provider/providerConfig.ts`):
>   - For `cherryin`, set `extraOptions.endpointType` from model, plus `anthropicBaseURL` and `geminiBaseURL` (from `getProviderById(SystemProviderIds.cherryin)`).
> - **Store**:
>   - Bump persist version to `183`.
>   - Migration `183`: initialize `cherryin` `apiHost`/`anthropicApiHost` to `https://open.cherryin.cc`; reorder `poe` provider.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ebb0ad400c522e55707fb9cb617002892db779e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->