### PR TITLE
feat: support clipboard images in mini assistant

### DIFF
--- a/src/renderer/src/windows/mini/home/components/InputBar.tsx
+++ b/src/renderer/src/windows/mini/home/components/InputBar.tsx
@@ -14,6 +14,7 @@ interface InputBarProps {
   loading: boolean
   handleKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void
   handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  handlePaste: (e: React.ClipboardEvent<HTMLInputElement>) => void
 }
 
 const InputBar = ({
@@ -23,7 +24,8 @@ const InputBar = ({
   placeholder,
   loading,
   handleKeyDown,
-  handleChange
+  handleChange,
+  handlePaste
 }: InputBarProps & { ref?: React.RefObject<HTMLDivElement | null> }) => {
   const inputRef = useRef<InputRef>(null)
   const { setTimeoutTimer } = useTimer()
@@ -40,6 +42,7 @@ const InputBar = ({
         autoFocus
         onKeyDown={handleKeyDown}
         onChange={handleChange}
+        onPaste={handlePaste}
         ref={inputRef}
       />
     </InputWrapper>


### PR DESCRIPTION
### What this PR does

Before this PR:
- Quick assistant input only accepted text and could not attach images.

After this PR:
- Added image picker and paste handling to the quick assistant input, including an icon shortcut.
- Displayed attached images with the existing attachment preview and allowed sending image-only prompts.

Fixes #N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Reused the existing attachment preview to keep UI behavior consistent and avoid duplicating attachment controls.

The following alternatives were considered:
- Building a new lightweight preview component, but leveraging the shared one simplified maintenance.

Links to places where the discussion took place: None.

### Breaking changes

None.

### Special notes for your reviewer

None.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
Added image attachment support to the quick assistant input triggered by Ctrl + E.
```

------
https://github.com/CherryHQ/cherry-studio/issues/11275