### PR TITLE
fix(ThinkingButton): show correct icon when isFixedReasoning

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/tools/components/ThinkingButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/tools/components/ThinkingButton.tsx
@@ -93,7 +93,7 @@ const ThinkingButton: FC<Props> = ({ quickPanel, model, assistantId }): ReactEle
       level: option,
       label: getReasoningEffortOptionsLabel(option),
       description: '',
-      icon: ThinkingIcon(option),
+      icon: ThinkingIcon({ option }),
       isSelected: currentReasoningEffort === option,
       action: () => onThinkingChange(option)
     }))
@@ -135,7 +135,7 @@ const ThinkingButton: FC<Props> = ({ quickPanel, model, assistantId }): ReactEle
       {
         label: t('assistants.settings.reasoning_effort.label'),
         description: '',
-        icon: ThinkingIcon(currentReasoningEffort),
+        icon: ThinkingIcon({ option: currentReasoningEffort }),
         isMenu: true,
         action: () => openQuickPanel()
       }
@@ -163,37 +163,40 @@ const ThinkingButton: FC<Props> = ({ quickPanel, model, assistantId }): ReactEle
         aria-label={ariaLabel}
         aria-pressed={currentReasoningEffort !== 'none'}
         style={isFixedReasoning ? { cursor: 'default' } : undefined}>
-        {ThinkingIcon(currentReasoningEffort)}
+        {ThinkingIcon({ option: currentReasoningEffort, isFixedReasoning })}
       </ActionIconButton>
     </Tooltip>
   )
 }
 
-const ThinkingIcon = (option?: ThinkingOption) => {
+const ThinkingIcon = (props: { option?: ThinkingOption; isFixedReasoning?: boolean }) => {
   let IconComponent: React.FC<React.SVGProps<SVGSVGElement>> | null = null
-
-  switch (option) {
-    case 'minimal':
-      IconComponent = MdiLightbulbOn30
-      break
-    case 'low':
-      IconComponent = MdiLightbulbOn50
-      break
-    case 'medium':
-      IconComponent = MdiLightbulbOn80
-      break
-    case 'high':
-      IconComponent = MdiLightbulbOn
-      break
-    case 'auto':
-      IconComponent = MdiLightbulbAutoOutline
-      break
-    case 'none':
-      IconComponent = MdiLightbulbOffOutline
-      break
-    default:
-      IconComponent = MdiLightbulbOffOutline
-      break
+  if (props.isFixedReasoning) {
+    IconComponent = MdiLightbulbAutoOutline
+  } else {
+    switch (props.option) {
+      case 'minimal':
+        IconComponent = MdiLightbulbOn30
+        break
+      case 'low':
+        IconComponent = MdiLightbulbOn50
+        break
+      case 'medium':
+        IconComponent = MdiLightbulbOn80
+        break
+      case 'high':
+        IconComponent = MdiLightbulbOn
+        break
+      case 'auto':
+        IconComponent = MdiLightbulbAutoOutline
+        break
+      case 'none':
+        IconComponent = MdiLightbulbOffOutline
+        break
+      default:
+        IconComponent = MdiLightbulbOffOutline
+        break
+    }
   }
 
   return <IconComponent className="icon" width={18} height={18} style={{ marginTop: -2 }} />


### PR DESCRIPTION
### What this PR does

Before this PR:
- For fixed reasoning models (like `o1`, `o3-mini`), the `reasoningEffort` is automatically adjusted to `undefined`
- When `ThinkingIcon` receives `undefined` as the option parameter, it falls through to the `default` case in the switch statement
- The `default` case returns `MdiLightbulbOffOutline` (the "none" state icon)
- This is misleading because fixed reasoning models actually use auto reasoning, not "none"

After this PR:
- When `isFixedReasoning` is true, the ThinkingButton always displays the `MdiLightbulbAutoOutline` icon
- This correctly represents that fixed reasoning models use automatic reasoning selection
- The icon now accurately reflects the actual behavior instead of incorrectly showing the "none/off" icon

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Modified the `ThinkingIcon` component to accept an object parameter with `option` and `isFixedReasoning` properties
- Added explicit check for `isFixedReasoning` before the switch statement to prevent falling through to the incorrect `default` case
- This ensures the correct icon is always shown for fixed reasoning models

The following alternatives were considered:
- Modifying the reasoning effort value itself to be "auto" instead of `undefined` for fixed models, but this would affect logic elsewhere
- Changing the default case to return auto icon, but that would be incorrect for truly undefined cases

Links to places where the discussion took place:
N/A

### Breaking changes

None - This is a UI bug fix with no API changes or breaking behavior modifications.

### Special notes for your reviewer

- The root cause: `undefined` option value → `default` case → wrong "none/off" icon
- The fix: Check `isFixedReasoning` first → show correct "auto" icon
- Please verify that fixed reasoning models now show the auto lightbulb icon instead of the off icon
- The change is purely visual and does not affect the actual reasoning behavior

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
fix: ThinkingButton now correctly displays the auto reasoning icon instead of the off icon for models with fixed reasoning (o1, o3-mini, etc.)
```