### PR TITLE
fix(knowledge): prioritize query & refine intent prompt

### DIFF
--- a/src/renderer/src/config/prompts.ts
+++ b/src/renderer/src/config/prompts.ts
@@ -306,7 +306,7 @@ export const SEARCH_SUMMARY_PROMPT_KNOWLEDGE_ONLY = `
   **Use user's language to rephrase the question.**
   Follow these guidelines:
   1. If the question is a simple writing task, greeting (e.g., Hi, Hello, How are you), or does not require searching for information (unless the greeting contains a follow-up question), return 'not_needed' in the 'question' XML block. This indicates that no search is required.
-  2. For knowledge, You need rewrite user query into 'rewrite' XML block with one alternative version while preserving the original intent and meaning. Also include the original question in the 'question' block.
+  2. For knowledge, You need rewrite user query into 'rewrite' XML block with one alternative version while preserving the original intent and meaning. Also include the rephrased or decomposed question(s) in the 'question' block.
   3. Always return the rephrased question inside the 'question' XML block.
   4. Always wrap the rephrased question in the appropriate XML blocks: use <knowledge></knowledge> for queries that can be answered from a pre-existing knowledge base. Ensure that the rephrased question is always contained within a <question></question> block inside the wrapper.
   5. *use knowledge to rephrase the question*

--- a/src/renderer/src/services/KnowledgeService.ts
+++ b/src/renderer/src/services/KnowledgeService.ts
@@ -162,7 +162,7 @@ export const searchKnowledgeBase = async (
 
     const searchResults: KnowledgeSearchResult[] = await window.api.knowledgeBase.search(
       {
-        search: rewrite || query,
+        search: query || rewrite || '',
         base: baseParams
       },
       currentSpan?.spanContext()


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

⚠️ Important: Redux/IndexedDB Data-Changing Feature PRs Temporarily On Hold ⚠️

Please note: For our current development cycle, we are not accepting feature Pull Requests that introduce changes to Redux data models or IndexedDB schemas.

While we value your contributions, PRs of this nature will be blocked without merge. We welcome all other contributions (bug fixes, perf enhancements, docs, etc.). Thank you!

Once version 2.0.0 is released, we will resume reviewing feature PRs.

-->

### What this PR does

This PR addresses two critical issues in the Knowledge Base search logic (specifically in `knowledgeRecognition: 'on'` mode) that prevented effective query decomposition:

1.  **Logic Fix (`KnowledgeService.ts`):** Inverted the search priority to `search: query || rewrite || ''`.
    -   **Before:** The code prioritized the generic `rewrite` summary, ignoring any specific sub-queries (`query`) generated by the intent analyzer.
    -   **After:** The system now prioritizes the specific `query` (e.g., decomposed sub-questions) if available, falling back to `rewrite` only if necessary.

2.  **Prompt Fix (`prompts.ts`):** Updated `SEARCH_SUMMARY_PROMPT_KNOWLEDGE_ONLY`.
    -   **Before:** It explicitly asked the AI to include the "original question", conflicting with the intent decomposition logic.
    -   **After:** Updated to explicitly ask for "rephrased or decomposed question(s)", enabling the AI to properly break down complex queries.

Fixes #11827

### Why we need it and why it was done in this way

- **Code:** Changing the priority to `query || rewrite` is the most direct and surgical fix. It ensures that granular queries are respected without breaking the fallback mechanism for Force Mode (where query == rewrite).
- **Prompt:** Changing "original" to "rephrased/decomposed" aligns the prompt instruction with the few-shot examples, resolving the instruction conflict that made the model "lazy".

### Breaking changes

<!-- optional -->

No breaking changes.
- In **Force Mode** (`knowledgeRecognition: 'off'`), `query` and `rewrite` are identical (raw user input), so the priority change has no effect.
- In **Smart Mode**, this enhances retrieval precision.

### Special notes for your reviewer

None

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ x] PR: The PR description is expressive enough and will help future contributors
- [ x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note

Fix: Improved Knowledge Base search logic in Smart Mode to correctly execute decomposed sub-queries for better retrieval precision.

```
