### PR TITLE
🐛 fix: stabilize MCP log IPC registration

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -766,7 +766,6 @@ export function registerIpc(mainWindow: BrowserWindow, app: Electron.App) {
   ipcMain.handle(IpcChannel.Mcp_AbortTool, mcpService.abortTool)
   ipcMain.handle(IpcChannel.Mcp_GetServerVersion, mcpService.getServerVersion)
   ipcMain.handle(IpcChannel.Mcp_GetServerLogs, mcpService.getServerLogs)
-  ipcMain.handle(IpcChannel.Mcp_GetServerLogs, mcpService.getServerLogs)
 
   // DXT upload handler
   ipcMain.handle(IpcChannel.Mcp_UploadDxt, async (event, fileBuffer: ArrayBuffer, fileName: string) => {

--- a/src/main/services/MCPService.ts
+++ b/src/main/services/MCPService.ts
@@ -162,6 +162,7 @@ class McpService {
     this.cleanup = this.cleanup.bind(this)
     this.checkMcpConnectivity = this.checkMcpConnectivity.bind(this)
     this.getServerVersion = this.getServerVersion.bind(this)
+    this.getServerLogs = this.getServerLogs.bind(this)
   }
 
   private getServerKey(server: MCPServer): string {
@@ -392,15 +393,8 @@ class McpService {
                 source: 'stdio'
               })
             })
-            ;(stdioTransport as any).stdout?.on('data', (data: any) => {
-              const msg = data.toString()
-              this.emitServerLog(server, {
-                timestamp: Date.now(),
-                level: 'stdout',
-                message: msg.trim(),
-                source: 'stdio'
-              })
-            })
+            // StdioClientTransport does not expose stdout as a readable stream for raw logging
+            // (stdout is reserved for JSON-RPC). Avoid attaching a listener that would never fire.
             return stdioTransport
           } else {
             throw new Error('Either baseUrl or command must be provided')


### PR DESCRIPTION
### What this PR does

Before this PR:
- Duplicate IPC handler registration for `Mcp_GetServerLogs` caused errors
- A non-functional stdout listener was attached to `StdioClientTransport` (stdout is reserved for JSON-RPC, not raw logging)
- `getServerLogs` method was not properly bound to `this`

After this PR:
- Removed duplicate IPC handler registration
- Removed the non-functional stdout listener with explanatory comment
- Added proper `this` binding for `getServerLogs` method

### Why we need it and why it was done in this way

The following tradeoffs were made:
- None significant

The following alternatives were considered:
- Keeping the stdout listener but it would never fire since StdioClientTransport uses stdout exclusively for JSON-RPC communication

### Breaking changes

None. This is a bug fix that removes dead code and fixes IPC registration.

### Special notes for your reviewer

The duplicate IPC registration was likely introduced during the MCP server log viewer feature development (#11826).

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: N/A - bug fix only

### Release note

```release-note
Fixed duplicate IPC handler registration and removed non-functional stdout listener in MCP service
```