### PR TITLE
feat: OVMS remove intel ultra limit

### DIFF
--- a/resources/scripts/install-ovms.js
+++ b/resources/scripts/install-ovms.js
@@ -11,7 +11,7 @@ const OVMS_EX_URL = 'https://gitcode.com/gcw_ggDjjkY3/kjfile/releases/download/d
 
 /**
  * error code:
- * 101: Unsupported CPU (not Intel Ultra)
+ * 101: Unsupported CPU (not Intel)
  * 102: Unsupported platform (not Windows)
  * 103: Download failed
  * 104: Installation failed
@@ -213,8 +213,8 @@ async function installOvms() {
   console.log(`CPU Name: ${cpuName}`)
 
   // Check if CPU name contains "Ultra"
-  if (!cpuName.toLowerCase().includes('intel') || !cpuName.toLowerCase().includes('ultra')) {
-    console.error('OVMS installation requires an Intel(R) Core(TM) Ultra CPU.')
+  if (!cpuName.toLowerCase().includes('intel')) {
+    console.error('OVMS installation requires an Intel CPU.')
     return 101
   }
 

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -2317,7 +2317,7 @@
     "failed": {
       "install": "Install OVMS failed:",
       "install_code_100": "Unknown Error",
-      "install_code_101": "Only supports Intel(R) Core(TM) Ultra CPU",
+      "install_code_101": "Only supports Intel(R) CPU",
       "install_code_102": "Only supports Windows",
       "install_code_103": "Download OVMS runtime failed",
       "install_code_104": "Failed to install OVMS runtime",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -2317,7 +2317,7 @@
     "failed": {
       "install": "安装 OVMS 失败:",
       "install_code_100": "未知错误",
-      "install_code_101": "仅支持 Intel(R) Core(TM) Ultra CPU",
+      "install_code_101": "仅支持 Intel(R) CPU",
       "install_code_102": "仅支持 Windows",
       "install_code_103": "下载 OVMS runtime 失败",
       "install_code_104": "安装 OVMS runtime 失败",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -2317,7 +2317,7 @@
     "failed": {
       "install": "安裝 OVMS 失敗:",
       "install_code_100": "未知錯誤",
-      "install_code_101": "僅支援 Intel(R) Core(TM) Ultra CPU",
+      "install_code_101": "僅支援 Intel(R) CPU",
       "install_code_102": "僅支援 Windows",
       "install_code_103": "下載 OVMS runtime 失敗",
       "install_code_104": "安裝 OVMS runtime 失敗",


### PR DESCRIPTION
### What this PR does

Before this PR:

OVMS can only be installed on the Intel Ultra platform.

After this PR:

OVMS can be installed on all Intel platform.

### Release note

```release-note
OVMS can be installed on all Intel Platform.
```
