### PR TITLE
fix: disable reasoning in translation by default

### DIFF
--- a/src/renderer/src/aiCore/middleware/AiSdkMiddlewareBuilder.ts
+++ b/src/renderer/src/aiCore/middleware/AiSdkMiddlewareBuilder.ts
@@ -244,7 +244,9 @@ function addModelSpecificMiddlewares(builder: AiSdkMiddlewareBuilder, config: Ai
     isSupportedThinkingTokenQwenModel(config.model) &&
     !isSupportEnableThinkingProvider(config.provider)
   ) {
-    const enableThinking = config.assistant?.settings?.reasoning_effort !== undefined
+    const enableThinking =
+      config.assistant?.settings?.reasoning_effort !== undefined &&
+      config.assistant?.settings?.reasoning_effort !== 'none'
     builder.add({
       name: 'qwen-thinking-control',
       middleware: qwenThinkingMiddleware(enableThinking)

--- a/src/renderer/src/aiCore/prepareParams/parameterBuilder.ts
+++ b/src/renderer/src/aiCore/prepareParams/parameterBuilder.ts
@@ -103,11 +103,11 @@ export async function buildStreamTextParams(
 
   // 这三个变量透传出来，交给下面启用插件/中间件
   // 也可以在外部构建好再传入buildStreamTextParams
-  // FIXME: qwen3即使关闭思考仍然会导致enableReasoning的结果为true
   const enableReasoning =
     ((isSupportedThinkingTokenModel(model) || isSupportedReasoningEffortModel(model)) &&
-      assistant.settings?.reasoning_effort !== undefined) ||
-    isFixedReasoningModel(model)
+      assistant.settings?.reasoning_effort !== undefined &&
+      assistant.settings?.reasoning_effort !== 'none') ||
+    (isFixedReasoningModel(model) && assistant.settings?.reasoning_effort !== 'none')
 
   // 判断是否使用内置搜索
   // 条件：没有外部搜索提供商 && (用户开启了内置搜索 || 模型强制使用内置搜索)

--- a/src/renderer/src/services/AssistantService.ts
+++ b/src/renderer/src/services/AssistantService.ts
@@ -68,8 +68,9 @@ export function getDefaultTranslateAssistant(targetLanguage: TranslateLanguage, 
     throw new Error('Unknown target language')
   }
 
-  const settings = {
-    temperature: 0.7
+  const settings: Partial<AssistantSettings> = {
+    temperature: 0.7,
+    reasoning_effort: 'none'
   }
 
   const getTranslateContent = (model: Model, text: string, targetLanguage: TranslateLanguage): string => {

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -105,7 +105,7 @@ const ThinkModelTypes = [
   'deepseek_hybrid'
 ] as const
 
-export type ReasoningEffortOption = NonNullable<OpenAI.ReasoningEffort> | 'auto'
+export type ReasoningEffortOption = NonNullable<OpenAI.ReasoningEffort> | 'auto' | 'none'
 export type ThinkingOption = ReasoningEffortOption
 export type ThinkingModelType = (typeof ThinkModelTypes)[number]
 export type ThinkingOptionConfig = Record<ThinkingModelType, ThinkingOption[]>


### PR DESCRIPTION
- Add 'none' to ReasoningEffortOption type definition
- Set reasoning_effort to 'none' in translation assistant settings
- Ensure translation always disables reasoning functionality regardless of model type

<img width="1353" height="524" alt="image" src="https://github.com/user-attachments/assets/bfc375e6-5781-42b3-af26-955c13d8cf66" />
