### PR TITLE
fix: use ModernAiProvider for embedding dimensions

### DIFF
--- a/src/renderer/src/aiCore/legacy/index.ts
+++ b/src/renderer/src/aiCore/legacy/index.ts
@@ -2,7 +2,6 @@ import { loggerService } from '@logger'
 import { ApiClientFactory } from '@renderer/aiCore/legacy/clients/ApiClientFactory'
 import type { BaseApiClient } from '@renderer/aiCore/legacy/clients/BaseApiClient'
 import { isDedicatedImageGenerationModel, isFunctionCallingModel } from '@renderer/config/models'
-import { getProviderByModel } from '@renderer/services/AssistantService'
 import { withSpanResult } from '@renderer/services/SpanManagerService'
 import type { StartSpanParams } from '@renderer/trace/types/ModelSpanEntity'
 import type { GenerateImageParams, Model, Provider } from '@renderer/types'
@@ -160,9 +159,6 @@ export default class AiProvider {
   public async getEmbeddingDimensions(model: Model): Promise<number> {
     try {
       // Use the SDK instance to test embedding capabilities
-      if (this.apiClient instanceof OpenAIResponseAPIClient && getProviderByModel(model).type === 'azure-openai') {
-        this.apiClient = this.apiClient.getClient(model) as BaseApiClient
-      }
       const dimensions = await this.apiClient.getEmbeddingDimensions(model)
       return dimensions
     } catch (error) {

--- a/src/renderer/src/components/InputEmbeddingDimension.tsx
+++ b/src/renderer/src/components/InputEmbeddingDimension.tsx
@@ -1,5 +1,4 @@
 import { loggerService } from '@logger'
-import AiProvider from '@renderer/aiCore'
 import { RefreshIcon } from '@renderer/components/Icons'
 import { useProvider } from '@renderer/hooks/useProvider'
 import type { Model } from '@renderer/types'
@@ -7,6 +6,8 @@ import { getErrorMessage } from '@renderer/utils'
 import { Button, InputNumber, Space, Tooltip } from 'antd'
 import { memo, useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+
+import AiProviderNew from '../aiCore/index_new'
 
 const logger = loggerService.withContext('DimensionsInput')
 
@@ -47,7 +48,7 @@ const InputEmbeddingDimension = ({
 
     setLoading(true)
     try {
-      const aiProvider = new AiProvider(provider)
+      const aiProvider = new AiProviderNew(provider)
       const dimension = await aiProvider.getEmbeddingDimensions(model)
       // for controlled input
       if (ref?.current) {

--- a/src/renderer/src/components/__tests__/InputEmbeddingDimension.test.tsx
+++ b/src/renderer/src/components/__tests__/InputEmbeddingDimension.test.tsx
@@ -79,7 +79,7 @@ vi.mock('antd', () => {
 })
 
 // Mock dependencies
-vi.mock('@renderer/aiCore', () => ({
+vi.mock('@renderer/aiCore/index_new', () => ({
   default: vi.fn().mockImplementation(() => ({
     getEmbeddingDimensions: mocks.aiCore.getEmbeddingDimensions
   }))


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

⚠️ Important: Redux/IndexedDB Data-Changing Feature PRs Temporarily On Hold ⚠️

Please note: For our current development cycle, we are not accepting feature Pull Requests that introduce changes to Redux data models or IndexedDB schemas.

While we value your contributions, PRs of this nature will be blocked without merge. We welcome all other contributions (bug fixes, perf enhancements, docs, etc.). Thank you!

Once version 2.0.0 is released, we will resume reviewing feature PRs.

-->

### What this PR does

Before this PR:
Uses legacy ai provider, embedding urls were not properly formatted

After this PR:
Uses ModernAiProvider, removed special logic for `azure-openai`, URLs are correctly formatted through `adaptProvider`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
