### PR TITLE
fix: add capabilities support for Doubao Seed Code models

### DIFF
--- a/src/renderer/src/config/models/reasoning.ts
+++ b/src/renderer/src/config/models/reasoning.ts
@@ -388,7 +388,7 @@ export function isQwenAlwaysThinkModel(model?: Model): boolean {
 
 // Doubao 支持思考模式的模型正则
 export const DOUBAO_THINKING_MODEL_REGEX =
-  /doubao-(?:1[.-]5-thinking-vision-pro|1[.-]5-thinking-pro-m|seed-1[.-]6(?:-flash)?(?!-(?:thinking)(?:-|$)))(?:-[\w-]+)*/i
+  /doubao-(?:1[.-]5-thinking-vision-pro|1[.-]5-thinking-pro-m|seed-1[.-]6(?:-flash)?(?!-(?:thinking)(?:-|$))|seed-code(?:-preview)?(?:-\d+)?)(?:-[\w-]+)*/i
 
 // 支持 auto 的 Doubao 模型 doubao-seed-1.6-xxx doubao-seed-1-6-xxx  doubao-1-5-thinking-pro-m-xxx
 // Auto thinking is no longer supported after version 251015, see https://console.volcengine.com/ark/region:ark+cn-beijing/model/detail?Id=doubao-seed-1-6

--- a/src/renderer/src/config/models/tooluse.ts
+++ b/src/renderer/src/config/models/tooluse.ts
@@ -26,6 +26,7 @@ export const FUNCTION_CALLING_MODELS = [
   'gemini(?:-[\\w-]+)?', // 提前排除了gemini的嵌入模型
   'grok-3(?:-[\\w-]+)?',
   'doubao-seed-1[.-]6(?:-[\\w-]+)?',
+  'doubao-seed-code(?:-[\\w-]+)?',
   'kimi-k2(?:-[\\w-]+)?',
   'ling-\\w+(?:-[\\w-]+)?',
   'ring-\\w+(?:-[\\w-]+)?',

--- a/src/renderer/src/config/models/vision.ts
+++ b/src/renderer/src/config/models/vision.ts
@@ -46,6 +46,7 @@ const visionAllowedModels = [
   'kimi-latest',
   'gemma-3(?:-[\\w-]+)',
   'doubao-seed-1[.-]6(?:-[\\w-]+)?',
+  'doubao-seed-code(?:-[\\w-]+)?',
   'kimi-thinking-preview',
   `gemma3(?:[-:\\w]+)?`,
   'kimi-vl-a3b-thinking(?:-[\\w-]+)?',


### PR DESCRIPTION
### What this PR does

Before this PR:
- Doubao Seed Code models lacked support for tool/function calling, explicit reasoning (deep thinking) toggles, and vision/image understanding.

After this PR:
- Adds capabilities support for Doubao Seed Code models:
  - Tool calling support in tooluse.ts
  - Reasoning (deep thinking enable/disable) support in reasoning.ts
  - Vision/image understanding support in vision.ts

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Implemented per-capability files to keep concerns separated (tooluse, reasoning, vision).

The following alternatives were considered:
- N/A

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

- None

### Special notes for your reviewer

- Review the new capability handlers in tooluse.ts, reasoning.ts, and vision.ts for integration with existing model capability checks.

### Checklist

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (if required)

### Release note

```release-note
```