### PR TITLE
fix: default reasoning_effort to 'none' for new assistants

### DIFF
--- a/src/renderer/src/services/AssistantService.ts
+++ b/src/renderer/src/services/AssistantService.ts
@@ -38,7 +38,9 @@ export const DEFAULT_ASSISTANT_SETTINGS = {
   enableTopP: false,
   // It would gracefully fallback to prompt if not supported by model.
   toolUseMode: 'function',
-  customParameters: []
+  customParameters: [],
+  // Default reasoning_effort to 'none'
+  reasoning_effort: 'none'
 } as const satisfies AssistantSettings
 
 export function getDefaultAssistant(): Assistant {


### PR DESCRIPTION
### What this PR does

Before this PR:
- Newly created assistants had reasoning_effort undefined, which conflicted with the UI's "off" semantics.

After this PR:
- Set reasoning_effort to 'none' in DEFAULT_ASSISTANT_SETTINGS so new assistants default to reasoning disabled.

Fixes #11919

### Why we need it and why it was done in this way

- Ensures default assistant settings match UI and user expectations.
- Applied at DEFAULT_ASSISTANT_SETTINGS to cover all new assistants and all reasoning models (not just Cerebras).

### Breaking changes

- None (only affects defaults for newly created assistants).

### Special notes for your reviewer

- Change is in src/renderer/src/services/AssistantService.ts: initializes reasoning_effort to 'none'.

### Checklist

- [ ] PR description is expressive enough
- [ ] Code is readable and simple
- [ ] No upgrade flow required

### Release note

```release-note
Set default reasoning_effort to 'none' for new assistants to match UI "off" semantics.
```