### PR TITLE
fix: Bind OAuth callback server to localhost

### DIFF
--- a/src/main/services/mcp/oauth/callback.ts
+++ b/src/main/services/mcp/oauth/callback.ts
@@ -128,8 +128,8 @@ export class CallBackServer {
     })
 
     return new Promise<http.Server>((resolve, reject) => {
-      server.listen(port, () => {
-        logger.info(`OAuth callback server listening on port ${port}`)
+      server.listen(port, '127.0.0.1', () => {
+        logger.info(`OAuth callback server listening on 127.0.0.1:${port}`)
         resolve(server)
       })
 


### PR DESCRIPTION
Updated the server to listen explicitly on 127.0.0.1 instead of all interfaces. The log message was also updated to reflect the new binding address.

Reference:
https://github.com/MCPJam/inspector/issues/1095
https://github.com/nbonamy/witsy/commit/a23d4e52e25685d223c67ced3c5f1bd742896d4b