### PR TITLE
fix: implement infinite scroll for sessions list

### DIFF
--- a/src/renderer/src/api/agent.ts
+++ b/src/renderer/src/api/agent.ts
@@ -175,16 +175,7 @@ export class AgentApiClient {
   public async listSessions(agentId: string, options?: ListOptions): Promise<ListAgentSessionsResponse> {
     const url = this.getSessionPaths(agentId).base
     try {
-      const params = new URLSearchParams()
-      if (options?.limit !== undefined) params.append('limit', String(options.limit))
-      if (options?.offset !== undefined) params.append('offset', String(options.offset))
-      if (options?.sortBy) params.append('sortBy', options.sortBy)
-      if (options?.orderBy) params.append('orderBy', options.orderBy)
-
-      const queryString = params.toString()
-      const fullUrl = queryString ? `${url}?${queryString}` : url
-
-      const response = await this.axios.get(fullUrl)
+      const response = await this.axios.get(url, { params: options })
       const result = ListAgentSessionsResponseSchema.safeParse(response.data)
       if (!result.success) {
         throw new Error('Not a valid Sessions array.')


### PR DESCRIPTION
Fix #11935 

Refactored session fetching to use paginated API calls and SWR's useSWRInfinite for infinite loading. Updated the Sessions component to use DraggableVirtualList, handle scroll events to load more sessions, and display a loading spinner when fetching additional data. Adjusted session creation, update, and deletion logic to work with paginated data.