### PR TITLE
fix: correct typo in Gemini 3 Pro Image Preview model name

### DIFF
--- a/src/renderer/src/config/models/default.ts
+++ b/src/renderer/src/config/models/default.ts
@@ -362,7 +362,7 @@ export const SYSTEM_MODELS: Record<SystemProviderId | 'defaultModel', Model[]> =
     {
       id: 'gemini-3-pro-image-preview',
       provider: 'gemini',
-      name: 'Gemini 3 Pro Image Privew',
+      name: 'Gemini 3 Pro Image Preview',
       group: 'Gemini 3'
     },
     {


### PR DESCRIPTION
### What this PR does

Before this PR:
The Gemini 3 Pro Image Preview model was displayed with a typo: "Gemini 3 Pro Image Privew"

After this PR:
The model name is correctly displayed as "Gemini 3 Pro Image Preview"

Fixes #11967

### Why we need it and why it was done in this way

This is a simple typo fix to correct the spelling error in the model display name. The fix was implemented by updating the hardcoded string in the default models configuration.

The following tradeoffs were made:
- None, this is a straightforward typo correction

The following alternatives were considered:
- None, the fix is obvious and requires no alternative approaches

Links to places where the discussion took place:
- Issue #11967

### Breaking changes

None. This is a display-only change that corrects a spelling error. No functional behavior is affected.

### Special notes for your reviewer

This is a trivial typo fix. The change is limited to a single string in the model configuration file.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
fix: corrected typo in Gemini 3 Pro Image Preview model display name (was "Privew", now "Preview")
```