### PR TITLE
fix: disable reasoning mode for translation to improve efficiency

### DIFF
--- a/src/renderer/src/services/AssistantService.ts
+++ b/src/renderer/src/services/AssistantService.ts
@@ -6,6 +6,7 @@ import {
   MAX_CONTEXT_COUNT,
   UNLIMITED_CONTEXT_COUNT
 } from '@renderer/config/constant'
+import { getModelSupportedReasoningEffortOptions } from '@renderer/config/models'
 import { isQwenMTModel } from '@renderer/config/models/qwen'
 import { UNKNOWN } from '@renderer/config/translate'
 import { getStoreProviders } from '@renderer/hooks/useStore'
@@ -73,7 +74,9 @@ export function getDefaultTranslateAssistant(
     throw new Error('Unknown target language')
   }
 
-  const reasoningEffort = 'none'  // 翻译不需要思考模式，直接禁用
+  const supportedOptions = getModelSupportedReasoningEffortOptions(model)
+  // disable reasoning if it could be disabled, otherwise no configuration
+  const reasoningEffort = supportedOptions?.includes('none') ? 'none' : 'default'
   const settings = {
     temperature: 0.7,
     reasoning_effort: reasoningEffort,


### PR DESCRIPTION
### What this PR does

Before this PR:
- Translation assistant defaulted to a 'default' reasoning option that re-enabled reasoning mode, causing slower translations.

After this PR:
- getDefaultTranslateAssistant now sets the default reasoning option to 'none', disabling reasoning for translation and improving speed and performance.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Disabled reasoning to prioritize translation efficiency since translation scenarios do not require complex reasoning.

The following alternatives were considered:
- Keeping the 'default' option (rejected due to performance regression).

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

If this PR introduces breaking changes, please describe the changes and the impact on users.
- None expected; change only affects translation assistant default behavior to improve performance.

### Special notes for your reviewer

- Verify getDefaultTranslateAssistant default is 'none' and translation speed/performance improvements.

### Checklist

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: Write code that humans can understand and Keep it simple
- [ ] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required.

### Release note

```release-note
Disable reasoning mode by default for translation assistant to improve translation speed and performance.
```