### PR TITLE
fix(models): include GPT5.2 series in verbosity check

### DIFF
--- a/src/renderer/src/config/models/openai.ts
+++ b/src/renderer/src/config/models/openai.ts
@@ -72,7 +72,9 @@ export const isGPT52SeriesModel = (model: Model) => {
 
 export function isSupportVerbosityModel(model: Model): boolean {
   const modelId = getLowerBaseModelName(model.id)
-  return (isGPT5SeriesModel(model) || isGPT51SeriesModel(model)) && !modelId.includes('chat')
+  return (
+    (isGPT5SeriesModel(model) || isGPT51SeriesModel(model) || isGPT52SeriesModel(model)) && !modelId.includes('chat')
+  )
 }
 
 export function isOpenAIChatCompletionOnlyModel(model: Model): boolean {


### PR DESCRIPTION
### What this PR does

Before this PR:
- The `isSupportVerbosityModel` function only checked for GPT5 and GPT5.1 series models when determining verbosity support
- GPT5.2 series models were excluded from the verbosity feature even though they support it

After this PR:
- GPT5.2 series models are now properly included in the verbosity support check
- The function now checks `isGPT5SeriesModel(model) || isGPT51SeriesModel(model) || isGPT52SeriesModel(model)`

Fixes #

### Why we need it and why it was done in this way

This fix ensures that GPT5.2 series models can utilize the verbosity parameter, which they support. The implementation follows the existing pattern of checking model series.

The following tradeoffs were made:
- None - this is a straightforward bug fix

The following alternatives were considered:
- Consolidating the series checks into a single helper function, but maintaining separate checks preserves clarity and follows the existing codebase pattern

Links to places where the discussion took place:
N/A

### Breaking changes

None - this is a bug fix that extends existing functionality to GPT5.2 models.

### Special notes for your reviewer

This is a minimal change that adds GPT5.2 series to the verbosity check alongside GPT5 and GPT5.1. The change maintains consistency with how other model series are handled.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
fix: include GPT5.2 series models in verbosity support check
```