### PR TITLE
feat: support provider apiIdentifier for API relay

### DIFF
--- a/src/main/apiServer/utils/__tests__/provider-alias.test.ts
+++ b/src/main/apiServer/utils/__tests__/provider-alias.test.ts
@@ -1,0 +1,118 @@
+import { CacheService } from '@main/services/CacheService'
+import type { Model, Provider } from '@types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { selectMock } = vi.hoisted(() => ({
+  selectMock: vi.fn()
+}))
+
+vi.mock('@main/services/ReduxService', () => ({
+  reduxService: {
+    select: selectMock
+  }
+}))
+
+import { getProviderByModel, transformModelToOpenAI, validateModelId } from '..'
+
+describe('api server provider alias', () => {
+  beforeEach(() => {
+    CacheService.clear()
+    selectMock.mockReset()
+  })
+
+  it('formats model id using provider apiIdentifier when present', () => {
+    const provider: Provider = {
+      id: 'test-provider-uuid',
+      apiIdentifier: 'short',
+      type: 'openai',
+      name: 'Custom Provider',
+      apiKey: 'test-key',
+      apiHost: 'https://example.com/v1',
+      models: [],
+      enabled: true
+    }
+
+    const model: Model = {
+      id: 'glm-4.6',
+      provider: provider.id,
+      name: 'glm-4.6',
+      group: 'glm'
+    }
+
+    const apiModel = transformModelToOpenAI(model, provider)
+    expect(apiModel.id).toBe('short:glm-4.6')
+    expect(apiModel.provider).toBe('test-provider-uuid')
+  })
+
+  it('resolves provider by apiIdentifier for model routing', async () => {
+    const provider: Provider = {
+      id: 'test-provider-uuid',
+      apiIdentifier: 'short',
+      type: 'openai',
+      name: 'Custom Provider',
+      apiKey: 'test-key',
+      apiHost: 'https://example.com/v1',
+      models: [],
+      enabled: true
+    }
+
+    selectMock.mockResolvedValue([provider])
+
+    const resolved = await getProviderByModel('short:glm-4.6')
+    expect(resolved?.id).toBe('test-provider-uuid')
+  })
+
+  it('validates model ids with apiIdentifier prefix', async () => {
+    const provider: Provider = {
+      id: 'test-provider-uuid',
+      apiIdentifier: 'short',
+      type: 'openai',
+      name: 'Custom Provider',
+      apiKey: 'test-key',
+      apiHost: 'https://example.com/v1',
+      models: [
+        {
+          id: 'glm-4.6',
+          provider: 'test-provider-uuid',
+          name: 'glm-4.6',
+          group: 'glm'
+        }
+      ],
+      enabled: true
+    }
+
+    selectMock.mockResolvedValue([provider])
+
+    const result = await validateModelId('short:glm-4.6')
+    expect(result.valid).toBe(true)
+    expect(result.provider?.id).toBe('test-provider-uuid')
+    expect(result.modelId).toBe('glm-4.6')
+  })
+
+  it('still supports provider.id prefix', async () => {
+    const provider: Provider = {
+      id: 'test-provider-uuid',
+      apiIdentifier: 'short',
+      type: 'openai',
+      name: 'Custom Provider',
+      apiKey: 'test-key',
+      apiHost: 'https://example.com/v1',
+      models: [
+        {
+          id: 'glm-4.6',
+          provider: 'test-provider-uuid',
+          name: 'glm-4.6',
+          group: 'glm'
+        }
+      ],
+      enabled: true
+    }
+
+    selectMock.mockResolvedValue([provider])
+
+    const result = await validateModelId('test-provider-uuid:glm-4.6')
+    expect(result.valid).toBe(true)
+    expect(result.provider?.id).toBe('test-provider-uuid')
+    expect(result.modelId).toBe('glm-4.6')
+  })
+})

--- a/src/renderer/src/types/provider.ts
+++ b/src/renderer/src/types/provider.ts
@@ -98,6 +98,11 @@ export type Provider = {
   id: string
   type: ProviderType
   name: string
+  /**
+   * Optional short identifier used by the built-in API relay.
+   * When set, models can be referenced as `${apiIdentifier}:${modelId}` instead of `${id}:${modelId}`.
+   */
+  apiIdentifier?: string
   apiKey: string
   apiHost: string
   anthropicApiHost?: string


### PR DESCRIPTION
  - PR1 变更点：
      - src/renderer/src/types/provider.ts：给 Provider 新增可选字段 apiIdentifier
      - src/main/apiServer/utils/index.ts：/v1/models 的 id 前缀优先用 apiIdentifier；解
      - src/main/apiServer/utils/__tests__/provider-alias.test.ts：补 main 单测覆盖
  - 校验已跑通（在 ../Cherry-Studio-issue-11997）：yarn format / yarn lint / yarn test 全部通过。

当前为首个PR 预计实现：

  - 给 Provider 增加一个“对外（API Relay）用的短 ID/别名”字段（例如 apiIdentifier），仅用于 API Relay 的模型 ID 前缀展示与解析；内部仍保持 provider.id=UUID 不动。
  - API Relay：
      - 列表输出：id 用 ${apiIdentifier ?? provider.id}:${model.id}（只影响 id 字段），同时 provider 字段继续保持内部的 provider.id，避免影响应用内按 provider 分组/展示逻辑。
      - 请求解析：接受两种前缀——UUID（原来的）和 apiIdentifier（新的），都能路由到同一个 provider。
  - UI：在“添加/编辑自定义 Provider”的弹窗里加一个“Provider ID（用于 API Relay）”输入框（复用现有文案 settings.models.provider_id），做简单合法性/去重（避免和系统 provider id 冲突）。


解决Issue #11997
