### PR TITLE
Feat/11997 provider api identifier add popup

### DIFF
--- a/src/main/apiServer/utils/__tests__/provider-alias.test.ts
+++ b/src/main/apiServer/utils/__tests__/provider-alias.test.ts
@@ -1,0 +1,118 @@
+import { CacheService } from '@main/services/CacheService'
+import type { Model, Provider } from '@types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { selectMock } = vi.hoisted(() => ({
+  selectMock: vi.fn()
+}))
+
+vi.mock('@main/services/ReduxService', () => ({
+  reduxService: {
+    select: selectMock
+  }
+}))
+
+import { getProviderByModel, transformModelToOpenAI, validateModelId } from '..'
+
+describe('api server provider alias', () => {
+  beforeEach(() => {
+    CacheService.clear()
+    selectMock.mockReset()
+  })
+
+  it('formats model id using provider apiIdentifier when present', () => {
+    const provider: Provider = {
+      id: 'test-provider-uuid',
+      apiIdentifier: 'short',
+      type: 'openai',
+      name: 'Custom Provider',
+      apiKey: 'test-key',
+      apiHost: 'https://example.com/v1',
+      models: [],
+      enabled: true
+    }
+
+    const model: Model = {
+      id: 'glm-4.6',
+      provider: provider.id,
+      name: 'glm-4.6',
+      group: 'glm'
+    }
+
+    const apiModel = transformModelToOpenAI(model, provider)
+    expect(apiModel.id).toBe('short:glm-4.6')
+    expect(apiModel.provider).toBe('test-provider-uuid')
+  })
+
+  it('resolves provider by apiIdentifier for model routing', async () => {
+    const provider: Provider = {
+      id: 'test-provider-uuid',
+      apiIdentifier: 'short',
+      type: 'openai',
+      name: 'Custom Provider',
+      apiKey: 'test-key',
+      apiHost: 'https://example.com/v1',
+      models: [],
+      enabled: true
+    }
+
+    selectMock.mockResolvedValue([provider])
+
+    const resolved = await getProviderByModel('short:glm-4.6')
+    expect(resolved?.id).toBe('test-provider-uuid')
+  })
+
+  it('validates model ids with apiIdentifier prefix', async () => {
+    const provider: Provider = {
+      id: 'test-provider-uuid',
+      apiIdentifier: 'short',
+      type: 'openai',
+      name: 'Custom Provider',
+      apiKey: 'test-key',
+      apiHost: 'https://example.com/v1',
+      models: [
+        {
+          id: 'glm-4.6',
+          provider: 'test-provider-uuid',
+          name: 'glm-4.6',
+          group: 'glm'
+        }
+      ],
+      enabled: true
+    }
+
+    selectMock.mockResolvedValue([provider])
+
+    const result = await validateModelId('short:glm-4.6')
+    expect(result.valid).toBe(true)
+    expect(result.provider?.id).toBe('test-provider-uuid')
+    expect(result.modelId).toBe('glm-4.6')
+  })
+
+  it('still supports provider.id prefix', async () => {
+    const provider: Provider = {
+      id: 'test-provider-uuid',
+      apiIdentifier: 'short',
+      type: 'openai',
+      name: 'Custom Provider',
+      apiKey: 'test-key',
+      apiHost: 'https://example.com/v1',
+      models: [
+        {
+          id: 'glm-4.6',
+          provider: 'test-provider-uuid',
+          name: 'glm-4.6',
+          group: 'glm'
+        }
+      ],
+      enabled: true
+    }
+
+    selectMock.mockResolvedValue([provider])
+
+    const result = await validateModelId('test-provider-uuid:glm-4.6')
+    expect(result.valid).toBe(true)
+    expect(result.provider?.id).toBe('test-provider-uuid')
+    expect(result.modelId).toBe('glm-4.6')
+  })
+})

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -4469,6 +4469,16 @@
       "api_host_no_valid": "API address is invalid",
       "api_host_preview": "Preview: {{url}}",
       "api_host_tooltip": "Override only when your provider requires a custom OpenAI-compatible endpoint.",
+      "api_identifier": {
+        "error": {
+          "duplicate": "Identifier is already used by another provider",
+          "invalid": "Only letters, numbers, '-' and '_' are allowed, and ':' is not allowed"
+        },
+        "label": "API Identifier",
+        "placeholder": "Example: my-provider",
+        "preview": "Example: {{model}}",
+        "tip": "Used as the model prefix in API relay. Leave empty to use the internal UUID."
+      },
       "api_key": {
         "label": "API Key",
         "tip": "Use commas to separate multiple keys"

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -4469,6 +4469,16 @@
       "api_host_no_valid": "API 地址不合法",
       "api_host_preview": "预览：{{url}}",
       "api_host_tooltip": "仅在服务商需要自定义的 OpenAI 兼容地址时覆盖。",
+      "api_identifier": {
+        "error": {
+          "duplicate": "该标识符已被其他提供商使用",
+          "invalid": "仅支持字母、数字、“-”、“_”，且不能包含“:”"
+        },
+        "label": "API 标识符",
+        "placeholder": "例如：my-provider",
+        "preview": "示例：{{model}}",
+        "tip": "用于 API Relay 的模型前缀。留空则使用内部 UUID。"
+      },
       "api_key": {
         "label": "API 密钥",
         "tip": "多个密钥使用逗号分隔"

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -4469,6 +4469,16 @@
       "api_host_no_valid": "API 位址不合法",
       "api_host_preview": "預覽：{{url}}",
       "api_host_tooltip": "僅在供應商需要自訂的 OpenAI 相容端點時才覆蓋。",
+      "api_identifier": {
+        "error": {
+          "duplicate": "此識別碼已被其他供應商使用",
+          "invalid": "僅支援字母、數字、“-”、“_”，且不能包含“:”"
+        },
+        "label": "API 識別碼",
+        "placeholder": "例如：my-provider",
+        "preview": "範例：{{model}}",
+        "tip": "用於 API Relay 的模型前綴。留空則使用內部 UUID。"
+      },
       "api_key": {
         "label": "API 金鑰",
         "tip": "多個金鑰使用逗號分隔"

--- a/src/renderer/src/pages/settings/ProviderSettings/ProviderList.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ProviderList.tsx
@@ -144,7 +144,14 @@ const ProviderList: FC = () => {
   }, [searchParams])
 
   const onAddProvider = async () => {
-    const { name: providerName, type, logo } = await AddProviderPopup.show()
+    const {
+      name: providerName,
+      type,
+      logo,
+      apiIdentifier
+    } = await AddProviderPopup.show(undefined, {
+      existingProviders: providers
+    })
 
     if (!providerName.trim()) {
       return
@@ -156,6 +163,7 @@ const ProviderList: FC = () => {
       type,
       apiKey: '',
       apiHost: '',
+      apiIdentifier: apiIdentifier?.trim() || undefined,
       models: [],
       enabled: true,
       isSystem: false
@@ -193,10 +201,12 @@ const ProviderList: FC = () => {
       key: 'edit',
       icon: <EditIcon size={14} />,
       async onClick() {
-        const { name, type, logoFile, logo } = await AddProviderPopup.show(provider)
+        const { name, type, logoFile, logo, apiIdentifier } = await AddProviderPopup.show(provider, {
+          existingProviders: providers
+        })
 
         if (name) {
-          updateProvider({ ...provider, name, type })
+          updateProvider({ ...provider, name, type, apiIdentifier: apiIdentifier?.trim() || undefined })
           if (provider.id) {
             if (logo) {
               try {

--- a/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
@@ -92,6 +92,8 @@ const isAnthropicCompatibleProviderId = (id: string): id is AnthropicCompatibleP
 
 type HostField = 'apiHost' | 'anthropicApiHost'
 
+const API_IDENTIFIER_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,31}$/
+
 const ProviderSetting: FC<Props> = ({ providerId }) => {
   const { provider, updateProvider, models } = useProvider(providerId)
   const allProviders = useAllProviders()
@@ -122,6 +124,7 @@ const ProviderSetting: FC<Props> = ({ providerId }) => {
   const fancyProviderName = getFancyProviderName(provider)
 
   const [localApiKey, setLocalApiKey] = useState(provider.apiKey)
+  const [apiIdentifier, setApiIdentifier] = useState(provider.apiIdentifier ?? '')
   const [apiKeyConnectivity, setApiKeyConnectivity] = useState<ApiKeyConnectivity>({
     status: HealthStatus.NOT_CHECKED,
     checking: false
@@ -146,6 +149,10 @@ const ProviderSetting: FC<Props> = ({ providerId }) => {
     setLocalApiKey(provider.apiKey)
     setApiKeyConnectivity({ status: HealthStatus.NOT_CHECKED })
   }, [provider.apiKey])
+
+  useEffect(() => {
+    setApiIdentifier(provider.apiIdentifier ?? '')
+  }, [provider.apiIdentifier])
 
   // 同步 localApiKey 到 provider.apiKey（防抖）
   useEffect(() => {
@@ -385,6 +392,41 @@ const ProviderSetting: FC<Props> = ({ providerId }) => {
 
   const isAnthropicOAuth = () => provider.id === 'anthropic' && provider.authType === 'oauth'
 
+  const onUpdateApiIdentifier = useCallback(() => {
+    const normalizedIdentifier = apiIdentifier.trim()
+
+    if (!normalizedIdentifier) {
+      updateProvider({ apiIdentifier: undefined })
+      setApiIdentifier('')
+      return
+    }
+
+    if (!API_IDENTIFIER_PATTERN.test(normalizedIdentifier) || normalizedIdentifier.includes(':')) {
+      window.toast.error(t('settings.provider.api_identifier.error.invalid'))
+      setApiIdentifier(provider.apiIdentifier ?? '')
+      return
+    }
+
+    const conflictProvider = allProviders.find((p) => {
+      if (p.id === provider.id) {
+        return false
+      }
+      if (p.id === normalizedIdentifier) {
+        return true
+      }
+      return p.apiIdentifier?.trim() === normalizedIdentifier
+    })
+
+    if (conflictProvider) {
+      window.toast.error(t('settings.provider.api_identifier.error.duplicate'))
+      setApiIdentifier(provider.apiIdentifier ?? '')
+      return
+    }
+
+    updateProvider({ apiIdentifier: normalizedIdentifier })
+    setApiIdentifier(normalizedIdentifier)
+  }, [allProviders, apiIdentifier, provider.apiIdentifier, provider.id, t, updateProvider])
+
   return (
     <SettingContainer theme={theme} style={{ background: 'var(--color-background)' }}>
       <SettingTitle>
@@ -418,6 +460,34 @@ const ProviderSetting: FC<Props> = ({ providerId }) => {
         />
       </SettingTitle>
       <Divider style={{ width: '100%', margin: '10px 0' }} />
+      {!isSystemProvider(provider) && (
+        <>
+          <SettingSubtitle style={{ marginTop: 5, display: 'flex', alignItems: 'center', gap: 6 }}>
+            {t('settings.provider.api_identifier.label')}
+            <HelpTooltip title={t('settings.provider.api_identifier.tip')}></HelpTooltip>
+          </SettingSubtitle>
+          <Input
+            value={apiIdentifier}
+            placeholder={t('settings.provider.api_identifier.placeholder')}
+            onChange={(e) => setApiIdentifier(e.target.value)}
+            onBlur={onUpdateApiIdentifier}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+                onUpdateApiIdentifier()
+              }
+            }}
+            spellCheck={false}
+            maxLength={32}
+          />
+          <SettingHelpTextRow style={{ justifyContent: 'space-between' }}>
+            <SettingHelpText>
+              {t('settings.provider.api_identifier.preview', {
+                model: `${apiIdentifier.trim() || provider.id}:glm-4.6`
+              })}
+            </SettingHelpText>
+          </SettingHelpTextRow>
+        </>
+      )}
       {isProviderSupportAuth(provider) && <ProviderOAuth providerId={provider.id} />}
       {provider.id === 'openai' && <OpenAIAlert />}
       {provider.id === 'ovms' && <OVMSSettings />}

--- a/src/renderer/src/types/provider.ts
+++ b/src/renderer/src/types/provider.ts
@@ -98,6 +98,11 @@ export type Provider = {
   id: string
   type: ProviderType
   name: string
+  /**
+   * Optional short identifier used by the built-in API relay.
+   * When set, models can be referenced as `${apiIdentifier}:${modelId}` instead of `${id}:${modelId}`.
+   */
+  apiIdentifier?: string
   apiKey: string
   apiHost: string
   anthropicApiHost?: string


### PR DESCRIPTION

  - 新增字段输入 + 自动建议（基于名称生成 slug，并在冲突时自动加 -2/-3）+ 校验/去重：
    src/renderer/src/pages/settings/ProviderSettings/AddProviderPopup.tsx:19
  - Provider 新建/编辑时写入 provider.apiIdentifier：src/renderer/src/pages/settings/
    ProviderSettings/ProviderList.tsx:152
  - 已通过：yarn format / yarn lint / yarn test
  - 分支：feat/11997-provider-api-identifier-add-popup

当前为第三个（最后）PR，预计实现：

给 Provider 增加一个“对外（API Relay）用的短 ID/别名”字段（例如 apiIdentifier），仅用于 API Relay 的模型 ID 前缀展示与解析；内部仍保持 provider.id=UUID 不动。
API Relay：
列表输出：id 用 ${apiIdentifier ?? provider.id}:${model.id}（只影响 id 字段），同时 provider 字段继续保持内部的 provider.id，避免影响应用内按 provider 分组/展示逻辑。
请求解析：接受两种前缀——UUID（原来的）和 apiIdentifier（新的），都能路由到同一个 provider。
UI：在“添加/编辑自定义 Provider”的弹窗里加一个“Provider ID（用于 API Relay）”输入框（复用现有文案 settings.models.provider_id），做简单合法性/去重（避免和系统 provider id 冲突）。
解决Issue #11997  前置PR #12004 #12005
