### PR TITLE
feat(responses): add request and SSE idle timeouts

### DIFF
--- a/src/renderer/src/aiCore/chunk/AiSdkToChunkAdapter.ts
+++ b/src/renderer/src/aiCore/chunk/AiSdkToChunkAdapter.ts
@@ -4,6 +4,7 @@
  */
 
 import { loggerService } from '@logger'
+import i18n from '@renderer/i18n'
 import type { AISDKWebSearchResult, MCPTool, WebSearchResults } from '@renderer/types'
 import { WebSearchSource } from '@renderer/types'
 import type { Chunk } from '@renderer/types/chunk'
@@ -32,6 +33,10 @@ export class AiSdkToChunkAdapter {
   private firstTokenTimestamp: number | null = null
   private hasTextContent = false
   private getSessionWasCleared?: () => boolean
+  private idleTimeoutMs?: number
+  private idleAbortController?: AbortController
+  private idleTimeoutTimer: ReturnType<typeof setTimeout> | null = null
+  private idleTimeoutTriggered = false
 
   constructor(
     private onChunk: (chunk: Chunk) => void,
@@ -39,13 +44,19 @@ export class AiSdkToChunkAdapter {
     accumulate?: boolean,
     enableWebSearch?: boolean,
     onSessionUpdate?: (sessionId: string) => void,
-    getSessionWasCleared?: () => boolean
+    getSessionWasCleared?: () => boolean,
+    streamingConfig?: {
+      idleTimeoutMs: number
+      idleAbortController: AbortController
+    }
   ) {
     this.toolCallHandler = new ToolCallChunkHandler(onChunk, mcpTools)
     this.accumulate = accumulate
     this.enableWebSearch = enableWebSearch || false
     this.onSessionUpdate = onSessionUpdate
     this.getSessionWasCleared = getSessionWasCleared
+    this.idleTimeoutMs = streamingConfig?.idleTimeoutMs
+    this.idleAbortController = streamingConfig?.idleAbortController
   }
 
   private markFirstTokenIfNeeded() {
@@ -57,6 +68,27 @@ export class AiSdkToChunkAdapter {
   private resetTimingState() {
     this.responseStartTimestamp = null
     this.firstTokenTimestamp = null
+  }
+
+  private clearIdleTimeoutTimer() {
+    if (this.idleTimeoutTimer) {
+      clearTimeout(this.idleTimeoutTimer)
+      this.idleTimeoutTimer = null
+    }
+  }
+
+  private resetIdleTimeoutTimer() {
+    if (!this.idleTimeoutMs || this.idleTimeoutMs <= 0 || !this.idleAbortController) {
+      return
+    }
+
+    this.clearIdleTimeoutTimer()
+
+    this.idleTimeoutTimer = setTimeout(() => {
+      this.idleTimeoutTriggered = true
+      logger.warn('SSE idle timeout reached; aborting request', { idleTimeoutMs: this.idleTimeoutMs })
+      this.idleAbortController?.abort()
+    }, this.idleTimeoutMs)
   }
 
   /**
@@ -88,6 +120,8 @@ export class AiSdkToChunkAdapter {
     }
     this.resetTimingState()
     this.responseStartTimestamp = Date.now()
+    this.idleTimeoutTriggered = false
+    this.resetIdleTimeoutTimer()
     // Reset state at the start of stream
     this.isFirstChunk = true
     this.hasTextContent = false
@@ -111,10 +145,12 @@ export class AiSdkToChunkAdapter {
           break
         }
 
+        this.resetIdleTimeoutTimer()
         // 转换并发送 chunk
         this.convertAndEmitChunk(value, final)
       }
     } finally {
+      this.clearIdleTimeoutTimer()
       reader.releaseLock()
       this.resetTimingState()
     }
@@ -378,10 +414,18 @@ export class AiSdkToChunkAdapter {
         })
         break
       case 'abort':
-        this.onChunk({
-          type: ChunkType.ERROR,
-          error: new DOMException('Request was aborted', 'AbortError')
-        })
+        if (this.idleTimeoutTriggered) {
+          const minutes = Math.round((this.idleTimeoutMs ?? 0) / 60000)
+          this.onChunk({
+            type: ChunkType.ERROR,
+            error: new DOMException(i18n.t('message.error.sse_idle_timeout', { minutes }), 'TimeoutError')
+          })
+        } else {
+          this.onChunk({
+            type: ChunkType.ERROR,
+            error: new DOMException('Request was aborted', 'AbortError')
+          })
+        }
         break
       case 'error':
         this.onChunk({

--- a/src/renderer/src/aiCore/chunk/__tests__/AiSdkToChunkAdapter.idle-timeout.test.ts
+++ b/src/renderer/src/aiCore/chunk/__tests__/AiSdkToChunkAdapter.idle-timeout.test.ts
@@ -1,0 +1,135 @@
+import i18n from '@renderer/i18n'
+import { ChunkType } from '@renderer/types/chunk'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AiSdkToChunkAdapter } from '../AiSdkToChunkAdapter'
+
+type ReadResult = { done: boolean; value?: any }
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+function createFakeStream(reads: Array<ReturnType<typeof createDeferred<ReadResult>>>) {
+  let readIndex = 0
+  const reader = {
+    read: vi.fn(() => {
+      const next = reads[readIndex]
+      readIndex += 1
+      return next?.promise ?? Promise.resolve({ done: true })
+    }),
+    releaseLock: vi.fn()
+  }
+
+  const stream = {
+    getReader: () => reader
+  } as any
+
+  return { stream, reader }
+}
+
+describe('AiSdkToChunkAdapter idle timeout', () => {
+  beforeEach(async () => {
+    vi.useFakeTimers()
+    await i18n.changeLanguage('en-US')
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('aborts when no stream events are received within idleTimeoutMs', async () => {
+    const idleAbortController = new AbortController()
+    const reads = [createDeferred<ReadResult>()]
+    const { stream } = createFakeStream(reads)
+
+    const adapter = new AiSdkToChunkAdapter(() => {}, [], false, false, undefined, undefined, {
+      idleTimeoutMs: 1000,
+      idleAbortController
+    })
+
+    const processing = adapter.processStream({ fullStream: stream, text: Promise.resolve('') })
+
+    vi.advanceTimersByTime(1000)
+    expect(idleAbortController.signal.aborted).toBe(true)
+
+    reads[0].resolve({ done: true })
+    await processing
+  })
+
+  it('resets the timer whenever a chunk is received', async () => {
+    const idleAbortController = new AbortController()
+    const reads = [createDeferred<ReadResult>(), createDeferred<ReadResult>()]
+    const { stream } = createFakeStream(reads)
+
+    const adapter = new AiSdkToChunkAdapter(() => {}, [], false, false, undefined, undefined, {
+      idleTimeoutMs: 1000,
+      idleAbortController
+    })
+
+    const processing = adapter.processStream({ fullStream: stream, text: Promise.resolve('') })
+
+    vi.advanceTimersByTime(900)
+    expect(idleAbortController.signal.aborted).toBe(false)
+
+    reads[0].resolve({ done: false, value: { type: 'text-delta', text: 'hi' } })
+    await Promise.resolve()
+
+    // If the timer wasn't reset, it would have fired at t=1000ms.
+    vi.advanceTimersByTime(200)
+    expect(idleAbortController.signal.aborted).toBe(false)
+
+    reads[1].resolve({ done: true })
+    await processing
+  })
+
+  it('cleans up timers when the stream completes', async () => {
+    const idleAbortController = new AbortController()
+    const reads = [createDeferred<ReadResult>()]
+    const { stream } = createFakeStream(reads)
+
+    const adapter = new AiSdkToChunkAdapter(() => {}, [], false, false, undefined, undefined, {
+      idleTimeoutMs: 1000,
+      idleAbortController
+    })
+
+    const processing = adapter.processStream({ fullStream: stream, text: Promise.resolve('') })
+    reads[0].resolve({ done: true })
+    await processing
+
+    vi.advanceTimersByTime(1000)
+    expect(idleAbortController.signal.aborted).toBe(false)
+  })
+
+  it('emits a localized TimeoutError when the idle timeout triggers', async () => {
+    const chunks: any[] = []
+    const idleAbortController = new AbortController()
+    const reads = [createDeferred<ReadResult>(), createDeferred<ReadResult>()]
+    const { stream } = createFakeStream(reads)
+
+    const adapter = new AiSdkToChunkAdapter((chunk) => chunks.push(chunk), [], false, false, undefined, undefined, {
+      idleTimeoutMs: 60_000,
+      idleAbortController
+    })
+
+    const processing = adapter.processStream({ fullStream: stream, text: Promise.resolve('') })
+
+    vi.advanceTimersByTime(60_000)
+    reads[0].resolve({ done: false, value: { type: 'abort' } })
+    await Promise.resolve()
+
+    reads[1].resolve({ done: true })
+    await processing
+
+    const errorChunk = chunks.find((chunk) => chunk.type === ChunkType.ERROR)
+    expect(errorChunk).toBeDefined()
+    expect(errorChunk.error?.name).toBe('TimeoutError')
+    expect(errorChunk.error?.message).toBe('SSE idle timeout after 1 minutes')
+  })
+})

--- a/src/renderer/src/aiCore/index_new.ts
+++ b/src/renderer/src/aiCore/index_new.ts
@@ -42,6 +42,10 @@ export type ModernAiProviderConfig = AiSdkMiddlewareConfig & {
   // topicId for tracing
   topicId?: string
   callType: string
+  streamingConfig?: {
+    idleTimeoutMs: number
+    idleAbortController: AbortController
+  }
 }
 
 export default class ModernAiProvider {
@@ -330,7 +334,15 @@ export default class ModernAiProvider {
     // 创建带有中间件的执行器
     if (config.onChunk) {
       const accumulate = this.model!.supported_text_delta !== false // true and undefined
-      const adapter = new AiSdkToChunkAdapter(config.onChunk, config.mcpTools, accumulate, config.enableWebSearch)
+      const adapter = new AiSdkToChunkAdapter(
+        config.onChunk,
+        config.mcpTools ?? [],
+        accumulate,
+        config.enableWebSearch,
+        undefined,
+        undefined,
+        config.streamingConfig
+      )
 
       const streamResult = await executor.streamText({
         ...params,

--- a/src/renderer/src/aiCore/prepareParams/__tests__/parameterBuilder.streamingTimeouts.test.ts
+++ b/src/renderer/src/aiCore/prepareParams/__tests__/parameterBuilder.streamingTimeouts.test.ts
@@ -1,0 +1,117 @@
+import type { Assistant, Model, Provider } from '@renderer/types'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@renderer/services/AssistantService', () => ({
+  DEFAULT_ASSISTANT_SETTINGS: {
+    temperature: 0.7,
+    enableTemperature: true,
+    contextCount: 5,
+    enableMaxTokens: false,
+    maxTokens: 0,
+    streamOutput: true,
+    topP: 1,
+    enableTopP: false,
+    toolUseMode: 'function',
+    customParameters: []
+  },
+  getDefaultAssistant: vi.fn(() => ({
+    id: 'default',
+    name: 'Default Assistant',
+    prompt: '',
+    type: 'assistant',
+    topics: [],
+    settings: {}
+  })),
+  getAssistantSettings: vi.fn((assistant: any) => assistant?.settings ?? {}),
+  getDefaultModel: vi.fn(() => ({
+    id: 'gpt-4o',
+    provider: 'openai',
+    name: 'GPT-4o',
+    group: 'openai'
+  })),
+  getProviderByModel: vi.fn(() => ({
+    id: 'openai',
+    type: 'openai',
+    name: 'OpenAI',
+    apiKey: '',
+    apiHost: 'https://example.com/v1',
+    models: []
+  }))
+}))
+
+vi.mock('@renderer/store', () => ({
+  default: {
+    getState: vi.fn(() => ({
+      websearch: {
+        maxResults: 5,
+        excludeDomains: [],
+        searchWithTime: false
+      }
+    }))
+  }
+}))
+
+vi.mock('@renderer/utils/prompt', () => ({
+  replacePromptVariables: vi.fn(async (prompt: string) => prompt)
+}))
+
+vi.mock('../../utils/mcp', () => ({
+  setupToolsConfig: vi.fn(() => undefined)
+}))
+
+vi.mock('../../utils/options', () => ({
+  buildProviderOptions: vi.fn(() => ({
+    providerOptions: {},
+    standardParams: {}
+  }))
+}))
+
+import { buildStreamTextParams } from '../parameterBuilder'
+
+const createModel = (): Model => ({
+  id: 'gpt-4o',
+  provider: 'openai',
+  name: 'GPT-4o',
+  group: 'openai'
+})
+
+const createAssistant = (model: Model): Assistant => ({
+  id: 'assistant-1',
+  name: 'Assistant',
+  prompt: '',
+  type: 'assistant',
+  topics: [],
+  model,
+  settings: {}
+})
+
+const createProvider = (model: Model, overrides: Partial<Provider> = {}): Provider => ({
+  id: 'openai-response',
+  type: 'openai-response',
+  name: 'OpenAI Responses',
+  apiKey: 'test',
+  apiHost: 'https://example.com/v1',
+  models: [model],
+  ...overrides
+})
+
+describe('parameterBuilder.buildStreamTextParams (timeouts)', () => {
+  it('returns streamingConfig and abortSignal when SSE idle timeout is enabled', async () => {
+    const model = createModel()
+    const assistant = createAssistant(model)
+    const provider = createProvider(model, { sseIdleTimeoutMinutes: 10 })
+
+    const userAbortController = new AbortController()
+
+    const { params, streamingConfig } = await buildStreamTextParams([], assistant, provider, {
+      requestOptions: { signal: userAbortController.signal }
+    })
+
+    expect(streamingConfig?.idleTimeoutMs).toBe(10 * 60 * 1000)
+    expect(streamingConfig?.idleAbortController).toBeInstanceOf(AbortController)
+    expect(params.abortSignal).toBeDefined()
+
+    userAbortController.abort()
+    expect(params.abortSignal?.aborted).toBe(true)
+  })
+})

--- a/src/renderer/src/aiCore/prepareParams/parameterBuilder.ts
+++ b/src/renderer/src/aiCore/prepareParams/parameterBuilder.ts
@@ -40,6 +40,7 @@ import { stepCountIs } from 'ai'
 import { getAiSdkProviderId } from '../provider/factory'
 import { setupToolsConfig } from '../utils/mcp'
 import { buildProviderOptions } from '../utils/options'
+import { buildCombinedAbortSignal, timeoutMinutesToMs } from '../utils/streamingTimeout'
 import { buildProviderBuiltinWebSearchConfig } from '../utils/websearch'
 import { addAnthropicHeaders } from './header'
 import { getMaxTokens, getTemperature, getTopP } from './modelParameters'
@@ -95,6 +96,10 @@ export async function buildStreamTextParams(
     enableUrlContext: boolean
   }
   webSearchPluginConfig?: WebSearchPluginConfig
+  streamingConfig?: {
+    idleTimeoutMs: number
+    idleAbortController: AbortController
+  }
 }> {
   const { mcpTools } = options
 
@@ -218,6 +223,16 @@ export async function buildStreamTextParams(
   // Note: standardParams (topK, frequencyPenalty, presencePenalty, stopSequences, seed)
   // are extracted from custom parameters and passed directly to streamText()
   // instead of being placed in providerOptions
+  const requestTimeoutMs = timeoutMinutesToMs(provider.requestTimeoutMinutes)
+  const idleTimeoutMs = timeoutMinutesToMs(provider.sseIdleTimeoutMinutes)
+  const idleAbortController = idleTimeoutMs ? new AbortController() : undefined
+
+  const abortSignal = buildCombinedAbortSignal([
+    options.requestOptions?.signal,
+    requestTimeoutMs ? AbortSignal.timeout(requestTimeoutMs) : undefined,
+    idleAbortController?.signal
+  ])
+
   const params: StreamTextParams = {
     messages: sdkMessages,
     maxOutputTokens: getMaxTokens(assistant, model),
@@ -225,7 +240,7 @@ export async function buildStreamTextParams(
     topP: getTopP(assistant, model),
     // Include AI SDK standard params extracted from custom parameters
     ...standardParams,
-    abortSignal: options.requestOptions?.signal,
+    abortSignal,
     headers,
     providerOptions,
     stopWhen: stepCountIs(20),
@@ -246,7 +261,14 @@ export async function buildStreamTextParams(
     params,
     modelId: model.id,
     capabilities: { enableReasoning, enableWebSearch, enableGenerateImage, enableUrlContext },
-    webSearchPluginConfig
+    webSearchPluginConfig,
+    streamingConfig:
+      idleTimeoutMs && idleAbortController
+        ? {
+            idleTimeoutMs,
+            idleAbortController
+          }
+        : undefined
   }
 }
 

--- a/src/renderer/src/aiCore/utils/__tests__/streamingTimeout.test.ts
+++ b/src/renderer/src/aiCore/utils/__tests__/streamingTimeout.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildCombinedAbortSignal, normalizeTimeoutMinutes, timeoutMinutesToMs } from '../streamingTimeout'
+
+describe('streamingTimeout utils', () => {
+  it('normalizeTimeoutMinutes returns undefined for non-numbers', () => {
+    expect(normalizeTimeoutMinutes(undefined)).toBeUndefined()
+    expect(normalizeTimeoutMinutes(null)).toBeUndefined()
+    expect(normalizeTimeoutMinutes('10')).toBeUndefined()
+  })
+
+  it('normalizeTimeoutMinutes clamps to integer >= 0', () => {
+    expect(normalizeTimeoutMinutes(-1)).toBe(0)
+    expect(normalizeTimeoutMinutes(0)).toBe(0)
+    expect(normalizeTimeoutMinutes(1.9)).toBe(1)
+  })
+
+  it('timeoutMinutesToMs returns undefined for 0/undefined and converts minutes to ms', () => {
+    expect(timeoutMinutesToMs(undefined)).toBeUndefined()
+    expect(timeoutMinutesToMs(0)).toBeUndefined()
+    expect(timeoutMinutesToMs(2)).toBe(2 * 60 * 1000)
+  })
+
+  it('buildCombinedAbortSignal returns undefined for empty and combines signals', () => {
+    expect(buildCombinedAbortSignal([])).toBeUndefined()
+
+    const controllerA = new AbortController()
+    const controllerB = new AbortController()
+
+    const single = buildCombinedAbortSignal([controllerA.signal])
+    expect(single).toBe(controllerA.signal)
+
+    const combined = buildCombinedAbortSignal([controllerA.signal, controllerB.signal])
+    expect(combined?.aborted).toBe(false)
+    controllerB.abort()
+    expect(combined?.aborted).toBe(true)
+  })
+})

--- a/src/renderer/src/aiCore/utils/reasoning.ts
+++ b/src/renderer/src/aiCore/utils/reasoning.ts
@@ -546,7 +546,6 @@ function mapToGeminiThinkingLevel(reasoningEffort: ReasoningEffortOption): Googl
     case 'default':
       return undefined
     case 'minimal':
-      return 'minimal'
     case 'low':
       return 'low'
     case 'medium':

--- a/src/renderer/src/aiCore/utils/streamingTimeout.ts
+++ b/src/renderer/src/aiCore/utils/streamingTimeout.ts
@@ -1,0 +1,18 @@
+export function normalizeTimeoutMinutes(value: unknown): number | undefined {
+  if (value === undefined || value === null) return undefined
+  if (typeof value !== 'number' || !Number.isFinite(value)) return undefined
+  return Math.max(0, Math.floor(value))
+}
+
+export function timeoutMinutesToMs(minutes: unknown): number | undefined {
+  const normalized = normalizeTimeoutMinutes(minutes)
+  if (normalized === undefined || normalized <= 0) return undefined
+  return normalized * 60 * 1000
+}
+
+export function buildCombinedAbortSignal(signals: Array<AbortSignal | undefined | null>): AbortSignal | undefined {
+  const validSignals = signals.filter((signal): signal is AbortSignal => Boolean(signal))
+  if (validSignals.length === 0) return undefined
+  if (validSignals.length === 1) return validSignals[0]
+  return AbortSignal.any(validSignals)
+}

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -1877,6 +1877,7 @@
         "export": "Failed to export to Siyuan Note, please check connection status and configuration according to documentation",
         "no_config": "Siyuan Note API address or token is not configured"
       },
+      "sse_idle_timeout": "SSE idle timeout after {{minutes}} minutes",
       "unknown": "Unknown error",
       "yuque": {
         "export": "Failed to export to Yuque. Please check connection status and configuration according to documentation",
@@ -4579,6 +4580,20 @@
       "remove_invalid_keys": "Remove Invalid Keys",
       "search": "Search Providers...",
       "search_placeholder": "Search model id or name",
+      "streaming": {
+        "description": "Configure client-side limits for long-running streaming requests (e.g., OpenAI Responses SSE).",
+        "label": "Streaming & Timeouts",
+        "request_timeout": {
+          "help": "Abort the request after this time. Set to 0 to disable.",
+          "label": "Request hard timeout (minutes)"
+        },
+        "reset": "Reset to defaults",
+        "sse_idle_timeout": {
+          "help": "Abort if no stream events are received for this time. Increase it for long silent reasoning/tool runs; set to 0 to disable.",
+          "label": "SSE idle timeout (minutes)"
+        },
+        "title": "Streaming & Timeouts"
+      },
       "title": "Model Provider",
       "vertex_ai": {
         "api_host_help": "The API host for Vertex AI, not recommended to fill in, generally applicable to reverse proxy",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -1877,6 +1877,7 @@
         "export": "导出思源笔记失败，请检查连接状态并对照文档检查配置",
         "no_config": "未配置思源笔记 API 地址或令牌"
       },
+      "sse_idle_timeout": "SSE 空闲超时：{{minutes}} 分钟未收到流事件",
       "unknown": "未知错误",
       "yuque": {
         "export": "导出语雀错误，请检查连接状态并对照文档检查配置",
@@ -4579,6 +4580,20 @@
       "remove_invalid_keys": "删除无效密钥",
       "search": "搜索模型平台...",
       "search_placeholder": "搜索模型 ID 或名称",
+      "streaming": {
+        "description": "为长时间运行的流式请求配置客户端限制（例如 OpenAI Responses SSE）。",
+        "label": "流式与超时",
+        "request_timeout": {
+          "help": "超过此时间将中止请求。设为 0 表示禁用。",
+          "label": "请求硬超时（分钟）"
+        },
+        "reset": "恢复默认",
+        "sse_idle_timeout": {
+          "help": "在此时间内未收到任何流事件将中止请求。对于长时间静默的推理/工具调用可适当调大；设为 0 表示禁用。",
+          "label": "SSE 空闲超时（分钟）"
+        },
+        "title": "流式与超时"
+      },
       "title": "模型服务",
       "vertex_ai": {
         "api_host_help": "Vertex AI 的 API 地址，不建议填写，通常适用于反向代理",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -1877,6 +1877,7 @@
         "export": "匯出思源筆記失敗，請檢查連線狀態並參考說明文件確認設定",
         "no_config": "未設定思源筆記 API 位址或權杖"
       },
+      "sse_idle_timeout": "SSE 閒置逾時：{{minutes}} 分鐘未收到串流事件",
       "unknown": "未知錯誤",
       "yuque": {
         "export": "匯出語雀失敗，請檢查連線狀態並參考說明文件確認設定",
@@ -4579,6 +4580,20 @@
       "remove_invalid_keys": "刪除無效金鑰",
       "search": "搜尋模型平臺...",
       "search_placeholder": "搜尋模型 ID 或名稱",
+      "streaming": {
+        "description": "為長時間執行的串流請求設定用戶端限制（例如 OpenAI Responses SSE）。",
+        "label": "串流與逾時",
+        "request_timeout": {
+          "help": "超過此時間將中止請求。設定為 0 以停用。",
+          "label": "請求硬逾時（分鐘）"
+        },
+        "reset": "重設為預設值",
+        "sse_idle_timeout": {
+          "help": "在此時間內未收到任何串流事件將中止請求。對於長時間靜默的推理/工具呼叫可適度調大；設定為 0 以停用。",
+          "label": "SSE 閒置逾時（分鐘）"
+        },
+        "title": "串流與逾時"
+      },
       "title": "模型提供者",
       "vertex_ai": {
         "api_host_help": "Vertex AI 的 API 位址，不建議填寫，通常適用於反向代理",

--- a/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
@@ -36,7 +36,7 @@ import {
 import { Button, Divider, Flex, Input, Select, Space, Switch, Tooltip } from 'antd'
 import Link from 'antd/es/typography/Link'
 import { debounce, isEmpty } from 'lodash'
-import { Bolt, Check, Settings2, SquareArrowOutUpRight, TriangleAlert } from 'lucide-react'
+import { Bolt, Check, Settings2, SquareArrowOutUpRight, Timer, TriangleAlert } from 'lucide-react'
 import type { FC } from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -61,6 +61,7 @@ import LMStudioSettings from './LMStudioSettings'
 import OVMSSettings from './OVMSSettings'
 import ProviderOAuth from './ProviderOAuth'
 import SelectProviderModelPopup from './SelectProviderModelPopup'
+import StreamingSettingsPopup from './StreamingSettings/StreamingSettingsPopup'
 import VertexAISettings from './VertexAISettings'
 
 interface Props {
@@ -395,6 +396,14 @@ const ProviderSetting: FC<Props> = ({ providerId }) => {
               <Button type="text" size="small" icon={<SquareArrowOutUpRight size={14} />} />
             </Link>
           )}
+          <Tooltip title={t('settings.provider.streaming.label')}>
+            <Button
+              type="text"
+              icon={<Timer size={14} />}
+              size="small"
+              onClick={() => StreamingSettingsPopup.show({ providerId: provider.id })}
+            />
+          </Tooltip>
           {!isSystemProvider(provider) && (
             <Tooltip title={t('settings.provider.api.options.label')}>
               <Button

--- a/src/renderer/src/pages/settings/ProviderSettings/StreamingSettings/StreamingSettings.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/StreamingSettings/StreamingSettings.tsx
@@ -1,0 +1,93 @@
+import { HStack } from '@renderer/components/Layout'
+import { InfoTooltip } from '@renderer/components/TooltipIcons'
+import { useProvider } from '@renderer/hooks/useProvider'
+import type { Provider } from '@renderer/types'
+import { Button, Flex, InputNumber } from 'antd'
+import { startTransition, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { SettingHelpText, SettingHelpTextRow, SettingSubtitle } from '../..'
+
+type Props = {
+  providerId: string
+}
+
+const StreamingSettings = ({ providerId }: Props) => {
+  const { t } = useTranslation()
+  const { provider, updateProvider } = useProvider(providerId)
+
+  const updateProviderTransition = useCallback(
+    (updates: Partial<Provider>) => {
+      startTransition(() => {
+        updateProvider(updates)
+      })
+    },
+    [updateProvider]
+  )
+
+  const requestTimeoutMinutes = provider.requestTimeoutMinutes ?? 0
+  const sseIdleTimeoutMinutes = provider.sseIdleTimeoutMinutes ?? 0
+
+  return (
+    <Flex vertical gap="middle">
+      <SettingSubtitle style={{ marginTop: 0 }}>{t('settings.provider.streaming.title')}</SettingSubtitle>
+      <SettingHelpTextRow style={{ paddingTop: 0 }}>
+        <SettingHelpText>{t('settings.provider.streaming.description')}</SettingHelpText>
+      </SettingHelpTextRow>
+
+      <HStack justifyContent="space-between" alignItems="center">
+        <HStack alignItems="center" gap={6}>
+          <label style={{ cursor: 'pointer' }} htmlFor="provider-request-timeout-minutes">
+            {t('settings.provider.streaming.request_timeout.label')}
+          </label>
+          <InfoTooltip title={t('settings.provider.streaming.request_timeout.help')}></InfoTooltip>
+        </HStack>
+        <InputNumber
+          id="provider-request-timeout-minutes"
+          min={0}
+          max={720}
+          step={1}
+          value={requestTimeoutMinutes}
+          onChange={(value) => {
+            updateProviderTransition({ requestTimeoutMinutes: value ?? 0 })
+          }}
+          style={{ width: 160 }}
+        />
+      </HStack>
+
+      <HStack justifyContent="space-between" alignItems="center">
+        <HStack alignItems="center" gap={6}>
+          <label style={{ cursor: 'pointer' }} htmlFor="provider-sse-idle-timeout-minutes">
+            {t('settings.provider.streaming.sse_idle_timeout.label')}
+          </label>
+          <InfoTooltip title={t('settings.provider.streaming.sse_idle_timeout.help')}></InfoTooltip>
+        </HStack>
+        <InputNumber
+          id="provider-sse-idle-timeout-minutes"
+          min={0}
+          max={720}
+          step={1}
+          value={sseIdleTimeoutMinutes}
+          onChange={(value) => {
+            updateProviderTransition({ sseIdleTimeoutMinutes: value ?? 0 })
+          }}
+          style={{ width: 160 }}
+        />
+      </HStack>
+
+      <HStack justifyContent="flex-end">
+        <Button
+          onClick={() => {
+            updateProviderTransition({
+              requestTimeoutMinutes: 0,
+              sseIdleTimeoutMinutes: 0
+            })
+          }}>
+          {t('settings.provider.streaming.reset')}
+        </Button>
+      </HStack>
+    </Flex>
+  )
+}
+
+export default StreamingSettings

--- a/src/renderer/src/pages/settings/ProviderSettings/StreamingSettings/StreamingSettingsPopup.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/StreamingSettings/StreamingSettingsPopup.tsx
@@ -1,0 +1,66 @@
+import { TopView } from '@renderer/components/TopView'
+import { Modal } from 'antd'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import StreamingSettings from './StreamingSettings'
+
+interface ShowParams {
+  providerId: string
+}
+
+interface Props extends ShowParams {
+  resolve: (data: any) => void
+}
+
+const PopupContainer: React.FC<Props> = ({ providerId, resolve }) => {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(true)
+
+  const onCancel = () => {
+    setOpen(false)
+  }
+
+  const onClose = () => {
+    resolve({})
+  }
+
+  StreamingSettingsPopup.hide = onCancel
+
+  return (
+    <Modal
+      title={t('settings.provider.streaming.title')}
+      open={open}
+      onCancel={onCancel}
+      afterClose={onClose}
+      transitionName="animation-move-down"
+      styles={{ body: { padding: '20px 16px' } }}
+      footer={null}
+      centered>
+      <StreamingSettings providerId={providerId} />
+    </Modal>
+  )
+}
+
+const TopViewKey = 'StreamingSettingsPopup'
+
+export default class StreamingSettingsPopup {
+  static topviewId = 0
+  static hide() {
+    TopView.hide(TopViewKey)
+  }
+  static show(props: ShowParams) {
+    return new Promise<any>((resolve) => {
+      TopView.show(
+        <PopupContainer
+          {...props}
+          resolve={(v) => {
+            resolve(v)
+            TopView.hide(TopViewKey)
+          }}
+        />,
+        TopViewKey
+      )
+    })
+  }
+}

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -187,7 +187,8 @@ export async function fetchChatCompletion({
     params: aiSdkParams,
     modelId,
     capabilities,
-    webSearchPluginConfig
+    webSearchPluginConfig,
+    streamingConfig
   } = await buildStreamTextParams(messages, assistant, provider, {
     mcpTools: mcpTools,
     webSearchProviderId: assistant.webSearchProviderId,
@@ -221,7 +222,8 @@ export async function fetchChatCompletion({
     assistant,
     topicId,
     callType: 'chat',
-    uiMessages
+    uiMessages,
+    streamingConfig
   })
 }
 

--- a/src/renderer/src/types/provider.ts
+++ b/src/renderer/src/types/provider.ts
@@ -109,6 +109,19 @@ export type Provider = {
   isAuthed?: boolean
   rateLimit?: number
 
+  /**
+   * Client-side hard timeout for a single model request.
+   * - `0`/`undefined`: no additional client-enforced timeout (recommended when upstream supports long-running streams).
+   * - `> 0`: abort the request after N minutes.
+   */
+  requestTimeoutMinutes?: number
+  /**
+   * Client-side idle timeout for SSE streaming.
+   * - `0`/`undefined`: disabled.
+   * - `> 0`: abort the request if no stream events are received for N minutes.
+   */
+  sseIdleTimeoutMinutes?: number
+
   // API options
   apiOptions?: ProviderApiOptions
   serviceTier?: ServiceTier


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

⚠️ Important: Redux/IndexedDB Data-Changing Feature PRs Temporarily On Hold ⚠️

Please note: For our current development cycle, we are not accepting feature Pull Requests that introduce changes to Redux data models or IndexedDB schemas.

While we value your contributions, PRs of this nature will be blocked without merge. We welcome all other contributions (bug fixes, perf enhancements, docs, etc.). Thank you!

Once version 2.0.0 is released, we will resume reviewing feature PRs.

-->

### What this PR does

Before this PR:
- OpenAI-Responses (SSE streaming) long-running agentic workflows could disconnect around ~30 minutes.
- No per-provider request hard timeout / SSE idle timeout controls.
- No localized error message for an idle-timeout abort.

After this PR:
- Add per-provider `requestTimeoutMinutes` (hard timeout) and `sseIdleTimeoutMinutes` (SSE idle timeout) settings (UI + i18n).
- Combine user abort signal with `AbortSignal.timeout(...)` for request hard-timeout.
- Abort stalled streams when no SSE events arrive within the idle timeout via `AiSdkToChunkAdapter`, emitting a localized `TimeoutError`.
- Add tests for param building + adapter idle-timeout behavior.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #11965

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Uses a combined abort signal to keep cancellation behavior consistent with AI SDK calls.
- Idle-timeout is implemented in the stream adapter layer to reliably detect "no events" regardless of provider payload.

The following alternatives were considered:
- Provider-specific timeout logic (rejected: duplicated logic across providers).
- Only hard timeout (rejected: does not solve "stalled SSE" cases).

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
- https://github.com/CherryHQ/cherry-studio/issues/11965

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

- None (new provider fields are optional; defaults preserve existing behavior).

### Special notes for your reviewer

<!-- optional -->

- Step 1/2 for #11965 (timeouts): request hard-timeout + SSE idle-timeout.
- Depends on #12010 until it merges (shared prerequisite to keep typecheck green).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Add configurable request hard-timeout and SSE idle-timeout for Responses streaming.
```
