### PR TITLE
🐛 fix(mcp): check system npx/uvx before falling back to bundled binaries

### DIFF
--- a/src/main/services/MCPService.ts
+++ b/src/main/services/MCPService.ts
@@ -357,7 +357,9 @@ class McpService {
                 if (await isBinaryExists('bun')) {
                   // Fall back to bundled bun
                   cmd = await getBinaryPath('bun')
-                  getServerLogger(server).info(`Using bundled bun as fallback (npx not found in PATH)`, { command: cmd })
+                  getServerLogger(server).info(`Using bundled bun as fallback (npx not found in PATH)`, {
+                    command: cmd
+                  })
 
                   // Transform args for bun x format
                   if (args && args.length > 0) {


### PR DESCRIPTION
### What this PR does

Before this PR:
- MCP servers using `npx` command failed silently because the code unconditionally replaced `npx` with bundled `bun`
- If `bun` was not installed in `~/.cherrystudio/bin/`, the MCP server would fail to start with no clear error message
- Users who had `npx` installed on their system couldn't use it

After this PR:
- First checks if `npx`/`uvx`/`uv` is available in the user's system PATH
- If system command is found, uses it directly
- If not found, falls back to bundled `bun`/`uv` in `~/.cherrystudio/bin/`
- If neither is available, shows a clear error message with actionable guidance

<img width="1300" height="817" alt="image" src="https://github.com/user-attachments/assets/3f1796c1-dbeb-4034-96b4-d56a38164d38" />


Fixes #11981

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Added ~100-200ms overhead per MCP server startup for command detection (acceptable for startup operations)
- On Windows, only `.exe` files are accepted (not `.cmd`/`.bat`) because MCP SDK's `StdioClientTransport` uses `spawn({ shell: false })`

The following alternatives were considered:
- Manual PATH parsing instead of spawning `command -v`/`where` - rejected because it doesn't handle all edge cases reliably
- Always using bundled binaries - rejected because it doesn't respect user's existing toolchain

Links to places where the discussion took place:
- Issue: https://github.com/CherryHQ/cherry-studio/issues/11981

### Breaking changes

None. This is a backward-compatible improvement that respects user's system configuration.

### Special notes for your reviewer

Key implementation details:
1. `findCommandInShellEnv()` in `process.ts` - cross-platform command detection with:
   - Command injection prevention (regex validation)
   - Uses `/bin/sh` on Unix for reliability (avoids csh/fish issues)
   - Validates output is absolute path (filters aliases/functions)
   - On Windows, only accepts `.exe` files
   - 5-second timeout protection

2. `MCPService.ts` changes:
   - Moved `getLoginShellEnvironment()` call earlier for command detection
   - Added fallback logic: system command → bundled binary → clear error

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: Not required - internal behavior change

### Release note

```release-note
fix: MCP servers now check for system npx/uvx before falling back to bundled binaries, fixing silent failures when bundled bun is not installed
```