### PR TITLE
fix(openai): preserve Responses API reasoning/tool history for multi-turn conversations

### DIFF
--- a/src/renderer/src/aiCore/legacy/clients/openai/OpenAIResponseAPIClient.ts
+++ b/src/renderer/src/aiCore/legacy/clients/openai/OpenAIResponseAPIClient.ts
@@ -41,7 +41,7 @@ import {
   mcpToolsToOpenAIResponseTools,
   openAIToolsToMcpTool
 } from '@renderer/utils/mcp-tools'
-import { findFileBlocks, findImageBlocks } from '@renderer/utils/messageUtils/find'
+import { findFileBlocks, findImageBlocks, findToolBlocks } from '@renderer/utils/messageUtils/find'
 import { isSupportDeveloperRoleProvider } from '@renderer/utils/provider'
 import { MB } from '@shared/config/constant'
 import { t } from 'i18next'
@@ -169,24 +169,83 @@ export class OpenAIResponseAPIClient extends OpenAIBaseClient<
     } as OpenAI.Responses.ResponseInputFile
   }
 
-  public async convertMessageToSdkParam(message: Message, model: Model): Promise<OpenAIResponseSdkMessageParam> {
+  public async convertMessageToSdkParam(
+    message: Message,
+    model: Model
+  ): Promise<OpenAIResponseSdkMessageParam | OpenAIResponseSdkMessageParam[]> {
     const isVision = isVisionModel(model)
     const { textContent, imageContents } = await this.getMessageContent(message)
     const fileBlocks = findFileBlocks(message)
     const imageBlocks = findImageBlocks(message)
 
-    if (fileBlocks.length === 0 && imageBlocks.length === 0 && imageContents.length === 0) {
-      if (message.role === 'assistant') {
-        return {
+    // For assistant messages, also handle tool history replay
+    if (message.role === 'assistant') {
+      const result: OpenAIResponseSdkMessageParam[] = []
+
+      // Add encrypted reasoning content for Responses API history replay
+      if (message.responsesReasoningItemId && message.responsesReasoningEncryptedContent) {
+        result.push({
+          type: 'reasoning',
+          id: message.responsesReasoningItemId,
+          encrypted_content: message.responsesReasoningEncryptedContent
+        } as OpenAIResponseSdkMessageParam)
+      }
+
+      // Handle tool history - create function_call and function_call_output items
+      const toolBlocks = findToolBlocks(message)
+      const toolResponses = toolBlocks.map((block) => (block as any)?.metadata?.rawMcpToolResponse).filter(Boolean)
+      // Only replay client-side tools (function_call/function_call_output)
+      // Provider-executed tools (e.g. web_search) have special replay semantics
+      const replayableTools = toolResponses.filter((tr: any) => tr?.tool?.type !== 'provider')
+
+      for (const tr of replayableTools) {
+        const callId = tr.toolCallId ?? tr.id
+        const toolName = tr.tool?.name ?? tr.toolName
+        const args = typeof tr.arguments === 'string' ? tr.arguments : JSON.stringify(tr.arguments)
+
+        // Add function_call item
+        result.push({
+          type: 'function_call',
+          call_id: callId,
+          name: toolName,
+          arguments: args
+        } as OpenAIResponseSdkMessageParam)
+
+        // Add function_call_output if tool has completed
+        if (tr.status === 'done' || tr.status === 'error' || tr.status === 'cancelled') {
+          const output = (() => {
+            if (typeof tr.response === 'string') return tr.response
+            try {
+              return JSON.stringify(tr.response)
+            } catch {
+              return String(tr.response)
+            }
+          })()
+
+          result.push({
+            type: 'function_call_output',
+            call_id: callId,
+            output
+          } as OpenAIResponseSdkMessageParam)
+        }
+      }
+
+      // Add the assistant text content
+      if (textContent) {
+        result.push({
           role: 'assistant',
           content: textContent
-        }
-      } else {
-        return {
-          role: message.role === 'system' ? 'user' : message.role,
-          content: textContent ? [{ type: 'input_text', text: textContent }] : []
-        } as OpenAI.Responses.EasyInputMessage
+        })
       }
+
+      return result.length > 0 ? result : { role: 'assistant', content: '' }
+    }
+
+    if (fileBlocks.length === 0 && imageBlocks.length === 0 && imageContents.length === 0) {
+      return {
+        role: message.role === 'system' ? 'user' : message.role,
+        content: textContent ? [{ type: 'input_text', text: textContent }] : []
+      } as OpenAI.Responses.EasyInputMessage
     }
 
     const parts: OpenAI.Responses.ResponseInputContent[] = []
@@ -455,7 +514,13 @@ export class OpenAIResponseAPIClient extends OpenAIBaseClient<
         } else {
           const processedMessages = addImageFileToContents(messages)
           for (const message of processedMessages) {
-            userMessage.push(await this.convertMessageToSdkParam(message, model))
+            const result = await this.convertMessageToSdkParam(message, model)
+            // Flatten arrays (tool history can return multiple items)
+            if (Array.isArray(result)) {
+              userMessage.push(...result)
+            } else {
+              userMessage.push(result)
+            }
           }
         }
         // FIXME: 最好还是直接使用previous_response_id来处理（或者在数据库中存储image_generation_call的id）
@@ -635,6 +700,19 @@ export class OpenAIResponseAPIClient extends OpenAIBaseClient<
               } else if (chunk.item.type === 'web_search_call') {
                 controller.enqueue({
                   type: ChunkType.LLM_WEB_SEARCH_IN_PROGRESS
+                })
+              }
+              break
+            case 'response.output_item.done':
+              // Capture encrypted reasoning content for Responses API history replay
+              if (chunk.item.type === 'reasoning' && chunk.item.encrypted_content) {
+                controller.enqueue({
+                  type: ChunkType.RAW,
+                  content: {
+                    type: 'responses_reasoning',
+                    itemId: chunk.item.id,
+                    encryptedContent: chunk.item.encrypted_content
+                  }
                 })
               }
               break

--- a/src/renderer/src/aiCore/legacy/clients/openai/OpenAIResponseAPIClient.ts
+++ b/src/renderer/src/aiCore/legacy/clients/openai/OpenAIResponseAPIClient.ts
@@ -214,6 +214,9 @@ export class OpenAIResponseAPIClient extends OpenAIBaseClient<
         // Add function_call_output if tool has completed
         if (tr.status === 'done' || tr.status === 'error' || tr.status === 'cancelled') {
           const output = (() => {
+            if (tr.status === 'cancelled' && (tr.response === undefined || tr.response === null)) {
+              return JSON.stringify({ status: 'cancelled' })
+            }
             if (typeof tr.response === 'string') return tr.response
             try {
               return JSON.stringify(tr.response)

--- a/src/renderer/src/aiCore/prepareParams/__tests__/message-converter.test.ts
+++ b/src/renderer/src/aiCore/prepareParams/__tests__/message-converter.test.ts
@@ -197,6 +197,34 @@ describe('messageConverter', () => {
       })
     })
 
+    it('suppresses thinking blocks when Responses API encrypted reasoning replay is present', async () => {
+      const model = createModel()
+      const message = createMessage('assistant')
+      message.__mockContent = 'Done.'
+      message.responsesReasoningItemId = 'rs_123'
+      message.responsesReasoningEncryptedContent = 'enc_abc'
+      message.__mockThinkingBlocks = [createThinkingBlock(message.id, { content: 'This should not be sent' })]
+
+      const result = await convertMessageToSdkParam(message, false, model)
+
+      expect(result).toEqual({
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: '',
+            providerOptions: {
+              openai: {
+                itemId: 'rs_123',
+                reasoningEncryptedContent: 'enc_abc'
+              }
+            }
+          },
+          { type: 'text', text: 'Done.' }
+        ]
+      })
+    })
+
     it('replays tool calls/results from tool blocks for assistant messages', async () => {
       const model = createModel()
       const message = createMessage('assistant')

--- a/src/renderer/src/aiCore/prepareParams/__tests__/message-converter.test.ts
+++ b/src/renderer/src/aiCore/prepareParams/__tests__/message-converter.test.ts
@@ -174,8 +174,7 @@ describe('messageConverter', () => {
       const model = createModel()
       const message = createMessage('assistant')
       message.__mockContent = 'Done.'
-      message.responsesReasoningItemId = 'rs_123'
-      message.responsesReasoningEncryptedContent = 'enc_abc'
+      message.providerMetadata = { openai: { itemId: 'rs_123', reasoningEncryptedContent: 'enc_abc' } }
 
       const result = await convertMessageToSdkParam(message, false, model)
 
@@ -201,8 +200,7 @@ describe('messageConverter', () => {
       const model = createModel()
       const message = createMessage('assistant')
       message.__mockContent = 'Done.'
-      message.responsesReasoningItemId = 'rs_123'
-      message.responsesReasoningEncryptedContent = 'enc_abc'
+      message.providerMetadata = { openai: { itemId: 'rs_123', reasoningEncryptedContent: 'enc_abc' } }
       message.__mockThinkingBlocks = [createThinkingBlock(message.id, { content: 'This should not be sent' })]
 
       const result = await convertMessageToSdkParam(message, false, model)
@@ -261,8 +259,7 @@ describe('messageConverter', () => {
       const message = createMessage('assistant')
       message.__mockContent = 'Final answer'
       message.__mockToolBlocks = [createToolBlock(message.id)]
-      message.responsesReasoningItemId = 'rs_123'
-      message.responsesReasoningEncryptedContent = 'enc_abc'
+      message.providerMetadata = { openai: { itemId: 'rs_123', reasoningEncryptedContent: 'enc_abc' } }
 
       const result = await convertMessageToSdkParam(message, false, model)
 

--- a/src/renderer/src/aiCore/prepareParams/__tests__/message-converter.test.ts
+++ b/src/renderer/src/aiCore/prepareParams/__tests__/message-converter.test.ts
@@ -8,6 +8,7 @@ import {
   MessageBlockStatus,
   MessageBlockType,
   type ThinkingMessageBlock,
+  type ToolMessageBlock,
   UserMessageStatus
 } from '@renderer/types/newMessage'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -35,13 +36,15 @@ type MockableMessage = Message & {
   __mockFileBlocks?: FileMessageBlock[]
   __mockImageBlocks?: ImageMessageBlock[]
   __mockThinkingBlocks?: ThinkingMessageBlock[]
+  __mockToolBlocks?: ToolMessageBlock[]
 }
 
 vi.mock('@renderer/utils/messageUtils/find', () => ({
   getMainTextContent: (message: Message) => (message as MockableMessage).__mockContent ?? '',
   findFileBlocks: (message: Message) => (message as MockableMessage).__mockFileBlocks ?? [],
   findImageBlocks: (message: Message) => (message as MockableMessage).__mockImageBlocks ?? [],
-  findThinkingBlocks: (message: Message) => (message as MockableMessage).__mockThinkingBlocks ?? []
+  findThinkingBlocks: (message: Message) => (message as MockableMessage).__mockThinkingBlocks ?? [],
+  findToolBlocks: (message: Message) => (message as MockableMessage).__mockToolBlocks ?? []
 }))
 
 import { convertMessagesToSdkMessages, convertMessageToSdkParam } from '../messageConverter'
@@ -123,6 +126,39 @@ const createThinkingBlock = (
   ...overrides
 })
 
+const createToolBlock = (
+  messageId: string,
+  overrides: Partial<Omit<ToolMessageBlock, 'type' | 'messageId' | 'toolId'>> & {
+    toolId?: string
+    rawMcpToolResponse?: any
+  } = {}
+): ToolMessageBlock => {
+  const { rawMcpToolResponse, ...blockOverrides } = overrides
+  const timestamp = new Date(2024, 0, 1, 0, 0, ++blockCounter).toISOString()
+  return {
+    id: blockOverrides.id ?? `tool-block-${blockCounter}`,
+    messageId,
+    type: MessageBlockType.TOOL,
+    createdAt: blockOverrides.createdAt ?? timestamp,
+    status: blockOverrides.status ?? MessageBlockStatus.SUCCESS,
+    toolId: blockOverrides.toolId ?? `tool-call-${blockCounter}`,
+    toolName: (blockOverrides as any)?.toolName ?? 'test-tool',
+    metadata: {
+      rawMcpToolResponse:
+        rawMcpToolResponse ??
+        ({
+          id: 'call-1',
+          toolCallId: 'call-1',
+          tool: { id: 'test-tool', name: 'test-tool', description: 'test-tool', type: 'builtin' },
+          arguments: '{"a":1}',
+          status: 'done',
+          response: { ok: true }
+        } as any)
+    },
+    ...blockOverrides
+  }
+}
+
 describe('messageConverter', () => {
   beforeEach(() => {
     convertFileBlockToFilePartMock.mockReset()
@@ -134,6 +170,64 @@ describe('messageConverter', () => {
   })
 
   describe('convertMessageToSdkParam', () => {
+    it('replays Responses API encrypted reasoning content when present on assistant message', async () => {
+      const model = createModel()
+      const message = createMessage('assistant')
+      message.__mockContent = 'Done.'
+      message.responsesReasoningItemId = 'rs_123'
+      message.responsesReasoningEncryptedContent = 'enc_abc'
+
+      const result = await convertMessageToSdkParam(message, false, model)
+
+      expect(result).toEqual({
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: '',
+            providerOptions: {
+              openai: {
+                itemId: 'rs_123',
+                reasoningEncryptedContent: 'enc_abc'
+              }
+            }
+          },
+          { type: 'text', text: 'Done.' }
+        ]
+      })
+    })
+
+    it('replays tool calls/results from tool blocks for assistant messages', async () => {
+      const model = createModel()
+      const message = createMessage('assistant')
+      message.__mockContent = 'Final answer'
+      message.__mockToolBlocks = [createToolBlock(message.id)]
+
+      const result = await convertMessageToSdkParam(message, false, model)
+
+      expect(result).toEqual([
+        {
+          role: 'assistant',
+          content: [{ type: 'tool-call', toolCallId: 'call-1', toolName: 'test-tool', input: { a: 1 } }]
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call-1',
+              toolName: 'test-tool',
+              output: { type: 'text', value: '{"ok":true}' }
+            }
+          ]
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Final answer' }]
+        }
+      ])
+    })
+
     it('includes text and image parts for user messages on vision models', async () => {
       const model = createModel()
       const message = createMessage('user')
@@ -255,8 +349,8 @@ describe('messageConverter', () => {
       expect(result).toEqual({
         role: 'assistant',
         content: [
-          { type: 'text', text: 'Here is my answer' },
-          { type: 'reasoning', text: 'Let me think...' }
+          { type: 'reasoning', text: 'Let me think...' },
+          { type: 'text', text: 'Here is my answer' }
         ]
       })
     })

--- a/src/renderer/src/aiCore/prepareParams/messageConverter.ts
+++ b/src/renderer/src/aiCore/prepareParams/messageConverter.ts
@@ -111,8 +111,11 @@ function buildToolHistoryMessages(toolBlocks: any[]): ModelMessage[] {
       toolCallId: tr.toolCallId ?? tr.id,
       toolName: tr.tool?.name ?? tr.toolName,
       output: {
-        type: tr.status === 'error' ? ('error-text' as const) : ('text' as const),
-        value: stringifyToolOutput(tr.response)
+        type: tr.status === 'error' || tr.status === 'cancelled' ? ('error-text' as const) : ('text' as const),
+        value:
+          tr.status === 'cancelled' && (tr.response === undefined || tr.response === null)
+            ? 'cancelled'
+            : stringifyToolOutput(tr.response)
       }
     }))
 

--- a/src/renderer/src/services/messageStreaming/callbacks/responsesReasoningCallbacks.ts
+++ b/src/renderer/src/services/messageStreaming/callbacks/responsesReasoningCallbacks.ts
@@ -2,8 +2,9 @@ import { loggerService } from '@logger'
 import type { AppDispatch, RootState } from '@renderer/store'
 import { newMessagesActions } from '@renderer/store/newMessage'
 import type { Message } from '@renderer/types'
+import type { ResponsesReasoningRawPayload } from '@renderer/utils/responsesReasoning'
+import { parseResponsesReasoningRawPayload } from '@renderer/utils/responsesReasoning'
 import type { ProviderMetadata } from 'ai'
-import * as z from 'zod'
 
 const logger = loggerService.withContext('ResponsesReasoningCallbacks')
 
@@ -18,24 +19,6 @@ interface ResponsesReasoningCallbacksDependencies {
     messageUpdates: Partial<Message>,
     blocksToUpdate: any[]
   ) => Promise<void>
-}
-
-type ResponsesReasoningRawPayload = {
-  type: 'responses_reasoning'
-  itemId: string
-  encryptedContent: string
-}
-
-const ResponsesReasoningRawPayloadSchema = z.object({
-  type: z.literal('responses_reasoning'),
-  itemId: z.string().min(1),
-  encryptedContent: z.string().min(1)
-})
-
-function parseResponsesReasoningRawPayload(value: unknown): ResponsesReasoningRawPayload | undefined {
-  const parsed = ResponsesReasoningRawPayloadSchema.safeParse(value)
-  if (!parsed.success) return undefined
-  return parsed.data
 }
 
 export const createResponsesReasoningCallbacks = (deps: ResponsesReasoningCallbacksDependencies) => {

--- a/src/renderer/src/services/messageStreaming/callbacks/responsesReasoningCallbacks.ts
+++ b/src/renderer/src/services/messageStreaming/callbacks/responsesReasoningCallbacks.ts
@@ -1,0 +1,86 @@
+import { loggerService } from '@logger'
+import type { AppDispatch, RootState } from '@renderer/store'
+import { newMessagesActions } from '@renderer/store/newMessage'
+import type { Message } from '@renderer/types'
+
+const logger = loggerService.withContext('ResponsesReasoningCallbacks')
+
+interface ResponsesReasoningCallbacksDependencies {
+  dispatch: AppDispatch
+  getState: () => RootState
+  topicId: string
+  assistantMsgId: string
+  saveUpdatesToDB: (
+    messageId: string,
+    topicId: string,
+    messageUpdates: Partial<Message>,
+    blocksToUpdate: any[]
+  ) => Promise<void>
+}
+
+type ResponsesReasoningRawPayload = {
+  type: 'responses_reasoning'
+  itemId: string
+  encryptedContent: string
+}
+
+function isResponsesReasoningRawPayload(value: unknown): value is ResponsesReasoningRawPayload {
+  if (typeof value !== 'object' || value === null) return false
+  const payload = value as Partial<ResponsesReasoningRawPayload>
+  if (payload.type !== 'responses_reasoning') return false
+  if (typeof payload.itemId !== 'string' || payload.itemId.length === 0) return false
+  if (typeof payload.encryptedContent !== 'string' || payload.encryptedContent.length === 0) return false
+  return true
+}
+
+export const createResponsesReasoningCallbacks = (deps: ResponsesReasoningCallbacksDependencies) => {
+  const { dispatch, getState, topicId, assistantMsgId, saveUpdatesToDB } = deps
+
+  const persistResponsesReasoning = async (payload: ResponsesReasoningRawPayload) => {
+    const state = getState()
+    const assistantMessage = state.messages.entities[assistantMsgId]
+    if (!assistantMessage) {
+      logger.warn('[persistResponsesReasoning] Assistant message not found, skipping.', { assistantMsgId, topicId })
+      return
+    }
+
+    const updates: Partial<Message> = {
+      responsesReasoningItemId: payload.itemId,
+      responsesReasoningEncryptedContent: payload.encryptedContent
+    }
+
+    dispatch(
+      newMessagesActions.updateMessage({
+        topicId,
+        messageId: assistantMsgId,
+        updates
+      })
+    )
+
+    try {
+      await saveUpdatesToDB(assistantMsgId, topicId, updates, [])
+    } catch (error) {
+      logger.error('[persistResponsesReasoning] Failed to persist responses reasoning fields to DB.', error as Error, {
+        assistantMsgId,
+        topicId
+      })
+    }
+  }
+
+  const onRawData = (content: unknown, metadata?: Record<string, any>) => {
+    if (!isResponsesReasoningRawPayload(content)) return
+
+    logger.debug('[onRawData] Persisting responses reasoning encrypted content.', {
+      assistantMsgId,
+      topicId,
+      itemId: content.itemId,
+      metadata
+    })
+
+    void persistResponsesReasoning(content)
+  }
+
+  return {
+    onRawData
+  }
+}

--- a/src/renderer/src/store/thunk/__tests__/streamCallback.integration.test.ts
+++ b/src/renderer/src/store/thunk/__tests__/streamCallback.integration.test.ts
@@ -526,8 +526,8 @@ describe('streamCallback Integration Tests', () => {
     const state = getState()
     const message = state.messages.entities[mockAssistantMsgId]
     expect(message).toBeDefined()
-    expect((message as any)?.responsesReasoningItemId).toBe('rs_123')
-    expect((message as any)?.responsesReasoningEncryptedContent).toBe('enc_abc')
+    expect((message as any)?.providerMetadata?.openai?.itemId).toBe('rs_123')
+    expect((message as any)?.providerMetadata?.openai?.reasoningEncryptedContent).toBe('enc_abc')
   })
 
   it('should handle image generation flow', async () => {

--- a/src/renderer/src/store/thunk/__tests__/streamCallback.integration.test.ts
+++ b/src/renderer/src/store/thunk/__tests__/streamCallback.integration.test.ts
@@ -502,6 +502,34 @@ describe('streamCallback Integration Tests', () => {
     expect((toolBlock as any)?.toolName).toBe('test-tool')
   })
 
+  it('should persist Responses reasoning encrypted content from RAW chunks', async () => {
+    const callbacks = createMockCallbacks(mockAssistantMsgId, mockTopicId, mockAssistant, dispatch, getState)
+
+    const rawResponsesReasoningPayload = {
+      type: 'responses_reasoning',
+      itemId: 'rs_123',
+      encryptedContent: 'enc_abc'
+    }
+
+    const chunks: Chunk[] = [
+      { type: ChunkType.LLM_RESPONSE_CREATED },
+      {
+        type: ChunkType.RAW,
+        content: rawResponsesReasoningPayload,
+        metadata: { source: 'ai-sdk', provider: 'openai' }
+      },
+      { type: ChunkType.BLOCK_COMPLETE }
+    ]
+
+    await processChunks(chunks, callbacks)
+
+    const state = getState()
+    const message = state.messages.entities[mockAssistantMsgId]
+    expect(message).toBeDefined()
+    expect((message as any)?.responsesReasoningItemId).toBe('rs_123')
+    expect((message as any)?.responsesReasoningEncryptedContent).toBe('enc_abc')
+  })
+
   it('should handle image generation flow', async () => {
     const callbacks = createMockCallbacks(mockAssistantMsgId, mockTopicId, mockAssistant, dispatch, getState)
 

--- a/src/renderer/src/types/newMessage.ts
+++ b/src/renderer/src/types/newMessage.ts
@@ -221,6 +221,18 @@ export type Message = {
   // raw data
   // TODO: add this providerMetadata to MessageBlock to save raw provider data for each block
   providerMetadata?: ProviderMetadata
+
+  /**
+   * Responses API reasoning item id (e.g. `rs_...`) for this assistant reply.
+   * Used to replay encrypted reasoning content in follow-up requests.
+   */
+  responsesReasoningItemId?: string
+
+  /**
+   * Responses API encrypted reasoning content for this assistant reply.
+   * Must be echoed back in follow-up requests to preserve internal reasoning state.
+   */
+  responsesReasoningEncryptedContent?: string
 }
 
 export interface Response {

--- a/src/renderer/src/types/newMessage.ts
+++ b/src/renderer/src/types/newMessage.ts
@@ -221,18 +221,6 @@ export type Message = {
   // raw data
   // TODO: add this providerMetadata to MessageBlock to save raw provider data for each block
   providerMetadata?: ProviderMetadata
-
-  /**
-   * Responses API reasoning item id (e.g. `rs_...`) for this assistant reply.
-   * Used to replay encrypted reasoning content in follow-up requests.
-   */
-  responsesReasoningItemId?: string
-
-  /**
-   * Responses API encrypted reasoning content for this assistant reply.
-   * Must be echoed back in follow-up requests to preserve internal reasoning state.
-   */
-  responsesReasoningEncryptedContent?: string
 }
 
 export interface Response {

--- a/src/renderer/src/utils/messageUtils/find.ts
+++ b/src/renderer/src/utils/messageUtils/find.ts
@@ -9,6 +9,7 @@ import type {
   Message,
   MessageBlock,
   ThinkingMessageBlock,
+  ToolMessageBlock,
   TranslationMessageBlock
 } from '@renderer/types/newMessage'
 import { MessageBlockType } from '@renderer/types/newMessage'
@@ -106,6 +107,26 @@ export const findFileBlocks = (message: Message): FileMessageBlock[] => {
     }
   }
   return fileBlocks
+}
+
+/**
+ * Finds all ToolMessageBlocks associated with a given message.
+ * @param message - The message object.
+ * @returns An array of ToolMessageBlocks (empty if none found).
+ */
+export const findToolBlocks = (message: Message): ToolMessageBlock[] => {
+  if (!message || !message.blocks || message.blocks.length === 0) {
+    return []
+  }
+  const state = store.getState()
+  const toolBlocks: ToolMessageBlock[] = []
+  for (const blockId of message.blocks) {
+    const block = messageBlocksSelectors.selectById(state, blockId)
+    if (block && block.type === MessageBlockType.TOOL) {
+      toolBlocks.push(block as ToolMessageBlock)
+    }
+  }
+  return toolBlocks
 }
 
 /**

--- a/src/renderer/src/utils/responsesReasoning.ts
+++ b/src/renderer/src/utils/responsesReasoning.ts
@@ -1,0 +1,52 @@
+import * as z from 'zod'
+
+export type ResponsesReasoningRawPayload = {
+  itemId: string
+  encryptedContent: string
+}
+
+const ResponsesReasoningRawPayloadSchema = z.object({
+  type: z.literal('responses_reasoning'),
+  itemId: z.string().min(1),
+  encryptedContent: z.string().min(1)
+})
+
+const ResponsesReasoningProviderMetadataSchema = z.object({
+  itemId: z.string().min(1),
+  reasoningEncryptedContent: z.string().min(1)
+})
+
+const ResponsesReasoningProviderMetadataLegacySchema = z.object({
+  itemId: z.string().min(1),
+  encryptedContent: z.string().min(1)
+})
+
+export function parseResponsesReasoningRawPayload(value: unknown): ResponsesReasoningRawPayload | undefined {
+  const rawParsed = ResponsesReasoningRawPayloadSchema.safeParse(value)
+  if (rawParsed.success) {
+    return { itemId: rawParsed.data.itemId, encryptedContent: rawParsed.data.encryptedContent }
+  }
+
+  // If this looks like a RAW chunk but isn't our expected type, don't fall back to metadata parsing.
+  if (typeof value === 'object' && value !== null && !Array.isArray(value) && 'type' in value) {
+    return undefined
+  }
+
+  const providerMetadataParsed = ResponsesReasoningProviderMetadataSchema.safeParse(value)
+  if (providerMetadataParsed.success) {
+    return {
+      itemId: providerMetadataParsed.data.itemId,
+      encryptedContent: providerMetadataParsed.data.reasoningEncryptedContent
+    }
+  }
+
+  const legacyProviderMetadataParsed = ResponsesReasoningProviderMetadataLegacySchema.safeParse(value)
+  if (legacyProviderMetadataParsed.success) {
+    return {
+      itemId: legacyProviderMetadataParsed.data.itemId,
+      encryptedContent: legacyProviderMetadataParsed.data.encryptedContent
+    }
+  }
+
+  return undefined
+}


### PR DESCRIPTION
### What this PR does

Before this PR:
- When using OpenAI Responses API with `store=false`, multi-turn conversations fail because reasoning `encrypted_content` and tool call history are not preserved
- This affects both the AI SDK path (regular chat) and the legacy client path

After this PR:
- **AI SDK path** (commit 914e4d207): Captures `encrypted_content` from reasoning items and emits it via `ChunkType.RAW` for persistence
- **Legacy client path** (commit 36eaedae0): 
  - Captures `encrypted_content` from `response.output_item.done` events
  - Replays reasoning items with `id` and `encrypted_content` for history preservation
  - Replays `function_call` and `function_call_output` items for tool history
  - Flattens array results when building request messages

Fixes #12039

### Why we need it and why it was done in this way

Cherry Studio has two parallel code paths for AI completions:
- **AI SDK path** (`index_new.ts` → Vercel AI SDK): Used for most chat completions, including OpenAI Responses API with `mode: 'responses'`
- **Legacy client path** (`OpenAIResponseAPIClient.ts`): Used for **image generation** with OpenAI Responses API, as well as for unsupported providers (ie. `isModernSdkSupported()` returns false). In my testing, the requests were handled by this path.

Both paths needed the fix because:
- Regular chat with OpenAI Responses API → AI SDK path
- Image generation with OpenAI Responses API, or unsupported providers → Legacy path

The following tradeoffs were made:
- Uses type assertions for new item types since SDK types may not include all Responses API item types

The following alternatives were considered:
- Using `previous_response_id` instead of client-side history replay, but this is impossible when store=False

### Breaking changes

None. This is a bug fix that adds missing functionality.

### Special notes for your reviewer

- The implementation in the legacy path mirrors `buildToolHistoryMessages()` in `messageConverter.ts` to ensure consistent behavior across both paths
- Provider-executed tools (e.g., `web_search`) are filtered out as they have special replay semantics handled by the provider

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: Not required (internal bug fix)

### Release note

```release-note
fix(openai): Fixed multi-turn conversations with OpenAI Responses API when using `store=false` by properly preserving reasoning encrypted content and tool call history in both AI SDK and legacy image generation paths
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)