### PR TITLE
fix(azure-openai): normalize Azure endpoint

### DIFF
--- a/src/renderer/src/aiCore/legacy/clients/__tests__/OpenAIBaseClient.azureEndpoint.test.ts
+++ b/src/renderer/src/aiCore/legacy/clients/__tests__/OpenAIBaseClient.azureEndpoint.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeAzureOpenAIEndpoint } from '../openai/azureOpenAIEndpoint'
+
+describe('normalizeAzureOpenAIEndpoint', () => {
+  it.each([
+    {
+      apiHost: 'https://example.openai.azure.com/openai',
+      expectedEndpoint: 'https://example.openai.azure.com'
+    },
+    {
+      apiHost: 'https://example.openai.azure.com/openai/',
+      expectedEndpoint: 'https://example.openai.azure.com'
+    },
+    {
+      apiHost: 'https://example.openai.azure.com/openai/v1',
+      expectedEndpoint: 'https://example.openai.azure.com'
+    },
+    {
+      apiHost: 'https://example.openai.azure.com/openai/v1/',
+      expectedEndpoint: 'https://example.openai.azure.com'
+    },
+    {
+      apiHost: 'https://example.openai.azure.com',
+      expectedEndpoint: 'https://example.openai.azure.com'
+    },
+    {
+      apiHost: 'https://example.openai.azure.com/',
+      expectedEndpoint: 'https://example.openai.azure.com'
+    },
+    {
+      apiHost: 'https://example.openai.azure.com/OPENAI/V1',
+      expectedEndpoint: 'https://example.openai.azure.com'
+    }
+  ])('strips trailing /openai from $apiHost', ({ apiHost, expectedEndpoint }) => {
+    expect(normalizeAzureOpenAIEndpoint(apiHost)).toBe(expectedEndpoint)
+  })
+})

--- a/src/renderer/src/aiCore/legacy/clients/openai/OpenAIBaseClient.ts
+++ b/src/renderer/src/aiCore/legacy/clients/openai/OpenAIBaseClient.ts
@@ -29,6 +29,7 @@ import { withoutTrailingSlash } from '@renderer/utils/api'
 import { isOllamaProvider } from '@renderer/utils/provider'
 
 import { BaseApiClient } from '../BaseApiClient'
+import { normalizeAzureOpenAIEndpoint } from './azureOpenAIEndpoint'
 
 const logger = loggerService.withContext('OpenAIBaseClient')
 
@@ -213,7 +214,7 @@ export abstract class OpenAIBaseClient<
         dangerouslyAllowBrowser: true,
         apiKey: apiKeyForSdkInstance,
         apiVersion: this.provider.apiVersion,
-        endpoint: this.provider.apiHost
+        endpoint: normalizeAzureOpenAIEndpoint(this.provider.apiHost)
       }) as TSdkInstance
     } else {
       this.sdkInstance = new OpenAI({

--- a/src/renderer/src/aiCore/legacy/clients/openai/azureOpenAIEndpoint.ts
+++ b/src/renderer/src/aiCore/legacy/clients/openai/azureOpenAIEndpoint.ts
@@ -1,0 +1,4 @@
+export function normalizeAzureOpenAIEndpoint(apiHost: string): string {
+  const normalizedHost = apiHost.replace(/\/+$/, '')
+  return normalizedHost.replace(/\/openai(?:\/v1)?$/i, '')
+}


### PR DESCRIPTION
### What this PR does

Before this PR:
- Azure OpenAI `gpt-image-1` requests could hit a duplicated path like `.../openai/openai/...` when using the legacy OpenAI SDK client.

After this PR:
- Azure OpenAI `endpoint` is normalized (strips trailing `/openai` or `/openai/v1`) so image generation requests go to the correct Azure base endpoint.

Fixes #N/A (reported in #11966 comment)

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Added a tiny, dependency-free helper to avoid importing the heavier legacy client module in tests.

The following alternatives were considered:
- Adjusting `provider.apiHost` formatting globally; rejected because other call sites rely on the current normalization.

Links to places where the discussion took place:
- https://github.com/CherryHQ/cherry-studio/pull/11966#issuecomment-3677748566

### Breaking changes

None.

### Special notes for your reviewer

@DeJeune This addresses the “azure gpt-image-1 is not working” regression by ensuring `AzureOpenAI` receives the correct Azure resource endpoint (without a duplicated `/openai`).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
Fix Azure OpenAI image generation (gpt-image-1) by normalizing the Azure endpoint to avoid duplicated `/openai` in requests.
```
