### PR TITLE
fix(display): improve font selector for long font names

### DIFF
--- a/src/renderer/src/pages/settings/DisplaySettings/DisplaySettings.tsx
+++ b/src/renderer/src/pages/settings/DisplaySettings/DisplaySettings.tsx
@@ -199,16 +199,13 @@ const DisplaySettings: FC = () => {
   const renderFontOption = useCallback(
     (font: string) => (
       <Tooltip title={font} placement="left" mouseEnterDelay={0.5}>
-        <span
+        <div
+          className="truncate"
           style={{
-            fontFamily: font,
-            display: 'block',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap'
+            fontFamily: font
           }}>
           {font}
-        </span>
+        </div>
       </Tooltip>
     ),
     []


### PR DESCRIPTION
fix #12051

<img width="1792" height="907" alt="image" src="https://github.com/user-attachments/assets/6f0149bf-a1c6-4962-80d8-7842c6a3feee" />


- Increase Select width from 200px to 280px
- Increase SelectRow container width from 300px to 380px
- Add Tooltip to show full font name on hover
- Add text-overflow ellipsis for long font names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

