### PR TITLE
fix: resolve unexpected miniwindow loop closure on Mac

### DIFF
--- a/src/main/services/WindowService.ts
+++ b/src/main/services/WindowService.ts
@@ -635,6 +635,11 @@ export class WindowService {
       return
     } else if (isMac) {
       this.miniWindow.hide()
+      const majorVersion = parseInt(process.getSystemVersion().split('.')[0], 10)
+      if (majorVersion >= 26) {
+        // on macOS 26+, the popup of the mimiWindow would not change the focus to previous application.
+        return
+      }
       if (!this.wasMainWindowFocused) {
         app.hide()
       }


### PR DESCRIPTION
### What this PR does

Before this PR: The miniWindow could not popup once closed.

![before](https://github.com/user-attachments/assets/7d421efa-cb2c-49db-b29c-3cf6226a3a30)


After this PR: Expeteced behavior

![after](https://github.com/user-attachments/assets/8764b622-0ba1-400a-be99-4a7fb4c2a98f)


### Why we need it and why it was done in this way

The implementation of hideMiniWindow in [WindowService.ts](https://github.com/CherryHQ/cherry-studio/blob/main/src/main/services/WindowService.ts) invokes app.hide(), which is redundant on macOS. Since the miniWindow is not a standard window, application switching does not occur as expected.

If the miniWindow is displayed after the application is hidden, the focus will automatically shift from the miniWindow to the main window, triggering the blur event and causing both windows to be hidden. As a result, the miniWindow cannot be properly displayed.

### Breaking changes

NONE

### Special notes for your reviewer

NONE

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x ] PR: The PR description is expressive enough and will help future contributors
- [ x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

NONE
