### PR TITLE
fix: correct aihubmix anthropic API path

### DIFF
--- a/src/renderer/src/config/providers.ts
+++ b/src/renderer/src/config/providers.ts
@@ -107,7 +107,7 @@ export const SYSTEM_PROVIDERS_CONFIG: Record<SystemProviderId, SystemProvider> =
     type: 'openai',
     apiKey: '',
     apiHost: 'https://aihubmix.com',
-    anthropicApiHost: 'https://aihubmix.com/anthropic',
+    anthropicApiHost: 'https://aihubmix.com',
     models: SYSTEM_MODELS.aihubmix,
     isSystem: true,
     enabled: false


### PR DESCRIPTION
### What this PR does

Before this PR:
When users try to use Claude models with the aihubmix provider, requests are sent to an incorrect endpoint: `https://aihubmix.com/anthropic/v1/messages`

After this PR:
Claude API requests are correctly sent to: `https://aihubmix.com/v1/messages`

Fixes #
- User reported issue with aihubmix Claude API path containing extra /anthropic segment

### Why we need it and why it was done in this way

The aihubmix provider configuration had an incorrect `anthropicApiHost` value that included an unnecessary `/anthropic` path segment. This caused API requests to fail because the endpoint doesn't exist.

The fix removes the `/anthropic` suffix from the `anthropicApiHost` configuration, aligning it with the correct API endpoint structure.

The following tradeoffs were made:
- None, this is a straightforward bug fix

The following alternatives were considered:
- Modifying the API client logic, but fixing the configuration is the correct approach

### Breaking changes

None. This is a bug fix that corrects the API endpoint to work as intended.

### Special notes for your reviewer

This change only affects the aihubmix provider configuration. Other providers with similar `/anthropic` paths in their configuration are intentionally different and should not be changed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
Fix aihubmix provider Claude API endpoint configuration
```