### PR TITLE
fix: align MCP tool ids for permissions

### DIFF
--- a/src/main/services/agents/services/AgentService.ts
+++ b/src/main/services/agents/services/AgentService.ts
@@ -89,8 +89,9 @@ export class AgentService extends BaseService {
     }
 
     const agent = this.deserializeJsonFields(result[0]) as GetAgentResponse
-    agent.tools = await this.listMcpTools(agent.type, agent.mcps)
-    agent.allowed_tools = this.normalizeAllowedTools(agent.allowed_tools, agent.tools)
+    const { tools, legacyIdMap } = await this.listMcpTools(agent.type, agent.mcps)
+    agent.tools = tools
+    agent.allowed_tools = this.normalizeAllowedTools(agent.allowed_tools, agent.tools, legacyIdMap)
 
     // Load installed_plugins from cache file instead of database
     const workdir = agent.accessible_paths?.[0]
@@ -135,8 +136,9 @@ export class AgentService extends BaseService {
     const agents = result.map((row) => this.deserializeJsonFields(row)) as GetAgentResponse[]
 
     for (const agent of agents) {
-      agent.tools = await this.listMcpTools(agent.type, agent.mcps)
-      agent.allowed_tools = this.normalizeAllowedTools(agent.allowed_tools, agent.tools)
+      const { tools, legacyIdMap } = await this.listMcpTools(agent.type, agent.mcps)
+      agent.tools = tools
+      agent.allowed_tools = this.normalizeAllowedTools(agent.allowed_tools, agent.tools, legacyIdMap)
     }
 
     return { agents, total: totalResult[0].count }

--- a/src/main/services/agents/services/SessionService.ts
+++ b/src/main/services/agents/services/SessionService.ts
@@ -156,8 +156,9 @@ export class SessionService extends BaseService {
     }
 
     const session = this.deserializeJsonFields(result[0]) as GetAgentSessionResponse
-    session.tools = await this.listMcpTools(session.agent_type, session.mcps)
-    session.allowed_tools = this.normalizeAllowedTools(session.allowed_tools, session.tools)
+    const { tools, legacyIdMap } = await this.listMcpTools(session.agent_type, session.mcps)
+    session.tools = tools
+    session.allowed_tools = this.normalizeAllowedTools(session.allowed_tools, session.tools, legacyIdMap)
 
     // If slash_commands is not in database yet (e.g., first invoke before init message),
     // fall back to builtin + local commands. Otherwise, use the merged commands from database.
@@ -204,8 +205,9 @@ export class SessionService extends BaseService {
     const sessions = result.map((row) => this.deserializeJsonFields(row)) as GetAgentSessionResponse[]
 
     for (const session of sessions) {
-      session.tools = await this.listMcpTools(session.agent_type, session.mcps)
-      session.allowed_tools = this.normalizeAllowedTools(session.allowed_tools, session.tools)
+      const { tools, legacyIdMap } = await this.listMcpTools(session.agent_type, session.mcps)
+      session.tools = tools
+      session.allowed_tools = this.normalizeAllowedTools(session.allowed_tools, session.tools, legacyIdMap)
     }
 
     return { sessions, total }


### PR DESCRIPTION
### What this PR does

Before this PR:
- MCP tools were listed with `mcp_` IDs but the agent SDK used `mcp__` tool names, so allowed tool toggles did not auto-approve.

After this PR:
- MCP tools are listed with `mcp__` IDs and legacy allowlist entries are normalized for agents and sessions.

Fixes # (none)

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Normalize allowlists on read to keep existing data working without a migration.

The following alternatives were considered:
- Data migration to rewrite stored IDs, which would be heavier and more intrusive.

Links to places where the discussion took place:

### Breaking changes

None.

### Special notes for your reviewer

None.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required

### Release note

```release-note
Fix MCP tool auto-approval to respect allowed tool toggles by aligning tool IDs.
```