### PR TITLE
fix(windows): remember size not working for SelectionAction window

### DIFF
--- a/src/main/services/SelectionService.ts
+++ b/src/main/services/SelectionService.ts
@@ -1435,6 +1435,12 @@ export class SelectionService {
     }
 
     actionWindow.setBounds({ x, y, width, height })
+
+    // [Windows only] Update remembered window size for custom resize
+    // setBounds() may not trigger the 'resized' event, so we need to update manually
+    if (this.isRemeberWinSize) {
+      this.lastActionWindowSize = { width, height }
+    }
   }
 
   /**


### PR DESCRIPTION
### What this PR does

Before this PR:
- On Windows, the SelectionAction window's "Remember Size" option is enabled but doesn't actually work when resizing via the custom resize handles added in PR #11766.

After this PR:
- The remembered window size is correctly updated when users resize the SelectionAction window using the custom resize handles on Windows.

Fixes the issue reported by users where "Remember Size" option doesn't work after PR #11766.

### Why we need it and why it was done in this way

**The following tradeoffs were made:**
- Added manual `lastActionWindowSize` update after `setBounds()` call in the custom resize handler.

**The following alternatives were considered:**
- Relying on the `'resized'` event: This doesn't work because `setBounds()` may not trigger the `'resized'` event consistently.

**Links to places where the discussion took place:**
- Related PR: #11766 (added custom resize handles for Windows)

### Breaking changes

None.

### Special notes for your reviewer

- This is a minimal fix that adds the missing size update in the `resizeActionWindow` method.
- The existing `'resized'` event listener (line 1217-1224) handles native resize, but the custom resize via `setBounds()` bypasses this event.
- The fix follows the same pattern as the existing size update logic.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: Not required (internal bug fix)

### Release note

```release-note
fix(windows): SelectionAction window now correctly remembers its size when resized via custom resize handles
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)