### PR TITLE
docs: fix copy -> cp in development guide

### DIFF
--- a/docs/en/guides/development.md
+++ b/docs/en/guides/development.md
@@ -36,7 +36,7 @@ yarn install
 ### ENV
 
 ```bash
-copy .env.example .env
+cp .env.example .env
 ```
 
 ### Start

--- a/docs/zh/guides/development.md
+++ b/docs/zh/guides/development.md
@@ -36,7 +36,7 @@ yarn install
 ### ENV
 
 ```bash
-copy .env.example .env
+cp .env.example .env
 ```
 
 ### Start


### PR DESCRIPTION
Fixes #12141

Changed `copy .env.example .env` to `cp .env.example .env` in the development guide.

The code block uses bash syntax, so `cp` is the correct command.