### PR TITLE
fix: remove trailing api version in ANTHROPIC_BASE_URL

### DIFF
--- a/packages/shared/utils.ts
+++ b/packages/shared/utils.ts
@@ -35,3 +35,56 @@ export const defaultAppHeaders = () => {
 //     return value
 //   }
 // }
+
+/**
+ * Extracts the trailing API version segment from a URL path.
+ *
+ * This function extracts API version patterns (e.g., `v1`, `v2beta`) from the end of a URL.
+ * Only versions at the end of the path are extracted, not versions in the middle.
+ * The returned version string does not include leading or trailing slashes.
+ *
+ * @param {string} url - The URL string to parse.
+ * @returns {string | undefined} The trailing API version found (e.g., 'v1', 'v2beta'), or undefined if none found.
+ *
+ * @example
+ * getTrailingApiVersion('https://api.example.com/v1') // 'v1'
+ * getTrailingApiVersion('https://api.example.com/v2beta/') // 'v2beta'
+ * getTrailingApiVersion('https://api.example.com/v1/chat') // undefined (version not at end)
+ * getTrailingApiVersion('https://gateway.ai.cloudflare.com/v1/xxx/v1beta') // 'v1beta'
+ * getTrailingApiVersion('https://api.example.com') // undefined
+ */
+export function getTrailingApiVersion(url: string): string | undefined {
+  const match = url.match(TRAILING_VERSION_REGEX)
+
+  if (match) {
+    // Extract version without leading slash and trailing slash
+    return match[0].replace(/^\//, '').replace(/\/$/, '')
+  }
+
+  return undefined
+}
+
+/**
+ * Matches an API version at the end of a URL (with optional trailing slash).
+ * Used to detect and extract versions only from the trailing position.
+ */
+const TRAILING_VERSION_REGEX = /\/v\d+(?:alpha|beta)?\/?$/i
+
+/**
+ * Removes the trailing API version segment from a URL path.
+ *
+ * This function removes API version patterns (e.g., `/v1`, `/v2beta`) from the end of a URL.
+ * Only versions at the end of the path are removed, not versions in the middle.
+ *
+ * @param {string} url - The URL string to process.
+ * @returns {string} The URL with the trailing API version removed, or the original URL if no trailing version found.
+ *
+ * @example
+ * withoutTrailingApiVersion('https://api.example.com/v1') // 'https://api.example.com'
+ * withoutTrailingApiVersion('https://api.example.com/v2beta/') // 'https://api.example.com'
+ * withoutTrailingApiVersion('https://api.example.com/v1/chat') // 'https://api.example.com/v1/chat' (no change)
+ * withoutTrailingApiVersion('https://api.example.com') // 'https://api.example.com'
+ */
+export function withoutTrailingApiVersion(url: string): string {
+  return url.replace(TRAILING_VERSION_REGEX, '')
+}

--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -18,6 +18,7 @@ import { validateModelId } from '@main/apiServer/utils'
 import { isWin } from '@main/constant'
 import { autoDiscoverGitBash } from '@main/utils/process'
 import getLoginShellEnvironment from '@main/utils/shell-env'
+import { withoutTrailingApiVersion } from '@shared/utils'
 import { app } from 'electron'
 
 import type { GetAgentSessionResponse } from '../..'
@@ -112,6 +113,13 @@ class ClaudeCodeService implements AgentServiceInterface {
     // Auto-discover Git Bash path on Windows (already logs internally)
     const customGitBashPath = isWin ? autoDiscoverGitBash() : null
 
+    // Claude Agent SDK builds the final endpoint as `${ANTHROPIC_BASE_URL}/v1/messages`.
+    // To avoid malformed URLs like `/v1/v1/messages`, we normalize the provider host
+    // by stripping any trailing API version (e.g. `/v1`).
+    const anthropicBaseUrl = withoutTrailingApiVersion(
+      modelInfo.provider.anthropicApiHost?.trim() || modelInfo.provider.apiHost
+    )
+
     const env = {
       ...loginShellEnvWithoutProxies,
       // TODO: fix the proxy api server
@@ -120,7 +128,7 @@ class ClaudeCodeService implements AgentServiceInterface {
       // ANTHROPIC_BASE_URL: `http://${apiConfig.host}:${apiConfig.port}/${modelInfo.provider.id}`,
       ANTHROPIC_API_KEY: modelInfo.provider.apiKey,
       ANTHROPIC_AUTH_TOKEN: modelInfo.provider.apiKey,
-      ANTHROPIC_BASE_URL: modelInfo.provider.anthropicApiHost?.trim() || modelInfo.provider.apiHost,
+      ANTHROPIC_BASE_URL: anthropicBaseUrl,
       ANTHROPIC_MODEL: modelInfo.modelId,
       ANTHROPIC_DEFAULT_OPUS_MODEL: modelInfo.modelId,
       ANTHROPIC_DEFAULT_SONNET_MODEL: modelInfo.modelId,

--- a/src/renderer/src/aiCore/legacy/clients/gemini/GeminiAPIClient.ts
+++ b/src/renderer/src/aiCore/legacy/clients/gemini/GeminiAPIClient.ts
@@ -46,7 +46,6 @@ import type {
   GeminiSdkRawOutput,
   GeminiSdkToolCall
 } from '@renderer/types/sdk'
-import { getTrailingApiVersion, withoutTrailingApiVersion } from '@renderer/utils'
 import { isToolUseModeFunction } from '@renderer/utils/assistant'
 import {
   geminiFunctionCallToMcpTool,
@@ -56,6 +55,7 @@ import {
 } from '@renderer/utils/mcp-tools'
 import { findFileBlocks, findImageBlocks, getMainTextContent } from '@renderer/utils/messageUtils/find'
 import { defaultTimeout, MB } from '@shared/config/constant'
+import { getTrailingApiVersion, withoutTrailingApiVersion } from '@shared/utils'
 import { t } from 'i18next'
 
 import type { GenericChunk } from '../../middleware/schemas'

--- a/src/renderer/src/aiCore/legacy/clients/ovms/OVMSClient.ts
+++ b/src/renderer/src/aiCore/legacy/clients/ovms/OVMSClient.ts
@@ -3,7 +3,8 @@ import { loggerService } from '@logger'
 import { isSupportedModel } from '@renderer/config/models'
 import type { Provider } from '@renderer/types'
 import { objectKeys } from '@renderer/types'
-import { formatApiHost, withoutTrailingApiVersion } from '@renderer/utils'
+import { formatApiHost } from '@renderer/utils'
+import { withoutTrailingApiVersion } from '@shared/utils'
 
 import { OpenAIAPIClient } from '../openai/OpenAIApiClient'
 

--- a/src/renderer/src/utils/__tests__/api.test.ts
+++ b/src/renderer/src/utils/__tests__/api.test.ts
@@ -1,5 +1,6 @@
 import store from '@renderer/store'
 import type { VertexProvider } from '@renderer/types'
+import { getTrailingApiVersion, withoutTrailingApiVersion } from '@shared/utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -8,14 +9,12 @@ import {
   formatAzureOpenAIApiHost,
   formatOllamaApiHost,
   formatVertexApiHost,
-  getTrailingApiVersion,
   hasAPIVersion,
   isWithTrailingSharp,
   maskApiKey,
   routeToEndpoint,
   splitApiKeyString,
   validateApiHost,
-  withoutTrailingApiVersion,
   withoutTrailingSharp
 } from '../api'
 

--- a/src/renderer/src/utils/api.ts
+++ b/src/renderer/src/utils/api.ts
@@ -20,12 +20,6 @@ export function formatApiKeys(value: string): string {
 const VERSION_REGEX_PATTERN = '\\/v\\d+(?:alpha|beta)?(?=\\/|$)'
 
 /**
- * Matches an API version at the end of a URL (with optional trailing slash).
- * Used to detect and extract versions only from the trailing position.
- */
-const TRAILING_VERSION_REGEX = /\/v\d+(?:alpha|beta)?\/?$/i
-
-/**
  * 判断 host 的 path 中是否包含形如版本的字符串（例如 /v1、/v2beta 等），
  *
  * @param host - 要检查的 host 或 path 字符串
@@ -271,51 +265,4 @@ export function splitApiKeyString(keyStr: string): string[] {
     .map((k) => k.trim())
     .map((k) => k.replace(/\\,/g, ','))
     .filter((k) => k)
-}
-
-/**
- * Extracts the trailing API version segment from a URL path.
- *
- * This function extracts API version patterns (e.g., `v1`, `v2beta`) from the end of a URL.
- * Only versions at the end of the path are extracted, not versions in the middle.
- * The returned version string does not include leading or trailing slashes.
- *
- * @param {string} url - The URL string to parse.
- * @returns {string | undefined} The trailing API version found (e.g., 'v1', 'v2beta'), or undefined if none found.
- *
- * @example
- * getTrailingApiVersion('https://api.example.com/v1') // 'v1'
- * getTrailingApiVersion('https://api.example.com/v2beta/') // 'v2beta'
- * getTrailingApiVersion('https://api.example.com/v1/chat') // undefined (version not at end)
- * getTrailingApiVersion('https://gateway.ai.cloudflare.com/v1/xxx/v1beta') // 'v1beta'
- * getTrailingApiVersion('https://api.example.com') // undefined
- */
-export function getTrailingApiVersion(url: string): string | undefined {
-  const match = url.match(TRAILING_VERSION_REGEX)
-
-  if (match) {
-    // Extract version without leading slash and trailing slash
-    return match[0].replace(/^\//, '').replace(/\/$/, '')
-  }
-
-  return undefined
-}
-
-/**
- * Removes the trailing API version segment from a URL path.
- *
- * This function removes API version patterns (e.g., `/v1`, `/v2beta`) from the end of a URL.
- * Only versions at the end of the path are removed, not versions in the middle.
- *
- * @param {string} url - The URL string to process.
- * @returns {string} The URL with the trailing API version removed, or the original URL if no trailing version found.
- *
- * @example
- * withoutTrailingApiVersion('https://api.example.com/v1') // 'https://api.example.com'
- * withoutTrailingApiVersion('https://api.example.com/v2beta/') // 'https://api.example.com'
- * withoutTrailingApiVersion('https://api.example.com/v1/chat') // 'https://api.example.com/v1/chat' (no change)
- * withoutTrailingApiVersion('https://api.example.com') // 'https://api.example.com'
- */
-export function withoutTrailingApiVersion(url: string): string {
-  return url.replace(TRAILING_VERSION_REGEX, '')
 }


### PR DESCRIPTION
### What this PR does

Before this PR:
- When `ANTHROPIC_BASE_URL` is set with a trailing API version (e.g., `https://api.anthropic.com/v1`), the Claude Agent SDK would build malformed URLs like `/v1/v1/messages`.

After this PR:
- The `ANTHROPIC_BASE_URL` is normalized by stripping any trailing API version (e.g., `/v1`) before passing to the SDK.
- Moved `getTrailingApiVersion` and `withoutTrailingApiVersion` utilities from renderer to shared package for reuse in main process.

### Why we need it and why it was done in this way

The Claude Agent SDK internally appends `/v1/messages` to the base URL. If users configure their provider with a base URL that already includes `/v1`, this results in double versioning (`/v1/v1/messages`), causing API requests to fail.

The following tradeoffs were made:
- Moved utility functions to shared package to avoid code duplication between main and renderer processes.

The following alternatives were considered:
- Documenting that users should not include `/v1` in the base URL, but this would be error-prone and break existing configurations.

### Breaking changes

None. This is a transparent fix that normalizes URLs internally.

### Special notes for your reviewer

The regex pattern `TRAILING_VERSION_REGEX` only matches versions at the end of the URL path, so URLs like `https://gateway.ai.cloudflare.com/v1/xxx/anthropic` are not affected.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required.

### Release note

```release-note
fix: Prevent double API versioning in ANTHROPIC_BASE_URL for Claude Agent SDK
```