### PR TITLE
fix(memory): fix global memory settings submit failure

### DIFF
--- a/src/renderer/src/pages/settings/MemorySettings/MemorySettingsModal.tsx
+++ b/src/renderer/src/pages/settings/MemorySettings/MemorySettingsModal.tsx
@@ -3,7 +3,7 @@ import InputEmbeddingDimension from '@renderer/components/InputEmbeddingDimensio
 import ModelSelector from '@renderer/components/ModelSelector'
 import { InfoTooltip } from '@renderer/components/TooltipIcons'
 import { isEmbeddingModel, isRerankModel } from '@renderer/config/models'
-import { getModel, useModel } from '@renderer/hooks/useModel'
+import { useModel } from '@renderer/hooks/useModel'
 import { useProviders } from '@renderer/hooks/useProvider'
 import { getModelUniqId } from '@renderer/services/ModelService'
 import { selectMemoryConfig, updateMemoryConfig } from '@renderer/store/memory'
@@ -55,8 +55,12 @@ const MemorySettingsModal: FC<MemorySettingsModalProps> = ({ visible, onSubmit, 
   const handleFormSubmit = async (values: formValue) => {
     try {
       // Convert model IDs back to Model objects
-      const llmModel = getModel(values.llmModel)
-      const embeddingModel = getModel(values.embeddingModel)
+      // values.llmModel and values.embeddingModel are JSON strings from getModelUniqId()
+      // e.g., '{"id":"gpt-4","provider":"openai"}'
+      // We need to find models by comparing with getModelUniqId() result
+      const allModels = providers.flatMap((p) => p.models)
+      const llmModel = allModels.find((m) => getModelUniqId(m) === values.llmModel)
+      const embeddingModel = allModels.find((m) => getModelUniqId(m) === values.embeddingModel)
 
       if (embeddingModel) {
         setLoading(true)
@@ -141,7 +145,9 @@ const MemorySettingsModal: FC<MemorySettingsModalProps> = ({ visible, onSubmit, 
           shouldUpdate={(prevValues, currentValues) => prevValues.embeddingModel !== currentValues.embeddingModel}>
           {({ getFieldValue }) => {
             const embeddingModelId = getFieldValue('embeddingModel')
-            const embeddingModel = getModel(embeddingModelId)
+            // embeddingModelId is a JSON string from getModelUniqId(), find model by comparing
+            const allModels = providers.flatMap((p) => p.models)
+            const embeddingModel = allModels.find((m) => getModelUniqId(m) === embeddingModelId)
             return (
               <Form.Item
                 label={


### PR DESCRIPTION
## What's the problem?

When submitting global memory settings, nothing happens - the modal just won't save.

## Why?

The `ModelSelector` returns a JSON string like `{"id":"gpt-4","provider":"openai"}`, but `getModel()` expects a plain ID like `"gpt-4"`. Mismatch = model not found = silent failure.

## The fix

Match models using `getModelUniqId()` comparison instead of `getModel()`.

Fixes #12139