### PR TITLE
fix: shortcut icons sorting disorder

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/InputbarTools.tsx
+++ b/src/renderer/src/pages/home/Inputbar/InputbarTools.tsx
@@ -261,9 +261,12 @@ const InputbarTools = ({ scope, assistantId, session }: InputbarToolsNewProps) =
     const sourceId = source.droppableId
     const destinationId = destination.droppableId
 
+    const visibleKeys = visibleTools.map((t) => t.key)
+    const hiddenKeys = hiddenTools.map((t) => t.key)
+
     const newToolOrder: ToolOrderConfig = {
-      visible: [...toolOrder.visible],
-      hidden: [...toolOrder.hidden]
+      visible: [...visibleKeys],
+      hidden: [...hiddenKeys]
     }
 
     const sourceArray = sourceId === 'inputbar-tools-visible' ? 'visible' : 'hidden'


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

⚠️ Important: Redux/IndexedDB Data-Changing Feature PRs Temporarily On Hold ⚠️

Please note: For our current development cycle, we are not accepting feature Pull Requests that introduce changes to Redux data models or IndexedDB schemas.

While we value your contributions, PRs of this nature will be blocked without merge. We welcome all other contributions (bug fixes, perf enhancements, docs, etc.). Thank you!

Once version 2.0.0 is released, we will resume reviewing feature PRs.

-->

### What this PR does

Before this PR:
Icons order became disordered after drag and drop

After this PR:
Shortcut icons maintain stable order
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #12143 

### Why we need it and why it was done in this way

The following tradeoffs were made:
N/A

The following alternatives were considered:
N/A

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
N/A

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
