### PR TITLE
fix(aiCore): skip reasoning_content for non-reasoning models

### DIFF
--- a/src/renderer/src/aiCore/prepareParams/__tests__/message-converter.test.ts
+++ b/src/renderer/src/aiCore/prepareParams/__tests__/message-converter.test.ts
@@ -24,10 +24,12 @@ vi.mock('../fileProcessor', () => ({
 
 const visionModelIds = new Set(['gpt-4o-mini', 'qwen-image-edit'])
 const imageEnhancementModelIds = new Set(['qwen-image-edit'])
+const reasoningModelIds = new Set(['deepseek-reasoner', 'o1-mini'])
 
 vi.mock('@renderer/config/models', () => ({
   isVisionModel: (model: Model) => visionModelIds.has(model.id),
-  isImageEnhancementModel: (model: Model) => imageEnhancementModelIds.has(model.id)
+  isImageEnhancementModel: (model: Model) => imageEnhancementModelIds.has(model.id),
+  isReasoningModel: (model: Model) => reasoningModelIds.has(model.id)
 }))
 
 type MockableMessage = Message & {
@@ -244,8 +246,9 @@ describe('messageConverter', () => {
       ])
     })
 
-    it('includes reasoning parts for assistant messages with thinking blocks', async () => {
-      const model = createModel()
+    it('includes reasoning parts for assistant messages with thinking blocks when model supports reasoning', async () => {
+      // Use a reasoning model to ensure reasoning parts are included
+      const model = createModel({ id: 'deepseek-reasoner', name: 'DeepSeek Reasoner', provider: 'deepseek' })
       const message = createMessage('assistant')
       message.__mockContent = 'Here is my answer'
       message.__mockThinkingBlocks = [createThinkingBlock(message.id, { content: 'Let me think...' })]
@@ -257,6 +260,43 @@ describe('messageConverter', () => {
         content: [
           { type: 'text', text: 'Here is my answer' },
           { type: 'reasoning', text: 'Let me think...' }
+        ]
+      })
+    })
+
+    it('excludes reasoning parts for assistant messages when model does not support reasoning', async () => {
+      // Use a non-reasoning model (gpt-4o-mini is not in reasoningModelIds)
+      const model = createModel({ id: 'gpt-4o-mini', name: 'GPT-4o Mini', provider: 'openai' })
+      const message = createMessage('assistant')
+      message.__mockContent = 'Here is my answer'
+      message.__mockThinkingBlocks = [createThinkingBlock(message.id, { content: 'Let me think...' })]
+
+      const result = await convertMessageToSdkParam(message, false, model)
+
+      // Reasoning parts should be excluded for non-reasoning models
+      // This prevents sending reasoning_content to APIs that don't support it (e.g., Groq)
+      expect(result).toEqual({
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Here is my answer' }]
+      })
+    })
+
+    it('excludes empty thinking blocks even for reasoning models', async () => {
+      const model = createModel({ id: 'deepseek-reasoner', name: 'DeepSeek Reasoner', provider: 'deepseek' })
+      const message = createMessage('assistant')
+      message.__mockContent = 'Here is my answer'
+      message.__mockThinkingBlocks = [
+        createThinkingBlock(message.id, { content: '' }), // Empty content should be filtered
+        createThinkingBlock(message.id, { content: 'Valid thinking' })
+      ]
+
+      const result = await convertMessageToSdkParam(message, false, model)
+
+      expect(result).toEqual({
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Here is my answer' },
+          { type: 'reasoning', text: 'Valid thinking' }
         ]
       })
     })


### PR DESCRIPTION
### What this PR does

**Before this PR:**
When using non-reasoning models (like Kimi K2 via Groq), the second request fails with:
`'messages.2' : property 'reasoning_content' is unsupported`

**After this PR:**
Reasoning parts are only included when the target model actually supports reasoning, preventing API errors.

Fixes #12140

### Why we need it and why it was done in this way

The `messageConverter.ts` was unconditionally converting thinking blocks to reasoning parts for all assistant messages. APIs like Groq don't support the `reasoning_content` field, causing requests to fail.

The fix adds a simple model capability check before including reasoning parts.

### Breaking changes

None.

### Checklist

- [x] PR: The PR description is expressive enough
- [x] Code: Simple and focused fix
- [x] Refactor: Added helpful comments for future maintainers

### Release note

```release-note
Fixed Groq channel failing on second request when using non-reasoning models
```