### PR TITLE
perf(ModelList): use Map for O(1) model status lookup

### DIFF
--- a/src/renderer/src/pages/settings/ProviderSettings/ModelList/ModelListGroup.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ModelList/ModelListGroup.tsx
@@ -15,7 +15,8 @@ const MAX_SCROLLER_HEIGHT = 390
 interface ModelListGroupProps {
   groupName: string
   models: Model[]
-  modelStatuses: ModelWithStatus[]
+  /** 使用 Map 实现 O(1) 查找，替代原来的数组线性搜索 */
+  modelStatusMap: Map<string, ModelWithStatus>
   defaultOpen: boolean
   disabled?: boolean
   onEditModel: (model: Model) => void
@@ -26,7 +27,7 @@ interface ModelListGroupProps {
 const ModelListGroup: React.FC<ModelListGroupProps> = ({
   groupName,
   models,
-  modelStatuses,
+  modelStatusMap,
   defaultOpen,
   disabled,
   onEditModel,
@@ -89,7 +90,7 @@ const ModelListGroup: React.FC<ModelListGroupProps> = ({
           {(model) => (
             <ModelListItem
               model={model}
-              modelStatus={modelStatuses.find((status) => status.model.id === model.id)}
+              modelStatus={modelStatusMap.get(model.id)}
               onEdit={onEditModel}
               onRemove={onRemoveModel}
               disabled={disabled}


### PR DESCRIPTION
### What this PR does

Before this PR:
- Model status lookup used `Array.find()` with O(n) complexity
- Each model render triggered a linear search through all statuses
- With 100+ models, this caused UI freezing when editing model names

After this PR:
- Uses `Map.get()` for O(1) constant-time lookup
- Stabilized `onEditModel` callback to prevent unnecessary re-renders

Fixes #12035

### Why we need it and why it was done in this way

The root cause of the freezing issue was identified through code analysis:
- `modelStatuses.find()` was called for every model item during render
- With n models, this resulted in O(n²) total comparisons

The fix uses `useMemo` to create a Map once, then `Map.get()` for instant lookups.

### Breaking changes

None.

### Checklist

- [x] PR: The PR description is expressive enough
- [x] Code: Simple and readable changes
- [x] Refactor: Improved performance without changing behavior

### Release note

```release-note
Fixed UI freezing when modifying model names in settings (#12035)
```