### PR TITLE
Update minimax API documentation link

### DIFF
--- a/src/renderer/src/config/providers.ts
+++ b/src/renderer/src/config/providers.ts
@@ -1089,7 +1089,7 @@ export const PROVIDER_URLS: Record<SystemProviderId, ProviderUrls> = {
     websites: {
       official: 'https://platform.minimaxi.com/',
       apiKey: 'https://platform.minimaxi.com/user-center/basic-information/interface-key',
-      docs: 'https://platform.minimaxi.com/document/Announcement',
+      docs: 'https://platform.minimaxi.com/docs/api-reference/text-openai-api',
       models: 'https://platform.minimaxi.com/document/Models'
     }
   },


### PR DESCRIPTION
### What this PR does

这个 PR 更新了 MiniMax API 供应商配置中的文档链接。

### Before this PR:

MiniMax API 文档链接指向旧的公告页面：
```
https://platform.minimaxi.com/document/Announcement
```

### After this PR:

MiniMax API 文档链接指向新的官方 API 参考文档：
```
https://platform.minimaxi.com/docs/api-reference/text-openai-api
```

### Why we need it and why it was done in this way

**为什么需要这个改动：**
- 旧的文档链接可能已经过时或失效
- 新的链接指向 MiniMax 官方的 API 参考页面，为用户提供更准确、全面的 API 文档

**采取这种方式的原因：**
- 仅更新配置文件中的一条 URL 链接，改动最小化
- 保持了配置文件的整体结构不变

### Why we need it and why it was done in this way

The following tradeoffs were made:
- 仅修改单个链接地址，保持其他配置不变

The following alternatives were considered:
- 无需考虑替代方案，这只是一个链接更新

### Breaking changes

无破坏性变更。这是一个纯配置文件的链接更新，不影响任何功能逻辑。

### Special notes for your reviewer

这是一个简单的文档链接更新，仅修改了 `src/renderer/src/config/providers.ts` 文件中的一行代码。

### Checklist

- [x] PR: 描述清晰，改动简单明确
- [x] Code: 仅更新 URL 链接，保持代码简洁
- [x] Refactor: 遵循最小改动原则
- [x] Upgrade: 无需升级流程
- [x] Documentation: 本身就是文档链接的更新

### Release note

```release-note
NONE
```