### PR TITLE
refactor(ovms): lazy-load OVMS support check with SWR

### DIFF
--- a/src/renderer/src/hooks/useAppInit.ts
+++ b/src/renderer/src/hooks/useAppInit.ts
@@ -10,7 +10,7 @@ import { useAppDispatch } from '@renderer/store'
 import { useAppSelector } from '@renderer/store'
 import { handleSaveData } from '@renderer/store'
 import { selectMemoryConfig } from '@renderer/store/memory'
-import { setAvatar, setFilesPath, setIsOvmsSupported, setResourcesPath, setUpdateState } from '@renderer/store/runtime'
+import { setAvatar, setFilesPath, setResourcesPath, setUpdateState } from '@renderer/store/runtime'
 import {
   type ToolPermissionRequestPayload,
   type ToolPermissionResultPayload,
@@ -274,17 +274,4 @@ export function useAppInit() {
   useEffect(() => {
     checkDataLimit()
   }, [])
-
-  useEffect(() => {
-    // Check once when initing
-    window.api.ovms
-      .isSupported()
-      .then((result) => {
-        dispatch(setIsOvmsSupported(result))
-      })
-      .catch((e) => {
-        logger.error('Failed to check isOvmsSupported. Fallback to false.', e as Error)
-        dispatch(setIsOvmsSupported(false))
-      })
-  }, [dispatch])
 }

--- a/src/renderer/src/store/runtime.ts
+++ b/src/renderer/src/store/runtime.ts
@@ -73,7 +73,6 @@ export interface RuntimeState {
   export: ExportState
   chat: ChatState
   websearch: WebSearchState
-  isOvmsSupported: boolean | undefined
 }
 
 export interface ExportState {
@@ -116,8 +115,7 @@ const initialState: RuntimeState = {
   },
   websearch: {
     activeSearches: {}
-  },
-  isOvmsSupported: undefined
+  }
 }
 
 const runtimeSlice = createSlice({
@@ -162,9 +160,6 @@ const runtimeSlice = createSlice({
     },
     setExportState: (state, action: PayloadAction<Partial<ExportState>>) => {
       state.export = { ...state.export, ...action.payload }
-    },
-    setIsOvmsSupported: (state, action: PayloadAction<boolean>) => {
-      state.isOvmsSupported = action.payload
     },
     // Chat related actions
     toggleMultiSelectMode: (state, action: PayloadAction<boolean>) => {
@@ -228,7 +223,6 @@ export const {
   setResourcesPath,
   setUpdateState,
   setExportState,
-  setIsOvmsSupported,
   // Chat related actions
   toggleMultiSelectMode,
   setSelectedMessageIds,


### PR DESCRIPTION
### What this PR does

Before this PR:
- `isOvmsSupported` was stored in global Redux state and checked at app initialization in `useAppInit.ts`
- The check ran on every app startup regardless of whether the user visited the Provider settings

After this PR:
- `isOvmsSupported` is fetched lazily using `useSWRImmutable` only in `ProviderList.tsx` where it's actually used
- Removes `isOvmsSupported` from Redux store, reducing global state

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Using `useSWRImmutable` instead of regular `useSWR` since platform support is static and doesn't need revalidation
- OVMS provider is hidden during the brief loading state (consistent with previous behavior when `isOvmsSupported` was `undefined`)

The following alternatives were considered:
- Keeping in Redux but lazy-loading: rejected as it adds unnecessary complexity for state only used in one component
- Using React Query: rejected as SWR is already in use in the codebase

### Breaking changes

None. This is an internal refactoring with no API changes.

### Special notes for your reviewer

- The `useRuntime` hook import was removed from `ProviderList.tsx` as `isOvmsSupported` was the only property being used from it
- Error handling logs a warning and falls back to `false` (hiding OVMS provider)

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: Not required - internal refactoring

### Release note

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)