### PR TITLE
feat(inputbar): add code editor tool

### DIFF
--- a/docs/en/references/inputbar-architecture.md
+++ b/docs/en/references/inputbar-architecture.md
@@ -1,0 +1,131 @@
+# Inputbar Architecture
+
+This document describes the `src/renderer/src/pages/home/Inputbar` architecture, including component layering, shared state, and the tool system. It covers both Chat and Agent Session inputbars.
+
+## Goals and Scope
+
+- The inputbar is the main entry for composing and sending messages, handling text input, attachments, tool entry points, and quick panel triggers.
+- Business logic stays in the container layer, while `InputbarCore` focuses on reusable UI and interaction primitives.
+- The tool system is registry-driven and can expose different tools per scope.
+
+## Structure and Responsibilities
+
+- `Inputbar.tsx`: Chat inputbar container, owns message sending, topic actions, token estimation, knowledge base and model mentions.
+- `AgentSessionInputbar.tsx`: Agent Session inputbar container, adapts session data and slash commands with a different send flow.
+- `components/InputbarCore.tsx`: core UI and interaction container, including textarea, toolbars, drag/drop, and quick panel triggers.
+- `context/InputbarToolsProvider.tsx`: shared state and tool registry (tool state, triggers, root menu).
+- `InputbarTools.tsx`: tool rendering and orchestration, ordering, visibility, drag sorting, QuickPanel registration.
+- `hooks/`: inputbar interaction hooks (paste, drag/drop).
+- `tools/`: tool definitions and QuickPanel trigger configs registered to the tool system.
+- `types.ts`, `registry.ts`: scope definitions, tool types/registry, scope config.
+
+## Layering
+
+1) **Container layer (Inputbar / AgentSessionInputbar)**
+   - Owns business logic, message sending, topic actions, model capability checks.
+   - Builds `InputbarToolsProvider` initial state and actions for tools.
+
+2) **Core UI layer (InputbarCore)**
+   - Only consumes props and shared context; does not own business state.
+   - Handles text input, drag/paste, quick panel triggers, translate shortcut, attachment preview.
+
+3) **Tool system layer (InputbarToolsProvider + InputbarTools + tools/)**
+   - `InputbarToolsProvider` exposes state/dispatch and the QuickPanel registry.
+   - `InputbarTools` renders tool buttons and manages ordering/visibility.
+   - `tools/` uses `defineTool` to declare dependencies, conditions, QuickPanel triggers, and UI renderers.
+
+## Scope and Config
+
+- `types.ts` defines `InputbarScope`: `TopicType.Chat`, `TopicType.Session`, `mini-window`.
+- `registry.ts` supplies per-scope config: rows, tools collapsible, QuickPanel/drag toggles.
+- `InputbarCore` reads config by scope to apply behavior differences.
+
+## Main Data Flows
+
+### Chat mode (`Inputbar.tsx`)
+
+1. Initialize: draft from `CacheService`, last mentioned models from cache.
+2. Input state: `useInputText` for text, `useTextareaResize` for height.
+3. Send:
+   - Upload files via `FileManager.uploadFiles`.
+   - Build `MessageInputBaseParams`, estimate usage.
+   - `dispatch(_sendMessage)`, clear text and attachments.
+4. Quick actions: new topic, clear topic, new context emit via EventEmitter.
+5. Capability checks: decide support for image/text files and Web Search.
+
+### Agent Session mode (`AgentSessionInputbar.tsx`)
+
+1. Load session from `useSession`, build `assistantStub`.
+2. Draft persistence via `useInputText` + `CacheService`.
+3. Send:
+   - Do not upload files; append file paths to text.
+   - Use `dispatchSendMessage` with session context.
+4. Slash commands: QuickPanel shows command list and inserts into textarea.
+
+## InputbarCore Interaction Capabilities
+
+- **Paste**: `usePasteHandler` calls `PasteService.handlePaste` for text/image/file.
+- **Drag/drop**: `useFileDragDrop` handles files and text drop with extension filtering.
+- **QuickPanel**:
+  - Uses `QuickPanelReservedSymbol` (`/` root, `@` mention) to trigger panels.
+  - Tracks cursor/boundary to open or resume panels.
+- **Keyboard**:
+  - Enter sends based on shortcut setting; Shift+Enter inserts newline.
+  - Esc collapses expanded input.
+- **Attachments**:
+  - `AttachmentPreview` renders tags.
+  - Backspace removes the last attachment.
+
+## InputbarToolsProvider Model
+
+- **State**: `files`, `mentionedModels`, `selectedKnowledgeBases`, `isExpanded`.
+- **Derived**: `couldAddImageFile`, `couldMentionNotVisionModel`, `extensions`.
+- **Actions**: injected from container (resize, clearTopic, newContext, onTextChange, etc.).
+- **Registry**:
+  - `registerRootMenu`: collects `/` root menu entries.
+  - `registerTrigger`: registers QuickPanel symbol handlers.
+  - `emit` + `getRootMenu` are consumed by `InputbarCore`.
+
+## Tool System Design
+
+- `tools/index.ts` imports and registers all tools.
+- `defineTool` declares:
+  - `visibleInScopes` for scope visibility.
+  - `condition` for capability checks.
+  - `dependencies` to limit accessible state/actions.
+  - `quickPanel` for root menu and trigger behaviors.
+  - `render` for button UI (null means menu-only).
+
+### Typical Tools
+
+- `attachmentTool`: file upload, uses `files` and `extensions`.
+- `mentionModelsTool`: @ model selection with QuickPanel manager.
+- `knowledgeBaseTool`: knowledge base selection, enabled by tool capability.
+- `newTopicTool` / `clearTopicTool` / `newContextTool`: topic actions.
+- `toggleExpandTool`: expand/collapse input.
+- `slashCommandsTool` (Session): slash command entry and triggers.
+
+## Key UI Components
+
+- `AttachmentPreview.tsx`: attachment tags and preview/context menu.
+- `KnowledgeBaseInput.tsx`: knowledge base tag list.
+- `MentionModelsInput.tsx`: model mention tag list.
+- `TokenCount.tsx`: input/context token display.
+- `SendMessageButton.tsx`: send button.
+
+## Extension Tips
+
+- New tool: create under `tools/`, call `registerTool`, and import in `tools/index.ts`.
+- QuickPanel extensions: prefer declarative `quickPanel` configs.
+- If hooks are needed before registering menus, use `quickPanelManager`.
+
+## Related Files
+
+- `src/renderer/src/pages/home/Inputbar/Inputbar.tsx`
+- `src/renderer/src/pages/home/Inputbar/AgentSessionInputbar.tsx`
+- `src/renderer/src/pages/home/Inputbar/components/InputbarCore.tsx`
+- `src/renderer/src/pages/home/Inputbar/context/InputbarToolsProvider.tsx`
+- `src/renderer/src/pages/home/Inputbar/InputbarTools.tsx`
+- `src/renderer/src/pages/home/Inputbar/tools/`
+- `src/renderer/src/pages/home/Inputbar/types.ts`
+- `src/renderer/src/pages/home/Inputbar/registry.ts`

--- a/docs/zh/references/inputbar-architecture.md
+++ b/docs/zh/references/inputbar-architecture.md
@@ -1,0 +1,131 @@
+# Inputbar 架构说明
+
+本文档描述 `src/renderer/src/pages/home/Inputbar` 的组件分层、状态模型与工具系统，覆盖 Chat 与 Agent Session 两种输入栏形态。
+
+## 目标与边界
+
+- 输入栏是消息编辑与发送的入口，负责文本输入、附件处理、工具入口与快捷面板触发。
+- 业务逻辑尽量由外层容器注入，`InputbarCore` 保持 UI 框架与交互通用能力。
+- Tool 系统以注册表驱动，可在不同 scope 下显示不同工具与 QuickPanel 行为。
+
+## 目录结构与职责
+
+- `Inputbar.tsx`：Chat 模式输入栏容器，负责消息发送、topic 操作、token 估算、知识库/模型提及等业务逻辑。
+- `AgentSessionInputbar.tsx`：Agent Session 模式输入栏容器，适配会话数据与 slash commands，发送逻辑与 Chat 不同。
+- `components/InputbarCore.tsx`：核心 UI 与交互容器，集成文本区、工具栏、拖拽/粘贴、快捷面板触发。
+- `context/InputbarToolsProvider.tsx`：输入栏共享状态与工具注册中心（工具状态、触发器、root menu）。
+- `InputbarTools.tsx`：工具栏渲染与编排，处理工具排序、隐藏/显示、拖拽排序、QuickPanel 注册。
+- `hooks/`：输入栏交互 hooks（粘贴、拖拽等）。
+- `tools/`：工具定义与 QuickPanel 触发配置，注册到工具系统。
+- `types.ts`、`registry.ts`：scope 定义、工具类型与注册表、scope 配置。
+
+## 核心分层
+
+1) **容器层（Inputbar / AgentSessionInputbar）**
+   - 负责业务逻辑、消息发送、topic 操作、模型能力判断。
+   - 构建 `InputbarToolsProvider` 的初始 state 与 actions，供工具使用。
+
+2) **基础 UI 层（InputbarCore）**
+   - 仅依赖 props 和共享上下文，不直接关心业务状态来源。
+   - 处理：文本编辑、拖拽/粘贴、快捷面板触发、翻译快捷、附件预览。
+
+3) **工具系统层（InputbarToolsProvider + InputbarTools + tools/）**
+   - `InputbarToolsProvider` 提供状态与 dispatch，并维护 QuickPanel trigger/root menu 注册表。
+   - `InputbarTools` 读取工具定义并渲染按钮，维护工具排序与可见性。
+   - `tools/` 使用 `defineTool` 声明依赖、条件、QuickPanel 触发与渲染组件。
+
+## Scope 与配置
+
+- `types.ts` 定义 `InputbarScope`，主要是 `TopicType.Chat`、`TopicType.Session`、`mini-window`。
+- `registry.ts` 为不同 scope 提供配置：行数、工具可折叠、QuickPanel/拖拽开关等。
+- `InputbarCore` 根据 scope 读取配置，实现通用行为差异。
+
+## 主要数据流
+
+### Chat 模式（`Inputbar.tsx`）
+
+1. 初始化：从 `CacheService` 读取草稿、读取上次 `mentionedModels` 缓存。
+2. 输入状态：`useInputText` 管理文本，`useTextareaResize` 管理高度。
+3. 发送消息：
+   - 上传文件 `FileManager.uploadFiles`。
+   - 构造 `MessageInputBaseParams`，估算 token 用量。
+   - `dispatch(_sendMessage)`，清空文本与附件。
+4. 快捷操作：新 topic、清空 topic、切换上下文等通过 EventEmitter 广播。
+5. 能力判定：基于模型支持能力决定是否支持图片/文本文件与 Web Search。
+
+### Agent Session 模式（`AgentSessionInputbar.tsx`）
+
+1. 从 `useSession` 获取 session，构建 `assistantStub`。
+2. 使用 `useInputText` + `CacheService` 做草稿缓存。
+3. 发送消息：
+   - 不上传文件，将文件路径拼接进消息文本。
+   - 使用 `dispatchSendMessage` 与 session context。
+4. Slash commands：通过 QuickPanel 直接显示命令列表并插入输入框。
+
+## InputbarCore 交互能力
+
+- **粘贴**：`usePasteHandler` 调用 `PasteService.handlePaste` 处理文本/图片/文件。
+- **拖拽**：`useFileDragDrop` 处理文件与文本拖拽、扩展名过滤。
+- **快捷面板**：
+  - 使用 `QuickPanelReservedSymbol` (`/` root, `@` mention) 触发。
+  - 根据输入边界与光标位置判断是否打开或恢复面板。
+- **输入键位**：
+  - Enter 发送（按设置快捷键），Shift+Enter 换行。
+  - Esc 退出扩展输入。
+- **附件处理**：
+  - `AttachmentPreview` 渲染附件 tag。
+  - `Backspace` 清除最后一个附件。
+
+## InputbarToolsProvider 结构
+
+- **State**：`files`、`mentionedModels`、`selectedKnowledgeBases`、`isExpanded`。
+- **Derived State**：`couldAddImageFile`、`couldMentionNotVisionModel`、`extensions`。
+- **Actions**：由容器层注入（resize、clearTopic、newContext、onTextChange 等）。
+- **Registry**：
+  - `registerRootMenu`：收集 `/` 根菜单条目。
+  - `registerTrigger`：注册 QuickPanel 的 symbol 触发器。
+  - `emit` + `getRootMenu` 提供给 `InputbarCore`。
+
+## 工具系统设计
+
+- `tools/index.ts` 负责导入并注册所有工具。
+- `defineTool` 声明：
+  - `visibleInScopes`：控制 scope 可见性。
+  - `condition`：按能力/状态过滤。
+  - `dependencies`：限定可访问的 state/actions，避免上下文滥用。
+  - `quickPanel`：声明 root menu 与 trigger 逻辑。
+  - `render`：返回按钮 UI（null 表示纯菜单贡献）。
+
+### 典型工具
+
+- `attachmentTool`：上传文件，依赖 `files/extension`。
+- `mentionModelsTool`：@ 模型选择与 QuickPanel 管理。
+- `knowledgeBaseTool`：知识库选择，条件为模型支持工具或 prompt tool。
+- `newTopicTool` / `clearTopicTool` / `newContextTool`：topic 操作。
+- `toggleExpandTool`：折叠与展开输入框。
+- `slashCommandsTool`（Session）：Slash 命令入口与触发器。
+
+## 关键 UI 组件
+
+- `AttachmentPreview.tsx`：附件 tag 与预览/上下文菜单。
+- `KnowledgeBaseInput.tsx`：知识库 tag 列表。
+- `MentionModelsInput.tsx`：模型 tag 列表。
+- `TokenCount.tsx`：输入与上下文 token 显示。
+- `SendMessageButton.tsx`：发送按钮。
+
+## 交互与扩展建议
+
+- 新增工具：在 `tools/` 创建并 `registerTool`，再由 `tools/index.ts` 引入。
+- QuickPanel 扩展：优先通过 `quickPanel` 声明式配置注册菜单与触发。
+- 若工具需要 hooks：使用 `quickPanelManager` 组件注入。
+
+## 相关文件
+
+- `src/renderer/src/pages/home/Inputbar/Inputbar.tsx`
+- `src/renderer/src/pages/home/Inputbar/AgentSessionInputbar.tsx`
+- `src/renderer/src/pages/home/Inputbar/components/InputbarCore.tsx`
+- `src/renderer/src/pages/home/Inputbar/context/InputbarToolsProvider.tsx`
+- `src/renderer/src/pages/home/Inputbar/InputbarTools.tsx`
+- `src/renderer/src/pages/home/Inputbar/tools/`
+- `src/renderer/src/pages/home/Inputbar/types.ts`
+- `src/renderer/src/pages/home/Inputbar/registry.ts`

--- a/src/renderer/src/components/Popups/CodeEditorPopup.tsx
+++ b/src/renderer/src/components/Popups/CodeEditorPopup.tsx
@@ -1,0 +1,105 @@
+import CodeEditor from '@renderer/components/CodeEditor'
+import type { ModalProps } from 'antd'
+import { Modal } from 'antd'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+
+import { TopView } from '../TopView'
+
+interface ShowParams {
+  content?: string
+  language?: string
+  modalProps?: ModalProps
+}
+
+interface Props extends ShowParams {
+  resolve: (data: string | null) => void
+}
+
+const PopupContainer: React.FC<Props> = ({ content = '', language = 'plaintext', modalProps, resolve }) => {
+  const [open, setOpen] = useState(true)
+  const [code, setCode] = useState(content)
+  const { t } = useTranslation()
+
+  const onOk = () => {
+    setOpen(false)
+    resolve(code)
+  }
+
+  const onCancel = () => {
+    setOpen(false)
+  }
+
+  const onClose = () => {
+    resolve(null)
+  }
+
+  useEffect(() => {
+    CodeEditorPopup.hide = onCancel
+  }, [])
+
+  return (
+    <Modal
+      title={t('chat.input.code_editor.title')}
+      width="70vw"
+      style={{ maxHeight: '80vh' }}
+      transitionName="animation-move-down"
+      okText={t('chat.input.code_editor.insert')}
+      {...modalProps}
+      open={open}
+      onOk={onOk}
+      onCancel={onCancel}
+      afterClose={onClose}
+      maskClosable={false}
+      keyboard={false}
+      centered>
+      <EditorContainer>
+        <CodeEditor
+          value={code}
+          language={language}
+          onChange={setCode}
+          expanded={false}
+          height="50vh"
+          maxHeight="60vh"
+          minHeight="240px"
+        />
+      </EditorContainer>
+    </Modal>
+  )
+}
+
+const TopViewKey = 'CodeEditorPopup'
+
+const EditorContainer = styled.div`
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-background);
+  overflow: hidden;
+
+  &:focus-within {
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 2px var(--color-primary-alpha);
+  }
+`
+
+export default class CodeEditorPopup {
+  static topviewId = 0
+  static hide() {
+    TopView.hide(TopViewKey)
+  }
+  static show(props: ShowParams) {
+    return new Promise<string | null>((resolve) => {
+      TopView.show(
+        <PopupContainer
+          {...props}
+          resolve={(value) => {
+            resolve(value)
+            TopView.hide(TopViewKey)
+          }}
+        />,
+        TopViewKey
+      )
+    })
+  }
+}

--- a/src/renderer/src/components/Popups/CodeEditorPopup.tsx
+++ b/src/renderer/src/components/Popups/CodeEditorPopup.tsx
@@ -3,7 +3,6 @@ import type { ModalProps } from 'antd'
 import { Modal } from 'antd'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import styled from 'styled-components'
 
 import { TopView } from '../TopView'
 
@@ -54,7 +53,7 @@ const PopupContainer: React.FC<Props> = ({ content = '', language = 'plaintext',
       maskClosable={false}
       keyboard={false}
       centered>
-      <EditorContainer>
+      <div className="overflow-hidden rounded border border-[var(--color-border)] bg-[var(--color-background)] focus-within:border-[var(--color-primary)] focus-within:shadow-[0_0_0_2px_var(--color-primary-alpha)]">
         <CodeEditor
           value={code}
           language={language}
@@ -64,24 +63,12 @@ const PopupContainer: React.FC<Props> = ({ content = '', language = 'plaintext',
           maxHeight="60vh"
           minHeight="240px"
         />
-      </EditorContainer>
+      </div>
     </Modal>
   )
 }
 
 const TopViewKey = 'CodeEditorPopup'
-
-const EditorContainer = styled.div`
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  background: var(--color-background);
-  overflow: hidden;
-
-  &:focus-within {
-    border-color: var(--color-primary);
-    box-shadow: 0 0 0 2px var(--color-primary-alpha);
-  }
-`
 
 export default class CodeEditorPopup {
   static topviewId = 0

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -706,6 +706,10 @@
         "label": "Clear {{Command}}",
         "title": "Clear all messages?"
       },
+      "code_editor": {
+        "insert": "Insert",
+        "title": "Code Editor"
+      },
       "collapse": "Collapse",
       "context_count": {
         "tip": "Context / Max Context"

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -706,6 +706,10 @@
         "label": "清空消息 {{Command}}",
         "title": "清空消息"
       },
+      "code_editor": {
+        "insert": "插入",
+        "title": "代码编辑器"
+      },
       "collapse": "收起",
       "context_count": {
         "tip": "上下文数 / 最大上下文数"

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -706,6 +706,10 @@
         "label": "清除 {{Command}}",
         "title": "清除所有訊息？"
       },
+      "code_editor": {
+        "insert": "插入",
+        "title": "程式碼編輯器"
+      },
       "collapse": "折疊",
       "context_count": {
         "tip": "上下文數 / 最大上下文數"

--- a/src/renderer/src/i18n/translate/de-de.json
+++ b/src/renderer/src/i18n/translate/de-de.json
@@ -706,6 +706,10 @@
         "label": "Nachrichten leeren {{Command}}",
         "title": "Nachrichten leeren"
       },
+      "code_editor": {
+        "insert": "[to be translated]:Insert",
+        "title": "[to be translated]:Code Editor"
+      },
       "collapse": "Einklappen",
       "context_count": {
         "tip": "Kontextanzahl / Maximale Kontextanzahl"

--- a/src/renderer/src/i18n/translate/el-gr.json
+++ b/src/renderer/src/i18n/translate/el-gr.json
@@ -706,6 +706,10 @@
         "label": "Καθαρισμός μηνυμάτων {{Command}}",
         "title": "Καθαρισμός μηνυμάτων"
       },
+      "code_editor": {
+        "insert": "[to be translated]:Insert",
+        "title": "[to be translated]:Code Editor"
+      },
       "collapse": "Συμπιέζω",
       "context_count": {
         "tip": "Πλήθος ενδιάμεσων/Μέγιστο πλήθος ενδιάμεσων"

--- a/src/renderer/src/i18n/translate/es-es.json
+++ b/src/renderer/src/i18n/translate/es-es.json
@@ -706,6 +706,10 @@
         "label": "Limpiar mensajes {{Command}}",
         "title": "Limpiar mensajes"
       },
+      "code_editor": {
+        "insert": "[to be translated]:Insert",
+        "title": "[to be translated]:Code Editor"
+      },
       "collapse": "Colapsar",
       "context_count": {
         "tip": "Número de contextos / Número máximo de contextos"

--- a/src/renderer/src/i18n/translate/fr-fr.json
+++ b/src/renderer/src/i18n/translate/fr-fr.json
@@ -706,6 +706,10 @@
         "label": "Effacer le message {{Command}}",
         "title": "Effacer le message"
       },
+      "code_editor": {
+        "insert": "[to be translated]:Insert",
+        "title": "[to be translated]:Code Editor"
+      },
       "collapse": "Récupérer",
       "context_count": {
         "tip": "Nombre de contextes / Nombre maximal de contextes"

--- a/src/renderer/src/i18n/translate/ja-jp.json
+++ b/src/renderer/src/i18n/translate/ja-jp.json
@@ -706,6 +706,10 @@
         "label": "クリア {{Command}}",
         "title": "すべてのメッセージをクリアしますか？"
       },
+      "code_editor": {
+        "insert": "[to be translated]:Insert",
+        "title": "[to be translated]:Code Editor"
+      },
       "collapse": "折りたたむ",
       "context_count": {
         "tip": "コンテキスト数 / 最大コンテキスト数"

--- a/src/renderer/src/i18n/translate/pt-pt.json
+++ b/src/renderer/src/i18n/translate/pt-pt.json
@@ -706,6 +706,10 @@
         "label": "Limpar mensagens {{Command}}",
         "title": "Limpar mensagens"
       },
+      "code_editor": {
+        "insert": "[to be translated]:Insert",
+        "title": "[to be translated]:Code Editor"
+      },
       "collapse": "Colapsar",
       "context_count": {
         "tip": "Número de contexto / Número máximo de contexto"

--- a/src/renderer/src/i18n/translate/ru-ru.json
+++ b/src/renderer/src/i18n/translate/ru-ru.json
@@ -706,6 +706,10 @@
         "label": "Очистить {{Command}}",
         "title": "Очистить все сообщения?"
       },
+      "code_editor": {
+        "insert": "[to be translated]:Insert",
+        "title": "[to be translated]:Code Editor"
+      },
       "collapse": "Свернуть",
       "context_count": {
         "tip": "Контекст / Макс. контекст"

--- a/src/renderer/src/pages/home/Inputbar/tools/codeEditorTool.tsx
+++ b/src/renderer/src/pages/home/Inputbar/tools/codeEditorTool.tsx
@@ -1,0 +1,37 @@
+import CodeEditorPopup from '@renderer/components/Popups/CodeEditorPopup'
+import { defineTool, registerTool, TopicType } from '@renderer/pages/home/Inputbar/types'
+import type { FC } from 'react'
+import { useCallback } from 'react'
+
+import CodeEditorButton from './components/CodeEditorButton'
+
+interface CodeEditorToolButtonProps {
+  onTextChange: (updater: (prev: string) => string) => void
+}
+
+const CodeEditorToolButton: FC<CodeEditorToolButtonProps> = ({ onTextChange }) => {
+  const handleOpen = useCallback(async () => {
+    const textarea = document.querySelector('.inputbar textarea') as HTMLTextAreaElement | null
+    const currentText = textarea?.value ?? ''
+    const content = await CodeEditorPopup.show({ content: currentText })
+    if (content === null) return
+
+    onTextChange(() => content)
+  }, [onTextChange])
+
+  return <CodeEditorButton onClick={handleOpen} />
+}
+
+const codeEditorTool = defineTool({
+  key: 'code_editor',
+  label: (t) => t('chat.input.code_editor.title'),
+  visibleInScopes: [TopicType.Chat, TopicType.Session, 'mini-window'],
+  dependencies: {
+    actions: ['onTextChange'] as const
+  },
+  render: ({ actions }) => <CodeEditorToolButton onTextChange={actions.onTextChange} />
+})
+
+registerTool(codeEditorTool)
+
+export default codeEditorTool

--- a/src/renderer/src/pages/home/Inputbar/tools/components/CodeEditorButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/tools/components/CodeEditorButton.tsx
@@ -1,0 +1,23 @@
+import { ActionIconButton } from '@renderer/components/Buttons'
+import { Tooltip } from 'antd'
+import { Code2 } from 'lucide-react'
+import type { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface Props {
+  onClick: () => void
+}
+
+const CodeEditorButton: FC<Props> = ({ onClick }) => {
+  const { t } = useTranslation()
+
+  return (
+    <Tooltip placement="top" title={t('chat.input.code_editor.title')} mouseLeaveDelay={0} arrow>
+      <ActionIconButton onClick={onClick} aria-label={t('chat.input.code_editor.title')}>
+        <Code2 size={18} />
+      </ActionIconButton>
+    </Tooltip>
+  )
+}
+
+export default CodeEditorButton

--- a/src/renderer/src/pages/home/Inputbar/tools/index.ts
+++ b/src/renderer/src/pages/home/Inputbar/tools/index.ts
@@ -2,6 +2,7 @@
 // Import all tool definitions to register them
 
 import './attachmentTool'
+import './codeEditorTool'
 import './mentionModelsTool'
 import './newTopicTool'
 import './quickPhrasesTool'

--- a/src/renderer/src/store/inputTools.ts
+++ b/src/renderer/src/store/inputTools.ts
@@ -29,6 +29,7 @@ export const DEFAULT_TOOL_ORDER: ToolOrder = {
   visible: [
     'new_topic',
     'attachment',
+    'code_editor',
     'thinking',
     'web_search',
     'url_context',

--- a/src/renderer/src/types/chat.ts
+++ b/src/renderer/src/types/chat.ts
@@ -3,6 +3,7 @@ export type Tab = 'assistants' | 'topic'
 export type InputBarToolType =
   | 'new_topic'
   | 'attachment'
+  | 'code_editor'
   | 'thinking'
   | 'web_search'
   | 'url_context'


### PR DESCRIPTION
### What this PR does

Before this PR:
- Users edited code snippets directly in the textarea without code-completion or tab indentation support.

After this PR:
- Adds a Code Editor tool that opens a CodeMirror-based modal and replaces the Inputbar text with the edited content.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Uses a modal CodeMirror editor for focused code editing rather than embedding a full editor inline.

The following alternatives were considered:
- Inline CodeMirror inside the inputbar, which would significantly change layout and interactions.

Links to places where the discussion took place:

### Breaking changes

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- Tests: `yarn lint` (passes); `yarn test` not completed due to timeouts in local run.

### Checklist

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
Adds a code editor tool for the input bar that opens a modal with code editing features and replaces the input content with the edited code.
```
