### PR TITLE
fix:  implement navigation in agent mode

### DIFF
--- a/src/renderer/src/pages/home/Chat.tsx
+++ b/src/renderer/src/pages/home/Chat.tsx
@@ -233,6 +233,7 @@ const Chat: FC<Props> = (props) => {
                     ) : (
                       <AgentSessionMessages agentId={activeAgentId} sessionId={activeSessionId} />
                     )}
+                    {messageNavigation === 'buttons' && <ChatNavigation containerId="messages" />}
                     <AgentSessionInputbar agentId={activeAgentId} sessionId={activeSessionId} />
                   </>
                 )}


### PR DESCRIPTION
We have the navigation selector in agent mode, but the the functionality was not implemented.
<img width="1450" height="947" alt="屏幕截图 2026-01-02 173331" src="https://github.com/user-attachments/assets/cac6d9dd-5111-44f7-9df7-2a2140675309" />

