### PR TITLE
fix: prevent crash when switching between agent and assistant

### DIFF
--- a/src/renderer/src/pages/home/Tabs/components/TopicManageMode.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/TopicManageMode.tsx
@@ -96,7 +96,7 @@ export const TopicManagePanel: React.FC<TopicManagePanelProps> = ({
   // Topics that can be selected (non-pinned, and filtered when in search mode)
   const selectableTopics = useMemo(() => {
     const baseTopics = isSearchMode ? filteredTopics : assistant.topics
-    return baseTopics.filter((topic) => !topic.pinned)
+    return (baseTopics ?? []).filter((topic) => !topic.pinned)
   }, [assistant.topics, filteredTopics, isSearchMode])
 
   // Check if all selectable topics are selected


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

⚠️ Important: Redux/IndexedDB Data-Changing Feature PRs Temporarily On Hold ⚠️

Please note: For our current development cycle, we are not accepting feature Pull Requests that introduce changes to Redux data models or IndexedDB schemas.

While we value your contributions, PRs of this nature will be blocked without merge. We welcome all other contributions (bug fixes, perf enhancements, docs, etc.). Thank you!

Once version 2.0.0 is released, we will resume reviewing feature PRs.

-->

### What this PR does

Before this PR:
When switching from agent to assistant (especially with sidebar hidden), the page crashes with error:
`Uncaught TypeError: Cannot read properties of undefined (reading 'filter')` at `TopicManageMode.tsx:99`

After this PR:
Switching between agent and assistant works correctly without crashes.
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #12207 

### Why we need it and why it was done in this way

The following tradeoffs were made:
None - this is a minimal defensive fix.

The following alternatives were considered:
N/A

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
N/A

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
fix: prevent crash when switching between agent and assistant
```
