### PR TITLE
feat(hooks): add validator support to useInPlaceEdit

### DIFF
--- a/packages/shared/utils/index.ts
+++ b/packages/shared/utils/index.ts
@@ -1,0 +1,2 @@
+export type { ValidatorConfig } from './validators'
+export { composeValidators, validators } from './validators'

--- a/packages/shared/utils/validators.ts
+++ b/packages/shared/utils/validators.ts
@@ -50,7 +50,18 @@ export function composeValidators(...configs: ValidatorConfig[]): ValidatorConfi
 }
 
 /**
+ * Validation error i18n keys
+ * These keys should be translated in the UI layer using t() function
+ */
+export const ValidationErrorKeys = {
+  NAME_REQUIRED: 'validation.name_required',
+  FIELD_REQUIRED: 'validation.field_required',
+  FILE_NAME_REQUIRED: 'validation.file_name_required'
+} as const
+
+/**
  * Preset validators for common use cases
+ * Note: Validators return i18n keys, UI layer should translate them
  */
 export const validators = {
   /**
@@ -65,7 +76,7 @@ export const validators = {
         .toLowerCase()
         .replace(/[^a-z0-9-]/g, '')
         .slice(0, maxLength),
-    validate: (v) => (!v ? 'Name is required' : null),
+    validate: (v) => (!v ? ValidationErrorKeys.NAME_REQUIRED : null),
     debounceMs: 300
   }),
 
@@ -73,15 +84,15 @@ export const validators = {
    * Required field validator (non-empty after trim)
    */
   required: (): ValidatorConfig => ({
-    validate: (v) => (!v.trim() ? 'This field is required' : null)
+    validate: (v) => (!v.trim() ? ValidationErrorKeys.FIELD_REQUIRED : null)
   }),
 
   /**
    * Max length validator
+   * Note: Since transform already limits length, validate won't trigger
    */
   maxLength: (max: number): ValidatorConfig => ({
-    transform: (v) => v.slice(0, max),
-    validate: (v) => (v.length > max ? `Maximum ${max} characters` : null)
+    transform: (v) => v.slice(0, max)
   }),
 
   /**
@@ -97,7 +108,7 @@ export const validators = {
         .replace(/[<>:"/\\|?*\x00-\x1f]/g, '') // Invalid on Windows + null/control chars
         .replace(/[\s.]+$/, '') // Remove trailing spaces and dots
         .slice(0, maxLength),
-    validate: (v) => (!v.trim() ? 'File name is required' : null),
+    validate: (v) => (!v.trim() ? ValidationErrorKeys.FILE_NAME_REQUIRED : null),
     debounceMs: 300
   })
 }

--- a/packages/shared/utils/validators.ts
+++ b/packages/shared/utils/validators.ts
@@ -1,0 +1,103 @@
+/**
+ * Validator configuration for real-time input validation
+ */
+export interface ValidatorConfig {
+  /** Validation function, returns error message or null */
+  validate?: (value: string) => string | null
+  /** Transform input value (e.g., lowercase, remove invalid chars) */
+  transform?: (value: string) => string
+  /** Debounce delay in milliseconds (default: 300) */
+  debounceMs?: number
+}
+
+/**
+ * Compose multiple validators into one
+ *
+ * @example
+ * ```ts
+ * const validator = composeValidators(
+ *   validators.urlSafe(32),
+ *   { validate: (v) => v.startsWith('-') ? 'Cannot start with hyphen' : null }
+ * )
+ * ```
+ */
+export function composeValidators(...configs: ValidatorConfig[]): ValidatorConfig {
+  return {
+    // Chain transforms: apply each transform in order
+    transform: (value) => {
+      return configs.reduce((v, config) => (config.transform ? config.transform(v) : v), value)
+    },
+
+    // Chain validates: return first error found
+    validate: (value) => {
+      for (const config of configs) {
+        if (config.validate) {
+          const error = config.validate(value)
+          if (error) return error
+        }
+      }
+      return null
+    },
+
+    // Use the smallest non-zero debounce
+    debounceMs: configs.reduce((min, config) => {
+      if (config.debounceMs && (min === 0 || config.debounceMs < min)) {
+        return config.debounceMs
+      }
+      return min
+    }, 0)
+  }
+}
+
+/**
+ * Preset validators for common use cases
+ */
+export const validators = {
+  /**
+   * URL-safe characters validator (for API paths, slugs, etc.)
+   * - Auto lowercase
+   * - Only allow a-z, 0-9, and hyphen
+   * - Limit to maxLength characters
+   */
+  urlSafe: (maxLength = 32): ValidatorConfig => ({
+    transform: (v) =>
+      v
+        .toLowerCase()
+        .replace(/[^a-z0-9-]/g, '')
+        .slice(0, maxLength),
+    validate: (v) => (!v ? 'Name is required' : null),
+    debounceMs: 300
+  }),
+
+  /**
+   * Required field validator (non-empty after trim)
+   */
+  required: (): ValidatorConfig => ({
+    validate: (v) => (!v.trim() ? 'This field is required' : null)
+  }),
+
+  /**
+   * Max length validator
+   */
+  maxLength: (max: number): ValidatorConfig => ({
+    transform: (v) => v.slice(0, max),
+    validate: (v) => (v.length > max ? `Maximum ${max} characters` : null)
+  }),
+
+  /**
+   * Universal file name validator (works across all platforms)
+   * - Removes characters invalid on Windows/macOS/Linux
+   * - Removes trailing spaces and dots
+   * - Limits to maxLength characters
+   */
+  fileName: (maxLength = 255): ValidatorConfig => ({
+    transform: (v) =>
+      v
+
+        .replace(/[<>:"/\\|?*\x00-\x1f]/g, '') // Invalid on Windows + null/control chars
+        .replace(/[\s.]+$/, '') // Remove trailing spaces and dots
+        .slice(0, maxLength),
+    validate: (v) => (!v.trim() ? 'File name is required' : null),
+    debounceMs: 300
+  })
+}

--- a/packages/shared/utils/validators.ts
+++ b/packages/shared/utils/validators.ts
@@ -104,8 +104,7 @@ export const validators = {
   fileName: (maxLength = 255): ValidatorConfig => ({
     transform: (v) =>
       v
-
-        .replace(/[<>:"/\\|?*\x00-\x1f]/g, '') // Invalid on Windows + null/control chars
+        .replace(/[<>:"/\\|?*]|\p{Cc}/gu, '') // Invalid on Windows + control chars
         .replace(/[\s.]+$/, '') // Remove trailing spaces and dots
         .slice(0, maxLength),
     validate: (v) => (!v.trim() ? ValidationErrorKeys.FILE_NAME_REQUIRED : null),

--- a/src/renderer/src/hooks/useInPlaceEdit.ts
+++ b/src/renderer/src/hooks/useInPlaceEdit.ts
@@ -1,14 +1,19 @@
 import { loggerService } from '@logger'
-import { useCallback, useLayoutEffect, useRef, useState } from 'react'
+import type { ValidatorConfig } from '@shared/utils/validators'
+import { debounce } from 'lodash'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 const logger = loggerService.withContext('useInPlaceEdit')
+
 export interface UseInPlaceEditOptions {
   onSave: ((value: string) => void) | ((value: string) => Promise<void>)
   onCancel?: () => void
   onError?: (error: unknown) => void
   autoSelectOnStart?: boolean
   trimOnSave?: boolean
+  /** Optional validator for real-time input validation */
+  validator?: ValidatorConfig
 }
 
 export interface UseInPlaceEditReturn {
@@ -18,6 +23,8 @@ export interface UseInPlaceEditReturn {
   saveEdit: () => void
   cancelEdit: () => void
   inputProps: React.InputHTMLAttributes<HTMLInputElement> & { ref: React.RefObject<HTMLInputElement | null> }
+  /** Current validation error message, null if valid */
+  validationError: string | null
 }
 
 /**
@@ -27,21 +34,41 @@ export interface UseInPlaceEditReturn {
  * @param options.onCancel - Optional callback function called when editing is cancelled
  * @param options.autoSelectOnStart - Whether to automatically select text when editing starts (default: true)
  * @param options.trimOnSave - Whether to trim whitespace when saving (default: true)
+ * @param options.validator - Optional validator for real-time input validation
  * @returns An object containing the editing state and handler functions
  */
 export function useInPlaceEdit(options: UseInPlaceEditOptions): UseInPlaceEditReturn {
-  const { onSave, onCancel, onError, autoSelectOnStart = true, trimOnSave = true } = options
+  const { onSave, onCancel, onError, autoSelectOnStart = true, trimOnSave = true, validator } = options
   const { t } = useTranslation()
 
   const [isSaving, setIsSaving] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
   const [editValue, setEditValue] = useState('')
+  const [validationError, setValidationError] = useState<string | null>(null)
   const originalValueRef = useRef('')
   const inputRef = useRef<HTMLInputElement>(null)
+
+  // Debounced validation function
+  const debouncedValidate = useMemo(
+    () =>
+      debounce((value: string) => {
+        const error = validator?.validate?.(value) ?? null
+        setValidationError(error)
+      }, validator?.debounceMs ?? 300),
+    [validator]
+  )
+
+  // Cleanup debounced function on unmount
+  useEffect(() => {
+    return () => {
+      debouncedValidate.cancel()
+    }
+  }, [debouncedValidate])
 
   const startEdit = useCallback((initialValue: string) => {
     setIsEditing(true)
     setEditValue(initialValue)
+    setValidationError(null)
     originalValueRef.current = initialValue
   }, [])
 
@@ -58,12 +85,24 @@ export function useInPlaceEdit(options: UseInPlaceEditOptions): UseInPlaceEditRe
     if (isSaving) return
 
     const finalValue = trimOnSave ? editValue.trim() : editValue
+
+    // Final validation (sync, no debounce)
+    if (validator?.validate) {
+      const error = validator.validate(finalValue)
+      if (error) {
+        setValidationError(error)
+        return // Block save, error will be shown inline
+      }
+    }
+
     if (finalValue === originalValueRef.current) {
       setIsEditing(false)
+      setValidationError(null)
       return
     }
 
     setIsSaving(true)
+    setValidationError(null)
 
     try {
       await onSave(finalValue)
@@ -81,11 +120,12 @@ export function useInPlaceEdit(options: UseInPlaceEditOptions): UseInPlaceEditRe
     } finally {
       setIsSaving(false)
     }
-  }, [isSaving, trimOnSave, editValue, onSave, onError, t])
+  }, [isSaving, trimOnSave, editValue, onSave, onError, t, validator])
 
   const cancelEdit = useCallback(() => {
     setIsEditing(false)
     setEditValue('')
+    setValidationError(null)
     onCancel?.()
   }, [onCancel])
 
@@ -104,13 +144,30 @@ export function useInPlaceEdit(options: UseInPlaceEditOptions): UseInPlaceEditRe
     [saveEdit, cancelEdit]
   )
 
-  const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setEditValue(e.target.value)
-  }, [])
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      let value = e.target.value
+
+      // Apply transform (e.g., lowercase, remove invalid chars)
+      if (validator?.transform) {
+        value = validator.transform(value)
+      }
+
+      setEditValue(value)
+
+      // Trigger validation with debounce
+      if (validator?.validate) {
+        debouncedValidate(value)
+      } else {
+        setValidationError(null)
+      }
+    },
+    [validator, debouncedValidate]
+  )
 
   const handleBlur = useCallback(() => {
     // 这里的逻辑需要注意：
-    // 如果点击了“取消”按钮，可能会先触发 Blur 保存。
+    // 如果点击了"取消"按钮，可能会先触发 Blur 保存。
     // 通常 InPlaceEdit 的逻辑是 Blur 即 Save。
     // 如果不想 Blur 保存，可以去掉这一行，或者判断 relatedTarget。
     if (!isSaving) {
@@ -131,6 +188,7 @@ export function useInPlaceEdit(options: UseInPlaceEditOptions): UseInPlaceEditRe
       onKeyDown: handleKeyDown,
       onBlur: handleBlur,
       disabled: isSaving // 保存时禁用输入
-    }
+    },
+    validationError
   }
 }

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -5089,6 +5089,11 @@
     "saveDataError": "Failed to save data, please try again.",
     "title": "Update"
   },
+  "validation": {
+    "field_required": "This field is required",
+    "file_name_required": "File name is required",
+    "name_required": "Name is required"
+  },
   "warning": {
     "missing_provider": "The supplier does not exist; reverted to the default supplier {{provider}}. This may cause issues."
   },

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -5089,6 +5089,11 @@
     "saveDataError": "保存数据失败，请重试",
     "title": "更新提示"
   },
+  "validation": {
+    "field_required": "此字段为必填项",
+    "file_name_required": "文件名为必填项",
+    "name_required": "名称为必填项"
+  },
   "warning": {
     "missing_provider": "供应商不存在，已回退到默认供应商 {{provider}}。这可能导致问题。"
   },

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -5089,6 +5089,11 @@
     "saveDataError": "儲存資料失敗，請重試",
     "title": "更新提示"
   },
+  "validation": {
+    "field_required": "[to be translated]:This field is required",
+    "file_name_required": "[to be translated]:File name is required",
+    "name_required": "[to be translated]:Name is required"
+  },
   "warning": {
     "missing_provider": "供應商不存在，已改用預設供應商 {{provider}}。這可能導致問題。"
   },

--- a/src/renderer/src/i18n/translate/de-de.json
+++ b/src/renderer/src/i18n/translate/de-de.json
@@ -5089,6 +5089,11 @@
     "saveDataError": "Speichern fehlgeschlagen, bitte erneut versuchen",
     "title": "Update-Hinweis"
   },
+  "validation": {
+    "field_required": "[to be translated]:This field is required",
+    "file_name_required": "[to be translated]:File name is required",
+    "name_required": "[to be translated]:Name is required"
+  },
   "warning": {
     "missing_provider": "Anbieter nicht gefunden, Standardanbieter {{provider}} verwendet. Dies kann zu Problemen führen."
   },

--- a/src/renderer/src/i18n/translate/el-gr.json
+++ b/src/renderer/src/i18n/translate/el-gr.json
@@ -5089,6 +5089,11 @@
     "saveDataError": "Η αποθήκευση των δεδομένων απέτυχε, δοκιμάστε ξανά",
     "title": "Ενημέρωση"
   },
+  "validation": {
+    "field_required": "[to be translated]:This field is required",
+    "file_name_required": "[to be translated]:File name is required",
+    "name_required": "[to be translated]:Name is required"
+  },
   "warning": {
     "missing_provider": "Ο προμηθευτής δεν υπάρχει, έγινε επαναφορά στον προεπιλεγμένο προμηθευτή {{provider}}. Αυτό μπορεί να προκαλέσει προβλήματα."
   },

--- a/src/renderer/src/i18n/translate/es-es.json
+++ b/src/renderer/src/i18n/translate/es-es.json
@@ -5089,6 +5089,11 @@
     "saveDataError": "Error al guardar los datos, inténtalo de nuevo",
     "title": "Actualización"
   },
+  "validation": {
+    "field_required": "[to be translated]:This field is required",
+    "file_name_required": "[to be translated]:File name is required",
+    "name_required": "[to be translated]:Name is required"
+  },
   "warning": {
     "missing_provider": "El proveedor no existe, se ha revertido al proveedor predeterminado {{provider}}. Esto podría causar problemas."
   },

--- a/src/renderer/src/i18n/translate/fr-fr.json
+++ b/src/renderer/src/i18n/translate/fr-fr.json
@@ -5089,6 +5089,11 @@
     "saveDataError": "Échec de la sauvegarde des données, veuillez réessayer",
     "title": "Mise à jour"
   },
+  "validation": {
+    "field_required": "[to be translated]:This field is required",
+    "file_name_required": "[to be translated]:File name is required",
+    "name_required": "[to be translated]:Name is required"
+  },
   "warning": {
     "missing_provider": "Le fournisseur n’existe pas, retour au fournisseur par défaut {{provider}}. Cela peut entraîner des problèmes."
   },

--- a/src/renderer/src/i18n/translate/ja-jp.json
+++ b/src/renderer/src/i18n/translate/ja-jp.json
@@ -5089,6 +5089,11 @@
     "saveDataError": "データの保存に失敗しました。もう一度お試しください。",
     "title": "更新"
   },
+  "validation": {
+    "field_required": "[to be translated]:This field is required",
+    "file_name_required": "[to be translated]:File name is required",
+    "name_required": "[to be translated]:Name is required"
+  },
   "warning": {
     "missing_provider": "サプライヤーが存在しないため、デフォルトのサプライヤー {{provider}} にロールバックされました。これにより問題が発生する可能性があります。"
   },

--- a/src/renderer/src/i18n/translate/pt-pt.json
+++ b/src/renderer/src/i18n/translate/pt-pt.json
@@ -5089,6 +5089,11 @@
     "saveDataError": "Falha ao salvar os dados, tente novamente",
     "title": "Atualização"
   },
+  "validation": {
+    "field_required": "[to be translated]:This field is required",
+    "file_name_required": "[to be translated]:File name is required",
+    "name_required": "[to be translated]:Name is required"
+  },
   "warning": {
     "missing_provider": "O fornecedor não existe; foi revertido para o fornecedor predefinido {{provider}}. Isto pode causar problemas."
   },

--- a/src/renderer/src/i18n/translate/ru-ru.json
+++ b/src/renderer/src/i18n/translate/ru-ru.json
@@ -5089,6 +5089,11 @@
     "saveDataError": "Ошибка сохранения данных, повторите попытку",
     "title": "Обновление"
   },
+  "validation": {
+    "field_required": "[to be translated]:This field is required",
+    "file_name_required": "[to be translated]:File name is required",
+    "name_required": "[to be translated]:Name is required"
+  },
   "warning": {
     "missing_provider": "Поставщик не существует, возвращение к поставщику по умолчанию {{provider}}. Это может привести к проблемам."
   },

--- a/src/renderer/src/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/Topics.tsx
@@ -91,7 +91,7 @@ export const Topics: React.FC<Props> = ({ assistant: _assistant, activeTopic, se
   const manageState = useTopicManageMode()
   const { isManageMode, selectedIds, searchText, enterManageMode, exitManageMode, toggleSelectTopic } = manageState
 
-  const { startEdit, isEditing, inputProps } = useInPlaceEdit({
+  const { startEdit, isEditing, inputProps, validationError } = useInPlaceEdit({
     onSave: (name: string) => {
       const topic = assistant.topics.find((t) => t.id === editingTopicId)
       if (topic && name !== topic.name) {
@@ -608,7 +608,13 @@ export const Topics: React.FC<Props> = ({ assistant: _assistant, activeTopic, se
                     </SelectIcon>
                   )}
                   {editingTopicId === topic.id && isEditing ? (
-                    <TopicEditInput {...inputProps} onClick={(e) => e.stopPropagation()} />
+                    <Tooltip title={validationError} open={!!validationError} color="var(--color-error)">
+                      <TopicEditInput
+                        {...inputProps}
+                        onClick={(e) => e.stopPropagation()}
+                        className={validationError ? 'error' : ''}
+                      />
+                    </Tooltip>
                   ) : (
                     <TopicName
                       className={getTopicNameClassName()}
@@ -803,14 +809,18 @@ const TopicName = styled.div`
 
 const TopicEditInput = styled.input`
   background: var(--color-background);
-  border: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
   color: var(--color-text-1);
   font-size: 13px;
   font-family: inherit;
-  padding: 2px 6px;
+  padding: 1px 5px;
   width: 100%;
   outline: none;
-  padding: 0;
+
+  &.error {
+    border-color: var(--color-error);
+  }
 `
 
 const PendingIndicator = styled.div.attrs({

--- a/src/renderer/src/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/Topics.tsx
@@ -31,7 +31,7 @@ import {
   exportTopicToNotion,
   topicToMarkdown
 } from '@renderer/utils/export'
-import { validators } from '@shared/utils/validators'
+import { composeValidators, validators } from '@shared/utils/validators'
 import type { MenuProps } from 'antd'
 import { Dropdown, Tooltip } from 'antd'
 import type { ItemType, MenuItemType } from 'antd/es/menu/interface'
@@ -104,7 +104,7 @@ export const Topics: React.FC<Props> = ({ assistant: _assistant, activeTopic, se
     onCancel: () => {
       setEditingTopicId(null)
     },
-    validator: validators.maxLength(100)
+    validator: composeValidators(validators.required(), validators.maxLength(100))
   })
 
   const isPending = useCallback((topicId: string) => topicLoadingQuery[topicId], [topicLoadingQuery])

--- a/src/renderer/src/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/Topics.tsx
@@ -608,7 +608,10 @@ export const Topics: React.FC<Props> = ({ assistant: _assistant, activeTopic, se
                     </SelectIcon>
                   )}
                   {editingTopicId === topic.id && isEditing ? (
-                    <Tooltip title={validationError} open={!!validationError} color="var(--color-error)">
+                    <Tooltip
+                      title={validationError ? t(validationError) : undefined}
+                      open={!!validationError}
+                      color="var(--color-error)">
                       <TopicEditInput
                         {...inputProps}
                         onClick={(e) => e.stopPropagation()}

--- a/src/renderer/src/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/Topics.tsx
@@ -31,6 +31,7 @@ import {
   exportTopicToNotion,
   topicToMarkdown
 } from '@renderer/utils/export'
+import { validators } from '@shared/utils/validators'
 import type { MenuProps } from 'antd'
 import { Dropdown, Tooltip } from 'antd'
 import type { ItemType, MenuItemType } from 'antd/es/menu/interface'
@@ -102,7 +103,8 @@ export const Topics: React.FC<Props> = ({ assistant: _assistant, activeTopic, se
     },
     onCancel: () => {
       setEditingTopicId(null)
-    }
+    },
+    validator: validators.maxLength(100)
   })
 
   const isPending = useCallback((topicId: string) => topicLoadingQuery[topicId], [topicLoadingQuery])

--- a/src/renderer/src/pages/notes/components/TreeNode.tsx
+++ b/src/renderer/src/pages/notes/components/TreeNode.tsx
@@ -10,7 +10,7 @@ import {
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import type { SearchMatch, SearchResult } from '@renderer/services/NotesSearchService'
 import type { NotesTreeNode } from '@renderer/types/note'
-import { Dropdown } from 'antd'
+import { Dropdown, Tooltip } from 'antd'
 import { ChevronDown, ChevronRight, File, FilePlus, Folder, FolderOpen } from 'lucide-react'
 import { memo, useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -36,7 +36,7 @@ const TreeNode = memo<TreeNodeProps>(({ node, depth, renderChildren = true, onHi
   const { getMenuItems, onSelectNode, onToggleExpanded, onDropdownOpenChange } = useNotesActions()
 
   const [showAllMatches, setShowAllMatches] = useState(false)
-  const { isEditing: isInputEditing, inputProps } = inPlaceEdit
+  const { isEditing: isInputEditing, inputProps, validationError } = inPlaceEdit
 
   // 检查是否是 hint 节点
   const isHintNode = node.type === 'hint'
@@ -172,7 +172,14 @@ const TreeNode = memo<TreeNodeProps>(({ node, depth, renderChildren = true, onHi
               </NodeIcon>
 
               {isEditing ? (
-                <EditInput {...inputProps} onClick={(e) => e.stopPropagation()} autoFocus />
+                <Tooltip title={validationError} open={!!validationError} color="var(--color-error)">
+                  <EditInput
+                    {...inputProps}
+                    onClick={(e) => e.stopPropagation()}
+                    autoFocus
+                    className={validationError ? 'error' : ''}
+                  />
+                </Tooltip>
               ) : (
                 <NodeNameContainer>
                   <NodeName className={getNodeNameClassName()}>
@@ -487,6 +494,14 @@ export const MoreMatches = styled.div<{ depth: number }>`
 const EditInput = styled.input`
   flex: 1;
   font-size: 13px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  padding: 1px 4px;
+  outline: none;
+
+  &.error {
+    border-color: var(--color-error);
+  }
 `
 
 const DropHintText = styled.div`

--- a/src/renderer/src/pages/notes/components/TreeNode.tsx
+++ b/src/renderer/src/pages/notes/components/TreeNode.tsx
@@ -172,7 +172,10 @@ const TreeNode = memo<TreeNodeProps>(({ node, depth, renderChildren = true, onHi
               </NodeIcon>
 
               {isEditing ? (
-                <Tooltip title={validationError} open={!!validationError} color="var(--color-error)">
+                <Tooltip
+                  title={validationError ? t(validationError) : undefined}
+                  open={!!validationError}
+                  color="var(--color-error)">
                   <EditInput
                     {...inputProps}
                     onClick={(e) => e.stopPropagation()}

--- a/src/renderer/src/pages/notes/hooks/useNotesEditing.ts
+++ b/src/renderer/src/pages/notes/hooks/useNotesEditing.ts
@@ -2,7 +2,7 @@ import { loggerService } from '@logger'
 import { useInPlaceEdit } from '@renderer/hooks/useInPlaceEdit'
 import { fetchNoteSummary } from '@renderer/services/ApiService'
 import type { NotesTreeNode } from '@renderer/types/note'
-import { validators } from '@shared/utils/validators'
+import { composeValidators, validators } from '@shared/utils/validators'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -30,7 +30,7 @@ export const useNotesEditing = ({ onRenameNode }: UseNotesEditingProps) => {
     onCancel: () => {
       setEditingNodeId(null)
     },
-    validator: validators.fileName(100)
+    validator: composeValidators(validators.required(), validators.fileName(100))
   })
 
   const handleStartEdit = useCallback(

--- a/src/renderer/src/pages/notes/hooks/useNotesEditing.ts
+++ b/src/renderer/src/pages/notes/hooks/useNotesEditing.ts
@@ -2,6 +2,7 @@ import { loggerService } from '@logger'
 import { useInPlaceEdit } from '@renderer/hooks/useInPlaceEdit'
 import { fetchNoteSummary } from '@renderer/services/ApiService'
 import type { NotesTreeNode } from '@renderer/types/note'
+import { validators } from '@shared/utils/validators'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -28,7 +29,8 @@ export const useNotesEditing = ({ onRenameNode }: UseNotesEditingProps) => {
     },
     onCancel: () => {
       setEditingNodeId(null)
-    }
+    },
+    validator: validators.fileName(100)
   })
 
   const handleStartEdit = useCallback(


### PR DESCRIPTION
Split from #12258 

### What this PR does

Before this PR:
- `useInPlaceEdit` hook has no built-in validation support
- Validation must be done manually in onSave callback
- No real-time feedback during input

After this PR:
- `useInPlaceEdit` supports real-time validation via `validator` option
- Built-in transform support (e.g., auto-lowercase, remove invalid chars)
- Returns `validationError` for inline error display
- Preset validators available: `validators.urlSafe()`, `validators.fileName()`, `validators.required()`
- `composeValidators()` utility for combining multiple validators

### Why we need it and why it was done in this way

Real-time input validation provides better UX by giving immediate feedback instead of waiting until save.

The following tradeoffs were made:
- Debounce is configurable (default 300ms) to balance responsiveness vs performance
- Transform is applied before validation to ensure consistent behavior

The following alternatives were considered:
- Builder pattern with fluent API - decided against to avoid over-engineering
- Separate validation hook - decided to integrate into existing hook for simpler usage

### Breaking changes

None. The `validator` option is optional and backward compatible.

### Special notes for your reviewer

Usage example:
```typescript
const { inputProps, validationError } = useInPlaceEdit({
  onSave: async (name) => { ... },
  validator: validators.urlSafe(32)
})

// In JSX
<Input {...inputProps} status={validationError ? 'error' : undefined} />
{validationError && <Text type="danger">{validationError}</Text>}
```

### Checklist

- [x] PR: The PR description is expressive enough
- [x] Code: Keep it simple
- [x] Refactor: Left the code cleaner
- [ ] Upgrade: N/A
- [ ] Documentation: N/A (internal hook)

### Release note

```release-note
Add validator support to useInPlaceEdit hook for real-time input validation with preset validators
```