### PR TITLE
fix: prevent zoom reset during in-page navigation

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1061,12 +1061,18 @@ export async function registerIpc(mainWindow: BrowserWindow, app: Electron.App) 
     } catch (error) {
       const pluginError = extractPluginError(error)
       if (pluginError) {
-        logger.error('Failed to list installed plugins', { agentId, error: pluginError })
+        logger.error('Failed to list installed plugins', {
+          agentId,
+          error: pluginError
+        })
         return { success: false, error: pluginError }
       }
 
       const err = normalizeError(error)
-      logger.error('Failed to list installed plugins', { agentId, error: err })
+      logger.error('Failed to list installed plugins', {
+        agentId,
+        error: err
+      })
       return {
         success: false,
         error: {

--- a/src/main/services/WindowService.ts
+++ b/src/main/services/WindowService.ts
@@ -255,6 +255,12 @@ export class WindowService {
   }
 
   private setupWebContentsHandlers(mainWindow: BrowserWindow) {
+    // Fix for Electron bug where zoom resets during in-page navigation (route changes)
+    // This complements the resize-based workaround by catching navigation events
+    mainWindow.webContents.on('did-navigate-in-page', () => {
+      mainWindow.webContents.setZoomFactor(configManager.getZoomFactor())
+    })
+
     mainWindow.webContents.on('will-navigate', (event, url) => {
       if (url.includes('localhost:517')) {
         return
@@ -516,7 +522,9 @@ export class WindowService {
     miniWindowState.manage(this.miniWindow)
 
     //miniWindow should show in current desktop
-    this.miniWindow?.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })
+    this.miniWindow?.setVisibleOnAllWorkspaces(true, {
+      visibleOnFullScreen: true
+    })
     //make miniWindow always on top of fullscreen apps with level set
     //[mac] level higher than 'floating' will cover the pinyin input method
     this.miniWindow.setAlwaysOnTop(true, 'floating')


### PR DESCRIPTION
Fixes an Electron bug where zoom factor resets during route changes by listening to the 'did-navigate-in-page' event and reapplying the configured zoom factor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


