### PR TITLE
fix(agents): move agents.db to DATA_PATH for backup support

### DIFF
--- a/src/main/services/agents/drizzle.config.ts
+++ b/src/main/services/agents/drizzle.config.ts
@@ -18,17 +18,30 @@
  * Drizzle Kit configuration for agents database
  */
 
+import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
+import { DATA_PATH } from '@main/config'
+import { isDev } from '@main/constant'
+import { makeSureDirExists } from '@main/utils'
 import { defineConfig } from 'drizzle-kit'
 import { app } from 'electron'
 
 function getDbPath() {
-  if (process.env.NODE_ENV === 'development') {
-    return path.join(os.homedir(), '.cherrystudio', 'data', 'agents.db')
+  const oldAgentsDbPath = isDev
+    ? path.join(os.homedir(), '.cherrystudio', 'data', 'agents.db')
+    : path.join(app.getPath('userData'), 'agents.db')
+
+  const agentsDbPath = path.join(DATA_PATH, 'Agents', 'agents.db')
+
+  makeSureDirExists(path.dirname(agentsDbPath))
+
+  if (fs.existsSync(oldAgentsDbPath)) {
+    fs.renameSync(oldAgentsDbPath, agentsDbPath)
   }
-  return path.join(app.getPath('userData'), 'agents.db')
+
+  return agentsDbPath
 }
 
 const resolvedDbPath = getDbPath()

--- a/src/main/services/agents/drizzle.config.ts
+++ b/src/main/services/agents/drizzle.config.ts
@@ -37,7 +37,9 @@ function getDbPath() {
 
   makeSureDirExists(path.dirname(agentsDbPath))
 
-  if (fs.existsSync(oldAgentsDbPath)) {
+  // Only migrate if old database exists and new database doesn't exist yet
+  // This prevents overwriting a newer database with stale data from old location
+  if (fs.existsSync(oldAgentsDbPath) && !fs.existsSync(agentsDbPath)) {
     fs.renameSync(oldAgentsDbPath, agentsDbPath)
   }
 

--- a/tests/main.setup.ts
+++ b/tests/main.setup.ts
@@ -115,25 +115,31 @@ vi.mock('node:path', async () => {
   }
 })
 
-vi.mock('node:fs', () => ({
-  promises: {
-    access: vi.fn(),
-    readFile: vi.fn(),
-    writeFile: vi.fn(),
-    mkdir: vi.fn(),
-    readdir: vi.fn(),
-    stat: vi.fn(),
-    unlink: vi.fn(),
-    rmdir: vi.fn()
-  },
-  existsSync: vi.fn(),
-  readFileSync: vi.fn(),
-  writeFileSync: vi.fn(),
-  mkdirSync: vi.fn(),
-  readdirSync: vi.fn(),
-  statSync: vi.fn(),
-  unlinkSync: vi.fn(),
-  rmdirSync: vi.fn(),
-  createReadStream: vi.fn(),
-  createWriteStream: vi.fn()
-}))
+vi.mock('node:fs', () => {
+  const fsMock = {
+    promises: {
+      access: vi.fn(),
+      readFile: vi.fn(),
+      writeFile: vi.fn(),
+      mkdir: vi.fn(),
+      readdir: vi.fn(),
+      stat: vi.fn(),
+      unlink: vi.fn(),
+      rmdir: vi.fn()
+    },
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    readdirSync: vi.fn(),
+    statSync: vi.fn(),
+    unlinkSync: vi.fn(),
+    rmdirSync: vi.fn(),
+    createReadStream: vi.fn(),
+    createWriteStream: vi.fn()
+  }
+  return {
+    ...fsMock,
+    default: fsMock
+  }
+})


### PR DESCRIPTION
### What this PR does

Before this PR:
- `agents.db` was stored in the Electron `userData` root directory (e.g., `~/Library/Application Support/Cherry Studio/agents.db`)
- The database was not included in app backup and restore operations

After this PR:
- `agents.db` is stored in `DATA_PATH/Agents/agents.db`
- The database is now included in app backup and restore operations
- Existing databases are automatically migrated from the old location to the new location

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Added automatic migration logic to move existing `agents.db` from the old location to ensure no data loss for existing users

The following alternatives were considered:
- Copy instead of rename: Rejected because it would waste disk space and leave orphan files

### Breaking changes

None. The migration is automatic and transparent to users.

### Special notes for your reviewer

This is a critical bug fix that ensures the agents database is properly backed up when users use the app's backup/restore functionality.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: Left the code cleaner (added proper migration logic)
- [x] Upgrade: Migration from old path to new path is handled automatically
- [ ] Documentation: Not required - this is an internal storage change

### Release note

```release-note
fix: agents.db is now stored in DATA_PATH to ensure it's included in app backup and restore operations
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Agents DB relocation and migration**
> 
> - Stores `agents.db` at `DATA_PATH/Agents/agents.db` and ensures directory exists via `makeSureDirExists`
> - Adds one-time migration: if old DB exists (dev `~/.cherrystudio/data/agents.db` or prod `app.getPath('userData')/agents.db`) and new DB doesn't, rename to new path
> - Updates Drizzle config to use the resolved path (`file:${resolvedDbPath}`)
> 
> **Tests**
> 
> - Revises `node:fs` mock to provide both named and default exports, matching new `import fs from 'node:fs'` usage
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0c6aace54366f68f57da91c3e84a02a7df616ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->