### PR TITLE
fix: replace nullish coalescing with logical OR in reasoning_content

### DIFF
--- a/.yarn/patches/@ai-sdk-openai-compatible-npm-1.0.28-5705188855.patch
+++ b/.yarn/patches/@ai-sdk-openai-compatible-npm-1.0.28-5705188855.patch
@@ -9,7 +9,7 @@ index 48e2f6263c6ee4c75d7e5c28733e64f6ebe92200..00d0729c4a3cbf9a48e8e1e962c7e2b2
 +    sendReasoning: z.ZodOptional<z.ZodBoolean>;
  }, z.core.$strip>;
  type OpenAICompatibleProviderOptions = z.infer<typeof openaiCompatibleProviderOptions>;
- 
+
 diff --git a/dist/index.js b/dist/index.js
 index da237bb35b7fa8e24b37cd861ee73dfc51cdfc72..b3060fbaf010e30b64df55302807828e5bfe0f9a 100644
 --- a/dist/index.js
@@ -48,7 +48,7 @@ index da237bb35b7fa8e24b37cd861ee73dfc51cdfc72..b3060fbaf010e30b64df55302807828e
          messages.push({
            role: "assistant",
            content: text,
-+          reasoning_content: reasoning_text ?? undefined,
++          reasoning_content: reasoning_text || undefined,
            tool_calls: toolCalls.length > 0 ? toolCalls : void 0,
            ...metadata
          });
@@ -60,7 +60,7 @@ index da237bb35b7fa8e24b37cd861ee73dfc51cdfc72..b3060fbaf010e30b64df55302807828e
 +  textVerbosity: import_v4.z.string().optional(),
 +  sendReasoning: import_v4.z.boolean().optional()
  });
- 
+
  // src/openai-compatible-error.ts
 @@ -378,7 +387,7 @@ var OpenAICompatibleChatLanguageModel = class {
          reasoning_effort: compatibleOptions.reasoningEffort,
@@ -175,7 +175,7 @@ index a809a7aa0e148bfd43e01dd7b018568b151c8ad5..565b605eeacd9830b2b0e817e58ad0c5
          messages.push({
            role: "assistant",
            content: text,
-+          reasoning_content: reasoning_text ?? undefined,
++          reasoning_content: reasoning_text || undefined,
            tool_calls: toolCalls.length > 0 ? toolCalls : void 0,
            ...metadata
          });
@@ -187,7 +187,7 @@ index a809a7aa0e148bfd43e01dd7b018568b151c8ad5..565b605eeacd9830b2b0e817e58ad0c5
 +  textVerbosity: z.string().optional(),
 +  sendReasoning: z.boolean().optional()
  });
- 
+
  // src/openai-compatible-error.ts
 @@ -362,7 +371,7 @@ var OpenAICompatibleChatLanguageModel = class {
          reasoning_effort: compatibleOptions.reasoningEffort,

--- a/yarn.lock
+++ b/yarn.lock
@@ -256,13 +256,13 @@ __metadata:
 
 "@ai-sdk/openai-compatible@patch:@ai-sdk/openai-compatible@npm%3A1.0.28#~/.yarn/patches/@ai-sdk-openai-compatible-npm-1.0.28-5705188855.patch":
   version: 1.0.28
-  resolution: "@ai-sdk/openai-compatible@patch:@ai-sdk/openai-compatible@npm%3A1.0.28#~/.yarn/patches/@ai-sdk-openai-compatible-npm-1.0.28-5705188855.patch::version=1.0.28&hash=f2cb20"
+  resolution: "@ai-sdk/openai-compatible@patch:@ai-sdk/openai-compatible@npm%3A1.0.28#~/.yarn/patches/@ai-sdk-openai-compatible-npm-1.0.28-5705188855.patch::version=1.0.28&hash=4b4acf"
   dependencies:
     "@ai-sdk/provider": "npm:2.0.0"
     "@ai-sdk/provider-utils": "npm:3.0.18"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/0b1d99fe8ce506e5c0a3703ae0511ac2017781584074d41faa2df82923c64eb1229ffe9f036de150d0248923613c761a463fe89d5923493983e0463a1101e792
+  checksum: 10c0/4b1c3473e3e1a9ccf132a6e529d8d3891bc22aeb04883739e1f79b4f58436e3b0c62ac42552b4a901461f5c5ab008ee31e52b13878764eb9c4c41020439ab7e6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What this PR does

Before this PR:
When users chat on providers that don't support reasoning (e.g., Groq), if previous messages contain empty thinking blocks (`reasoning_content: ""`), the request fails with `property 'reasoning_content' is unsupported`.

After this PR:
Empty `reasoning_content` strings are converted to `undefined`, so the property is not sent to APIs that don't support it.

Fixes #12140, Fixes #12153

### Why we need it and why it was done in this way

The root cause is in the `@ai-sdk/openai-compatible` patch. When `reasoning_text` is an empty string `""`:
- `reasoning_text ?? undefined` → `""` (empty string is preserved and sent to API)
- `reasoning_text || undefined` → `undefined` (empty string becomes undefined, property not sent)

By using `||` instead of `??`, empty reasoning content is filtered out at the SDK level, preventing the error on providers like Groq that don't support the `reasoning_content` property.

The following alternatives were considered:
- Filter at application level by checking model capabilities (PR #12213): More complex, requires changes across multiple places
- This approach: Simpler, fixes the issue at the source in the SDK patch

### Breaking changes

None. This is a bug fix that doesn't affect normal usage of reasoning models. Models with actual reasoning content will still work correctly.

### Special notes for your reviewer

This is a minimal fix in the existing `@ai-sdk/openai-compatible` patch file.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: Not required for this bug fix

```release-note
fix: conversations with thinking content no longer fail on non-reasoning providers like Groq
```