### PR TITLE
fix(notes): prevent sticky folder z-index from overlapping webview

### DIFF
--- a/src/renderer/src/pages/notes/NotesSidebar.tsx
+++ b/src/renderer/src/pages/notes/NotesSidebar.tsx
@@ -452,6 +452,7 @@ export const SidebarContainer = styled.div`
   display: flex;
   flex-direction: column;
   position: relative;
+  isolation: isolate;
 `
 
 export const NotesTreeContainer = styled.div`


### PR DESCRIPTION
### What this PR does

Before this PR:
In top navbar mode, when navigating from Notes page to MinApp page, the sticky folder elements in NotesSidebar have a very high z-index (1000+), which overlaps with the MinApp webview layer.

After this PR:
The NotesSidebar container creates an isolated stacking context using `isolation: isolate`, ensuring its internal z-index values don't affect external components like the MinApp webview.

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Using `isolation: isolate` instead of modifying z-index values in DynamicVirtualList, as this is a more localized fix that doesn't affect other components using the virtual list.

The following alternatives were considered:
- **Alternative A**: Lowering the z-index values in `DynamicVirtualList` from 1000+ to lower values. Rejected because it would affect all usages of the component.
- **Alternative B**: Adding z-index to the parent containers. Rejected because `isolation: isolate` is a cleaner CSS solution for creating stacking contexts.

### Breaking changes

None.

### Special notes for your reviewer

**Steps to reproduce the issue:**
1. Use **top navbar mode** (Settings → Display → Navbar position: Top)
2. Open the **Notes** page
3. Create a folder structure with multiple nested folders
4. Scroll down until a folder becomes **sticky** (pinned at the top)
5. Open a **MinApp** page (e.g., click on any mini app)
6. **Before fix**: The sticky folder element overlaps the webview
7. **After fix**: The webview displays correctly without overlap

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required.

### Release note

```release-note
fix: prevent Notes sidebar sticky folders from overlapping MinApp webview in top navbar mode
```