### PR TITLE
fix: use ipinfo lite API with token for IP country detection

### DIFF
--- a/src/main/utils/ipService.ts
+++ b/src/main/utils/ipService.ts
@@ -19,7 +19,7 @@ export async function getIpCountry(): Promise<string> {
 
     clearTimeout(timeoutId)
     const data = await ipinfo.json()
-    const country = data.country || 'CN'
+    const country = data.country_code || 'CN'
     logger.info(`Detected user IP address country: ${country}`)
     return country
   } catch (error) {


### PR DESCRIPTION
Switch from ipinfo.io/json to api.ipinfo.io/lite/me endpoint with authentication token to improve reliability and avoid rate limiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)