### PR TITLE
fix(prompts): standardize tool use example format to use 'A:' label consistently

### DIFF
--- a/packages/aiCore/src/core/plugins/built-in/toolUsePlugin/promptToolUsePlugin.ts
+++ b/packages/aiCore/src/core/plugins/built-in/toolUsePlugin/promptToolUsePlugin.ts
@@ -154,7 +154,8 @@ User: <tool_use_result>
   <name>search</name>
   <result>26 million (2019)</result>
 </tool_use_result>
-Assistant: The population of Shanghai is 26 million, while Guangzhou has a population of 15 million. Therefore, Shanghai has the highest population.`
+
+A: The population of Shanghai is 26 million, while Guangzhou has a population of 15 million. Therefore, Shanghai has the highest population.`
 
 /**
  * 构建可用工具部分（提取自 Cherry Studio）

--- a/src/renderer/src/utils/prompt.ts
+++ b/src/renderer/src/utils/prompt.ts
@@ -14,7 +14,7 @@ Here are a few examples using notional tools:
 ---
 User: Generate an image of the oldest person in this document.
 
-Assistant: I can use the document_qa tool to find out who the oldest person is in the document.
+A: I can use the document_qa tool to find out who the oldest person is in the document.
 <tool_use>
   <name>document_qa</name>
   <arguments>{"document": "document.pdf", "question": "Who is the oldest person mentioned?"}</arguments>
@@ -25,7 +25,7 @@ User: <tool_use_result>
   <result>John Doe, a 55 year old lumberjack living in Newfoundland.</result>
 </tool_use_result>
 
-Assistant: I can use the image_generator tool to create a portrait of John Doe.
+A: I can use the image_generator tool to create a portrait of John Doe.
 <tool_use>
   <name>image_generator</name>
   <arguments>{"prompt": "A portrait of John Doe, a 55-year-old man living in Canada."}</arguments>
@@ -36,12 +36,12 @@ User: <tool_use_result>
   <result>image.png</result>
 </tool_use_result>
 
-Assistant: the image is generated as image.png
+A: the image is generated as image.png
 
 ---
 User: "What is the result of the following operation: 5 + 3 + 1294.678?"
 
-Assistant: I can use the python_interpreter tool to calculate the result of the operation.
+A: I can use the python_interpreter tool to calculate the result of the operation.
 <tool_use>
   <name>python_interpreter</name>
   <arguments>{"code": "5 + 3 + 1294.678"}</arguments>
@@ -52,12 +52,12 @@ User: <tool_use_result>
   <result>1302.678</result>
 </tool_use_result>
 
-Assistant: The result of the operation is 1302.678.
+A: The result of the operation is 1302.678.
 
 ---
 User: "Which city has the highest population , Guangzhou or Shanghai?"
 
-Assistant: I can use the search tool to find the population of Guangzhou.
+A: I can use the search tool to find the population of Guangzhou.
 <tool_use>
   <name>search</name>
   <arguments>{"query": "Population Guangzhou"}</arguments>
@@ -68,7 +68,7 @@ User: <tool_use_result>
   <result>Guangzhou has a population of 15 million inhabitants as of 2021.</result>
 </tool_use_result>
 
-Assistant: I can use the search tool to find the population of Shanghai.
+A: I can use the search tool to find the population of Shanghai.
 <tool_use>
   <name>search</name>
   <arguments>{"query": "Population Shanghai"}</arguments>
@@ -78,7 +78,8 @@ User: <tool_use_result>
   <name>search</name>
   <result>26 million (2019)</result>
 </tool_use_result>
-Assistant: The population of Shanghai is 26 million, while Guangzhou has a population of 15 million. Therefore, Shanghai has the highest population.
+
+A: The population of Shanghai is 26 million, while Guangzhou has a population of 15 million. Therefore, Shanghai has the highest population.
 `
 
 export const AvailableTools = (tools: MCPTool[]) => {


### PR DESCRIPTION
### What this PR does

Before this PR:
- Tool use examples used varying labels (e.g., "Assistant:") and lacked a consistent format.
- Some examples were missing a blank line before the final response.

After this PR:
- Standardizes tool use example labels to use "A:" consistently.
- Adds the missing blank line before the final response in both affected files.
- Changes applied to promptToolUsePlugin.ts and prompt.ts.

Fixes #12310

### Why we need it and why it was done in this way

The change ensures consistent prompt formatting for clarity and uniform parsing across tools and examples.

### Checklist

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: Write code that humans can understand and keep it simple
- [ ] Refactor: Left the code cleaner than found
- [ ] Documentation: User-guide update not required

Release note

```release-note
Standardize tool use example format to use "A:" label consistently and add missing blank lines before final responses.
```