### PR TITLE
fix: Add reasoning control for Deepseek hybrid inference models when reasoning effort is 'none'

### DIFF
--- a/src/renderer/src/aiCore/utils/reasoning.ts
+++ b/src/renderer/src/aiCore/utils/reasoning.ts
@@ -118,6 +118,11 @@ export function getReasoningEffort(assistant: Assistant, model: Model): Reasonin
       return { thinking: { type: 'disabled' } }
     }
 
+    // Deepseek, default behavior is non-thinking
+    if (isDeepSeekHybridInferenceModel(model)) {
+      return {}
+    }
+
     // GPT 5.1, GPT 5.2, or newer
     if (isSupportNoneReasoningEffortModel(model)) {
       return {


### PR DESCRIPTION
### What this PR does

Before this PR:
When reasoning effort is set to 'none' for Deepseek hybrid inference models (like deepseek-reasoner), the system would show a warning because these models were not explicitly handled in the reasoning effort logic.

After this PR:
Deepseek hybrid inference models now return an empty object `{}` when reasoning effort is 'none', which maintains the default non-thinking behavior without triggering any warnings.

### Why we need it and why it was done in this way

Deepseek hybrid inference models default to non-thinking mode, so when users set reasoning effort to 'none', the expected behavior is already the default. By returning an empty object instead of falling through to other logic, we:

1. Maintain the same behavior (non-thinking mode)
2. Avoid unnecessary warnings to users
3. Keep the code explicit about handling this model type

The following tradeoffs were made:
- Assumes all providers follow the default non-reasoning behavior. Different providers have varying implementations of reasoning control APIs, and adapting to each one individually would be costly.

The following alternatives were considered:
- Could have modified the warning logic, but explicitly handling the model type is cleaner and more maintainable

### Breaking changes

None. This is a behavioral improvement that maintains the same functionality.

### Special notes for your reviewer

The change is minimal - just adding an early return for Deepseek hybrid inference models in the `getReasoningEffort` function.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required

### Release note

```release-note
fix: Deepseek hybrid inference models no longer show warnings when reasoning effort is set to 'none'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)