### PR TITLE
fix: normalize topics in useAssistant and assistants slice to prevent errors

### DIFF
--- a/src/renderer/src/hooks/useAssistant.ts
+++ b/src/renderer/src/hooks/useAssistant.ts
@@ -83,7 +83,14 @@ export function useAssistant(id: string) {
     throw new Error(`Assistant model is not set for assistant with name: ${assistant?.name ?? 'unknown'}`)
   }
 
-  const assistantWithModel = useMemo(() => ({ ...assistant, model }), [assistant, model])
+  const normalizedTopics = useMemo(
+    () => (Array.isArray(assistant?.topics) ? assistant.topics : []),
+    [assistant?.topics]
+  )
+  const assistantWithModel = useMemo(
+    () => ({ ...assistant, model, topics: normalizedTopics }),
+    [assistant, model, normalizedTopics]
+  )
 
   const settingsRef = useRef(assistant?.settings)
 


### PR DESCRIPTION
### What this PR does

Before this PR:
- Opening certain agents could crash with `assistant.topics is not iterable` when topics data was malformed or non-array.

<img width="1348" height="342" alt="81385db4992e99d3ea343419d792072d" src="https://github.com/user-attachments/assets/df58f7c7-d958-4946-bc07-92161da289b5" />


After this PR:
- Reducers and `useAssistant` guard against non-array topics so agent open no longer crashes.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

- Prevent a crash reported when opening agents with malformed `assistant.topics` data.
- Implemented as defensive normalization in reducers and hook to avoid iterating non-arrays, minimizing risk and avoiding a migration.

The following tradeoffs were made:
- Malformed topics are treated as empty lists, which may mask bad data until it is corrected elsewhere.

The following alternatives were considered:
- Migrate or validate persisted assistant data at load time to enforce an array shape.

Links to places where the discussion took place: None.

### Breaking changes

None.

### Special notes for your reviewer

- `pnpm lint` failed at `pnpm i18n:check` due to `listen EPERM` (tsx IPC pipe under sandbox).
- `pnpm test` passed.
- `pnpm format` passed (Biome warned about large `coverage/coverage-final.json`, no changes).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [ ] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Fixed a crash when opening agents if assistant topics data is malformed (non-array).
```
