### PR TITLE
fix: TokenFlux models list empty in drawing panel

### DIFF
--- a/src/renderer/src/pages/paintings/utils/TokenFluxService.ts
+++ b/src/renderer/src/pages/paintings/utils/TokenFluxService.ts
@@ -6,6 +6,9 @@ import type { TokenFluxModel } from '../config/tokenFluxConfig'
 
 const logger = loggerService.withContext('TokenFluxService')
 
+// 图片 API 使用固定的基础地址，独立于 provider.apiHost（后者是 OpenAI 兼容的聊天 API 地址）
+const TOKENFLUX_IMAGE_API_HOST = 'https://api.tokenflux.ai'
+
 export interface TokenFluxGenerationRequest {
   model: string
   input: {
@@ -66,7 +69,7 @@ export class TokenFluxService {
       return cachedModels
     }
 
-    const response = await fetch(`${this.apiHost}/v1/images/models`, {
+    const response = await fetch(`${TOKENFLUX_IMAGE_API_HOST}/v1/images/models`, {
       headers: {
         Authorization: `Bearer ${this.apiKey}`
       }
@@ -88,7 +91,7 @@ export class TokenFluxService {
    * Create a new image generation request
    */
   async createGeneration(request: TokenFluxGenerationRequest, signal?: AbortSignal): Promise<string> {
-    const response = await fetch(`${this.apiHost}/v1/images/generations`, {
+    const response = await fetch(`${TOKENFLUX_IMAGE_API_HOST}/v1/images/generations`, {
       method: 'POST',
       headers: this.getHeaders(),
       body: JSON.stringify(request),
@@ -108,7 +111,7 @@ export class TokenFluxService {
    * Get the status and result of a generation
    */
   async getGenerationResult(generationId: string): Promise<TokenFluxGenerationResponse['data']> {
-    const response = await fetch(`${this.apiHost}/v1/images/generations/${generationId}`, {
+    const response = await fetch(`${TOKENFLUX_IMAGE_API_HOST}/v1/images/generations/${generationId}`, {
       headers: {
         Authorization: `Bearer ${this.apiKey}`
       }


### PR DESCRIPTION
### What this PR does

Before this PR:
TokenFlux models list is empty in the drawing panel after upgrading to v1.7.9.

After this PR:
TokenFlux models list displays correctly.

Fixes #12284

### Why we need it and why it was done in this way

**Root cause**: Migration 191 changed `provider.apiHost` to `https://api.tokenflux.ai/openai/v1` for chat API compatibility. But `TokenFluxService` was using this same `apiHost` for image API, resulting in wrong URL:
- Expected: `https://api.tokenflux.ai/v1/images/models`
- Actual: `https://api.tokenflux.ai/openai/v1/v1/images/models` ❌

**Fix**: Use a fixed base URL `https://api.tokenflux.ai` for image API calls, since the image API endpoint is independent of the chat API configuration.

The following alternatives were considered:
- Adding URL processing logic to strip `/openai/v1` suffix - more complex, less explicit
- Adding new `imageApiHost` field to Provider - requires type changes, migration, too heavy for this fix

### Breaking changes

None.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple

```release-note
fix: TokenFlux models list empty in drawing panel after v1.7.9 upgrade
```