### PR TITLE
fix: prevent sending reasoning_content to unsupported providers like Groq

### DIFF
--- a/patches/@ai-sdk-openai-compatible-npm-1.0.28-5705188855.patch
+++ b/patches/@ai-sdk-openai-compatible-npm-1.0.28-5705188855.patch
@@ -48,7 +48,7 @@ index da237bb35b7fa8e24b37cd861ee73dfc51cdfc72..b3060fbaf010e30b64df55302807828e
          messages.push({
            role: "assistant",
            content: text,
-+          reasoning_content: reasoning_text || undefined,
++          ...(options.sendReasoning && reasoning_text ? { reasoning_content: reasoning_text } : {}),
            tool_calls: toolCalls.length > 0 ? toolCalls : void 0,
            ...metadata
          });
@@ -175,7 +175,7 @@ index a809a7aa0e148bfd43e01dd7b018568b151c8ad5..565b605eeacd9830b2b0e817e58ad0c5
          messages.push({
            role: "assistant",
            content: text,
-+          reasoning_content: reasoning_text || undefined,
++          ...(options.sendReasoning && reasoning_text ? { reasoning_content: reasoning_text } : {}),
            tool_calls: toolCalls.length > 0 ? toolCalls : void 0,
            ...metadata
          });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ patchedDependencies:
     hash: 279e9d43f675e4b979b32b78954dd37acc3026aa36ae2dd7701b5bad2f061522
     path: patches/@ai-sdk-google-npm-2.0.49-84720f41bd.patch
   '@ai-sdk/openai-compatible@1.0.28':
-    hash: 66f6605ef3f852d8f2b638a1d64b138eb8b2ad34ca6f331a0496c1d1379379c1
+    hash: 5235e50ab8e82e7f8252d0c9dfccd2a9a4ea00c901b77187b59b3e9d8a4c1983
     path: patches/@ai-sdk-openai-compatible-npm-1.0.28-5705188855.patch
   '@ai-sdk/openai@2.0.85':
     hash: f2077f4759520d1de69b164dfd8adca1a9ace9de667e35cb0e55e812ce2ac13b
@@ -1131,7 +1131,7 @@ importers:
         version: 2.0.85(patch_hash=f2077f4759520d1de69b164dfd8adca1a9ace9de667e35cb0e55e812ce2ac13b)(zod@4.3.5)
       '@ai-sdk/openai-compatible':
         specifier: 1.0.28
-        version: 1.0.28(patch_hash=66f6605ef3f852d8f2b638a1d64b138eb8b2ad34ca6f331a0496c1d1379379c1)(zod@4.3.5)
+        version: 1.0.28(patch_hash=5235e50ab8e82e7f8252d0c9dfccd2a9a4ea00c901b77187b59b3e9d8a4c1983)(zod@4.3.5)
       '@ai-sdk/provider':
         specifier: ^2.0.0
         version: 2.0.1
@@ -1171,7 +1171,7 @@ importers:
         version: 2.0.85(patch_hash=f2077f4759520d1de69b164dfd8adca1a9ace9de667e35cb0e55e812ce2ac13b)(zod@4.3.4)
       '@ai-sdk/openai-compatible':
         specifier: 1.0.28
-        version: 1.0.28(patch_hash=66f6605ef3f852d8f2b638a1d64b138eb8b2ad34ca6f331a0496c1d1379379c1)(zod@4.3.4)
+        version: 1.0.28(patch_hash=5235e50ab8e82e7f8252d0c9dfccd2a9a4ea00c901b77187b59b3e9d8a4c1983)(zod@4.3.4)
       '@ai-sdk/provider':
         specifier: ^2.0.0
         version: 2.0.1
@@ -11911,7 +11911,7 @@ packages:
         optional: true
 
   xlsx@https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz:
-    resolution: {tarball: https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz}
+    resolution: {integrity: sha512-+nKZ39+nvK7Qq6i0PvWWRA4j/EkfWOtkP/YhMtupm+lJIiHxUrgTr1CcKv1nBk1rHtkRRQ3O2+Ih/q/sA+FXZA==, tarball: https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz}
     version: 0.20.2
     engines: {node: '>=0.8'}
     hasBin: true
@@ -12215,7 +12215,7 @@ snapshots:
 
   '@ai-sdk/huggingface@0.0.10(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/openai-compatible': 1.0.28(patch_hash=66f6605ef3f852d8f2b638a1d64b138eb8b2ad34ca6f331a0496c1d1379379c1)(zod@4.3.4)
+      '@ai-sdk/openai-compatible': 1.0.28(patch_hash=5235e50ab8e82e7f8252d0c9dfccd2a9a4ea00c901b77187b59b3e9d8a4c1983)(zod@4.3.4)
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.17(zod@4.3.4)
       zod: 4.3.4
@@ -12226,13 +12226,13 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.20(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/openai-compatible@1.0.28(patch_hash=66f6605ef3f852d8f2b638a1d64b138eb8b2ad34ca6f331a0496c1d1379379c1)(zod@4.3.4)':
+  '@ai-sdk/openai-compatible@1.0.28(patch_hash=5235e50ab8e82e7f8252d0c9dfccd2a9a4ea00c901b77187b59b3e9d8a4c1983)(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.18(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/openai-compatible@1.0.28(patch_hash=66f6605ef3f852d8f2b638a1d64b138eb8b2ad34ca6f331a0496c1d1379379c1)(zod@4.3.5)':
+  '@ai-sdk/openai-compatible@1.0.28(patch_hash=5235e50ab8e82e7f8252d0c9dfccd2a9a4ea00c901b77187b59b3e9d8a4c1983)(zod@4.3.5)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.18(zod@4.3.5)
@@ -12338,7 +12338,7 @@ snapshots:
 
   '@ai-sdk/xai@2.0.36(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/openai-compatible': 1.0.28(patch_hash=66f6605ef3f852d8f2b638a1d64b138eb8b2ad34ca6f331a0496c1d1379379c1)(zod@4.3.4)
+      '@ai-sdk/openai-compatible': 1.0.28(patch_hash=5235e50ab8e82e7f8252d0c9dfccd2a9a4ea00c901b77187b59b3e9d8a4c1983)(zod@4.3.4)
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.17(zod@4.3.4)
       zod: 4.3.4
@@ -15115,7 +15115,7 @@ snapshots:
   '@opeoginni/github-copilot-openai-compatible@0.1.22(zod@4.3.4)':
     dependencies:
       '@ai-sdk/openai': 2.0.85(patch_hash=f2077f4759520d1de69b164dfd8adca1a9ace9de667e35cb0e55e812ce2ac13b)(zod@4.3.4)
-      '@ai-sdk/openai-compatible': 1.0.28(patch_hash=66f6605ef3f852d8f2b638a1d64b138eb8b2ad34ca6f331a0496c1d1379379c1)(zod@4.3.4)
+      '@ai-sdk/openai-compatible': 1.0.28(patch_hash=5235e50ab8e82e7f8252d0c9dfccd2a9a4ea00c901b77187b59b3e9d8a4c1983)(zod@4.3.4)
       '@ai-sdk/provider': 2.1.0-beta.5
       '@ai-sdk/provider-utils': 3.0.20(zod@4.3.4)
     transitivePeerDependencies:


### PR DESCRIPTION
### What this PR does

**Before this PR:**
Using Groq's GPT-OSS 120B model, the second message in a conversation fails with error `'reasoning_content' is not supported`.

**After this PR:**
Conversations with Groq's reasoning models work normally without errors.

Fixes #12302

### Why we need it and why it was done in this way

The AI SDK patch was unconditionally adding `reasoning_content` field to assistant messages in the request body, even when `sendReasoning` was `false`. Groq's API doesn't accept this field and rejects the request.

The fix makes `reasoning_content` conditional - it's only added when `sendReasoning` is explicitly `true` AND there's actual content to send.

**Alternatives considered:**
- Filter at messageConverter.ts level - would require changing multiple function signatures
- Add provider-specific handling - more complex and less generic

This approach fixes the root cause at the SDK patch level.

### Breaking changes

None.

### Checklist

- [x] PR: The PR description is expressive enough
- [x] Code: Simple and focused fix
- [x] Refactor: N/A - minimal change

```release-note
fix: Groq reasoning models now work correctly in multi-turn conversations
```