### PR TITLE
fix: Azure OpenAI DeepSeek-R1 returns 422 with system prompts

### DIFF
--- a/src/renderer/src/aiCore/legacy/clients/openai/OpenAIApiClient.ts
+++ b/src/renderer/src/aiCore/legacy/clients/openai/OpenAIApiClient.ts
@@ -17,6 +17,7 @@ import {
   isGrokReasoningModel,
   isNotSupportSystemMessageModel,
   isOpenAIDeepResearchModel,
+  isOpenAINativeDeveloperRoleModel,
   isOpenAIOpenWeightModel,
   isOpenAIReasoningModel,
   isQwenAlwaysThinkModel,
@@ -24,7 +25,6 @@ import {
   isQwenReasoningModel,
   isReasoningModel,
   isSupportedReasoningEffortModel,
-  isSupportedReasoningEffortOpenAIModel,
   isSupportedThinkingTokenClaudeModel,
   isSupportedThinkingTokenDoubaoModel,
   isSupportedThinkingTokenGeminiModel,
@@ -617,8 +617,10 @@ export class OpenAIAPIClient extends OpenAIBaseClient<
         // 1. 处理系统消息
         const systemMessage = { role: 'system', content: assistant.prompt || '' }
 
+        // Only use 'developer' role for OpenAI native reasoning models (o1, o3, o4, gpt-5 series)
+        // Third-party models like DeepSeek-R1 deployed through Azure do not support 'developer' role
         if (
-          isSupportedReasoningEffortOpenAIModel(model) &&
+          isOpenAINativeDeveloperRoleModel(model) &&
           isSupportDeveloperRoleProvider(this.provider) &&
           !isOpenAIOpenWeightModel(model)
         ) {

--- a/src/renderer/src/aiCore/legacy/clients/openai/OpenAIResponseAPIClient.ts
+++ b/src/renderer/src/aiCore/legacy/clients/openai/OpenAIResponseAPIClient.ts
@@ -7,8 +7,8 @@ import {
   isGPT5SeriesModel,
   isOpenAIChatCompletionOnlyModel,
   isOpenAILLMModel,
+  isOpenAINativeDeveloperRoleModel,
   isOpenAIOpenWeightModel,
-  isSupportedReasoningEffortOpenAIModel,
   isSupportVerbosityModel,
   isVisionModel
 } from '@renderer/config/models'
@@ -429,8 +429,10 @@ export class OpenAIResponseAPIClient extends OpenAIBaseClient<
           text: assistant.prompt || '',
           type: 'input_text'
         }
+        // Only use 'developer' role for OpenAI native reasoning models (o1, o3, o4, gpt-5 series)
+        // Third-party models like DeepSeek-R1 deployed through Azure do not support 'developer' role
         if (
-          isSupportedReasoningEffortOpenAIModel(model) &&
+          isOpenAINativeDeveloperRoleModel(model) &&
           isSupportDeveloperRoleProvider(this.provider) &&
           isOpenAIOpenWeightModel(model)
         ) {

--- a/src/renderer/src/config/models/openai.ts
+++ b/src/renderer/src/config/models/openai.ts
@@ -135,6 +135,40 @@ export function isSupportedReasoningEffortOpenAIModel(model: Model): boolean {
   )
 }
 
+/**
+ * Checks if the model is an OpenAI native reasoning model that supports the 'developer' role.
+ * This excludes third-party models (like DeepSeek-R1) deployed through Azure OpenAI or other providers.
+ *
+ * The 'developer' role is only supported by OpenAI's native reasoning models (o1, o3, o4, gpt-5 series).
+ * Third-party models like DeepSeek-R1 deployed through Azure do not support this role and should use 'system' instead.
+ *
+ * @param model - The model to check
+ * @returns true if the model is an OpenAI native reasoning model that supports 'developer' role
+ */
+export function isOpenAINativeDeveloperRoleModel(model: Model): boolean {
+  if (!isSupportedReasoningEffortOpenAIModel(model)) {
+    return false
+  }
+
+  const modelId = getLowerBaseModelName(model.id, '/')
+
+  // Exclude third-party models that might be deployed through Azure or other providers
+  // DeepSeek models use naming patterns like: deepseek-*, DeepSeek-*, *deepseek*
+  if (modelId.includes('deepseek')) {
+    return false
+  }
+
+  // Exclude other known third-party models that might be deployed through Azure
+  // but don't support the 'developer' role
+  const thirdPartyPatterns = ['llama', 'mistral', 'phi-', 'cohere', 'jamba']
+
+  if (thirdPartyPatterns.some((pattern) => modelId.includes(pattern))) {
+    return false
+  }
+
+  return true
+}
+
 const OPENAI_DEEP_RESEARCH_MODEL_REGEX = /deep[-_]?research/
 
 export function isOpenAIDeepResearchModel(model?: Model): boolean {


### PR DESCRIPTION
### What this PR does

**Before this PR:**
Using DeepSeek-R1 on Azure OpenAI with a system prompt causes a 422 error because the app sends `role: "developer"` which Azure's DeepSeek-R1 doesn't support.

**After this PR:**
Third-party models like DeepSeek-R1 now correctly use `role: "system"` instead of `"developer"`.

Fixes #12321

### Why we need it and why it was done in this way

The `developer` role is an OpenAI-specific feature only supported by their native reasoning models (o1, o3, o4, gpt-5 series). Third-party models deployed through Azure don't support it.

**Solution:** Added `isOpenAINativeDeveloperRoleModel()` to detect actual OpenAI reasoning models and exclude third-party models (DeepSeek, Llama, Mistral, etc.) from using the developer role.

**Alternatives considered:**
- Adding `azure-openai` to the blocklist — too broad, would break native OpenAI models on Azure
- Inline condition check — less maintainable, duplicated logic

### Breaking changes

None.

### Checklist

- [x] PR: The PR description is expressive enough
- [x] Code: Simple and readable solution
- [x] Refactor: Followed existing patterns

```release-note
fix: Azure OpenAI DeepSeek-R1 no longer returns 422 when using system prompts
```