### PR TITLE
fix: resolve ActionTranslate stalling after initialization

### DIFF
--- a/src/renderer/src/windows/selection/action/components/ActionTranslate.tsx
+++ b/src/renderer/src/windows/selection/action/components/ActionTranslate.tsx
@@ -115,7 +115,7 @@ const ActionTranslate: FC<Props> = ({ action, scrollToBottom }) => {
     // Initialize topic
     topicRef.current = getDefaultTopic(currentAssistant.id)
     setInitialized(true)
-  }, [action.selectedText, isLanguagesLoaded, updateLanguagePair])
+  }, [action.selectedText, initialized, isLanguagesLoaded, updateLanguagePair])
 
   // Try to initialize when:
   // 1. action.selectedText change (generally will not)


### PR DESCRIPTION
Issue: When invoking translate from the selection assistant, the fetchResult function does not react to the completion of initialize, causing the ActionTranslate component to enter an infinite loading state.

Cause: In commit 680bda3993ced26b028cdafbb61fadc5a4a70822, the initialize effect hook was refactored into a callback function. This refactor omitted the notification that fetchResult should run after initialization, so fetchResult never executes post‑initialization.

Fix: Change the initialized flag from a ref to a state variable and have fetchResult listen to this state. This modification ensures the effect hook triggers fetchResult exactly once after initialization is complete.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

⚠️ Important: Redux/IndexedDB Data-Changing Feature PRs Temporarily On Hold ⚠️

Please note: For our current development cycle, we are not accepting feature Pull Requests that introduce changes to Redux data models or IndexedDB schemas.

While we value your contributions, PRs of this nature will be blocked without merge. We welcome all other contributions (bug fixes, perf enhancements, docs, etc.). Thank you!

Once version 2.0.0 is released, we will resume reviewing feature PRs.

-->

### What this PR does

Before this PR: ActionTranslate stalling after initialization in v1.7.9, fetchResult function doesn't run after initialize.

After this PR: ActionTranslate ensure fetchResult triggered exactly once after initialize done.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

It was related to commit 680bda3993ced26b028cdafbb61fadc5a4a70822, after this commit, fetchResult function doesn't get notification after initialize done.

This will cause unstable behavior of ActionTranslate function, if fetchResult callback doesn't respond to initialize function, it won't be triggered correctly.

To fix issue, use initialized flag as an dependency for `fetchResult` callback, this will ensure `fetchResult` callback change after initialize done, ensure it triggered exactly once after init.

Since React do not allow ref as an dependency, need to change `initialized` flag from an ref to state.

The following alternatives were considered:

* As I checked, revert commit 680bda3993ced26b028cdafbb61fadc5a4a70822 from latest main branch also fix this issue.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

None

### Special notes for your reviewer

None

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors.
- [x] Code: This commit is only focus on fix issue, do not contain anything else.
- [x] Refactor: No refactor needed, only focus on fix issue.
- [x] Test: Function test good in local PC. Run `pnpm test` also passed in an local Ubuntu 24.04 environment.
- [x] Documentation: No document need update.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
fix: resolve selection assistant translate function stalling after initialization
```
