### PR TITLE
fix: disable differential package for nsis and dmg

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -96,6 +96,7 @@ nsis:
   oneClick: false
   include: build/nsis-installer.nsh
   buildUniversalInstaller: false
+  differentialPackage: false
 portable:
   artifactName: ${productName}-${version}-${arch}-portable.${ext}
   buildUniversalInstaller: false
@@ -111,6 +112,8 @@ mac:
   target:
     - target: dmg
     - target: zip
+dmg:
+  writeUpdateInfo: false
 linux:
   artifactName: ${productName}-${version}-${arch}.${ext}
   target:


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

github/gitcode目前都不支持多段http range请求，所以增量更新实现不了。直接可以disable blockmap的文件生成了，可以加快build包的速度。