### PR TITLE
fix: cot bug

### DIFF
--- a/src/renderer/src/aiCore/middleware/AiSdkMiddlewareBuilder.ts
+++ b/src/renderer/src/aiCore/middleware/AiSdkMiddlewareBuilder.ts
@@ -183,13 +183,12 @@ function addProviderSpecificMiddlewares(builder: AiSdkMiddlewareBuilder, config:
       break
     case 'openai':
     case 'azure-openai': {
-      if (config.enableReasoning) {
-        const tagName = getReasoningTagName(config.model?.id.toLowerCase())
-        builder.add({
-          name: 'thinking-tag-extraction',
-          middleware: extractReasoningMiddleware({ tagName })
-        })
-      }
+      // 就算这里不传参数也有可能调用推理
+      const tagName = getReasoningTagName(config.model?.id.toLowerCase())
+      builder.add({
+        name: 'thinking-tag-extraction',
+        middleware: extractReasoningMiddleware({ tagName })
+      })
       break
     }
     case 'gemini':


### PR DESCRIPTION
### What this PR does

Before this PR:
- The `thinking-tag-extraction` middleware was only added when `enableReasoning` was explicitly enabled
- When using Gemini models proxied through services like newapi (OpenAI-compatible API), the CoT (Chain of Thought) wrapped in `<thinking>` tags was output directly to the main text instead of being properly parsed

After this PR:
- The `thinking-tag-extraction` middleware is now always added for OpenAI/Azure-OpenAI providers
- CoT content wrapped in `<thinking>` tags is correctly extracted and displayed in the reasoning section, even when using proxied models

Fixes #12337

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Always applying the thinking-tag-extraction middleware may have a minor performance overhead, but it ensures compatibility with proxied reasoning models

The following alternatives were considered:
- Detecting proxy services automatically - rejected due to complexity and unreliability
- Adding a user setting to force reasoning extraction - rejected as it adds unnecessary configuration burden

### Breaking changes

None. This change is backward compatible.

### Special notes for your reviewer

The core change is removing the `if (config.enableReasoning)` condition, so the middleware is always applied for OpenAI-compatible providers. This handles the case where users access reasoning models (like Gemini) through proxy services that use the OpenAI API format.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
fix: correctly parse CoT chain of thought wrapped in <thinking> tags for proxied models
```