### PR TITLE
fix(Tray): set X11 window class and name to cherry-studio

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -75,6 +75,15 @@ if (isLinux && process.env.XDG_SESSION_TYPE === 'wayland') {
   app.commandLine.appendSwitch('enable-features', 'GlobalShortcutsPortal')
 }
 
+/**
+ * Set window class and name for X11
+ * This ensures the system tray and window manager identify the app correctly
+ */
+if (isLinux) {
+  app.commandLine.appendSwitch('class', 'cherry-studio')
+  app.commandLine.appendSwitch('name', 'cherry-studio')
+}
+
 // DocumentPolicyIncludeJSCallStacksInCrashReports: Enable features for unresponsive renderer js call stacks
 // EarlyEstablishGpuChannel,EstablishGpuChannelAsync: Enable features for early establish gpu channel
 // speed up the startup time


### PR DESCRIPTION
### What this PR does

Set window class and name for Linux X11 to ensure system tray and window manager identify the app correctly instead of using default 'electron' identifier.

Before this PR:

The X11 properties of the system tray icon are oriented from 'electron'
```
$ xwininfo -tree -id 0x1a00002
xwininfo: Window id: 0x1a00002 "polybar-primary_HDMI-0"
  Root window id: 0x21a (the root window) "i3"
  // others
        0x7000003 "electron": ("electron" "Electron")  21x21+0+0  +3746+80
```

Both the `WM_NAME` and `WM__CLASS` of the tray are not right.

After this PR:

```diff
$ xwininfo -tree -id 0x1a00002
xwininfo: Window id: 0x1a00002 "polybar-primary_HDMI-0"
  Root window id: 0x21a (the root window) "i3"
-        0x7000003 "electron": ("electron" "Electron")  21x21+0+0  +3746+80
+        0x6000003 "cherry-studio": ("cherry-studio" "cherry-studio")   21x21+0+0  +3746+80
```

### Why we need it and why it was done in this way

Setting the class and instance names correctly ensures the application is uniquely identifiable to the window manager, allowing users to apply specific rules (like custom icons, workspace assignments, or theming) without confusing it with other generic Electron apps.

`app.setName('CherryStudio')` fails to update the `WM_CLASS` because it only changes the internal JavaScript metadata of the application. It updates what the app "thinks" its name is, but it does not tell the X11 window server to change the window's identification properties.

On Linux (X11), the `WM_CLASS` is not derived from `app.setName()`. Instead, it is derived from one of two things:

1. The filename of the executable (e.g., if you run `./electron`, the class is `electron`).
2. Chromium Command Line Switches.

That's why we should use `app.commandLine` to force Chromium (which powers Electron) to override the class name before the application fully initializes.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [X] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

NONE
