### PR TITLE
fix(SelectionService): add macOS key code support for modifier key detection

### DIFF
--- a/src/main/services/SelectionService.ts
+++ b/src/main/services/SelectionService.ts
@@ -1083,18 +1083,33 @@ export class SelectionService {
     this.lastCtrlkeyDownTime = -1
   }
 
-  //check if the key is ctrl key
+  // Check if the key is ctrl key
+  // Windows: VK_LCONTROL(162), VK_RCONTROL(163)
+  // macOS: kVK_Control(59), kVK_RightControl(62)
   private isCtrlkey(vkCode: number) {
+    if (isMac) {
+      return vkCode === 59 || vkCode === 62
+    }
     return vkCode === 162 || vkCode === 163
   }
 
-  //check if the key is shift key
+  // Check if the key is shift key
+  // Windows: VK_LSHIFT(160), VK_RSHIFT(161)
+  // macOS: kVK_Shift(56), kVK_RightShift(60)
   private isShiftkey(vkCode: number) {
+    if (isMac) {
+      return vkCode === 56 || vkCode === 60
+    }
     return vkCode === 160 || vkCode === 161
   }
 
-  //check if the key is alt key
+  // Check if the key is alt/option key
+  // Windows: VK_LMENU(164), VK_RMENU(165)
+  // macOS: kVK_Option(58), kVK_RightOption(61)
   private isAltkey(vkCode: number) {
+    if (isMac) {
+      return vkCode === 58 || vkCode === 61
+    }
     return vkCode === 164 || vkCode === 165
   }
 


### PR DESCRIPTION
### What this PR does

Before this PR:
- The `isCtrlkey`, `isShiftkey`, and `isAltkey` methods in `SelectionService.ts` only checked Windows virtual key codes (VK_*), causing these functions to always return `false` on macOS.
- On macOS, the Ctrl key trigger mode did not work.
- On macOS, pressing Shift/Option keys would incorrectly hide the toolbar during text selection.

After this PR:
- Added platform-specific key code detection using `isMac` check.
- macOS modifier keys are now correctly detected using kVK_* key codes from HIToolbox/Events.h.
- The Selection Assistant works correctly on both Windows and macOS.

### Why we need it and why it was done in this way

According to the `selection-hook` library documentation, `vkCode` returns different values on different platforms:
- Windows: VK_* values
- macOS: kVK_* values (from HIToolbox/Events.h)

The key code mappings are:

| Key | Windows vkCode | macOS kVK |
|-----|----------------|-----------|
| Left Ctrl | 162 (VK_LCONTROL) | 59 (kVK_Control) |
| Right Ctrl | 163 (VK_RCONTROL) | 62 (kVK_RightControl) |
| Left Shift | 160 (VK_LSHIFT) | 56 (kVK_Shift) |
| Right Shift | 161 (VK_RSHIFT) | 60 (kVK_RightShift) |
| Left Alt/Option | 164 (VK_LMENU) | 58 (kVK_Option) |
| Right Alt/Option | 165 (VK_RMENU) | 61 (kVK_RightOption) |

The following tradeoffs were made:
- Used platform check (`isMac`) instead of combining all key codes in a single check, because macOS key codes 56-62 conflict with Windows character keys (e.g., '8', '9', ';', '=').

The following alternatives were considered:
- Combining all key codes without platform check was rejected due to key code conflicts between platforms.

### Breaking changes

None.

### Special notes for your reviewer

- The `isMac` constant is already imported at the top of the file.
- This fix is essential for the Selection Assistant feature to work on macOS.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required.

### Release note

```release-note
Fixed Selection Assistant modifier key detection on macOS (Ctrl key trigger mode and Shift/Option key handling)
```