### PR TITLE
refactor: streamline package management and filtering logic in before…

### DIFF
--- a/scripts/before-pack.js
+++ b/scripts/before-pack.js
@@ -8,40 +8,28 @@ const workspaceConfigPath = path.join(__dirname, '..', 'pnpm-workspace.yaml')
 
 // if you want to add new prebuild binaries packages with different architectures, you can add them here
 // please add to allX64 and allArm64 from pnpm-lock.yaml
-const allArm64 = {
-  '@img/sharp-darwin-arm64': '0.34.3',
-  '@img/sharp-win32-arm64': '0.34.3',
-  '@img/sharp-linux-arm64': '0.34.3',
-
-  '@img/sharp-libvips-darwin-arm64': '1.2.4',
-  '@img/sharp-libvips-linux-arm64': '1.2.4',
-
-  '@libsql/darwin-arm64': '0.4.7',
-  '@libsql/linux-arm64-gnu': '0.4.7',
-  '@strongtz/win32-arm64-msvc': '0.4.7',
-
-  '@napi-rs/system-ocr-darwin-arm64': '1.0.2',
-  '@napi-rs/system-ocr-win32-arm64-msvc': '1.0.2'
-}
-
-const allX64 = {
-  '@img/sharp-darwin-x64': '0.34.3',
-  '@img/sharp-linux-x64': '0.34.3',
-  '@img/sharp-win32-x64': '0.34.3',
-
-  '@img/sharp-libvips-darwin-x64': '1.2.0',
-  '@img/sharp-libvips-linux-x64': '1.2.0',
-
-  '@libsql/darwin-x64': '0.4.7',
-  '@libsql/linux-x64-gnu': '0.4.7',
-  '@libsql/win32-x64-msvc': '0.4.7',
-
-  '@napi-rs/system-ocr-darwin-x64': '1.0.2',
-  '@napi-rs/system-ocr-win32-x64-msvc': '1.0.2'
-}
-
-const claudeCodeVenderPath = '@anthropic-ai/claude-agent-sdk/vendor'
-const claudeCodeVenders = ['arm64-darwin', 'arm64-linux', 'x64-darwin', 'x64-linux', 'x64-win32']
+const packages = [
+  '@img/sharp-darwin-arm64',
+  '@img/sharp-darwin-x64',
+  '@img/sharp-linux-arm64',
+  '@img/sharp-linux-x64',
+  '@img/sharp-win32-arm64',
+  '@img/sharp-win32-x64',
+  '@img/sharp-libvips-darwin-arm64',
+  '@img/sharp-libvips-darwin-x64',
+  '@img/sharp-libvips-linux-arm64',
+  '@img/sharp-libvips-linux-x64',
+  '@libsql/darwin-arm64',
+  '@libsql/darwin-x64',
+  '@libsql/linux-arm64-gnu',
+  '@libsql/linux-x64-gnu',
+  '@libsql/win32-x64-msvc',
+  '@napi-rs/system-ocr-darwin-arm64',
+  '@napi-rs/system-ocr-darwin-x64',
+  '@napi-rs/system-ocr-win32-arm64-msvc',
+  '@napi-rs/system-ocr-win32-x64-msvc',
+  '@strongtz/win32-arm64-msvc'
+]
 
 const platformToArch = {
   mac: 'darwin',
@@ -50,33 +38,31 @@ const platformToArch = {
 }
 
 exports.default = async function (context) {
-  const arch = context.arch
-  const archType = arch === Arch.arm64 ? 'arm64' : 'x64'
-  const platform = context.packager.platform.name
+  const arch = context.arch === Arch.arm64 ? 'arm64' : 'x64'
+  const platformName = context.packager.platform.name
+  const platform = platformToArch[platformName]
 
   const downloadPackages = async () => {
-    const targetPlatform = platformToArch[platform]
-
     // Skip if target platform and architecture match current system
-    if (targetPlatform === process.platform && archType === process.arch) {
-      console.log(`Skipping install: target (${targetPlatform}/${archType}) matches current system`)
+    if (platform === process.platform && arch === process.arch) {
+      console.log(`Skipping install: target (${platform}/${arch}) matches current system`)
       return
     }
 
-    console.log(`Installing packages for target platform=${targetPlatform} arch=${archType}...`)
+    console.log(`Installing packages for target platform=${platform} arch=${arch}...`)
 
     // Backup and modify pnpm-workspace.yaml to add target platform support
     const originalWorkspaceConfig = fs.readFileSync(workspaceConfigPath, 'utf-8')
     const workspaceConfig = yaml.load(originalWorkspaceConfig)
 
     // Add target platform to supportedArchitectures.os
-    if (!workspaceConfig.supportedArchitectures.os.includes(targetPlatform)) {
-      workspaceConfig.supportedArchitectures.os.push(targetPlatform)
+    if (!workspaceConfig.supportedArchitectures.os.includes(platform)) {
+      workspaceConfig.supportedArchitectures.os.push(platform)
     }
 
     // Add target architecture to supportedArchitectures.cpu
-    if (!workspaceConfig.supportedArchitectures.cpu.includes(archType)) {
-      workspaceConfig.supportedArchitectures.cpu.push(archType)
+    if (!workspaceConfig.supportedArchitectures.cpu.includes(arch)) {
+      workspaceConfig.supportedArchitectures.cpu.push(arch)
     }
 
     const modifiedWorkspaceConfig = yaml.dump(workspaceConfig)
@@ -91,46 +77,41 @@ exports.default = async function (context) {
     }
   }
 
-  const changeFilters = async (filtersToExclude, filtersToInclude) => {
+  await downloadPackages()
+
+  const excludePackages = async (packagesToExclude) => {
     // remove filters for the target architecture (allow inclusion)
     let filters = context.packager.config.files[0].filter
-    filters = filters.filter((filter) => !filtersToInclude.includes(filter))
 
     // add filters for other architectures (exclude them)
-    filters.push(...filtersToExclude)
+    filters.push(...packagesToExclude)
 
     context.packager.config.files[0].filter = filters
   }
 
-  await downloadPackages()
+  const arm64KeepPackages = packages.filter((p) => p.includes('arm64') && p.includes(platform))
+  const arm64ExcludePackages = packages
+    .filter((p) => !arm64KeepPackages.includes(p))
+    .map((p) => '!node_modules/' + p + '/**')
 
-  const arm64Filters = Object.keys(allArm64).map((f) => '!node_modules/' + f + '/**')
-  const x64Filters = Object.keys(allX64).map((f) => '!node_modules/' + f + '/*')
+  const x64KeepPackages = packages.filter((p) => p.includes('x64') && p.includes(platform))
+  const x64ExcludePackages = packages
+    .filter((p) => !x64KeepPackages.includes(p))
+    .map((p) => '!node_modules/' + p + '/**')
 
-  // Determine which claudeCodeVenders to include
-  // For Windows ARM64, also include x64-win32 for compatibility
-  const includedClaudeCodeVenders = [`${archType}-${platformToArch[platform]}`]
-  if (platform === 'windows' && arch === Arch.arm64) {
-    includedClaudeCodeVenders.push('x64-win32')
-  }
+  const excludeRipgrepFilters = ['arm64-darwin', 'arm64-linux', 'x64-darwin', 'x64-linux', 'x64-win32']
+    .filter((f) => {
+      // On Windows ARM64, also keep x64-win32 for emulation compatibility
+      if (platform === 'win32' && context.arch === Arch.arm64 && f === 'x64-win32') {
+        return false
+      }
+      return f !== `${arch}-${platform}`
+    })
+    .map((f) => '!node_modules/@anthropic-ai/claude-agent-sdk/vendor/ripgrep/' + f + '/**')
 
-  const excludeClaudeCodeRipgrepFilters = claudeCodeVenders
-    .filter((f) => !includedClaudeCodeVenders.includes(f))
-    .map((f) => '!node_modules/' + claudeCodeVenderPath + '/ripgrep/' + f + '/**')
-
-  const includeClaudeCodeFilters = includedClaudeCodeVenders.map(
-    (f) => '!node_modules/' + claudeCodeVenderPath + '/ripgrep/' + f + '/**'
-  )
-
-  if (arch === Arch.arm64) {
-    await changeFilters(
-      [...x64Filters, ...excludeClaudeCodeRipgrepFilters],
-      [...arm64Filters, ...includeClaudeCodeFilters]
-    )
+  if (context.arch === Arch.arm64) {
+    await excludePackages([...arm64ExcludePackages, ...excludeRipgrepFilters])
   } else {
-    await changeFilters(
-      [...arm64Filters, ...excludeClaudeCodeRipgrepFilters],
-      [...x64Filters, ...includeClaudeCodeFilters]
-    )
+    await excludePackages([...x64ExcludePackages, ...excludeRipgrepFilters])
   }
 }


### PR DESCRIPTION
简化了一下配置

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies build-time package management and filtering in `scripts/before-pack.js`.
> 
> - Replace per-arch maps with a single `packages` list; derive include/exclude patterns dynamically
> - Normalize `arch`/`platform` resolution and skip `pnpm install` when target matches host
> - Temporarily extend `pnpm-workspace.yaml` `supportedArchitectures` during install, then restore
> - Consolidate filter logic into `excludePackages`; compute arm64/x64 exclusions based on target platform
> - Streamline `@anthropic-ai/claude-agent-sdk` ripgrep exclusions with Windows ARM64 `x64-win32` compatibility exception
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8f382202685036a1c56512261256ba8f7810e0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->