### PR TITLE
fix(workflows): add pnpm installing and caching

### DIFF
--- a/.github/workflows/github-issue-tracker.yml
+++ b/.github/workflows/github-issue-tracker.yml
@@ -58,6 +58,22 @@ jobs:
         with:
           node-version: 22
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+      - name: Cache pnpm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
       - name: Install dependencies
         if: steps.check_time.outputs.should_delay == 'false'
         run: pnpm install


### PR DESCRIPTION
### What this PR does

Before this PR:
- GitHub issue tracker workflow 缺少 pnpm 安装步骤，导致 `pnpm install` 命令执行失败

After this PR:
- 添加了 pnpm 安装步骤（使用 `pnpm/action-setup@v4`）
- 添加了 pnpm 依赖缓存配置，优化 CI 执行速度

Fixes #

### Why we need it and why it was done in this way

该 workflow 在执行 `pnpm install` 时会失败，因为运行环境中没有预先安装 pnpm。

The following tradeoffs were made:
- 使用官方 `pnpm/action-setup@v4` action 确保稳定性和兼容性
- 添加了缓存机制以提高后续 workflow 执行效率

The following alternatives were considered:
- 使用 `npm install -g pnpm` 手动安装，但官方 action 更可靠且提供更好的版本管理

Links to places where the discussion took place: N/A

### Breaking changes

无破坏性改动

### Special notes for your reviewer

这是一个纯粹的 CI/CD 配置修复，不涉及任何业务逻辑或数据模型变更。

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
NONE
```