### PR TITLE
fix(mcp): 修复 MCP 配置 timeout 字段不支持字符串类型的问题

### DIFF
--- a/src/renderer/src/types/mcp.ts
+++ b/src/renderer/src/types/mcp.ts
@@ -123,7 +123,15 @@ export const McpServerConfigSchema = z
      * 请求超时时间
      * 可选。单位为秒，默认为60秒。
      */
-    timeout: z.number().optional().describe('Timeout in seconds for requests to this server'),
+    timeout: z
+      .preprocess((val) => {
+        if (typeof val === 'string' && val.trim() !== '') {
+          const parsed = Number(val)
+          return isNaN(parsed) ? val : parsed
+        }
+        return val
+      }, z.number().optional())
+      .describe('Timeout in seconds for requests to this server'),
     /**
      * DXT包版本号
      * 可选。用于标识DXT包的版本。


### PR DESCRIPTION
**问题原因 / Motivation**
用户在编辑 MCP 配置时，如果在 JSON 配置中为 `timeout` 字段输入了字符串类型的数字（例如 `"timeout": "600"`），保存时会因为类型校验失败（Expect number, received string）而报错。

**更改内容 / Modification**
修改了 `src/renderer/src/types/mcp.ts` 中的 `McpServerConfigSchema`：
- 为 `timeout` 字段添加了 `z.preprocess` 预处理逻辑。
- 自动将非空的字符串类型的数字转换为 `number` 类型，从而兼容字符串输入。

**测试说明 / Testing**
- [x] 手动验证：在配置中输入字符串格式的超时时间（如 `"600"`），可以成功保存并被解析为数字 `600`。
- [x] 验证非数字字符串仍然会被拦截。