### PR TITLE
fix(aiCore): only apply sendReasoning for openai-compatible SDK providers

### DIFF
--- a/src/renderer/src/aiCore/utils/options.ts
+++ b/src/renderer/src/aiCore/utils/options.ts
@@ -3,7 +3,7 @@ import { type AnthropicProviderOptions } from '@ai-sdk/anthropic'
 import type { GoogleGenerativeAIProviderOptions } from '@ai-sdk/google'
 import type { OpenAIResponsesProviderOptions } from '@ai-sdk/openai'
 import type { XaiProviderOptions } from '@ai-sdk/xai'
-import { baseProviderIdSchema, customProviderIdSchema } from '@cherrystudio/ai-core/provider'
+import { baseProviderIdSchema, customProviderIdSchema, hasProviderConfig } from '@cherrystudio/ai-core/provider'
 import { loggerService } from '@logger'
 import {
   getModelSupportedVerbosity,
@@ -616,9 +616,14 @@ function buildGenericProviderOptions(
   }
   if (enableReasoning) {
     if (isInterleavedThinkingModel(model)) {
-      providerOptions = {
-        ...providerOptions,
-        sendReasoning: true
+      // sendReasoning is a patch specific to @ai-sdk/openai-compatible
+      // Only apply when provider will actually use openai-compatible SDK
+      // (i.e., no dedicated SDK registered OR explicitly openai-compatible)
+      if (!hasProviderConfig(providerId) || providerId === 'openai-compatible') {
+        providerOptions = {
+          ...providerOptions,
+          sendReasoning: true
+        }
       }
     }
   }


### PR DESCRIPTION
### What this PR does

Before this PR:
`sendReasoning: true` was incorrectly applied to ALL providers in `buildGenericProviderOptions`, including those with dedicated SDK packages (e.g., cerebras, deepseek, openrouter).

After this PR:
`sendReasoning: true` is only applied when the provider will actually use the `openai-compatible` SDK:
- No dedicated SDK registered (`!hasProviderConfig(providerId)`)
- OR explicitly openai-compatible (`providerId === 'openai-compatible'`)

Fixes #12382

### Why we need it and why it was done in this way

`sendReasoning` is a patch specific to `@ai-sdk/openai-compatible` package. Providers with dedicated SDK packages (like `cerebras` → `@ai-sdk/cerebras`) don't support this option.

The following tradeoffs were made:
- Used `hasProviderConfig()` to check if a dedicated SDK exists, which mirrors the logic in `providerToAiSdkConfig` (providerConfig.ts:276-294)

The following alternatives were considered:
- Hardcoding a list of providers that use `openai-compatible` - rejected because it would require maintenance when new providers are added
- Using `hasProviderConfig()` is more maintainable as it automatically reflects the registered SDK configurations

### Breaking changes

None. This is a bug fix that prevents incorrect options from being passed to providers.

### Special notes for your reviewer

The fix aligns with the existing logic in `providerToAiSdkConfig`:
```typescript
if (hasProviderConfig(aiSdkProviderId) && aiSdkProviderId !== 'openai-compatible') {
  // Use dedicated SDK
} else {
  // Fallback to openai-compatible
}
```

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: Not required - internal bug fix

```release-note
fix: only apply sendReasoning option for providers using openai-compatible SDK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)