### PR TITLE
ci(workflows): fix pnpm installation and improve issue tracker

### DIFF
--- a/.github/workflows/github-issue-tracker.yml
+++ b/.github/workflows/github-issue-tracker.yml
@@ -111,8 +111,7 @@ jobs:
                - 重要的技术细节
 
             2. **发送飞书通知**
-               使用CLI工具发送飞书通知，运行 `pnpm tsx scripts/feishu-notify.ts issue --help` 查看参数说明。
-               示例：
+               使用CLI工具发送飞书通知，参考以下示例：
                ```bash
                pnpm tsx scripts/feishu-notify.ts issue \
                  -u "${{ github.event.issue.html_url }}" \
@@ -198,8 +197,7 @@ jobs:
                - 重要的技术细节
 
             3. **发送飞书通知**
-               使用CLI工具发送飞书通知，运行 `pnpm tsx scripts/feishu-notify.ts issue --help` 查看参数说明。
-               示例：
+               使用CLI工具发送飞书通知，参考以下示例：
                ```bash
                pnpm tsx scripts/feishu-notify.ts issue \
                  -u "<issue的html_url>" \


### PR DESCRIPTION
### What this PR does

Before this PR:
- The `process-pending-issues` job was missing pnpm installation step
- Both jobs used unstable `claude-code-action@main` version
- The workflow contained `--help` flags in `claude_args` and prompts, triggering an **upstream bug** in claude-code-action
- Issue body was passed directly without formatting

After this PR:
- ✅ Added pnpm installation with caching for `process-pending-issues` job
- ✅ Unified both jobs to use stable `claude-code-action@v1`
- ✅ **Fixed the root cause**: Removed `--help` from `claude_args` and prompts to avoid upstream parsing bug
- ✅ Improved issue body formatting with markdown code blocks

Fixes #

### Why we need it and why it was done in this way

**Problem**: The workflow was experiencing JSON parsing errors:
```
SyntaxError: JSON Parse error: Unexpected identifier "Usage"
  at withSlowLogging (sdk.mjs:7275:12)
```

**Root Cause Identified** (by Anthropic engineers):
- The `--help` strings in our `claude_args` and prompts were being incorrectly interpreted as actual CLI arguments
- This caused `claude --help` to execute, outputting "Usage..." text
- The SDK tried to parse this help text as JSON, causing the error
- **This is a confirmed upstream bug**: https://github.com/anthropics/claude-code-action/issues/806#issuecomment-3727437897

**Our Solution**:
1. **Removed `--help` from allowed-tools** - Changed from explicit patterns like:
   ```yaml
   Bash(pnpm tsx scripts/feishu-notify.ts --help),Bash(pnpm tsx scripts/feishu-notify.ts issue --help)
   ```
   to wildcard pattern:
   ```yaml
   Bash(pnpm tsx scripts/feishu-notify.ts*)
   ```
   This still allows Claude to run help commands but avoids triggering the parser bug.

2. **Removed `--help` references from prompts** - The example commands are comprehensive enough without mentioning help flags.

3. **Added missing pnpm setup** - Required for running TypeScript notification scripts in the second job.

4. **Switched to v1 stable release** - Best practice for GitHub Actions to avoid unexpected breaking changes from main branch.

The following tradeoffs were made:
- Slightly broader tool permissions (wildcard `*` instead of specific patterns), but this is safe as it's our internal script

The following alternatives were considered:
- Keep using explicit `--help` patterns: Rejected due to upstream bug
- Quote/escape `--help`: Would not work as the bug is in argument parsing logic
- Wait for upstream fix: Too slow, this is blocking our workflows

Links to places where the discussion took place:
- Upstream bug report: https://github.com/anthropics/claude-code-action/issues/806#issuecomment-3727437897

### Breaking changes

None. This is a CI/CD workflow improvement that doesn't affect application functionality.

### Special notes for your reviewer

**Critical**: This PR needs to be merged to test the fix, as the workflow only runs on the main branch for real issues.

**What we fixed**:
1. ✅ Removed the trigger for the upstream bug (`--help` in args/prompts)
2. ✅ Added missing dependencies (pnpm setup)
3. ✅ Improved stability (v1 instead of main)

**Testing**: Once merged, the next issue creation will validate if our workaround resolves the JSON parsing errors.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required

### Release note

```release-note
NONE
```