### PR TITLE
fix: restore patch for claude-agent-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -453,7 +453,8 @@
       "file-stream-rotator@0.6.1": "patches/file-stream-rotator-npm-0.6.1-eab45fb13d.patch",
       "libsql@0.4.7": "patches/libsql-npm-0.4.7-444e260fb1.patch",
       "pdf-parse@1.1.1": "patches/pdf-parse-npm-1.1.1-04a6109b2a.patch",
-      "@ai-sdk/openai-compatible@1.0.28": "patches/@ai-sdk-openai-compatible-npm-1.0.28-5705188855.patch"
+      "@ai-sdk/openai-compatible@1.0.28": "patches/@ai-sdk-openai-compatible-npm-1.0.28-5705188855.patch",
+      "@anthropic-ai/claude-agent-sdk@0.1.76": "patches/@anthropic-ai__claude-agent-sdk@0.1.76.patch"
     },
     "onlyBuiltDependencies": [
       "@kangfenmao/keyv-storage",

--- a/patches/@anthropic-ai__claude-agent-sdk@0.1.76.patch
+++ b/patches/@anthropic-ai__claude-agent-sdk@0.1.76.patch
@@ -1,0 +1,33 @@
+diff --git a/sdk.mjs b/sdk.mjs
+index 1e1c3e4e3f81db622fb2789d17f3d421f212306e..5d193cdb6a43c7799fd5eff2d8af80827bfbdf1e 100755
+--- a/sdk.mjs
++++ b/sdk.mjs
+@@ -11985,7 +11985,7 @@ function createAbortController(maxListeners = DEFAULT_MAX_LISTENERS) {
+ }
+ 
+ // ../src/transport/ProcessTransport.ts
+-import { spawn } from "child_process";
++import { fork } from "child_process";
+ import { createInterface } from "readline";
+ 
+ // ../src/utils/fsOperations.ts
+@@ -12999,14 +12999,14 @@ class ProcessTransport {
+     return isRunningWithBun() ? "bun" : "node";
+   }
+   spawnLocalProcess(spawnOptions) {
+-    const { command, args, cwd: cwd2, env, signal } = spawnOptions;
++    const { args, cwd: cwd2, env, signal } = spawnOptions;
+     const stderrMode = env.DEBUG_CLAUDE_AGENT_SDK || this.options.stderr ? "pipe" : "ignore";
+-    const childProcess = spawn(command, args, {
++    logForSdkDebugging(`Forking Claude Code Node.js process: ${args[0]} ${args.slice(1).join(" ")}`);
++    const childProcess = fork(args[0], args.slice(1), {
+       cwd: cwd2,
+-      stdio: ["pipe", "pipe", stderrMode],
++      stdio: stderrMode === "pipe" ? ["pipe", "pipe", "pipe", "ipc"] : ["pipe", "pipe", "ignore", "ipc"],
+       signal,
+-      env,
+-      windowsHide: true
++      env
+     });
+     if (env.DEBUG_CLAUDE_AGENT_SDK || this.options.stderr) {
+       childProcess.stderr.on("data", (data) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ patchedDependencies:
   '@ai-sdk/openai@2.0.85':
     hash: f2077f4759520d1de69b164dfd8adca1a9ace9de667e35cb0e55e812ce2ac13b
     path: patches/@ai-sdk-openai-npm-2.0.85-27483d1d6a.patch
+  '@anthropic-ai/claude-agent-sdk@0.1.76':
+    hash: e063a8ede82d78f452f7f1290b9d4d9323866159b5624679163caa8edd4928d5
+    path: patches/@anthropic-ai__claude-agent-sdk@0.1.76.patch
   '@anthropic-ai/vertex-sdk@0.11.4':
     hash: 12e3275df5632dfe717d4db64df70e9b0128dfac86195da27722effe4749662f
     path: patches/@anthropic-ai-vertex-sdk-npm-0.11.4-c19cb41edb.patch
@@ -86,7 +89,7 @@ importers:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
         specifier: 0.1.76
-        version: 0.1.76(zod@4.3.4)
+        version: 0.1.76(patch_hash=e063a8ede82d78f452f7f1290b9d4d9323866159b5624679163caa8edd4928d5)(zod@4.3.4)
       '@libsql/client':
         specifier: 0.14.0
         version: 0.14.0
@@ -12573,7 +12576,7 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.0.2
 
-  '@anthropic-ai/claude-agent-sdk@0.1.76(zod@4.3.4)':
+  '@anthropic-ai/claude-agent-sdk@0.1.76(patch_hash=e063a8ede82d78f452f7f1290b9d4d9323866159b5624679163caa8edd4928d5)(zod@4.3.4)':
     dependencies:
       zod: 4.3.4
     optionalDependencies:


### PR DESCRIPTION
### What this PR does

Before this PR:
- Claude Agent SDK 0.1.76 uses `spawn` to run the CLI process, which requires `node` to be available in the system PATH
- Users without Node.js installed get error: `spawn node ENOENT`

After this PR:
- Restores the patch that was removed in #12317 when upgrading SDK from 0.1.62 to 0.1.76
- Uses `fork` instead of `spawn` to run the CLI process
- `fork` automatically uses Electron's built-in Node.js runtime (`process.execPath`), no system `node` required

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Patch approach vs `spawnClaudeCodeProcess` option: Patch is simpler and matches the previous working solution

The following alternatives were considered:
- Using SDK's `spawnClaudeCodeProcess` option to customize process spawning - this is a quick fix for now, may migrate to this approach in the future

### Breaking changes

None

### Special notes for your reviewer

This patch is functionally equivalent to the previous 0.1.62 patch, adapted for the new SDK architecture where process spawning logic moved to `spawnLocalProcess` method.

Key changes in patch:
1. `import { spawn }` → `import { fork }`
2. `fork(args[0], args.slice(1), ...)` instead of `spawn(command, args, ...)`
3. stdio adds `ipc` channel for Node.js IPC communication

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: Not required

### Release note

```release-note
fix: restore patch for claude-agent-sdk to fix "spawn node ENOENT" error when Node.js is not installed
```

🤖 Generated with [Claude Code](https://claude.ai/code)