### PR TITLE
fix: keep dock icon visible on close on macOS

### DIFF
--- a/src/main/services/WindowService.ts
+++ b/src/main/services/WindowService.ts
@@ -380,17 +380,6 @@ export class WindowService {
       }
 
       mainWindow.hide()
-
-      //for mac users, should hide dock icon if close to tray
-      if (isMac && isTrayOnClose) {
-        app.dock?.hide()
-
-        mainWindow.once('show', () => {
-          //restore the window can hide by cmd+h when the window is shown again
-          // https://github.com/electron/electron/pull/47970
-          app.dock?.show()
-        })
-      }
     })
 
     mainWindow.on('closed', () => {


### PR DESCRIPTION
### What this PR does

  Before this PR:
  - On macOS, clicking the red close button hides the window and also hides the Dock icon (app appears closed).

  After this PR:
  - On macOS, clicking the red close button hides the window but keeps the Dock icon visible (matches common macOS
  behavior).

  <!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR
  gets merged)*: -->

  Fixes # (issue to be filed)

  ### Why we need it and why it was done in this way

  The following tradeoffs were made:
  - Keeps current behavior on Windows/Linux; only changes macOS Dock visibility.

  The following alternatives were considered:
  - Keep current behavior (confusing for macOS users).
  - Add a setting toggle (extra UI not needed for a platform convention).

  Links to places where the discussion took place: N/A

  ### Breaking changes

  None.

  ### Special notes for your reviewer

  - Tests: `pnpm lint`, `pnpm test`

  ### Checklist

  This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
  Approvers are expected to review this list.

  - [ ] PR: The PR description is expressive enough and will help future contributors
  - [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans)
  and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
  - [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/
  library/view/97-things-every/9780596809515/ch08.html)
  - [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
  - [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or
  not required. You want a user-guide update if it's a user facing feature.

  ### Release note

  ```release-note
  NONE