### PR TITLE
fix: switch to new URL in qwen miniapp

### DIFF
--- a/src/renderer/src/config/minapps.ts
+++ b/src/renderer/src/config/minapps.ts
@@ -145,7 +145,7 @@ const ORIGIN_DEFAULT_MIN_APPS: MinAppType[] = [
   {
     id: 'dashscope',
     name: i18n.t('minapps.qwen'),
-    url: 'https://www.tongyi.com/',
+    url: 'https://www.qianwen.com',
     logo: QwenModelLogo
   },
   {
@@ -328,9 +328,9 @@ const ORIGIN_DEFAULT_MIN_APPS: MinAppType[] = [
   },
   {
     id: 'qwenlm',
-    name: 'QwenLM',
+    name: 'QwenChat',
     logo: QwenlmAppLogo,
-    url: 'https://qwenlm.ai/'
+    url: 'https://chat.qwen.ai'
   },
   {
     id: 'flowith',


### PR DESCRIPTION
### What this PR does

Before this PR: Qwen miniapp use old urls

After this PR: Switch to new urls

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
NONE
```
