### PR TITLE
feat(scrollbar): expand scrollbar on hover with visual enhancements

### DIFF
--- a/src/renderer/src/components/Scrollbar/index.tsx
+++ b/src/renderer/src/components/Scrollbar/index.tsx
@@ -8,8 +8,12 @@ export interface ScrollbarProps extends Omit<React.HTMLAttributes<HTMLDivElement
   onScroll?: () => void // Custom onScroll prop for useScrollPosition's handleScroll
 }
 
+const SCROLLBAR_HOVER_ZONE = 16 // 检测区域稍大一些，提升体验
+
 const Scrollbar: FC<ScrollbarProps> = ({ ref: passedRef, children, onScroll: externalOnScroll, ...htmlProps }) => {
   const [isScrolling, setIsScrolling] = useState(false)
+  const [isHoveringScrollbar, setIsHoveringScrollbar] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
 
   const clearScrollingTimeout = useCallback(() => {
@@ -41,6 +45,22 @@ const Scrollbar: FC<ScrollbarProps> = ({ ref: passedRef, children, onScroll: ext
     }
   }, [throttledInternalScrollHandler, externalOnScroll])
 
+  // 检测鼠标是否在滚动条区域
+  const handleMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const container = containerRef.current
+    if (!container) return
+
+    const rect = container.getBoundingClientRect()
+    const distanceFromRight = rect.right - e.clientX
+    const hasScrollbar = container.scrollHeight > container.clientHeight
+
+    setIsHoveringScrollbar(hasScrollbar && distanceFromRight <= SCROLLBAR_HOVER_ZONE)
+  }, [])
+
+  const handleMouseLeave = useCallback(() => {
+    setIsHoveringScrollbar(false)
+  }, [])
+
   useEffect(() => {
     return () => {
       clearScrollingTimeout()
@@ -48,24 +68,71 @@ const Scrollbar: FC<ScrollbarProps> = ({ ref: passedRef, children, onScroll: ext
     }
   }, [throttledInternalScrollHandler, clearScrollingTimeout])
 
+  // 合并 ref
+  const setRefs = useCallback(
+    (node: HTMLDivElement | null) => {
+      containerRef.current = node
+      if (typeof passedRef === 'function') {
+        passedRef(node)
+      } else if (passedRef && 'current' in passedRef) {
+        passedRef.current = node
+      }
+    },
+    [passedRef]
+  )
+
   return (
     <ScrollBarContainer
-      {...htmlProps} // Pass other HTML attributes
+      {...htmlProps}
       $isScrolling={isScrolling}
-      onScroll={combinedOnScroll} // Use the combined handler
-      ref={passedRef}>
+      $isHoveringScrollbar={isHoveringScrollbar}
+      className={`${htmlProps.className || ''} ${isHoveringScrollbar ? 'scrollbar-hover' : ''}`.trim()}
+      onScroll={combinedOnScroll}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
+      ref={setRefs}>
       {children}
     </ScrollBarContainer>
   )
 }
 
-const ScrollBarContainer = styled.div<{ $isScrolling: boolean }>`
+const ScrollBarContainer = styled.div<{ $isScrolling: boolean; $isHoveringScrollbar: boolean }>`
   overflow-y: auto;
+
+  &::-webkit-scrollbar {
+    width: var(--scrollbar-width);
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
   &::-webkit-scrollbar-thumb {
-    transition: background 2s ease;
     background: ${(props) => (props.$isScrolling ? 'var(--color-scrollbar-thumb)' : 'transparent')};
+    border-radius: var(--scrollbar-thumb-radius);
     &:hover {
       background: var(--color-scrollbar-thumb-hover);
+    }
+  }
+
+  &.scrollbar-hover {
+    &::-webkit-scrollbar {
+      width: calc(2 * var(--scrollbar-width));
+    }
+
+    &::-webkit-scrollbar-track {
+      background: var(--color-background-soft);
+      border-left: 1px solid var(--color-border);
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: var(--color-scrollbar-thumb);
+      background-clip: padding-box;
+      border-left: calc(var(--scrollbar-width) / 2) solid transparent;
+      &:hover {
+        background: var(--color-scrollbar-thumb-hover);
+        background-clip: padding-box;
+      }
     }
   }
 `


### PR DESCRIPTION
### What this PR does

Before this PR:
- Scrollbar is always the same width (6px)
- Scrollbar thumb only appears when scrolling
- No visual distinction for the scrollbar area

After this PR:
- Scrollbar expands to 2x width when hovering over the scrollbar area
- Shows a background color and left border on the track when hovered
- Thumb is always visible when hovering, with padding from the left border
- Uses JavaScript to detect when mouse is within 16px of the right edge (scrollbar zone)

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Used JavaScript mouse position detection instead of pure CSS because `::-webkit-scrollbar:hover` cannot trigger styles on sibling pseudo-elements (track/thumb)
- Added a CSS class toggle (`scrollbar-hover`) instead of styled-components props for the width change, as webkit scrollbar pseudo-elements don't respond well to dynamic prop changes

The following alternatives were considered:
- Pure CSS with `:hover` on the container - rejected because it would trigger on the entire container, not just the scrollbar area
- CSS custom properties for dynamic width - tested but webkit scrollbar didn't respond to CSS variable changes properly

### Breaking changes

None. This is a visual enhancement that doesn't change the component's API.

### Special notes for your reviewer

- The `SCROLLBAR_HOVER_ZONE` constant (16px) defines how close the mouse needs to be to the right edge to trigger the hover state
- Uses `background-clip: padding-box` with transparent border to create padding effect on the thumb

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
Scrollbar now expands with visual enhancements (background, border) when hovering over the scrollbar area
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)