### PR TITLE
feat: add n1n.ai provider preset

### DIFF
--- a/src/renderer/src/config/models/default.ts
+++ b/src/renderer/src/config/models/default.ts
@@ -238,6 +238,26 @@ export const SYSTEM_MODELS: Record<SystemProviderId | 'defaultModel', Model[]> =
       group: 'llama'
     }
   ],
+  n1n: [
+    {
+      id: 'claude-3-5-sonnet-20240620',
+      name: 'Claude 3.5 Sonnet',
+      provider: 'n1n',
+      group: 'Anthropic'
+    },
+    {
+      id: 'gpt-4o',
+      name: 'GPT-4o',
+      provider: 'n1n',
+      group: 'OpenAI'
+    },
+    {
+      id: 'gemini-1.5-pro-latest',
+      name: 'Gemini 1.5 Pro',
+      provider: 'n1n',
+      group: 'Gemini'
+    }
+  ],
 
   burncloud: [
     { id: 'claude-opus-4-5-20251101', provider: 'burncloud', name: 'Claude 4.5 Opus', group: 'Claude 4.5' },

--- a/src/renderer/src/config/providers.ts
+++ b/src/renderer/src/config/providers.ts
@@ -60,6 +60,7 @@ import VoyageAIProviderLogo from '@renderer/assets/images/providers/voyageai.png
 import XirangProviderLogo from '@renderer/assets/images/providers/xirang.png'
 import ZeroOneProviderLogo from '@renderer/assets/images/providers/zero-one.png'
 import ZhipuProviderLogo from '@renderer/assets/images/providers/zhipu.png'
+import N1NProviderLogo from '@renderer/assets/images/providers/openai.png'
 import type { AtLeast, SystemProvider, SystemProviderId } from '@renderer/types'
 import { OpenAIServiceTiers } from '@renderer/types'
 
@@ -709,6 +710,17 @@ export const SYSTEM_PROVIDERS_CONFIG: Record<SystemProviderId, SystemProvider> =
     models: SYSTEM_MODELS.mimo,
     isSystem: true,
     enabled: false
+  },
+  n1n: {
+    id: 'n1n',
+    name: 'n1n.ai',
+    type: 'openai',
+    apiKey: '',
+    apiHost: 'https://api.n1n.ai/v1',
+    anthropicApiHost: 'https://api.n1n.ai/v1',
+    models: SYSTEM_MODELS.n1n,
+    isSystem: true,
+    enabled: false
   }
 } as const
 
@@ -778,7 +790,8 @@ export const PROVIDER_LOGO_MAP: AtLeast<SystemProviderId, string> = {
   sophnet: SophnetProviderLogo,
   gateway: AIGatewayProviderLogo,
   cerebras: CerebrasProviderLogo,
-  mimo: MiMoProviderLogo
+  mimo: MiMoProviderLogo,
+  n1n: N1NProviderLogo
 } as const
 
 export function getProviderLogo(providerId: string) {

--- a/src/renderer/src/types/provider.ts
+++ b/src/renderer/src/types/provider.ts
@@ -199,7 +199,8 @@ export const SystemProviderIdSchema = z.enum([
   'sophnet',
   'gateway',
   'cerebras',
-  'mimo'
+  'mimo',
+  'n1n'
 ])
 
 export type SystemProviderId = z.infer<typeof SystemProviderIdSchema>
@@ -269,7 +270,8 @@ export const SystemProviderIds = {
   huggingface: 'huggingface',
   gateway: 'gateway',
   cerebras: 'cerebras',
-  mimo: 'mimo'
+  mimo: 'mimo',
+  n1n: 'n1n'
 } as const satisfies Record<SystemProviderId, SystemProviderId>
 
 type SystemProviderIdTypeMap = typeof SystemProviderIds


### PR DESCRIPTION
This PR adds n1n.ai as a system provider.

Changes:
- Added `n1n` to provider types.
- Registered `n1n` in default models configuration.
- Added `n1n` provider configuration in providers list.

