### PR TITLE
fix(linux): fix main window not coming to front when clicked from tray

### DIFF
--- a/src/main/services/WindowService.ts
+++ b/src/main/services/WindowService.ts
@@ -416,6 +416,23 @@ export class WindowService {
       }
 
       /**
+       * [Linux] Special handling for window activation
+       * When the window is visible but covered by other windows, simply calling show() and focus()
+       * is not enough to bring it to the front. We need to hide it first, then show it again.
+       * This mimics the "close to tray and reopen" behavior which works correctly.
+       */
+      if (isLinux && this.mainWindow.isVisible() && !this.mainWindow.isFocused()) {
+        this.mainWindow.hide()
+        setImmediate(() => {
+          if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+            this.mainWindow.show()
+            this.mainWindow.focus()
+          }
+        })
+        return
+      }
+
+      /**
        * About setVisibleOnAllWorkspaces
        *
        * [macOS] Known Issue


### PR DESCRIPTION
When clicking the tray icon on Linux with another window on top, the main window would not properly come to the front. This was due to Linux window managers' focus stealing prevention.

The fix uses a hide/show sequence to simulate the "close to tray and reopen" behavior which works correctly. This approach resets the window state and makes the window manager treat it as a new window activation request.

