### PR TITLE
feat(import): add Claude conversation importer

### DIFF
--- a/src/renderer/src/components/Popups/ImportPopup.tsx
+++ b/src/renderer/src/components/Popups/ImportPopup.tsx
@@ -68,16 +68,19 @@ const PopupContainer: React.FC<Props> = ({ resolve, initialSource }) => {
 
     logger.info('Found files', { count: filePaths?.length, sample: filePaths?.slice(0, 5) })
 
+    // Helper: check for absolute path on both Unix and Windows
+    const isAbsolutePath = (p: string) => p.startsWith('/') || /^[A-Za-z]:/.test(p)
+
     // Log any non-absolute paths for debugging
-    const invalidPaths = (filePaths || []).filter((p: string) => !p.startsWith('/'))
+    const invalidPaths = (filePaths || []).filter((p: string) => !isAbsolutePath(p))
     if (invalidPaths.length > 0) {
       logger.warn('Found non-absolute paths', { count: invalidPaths.length, sample: invalidPaths.slice(0, 5) })
     }
 
     // Filter to only JSON files (exclude summary files and artifacts folders)
     const jsonFilePaths = (filePaths || []).filter((filePath: string) => {
-      // Must be an absolute path (starts with /)
-      if (!filePath.startsWith('/')) return false
+      // Must be an absolute path (Unix: /... or Windows: C:/...)
+      if (!isAbsolutePath(filePath)) return false
       const fileName = filePath.split('/').pop() || ''
       const isJson = fileName.endsWith('.json')
       const isNotSummary = fileName !== '.json' // Exclude summary file at root

--- a/src/renderer/src/components/Popups/ImportPopup.tsx
+++ b/src/renderer/src/components/Popups/ImportPopup.tsx
@@ -1,9 +1,14 @@
-import { importChatGPTConversations } from '@renderer/services/import'
-import { Alert, Modal, Progress, Space, Spin } from 'antd'
+import { loggerService } from '@logger'
+import { ImportService } from '@renderer/services/import'
+import { Alert, Checkbox, Modal, Progress, Radio, Space, Spin } from 'antd'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { TopView } from '../TopView'
+
+const logger = loggerService.withContext('ImportPopup')
+
+type ImportSource = 'auto' | 'chatgpt' | 'claude'
 
 interface PopupResult {
   success?: boolean
@@ -11,53 +16,147 @@ interface PopupResult {
 
 interface Props {
   resolve: (data: PopupResult) => void
+  initialSource?: ImportSource
 }
 
-const PopupContainer: React.FC<Props> = ({ resolve }) => {
+const PopupContainer: React.FC<Props> = ({ resolve, initialSource }) => {
   const [open, setOpen] = useState(true)
   const [selecting, setSelecting] = useState(false)
   const [importing, setImporting] = useState(false)
+  const [importProgress, setImportProgress] = useState({ current: 0, total: 0 })
+  const [source, setSource] = useState<ImportSource>(initialSource || 'auto')
+  const [importAllBranches, setImportAllBranches] = useState(false)
   const { t } = useTranslation()
+
+  // Import a single file
+  const importSingleFile = async () => {
+    const filterName =
+      source === 'auto' ? 'Conversations' : source === 'chatgpt' ? 'ChatGPT Conversations' : 'Claude Conversations'
+    const file = await window.api.file.open({
+      filters: [{ name: filterName, extensions: ['json'] }]
+    })
+
+    if (!file) {
+      return null
+    }
+
+    const fileContent = typeof file.content === 'string' ? file.content : new TextDecoder().decode(file.content)
+    const importerName = source === 'auto' ? undefined : source
+    return ImportService.importConversations(fileContent, importerName)
+  }
+
+  // Import Claude folder with multiple JSON files (batch import into single assistant)
+  const importClaudeFolder = async () => {
+    const folderPath = await window.api.file.selectFolder({
+      title: t('import.claude.selectFolder', { defaultValue: 'Select Claude Export Folder' })
+    })
+
+    if (!folderPath) {
+      return null
+    }
+
+    // List all files in the folder recursively
+    // listDirectory returns an array of file path strings
+    const filePaths: string[] = await window.api.file.listDirectory(folderPath, {
+      recursive: true,
+      maxDepth: 10, // Claude exports can have deeply nested folder structures
+      includeFiles: true,
+      includeDirectories: false,
+      maxEntries: 10000, // Override default limit of 20 to handle large exports
+      searchPattern: '.json'
+    })
+
+    logger.info('Found files', { count: filePaths?.length, sample: filePaths?.slice(0, 5) })
+
+    // Log any non-absolute paths for debugging
+    const invalidPaths = (filePaths || []).filter((p: string) => !p.startsWith('/'))
+    if (invalidPaths.length > 0) {
+      logger.warn('Found non-absolute paths', { count: invalidPaths.length, sample: invalidPaths.slice(0, 5) })
+    }
+
+    // Filter to only JSON files (exclude summary files and artifacts folders)
+    const jsonFilePaths = (filePaths || []).filter((filePath: string) => {
+      // Must be an absolute path (starts with /)
+      if (!filePath.startsWith('/')) return false
+      const fileName = filePath.split('/').pop() || ''
+      const isJson = fileName.endsWith('.json')
+      const isNotSummary = fileName !== '.json' // Exclude summary file at root
+      const isNotInArtifacts = !filePath.includes('/artifacts/') // Exclude artifact JSON files
+      return isJson && isNotSummary && isNotInArtifacts
+    })
+
+    logger.info('Filtered JSON files', { count: jsonFilePaths?.length, sample: jsonFilePaths?.slice(0, 3) })
+
+    if (jsonFilePaths.length === 0) {
+      return {
+        success: false,
+        error: t('import.claude.error.no_json_files', {
+          defaultValue: 'No JSON files found in the selected folder. Make sure you selected the Claude export folder.'
+        }),
+        topicsCount: 0,
+        messagesCount: 0
+      }
+    }
+
+    setImportProgress({ current: 0, total: jsonFilePaths.length })
+
+    // Process files in chunks - read, import, and discard each chunk immediately
+    // This prevents memory buildup from loading all files at once
+    const CHUNK_SIZE = 50 // Smaller chunks for better memory management
+    const totalChunks = Math.ceil(jsonFilePaths.length / CHUNK_SIZE)
+
+    logger.info('Processing files', { total: jsonFilePaths.length, chunks: totalChunks, chunkSize: CHUNK_SIZE })
+
+    // Use streaming import - process each chunk immediately
+    const result = await ImportService.importStreamingChunks(
+      jsonFilePaths,
+      CHUNK_SIZE,
+      async (filePath: string) => {
+        // Read single file - called by ImportService for each file
+        return await window.api.fs.readText(filePath)
+      },
+      'claude',
+      (current, total) => setImportProgress({ current, total }),
+      { importAllBranches }
+    )
+
+    return result
+  }
 
   const onOk = async () => {
     setSelecting(true)
     try {
-      // Select ChatGPT JSON file
-      const file = await window.api.file.open({
-        filters: [{ name: 'ChatGPT Conversations', extensions: ['json'] }]
-      })
-
       setSelecting(false)
+      setImporting(true)
 
-      if (!file) {
+      // For Claude, use folder selection; for others, use file selection
+      const result = source === 'claude' ? await importClaudeFolder() : await importSingleFile()
+
+      if (!result) {
+        // User cancelled
+        setImporting(false)
         return
       }
 
-      setImporting(true)
-
-      // Parse file content
-      const fileContent = typeof file.content === 'string' ? file.content : new TextDecoder().decode(file.content)
-
-      // Import conversations
-      const result = await importChatGPTConversations(fileContent)
-
       if (result.success) {
         window.toast.success(
-          t('import.chatgpt.success', {
+          t('import.success', {
             topics: result.topicsCount,
-            messages: result.messagesCount
+            messages: result.messagesCount,
+            defaultValue: `Successfully imported ${result.topicsCount} conversations with ${result.messagesCount} messages`
           })
         )
         setOpen(false)
       } else {
-        window.toast.error(result.error || t('import.chatgpt.error.unknown'))
+        window.toast.error(result.error || t('import.error.unknown', { defaultValue: 'Unknown error occurred' }))
       }
     } catch (error) {
-      window.toast.error(t('import.chatgpt.error.unknown'))
+      window.toast.error(t('import.error.unknown', { defaultValue: 'Unknown error occurred' }))
       setOpen(false)
     } finally {
       setSelecting(false)
       setImporting(false)
+      setImportProgress({ current: 0, total: 0 })
     }
   }
 
@@ -71,14 +170,103 @@ const PopupContainer: React.FC<Props> = ({ resolve }) => {
 
   ImportPopup.hide = onCancel
 
+  const getHelpContent = () => {
+    if (source === 'claude') {
+      return (
+        <Alert
+          message={t('import.claude.help.title', { defaultValue: 'How to export from Claude' })}
+          description={
+            <div>
+              <p>
+                {t('import.claude.help.step1', {
+                  defaultValue: '1. Install the Claude Exporter extension (agoramachina/claude-exporter)'
+                })}
+              </p>
+              <p>{t('import.claude.help.step2', { defaultValue: '2. Go to Claude.ai and open the extension' })}</p>
+              <p>
+                {t('import.claude.help.step3', {
+                  defaultValue: '3. Click "Export All" or select specific conversations'
+                })}
+              </p>
+              <p>
+                {t('import.claude.help.step4', {
+                  defaultValue: '4. Choose JSON format and enable "Include Thinking" for extended thinking'
+                })}
+              </p>
+              <p>
+                {t('import.claude.help.step5', {
+                  defaultValue: '5. Select the exported folder (contains one JSON per conversation)'
+                })}
+              </p>
+              <p style={{ marginTop: 8, fontStyle: 'italic', opacity: 0.8 }}>
+                {t('import.claude.help.note', {
+                  defaultValue: 'Artifacts (code), thinking blocks, and tool calls are preserved.'
+                })}
+              </p>
+            </div>
+          }
+          type="info"
+          showIcon
+          style={{ marginTop: 12 }}
+        />
+      )
+    }
+
+    if (source === 'chatgpt') {
+      return (
+        <Alert
+          message={t('import.chatgpt.help.title')}
+          description={
+            <div>
+              <p>{t('import.chatgpt.help.step1')}</p>
+              <p>{t('import.chatgpt.help.step2')}</p>
+              <p>{t('import.chatgpt.help.step3')}</p>
+            </div>
+          }
+          type="info"
+          showIcon
+          style={{ marginTop: 12 }}
+        />
+      )
+    }
+
+    // Auto-detect
+    return (
+      <Alert
+        message={t('import.auto.help.title', { defaultValue: 'Auto-detect format' })}
+        description={t('import.auto.help.description', {
+          defaultValue: 'Select a JSON file and we will automatically detect whether it is from ChatGPT or Claude.'
+        })}
+        type="info"
+        showIcon
+        style={{ marginTop: 12 }}
+      />
+    )
+  }
+
+  // Get title based on source
+  const getTitle = () => {
+    if (source === 'claude') {
+      return t('import.claude.title', { defaultValue: 'Import from Claude' })
+    }
+    if (source === 'chatgpt') {
+      return t('import.chatgpt.title', { defaultValue: 'Import from ChatGPT' })
+    }
+    return t('import.title', { defaultValue: 'Import Conversations' })
+  }
+
   return (
     <Modal
-      title={t('import.chatgpt.title')}
+      title={getTitle()}
       open={open}
       onOk={onOk}
       onCancel={onCancel}
       afterClose={onClose}
-      okText={t('import.chatgpt.button')}
+      okText={
+        source === 'claude'
+          ? t('import.button.folder', { defaultValue: 'Select Folder' })
+          : t('import.button', { defaultValue: 'Select File' })
+      }
       okButtonProps={{ disabled: selecting || importing, loading: selecting }}
       cancelButtonProps={{ disabled: selecting || importing }}
       maskClosable={false}
@@ -86,32 +274,69 @@ const PopupContainer: React.FC<Props> = ({ resolve }) => {
       centered>
       {!selecting && !importing && (
         <Space direction="vertical" style={{ width: '100%' }}>
-          <div>{t('import.chatgpt.description')}</div>
-          <Alert
-            message={t('import.chatgpt.help.title')}
-            description={
-              <div>
-                <p>{t('import.chatgpt.help.step1')}</p>
-                <p>{t('import.chatgpt.help.step2')}</p>
-                <p>{t('import.chatgpt.help.step3')}</p>
+          <div>
+            {source === 'claude'
+              ? t('import.claude.description', {
+                  defaultValue:
+                    'Import conversations from Claude. Only text content is imported; images and attachments are not included.'
+                })
+              : t('import.description', {
+                  defaultValue:
+                    'Import conversations from external AI assistants. Only text content is imported; images and attachments are not included.'
+                })}
+          </div>
+
+          {/* Only show source selector when no initialSource is specified */}
+          {!initialSource && (
+            <div style={{ marginTop: 16 }}>
+              <div style={{ marginBottom: 8, fontWeight: 500 }}>
+                {t('import.source.label', { defaultValue: 'Source:' })}
               </div>
-            }
-            type="info"
-            showIcon
-            style={{ marginTop: 12 }}
-          />
+              <Radio.Group value={source} onChange={(e) => setSource(e.target.value)}>
+                <Radio.Button value="auto">{t('import.source.auto', { defaultValue: 'Auto-detect' })}</Radio.Button>
+                <Radio.Button value="chatgpt">ChatGPT</Radio.Button>
+                <Radio.Button value="claude">Claude</Radio.Button>
+              </Radio.Group>
+            </div>
+          )}
+
+          {/* Claude-specific options */}
+          {source === 'claude' && (
+            <div style={{ marginTop: 16 }}>
+              <Checkbox checked={importAllBranches} onChange={(e) => setImportAllBranches(e.target.checked)}>
+                {t('import.claude.option.allBranches', {
+                  defaultValue: 'Import all branches (includes edit history and regenerations)'
+                })}
+              </Checkbox>
+            </div>
+          )}
+
+          {getHelpContent()}
         </Space>
       )}
       {selecting && (
         <div style={{ textAlign: 'center', padding: '40px 0' }}>
           <Spin size="large" />
-          <div style={{ marginTop: 16 }}>{t('import.chatgpt.selecting')}</div>
+          <div style={{ marginTop: 16 }}>{t('import.selecting', { defaultValue: 'Selecting file...' })}</div>
         </div>
       )}
       {importing && (
         <div style={{ textAlign: 'center', padding: '20px 0' }}>
-          <Progress percent={100} status="active" strokeColor="var(--color-primary)" showInfo={false} />
-          <div style={{ marginTop: 16 }}>{t('import.chatgpt.importing')}</div>
+          <Progress
+            percent={importProgress.total > 0 ? Math.round((importProgress.current / importProgress.total) * 100) : 100}
+            status="active"
+            strokeColor="var(--color-primary)"
+            showInfo={importProgress.total > 1}
+          />
+          <div style={{ marginTop: 16 }}>
+            {importProgress.total > 1
+              ? t('import.importing_progress', {
+                  current: importProgress.current,
+                  total: importProgress.total,
+                  defaultValue: `Importing file ${importProgress.current} of ${importProgress.total}...`
+                })
+              : t('import.importing', { defaultValue: 'Importing conversations...' })}
+          </div>
         </div>
       )}
     </Modal>
@@ -125,7 +350,7 @@ export default class ImportPopup {
   static hide() {
     TopView.hide(TopViewKey)
   }
-  static show() {
+  static show(initialSource?: ImportSource) {
     return new Promise<PopupResult>((resolve) => {
       TopView.show(
         <PopupContainer
@@ -133,6 +358,7 @@ export default class ImportPopup {
             resolve(v)
             TopView.hide(TopViewKey)
           }}
+          initialSource={initialSource}
         />,
         TopViewKey
       )

--- a/src/renderer/src/components/Popups/ImportPopup.tsx
+++ b/src/renderer/src/components/Popups/ImportPopup.tsx
@@ -67,10 +67,10 @@ const PopupContainer: React.FC<Props> = ({ resolve, initialSource }) => {
     // listDirectory returns an array of file path strings
     const filePaths: string[] = await window.api.file.listDirectory(folderPath, {
       recursive: true,
-      maxDepth: 10, // Claude exports can have deeply nested folder structures
+      maxDepth: 3,
       includeFiles: true,
       includeDirectories: false,
-      maxEntries: 10000, // Override default limit of 20 to handle large exports
+      maxEntries: 2000,
       searchPattern: '.json'
     })
 

--- a/src/renderer/src/components/Popups/ImportPopup.tsx
+++ b/src/renderer/src/components/Popups/ImportPopup.tsx
@@ -169,6 +169,9 @@ const PopupContainer: React.FC<Props> = ({ resolve, initialSource }) => {
             defaultValue: `Successfully imported ${result.topicsCount} conversations with ${result.messagesCount} messages`
           })
         )
+        if (result.error) {
+          window.toast.warning(result.error)
+        }
         setOpen(false)
       } else {
         window.toast.error(result.error || t('import.error.unknown', { defaultValue: 'Unknown error occurred' }))

--- a/src/renderer/src/components/Popups/ImportPopup.tsx
+++ b/src/renderer/src/components/Popups/ImportPopup.tsx
@@ -65,16 +65,28 @@ const PopupContainer: React.FC<Props> = ({ resolve, initialSource }) => {
 
     // List all files in the folder recursively
     // listDirectory returns an array of file path strings
+    const MAX_ENTRIES = 2000
     const filePaths: string[] = await window.api.file.listDirectory(folderPath, {
       recursive: true,
       maxDepth: 3,
       includeFiles: true,
       includeDirectories: false,
-      maxEntries: 2000,
+      maxEntries: MAX_ENTRIES,
       searchPattern: '.json'
     })
 
     logger.info('Found files', { count: filePaths?.length, sample: filePaths?.slice(0, 5) })
+
+    // Warn if listing was likely truncated — real conversation files may have been dropped
+    if (filePaths?.length === MAX_ENTRIES) {
+      logger.warn('listDirectory returned exactly maxEntries — results may be truncated')
+      window.toast.warning(
+        t('import.claude.error.too_many_files', {
+          defaultValue:
+            'The selected folder contains too many files. Some conversations may not be imported. Try selecting a more specific subfolder.'
+        })
+      )
+    }
 
     // Helper: check for absolute path on both Unix and Windows
     const isAbsolutePath = (p: string) => p.startsWith('/') || /^[A-Za-z]:/.test(p)

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -1964,12 +1964,47 @@
       "title": "Import ChatGPT Conversations",
       "untitled_conversation": "Untitled Conversation"
     },
+    "claude": {
+      "assistant_name": "Claude Import",
+      "description": "Import conversations from Claude. Only text content is imported; images and attachments are not included.",
+      "error": {
+        "no_conversations": "No conversations found in file",
+        "no_json_files": "No JSON files found in the selected folder. Make sure you selected the Claude export folder.",
+        "no_valid_conversations": "No valid conversations to import"
+      },
+      "help": {
+        "note": "Artifacts (code), thinking blocks, and tool calls are preserved.",
+        "step1": "1. Install the Claude Exporter extension (agoramachina/claude-exporter)",
+        "step2": "2. Go to Claude.ai and open the extension",
+        "step3": "3. Click \"Export All\" or select specific conversations",
+        "step4": "4. Choose JSON format and enable \"Include Thinking\" for extended thinking",
+        "step5": "5. Select the exported folder (contains one JSON per conversation)",
+        "title": "How to export from Claude"
+      },
+      "option": {
+        "allBranches": "Import all branches (includes edit history and regenerations)"
+      },
+      "selectFolder": "Select Claude Export Folder",
+      "title": "Import from Claude",
+      "untitled_conversation": "Untitled Conversation"
+    },
+    "button": {
+      "folder": "Select Folder"
+    },
     "confirm": {
       "button": "Select Import File",
       "label": "Are you sure you want to import external data?"
     },
     "content": "Select external application conversation file to import, currently only supports ChatGPT JSON format files",
-    "title": "Import External Conversations"
+    "description": "Import conversations from external AI assistants. Only text content is imported; images and attachments are not included.",
+    "importing": "Importing conversations...",
+    "importing_progress": "Importing file {{current}} of {{total}}...",
+    "source": {
+      "auto": "Auto-detect",
+      "label": "Source:"
+    },
+    "success": "Successfully imported {{topics}} conversations with {{messages}} messages",
+    "title": "Import Conversations"
   },
   "knowledge": {
     "add": {
@@ -4111,7 +4146,9 @@
       "hour_interval_other": "{{count}} hours",
       "import_settings": {
         "button": "Import Json File",
+        "button_folder": "Import Folder",
         "chatgpt": "Import from ChatGPT",
+        "claude": "Import from Claude",
         "title": "Import Outside Application Data"
       },
       "joplin": {

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -1975,7 +1975,8 @@
       "error": {
         "no_conversations": "No conversations found in file",
         "no_json_files": "No JSON files found in the selected folder. Make sure you selected the Claude export folder.",
-        "no_valid_conversations": "No valid conversations to import"
+        "no_valid_conversations": "No valid conversations to import",
+        "too_many_files": "The selected folder contains too many files. Some conversations may not be imported. Try selecting a more specific subfolder."
       },
       "help": {
         "note": "Artifacts (code), thinking blocks, and tool calls are preserved.",
@@ -2010,12 +2011,19 @@
       "mixed": "Mixed Models",
       "unknown": "Unknown Model"
     },
+    "selecting": "Selecting file...",
     "source": {
       "auto": "Auto-detect",
       "label": "Source:"
     },
     "success": "Successfully imported {{topics}} conversations with {{messages}} messages",
-    "title": "Import Conversations"
+    "title": "Import Conversations",
+    "auto": {
+      "help": {
+        "title": "Auto-detect format",
+        "description": "Select a JSON file and we will automatically detect whether it is from ChatGPT or Claude."
+      }
+    }
   },
   "knowledge": {
     "add": {

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -1942,6 +1942,10 @@
     "split": "Split"
   },
   "import": {
+    "assistant_name_pattern": "{{model}} (Import)",
+    "button": {
+      "folder": "Select Folder"
+    },
     "chatgpt": {
       "assistant_name": "ChatGPT Import",
       "button": "Select File",
@@ -1966,6 +1970,7 @@
     },
     "claude": {
       "assistant_name": "Claude Import",
+      "branch_name": "{{name}} (branch {{index}})",
       "description": "Import conversations from Claude. Only text content is imported; images and attachments are not included.",
       "error": {
         "no_conversations": "No conversations found in file",
@@ -1988,17 +1993,23 @@
       "title": "Import from Claude",
       "untitled_conversation": "Untitled Conversation"
     },
-    "button": {
-      "folder": "Select Folder"
-    },
     "confirm": {
       "button": "Select Import File",
       "label": "Are you sure you want to import external data?"
     },
     "content": "Select external application conversation file to import, currently only supports ChatGPT JSON format files",
     "description": "Import conversations from external AI assistants. Only text content is imported; images and attachments are not included.",
+    "error": {
+      "invalid_format": "Invalid {{importer}} format",
+      "unknown": "Unknown error",
+      "unsupported_format": "Unsupported file format"
+    },
     "importing": "Importing conversations...",
     "importing_progress": "Importing file {{current}} of {{total}}...",
+    "model": {
+      "mixed": "Mixed Models",
+      "unknown": "Unknown Model"
+    },
     "source": {
       "auto": "Auto-detect",
       "label": "Source:"

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -1975,7 +1975,8 @@
       "error": {
         "no_conversations": "文件中未找到任何对话",
         "no_json_files": "所选文件夹中未找到 JSON 文件。请确保选择了 Claude 导出文件夹。",
-        "no_valid_conversations": "没有可导入的有效对话"
+        "no_valid_conversations": "没有可导入的有效对话",
+        "too_many_files": "所选文件夹包含过多文件，部分对话可能未被导入。请尝试选择更具体的子文件夹。"
       },
       "help": {
         "note": "代码工件、思考过程和工具调用均会被保留。",
@@ -2010,12 +2011,19 @@
       "mixed": "混合模型",
       "unknown": "未知模型"
     },
+    "selecting": "正在选择文件...",
     "source": {
       "auto": "自动检测",
       "label": "来源："
     },
     "success": "成功导入 {{topics}} 个对话，共 {{messages}} 条消息",
-    "title": "导入外部对话"
+    "title": "导入外部对话",
+    "auto": {
+      "help": {
+        "title": "自动检测格式",
+        "description": "选择一个 JSON 文件，我们将自动检测它是来自 ChatGPT 还是 Claude。"
+      }
+    }
   },
   "knowledge": {
     "add": {

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -1942,6 +1942,10 @@
     "split": "分屏"
   },
   "import": {
+    "assistant_name_pattern": "{{model}} (导入)",
+    "button": {
+      "folder": "选择文件夹"
+    },
     "chatgpt": {
       "assistant_name": "ChatGPT 导入",
       "button": "选择文件",
@@ -1966,11 +1970,27 @@
     },
     "claude": {
       "assistant_name": "Claude 导入",
+      "branch_name": "{{name}} (分支 {{index}})",
       "description": "仅导入对话文字，不携带图片和附件",
       "error": {
         "no_conversations": "文件中未找到任何对话",
+        "no_json_files": "所选文件夹中未找到 JSON 文件。请确保选择了 Claude 导出文件夹。",
         "no_valid_conversations": "没有可导入的有效对话"
       },
+      "help": {
+        "note": "代码工件、思考过程和工具调用均会被保留。",
+        "step1": "1. 安装 Claude Exporter 浏览器扩展 (agoramachina/claude-exporter)",
+        "step2": "2. 访问 Claude.ai 并打开该扩展",
+        "step3": "3. 点击「全部导出」或选择特定对话",
+        "step4": "4. 选择 JSON 格式并启用「包含思考过程」以导出扩展思考",
+        "step5": "5. 选择导出的文件夹（每个对话一个 JSON 文件）",
+        "title": "如何从 Claude 导出对话？"
+      },
+      "option": {
+        "allBranches": "导入所有分支（包含编辑历史和重新生成）"
+      },
+      "selectFolder": "选择 Claude 导出文件夹",
+      "title": "从 Claude 导入",
       "untitled_conversation": "未命名对话"
     },
     "confirm": {
@@ -1978,6 +1998,23 @@
       "label": "确定要导入外部数据吗？"
     },
     "content": "选择要导入的外部应用对话文件，暂时仅支持ChatGPT的JSON格式文件",
+    "description": "从外部 AI 助手导入对话。仅导入文字内容，不包括图片和附件。",
+    "error": {
+      "invalid_format": "无效的 {{importer}} 格式",
+      "unknown": "未知错误",
+      "unsupported_format": "不支持的文件格式"
+    },
+    "importing": "正在导入对话...",
+    "importing_progress": "正在导入第 {{current}}/{{total}} 个文件...",
+    "model": {
+      "mixed": "混合模型",
+      "unknown": "未知模型"
+    },
+    "source": {
+      "auto": "自动检测",
+      "label": "来源："
+    },
+    "success": "成功导入 {{topics}} 个对话，共 {{messages}} 条消息",
     "title": "导入外部对话"
   },
   "knowledge": {
@@ -4120,7 +4157,9 @@
       "hour_interval_other": "{{count}} 小时",
       "import_settings": {
         "button": "导入文件",
+        "button_folder": "导入文件夹",
         "chatgpt": "导入 ChatGPT 数据",
+        "claude": "从 Claude 导入",
         "title": "导入外部应用数据"
       },
       "joplin": {

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -1964,6 +1964,15 @@
       "title": "导入 ChatGPT 对话",
       "untitled_conversation": "未命名对话"
     },
+    "claude": {
+      "assistant_name": "Claude 导入",
+      "description": "仅导入对话文字，不携带图片和附件",
+      "error": {
+        "no_conversations": "文件中未找到任何对话",
+        "no_valid_conversations": "没有可导入的有效对话"
+      },
+      "untitled_conversation": "未命名对话"
+    },
     "confirm": {
       "button": "选择导入文件",
       "label": "确定要导入外部数据吗？"

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -1964,6 +1964,15 @@
       "title": "匯入 ChatGPT 對話",
       "untitled_conversation": "未命名對話"
     },
+    "claude": {
+      "assistant_name": "Claude 匯入",
+      "description": "僅匯入對話文字，不攜帶圖片和附件",
+      "error": {
+        "no_conversations": "檔案中未找到任何對話",
+        "no_valid_conversations": "沒有可匯入的有效對話"
+      },
+      "untitled_conversation": "未命名對話"
+    },
     "confirm": {
       "button": "選擇匯入檔案",
       "label": "確定要匯入外部資料嗎？"

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -1975,7 +1975,8 @@
       "error": {
         "no_conversations": "檔案中未找到任何對話",
         "no_json_files": "所選資料夾中未找到 JSON 檔案。請確保選擇了 Claude 匯出資料夾。",
-        "no_valid_conversations": "沒有可匯入的有效對話"
+        "no_valid_conversations": "沒有可匯入的有效對話",
+        "too_many_files": "所選資料夾包含過多檔案，部分對話可能未被匯入。請嘗試選擇更具體的子資料夾。"
       },
       "help": {
         "note": "程式碼工件、思考過程和工具呼叫均會被保留。",
@@ -2010,12 +2011,19 @@
       "mixed": "混合模型",
       "unknown": "未知模型"
     },
+    "selecting": "正在選擇檔案...",
     "source": {
       "auto": "自動偵測",
       "label": "來源："
     },
     "success": "成功匯入 {{topics}} 個對話，共 {{messages}} 則訊息",
-    "title": "匯入外部對話"
+    "title": "匯入外部對話",
+    "auto": {
+      "help": {
+        "title": "自動偵測格式",
+        "description": "選擇一個 JSON 檔案，我們將自動偵測它是來自 ChatGPT 還是 Claude。"
+      }
+    }
   },
   "knowledge": {
     "add": {

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -1942,6 +1942,10 @@
     "split": "分割畫面"
   },
   "import": {
+    "assistant_name_pattern": "{{model}} (匯入)",
+    "button": {
+      "folder": "選擇資料夾"
+    },
     "chatgpt": {
       "assistant_name": "ChatGPT 匯入",
       "button": "選擇檔案",
@@ -1966,11 +1970,27 @@
     },
     "claude": {
       "assistant_name": "Claude 匯入",
+      "branch_name": "{{name}} (分支 {{index}})",
       "description": "僅匯入對話文字，不攜帶圖片和附件",
       "error": {
         "no_conversations": "檔案中未找到任何對話",
+        "no_json_files": "所選資料夾中未找到 JSON 檔案。請確保選擇了 Claude 匯出資料夾。",
         "no_valid_conversations": "沒有可匯入的有效對話"
       },
+      "help": {
+        "note": "程式碼工件、思考過程和工具呼叫均會被保留。",
+        "step1": "1. 安裝 Claude Exporter 瀏覽器擴充功能 (agoramachina/claude-exporter)",
+        "step2": "2. 前往 Claude.ai 並開啟該擴充功能",
+        "step3": "3. 點擊「全部匯出」或選擇特定對話",
+        "step4": "4. 選擇 JSON 格式並啟用「包含思考過程」以匯出延伸思考",
+        "step5": "5. 選擇匯出的資料夾（每個對話一個 JSON 檔案）",
+        "title": "如何從 Claude 匯出對話？"
+      },
+      "option": {
+        "allBranches": "匯入所有分支（包含編輯歷史和重新生成）"
+      },
+      "selectFolder": "選擇 Claude 匯出資料夾",
+      "title": "從 Claude 匯入",
       "untitled_conversation": "未命名對話"
     },
     "confirm": {
@@ -1978,6 +1998,23 @@
       "label": "確定要匯入外部資料嗎？"
     },
     "content": "選擇要匯入的外部應用對話檔案，暫時僅支援 ChatGPT 的 JSON 格式檔案",
+    "description": "從外部 AI 助手匯入對話。僅匯入文字內容，不包括圖片和附件。",
+    "error": {
+      "invalid_format": "無效的 {{importer}} 格式",
+      "unknown": "未知錯誤",
+      "unsupported_format": "不支援的檔案格式"
+    },
+    "importing": "正在匯入對話...",
+    "importing_progress": "正在匯入第 {{current}}/{{total}} 個檔案...",
+    "model": {
+      "mixed": "混合模型",
+      "unknown": "未知模型"
+    },
+    "source": {
+      "auto": "自動偵測",
+      "label": "來源："
+    },
+    "success": "成功匯入 {{topics}} 個對話，共 {{messages}} 則訊息",
     "title": "匯入外部對話"
   },
   "knowledge": {
@@ -4120,7 +4157,9 @@
       "hour_interval_other": "{{count}} 小時",
       "import_settings": {
         "button": "匯入 JSON 檔案",
+        "button_folder": "匯入資料夾",
         "chatgpt": "匯入 ChatGPT 資料",
+        "claude": "從 Claude 匯入",
         "title": "匯入外部應用程式資料"
       },
       "joplin": {

--- a/src/renderer/src/i18n/translate/de-de.json
+++ b/src/renderer/src/i18n/translate/de-de.json
@@ -1942,6 +1942,10 @@
     "split": "Geteilte Ansicht"
   },
   "import": {
+    "assistant_name_pattern": "[to be translated]:{{model}} (Import)",
+    "button": {
+      "folder": "[to be translated]:Select Folder"
+    },
     "chatgpt": {
       "assistant_name": "ChatGPT-Import",
       "button": "Datei auswählen",
@@ -1964,11 +1968,53 @@
       "title": "ChatGPT-Unterhaltungen importieren",
       "untitled_conversation": "Unbenannte Unterhaltung"
     },
+    "claude": {
+      "assistant_name": "[to be translated]:Claude Import",
+      "branch_name": "[to be translated]:{{name}} (branch {{index}})",
+      "description": "[to be translated]:Import conversations from Claude. Only text content is imported; images and attachments are not included.",
+      "error": {
+        "no_conversations": "[to be translated]:No conversations found in file",
+        "no_json_files": "[to be translated]:No JSON files found in the selected folder. Make sure you selected the Claude export folder.",
+        "no_valid_conversations": "[to be translated]:No valid conversations to import"
+      },
+      "help": {
+        "note": "[to be translated]:Artifacts (code), thinking blocks, and tool calls are preserved.",
+        "step1": "[to be translated]:1. Install the Claude Exporter extension (agoramachina/claude-exporter)",
+        "step2": "[to be translated]:2. Go to Claude.ai and open the extension",
+        "step3": "[to be translated]:3. Click \"Export All\" or select specific conversations",
+        "step4": "[to be translated]:4. Choose JSON format and enable \"Include Thinking\" for extended thinking",
+        "step5": "[to be translated]:5. Select the exported folder (contains one JSON per conversation)",
+        "title": "[to be translated]:How to export from Claude"
+      },
+      "option": {
+        "allBranches": "[to be translated]:Import all branches (includes edit history and regenerations)"
+      },
+      "selectFolder": "[to be translated]:Select Claude Export Folder",
+      "title": "[to be translated]:Import from Claude",
+      "untitled_conversation": "[to be translated]:Untitled Conversation"
+    },
     "confirm": {
       "button": "Importdatei auswählen",
       "label": "Sind Sie sicher, dass Sie externe Daten importieren möchten?"
     },
     "content": "Wählen Sie die zu importierende Gesprächsdatei einer externen Anwendung aus; derzeit werden nur ChatGPT-JSON-Formatdateien unterstützt.",
+    "description": "[to be translated]:Import conversations from external AI assistants. Only text content is imported; images and attachments are not included.",
+    "error": {
+      "invalid_format": "[to be translated]:Invalid {{importer}} format",
+      "unknown": "[to be translated]:Unknown error",
+      "unsupported_format": "[to be translated]:Unsupported file format"
+    },
+    "importing": "[to be translated]:Importing conversations...",
+    "importing_progress": "[to be translated]:Importing file {{current}} of {{total}}...",
+    "model": {
+      "mixed": "[to be translated]:Mixed Models",
+      "unknown": "[to be translated]:Unknown Model"
+    },
+    "source": {
+      "auto": "[to be translated]:Auto-detect",
+      "label": "[to be translated]:Source:"
+    },
+    "success": "[to be translated]:Successfully imported {{topics}} conversations with {{messages}} messages",
     "title": "Externe Gespräche importieren"
   },
   "knowledge": {
@@ -4111,7 +4157,9 @@
       "hour_interval_other": "{{count}} Stunden",
       "import_settings": {
         "button": "JSON-Datei importieren",
+        "button_folder": "[to be translated]:Import Folder",
         "chatgpt": "Import aus ChatGPT",
+        "claude": "[to be translated]:Import from Claude",
         "title": "Importiere Daten von externen Anwendungen"
       },
       "joplin": {

--- a/src/renderer/src/i18n/translate/el-gr.json
+++ b/src/renderer/src/i18n/translate/el-gr.json
@@ -1942,6 +1942,10 @@
     "split": "Διαχωρισμός"
   },
   "import": {
+    "assistant_name_pattern": "[to be translated]:{{model}} (Import)",
+    "button": {
+      "folder": "[to be translated]:Select Folder"
+    },
     "chatgpt": {
       "assistant_name": "Εισαγωγή ChatGPT",
       "button": "Επιλέξτε Αρχείο",
@@ -1964,11 +1968,53 @@
       "title": "Εισαγωγή Συνομιλιών του ChatGPT",
       "untitled_conversation": "Συνομιλία χωρίς τίτλο"
     },
+    "claude": {
+      "assistant_name": "[to be translated]:Claude Import",
+      "branch_name": "[to be translated]:{{name}} (branch {{index}})",
+      "description": "[to be translated]:Import conversations from Claude. Only text content is imported; images and attachments are not included.",
+      "error": {
+        "no_conversations": "[to be translated]:No conversations found in file",
+        "no_json_files": "[to be translated]:No JSON files found in the selected folder. Make sure you selected the Claude export folder.",
+        "no_valid_conversations": "[to be translated]:No valid conversations to import"
+      },
+      "help": {
+        "note": "[to be translated]:Artifacts (code), thinking blocks, and tool calls are preserved.",
+        "step1": "[to be translated]:1. Install the Claude Exporter extension (agoramachina/claude-exporter)",
+        "step2": "[to be translated]:2. Go to Claude.ai and open the extension",
+        "step3": "[to be translated]:3. Click \"Export All\" or select specific conversations",
+        "step4": "[to be translated]:4. Choose JSON format and enable \"Include Thinking\" for extended thinking",
+        "step5": "[to be translated]:5. Select the exported folder (contains one JSON per conversation)",
+        "title": "[to be translated]:How to export from Claude"
+      },
+      "option": {
+        "allBranches": "[to be translated]:Import all branches (includes edit history and regenerations)"
+      },
+      "selectFolder": "[to be translated]:Select Claude Export Folder",
+      "title": "[to be translated]:Import from Claude",
+      "untitled_conversation": "[to be translated]:Untitled Conversation"
+    },
     "confirm": {
       "button": "Επιλέξτε Εισαγωγή Αρχείου",
       "label": "Είστε σίγουροι ότι θέλετε να εισάγετε εξωτερικά δεδομένα;"
     },
     "content": "Επιλέξτε εξωτερικό αρχείο συνομιλίας εφαρμογής για εισαγωγή, προς το παρόν υποστηρίζονται μόνο αρχεία μορφής JSON του ChatGPT",
+    "description": "[to be translated]:Import conversations from external AI assistants. Only text content is imported; images and attachments are not included.",
+    "error": {
+      "invalid_format": "[to be translated]:Invalid {{importer}} format",
+      "unknown": "[to be translated]:Unknown error",
+      "unsupported_format": "[to be translated]:Unsupported file format"
+    },
+    "importing": "[to be translated]:Importing conversations...",
+    "importing_progress": "[to be translated]:Importing file {{current}} of {{total}}...",
+    "model": {
+      "mixed": "[to be translated]:Mixed Models",
+      "unknown": "[to be translated]:Unknown Model"
+    },
+    "source": {
+      "auto": "[to be translated]:Auto-detect",
+      "label": "[to be translated]:Source:"
+    },
+    "success": "[to be translated]:Successfully imported {{topics}} conversations with {{messages}} messages",
     "title": "Εισαγωγή Εξωτερικών Συνομιλιών"
   },
   "knowledge": {
@@ -4111,7 +4157,9 @@
       "hour_interval_other": "{{count}} ώρες",
       "import_settings": {
         "button": "Εισαγωγή αρχείου Json",
+        "button_folder": "[to be translated]:Import Folder",
         "chatgpt": "Εισαγωγή από το ChatGPT",
+        "claude": "[to be translated]:Import from Claude",
         "title": "Εισαγωγή Δεδομένων Εξωτερικής Εφαρμογής"
       },
       "joplin": {

--- a/src/renderer/src/i18n/translate/es-es.json
+++ b/src/renderer/src/i18n/translate/es-es.json
@@ -1942,6 +1942,10 @@
     "split": "Dividir"
   },
   "import": {
+    "assistant_name_pattern": "[to be translated]:{{model}} (Import)",
+    "button": {
+      "folder": "[to be translated]:Select Folder"
+    },
     "chatgpt": {
       "assistant_name": "Importación de ChatGPT",
       "button": "Seleccionar archivo",
@@ -1964,11 +1968,53 @@
       "title": "Importar conversaciones de ChatGPT",
       "untitled_conversation": "Conversación Sin Título"
     },
+    "claude": {
+      "assistant_name": "[to be translated]:Claude Import",
+      "branch_name": "[to be translated]:{{name}} (branch {{index}})",
+      "description": "[to be translated]:Import conversations from Claude. Only text content is imported; images and attachments are not included.",
+      "error": {
+        "no_conversations": "[to be translated]:No conversations found in file",
+        "no_json_files": "[to be translated]:No JSON files found in the selected folder. Make sure you selected the Claude export folder.",
+        "no_valid_conversations": "[to be translated]:No valid conversations to import"
+      },
+      "help": {
+        "note": "[to be translated]:Artifacts (code), thinking blocks, and tool calls are preserved.",
+        "step1": "[to be translated]:1. Install the Claude Exporter extension (agoramachina/claude-exporter)",
+        "step2": "[to be translated]:2. Go to Claude.ai and open the extension",
+        "step3": "[to be translated]:3. Click \"Export All\" or select specific conversations",
+        "step4": "[to be translated]:4. Choose JSON format and enable \"Include Thinking\" for extended thinking",
+        "step5": "[to be translated]:5. Select the exported folder (contains one JSON per conversation)",
+        "title": "[to be translated]:How to export from Claude"
+      },
+      "option": {
+        "allBranches": "[to be translated]:Import all branches (includes edit history and regenerations)"
+      },
+      "selectFolder": "[to be translated]:Select Claude Export Folder",
+      "title": "[to be translated]:Import from Claude",
+      "untitled_conversation": "[to be translated]:Untitled Conversation"
+    },
     "confirm": {
       "button": "Seleccionar Archivo de Importación",
       "label": "¿Estás seguro de que quieres importar datos externos?"
     },
     "content": "Selecciona el archivo de conversación de la aplicación externa para importar; actualmente solo admite archivos en formato JSON de ChatGPT",
+    "description": "[to be translated]:Import conversations from external AI assistants. Only text content is imported; images and attachments are not included.",
+    "error": {
+      "invalid_format": "[to be translated]:Invalid {{importer}} format",
+      "unknown": "[to be translated]:Unknown error",
+      "unsupported_format": "[to be translated]:Unsupported file format"
+    },
+    "importing": "[to be translated]:Importing conversations...",
+    "importing_progress": "[to be translated]:Importing file {{current}} of {{total}}...",
+    "model": {
+      "mixed": "[to be translated]:Mixed Models",
+      "unknown": "[to be translated]:Unknown Model"
+    },
+    "source": {
+      "auto": "[to be translated]:Auto-detect",
+      "label": "[to be translated]:Source:"
+    },
+    "success": "[to be translated]:Successfully imported {{topics}} conversations with {{messages}} messages",
     "title": "Importar Conversaciones Externas"
   },
   "knowledge": {
@@ -4111,7 +4157,9 @@
       "hour_interval_other": "{{count}} horas",
       "import_settings": {
         "button": "Importar archivo Json",
+        "button_folder": "[to be translated]:Import Folder",
         "chatgpt": "Importar desde ChatGPT",
+        "claude": "[to be translated]:Import from Claude",
         "title": "Importar datos de aplicaciones externas"
       },
       "joplin": {

--- a/src/renderer/src/i18n/translate/fr-fr.json
+++ b/src/renderer/src/i18n/translate/fr-fr.json
@@ -1942,6 +1942,10 @@
     "split": "Diviser"
   },
   "import": {
+    "assistant_name_pattern": "[to be translated]:{{model}} (Import)",
+    "button": {
+      "folder": "[to be translated]:Select Folder"
+    },
     "chatgpt": {
       "assistant_name": "Importation de ChatGPT",
       "button": "Sélectionner le fichier",
@@ -1964,11 +1968,53 @@
       "title": "Importer les conversations de ChatGPT",
       "untitled_conversation": "Conversation sans titre"
     },
+    "claude": {
+      "assistant_name": "[to be translated]:Claude Import",
+      "branch_name": "[to be translated]:{{name}} (branch {{index}})",
+      "description": "[to be translated]:Import conversations from Claude. Only text content is imported; images and attachments are not included.",
+      "error": {
+        "no_conversations": "[to be translated]:No conversations found in file",
+        "no_json_files": "[to be translated]:No JSON files found in the selected folder. Make sure you selected the Claude export folder.",
+        "no_valid_conversations": "[to be translated]:No valid conversations to import"
+      },
+      "help": {
+        "note": "[to be translated]:Artifacts (code), thinking blocks, and tool calls are preserved.",
+        "step1": "[to be translated]:1. Install the Claude Exporter extension (agoramachina/claude-exporter)",
+        "step2": "[to be translated]:2. Go to Claude.ai and open the extension",
+        "step3": "[to be translated]:3. Click \"Export All\" or select specific conversations",
+        "step4": "[to be translated]:4. Choose JSON format and enable \"Include Thinking\" for extended thinking",
+        "step5": "[to be translated]:5. Select the exported folder (contains one JSON per conversation)",
+        "title": "[to be translated]:How to export from Claude"
+      },
+      "option": {
+        "allBranches": "[to be translated]:Import all branches (includes edit history and regenerations)"
+      },
+      "selectFolder": "[to be translated]:Select Claude Export Folder",
+      "title": "[to be translated]:Import from Claude",
+      "untitled_conversation": "[to be translated]:Untitled Conversation"
+    },
     "confirm": {
       "button": "Sélectionner le fichier à importer",
       "label": "Êtes-vous sûr de vouloir importer des données externes ?"
     },
     "content": "Sélectionnez le fichier de conversation de l'application externe à importer, actuellement uniquement les fichiers au format JSON de ChatGPT sont pris en charge",
+    "description": "[to be translated]:Import conversations from external AI assistants. Only text content is imported; images and attachments are not included.",
+    "error": {
+      "invalid_format": "[to be translated]:Invalid {{importer}} format",
+      "unknown": "[to be translated]:Unknown error",
+      "unsupported_format": "[to be translated]:Unsupported file format"
+    },
+    "importing": "[to be translated]:Importing conversations...",
+    "importing_progress": "[to be translated]:Importing file {{current}} of {{total}}...",
+    "model": {
+      "mixed": "[to be translated]:Mixed Models",
+      "unknown": "[to be translated]:Unknown Model"
+    },
+    "source": {
+      "auto": "[to be translated]:Auto-detect",
+      "label": "[to be translated]:Source:"
+    },
+    "success": "[to be translated]:Successfully imported {{topics}} conversations with {{messages}} messages",
     "title": "Importer des conversations externes"
   },
   "knowledge": {
@@ -4111,7 +4157,9 @@
       "hour_interval_other": "{{count}} heures",
       "import_settings": {
         "button": "Importer le fichier JSON",
+        "button_folder": "[to be translated]:Import Folder",
         "chatgpt": "Importer depuis ChatGPT",
+        "claude": "[to be translated]:Import from Claude",
         "title": "Importer des données d'applications externes"
       },
       "joplin": {

--- a/src/renderer/src/i18n/translate/ja-jp.json
+++ b/src/renderer/src/i18n/translate/ja-jp.json
@@ -1942,6 +1942,10 @@
     "split": "分割"
   },
   "import": {
+    "assistant_name_pattern": "[to be translated]:{{model}} (Import)",
+    "button": {
+      "folder": "[to be translated]:Select Folder"
+    },
     "chatgpt": {
       "assistant_name": "ChatGPTインポート",
       "button": "ファイルを選択",
@@ -1964,11 +1968,53 @@
       "title": "ChatGPTの会話をインポート",
       "untitled_conversation": "無題の会話"
     },
+    "claude": {
+      "assistant_name": "[to be translated]:Claude Import",
+      "branch_name": "[to be translated]:{{name}} (branch {{index}})",
+      "description": "[to be translated]:Import conversations from Claude. Only text content is imported; images and attachments are not included.",
+      "error": {
+        "no_conversations": "[to be translated]:No conversations found in file",
+        "no_json_files": "[to be translated]:No JSON files found in the selected folder. Make sure you selected the Claude export folder.",
+        "no_valid_conversations": "[to be translated]:No valid conversations to import"
+      },
+      "help": {
+        "note": "[to be translated]:Artifacts (code), thinking blocks, and tool calls are preserved.",
+        "step1": "[to be translated]:1. Install the Claude Exporter extension (agoramachina/claude-exporter)",
+        "step2": "[to be translated]:2. Go to Claude.ai and open the extension",
+        "step3": "[to be translated]:3. Click \"Export All\" or select specific conversations",
+        "step4": "[to be translated]:4. Choose JSON format and enable \"Include Thinking\" for extended thinking",
+        "step5": "[to be translated]:5. Select the exported folder (contains one JSON per conversation)",
+        "title": "[to be translated]:How to export from Claude"
+      },
+      "option": {
+        "allBranches": "[to be translated]:Import all branches (includes edit history and regenerations)"
+      },
+      "selectFolder": "[to be translated]:Select Claude Export Folder",
+      "title": "[to be translated]:Import from Claude",
+      "untitled_conversation": "[to be translated]:Untitled Conversation"
+    },
     "confirm": {
       "button": "ファイルのインポートを選択",
       "label": "外部データをインポートしてもよろしいですか？"
     },
     "content": "外部アプリケーションの会話ファイルを選択してインポートします。現在、ChatGPT JSON形式ファイルのみサポートしています。",
+    "description": "[to be translated]:Import conversations from external AI assistants. Only text content is imported; images and attachments are not included.",
+    "error": {
+      "invalid_format": "[to be translated]:Invalid {{importer}} format",
+      "unknown": "[to be translated]:Unknown error",
+      "unsupported_format": "[to be translated]:Unsupported file format"
+    },
+    "importing": "[to be translated]:Importing conversations...",
+    "importing_progress": "[to be translated]:Importing file {{current}} of {{total}}...",
+    "model": {
+      "mixed": "[to be translated]:Mixed Models",
+      "unknown": "[to be translated]:Unknown Model"
+    },
+    "source": {
+      "auto": "[to be translated]:Auto-detect",
+      "label": "[to be translated]:Source:"
+    },
+    "success": "[to be translated]:Successfully imported {{topics}} conversations with {{messages}} messages",
     "title": "外部会話をインポート"
   },
   "knowledge": {
@@ -4111,7 +4157,9 @@
       "hour_interval_other": "{{count}} 時間",
       "import_settings": {
         "button": "JSONファイルをインポート",
+        "button_folder": "[to be translated]:Import Folder",
         "chatgpt": "ChatGPTからインポート",
+        "claude": "[to be translated]:Import from Claude",
         "title": "外部アプリケーションデータをインポート"
       },
       "joplin": {

--- a/src/renderer/src/i18n/translate/pt-pt.json
+++ b/src/renderer/src/i18n/translate/pt-pt.json
@@ -1942,6 +1942,10 @@
     "split": "Dividir"
   },
   "import": {
+    "assistant_name_pattern": "[to be translated]:{{model}} (Import)",
+    "button": {
+      "folder": "[to be translated]:Select Folder"
+    },
     "chatgpt": {
       "assistant_name": "Importação do ChatGPT",
       "button": "Selecionar Arquivo",
@@ -1964,11 +1968,53 @@
       "title": "Importar Conversas do ChatGPT",
       "untitled_conversation": "Conversa Sem Título"
     },
+    "claude": {
+      "assistant_name": "[to be translated]:Claude Import",
+      "branch_name": "[to be translated]:{{name}} (branch {{index}})",
+      "description": "[to be translated]:Import conversations from Claude. Only text content is imported; images and attachments are not included.",
+      "error": {
+        "no_conversations": "[to be translated]:No conversations found in file",
+        "no_json_files": "[to be translated]:No JSON files found in the selected folder. Make sure you selected the Claude export folder.",
+        "no_valid_conversations": "[to be translated]:No valid conversations to import"
+      },
+      "help": {
+        "note": "[to be translated]:Artifacts (code), thinking blocks, and tool calls are preserved.",
+        "step1": "[to be translated]:1. Install the Claude Exporter extension (agoramachina/claude-exporter)",
+        "step2": "[to be translated]:2. Go to Claude.ai and open the extension",
+        "step3": "[to be translated]:3. Click \"Export All\" or select specific conversations",
+        "step4": "[to be translated]:4. Choose JSON format and enable \"Include Thinking\" for extended thinking",
+        "step5": "[to be translated]:5. Select the exported folder (contains one JSON per conversation)",
+        "title": "[to be translated]:How to export from Claude"
+      },
+      "option": {
+        "allBranches": "[to be translated]:Import all branches (includes edit history and regenerations)"
+      },
+      "selectFolder": "[to be translated]:Select Claude Export Folder",
+      "title": "[to be translated]:Import from Claude",
+      "untitled_conversation": "[to be translated]:Untitled Conversation"
+    },
     "confirm": {
       "button": "Selecionar Arquivo de Importação",
       "label": "Tem certeza de que deseja importar dados externos?"
     },
     "content": "Selecione o arquivo de conversa do aplicativo externo para importar; atualmente, apenas arquivos no formato JSON do ChatGPT são suportados.",
+    "description": "[to be translated]:Import conversations from external AI assistants. Only text content is imported; images and attachments are not included.",
+    "error": {
+      "invalid_format": "[to be translated]:Invalid {{importer}} format",
+      "unknown": "[to be translated]:Unknown error",
+      "unsupported_format": "[to be translated]:Unsupported file format"
+    },
+    "importing": "[to be translated]:Importing conversations...",
+    "importing_progress": "[to be translated]:Importing file {{current}} of {{total}}...",
+    "model": {
+      "mixed": "[to be translated]:Mixed Models",
+      "unknown": "[to be translated]:Unknown Model"
+    },
+    "source": {
+      "auto": "[to be translated]:Auto-detect",
+      "label": "[to be translated]:Source:"
+    },
+    "success": "[to be translated]:Successfully imported {{topics}} conversations with {{messages}} messages",
     "title": "Importar Conversas Externas"
   },
   "knowledge": {
@@ -4111,7 +4157,9 @@
       "hour_interval_other": "{{count}} horas",
       "import_settings": {
         "button": "Importar Arquivo Json",
+        "button_folder": "[to be translated]:Import Folder",
         "chatgpt": "Importar do ChatGPT",
+        "claude": "[to be translated]:Import from Claude",
         "title": "Importar Dados de Aplicações Externas"
       },
       "joplin": {

--- a/src/renderer/src/i18n/translate/ro-ro.json
+++ b/src/renderer/src/i18n/translate/ro-ro.json
@@ -1942,6 +1942,10 @@
     "split": "Divizat"
   },
   "import": {
+    "assistant_name_pattern": "[to be translated]:{{model}} (Import)",
+    "button": {
+      "folder": "[to be translated]:Select Folder"
+    },
     "chatgpt": {
       "assistant_name": "Import ChatGPT",
       "button": "Selectează fișierul",
@@ -1964,11 +1968,53 @@
       "title": "Importă conversații ChatGPT",
       "untitled_conversation": "Conversație fără titlu"
     },
+    "claude": {
+      "assistant_name": "[to be translated]:Claude Import",
+      "branch_name": "[to be translated]:{{name}} (branch {{index}})",
+      "description": "[to be translated]:Import conversations from Claude. Only text content is imported; images and attachments are not included.",
+      "error": {
+        "no_conversations": "[to be translated]:No conversations found in file",
+        "no_json_files": "[to be translated]:No JSON files found in the selected folder. Make sure you selected the Claude export folder.",
+        "no_valid_conversations": "[to be translated]:No valid conversations to import"
+      },
+      "help": {
+        "note": "[to be translated]:Artifacts (code), thinking blocks, and tool calls are preserved.",
+        "step1": "[to be translated]:1. Install the Claude Exporter extension (agoramachina/claude-exporter)",
+        "step2": "[to be translated]:2. Go to Claude.ai and open the extension",
+        "step3": "[to be translated]:3. Click \"Export All\" or select specific conversations",
+        "step4": "[to be translated]:4. Choose JSON format and enable \"Include Thinking\" for extended thinking",
+        "step5": "[to be translated]:5. Select the exported folder (contains one JSON per conversation)",
+        "title": "[to be translated]:How to export from Claude"
+      },
+      "option": {
+        "allBranches": "[to be translated]:Import all branches (includes edit history and regenerations)"
+      },
+      "selectFolder": "[to be translated]:Select Claude Export Folder",
+      "title": "[to be translated]:Import from Claude",
+      "untitled_conversation": "[to be translated]:Untitled Conversation"
+    },
     "confirm": {
       "button": "Selectează fișierul de import",
       "label": "Ești sigur că vrei să imporți date externe?"
     },
     "content": "Selectează fișierul de conversație din aplicația externă pentru import; momentan acceptă doar fișiere în format JSON ChatGPT",
+    "description": "[to be translated]:Import conversations from external AI assistants. Only text content is imported; images and attachments are not included.",
+    "error": {
+      "invalid_format": "[to be translated]:Invalid {{importer}} format",
+      "unknown": "[to be translated]:Unknown error",
+      "unsupported_format": "[to be translated]:Unsupported file format"
+    },
+    "importing": "[to be translated]:Importing conversations...",
+    "importing_progress": "[to be translated]:Importing file {{current}} of {{total}}...",
+    "model": {
+      "mixed": "[to be translated]:Mixed Models",
+      "unknown": "[to be translated]:Unknown Model"
+    },
+    "source": {
+      "auto": "[to be translated]:Auto-detect",
+      "label": "[to be translated]:Source:"
+    },
+    "success": "[to be translated]:Successfully imported {{topics}} conversations with {{messages}} messages",
     "title": "Importă conversații externe"
   },
   "knowledge": {
@@ -4111,7 +4157,9 @@
       "hour_interval_other": "{{count}} ore",
       "import_settings": {
         "button": "Importă fișier Json",
+        "button_folder": "[to be translated]:Import Folder",
         "chatgpt": "Importă din ChatGPT",
+        "claude": "[to be translated]:Import from Claude",
         "title": "Importă date din aplicație externă"
       },
       "joplin": {

--- a/src/renderer/src/i18n/translate/ru-ru.json
+++ b/src/renderer/src/i18n/translate/ru-ru.json
@@ -1942,6 +1942,10 @@
     "split": "Разделить"
   },
   "import": {
+    "assistant_name_pattern": "[to be translated]:{{model}} (Import)",
+    "button": {
+      "folder": "[to be translated]:Select Folder"
+    },
     "chatgpt": {
       "assistant_name": "Импорт ChatGPT",
       "button": "Выбрать файл",
@@ -1964,11 +1968,53 @@
       "title": "Импортировать диалоги ChatGPT",
       "untitled_conversation": "Безымянный разговор"
     },
+    "claude": {
+      "assistant_name": "[to be translated]:Claude Import",
+      "branch_name": "[to be translated]:{{name}} (branch {{index}})",
+      "description": "[to be translated]:Import conversations from Claude. Only text content is imported; images and attachments are not included.",
+      "error": {
+        "no_conversations": "[to be translated]:No conversations found in file",
+        "no_json_files": "[to be translated]:No JSON files found in the selected folder. Make sure you selected the Claude export folder.",
+        "no_valid_conversations": "[to be translated]:No valid conversations to import"
+      },
+      "help": {
+        "note": "[to be translated]:Artifacts (code), thinking blocks, and tool calls are preserved.",
+        "step1": "[to be translated]:1. Install the Claude Exporter extension (agoramachina/claude-exporter)",
+        "step2": "[to be translated]:2. Go to Claude.ai and open the extension",
+        "step3": "[to be translated]:3. Click \"Export All\" or select specific conversations",
+        "step4": "[to be translated]:4. Choose JSON format and enable \"Include Thinking\" for extended thinking",
+        "step5": "[to be translated]:5. Select the exported folder (contains one JSON per conversation)",
+        "title": "[to be translated]:How to export from Claude"
+      },
+      "option": {
+        "allBranches": "[to be translated]:Import all branches (includes edit history and regenerations)"
+      },
+      "selectFolder": "[to be translated]:Select Claude Export Folder",
+      "title": "[to be translated]:Import from Claude",
+      "untitled_conversation": "[to be translated]:Untitled Conversation"
+    },
     "confirm": {
       "button": "Выберите файл для импорта",
       "label": "Вы уверены, что хотите импортировать внешние данные?"
     },
     "content": "Выберите внешний файл с перепиской для импорта; в настоящее время поддерживаются только файлы в формате JSON ChatGPT",
+    "description": "[to be translated]:Import conversations from external AI assistants. Only text content is imported; images and attachments are not included.",
+    "error": {
+      "invalid_format": "[to be translated]:Invalid {{importer}} format",
+      "unknown": "[to be translated]:Unknown error",
+      "unsupported_format": "[to be translated]:Unsupported file format"
+    },
+    "importing": "[to be translated]:Importing conversations...",
+    "importing_progress": "[to be translated]:Importing file {{current}} of {{total}}...",
+    "model": {
+      "mixed": "[to be translated]:Mixed Models",
+      "unknown": "[to be translated]:Unknown Model"
+    },
+    "source": {
+      "auto": "[to be translated]:Auto-detect",
+      "label": "[to be translated]:Source:"
+    },
+    "success": "[to be translated]:Successfully imported {{topics}} conversations with {{messages}} messages",
     "title": "Импорт внешних бесед"
   },
   "knowledge": {
@@ -4111,7 +4157,9 @@
       "hour_interval_other": "{{count}} часов",
       "import_settings": {
         "button": "Импортировать файл JSON",
+        "button_folder": "[to be translated]:Import Folder",
         "chatgpt": "Импорт из ChatGPT",
+        "claude": "[to be translated]:Import from Claude",
         "title": "Импорт внешних данных приложения"
       },
       "joplin": {

--- a/src/renderer/src/pages/settings/DataSettings/ImportMenuSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/ImportMenuSettings.tsx
@@ -1,7 +1,6 @@
-import { RowFlex } from '@cherrystudio/ui'
+import { Button, RowFlex } from '@cherrystudio/ui'
 import ImportPopup from '@renderer/components/Popups/ImportPopup'
 import { useTheme } from '@renderer/context/ThemeProvider'
-import { Button } from 'antd'
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 

--- a/src/renderer/src/pages/settings/DataSettings/ImportMenuSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/ImportMenuSettings.tsx
@@ -10,6 +10,7 @@ import { SettingDivider, SettingGroup, SettingRow, SettingRowTitle, SettingTitle
 const ImportMenuOptions: FC = () => {
   const { t } = useTranslation()
   const { theme } = useTheme()
+
   return (
     <SettingGroup theme={theme}>
       <SettingRow>
@@ -19,7 +20,18 @@ const ImportMenuOptions: FC = () => {
       <SettingRow>
         <SettingRowTitle>{t('settings.data.import_settings.chatgpt')}</SettingRowTitle>
         <RowFlex className="justify-between gap-[5px]">
-          <Button onClick={ImportPopup.show}>{t('settings.data.import_settings.button')}</Button>
+          <Button onClick={() => ImportPopup.show('chatgpt')}>{t('settings.data.import_settings.button')}</Button>
+        </RowFlex>
+      </SettingRow>
+      <SettingDivider />
+      <SettingRow>
+        <SettingRowTitle>
+          {t('settings.data.import_settings.claude', { defaultValue: 'Import from Claude' })}
+        </SettingRowTitle>
+        <RowFlex className="justify-between gap-[5px]">
+          <Button onClick={() => ImportPopup.show('claude')}>
+            {t('settings.data.import_settings.button_folder', { defaultValue: 'Import Folder' })}
+          </Button>
         </RowFlex>
       </SettingRow>
     </SettingGroup>

--- a/src/renderer/src/services/import/ImportService.ts
+++ b/src/renderer/src/services/import/ImportService.ts
@@ -2,11 +2,13 @@ import { loggerService } from '@logger'
 import i18n from '@renderer/i18n'
 import store from '@renderer/store'
 import { addAssistant } from '@renderer/store/assistants'
-import type { Assistant } from '@renderer/types'
+import type { Assistant, Topic } from '@renderer/types'
+import type { Message, MessageBlock } from '@renderer/types/newMessage'
 import { uuid } from '@renderer/utils'
 
 import { DEFAULT_ASSISTANT_SETTINGS } from '../AssistantService'
 import { availableImporters } from './importers'
+import type { ClaudeImporter } from './importers/ClaudeImporter'
 import type { ConversationImporter, ImportResponse } from './types'
 import { saveImportToDatabase } from './utils/database'
 
@@ -157,6 +159,743 @@ class ImportServiceClass {
    */
   async importChatGPTConversations(fileContent: string): Promise<ImportResponse> {
     return this.importConversations(fileContent, 'chatgpt')
+  }
+
+  /**
+   * Import multiple files into a single assistant (for batch imports like Claude folder)
+   * @param fileContents - Array of file contents to import
+   * @param importerName - Name of the importer to use
+   * @param onProgress - Optional callback for progress updates
+   */
+  async importBatch(
+    fileContents: string[],
+    importerName: string,
+    onProgress?: (current: number, total: number) => void
+  ): Promise<ImportResponse> {
+    try {
+      logger.info(`Starting batch import of ${fileContents.length} files...`)
+
+      const importer = this.getImporter(importerName)
+      if (!importer) {
+        return {
+          success: false,
+          topicsCount: 0,
+          messagesCount: 0,
+          error: `Importer "${importerName}" not found`
+        }
+      }
+
+      if (importerName.toLowerCase() === 'claude') {
+        const claudeImporter = importer as ClaudeImporter
+        const unknownModelKey = '__unknown__'
+        const mixedModelKey = '__mixed__'
+        const modelBuckets = new Map<
+          string,
+          { assistantId: string; modelLabel: string; topics: Topic[]; messages: Message[]; blocks: MessageBlock[] }
+        >()
+        const allTopics: Topic[] = []
+        const allMessages: Message[] = []
+        const allBlocks: MessageBlock[] = []
+        const errors: string[] = []
+
+        const getClaudeModelKey = (fileContent: string): string | null => {
+          try {
+            const parsed = JSON.parse(fileContent)
+            const conversations = Array.isArray(parsed) ? parsed : [parsed]
+            const models = new Set<string>()
+            for (const conversation of conversations) {
+              const model = typeof conversation?.model === 'string' ? conversation.model.trim() : ''
+              if (model) {
+                models.add(model)
+              }
+            }
+            if (models.size === 1) {
+              return Array.from(models)[0]
+            }
+            if (models.size > 1) {
+              return mixedModelKey
+            }
+            return null
+          } catch {
+            return null
+          }
+        }
+
+        for (let i = 0; i < fileContents.length; i++) {
+          const fileContent = fileContents[i]
+          onProgress?.(i + 1, fileContents.length)
+
+          try {
+            if (!importer.validate(fileContent)) {
+              errors.push(`File ${i + 1}: Invalid format`)
+              continue
+            }
+
+            const detectedModelKey = getClaudeModelKey(fileContent) || unknownModelKey
+            let bucket = modelBuckets.get(detectedModelKey)
+            if (!bucket) {
+              const modelLabel =
+                detectedModelKey === unknownModelKey
+                  ? 'Unknown Model'
+                  : detectedModelKey === mixedModelKey
+                    ? 'Mixed Models'
+                    : claudeImporter.getAssistantModelLabel(detectedModelKey)
+              bucket = {
+                assistantId: uuid(),
+                modelLabel,
+                topics: [],
+                messages: [],
+                blocks: []
+              }
+              modelBuckets.set(detectedModelKey, bucket)
+            }
+
+            const result = await importer.parse(fileContent, bucket.assistantId)
+            bucket.topics.push(...result.topics)
+            bucket.messages.push(...result.messages)
+            bucket.blocks.push(...result.blocks)
+            allTopics.push(...result.topics)
+            allMessages.push(...result.messages)
+            allBlocks.push(...result.blocks)
+          } catch (error) {
+            errors.push(`File ${i + 1}: ${error instanceof Error ? error.message : 'Unknown error'}`)
+          }
+        }
+
+        if (allTopics.length === 0) {
+          return {
+            success: false,
+            topicsCount: 0,
+            messagesCount: 0,
+            error: errors.length > 0 ? errors.slice(0, 3).join('; ') : 'No valid conversations found'
+          }
+        }
+
+        await saveImportToDatabase({
+          topics: allTopics,
+          messages: allMessages,
+          blocks: allBlocks
+        })
+
+        const importerKey = `import.${importer.name.toLowerCase()}.assistant_name`
+        const baseAssistantName = i18n.t(importerKey, {
+          defaultValue: `${importer.name} Import`
+        })
+
+        const assistants: Assistant[] = []
+        const buckets = Array.from(modelBuckets.values()).filter((bucket) => bucket.topics.length > 0)
+        for (const bucket of buckets) {
+          const assistant: Assistant = {
+            id: bucket.assistantId,
+            name: `${baseAssistantName} - ${bucket.modelLabel}`,
+            emoji: importer.emoji,
+            prompt: '',
+            topics: bucket.topics,
+            messages: [],
+            type: 'assistant',
+            settings: DEFAULT_ASSISTANT_SETTINGS
+          }
+          store.dispatch(addAssistant(assistant))
+          assistants.push(assistant)
+        }
+
+        logger.info(
+          `Batch import completed: ${allTopics.length} conversations, ${allMessages.length} messages imported`
+        )
+
+        if (errors.length > 0) {
+          logger.warn(`Batch import had ${errors.length} errors:`, errors.slice(0, 5))
+        }
+
+        return {
+          success: true,
+          assistant: assistants[0],
+          topicsCount: allTopics.length,
+          messagesCount: allMessages.length,
+          error: errors.length > 0 ? `${errors.length} files had errors` : undefined
+        }
+      }
+
+      // Create a single assistant for all files
+      const assistantId = uuid()
+
+      const allTopics: Topic[] = []
+      const allMessages: Message[] = []
+      const allBlocks: MessageBlock[] = []
+      const errors: string[] = []
+
+      for (let i = 0; i < fileContents.length; i++) {
+        const fileContent = fileContents[i]
+        onProgress?.(i + 1, fileContents.length)
+
+        try {
+          // Validate format
+          if (!importer.validate(fileContent)) {
+            errors.push(`File ${i + 1}: Invalid format`)
+            continue
+          }
+
+          // Parse conversations
+          const result = await importer.parse(fileContent, assistantId)
+
+          allTopics.push(...result.topics)
+          allMessages.push(...result.messages)
+          allBlocks.push(...result.blocks)
+        } catch (error) {
+          errors.push(`File ${i + 1}: ${error instanceof Error ? error.message : 'Unknown error'}`)
+        }
+      }
+
+      if (allTopics.length === 0) {
+        return {
+          success: false,
+          topicsCount: 0,
+          messagesCount: 0,
+          error: errors.length > 0 ? errors.slice(0, 3).join('; ') : 'No valid conversations found'
+        }
+      }
+
+      // Save all to database
+      await saveImportToDatabase({
+        topics: allTopics,
+        messages: allMessages,
+        blocks: allBlocks
+      })
+
+      // Create single assistant for all imported conversations
+      const importerKey = `import.${importer.name.toLowerCase()}.assistant_name`
+      const assistant: Assistant = {
+        id: assistantId,
+        name: i18n.t(importerKey, {
+          defaultValue: `${importer.name} Import`
+        }),
+        emoji: importer.emoji,
+        prompt: '',
+        topics: allTopics,
+        messages: [],
+        type: 'assistant',
+        settings: DEFAULT_ASSISTANT_SETTINGS
+      }
+
+      // Add assistant to store
+      store.dispatch(addAssistant(assistant))
+
+      logger.info(`Batch import completed: ${allTopics.length} conversations, ${allMessages.length} messages imported`)
+
+      if (errors.length > 0) {
+        logger.warn(`Batch import had ${errors.length} errors:`, errors.slice(0, 5))
+      }
+
+      return {
+        success: true,
+        assistant,
+        topicsCount: allTopics.length,
+        messagesCount: allMessages.length,
+        error: errors.length > 0 ? `${errors.length} files had errors` : undefined
+      }
+    } catch (error) {
+      logger.error('Batch import failed:', error as Error)
+      return {
+        success: false,
+        topicsCount: 0,
+        messagesCount: 0,
+        error:
+          error instanceof Error ? error.message : i18n.t('import.error.unknown', { defaultValue: 'Unknown error' })
+      }
+    }
+  }
+
+  /**
+   * True streaming import - reads, processes, and saves each chunk before moving to next
+   * Never holds more than one chunk in memory at a time
+   * @param filePaths - Array of file paths to import
+   * @param chunkSize - Number of files per chunk
+   * @param readFile - Function to read a single file (provided by caller)
+   * @param importerName - Name of the importer to use
+   * @param onProgress - Optional callback for progress updates
+   * @param options - Optional import options (e.g., importAllBranches for Claude)
+   */
+  async importStreamingChunks(
+    filePaths: string[],
+    chunkSize: number,
+    readFile: (path: string) => Promise<string>,
+    importerName: string,
+    onProgress?: (current: number, total: number) => void,
+    options?: { importAllBranches?: boolean }
+  ): Promise<ImportResponse> {
+    try {
+      const totalFiles = filePaths.length
+      const totalChunks = Math.ceil(totalFiles / chunkSize)
+      logger.info(`Starting streaming import: ${totalFiles} files in ${totalChunks} chunks of ${chunkSize}`)
+
+      const importer = this.getImporter(importerName)
+      if (!importer) {
+        return {
+          success: false,
+          topicsCount: 0,
+          messagesCount: 0,
+          error: `Importer "${importerName}" not found`
+        }
+      }
+
+      // Model bucketing for Claude imports
+      const isClaudeImport = importerName.toLowerCase() === 'claude'
+      const claudeImporter = isClaudeImport ? (importer as { getAssistantModelLabel?: (m: string) => string }) : null
+      const unknownModelKey = '__unknown__'
+      const mixedModelKey = '__mixed__'
+
+      interface ModelBucket {
+        assistantId: string
+        modelLabel: string
+        topicRefs: Topic[]
+      }
+
+      const modelBuckets = new Map<string, ModelBucket>()
+      let totalTopics = 0
+      let totalMessages = 0
+      const errors: string[] = []
+
+      // Helper to get model key from file content
+      const getClaudeModelKey = (fileContent: string): string | null => {
+        try {
+          const parsed = JSON.parse(fileContent)
+          const conversations = Array.isArray(parsed) ? parsed : [parsed]
+          const models = new Set<string>()
+          for (const conversation of conversations) {
+            const model = typeof conversation?.model === 'string' ? conversation.model.trim() : ''
+            if (model) models.add(model)
+          }
+          if (models.size === 1) return Array.from(models)[0]
+          if (models.size > 1) return mixedModelKey
+          return null
+        } catch {
+          return null
+        }
+      }
+
+      // Process chunks one at a time - TRUE STREAMING
+      for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
+        const startIdx = chunkIndex * chunkSize
+        const endIdx = Math.min(startIdx + chunkSize, totalFiles)
+        const chunkPaths = filePaths.slice(startIdx, endIdx)
+
+        logger.info(`Chunk ${chunkIndex + 1}/${totalChunks}: Reading ${chunkPaths.length} files...`)
+
+        // Read files for THIS chunk only - track which files succeeded
+        const chunkContents: Array<{ content: string; filePath: string }> = []
+        for (let i = 0; i < chunkPaths.length; i++) {
+          const filePath = chunkPaths[i]
+          const fileName = filePath.split('/').pop() || filePath
+          onProgress?.(startIdx + i + 1, totalFiles)
+
+          try {
+            const content = await readFile(filePath)
+            chunkContents.push({ content, filePath })
+          } catch (error) {
+            const errMsg = `READ FAILED: ${fileName}`
+            logger.warn(errMsg, { filePath, error })
+            errors.push(errMsg)
+          }
+        }
+
+        // Process THIS chunk
+        const chunkTopics: Topic[] = []
+        const chunkMessages: Message[] = []
+        const chunkBlocks: MessageBlock[] = []
+        const topicToBucket = new Map<string, string>()
+
+        for (let i = 0; i < chunkContents.length; i++) {
+          const { content: fileContent, filePath } = chunkContents[i]
+          const fileName = filePath.split('/').pop() || filePath
+
+          try {
+            if (!importer.validate(fileContent)) {
+              const errMsg = `INVALID FORMAT: ${fileName}`
+              logger.warn(errMsg, { filePath })
+              errors.push(errMsg)
+              continue
+            }
+
+            // Determine model bucket
+            let bucketKey = 'default'
+            if (isClaudeImport) {
+              bucketKey = getClaudeModelKey(fileContent) || unknownModelKey
+            }
+
+            // Get or create bucket
+            let bucket = modelBuckets.get(bucketKey)
+            if (!bucket) {
+              let modelLabel = 'Import'
+              if (isClaudeImport && claudeImporter?.getAssistantModelLabel) {
+                modelLabel =
+                  bucketKey === unknownModelKey
+                    ? 'Unknown Model'
+                    : bucketKey === mixedModelKey
+                      ? 'Mixed Models'
+                      : claudeImporter.getAssistantModelLabel(bucketKey)
+              }
+              bucket = {
+                assistantId: uuid(),
+                modelLabel,
+                topicRefs: []
+              }
+              modelBuckets.set(bucketKey, bucket)
+            }
+
+            const result = await importer.parse(fileContent, bucket.assistantId, options)
+
+            // Check if parsing produced any topics
+            if (result.topics.length === 0) {
+              const errMsg = `EMPTY (no messages): ${fileName}`
+              logger.warn(errMsg, { filePath })
+              errors.push(errMsg)
+              continue
+            }
+
+            for (const topic of result.topics) {
+              topicToBucket.set(topic.id, bucketKey)
+            }
+
+            chunkTopics.push(...result.topics)
+            chunkMessages.push(...result.messages)
+            chunkBlocks.push(...result.blocks)
+          } catch (error) {
+            const errMsg = `PARSE ERROR: ${fileName} - ${error instanceof Error ? error.message : 'Unknown error'}`
+            logger.warn(errMsg, { filePath, error })
+            errors.push(errMsg)
+          }
+        }
+
+        // SAVE THIS CHUNK TO DATABASE IMMEDIATELY
+        if (chunkTopics.length > 0) {
+          logger.info(
+            `Chunk ${chunkIndex + 1}: Saving ${chunkTopics.length} topics, ${chunkMessages.length} messages to DB...`
+          )
+          await saveImportToDatabase({
+            topics: chunkTopics,
+            messages: chunkMessages,
+            blocks: chunkBlocks
+          })
+
+          // Add minimal topic refs to buckets (only id, name, assistantId - not full messages)
+          for (const topic of chunkTopics) {
+            const bucketKey = topicToBucket.get(topic.id) || 'default'
+            const bucket = modelBuckets.get(bucketKey)
+            if (bucket) {
+              // Store minimal reference only
+              bucket.topicRefs.push({
+                id: topic.id,
+                assistantId: topic.assistantId,
+                name: topic.name,
+                createdAt: topic.createdAt,
+                updatedAt: topic.updatedAt,
+                messages: [], // Empty - don't hold message refs
+                isNameManuallyEdited: topic.isNameManuallyEdited
+              })
+            }
+          }
+
+          totalTopics += chunkTopics.length
+          totalMessages += chunkMessages.length
+        }
+
+        // EXPLICIT MEMORY CLEANUP - help GC by clearing references
+        chunkContents.length = 0
+        chunkTopics.length = 0
+        chunkMessages.length = 0
+        chunkBlocks.length = 0
+        topicToBucket.clear()
+
+        // Small delay to allow garbage collection to run
+        await new Promise((resolve) => setTimeout(resolve, 10))
+
+        logger.info(`Chunk ${chunkIndex + 1}: Complete. Total so far: ${totalTopics} topics`)
+      }
+
+      if (totalTopics === 0) {
+        return {
+          success: false,
+          topicsCount: 0,
+          messagesCount: 0,
+          error: errors.length > 0 ? errors.slice(0, 3).join('; ') : 'No valid conversations found'
+        }
+      }
+
+      // Create assistants
+      const assistants: Assistant[] = []
+      const buckets = Array.from(modelBuckets.values()).filter((b) => b.topicRefs.length > 0)
+
+      for (const bucket of buckets) {
+        // Use "[Model] (Import)" format for Claude, just "Import" for others
+        const assistantName = isClaudeImport ? `${bucket.modelLabel} (Import)` : 'Import'
+        const assistant: Assistant = {
+          id: bucket.assistantId,
+          name: assistantName,
+          emoji: importer.emoji,
+          prompt: '',
+          topics: bucket.topicRefs,
+          messages: [],
+          type: 'assistant',
+          settings: DEFAULT_ASSISTANT_SETTINGS
+        }
+        store.dispatch(addAssistant(assistant))
+        assistants.push(assistant)
+      }
+
+      logger.info(
+        `Streaming import complete: ${totalTopics} topics, ${totalMessages} messages, ${assistants.length} assistants`
+      )
+
+      // Log detailed error summary
+      if (errors.length > 0) {
+        logger.warn(`=== IMPORT ERRORS SUMMARY (${errors.length} files) ===`)
+        const readErrors = errors.filter((e) => e.startsWith('READ FAILED'))
+        const formatErrors = errors.filter((e) => e.startsWith('INVALID FORMAT'))
+        const emptyErrors = errors.filter((e) => e.startsWith('EMPTY'))
+        const parseErrors = errors.filter((e) => e.startsWith('PARSE ERROR'))
+
+        if (readErrors.length > 0) {
+          logger.warn(`Read failures (${readErrors.length}):`, readErrors)
+        }
+        if (formatErrors.length > 0) {
+          logger.warn(`Invalid format (${formatErrors.length}):`, formatErrors)
+        }
+        if (emptyErrors.length > 0) {
+          logger.warn(`Empty conversations (${emptyErrors.length}):`, emptyErrors)
+        }
+        if (parseErrors.length > 0) {
+          logger.warn(`Parse errors (${parseErrors.length}):`, parseErrors)
+        }
+        logger.warn(`=== END ERROR SUMMARY ===`)
+      }
+
+      return {
+        success: true,
+        assistant: assistants[0],
+        topicsCount: totalTopics,
+        messagesCount: totalMessages,
+        error: errors.length > 0 ? `${errors.length} files had errors` : undefined
+      }
+    } catch (error) {
+      logger.error('Streaming import failed:', error as Error)
+      return {
+        success: false,
+        topicsCount: 0,
+        messagesCount: 0,
+        error:
+          error instanceof Error ? error.message : i18n.t('import.error.unknown', { defaultValue: 'Unknown error' })
+      }
+    }
+  }
+
+  /**
+   * Import files in chunks to avoid memory issues with large imports
+   * Processes each chunk and saves to database before moving to next chunk
+   * Groups by model like importBatch for Claude imports
+   * @deprecated Use importStreamingChunks instead for true streaming
+   */
+  async importBatchChunked(
+    chunks: string[][],
+    importerName: string,
+    onProgress?: (current: number, total: number) => void
+  ): Promise<ImportResponse> {
+    try {
+      const totalFiles = chunks.reduce((sum, chunk) => sum + chunk.length, 0)
+      logger.info(`Starting chunked import: ${chunks.length} chunks, ${totalFiles} total files`)
+
+      const importer = this.getImporter(importerName)
+      if (!importer) {
+        return {
+          success: false,
+          topicsCount: 0,
+          messagesCount: 0,
+          error: `Importer "${importerName}" not found`
+        }
+      }
+
+      // Model bucketing for Claude imports (creates separate assistants per model)
+      const isClaudeImport = importerName.toLowerCase() === 'claude'
+      const claudeImporter = isClaudeImport ? (importer as { getAssistantModelLabel?: (m: string) => string }) : null
+      const unknownModelKey = '__unknown__'
+      const mixedModelKey = '__mixed__'
+
+      interface ModelBucket {
+        assistantId: string
+        modelLabel: string
+        topicRefs: Topic[] // Only minimal refs for assistant
+      }
+
+      const modelBuckets = new Map<string, ModelBucket>()
+      let totalTopics = 0
+      let totalMessages = 0
+      const errors: string[] = []
+      let processedFiles = 0
+
+      // Helper to get model key from file content
+      const getClaudeModelKey = (fileContent: string): string | null => {
+        try {
+          const parsed = JSON.parse(fileContent)
+          const conversations = Array.isArray(parsed) ? parsed : [parsed]
+          const models = new Set<string>()
+          for (const conversation of conversations) {
+            const model = typeof conversation?.model === 'string' ? conversation.model.trim() : ''
+            if (model) models.add(model)
+          }
+          if (models.size === 1) return Array.from(models)[0]
+          if (models.size > 1) return mixedModelKey
+          return null
+        } catch {
+          return null
+        }
+      }
+
+      // Process each chunk separately
+      for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
+        const chunk = chunks[chunkIndex]
+        const chunkTopics: Topic[] = []
+        const chunkMessages: Message[] = []
+        const chunkBlocks: MessageBlock[] = []
+
+        // Track which bucket each topic belongs to (for this chunk)
+        const topicToBucket = new Map<string, string>()
+
+        logger.info(`Processing chunk ${chunkIndex + 1}/${chunks.length} with ${chunk.length} files`)
+
+        for (let i = 0; i < chunk.length; i++) {
+          const fileContent = chunk[i]
+          processedFiles++
+          onProgress?.(processedFiles, totalFiles)
+
+          try {
+            if (!importer.validate(fileContent)) {
+              errors.push(`Chunk ${chunkIndex + 1}, File ${i + 1}: Invalid format`)
+              continue
+            }
+
+            // Determine model bucket for Claude imports
+            let bucketKey = 'default'
+            if (isClaudeImport) {
+              bucketKey = getClaudeModelKey(fileContent) || unknownModelKey
+            }
+
+            // Get or create bucket
+            let bucket = modelBuckets.get(bucketKey)
+            if (!bucket) {
+              let modelLabel = 'Import'
+              if (isClaudeImport && claudeImporter?.getAssistantModelLabel) {
+                modelLabel =
+                  bucketKey === unknownModelKey
+                    ? 'Unknown Model'
+                    : bucketKey === mixedModelKey
+                      ? 'Mixed Models'
+                      : claudeImporter.getAssistantModelLabel(bucketKey)
+              }
+              bucket = {
+                assistantId: uuid(),
+                modelLabel,
+                topicRefs: []
+              }
+              modelBuckets.set(bucketKey, bucket)
+            }
+
+            const result = await importer.parse(fileContent, bucket.assistantId)
+
+            // Track which bucket these topics belong to
+            for (const topic of result.topics) {
+              topicToBucket.set(topic.id, bucketKey)
+            }
+
+            chunkTopics.push(...result.topics)
+            chunkMessages.push(...result.messages)
+            chunkBlocks.push(...result.blocks)
+          } catch (error) {
+            errors.push(
+              `Chunk ${chunkIndex + 1}, File ${i + 1}: ${error instanceof Error ? error.message : 'Unknown error'}`
+            )
+          }
+        }
+
+        // Save this chunk to database immediately to free memory
+        if (chunkTopics.length > 0) {
+          logger.info(`Saving chunk ${chunkIndex + 1}: ${chunkTopics.length} topics, ${chunkMessages.length} messages`)
+          await saveImportToDatabase({
+            topics: chunkTopics,
+            messages: chunkMessages,
+            blocks: chunkBlocks
+          })
+
+          // Add topic refs to appropriate buckets (minimal memory)
+          for (const topic of chunkTopics) {
+            const bucketKey = topicToBucket.get(topic.id) || 'default'
+            const bucket = modelBuckets.get(bucketKey)
+            if (bucket) {
+              bucket.topicRefs.push({ ...topic, messages: [] })
+            }
+          }
+
+          totalTopics += chunkTopics.length
+          totalMessages += chunkMessages.length
+        }
+      }
+
+      if (totalTopics === 0) {
+        return {
+          success: false,
+          topicsCount: 0,
+          messagesCount: 0,
+          error: errors.length > 0 ? errors.slice(0, 3).join('; ') : 'No valid conversations found'
+        }
+      }
+
+      // Create assistants (one per model bucket for Claude, one for others)
+      const importerKey = `import.${importer.name.toLowerCase()}.assistant_name`
+      const baseAssistantName = i18n.t(importerKey, {
+        defaultValue: `${importer.name} Import`
+      })
+
+      const assistants: Assistant[] = []
+      const buckets = Array.from(modelBuckets.values()).filter((b) => b.topicRefs.length > 0)
+
+      for (const bucket of buckets) {
+        const assistant: Assistant = {
+          id: bucket.assistantId,
+          name: isClaudeImport ? `${baseAssistantName} - ${bucket.modelLabel}` : baseAssistantName,
+          emoji: importer.emoji,
+          prompt: '',
+          topics: bucket.topicRefs,
+          messages: [],
+          type: 'assistant',
+          settings: DEFAULT_ASSISTANT_SETTINGS
+        }
+        store.dispatch(addAssistant(assistant))
+        assistants.push(assistant)
+      }
+
+      logger.info(
+        `Chunked import completed: ${totalTopics} conversations, ${totalMessages} messages, ${assistants.length} assistants`
+      )
+
+      if (errors.length > 0) {
+        logger.warn(`Chunked import had ${errors.length} errors`)
+      }
+
+      return {
+        success: true,
+        assistant: assistants[0],
+        topicsCount: totalTopics,
+        messagesCount: totalMessages,
+        error: errors.length > 0 ? `${errors.length} files had errors` : undefined
+      }
+    } catch (error) {
+      logger.error('Chunked import failed:', error as Error)
+      return {
+        success: false,
+        topicsCount: 0,
+        messagesCount: 0,
+        error:
+          error instanceof Error ? error.message : i18n.t('import.error.unknown', { defaultValue: 'Unknown error' })
+      }
+    }
   }
 }
 

--- a/src/renderer/src/services/import/ImportService.ts
+++ b/src/renderer/src/services/import/ImportService.ts
@@ -8,7 +8,6 @@ import { uuid } from '@renderer/utils'
 
 import { DEFAULT_ASSISTANT_SETTINGS } from '../AssistantService'
 import { availableImporters } from './importers'
-import type { ClaudeImporter } from './importers/ClaudeImporter'
 import type { ConversationImporter, ImportResponse } from './types'
 import { saveImportToDatabase } from './utils/database'
 
@@ -172,6 +171,18 @@ class ImportServiceClass {
     importerName: string,
     onProgress?: (current: number, total: number) => void
   ): Promise<ImportResponse> {
+    // Unified base type for model bucketing
+    interface ModelBucketBase {
+      assistantId: string
+      modelLabel: string
+    }
+    // Batch: accumulates all data in memory before saving
+    type BatchModelBucket = ModelBucketBase & {
+      topics: Topic[]
+      messages: Message[]
+      blocks: MessageBlock[]
+    }
+
     try {
       logger.info(`Starting batch import of ${fileContents.length} files...`)
 
@@ -185,41 +196,18 @@ class ImportServiceClass {
         }
       }
 
-      if (importerName.toLowerCase() === 'claude') {
-        const claudeImporter = importer as ClaudeImporter
-        const unknownModelKey = '__unknown__'
-        const mixedModelKey = '__mixed__'
-        const modelBuckets = new Map<
-          string,
-          { assistantId: string; modelLabel: string; topics: Topic[]; messages: Message[]; blocks: MessageBlock[] }
-        >()
+      // Check if importer supports model bucketing (polymorphic interface method)
+      const getModelBucket = importer.getModelBucket?.bind(importer)
+
+      if (getModelBucket) {
+        // Importer supports model bucketing - create separate assistants per model
+        const modelBuckets = new Map<string, BatchModelBucket>()
+        const unknownBucketKey = '__unknown__'
+        const unknownModelLabel = i18n.t('import.model.unknown', { defaultValue: 'Unknown Model' })
         const allTopics: Topic[] = []
         const allMessages: Message[] = []
         const allBlocks: MessageBlock[] = []
         const errors: string[] = []
-
-        const getClaudeModelKey = (fileContent: string): string | null => {
-          try {
-            const parsed = JSON.parse(fileContent)
-            const conversations = Array.isArray(parsed) ? parsed : [parsed]
-            const models = new Set<string>()
-            for (const conversation of conversations) {
-              const model = typeof conversation?.model === 'string' ? conversation.model.trim() : ''
-              if (model) {
-                models.add(model)
-              }
-            }
-            if (models.size === 1) {
-              return Array.from(models)[0]
-            }
-            if (models.size > 1) {
-              return mixedModelKey
-            }
-            return null
-          } catch {
-            return null
-          }
-        }
 
         for (let i = 0; i < fileContents.length; i++) {
           const fileContent = fileContents[i]
@@ -231,23 +219,25 @@ class ImportServiceClass {
               continue
             }
 
-            const detectedModelKey = getClaudeModelKey(fileContent) || unknownModelKey
-            let bucket = modelBuckets.get(detectedModelKey)
+            // Get bucket info from importer (includes both key AND label)
+            let bucketInfo: { key: string; label: string }
+            try {
+              bucketInfo = getModelBucket(fileContent) ?? { key: unknownBucketKey, label: unknownModelLabel }
+            } catch (error) {
+              logger.warn('getModelBucket failed, using unknown bucket', { error })
+              bucketInfo = { key: unknownBucketKey, label: unknownModelLabel }
+            }
+
+            let bucket = modelBuckets.get(bucketInfo.key)
             if (!bucket) {
-              const modelLabel =
-                detectedModelKey === unknownModelKey
-                  ? 'Unknown Model'
-                  : detectedModelKey === mixedModelKey
-                    ? 'Mixed Models'
-                    : claudeImporter.getAssistantModelLabel(detectedModelKey)
               bucket = {
                 assistantId: uuid(),
-                modelLabel,
+                modelLabel: bucketInfo.label,
                 topics: [],
                 messages: [],
                 blocks: []
               }
-              modelBuckets.set(detectedModelKey, bucket)
+              modelBuckets.set(bucketInfo.key, bucket)
             }
 
             const result = await importer.parse(fileContent, bucket.assistantId)
@@ -277,17 +267,18 @@ class ImportServiceClass {
           blocks: allBlocks
         })
 
-        const importerKey = `import.${importer.name.toLowerCase()}.assistant_name`
-        const baseAssistantName = i18n.t(importerKey, {
-          defaultValue: `${importer.name} Import`
-        })
+        // Filter empty buckets before creating assistants
+        const nonEmptyBuckets = Array.from(modelBuckets.values()).filter((b) => b.topics.length > 0)
 
+        // Create assistants - CONSISTENT naming: "[Model] (Import)"
         const assistants: Assistant[] = []
-        const buckets = Array.from(modelBuckets.values()).filter((bucket) => bucket.topics.length > 0)
-        for (const bucket of buckets) {
+        for (const bucket of nonEmptyBuckets) {
           const assistant: Assistant = {
             id: bucket.assistantId,
-            name: `${baseAssistantName} - ${bucket.modelLabel}`,
+            name: i18n.t('import.assistant_name_pattern', {
+              model: bucket.modelLabel,
+              defaultValue: `${bucket.modelLabel} (Import)`
+            }),
             emoji: importer.emoji,
             prompt: '',
             topics: bucket.topics,
@@ -316,7 +307,7 @@ class ImportServiceClass {
         }
       }
 
-      // Create a single assistant for all files
+      // Fallback: single assistant (existing behavior for ChatGPT and importers without getModelBucket)
       const assistantId = uuid()
 
       const allTopics: Topic[] = []
@@ -423,6 +414,16 @@ class ImportServiceClass {
     onProgress?: (current: number, total: number) => void,
     options?: { importAllBranches?: boolean }
   ): Promise<ImportResponse> {
+    // Unified base type for model bucketing (same shape as batch)
+    interface ModelBucketBase {
+      assistantId: string
+      modelLabel: string
+    }
+    // Streaming: stores minimal refs, saves to DB immediately per chunk
+    type StreamingModelBucket = ModelBucketBase & {
+      topicRefs: Topic[]
+    }
+
     try {
       const totalFiles = filePaths.length
       const totalChunks = Math.ceil(totalFiles / chunkSize)
@@ -438,40 +439,15 @@ class ImportServiceClass {
         }
       }
 
-      // Model bucketing for Claude imports
-      const isClaudeImport = importerName.toLowerCase() === 'claude'
-      const claudeImporter = isClaudeImport ? (importer as { getAssistantModelLabel?: (m: string) => string }) : null
-      const unknownModelKey = '__unknown__'
-      const mixedModelKey = '__mixed__'
+      // Check if importer supports model bucketing (polymorphic interface method)
+      const getModelBucket = importer.getModelBucket?.bind(importer)
+      const unknownBucketKey = '__unknown__'
+      const unknownModelLabel = i18n.t('import.model.unknown', { defaultValue: 'Unknown Model' })
 
-      interface ModelBucket {
-        assistantId: string
-        modelLabel: string
-        topicRefs: Topic[]
-      }
-
-      const modelBuckets = new Map<string, ModelBucket>()
+      const modelBuckets = new Map<string, StreamingModelBucket>()
       let totalTopics = 0
       let totalMessages = 0
       const errors: string[] = []
-
-      // Helper to get model key from file content
-      const getClaudeModelKey = (fileContent: string): string | null => {
-        try {
-          const parsed = JSON.parse(fileContent)
-          const conversations = Array.isArray(parsed) ? parsed : [parsed]
-          const models = new Set<string>()
-          for (const conversation of conversations) {
-            const model = typeof conversation?.model === 'string' ? conversation.model.trim() : ''
-            if (model) models.add(model)
-          }
-          if (models.size === 1) return Array.from(models)[0]
-          if (models.size > 1) return mixedModelKey
-          return null
-        } catch {
-          return null
-        }
-      }
 
       // Process chunks one at a time - TRUE STREAMING
       for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
@@ -516,30 +492,29 @@ class ImportServiceClass {
               continue
             }
 
-            // Determine model bucket
-            let bucketKey = 'default'
-            if (isClaudeImport) {
-              bucketKey = getClaudeModelKey(fileContent) || unknownModelKey
+            // Get bucket info from importer (includes both key AND label)
+            let bucketInfo: { key: string; label: string }
+            if (getModelBucket) {
+              try {
+                bucketInfo = getModelBucket(fileContent) ?? { key: unknownBucketKey, label: unknownModelLabel }
+              } catch (error) {
+                logger.warn('getModelBucket failed, using unknown bucket', { error })
+                bucketInfo = { key: unknownBucketKey, label: unknownModelLabel }
+              }
+            } else {
+              // No model bucketing - use importer name as label (e.g., "ChatGPT", "Claude")
+              bucketInfo = { key: 'default', label: importer.name }
             }
 
             // Get or create bucket
-            let bucket = modelBuckets.get(bucketKey)
+            let bucket = modelBuckets.get(bucketInfo.key)
             if (!bucket) {
-              let modelLabel = 'Import'
-              if (isClaudeImport && claudeImporter?.getAssistantModelLabel) {
-                modelLabel =
-                  bucketKey === unknownModelKey
-                    ? 'Unknown Model'
-                    : bucketKey === mixedModelKey
-                      ? 'Mixed Models'
-                      : claudeImporter.getAssistantModelLabel(bucketKey)
-              }
               bucket = {
                 assistantId: uuid(),
-                modelLabel,
+                modelLabel: bucketInfo.label,
                 topicRefs: []
               }
-              modelBuckets.set(bucketKey, bucket)
+              modelBuckets.set(bucketInfo.key, bucket)
             }
 
             const result = await importer.parse(fileContent, bucket.assistantId, options)
@@ -553,7 +528,7 @@ class ImportServiceClass {
             }
 
             for (const topic of result.topics) {
-              topicToBucket.set(topic.id, bucketKey)
+              topicToBucket.set(topic.id, bucketInfo.key)
             }
 
             chunkTopics.push(...result.topics)
@@ -621,13 +596,22 @@ class ImportServiceClass {
         }
       }
 
-      // Create assistants
-      const assistants: Assistant[] = []
-      const buckets = Array.from(modelBuckets.values()).filter((b) => b.topicRefs.length > 0)
+      // Filter empty buckets before creating assistants
+      const nonEmptyBuckets = Array.from(modelBuckets.values()).filter((b) => b.topicRefs.length > 0)
 
-      for (const bucket of buckets) {
-        // Use "[Model] (Import)" format for Claude, just "Import" for others
-        const assistantName = isClaudeImport ? `${bucket.modelLabel} (Import)` : 'Import'
+      // Create assistants
+      // - If getModelBucket exists: use "[Model] (Import)" pattern (e.g., "Claude Opus 4.5 (Import)")
+      // - If no getModelBucket (fallback): use importer-specific name (e.g., "ChatGPT Import") for consistency with batch
+      const assistants: Assistant[] = []
+      for (const bucket of nonEmptyBuckets) {
+        const assistantName = getModelBucket
+          ? i18n.t('import.assistant_name_pattern', {
+              model: bucket.modelLabel,
+              defaultValue: `${bucket.modelLabel} (Import)`
+            })
+          : i18n.t(`import.${importer.name.toLowerCase()}.assistant_name`, {
+              defaultValue: `${importer.name} Import`
+            })
         const assistant: Assistant = {
           id: bucket.assistantId,
           name: assistantName,
@@ -678,216 +662,6 @@ class ImportServiceClass {
       }
     } catch (error) {
       logger.error('Streaming import failed:', error as Error)
-      return {
-        success: false,
-        topicsCount: 0,
-        messagesCount: 0,
-        error:
-          error instanceof Error ? error.message : i18n.t('import.error.unknown', { defaultValue: 'Unknown error' })
-      }
-    }
-  }
-
-  /**
-   * Import files in chunks to avoid memory issues with large imports
-   * Processes each chunk and saves to database before moving to next chunk
-   * Groups by model like importBatch for Claude imports
-   * @deprecated Use importStreamingChunks instead for true streaming
-   */
-  async importBatchChunked(
-    chunks: string[][],
-    importerName: string,
-    onProgress?: (current: number, total: number) => void
-  ): Promise<ImportResponse> {
-    try {
-      const totalFiles = chunks.reduce((sum, chunk) => sum + chunk.length, 0)
-      logger.info(`Starting chunked import: ${chunks.length} chunks, ${totalFiles} total files`)
-
-      const importer = this.getImporter(importerName)
-      if (!importer) {
-        return {
-          success: false,
-          topicsCount: 0,
-          messagesCount: 0,
-          error: `Importer "${importerName}" not found`
-        }
-      }
-
-      // Model bucketing for Claude imports (creates separate assistants per model)
-      const isClaudeImport = importerName.toLowerCase() === 'claude'
-      const claudeImporter = isClaudeImport ? (importer as { getAssistantModelLabel?: (m: string) => string }) : null
-      const unknownModelKey = '__unknown__'
-      const mixedModelKey = '__mixed__'
-
-      interface ModelBucket {
-        assistantId: string
-        modelLabel: string
-        topicRefs: Topic[] // Only minimal refs for assistant
-      }
-
-      const modelBuckets = new Map<string, ModelBucket>()
-      let totalTopics = 0
-      let totalMessages = 0
-      const errors: string[] = []
-      let processedFiles = 0
-
-      // Helper to get model key from file content
-      const getClaudeModelKey = (fileContent: string): string | null => {
-        try {
-          const parsed = JSON.parse(fileContent)
-          const conversations = Array.isArray(parsed) ? parsed : [parsed]
-          const models = new Set<string>()
-          for (const conversation of conversations) {
-            const model = typeof conversation?.model === 'string' ? conversation.model.trim() : ''
-            if (model) models.add(model)
-          }
-          if (models.size === 1) return Array.from(models)[0]
-          if (models.size > 1) return mixedModelKey
-          return null
-        } catch {
-          return null
-        }
-      }
-
-      // Process each chunk separately
-      for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
-        const chunk = chunks[chunkIndex]
-        const chunkTopics: Topic[] = []
-        const chunkMessages: Message[] = []
-        const chunkBlocks: MessageBlock[] = []
-
-        // Track which bucket each topic belongs to (for this chunk)
-        const topicToBucket = new Map<string, string>()
-
-        logger.info(`Processing chunk ${chunkIndex + 1}/${chunks.length} with ${chunk.length} files`)
-
-        for (let i = 0; i < chunk.length; i++) {
-          const fileContent = chunk[i]
-          processedFiles++
-          onProgress?.(processedFiles, totalFiles)
-
-          try {
-            if (!importer.validate(fileContent)) {
-              errors.push(`Chunk ${chunkIndex + 1}, File ${i + 1}: Invalid format`)
-              continue
-            }
-
-            // Determine model bucket for Claude imports
-            let bucketKey = 'default'
-            if (isClaudeImport) {
-              bucketKey = getClaudeModelKey(fileContent) || unknownModelKey
-            }
-
-            // Get or create bucket
-            let bucket = modelBuckets.get(bucketKey)
-            if (!bucket) {
-              let modelLabel = 'Import'
-              if (isClaudeImport && claudeImporter?.getAssistantModelLabel) {
-                modelLabel =
-                  bucketKey === unknownModelKey
-                    ? 'Unknown Model'
-                    : bucketKey === mixedModelKey
-                      ? 'Mixed Models'
-                      : claudeImporter.getAssistantModelLabel(bucketKey)
-              }
-              bucket = {
-                assistantId: uuid(),
-                modelLabel,
-                topicRefs: []
-              }
-              modelBuckets.set(bucketKey, bucket)
-            }
-
-            const result = await importer.parse(fileContent, bucket.assistantId)
-
-            // Track which bucket these topics belong to
-            for (const topic of result.topics) {
-              topicToBucket.set(topic.id, bucketKey)
-            }
-
-            chunkTopics.push(...result.topics)
-            chunkMessages.push(...result.messages)
-            chunkBlocks.push(...result.blocks)
-          } catch (error) {
-            errors.push(
-              `Chunk ${chunkIndex + 1}, File ${i + 1}: ${error instanceof Error ? error.message : 'Unknown error'}`
-            )
-          }
-        }
-
-        // Save this chunk to database immediately to free memory
-        if (chunkTopics.length > 0) {
-          logger.info(`Saving chunk ${chunkIndex + 1}: ${chunkTopics.length} topics, ${chunkMessages.length} messages`)
-          await saveImportToDatabase({
-            topics: chunkTopics,
-            messages: chunkMessages,
-            blocks: chunkBlocks
-          })
-
-          // Add topic refs to appropriate buckets (minimal memory)
-          for (const topic of chunkTopics) {
-            const bucketKey = topicToBucket.get(topic.id) || 'default'
-            const bucket = modelBuckets.get(bucketKey)
-            if (bucket) {
-              bucket.topicRefs.push({ ...topic, messages: [] })
-            }
-          }
-
-          totalTopics += chunkTopics.length
-          totalMessages += chunkMessages.length
-        }
-      }
-
-      if (totalTopics === 0) {
-        return {
-          success: false,
-          topicsCount: 0,
-          messagesCount: 0,
-          error: errors.length > 0 ? errors.slice(0, 3).join('; ') : 'No valid conversations found'
-        }
-      }
-
-      // Create assistants (one per model bucket for Claude, one for others)
-      const importerKey = `import.${importer.name.toLowerCase()}.assistant_name`
-      const baseAssistantName = i18n.t(importerKey, {
-        defaultValue: `${importer.name} Import`
-      })
-
-      const assistants: Assistant[] = []
-      const buckets = Array.from(modelBuckets.values()).filter((b) => b.topicRefs.length > 0)
-
-      for (const bucket of buckets) {
-        const assistant: Assistant = {
-          id: bucket.assistantId,
-          name: isClaudeImport ? `${baseAssistantName} - ${bucket.modelLabel}` : baseAssistantName,
-          emoji: importer.emoji,
-          prompt: '',
-          topics: bucket.topicRefs,
-          messages: [],
-          type: 'assistant',
-          settings: DEFAULT_ASSISTANT_SETTINGS
-        }
-        store.dispatch(addAssistant(assistant))
-        assistants.push(assistant)
-      }
-
-      logger.info(
-        `Chunked import completed: ${totalTopics} conversations, ${totalMessages} messages, ${assistants.length} assistants`
-      )
-
-      if (errors.length > 0) {
-        logger.warn(`Chunked import had ${errors.length} errors`)
-      }
-
-      return {
-        success: true,
-        assistant: assistants[0],
-        topicsCount: totalTopics,
-        messagesCount: totalMessages,
-        error: errors.length > 0 ? `${errors.length} files had errors` : undefined
-      }
-    } catch (error) {
-      logger.error('Chunked import failed:', error as Error)
       return {
         success: false,
         topicsCount: 0,

--- a/src/renderer/src/services/import/ImportService.ts
+++ b/src/renderer/src/services/import/ImportService.ts
@@ -98,6 +98,7 @@ class ImportServiceClass {
           topicsCount: 0,
           messagesCount: 0,
           error: i18n.t('import.error.invalid_format', {
+            importer: importer.name,
             defaultValue: `Invalid ${importer.name} format`
           })
         }

--- a/src/renderer/src/services/import/ImportService.ts
+++ b/src/renderer/src/services/import/ImportService.ts
@@ -202,8 +202,10 @@ class ImportServiceClass {
       let totalTopics = 0
       let totalMessages = 0
       const errors: string[] = []
+      let totalErrorCount = 0
       const MAX_ERRORS = 100
       const pushError = (msg: string) => {
+        totalErrorCount++
         if (errors.length < MAX_ERRORS) errors.push(msg)
       }
 
@@ -340,7 +342,7 @@ class ImportServiceClass {
           success: false,
           topicsCount: 0,
           messagesCount: 0,
-          error: errors.length > 0 ? errors.slice(0, 3).join('; ') : 'No valid conversations found'
+          error: totalErrorCount > 0 ? errors.slice(0, 3).join('; ') : 'No valid conversations found'
         }
       }
 
@@ -379,8 +381,8 @@ class ImportServiceClass {
       )
 
       // Log detailed error summary
-      if (errors.length > 0) {
-        logger.warn(`=== IMPORT ERRORS SUMMARY (${errors.length} files) ===`)
+      if (totalErrorCount > 0) {
+        logger.warn(`=== IMPORT ERRORS SUMMARY (${totalErrorCount} files) ===`)
         const readErrors = errors.filter((e) => e.startsWith('READ FAILED'))
         const formatErrors = errors.filter((e) => e.startsWith('INVALID FORMAT'))
         const emptyErrors = errors.filter((e) => e.startsWith('EMPTY'))
@@ -406,7 +408,7 @@ class ImportServiceClass {
         assistant: assistants[0],
         topicsCount: totalTopics,
         messagesCount: totalMessages,
-        error: errors.length > 0 ? `${errors.length} files had errors` : undefined
+        error: totalErrorCount > 0 ? `${totalErrorCount} files had errors` : undefined
       }
     } catch (error) {
       logger.error('Streaming import failed:', error as Error)

--- a/src/renderer/src/services/import/ImportService.ts
+++ b/src/renderer/src/services/import/ImportService.ts
@@ -388,6 +388,9 @@ class ImportServiceClass {
         const emptyErrors = errors.filter((e) => e.startsWith('EMPTY'))
         const parseErrors = errors.filter((e) => e.startsWith('PARSE ERROR'))
 
+        if (errors.length < totalErrorCount) {
+          logger.warn(`(showing ${errors.length} of ${totalErrorCount} errors — breakdown is approximate)`)
+        }
         if (readErrors.length > 0) {
           logger.warn(`Read failures (${readErrors.length}):`, readErrors)
         }

--- a/src/renderer/src/services/import/ImportService.ts
+++ b/src/renderer/src/services/import/ImportService.ts
@@ -8,7 +8,7 @@ import { uuid } from '@renderer/utils'
 
 import { DEFAULT_ASSISTANT_SETTINGS } from '../AssistantService'
 import { availableImporters } from './importers'
-import type { ConversationImporter, ImportOptions, ImportResponse } from './types'
+import type { ConversationImporter, ImportOptions, ImportResponse, ModelBucket } from './types'
 import { saveImportToDatabase } from './utils/database'
 
 const logger = loggerService.withContext('ImportService')
@@ -178,12 +178,6 @@ class ImportServiceClass {
     onProgress?: (current: number, total: number) => void,
     options?: ImportOptions
   ): Promise<ImportResponse> {
-    interface StreamingModelBucket {
-      assistantId: string
-      modelLabel: string
-      topicRefs: Topic[]
-    }
-
     try {
       const totalFiles = filePaths.length
       const totalChunks = Math.ceil(totalFiles / chunkSize)
@@ -204,10 +198,14 @@ class ImportServiceClass {
       const unknownBucketKey = '__unknown__'
       const unknownModelLabel = i18n.t('import.model.unknown', { defaultValue: 'Unknown Model' })
 
-      const modelBuckets = new Map<string, StreamingModelBucket>()
+      const modelBuckets = new Map<string, ModelBucket>()
       let totalTopics = 0
       let totalMessages = 0
       const errors: string[] = []
+      const MAX_ERRORS = 100
+      const pushError = (msg: string) => {
+        if (errors.length < MAX_ERRORS) errors.push(msg)
+      }
 
       // Process chunks one at a time - TRUE STREAMING
       for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
@@ -230,7 +228,7 @@ class ImportServiceClass {
           } catch (error) {
             const errMsg = `READ FAILED: ${fileName}`
             logger.warn(errMsg, { filePath, error })
-            errors.push(errMsg)
+            pushError(errMsg)
           }
         }
 
@@ -248,7 +246,7 @@ class ImportServiceClass {
             if (!importer.validate(fileContent)) {
               const errMsg = `INVALID FORMAT: ${fileName}`
               logger.warn(errMsg, { filePath })
-              errors.push(errMsg)
+              pushError(errMsg)
               continue
             }
 
@@ -283,7 +281,7 @@ class ImportServiceClass {
             if (result.topics.length === 0) {
               const errMsg = `EMPTY (no messages): ${fileName}`
               logger.warn(errMsg, { filePath })
-              errors.push(errMsg)
+              pushError(errMsg)
               continue
             }
 
@@ -297,7 +295,7 @@ class ImportServiceClass {
           } catch (error) {
             const errMsg = `PARSE ERROR: ${fileName} - ${error instanceof Error ? error.message : 'Unknown error'}`
             logger.warn(errMsg, { filePath, error })
-            errors.push(errMsg)
+            pushError(errMsg)
           }
         }
 

--- a/src/renderer/src/services/import/importers/ClaudeImporter.ts
+++ b/src/renderer/src/services/import/importers/ClaudeImporter.ts
@@ -1,0 +1,667 @@
+import { loggerService } from '@logger'
+import i18n from '@renderer/i18n'
+import type { Model, Topic } from '@renderer/types'
+import {
+  AssistantMessageStatus,
+  type MainTextMessageBlock,
+  type Message,
+  type MessageBlock,
+  MessageBlockStatus,
+  MessageBlockType,
+  type ThinkingMessageBlock,
+  type ToolMessageBlock,
+  UserMessageStatus
+} from '@renderer/types/newMessage'
+import { uuid } from '@renderer/utils'
+
+import type { ConversationImporter, ImportOptions, ImportResult } from '../types'
+
+const logger = loggerService.withContext('ClaudeImporter')
+
+/**
+ * Claude Export Format Types (from agoramachina/claude-exporter)
+ */
+interface ClaudeContentBlock {
+  type: 'text' | 'thinking' | 'tool_use' | 'tool_result'
+  text?: string
+  thinking?: string
+  name?: string // tool name for tool_use
+  input?: Record<string, unknown> // tool input for tool_use
+  display_content?: {
+    type: string
+    code?: string
+    language?: string
+    filename?: string
+    json_block?: string // Stringified JSON containing {code, language} for some artifacts
+  }
+}
+
+interface ClaudeMessage {
+  uuid: string
+  parent_message_uuid: string | null
+  child_message_uuids: string[]
+  sender: 'human' | 'assistant'
+  content: ClaudeContentBlock[]
+  created_at: string
+}
+
+interface ClaudeConversation {
+  uuid: string
+  name: string
+  model: string | null
+  created_at: string
+  updated_at: string
+  chat_messages: ClaudeMessage[]
+  current_leaf_message_uuid: string
+}
+
+/**
+ * Claude conversation importer
+ * Handles importing conversations from the agoramachina/claude-exporter Chrome extension
+ */
+export class ClaudeImporter implements ConversationImporter {
+  readonly name = 'Claude'
+  readonly emoji = '🤖'
+
+  /**
+   * Validate if the file content is a valid Claude export
+   */
+  validate(fileContent: string): boolean {
+    try {
+      const parsed = JSON.parse(fileContent)
+      const conversations = Array.isArray(parsed) ? parsed : [parsed]
+
+      // Check if it has the Claude conversation structure
+      // Must have chat_messages array and uuid - distinguishes from ChatGPT's mapping structure
+      return conversations.every(
+        (conv) =>
+          conv &&
+          typeof conv === 'object' &&
+          'chat_messages' in conv &&
+          Array.isArray(conv.chat_messages) &&
+          'uuid' in conv &&
+          typeof conv.uuid === 'string'
+      )
+    } catch {
+      return false
+    }
+  }
+
+  /**
+   * Parse Claude conversations and convert to unified format
+   * @param options.importAllBranches - If true, imports ALL branches (edit history, regenerations)
+   *                                    If false (default), imports only the current/main branch
+   */
+  async parse(fileContent: string, assistantId: string, options?: ImportOptions): Promise<ImportResult> {
+    const importAllBranches = options?.importAllBranches ?? false
+    logger.info(`Starting Claude import... (importAllBranches: ${importAllBranches})`)
+
+    // Parse JSON
+    const parsed = JSON.parse(fileContent)
+    const conversations: ClaudeConversation[] = Array.isArray(parsed) ? parsed : [parsed]
+
+    if (!conversations || conversations.length === 0) {
+      throw new Error(i18n.t('import.claude.error.no_conversations'))
+    }
+
+    logger.info(`Found ${conversations.length} conversations`)
+
+    const topics: Topic[] = []
+    const allMessages: Message[] = []
+    const allBlocks: MessageBlock[] = []
+
+    // Convert each conversation (may produce multiple topics if importAllBranches is true)
+    for (const conversation of conversations) {
+      try {
+        const results = this.convertConversationToTopics(conversation, assistantId, importAllBranches)
+        for (const result of results) {
+          topics.push(result.topic)
+          allMessages.push(...result.messages)
+          allBlocks.push(...result.blocks)
+        }
+      } catch (convError) {
+        logger.warn(`Failed to convert conversation "${conversation.name}":`, convError as Error)
+        // Continue with other conversations
+      }
+    }
+
+    if (topics.length === 0) {
+      throw new Error(i18n.t('import.claude.error.no_valid_conversations'))
+    }
+
+    return {
+      topics,
+      messages: allMessages,
+      blocks: allBlocks
+    }
+  }
+
+  /**
+   * Find all leaf nodes in the message tree
+   * Leaf nodes are messages with no children
+   */
+  private findAllLeafNodes(messages: ClaudeMessage[]): ClaudeMessage[] {
+    return messages.filter((msg) => !msg.child_message_uuids || msg.child_message_uuids.length === 0)
+  }
+
+  /**
+   * Trace from a leaf node back to the root to get a branch
+   */
+  private traceToRoot(messageMap: Map<string, ClaudeMessage>, leafUuid: string): ClaudeMessage[] {
+    const branch: ClaudeMessage[] = []
+    let currentUuid: string | null = leafUuid
+
+    while (currentUuid) {
+      const msg = messageMap.get(currentUuid)
+      if (!msg) break
+      branch.unshift(msg)
+      currentUuid = msg.parent_message_uuid
+    }
+
+    return branch
+  }
+
+  /**
+   * Extract all branches from a conversation
+   * Each branch represents a different path through the conversation tree
+   * Used when importAllBranches option is enabled
+   */
+  private extractAllBranches(messages: ClaudeMessage[], currentLeafUuid?: string): ClaudeMessage[][] {
+    // Build message lookup map for O(1) access
+    const messageMap = new Map<string, ClaudeMessage>()
+    for (const msg of messages) {
+      messageMap.set(msg.uuid, msg)
+    }
+
+    // Find all leaf nodes
+    const leafNodes = this.findAllLeafNodes(messages)
+
+    if (leafNodes.length === 0) {
+      return []
+    }
+
+    // Extract each branch by tracing from leaf to root
+    const branches: ClaudeMessage[][] = []
+    for (const leaf of leafNodes) {
+      const branch = this.traceToRoot(messageMap, leaf.uuid)
+      if (branch.length > 0) {
+        branches.push(branch)
+      }
+    }
+
+    // Sort branches: main branch (current_leaf) first, then by earliest message timestamp
+    branches.sort((a, b) => {
+      const aLeafUuid = a[a.length - 1]?.uuid
+      const bLeafUuid = b[b.length - 1]?.uuid
+
+      // Current leaf branch should be first
+      if (aLeafUuid === currentLeafUuid) return -1
+      if (bLeafUuid === currentLeafUuid) return 1
+
+      // Sort by earliest message timestamp (branch creation order)
+      const aFirstTime = a[0]?.created_at ? new Date(a[0].created_at).getTime() : 0
+      const bFirstTime = b[0]?.created_at ? new Date(b[0].created_at).getTime() : 0
+      return aFirstTime - bFirstTime
+    })
+
+    return branches
+  }
+
+  /**
+   * Map Claude sender to Cherry Studio role
+   */
+  private mapRole(sender: 'human' | 'assistant'): 'user' | 'assistant' {
+    return sender === 'human' ? 'user' : 'assistant'
+  }
+
+  /**
+   * Process Claude content blocks and create typed MessageBlocks
+   * PRESERVES ORIGINAL ORDER from Claude's response
+   * Returns blocks in the same order as they appeared in the original conversation
+   */
+  private processContentBlocks(
+    contentBlocks: ClaudeContentBlock[],
+    messageId: string,
+    createdAt: string
+  ): MessageBlock[] {
+    const blocks: MessageBlock[] = []
+    let pendingTextParts: string[] = []
+
+    // Helper to flush accumulated text as a MainTextMessageBlock
+    const flushText = () => {
+      if (pendingTextParts.length > 0) {
+        const mainTextBlock: MainTextMessageBlock = {
+          id: uuid(),
+          messageId,
+          type: MessageBlockType.MAIN_TEXT,
+          content: pendingTextParts.join('\n\n').trim(),
+          createdAt,
+          updatedAt: createdAt,
+          status: MessageBlockStatus.SUCCESS
+        }
+        blocks.push(mainTextBlock)
+        pendingTextParts = []
+      }
+    }
+
+    for (const block of contentBlocks) {
+      if (block.type === 'text' && block.text) {
+        // Accumulate consecutive text blocks
+        pendingTextParts.push(block.text)
+      } else if (block.type === 'thinking' && block.thinking) {
+        // Flush any pending text BEFORE the thinking block
+        flushText()
+        // Create ThinkingMessageBlock
+        const thinkingBlock: ThinkingMessageBlock = {
+          id: uuid(),
+          messageId,
+          type: MessageBlockType.THINKING,
+          content: block.thinking,
+          thinking_millsec: 0, // Not available in export, default to 0
+          createdAt,
+          updatedAt: createdAt,
+          status: MessageBlockStatus.SUCCESS
+        }
+        blocks.push(thinkingBlock)
+      } else if (block.type === 'tool_use') {
+        // DEBUG: Log tool_use block details for artifact extraction
+        logger.debug(`Processing tool_use block: name=${block.name}`, {
+          displayContentType: block.display_content?.type,
+          hasJsonBlock: !!block.display_content?.json_block,
+          hasDirectCode: !!block.display_content?.code,
+          hasInputFileText: !!(block.input as Record<string, unknown>)?.file_text
+        })
+
+        // Try to extract artifact/file content from multiple sources
+        // Each source is tried in order until we find code
+        let artifactCode: string | undefined
+        let artifactLanguage: string | undefined
+        let artifactFilename: string | undefined
+
+        // Source 1: Direct code field in display_content
+        if (block.display_content?.code) {
+          artifactCode = block.display_content.code
+          artifactLanguage = block.display_content.language
+          artifactFilename = block.display_content.filename
+        }
+
+        // Source 2: json_block in display_content (stringified JSON with code)
+        if (!artifactCode && block.display_content?.type === 'json_block' && block.display_content.json_block) {
+          try {
+            const parsed = JSON.parse(block.display_content.json_block)
+            if (parsed.code) {
+              artifactCode = parsed.code
+              artifactLanguage = parsed.language
+              artifactFilename = parsed.filename
+            }
+          } catch {
+            // JSON parsing failed, try next source
+          }
+        }
+
+        // Source 3: input.file_text for filesystem MCP tools (create_file, write_file, etc.)
+        if (!artifactCode && block.input && typeof block.input === 'object') {
+          const input = block.input as Record<string, unknown>
+          if (typeof input.file_text === 'string' && input.file_text) {
+            artifactCode = input.file_text
+            artifactFilename = typeof input.path === 'string' ? input.path : undefined
+            const ext = artifactFilename?.split('.').pop()?.toLowerCase()
+            artifactLanguage = this.getLanguageFromExtension(ext)
+          }
+        }
+
+        // DEBUG: Log extraction result
+        logger.debug(`Artifact extraction result: hasCode=${!!artifactCode}, codeLength=${artifactCode?.length || 0}`, {
+          language: artifactLanguage,
+          filename: artifactFilename
+        })
+
+        if (artifactCode) {
+          // Flush any pending text BEFORE the code block
+          flushText()
+          // Render as MAIN_TEXT with markdown code fence (workaround for CODE block rendering bug in Blocks/index.tsx)
+          const markdownContent = `\`\`\`${artifactLanguage || 'text'}\n${artifactFilename ? `// ${artifactFilename}\n` : ''}${artifactCode}\n\`\`\``
+          const mainTextBlock: MainTextMessageBlock = {
+            id: uuid(),
+            messageId,
+            type: MessageBlockType.MAIN_TEXT,
+            content: markdownContent,
+            createdAt,
+            updatedAt: createdAt,
+            status: MessageBlockStatus.SUCCESS
+          }
+          blocks.push(mainTextBlock)
+        } else if (block.name) {
+          // Flush any pending text BEFORE the tool block
+          flushText()
+          // MCP/Tool use without artifact - create ToolMessageBlock
+          const toolBlock: ToolMessageBlock = {
+            id: uuid(),
+            messageId,
+            type: MessageBlockType.TOOL,
+            toolId: block.name,
+            toolName: block.name,
+            arguments: block.input,
+            createdAt,
+            updatedAt: createdAt,
+            status: MessageBlockStatus.SUCCESS
+          }
+          blocks.push(toolBlock)
+        }
+      }
+      // Skip 'tool_result' blocks (handled as part of tool flow)
+    }
+
+    // Flush any remaining text at the end
+    flushText()
+
+    return blocks
+  }
+
+  /**
+   * Map model string to Model object, preserving the exact model identifier
+   */
+  private mapModelToModelObject(modelString: string | null): Model | undefined {
+    if (!modelString) {
+      // Default fallback when no model is specified
+      const fallbackModelId = 'claude-3-opus-20240229'
+      return {
+        id: fallbackModelId,
+        provider: 'anthropic',
+        name: this.getModelDisplayName(fallbackModelId),
+        group: this.getModelGroup(fallbackModelId)
+      }
+    }
+
+    return {
+      id: modelString,
+      provider: 'anthropic',
+      name: this.getModelDisplayName(modelString),
+      group: this.getModelGroup(modelString)
+    }
+  }
+
+  public getAssistantModelLabel(modelString: string | null): string {
+    if (!modelString) {
+      return 'Unknown Model'
+    }
+
+    const displayName = this.getModelDisplayName(modelString)
+    return displayName === 'Claude' ? modelString : displayName
+  }
+
+  /**
+   * Extract display name from model string
+   */
+  private getModelDisplayName(modelId: string): string {
+    const parsed = this.parseClaudeModelId(modelId)
+    if (parsed.family && parsed.version) {
+      const family = this.capitalize(parsed.family)
+      if (parsed.ordering === 'version-first') {
+        return `Claude ${parsed.version} ${family}`
+      }
+      return `Claude ${family} ${parsed.version}`
+    }
+
+    // Extract base name for common Claude models
+    const lowerModelId = modelId.toLowerCase()
+    if (lowerModelId.includes('opus')) return 'Claude Opus'
+    if (lowerModelId.includes('sonnet')) return 'Claude Sonnet'
+    if (lowerModelId.includes('haiku')) return 'Claude Haiku'
+    return 'Claude'
+  }
+
+  /**
+   * Extract model group from model string
+   */
+  private getModelGroup(modelId: string): string {
+    const parsed = this.parseClaudeModelId(modelId)
+    if (parsed.version) {
+      return `claude-${parsed.version}`
+    }
+
+    // Extract version group (claude-3, claude-3.5, etc.)
+    const match = modelId.match(/claude-(\d+(?:\.\d+)?)/i)
+    if (match) {
+      return `claude-${match[1]}`
+    }
+    return 'claude'
+  }
+
+  private parseClaudeModelId(modelId: string): {
+    family?: 'opus' | 'sonnet' | 'haiku'
+    version?: string
+    ordering?: 'version-first' | 'family-first'
+  } {
+    const normalized = modelId.toLowerCase().trim()
+    const withoutPrefix = normalized.replace(/^anthropic[/.]/, '')
+    // Strip trailing date suffix (8-digit date like 20250514) before parsing
+    // This handles new model IDs like "claude-sonnet-4-20250514" → extracts just "4"
+    const base = withoutPrefix
+      .split('@')[0]
+      .split(':')[0]
+      .replace(/-\d{8}$/, '')
+
+    const versionFirst = base.match(/^claude-(\d+(?:[.-]\d+)?)-(opus|sonnet|haiku)/)
+    if (versionFirst) {
+      return {
+        version: this.normalizeClaudeVersion(versionFirst[1]),
+        family: versionFirst[2] as 'opus' | 'sonnet' | 'haiku',
+        ordering: 'version-first'
+      }
+    }
+
+    const familyFirst = base.match(/^claude-(opus|sonnet|haiku)-(\d+(?:[.-]\d+)?)/)
+    if (familyFirst) {
+      return {
+        version: this.normalizeClaudeVersion(familyFirst[2]),
+        family: familyFirst[1] as 'opus' | 'sonnet' | 'haiku',
+        ordering: 'family-first'
+      }
+    }
+
+    return {}
+  }
+
+  private normalizeClaudeVersion(version: string): string {
+    return version.replace('-', '.')
+  }
+
+  private capitalize(value: string): string {
+    return value ? value.charAt(0).toUpperCase() + value.slice(1) : value
+  }
+
+  /**
+   * Map file extension to language identifier for syntax highlighting
+   */
+  private getLanguageFromExtension(ext?: string): string {
+    if (!ext) return 'text'
+    const extMap: Record<string, string> = {
+      js: 'javascript',
+      ts: 'typescript',
+      tsx: 'typescript',
+      jsx: 'javascript',
+      py: 'python',
+      rb: 'ruby',
+      rs: 'rust',
+      go: 'go',
+      java: 'java',
+      kt: 'kotlin',
+      swift: 'swift',
+      c: 'c',
+      cpp: 'cpp',
+      h: 'c',
+      hpp: 'cpp',
+      cs: 'csharp',
+      php: 'php',
+      sh: 'bash',
+      bash: 'bash',
+      zsh: 'bash',
+      json: 'json',
+      yaml: 'yaml',
+      yml: 'yaml',
+      xml: 'xml',
+      html: 'html',
+      css: 'css',
+      scss: 'scss',
+      less: 'less',
+      sql: 'sql',
+      md: 'markdown',
+      markdown: 'markdown',
+      txt: 'text',
+      toml: 'toml',
+      ini: 'ini',
+      cfg: 'ini',
+      dockerfile: 'dockerfile'
+    }
+    return extMap[ext] || ext
+  }
+
+  /**
+   * Create Message and MessageBlocks from Claude message
+   * Returns multiple blocks for thinking, code artifacts, tool use, and main text
+   */
+  private createMessageAndBlocks(
+    claudeMessage: ClaudeMessage,
+    topicId: string,
+    assistantId: string,
+    conversationModel: string | null
+  ): { message: Message; blocks: MessageBlock[] } | null {
+    const messageId = uuid()
+    const role = this.mapRole(claudeMessage.sender)
+    const createdAt = claudeMessage.created_at || new Date().toISOString()
+
+    // Process all content blocks and create typed MessageBlocks
+    const blocks = this.processContentBlocks(claudeMessage.content, messageId, createdAt)
+
+    // Skip messages with no blocks
+    if (blocks.length === 0) {
+      return null
+    }
+
+    // Create message with references to all block IDs
+    const message: Message = {
+      id: messageId,
+      role,
+      assistantId,
+      topicId,
+      createdAt,
+      updatedAt: createdAt,
+      status: role === 'user' ? UserMessageStatus.SUCCESS : AssistantMessageStatus.SUCCESS,
+      blocks: blocks.map((b) => b.id),
+      // Set model for assistant messages - preserve the actual model used
+      ...(role === 'assistant' && {
+        model: this.mapModelToModelObject(conversationModel)
+      })
+    }
+
+    return { message, blocks }
+  }
+
+  /**
+   * Convert Claude conversation to Cherry Studio Topics
+   * Only imports the current/main branch (identified by current_leaf_message_uuid)
+   * This avoids creating thousands of topics from abandoned edit/regeneration branches
+   */
+  private convertConversationToTopics(
+    conversation: ClaudeConversation,
+    assistantId: string,
+    importAllBranches = false
+  ): Array<{ topic: Topic; messages: Message[]; blocks: MessageBlock[] }> {
+    const results: Array<{ topic: Topic; messages: Message[]; blocks: MessageBlock[] }> = []
+
+    // Get branches to import
+    let branches: ClaudeMessage[][]
+    if (importAllBranches) {
+      // Import ALL branches (edit history, regenerations, etc.)
+      branches = this.extractAllBranches(conversation.chat_messages, conversation.current_leaf_message_uuid)
+    } else {
+      // Only import the current/main branch (default)
+      const currentBranch = this.extractCurrentBranch(
+        conversation.chat_messages,
+        conversation.current_leaf_message_uuid
+      )
+      branches = currentBranch.length > 0 ? [currentBranch] : []
+    }
+
+    if (branches.length === 0) {
+      logger.warn(`No messages found in conversation "${conversation.name}"`)
+      return results
+    }
+
+    // Process each branch as a separate topic
+    for (let branchIndex = 0; branchIndex < branches.length; branchIndex++) {
+      const branch = branches[branchIndex]
+      const topicId = uuid()
+      const messages: Message[] = []
+      const blocks: MessageBlock[] = []
+
+      // Convert each message in the branch
+      for (const claudeMessage of branch) {
+        const result = this.createMessageAndBlocks(claudeMessage, topicId, assistantId, conversation.model)
+        if (result) {
+          messages.push(result.message)
+          blocks.push(...result.blocks)
+        }
+      }
+
+      // Skip if no valid messages
+      if (messages.length === 0) {
+        continue
+      }
+
+      // Use conversation name as topic name (with branch suffix for non-main branches)
+      const baseName = conversation.name || i18n.t('import.claude.untitled_conversation')
+      const topicName = branchIndex === 0 ? baseName : `${baseName} (branch ${branchIndex + 1})`
+
+      // Create topic
+      const topic: Topic = {
+        id: topicId,
+        assistantId,
+        name: topicName,
+        createdAt: conversation.created_at || new Date().toISOString(),
+        updatedAt: conversation.updated_at || new Date().toISOString(),
+        messages,
+        isNameManuallyEdited: true
+      }
+
+      results.push({ topic, messages, blocks })
+    }
+
+    return results
+  }
+
+  /**
+   * Extract only the current/main branch from the conversation
+   * Uses current_leaf_message_uuid to find the active branch
+   */
+  private extractCurrentBranch(messages: ClaudeMessage[], currentLeafUuid?: string): ClaudeMessage[] {
+    if (messages.length === 0) {
+      return []
+    }
+
+    // Build message lookup map
+    const messageMap = new Map<string, ClaudeMessage>()
+    for (const msg of messages) {
+      messageMap.set(msg.uuid, msg)
+    }
+
+    // If we have the current leaf UUID, trace from it to root
+    if (currentLeafUuid && messageMap.has(currentLeafUuid)) {
+      return this.traceToRoot(messageMap, currentLeafUuid)
+    }
+
+    // Fallback: find the first leaf node (message with no children)
+    const leafNodes = this.findAllLeafNodes(messages)
+    if (leafNodes.length > 0) {
+      return this.traceToRoot(messageMap, leafNodes[0].uuid)
+    }
+
+    // Last resort: return all messages in order (linear conversation)
+    return [...messages].sort((a, b) => {
+      const aTime = a.created_at ? new Date(a.created_at).getTime() : 0
+      const bTime = b.created_at ? new Date(b.created_at).getTime() : 0
+      return aTime - bTime
+    })
+  }
+}

--- a/src/renderer/src/services/import/importers/ClaudeImporter.ts
+++ b/src/renderer/src/services/import/importers/ClaudeImporter.ts
@@ -117,8 +117,14 @@ export class ClaudeImporter implements ConversationImporter {
       }
 
       if (models.size === 1) {
-        const modelKey = Array.from(models)[0]
-        return { key: modelKey, label: this.getAssistantModelLabel(modelKey) }
+        const rawModel = Array.from(models)[0]
+        // Normalize key: strip prefix and trailing date suffix so variants bucket together
+        const modelKey = rawModel
+          .toLowerCase()
+          .trim()
+          .replace(/^anthropic[/.:]/, '')
+          .replace(/-\d{8}$/, '')
+        return { key: modelKey, label: this.getAssistantModelLabel(rawModel) }
       }
       if (models.size > 1) {
         // Use generic i18n key for user-visible string
@@ -190,7 +196,13 @@ export class ClaudeImporter implements ConversationImporter {
    * Leaf nodes are messages with no children
    */
   private findAllLeafNodes(messages: ClaudeMessage[]): ClaudeMessage[] {
-    return messages.filter((msg) => !msg.child_message_uuids || msg.child_message_uuids.length === 0)
+    const knownUuids = new Set(messages.map((msg) => msg.uuid))
+    return messages.filter(
+      (msg) =>
+        !msg.child_message_uuids ||
+        msg.child_message_uuids.length === 0 ||
+        msg.child_message_uuids.every((id) => !knownUuids.has(id))
+    )
   }
 
   /**
@@ -380,7 +392,10 @@ export class ClaudeImporter implements ConversationImporter {
           while (artifactCode.includes(fence)) {
             fence += '`'
           }
-          const markdownContent = `${fence}${artifactLanguage || 'text'}\n${artifactFilename ? `// ${artifactFilename}\n` : ''}${artifactCode}\n${fence}`
+          // Sanitize language/filename to prevent code fence breakout
+          const safeLang = (artifactLanguage || 'text').replace(/[\r\n`]/g, '')
+          const safeFilename = artifactFilename?.replace(/[\r\n`]/g, '')
+          const markdownContent = `${fence}${safeLang}\n${safeFilename ? `// ${safeFilename}\n` : ''}${artifactCode}\n${fence}`
           const mainTextBlock: MainTextMessageBlock = {
             id: uuid(),
             messageId,
@@ -398,13 +413,31 @@ export class ClaudeImporter implements ConversationImporter {
           // expects rawMcpToolResponse metadata that imported blocks don't have,
           // so we use MainTextMessageBlock to guarantee visibility
           const argsStr = block.input ? JSON.stringify(block.input, null, 2) : ''
+          let toolFence = '```'
+          while (argsStr.includes(toolFence)) {
+            toolFence += '`'
+          }
           const toolMarkdown = argsStr
-            ? `**Tool: ${block.name}**\n\`\`\`json\n${argsStr}\n\`\`\``
+            ? `**Tool: ${block.name}**\n${toolFence}json\n${argsStr}\n${toolFence}`
             : `**Tool: ${block.name}**`
           pendingTextParts.push(toolMarkdown)
         }
+      } else if (block.type === 'tool_result') {
+        // Extract text from tool result blocks (contains tool output like search results)
+        const resultBlock = block as unknown as Record<string, unknown>
+        let resultText = ''
+        if (typeof resultBlock.content === 'string') {
+          resultText = resultBlock.content
+        } else if (Array.isArray(resultBlock.content)) {
+          resultText = (resultBlock.content as Array<Record<string, unknown>>)
+            .filter((item) => item?.type === 'text' && typeof item?.text === 'string')
+            .map((item) => item.text as string)
+            .join('\n')
+        }
+        if (resultText) {
+          pendingTextParts.push(resultText)
+        }
       }
-      // Skip 'tool_result' blocks (handled as part of tool flow)
     }
 
     // Flush any remaining text at the end
@@ -580,7 +613,11 @@ export class ClaudeImporter implements ConversationImporter {
     const createdAt = claudeMessage.created_at || new Date().toISOString()
 
     // Process all content blocks and create typed MessageBlocks
-    const blocks = this.processContentBlocks(claudeMessage.content, messageId, createdAt)
+    const blocks = this.processContentBlocks(
+      Array.isArray(claudeMessage.content) ? claudeMessage.content : [],
+      messageId,
+      createdAt
+    )
 
     // Skip messages with no blocks
     if (blocks.length === 0) {

--- a/src/renderer/src/services/import/importers/ClaudeImporter.ts
+++ b/src/renderer/src/services/import/importers/ClaudeImporter.ts
@@ -9,7 +9,6 @@ import {
   MessageBlockStatus,
   MessageBlockType,
   type ThinkingMessageBlock,
-  type ToolMessageBlock,
   UserMessageStatus
 } from '@renderer/types/newMessage'
 import { uuid } from '@renderer/utils'
@@ -395,19 +394,14 @@ export class ClaudeImporter implements ConversationImporter {
         } else if (block.name) {
           // Flush any pending text BEFORE the tool block
           flushText()
-          // MCP/Tool use without artifact - create ToolMessageBlock
-          const toolBlock: ToolMessageBlock = {
-            id: uuid(),
-            messageId,
-            type: MessageBlockType.TOOL,
-            toolId: block.name,
-            toolName: block.name,
-            arguments: block.input,
-            createdAt,
-            updatedAt: createdAt,
-            status: MessageBlockStatus.SUCCESS
-          }
-          blocks.push(toolBlock)
+          // Render tool calls as markdown text — the ToolMessageBlock renderer
+          // expects rawMcpToolResponse metadata that imported blocks don't have,
+          // so we use MainTextMessageBlock to guarantee visibility
+          const argsStr = block.input ? JSON.stringify(block.input, null, 2) : ''
+          const toolMarkdown = argsStr
+            ? `**Tool: ${block.name}**\n\`\`\`json\n${argsStr}\n\`\`\``
+            : `**Tool: ${block.name}**`
+          pendingTextParts.push(toolMarkdown)
         }
       }
       // Skip 'tool_result' blocks (handled as part of tool flow)
@@ -488,7 +482,7 @@ export class ClaudeImporter implements ConversationImporter {
     ordering?: 'version-first' | 'family-first'
   } {
     const normalized = modelId.toLowerCase().trim()
-    const withoutPrefix = normalized.replace(/^anthropic[/.]/, '')
+    const withoutPrefix = normalized.replace(/^anthropic[/.:]/, '')
     // Strip trailing date suffix (8-digit date like 20250514) before parsing
     // This handles new model IDs like "claude-sonnet-4-20250514" → extracts just "4"
     const base = withoutPrefix
@@ -712,10 +706,15 @@ export class ClaudeImporter implements ConversationImporter {
       return this.traceToRoot(messageMap, currentLeafUuid)
     }
 
-    // Fallback: find the first leaf node (message with no children)
+    // Fallback: find the latest leaf node by timestamp (most likely the active branch)
     const leafNodes = this.findAllLeafNodes(messages)
     if (leafNodes.length > 0) {
-      return this.traceToRoot(messageMap, leafNodes[0].uuid)
+      const latestLeaf = leafNodes.reduce((latest, leaf) => {
+        const latestTime = latest.created_at ? new Date(latest.created_at).getTime() : 0
+        const leafTime = leaf.created_at ? new Date(leaf.created_at).getTime() : 0
+        return leafTime > latestTime ? leaf : latest
+      })
+      return this.traceToRoot(messageMap, latestLeaf.uuid)
     }
 
     // Last resort: return all messages in order (linear conversation)

--- a/src/renderer/src/services/import/importers/__tests__/ClaudeImporter.test.ts
+++ b/src/renderer/src/services/import/importers/__tests__/ClaudeImporter.test.ts
@@ -1,0 +1,691 @@
+import { MessageBlockStatus, MessageBlockType } from '@renderer/types/newMessage'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ClaudeImporter } from '../ClaudeImporter'
+
+const mockState = vi.hoisted(() => ({
+  uuidCounter: 0,
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  }
+}))
+
+vi.mock('@renderer/i18n', () => ({
+  default: {
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key
+  }
+}))
+
+vi.mock('@renderer/utils', () => ({
+  uuid: () => `uuid-${++mockState.uuidCounter}`
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: vi.fn(() => mockState.logger)
+  }
+}))
+
+type ClaudeContentBlockForTest = {
+  type: 'text' | 'thinking' | 'tool_use' | 'tool_result'
+  text?: string
+  thinking?: string
+  name?: string
+  input?: Record<string, unknown>
+  display_content?: {
+    type: string
+    code?: string
+    language?: string
+    filename?: string
+    json_block?: string
+  }
+  content?: unknown
+}
+
+type ClaudeMessageForTest = {
+  uuid: string
+  parent_message_uuid: string | null
+  child_message_uuids: string[]
+  sender: 'human' | 'assistant'
+  content: ClaudeContentBlockForTest[] | null
+  created_at: string
+}
+
+type ClaudeConversationForTest = {
+  uuid: string
+  name: string
+  model: string | null
+  created_at: string
+  updated_at: string
+  current_leaf_message_uuid: string
+  chat_messages: ClaudeMessageForTest[]
+}
+
+const assistantId = 'assistant-1'
+
+const stringify = (value: unknown) => JSON.stringify(value)
+
+const cloneConversation = (conversation: ClaudeConversationForTest): ClaudeConversationForTest =>
+  JSON.parse(JSON.stringify(conversation)) as ClaudeConversationForTest
+
+const createMessage = (overrides: Partial<ClaudeMessageForTest> = {}): ClaudeMessageForTest => ({
+  uuid: 'msg-1',
+  parent_message_uuid: null,
+  child_message_uuids: [],
+  sender: 'human',
+  content: [{ type: 'text', text: 'Hello' }],
+  created_at: '2025-01-01T00:00:00Z',
+  ...overrides
+})
+
+const createConversation = (overrides: Partial<ClaudeConversationForTest> = {}): ClaudeConversationForTest => ({
+  uuid: 'conv-1',
+  name: 'Test Conversation',
+  model: 'claude-sonnet-4-20250514',
+  created_at: '2025-01-01T00:00:00Z',
+  updated_at: '2025-01-01T00:00:00Z',
+  current_leaf_message_uuid: 'msg-2',
+  chat_messages: [
+    createMessage({
+      uuid: 'msg-1',
+      parent_message_uuid: null,
+      child_message_uuids: ['msg-2'],
+      sender: 'human',
+      content: [{ type: 'text', text: 'Hello' }],
+      created_at: '2025-01-01T00:00:00Z'
+    }),
+    createMessage({
+      uuid: 'msg-2',
+      parent_message_uuid: 'msg-1',
+      child_message_uuids: [],
+      sender: 'assistant',
+      content: [{ type: 'text', text: 'Hi there!' }],
+      created_at: '2025-01-01T00:00:01Z'
+    })
+  ],
+  ...overrides
+})
+
+describe('ClaudeImporter', () => {
+  let importer: ClaudeImporter
+
+  beforeEach(() => {
+    mockState.uuidCounter = 0
+    vi.clearAllMocks()
+    importer = new ClaudeImporter()
+  })
+
+  describe('validate', () => {
+    it('accepts a single valid Claude conversation', () => {
+      expect(importer.validate(stringify(createConversation()))).toBe(true)
+    })
+
+    it('accepts an array of valid Claude conversations', () => {
+      const first = createConversation()
+      const second = createConversation({
+        uuid: 'conv-2',
+        name: 'Second Conversation'
+      })
+
+      expect(importer.validate(stringify([first, second]))).toBe(true)
+    })
+
+    it('rejects ChatGPT mapping format', () => {
+      const chatGptExport = {
+        title: 'ChatGPT Conversation',
+        mapping: {
+          msg1: {
+            id: 'msg1',
+            message: { author: { role: 'user' }, content: { parts: ['Hello'] } }
+          }
+        }
+      }
+
+      expect(importer.validate(stringify(chatGptExport))).toBe(false)
+    })
+
+    it('rejects invalid JSON strings', () => {
+      expect(importer.validate('{not json')).toBe(false)
+    })
+
+    it('rejects non-object JSON values', () => {
+      expect(importer.validate(stringify('plain text'))).toBe(false)
+      expect(importer.validate(stringify(42))).toBe(false)
+      expect(importer.validate(stringify(null))).toBe(false)
+      expect(importer.validate(stringify([42]))).toBe(false)
+    })
+  })
+
+  describe('parse basic conversations', () => {
+    it('creates topics, messages, and blocks for human and assistant text messages', async () => {
+      const result = await importer.parse(stringify(createConversation()), assistantId)
+
+      expect(result.topics).toHaveLength(1)
+      expect(result.messages).toHaveLength(2)
+      expect(result.blocks).toHaveLength(2)
+
+      expect(result.topics[0]).toMatchObject({
+        id: 'uuid-1',
+        assistantId,
+        name: 'Test Conversation',
+        createdAt: '2025-01-01T00:00:00Z',
+        updatedAt: '2025-01-01T00:00:00Z',
+        isNameManuallyEdited: true
+      })
+      expect(result.topics[0].messages).toStrictEqual(result.messages)
+
+      expect(result.messages[0]).toMatchObject({
+        id: 'uuid-2',
+        role: 'user',
+        assistantId,
+        topicId: 'uuid-1',
+        createdAt: '2025-01-01T00:00:00Z',
+        blocks: ['uuid-3']
+      })
+      expect(result.messages[1]).toMatchObject({
+        id: 'uuid-4',
+        role: 'assistant',
+        assistantId,
+        topicId: 'uuid-1',
+        createdAt: '2025-01-01T00:00:01Z',
+        blocks: ['uuid-5'],
+        model: {
+          id: 'claude-sonnet-4-20250514',
+          provider: 'anthropic',
+          name: 'Claude Sonnet 4',
+          group: 'claude-4'
+        }
+      })
+
+      expect(result.blocks[0]).toMatchObject({
+        id: 'uuid-3',
+        messageId: 'uuid-2',
+        type: MessageBlockType.MAIN_TEXT,
+        content: 'Hello',
+        status: MessageBlockStatus.SUCCESS
+      })
+      expect(result.blocks[1]).toMatchObject({
+        id: 'uuid-5',
+        messageId: 'uuid-4',
+        type: MessageBlockType.MAIN_TEXT,
+        content: 'Hi there!',
+        status: MessageBlockStatus.SUCCESS
+      })
+    })
+  })
+
+  describe('parse content blocks', () => {
+    it('preserves text, thinking, artifact, tool call, and tool result content', async () => {
+      const conversation = createConversation({
+        current_leaf_message_uuid: 'msg-1',
+        chat_messages: [
+          createMessage({
+            uuid: 'msg-1',
+            sender: 'assistant',
+            content: [
+              { type: 'text', text: 'Intro text' },
+              { type: 'thinking', thinking: 'Internal reasoning' },
+              { type: 'text', text: 'After thinking' },
+              { type: 'text', text: 'More text' },
+              {
+                type: 'tool_use',
+                name: 'antArtifact',
+                input: { title: 'Example' },
+                display_content: {
+                  type: 'artifact',
+                  code: 'const answer: number = 42',
+                  language: 'typescript',
+                  filename: 'answer.ts'
+                }
+              },
+              {
+                type: 'tool_use',
+                name: 'web_search',
+                input: { query: 'Claude importer' }
+              },
+              {
+                type: 'tool_result',
+                content: 'String tool result'
+              },
+              {
+                type: 'tool_result',
+                content: [
+                  { type: 'text', text: 'Array result one' },
+                  { type: 'image', url: 'ignored.png' },
+                  { type: 'text', text: 'Array result two' }
+                ]
+              }
+            ],
+            created_at: '2025-01-01T00:00:02Z'
+          })
+        ]
+      })
+
+      const result = await importer.parse(stringify(conversation), assistantId)
+
+      expect(result.messages).toHaveLength(1)
+      expect(result.blocks).toHaveLength(5)
+      expect(result.blocks.map((block) => block.type)).toEqual([
+        MessageBlockType.MAIN_TEXT,
+        MessageBlockType.THINKING,
+        MessageBlockType.MAIN_TEXT,
+        MessageBlockType.MAIN_TEXT,
+        MessageBlockType.MAIN_TEXT
+      ])
+
+      expect(result.blocks[0]).toMatchObject({
+        type: MessageBlockType.MAIN_TEXT,
+        content: 'Intro text'
+      })
+      expect(result.blocks[1]).toMatchObject({
+        type: MessageBlockType.THINKING,
+        content: 'Internal reasoning',
+        thinking_millsec: 0
+      })
+      expect(result.blocks[2]).toMatchObject({
+        type: MessageBlockType.MAIN_TEXT,
+        content: 'After thinking\n\nMore text'
+      })
+      expect(result.blocks[3]).toMatchObject({
+        type: MessageBlockType.MAIN_TEXT,
+        content: '```typescript\n// answer.ts\nconst answer: number = 42\n```'
+      })
+      expect(result.blocks[4]).toMatchObject({
+        type: MessageBlockType.MAIN_TEXT,
+        content:
+          '**Tool: web_search**\n```json\n{\n  "query": "Claude importer"\n}\n```\n\nString tool result\n\nArray result one\nArray result two'
+      })
+    })
+
+    it('extracts artifact code from json_block display content', async () => {
+      const conversation = createConversation({
+        current_leaf_message_uuid: 'msg-1',
+        chat_messages: [
+          createMessage({
+            uuid: 'msg-1',
+            sender: 'assistant',
+            content: [
+              {
+                type: 'tool_use',
+                name: 'antArtifact',
+                display_content: {
+                  type: 'json_block',
+                  json_block: JSON.stringify({
+                    code: 'print("hello")',
+                    language: 'python',
+                    filename: 'hello.py'
+                  })
+                }
+              }
+            ]
+          })
+        ]
+      })
+
+      const result = await importer.parse(stringify(conversation), assistantId)
+
+      expect(result.blocks).toHaveLength(1)
+      expect(result.blocks[0]).toMatchObject({
+        type: MessageBlockType.MAIN_TEXT,
+        content: '```python\n// hello.py\nprint("hello")\n```'
+      })
+    })
+
+    it('extracts filesystem tool code from input.file_text and infers language from path', async () => {
+      const conversation = createConversation({
+        current_leaf_message_uuid: 'msg-1',
+        chat_messages: [
+          createMessage({
+            uuid: 'msg-1',
+            sender: 'assistant',
+            content: [
+              {
+                type: 'tool_use',
+                name: 'create_file',
+                input: {
+                  path: 'src/example.tsx',
+                  file_text: 'export const Example = () => null'
+                }
+              }
+            ]
+          })
+        ]
+      })
+
+      const result = await importer.parse(stringify(conversation), assistantId)
+
+      expect(result.blocks).toHaveLength(1)
+      expect(result.blocks[0]).toMatchObject({
+        type: MessageBlockType.MAIN_TEXT,
+        content: '```typescript\n// src/example.tsx\nexport const Example = () => null\n```'
+      })
+    })
+  })
+
+  describe('parse null content guard', () => {
+    it('skips messages with null content without throwing', async () => {
+      const conversation = createConversation({
+        current_leaf_message_uuid: 'msg-2',
+        chat_messages: [
+          createMessage({
+            uuid: 'msg-1',
+            parent_message_uuid: null,
+            child_message_uuids: ['msg-2'],
+            sender: 'human',
+            content: null
+          }),
+          createMessage({
+            uuid: 'msg-2',
+            parent_message_uuid: 'msg-1',
+            child_message_uuids: [],
+            sender: 'assistant',
+            content: [{ type: 'text', text: 'Still imports this response' }]
+          })
+        ]
+      })
+
+      await expect(importer.parse(stringify(conversation), assistantId)).resolves.toMatchObject({
+        messages: [
+          {
+            role: 'assistant',
+            blocks: ['uuid-4']
+          }
+        ],
+        blocks: [
+          {
+            type: MessageBlockType.MAIN_TEXT,
+            content: 'Still imports this response'
+          }
+        ]
+      })
+    })
+  })
+
+  describe('parse branch extraction', () => {
+    const createBranchedConversation = () =>
+      createConversation({
+        name: 'Branched Conversation',
+        current_leaf_message_uuid: 'msg-3b',
+        chat_messages: [
+          createMessage({
+            uuid: 'msg-1',
+            parent_message_uuid: null,
+            child_message_uuids: ['msg-2a', 'msg-2b'],
+            sender: 'human',
+            content: [{ type: 'text', text: 'Root prompt' }],
+            created_at: '2025-01-01T00:00:00Z'
+          }),
+          createMessage({
+            uuid: 'msg-2a',
+            parent_message_uuid: 'msg-1',
+            child_message_uuids: ['msg-3a'],
+            sender: 'assistant',
+            content: [{ type: 'text', text: 'Branch A first answer' }],
+            created_at: '2025-01-01T00:00:01Z'
+          }),
+          createMessage({
+            uuid: 'msg-3a',
+            parent_message_uuid: 'msg-2a',
+            child_message_uuids: [],
+            sender: 'human',
+            content: [{ type: 'text', text: 'Branch A leaf' }],
+            created_at: '2025-01-01T00:00:02Z'
+          }),
+          createMessage({
+            uuid: 'msg-2b',
+            parent_message_uuid: 'msg-1',
+            child_message_uuids: ['msg-3b'],
+            sender: 'assistant',
+            content: [{ type: 'text', text: 'Branch B first answer' }],
+            created_at: '2025-01-01T00:00:03Z'
+          }),
+          createMessage({
+            uuid: 'msg-3b',
+            parent_message_uuid: 'msg-2b',
+            child_message_uuids: [],
+            sender: 'human',
+            content: [{ type: 'text', text: 'Branch B leaf' }],
+            created_at: '2025-01-01T00:00:04Z'
+          })
+        ]
+      })
+
+    it('imports only the current leaf branch by default', async () => {
+      const result = await importer.parse(stringify(createBranchedConversation()), assistantId)
+
+      expect(result.topics).toHaveLength(1)
+      expect(result.messages).toHaveLength(3)
+      expect(result.blocks.map((block) => ('content' in block ? block.content : undefined))).toEqual([
+        'Root prompt',
+        'Branch B first answer',
+        'Branch B leaf'
+      ])
+    })
+
+    it('imports all leaf branches when importAllBranches is true', async () => {
+      const result = await importer.parse(stringify(createBranchedConversation()), assistantId, {
+        importAllBranches: true
+      })
+
+      expect(result.topics).toHaveLength(2)
+      expect(result.messages).toHaveLength(6)
+      expect(result.topics.map((topic) => topic.name)).toEqual([
+        'Branched Conversation',
+        'Branched Conversation (branch 2)'
+      ])
+      expect(result.topics[0].messages.map((message) => message.role)).toEqual(['user', 'assistant', 'user'])
+      expect(result.topics[0].messages.map((message) => message.blocks[0])).toEqual(['uuid-3', 'uuid-5', 'uuid-7'])
+      expect(result.blocks.slice(0, 3).map((block) => ('content' in block ? block.content : undefined))).toEqual([
+        'Root prompt',
+        'Branch B first answer',
+        'Branch B leaf'
+      ])
+      expect(result.blocks.slice(3).map((block) => ('content' in block ? block.content : undefined))).toEqual([
+        'Root prompt',
+        'Branch A first answer',
+        'Branch A leaf'
+      ])
+    })
+  })
+
+  describe('getModelBucket', () => {
+    it('returns a normalized bucket for a single model', () => {
+      const conversation = createConversation({
+        model: 'anthropic:claude-3-5-sonnet-20241022'
+      })
+
+      expect(importer.getModelBucket(stringify(conversation))).toEqual({
+        key: 'claude-3-5-sonnet',
+        label: 'Claude 3.5 Sonnet'
+      })
+    })
+
+    it('returns a mixed bucket when conversations use multiple models', () => {
+      const first = createConversation({ model: 'claude-3-5-sonnet-20241022' })
+      const second = createConversation({
+        uuid: 'conv-2',
+        model: 'claude-opus-4-5-20251101'
+      })
+
+      expect(importer.getModelBucket(stringify([first, second]))).toEqual({
+        key: '__mixed__',
+        label: 'Mixed Models'
+      })
+    })
+
+    it('returns null when all conversations have null or empty models', () => {
+      const first = createConversation({ model: null })
+      const second = createConversation({ uuid: 'conv-2', model: '   ' })
+
+      expect(importer.getModelBucket(stringify([first, second]))).toBeNull()
+    })
+
+    it('normalizes anthropic slash and dot prefixes and strips date suffixes', () => {
+      expect(
+        importer.getModelBucket(
+          stringify(
+            createConversation({
+              model: 'anthropic/claude-opus-4-5-20251101'
+            })
+          )
+        )
+      ).toEqual({
+        key: 'claude-opus-4-5',
+        label: 'Claude Opus 4.5'
+      })
+
+      expect(
+        importer.getModelBucket(
+          stringify(
+            createConversation({
+              model: 'anthropic.claude-3-haiku-20240307'
+            })
+          )
+        )
+      ).toEqual({
+        key: 'claude-3-haiku',
+        label: 'Claude 3 Haiku'
+      })
+    })
+  })
+
+  describe('model display names', () => {
+    it('formats known Claude model IDs into readable labels', () => {
+      expect(importer.getAssistantModelLabel('claude-3-5-sonnet-20241022')).toBe('Claude 3.5 Sonnet')
+      expect(importer.getAssistantModelLabel('claude-opus-4-5-20251101')).toBe('Claude Opus 4.5')
+      expect(importer.getAssistantModelLabel('anthropic/claude-3-haiku-20240307')).toBe('Claude 3 Haiku')
+      expect(importer.getAssistantModelLabel('claude-sonnet-4-20250514')).toBe('Claude Sonnet 4')
+    })
+
+    it('falls back to the raw model ID or unknown model label when no display name can be parsed', () => {
+      expect(importer.getAssistantModelLabel('custom-claude-model')).toBe('custom-claude-model')
+      expect(importer.getAssistantModelLabel(null)).toBe('Unknown Model')
+    })
+  })
+
+  describe('findAllLeafNodes behavior', () => {
+    it('treats messages with only dangling child UUIDs as leaves', async () => {
+      const conversation = createConversation({
+        current_leaf_message_uuid: 'missing-leaf',
+        chat_messages: [
+          createMessage({
+            uuid: 'msg-1',
+            child_message_uuids: ['missing-child'],
+            sender: 'human',
+            content: [{ type: 'text', text: 'Dangling child prompt' }]
+          })
+        ]
+      })
+
+      const result = await importer.parse(stringify(conversation), assistantId, {
+        importAllBranches: true
+      })
+
+      expect(result.topics).toHaveLength(1)
+      expect(result.messages).toHaveLength(1)
+      expect(result.blocks[0]).toMatchObject({
+        type: MessageBlockType.MAIN_TEXT,
+        content: 'Dangling child prompt'
+      })
+    })
+  })
+
+  describe('fence sanitization', () => {
+    it('sanitizes artifact language and filename before building code fences', async () => {
+      const conversation = createConversation({
+        current_leaf_message_uuid: 'msg-1',
+        chat_messages: [
+          createMessage({
+            uuid: 'msg-1',
+            sender: 'assistant',
+            content: [
+              {
+                type: 'tool_use',
+                name: 'antArtifact',
+                display_content: {
+                  type: 'artifact',
+                  code: 'const markdown = "``` inside code"',
+                  language: 'ts`\njson',
+                  filename: 'bad`\nname.ts'
+                }
+              }
+            ]
+          })
+        ]
+      })
+
+      const result = await importer.parse(stringify(conversation), assistantId)
+      const block = result.blocks[0]
+
+      expect(block).toMatchObject({
+        type: MessageBlockType.MAIN_TEXT
+      })
+      expect('content' in block ? block.content : '').toBe(
+        '````tsjson\n// badname.ts\nconst markdown = "``` inside code"\n````'
+      )
+      expect('content' in block ? block.content : '').not.toContain('ts`\njson')
+      expect('content' in block ? block.content : '').not.toContain('bad`\nname.ts')
+    })
+  })
+
+  describe('parse cache isolation', () => {
+    it('does not reuse stale parsed content after parse clears the cache', async () => {
+      const first = createConversation()
+      const second = createConversation({
+        name: 'Second Parse',
+        chat_messages: [
+          createMessage({
+            uuid: 'msg-1',
+            child_message_uuids: [],
+            content: [{ type: 'text', text: 'Only second content' }]
+          })
+        ],
+        current_leaf_message_uuid: 'msg-1'
+      })
+
+      expect(importer.validate(stringify(first))).toBe(true)
+      await importer.parse(stringify(first), assistantId)
+
+      const result = await importer.parse(stringify(second), assistantId)
+
+      expect(result.topics[0].name).toBe('Second Parse')
+      expect(result.blocks[0]).toMatchObject({
+        type: MessageBlockType.MAIN_TEXT,
+        content: 'Only second content'
+      })
+    })
+  })
+
+  describe('array conversations', () => {
+    it('parses multiple conversations from one file', async () => {
+      const first = createConversation()
+      const second = cloneConversation(
+        createConversation({
+          uuid: 'conv-2',
+          name: 'Second Conversation',
+          current_leaf_message_uuid: 'second-msg-1',
+          chat_messages: [
+            createMessage({
+              uuid: 'second-msg-1',
+              child_message_uuids: [],
+              content: [{ type: 'text', text: 'Second hello' }]
+            })
+          ]
+        })
+      )
+
+      const result = await importer.parse(stringify([first, second]), assistantId)
+
+      expect(result.topics.map((topic) => topic.name)).toEqual(['Test Conversation', 'Second Conversation'])
+      expect(result.messages).toHaveLength(3)
+      expect(result.blocks.map((block) => ('content' in block ? block.content : undefined))).toEqual([
+        'Hello',
+        'Hi there!',
+        'Second hello'
+      ])
+    })
+  })
+})

--- a/src/renderer/src/services/import/importers/index.ts
+++ b/src/renderer/src/services/import/importers/index.ts
@@ -1,12 +1,13 @@
 import { ChatGPTImporter } from './ChatGPTImporter'
+import { ClaudeImporter } from './ClaudeImporter'
 
 /**
  * Export all available importers
  */
-export { ChatGPTImporter }
+export { ChatGPTImporter, ClaudeImporter }
 
 /**
  * Registry of all available importers
  * Add new importers here as they are implemented
  */
-export const availableImporters = [new ChatGPTImporter()] as const
+export const availableImporters = [new ChatGPTImporter(), new ClaudeImporter()] as const

--- a/src/renderer/src/services/import/types.ts
+++ b/src/renderer/src/services/import/types.ts
@@ -1,5 +1,5 @@
 import type { Assistant, Topic } from '@renderer/types'
-import type { MainTextMessageBlock, Message } from '@renderer/types/newMessage'
+import type { Message, MessageBlock } from '@renderer/types/newMessage'
 
 /**
  * Import result containing parsed data
@@ -7,7 +7,7 @@ import type { MainTextMessageBlock, Message } from '@renderer/types/newMessage'
 export interface ImportResult {
   topics: Topic[]
   messages: Message[]
-  blocks: MainTextMessageBlock[]
+  blocks: MessageBlock[]
   metadata?: Record<string, unknown>
 }
 
@@ -20,6 +20,16 @@ export interface ImportResponse {
   topicsCount: number
   messagesCount: number
   error?: string
+}
+
+/**
+ * Import options that can be passed to importers
+ */
+export interface ImportOptions {
+  /**
+   * For Claude imports: import all branches (edit history, regenerations) instead of just the main branch
+   */
+  importAllBranches?: boolean
 }
 
 /**
@@ -46,7 +56,8 @@ export interface ConversationImporter {
    * Parse file content and convert to unified format
    * @param fileContent - Raw file content (usually JSON string)
    * @param assistantId - ID of the assistant to associate with
+   * @param options - Optional import options
    * @returns Parsed topics, messages, and blocks
    */
-  parse(fileContent: string, assistantId: string): Promise<ImportResult>
+  parse(fileContent: string, assistantId: string, options?: ImportOptions): Promise<ImportResult>
 }

--- a/src/renderer/src/services/import/types.ts
+++ b/src/renderer/src/services/import/types.ts
@@ -60,4 +60,12 @@ export interface ConversationImporter {
    * @returns Parsed topics, messages, and blocks
    */
   parse(fileContent: string, assistantId: string, options?: ImportOptions): Promise<ImportResult>
+
+  /**
+   * Optional: Extract model bucket info for grouping conversations during batch imports.
+   * If implemented, ImportService will create separate assistants for each unique model key.
+   * @param fileContent - Raw file content to analyze
+   * @returns { key: model identifier, label: display name } or null if not applicable
+   */
+  getModelBucket?(fileContent: string): { key: string; label: string } | null
 }

--- a/src/renderer/src/services/import/types.ts
+++ b/src/renderer/src/services/import/types.ts
@@ -33,6 +33,15 @@ export interface ImportOptions {
 }
 
 /**
+ * Model bucket used during streaming/batch imports to group conversations by model
+ */
+export interface ModelBucket {
+  assistantId: string
+  modelLabel: string
+  topicRefs: Topic[]
+}
+
+/**
  * Base interface for conversation importers
  * Each chat application (ChatGPT, Claude, Gemini, etc.) should implement this interface
  */


### PR DESCRIPTION
### What this PR does

Before this PR:
- Cherry Studio can only import conversations from ChatGPT

After this PR:
- Cherry Studio can import conversations from Claude.ai via the [agoramachina/claude-exporter](https://github.com/agoramachina/claude-exporter) Chrome extension
- Users can import entire Claude export folders (one JSON per conversation)
- Conversations are grouped by AI model family (separate assistants for Opus, Sonnet, etc.)

### Why we need it and why it was done in this way

**Why agoramachina/claude-exporter instead of official Anthropic export:**

The official Anthropic data export does NOT include per-conversation model information. This third-party exporter preserves the actual model used (e.g., `claude-opus-4-5-20251101`, `claude-3-5-sonnet-20241022`) which is valuable for users who want to:
- Track which model was used for each conversation
- Organize imports by model family
- Preserve accurate historical context

**Implementation approach:**
- Folder-based import (Claude exporter creates one JSON file per conversation)
- Memory-efficient chunked processing for large exports (50 files per chunk)
- Model-based grouping creates separate assistants per model family
- Native block types: `ThinkingMessageBlock` for thinking, markdown code fences for artifacts and tool calls
- Optional "import all branches" checkbox for users who want edit history and regenerations
- 22 unit tests covering validation, parsing, branch extraction, model bucketing, and edge cases

The following tradeoffs were made:
- Artifacts render as markdown code blocks (workaround for a rendering bug with `CodeMessageBlock`)
- Tool calls render as markdown with name + JSON args (`ToolMessageBlock` renderer expects `rawMcpToolResponse` metadata that imported blocks don't have)
- Model accuracy depends on Claude API returning model info (some conversations return `model: null`)

The following alternatives were considered:
- Single-file import (rejected: exporter creates folder structure)
- Single assistant for all models (rejected: model-based grouping more useful)
- Official Anthropic export format (rejected: lacks model information)

### Breaking changes

None. This is a new feature that does not affect existing functionality.

### Special notes for your reviewer

**For reviewers in regions where Claude.ai is unavailable:**

To test this feature, you would need:
1. Access to Claude.ai to create conversations
2. The agoramachina/claude-exporter Chrome extension to export them
3. Import the exported folder into Cherry Studio

The importer handles:
- Text messages with role mapping (`human` → `user`, `assistant` → `assistant`)
- Extended thinking blocks (native `ThinkingMessageBlock`)
- Code artifacts from both old (`<antArtifact>`) and new (`tool_use`) formats
- MCP/tool calls rendered as markdown (tool name + JSON arguments)
- Tool results (string and array content formats)
- Conversation branching (main branch by default, all branches optional)
- Dangling child UUIDs, null content, and other malformed export edge cases

**Known limitations:**
- User attachments (images, PDFs) are NOT imported - the exporter doesn't export these
- Model accuracy may vary for auto-compacted conversations where Claude API returns `model: null`

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: Left the code cleaner than found (Boy Scout Rule)
- [x] Upgrade: No impact on upgrade flows
- [x] Tests: 22 unit tests for ClaudeImporter (validate, parse, branches, models, edge cases)
- [ ] Documentation: User-guide update may be needed for import instructions

### Release note

```release-note
feat(import): Add Claude conversation importer supporting agoramachina/claude-exporter JSON exports with model preservation, thinking blocks, artifacts, and tool calls
```