### PR TITLE
refactor: convert nested component to render function in settings popups

### DIFF
--- a/src/renderer/src/pages/settings/AgentSettings/AgentSettingsPopup.tsx
+++ b/src/renderer/src/pages/settings/AgentSettings/AgentSettingsPopup.tsx
@@ -44,32 +44,30 @@ const AgentSettingPopupContainer: React.FC<AgentSettingPopupParams> = ({ tab, ag
     resolve()
   }
 
-  const items = (
-    [
-      {
-        key: 'essential',
-        label: t('agent.settings.essential')
-      },
-      {
-        key: 'prompt',
-        label: t('agent.settings.prompt')
-      },
-      {
-        key: 'tooling',
-        label: t('agent.settings.tooling.tab', 'Tooling & permissions')
-      },
-      {
-        key: 'plugins',
-        label: t('agent.settings.plugins.tab', 'Plugins')
-      },
-      {
-        key: 'advanced',
-        label: t('agent.settings.advance.title', 'Advanced Settings')
-      }
-    ] as const satisfies { key: AgentSettingPopupTab; label: string }[]
-  ).filter(Boolean)
+  const items = [
+    {
+      key: 'essential',
+      label: t('agent.settings.essential')
+    },
+    {
+      key: 'prompt',
+      label: t('agent.settings.prompt')
+    },
+    {
+      key: 'tooling',
+      label: t('agent.settings.tooling.tab', 'Tooling & permissions')
+    },
+    {
+      key: 'plugins',
+      label: t('agent.settings.plugins.tab', 'Plugins')
+    },
+    {
+      key: 'advanced',
+      label: t('agent.settings.advance.title', 'Advanced Settings')
+    }
+  ] as const satisfies { key: AgentSettingPopupTab; label: string }[]
 
-  const ModalContent = () => {
+  const renderModalContent = () => {
     if (isLoading) {
       // TODO: use skeleton for better ux
       return (
@@ -146,7 +144,7 @@ const AgentSettingPopupContainer: React.FC<AgentSettingPopupParams> = ({ tab, ag
       }}
       width="min(800px, 70vw)"
       centered>
-      <ModalContent />
+      {renderModalContent()}
     </StyledModal>
   )
 }

--- a/src/renderer/src/pages/settings/AgentSettings/SessionSettingsPopup.tsx
+++ b/src/renderer/src/pages/settings/AgentSettings/SessionSettingsPopup.tsx
@@ -45,28 +45,26 @@ const SessionSettingPopupContainer: React.FC<SessionSettingPopupParams> = ({ tab
     resolve()
   }
 
-  const items = (
-    [
-      {
-        key: 'essential',
-        label: t('agent.settings.essential')
-      },
-      {
-        key: 'prompt',
-        label: t('agent.settings.prompt')
-      },
-      {
-        key: 'tooling',
-        label: t('agent.settings.tooling.tab', 'Tooling & permissions')
-      },
-      {
-        key: 'advanced',
-        label: t('agent.settings.advance.title', 'Advanced Settings')
-      }
-    ] as const satisfies { key: AgentSettingPopupTab; label: string }[]
-  ).filter(Boolean)
+  const items = [
+    {
+      key: 'essential',
+      label: t('agent.settings.essential')
+    },
+    {
+      key: 'prompt',
+      label: t('agent.settings.prompt')
+    },
+    {
+      key: 'tooling',
+      label: t('agent.settings.tooling.tab', 'Tooling & permissions')
+    },
+    {
+      key: 'advanced',
+      label: t('agent.settings.advance.title', 'Advanced Settings')
+    }
+  ] as const satisfies { key: AgentSettingPopupTab; label: string }[]
 
-  const ModalContent = () => {
+  const renderModalContent = () => {
     if (isLoading) {
       // TODO: use skeleton for better ux
       return (
@@ -132,7 +130,7 @@ const SessionSettingPopupContainer: React.FC<SessionSettingPopupParams> = ({ tab
       }}
       width="min(800px, 70vw)"
       centered>
-      <ModalContent />
+      {renderModalContent()}
     </StyledModal>
   )
 }


### PR DESCRIPTION
### What this PR does

Before this PR:
- `AgentSettingsPopup` and `SessionSettingsPopup` defined `ModalContent` as a nested component inside the parent component function body

After this PR:
- Changed to `renderModalContent` render function pattern, avoiding React reconciliation issues

### Why we need it and why it was done in this way

Defining a component inside another component's function body is a React anti-pattern. Every time the parent re-renders, React sees `ModalContent` as a brand new component type (different function reference), causing:
- Unnecessary unmount/remount of the entire subtree
- Loss of internal state (input focus, scroll position, etc.)
- Wasted performance

Using a render function (`renderModalContent()`) instead of a component (`<ModalContent />`) solves this because React only cares about the returned JSX, not the function identity.

### Breaking changes

None.

### Checklist

- [x] PR: The PR description is expressive enough
- [x] Code: Simple and easy to understand
- [x] Refactor: Left the code cleaner (Boy Scout Rule)

```release-note
NONE
```