### PR TITLE
refactor: extract reusable IconTooltip base component

### DIFF
--- a/src/renderer/src/components/TooltipIcons/HelpTooltip.tsx
+++ b/src/renderer/src/components/TooltipIcons/HelpTooltip.tsx
@@ -1,21 +1,15 @@
-import type { TooltipProps } from 'antd'
-import { Tooltip } from 'antd'
 import { HelpCircle } from 'lucide-react'
 
-type InheritedTooltipProps = Omit<TooltipProps, 'children'>
+import IconTooltip, { type IconTooltipProps } from './IconTooltip'
 
-interface HelpTooltipProps extends InheritedTooltipProps {
-  iconColor?: string
-  iconSize?: string | number
-  iconStyle?: React.CSSProperties
-}
+type HelpTooltipProps = Omit<IconTooltipProps, 'icon' | 'ariaLabel'>
 
-const HelpTooltip = ({ iconColor = 'var(--color-text-2)', iconSize = 14, iconStyle, ...rest }: HelpTooltipProps) => {
-  return (
-    <Tooltip {...rest}>
-      <HelpCircle size={iconSize} color={iconColor} style={{ ...iconStyle }} role="img" aria-label="Help" />
-    </Tooltip>
-  )
+/**
+ * A tooltip with a help icon.
+ * Used for providing help or guidance.
+ */
+const HelpTooltip = ({ iconColor = 'var(--color-text-2)', ...rest }: HelpTooltipProps) => {
+  return <IconTooltip icon={HelpCircle} iconColor={iconColor} ariaLabel="Help" {...rest} />
 }
 
 export default HelpTooltip

--- a/src/renderer/src/components/TooltipIcons/IconTooltip.tsx
+++ b/src/renderer/src/components/TooltipIcons/IconTooltip.tsx
@@ -1,0 +1,39 @@
+import type { TooltipProps } from 'antd'
+import { Tooltip } from 'antd'
+import type { LucideIcon } from 'lucide-react'
+
+type InheritedTooltipProps = Omit<TooltipProps, 'children'>
+
+export interface IconTooltipProps extends InheritedTooltipProps {
+  /** The Lucide icon component to render */
+  icon: LucideIcon
+  /** Icon color, can be CSS variable or color value */
+  iconColor?: string
+  /** Icon size in pixels */
+  iconSize?: string | number
+  /** Additional styles for the icon */
+  iconStyle?: React.CSSProperties
+  /** Accessible label for screen readers */
+  ariaLabel?: string
+}
+
+/**
+ * A reusable tooltip component that wraps a Lucide icon.
+ * This is the base component for InfoTooltip, WarnTooltip, and HelpTooltip.
+ */
+const IconTooltip = ({
+  icon: Icon,
+  iconColor,
+  iconSize = 14,
+  iconStyle,
+  ariaLabel = 'Icon',
+  ...tooltipProps
+}: IconTooltipProps) => {
+  return (
+    <Tooltip {...tooltipProps}>
+      <Icon size={iconSize} color={iconColor} style={{ ...iconStyle }} role="img" aria-label={ariaLabel} />
+    </Tooltip>
+  )
+}
+
+export default IconTooltip

--- a/src/renderer/src/components/TooltipIcons/InfoTooltip.tsx
+++ b/src/renderer/src/components/TooltipIcons/InfoTooltip.tsx
@@ -1,21 +1,15 @@
-import type { TooltipProps } from 'antd'
-import { Tooltip } from 'antd'
 import { Info } from 'lucide-react'
 
-type InheritedTooltipProps = Omit<TooltipProps, 'children'>
+import IconTooltip, { type IconTooltipProps } from './IconTooltip'
 
-interface InfoTooltipProps extends InheritedTooltipProps {
-  iconColor?: string
-  iconSize?: string | number
-  iconStyle?: React.CSSProperties
-}
+type InfoTooltipProps = Omit<IconTooltipProps, 'icon' | 'ariaLabel'>
 
-const InfoTooltip = ({ iconColor = 'var(--color-text-2)', iconSize = 14, iconStyle, ...rest }: InfoTooltipProps) => {
-  return (
-    <Tooltip {...rest}>
-      <Info size={iconSize} color={iconColor} style={{ ...iconStyle }} role="img" aria-label="Information" />
-    </Tooltip>
-  )
+/**
+ * A tooltip with an info icon.
+ * Used for providing additional information or context.
+ */
+const InfoTooltip = ({ iconColor = 'var(--color-text-2)', ...rest }: InfoTooltipProps) => {
+  return <IconTooltip icon={Info} iconColor={iconColor} ariaLabel="Information" {...rest} />
 }
 
 export default InfoTooltip

--- a/src/renderer/src/components/TooltipIcons/WarnTooltip.tsx
+++ b/src/renderer/src/components/TooltipIcons/WarnTooltip.tsx
@@ -1,26 +1,15 @@
-import type { TooltipProps } from 'antd'
-import { Tooltip } from 'antd'
 import { AlertTriangle } from 'lucide-react'
 
-type InheritedTooltipProps = Omit<TooltipProps, 'children'>
+import IconTooltip, { type IconTooltipProps } from './IconTooltip'
 
-interface WarnTooltipProps extends InheritedTooltipProps {
-  iconColor?: string
-  iconSize?: string | number
-  iconStyle?: React.CSSProperties
-}
+type WarnTooltipProps = Omit<IconTooltipProps, 'icon' | 'ariaLabel'>
 
-const WarnTooltip = ({
-  iconColor = 'var(--color-status-warning)',
-  iconSize = 14,
-  iconStyle,
-  ...rest
-}: WarnTooltipProps) => {
-  return (
-    <Tooltip {...rest}>
-      <AlertTriangle size={iconSize} color={iconColor} style={{ ...iconStyle }} role="img" aria-label="Information" />
-    </Tooltip>
-  )
+/**
+ * A tooltip with a warning icon.
+ * Used for displaying warnings or cautions.
+ */
+const WarnTooltip = ({ iconColor = 'var(--color-status-warning)', ...rest }: WarnTooltipProps) => {
+  return <IconTooltip icon={AlertTriangle} iconColor={iconColor} ariaLabel="Warning" {...rest} />
 }
 
 export default WarnTooltip

--- a/src/renderer/src/components/TooltipIcons/index.ts
+++ b/src/renderer/src/components/TooltipIcons/index.ts
@@ -1,3 +1,4 @@
 export { default as HelpTooltip } from './HelpTooltip'
+export { default as IconTooltip, type IconTooltipProps } from './IconTooltip'
 export { default as InfoTooltip } from './InfoTooltip'
 export { default as WarnTooltip } from './WarnTooltip'


### PR DESCRIPTION
### What this PR does

Before this PR:
- `InfoTooltip`, `WarnTooltip`, and `HelpTooltip` had 90%+ duplicated code
- `WarnTooltip` had a bug: its aria-label was "Information" instead of "Warning"

After this PR:
- A new `IconTooltip` base component handles the shared logic
- Each tooltip component is now just a thin wrapper (~15 lines vs ~25 lines)
- The aria-label bug is fixed

### Why we need it and why it was done in this way

Noticed these three components were nearly identical while exploring the codebase. Extracting a base component follows React best practices and makes adding new tooltip variants easier in the future.

No tradeoffs or breaking changes - this is a pure refactor with the same external API.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: Left the code cleaner than I found it (Boy Scout Rule)

```release-note
NONE
```