### PR TITLE
test: add unit tests for TextBadge component

### DIFF
--- a/src/renderer/src/components/__tests__/TextBadge.test.tsx
+++ b/src/renderer/src/components/__tests__/TextBadge.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import TextBadge from '../TextBadge'
+
+describe('TextBadge', () => {
+  it('should render text correctly', () => {
+    render(<TextBadge text="Beta" />)
+    expect(screen.getByText('Beta')).toBeInTheDocument()
+  })
+
+  it('should render as span element', () => {
+    render(<TextBadge text="New" />)
+    const element = screen.getByText('New')
+    expect(element.tagName).toBe('SPAN')
+  })
+
+  it('should apply custom styles', () => {
+    const customStyle = { marginLeft: '10px' }
+    render(<TextBadge text="Test" style={customStyle} />)
+    const element = screen.getByText('Test')
+    expect(element).toHaveStyle(customStyle)
+  })
+
+  it('should handle empty text', () => {
+    const { container } = render(<TextBadge text="" />)
+    const span = container.querySelector('span')
+    expect(span).toBeInTheDocument()
+    expect(span?.textContent).toBe('')
+  })
+
+  it('should handle special characters', () => {
+    const specialText = '特殊字符 & Symbols: <>&"\''
+    render(<TextBadge text={specialText} />)
+    expect(screen.getByText(specialText)).toBeInTheDocument()
+  })
+
+  it('should match snapshot', () => {
+    const { container } = render(<TextBadge text="Feature" />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+})

--- a/src/renderer/src/components/__tests__/__snapshots__/TextBadge.test.tsx.snap
+++ b/src/renderer/src/components/__tests__/__snapshots__/TextBadge.test.tsx.snap
@@ -1,0 +1,18 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`TextBadge > should match snapshot 1`] = `
+.c0 {
+  font-size: 12px;
+  color: var(--color-primary);
+  background: var(--color-primary-bg);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+<span
+  class="c0"
+>
+  Feature
+</span>
+`;


### PR DESCRIPTION
### What this PR does

Before this PR:
- `TextBadge` component had no unit tests

After this PR:
- Added comprehensive tests covering text rendering, styling, edge cases, and snapshot

### Why we need it and why it was done in this way

Just noticed this simple component was missing tests while browsing the codebase. Added tests following the same pattern as `DividerWithText.test.tsx` for consistency.

No tradeoffs or alternatives to consider - straightforward test addition.

### Breaking changes

None

### Checklist

- [x] PR: The PR description is expressive enough
- [x] Code: Tests are simple and readable
- [x] Refactor: N/A

### Release note

```release-note
NONE
```