### PR TITLE
fix: version check logic for CLI tool updates

### DIFF
--- a/src/main/services/CodeToolsService.ts
+++ b/src/main/services/CodeToolsService.ts
@@ -451,7 +451,7 @@ class CodeToolsService {
       }
     }
 
-    const needsUpdate = !!(installedVersion && latestVersion && installedVersion !== latestVersion)
+    const needsUpdate = !!(latestVersion && isInstalled && (!installedVersion || installedVersion !== latestVersion))
     logger.info(
       `Version check result for ${cliTool}: installed=${installedVersion}, latest=${latestVersion}, needsUpdate=${needsUpdate}`
     )


### PR DESCRIPTION
Updated the needsUpdate condition to handle cases where the tool is installed but has no version, ensuring updates are correctly flagged when necessary.
