### PR TITLE
refactor: replace antd Input/TextArea with Shadcn UI components

### DIFF
--- a/src/renderer/src/pages/settings/AgentSettings/DescriptionSetting.tsx
+++ b/src/renderer/src/pages/settings/AgentSettings/DescriptionSetting.tsx
@@ -1,5 +1,5 @@
+import { Textarea } from '@cherrystudio/ui'
 import type { AgentBaseWithId, UpdateAgentBaseForm, UpdateAgentFunctionUnion } from '@renderer/types'
-import TextArea from 'antd/es/input/TextArea'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -26,9 +26,9 @@ export const DescriptionSetting = ({ base, update }: DescriptionSettingProps) =>
   return (
     <SettingsItem divider={false}>
       <SettingsTitle>{t('common.description')}</SettingsTitle>
-      <TextArea
+      <Textarea.Input
         value={description}
-        onChange={(e) => setDescription(e.target.value)}
+        onValueChange={setDescription}
         rows={4}
         onBlur={() => {
           if (description !== base.description) {

--- a/src/renderer/src/pages/settings/AgentSettings/NameSetting.tsx
+++ b/src/renderer/src/pages/settings/AgentSettings/NameSetting.tsx
@@ -1,7 +1,7 @@
+import { Input } from '@cherrystudio/ui'
 import { EmojiAvatarWithPicker } from '@renderer/components/Avatar/EmojiAvatarWithPicker'
 import type { AgentBaseWithId, UpdateAgentBaseForm, UpdateAgentFunctionUnion } from '@renderer/types'
 import { AgentConfigurationSchema, isAgentEntity, isAgentType } from '@renderer/types'
-import { Input } from 'antd'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 

--- a/src/renderer/src/pages/settings/DataSettings/LocalBackupSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/LocalBackupSettings.tsx
@@ -1,5 +1,5 @@
 import { DeleteOutlined, FolderOpenOutlined, SaveOutlined, SyncOutlined } from '@ant-design/icons'
-import { Button, RowFlex, Switch, WarnTooltip } from '@cherrystudio/ui'
+import { Button, Input, RowFlex, Switch, WarnTooltip } from '@cherrystudio/ui'
 import { usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
 import { LocalBackupManager } from '@renderer/components/LocalBackupManager'
@@ -9,7 +9,6 @@ import { useTheme } from '@renderer/context/ThemeProvider'
 import { startAutoSync, stopAutoSync } from '@renderer/services/BackupService'
 import { useAppSelector } from '@renderer/store'
 import type { AppInfo } from '@renderer/types'
-import { Input } from 'antd'
 import dayjs from 'dayjs'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -191,7 +190,7 @@ const LocalBackupSettings: React.FC = () => {
             onChange={(e) => setLocalBackupDir(e.target.value)}
             onBlur={(e) => handleLocalBackupDirChange(e.target.value)}
             placeholder={t('settings.data.local.directory.placeholder')}
-            style={{ minWidth: 200, maxWidth: 400, flex: 1 }}
+            className="min-w-[200px] max-w-[400px] flex-1"
           />
           <Button onClick={handleBrowseDirectory}>
             <FolderOpenOutlined />

--- a/src/renderer/src/pages/settings/GeneralSettings.tsx
+++ b/src/renderer/src/pages/settings/GeneralSettings.tsx
@@ -1,6 +1,4 @@
-import { InfoTooltip, RowFlex } from '@cherrystudio/ui'
-import { Flex } from '@cherrystudio/ui'
-import { Switch } from '@cherrystudio/ui'
+import { Flex, InfoTooltip, Input, RowFlex, Switch } from '@cherrystudio/ui'
 import { useMultiplePreferences, usePreference } from '@data/hooks/usePreference'
 import Selector from '@renderer/components/Selector'
 import { isMac } from '@renderer/config/constant'
@@ -12,7 +10,6 @@ import { isValidProxyUrl } from '@renderer/utils'
 import { formatErrorMessage } from '@renderer/utils/error'
 import { defaultByPassRules, defaultLanguage } from '@shared/config/constant'
 import type { LanguageVarious } from '@shared/data/preference/preferenceTypes'
-import { Input } from 'antd'
 import type { FC } from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -218,7 +215,7 @@ const GeneralSettings: FC = () => {
                 placeholder="socks5://127.0.0.1:6153"
                 value={proxyUrl}
                 onChange={(e) => setProxyUrl(e.target.value)}
-                style={{ width: 180 }}
+                className="w-[180px]"
                 onBlur={() => onSetProxyUrl()}
                 type="url"
               />
@@ -242,7 +239,7 @@ const GeneralSettings: FC = () => {
                 placeholder={defaultByPassRules}
                 value={proxyBypassRules}
                 onChange={(e) => setProxyBypassRules(e.target.value)}
-                style={{ width: 180 }}
+                className="w-[180px]"
                 onBlur={() => onSetProxyBypassRules()}
               />
             </SettingRow>


### PR DESCRIPTION
### What this PR does

Before this PR:
- Settings pages used antd `Input` and `TextArea` components
- Inline styles like `style={{ width: 180 }}`

After this PR:
- Migrated to `@cherrystudio/ui` Input and Textarea components
- Uses Tailwind CSS classes instead of inline styles

### Why we need it and why it was done in this way

Part of the ongoing v2 migration from antd to Shadcn UI. These are simple, self-contained changes in 4 settings files.

The following tradeoffs were made:
- None, straightforward component replacement

The following alternatives were considered:
- N/A

### Breaking changes

None. The components have compatible APIs.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: Left the code cleaner than found (consolidated imports, removed antd dependency from these files)

### Release note

```release-note
NONE
```