### PR TITLE
refactor(ThinkingEffect): replace useState+useEffect with useMemo

### DIFF
--- a/src/renderer/src/components/ThinkingEffect.tsx
+++ b/src/renderer/src/components/ThinkingEffect.tsx
@@ -1,8 +1,7 @@
 import { lightbulbVariants } from '@renderer/utils/motionVariants'
-import { isEqual } from 'lodash'
 import { ChevronRight, Lightbulb } from 'lucide-react'
 import { motion } from 'motion/react'
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useMemo } from 'react'
 import styled from 'styled-components'
 
 interface Props {
@@ -13,17 +12,11 @@ interface Props {
 }
 
 const ThinkingEffect: React.FC<Props> = ({ isThinking, thinkingTimeText, content, expanded }) => {
-  const [messages, setMessages] = useState<string[]>([])
-
-  useEffect(() => {
+  const messages = useMemo(() => {
     const allLines = (content || '').split('\n')
     const newMessages = isThinking ? allLines.slice(0, -1) : allLines
-    const validMessages = newMessages.filter((line) => line.trim() !== '')
-
-    if (!isEqual(messages, validMessages)) {
-      setMessages(validMessages)
-    }
-  }, [content, isThinking, messages])
+    return newMessages.filter((line) => line.trim() !== '')
+  }, [content, isThinking])
 
   const showThinking = useMemo(() => {
     return isThinking && !expanded


### PR DESCRIPTION
### What this PR does

Before this PR:
`ThinkingEffect` used `useState` + `useEffect` to manage `messages`, which is derived from props. This caused double renders and required `lodash.isEqual` for comparison.

After this PR:
Uses `useMemo` for the derived state, making the code simpler and more performant.

### Why we need it and why it was done in this way

The `messages` array is purely computed from `content` and `isThinking` props - no API calls involved. Using `useState` + `useEffect` for derived state is a React anti-pattern that causes unnecessary re-renders.

`useMemo` is the right tool here because:
- It computes during render (no double render cycle)
- It has built-in dependency checking (no need for `isEqual`)
- It's simpler and more idiomatic React

### Breaking changes

None.

### Checklist

- [x] PR: The PR description is expressive enough
- [x] Code: Write code that humans can understand
- [x] Refactor: Left the code cleaner than I found it

```release-note
NONE
```