### PR TITLE
feat(hooks): add saveOnBlur option to useInPlaceEdit

### DIFF
--- a/src/renderer/src/hooks/useInPlaceEdit.ts
+++ b/src/renderer/src/hooks/useInPlaceEdit.ts
@@ -9,6 +9,7 @@ export interface UseInPlaceEditOptions {
   onError?: (error: unknown) => void
   autoSelectOnStart?: boolean
   trimOnSave?: boolean
+  saveOnBlur?: boolean
 }
 
 export interface UseInPlaceEditReturn {
@@ -27,10 +28,11 @@ export interface UseInPlaceEditReturn {
  * @param options.onCancel - Optional callback function called when editing is cancelled
  * @param options.autoSelectOnStart - Whether to automatically select text when editing starts (default: true)
  * @param options.trimOnSave - Whether to trim whitespace when saving (default: true)
+ * @param options.saveOnBlur - Whether to automatically save when input loses focus (default: true)
  * @returns An object containing the editing state and handler functions
  */
 export function useInPlaceEdit(options: UseInPlaceEditOptions): UseInPlaceEditReturn {
-  const { onSave, onCancel, onError, autoSelectOnStart = true, trimOnSave = true } = options
+  const { onSave, onCancel, onError, autoSelectOnStart = true, trimOnSave = true, saveOnBlur = true } = options
   const { t } = useTranslation()
 
   const [isSaving, setIsSaving] = useState(false)
@@ -109,14 +111,10 @@ export function useInPlaceEdit(options: UseInPlaceEditOptions): UseInPlaceEditRe
   }, [])
 
   const handleBlur = useCallback(() => {
-    // 这里的逻辑需要注意：
-    // 如果点击了“取消”按钮，可能会先触发 Blur 保存。
-    // 通常 InPlaceEdit 的逻辑是 Blur 即 Save。
-    // 如果不想 Blur 保存，可以去掉这一行，或者判断 relatedTarget。
-    if (!isSaving) {
+    if (saveOnBlur && !isSaving) {
       saveEdit()
     }
-  }, [saveEdit, isSaving])
+  }, [saveEdit, isSaving, saveOnBlur])
 
   return {
     isEditing,


### PR DESCRIPTION
### What this PR does

Before this PR:
- `useInPlaceEdit` hook always saves when input loses focus (blur event)

After this PR:
- Added a configurable `saveOnBlur` option to control whether the input automatically saves when losing focus
- Defaults to `true` to maintain backward compatibility

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Added a new optional parameter with default value `true` to maintain backward compatibility

The following alternatives were considered:
- Could have changed the default behavior, but that would break existing usage

### Breaking changes

None. The default behavior is preserved (`saveOnBlur: true`).

### Special notes for your reviewer

This gives callers flexibility for scenarios with explicit save/cancel buttons where blur-to-save behavior may cause unintended saves.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required

### Release note

```release-note
feat(hooks): add saveOnBlur option to useInPlaceEdit for flexible blur behavior control
```