### PR TITLE
refactor(ThinkingEffect): replace useState+useEffect with useMemo

### DIFF
--- a/src/renderer/src/components/ThinkingEffect.tsx
+++ b/src/renderer/src/components/ThinkingEffect.tsx
@@ -1,8 +1,7 @@
 import { lightbulbVariants } from '@renderer/utils/motionVariants'
-import { isEqual } from 'lodash'
 import { ChevronRight, Lightbulb } from 'lucide-react'
 import { motion } from 'motion/react'
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useMemo } from 'react'
 import styled from 'styled-components'
 
 interface Props {
@@ -13,17 +12,11 @@ interface Props {
 }
 
 const ThinkingEffect: React.FC<Props> = ({ isThinking, thinkingTimeText, content, expanded }) => {
-  const [messages, setMessages] = useState<string[]>([])
-
-  useEffect(() => {
+  const messages = useMemo(() => {
     const allLines = (content || '').split('\n')
     const newMessages = isThinking ? allLines.slice(0, -1) : allLines
-    const validMessages = newMessages.filter((line) => line.trim() !== '')
-
-    if (!isEqual(messages, validMessages)) {
-      setMessages(validMessages)
-    }
-  }, [content, isThinking, messages])
+    return newMessages.filter((line) => line.trim() !== '')
+  }, [content, isThinking])
 
   const showThinking = useMemo(() => {
     return isThinking && !expanded


### PR DESCRIPTION
### What this PR does

Before this PR:
- `ThinkingEffect` component uses `useState` + `useEffect` to manage `messages` array derived from `content` and `isThinking` props
- This pattern causes unnecessary re-renders and double render cycles

After this PR:
- Replaced with `useMemo` for derived state
- Removed `lodash.isEqual` dependency
- Cleaner and more performant code

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Using `useMemo` is the idiomatic React pattern for derived state

The following alternatives were considered:
- Keep the current implementation, but it's an anti-pattern that causes unnecessary complexity

### Breaking changes

None.

### Special notes for your reviewer

The messages array is purely derived from `content` and `isThinking` props, not fetched from an API. Using `useState` + `useEffect` for derived state is a React anti-pattern.

This change:
- Removes lodash isEqual dependency
- Reduces code complexity
- Avoids double render cycle

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required

### Release note

```release-note
refactor(ThinkingEffect): replace useState+useEffect with useMemo for derived state
```