### PR TITLE
fix: memoize provider selectors to prevent infinite re-renders

### DIFF
--- a/src/renderer/src/hooks/useProvider.ts
+++ b/src/renderer/src/hooks/useProvider.ts
@@ -1,7 +1,7 @@
 import { createSelector } from '@reduxjs/toolkit'
 import { CHERRYAI_PROVIDER } from '@renderer/config/providers'
 import { getDefaultProvider } from '@renderer/services/AssistantService'
-import { useAppDispatch, useAppSelector } from '@renderer/store'
+import { type RootState, useAppDispatch, useAppSelector } from '@renderer/store'
 import {
   addModel,
   addProvider,
@@ -14,6 +14,7 @@ import {
 import type { Assistant, Model, Provider } from '@renderer/types'
 import { isSystemProvider } from '@renderer/types'
 import { withoutTrailingSlash } from '@renderer/utils/api'
+import { useMemo } from 'react'
 
 import { useDefaultModel } from './useAssistant'
 
@@ -28,13 +29,27 @@ function normalizeProvider<T extends Provider>(provider: T): T {
   }
 }
 
-const selectEnabledProviders = createSelector(
-  (state) => state.llm.providers,
-  (providers) =>
-    providers
-      .map(normalizeProvider)
-      .filter((p) => p.enabled)
-      .concat(CHERRYAI_PROVIDER)
+const selectProviders = (state: RootState) => state.llm.providers
+
+const selectEnabledProviders = createSelector(selectProviders, (providers) =>
+  providers
+    .map(normalizeProvider)
+    .filter((p) => p.enabled)
+    .concat(CHERRYAI_PROVIDER)
+)
+
+const selectSystemProviders = createSelector(selectProviders, (providers) =>
+  providers.filter((p) => isSystemProvider(p)).map(normalizeProvider)
+)
+
+const selectUserProviders = createSelector(selectProviders, (providers) =>
+  providers.filter((p) => !isSystemProvider(p)).map(normalizeProvider)
+)
+
+const selectAllProviders = createSelector(selectProviders, (providers) => providers.map(normalizeProvider))
+
+const selectAllProvidersWithCherryAI = createSelector(selectProviders, (providers) =>
+  [...providers, CHERRYAI_PROVIDER].map(normalizeProvider)
 )
 
 export function useProviders() {
@@ -51,25 +66,20 @@ export function useProviders() {
 }
 
 export function useSystemProviders() {
-  return useAppSelector((state) => state.llm.providers.filter((p) => isSystemProvider(p)).map(normalizeProvider))
+  return useAppSelector(selectSystemProviders)
 }
 
 export function useUserProviders() {
-  return useAppSelector((state) => state.llm.providers.filter((p) => !isSystemProvider(p)).map(normalizeProvider))
+  return useAppSelector(selectUserProviders)
 }
 
 export function useAllProviders() {
-  return useAppSelector((state) => state.llm.providers.map(normalizeProvider))
+  return useAppSelector(selectAllProviders)
 }
 
 export function useProvider(id: string) {
-  const provider =
-    useAppSelector((state) =>
-      state.llm.providers
-        .concat([CHERRYAI_PROVIDER])
-        .map(normalizeProvider)
-        .find((p) => p.id === id)
-    ) || getDefaultProvider()
+  const allProviders = useAppSelector(selectAllProvidersWithCherryAI)
+  const provider = useMemo(() => allProviders.find((p) => p.id === id) || getDefaultProvider(), [allProviders, id])
   const dispatch = useAppDispatch()
 
   return {


### PR DESCRIPTION
### What this PR does

Before this PR:
- Components using `useProvider`, `useAllProviders`, `useSystemProviders`, `useUserProviders` would receive new object references on every render due to `normalizeProvider()` creating new objects inside `useAppSelector` callbacks
- This caused infinite re-render loops ("Maximum update depth exceeded") in components that depend on provider objects in their `useEffect` dependencies

<img width="1512" height="948" alt="image" src="https://github.com/user-attachments/assets/53d70584-c5d7-44e7-bdcc-29d47260e621" />


After this PR:
- Provider selectors are properly memoized using `createSelector` from Redux Toolkit
- Components receive stable object references when the underlying data hasn't changed
- No more infinite re-render loops

<img width="1154" height="490" alt="image" src="https://github.com/user-attachments/assets/2db06491-46f1-45f9-aafc-987c0f2c071b" />


Fixes the regression introduced in 8186d4fa291041d82a77edc8a1cc6efa73e55605

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Used `createSelector` for memoization instead of `useMemo` inside each hook, which is more efficient and follows Redux best practices

The following alternatives were considered:
- Using `useMemo` inside each hook - rejected because `createSelector` provides better memoization at the selector level
- Removing the `normalizeProvider` call entirely - rejected because trailing slash normalization is still needed

### Breaking changes

None. This is a bug fix that restores the expected behavior.

### Special notes for your reviewer

The key insight is that `.map(normalizeProvider)` inside `useAppSelector` creates new object references on every render. Moving this into `createSelector` ensures the result is memoized and only recalculated when the input providers array changes.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: Not required for this bug fix

### Release note

```release-note
fix: resolve infinite re-render loop in provider settings and painting pages
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)