### PR TITLE
fix: Improve provider config type safety and ensure required fields

### DIFF
--- a/src/renderer/src/aiCore/provider/providerConfig.ts
+++ b/src/renderer/src/aiCore/provider/providerConfig.ts
@@ -11,7 +11,8 @@ import { createVertexProvider, isVertexAIConfigured } from '@renderer/hooks/useV
 import { getProviderByModel } from '@renderer/services/AssistantService'
 import { getProviderById } from '@renderer/services/ProviderService'
 import store from '@renderer/store'
-import { EndpointType, isSystemProvider, type Model, type Provider, SystemProviderIds } from '@renderer/types'
+import type { EndpointType } from '@renderer/types'
+import { isSystemProvider, type Model, type Provider, SystemProviderIds } from '@renderer/types'
 import type { OpenAICompletionsStreamOptions } from '@renderer/types/aiCoreTypes'
 import {
   formatApiHost,


### PR DESCRIPTION
### What this PR does

Before this PR:
- **Critical Bug**: All Responses API providers were broken in v1.7.14
- `TypeError: Cannot set properties of undefined (setting 'X-Api-Key')` occurred when `extra_headers` was undefined
- **Root Cause**: The use of `any` type for `extraOptions` bypassed TypeScript's type checking, allowing unsafe operations that would have been caught at compile time
- No type safety enforcement for provider-specific configurations

After this PR:
- **Fixed**: Headers field is now safely initialized with fallback to empty object (`actualProvider.extra_headers || {}`)
- **Eliminated `any` type**: Introduced strongly-typed interfaces for different provider configurations (`BaseExtraOptions`, `AzureOpenAIExtraOptions`, `BedrockExtraOptions`, `VertexExtraOptions`, `CherryInExtraOptions`)
- **Type safety at compile time**: TypeScript now enforces that all required fields are present, preventing undefined access errors
- Ensured Vertex-specific fields (project, location, googleCredentials) are always present
- Improved type safety throughout the provider configuration flow to prevent similar issues

Fixes #12588

### Why we need it and why it was done in this way

**Root Cause Analysis**: This bug was fundamentally caused by using the `any` type, which bypassed TypeScript's type checking system. When `extraOptions.headers` was undefined (because `extra_headers` was not set), attempting to set `extraOptions.headers['X-Api-Key']` threw a runtime error that TypeScript could not catch.

**Solution**: By replacing `any` with strongly-typed interfaces, TypeScript can now verify at compile time that:
1. The `headers` field is always defined (required field in `BaseExtraOptions`)
2. Provider-specific fields are present when needed
3. No unsafe property access can occur

This approach not only fixes the immediate bug but also prevents an entire class of similar runtime errors from occurring in the future.

The following tradeoffs were made:
- Introduced more verbose type definitions in exchange for compile-time safety and elimination of runtime errors
- Required headers field to be always defined (empty object by default) to avoid undefined access

The following alternatives were considered:
- **Simple null check only** - rejected because it doesn't address the root cause (use of `any` type) and doesn't prevent future similar issues
- **Using union types with discriminated unions** - current approach with separate interfaces provides better IntelliSense and clearer intent
- **Keeping the loose `any` type** - rejected as it defeats the purpose of TypeScript and allows these runtime errors to slip through

### Breaking changes

None. This is a bug fix with internal refactoring that maintains backward compatibility.

### Special notes for your reviewer

- **Priority**: This is a critical bug fix for v1.7.14 regression
- **Core fix**: Replaced `any` type with strongly-typed interfaces to catch errors at compile time
- The immediate fix is the safe initialization: `const headers = actualProvider.extra_headers || {}`
- Type system now enforces that `headers` field is always defined in all provider configurations
- All provider-specific configurations are now properly typed with required fields

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required (internal bug fix)

### Release note

```release-note
fix: Critical bug fix for v1.7.14 regression that broke all Responses API providers. Replaced loose `any` type with strongly-typed interfaces to prevent similar runtime errors and improve type safety.
```