### PR TITLE
Update together models URL in providers configuration

### DIFF
--- a/src/renderer/src/config/providers.ts
+++ b/src/renderer/src/config/providers.ts
@@ -932,7 +932,7 @@ export const PROVIDER_URLS: Record<SystemProviderId, ProviderUrls> = {
       official: 'https://www.together.ai/',
       apiKey: 'https://api.together.ai/settings/api-keys',
       docs: 'https://docs.together.ai/docs/introduction',
-      models: 'https://docs.together.ai/docs/chat-models'
+      models: 'https://docs.together.ai/docs/serverless-models'
     }
   },
   dmxapi: {


### PR DESCRIPTION
### What this PR does

This PR updates the documentation URL for Together AI provider's models in the providers configuration file. The models link now points to the serverless models documentation instead of the chat models documentation.

### Before this PR

The Together AI provider configuration pointed to the chat models documentation at:
`https://docs.together.ai/docs/chat-models`

### After this PR

The Together AI provider configuration now points to the serverless models documentation at:
`https://docs.together.ai/docs/serverless-models`

Fixes #

### Why we need it and why it was done in this way

The Together AI API has updated their documentation structure. The chat models documentation has been moved to a new location under the serverless models section. This change ensures that users are directed to the correct and up-to-date documentation for the available models.

### The following tradeoffs were made

- Only a single URL was updated, minimizing the scope of changes
- No functional code changes were made, only documentation links

### The following alternatives were considered

- Keeping the old URL (rejected, as it may become outdated or broken in the future)
- Using a redirect URL (not chosen, as direct links to current documentation are preferred)

### Breaking changes

None. This change only updates a documentation URL and does not affect any runtime functionality.

### Special notes for your reviewer

This is a simple documentation URL update. The change is straightforward and only affects the `models` field in the Together AI provider configuration.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: The code change is simple and focused on a single URL update
- [x] Refactor: The change maintains the existing code structure
- [x] Upgrade: No upgrade flow impact
- [x] Documentation: This change IS the documentation update

### Release note

```release-note
Update Together AI provider's models documentation URL to point to the serverless models documentation.