### PR TITLE
feat: allow Kimi K2.5 to be specified via Model Name

### DIFF
--- a/src/renderer/src/config/models/reasoning.ts
+++ b/src/renderer/src/config/models/reasoning.ts
@@ -603,9 +603,14 @@ export const isSupportedThinkingTokenMiMoModel = (model: Model): boolean => {
  * @param model - The model object to check
  * @returns true if the model supports thinking control, false otherwise
  */
-export const isSupportedThinkingTokenKimiModel = (model: Model): boolean => {
+const _isSupportedThinkingTokenKimiModel = (model: Model): boolean => {
   const modelId = getLowerBaseModelName(model.id, '/')
   return ['kimi-k2.5'].some((id) => modelId.includes(id))
+}
+
+export const isSupportedThinkingTokenKimiModel = (model: Model): boolean => {
+  const { idResult, nameResult } = withModelIdAndNameAsId(model, _isSupportedThinkingTokenKimiModel)
+  return idResult || nameResult
 }
 
 export const isDeepSeekHybridInferenceModel = (model: Model) => {


### PR DESCRIPTION
**Before this PR:**
`isSupportedThinkingTokenKimiModel` only checked the model ID to determine if a model supports Kimi K2.5 thinking control. Users with Kimi K2.5 models from third-party providers (e.g., `accounts/fireworks/models/kimi-k2p5`) could not get automatic thinking control support even if they edited the model name to `kimi-k2.5`.

**After this PR:**
The function now uses the `withModelIdAndNameAsId` pattern to check both the model ID and model name. Users can edit their model's display name to `kimi-k2.5` to enable full Kimi thinking control (`{ thinking: { type: 'enabled/disabled' } }`) functionality.

### Why we need it and why it was done in this way

Many users access Kimi K2.5 through third-party providers like Fireworks, OpenRouter, or other aggregators where the model ID doesn't match the standard `kimi-k2.5` pattern. This prevents them from using the built-in thinking control UI.

The following tradeoffs were made:
- None significant. This is a consistent pattern already used by other detection functions like `isDeepSeekHybridInferenceModel`.

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Kimi K2.5 models from third-party providers can now be recognized by editing the model name to include "kimi-k2.5", enabling full thinking control support.
```
