### PR TITLE
feat: allow Kimi K2.5 to be specified via Model Name

### DIFF
--- a/src/renderer/src/config/models/reasoning.ts
+++ b/src/renderer/src/config/models/reasoning.ts
@@ -690,14 +690,19 @@ export const isBaichuanReasoningModel = (model?: Model): boolean => {
  * @param model - The model object to check, can be undefined
  * @returns true if it's a Kimi reasoning model, false otherwise
  */
-export function isKimiReasoningModel(model?: Model): boolean {
-  if (!model) {
-    return false
-  }
+const _isKimiReasoningModel = (model: Model): boolean => {
   const modelId = getLowerBaseModelName(model.id, '/')
   // Match kimi-k2-thinking, kimi-k2-thinking-turbo, or kimi-k2.5
   // The regex ensures no extra suffixes after these patterns
   return /^kimi-k2-thinking(?:-turbo)?$|^kimi-k2\.5(?:-\w)*$/.test(modelId)
+}
+
+export function isKimiReasoningModel(model?: Model): boolean {
+  if (!model) {
+    return false
+  }
+  const { idResult, nameResult } = withModelIdAndNameAsId(model, _isKimiReasoningModel)
+  return idResult || nameResult
 }
 
 export function isReasoningModel(model?: Model): boolean {


### PR DESCRIPTION
### What this PR does

**Before this PR:**
`isKimiReasoningModel` and `isSupportedThinkingTokenKimiModel` only checked the model ID to determine Kimi K2.5 support. Users with Kimi K2.5 models from third-party providers (e.g., `accounts/fireworks/models/kimi-k2p5`) could not get the reasoning control UI or automatic thinking control even if they edited the model name to `kimi-k2.5`.

**After this PR:**
Both functions now use the `withModelIdAndNameAsId` pattern to check both the model ID and model name. Users can edit their model's display name to `kimi-k2.5` to enable:
1. The reasoning control button in the input bar
2. Full Kimi thinking control (`{ thinking: { type: 'enabled/disabled' } }`) functionality

### Why we need it and why it was done in this way

Many users access Kimi K2.5 through third-party providers like Fireworks, OpenRouter, or other aggregators where the model ID doesn't match the standard `kimi-k2.5` pattern. This prevents them from using the built-in thinking control UI.

The following tradeoffs were made:
- None significant. This is a consistent pattern already used by other detection functions like `isDeepSeekHybridInferenceModel`.

The following alternatives were considered:
- Adding a dedicated "model alias" field - rejected as overly complex when the name-based fallback pattern already exists
- Hardcoding additional model ID patterns - rejected as not scalable for all providers

### Breaking changes

None. This is a backwards-compatible enhancement that only adds functionality.

### Special notes for your reviewer

This follows the existing pattern used by `isDeepSeekHybridInferenceModel`, `getThinkModelType`, and other detection functions that use `withModelIdAndNameAsId` for fallback detection.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required.

### Release note

```release-note
Kimi K2.5 models from third-party providers can now be recognized by editing the model name to include "kimi-k2.5", enabling full thinking control support.
```
