### PR TITLE
fix: prevent System Prompt duplication on recursive MCP tool calls

### DIFF
--- a/packages/aiCore/src/core/plugins/built-in/toolUsePlugin/__tests__/promptToolUsePlugin.test.ts
+++ b/packages/aiCore/src/core/plugins/built-in/toolUsePlugin/__tests__/promptToolUsePlugin.test.ts
@@ -1,0 +1,183 @@
+/**
+ * PromptToolUsePlugin Tests
+ * Tests for prompt-based tool use plugin functionality
+ */
+
+import type { ToolSet } from 'ai'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { AiRequestContext } from '../../../types'
+import { createPromptToolUsePlugin, DEFAULT_SYSTEM_PROMPT } from '../promptToolUsePlugin'
+
+describe('createPromptToolUsePlugin', () => {
+  let mockContext: AiRequestContext
+
+  // Create a mock ToolSet that matches the expected structure
+  const mockTools = {
+    test_tool: {
+      type: 'function',
+      description: 'A test tool',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string' }
+        },
+        required: ['query']
+      }
+    }
+  } as unknown as ToolSet
+
+  beforeEach(() => {
+    mockContext = {
+      model: 'test-model',
+      isRecursiveCall: false
+    } as AiRequestContext
+  })
+
+  describe('transformParams', () => {
+    it('should build system prompt with tool definitions on first call', () => {
+      const plugin = createPromptToolUsePlugin({ enabled: true })
+
+      const params = {
+        system: 'User system prompt',
+        tools: mockTools,
+        messages: []
+      }
+
+      const result = plugin.transformParams!(params, mockContext) as Record<string, unknown>
+
+      // System prompt should contain tool definitions
+      expect(result.system).toContain('In this environment you have access to a set of tools')
+      expect(result.system).toContain('test_tool')
+      expect(result.system).toContain('A test tool')
+      expect(result.system).toContain('User system prompt')
+
+      // Tools should be removed from params (converted to prompt mode)
+      expect(result.tools).toBeUndefined()
+
+      // mcpTools should be saved in context
+      expect(mockContext.mcpTools).toBeDefined()
+      expect(mockContext.mcpTools!.test_tool).toBeDefined()
+    })
+
+    it('should NOT rebuild system prompt on recursive call (fix for issue #12638)', () => {
+      const plugin = createPromptToolUsePlugin({ enabled: true })
+
+      // First call: build the system prompt with tools
+      const firstParams = {
+        system: 'User system prompt',
+        tools: mockTools,
+        messages: []
+      }
+
+      const firstResult = plugin.transformParams!(firstParams, mockContext) as Record<string, unknown>
+      const firstSystemPrompt = firstResult.system as string
+
+      // Verify first call includes tool definitions
+      expect(firstSystemPrompt).toContain('test_tool')
+
+      // Simulate recursive call: isRecursiveCall is true
+      // The system prompt already contains tool definitions from first call
+      mockContext.isRecursiveCall = true
+
+      const recursiveParams = {
+        system: firstSystemPrompt, // Already contains tool definitions
+        tools: mockTools,
+        messages: []
+      }
+
+      const recursiveResult = plugin.transformParams!(recursiveParams, mockContext) as Record<string, unknown>
+
+      // System prompt should NOT be rebuilt - it should remain the same
+      // This prevents duplicate tool definitions
+      expect(recursiveResult.system).toBe(firstSystemPrompt)
+
+      // Count occurrences of tool definition to ensure no duplication
+      const toolOccurrences = (recursiveResult.system as string).split('test_tool').length - 1
+      const firstToolOccurrences = firstSystemPrompt.split('test_tool').length - 1
+      expect(toolOccurrences).toBe(firstToolOccurrences)
+    })
+
+    it('should return params unchanged when disabled', () => {
+      const plugin = createPromptToolUsePlugin({ enabled: false })
+
+      const params = {
+        system: 'User system prompt',
+        tools: mockTools,
+        messages: []
+      }
+
+      const result = plugin.transformParams!(params, mockContext)
+
+      expect(result).toBe(params)
+    })
+
+    it('should return params unchanged when no tools provided', () => {
+      const plugin = createPromptToolUsePlugin({ enabled: true })
+
+      const params = {
+        system: 'User system prompt',
+        messages: []
+      }
+
+      const result = plugin.transformParams!(params, mockContext)
+
+      expect(result).toBe(params)
+    })
+
+    it('should preserve provider-defined tools in params', () => {
+      const plugin = createPromptToolUsePlugin({ enabled: true })
+
+      const mixedTools = {
+        ...mockTools,
+        provider_tool: {
+          type: 'provider-defined' as const,
+          id: 'provider_tool',
+          args: {}
+        }
+      } as unknown as ToolSet
+
+      const params = {
+        system: 'User system prompt',
+        tools: mixedTools,
+        messages: []
+      }
+
+      const result = plugin.transformParams!(params, mockContext) as Record<string, unknown>
+      const resultTools = result.tools as ToolSet | undefined
+
+      // Provider-defined tools should remain in params.tools
+      expect(resultTools).toBeDefined()
+      expect(resultTools!.provider_tool).toBeDefined()
+
+      // Regular tools should be converted to prompt mode
+      expect(resultTools!.test_tool).toBeUndefined()
+      expect(mockContext.mcpTools!.test_tool).toBeDefined()
+    })
+
+    it('should set originalParams in context', () => {
+      const plugin = createPromptToolUsePlugin({ enabled: true })
+
+      const params = {
+        system: 'User system prompt',
+        tools: mockTools,
+        messages: []
+      }
+
+      plugin.transformParams!(params, mockContext)
+
+      expect(mockContext.originalParams).toBeDefined()
+      expect(mockContext.originalParams.system).toContain('test_tool')
+    })
+  })
+
+  describe('DEFAULT_SYSTEM_PROMPT', () => {
+    it('should contain required sections', () => {
+      expect(DEFAULT_SYSTEM_PROMPT).toContain('Tool Use Formatting')
+      expect(DEFAULT_SYSTEM_PROMPT).toContain('<tool_use>')
+      expect(DEFAULT_SYSTEM_PROMPT).toContain('Tool Use Rules')
+      expect(DEFAULT_SYSTEM_PROMPT).toContain('{{ TOOLS_INFO }}')
+      expect(DEFAULT_SYSTEM_PROMPT).toContain('{{ USER_SYSTEM_PROMPT }}')
+    })
+  })
+})

--- a/packages/aiCore/src/core/plugins/built-in/toolUsePlugin/promptToolUsePlugin.ts
+++ b/packages/aiCore/src/core/plugins/built-in/toolUsePlugin/promptToolUsePlugin.ts
@@ -314,6 +314,16 @@ export const createPromptToolUsePlugin = (config: PromptToolUseConfig = {}) => {
         context.mcpTools = promptTools
       }
 
+      // 递归调用时，不重新构建 system prompt，避免重复追加工具定义
+      if (context.isRecursiveCall) {
+        const transformedParams = {
+          ...params,
+          tools: Object.keys(providerDefinedTools).length > 0 ? providerDefinedTools : undefined
+        }
+        context.originalParams = transformedParams
+        return transformedParams
+      }
+
       // 构建系统提示符（只包含非 provider-defined 工具）
       const userSystemPrompt = typeof params.system === 'string' ? params.system : ''
       const systemPrompt = buildSystemPrompt(userSystemPrompt, promptTools, mcpMode)


### PR DESCRIPTION
### What this PR does

Before this PR:
When using prompt-based tool calling (for models without native function call support), the System Prompt containing MCP tool definitions was duplicated on each recursive call after tool execution. This caused token consumption to multiply with each tool call.

After this PR:
The System Prompt remains unique throughout the conversation, regardless of how many tool calls are made. Tool definitions are only added once during the initial call.

Fixes #12638

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Added a simple `isRecursiveCall` check in `transformParams` to skip system prompt rebuilding on recursive calls. This is the minimal change needed to fix the issue.

The following alternatives were considered:
- Storing the original user system prompt in context and restoring it during recursive calls - more complex and requires additional context management.
- Modifying `buildRecursiveParams` to exclude the system field - would require changes to StreamEventManager and could affect other behaviors.

The chosen approach is the simplest fix that directly addresses the root cause.

### Breaking changes

None. This is a bug fix that corrects unintended behavior.

### Special notes for your reviewer

Key changes:
1. `packages/aiCore/src/core/plugins/built-in/toolUsePlugin/promptToolUsePlugin.ts` - Added check for `context.isRecursiveCall` before rebuilding system prompt
2. Added unit tests to verify the fix and prevent regression

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required.

### Release note

```release-note
fix: Fixed an issue where System Prompt was duplicated when using MCP tools with prompt method, causing excessive token consumption (#12638)
```