### PR TITLE
fix: hardcoded ui string

### DIFF
--- a/packages/shared/data/migration/v2/types.ts
+++ b/packages/shared/data/migration/v2/types.ts
@@ -24,11 +24,19 @@ export interface MigratorProgress {
   error?: string
 }
 
+// I18n message with key and interpolation params
+export interface I18nMessage {
+  key: string
+  params?: Record<string, string | number>
+}
+
 // Overall migration progress
 export interface MigrationProgress {
   stage: MigrationStage
   overallProgress: number // 0-100
   currentMessage: string
+  /** Optional i18n key with params for translation in renderer */
+  i18nMessage?: I18nMessage
   migrators: MigratorProgress[]
   error?: string
 }

--- a/scripts/check-hardcoded-strings.ts
+++ b/scripts/check-hardcoded-strings.ts
@@ -247,6 +247,22 @@ class HardcodedStringDetector {
           if (['title', 'desc', 'text', 'tspan'].includes(tagName)) {
             return
           }
+
+          // Skip native language names in language selectors (SelectItem, Option, etc.)
+          if (['SelectItem', 'Option', 'MenuItem'].includes(tagName)) {
+            const jsxElement = Node.isJsxElement(parent) ? parent.getOpeningElement() : parent
+            const valueAttr = jsxElement.getAttribute('value')
+            if (valueAttr && Node.isJsxAttribute(valueAttr)) {
+              const initializer = valueAttr.getInitializer()
+              if (initializer && Node.isStringLiteral(initializer)) {
+                const value = initializer.getLiteralValue()
+                // Language/locale codes like 'zh-CN', 'en-US', 'ja-JP', etc.
+                if (/^[a-z]{2}(-[A-Z]{2})?$/.test(value)) {
+                  return
+                }
+              }
+            }
+          }
         }
         findings.push(createFinding(node, sourceFile, 'chinese', source, 'JsxText'))
       }

--- a/src/main/data/migration/v2/migrators/BaseMigrator.ts
+++ b/src/main/data/migration/v2/migrators/BaseMigrator.ts
@@ -3,9 +3,14 @@
  * Each migrator handles migration of a specific business domain
  */
 
-import type { ExecuteResult, PrepareResult, ValidateResult } from '@shared/data/migration/v2/types'
+import type { ExecuteResult, I18nMessage, PrepareResult, ValidateResult } from '@shared/data/migration/v2/types'
 
 import type { MigrationContext } from '../core/MigrationContext'
+
+export interface ProgressMessage {
+  message: string
+  i18nMessage?: I18nMessage
+}
 
 export abstract class BaseMigrator {
   // Metadata - must be implemented by subclasses
@@ -15,22 +20,23 @@ export abstract class BaseMigrator {
   abstract readonly order: number // Execution order (lower runs first)
 
   // Progress callback for UI updates
-  protected onProgress?: (progress: number, message: string) => void
+  protected onProgress?: (progress: number, progressMessage: ProgressMessage) => void
 
   /**
    * Set progress callback for reporting progress to UI
    */
-  setProgressCallback(callback: (progress: number, message: string) => void): void {
+  setProgressCallback(callback: (progress: number, progressMessage: ProgressMessage) => void): void {
     this.onProgress = callback
   }
 
   /**
    * Report progress to UI
    * @param progress - Progress percentage (0-100)
-   * @param message - Progress message
+   * @param message - Progress message (fallback text)
+   * @param i18nMessage - Optional i18n key with params for translation
    */
-  protected reportProgress(progress: number, message: string): void {
-    this.onProgress?.(progress, message)
+  protected reportProgress(progress: number, message: string, i18nMessage?: I18nMessage): void {
+    this.onProgress?.(progress, { message, i18nMessage })
   }
 
   /**

--- a/src/main/data/migration/v2/migrators/ChatMigrator.ts
+++ b/src/main/data/migration/v2/migrators/ChatMigrator.ts
@@ -341,7 +341,11 @@ export class ChatMigrator extends BaseMigrator {
         const progress = Math.round((processedTopics / this.topicCount) * 100)
         this.reportProgress(
           progress,
-          `已迁移 ${processedTopics}/${this.topicCount} 个对话，${processedMessages} 条消息`
+          `Migrated ${processedTopics}/${this.topicCount} conversations, ${processedMessages} messages`,
+          {
+            key: 'migration.progress.migrated_chats',
+            params: { processed: processedTopics, total: this.topicCount, messages: processedMessages }
+          }
         )
       })
 

--- a/src/main/data/migration/v2/migrators/PreferencesMigrator.ts
+++ b/src/main/data/migration/v2/migrators/PreferencesMigrator.ts
@@ -187,7 +187,10 @@ export class PreferencesMigrator extends BaseMigrator {
 
           // Report progress
           const progress = Math.round(((i + batch.length) / insertValues.length) * 100)
-          this.reportProgress(progress, `已迁移 ${i + batch.length}/${insertValues.length} 条配置`)
+          this.reportProgress(progress, `Migrated ${i + batch.length}/${insertValues.length} preferences`, {
+            key: 'migration.progress.migrated_preferences',
+            params: { processed: i + batch.length, total: insertValues.length }
+          })
         }
       })
 

--- a/src/renderer/src/windows/migrationV2/MigrationApp.tsx
+++ b/src/renderer/src/windows/migrationV2/MigrationApp.tsx
@@ -95,6 +95,14 @@ const MigrationApp: React.FC = () => {
     }
   }
 
+  // Translate progress message using i18n if available
+  const getProgressMessage = () => {
+    if (progress.i18nMessage) {
+      return t(progress.i18nMessage.key, progress.i18nMessage.params)
+    }
+    return progress.currentMessage
+  }
+
   const getCurrentStepIcon = () => {
     switch (progress.stage) {
       case 'introduction':
@@ -275,7 +283,7 @@ const MigrationApp: React.FC = () => {
               <div style={{ width: '100%', maxWidth: '600px', margin: '0 auto' }}>
                 <InfoCard>
                   <InfoTitle>{t('migration.migration.title')}</InfoTitle>
-                  <InfoDescription>{progress.currentMessage}</InfoDescription>
+                  <InfoDescription>{getProgressMessage()}</InfoDescription>
                 </InfoCard>
                 <ProgressContainer>
                   <Progress

--- a/src/renderer/src/windows/migrationV2/components/ActionButtons.tsx
+++ b/src/renderer/src/windows/migrationV2/components/ActionButtons.tsx
@@ -5,6 +5,7 @@
 import { Button } from '@cherrystudio/ui'
 import type { MigrationStage } from '@shared/data/migration/v2/types'
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 
 interface Props {
   stage: MigrationStage
@@ -27,15 +28,17 @@ export const ActionButtons: React.FC<Props> = ({
   onRestart,
   isLoading = false
 }) => {
+  const { t } = useTranslation()
+
   switch (stage) {
     case 'introduction':
       return (
         <div className="flex justify-end gap-3">
           <Button variant="ghost" onClick={onCancel}>
-            取消
+            {t('migration.buttons.cancel')}
           </Button>
           <Button variant="default" onClick={onProceedToBackup}>
-            下一步
+            {t('migration.buttons.next')}
           </Button>
         </div>
       )
@@ -44,10 +47,10 @@ export const ActionButtons: React.FC<Props> = ({
       return (
         <div className="flex justify-end gap-3">
           <Button variant="ghost" onClick={onCancel}>
-            取消
+            {t('migration.buttons.cancel')}
           </Button>
           <Button variant="default" onClick={onConfirmBackup}>
-            已完成备份
+            {t('migration.buttons.backup_completed')}
           </Button>
         </div>
       )
@@ -56,10 +59,10 @@ export const ActionButtons: React.FC<Props> = ({
       return (
         <div className="flex justify-end gap-3">
           <Button variant="ghost" onClick={onCancel}>
-            取消
+            {t('migration.buttons.cancel')}
           </Button>
           <Button variant="default" onClick={onStartMigration} loading={isLoading}>
-            开始迁移
+            {t('migration.buttons.start_migration')}
           </Button>
         </div>
       )
@@ -68,7 +71,7 @@ export const ActionButtons: React.FC<Props> = ({
       return (
         <div className="flex justify-end gap-3">
           <Button variant="default" disabled loading>
-            迁移中...
+            {t('migration.buttons.migrating')}
           </Button>
         </div>
       )
@@ -77,7 +80,7 @@ export const ActionButtons: React.FC<Props> = ({
       return (
         <div className="flex justify-end gap-3">
           <Button variant="default" onClick={onRestart} className="bg-green-600 hover:bg-green-700">
-            重启应用
+            {t('migration.buttons.restart')}
           </Button>
         </div>
       )
@@ -86,10 +89,10 @@ export const ActionButtons: React.FC<Props> = ({
       return (
         <div className="flex justify-end gap-3">
           <Button variant="ghost" onClick={onCancel}>
-            退出
+            {t('migration.buttons.exit')}
           </Button>
           <Button variant="default" onClick={onRetry}>
-            重试
+            {t('migration.buttons.retry')}
           </Button>
         </div>
       )

--- a/src/renderer/src/windows/migrationV2/components/StageIndicator.tsx
+++ b/src/renderer/src/windows/migrationV2/components/StageIndicator.tsx
@@ -6,6 +6,7 @@
 import type { MigrationStage } from '@shared/data/migration/v2/types'
 import { CheckCircle2, Database, FileArchive, Rocket } from 'lucide-react'
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 
 interface Props {
   stage: MigrationStage
@@ -13,15 +14,15 @@ interface Props {
 
 interface StepInfo {
   id: string
-  label: string
+  labelKey: string
   icon: React.ReactNode
 }
 
 const steps: StepInfo[] = [
-  { id: 'intro', label: '开始', icon: <Rocket className="h-4 w-4" /> },
-  { id: 'backup', label: '备份', icon: <FileArchive className="h-4 w-4" /> },
-  { id: 'migrate', label: '迁移', icon: <Database className="h-4 w-4" /> },
-  { id: 'complete', label: '完成', icon: <CheckCircle2 className="h-4 w-4" /> }
+  { id: 'intro', labelKey: 'migration.steps.start', icon: <Rocket className="h-4 w-4" /> },
+  { id: 'backup', labelKey: 'migration.steps.backup', icon: <FileArchive className="h-4 w-4" /> },
+  { id: 'migrate', labelKey: 'migration.steps.migrate', icon: <Database className="h-4 w-4" /> },
+  { id: 'complete', labelKey: 'migration.steps.complete', icon: <CheckCircle2 className="h-4 w-4" /> }
 ]
 
 function getStepIndex(stage: MigrationStage): number {
@@ -44,6 +45,7 @@ function getStepIndex(stage: MigrationStage): number {
 }
 
 export const StageIndicator: React.FC<Props> = ({ stage }) => {
+  const { t } = useTranslation()
   const currentIndex = getStepIndex(stage)
   const isError = stage === 'error'
 
@@ -72,7 +74,7 @@ export const StageIndicator: React.FC<Props> = ({ stage }) => {
                   ${isCurrent && isError ? 'text-red-600 dark:text-red-400' : ''}
                   ${isPending ? 'text-muted-foreground' : ''}
                 `}>
-                {step.label}
+                {t(step.labelKey)}
               </span>
             </div>
 

--- a/src/renderer/src/windows/migrationV2/i18n/locales.ts
+++ b/src/renderer/src/windows/migrationV2/i18n/locales.ts
@@ -12,18 +12,26 @@ export const zhCN = {
       migration: '迁移',
       completed: '完成'
     },
+    steps: {
+      start: '开始',
+      backup: '备份',
+      migrate: '迁移',
+      complete: '完成'
+    },
     buttons: {
       cancel: '取消',
       next: '下一步',
       create_backup: '创建备份',
+      backup_completed: '已完成备份',
       confirm_backup: '我已备份，开始迁移',
       start_migration: '开始迁移',
       confirm: '确定',
       restart: '重启应用',
-      retry: '重新尝试',
+      retry: '重试',
+      exit: '退出',
       close: '关闭应用',
       backing_up: '正在备份...',
-      migrating: '迁移进行中...'
+      migrating: '迁移中...'
     },
     status: {
       pending: '等待中',
@@ -52,6 +60,11 @@ export const zhCN = {
     migration: {
       title: '正在迁移数据...'
     },
+    progress: {
+      processing: '正在处理{{name}}...',
+      migrated_chats: '已迁移 {{processed}}/{{total}} 个对话，{{messages}} 条消息',
+      migrated_preferences: '已迁移 {{processed}}/{{total}} 条配置'
+    },
     migration_completed: {
       title: '数据迁移完成！',
       description: '所有数据已成功迁移到新架构，请点击确定继续。'
@@ -77,15 +90,23 @@ export const enUS = {
       migration: 'Migration',
       completed: 'Completed'
     },
+    steps: {
+      start: 'Start',
+      backup: 'Backup',
+      migrate: 'Migrate',
+      complete: 'Complete'
+    },
     buttons: {
       cancel: 'Cancel',
       next: 'Next',
       create_backup: 'Create Backup',
+      backup_completed: 'Backup Completed',
       confirm_backup: 'I Have Backup, Start Migration',
       start_migration: 'Start Migration',
       confirm: 'OK',
       restart: 'Restart App',
       retry: 'Retry',
+      exit: 'Exit',
       close: 'Close App',
       backing_up: 'Backing up...',
       migrating: 'Migrating...'
@@ -119,6 +140,11 @@ export const enUS = {
     },
     migration: {
       title: 'Migrating Data...'
+    },
+    progress: {
+      processing: 'Processing {{name}}...',
+      migrated_chats: 'Migrated {{processed}}/{{total}} conversations, {{messages}} messages',
+      migrated_preferences: 'Migrated {{processed}}/{{total}} preferences'
     },
     migration_completed: {
       title: 'Data Migration Completed!',


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

⚠️ Important: Redux/IndexedDB Data-Changing Feature PRs Temporarily On Hold ⚠️

Please note: For our current development cycle, we are not accepting feature Pull Requests that introduce changes to Redux data models or IndexedDB schemas.

While we value your contributions, PRs of this nature will be blocked without merge. We welcome all other contributions (bug fixes, perf enhancements, docs, etc.). Thank you!

Once version 2.0.0 is released, we will resume reviewing feature PRs.

-->

### What this PR does

Before this PR:
- Migration v2 UI had hardcoded Chinese strings in button labels, stage indicators, and progress messages
- Progress messages from main process migrators (ChatMigrator, PreferencesMigrator) were hardcoded in Chinese
- The hardcoded string checker script flagged false positives for native language names in SelectItem components

After this PR:
- All UI strings are internationalized using i18n with support for both Chinese (zh-CN) and English (en-US)
- Migration progress messages now support i18n with interpolation params via a new `I18nMessage` interface
- Progress messages are translated in the renderer using i18n keys passed from main process
- The hardcoded string checker correctly ignores language selector items with locale codes

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Introduced `I18nMessage` interface to pass i18n keys with interpolation params from main process to renderer, since main process cannot directly use i18n translation functions
- Used a fallback message string alongside i18n keys to ensure backwards compatibility

The following alternatives were considered:
- Direct translation in main process: Not feasible as i18n context is only available in renderer
- String-only approach without interpolation: Would not support dynamic values like counts

### Breaking changes

None. This is a non-breaking fix that adds i18n support while maintaining backwards compatibility with fallback messages.

### Special notes for your reviewer

- The `I18nMessage` interface allows main process to specify i18n keys with typed interpolation params
- Renderer's `MigrationApp.tsx` now translates messages using the i18n key when available
- Added translation keys under `migration.steps`, `migration.buttons`, and `migration.progress` namespaces

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
fix: internationalized hardcoded Chinese strings in migration v2 UI with proper i18n support
```