### PR TITLE
fix(agent): prevent claude agent sdk from using bedrock api

### DIFF
--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -126,6 +126,8 @@ class ClaudeCodeService implements AgentServiceInterface {
 
     const env = {
       ...loginShellEnvWithoutProxies,
+      // prevent claude agent sdk using bedrock api
+      CLAUDE_CODE_USE_BEDROCK: '0',
       // TODO: fix the proxy api server
       // ANTHROPIC_API_KEY: apiConfig.apiKey,
       // ANTHROPIC_AUTH_TOKEN: apiConfig.apiKey,


### PR DESCRIPTION
### What this PR does

Before this PR:
- If users have AWS credentials configured, Claude Agent SDK automatically uses Bedrock API, causing agent functionality to malfunction by directly accessing Bedrock API instead of the user-selected model.

After this PR:
- Set `CLAUDE_CODE_USE_BEDROCK=0` environment variable to disable Bedrock API auto-detection, ensuring the user-selected model is used.

### Why we need it and why it was done in this way

Claude Agent SDK automatically detects AWS credentials and uses Bedrock API, which bypasses the model configuration selected by users in Cherry Studio.

The following tradeoffs were made:
- None

The following alternatives were considered:
- None

### Breaking changes

None

### Special notes for your reviewer

N/A

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required.

### Release note

```release-note
fix: prevent claude agent sdk from automatically using bedrock api
```