### PR TITLE
fix: add placeholder text for image-only assistant messages

### DIFF
--- a/src/renderer/src/aiCore/prepareParams/messageConverter.ts
+++ b/src/renderer/src/aiCore/prepareParams/messageConverter.ts
@@ -45,7 +45,7 @@ export async function convertMessageToSdkParam(
   if (message.role === 'user' || message.role === 'system') {
     return convertMessageToUserModelMessage(content, fileBlocks, imageBlocks, isVisionModel, model)
   } else {
-    return convertMessageToAssistantModelMessage(content, fileBlocks, reasoningBlocks, model)
+    return convertMessageToAssistantModelMessage(content, fileBlocks, imageBlocks, reasoningBlocks, model)
   }
 }
 
@@ -155,10 +155,13 @@ async function convertMessageToUserModelMessage(
 
 /**
  * 转换为助手模型消息
+ * 注意：当助手消息只包含图片（如图片生成模型的响应）而没有文本时，
+ * 需要添加占位文本，因为某些 API（如 Gemini）不接受空的 assistant 消息
  */
 async function convertMessageToAssistantModelMessage(
   content: string,
   fileBlocks: FileMessageBlock[],
+  imageBlocks: ImageMessageBlock[],
   thinkingBlocks: ThinkingMessageBlock[],
   model?: Model
 ): Promise<AssistantModelMessage> {
@@ -186,6 +189,12 @@ async function convertMessageToAssistantModelMessage(
     if (textPart) {
       parts.push(textPart)
     }
+  }
+
+  // 当 parts 为空但有图片时，添加占位文本
+  // 这对于图片生成模型的继续对话很重要，因为助手消息可能只包含生成的图片
+  if (parts.length === 0 && imageBlocks.length > 0) {
+    parts.push({ type: 'text', text: '[Image]' })
   }
 
   return {


### PR DESCRIPTION
### What this PR does

Before this PR:
When using Gemini image generation models (e.g., `gemini-2.5-flash-image-preview`), continuing a conversation after the first image generation fails. The assistant message contains only images without text, which after SDK conversion results in an empty `content: []` array. Gemini API rejects empty assistant messages.

After this PR:
When an assistant message has images but no text content, a `[Image]` placeholder text is added to ensure the message is not empty. This allows users to continue conversations after image generation.

Fixes #12701

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Using a simple `[Image]` placeholder instead of including the actual image data in the assistant message, because:
  1. The image is already extracted and merged into the user message by the `isImageEnhancementModel` logic
  2. Some APIs (like qwen-image-edit) don't support multi-turn conversations, so the image extraction approach is still needed
  3. This is the minimal change to fix the issue

The following alternatives were considered:
- Including actual image data in the assistant message: More complex and may cause duplicate images in some scenarios
- Filtering out empty assistant messages: Could lose context in the conversation

### Breaking changes

None. This is a backward-compatible fix.

### Special notes for your reviewer

- The root cause is in `convertMessageToAssistantModelMessage` which doesn't handle `imageBlocks`
- When the assistant message only contains generated images (no text), `parts` array becomes empty
- The fix adds `imageBlocks` parameter to detect this case and add placeholder text

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required.

### Release note

```release-note
fix: Gemini image generation models can now continue conversations after generating images
```