### PR TITLE
fix(bedrock): reorder content blocks for Claude extended thinking

### DIFF
--- a/src/renderer/src/aiCore/prepareParams/messageConverter.ts
+++ b/src/renderer/src/aiCore/prepareParams/messageConverter.ts
@@ -163,12 +163,16 @@ async function convertMessageToAssistantModelMessage(
   model?: Model
 ): Promise<AssistantModelMessage> {
   const parts: Array<TextPart | ReasoningPart | FilePart> = []
-  if (content) {
-    parts.push({ type: 'text', text: content })
-  }
 
+  // Add reasoning blocks first (required by AWS Bedrock for Claude extended thinking)
   for (const thinkingBlock of thinkingBlocks) {
     parts.push({ type: 'reasoning', text: thinkingBlock.content })
+  }
+
+  // Add text content after reasoning blocks, only if non-empty after trimming
+  const trimmedContent = content?.trim()
+  if (trimmedContent) {
+    parts.push({ type: 'text', text: trimmedContent })
   }
 
   for (const fileBlock of fileBlocks) {


### PR DESCRIPTION
### What this PR does

Before this PR:
- Text content blocks were added before reasoning blocks in assistant messages
- Empty or whitespace-only content could create invalid text blocks
- AWS Bedrock validation failed when thinking blocks followed text blocks

After this PR:
- Reasoning blocks are now added first, then text blocks
- Content is trimmed before being added, empty content is skipped
- AWS Bedrock Claude extended thinking works correctly

Fixes #

### Why we need it and why it was done in this way

AWS Bedrock and Anthropic API have strict validation requirements for Claude models with extended thinking enabled. When thinking (reasoning) blocks are present, they must appear **before** any text blocks in the assistant message content array.

**Root Cause Analysis:**

After investigating the AI SDK source code (`@ai-sdk/amazon-bedrock` and `@ai-sdk/anthropic`), I found that:

1. **AI SDK does NOT reorder content blocks** - both providers process content parts in the order they are provided:
   ```typescript
   // From AI SDK: packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
   for (const part of content) {
     switch (part.type) {
       case 'text': { anthropicContent.push(...); break; }
       case 'reasoning': { anthropicContent.push(...); break; }
     }
   }
   ```

2. **Cherry Studio's messageConverter.ts was adding text before reasoning:**
   ```typescript
   // Before fix
   if (content) {
     parts.push({ type: 'text', text: content })  // ← text first
   }
   for (const thinkingBlock of thinkingBlocks) {
     parts.push({ type: 'reasoning', ... })  // ← reasoning after
   }
   ```

3. This caused AWS Bedrock/Anthropic API validation errors when extended thinking was enabled.

The following tradeoffs were made:
- None significant - this is a straightforward fix to comply with API requirements

The following alternatives were considered:
- Provider-specific message transformation in AI SDK: rejected as the fix belongs in the application layer where message order is determined

### Breaking changes

None. This change only affects the internal message format sent to the model API.

### Special notes for your reviewer

The issue occurred when:
1. A previous assistant message had both thinking and text content
2. This message was converted and sent as context for the next request
3. The text block appeared before thinking block → API validation error

This was particularly noticeable when web search returned empty results, causing edge cases with whitespace-only content.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required

### Release note

```release-note
fix(bedrock): Fix AWS Bedrock validation error for Claude extended thinking by reordering content blocks
```

🤖 Generated with [Claude Code](https://claude.ai/code)