### PR TITLE
fix(nsis): auto-elevate silent updates for per-machine installations

### DIFF
--- a/build/nsis-installer.nsh
+++ b/build/nsis-installer.nsh
@@ -92,7 +92,11 @@
     ${If} $R1 != "admin"
       ${GetParameters} $R2
       ExecShell "runas" "$EXEPATH" "$R2"
-      SetErrorLevel 0
+      ${If} ${Errors}
+        SetErrorLevel 1
+      ${Else}
+        SetErrorLevel 0
+      ${EndIf}
       Quit
     ${EndIf}
   ${EndIf}


### PR DESCRIPTION
When users chose "Install for all users", subsequent auto-updates would fail with "cannot close app" because the silent installer ran without admin privileges. Detect per-machine installations via HKLM registry and re-launch with elevation (runas) during silent updates.

Reproduction Path:
Install the exe, choose "install for all", then during the second installation, choose "install for me". This will result in a "cannot close app" error, and retrying continuously will not work.

Fix:
Check if the installation is "install for all". If so, and if the user is an admin, directly escalate privileges. This will allow the app to be closed.