### PR TITLE
fix: disable temperature and top_p for kimi-k2.5 model

### DIFF
--- a/src/renderer/src/config/models/reasoning.ts
+++ b/src/renderer/src/config/models/reasoning.ts
@@ -21,7 +21,13 @@ import {
   isOpenAIReasoningModel,
   isSupportedReasoningEffortOpenAIModel
 } from './openai'
-import { GEMINI_FLASH_MODEL_REGEX, isGemini3FlashModel, isGemini3ProModel } from './utils'
+import {
+  GEMINI_FLASH_MODEL_REGEX,
+  isGemini3FlashModel,
+  isGemini3ProModel,
+  isKimi25Model,
+  withModelIdAndNameAsId
+} from './utils'
 import { isTextToImageModel } from './vision'
 
 // Reasoning models
@@ -94,14 +100,6 @@ export const MODEL_SUPPORTED_OPTIONS: ThinkingOptionConfig = {
   deepseek_hybrid: ['default', 'none', ...MODEL_SUPPORTED_REASONING_EFFORT.deepseek_hybrid] as const,
   kimi_k2_5: ['default', ...MODEL_SUPPORTED_REASONING_EFFORT.kimi_k2_5] as const
 } as const
-
-const withModelIdAndNameAsId = <T>(model: Model, fn: (model: Model) => T): { idResult: T; nameResult: T } => {
-  const modelWithNameAsId = { ...model, id: model.name }
-  return {
-    idResult: fn(model),
-    nameResult: fn(modelWithNameAsId)
-  }
-}
 
 // TODO: add ut
 const _getThinkModelType = (model: Model): ThinkingModelType => {
@@ -604,8 +602,7 @@ export const isSupportedThinkingTokenMiMoModel = (model: Model): boolean => {
  * @returns true if the model supports thinking control, false otherwise
  */
 const _isSupportedThinkingTokenKimiModel = (model: Model): boolean => {
-  const modelId = getLowerBaseModelName(model.id, '/')
-  return ['kimi-k2.5'].some((id) => modelId.includes(id))
+  return isKimi25Model(model)
 }
 
 export const isSupportedThinkingTokenKimiModel = (model: Model): boolean => {

--- a/src/renderer/src/config/models/utils.ts
+++ b/src/renderer/src/config/models/utils.ts
@@ -21,6 +21,14 @@ import { isGenerateImageModel, isTextToImageModel, isVisionModel } from './visio
 export const NOT_SUPPORTED_REGEX = /(?:^tts|whisper|speech)/i
 export const GEMINI_FLASH_MODEL_REGEX = new RegExp('gemini.*-flash.*$', 'i')
 
+export const withModelIdAndNameAsId = <T>(model: Model, fn: (model: Model) => T): { idResult: T; nameResult: T } => {
+  const modelWithNameAsId = { ...model, id: model.name }
+  return {
+    idResult: fn(model),
+    nameResult: fn(modelWithNameAsId)
+  }
+}
+
 export function isSupportFlexServiceTierModel(model: Model): boolean {
   if (!model) {
     return false


### PR DESCRIPTION
### What this PR does

Before this PR:
- Using kimi-k2.5 model with custom top_p value causes API error: "invalid top_p: only 0.95 is allowed for this model"

After this PR:
- The app no longer sends top_p parameter for kimi-k2.5 models, allowing the API to use its default value (0.95)

### Why we need it and why it was done in this way

The Moonshot API for kimi-k2.5 model only accepts `top_p=0.95`. Sending any other value results in an error.

The following tradeoffs were made:
- Added a new `isKimi25Model()` function to specifically identify kimi-k2.5 models (not all kimi reasoning models)

The following alternatives were considered:
- Force top_p to 0.95 for this model - rejected as it's cleaner to just not send the parameter

### Breaking changes

None

### Special notes for your reviewer

This fix only affects kimi-k2.5 models. Other kimi models (like kimi-k2-thinking) are not affected.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required

### Release note

```release-note
fix: disable top_p parameter for kimi-k2.5 model to prevent API error
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)