### PR TITLE
fix(test): add missing ipcRenderer.invoke mock to renderer setup

### DIFF
--- a/tests/renderer.setup.ts
+++ b/tests/renderer.setup.ts
@@ -46,7 +46,8 @@ vi.mock('axios', () => {
 vi.stubGlobal('electron', {
   ipcRenderer: {
     on: vi.fn(),
-    send: vi.fn()
+    send: vi.fn(),
+    invoke: vi.fn().mockResolvedValue(undefined)
   }
 })
 vi.stubGlobal('api', {


### PR DESCRIPTION
### What this PR does

Before this PR:
- Running `pnpm test` showed 18 unhandled rejection errors: `TypeError: window.electron.ipcRenderer.invoke is not a function`
- All 2941 tests passed, but the test suite exited with error code 1 due to these unhandled rejections

After this PR:
- Tests run cleanly with no unhandled rejection errors
- Test suite exits with code 0 when all tests pass

### Why we need it and why it was done in this way

The Redux store (`src/renderer/src/store/index.ts:144`) calls `window.electron.ipcRenderer.invoke(IpcChannel.ReduxStoreReady)` during rehydration to notify the main process that the store is ready. However, the electron mock in `tests/renderer.setup.ts` only mocked `on` and `send` methods, not `invoke`.

The following tradeoffs were made:
- Simple fix that adds the missing mock without changing test behavior

The following alternatives were considered:
- Mocking the entire store module - too invasive for a simple missing mock

### Breaking changes

None

### Special notes for your reviewer

This is a minimal fix that adds one line to the existing electron mock.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: Not required - this is a test infrastructure fix

### Release note

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.ai/code)