### PR TITLE
fix: prevent MCP multimodal tool results from exceeding API message size limits

### DIFF
--- a/src/renderer/src/aiCore/utils/__tests__/mcp.test.ts
+++ b/src/renderer/src/aiCore/utils/__tests__/mcp.test.ts
@@ -7,7 +7,7 @@ import type { MCPTool } from '@renderer/types'
 import type { Tool } from 'ai'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { convertMcpToolsToAiSdkTools, setupToolsConfig } from '../mcp'
+import { convertMcpToolsToAiSdkTools, hasMultimodalContent, mcpResultToTextSummary, setupToolsConfig } from '../mcp'
 
 // Mock dependencies
 vi.mock('@logger', () => ({
@@ -285,6 +285,136 @@ describe('mcp utils', () => {
       expect(result['string-tool-id']).toBeDefined()
       expect(result['number-tool-id']).toBeDefined()
       expect(result['boolean-tool-id']).toBeDefined()
+    })
+  })
+
+  describe('hasMultimodalContent', () => {
+    it('should return false for pure text content', () => {
+      expect(hasMultimodalContent({ content: [{ type: 'text', text: 'hello' }] })).toBe(false)
+    })
+
+    it('should return true for image content', () => {
+      expect(hasMultimodalContent({ content: [{ type: 'image', data: 'base64...', mimeType: 'image/png' }] })).toBe(
+        true
+      )
+    })
+
+    it('should return true for audio content', () => {
+      expect(hasMultimodalContent({ content: [{ type: 'audio', data: 'base64...', mimeType: 'audio/mp3' }] })).toBe(
+        true
+      )
+    })
+
+    it('should return true for resource with blob', () => {
+      expect(
+        hasMultimodalContent({
+          content: [{ type: 'resource', resource: { blob: 'base64...', mimeType: 'image/png', uri: 'file://a.png' } }]
+        })
+      ).toBe(true)
+    })
+
+    it('should return false for resource without blob', () => {
+      expect(
+        hasMultimodalContent({
+          content: [{ type: 'resource', resource: { text: 'plain text', uri: 'file://a.txt' } }]
+        })
+      ).toBe(false)
+    })
+
+    it('should return true for mixed content with at least one multimodal item', () => {
+      expect(
+        hasMultimodalContent({
+          content: [
+            { type: 'text', text: 'hello' },
+            { type: 'image', data: 'base64...', mimeType: 'image/png' }
+          ]
+        })
+      ).toBe(true)
+    })
+
+    it('should return false for empty content array', () => {
+      expect(hasMultimodalContent({ content: [] })).toBe(false)
+    })
+
+    it('should return false for null/undefined result', () => {
+      expect(hasMultimodalContent(null as any)).toBe(false)
+      expect(hasMultimodalContent(undefined as any)).toBe(false)
+    })
+
+    it('should return false when content is not an array', () => {
+      expect(hasMultimodalContent({ content: 'not-array' } as any)).toBe(false)
+    })
+  })
+
+  describe('mcpResultToTextSummary', () => {
+    it('should extract text from text content', () => {
+      expect(mcpResultToTextSummary({ content: [{ type: 'text', text: 'hello world' }] })).toBe('hello world')
+    })
+
+    it('should replace image with placeholder', () => {
+      expect(mcpResultToTextSummary({ content: [{ type: 'image', data: 'base64...', mimeType: 'image/jpeg' }] })).toBe(
+        '[Image: image/jpeg, delivered to user]'
+      )
+    })
+
+    it('should use default mimeType for image without mimeType', () => {
+      expect(mcpResultToTextSummary({ content: [{ type: 'image', data: 'base64...' }] })).toBe(
+        '[Image: image/png, delivered to user]'
+      )
+    })
+
+    it('should replace audio with placeholder', () => {
+      expect(mcpResultToTextSummary({ content: [{ type: 'audio', data: 'base64...', mimeType: 'audio/wav' }] })).toBe(
+        '[Audio: audio/wav, delivered to user]'
+      )
+    })
+
+    it('should use default mimeType for audio without mimeType', () => {
+      expect(mcpResultToTextSummary({ content: [{ type: 'audio', data: 'base64...' }] })).toBe(
+        '[Audio: audio/mp3, delivered to user]'
+      )
+    })
+
+    it('should replace resource with blob with placeholder', () => {
+      expect(
+        mcpResultToTextSummary({
+          content: [
+            { type: 'resource', resource: { blob: 'base64...', mimeType: 'application/pdf', uri: 'file://doc.pdf' } }
+          ]
+        })
+      ).toBe('[Resource: application/pdf, uri=file://doc.pdf, delivered to user]')
+    })
+
+    it('should use resource text when no blob', () => {
+      expect(
+        mcpResultToTextSummary({
+          content: [{ type: 'resource', resource: { text: 'resource content', uri: 'file://a.txt' } }]
+        })
+      ).toBe('resource content')
+    })
+
+    it('should JSON.stringify unknown content types', () => {
+      const item = { type: 'unknown' as any, foo: 'bar' }
+      expect(mcpResultToTextSummary({ content: [item] })).toBe(JSON.stringify(item))
+    })
+
+    it('should join multiple content parts with newline', () => {
+      const result = mcpResultToTextSummary({
+        content: [
+          { type: 'text', text: 'Description' },
+          { type: 'image', data: 'base64...', mimeType: 'image/png' }
+        ]
+      })
+      expect(result).toBe('Description\n[Image: image/png, delivered to user]')
+    })
+
+    it('should JSON.stringify result when content is missing', () => {
+      expect(mcpResultToTextSummary(null as any)).toBe('null')
+      expect(mcpResultToTextSummary({} as any)).toBe('{}')
+    })
+
+    it('should handle empty text gracefully', () => {
+      expect(mcpResultToTextSummary({ content: [{ type: 'text' }] })).toBe('')
     })
   })
 


### PR DESCRIPTION
### What this PR does

**Before this PR:**

When MCP tools return images (e.g. screenshot tools, image generation), the entire base64 image data (~6-8MB) was serialized into the tool result message sent back to the model. This caused two problems:

1. **Gemini**: Image data was stuffed inside `functionResponse` as plain JSON text — the model could not actually "see" the image (ref: [google-gemini/gemini-cli#2136](https://github.com/google-gemini/gemini-cli/issues/2136))
2. **OpenAI-compatible providers** (e.g. Kimi): `JSON.stringify` of the full base64 data exceeded message size limits (`total message size 7964610 exceeds limit 4194304`)

**After this PR:**

- Added `toModelOutput` to MCP tool definitions to intercept multimodal results
- Image/audio content is replaced with text placeholders (e.g. `[Image: image/png, delivered to user]`)
- UI image display is **unaffected** — images still show via the `IMAGE_COMPLETE` chunk path
- Also includes `mcpResultToModelOutput` helper (content + media format) for future provider-specific handling (e.g. Gemini `inlineData`)

> **Note**: This PR contains two commits with slightly different approaches — the first adds multimodal content support (media format), the second adopts a conservative text-summary strategy for cross-provider compatibility. I kept both to show the evolution of thinking and for easier review.

### Why we need it and why it was done in this way

**The following tradeoffs were made:**

- Currently returns **text summaries for all providers** (including Gemini) because `toModelOutput` has no way to know which provider is consuming the result
- This means Gemini cannot "see" images through tool results either, even though `@ai-sdk/google` supports `inlineData` via the `media` content type

**The following alternatives were considered:**

1. **Always send media format**: Works for Gemini but breaks OpenAI-compatible providers (base64 gets JSON.stringified → exceeds size limits)
2. **Provider detection in toModelOutput**: Not possible with current AI SDK architecture — `toModelOutput` receives only the raw output, no provider context

**Follow-up: per-assistant toggle**

I also implemented a version with a `sendMcpToolImages` toggle on branch [`feat/mcp-tool-image-toggle`](https://github.com/Moeblack/cherry-studio/tree/feat/mcp-tool-image-toggle). It adds a `sendMcpToolImages` field to the Assistant type and a toolbar button (ScanEye icon) that appears when MCP is enabled. When toggled on, `toModelOutput` returns `content` + `media` format so providers like Gemini can actually see images. When off (default), only text summaries are sent — safe for all providers.

Would you be interested in having this toggle included? Happy to clean it up and add it to this PR or a follow-up if so.

References:
- [Gemini CLI #2136: Support Image Content in MCP tool results](https://github.com/google-gemini/gemini-cli/issues/2136)
- [AI SDK docs: Multi-modal Tool Results](https://sdk.vercel.ai/docs/ai-sdk-core/tools-and-tool-calling#multi-modal-tool-results)

### Breaking changes

None. This only affects the data sent to the model via AI SDK's `toModelOutput`; UI rendering and existing tool execution flows are unchanged.

### Special notes for your reviewer

- Only **1 file** changed: `src/renderer/src/aiCore/utils/mcp.ts` (no Redux/IndexedDB changes)
- All 14 existing tests pass

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered — no data model changes
- [ ] Documentation: Not required for this bugfix

### Release note

```release-note
fix: MCP tools returning images no longer cause API message size limit errors
```
