### PR TITLE
fix: refine reasoning controls for Together and DashScope

### DIFF
--- a/src/renderer/src/aiCore/utils/reasoning.ts
+++ b/src/renderer/src/aiCore/utils/reasoning.ts
@@ -338,7 +338,7 @@ export function getReasoningEffort(assistant: Assistant, model: Model): Reasonin
     }
   }
 
-  // https://docs.together.ai/reference/chat-completions-1
+  // https://docs.together.ai/reference/chat-completions-1#body-reasoning-effort
   if (provider.id === SystemProviderIds.together) {
     let adjustedReasoningEffort: 'low' | 'medium' | 'high' = 'medium'
     switch (reasoningEffort) {


### PR DESCRIPTION
### What this PR does

Before this PR:
- Together AI forwarded whatever `reasoningEffort` value users picked (e.g. `xhigh`, `auto`), but its API only accepts `low`, `medium`, or `high`, so requests could be rejected instead of coerced.
- Disabling reasoning via `none` reused model-specific logic (e.g. Moonshot/Kimi rules) that does not apply to Together AI or DashScope, so those providers never turned reasoning off as expected.
- DashScope had just onboarded Kimi reasoning models but we still sent the Moonshot-style `thinking` payload; DashScope expects its own `enable_thinking` toggle so the controls became no-ops.

After this PR:
- Together AI now clamps effort to `low`/`medium`/`high`, always enables reasoning for supported models, and explicitly disables it when users select `none`.
- DashScope Kimi reasoning models receive provider-specific `enable_thinking` plus `thinking_budget`, so both `none` and positive effort values map to the API’s expectations.
- Provider-specific overrides ensure `none` uses the per-provider switches while other effort values still propagate for downstream logic.

Fixes #12736

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Centralizing more provider-specific reasoning logic in `getReasoningEffort` increases branching, but it keeps all compatibility rules in one location for consistent maintenance.

The following alternatives were considered:
- Extracting per-provider adapters was considered but deferred to avoid touching more files during a hotfix.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- `pnpm test` currently fails due to `TypeError: window.electron.ipcRenderer.invoke is not a function` thrown during Redux persist rehydration when running `src/renderer/src/components/RichEditor/__tests__/commandSuggestion.test.ts`. The failure reproduces on `main` (see `pnpm vitest run src/renderer/src/components/RichEditor/__tests__/commandSuggestion.test.ts`). Linting (`pnpm lint`) and formatting (`pnpm format`) both succeed.

### Checklist

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
Fix reasoning parameter handling for Together AI and DashScope Kimi reasoning models, and allow unknown effort values to pass through for provider-specific logic.
```
