### PR TITLE
fix(test): add ipcRenderer.invoke mock to fix unhandled rejections

### DIFF
--- a/tests/renderer.setup.ts
+++ b/tests/renderer.setup.ts
@@ -46,7 +46,8 @@ vi.mock('axios', () => {
 vi.stubGlobal('electron', {
   ipcRenderer: {
     on: vi.fn(),
-    send: vi.fn()
+    send: vi.fn(),
+    invoke: vi.fn().mockResolvedValue(undefined)
   }
 })
 vi.stubGlobal('api', {


### PR DESCRIPTION
### What this PR does

Before this PR:
- Tests fail with 15 unhandled rejection errors: `window.electron.ipcRenderer.invoke is not a function`
- This was introduced in #12607 (CherryIn OAuth) which added `ipcRenderer.invoke` calls in store initialization

After this PR:
- Tests pass without errors
- Added `invoke` mock to the electron ipcRenderer stub in test setup

Fixes test failures on main branch.

### Why we need it and why it was done in this way

The CherryIn OAuth feature added `window.electron.ipcRenderer.invoke(IpcChannel.ReduxStoreReady)` in `src/renderer/src/store/index.ts:144`, but the test setup at `tests/renderer.setup.ts` only mocked `on` and `send` methods.

Simple fix: add `invoke: vi.fn().mockResolvedValue(undefined)` to the mock.

### Breaking changes

None

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple

### Release note

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)