### PR TITLE
fix: WriteTool streaming and duplicate React keys

### DIFF
--- a/src/renderer/src/pages/home/Messages/Blocks/index.tsx
+++ b/src/renderer/src/pages/home/Messages/Blocks/index.tsx
@@ -242,9 +242,7 @@ const MessageBlockRenderer: React.FC<Props> = ({ blocks, message }) => {
         }
 
         return (
-          <AnimatedBlockWrapper
-            key={block.type === MessageBlockType.UNKNOWN ? 'placeholder' : block.id}
-            enableAnimation={message.status.includes('ing')}>
+          <AnimatedBlockWrapper key={block.id} enableAnimation={message.status.includes('ing')}>
             {blockComponent}
           </AnimatedBlockWrapper>
         )

--- a/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/BashTool.tsx
+++ b/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/BashTool.tsx
@@ -21,7 +21,7 @@ export function BashTool({
   const { data: truncatedOutput, isTruncated, originalLength } = truncateOutput(output)
 
   return {
-    key: 'tool',
+    key: AgentToolsType.Bash,
     label: (
       <ToolHeader
         toolName={AgentToolsType.Bash}

--- a/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/GlobTool.tsx
+++ b/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/GlobTool.tsx
@@ -22,7 +22,7 @@ export function GlobTool({
   const { data: truncatedOutput, isTruncated, originalLength } = truncateOutput(output)
 
   return {
-    key: 'tool',
+    key: AgentToolsType.Glob,
     label: (
       <ToolHeader
         toolName={AgentToolsType.Glob}

--- a/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/GrepTool.tsx
+++ b/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/GrepTool.tsx
@@ -18,7 +18,7 @@ export function GrepTool({
   const { data: truncatedOutput, isTruncated, originalLength } = truncateOutput(output)
 
   return {
-    key: 'tool',
+    key: AgentToolsType.Grep,
     label: (
       <ToolHeader
         toolName={AgentToolsType.Grep}

--- a/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/SearchTool.tsx
+++ b/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/SearchTool.tsx
@@ -22,7 +22,7 @@ export function SearchTool({
   const { data: truncatedOutput, isTruncated, originalLength } = truncateOutput(output)
 
   return {
-    key: 'tool',
+    key: AgentToolsType.Search,
     label: (
       <ToolHeader
         toolName={AgentToolsType.Search}

--- a/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/SkillTool.tsx
+++ b/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/SkillTool.tsx
@@ -16,7 +16,7 @@ export function SkillTool({
   const { data: truncatedOutput, isTruncated, originalLength } = truncateOutput(output)
 
   return {
-    key: 'tool',
+    key: AgentToolsType.Skill,
     label: (
       <ToolHeader
         toolName={AgentToolsType.Skill}

--- a/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/TaskTool.tsx
+++ b/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/TaskTool.tsx
@@ -30,7 +30,7 @@ export function TaskTool({
   }, [output, hasOutput])
 
   return {
-    key: 'tool',
+    key: AgentToolsType.Task,
     label: (
       <ToolHeader
         toolName={AgentToolsType.Task}

--- a/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/WebFetchTool.tsx
+++ b/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/WebFetchTool.tsx
@@ -14,7 +14,7 @@ export function WebFetchTool({
   const { data: truncatedOutput, isTruncated, originalLength } = truncateOutput(output)
 
   return {
-    key: 'tool',
+    key: AgentToolsType.WebFetch,
     label: (
       <ToolHeader toolName={AgentToolsType.WebFetch} params={input?.url} variant="collapse-label" showStatus={false} />
     ),

--- a/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/WebSearchTool.tsx
+++ b/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/WebSearchTool.tsx
@@ -18,7 +18,7 @@ export function WebSearchTool({
   const { data: truncatedOutput, isTruncated, originalLength } = truncateOutput(output)
 
   return {
-    key: 'tool',
+    key: AgentToolsType.WebSearch,
     label: (
       <ToolHeader
         toolName={AgentToolsType.WebSearch}

--- a/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/WriteTool.tsx
+++ b/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/WriteTool.tsx
@@ -15,7 +15,7 @@ export function WriteTool({
   const language = useMemo(() => getLanguageByFilePath(input?.file_path ?? ''), [input?.file_path])
 
   return {
-    key: 'tool',
+    key: AgentToolsType.Write,
     label: (
       <ToolHeader
         toolName={AgentToolsType.Write}
@@ -24,9 +24,9 @@ export function WriteTool({
         showStatus={false}
       />
     ),
-    children: input?.content ? (
+    children: input ? (
       <CodeViewer
-        value={input.content}
+        value={input.content ?? ''}
         language={language}
         maxHeight={240}
         expanded={false}


### PR DESCRIPTION
### What this PR does

**Before this PR:**
- WriteTool displayed blank/empty content during streaming instead of showing partial content
- React console warnings about duplicate keys `placeholder` and `tool` causing unnecessary re-renders
- Multiple agent tools (Bash, Glob, Grep, Search, Skill, Task, WebFetch, WebSearch) all used identical `key: 'tool'`

**After this PR:**
- WriteTool renders content during streaming by checking input existence instead of content truthiness
- All React keys are now unique using `AgentToolsType` enum values for each tool
- Block rendering uses `block.id` instead of conditional `placeholder` key

### Why we need it and why it was done in this way

**Problem:** During tool streaming, the partial JSON is parsed with `partial-json` library and passed to tool components. In WriteTool, the condition `input?.content ?` failed when content was an empty string (falsy) during early streaming, causing it to show empty skeleton instead of updating content.

**Solution:** Changed to check `input ?` existence instead, matching the pattern used by EditTool. This allows CodeViewer to render even with empty string and update as streaming progresses.

**React Keys:** Duplicate keys in lists cause React reconciliation issues and warn in console. Fixed by using unique `AgentToolsType[ToolName]` enum values matching what working tools (ReadTool, EditTool) already do.

The following alternatives were considered:
- Using `input?.content ?? null` instead of `input ?` — rejected because it doesn't match established patterns
- Keeping generic `'tool'` keys — rejected because it violates React best practices and causes console warnings

### Breaking changes

None. This is a pure bug fix with no API or behavior changes.

### Checklist

- [x] Code follows existing patterns in the codebase (matched EditTool pattern, AgentToolsType enum pattern)
- [x] Changes are minimal and focused on the bug
- [x] No new dependencies added
- [x] Linting and formatting applied

### Release note

\`\`\`release-note
fix: WriteTool now displays content correctly during streaming and eliminated duplicate React key warnings
\`\`\`