### PR TITLE
fix: adjust UpdateAppButton display position

### DIFF
--- a/src/renderer/src/components/Tab/TabContainer.tsx
+++ b/src/renderer/src/components/Tab/TabContainer.tsx
@@ -10,6 +10,7 @@ import { useMinappPopup } from '@renderer/hooks/useMinappPopup'
 import { useMinapps } from '@renderer/hooks/useMinapps'
 import { useSettings } from '@renderer/hooks/useSettings'
 import { getThemeModeLabel, getTitleLabel } from '@renderer/i18n/label'
+import UpdateAppButton from '@renderer/pages/home/components/UpdateAppButton'
 import tabsService from '@renderer/services/TabsService'
 import { useAppDispatch, useAppSelector } from '@renderer/store'
 import type { Tab } from '@renderer/store/tabs'
@@ -274,6 +275,7 @@ const TabsContainer: React.FC<TabsContainerProps> = ({ children }) => {
           </AddTabButton>
         </HorizontalScrollContainer>
         <RightButtonsContainer style={{ paddingRight: isLinux && useSystemTitleBar ? '12px' : undefined }}>
+          <UpdateAppButton />
           <Tooltip
             title={t('settings.theme.title') + ': ' + getThemeModeLabel(settedTheme)}
             mouseEnterDelay={0.8}

--- a/src/renderer/src/pages/home/ChatNavbar.tsx
+++ b/src/renderer/src/pages/home/ChatNavbar.tsx
@@ -20,7 +20,6 @@ import styled from 'styled-components'
 import AssistantsDrawer from './components/AssistantsDrawer'
 import ChatNavbarContent from './components/ChatNavbarContent'
 import SettingsButton from './components/SettingsButton'
-import UpdateAppButton from './components/UpdateAppButton'
 
 interface Props {
   activeAssistant: Assistant
@@ -99,7 +98,6 @@ const HeaderNavbar: FC<Props> = ({ activeAssistant, setActiveAssistant, activeTo
         <ChatNavbarContent assistant={assistant} />
       </div>
       <HStack alignItems="center" gap={8}>
-        {isTopNavbar && <UpdateAppButton />}
         <SettingsButton assistant={assistant} />
         {isTopNavbar && (
           <Tooltip title={t('navbar.expand')} mouseEnterDelay={0.8}>

--- a/src/renderer/src/pages/home/Navbar.tsx
+++ b/src/renderer/src/pages/home/Navbar.tsx
@@ -127,6 +127,7 @@ const HeaderNavbar: FC<Props> = ({
         }}
         className="home-navbar-right">
         <HStack alignItems="center" gap={6}>
+          <UpdateAppButton />
           <Tooltip title={t('chat.assistant.search.placeholder')} mouseEnterDelay={0.8}>
             <NarrowIcon onClick={() => SearchPopup.show()}>
               <Search size={18} />
@@ -137,7 +138,6 @@ const HeaderNavbar: FC<Props> = ({
               <i className="iconfont icon-icon-adaptive-width"></i>
             </NarrowIcon>
           </Tooltip>
-          <UpdateAppButton />
           {topicPosition === 'right' && !showTopics && (
             <Tooltip title={t('navbar.show_sidebar')} mouseEnterDelay={2}>
               <NavbarIcon onClick={toggleShowTopics}>

--- a/src/renderer/src/pages/home/components/UpdateAppButton.tsx
+++ b/src/renderer/src/pages/home/components/UpdateAppButton.tsx
@@ -48,9 +48,6 @@ const Container = styled.div``
 const UpdateButton = styled(Button)`
   border-radius: 24px;
   font-size: 12px;
-  @media (max-width: 1000px) {
-    display: none;
-  }
 `
 
 export default UpdateAppButton


### PR DESCRIPTION
### What this PR does

Before this PR:
- UpdateAppButton was placed in ChatNavbar, only visible in top navbar mode
- The button was hidden on screens smaller than 1000px

After this PR:
- UpdateAppButton is moved to TabContainer (for tab layout) and Navbar (for sidebar layout)
- Removed the media query that hides the button on smaller screens
- The button is now consistently visible across different layouts

### Why we need it and why it was done in this way

The following tradeoffs were made:
- None

The following alternatives were considered:
- None

### Breaking changes

None

### Special notes for your reviewer

This is a UI position adjustment only, no logic changes.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: N/A

### Release note

```release-note
NONE
```