### PR TITLE
feat: use CodeEditor for JSON custom parameters with lint feedback

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -2281,6 +2281,7 @@
     },
     "function_calling": "Function Calling",
     "invalid_model": "Invalid Model",
+    "json_parse_error": "Invalid JSON format",
     "no_matches": "No models available",
     "parameter_name": "Parameter Name",
     "parameter_type": {

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -2281,6 +2281,7 @@
     },
     "function_calling": "函数调用",
     "invalid_model": "无效模型",
+    "json_parse_error": "JSON 格式无效",
     "no_matches": "无可用模型",
     "parameter_name": "参数名称",
     "parameter_type": {

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -2281,6 +2281,7 @@
     },
     "function_calling": "函式呼叫",
     "invalid_model": "無效模型",
+    "json_parse_error": "無效的 JSON 格式",
     "no_matches": "無可用模型",
     "parameter_name": "參數名稱",
     "parameter_type": {

--- a/src/renderer/src/i18n/translate/de-de.json
+++ b/src/renderer/src/i18n/translate/de-de.json
@@ -2281,6 +2281,7 @@
     },
     "function_calling": "Funktionsaufruf",
     "invalid_model": "Ungültiges Modell",
+    "json_parse_error": "Ungültiges JSON-Format",
     "no_matches": "Keine verfügbaren Modelle",
     "parameter_name": "Parametername",
     "parameter_type": {

--- a/src/renderer/src/i18n/translate/el-gr.json
+++ b/src/renderer/src/i18n/translate/el-gr.json
@@ -2281,6 +2281,7 @@
     },
     "function_calling": "Ξεχωριστική Κλήση Συναρτήσεων",
     "invalid_model": "Μη έγκυρο μοντέλο",
+    "json_parse_error": "Μη έγκυρη μορφή JSON",
     "no_matches": "Δεν υπάρχουν διαθέσιμα μοντέλα",
     "parameter_name": "Όνομα παραμέτρου",
     "parameter_type": {

--- a/src/renderer/src/i18n/translate/es-es.json
+++ b/src/renderer/src/i18n/translate/es-es.json
@@ -2281,6 +2281,7 @@
     },
     "function_calling": "Llamada a función",
     "invalid_model": "Modelo inválido",
+    "json_parse_error": "Formato JSON no válido",
     "no_matches": "No hay modelos disponibles",
     "parameter_name": "Nombre del parámetro",
     "parameter_type": {

--- a/src/renderer/src/i18n/translate/fr-fr.json
+++ b/src/renderer/src/i18n/translate/fr-fr.json
@@ -2281,6 +2281,7 @@
     },
     "function_calling": "Appel de fonction",
     "invalid_model": "Modèle invalide",
+    "json_parse_error": "Format JSON invalide",
     "no_matches": "Aucun modèle disponible",
     "parameter_name": "Nom du paramètre",
     "parameter_type": {

--- a/src/renderer/src/i18n/translate/ja-jp.json
+++ b/src/renderer/src/i18n/translate/ja-jp.json
@@ -2281,6 +2281,7 @@
     },
     "function_calling": "関数呼び出し",
     "invalid_model": "無効なモデル",
+    "json_parse_error": "無効なJSON形式",
     "no_matches": "利用可能なモデルがありません",
     "parameter_name": "パラメータ名",
     "parameter_type": {

--- a/src/renderer/src/i18n/translate/pt-pt.json
+++ b/src/renderer/src/i18n/translate/pt-pt.json
@@ -2281,6 +2281,7 @@
     },
     "function_calling": "Chamada de função",
     "invalid_model": "Modelo inválido",
+    "json_parse_error": "Formato JSON inválido",
     "no_matches": "Nenhum modelo disponível",
     "parameter_name": "Nome do parâmetro",
     "parameter_type": {

--- a/src/renderer/src/i18n/translate/ro-ro.json
+++ b/src/renderer/src/i18n/translate/ro-ro.json
@@ -2281,6 +2281,7 @@
     },
     "function_calling": "Apelare funcții",
     "invalid_model": "Model invalid",
+    "json_parse_error": "Format JSON invalid",
     "no_matches": "Nu există modele disponibile",
     "parameter_name": "Nume parametru",
     "parameter_type": {

--- a/src/renderer/src/i18n/translate/ru-ru.json
+++ b/src/renderer/src/i18n/translate/ru-ru.json
@@ -2281,6 +2281,7 @@
     },
     "function_calling": "Вызов функции",
     "invalid_model": "Недействительная модель",
+    "json_parse_error": "Неверный формат JSON",
     "no_matches": "Нет доступных моделей",
     "parameter_name": "Имя параметра",
     "parameter_type": {

--- a/src/renderer/src/pages/settings/AssistantSettings/AssistantModelSettings.tsx
+++ b/src/renderer/src/pages/settings/AssistantSettings/AssistantModelSettings.tsx
@@ -142,21 +142,28 @@ const AssistantModelSettings: FC<Props> = ({ assistant, updateAssistant, updateA
           }
         }
         return (
-          <CodeEditor
-            value={jsonValue}
-            language="json"
-            onChange={(value) => onUpdateCustomParameter(index, 'value', value)}
-            expanded={false}
-            height="auto"
-            maxHeight="200px"
-            minHeight="60px"
-            options={{ lint: true, lineNumbers: false, foldGutter: false, highlightActiveLine: false }}
-            style={{
-              borderRadius: 6,
-              overflow: 'hidden',
-              border: `1px solid ${hasJsonError ? 'var(--color-error)' : 'var(--color-border)'}`
-            }}
-          />
+          <>
+            <CodeEditor
+              value={jsonValue}
+              language="json"
+              onChange={(value) => onUpdateCustomParameter(index, 'value', value)}
+              expanded={false}
+              height="auto"
+              maxHeight="200px"
+              minHeight="60px"
+              options={{ lint: true, lineNumbers: false, foldGutter: false, highlightActiveLine: false }}
+              style={{
+                borderRadius: 6,
+                overflow: 'hidden',
+                border: `1px solid ${hasJsonError ? 'var(--color-error)' : 'var(--color-border)'}`
+              }}
+            />
+            {hasJsonError && (
+              <div style={{ color: 'var(--color-error)', fontSize: 12, marginTop: 4 }}>
+                {t('models.json_parse_error')}
+              </div>
+            )}
+          </>
         )
       }
       default:


### PR DESCRIPTION
### What this PR does

Before this PR:
JSON type custom parameters used a single-line `Input` component. Pasting multi-line JSON was collapsed into one line, making it hard to edit. When `JSON.parse()` failed (e.g., JSONC or JS object literal syntax), the catch block silently fell back to sending as a string with no user feedback.

After this PR:
- JSON type custom parameters use the project's existing `CodeEditor` component (CodeMirror-based) with JSON language mode and linting enabled
- Users get multi-line editing with syntax highlighting and real-time in-editor lint diagnostics (red underlines)
- Invalid JSON triggers a red border on the editor and a localized error message below it (e.g., "JSON 格式无效")
- The editor is displayed full-width below the name/type/delete row for adequate space

![](https://github.com/user-attachments/assets/678de1e2-2998-4a9b-8af5-ef188103ef5b)

![](https://github.com/user-attachments/assets/acbc0bf5-e879-4f6d-be32-6ab717c1dad9)

Fixes #12754

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Used `expanded={false}` with `maxHeight="200px"` to keep the editor compact within the settings form while still providing enough space for typical JSON values
- Disabled `lineNumbers` and `foldGutter` to save horizontal space since these are typically short JSON snippets
- External error hint uses a simple i18n message ("Invalid JSON format") rather than the raw `SyntaxError.message`, since detailed diagnostics are already visible inside the editor via CodeMirror lint

The following alternatives were considered:
- Using `Input.TextArea` from antd — rejected because it lacks syntax highlighting and JSON linting
- Exposing CodeMirror's lint diagnostics to the parent — rejected as overly complex; a simple `JSON.parse` check achieves the same goal

### Breaking changes

None. The value storage format remains the same (string), and the data flow through `getCustomParameters()` is unchanged.

### Special notes for your reviewer

- The `CodeEditor` component already exists in the project and supports `language="json"` + `options={{ lint: true }}` out of the box
- Only `AssistantModelSettings.tsx` is modified (plus i18n files for the new `models.json_parse_error` key); no new dependencies added
- Other parameter types (string, number, boolean) are completely unaffected

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: Not required — this is a UI enhancement for an existing feature

### Release note

```release-note
Use CodeEditor for JSON custom parameters with syntax highlighting, real-time linting, and localized error feedback
```