### PR TITLE
fix: correct openai-compatible strictJsonSchema patch

### DIFF
--- a/patches/@ai-sdk__openai-compatible@1.0.28.patch
+++ b/patches/@ai-sdk__openai-compatible@1.0.28.patch
@@ -59,7 +59,7 @@ index da237bb35b7fa8e24b37cd861ee73dfc51cdfc72..88349c614a69a268a2e4f3b157cb5e32
 -  textVerbosity: import_v4.z.string().optional()
 +  textVerbosity: import_v4.z.string().optional(),
 +  sendReasoning: import_v4.z.boolean().optional(),
-+  strictJsonSchema: z.boolean().optional()
++  strictJsonSchema: import_v4.z.boolean().optional()
  });
  
  // src/openai-compatible-error.ts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ patchedDependencies:
     hash: 279e9d43f675e4b979b32b78954dd37acc3026aa36ae2dd7701b5bad2f061522
     path: patches/@ai-sdk-google-npm-2.0.49-84720f41bd.patch
   '@ai-sdk/openai-compatible@1.0.28':
-    hash: 5ea49b4f07636a8e4630097e67e2787779ba7e933bd0459f81b1803cb125edda
+    hash: bb127b49c386dcf1b5de3e1a131e418497deed687bba0fc4e59a305b328eb94c
     path: patches/@ai-sdk__openai-compatible@1.0.28.patch
   '@ai-sdk/openai@2.0.85':
     hash: f2077f4759520d1de69b164dfd8adca1a9ace9de667e35cb0e55e812ce2ac13b
@@ -1217,7 +1217,7 @@ importers:
         version: 2.0.85(patch_hash=f2077f4759520d1de69b164dfd8adca1a9ace9de667e35cb0e55e812ce2ac13b)(zod@4.3.5)
       '@ai-sdk/openai-compatible':
         specifier: 1.0.28
-        version: 1.0.28(patch_hash=5ea49b4f07636a8e4630097e67e2787779ba7e933bd0459f81b1803cb125edda)(zod@4.3.5)
+        version: 1.0.28(patch_hash=bb127b49c386dcf1b5de3e1a131e418497deed687bba0fc4e59a305b328eb94c)(zod@4.3.5)
       '@ai-sdk/provider':
         specifier: ^2.0.0
         version: 2.0.1
@@ -1257,7 +1257,7 @@ importers:
         version: 2.0.85(patch_hash=f2077f4759520d1de69b164dfd8adca1a9ace9de667e35cb0e55e812ce2ac13b)(zod@4.3.4)
       '@ai-sdk/openai-compatible':
         specifier: 1.0.28
-        version: 1.0.28(patch_hash=5ea49b4f07636a8e4630097e67e2787779ba7e933bd0459f81b1803cb125edda)(zod@4.3.4)
+        version: 1.0.28(patch_hash=bb127b49c386dcf1b5de3e1a131e418497deed687bba0fc4e59a305b328eb94c)(zod@4.3.4)
       '@ai-sdk/provider':
         specifier: ^2.0.0
         version: 2.0.1
@@ -12300,7 +12300,7 @@ snapshots:
 
   '@ai-sdk/cerebras@1.0.34(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/openai-compatible': 1.0.28(patch_hash=5ea49b4f07636a8e4630097e67e2787779ba7e933bd0459f81b1803cb125edda)(zod@4.3.4)
+      '@ai-sdk/openai-compatible': 1.0.28(patch_hash=bb127b49c386dcf1b5de3e1a131e418497deed687bba0fc4e59a305b328eb94c)(zod@4.3.4)
       '@ai-sdk/provider': 2.0.1
       '@ai-sdk/provider-utils': 3.0.20(zod@4.3.4)
       zod: 4.3.4
@@ -12356,7 +12356,7 @@ snapshots:
 
   '@ai-sdk/huggingface@0.0.10(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/openai-compatible': 1.0.28(patch_hash=5ea49b4f07636a8e4630097e67e2787779ba7e933bd0459f81b1803cb125edda)(zod@4.3.4)
+      '@ai-sdk/openai-compatible': 1.0.28(patch_hash=bb127b49c386dcf1b5de3e1a131e418497deed687bba0fc4e59a305b328eb94c)(zod@4.3.4)
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.17(zod@4.3.4)
       zod: 4.3.4
@@ -12367,13 +12367,13 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.20(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/openai-compatible@1.0.28(patch_hash=5ea49b4f07636a8e4630097e67e2787779ba7e933bd0459f81b1803cb125edda)(zod@4.3.4)':
+  '@ai-sdk/openai-compatible@1.0.28(patch_hash=bb127b49c386dcf1b5de3e1a131e418497deed687bba0fc4e59a305b328eb94c)(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.18(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/openai-compatible@1.0.28(patch_hash=5ea49b4f07636a8e4630097e67e2787779ba7e933bd0459f81b1803cb125edda)(zod@4.3.5)':
+  '@ai-sdk/openai-compatible@1.0.28(patch_hash=bb127b49c386dcf1b5de3e1a131e418497deed687bba0fc4e59a305b328eb94c)(zod@4.3.5)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.18(zod@4.3.5)
@@ -12473,14 +12473,14 @@ snapshots:
 
   '@ai-sdk/xai@2.0.36(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/openai-compatible': 1.0.28(patch_hash=5ea49b4f07636a8e4630097e67e2787779ba7e933bd0459f81b1803cb125edda)(zod@4.3.4)
+      '@ai-sdk/openai-compatible': 1.0.28(patch_hash=bb127b49c386dcf1b5de3e1a131e418497deed687bba0fc4e59a305b328eb94c)(zod@4.3.4)
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.17(zod@4.3.4)
       zod: 4.3.4
 
   '@ai-sdk/xai@2.0.43(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/openai-compatible': 1.0.28(patch_hash=5ea49b4f07636a8e4630097e67e2787779ba7e933bd0459f81b1803cb125edda)(zod@4.3.4)
+      '@ai-sdk/openai-compatible': 1.0.28(patch_hash=bb127b49c386dcf1b5de3e1a131e418497deed687bba0fc4e59a305b328eb94c)(zod@4.3.4)
       '@ai-sdk/provider': 2.0.1
       '@ai-sdk/provider-utils': 3.0.20(zod@4.3.4)
       zod: 4.3.4
@@ -15262,7 +15262,7 @@ snapshots:
   '@opeoginni/github-copilot-openai-compatible@0.1.22(zod@4.3.4)':
     dependencies:
       '@ai-sdk/openai': 2.0.85(patch_hash=f2077f4759520d1de69b164dfd8adca1a9ace9de667e35cb0e55e812ce2ac13b)(zod@4.3.4)
-      '@ai-sdk/openai-compatible': 1.0.28(patch_hash=5ea49b4f07636a8e4630097e67e2787779ba7e933bd0459f81b1803cb125edda)(zod@4.3.4)
+      '@ai-sdk/openai-compatible': 1.0.28(patch_hash=bb127b49c386dcf1b5de3e1a131e418497deed687bba0fc4e59a305b328eb94c)(zod@4.3.4)
       '@ai-sdk/provider': 2.1.0-beta.5
       '@ai-sdk/provider-utils': 3.0.20(zod@4.3.4)
     transitivePeerDependencies:


### PR DESCRIPTION
### What this PR does

Before this PR:
- `patches/@ai-sdk__openai-compatible@1.0.28.patch` used `strictJsonSchema: z.boolean().optional()` in the CJS (`dist/index.js`) hunk.
- The identifier `z` is not in scope there (`import_v4.z` is used), which can break patch application/runtime.

After this PR:
- Fixes the patch line to `strictJsonSchema: import_v4.z.boolean().optional()`.
- Updates `pnpm-lock.yaml` patched dependency hash references for `@ai-sdk/openai-compatible@1.0.28`.

Fixes #
N/A

### Why we need it and why it was done in this way

This patch file must exactly match the target package format to apply cleanly and produce valid output. The smallest safe fix is to correct the namespace on the added `strictJsonSchema` field and keep all other patch behavior unchanged.

The following tradeoffs were made:
- Chose a surgical one-line patch fix instead of regenerating the full patch, minimizing review risk.
- Kept lockfile updates strictly to patch hash references required by pnpm.

The following alternatives were considered:
- Rebuilding the patch from scratch against upstream package files.
- Removing the `strictJsonSchema` addition entirely.

Links to places where the discussion took place:
- None

### Breaking changes

No breaking changes.

### Special notes for your reviewer

- Verified with `pnpm lint`, `pnpm test`, and `pnpm format`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
Fix an invalid zod namespace in the `@ai-sdk/openai-compatible@1.0.28` patch (`strictJsonSchema`) and update the lockfile patch hash references.
```
