### PR TITLE
fix: add window existence check in store subscription

### DIFF
--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -151,9 +151,11 @@ store.subscribe(() => {
   if (throttleTimer) return
   throttleTimer = setTimeout(() => {
     throttleTimer = null
+    // Guard for test environment where window may not exist (test tear-down)
+    if (typeof window === 'undefined') return
     const state = store.getState()
     // Guard for test environment where window.electron may not exist
-    window?.electron?.ipcRenderer?.send(IpcChannel.ReduxStateChange, state)
+    window.electron?.ipcRenderer?.send(IpcChannel.ReduxStateChange, state)
   }, 100) // 100ms throttle
 })
 


### PR DESCRIPTION
### What this PR does

This is a follow-up fix for #12730 where the test environment error was not completely resolved.

Before this PR:
- Tests occasionally fail with \"ReferenceError: window is not defined\" 
- The error occurs in `store/index.ts` when the throttled setTimeout callback executes after test tear-down
- #12730 attempted to fix this with optional chaining (`window?.electron`) but the issue persists

After this PR:
- Added explicit `typeof window === 'undefined'` check before accessing `window.electron`
- Prevents the error when test environment is destroyed before callback executes

### Why we need it and why it was done in this way

The issue is a race condition in the test environment:
1. `store.subscribe()` creates a throttled `setTimeout` (100ms)
2. Test finishes and environment is torn down (window object destroyed)
3. `setTimeout` callback executes and tries to access `window.electron`
4. Error: \"window is not defined\"

The fix in #12730 used optional chaining (`window?.electron`) but this doesn't work when `window` itself is not defined - optional chaining only handles `null`/`undefined` values, not undeclared variables.

This PR adds an explicit check `if (typeof window === 'undefined') return` before accessing `window`, which properly handles the case where `window` doesn't exist at all.

### Breaking changes

None.

### Special notes for your reviewer

This is a follow-up fix for #12730. The error appears occasionally in CI and local test runs when the setTimeout callback fires after test completion.

Verified with 20 consecutive test runs without the window error.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: Left the code cleaner than found it

### Release note

```release-note
NONE
```