### PR TITLE
fix: add missing capabilities field in AgentSessionInputbar model

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/AgentSessionInputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/AgentSessionInputbar.tsx
@@ -15,7 +15,7 @@ import { estimateUserPromptUsage } from '@renderer/services/TokenService'
 import { useAppDispatch, useAppSelector } from '@renderer/store'
 import { newMessagesActions, selectMessagesForTopic } from '@renderer/store/newMessage'
 import { sendMessage as dispatchSendMessage } from '@renderer/store/thunk/messageThunk'
-import type { Assistant, Message, Model, Topic } from '@renderer/types'
+import type { Assistant, Message } from '@renderer/types'
 import type { FileType } from '@renderer/types'
 import type { MessageBlock } from '@renderer/types/newMessage'
 import { MessageBlockStatus } from '@renderer/types/newMessage'
@@ -70,27 +70,17 @@ const AgentSessionInputbar: FC<Props> = ({ agentId, sessionId }) => {
     const [providerId, actualModelId] = session.model?.split(':') ?? [undefined, undefined]
     const actualModel = actualModelId ? getModel(actualModelId, providerId) : undefined
 
-    const model: Model | undefined = actualModel
-      ? {
-          id: actualModel.id,
-          name: actualModel.name,
-          provider: actualModel.provider,
-          group: actualModel.group,
-          capabilities: actualModel.capabilities
-        }
-      : undefined
-
     return {
       id: session.agent_id ?? agentId,
       name: session.name ?? 'Agent Session',
       prompt: session.instructions ?? '',
-      topics: [] as Topic[],
+      topics: [],
       type: 'agent-session',
-      model,
-      defaultModel: model,
+      model: actualModel,
+      defaultModel: actualModel,
       tags: [],
       enableWebSearch: false
-    } as Assistant
+    } satisfies Assistant
   }, [session, agentId])
 
   // Prepare session data for tools


### PR DESCRIPTION
The model object in AgentSessionInputbar was missing the 'capabilities' field, which caused vision capability settings from custom models to be ignored.

When users manually enabled vision for a custom model in the model settings, the setting was correctly saved but not recognized in Agent sessions because the isVisionModel() function relies on the capabilities field to check for user-selected model types.

This fix ensures the capabilities field is properly passed to the model object used in AgentSessionInputbar, allowing vision functionality to work correctly for custom models in Agent sessions.