### PR TITLE
fix: add 'local' to settingSources to load CLAUDE.local.md

### DIFF
--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -283,7 +283,7 @@ class ClaudeCodeService implements AgentServiceInterface {
             preset: 'claude_code',
             append: getLanguageInstruction()
           },
-      settingSources: ['project'],
+      settingSources: ['project', 'local'],
       includePartialMessages: true,
       permissionMode: session.configuration?.permission_mode,
       maxTurns: session.configuration?.max_turns,


### PR DESCRIPTION
### What this PR does

**Before this PR:**
The Claude Agent SDK's settingSources was configured as ['project'] only, which meant CLAUDE.local.md was not being loaded.

**After this PR:**
Changed settingSources to ['project', 'local'] to enable loading of local developer configurations (CLAUDE.local.md).

Fixes #12785

### Why we need it and why it was done in this way

The Claude Agent SDK supports three setting sources:
- 'user': Global user settings (~/.claude/settings.json)
- 'project': Project settings (.claude/settings.json) and CLAUDE.md
- 'local': Local settings (.claude/settings.local.json) and CLAUDE.local.md

According to the SDK documentation, 'local' must be explicitly included to load CLAUDE.local.md files. This is by design.

The following tradeoffs were made:
- Only added 'local' without 'user', as global user settings might conflict with Cherry Studio's integration behavior
- Kept 'project' first to ensure project-level CLAUDE.md still works as expected

### Breaking changes

None

### Special notes for your reviewer

This is a one-line fix that resolves the issue where developer local configurations were not taking effect.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)

### Release note

```release-note
Fix CLAUDE.local.md not being loaded by adding 'local' to settingSources
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>