### PR TITLE
fix: prevent Windows MAX_PATH errors

### DIFF
--- a/src/main/services/agents/plugins/PluginService.ts
+++ b/src/main/services/agents/plugins/PluginService.ts
@@ -1753,6 +1753,7 @@ export class PluginService {
    */
   private truncateWithHash(name: string, maxLength: number): string {
     if (name.length <= maxLength) return name
+    if (maxLength <= 9) return name.slice(0, maxLength)
     const hash = crypto.createHash('sha256').update(name).digest('hex').slice(0, 8)
     const truncated = name.slice(0, maxLength - 9).replace(/[-_]+$/, '')
     return `${truncated}-${hash}`


### PR DESCRIPTION
### What this PR does

Before this PR:
Plugin installation fails on Windows with "filename too long" errors when path depth exceeds the MAX_PATH limit (260 characters). This occurs with deeply nested cloned repositories or long plugin names.

After this PR:
Plugin and skill folder names are truncated to 80 characters with an 8-character SHA-256 hash suffix for uniqueness. This ensures paths stay within safe limits.

### Why we need it and why it was done in this way

**Why**: Windows has a hardcoded MAX_PATH limit of 260 characters for absolute file paths. Plugin installation constructs deeply nested paths that easily exceed this:
- Temp directory: `C:\Users\{user}\AppData\Local\Temp\cherry-studio\marketplace-install\{owner}-{repo}-{name}-{timestamp}\{cloned-repo-tree}`
- Final destination: `{workdir}\.claude\plugins\{plugin-name}\{nested-files}`

The existing `sanitizeFolderName()` and `sanitizeFilename()` methods sanitized invalid characters but had no length limits.

**How**: Added a `truncateWithHash()` helper that truncates names exceeding 80 characters and appends an 8-character hash suffix for uniqueness. This is applied cross-platform for consistency with cloud-synced workdirs (e.g., Dropbox, iCloud).

The following tradeoffs were made:
- 80 characters provides safe margin on all platforms given typical path depths
- 8-character hash (SHA-256 first 8 chars) balances readability with negligible collision probability
- Applied to all platforms (not just Windows) for consistency

The following alternatives were considered:
- Longer names (100+ chars) - less margin of safety
- Shorter hash suffix (4 chars) - higher collision probability
- Windows-only truncation - inconsistent behavior across platforms, problematic for synced workdirs

### Breaking changes

None. Existing installations are unaffected as truncation only applies to new installations. Users can manually rename existing plugins if desired.

### Special notes for your reviewer

- All 29 new tests pass, covering edge cases: short names unchanged, determinism, uniqueness, trailing separator cleanup
- Full build check passed: lint, typecheck, 2983 total tests (all passing)
- Follows existing test patterns from PluginService.test.ts (extract private methods for unit testing)

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and keep it simple
- [x] Refactor: Left the code cleaner (added focused, single-responsibility truncation method)
- [x] Upgrade: No upgrade flow impact - new installations only
- [x] Documentation: User-guide update not required - this is an internal fix

### Release note

```release-note
fix: prevent Windows MAX_PATH errors during plugin installation by truncating long folder/file names with hash suffix for uniqueness
```