### PR TITLE
fix: scroll to bottom when sending agent messages

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/AgentSessionInputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/AgentSessionInputbar.tsx
@@ -10,6 +10,7 @@ import { useSettings } from '@renderer/hooks/useSettings'
 import { useTextareaResize } from '@renderer/hooks/useTextareaResize'
 import { useTimer } from '@renderer/hooks/useTimer'
 import { CacheService } from '@renderer/services/CacheService'
+import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import { pauseTrace } from '@renderer/services/SpanManagerService'
 import { estimateUserPromptUsage } from '@renderer/services/TokenService'
 import { useAppDispatch, useAppSelector } from '@renderer/store'
@@ -423,6 +424,9 @@ const AgentSessionInputbarInner: FC<InnerProps> = ({ assistant, agentId, session
           sessionId
         })
       )
+
+      // Emit event to trigger scroll to bottom in AgentSessionMessages
+      EventEmitter.emit(EVENT_NAMES.SEND_MESSAGE, { topicId: sessionTopicId })
 
       // Clear text after successful send (draft is cleared automatically via onChange)
       setText('')


### PR DESCRIPTION
### What this PR does

**Before this PR:** When sending a message in an agent session, the message list would not scroll to the bottom to show the newly sent message.

**After this PR:** Messages now automatically scroll to the bottom when a user presses Enter to send a message in an agent session.

### Why we need it and why it was done in this way

The `AgentSessionInputbar` was not emitting the `SEND_MESSAGE` event that `AgentSessionMessages` listens to for auto-scrolling. This fix adds the event emission to maintain consistency with the regular `Inputbar` component, which already has this functionality.

### Checklist

- [x] Code: Follows existing patterns in the codebase
- [x] Testing: All existing tests pass

### Release note

\`\`\`release-note
fix(agent): auto-scroll message list to bottom when sending messages in agent sessions
\`\`\`