### PR TITLE
feat: isolate Cherry Studio OpenClaw config to separate file

### DIFF
--- a/src/main/services/OpenClawService.ts
+++ b/src/main/services/OpenClawService.ts
@@ -25,7 +25,7 @@ const OPENCLAW_CONFIG_DIR = path.join(os.homedir(), '.openclaw')
 // Original user config (read-only, used as template for first-time setup)
 const OPENCLAW_ORIGINAL_CONFIG_PATH = path.join(OPENCLAW_CONFIG_DIR, 'openclaw.json')
 // Cherry Studio's isolated config (read/write) — OpenClaw reads the OPENCLAW_CONFIG_PATH env var to locate this
-const OPENCLAW_CONFIG_PATH = path.join(OPENCLAW_CONFIG_DIR, 'openclaw_cherry.json')
+const OPENCLAW_CONFIG_PATH = path.join(OPENCLAW_CONFIG_DIR, 'openclaw.cherry.json')
 const DEFAULT_GATEWAY_PORT = 18789
 
 export type GatewayStatus = 'stopped' | 'starting' | 'running' | 'error'
@@ -771,7 +771,7 @@ class OpenClawService {
         try {
           const content = fs.readFileSync(OPENCLAW_ORIGINAL_CONFIG_PATH, 'utf-8')
           config = JSON.parse(content)
-          logger.info('Using original openclaw.json as base template for openclaw_cherry.json')
+          logger.info('Using original openclaw.json as base template for openclaw.cherry.json')
         } catch {
           logger.warn('Failed to parse original openclaw.json, creating new config')
         }


### PR DESCRIPTION
### What this PR does

Before this PR:
- Cherry Studio reads from and writes to the user's global `~/.openclaw/openclaw.json` file
- This can cause conflicts if the user also uses OpenClaw directly or with other tools

After this PR:
- Cherry Studio uses its own `~/.openclaw/openclaw_cherry.json` file
- The global `openclaw.json` is only read as a base template on first use, never modified
- Each application can maintain its own OpenClaw configuration independently

### Why we need it and why it was done in this way

This prevents Cherry Studio from inadvertently modifying configuration settings that may be used by other applications or the user's direct OpenClaw usage. The implementation:

1. Introduces a new constant `OPENCLAW_ORIGINAL_CONFIG_PATH` for the original `openclaw.json`
2. Changes `OPENCLAW_CONFIG_PATH` to point to `openclaw_cherry.json`
3. Adds fallback logic: if the cherry config doesn't exist, it copies the original config as a base template
4. Sets `OPENCLAW_CONFIG_PATH` as an environment variable when spawning OpenClaw processes

The tradeoffs made:
- Users will have two separate config files instead of one (necessary for isolation)
- First-time setup copies from the original config if available (ensures a smooth transition)

The alternatives considered:
- Storing config in Cherry Studio's app data directory (but this breaks compatibility with OpenClaw's native config format)
- Using command-line flags to override config (less reliable than environment variables)

### Breaking changes

None. This change is backward compatible. Existing `openclaw.json` files remain untouched.

### Release note

\`\`\`release-note
Improved: Cherry Studio now uses its own OpenClaw configuration file (openclaw_cherry.json) to avoid conflicts with the user's global OpenClaw settings or other applications using OpenClaw.
\`\`\`