### PR TITLE
fix: pin @uiw/codemirror-extensions-langs to 4.25.1 to fix production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -237,7 +237,7 @@
     "@types/uuid": "^10.0.0",
     "@types/word-extractor": "^1",
     "@typescript/native-preview": "7.0.0-dev.20260204.1",
-    "@uiw/codemirror-extensions-langs": "^4.25.1",
+    "@uiw/codemirror-extensions-langs": "4.25.1",
     "@uiw/codemirror-themes-all": "^4.25.1",
     "@uiw/react-codemirror": "^4.25.1",
     "@vitejs/plugin-react-swc": "^3.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -591,8 +591,8 @@ importers:
         specifier: 7.0.0-dev.20260204.1
         version: 7.0.0-dev.20260204.1
       '@uiw/codemirror-extensions-langs':
-        specifier: ^4.25.1
-        version: 4.25.4(@codemirror/autocomplete@6.20.0)(@codemirror/lang-css@6.3.1)(@codemirror/lang-html@6.4.11)(@codemirror/lang-javascript@6.2.4)(@codemirror/language-data@6.5.2)(@codemirror/language@6.11.3)(@codemirror/state@6.5.3)(@codemirror/view@6.38.1)(@lezer/common@1.5.0)(@lezer/highlight@1.2.3)(@lezer/javascript@1.5.4)(@lezer/lr@1.4.5)
+        specifier: 4.25.1
+        version: 4.25.1(@codemirror/autocomplete@6.20.0)(@codemirror/lang-css@6.3.1)(@codemirror/lang-html@6.4.11)(@codemirror/lang-javascript@6.2.4)(@codemirror/language-data@6.5.2)(@codemirror/language@6.11.3)(@codemirror/state@6.5.3)(@codemirror/view@6.38.1)(@lezer/common@1.5.0)(@lezer/highlight@1.2.3)(@lezer/javascript@1.5.4)(@lezer/lr@1.4.5)
       '@uiw/codemirror-themes-all':
         specifier: ^4.25.1
         version: 4.25.4(@codemirror/language@6.11.3)(@codemirror/state@6.5.3)(@codemirror/view@6.38.1)
@@ -5462,8 +5462,8 @@ packages:
       '@codemirror/state': '>=6.0.0'
       '@codemirror/view': 6.38.1
 
-  '@uiw/codemirror-extensions-langs@4.25.4':
-    resolution: {integrity: sha512-mLcEEg8Gt0wzNPaeI350INSLHlXv7qV8eYzQt3oExN+rDB54zL0k2pVhR445wZXDQKbP/fMWuq3qv8SiL/3pxQ==}
+  '@uiw/codemirror-extensions-langs@4.25.1':
+    resolution: {integrity: sha512-P9Sxk0w8WgxxoOK4hC2yNV2f3shE0CH8gmk8lG5rDrAYYyuUrTsTmJANXh30TuQWCPCkEXwXZZVy+dbTYAgvMQ==}
     peerDependencies:
       '@codemirror/language': 6.11.3
       '@codemirror/language-data': '>=6.0.0'
@@ -17226,7 +17226,7 @@ snapshots:
       '@codemirror/state': 6.5.3
       '@codemirror/view': 6.38.1
 
-  '@uiw/codemirror-extensions-langs@4.25.4(@codemirror/autocomplete@6.20.0)(@codemirror/lang-css@6.3.1)(@codemirror/lang-html@6.4.11)(@codemirror/lang-javascript@6.2.4)(@codemirror/language-data@6.5.2)(@codemirror/language@6.11.3)(@codemirror/state@6.5.3)(@codemirror/view@6.38.1)(@lezer/common@1.5.0)(@lezer/highlight@1.2.3)(@lezer/javascript@1.5.4)(@lezer/lr@1.4.5)':
+  '@uiw/codemirror-extensions-langs@4.25.1(@codemirror/autocomplete@6.20.0)(@codemirror/lang-css@6.3.1)(@codemirror/lang-html@6.4.11)(@codemirror/lang-javascript@6.2.4)(@codemirror/language-data@6.5.2)(@codemirror/language@6.11.3)(@codemirror/state@6.5.3)(@codemirror/view@6.38.1)(@lezer/common@1.5.0)(@lezer/highlight@1.2.3)(@lezer/javascript@1.5.4)(@lezer/lr@1.4.5)':
     dependencies:
       '@codemirror/language': 6.11.3
       '@codemirror/language-data': 6.5.2


### PR DESCRIPTION
### What this PR does

Before this PR:

`pnpm start` (production build) fails with:
```
Error: [vite]: Rolldown failed to resolve import "@codemirror/lang-cpp" from "@uiw/codemirror-extensions-langs/esm/index.js"
```

After this PR:

Production build works correctly by pinning `@uiw/codemirror-extensions-langs` to `4.25.1`.

### Why we need it and why it was done in this way

Versions 4.25.2+ of `@uiw/codemirror-extensions-langs` introduced phantom dependencies — the package directly imports `@codemirror/lang-cpp`, `@codemirror/lang-css`, etc., but does not declare them in its own `dependencies`. It only declares `@codemirror/language-data` (which transitively depends on these packages). Under pnpm's strict dependency isolation, these transitive dependencies are not accessible, causing Rolldown to fail during production builds.

This is a known upstream issue: [uiwjs/react-codemirror#754](https://github.com/uiwjs/react-codemirror/issues/754)

The following tradeoffs were made:

- Pinned to exact version `4.25.1` (removed `^` prefix) to prevent pnpm from auto-upgrading to broken versions.

The following alternatives were considered:

- Adding `public-hoist-pattern[]=@codemirror/*` to `.npmrc` — works but loosens pnpm isolation unnecessarily.
- Using `pnpm.packageExtensions` to patch the upstream package — would require listing ~20 individual `@codemirror/lang-*` packages.
- Upgrading to latest (4.25.4) — latest version still has the same issue.

### Breaking changes

None.

### Special notes for your reviewer

- `pnpm dev` was not affected because Vite's dev server uses optimizeDeps pre-bundling which resolves dependencies more permissively.
- Only the production build (`pnpm start` / `electron-vite preview`) was broken.
- Once upstream [uiwjs/react-codemirror#754](https://github.com/uiwjs/react-codemirror/issues/754) is fixed, the version pin can be relaxed back to `^`.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: Not required

### Release note

```release-note
fix: pin @uiw/codemirror-extensions-langs to 4.25.1 to fix production build failure caused by upstream phantom dependencies (uiwjs/react-codemirror#754)
```