### PR TITLE
fix(agent): move agents.db into Data/ directory for backup consistency

### DIFF
--- a/src/main/services/agents/drizzle.config.ts
+++ b/src/main/services/agents/drizzle.config.ts
@@ -28,6 +28,11 @@ function getDbPath() {
   if (process.env.NODE_ENV === 'development') {
     return path.join(os.homedir(), '.cherrystudio', 'data', 'agents.db')
   }
+  return path.join(app.getPath('userData'), 'Data', 'agents.db')
+}
+
+export function getOldDbPath() {
+  // production
   return path.join(app.getPath('userData'), 'agents.db')
 }
 


### PR DESCRIPTION
### What this PR does

Before this PR:

`agents.db` is stored at `{userData}/agents.db`, outside the `Data/` directory that BackupManager manages. This causes agent session data to be excluded from backup/restore, lost during restore, and left behind during data clearing.

After this PR:

`agents.db` is stored at `{userData}/Data/agents.db`, automatically included in BackupManager's backup/restore scope. Existing users' databases are migrated automatically on startup.

Fixes #12814

### Why we need it and why it was done in this way

The BackupManager backs up and restores the entire `{userData}/Data/` directory. By moving `agents.db` into this directory, it is automatically covered — no changes to BackupManager needed.

The following tradeoffs were made:

- Migration uses `fs.renameSync` (atomic on same filesystem) rather than copy+delete for safety.
- Migration is idempotent: only runs when old path exists AND new path does not, so it's safe across repeated startups.
- Development environment path is unchanged since dev has no backup concerns.
- SQLite WAL auxiliary files (`-wal`, `-shm`) are also migrated to prevent database corruption.

The following alternatives were considered:

- Modifying BackupManager to include `agents.db` from the parent directory — rejected as it breaks the clean `Data/` directory convention and adds special-case logic.
- Symlinking old path to new — rejected due to cross-platform compatibility concerns (Windows).

### Breaking changes

None. The migration is automatic and transparent to users.

### Special notes for your reviewer

- Only 2 files modified: `drizzle.config.ts` (path definition) and `DatabaseManager.ts` (migration logic).
- Migration pattern follows the existing `MemoryService.migrateMemoryDb()` approach at `src/main/services/memory/MemoryService.ts:81-89`.
- `pnpm build:check` passes (lint + typecheck + 3000 tests).
- **Note:** Could not verify via `pnpm start` (production build) due to an unrelated upstream build failure in `@uiw/codemirror-extensions-langs` 4.25.2+ (phantom dependencies under pnpm strict isolation). This is tracked separately in #12829. `pnpm dev` works correctly.
- v2 branch will fully rework the backup system, so this v1 fix will not conflict.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: Not required

### Release note

```release-note
fix: move agents.db into Data/ directory so it is included in backup/restore (#12814)
```