### PR TITLE
fix: support PP-OCRv5 response and handle corrupted PDF in PaddleOCR preprocess

### DIFF
--- a/src/main/knowledge/preprocess/PaddleocrPreprocessProvider.ts
+++ b/src/main/knowledge/preprocess/PaddleocrPreprocessProvider.ts
@@ -282,9 +282,16 @@ export default class PaddleocrPreprocessProvider extends BasePreprocessProvider 
         .map((layoutResult) => layoutResult.markdown.text)
         .join('\n\n')
     } else if (result.ocrResults && result.ocrResults.length > 0) {
-      markdownText = result.ocrResults.map((ocrResult) => ocrResult.prunedResult.rec_texts.join('\n')).join('\n\n')
+      markdownText = result.ocrResults
+        .filter((ocrResult) => ocrResult?.prunedResult?.rec_texts)
+        .map((ocrResult) => ocrResult.prunedResult.rec_texts.join('\n'))
+        .join('\n\n')
     } else {
       throw new Error(`No valid parsing result from PaddleOCR API for file [ID: ${file.id}]`)
+    }
+
+    if (!markdownText.trim()) {
+      throw new Error(`PaddleOCR returned empty text content for file [ID: ${file.id}]`)
     }
 
     // 直接构造目标文件名


### PR DESCRIPTION
### What this PR does

Before this PR:
- `PaddleocrPreprocessProvider` only accepted the `layoutParsingResults` response format (PP-StructureV3 pipeline). When the PaddleOCR API endpoint runs a PP-OCRv5 pipeline and returns `ocrResults`, Zod validation failed with `result.layoutParsingResults: Invalid input: expected array, received undefined`.
- When `pdf-lib` failed to parse a non-standard/corrupted PDF, the error was re-thrown despite the log message saying "Will attempt to process with PaddleOCR API", causing the entire processing to abort.

After this PR:
- The Zod schema accepts both `layoutParsingResults` (PP-StructureV3) and `ocrResults` (PP-OCRv5) response formats, with `layoutParsingResults` preferred when both are present.
- When local PDF parsing fails, page count validation is skipped and the file is still sent to PaddleOCR API for processing (which has its own more robust PDF parser).

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Both `layoutParsingResults` and `ocrResults` are optional in the schema. When neither is present, an explicit error is thrown in `saveResults`. This keeps the schema permissive at parse time while still enforcing that at least one result format exists at processing time.

The following alternatives were considered:
- Using a Zod discriminated union or `refine` to enforce "at least one of the two fields must exist" at schema level. This was rejected because it adds complexity and the runtime check in `saveResults` already covers this case with a clearer error message.

### Breaking changes

None. This is a backward-compatible fix — existing PP-StructureV3 responses continue to work as before.

### Special notes for your reviewer

- The `ocrResults` schema (`prunedResult.rec_texts`) matches the existing `PpocrService.ts` OCR service implementation which already handles PP-OCRv5 responses successfully.
- The PDF parsing error handling change aligns the actual behavior with the existing log message that already said "Will attempt to process with PaddleOCR API".

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required.

### Release note

```release-note
fix: PaddleOCR preprocessing now supports both PP-StructureV3 and PP-OCRv5 API response formats, and gracefully handles corrupted/non-standard PDFs by skipping local page count validation and delegating to the PaddleOCR API.
```