### PR TITLE
fix(claudecode): switch to acceptEdits mode after ExitPlanMode

### DIFF
--- a/packages/shared/IpcChannel.ts
+++ b/packages/shared/IpcChannel.ts
@@ -106,6 +106,8 @@ export enum IpcChannel {
   AgentToolPermission_Request = 'agent-tool-permission:request',
   AgentToolPermission_Response = 'agent-tool-permission:response',
   AgentToolPermission_Result = 'agent-tool-permission:result',
+  AgentExitPlanModeApproval_Request = 'agent-exit-plan-mode-approval:request',
+  AgentExitPlanModeApproval_Response = 'agent-exit-plan-mode-approval:response',
 
   //copilot
   Copilot_GetAuthMessage = 'copilot:get-auth-message',

--- a/src/main/services/agents/services/claudecode/claude-stream-state.ts
+++ b/src/main/services/agents/services/claudecode/claude-stream-state.ts
@@ -73,6 +73,11 @@ type ClaudeStreamStateOptions = {
   agentSessionId: string
 }
 
+// Interface for the SDK query iterator
+interface QueryIterator {
+  setPermissionMode(mode: string): Promise<void>
+}
+
 /**
  * Tracks the lifecycle of Claude streaming blocks (text, thinking, tool calls)
  * across individual websocket events. The transformer relies on this class to
@@ -94,7 +99,7 @@ export class ClaudeStreamState {
   private expectingSkillContent = false
 
   // Reference to SDK query iterator for setPermissionMode
-  queryIterator?: any
+  queryIterator?: QueryIterator
 
   constructor(options: ClaudeStreamStateOptions) {
     this.logger = loggerService.withContext('ClaudeStreamState')

--- a/src/main/services/agents/services/claudecode/claude-stream-state.ts
+++ b/src/main/services/agents/services/claudecode/claude-stream-state.ts
@@ -93,10 +93,31 @@ export class ClaudeStreamState {
    */
   private expectingSkillContent = false
 
+  // Reference to SDK query iterator for setPermissionMode
+  queryIterator?: any
+
   constructor(options: ClaudeStreamStateOptions) {
     this.logger = loggerService.withContext('ClaudeStreamState')
     this.agentSessionId = options.agentSessionId
     this.logger.silly('ClaudeStreamState', options)
+  }
+
+  /**
+   * Set the SDK query iterator reference to enable permission mode switching
+   * @param iterator - The query iterator returned by SDK's query() function
+   */
+  setQueryIterator(iterator: any) {
+    this.queryIterator = iterator
+  }
+
+  /**
+   * Switch the permission mode to 'acceptEdits' to auto-approve tool executions
+   * This is called after ExitPlanMode tool is invoked
+   */
+  async switchToAcceptEditsMode(): Promise<void> {
+    if (this.queryIterator?.setPermissionMode) {
+      await this.queryIterator.setPermissionMode('acceptEdits')
+    }
   }
 
   /** Marks the beginning of a new AiSDK step. */

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -536,7 +536,13 @@ const api = {
       updatedInput?: Record<string, unknown>
       message?: string
       updatedPermissions?: PermissionUpdate[]
-    }) => ipcRenderer.invoke(IpcChannel.AgentToolPermission_Response, payload)
+    }) => ipcRenderer.invoke(IpcChannel.AgentToolPermission_Response, payload),
+    respondToExitPlanModeApproval: (payload: {
+      requestId: string
+      behavior: 'allow' | 'deny'
+      updatedInput?: Record<string, unknown>
+      message?: string
+    }) => ipcRenderer.invoke(IpcChannel.AgentExitPlanModeApproval_Response, payload)
   },
   quoteToMainWindow: (text: string) => ipcRenderer.invoke(IpcChannel.App_QuoteToMain, text),
   setDisableHardwareAcceleration: (isDisable: boolean) =>

--- a/src/renderer/src/pages/home/Messages/Tools/ExitPlanModeApprovalDialog.tsx
+++ b/src/renderer/src/pages/home/Messages/Tools/ExitPlanModeApprovalDialog.tsx
@@ -1,0 +1,86 @@
+import { Button, Divider, Modal, Space, Typography } from 'antd'
+import React from 'react'
+import ReactMarkdown from 'react-markdown'
+
+const { Title, Paragraph } = Typography
+
+interface ExitPlanModeApprovalDialogProps {
+  open: boolean
+  plan: string
+  onCancel: () => void
+  onApprove: (mode: 'acceptEdits' | 'default') => void
+  currentPermissionMode: string
+}
+
+export const ExitPlanModeApprovalDialog: React.FC<ExitPlanModeApprovalDialogProps> = ({
+  open,
+  plan,
+  onCancel,
+  onApprove,
+  currentPermissionMode
+}) => {
+  return (
+    <Modal
+      open={open}
+      title={
+        <Space direction="vertical" style={{ width: '100%' }}>
+          <Title level={4}>Approve Plan and Continue</Title>
+          <Paragraph type="secondary">
+            Current permission mode: <strong>{currentPermissionMode}</strong>
+          </Paragraph>
+        </Space>
+      }
+      onCancel={onCancel}
+      footer={null}
+      width={800}>
+      <div style={{ maxHeight: '400px', overflowY: 'auto', marginBottom: '24px' }}>
+        <Paragraph strong>Plan Details:</Paragraph>
+        <div className="plan-preview" style={{ backgroundColor: '#f6f8fa', padding: '12px', borderRadius: '4px' }}>
+          <ReactMarkdown>{plan}</ReactMarkdown>
+        </div>
+      </div>
+
+      <Divider />
+
+      <Space direction="vertical" style={{ width: '100%' }} size="middle">
+        <Paragraph strong>Select how you want to proceed:</Paragraph>
+
+        <Button
+          type="primary"
+          size="large"
+          onClick={() => onApprove('acceptEdits')}
+          block
+          style={{ textAlign: 'left', height: 'auto', padding: '12px' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+            <span>✅ Yes, allow edits</span>
+            <small style={{ opacity: 0.7 }}>Switches to acceptEdits mode</small>
+          </div>
+        </Button>
+
+        <Button
+          type="default"
+          size="large"
+          onClick={() => onApprove('default')}
+          block
+          style={{ textAlign: 'left', height: 'auto', padding: '12px' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+            <span>✅ Yes, manually approve</span>
+            <small style={{ opacity: 0.7 }}>Switches to default mode</small>
+          </div>
+        </Button>
+
+        <Button
+          type="dashed"
+          size="large"
+          onClick={onCancel}
+          block
+          style={{ textAlign: 'left', height: 'auto', padding: '12px' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+            <span>❌ No, enter something else</span>
+            <small style={{ opacity: 0.7 }}>Stays in current mode</small>
+          </div>
+        </Button>
+      </Space>
+    </Modal>
+  )
+}

--- a/src/renderer/src/store/exitPlanModeApproval.ts
+++ b/src/renderer/src/store/exitPlanModeApproval.ts
@@ -1,0 +1,37 @@
+/**
+ * Store slice for ExitPlanMode approval dialog state management
+ */
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+
+export type ExitPlanModeApprovalRequest = {
+  requestId: string
+  plan: string
+  currentPermissionMode: string
+  toolCallId: string
+  createdAt: number
+  expiresAt: number
+}
+
+export interface ExitPlanModeApprovalState {
+  approvalRequest: ExitPlanModeApprovalRequest | null
+}
+
+const initialState: ExitPlanModeApprovalState = {
+  approvalRequest: null
+}
+
+const exitPlanModeApprovalSlice = createSlice({
+  name: 'exitPlanModeApproval',
+  initialState,
+  reducers: {
+    exitPlanModeApprovalRequested: (state, action: PayloadAction<ExitPlanModeApprovalRequest>) => {
+      state.approvalRequest = action.payload
+    },
+    exitPlanModeApprovalCleared: (state) => {
+      state.approvalRequest = null
+    }
+  }
+})
+
+export const exitPlanModeApprovalActions = exitPlanModeApprovalSlice.actions
+export default exitPlanModeApprovalSlice.reducer


### PR DESCRIPTION
### What this PR does

Before this PR:
- After exiting Plan mode, the editor did not switch back to acceptEdits mode, causing editing actions to remain disabled.

After this PR:
- Ensure the editor switches to acceptEdits mode immediately after ExitPlanMode.

Fixes #12834

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Simple, targeted fix to restore expected editor behavior without broader refactors.

The following alternatives were considered:
- More invasive state-management changes, which were deferred to keep this change minimal.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

None

### Special notes for your reviewer

- Focus review on state transition after ExitPlanMode and any side effects in editor event handling.

### Checklist

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: Write code that humans can understand and keep it simple
- [ ] Refactor: Left the code cleaner than you found it
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: User-guide update not required

Release note

```release-note
Ensure editor switches to acceptEdits mode after exiting Plan mode.
```