### PR TITLE
ci: trigger release build on PR from release branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,18 +20,30 @@ on:
   push:
     tags:
       - v*.*.*
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
 
 permissions:
   contents: write
 
 jobs:
   release:
+    # Only run for tag push, workflow_dispatch, or PR from release branches
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && startsWith(github.head_ref, 'release/v'))
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         os: ${{ fromJSON(
           github.event_name == 'push' && '["macos-latest", "windows-latest", "ubuntu-latest"]' ||
+          github.event_name == 'pull_request' && '["macos-latest", "windows-latest", "ubuntu-latest"]' ||
           github.event.inputs.platform == 'all' && '["macos-latest", "windows-latest", "ubuntu-latest"]' ||
           github.event.inputs.platform == 'linux' && '["ubuntu-latest"]' ||
           github.event.inputs.platform == 'windows' && '["windows-latest"]' ||
@@ -52,6 +64,10 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Extract version from branch name (release/v1.0.0 -> v1.0.0)
+            BRANCH="${{ github.head_ref }}"
+            echo "tag=${BRANCH#release/}" >> $GITHUB_OUTPUT
           else
             echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
### What this PR does

Before this PR:
- Release builds are only triggered when pushing tags (v*.*.*)

After this PR:
- Release builds can also be triggered when creating/updating PRs from `release/v*` branches to `main`
- This allows testing release builds before tagging

### Why we need it and why it was done in this way

This change enables the team to:
1. Create a `release/vX.X.X` branch and open a PR to `main`
2. Automatically trigger release builds for testing
3. Download and test the build artifacts before officially tagging and releasing

The following tradeoffs were made:
- Added conditional logic to distinguish between PR builds and tag builds
- Version is extracted from branch name for PR builds (e.g., `release/v1.0.0` → `v1.0.0`)

### Breaking changes

None. Tag-based releases continue to work as before.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple

### Release note

```release-note
NONE
```