### PR TITLE
fix: defer provider name trimming to submission time

### DIFF
--- a/src/renderer/src/pages/settings/ProviderSettings/AddProviderPopup.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/AddProviderPopup.tsx
@@ -52,7 +52,7 @@ const PopupContainer: React.FC<Props> = ({ provider, resolve }) => {
 
     // 返回结果，但不包含文件对象，因为文件已经直接保存到 ImageStorage
     const result = {
-      name,
+      name: name.trim(),
       type,
       logo: logo || undefined
     }
@@ -65,10 +65,10 @@ const PopupContainer: React.FC<Props> = ({ provider, resolve }) => {
   }
 
   const onClose = () => {
-    resolve({ name, type, logo: logo || undefined })
+    resolve({ name: name.trim(), type, logo: logo || undefined })
   }
 
-  const buttonDisabled = name.length === 0
+  const buttonDisabled = name.trim().length === 0
 
   // 处理内置头像的点击事件
   const handleProviderLogoClick = async (providerId: string) => {
@@ -234,7 +234,7 @@ const PopupContainer: React.FC<Props> = ({ provider, resolve }) => {
         <Form.Item label={t('settings.provider.add.name.label')} style={{ marginBottom: 8 }}>
           <Input
             value={name}
-            onChange={(e) => setName(e.target.value.trim())}
+            onChange={(e) => setName(e.target.value)}
             placeholder={t('settings.provider.add.name.placeholder')}
             onKeyDown={(e) => {
               if (e.key === 'Enter' && !e.nativeEvent.isComposing) {


### PR DESCRIPTION
### What this PR does

Before this PR:
- Provider name input was trimmed on every keystroke during typing
- Users couldn't type spaces between words without them being immediately removed
- Button disabled state checked raw name length

After this PR:
- Provider name input preserves spaces during typing
- Name is trimmed only when submitting (both `onOk` and `onClose`)
- Button disabled state correctly checks trimmed name length
- Improved UX while maintaining data integrity

Fixes #

### Why we need it and why it was done in this way

This improves the user experience by allowing natural typing behavior. Users can now type spaces between words (e.g., "My Provider") without the spaces being immediately stripped.

The following tradeoffs were made:
- Trade-off: Users can now see leading/trailing spaces in the input field during typing, but this is acceptable as the final value is properly trimmed on submission

The following alternatives were considered:
- Trimming only leading/trailing spaces on input: This would be more complex and still interfere with natural typing
- Not trimming at all: This would allow invalid provider names with whitespace

Links to places where the discussion took place:
N/A

### Breaking changes

None. This is a pure UX improvement with no API or data model changes.

### Special notes for your reviewer

- The change ensures both `onOk` (submit) and `onClose` paths trim the name
- The `buttonDisabled` logic now correctly checks if the trimmed name is empty
- No changes to data models or IndexedDB schema

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
Improved provider name input UX by allowing spaces during typing. Names are now trimmed only on submission.
```