### PR TITLE
Add experimental RTL text direction support

### DIFF
--- a/src/renderer/src/assets/styles/index.css
+++ b/src/renderer/src/assets/styles/index.css
@@ -1,6 +1,7 @@
 @import './color.css';
 @import './font.css';
 @import './markdown.css';
+@import './rtl-fix.css';
 @import './ant.css';
 @import './scrollbar.css';
 @import './container.css';

--- a/src/renderer/src/assets/styles/rtl-fix.css
+++ b/src/renderer/src/assets/styles/rtl-fix.css
@@ -1,0 +1,47 @@
+/*
+ * Experimental RTL/LTR mixed text rendering fix.
+ *
+ * Enabled by adding `experimental-rtl-text-fix` class to <body>.
+ * This intentionally targets only user-generated content areas and inputs,
+ * and keeps code/math blocks strictly LTR.
+ */
+
+body.experimental-rtl-text-fix textarea,
+body.experimental-rtl-text-fix input,
+body.experimental-rtl-text-fix [contenteditable='true'] {
+  unicode-bidi: plaintext;
+  text-align: start;
+}
+
+body.experimental-rtl-text-fix .markdown p,
+body.experimental-rtl-text-fix .markdown li,
+body.experimental-rtl-text-fix .markdown blockquote,
+body.experimental-rtl-text-fix .markdown h1,
+body.experimental-rtl-text-fix .markdown h2,
+body.experimental-rtl-text-fix .markdown h3,
+body.experimental-rtl-text-fix .markdown h4,
+body.experimental-rtl-text-fix .markdown h5,
+body.experimental-rtl-text-fix .markdown h6 {
+  text-align: start;
+}
+
+body.experimental-rtl-text-fix .markdown ul[dir='rtl'],
+body.experimental-rtl-text-fix .markdown ol[dir='rtl'] {
+  padding-right: 1.5em;
+  padding-left: 0;
+}
+
+body.experimental-rtl-text-fix pre,
+body.experimental-rtl-text-fix code,
+body.experimental-rtl-text-fix .code-block,
+body.experimental-rtl-text-fix .hljs,
+body.experimental-rtl-text-fix .shiki,
+body.experimental-rtl-text-fix .katex,
+body.experimental-rtl-text-fix .katex-display,
+body.experimental-rtl-text-fix .math,
+body.experimental-rtl-text-fix .math-inline,
+body.experimental-rtl-text-fix mjx-container {
+  direction: ltr;
+  text-align: left;
+  unicode-bidi: isolate;
+}

--- a/src/renderer/src/context/ThemeProvider.tsx
+++ b/src/renderer/src/context/ThemeProvider.tsx
@@ -32,7 +32,7 @@ const tailwindThemeChange = (theme: ThemeMode) => {
 
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
   // 用户设置的主题
-  const { theme: settedTheme, setTheme: setSettedTheme, language } = useSettings()
+  const { theme: settedTheme, setTheme: setSettedTheme, language, experimentalRtlTextFix } = useSettings()
   const [actualTheme, setActualTheme] = useState<ThemeMode>(
     window.matchMedia('(prefers-color-scheme: dark)').matches ? ThemeMode.dark : ThemeMode.light
   )
@@ -76,6 +76,10 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
       setActualTheme(actualTheme)
     })
   }, [actualTheme, initUserTheme, language, navbarPosition, setSettedTheme, settedTheme])
+
+  useEffect(() => {
+    document.body.classList.toggle('experimental-rtl-text-fix', !!experimentalRtlTextFix)
+  }, [experimentalRtlTextFix])
 
   useEffect(() => {
     tailwindThemeChange(actualTheme)

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -4174,6 +4174,14 @@
           "placeholder": "/* Put custom CSS here */"
         }
       },
+      "experimental": {
+        "badge": "Experimental",
+        "rtl_text_fix": {
+          "description": "Improves RTL (e.g., Persian/Arabic) rendering when mixed with LTR text. Code blocks and math remain LTR.",
+          "title": "RTL/LTR mixed text rendering fix"
+        },
+        "title": "Experimental"
+      },
       "font": {
         "code": "Code Font",
         "default": "Default",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -4174,6 +4174,14 @@
           "placeholder": "/* 这里写自定义 CSS */"
         }
       },
+      "experimental": {
+        "badge": "实验性",
+        "rtl_text_fix": {
+          "description": "改进 RTL（如波斯语/阿拉伯语）与 LTR 文本混排时的显示。代码块和数学公式保持为 LTR。",
+          "title": "RTL/LTR 混合文本渲染修复"
+        },
+        "title": "实验性功能"
+      },
       "font": {
         "code": "代码字体",
         "default": "默认",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -4174,6 +4174,14 @@
           "placeholder": "/* 這裡寫自訂 CSS */"
         }
       },
+      "experimental": {
+        "badge": "實驗性",
+        "rtl_text_fix": {
+          "description": "改善 RTL（例如波斯語/阿拉伯語）與 LTR 文字混排時的顯示。程式碼區塊與數學公式維持為 LTR。",
+          "title": "RTL/LTR 混合文字渲染修復"
+        },
+        "title": "實驗性功能"
+      },
       "font": {
         "code": "程式碼字型",
         "default": "預設",

--- a/src/renderer/src/pages/home/Messages/Blocks/MainTextBlock.tsx
+++ b/src/renderer/src/pages/home/Messages/Blocks/MainTextBlock.tsx
@@ -4,6 +4,7 @@ import type { RootState } from '@renderer/store'
 import { selectFormattedCitationsByBlockId } from '@renderer/store/messageBlock'
 import { type Model } from '@renderer/types'
 import type { MainTextMessageBlock, Message } from '@renderer/types/newMessage'
+import { detectBidiDirFromText } from '@renderer/utils/bidi'
 import { determineCitationSource, withCitationTags } from '@renderer/utils/citation'
 import { Flex } from 'antd'
 import React, { useCallback } from 'react'
@@ -21,7 +22,7 @@ interface Props {
 
 const MainTextBlock: React.FC<Props> = ({ block, citationBlockId, role, mentions = [] }) => {
   // Use the passed citationBlockId directly in the selector
-  const { renderInputMessageAsMarkdown } = useSettings()
+  const { renderInputMessageAsMarkdown, experimentalRtlTextFix } = useSettings()
 
   const rawCitations = useSelector((state: RootState) => selectFormattedCitationsByBlockId(state, citationBlockId))
 
@@ -51,7 +52,10 @@ const MainTextBlock: React.FC<Props> = ({ block, citationBlockId, role, mentions
         </Flex>
       )}
       {role === 'user' && !renderInputMessageAsMarkdown ? (
-        <p className="markdown" style={{ whiteSpace: 'pre-wrap' }}>
+        <p
+          className="markdown"
+          style={{ whiteSpace: 'pre-wrap' }}
+          dir={experimentalRtlTextFix ? detectBidiDirFromText(block.content) : undefined}>
           {block.content}
         </p>
       ) : (

--- a/src/renderer/src/pages/settings/DisplaySettings/DisplaySettings.tsx
+++ b/src/renderer/src/pages/settings/DisplaySettings/DisplaySettings.tsx
@@ -1,3 +1,4 @@
+import { InfoCircleOutlined } from '@ant-design/icons'
 import CodeEditor from '@renderer/components/CodeEditor'
 import { ResetIcon } from '@renderer/components/Icons'
 import { HStack } from '@renderer/components/Layout'
@@ -14,6 +15,7 @@ import {
   setAssistantIconType,
   setClickAssistantToShowTopic,
   setCustomCss,
+  setExperimentalRtlTextFix,
   setPinTopicsToTop,
   setShowTopicTime,
   setSidebarIcons
@@ -71,7 +73,8 @@ const DisplaySettings: FC = () => {
     assistantIconType,
     userTheme,
     useSystemTitleBar,
-    setUseSystemTitleBar
+    setUseSystemTitleBar,
+    experimentalRtlTextFix
   } = useSettings()
   const { navbarPosition, setNavbarPosition } = useNavbarPosition()
   const { theme, settedTheme } = useTheme()
@@ -469,6 +472,23 @@ const DisplaySettings: FC = () => {
           />
         </SettingGroup>
       )}
+      <SettingGroup theme={theme}>
+        <SettingTitle>{t('settings.display.experimental.title')}</SettingTitle>
+        <SettingDivider />
+        <SettingRow>
+          <SettingRowTitle style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <span>{t('settings.display.experimental.rtl_text_fix.title')}</span>
+            <TextBadge text={t('settings.display.experimental.badge')} />
+            <Tooltip title={t('settings.display.experimental.rtl_text_fix.description')} placement="left">
+              <InfoCircleOutlined style={{ cursor: 'pointer' }} />
+            </Tooltip>
+          </SettingRowTitle>
+          <Switch
+            checked={experimentalRtlTextFix}
+            onChange={(checked) => dispatch(setExperimentalRtlTextFix(checked))}
+          />
+        </SettingRow>
+      </SettingGroup>
       <SettingGroup theme={theme}>
         <SettingTitle>
           {t('settings.display.custom.css.label')}

--- a/src/renderer/src/store/settings.ts
+++ b/src/renderer/src/store/settings.ts
@@ -144,6 +144,8 @@ export interface SettingsState {
   showTranslateConfirm: boolean
   enableTopicNaming: boolean
   customCss: string
+  /** Experimental RTL/LTR mixed text rendering fix (opt-in, off by default) */
+  experimentalRtlTextFix: boolean
   topicNamingPrompt: string
   // 消息操作确认设置
   confirmDeleteMessage: boolean
@@ -337,6 +339,7 @@ export const initialState: SettingsState = {
   showTranslateConfirm: true,
   enableTopicNaming: true,
   customCss: '',
+  experimentalRtlTextFix: false,
   topicNamingPrompt: '',
   sidebarIcons: {
     visible: DEFAULT_SIDEBAR_ICONS,
@@ -517,6 +520,9 @@ const settingsSlice = createSlice({
     },
     setCustomCss: (state, action: PayloadAction<string>) => {
       state.customCss = action.payload
+    },
+    setExperimentalRtlTextFix: (state, action: PayloadAction<boolean>) => {
+      state.experimentalRtlTextFix = action.payload
     },
     setUserTheme: (state, action: PayloadAction<UserTheme>) => {
       state.userTheme = action.payload
@@ -963,6 +969,7 @@ export const {
   setEnableTopicNaming,
   setPasteLongTextThreshold,
   setCustomCss,
+  setExperimentalRtlTextFix,
   setTopicNamingPrompt,
   setSidebarIcons,
   setNarrowMode,

--- a/src/renderer/src/utils/bidi.ts
+++ b/src/renderer/src/utils/bidi.ts
@@ -1,0 +1,31 @@
+export type BidiDir = 'ltr' | 'rtl' | 'auto'
+
+const isRtlCodePoint = (codePoint: number) => {
+  // Hebrew, Arabic, Syriac, Arabic supplement/extended and presentation forms.
+  return (
+    (codePoint >= 0x0590 && codePoint <= 0x08ff) ||
+    (codePoint >= 0xfb1d && codePoint <= 0xfdff) ||
+    (codePoint >= 0xfe70 && codePoint <= 0xfefc)
+  )
+}
+
+/**
+ * Best-effort direction detection for mixed RTL/LTR user-generated content.
+ *
+ * Important: this is intentionally biased toward RTL when any RTL characters
+ * are present. This matches the practical expectation for Persian/Arabic text
+ * embedded in an otherwise LTR UI.
+ */
+export const detectBidiDirFromText = (text: string): BidiDir => {
+  if (!text) return 'auto'
+
+  for (let i = 0; i < text.length; i++) {
+    const codePoint = text.codePointAt(i) ?? 0
+    // Skip the surrogate pair second code unit
+    if (codePoint > 0xffff) i++
+
+    if (isRtlCodePoint(codePoint)) return 'rtl'
+  }
+
+  return text.trim().length > 0 ? 'ltr' : 'auto'
+}


### PR DESCRIPTION
### What this PR does

Before this PR:
RTL languages (like Persian/Arabic) display incorrectly, especially when mixed with LTR text (English). The text order gets messed up.

After this PR:
Added an "Experimental" toggle in **Settings > Display**. When enabled, it applies a fix that correctly handles mixed RTL/LTR content using a bidirectional text algorithm.

### Why we need it and why it was done in this way

Currently, users have to manually inject scripts into the console to read RTL text correctly. This feature makes it built-in but optional.

The following tradeoffs were made:
- Implemented as an "Experimental" opt-in feature to ensure it doesn't affect existing users unless enabled.
- Math blocks and Code blocks are forced to LTR to prevent rendering issues.

### Breaking changes

None. It is disabled by default.

### Checklist

- [x] PR: The PR description is expressive enough
- [x] Code: Keep it simple
- [x] Documentation: Added i18n strings for the new setting