### PR TITLE
feat(moonshot): add Kimi K2.5 series model support

### DIFF
--- a/src/renderer/src/config/models/__tests__/reasoning.test.ts
+++ b/src/renderer/src/config/models/__tests__/reasoning.test.ts
@@ -2290,7 +2290,7 @@ describe('isInterleavedThinkingModel', () => {
     })
   })
 
-  describe('Kimi K2 models', () => {
+  describe('Kimi models', () => {
     it('should return true for kimi-k2-thinking', () => {
       expect(isInterleavedThinkingModel(createModel({ id: 'kimi-k2-thinking' }))).toBe(true)
     })

--- a/src/renderer/src/config/models/__tests__/websearch.test.ts
+++ b/src/renderer/src/config/models/__tests__/websearch.test.ts
@@ -219,7 +219,7 @@ describe('websearch helpers', () => {
       expect(isWebSearchModel(createModel({ id: 'gemini-2.0-flash-latest' }))).toBe(true)
     })
 
-    it('evaluates hunyuan/zhipu/dashscope/openrouter/grok/moonshot providers', () => {
+    it('evaluates hunyuan/zhipu/dashscope/openrouter/grok providers', () => {
       providerMock.mockReturnValueOnce(createProvider({ id: 'hunyuan' }))
       expect(isWebSearchModel(createModel({ id: 'hunyuan-pro' }))).toBe(true)
       expect(isWebSearchModel(createModel({ id: 'hunyuan-lite', provider: 'hunyuan' }))).toBe(false)
@@ -235,19 +235,6 @@ describe('websearch helpers', () => {
 
       providerMock.mockReturnValueOnce(createProvider({ id: 'grok' }))
       expect(isWebSearchModel(createModel({ id: 'grok-2' }))).toBe(true)
-
-      // Moonshot Kimi K2.5 tests
-      providerMock.mockReturnValueOnce(createProvider({ id: 'moonshot' }))
-      expect(isWebSearchModel(createModel({ id: 'kimi-k2.5' }))).toBe(true)
-
-      providerMock.mockReturnValueOnce(createProvider({ id: 'moonshot' }))
-      expect(isWebSearchModel(createModel({ id: 'kimi-k2-thinking' }))).toBe(true)
-
-      providerMock.mockReturnValueOnce(createProvider({ id: 'moonshot' }))
-      expect(isWebSearchModel(createModel({ id: 'kimi-k2-0905-Preview' }))).toBe(true)
-
-      providerMock.mockReturnValueOnce(createProvider({ id: 'moonshot' }))
-      expect(isWebSearchModel(createModel({ id: 'moonshot-v1-auto' }))).toBe(false)
     })
   })
 

--- a/src/renderer/src/config/models/websearch.ts
+++ b/src/renderer/src/config/models/websearch.ts
@@ -120,10 +120,6 @@ export function isWebSearchModel(model: Model): boolean {
     return true
   }
 
-  if (provider.id === 'moonshot') {
-    return modelId.startsWith('kimi-k2') || modelId === 'kimi-k2.5'
-  }
-
   return false
 }
 


### PR DESCRIPTION
Add support for Moonshot's latest Kimi K2.5 series models:
- kimi-k2.5: Flagship multimodal model with vision support
- kimi-k2-0905-Preview: 256K context window
- kimi-k2-turbo-preview: Fast version
- kimi-k2-thinking: Thinking/reasoning model
- kimi-k2-thinking-turbo: Fast thinking model

Reference: https://platform.moonshot.cn/docs/guide/kimi-k2-5-quickstart

### What this PR does

Before this PR:
Cherry Studio did not include Moonshot's Kimi K2.5 series models, so users could not select them from the default model list.

After this PR:
Users can select and use Kimi K2.5 series models (kimi-k2.5, kimi-k2-0905-Preview, kimi-k2-turbo-preview, kimi-k2-thinking, kimi-k2-thinking-turbo) directly from the Moonshot provider. The kimi-k2.5 and kimi-k2-thinking models are also recognized as interleaved thinking models.

### Why we need it and why it was done in this way

Moonshot released the Kimi K2.5 series, which includes reasoning/thinking models and a multimodal flagship model. Adding these to the default model definitions lets users use them out of the box without manual configuration.

The models are added to `default.ts` with appropriate capabilities (vision for kimi-k2.5, function_calling for all). The thinking models (kimi-k2-thinking, kimi-k2-thinking-turbo, kimi-k2.5) are matched by the existing `INTERLEAVED_THINKING_MODEL_REGEX` pattern.

### Breaking changes

None.

### Special notes for your reviewer

- Web search support for Moonshot was intentionally removed per reviewer feedback (not implemented on provider side yet).
- Test cases cover both positive matches (thinking models) and negative matches (non-thinking kimi-k2 variants).

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
feat(moonshot): add Kimi K2.5 series model support (kimi-k2.5, kimi-k2-0905-Preview, kimi-k2-turbo-preview, kimi-k2-thinking, kimi-k2-thinking-turbo)
```