### PR TITLE
feat(selection-assistant): update Quote behavior to use XML `<quote>` tags

### DIFF
--- a/src/renderer/src/utils/formats.ts
+++ b/src/renderer/src/utils/formats.ts
@@ -145,5 +145,5 @@ export function addImageFileToContents(messages: Message[]) {
 }
 
 export function formatQuotedText(text: string) {
-  return '<quote>\n\n' + text + '\n\n</quote>\n'
+  return '<blockquote>\n\n' + text + '\n</blockquote>\n'
 }


### PR DESCRIPTION
### What this PR does

**Before this PR:**

The Quote feature in Selection Assistant prepended a `>` Markdown quote symbol to the beginning of *every line* of the selected content and appended a separator `-------------` at the end.

This broke original formatting (especially code blocks, indentation, lists, etc.) and wasted tokens.

**After this PR:**

The Quote feature now wraps the selected content cleanly in XML-style tags.

Fixes #12991

### Example

Quoted content:

```txt
a, b = 1, 2


def example_function(a, b) -> int:
    return a + b

```

Original behavior:

```txt
> a, b = 1, 2
> 
> 
> def example_function(a, b) -> int:
>     return a + b
> 
-------------
```

New behavior:

```txt
<quote>
a, b = 1, 2


def example_function(a, b) -> int:
    return a + b
</quote>
```

### Why we need it and why it was done in this way

Explained in #12991

### Breaking changes

None

### Release note

```release-note
Update Selection Assistant Quote feature.
```
