### PR TITLE
feat(minapp): support per-minapp proxy profiles with partition reuse

### DIFF
--- a/packages/shared/IpcChannel.ts
+++ b/packages/shared/IpcChannel.ts
@@ -56,6 +56,7 @@ export enum IpcChannel {
 
   Webview_SetOpenLinkExternal = 'webview:set-open-link-external',
   Webview_SetSpellCheckEnabled = 'webview:set-spell-check-enabled',
+  Webview_SetPartitionProxy = 'webview:set-partition-proxy',
   Webview_SearchHotkey = 'webview:search-hotkey',
   Webview_PrintToPDF = 'webview:print-to-pdf',
   Webview_SaveAsHTML = 'webview:save-as-html',

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -903,6 +903,26 @@ export async function registerIpc(mainWindow: BrowserWindow, app: Electron.App) 
     if (!webview) return
     webview.session.setSpellCheckerEnabled(isEnable)
   })
+  ipcMain.handle(
+    IpcChannel.Webview_SetPartitionProxy,
+    async (
+      _,
+      partition: string,
+      proxyConfig: {
+        mode: 'system' | 'fixed_servers' | 'direct'
+        proxyRules?: string
+        proxyBypassRules?: string
+      }
+    ) => {
+      const targetSession = session.fromPartition(partition)
+      const config: ProxyConfig = {
+        mode: proxyConfig.mode,
+        proxyRules: proxyConfig.proxyRules,
+        proxyBypassRules: proxyConfig.proxyBypassRules
+      }
+      await targetSession.setProxy(config)
+    }
+  )
 
   // Webview print and save handlers
   ipcMain.handle(IpcChannel.Webview_PrintToPDF, async (_, webviewId: number) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -490,6 +490,14 @@ const api = {
       ipcRenderer.invoke(IpcChannel.Webview_SetOpenLinkExternal, webviewId, isExternal),
     setSpellCheckEnabled: (webviewId: number, isEnable: boolean) =>
       ipcRenderer.invoke(IpcChannel.Webview_SetSpellCheckEnabled, webviewId, isEnable),
+    setPartitionProxy: (
+      partition: string,
+      proxyConfig: {
+        mode: 'system' | 'fixed_servers' | 'direct'
+        proxyRules?: string
+        proxyBypassRules?: string
+      }
+    ) => ipcRenderer.invoke(IpcChannel.Webview_SetPartitionProxy, partition, proxyConfig),
     printToPDF: (webviewId: number) => ipcRenderer.invoke(IpcChannel.Webview_PrintToPDF, webviewId),
     saveAsHTML: (webviewId: number) => ipcRenderer.invoke(IpcChannel.Webview_SaveAsHTML, webviewId),
     onFindShortcut: (callback: (payload: WebviewKeyEvent) => void) => {

--- a/src/renderer/src/components/MinApp/MinApp.tsx
+++ b/src/renderer/src/components/MinApp/MinApp.tsx
@@ -1,16 +1,18 @@
 import { loggerService } from '@logger'
 import MinAppIcon from '@renderer/components/Icons/MinAppIcon'
 import IndicatorLight from '@renderer/components/IndicatorLight'
-import { loadCustomMiniApp, ORIGIN_DEFAULT_MIN_APPS, updateAllMinApps } from '@renderer/config/minapps'
+import { reloadAllMinApps, updateAllMinApps, upsertMinAppProxyOverride } from '@renderer/config/minapps'
 import { useMinappPopup } from '@renderer/hooks/useMinappPopup'
 import { useMinapps } from '@renderer/hooks/useMinapps'
 import { useRuntime } from '@renderer/hooks/useRuntime'
 import { useNavbarPosition } from '@renderer/hooks/useSettings'
 import { setOpenedKeepAliveMinapps } from '@renderer/store/runtime'
 import type { MinAppType } from '@renderer/types'
+import { isValidProxyUrl } from '@renderer/utils'
 import type { MenuProps } from 'antd'
-import { Dropdown } from 'antd'
+import { Dropdown, Form, Input, Modal, Radio } from 'antd'
 import type { FC } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
@@ -37,6 +39,12 @@ const MinApp: FC<Props> = ({ app, onClick, size = 60, isLast }) => {
   const isActive = minappShow && currentMinappId === app.id
   const isOpened = openedKeepAliveMinapps.some((item) => item.id === app.id)
   const { isTopNavbar } = useNavbarPosition()
+  const [proxyModalOpen, setProxyModalOpen] = useState(false)
+  const [proxyForm] = Form.useForm<{
+    proxyMode: 'inherit' | 'custom' | 'system' | 'direct'
+    proxyUrl?: string
+    proxyBypassRules?: string
+  }>()
 
   const handleClick = () => {
     if (isTopNavbar) {
@@ -62,6 +70,18 @@ const MinApp: FC<Props> = ({ app, onClick, size = 60, isLast }) => {
       onClick: () => {
         const newPinned = isPinned ? pinned.filter((item) => item.id !== app.id) : [...(pinned || []), app]
         updatePinnedMinapps(newPinned)
+      }
+    },
+    {
+      key: 'proxySettings',
+      label: '代理设置',
+      onClick: () => {
+        proxyForm.setFieldsValue({
+          proxyMode: app.proxyMode || 'inherit',
+          proxyUrl: app.proxyUrl,
+          proxyBypassRules: app.proxyBypassRules
+        })
+        setProxyModalOpen(true)
       }
     },
     {
@@ -92,7 +112,7 @@ const MinApp: FC<Props> = ({ app, onClick, size = 60, isLast }) => {
                 const updatedApps = customApps.filter((customApp: MinAppType) => customApp.id !== app.id)
                 await window.api.file.writeWithId('custom-minapps.json', JSON.stringify(updatedApps, null, 2))
                 window.toast.success(t('settings.miniapps.custom.remove_success'))
-                const reloadedApps = [...ORIGIN_DEFAULT_MIN_APPS, ...(await loadCustomMiniApp())]
+                const reloadedApps = await reloadAllMinApps()
                 updateAllMinApps(reloadedApps)
                 updateMinapps(minapps.filter((item) => item.id !== app.id))
                 updatePinnedMinapps(pinned.filter((item) => item.id !== app.id))
@@ -111,20 +131,85 @@ const MinApp: FC<Props> = ({ app, onClick, size = 60, isLast }) => {
     return null
   }
 
+  const handleSaveProxySettings = async () => {
+    try {
+      const values = await proxyForm.validateFields()
+
+      if (values.proxyMode === 'custom' && values.proxyUrl && !isValidProxyUrl(values.proxyUrl)) {
+        window.toast.error(t('message.error.invalid.proxy.url'))
+        return
+      }
+
+      await upsertMinAppProxyOverride(app.id, {
+        proxyMode: values.proxyMode,
+        proxyUrl: values.proxyMode === 'custom' ? values.proxyUrl?.trim() : undefined,
+        proxyBypassRules: values.proxyMode === 'custom' ? values.proxyBypassRules?.trim() : undefined
+      })
+
+      const reloadedApps = await reloadAllMinApps()
+      updateAllMinApps(reloadedApps)
+      updateMinapps([...minapps])
+
+      setProxyModalOpen(false)
+      window.toast.success('小程序代理设置已保存，重新打开该小程序后生效')
+    } catch (error) {
+      logger.error('Failed to save minapp proxy settings:', error as Error)
+      window.toast.error('保存代理设置失败')
+    }
+  }
+
   return (
-    <Dropdown menu={{ items: menuItems }} trigger={['contextMenu']}>
-      <Container onClick={handleClick}>
-        <IconContainer>
-          <MinAppIcon size={size} app={app} />
-          {isOpened && (
-            <StyledIndicator>
-              <IndicatorLight color="#22c55e" size={6} animation={!isActive} />
-            </StyledIndicator>
-          )}
-        </IconContainer>
-        <AppTitle>{isLast ? t('settings.miniapps.custom.title') : app.nameKey ? t(app.nameKey) : app.name}</AppTitle>
-      </Container>
-    </Dropdown>
+    <>
+      <Dropdown menu={{ items: menuItems }} trigger={['contextMenu']}>
+        <Container onClick={handleClick}>
+          <IconContainer>
+            <MinAppIcon size={size} app={app} />
+            {isOpened && (
+              <StyledIndicator>
+                <IndicatorLight color="#22c55e" size={6} animation={!isActive} />
+              </StyledIndicator>
+            )}
+          </IconContainer>
+          <AppTitle>{isLast ? t('settings.miniapps.custom.title') : app.nameKey ? t(app.nameKey) : app.name}</AppTitle>
+        </Container>
+      </Dropdown>
+      <Modal
+        title={`代理设置 - ${app.nameKey ? t(app.nameKey) : app.name}`}
+        open={proxyModalOpen}
+        onCancel={() => setProxyModalOpen(false)}
+        onOk={handleSaveProxySettings}
+        okText="保存"
+        cancelText="取消"
+        destroyOnClose>
+        <Form layout="vertical" form={proxyForm} initialValues={{ proxyMode: app.proxyMode || 'inherit' }}>
+          <Form.Item name="proxyMode" label="代理模式" rules={[{ required: true }]}>
+            <Radio.Group>
+              <Radio value="inherit">跟随全局代理</Radio>
+              <Radio value="custom">自定义代理</Radio>
+              <Radio value="system">使用系统代理</Radio>
+              <Radio value="direct">不使用代理</Radio>
+            </Radio.Group>
+          </Form.Item>
+          <Form.Item noStyle shouldUpdate={(prev, next) => prev.proxyMode !== next.proxyMode}>
+            {({ getFieldValue }) =>
+              getFieldValue('proxyMode') === 'custom' ? (
+                <>
+                  <Form.Item
+                    name="proxyUrl"
+                    label="代理地址"
+                    rules={[{ required: true, message: '请输入代理地址（支持 http/socks）' }]}>
+                    <Input placeholder="例如：http://127.0.0.1:7890 或 socks5://127.0.0.1:1080" />
+                  </Form.Item>
+                  <Form.Item name="proxyBypassRules" label="绕过规则（可选）">
+                    <Input placeholder="例如：localhost,127.0.0.1,*.local" />
+                  </Form.Item>
+                </>
+              ) : null
+            }
+          </Form.Item>
+        </Form>
+      </Modal>
+    </>
   )
 }
 

--- a/src/renderer/src/components/MinApp/MinAppTabsPool.tsx
+++ b/src/renderer/src/components/MinApp/MinAppTabsPool.tsx
@@ -103,8 +103,7 @@ const MinAppTabsPool: React.FC = () => {
       {apps.map((app) => (
         <WebviewWrapper key={app.id} $active={app.id === currentMinappId}>
           <WebviewContainer
-            appid={app.id}
-            url={app.url}
+            app={app}
             onSetRefCallback={handleSetRef}
             onLoadedCallback={handleLoaded}
             onNavigateCallback={handleNavigate}

--- a/src/renderer/src/components/MinApp/MinappPopupContainer.tsx
+++ b/src/renderer/src/components/MinApp/MinappPopupContainer.tsx
@@ -509,8 +509,7 @@ const MinappPopupContainer: React.FC = () => {
     return combinedApps.map((app) => (
       <WebviewContainer
         key={app.id}
-        appid={app.id}
-        url={app.url}
+        app={app}
         onSetRefCallback={handleWebviewSetRef}
         onLoadedCallback={handleWebviewLoaded}
         onNavigateCallback={handleWebviewNavigate}

--- a/src/renderer/src/config/minapps.ts
+++ b/src/renderer/src/config/minapps.ts
@@ -59,6 +59,9 @@ import ZhipuProviderLogo from '@renderer/assets/images/providers/zhipu.png?url'
 import type { MinAppType } from '@renderer/types'
 
 const logger = loggerService.withContext('Config:minapps')
+const MINAPP_PROXY_OVERRIDES_FILE = 'minapp-proxy-overrides.json'
+
+type MinAppProxyOverride = Pick<MinAppType, 'proxyMode' | 'proxyUrl' | 'proxyBypassRules'>
 
 // 加载自定义小应用
 const loadCustomMiniApp = async (): Promise<MinAppType[]> => {
@@ -85,6 +88,41 @@ const loadCustomMiniApp = async (): Promise<MinAppType[]> => {
     logger.error('Failed to load custom mini apps:', error as Error)
     return []
   }
+}
+
+const loadMinappProxyOverrides = async (): Promise<Record<string, MinAppProxyOverride>> => {
+  try {
+    let content: string
+    try {
+      content = await window.api.file.read(MINAPP_PROXY_OVERRIDES_FILE)
+    } catch {
+      content = '{}'
+      await window.api.file.writeWithId(MINAPP_PROXY_OVERRIDES_FILE, content)
+    }
+    const parsed = JSON.parse(content)
+    if (!parsed || typeof parsed !== 'object') {
+      return {}
+    }
+    return parsed
+  } catch (error) {
+    logger.error('Failed to load minapp proxy overrides:', error as Error)
+    return {}
+  }
+}
+
+const saveMinappProxyOverrides = async (overrides: Record<string, MinAppProxyOverride>) => {
+  await window.api.file.writeWithId(MINAPP_PROXY_OVERRIDES_FILE, JSON.stringify(overrides, null, 2))
+}
+
+const applyMinappProxyOverrides = (
+  apps: MinAppType[],
+  overrides: Record<string, MinAppProxyOverride>
+): MinAppType[] => {
+  return apps.map((app) => {
+    const override = overrides[app.id]
+    if (!override) return app
+    return { ...app, ...override }
+  })
 }
 
 // 初始化默认小应用
@@ -527,11 +565,50 @@ const ORIGIN_DEFAULT_MIN_APPS: MinAppType[] = [
   }
 ]
 
+const loadAllMinApps = async (): Promise<MinAppType[]> => {
+  const customApps = await loadCustomMiniApp()
+  const proxyOverrides = await loadMinappProxyOverrides()
+  return applyMinappProxyOverrides([...ORIGIN_DEFAULT_MIN_APPS, ...customApps], proxyOverrides)
+}
+
 // All mini apps: built-in defaults + custom apps loaded from user config
-let allMinApps = [...ORIGIN_DEFAULT_MIN_APPS, ...(await loadCustomMiniApp())]
+let allMinApps = await loadAllMinApps()
 
 function updateAllMinApps(apps: MinAppType[]) {
   allMinApps = apps
 }
 
-export { allMinApps, loadCustomMiniApp, ORIGIN_DEFAULT_MIN_APPS, updateAllMinApps }
+const reloadAllMinApps = async (): Promise<MinAppType[]> => {
+  const apps = await loadAllMinApps()
+  updateAllMinApps(apps)
+  return apps
+}
+
+const upsertMinAppProxyOverride = async (
+  appId: string,
+  override: MinAppProxyOverride
+): Promise<Record<string, MinAppProxyOverride>> => {
+  const overrides = await loadMinappProxyOverrides()
+
+  if (!override.proxyMode || override.proxyMode === 'inherit') {
+    delete overrides[appId]
+  } else {
+    overrides[appId] = {
+      proxyMode: override.proxyMode,
+      proxyUrl: override.proxyUrl,
+      proxyBypassRules: override.proxyBypassRules
+    }
+  }
+
+  await saveMinappProxyOverrides(overrides)
+  return overrides
+}
+
+export {
+  allMinApps,
+  loadCustomMiniApp,
+  ORIGIN_DEFAULT_MIN_APPS,
+  reloadAllMinApps,
+  updateAllMinApps,
+  upsertMinAppProxyOverride
+}

--- a/src/renderer/src/pages/minapps/NewAppButton.tsx
+++ b/src/renderer/src/pages/minapps/NewAppButton.tsx
@@ -1,6 +1,6 @@
 import { PlusOutlined, UploadOutlined } from '@ant-design/icons'
 import { loggerService } from '@logger'
-import { loadCustomMiniApp, ORIGIN_DEFAULT_MIN_APPS, updateAllMinApps } from '@renderer/config/minapps'
+import { ORIGIN_DEFAULT_MIN_APPS, reloadAllMinApps, updateAllMinApps } from '@renderer/config/minapps'
 import { useMinapps } from '@renderer/hooks/useMinapps'
 import type { MinAppType } from '@renderer/types'
 import { Button, Form, Input, Modal, Radio, Upload } from 'antd'
@@ -59,7 +59,7 @@ const NewAppButton: FC<Props> = ({ size = 60 }) => {
       setIsModalVisible(false)
       form.resetFields()
       setFileList([])
-      const reloadedApps = [...ORIGIN_DEFAULT_MIN_APPS, ...(await loadCustomMiniApp())]
+      const reloadedApps = await reloadAllMinApps()
       updateAllMinApps(reloadedApps)
       updateMinapps([...minapps, newApp])
     } catch (error) {

--- a/src/renderer/src/pages/minapps/components/MinAppFullPageView.tsx
+++ b/src/renderer/src/pages/minapps/components/MinAppFullPageView.tsx
@@ -118,8 +118,7 @@ const MinAppFullPageView: FC<Props> = ({ app }) => {
 
         <WebviewContainer
           key={app.id}
-          appid={app.id}
-          url={app.url}
+          app={app}
           onSetRefCallback={handleWebviewSetRef}
           onLoadedCallback={handleWebviewLoaded}
           onNavigateCallback={handleWebviewNavigate}

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -517,6 +517,12 @@ export type MinAppType = {
   style?: CSSProperties
   addTime?: string
   type?: 'Custom' | 'Default' // Added the 'type' property
+  /** per-minapp proxy mode. inherit means use global app proxy settings. */
+  proxyMode?: 'inherit' | 'custom' | 'system' | 'direct'
+  /** proxy url, e.g. http://127.0.0.1:7890 or socks5://127.0.0.1:1080 */
+  proxyUrl?: string
+  /** bypass rules in Chromium format */
+  proxyBypassRules?: string
 }
 
 export enum ThemeMode {


### PR DESCRIPTION
## Summary
This PR adds per-minapp proxy support for webviews and introduces partition reuse by proxy profile.

## What’s Changed
- Add per-minapp proxy fields:
  - `proxyMode`: `inherit | custom | system | direct`
  - `proxyUrl`
  - `proxyBypassRules`
- Add new IPC channel for setting proxy on a specific webview partition:
  - `webview:set-partition-proxy`
- Update webview loading flow:
  - apply partition proxy first
  - then navigate to target URL
- Add minapp-level proxy settings entry in context menu (right click)
  - supports HTTP/SOCKS proxy URL
  - supports bypass rules
- Persist proxy overrides into local config and reload minapp definitions

## Partition Reuse Strategy
- `inherit` -> `persist:webview`
- `system` -> shared system partition
- `direct` -> shared direct partition
- `custom` -> partition keyed by hash of `proxyUrl + bypassRules`

This ensures:
- same proxy profile => session reuse
- different proxy profiles => isolation

## Usage Scenario
Users can run mixed mini-app networking in one client:
- some apps via proxy
- some apps direct
- multiple apps sharing the same proxy profile

## Verification
- `pnpm typecheck:web` passed
- `pnpm typecheck:node` passed
- `pnpm build` passed

Closes #13007
