### PR TITLE
fix: correct claude_args format for prepare-release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_TRANSLATOR_APIKEY }}
           github_token: ${{ secrets.TOKEN_GITHUB_WRITE }}
-          claude_args: '--allowed-tools "Bash(git:*)" "Bash(gh pr create:*)" "Bash(gh pr view:*)" "Bash(cat:*)" Edit Read Write Glob Grep'
+          claude_args: '--allowed-tools "Bash(git:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(cat:*),Edit,Read,Write,Glob,Grep"'
           prompt: |
             Run the prepare-release skill with version argument: ${{ github.event.inputs.version }}
 


### PR DESCRIPTION
### What this PR does

Fixes the `claude_args` format in the prepare-release workflow.

Before this PR:

```yaml
claude_args: '--allowed-tools Bash(git:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(cat:*),Edit,Read,Write,Glob,Grep'
```

After this PR:

```yaml
claude_args: '--allowed-tools "Bash(git:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(cat:*),Edit,Read,Write,Glob,Grep"'
```

Reference: https://code.claude.com/docs/en/cli-reference#cli-flags

### Why we need it and why it was done in this way

The original format without quotes was not being parsed correctly by Claude Code Action. The YAML string was being interpreted incorrectly, causing the subtool patterns to be lost. Adding quotes around the entire tools list ensures proper parsing.

The following tradeoffs were made:

- Using comma-separated format (both comma and space are supported per docs)

The following alternatives were considered:

- Using space-separated format (also valid but keeping original comma style)

### Breaking changes

None.

### Special notes for your reviewer

This fix enables the prepare-release workflow to successfully execute `git push` and `gh pr create` commands. The workflow ran successfully but the git operations were being silently skipped due to permission format issues.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required

### Release note

```release-note
NONE
```
