### PR TITLE
fix: Move labelMap inside PluginCard component

### DIFF
--- a/src/renderer/src/pages/settings/AgentSettings/components/PluginsSettings/components/PluginCard.tsx
+++ b/src/renderer/src/pages/settings/AgentSettings/components/PluginsSettings/components/PluginCard.tsx
@@ -1,6 +1,5 @@
 import type { PluginMetadata } from '@renderer/types/plugin'
 import { Button, Card, Spin, Tag } from 'antd'
-import { t } from 'i18next'
 import { Download, Star, Trash2 } from 'lucide-react'
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -16,12 +15,6 @@ export interface PluginCardProps {
   onUninstall: () => void
   loading: boolean
   onClick: () => void
-}
-
-const labelMap = {
-  skill: t('plugins.skills'),
-  agent: t('plugins.agents'),
-  command: t('plugins.commands')
 }
 
 export const PluginCard: FC<PluginCardProps> = ({
@@ -46,6 +39,12 @@ export const PluginCard: FC<PluginCardProps> = ({
     if (plugin.type === 'agent') return 'blue'
     if (plugin.type === 'skill') return 'green'
     return 'default'
+  }
+
+  const labelMap = {
+    skill: t('plugins.skills'),
+    agent: t('plugins.agents'),
+    command: t('plugins.commands')
   }
 
   const getTypeLabel = () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

⚠️ Important: Redux/IndexedDB Data-Changing Feature PRs Temporarily On Hold ⚠️

Please note: For our current development cycle, we are not accepting feature Pull Requests that introduce changes to Redux data models or IndexedDB schemas.

While we value your contributions, PRs of this nature will be blocked without merge. We welcome all other contributions (bug fixes, perf enhancements, docs, etc.). Thank you!

Once version 2.0.0 is released, we will resume reviewing feature PRs.

-->

### What this PR does

Before this PR:
The `labelMap` object was defined outside the `PluginCard` component using the global `t` instance from i18next. This meant the translations were captured once at module load time and never updated when the user switched languages.

After this PR:
The `labelMap` is now defined inside the `PluginCard` component, using the `t` function from the `useTranslation` hook. This ensures that when the language changes, the component re-renders and the translations are updated correctly.

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Moving `labelMap` inside the component is a minimal change that fixes the issue without requiring additional state management or context providers.

The following alternatives were considered: None

See: https://github.com/CherryHQ/cherry-studio/issues/13014#issuecomment-3951007403 (screenshot showing the issue)

### Breaking changes

None.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
fix: Update i18n text in PluginCard when language is switched
```
