### PR TITLE
feat(maintenance): add post-checkout hook to auto-run pnpm install on dependency changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_install_hook_types: [pre-commit, post-checkout]
+
 repos:
   - repo: local
     hooks:


### PR DESCRIPTION
### What this PR does

Before this PR:
After switching branches with `git checkout`, dependencies are not automatically synced, potentially causing stale `node_modules`.

After this PR:
A prek `post-checkout` hook automatically runs `pnpm install` when `package.json` or `pnpm-lock.yaml` changes between branches. If no dependency files changed, the install is skipped.

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:
Uses an inline bash script in the prek hook entry to keep configuration self-contained without requiring an external script file.

The following alternatives were considered:
A raw `.git/hooks/post-checkout` script was considered, but using prek keeps all hooks managed in one place via `.pre-commit-config.yaml`.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- The hook uses `PRE_COMMIT_FROM_REF` and `PRE_COMMIT_TO_REF` environment variables provided by prek during `post-checkout` stage.
- Requires `prek install -t post-checkout` to register the hook after pulling this change.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: N/A

### Release note

```release-note
NONE
```
