### PR TITLE
ci: add PR description check workflow

### DIFF
--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -122,33 +122,17 @@ jobs:
           script: |
             const marker = '<!-- pr-sync-reminder -->';
 
-            // Get latest commits with pagination to ensure we fetch the last page
-            const commitsResponse = await github.rest.pulls.listCommits({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-              per_page: 3,
-              page: 1,
-            });
-
-            // Determine last page from Link header, then fetch it
-            const linkHeader = commitsResponse.headers.link || '';
-            const lastPageMatch = linkHeader.match(/&page=(\d+)>;\s*rel="last"/);
-            let latestCommits;
-            if (lastPageMatch) {
-              const lastPage = parseInt(lastPageMatch[1], 10);
-              const { data: lastPageCommits } = await github.rest.pulls.listCommits({
+            // Fetch all commits via automatic pagination, then take the last 3
+            const allCommits = await github.paginate(
+              github.rest.pulls.listCommits,
+              {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: context.issue.number,
-                per_page: 3,
-                page: lastPage,
-              });
-              latestCommits = lastPageCommits.reverse();
-            } else {
-              // All commits fit in one page
-              latestCommits = commitsResponse.data.reverse();
-            }
+                per_page: 100,
+              }
+            );
+            const latestCommits = allCommits.slice(-3).reverse();
             const commitList = latestCommits
               .map(c => `- \`${c.sha.substring(0, 7)}\` ${c.commit.message.split('\n')[0]}`)
               .join('\n');


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:
There is no automated check to ensure PR authors fill in the required sections of the PR template. PRs can be submitted with empty or default-only descriptions.

After this PR:
A GitHub Actions workflow automatically validates that PR descriptions include actual content in the required sections (`What this PR does`, `Why we need it`, `release-note`). It also reminds authors to review their description when new commits are pushed.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The PR template exists to maintain quality and consistency in contributions, but without automated enforcement, authors may forget or skip filling it in. This workflow provides immediate feedback via check status and comments.

The implementation uses `actions/github-script@v7` with inline JavaScript to keep everything in a single file without external dependencies. HTML comment markers (`<!-- pr-description-check -->`, `<!-- pr-sync-reminder -->`) are used to track and update bot comments, avoiding duplicate noise.

The following tradeoffs were made:
- Inline script vs. external action: chose inline to minimize maintenance overhead and keep the logic visible in one place.

The following alternatives were considered:
- A dedicated GitHub App or external action for template checking — rejected as overkill for this scope.

### Breaking changes

N/A

### Special notes for your reviewer

- The workflow runs on `opened`, `edited`, `synchronize`, and `ready_for_review` events for branches `main`, `develop`, and `v2`, matching the existing `ci.yml` pattern.
- Draft PRs are skipped.
- The `notify-sync` job only runs on `synchronize` events and shows the latest 3 commit messages.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

```release-note
NONE
```
