### PR TITLE
docs: add user-facing change guidance for release notes and docs checkbox

### DIFF
--- a/.agents/skills/gh-create-pr/SKILL.md
+++ b/.agents/skills/gh-create-pr/SKILL.md
@@ -38,6 +38,19 @@ description: Create or update GitHub pull requests using the repository-required
 - PR title and body must be written in English.
 - Never create the PR before showing the full final body to the user, unless they explicitly waive the preview or confirmation.
 - Never rely on command permission prompts as PR body preview.
+- **Release note & Documentation checkbox** — both are driven by whether the change is **user-facing**. Use the table below:
+
+  | Change type | Release note | Docs `[x]` |
+  |---|---|---|
+  | New user-facing feature / setting / UI | Describe the change | ✅ |
+  | Bug fix visible to users | Describe the fix | ✅ if behavior changed |
+  | Behavior change / default value change | Describe + `action required` | ✅ |
+  | Security fix in a user-facing dependency | Describe the fix | ✅ if usage changed |
+  | CI / GitHub Actions changes | `NONE` | ❌ |
+  | Internal refactoring (user cannot tell) | `NONE` | ❌ |
+  | Dev / build tooling changes | `NONE` | ❌ |
+  | Dev-only dependency bump | `NONE` | ❌ |
+  | Test-only / code style changes | `NONE` | ❌ |
 
 ## Command Pattern
 

--- a/.claude/skills/gh-create-pr/SKILL.md
+++ b/.claude/skills/gh-create-pr/SKILL.md
@@ -38,6 +38,19 @@ description: Create or update GitHub pull requests using the repository-required
 - PR title and body must be written in English.
 - Never create the PR before showing the full final body to the user, unless they explicitly waive the preview or confirmation.
 - Never rely on command permission prompts as PR body preview.
+- **Release note & Documentation checkbox** — both are driven by whether the change is **user-facing**. Use the table below:
+
+  | Change type | Release note | Docs `[x]` |
+  |---|---|---|
+  | New user-facing feature / setting / UI | Describe the change | ✅ |
+  | Bug fix visible to users | Describe the fix | ✅ if behavior changed |
+  | Behavior change / default value change | Describe + `action required` | ✅ |
+  | Security fix in a user-facing dependency | Describe the fix | ✅ if usage changed |
+  | CI / GitHub Actions changes | `NONE` | ❌ |
+  | Internal refactoring (user cannot tell) | `NONE` | ❌ |
+  | Dev / build tooling changes | `NONE` | ❌ |
+  | Dev-only dependency bump | `NONE` | ❌ |
+  | Test-only / code style changes | `NONE` | ❌ |
 
 ## Command Pattern
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -52,13 +52,14 @@ Approvers are expected to review this list.
 - [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
 - [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
 - [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
-- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.
+- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
 
 ### Release note
 
 <!--  Write your release note:
 1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
 2. If no release note is required, just write "NONE".
+3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
 -->
 
 ```release-note


### PR DESCRIPTION
### What this PR does

Before this PR:
The `gh-create-pr` skill had no guidance on when to write a release note vs `NONE`, or when to check the Documentation checkbox. The PR template also lacked explicit guidance on release note scope.

After this PR:
- A lookup table is added to the skill so the model can match change types to the correct release note and documentation checkbox behavior.
- The PR template is updated to clarify that only user-facing changes belong in release notes, and the documentation checkbox should only be checked for user-facing features/behavior changes.

### Why we need it and why it was done in this way

The following tradeoffs were made:
A concise example table was chosen over verbose text rules, following the "concise examples over verbose explanations" principle from the skill-creator guide. This makes it easier for the model to pattern-match rather than reason about abstract rules.

The following alternatives were considered:
- Separate detailed text descriptions for release note and documentation rules — rejected as harder for the model to follow consistently.
- Keeping guidance only in the skill without updating the PR template — rejected to keep both in sync for human contributors as well.

### Breaking changes

None.

### Special notes for your reviewer

This is a docs/config-only change. No application code is affected.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.

### Release note

```release-note
NONE
```
