### PR TITLE
fix: disable translate button when sending message is disabled

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/components/InputbarCore.tsx
+++ b/src/renderer/src/pages/home/Inputbar/components/InputbarCore.tsx
@@ -606,7 +606,15 @@ export const InputbarCore: FC<InputbarCoreProps> = ({
 
   const rightSectionExtras = useMemo(() => {
     const extras: React.ReactNode[] = []
-    extras.push(<TranslateButton key="translate" text={text} onTranslated={onTranslated} isLoading={isTranslating} />)
+    extras.push(
+      <TranslateButton
+        key="translate"
+        text={text}
+        disabled={isSendDisabled}
+        onTranslated={onTranslated}
+        isLoading={isTranslating}
+      />
+    )
     extras.push(<SendMessageButton sendMessage={handleSendMessage} disabled={isSendDisabled} />)
 
     if (isLoading) {


### PR DESCRIPTION
Add `disabled` prop to `TranslateButton` component in `InputbarCore`