### PR TITLE
fix: remove extra divider in settings

### DIFF
--- a/src/renderer/src/pages/settings/DataSettings/DataSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/DataSettings.tsx
@@ -626,7 +626,6 @@ const DataSettings: FC = () => {
                   </Button>
                 </HStack>
               </SettingRow>
-              <SettingDivider />
             </SettingGroup>
             <SettingGroup theme={theme}>
               <SettingTitle>{t('settings.data.data.title')}</SettingTitle>


### PR DESCRIPTION

<table>
<tr>
 <td>
Before
 <td>
After
<tr>
 <td>
<img width="2372" height="552" alt="CleanShot 2026-02-25 at 17 03 57@2x" src="https://github.com/user-attachments/assets/68b431ff-4b16-4cbf-baeb-b66e942c29e7" />


 <td>
<img width="2358" height="486" alt="CleanShot 2026-02-25 at 17 03 51@2x" src="https://github.com/user-attachments/assets/d756b8dd-3df3-4a0e-b439-89e6ff750b69" />

</table>





