### PR TITLE
fix(resource-panel): show files and plugins when opening via button click

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/tools/components/ResourceButton.tsx
+++ b/src/renderer/src/pages/home/Inputbar/tools/components/ResourceButton.tsx
@@ -1,5 +1,6 @@
 import { ActionIconButton } from '@renderer/components/Buttons'
 import type { ToolQuickPanelApi, ToolQuickPanelController } from '@renderer/pages/home/Inputbar/types'
+import type { InstalledPlugin } from '@renderer/types/plugin'
 import { Tooltip } from 'antd'
 import { FolderOpen } from 'lucide-react'
 import type { FC } from 'react'
@@ -13,10 +14,19 @@ interface Props {
   quickPanel: ToolQuickPanelApi
   quickPanelController: ToolQuickPanelController
   accessiblePaths: string[]
+  plugins: InstalledPlugin[]
+  pluginsLoading: boolean
   setText: React.Dispatch<React.SetStateAction<string>>
 }
 
-const ResourceButton: FC<Props> = ({ quickPanel, quickPanelController, accessiblePaths, setText }) => {
+const ResourceButton: FC<Props> = ({
+  quickPanel,
+  quickPanelController,
+  accessiblePaths,
+  plugins,
+  pluginsLoading,
+  setText
+}) => {
   const { t } = useTranslation()
 
   const { handleOpenQuickPanel } = useResourcePanel(
@@ -24,8 +34,8 @@ const ResourceButton: FC<Props> = ({ quickPanel, quickPanelController, accessibl
       quickPanel,
       quickPanelController,
       accessiblePaths,
-      plugins: [], // Button only shows files, plugins are accessed via @ trigger
-      pluginsLoading: false,
+      plugins,
+      pluginsLoading,
       setText
     },
     'button'

--- a/src/renderer/src/pages/home/Inputbar/tools/components/useResourcePanel.tsx
+++ b/src/renderer/src/pages/home/Inputbar/tools/components/useResourcePanel.tsx
@@ -570,7 +570,7 @@ export const useResourcePanel = (params: Params, role: 'button' | 'manager' = 'b
    */
   useEffect(() => {
     if (role !== 'manager') return
-    if (!hasAttemptedLoadRef.current && fileList.length === 0 && !isLoading && plugins.length === 0) {
+    if (!hasAttemptedLoadRef.current && fileList.length === 0 && !isLoading) {
       return
     }
     if (isVisible && symbol === QuickPanelReservedSymbol.MentionModels) {

--- a/src/renderer/src/pages/home/Inputbar/tools/resourceTool.tsx
+++ b/src/renderer/src/pages/home/Inputbar/tools/resourceTool.tsx
@@ -1,3 +1,4 @@
+import { useInstalledPlugins } from '@renderer/hooks/usePlugins'
 import { defineTool, registerTool, TopicType } from '@renderer/pages/home/Inputbar/types'
 import type React from 'react'
 
@@ -27,6 +28,10 @@ const resourceTool = defineTool({
 
     // Get accessible paths from session data
     const accessiblePaths = session?.accessiblePaths ?? []
+    const agentId = session?.agentId
+
+    // Fetch installed plugins (agents and skills) for the button
+    const { plugins, loading: pluginsLoading } = useInstalledPlugins(agentId)
 
     // Only render if we have accessible paths
     if (accessiblePaths.length === 0) {
@@ -38,6 +43,8 @@ const resourceTool = defineTool({
         quickPanel={quickPanel}
         quickPanelController={quickPanelController}
         accessiblePaths={accessiblePaths}
+        plugins={plugins}
+        pluginsLoading={pluginsLoading}
         setText={onTextChange as React.Dispatch<React.SetStateAction<string>>}
       />
     )


### PR DESCRIPTION
### What this PR does

Before this PR:

When plugins/skills were installed, clicking the ResourceButton (folder icon) in the input bar showed only plugins but no files. The `@` trigger worked correctly.

After this PR:

Clicking the ResourceButton correctly shows both files and plugins (agents/skills), consistent with the `@` trigger behavior.

### Why we need it and why it was done in this way

The root cause was an architectural issue between two instances of `useResourcePanel`:

1. **ResourceButton** (role `'button'`) passed `plugins: []`, so it built a list with only files.
2. **ResourceQuickPanelManager** (role `'manager'`) had a `useEffect` that detected the panel opening (same `MentionModels` symbol) and overwrote the list with its own `categorizedItems` — which contained plugins but an empty file list.

The fix has two parts:
- Pass the actual `plugins` and `pluginsLoading` to `ResourceButton` so it builds a complete list independently.
- Tighten the manager's early-return guard (remove `plugins.length === 0` condition) so the manager only updates the QuickPanel list when it has actually loaded files itself (i.e., was opened via `@` trigger).

The following tradeoffs were made:

`useInstalledPlugins` is now called in both `resourceTool.tsx` (for the button) and `ResourceQuickPanelManager` (for the manager). This is a minor duplication but avoids changing the generic `quickPanelManager` interface.

The following alternatives were considered:

Lifting the plugin state to a shared parent was considered but would require changing the tool framework's `quickPanelManager` interface, which is overkill for this fix.

### Breaking changes

None.

### Special notes for your reviewer

The key insight is that both the button and the manager share the same `QuickPanelReservedSymbol.MentionModels` symbol. When the button opens the panel, the manager's `useEffect` fires and overwrites the list. The fix ensures each instance is self-sufficient and the manager only updates when it initiated the panel opening.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.

### Release note

```release-note
NONE
```
