### PR TITLE
fix: clear attached files after sending message in agent session inputbar

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/AgentSessionInputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/AgentSessionInputbar.tsx
@@ -179,7 +179,7 @@ const AgentSessionInputbarInner: FC<InnerProps> = ({ assistant, agentId, session
   const quickPanel = useQuickPanel()
 
   const { files } = useInputbarToolsState()
-  const { toolsRegistry, setIsExpanded } = useInputbarToolsDispatch()
+  const { toolsRegistry, setIsExpanded, setFiles } = useInputbarToolsDispatch()
   const { setCouldAddImageFile } = useInputbarToolsInternalDispatch()
 
   const { setTimeoutTimer } = useTimer()
@@ -419,8 +419,9 @@ const AgentSessionInputbarInner: FC<InnerProps> = ({ assistant, agentId, session
       // Emit event to trigger scroll to bottom in AgentSessionMessages
       EventEmitter.emit(EVENT_NAMES.SEND_MESSAGE, { topicId: sessionTopicId })
 
-      // Clear text after successful send (draft is cleared automatically via onChange)
+      // Clear text and files after successful send (draft is cleared automatically via onChange)
       setText('')
+      setFiles([])
       setTimeoutTimer('agentSession_sendMessage', () => setText(''), 500)
       // Restore focus to textarea after sending to maintain IME state (fcitx5 issue)
       focusTextarea()
@@ -435,6 +436,7 @@ const AgentSessionInputbarInner: FC<InnerProps> = ({ assistant, agentId, session
     sessionId,
     sessionTopicId,
     setText,
+    setFiles,
     setTimeoutTimer,
     text,
     files,


### PR DESCRIPTION
### What this PR does

Before this PR:
Attached files remained visible in the agent session input bar after sending a message.

After this PR:
Attached files are cleared from the input bar after the message is sent, matching the behavior of the regular chat Inputbar.

### Why we need it and why it was done in this way

The regular `Inputbar` already calls `setFiles([])` after sending. The `AgentSessionInputbar` was missing this cleanup call. The fix adds the same `setFiles([])` call to maintain consistency.

The following tradeoffs were made: None — this is a straightforward parity fix.

The following alternatives were considered: None.

### Breaking changes

None.

### Special notes for your reviewer

Minimal change — only adds `setFiles([])` after `setText('')` in the `sendMessage` callback, mirroring `Inputbar.tsx:267`.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: Not required — bug fix with no user-facing behavior change in docs
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix attached files not being cleared after sending a message in agent session input bar.
```
