### PR TITLE
fix(search): scroll local search to exact match

### DIFF
--- a/src/renderer/src/components/ContentSearch.tsx
+++ b/src/renderer/src/components/ContentSearch.tsx
@@ -1,6 +1,6 @@
 import { ActionIconButton } from '@renderer/components/Buttons'
 import NarrowLayout from '@renderer/pages/home/Messages/NarrowLayout'
-import { findNearestScrollableAncestor, scrollIntoView } from '@renderer/utils'
+import { findNearestScrollableAncestor, scrollIntoView, sortRangesByViewportPosition } from '@renderer/utils'
 import { Tooltip } from 'antd'
 import { debounce } from 'lodash'
 import { CaseSensitive, ChevronDown, ChevronUp, User, WholeWord, X } from 'lucide-react'
@@ -130,7 +130,8 @@ const findRangesInTarget = (
     }
   }
 
-  return ranges
+  // 让 next/prev 按“视觉上的上下顺序”移动（例如聊天消息列表是 column-reverse）。
+  return sortRangesByViewportPosition(ranges)
 }
 
 // eslint-disable-next-line @eslint-react/no-forward-ref

--- a/src/renderer/src/utils/__tests__/dom.test.ts
+++ b/src/renderer/src/utils/__tests__/dom.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { findNearestScrollableAncestor, scrollElementIntoView } from '../dom'
+import { findNearestScrollableAncestor, scrollElementIntoView, sortRangesByViewportPosition } from '../dom'
 
 const setElementSize = (
   el: HTMLElement,
@@ -148,5 +148,32 @@ describe('utils/dom', () => {
 
     expect((inner as any).scrollBy).toHaveBeenCalledOnce()
     document.body.removeChild(outer)
+  })
+
+  it('sortRangesByViewportPosition: 按 top/left 排序并保持稳定', () => {
+    const r1 = document.createRange()
+    const r2 = document.createRange()
+    const r3 = document.createRange()
+
+    // 模拟：r2 和 r3 在同一行，但 r3 更靠左；r1 在更靠下的位置
+    ;(r1 as any).getClientRects = () => [{ top: 200, left: 0 }]
+    ;(r2 as any).getClientRects = () => [{ top: 100, left: 100 }]
+    ;(r3 as any).getClientRects = () => [{ top: 100, left: 50 }]
+
+    const sorted = sortRangesByViewportPosition([r1, r2, r3])
+    expect(sorted[0]).toBe(r3)
+    expect(sorted[1]).toBe(r2)
+    expect(sorted[2]).toBe(r1)
+  })
+
+  it('sortRangesByViewportPosition: 相同坐标时保持原始顺序', () => {
+    const r1 = document.createRange()
+    const r2 = document.createRange()
+    ;(r1 as any).getClientRects = () => [{ top: 100, left: 0 }]
+    ;(r2 as any).getClientRects = () => [{ top: 100, left: 0 }]
+
+    const sorted = sortRangesByViewportPosition([r1, r2])
+    expect(sorted[0]).toBe(r1)
+    expect(sorted[1]).toBe(r2)
   })
 })


### PR DESCRIPTION
### What this PR does

  Before this PR:

  - 在聊天本地搜索中使用 next/prev（或 Enter / Shift+Enter）切换命中项时，列表会滚动但经常无法精确定位到当前高亮位置；在仅一条超长消息的场景尤为明显。

  After this PR:

  - 基于 Range 的可视区域（getClientRects / getBoundingClientRect）精确定位命中行，并滚动最近可滚动容器，使当前高亮尽量居中展示；兼容反向消息列表与单条长消息场景。

  Fixes #12591

  ### Why we need it and why it was done in this way

  The following tradeoffs were made:

  - 采用运行时 Range rect 计算来获得“命中行”的真实位置，相比仅滚动到 .message 容器更精确；代价是多一次 rect 读取，但仅发生在 next/prev 跳转时。

  The following alternatives were considered:

  - 仅对 .message 做 scrollIntoView：在超长消息内无法定位到命中行，体验不佳。
  - 手工计算 scrollTop：在反向列表（反向滚动）场景容易失准。

  Links to places where the discussion took place:

  - https://github.com/CherryHQ/cherry-studio/issues/12591

  ### Breaking changes

  - None

  ### Special notes for your reviewer

  - 新增 dom 工具函数相关单测覆盖回退滚动与反向布局场景。

  ### Release note

  修复：聊天本地搜索使用上一条/下一条切换命中项时，滚动无法精确定位到当前高亮的问题（包含单条超长消息场景）。