### PR TITLE
chore: Add post-merge hook for automatic pnpm install

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-default_install_hook_types: [pre-commit, post-checkout]
+default_install_hook_types: [pre-commit, post-checkout, post-merge]
 
 repos:
   - repo: local
@@ -29,5 +29,13 @@ repos:
         language: system
         entry: bash -c 'if [ "$PRE_COMMIT_FROM_REF" != "$PRE_COMMIT_TO_REF" ] && git diff --name-only "$PRE_COMMIT_FROM_REF" "$PRE_COMMIT_TO_REF" -- "**/package.json" pnpm-lock.yaml | grep -q .; then echo "Dependencies changed, running pnpm install..."; pnpm install; else echo "No dependency changes, skipping pnpm install."; fi'
         stages: [post-checkout]
+        always_run: true
+        pass_filenames: false
+
+      - id: post-merge-install
+        name: pnpm install after merge/pull
+        language: system
+        entry: bash -c 'PREV_HEAD=$(git rev-parse --short HEAD@{1} 2>/dev/null); if [ -n "$PREV_HEAD" ] && git diff --name-only "$PREV_HEAD" HEAD -- "**/package.json" pnpm-lock.yaml | grep -q .; then echo "Dependencies changed, running pnpm install..."; pnpm install; else echo "No dependency changes, skipping pnpm install."; fi'
+        stages: [post-merge]
         always_run: true
         pass_filenames: false


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

⚠️ Important: Redux/IndexedDB Data-Changing Feature PRs Temporarily On Hold ⚠️

Please note: For our current development cycle, we are not accepting feature Pull Requests that introduce changes to Redux data models or IndexedDB schemas.

While we value your contributions, PRs of this nature will be blocked without merge. We welcome all other contributions (bug fixes, perf enhancements, docs, etc.). Thank you!

Once version 2.0.0 is released, we will resume reviewing feature PRs.

-->

### What this PR does

Adds automatic `pnpm install` execution after `git pull` or `git merge` by configuring a post-merge hook via pre-commit.

### Why we need it and why it was done in this way

Developers often forget to run `pnpm install` after pulling changes, leading to inconsistent dependency states. This hook automatically detects changes to `package.json` or `pnpm-lock.yaml` and runs the install command.

The following tradeoffs were made:

- Following the existing post-checkout pattern (not using --frozen-lockfile)

The following alternatives were considered: None

### Breaking changes

None.

### Special notes for your reviewer

Run `pnpm prepare` after merging to activate the hook.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and keep it simple
- [x] Refactor: You have left the code cleaner than you found it
- [x] Upgrade: Impact of this change on upgrade flows was considered
- [ ] Documentation: Not required (dev tooling change)
- [x] Self-review: I have reviewed my own code

### Release note

```release-note
NONE
```
