### PR TITLE
fix: improve log message layout

### DIFF
--- a/src/renderer/src/pages/settings/MCPSettings/McpSettings.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/McpSettings.tsx
@@ -827,13 +827,11 @@ const McpSettings: React.FC = () => {
           {logs.length === 0 && <Text type="secondary">{t('settings.mcp.noLogs', 'No logs yet')}</Text>}
           {logs.map((log, idx) => (
             <LogItem key={`${log.timestamp}-${idx}`}>
-              <Flex gap={8} align="baseline">
+              <LogHeader>
                 <Timestamp>{new Date(log.timestamp).toLocaleTimeString()}</Timestamp>
                 <Tag color={mapLogLevelColor(log.level)}>{log.level}</Tag>
-                <Text className="flex-1 truncate" ellipsis={{ tooltip: true }}>
-                  {log.message}
-                </Text>
-              </Flex>
+                <LogMessage>{log.message}</LogMessage>
+              </LogHeader>
               {log.data && (
                 <PreBlock>{typeof log.data === 'string' ? log.data : JSON.stringify(log.data, null, 2)}</PreBlock>
               )}
@@ -879,9 +877,23 @@ const LogItem = styled.div`
   border: 1px solid var(--color-border, rgba(255, 255, 255, 0.08));
 `
 
+const LogHeader = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+`
+
 const Timestamp = styled.span`
   color: var(--color-text-3, #9aa2b1);
   font-size: 12px;
+  flex-shrink: 0;
+`
+
+const LogMessage = styled.span`
+  font-size: 13px;
+  line-height: 1.5;
+  word-break: break-word;
 `
 
 const PreBlock = styled.pre`


### PR DESCRIPTION
<table>
<tr>
 <td>
 Before
 <td>
After
<tr>
 <td>
<img width="1576" height="1106" alt="CleanShot 2026-03-01 at 12 55 50@2x" src="https://github.com/user-attachments/assets/b3633072-87e5-40c2-8e84-66f3f972473e" />

 <td>
<img width="1578" height="1504" alt="CleanShot 2026-03-01 at 13 23 34@2x" src="https://github.com/user-attachments/assets/8257ea8a-a518-47b0-9237-12147f47d4bc" />

</table>