### PR TITLE
fix: PinnedTodoPanel ignores narrow mode width setting

### DIFF
--- a/src/renderer/src/pages/home/Chat.tsx
+++ b/src/renderer/src/pages/home/Chat.tsx
@@ -35,6 +35,7 @@ import Inputbar from './Inputbar/Inputbar'
 import AgentSessionMessages from './Messages/AgentSessionMessages'
 import ChatNavigation from './Messages/ChatNavigation'
 import Messages from './Messages/Messages'
+import NarrowLayout from './Messages/NarrowLayout'
 import Tabs from './Tabs'
 
 const logger = loggerService.withContext('Chat')
@@ -247,7 +248,9 @@ const Chat: FC<Props> = (props) => {
                       <>
                         <AgentSessionMessages agentId={activeAgentId} sessionId={activeSessionId} />
                         <PinnedTodoPanelWrapper>
-                          <PinnedTodoPanel topicId={buildAgentSessionTopicId(activeSessionId)} />
+                          <NarrowLayout>
+                            <PinnedTodoPanel topicId={buildAgentSessionTopicId(activeSessionId)} />
+                          </NarrowLayout>
                         </PinnedTodoPanelWrapper>
                       </>
                     )}


### PR DESCRIPTION
### What this PR does

Before this PR:
The `PinnedTodoPanel` (agent todo list) always stretched to the full width of the chat area, ignoring the narrow mode ("伸縮對話框") setting.

After this PR:
The `PinnedTodoPanel` respects the narrow mode setting and constrains its width to 800px when narrow mode is active, consistent with the messages area and input bar.

### Why we need it and why it was done in this way

The messages (`Messages`, `AgentSessionMessages`) and input bar (`InputbarCore`) are each wrapped in `NarrowLayout` inside their own components. The `PinnedTodoPanel` was missing this wrapper, so it was the only element that didn't respond to the narrow mode toggle.

The fix wraps `PinnedTodoPanel` in `NarrowLayout` at the same level as the other components in `Chat.tsx`, following the existing pattern.

The following tradeoffs were made: None — this follows the established pattern exactly.

The following alternatives were considered: Moving the `NarrowLayout` wrapper inside `PinnedTodoPanel.tsx` itself, but the existing convention is to apply `NarrowLayout` at the usage site (as done for messages and inputbar), so we follow that pattern.

### Breaking changes

None.

### Special notes for your reviewer

Single-file, minimal change. The import was reordered by ESLint auto-fix to maintain alphabetical order.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
