### PR TITLE
docs: add review workflow to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,17 @@ This file provides guidance to AI coding assistants when working with code in th
 When creating a Pull Request, you MUST use the `gh-create-pr` skill.
 If the skill is unavailable, directly read `.agents/skills/gh-create-pr/SKILL.md` and follow it manually.
 
+## Review Workflow
+
+When reviewing a Pull Request, do NOT run `pnpm lint`, `pnpm test`, or `pnpm format` locally.
+Instead, check CI status directly using GitHub CLI:
+
+- **Check CI status**: `gh pr checks <PR_NUMBER>` - View all CI check results for the PR
+- **Check PR details**: `gh pr view <PR_NUMBER>` - View PR status, reviews, and merge readiness
+- **View failed logs**: `gh run view <RUN_ID> --log-failed` - Inspect logs for failed CI runs
+
+Only investigate CI failures by reading the logs, not by re-running checks locally.
+
 ## Issue Workflow
 
 When creating an Issue, you MUST use the `gh-create-issue` skill.


### PR DESCRIPTION
### What this PR does

Before this PR:
CLAUDE.md did not include guidance for AI assistants on how to review PRs. Assistants would run `pnpm lint`, `pnpm test`, and `pnpm format` locally during PR reviews, which is slow and unnecessary.

After this PR:
CLAUDE.md now includes a "Review Workflow" section that instructs AI assistants to check CI status directly via GitHub CLI (`gh pr checks`, `gh pr view`, `gh run view --log-failed`) instead of running checks locally.

### Why we need it and why it was done in this way

The following tradeoffs were made:
N/A - this is a straightforward documentation addition.

The following alternatives were considered:
N/A

### Breaking changes

None

### Special notes for your reviewer

This only modifies `CLAUDE.md` — no code changes. The new section is placed between "Pull Request Workflow" and "Issue Workflow" for logical grouping.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
