### PR TITLE
fix(ci): skip CI on PR body/title edits, only re-run on base branch changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   changes:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false) && (github.event.action != 'edited' || github.event.changes.base != null)
     outputs:
       main: ${{ steps.filter.outputs.main }}
       renderer: ${{ steps.filter.outputs.renderer }}
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI: true
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false) && (github.event.action != 'edited' || github.event.changes.base != null)
 
     steps:
       - name: Check out Git repository
@@ -198,7 +198,7 @@ jobs:
     runs-on: windows-latest
     env:
       CI: true
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false) && (github.event.action != 'edited' || github.event.changes.base != null)
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v6


### PR DESCRIPTION
### What this PR does

Before this PR:
The `edited` type on `pull_request` triggers CI on **any** PR edit, including body and title changes. This was introduced in #12847 to re-trigger CI when the base branch changes.

After this PR:
CI only re-triggers on `edited` events when the **base branch** actually changes (`github.event.changes.base != null`). Editing the PR body or title no longer triggers unnecessary CI runs.

### Why we need it and why it was done in this way

The following tradeoffs were made:
Using `github.event.changes.base != null` is a lightweight, well-documented GitHub Actions approach that requires no additional API calls or external actions.

The following alternatives were considered:
- Removing `edited` entirely: Would revert the base-branch-change fix from #12847.
- Using a separate workflow with `pull_request_target`: Overly complex for this use case.

### Breaking changes

None.

### Special notes for your reviewer

- The condition `github.event.action != 'edited' || github.event.changes.base != null` is added to 3 jobs: `changes`, `basic-checks`, and `skills-check-windows`.
- `general-test` and `render-test` are indirectly covered via their `needs: changes` dependency — if `changes` is skipped, these jobs are also skipped.
- `notify` depends on all upstream jobs, so it is also covered.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
