### PR TITLE
fix: show approval card for builtin and provider tools

### DIFF
--- a/src/renderer/src/pages/home/Messages/Tools/hooks/useToolApproval.ts
+++ b/src/renderer/src/pages/home/Messages/Tools/hooks/useToolApproval.ts
@@ -59,7 +59,9 @@ export function useToolApproval(
   const toolResponse = block.metadata?.rawMcpToolResponse
   const tool = toolResponse?.tool
 
-  const isMcpTool = forceType === 'mcp' || (forceType !== 'agent' && tool?.type === 'mcp')
+  const isMcpTool =
+    forceType === 'mcp' ||
+    (forceType !== 'agent' && (tool?.type === 'mcp' || tool?.type === 'builtin' || tool?.type === 'provider'))
   const mcpApproval = useMcpToolApproval(block, mcpOptions)
   const agentApproval = useAgentToolApproval(block)
 


### PR DESCRIPTION
Fixed an issue where builtin and provider tools would hang in streaming state without showing the approval card to users.

Fixes #13021

<img width="1339" height="406" alt="изображение" src="https://github.com/user-attachments/assets/b1cc4ca3-bc5b-4042-95b7-75732187c82f" />

Before this PR:
Builtin tools (like builtin_web_search, builtin_knowledge_search) and provider-executed tools would not show the approval card to users. The assistant would hang in streaming state because the UI was looking for permissions in the wrong place.
After this PR:
All tool types (MCP, builtin, and provider) now correctly display the approval card when user confirmation is required. Users can approve or deny tool executions, and the streaming state properly completes after the tool finishes.
Why we need it and why it was done in this way
The root cause was in the useToolApproval hook which only treated MCP tools as requiring the approval UI:
// Before: Only MCP tools used the correct approval flow
const isMcpTool = ... && tool?.type === 'mcp'
When a builtin or provider tool was called, the hook switched to useAgentToolApproval which looks for permissions in Redux store. However, these tools use a different permission system (requestToolConfirmation from userConfirmation.ts), so the Redux store was empty and no approval card was shown.
The fix extends the condition to include all tool types:
// After: All tool types use the correct approval flow
const isMcpTool = ... || tool?.type === 'builtin' || tool?.type === 'provider'