### PR TITLE
fix(aiCore): route Azure dated API versions to Chat Completions API

### DIFF
--- a/packages/aiCore/src/core/providers/__tests__/schemas.test.ts
+++ b/packages/aiCore/src/core/providers/__tests__/schemas.test.ts
@@ -28,7 +28,7 @@ describe('Provider Schemas', () => {
         'google',
         'xai',
         'azure',
-        'azure-responses',
+        'azure-chat',
         'deepseek',
         'openrouter',
         'cherryin',

--- a/packages/aiCore/src/core/providers/registry.ts
+++ b/packages/aiCore/src/core/providers/registry.ts
@@ -173,32 +173,20 @@ export function registerProvider(providerId: string, provider: any): boolean {
     // 获取aliases配置
     const aliases = config.aliases
 
-    // 处理特殊provider逻辑
-    if (providerId === 'openai') {
-      // 注册默认 openai
-      globalRegistryManagement.registerProvider(providerId, provider, aliases)
+    // Register the provider itself
+    globalRegistryManagement.registerProvider(providerId, provider, aliases)
 
-      // 创建并注册 openai-chat 变体
-      const openaiChatProvider = customProvider({
+    // For openai and azure, also register a -chat variant that forces chat completions
+    // (AI SDK v6 defaults languageModel to Responses API for these providers)
+    const providersNeedingChatVariant = ['openai', 'azure']
+    if (providersNeedingChatVariant.includes(providerId)) {
+      const chatVariant = customProvider({
         fallbackProvider: {
           ...provider,
           languageModel: (modelId: string) => provider.chat(modelId)
         }
       })
-      globalRegistryManagement.registerProvider(`${providerId}-chat`, openaiChatProvider)
-    } else if (providerId === 'azure') {
-      globalRegistryManagement.registerProvider(`${providerId}-chat`, provider, aliases)
-      // 跟上面相反,creator产出的默认会调用chat
-      const azureResponsesProvider = customProvider({
-        fallbackProvider: {
-          ...provider,
-          languageModel: (modelId: string) => provider.responses(modelId)
-        }
-      })
-      globalRegistryManagement.registerProvider(providerId, azureResponsesProvider)
-    } else {
-      // 其他provider直接注册
-      globalRegistryManagement.registerProvider(providerId, provider, aliases)
+      globalRegistryManagement.registerProvider(`${providerId}-chat`, chatVariant)
     }
 
     return true

--- a/packages/aiCore/src/core/providers/registry.ts
+++ b/packages/aiCore/src/core/providers/registry.ts
@@ -5,7 +5,7 @@
  */
 
 import { globalRegistryManagement } from './RegistryManagement'
-import { baseProviders, type ProviderConfig, wrapAsChatProvider } from './schemas'
+import { baseProviders, type ChatCapableProvider, type ProviderConfig, wrapAsChatProvider } from './schemas'
 
 /**
  * Provider 初始化错误类型
@@ -178,7 +178,11 @@ export function registerProvider(providerId: string, provider: any): boolean {
     // (AI SDK v6 defaults languageModel to Responses API for these providers)
     const providersNeedingChatVariant = ['openai', 'azure']
     if (providersNeedingChatVariant.includes(providerId)) {
-      globalRegistryManagement.registerProvider(`${providerId}-chat`, wrapAsChatProvider(provider))
+      // Note: provider is typed as `any` from registerProvider signature — future cleanup should narrow it
+      globalRegistryManagement.registerProvider(
+        `${providerId}-chat`,
+        wrapAsChatProvider(provider as ChatCapableProvider)
+      )
     }
 
     return true

--- a/packages/aiCore/src/core/providers/registry.ts
+++ b/packages/aiCore/src/core/providers/registry.ts
@@ -4,10 +4,8 @@
  * 集成了来自 ModelCreator 的特殊处理逻辑
  */
 
-import { customProvider } from 'ai'
-
 import { globalRegistryManagement } from './RegistryManagement'
-import { baseProviders, type ProviderConfig } from './schemas'
+import { baseProviders, type ProviderConfig, wrapAsChatProvider } from './schemas'
 
 /**
  * Provider 初始化错误类型
@@ -180,13 +178,7 @@ export function registerProvider(providerId: string, provider: any): boolean {
     // (AI SDK v6 defaults languageModel to Responses API for these providers)
     const providersNeedingChatVariant = ['openai', 'azure']
     if (providersNeedingChatVariant.includes(providerId)) {
-      const chatVariant = customProvider({
-        fallbackProvider: {
-          ...provider,
-          languageModel: (modelId: string) => provider.chat(modelId)
-        }
-      })
-      globalRegistryManagement.registerProvider(`${providerId}-chat`, chatVariant)
+      globalRegistryManagement.registerProvider(`${providerId}-chat`, wrapAsChatProvider(provider))
     }
 
     return true

--- a/packages/aiCore/src/core/providers/schemas.ts
+++ b/packages/aiCore/src/core/providers/schemas.ts
@@ -17,6 +17,23 @@ import { customProvider, wrapProvider } from 'ai'
 import * as z from 'zod'
 
 /**
+ * Creates a chat-only variant of a provider.
+ * Wraps the base creator so that languageModel() routes through provider.chat(),
+ * forcing the Chat Completions API instead of the default Responses API.
+ */
+function createChatVariant<T>(baseCreator: (options: T) => ProviderV3): (options: T) => ProviderV3 {
+  return (options: T) => {
+    const provider = baseCreator(options)
+    return customProvider({
+      fallbackProvider: {
+        ...provider,
+        languageModel: (modelId: string) => (provider as any).chat(modelId)
+      }
+    })
+  }
+}
+
+/**
  * 基础 Provider IDs
  */
 export const baseProviderIds = [
@@ -27,7 +44,7 @@ export const baseProviderIds = [
   'google',
   'xai',
   'azure',
-  'azure-responses',
+  'azure-chat',
   'deepseek',
   'openrouter',
   'cherryin',
@@ -69,15 +86,7 @@ export const baseProviders = [
   {
     id: 'openai-chat',
     name: 'OpenAI Chat',
-    creator: (options: OpenAIProviderSettings) => {
-      const provider = createOpenAI(options)
-      return customProvider({
-        fallbackProvider: {
-          ...provider,
-          languageModel: (modelId: string) => provider.chat(modelId)
-        }
-      })
-    },
+    creator: createChatVariant<OpenAIProviderSettings>(createOpenAI),
     supportsImageGeneration: true
   },
   {
@@ -111,17 +120,9 @@ export const baseProviders = [
     supportsImageGeneration: true
   },
   {
-    id: 'azure-responses',
-    name: 'Azure OpenAI Responses',
-    creator: (options: AzureOpenAIProviderSettings) => {
-      const provider = createAzure(options)
-      return customProvider({
-        fallbackProvider: {
-          ...provider,
-          languageModel: (modelId: string) => provider.responses(modelId)
-        }
-      })
-    },
+    id: 'azure-chat',
+    name: 'Azure OpenAI Chat',
+    creator: createChatVariant<AzureOpenAIProviderSettings>(createAzure),
     supportsImageGeneration: true
   },
   {
@@ -148,15 +149,7 @@ export const baseProviders = [
   {
     id: 'cherryin-chat',
     name: 'CherryIN Chat',
-    creator: (options: CherryInProviderSettings) => {
-      const provider = createCherryIn(options)
-      return customProvider({
-        fallbackProvider: {
-          ...provider,
-          languageModel: (modelId: string) => provider.chat(modelId)
-        }
-      })
-    },
+    creator: createChatVariant<CherryInProviderSettings>(createCherryIn),
     supportsImageGeneration: true
   }
 ] as const satisfies BaseProvider[]

--- a/packages/aiCore/src/core/providers/schemas.ts
+++ b/packages/aiCore/src/core/providers/schemas.ts
@@ -17,20 +17,25 @@ import { customProvider, wrapProvider } from 'ai'
 import * as z from 'zod'
 
 /**
- * Creates a chat-only variant of a provider.
- * Wraps the base creator so that languageModel() routes through provider.chat(),
+ * Wraps a provider instance so that languageModel() routes through provider.chat(),
  * forcing the Chat Completions API instead of the default Responses API.
  */
+export function wrapAsChatProvider(provider: ProviderV3): ProviderV3 {
+  return customProvider({
+    fallbackProvider: {
+      ...provider,
+      // ProviderV3 doesn't declare .chat(), but concrete providers (OpenAI, Azure, CherryIn) expose it at runtime
+      languageModel: (modelId: string) => (provider as any).chat(modelId)
+    }
+  })
+}
+
+/**
+ * Creates a chat-only variant of a provider creator.
+ * Wraps the base creator so that languageModel() routes through provider.chat().
+ */
 function createChatVariant<T>(baseCreator: (options: T) => ProviderV3): (options: T) => ProviderV3 {
-  return (options: T) => {
-    const provider = baseCreator(options)
-    return customProvider({
-      fallbackProvider: {
-        ...provider,
-        languageModel: (modelId: string) => (provider as any).chat(modelId)
-      }
-    })
-  }
+  return (options: T) => wrapAsChatProvider(baseCreator(options))
 }
 
 /**

--- a/packages/aiCore/src/core/providers/schemas.ts
+++ b/packages/aiCore/src/core/providers/schemas.ts
@@ -9,7 +9,7 @@ import { createDeepSeek } from '@ai-sdk/deepseek'
 import { createGoogleGenerativeAI } from '@ai-sdk/google'
 import { createOpenAI, type OpenAIProviderSettings } from '@ai-sdk/openai'
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
-import type { ProviderV3 } from '@ai-sdk/provider'
+import type { LanguageModelV3, ProviderV3 } from '@ai-sdk/provider'
 import { createXai } from '@ai-sdk/xai'
 import { type CherryInProviderSettings, createCherryIn } from '@cherrystudio/ai-sdk-provider'
 import { createOpenRouter, type OpenRouterProviderSettings } from '@openrouter/ai-sdk-provider'
@@ -17,15 +17,23 @@ import { customProvider, wrapProvider } from 'ai'
 import * as z from 'zod'
 
 /**
+ * Provider that exposes a .chat() method for Chat Completions API.
+ * Concrete providers like OpenAI, Azure, and CherryIn implement this at runtime,
+ * but ProviderV3 does not declare it — this interface provides compile-time safety.
+ */
+export interface ChatCapableProvider extends ProviderV3 {
+  chat(modelId: string): LanguageModelV3
+}
+
+/**
  * Wraps a provider instance so that languageModel() routes through provider.chat(),
  * forcing the Chat Completions API instead of the default Responses API.
  */
-export function wrapAsChatProvider(provider: ProviderV3): ProviderV3 {
+export function wrapAsChatProvider(provider: ChatCapableProvider): ProviderV3 {
   return customProvider({
     fallbackProvider: {
       ...provider,
-      // ProviderV3 doesn't declare .chat(), but concrete providers (OpenAI, Azure, CherryIn) expose it at runtime
-      languageModel: (modelId: string) => (provider as any).chat(modelId)
+      languageModel: (modelId: string) => provider.chat(modelId)
     }
   })
 }
@@ -34,7 +42,7 @@ export function wrapAsChatProvider(provider: ProviderV3): ProviderV3 {
  * Creates a chat-only variant of a provider creator.
  * Wraps the base creator so that languageModel() routes through provider.chat().
  */
-function createChatVariant<T>(baseCreator: (options: T) => ProviderV3): (options: T) => ProviderV3 {
+function createChatVariant<T>(baseCreator: (options: T) => ChatCapableProvider): (options: T) => ProviderV3 {
   return (options: T) => wrapAsChatProvider(baseCreator(options))
 }
 

--- a/src/renderer/src/aiCore/prepareParams/parameterBuilder.ts
+++ b/src/renderer/src/aiCore/prepareParams/parameterBuilder.ts
@@ -164,7 +164,7 @@ export async function buildStreamTextParams(
         maxUses: webSearchConfig.maxResults,
         blockedDomains: blockedDomains.length > 0 ? blockedDomains : undefined
       }) as ProviderDefinedTool
-    } else if (aiSdkProviderId === 'azure-responses') {
+    } else if (aiSdkProviderId === 'azure') {
       tools.web_search_preview = azure.tools.webSearchPreview({
         searchContextSize: webSearchPluginConfig?.openai!.searchContextSize
       }) as ProviderDefinedTool

--- a/src/renderer/src/aiCore/provider/__tests__/integratedRegistry.test.ts
+++ b/src/renderer/src/aiCore/provider/__tests__/integratedRegistry.test.ts
@@ -169,13 +169,22 @@ describe('createAiSdkProvider providerId redirection', () => {
     mockCreateProviderCore.mockResolvedValue({ id: 'mock-provider' })
   })
 
-  it('should pass azure providerId through without redirection', async () => {
+  it('should keep azure providerId when mode is responses', async () => {
     await createAiSdkProvider({
       providerId: 'azure',
       options: { mode: 'responses', apiKey: 'test', baseURL: 'https://test.openai.azure.com' }
     })
 
     expect(mockCreateProviderCore).toHaveBeenCalledWith('azure', expect.objectContaining({ mode: 'responses' }))
+  })
+
+  it('should redirect azure with mode chat to azure-chat', async () => {
+    await createAiSdkProvider({
+      providerId: 'azure',
+      options: { mode: 'chat', apiKey: 'test', baseURL: 'https://test.openai.azure.com' }
+    })
+
+    expect(mockCreateProviderCore).toHaveBeenCalledWith('azure-chat', expect.objectContaining({ mode: 'chat' }))
   })
 
   it('should pass azure-chat providerId through without redirection', async () => {

--- a/src/renderer/src/aiCore/provider/__tests__/integratedRegistry.test.ts
+++ b/src/renderer/src/aiCore/provider/__tests__/integratedRegistry.test.ts
@@ -1,9 +1,11 @@
 import type { Model, Provider } from '@renderer/types'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getAiSdkProviderId } from '../factory'
+import { createAiSdkProvider, getAiSdkProviderId } from '../factory'
 
 // Mock the external dependencies
+const mockCreateProviderCore = vi.fn().mockResolvedValue({ id: 'mock-provider' })
+
 vi.mock('@cherrystudio/ai-core', () => ({
   registerMultipleProviders: vi.fn(() => 4), // Mock successful registration of 4 providers
   getProviderMapping: vi.fn((id: string) => {
@@ -22,6 +24,14 @@ vi.mock('@cherrystudio/ai-core', () => ({
     isSupported: vi.fn(() => true)
   }
 }))
+
+vi.mock('@cherrystudio/ai-core/provider', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    createProvider: (...args: unknown[]) => mockCreateProviderCore(...args)
+  }
+})
 
 vi.mock('@renderer/services/AssistantService', () => ({
   getProviderByModel: vi.fn(),
@@ -51,6 +61,7 @@ vi.mock('../providerConfigs', () => ({
 vi.mock('@logger', () => ({
   loggerService: {
     withContext: () => ({
+      debug: vi.fn(),
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn()
@@ -124,16 +135,16 @@ describe('Integrated Provider Registry', () => {
       expect(result).toBe('unknown-provider')
     })
 
-    it('should handle Azure OpenAI providers correctly', () => {
+    it('should handle Azure OpenAI providers with dated API version correctly', () => {
       const azureProvider = createAzureProvider('azure-test', '2024-02-15', 'gpt-4o')
       const result = getAiSdkProviderId(azureProvider)
-      expect(result).toBe('azure')
+      expect(result).toBe('azure-chat')
     })
 
     it('should handle Azure OpenAI providers response endpoint correctly', () => {
       const azureProvider = createAzureProvider('azure-test', 'v1', 'gpt-4o')
       const result = getAiSdkProviderId(azureProvider)
-      expect(result).toBe('azure-responses')
+      expect(result).toBe('azure')
     })
 
     it('should handle Azure provider Claude Models', () => {
@@ -149,5 +160,48 @@ describe('Integrated Provider Registry', () => {
       const result = getAiSdkProviderId(grokProvider)
       expect(result).toBe('xai')
     })
+  })
+})
+
+describe('createAiSdkProvider providerId redirection', () => {
+  beforeEach(() => {
+    mockCreateProviderCore.mockClear()
+    mockCreateProviderCore.mockResolvedValue({ id: 'mock-provider' })
+  })
+
+  it('should pass azure providerId through without redirection', async () => {
+    await createAiSdkProvider({
+      providerId: 'azure',
+      options: { mode: 'responses', apiKey: 'test', baseURL: 'https://test.openai.azure.com' }
+    })
+
+    expect(mockCreateProviderCore).toHaveBeenCalledWith('azure', expect.objectContaining({ mode: 'responses' }))
+  })
+
+  it('should pass azure-chat providerId through without redirection', async () => {
+    await createAiSdkProvider({
+      providerId: 'azure-chat',
+      options: { mode: 'chat', apiKey: 'test', baseURL: 'https://test.openai.azure.com' }
+    })
+
+    expect(mockCreateProviderCore).toHaveBeenCalledWith('azure-chat', expect.objectContaining({ mode: 'chat' }))
+  })
+
+  it('should redirect openai with mode chat to openai-chat', async () => {
+    await createAiSdkProvider({
+      providerId: 'openai',
+      options: { mode: 'chat', apiKey: 'test', baseURL: 'https://api.openai.com' }
+    })
+
+    expect(mockCreateProviderCore).toHaveBeenCalledWith('openai-chat', expect.objectContaining({ mode: 'chat' }))
+  })
+
+  it('should redirect cherryin with mode chat to cherryin-chat', async () => {
+    await createAiSdkProvider({
+      providerId: 'cherryin',
+      options: { mode: 'chat', apiKey: 'test', baseURL: 'https://api.cherryin.com' }
+    })
+
+    expect(mockCreateProviderCore).toHaveBeenCalledWith('cherryin-chat', expect.objectContaining({ mode: 'chat' }))
   })
 })

--- a/src/renderer/src/aiCore/provider/__tests__/providerConfig.test.ts
+++ b/src/renderer/src/aiCore/provider/__tests__/providerConfig.test.ts
@@ -539,22 +539,41 @@ describe('Azure OpenAI traditional API routing', () => {
     const provider = createAzureProvider('2024-02-15-preview')
     const config = providerToAiSdkConfig(provider, createModel('gpt-4o', 'GPT-4o', provider.id))
 
-    expect(config.providerId).toBe('azure')
+    expect(config.providerId).toBe('azure-chat')
     expect(config.options.apiVersion).toBe('2024-02-15-preview')
+    expect(config.options.useDeploymentBasedUrls).toBe(true)
+  })
+
+  it('sets mode to chat for Azure with dated API versions', () => {
+    const provider = createAzureProvider('2024-12-01-preview')
+    const config = providerToAiSdkConfig(provider, createModel('gpt-5.1', 'GPT-5.1', provider.id))
+
+    expect(config.providerId).toBe('azure-chat')
+    expect(config.options.mode).toBe('chat')
     expect(config.options.useDeploymentBasedUrls).toBe(true)
   })
 
   it('does not force deployment-based URLs for apiVersion v1/preview', () => {
     const v1Provider = createAzureProvider('v1')
     const v1Config = providerToAiSdkConfig(v1Provider, createModel('gpt-4o', 'GPT-4o', v1Provider.id))
-    expect(v1Config.providerId).toBe('azure-responses')
+    expect(v1Config.providerId).toBe('azure')
     expect(v1Config.options.apiVersion).toBe('v1')
     expect(v1Config.options.useDeploymentBasedUrls).toBeUndefined()
 
     const previewProvider = createAzureProvider('preview')
     const previewConfig = providerToAiSdkConfig(previewProvider, createModel('gpt-4o', 'GPT-4o', previewProvider.id))
-    expect(previewConfig.providerId).toBe('azure-responses')
+    expect(previewConfig.providerId).toBe('azure')
     expect(previewConfig.options.apiVersion).toBe('preview')
     expect(previewConfig.options.useDeploymentBasedUrls).toBeUndefined()
+  })
+
+  it('sets mode to responses for Azure with v1/preview API versions', () => {
+    const v1Provider = createAzureProvider('v1')
+    const v1Config = providerToAiSdkConfig(v1Provider, createModel('gpt-4o', 'GPT-4o', v1Provider.id))
+    expect(v1Config.options.mode).toBe('responses')
+
+    const previewProvider = createAzureProvider('preview')
+    const previewConfig = providerToAiSdkConfig(previewProvider, createModel('gpt-4o', 'GPT-4o', previewProvider.id))
+    expect(previewConfig.options.mode).toBe('responses')
   })
 })

--- a/src/renderer/src/aiCore/provider/factory.ts
+++ b/src/renderer/src/aiCore/provider/factory.ts
@@ -60,57 +60,56 @@ function tryResolveProviderId(identifier: string): ProviderId | null {
  * TODO: 整理函数逻辑
  */
 export function getAiSdkProviderId(provider: Provider): string {
-  // 1. 尝试解析provider.id
-  const resolvedFromId = tryResolveProviderId(provider.id)
+  // 1. Azure requires special handling: pick responses vs chat variant based on API version
   if (isAzureOpenAIProvider(provider)) {
-    if (isAzureResponsesEndpoint(provider)) {
-      return 'azure-responses'
-    } else {
-      return 'azure'
-    }
+    return isAzureResponsesEndpoint(provider) ? 'azure' : 'azure-chat'
   }
+
+  // 2. 尝试解析provider.id（静态映射 + 别名）
+  const resolvedFromId = tryResolveProviderId(provider.id)
   if (resolvedFromId) {
     return resolvedFromId
   }
 
-  // 2. 尝试解析provider.type
-  // 会把所有类型为openai的自定义provider解析到aisdk的openaiProvider上
+  // 3. 尝试解析provider.type（跳过 'openai' 以避免把自定义provider错误映射）
   if (provider.type !== 'openai') {
     const resolvedFromType = tryResolveProviderId(provider.type)
     if (resolvedFromType) {
       return resolvedFromType
     }
   }
+
+  // 4. OpenAI API host detection
   if (provider.apiHost.includes('api.openai.com')) {
     return 'openai-chat'
   }
-  // 3. 最后的fallback（使用provider本身的id）
+
+  // 5. Fallback to provider's own id
   return provider.id
 }
 
 export async function createAiSdkProvider(config: AiSdkConfig): Promise<AiSdkProvider | null> {
-  let localProvider: Awaited<AiSdkProvider> | null = null
+  // Redirect providers that need the chat completions variant
+  const chatRedirectIds = ['openai', 'cherryin']
+  if (chatRedirectIds.includes(config.providerId) && config.options?.mode === 'chat') {
+    config.providerId = `${config.providerId}-chat`
+  }
+
   try {
-    if (config.providerId === 'openai' && config.options?.mode === 'chat') {
-      config.providerId = `${config.providerId}-chat`
-    } else if (config.providerId === 'azure' && config.options?.mode === 'responses') {
-      config.providerId = `${config.providerId}-responses`
-    } else if (config.providerId === 'cherryin' && config.options?.mode === 'chat') {
-      config.providerId = 'cherryin-chat'
-    }
-    localProvider = await createProviderCore(config.providerId, config.options)
+    const localProvider = await createProviderCore(config.providerId, config.options)
 
     logger.debug('Local provider created successfully', {
       providerId: config.providerId,
       hasOptions: !!config.options,
-      localProvider: localProvider,
+      localProvider,
       options: config.options
     })
+
+    return localProvider
   } catch (error) {
     logger.error('Failed to create local provider', error as Error, {
       providerId: config.providerId
     })
     throw error
   }
-  return localProvider
 }

--- a/src/renderer/src/aiCore/provider/factory.ts
+++ b/src/renderer/src/aiCore/provider/factory.ts
@@ -57,7 +57,6 @@ function tryResolveProviderId(identifier: string): ProviderId | null {
 /**
  * 获取AI SDK Provider ID
  * 简化版：减少重复逻辑，利用通用解析函数
- * TODO: 整理函数逻辑
  */
 export function getAiSdkProviderId(provider: Provider): string {
   // 1. Azure requires special handling: pick responses vs chat variant based on API version

--- a/src/renderer/src/aiCore/provider/factory.ts
+++ b/src/renderer/src/aiCore/provider/factory.ts
@@ -89,7 +89,9 @@ export function getAiSdkProviderId(provider: Provider): string {
 
 export async function createAiSdkProvider(config: AiSdkConfig): Promise<AiSdkProvider | null> {
   // Redirect providers that need the chat completions variant
-  const chatRedirectIds = ['openai', 'cherryin']
+  // Note: azure is included for defensive consistency with registry.ts,
+  // even though getAiSdkProviderId resolves azure-chat upstream for dated API versions
+  const chatRedirectIds = ['openai', 'azure', 'cherryin']
   if (chatRedirectIds.includes(config.providerId) && config.options?.mode === 'chat') {
     config.providerId = `${config.providerId}-chat`
   }

--- a/src/renderer/src/aiCore/provider/providerConfig.ts
+++ b/src/renderer/src/aiCore/provider/providerConfig.ts
@@ -246,13 +246,13 @@ export function providerToAiSdkConfig(actualProvider: Provider, model: Model): A
   let mode: BaseExtraOptions['mode']
   if (
     (actualProvider.type === 'openai-response' && !isOpenAIChatCompletionOnlyModel(model)) ||
-    aiSdkProviderId === 'azure-responses'
+    aiSdkProviderId === 'azure'
   ) {
     mode = 'responses'
   } else if (
     aiSdkProviderId === 'openai' ||
     (aiSdkProviderId === 'cherryin' && actualProvider.type === 'openai') ||
-    aiSdkProviderId === 'azure'
+    aiSdkProviderId === 'azure-chat'
   ) {
     mode = 'chat'
   }

--- a/src/renderer/src/aiCore/utils/__tests__/options.test.ts
+++ b/src/renderer/src/aiCore/utils/__tests__/options.test.ts
@@ -20,7 +20,7 @@ vi.mock('@cherrystudio/ai-core/provider', async (importOriginal) => {
           'openai',
           'openai-chat',
           'azure',
-          'azure-responses',
+          'azure-chat',
           'huggingface',
           'anthropic',
           'google',

--- a/src/renderer/src/aiCore/utils/options.ts
+++ b/src/renderer/src/aiCore/utils/options.ts
@@ -176,7 +176,7 @@ export function buildProviderOptions(
       case 'openai':
       case 'openai-chat':
       case 'azure':
-      case 'azure-responses':
+      case 'azure-chat':
         {
           providerSpecificOptions = buildOpenAIProviderOptions(
             assistant,

--- a/src/renderer/src/aiCore/utils/websearch.ts
+++ b/src/renderer/src/aiCore/utils/websearch.ts
@@ -49,7 +49,7 @@ export function buildProviderBuiltinWebSearchConfig(
   model?: Model
 ): WebSearchPluginConfig | undefined {
   switch (providerId) {
-    case 'azure-responses':
+    case 'azure':
     case 'openai': {
       const searchContextSize = isOpenAIDeepResearchModel(model)
         ? 'medium'


### PR DESCRIPTION
### What this PR does

Before this PR:

Azure OpenAI users with dated API versions (e.g., `2024-12-01-preview`) hit 404 errors because AI SDK v6's `@ai-sdk/azure` changed `createAzure().languageModel` to default to the Responses API (`/responses` endpoint) instead of Chat Completions (`/chat/completions`).

After this PR:

- Adds an `azure-chat` provider variant that wraps `createAzure` to force `languageModel` through `provider.chat()`, ensuring Chat Completions API is used.
- `getAiSdkProviderId` now returns `azure-chat` for dated API versions and `azure` for Responses API versions (`v1`/`preview`).
- Mode logic in `providerToAiSdkConfig` uses `aiSdkProviderId` directly instead of relying on indirect redirects.
- Removes the redundant `azure-responses` provider (since `azure` already defaults to Responses in AI SDK v6).
- Extracts a reusable `createChatVariant` helper for DRY chat-wrapping of providers (openai-chat, azure-chat, cherryin-chat).

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Added a new `azure-chat` base provider rather than patching the existing `azure` provider, keeping the Responses API path untouched for users who explicitly opt into it via `v1`/`preview` API versions.

The following alternatives were considered:

- Patching `createAzure` globally to always use Chat Completions — rejected because it would break users who intentionally use the Responses API.
- Adding a redirect in `createAiSdkProvider` (similar to openai → openai-chat) — rejected in favor of resolving the correct provider ID upfront in `getAiSdkProviderId`, which is cleaner and avoids indirect mode-based redirects.

### Breaking changes

None. Azure users with dated API versions will now correctly use Chat Completions. Users with `v1`/`preview` API versions continue to use the Responses API as before.

### Special notes for your reviewer

- The root cause is in `@ai-sdk/azure@3.0.37` where `provider.languageModel = createResponsesModel` (AI SDK v6 change).
- The same pattern already existed for `openai` vs `openai-chat`; this PR extends it to Azure.
- `createChatVariant` helper in `schemas.ts` now DRYs up three identical chat-wrapping creators.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix: Azure OpenAI 404 error with dated API versions after AI SDK v6 upgrade — now correctly routes to Chat Completions API
```
