### PR TITLE
fix(renderer): synchronize miniapp settings state and respect region filter

### DIFF
--- a/src/renderer/src/pages/minapps/MiniappSettings/MiniAppSettings.tsx
+++ b/src/renderer/src/pages/minapps/MiniappSettings/MiniAppSettings.tsx
@@ -54,12 +54,19 @@ const MiniAppSettings: FC = () => {
   const [messageApi, contextHolder] = message.useMessage()
   const debounceTimerRef = useRef<NodeJS.Timeout | null>(null)
 
+  // 当 store 数据变化时（例如切换地区）同步本地状态
+  useEffect(() => {
+    setVisibleMiniApps(minapps)
+    setDisabledMiniApps(disabled || [])
+  }, [minapps, disabled])
+
   const handleResetMinApps = useCallback(() => {
-    setVisibleMiniApps(allMinApps)
+    // 仅重置为当前地区可见的应用，以避免混淆
+    setVisibleMiniApps(minapps)
     setDisabledMiniApps([])
     updateMinapps(allMinApps)
     updateDisabledMinapps([])
-  }, [updateDisabledMinapps, updateMinapps])
+  }, [minapps, updateDisabledMinapps, updateMinapps])
 
   const handleSwapMinApps = useCallback(() => {
     const temp = visibleMiniApps


### PR DESCRIPTION
### What this PR does

**Before this PR:**

- Mini Program settings were not synchronized with the global Redux store in real-time. Changes to "Mini Program Region" (e.g., from Auto to China) did not reflect immediately in the visible/disabled lists.
- The "Reset" button bypassed region-based filtering logic, causing restricted apps (like Zhipu, Doubao, etc.) to appear temporarily and then "disappear" after reopening the settings window.
- Core synchronization logic lacked clear documentation for local maintainers.

**After this PR:**

- Added a `useEffect` hook in `MiniAppSettings.tsx` to synchronize local state with the `useMinapps` 

  hook whenever the underlying store data or region settings change.

- Refactored `handleResetMinApps` to respect the current region's filtering rules, ensuring UI consistency.

- Updated relevant code comments to Chinese as requested for better local team understanding.
### Visual Evidence (Bug Demonstration)

**Before Clicking "Reset" (Restricted apps hidden):**

<img width="500"  alt="20260303155923" src="https://github.com/user-attachments/assets/001b44eb-1e65-44ab-a8bc-21074ccd68b0" />

**After Clicking "Reset" (Ghost apps appear):**  
<img width="500"  alt="20260303155953" src="https://github.com/user-attachments/assets/9ebaae43-e391-4202-820b-611481e575ec" />

> *Note: After the fix, Clicking "Reset" will correctly maintain the region filter, and the list will remain consistent as shown in Picture 1.*
### Why we need it and why it was done in this way

Users in different regions (CN vs. Global) expect a consistent experience. The prior implementation had a disconnect between the persistent data layer and the configuration UI. By enforcing state synchronization at the component level, we eliminate "ghost" icons and ensure the settings UI always matches the actual application state.

### Checklist

- [x]  PR: The PR description is expressive enough and will help future contributors

- [x] Code: Write code that humans can understand and Keep it simple

- [x]  Self-review: I have reviewed my own code

### Release note

```
fix(renderer): synchronize mini program settings state and enforce region-based filtering consistency.
```