### PR TITLE
fix(Selection): prevent Windows crash when closing transparent action window

### DIFF
--- a/src/main/services/SelectionService.ts
+++ b/src/main/services/SelectionService.ts
@@ -347,10 +347,10 @@ export class SelectionService {
     this.isCtrlkeyListenerActive = false
     this.isHideByMouseKeyListenerActive = false
 
-    if (this.toolbarWindow) {
+    if (this.toolbarWindow && !this.toolbarWindow.isDestroyed()) {
       this.toolbarWindow.close()
-      this.toolbarWindow = null
     }
+    this.toolbarWindow = null
 
     this.closePreloadedActionWindows()
 
@@ -444,9 +444,6 @@ export class SelectionService {
 
     // Clean up when closed
     this.toolbarWindow.on('closed', () => {
-      if (!this.toolbarWindow?.isDestroyed()) {
-        this.toolbarWindow?.destroy()
-      }
       this.toolbarWindow = null
     })
 
@@ -1199,12 +1196,27 @@ export class SelectionService {
     // Get a window from the preloaded queue or create a new one if empty
     const actionWindow = this.preloadedActionWindows.pop() || this.createPreloadedActionWindow()
 
+    // [Windows] Workaround for Electron 40+ (Chromium 144) native crash.
+    // Calling close() on a visible transparent frameless window triggers DestroyWindow
+    // while the compositor still holds references to the transparent layer, causing a
+    // use-after-free crash. Hide first to release compositor resources, then destroy
+    // on the next tick.
+    if (isWin) {
+      actionWindow.on('close', (event) => {
+        if (!actionWindow.isVisible()) return
+        event.preventDefault()
+        actionWindow.hide()
+        setImmediate(() => {
+          if (!actionWindow.isDestroyed()) {
+            actionWindow.close()
+          }
+        })
+      })
+    }
+
     // Set up event listeners for this instance
     actionWindow.on('closed', () => {
       this.actionWindows.delete(actionWindow)
-      if (!actionWindow.isDestroyed()) {
-        actionWindow.destroy()
-      }
 
       // [macOS] a HACKY way
       // make sure other windows do not bring to front when action window is closed
@@ -1230,6 +1242,7 @@ export class SelectionService {
 
     //remember the action window size
     actionWindow.on('resized', () => {
+      if (actionWindow.isDestroyed()) return
       if (this.isRemeberWinSize) {
         this.lastActionWindowSize = {
           width: actionWindow.getBounds().width,
@@ -1383,6 +1396,7 @@ export class SelectionService {
 
     // unset everything
     setTimeout(() => {
+      if (actionWindow.isDestroyed()) return
       actionWindow.setVisibleOnAllWorkspaces(false, {
         visibleOnFullScreen: true,
         skipTransformProcessType: true
@@ -1397,14 +1411,17 @@ export class SelectionService {
   }
 
   public closeActionWindow(actionWindow: BrowserWindow): void {
+    if (actionWindow.isDestroyed()) return
     actionWindow.close()
   }
 
   public minimizeActionWindow(actionWindow: BrowserWindow): void {
+    if (actionWindow.isDestroyed()) return
     actionWindow.minimize()
   }
 
   public pinActionWindow(actionWindow: BrowserWindow, isPinned: boolean): void {
+    if (actionWindow.isDestroyed()) return
     actionWindow.setAlwaysOnTop(isPinned)
   }
 
@@ -1419,6 +1436,7 @@ export class SelectionService {
    * This method can be removed once the Electron bug is fixed.
    */
   public resizeActionWindow(actionWindow: BrowserWindow, deltaX: number, deltaY: number, direction: string): void {
+    if (actionWindow.isDestroyed()) return
     const bounds = actionWindow.getBounds()
     const minWidth = 300
     const minHeight = 200
@@ -1556,21 +1574,21 @@ export class SelectionService {
 
     ipcMain.handle(IpcChannel.Selection_ActionWindowClose, (event) => {
       const actionWindow = BrowserWindow.fromWebContents(event.sender)
-      if (actionWindow) {
+      if (actionWindow && !actionWindow.isDestroyed()) {
         selectionService?.closeActionWindow(actionWindow)
       }
     })
 
     ipcMain.handle(IpcChannel.Selection_ActionWindowMinimize, (event) => {
       const actionWindow = BrowserWindow.fromWebContents(event.sender)
-      if (actionWindow) {
+      if (actionWindow && !actionWindow.isDestroyed()) {
         selectionService?.minimizeActionWindow(actionWindow)
       }
     })
 
     ipcMain.handle(IpcChannel.Selection_ActionWindowPin, (event, isPinned: boolean) => {
       const actionWindow = BrowserWindow.fromWebContents(event.sender)
-      if (actionWindow) {
+      if (actionWindow && !actionWindow.isDestroyed()) {
         selectionService?.pinActionWindow(actionWindow, isPinned)
       }
     })
@@ -1581,7 +1599,7 @@ export class SelectionService {
       IpcChannel.Selection_ActionWindowResize,
       (event, deltaX: number, deltaY: number, direction: string) => {
         const actionWindow = BrowserWindow.fromWebContents(event.sender)
-        if (actionWindow) {
+        if (actionWindow && !actionWindow.isDestroyed()) {
           selectionService?.resizeActionWindow(actionWindow, deltaX, deltaY, direction)
         }
       }


### PR DESCRIPTION
### What this PR does

Before this PR:

On Windows, closing a Selection Assistant action window causes the entire app to crash (native crash / use-after-free). macOS is unaffected.

After this PR:

Action windows close gracefully on Windows without crashing. On macOS, behavior is unchanged.

### Why we need it and why it was done in this way

**Root cause:** In Electron 40+ (Chromium 144), calling `close()` on a **visible** transparent frameless window (`transparent: true` + `frame: false`) on Windows triggers `DestroyWindow` while the DirectComposition compositor still holds references to the transparent layer, causing a use-after-free native crash.

**Evidence:** The project's own `WindowService.ts` already avoids this by using `transparent: isMac` for the mini window (disabling transparency on Windows entirely). Since action windows need transparency for their UI, we cannot disable it.

**Approach — hide-then-close on Windows:**

1. Intercept the `close` event on Windows
2. If the window is visible, `preventDefault()` to block the synchronous `DestroyWindow`
3. `hide()` the window first to release compositor references
4. On the next tick (`setImmediate`), re-issue `close()` — now `isVisible()` returns `false`, so the handler passes through and the normal close path proceeds safely on a hidden window

This is the minimal, targeted fix. Alternatives considered:
- Setting `transparent: false` on Windows — would break the action window's visual design
- Using `destroy()` instead of `close()` — bypasses normal lifecycle; `close()` is cleaner
- Wrapping in try-catch — native crashes happen before JS exceptions are thrown

**Additional hardening:**
- Removed redundant `destroy()` calls from `closed` event handlers (the window is already closed)
- Added `isDestroyed()` guards to public methods, IPC handlers, `resized` event, and `setTimeout` callbacks

### Breaking changes

None.

### Special notes for your reviewer

- The core fix is the `close` event handler added in `popActionWindow()` (~15 lines), gated behind `if (isWin)`.
- The `isDestroyed()` guards are defense-in-depth — they prevent potential issues during race conditions but are not the primary fix.
- Tested on Windows: open action window → close → no crash. Rapid open/close cycles also stable.
- macOS: no behavioral change (the `close` handler is Windows-only).

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix app crash on Windows when closing Selection Assistant action window (Electron 40+ compatibility)
```
