### PR TITLE
fix(build): switch Windows code signing timestamp server to DigiCert

### DIFF
--- a/scripts/win-sign.js
+++ b/scripts/win-sign.js
@@ -15,7 +15,7 @@ exports.default = async function (configuration) {
 
         console.log('Start code signing...')
         console.log('Signing file:', path)
-        const signCommand = `signtool sign /tr http://timestamp.comodoca.com /td sha256 /fd sha256 /v /f "${certPath}" /csp "${csp}" /k "${keyContainer}" "${path}"`
+        const signCommand = `signtool sign /tr http://timestamp.digicert.com /td sha256 /fd sha256 /v /f "${certPath}" /csp "${csp}" /k "${keyContainer}" "${path}"`
         execSync(signCommand, { stdio: 'inherit' })
         console.log('Code signing completed')
       } catch (error) {


### PR DESCRIPTION
### What this PR does

Before this PR: Windows code signing uses `timestamp.comodoca.com` as the timestamp server, which is unreliable and frequently times out.

After this PR: Switches to `timestamp.digicert.com`, a more stable and widely-used timestamp server.

### Why we need it and why it was done in this way

The Comodo timestamp server (`timestamp.comodoca.com`) has been experiencing frequent connectivity issues, causing code signing failures during Windows builds. DigiCert's timestamp server is industry-standard and known for better reliability.

The following tradeoffs were made: N/A

The following alternatives were considered: N/A

### Breaking changes

None

### Special notes for your reviewer

Single-line URL change in the signing script.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
