### PR TITLE
fix(ci): correct node-version-file path in update-app-upgrade-config workflow

### DIFF
--- a/.github/workflows/update-app-upgrade-config.yml
+++ b/.github/workflows/update-app-upgrade-config.yml
@@ -152,7 +152,7 @@ jobs:
         if: steps.check.outputs.should_run == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.node-version'
+          node-version-file: 'main/.node-version'
 
       - name: Enable corepack
         if: steps.check.outputs.should_run == 'true'


### PR DESCRIPTION
### What this PR does

Before this PR: The `update-app-upgrade-config` workflow fails with `The specified node version file at: .node-version does not exist` on every release.

After this PR: The workflow correctly references `main/.node-version` since the default branch is checked out into the `main/` subdirectory.

Fixes the failure in https://github.com/CherryHQ/cherry-studio/actions/runs/22653172953

### Why we need it and why it was done in this way

The workflow uses `actions/checkout` with `path: main`, which places the repo contents in a `main/` subdirectory. However, `setup-node` with `node-version-file: '.node-version'` looks in the workspace root where the file doesn't exist.

The following tradeoffs were made: N/A

The following alternatives were considered: N/A

### Breaking changes

None

### Special notes for your reviewer

Single-line path fix. Can be verified by re-running the failed workflow after merge.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
