### PR TITLE
feat: mention Feishu user in issue notification card

### DIFF
--- a/scripts/feishu-notify.ts
+++ b/scripts/feishu-notify.ts
@@ -234,6 +234,13 @@ function createIssueCard(issueData: IssueData): FeishuCard {
         content: `**Summary:**\n${issueSummary}`
       }
     },
+    {
+      tag: 'div',
+      text: {
+        tag: 'lark_md',
+        content: `<at id=cli_a92d6e7ba3f85ced></at>`
+      }
+    },
     { tag: 'hr' },
     {
       tag: 'action',


### PR DESCRIPTION
### What this PR does

Before this PR:
Feishu issue notification cards did not @mention any specific user, so notifications could be easily missed.

After this PR:
The issue notification card now includes an `<at>` element that @mentions the Feishu user `cli_a92d6e7ba3f85ced` in the card body, ensuring they receive a direct notification for every new GitHub issue.

### Why we need it and why it was done in this way

The Feishu user needs to be actively notified when new GitHub issues are created. By embedding the `<at id=cli_a92d6e7ba3f85ced></at>` tag directly in the card's lark_md content, the user gets a native Feishu @mention notification without requiring changes to the workflow or CLI interface.

The following tradeoffs were made:
- The Feishu user ID is hardcoded in the card template rather than passed as a CLI option. This is simpler and sufficient for the current use case.

The following alternatives were considered:
- Adding a `--mention` CLI option: More flexible but unnecessary complexity for a single user.
- Adding the @mention via the workflow prompt: Less reliable since it depends on Claude's output.

### Breaking changes

None.

### Special notes for your reviewer

The TypeScript diagnostics shown for `feishu-notify.ts` (missing `process`, `Buffer`, etc.) are pre-existing and unrelated to this change — the script runs via `npx tsx` and is outside the project's tsconfig scope.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
