### PR TITLE
revert: remove Feishu at-mention from issue notification card

### DIFF
--- a/scripts/feishu-notify.ts
+++ b/scripts/feishu-notify.ts
@@ -234,13 +234,6 @@ function createIssueCard(issueData: IssueData): FeishuCard {
         content: `**Summary:**\n${issueSummary}`
       }
     },
-    {
-      tag: 'div',
-      text: {
-        tag: 'lark_md',
-        content: `<at id=ou_07e5565fa3a77665648fd85edb09432e></at>`
-      }
-    },
     { tag: 'hr' },
     {
       tag: 'action',


### PR DESCRIPTION
### What this PR does

Before this PR:
Attempted to add Feishu @mention notifications in issue cards using `<at id=...></at>` tags with various ID formats (app ID, open_id).

After this PR:
Reverted all mention-related changes. The Feishu card content is restored to its original state without @mention tags.

### Why we need it and why it was done in this way

Testing confirmed that while the `<at>` tag with open_id displays correctly in the card, Feishu does not provide a message receive API for bots — so bot users cannot actually receive @mention notifications. The feature is not feasible with the current Feishu API capabilities.

### Breaking changes

None

### Special notes for your reviewer

This PR reverts the mention feature added in #13199 and all subsequent test commits. Net diff against `main` should only contain the revert of #13199.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: N/A - no user-facing change
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
