### PR TITLE
feat(ci): add release issue notification workflow

### DIFF
--- a/.github/workflows/release-notify.yml
+++ b/.github/workflows/release-notify.yml
@@ -1,0 +1,137 @@
+name: Release Issue Notifications
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify released issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const version = context.payload.release.tag_name;
+            const releaseUrl = context.payload.release.html_url;
+            const isPrerelease = context.payload.release.prerelease;
+
+            // Get all releases to find the previous one
+            const releases = await github.rest.repos.listReleases({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 10
+            });
+
+            // Find previous release (not draft, different from current, same prerelease status)
+            const previousRelease = releases.data.find(r =>
+              r.tag_name !== version &&
+              !r.draft &&
+              r.prerelease === isPrerelease
+            );
+
+            if (!previousRelease) {
+              console.log('No previous release found, skipping notifications');
+              return;
+            }
+
+            console.log(`Comparing ${previousRelease.tag_name}...${version}`);
+
+            // Compare commits between releases
+            const comparison = await github.rest.repos.compareCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              base: previousRelease.tag_name,
+              head: version
+            });
+
+            // Extract issue numbers from commit messages
+            const issueNumbers = new Set();
+
+            for (const commit of comparison.data.commits) {
+              const message = commit.commit.message;
+
+              // Match "Fixes #123", "Closes #123", "Resolves #123" patterns (case insensitive)
+              const fixes = message.matchAll(/(?:fixes|closes|resolves)\s+#(\d+)/gi);
+              for (const match of fixes) {
+                issueNumbers.add(parseInt(match[1]));
+              }
+            }
+
+            if (issueNumbers.size === 0) {
+              console.log('No issues found to notify');
+              return;
+            }
+
+            console.log(`Found ${issueNumbers.size} issues: ${Array.from(issueNumbers).join(', ')}`);
+
+            // Bilingual comment template
+            const commentBody = `:tada: This issue has been resolved in **${version}** :tada:
+
+The release is available on [GitHub releases](${releaseUrl})
+
+---
+
+:tada: 此 Issue 已在 **${version}** 版本中修复 :tada:
+
+该版本可在 [GitHub releases](${releaseUrl}) 下载`;
+
+            // Labels to add
+            const labels = ['released'];
+            if (!isPrerelease) {
+              labels.push(`released-${version}`);
+            } else {
+              labels.push('released-prerelease');
+            }
+
+            const results = { success: [], failed: [] };
+
+            // Notify, label, and optionally close issues
+            for (const issueNumber of issueNumbers) {
+              try {
+                // Add comment
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  body: commentBody
+                });
+
+                // Add labels
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  labels: labels
+                });
+
+                // Close issue only if it's a stable release (not prerelease)
+                if (!isPrerelease) {
+                  await github.rest.issues.update({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    state: 'closed'
+                  });
+                  console.log(`✅ Notified and closed issue #${issueNumber}`);
+                } else {
+                  console.log(`✅ Notified issue #${issueNumber} (prerelease, not closing)`);
+                }
+                results.success.push(issueNumber);
+              } catch (error) {
+                console.error(`❌ Failed to notify issue #${issueNumber}: ${error.message}`);
+                results.failed.push({ number: issueNumber, error: error.message });
+              }
+            }
+
+            // Summary
+            console.log('\n📊 Summary:');
+            console.log(`${results.success.length} issues notified, ${results.failed.length} failed`);
+
+            if (results.failed.length > 0) {
+              console.log('⚠️ Some notifications failed. Check logs above for details.');
+            }


### PR DESCRIPTION
### What this PR does

Before this PR:
- When a release was published, issue creators were not automatically notified that their reported issues had been fixed
- Issues remained open even after being resolved in a release

After this PR:
- Added a new GitHub Actions workflow (`release-notify.yml`) that triggers when a release is published
- Automatically extracts issue numbers from commit messages (matching "Fixes/Closes/Resolves #123" patterns)
- Posts bilingual (English + Chinese) comments on resolved issues to notify creators
- Adds `released` and version-specific labels to issues
- Automatically closes issues for stable releases (prereleases are not closed)

Fixes #

### Why we need it and why it was done in this way

This improves the user experience by automatically notifying issue reporters when their issues are resolved, reducing the need for manual follow-up and issue management.

The following tradeoffs were made:
- Only notifies issue creators, not PR authors (as PR authors are typically core team members)
- Uses GitHub Script instead of semantic-release to avoid adding dependencies and complexity

The following alternatives were considered:
- Using semantic-release github plugin (rejected to avoid major workflow changes)
- Notifying PR authors as well (rejected as they are core team members)

Links to places where the discussion took place: N/A

### Breaking changes

None

### Special notes for your reviewer

The workflow:
1. Triggers on `release: published` event
2. Compares commits between current and previous release
3. Extracts issue numbers from commit messages
4. Posts comments and adds labels
5. Closes issues for stable releases

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
