### PR TITLE
feat: route Gemini 3.1 Flash Lite to gemini3_flash thinking type

### DIFF
--- a/src/renderer/src/config/models/reasoning.ts
+++ b/src/renderer/src/config/models/reasoning.ts
@@ -25,6 +25,7 @@ import {
   isClaude46SeriesModel,
   isGemini3FlashModel,
   isGemini3ProModel,
+  isGemini31FlashLiteModel,
   isGemini31ProModel,
   isKimi25Model,
   withModelIdAndNameAsId
@@ -143,7 +144,7 @@ const _getThinkModelType = (model: Model): ThinkingModelType => {
   } else if (isGrok4FastReasoningModel(model)) {
     thinkingModelType = 'grok4_fast'
   } else if (isSupportedThinkingTokenGeminiModel(model)) {
-    if (isGemini3FlashModel(model)) {
+    if (isGemini3FlashModel(model) || isGemini31FlashLiteModel(model)) {
       thinkingModelType = 'gemini3_flash'
     } else if (isGemini3ProModel(model)) {
       thinkingModelType = 'gemini3_pro'

--- a/src/renderer/src/config/models/utils.ts
+++ b/src/renderer/src/config/models/utils.ts
@@ -317,6 +317,20 @@ export const isGemini3FlashModel = (model: Model | undefined | null): boolean =>
 }
 
 /**
+ * Check if the model is a Gemini 3.1 Flash Lite model
+ * Matches: gemini-3.1-flash-lite-preview, gemini-3.1-flash-lite-preview-06-2025
+ * @param model - The model to check
+ * @returns true if the model is a Gemini 3.1 Flash Lite model
+ */
+export const isGemini31FlashLiteModel = (model: Model | undefined | null): boolean => {
+  if (!model) {
+    return false
+  }
+  const modelId = getLowerBaseModelName(model.id)
+  return /gemini-3\.1-flash-lite(?:-[\w-]+)*$/i.test(modelId)
+}
+
+/**
  * Check if the model is a Gemini 3 Pro model
  * Matches: gemini-3-pro, gemini-3-pro-preview, gemini-3-pro-preview-09-2025, gemini-pro-latest (alias)
  * Excludes: gemini-3-pro-image-preview, 3.x pro versions


### PR DESCRIPTION
### What this PR does

Before this PR:

`gemini-3.1-flash-lite-preview` was routed to `gemini2_flash` thinking model type, because it didn't match any specific Gemini 3.x detector and fell through to the generic `GEMINI_FLASH_MODEL_REGEX`.

After this PR:

`gemini-3.1-flash-lite-preview` is correctly routed to `gemini3_flash` thinking model type via a new `isGemini31FlashLiteModel` detector.

Fixes #13210

### Why we need it and why it was done in this way

Gemini 3.1 Flash Lite is a newer model that should share reasoning effort options with Gemini 3 Flash (`minimal`, `low`, `medium`, `high`) rather than Gemini 2 Flash (`low`, `medium`, `high`, `auto`).

The following tradeoffs were made:

A dedicated `isGemini31FlashLiteModel` function was added instead of broadening `isGemini3FlashModel`, to keep each detector focused and avoid unintended matches.

The following alternatives were considered:

Modifying `isGemini3FlashModel` regex to match `gemini-3.x-flash` patterns — rejected to keep the existing function's scope narrow and explicit.

### Breaking changes

None

### Special notes for your reviewer

The new regex `/gemini-3\.1-flash-lite(?:-[\w-]+)*$/i` intentionally only matches Flash **Lite** variants. Other Gemini 3.1 Flash models (if they exist) would still fall through to `gemini2_flash` until explicitly handled.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
