### PR TITLE
fix: skip auto backup when streaming response is in progress

### DIFF
--- a/src/renderer/src/services/BackupService.ts
+++ b/src/renderer/src/services/BackupService.ts
@@ -657,6 +657,15 @@ export function startAutoSync(immediate = false, type?: BackupType) {
       return
     }
 
+    // Check if any streaming response is in progress to avoid saving incomplete conversations
+    const messagesState = store.getState().messages
+    const isStreamingInProgress = Object.values(messagesState.loadingByTopic).some((loading) => loading === true)
+    if (isStreamingInProgress) {
+      logger.verbose(`${logPrefix} Streaming response in progress, skipping backup and rescheduling`)
+      scheduleNextBackup('fromNow', backupType)
+      return
+    }
+
     // 设置运行状态
     if (backupType === 'webdav') {
       isWebdavAutoBackupRunning = true


### PR DESCRIPTION
Fixes #13216

## Summary
This fix prevents the auto WebDAV (and S3/local) backup from interrupting streaming AI responses. When a streaming response is in progress, the backup is now skipped and rescheduled to a later time.

### Changes Made
- Added a check in `performAutoBackup()` to detect if any topic is currently loading (streaming response in progress)
- If streaming is detected, the backup is skipped and rescheduled using `scheduleNextBackup("fromNow", backupType)`
- This applies to all auto backup types: WebDAV, S3, and local backup

### Root Cause
The issue occurred because the auto backup would trigger during an active streaming response, saving the conversation to the database in an incomplete state. This caused:
- Truncated AI messages
- Conversations becoming stuck in "half-response" state
- Inability to send new messages in affected conversations

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one)*