### PR TITLE
fix: prompt caching crash for OpenRouter and non-Anthropic providers

### DIFF
--- a/src/renderer/src/aiCore/plugins/PluginBuilder.ts
+++ b/src/renderer/src/aiCore/plugins/PluginBuilder.ts
@@ -72,8 +72,8 @@ export function buildPlugins({ provider, model, config }: BuildPluginsContext): 
     plugins.push(createSimulateStreamingPlugin())
   }
 
-  if (providerType === 'anthropic' && provider.anthropicCacheControl?.tokenThreshold) {
-    plugins.push(createAnthropicCachePlugin())
+  if (provider.anthropicCacheControl?.tokenThreshold) {
+    plugins.push(createAnthropicCachePlugin(provider))
   }
 
   // 0.3 OpenRouter reasoning redaction

--- a/src/renderer/src/aiCore/plugins/anthropicCachePlugin.ts
+++ b/src/renderer/src/aiCore/plugins/anthropicCachePlugin.ts
@@ -85,12 +85,12 @@ function anthropicCacheMiddleware(provider: Provider): LanguageModelMiddleware {
   }
 }
 
-export const createAnthropicCachePlugin = () =>
+export const createAnthropicCachePlugin = (provider: Provider) =>
   definePlugin({
     name: 'anthropicCache',
     enforce: 'pre',
     configureContext: (context) => {
       context.middlewares = context.middlewares || []
-      context.middlewares.push(anthropicCacheMiddleware(context.provider))
+      context.middlewares.push(anthropicCacheMiddleware(provider))
     }
   })

--- a/src/renderer/src/utils/provider.ts
+++ b/src/renderer/src/utils/provider.ts
@@ -205,6 +205,7 @@ export const isSupportAnthropicPromptCacheProvider = (provider: Provider) => {
     provider.type === 'anthropic' ||
     isNewApiProvider(provider) ||
     provider.id === SystemProviderIds.aihubmix ||
+    provider.id === SystemProviderIds.openrouter ||
     isAzureOpenAIProvider(provider)
   )
 }


### PR DESCRIPTION
### What this PR does

Before this PR:

Enabling the "Prompt Caching" toggle for OpenRouter (or any non-`anthropic` type provider) caused an immediate crash: `Cannot read properties of undefined (reading 'anthropicCacheControl')`. The built-in OpenRouter provider also lacked the prompt caching settings UI.

After this PR:

Prompt caching works correctly for OpenRouter and other compatible providers. The built-in OpenRouter provider now shows the prompt caching toggle in settings.

Fixes #13219

### Why we need it and why it was done in this way

The following tradeoffs were made:

The root cause has two parts:

1. **Crash**: `createAnthropicCachePlugin()` took no arguments and relied on `context.provider` inside its `configureContext` hook. However, `AiRequestContext` (created by `createContext()` in the aiCore package) never sets a `provider` field — it only has `providerId` (a string). The `[key: string]: any` catch-all on the interface hid this at compile time, but at runtime `context.provider` was `undefined`, causing the TypeError.

2. **Guard too narrow**: `PluginBuilder.ts` only activated the cache plugin when `providerType === 'anthropic'`, excluding OpenRouter and other providers that support Anthropic prompt caching via their SDK (OpenRouter's AI SDK provider [now reads `providerOptions.anthropic.cacheControl`](https://github.com/OpenRouterTeam/ai-sdk-provider/blob/7c043a0/src/chat/convert-to-openrouter-chat-messages.ts#L20)).

The fix passes the `Provider` object directly via closure (consistent with how other plugins like `createTelemetryPlugin` and `createQwenThinkingPlugin` receive their dependencies), and broadens the guard to any provider with `anthropicCacheControl` settings configured.

The following alternatives were considered:

- Adding a `provider` field to `AiRequestContext` — rejected as it would require changes to the shared `@cherrystudio/ai-core` package and is unnecessary when closures work fine.

### Breaking changes

None.

### Special notes for your reviewer

- The `cacheProviderOptions` format (`{ anthropic: { cacheControl: { type: 'ephemeral' } } }`) is unchanged — OpenRouter's AI SDK provider already supports reading from `providerOptions.anthropic.cacheControl`.
- All 3468 tests pass, lint/typecheck/format all clean.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix prompt caching crash when using OpenRouter or other non-Anthropic providers with prompt caching enabled. Also add prompt caching toggle to the built-in OpenRouter provider settings.
```
