### PR TITLE
fix: use camelCase reasoningEffort for Gemini 3 models in openai-compatible provider

### DIFF
--- a/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
+++ b/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
@@ -91,6 +91,7 @@ vi.mock('@renderer/config/models', async (importOriginal) => {
     isSupportedThinkingTokenHunyuanModel: vi.fn(() => false),
     isSupportedThinkingTokenModel: vi.fn(() => false),
     isGPT51SeriesModel: vi.fn(() => false),
+    isGemini3ThinkingTokenModel: vi.fn(() => false),
     findTokenLimit: vi.fn(actual.findTokenLimit)
   }
 })
@@ -391,6 +392,54 @@ describe('reasoning utils', () => {
 
       const result = getReasoningEffort(assistant, model)
       expect(result).toEqual({ reasoning_effort: 'medium' })
+    })
+
+    it('should return camelCase reasoningEffort for Gemini 3 models', async () => {
+      const {
+        isReasoningModel,
+        isOpenAIDeepResearchModel,
+        isSupportedThinkingTokenGeminiModel,
+        isGemini3ThinkingTokenModel,
+        isQwenReasoningModel,
+        isSupportedThinkingTokenClaudeModel,
+        isSupportedThinkingTokenDoubaoModel,
+        isSupportedThinkingTokenZhipuModel,
+        isSupportedReasoningEffortModel,
+        isSupportedThinkingTokenQwenModel,
+        isSupportedThinkingTokenHunyuanModel,
+        isDeepSeekHybridInferenceModel
+      } = await import('@renderer/config/models')
+
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+      vi.mocked(isOpenAIDeepResearchModel).mockReturnValue(false)
+      vi.mocked(isSupportedThinkingTokenGeminiModel).mockReturnValue(true)
+      vi.mocked(isGemini3ThinkingTokenModel).mockReturnValue(true)
+      vi.mocked(isQwenReasoningModel).mockReturnValue(false)
+      vi.mocked(isSupportedThinkingTokenClaudeModel).mockReturnValue(false)
+      vi.mocked(isSupportedThinkingTokenDoubaoModel).mockReturnValue(false)
+      vi.mocked(isSupportedThinkingTokenZhipuModel).mockReturnValue(false)
+      vi.mocked(isSupportedReasoningEffortModel).mockReturnValue(false)
+      vi.mocked(isSupportedThinkingTokenQwenModel).mockReturnValue(false)
+      vi.mocked(isSupportedThinkingTokenHunyuanModel).mockReturnValue(false)
+      vi.mocked(isDeepSeekHybridInferenceModel).mockReturnValue(false)
+
+      const model: Model = {
+        id: 'gemini-3-flash-preview',
+        name: 'Gemini 3 Flash',
+        provider: 'custom-provider'
+      } as Model
+
+      const assistant: Assistant = {
+        id: 'test',
+        name: 'Test',
+        settings: {
+          reasoning_effort: 'high'
+        }
+      } as Assistant
+
+      const result = getReasoningEffort(assistant, model)
+      // Should use camelCase 'reasoningEffort' for AI SDK openai-compatible provider compatibility
+      expect(result).toEqual({ reasoningEffort: 'high' })
     })
 
     it('should return empty for groq provider', async () => {

--- a/src/renderer/src/aiCore/utils/reasoning.ts
+++ b/src/renderer/src/aiCore/utils/reasoning.ts
@@ -406,7 +406,7 @@ export function getReasoningEffort(assistant: Assistant, model: Model): Reasonin
     // https://ai.google.dev/gemini-api/docs/gemini-3?thinking=high#openai_compatibility
     if (isGemini3ThinkingTokenModel(model)) {
       return {
-        reasoning_effort: reasoningEffort
+        reasoningEffort
       }
     }
     if (reasoningEffort === 'auto') {


### PR DESCRIPTION
### What this PR does

Before this PR:
Gemini 3 models (e.g., `gemini-3-flash-preview`) did not include the `reasoning_effort` parameter in HTTP requests when deep thinking mode was enabled through OpenAI Compatible providers. The parameter was silently dropped.

<img width="922" height="239" alt="image" src="https://github.com/user-attachments/assets/355f37a0-80a7-478a-a0e7-df03dda0c1ab" />


After this PR:
Gemini 3 models correctly send the `reasoning_effort` parameter when using OpenAI Compatible providers.

<img width="1072" height="283" alt="image" src="https://github.com/user-attachments/assets/2ae084bd-7d4a-4c25-8e98-614646308147" />


Fixes #13221



### Why we need it and why it was done in this way

The AI SDK's `@ai-sdk/openai-compatible` provider schema only recognizes camelCase `reasoningEffort`, not snake_case `reasoning_effort`. When snake_case was passed via provider options, it failed schema validation. The SDK then explicitly mapped `reasoning_effort: compatibleOptions.reasoningEffort` in the request body, which resolved to `undefined` (since the schema rejected the snake_case key), overriding any spread value and silently dropping the parameter.

The fix changes the return value from `{ reasoning_effort: reasoningEffort }` to `{ reasoningEffort }` (camelCase) so the AI SDK schema recognizes it and properly maps it to `reasoning_effort` in the HTTP request body.

The following tradeoffs were made: N/A

The following alternatives were considered: Patching the AI SDK to accept snake_case — rejected because it's a third-party dependency and the camelCase format is the documented API.

### Breaking changes

None

### Special notes for your reviewer

The existing comment in `src/renderer/src/types/sdk.ts` (line 82) already warns about this exact behavior: `// WARN: This field will be overwrite to undefined by aisdk if the provider is openai-compatible. Use reasoningEffort instead.`

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: Not required — bug fix with no behavior change from the user's perspective
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix Gemini 3 models not sending reasoning_effort parameter when deep thinking mode is enabled through OpenAI Compatible providers.
```
