### PR TITLE
ci: pin claude-code-action to v1.0.66 in prepare-release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
 
       - name: Prepare Release via Claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@v1.0.66
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_TRANSLATOR_APIKEY }}
           github_token: ${{ secrets.TOKEN_GITHUB_WRITE }}


### PR DESCRIPTION
### What this PR does

Before this PR: The `prepare-release.yml` workflow uses `anthropics/claude-code-action@v1`, which tracks the latest v1 release and may introduce unexpected breaking changes.

After this PR: The action is pinned to `anthropics/claude-code-action@v1.0.66` for deterministic CI behavior.

### Why we need it and why it was done in this way

The `prepare-release` workflow failed in [this run](https://github.com/CherryHQ/cherry-studio/actions/runs/22706296259/job/65834731056). Pinning to a known-good version (`v1.0.66`) prevents future breakage from upstream action updates.

The following tradeoffs were made: N/A

The following alternatives were considered: N/A

### Breaking changes

None

### Special notes for your reviewer

N/A

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: Not required — CI-only change
- [x] Self-review: I have reviewed my own code before requesting review from others

```release-note
NONE
```
