### PR TITLE
chore: release v1.7.24

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -140,19 +140,45 @@ artifactBuildCompleted: scripts/artifact-build-completed.js
 releaseInfo:
   releaseNotes: |
     <!--LANG:en-->
-    Cherry Studio 1.7.23 - Bug Fixes
+    Cherry Studio 1.7.24 - Features & Improvements
+
+    ✨ New Features
+    - [Agent] Agent creation no longer requires selecting a workspace folder - a default workspace is automatically created
+    - [Agent] Added thinking/reasoning effort control (low/medium/high/max/adaptive) for Claude Code agent sessions
 
     🐛 Bug Fixes
-    - [Selection] Fix app crash on Windows when closing action window
-    - [MiniApp] Fix settings state synchronization and region filter consistency
-    - [Plugin Browser] Make detail modal text selectable and improve search experience
-    - [Tools] Fix approval card not showing for builtin and provider tools
+    - [Tools] Fix prompt caching crash when using OpenRouter or other non-Anthropic providers
+    - [Models] Fix Gemini 3 models not sending reasoning_effort parameter when deep thinking mode is enabled
+    - [Editor] Fix CodeMirror highlight crash caused by version conflict
+    - [MCP] Fix MCP tool parameter parsing and nested schema display
+    - [MCP] Fix MCP tools not being auto-approved when configured through agent allowed_tools
+    - [UI] Fix duplicate error blocks in aborting
+    - [Plugins] Fix plugin size displaying as 0 in the plugin detail modal
+    - [UI] Fix PinnedTodoPanel ignoring narrow mode width setting
+
+    💄 Improvements
+    - [Sessions] Implement infinite scroll for sessions list
+    - [Plugins] Improve plugin detail modal UI with better layout and styling
+    - [Performance] Fix renderer crash when agent streams large file writes by optimizing tool input delta handling
     <!--LANG:zh-CN-->
-    Cherry Studio 1.7.23 - 问题修复
+    Cherry Studio 1.7.24 - 功能与改进
+
+    ✨ 新功能
+    - [智能体] 创建智能体不再需要选择工作区文件夹 - 会自动创建默认工作区
+    - [智能体] 为 Claude Code 智能体会话添加思考/推理强度控制（低/中/高/最大/自适应）
 
     🐛 问题修复
-    - [选择助手] 修复 Windows 上关闭操作窗口时应用崩溃的问题
-    - [小程序] 修复设置状态同步和区域过滤一致性问题
-    - [插件浏览器] 使详情弹窗文本可选择，改进搜索体验
-    - [工具] 修复内置和提供商工具的批准卡片未显示的问题
+    - [工具] 修复使用 OpenRouter 或其他非 Anthropic 提供商时的提示缓存崩溃问题
+    - [模型] 修复启用深度思考模式时 Gemini 3 模型不发送 reasoning_effort 参数的问题
+    - [编辑器] 修复由版本冲突导致的 CodeMirror 高亮崩溃
+    - [MCP] 修复 MCP 工具参数解析和嵌套架构显示问题
+    - [MCP] 修复通过智能体 allowed_tools 配置时 MCP 工具无法自动批准的问题
+    - [UI] 修复中止时出现重复错误块的问题
+    - [插件] 修复插件详情弹窗中插件大小显示为 0 的问题
+    - [UI] 修复 PinnedTodoPanel 忽略窄模式宽度设置的问题
+
+    💄 改进
+    - [会话] 实现会话列表的无限滚动
+    - [插件] 改进插件详情弹窗的 UI，布局和样式更优化
+    - [性能] 通过优化工具输入增量处理，修复智能体流式传输大文件时的渲染器崩溃
     <!--LANG:END-->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CherryStudio",
-  "version": "1.7.23",
+  "version": "1.7.24",
   "private": true,
   "description": "A powerful AI assistant for producer.",
   "desktopName": "CherryStudio.desktop",


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

⚠️ Important: Redux/IndexedDB Data-Changing Feature PRs Temporarily On Hold ⚠️

Please note: For our current development cycle, we are not accepting feature Pull Requests that introduce changes to Redux data models or IndexedDB schemas.

While we value your contributions, PRs of this nature will be blocked without merge. We welcome all other contributions (bug fixes, perf enhancements, docs, etc.). Thank you!

Once version 2.0.0 is released, we will resume reviewing feature PRs.

-->

### What this PR does

Before this PR:
The latest release was v1.7.23

After this PR:
This PR prepares release v1.7.24, which includes:
- New features: Agent workspace auto-creation, thinking/reasoning effort control for agent sessions
- Bug fixes: Prompt caching crash, Gemini 3 reasoning_effort parameter, CodeMirror highlight crash, MCP tool parsing and auto-approval, plugin size display, UI fixes
- Improvements: Infinite scroll for sessions list, plugin detail modal UI, tool streaming performance

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

This is a regular patch release following the semantic versioning process. The version bump from 1.7.23 to 1.7.24 includes bug fixes and new features based on commits merged since the last release.

The following tradeoffs were made:
N/A

The following alternatives were considered:
N/A

Links to places where the discussion took places: N/A

### Breaking changes

None

### Special notes for your reviewer

This PR triggers the CI/CD pipeline to build release artifacts for macOS, Windows, and Linux. Once merged, a draft GitHub Release will be automatically created.

**Release Summary (English):**
- Agent creation no longer requires selecting a workspace folder
- Added thinking/reasoning effort control for Claude Code agent sessions
- Fixed prompt caching crash for OpenRouter and non-Anthropic providers
- Fixed Gemini 3 models not sending reasoning_effort parameter
- Fixed CodeMirror highlight crash
- Fixed MCP tool parameter parsing and auto-approval
- Implemented infinite scroll for sessions list
- Improved plugin detail modal UI
- Fixed renderer crash when streaming large file writes

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Cherry Studio 1.7.24 - Features & Improvements

✨ New Features
- [Agent] Agent creation no longer requires selecting a workspace folder - a default workspace is automatically created
- [Agent] Added thinking/reasoning effort control (low/medium/high/max/adaptive) for Claude Code agent sessions

🐛 Bug Fixes
- [Tools] Fix prompt caching crash when using OpenRouter or other non-Anthropic providers
- [Models] Fix Gemini 3 models not sending reasoning_effort parameter when deep thinking mode is enabled
- [Editor] Fix CodeMirror highlight crash caused by version conflict
- [MCP] Fix MCP tool parameter parsing and nested schema display
- [MCP] Fix MCP tools not being auto-approved when configured through agent allowed_tools
- [UI] Fix duplicate error blocks in aborting
- [Plugins] Fix plugin size displaying as 0 in the plugin detail modal
- [UI] Fix PinnedTodoPanel ignoring narrow mode width setting

💄 Improvements
- [Sessions] Implement infinite scroll for sessions list
- [Plugins] Improve plugin detail modal UI with better layout and styling
- [Performance] Fix renderer crash when agent streams large file writes by optimizing tool input delta handling
```
