### PR TITLE
feat: reset selected index when returning to home from feature routes

### DIFF
--- a/src/renderer/src/windows/mini/home/HomeWindow.tsx
+++ b/src/renderer/src/windows/mini/home/HomeWindow.tsx
@@ -126,7 +126,6 @@ const HomeWindow: FC<{ draggable?: boolean }> = ({ draggable = true }) => {
   }, [focusInput])
 
   const onWindowShow = useCallback(async () => {
-    featureMenusRef.current?.resetSelectedIndex()
     await readClipboard()
     focusInput()
   }, [readClipboard, focusInput])
@@ -479,6 +478,8 @@ const HomeWindow: FC<{ draggable?: boolean }> = ({ draggable = true }) => {
         // Reset the topic
         currentTopic.current = getDefaultTopic(currentAssistant.id)
 
+        // Reset selection only after using a feature and returning to home.
+        featureMenusRef.current?.resetSelectedIndex()
         setError(null)
         setRoute('home')
         setUserInputText('')


### PR DESCRIPTION
Before this PR:
- `featureMenusRef.current?.resetSelectedIndex()` ran on every window show.
- This cleared the selected feature index even in cases where user had not just returned from a feature route.

https://github.com/user-attachments/assets/c67e9aea-c2b7-4bf4-b99d-967adacf0da4


After this PR:
- Selected index is reset only when navigating back to `home` from feature routes.
- Normal window show flow no longer unconditionally resets feature menu selection.


https://github.com/user-attachments/assets/15889edf-1c28-4285-b18a-0803a9418519
