### PR TITLE
fix: update thinking_millsec during streaming to prevent timer reset on remount

### DIFF
--- a/src/renderer/src/services/messageStreaming/callbacks/thinkingCallbacks.ts
+++ b/src/renderer/src/services/messageStreaming/callbacks/thinkingCallbacks.ts
@@ -50,8 +50,8 @@ export const createThinkingCallbacks = (deps: ThinkingCallbacksDependencies) => 
       if (thinkingBlockId) {
         const blockChanges: Partial<MessageBlock> = {
           content: text,
-          status: MessageBlockStatus.STREAMING
-          // thinking_millsec: performance.now() - thinking_millsec_now
+          status: MessageBlockStatus.STREAMING,
+          thinking_millsec: performance.now() - thinking_millsec_now
         }
         blockManager.smartBlockUpdate(thinkingBlockId, blockChanges, MessageBlockType.THINKING)
       }


### PR DESCRIPTION
### What this PR does

Before this PR:

The `thinking_millsec` field on thinking blocks was only set at `onThinkingComplete`. During streaming, it remained `0`. If the `ThinkingTimeSeconds` component was unmounted and remounted (e.g., due to virtual list scrolling or navigation), the displayed thinking timer would reset to 0.

After this PR:

The `thinking_millsec` is now updated on every `onThinkingChunk` call, so the block always carries the current elapsed thinking time. When the component remounts, `useState` initializes from the up-to-date value instead of `0`.

Fixes #13277

### Why we need it and why it was done in this way

The following tradeoffs were made:

This adds `thinking_millsec` to the existing `smartBlockUpdate` call in `onThinkingChunk`, which already dispatches on every chunk for `content` and `status`. Adding one more field to the same update has negligible performance impact.

The following alternatives were considered:

- Storing a `thinking_start_time` timestamp on the block (requires data model change, blocked until v2.0.0)
- Using a module-level `Map<blockId, startTime>` in the UI component (works but is a workaround rather than fixing the data)

### Breaking changes

None.

### Special notes for your reviewer

The `thinking_millsec` update in `onThinkingChunk` was previously present but intentionally commented out. This PR simply re-enables it. The field is added to an existing Redux update call, so there is no additional dispatch overhead.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: Not required — internal bug fix with no user-facing behavior change
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
