### PR TITLE
fix(api-server): relax chat completion validation for tool calling messages

### DIFF
--- a/src/main/apiServer/services/chat-completion.ts
+++ b/src/main/apiServer/services/chat-completion.ts
@@ -128,26 +128,15 @@ export class ChatCompletionService {
   validateRequest(request: ChatCompletionCreateParams): ValidationResult {
     const errors: string[] = []
 
-    // Validate messages
+    // Only validate minimal structure required for routing.
+    // Detailed message validation is delegated to the upstream provider.
     if (!request.messages) {
       errors.push('Messages array is required')
     } else if (!Array.isArray(request.messages)) {
       errors.push('Messages must be an array')
     } else if (request.messages.length === 0) {
       errors.push('Messages array cannot be empty')
-    } else {
-      // Validate each message
-      request.messages.forEach((message, index) => {
-        if (!message.role) {
-          errors.push(`Message ${index}: role is required`)
-        }
-        if (!message.content) {
-          errors.push(`Message ${index}: content is required`)
-        }
-      })
     }
-
-    // Validate optional parameters
 
     return {
       isValid: errors.length === 0,


### PR DESCRIPTION
### What this PR does

Before this PR:
The API server's `ChatCompletionService.validateRequest()` required every message to have a non-empty `content` field. This rejected valid OpenAI-compatible tool calling messages where assistant messages have `content: null` with `tool_calls`, and `role: "tool"` result messages.

After this PR:
The validation only checks minimal structure (messages exists, is an array, non-empty). Per-message content/role validation is delegated to the upstream provider, which correctly handles tool calling message flows.

Fixes #13206

### Why we need it and why it was done in this way

The chat completions endpoint acts as a **request proxy** — it routes requests to upstream providers via the OpenAI SDK. The proxy should only validate what it needs for routing (messages array exists, model format is correct), not enforce message-level semantics that belong to the upstream provider.

The following tradeoffs were made:
- Removing per-message validation means malformed messages will be rejected by the upstream provider instead of locally, resulting in potentially less descriptive error messages. This is acceptable because upstream providers return standard OpenAI-format errors.

The following alternatives were considered:
- Relaxing validation only for specific cases (allowing `content: null` when `tool_calls` is present). Rejected because it adds complexity and will break again when the OpenAI API spec evolves (e.g., vision messages, structured outputs).

### Breaking changes

None. This change is strictly more permissive — all previously accepted requests remain valid.

### Special notes for your reviewer

The `validateRequest()` method now only has 3 checks for the `messages` field (exists, is array, non-empty). The model validation remains unchanged in `resolveProviderContext()`.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix API server rejecting valid tool calling messages in /v1/chat/completions. The validation no longer requires every message to have non-empty content, enabling OpenAI-compatible tool calling workflows.
```
