### PR TITLE
fix: check underlying tool permissions for hub invoke/exec

### DIFF
--- a/packages/shared/IpcChannel.ts
+++ b/packages/shared/IpcChannel.ts
@@ -93,6 +93,7 @@ export enum IpcChannel {
   Mcp_CheckConnectivity = 'mcp:check-connectivity',
   Mcp_UploadDxt = 'mcp:upload-dxt',
   Mcp_AbortTool = 'mcp:abort-tool',
+  Mcp_ResolveHubTool = 'mcp:resolve-hub-tool',
   Mcp_GetServerVersion = 'mcp:get-server-version',
   Mcp_Progress = 'mcp:progress',
   Mcp_GetServerLogs = 'mcp:get-server-logs',

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -822,6 +822,10 @@ export async function registerIpc(mainWindow: BrowserWindow, app: Electron.App) 
   ipcMain.handle(IpcChannel.Mcp_GetInstallInfo, mcpService.getInstallInfo)
   ipcMain.handle(IpcChannel.Mcp_CheckConnectivity, mcpService.checkMcpConnectivity)
   ipcMain.handle(IpcChannel.Mcp_AbortTool, mcpService.abortTool)
+  ipcMain.handle(IpcChannel.Mcp_ResolveHubTool, async (_event, nameOrId: string) => {
+    const { resolveHubToolName } = await import('@main/mcpServers/hub/mcp-bridge')
+    return resolveHubToolName(nameOrId)
+  })
   ipcMain.handle(IpcChannel.Mcp_GetServerVersion, mcpService.getServerVersion)
   ipcMain.handle(IpcChannel.Mcp_GetServerLogs, mcpService.getServerLogs)
 

--- a/src/main/mcpServers/hub/__tests__/mcp-bridge.test.ts
+++ b/src/main/mcpServers/hub/__tests__/mcp-bridge.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@main/services/MCPService', () => ({
+  default: {
+    listAllActiveServerTools: vi.fn(async () => []),
+    callToolById: vi.fn(async () => ({ content: [{ type: 'text', text: '{}' }] })),
+    abortTool: vi.fn(async () => true)
+  }
+}))
+
+import { clearToolMap, resolveHubToolName, syncToolMapFromTools } from '../mcp-bridge'
+
+describe('resolveHubToolName', () => {
+  beforeEach(() => {
+    clearToolMap()
+  })
+
+  afterEach(() => {
+    clearToolMap()
+    vi.clearAllMocks()
+  })
+
+  it('returns null when mapping is not initialized', () => {
+    expect(resolveHubToolName('githubSearchRepos')).toBeNull()
+  })
+
+  it('resolves JS name to serverId and toolName', () => {
+    syncToolMapFromTools([
+      {
+        id: 'github__search_repos',
+        name: 'search_repos',
+        serverId: 'github',
+        serverName: 'GitHub',
+        description: '',
+        inputSchema: { type: 'object' as const },
+        type: 'mcp'
+      },
+      {
+        id: 'database__query',
+        name: 'query',
+        serverId: 'database',
+        serverName: 'Database',
+        description: '',
+        inputSchema: { type: 'object' as const },
+        type: 'mcp'
+      }
+    ])
+
+    const result = resolveHubToolName('githubSearchRepos')
+    expect(result).toEqual({ serverId: 'github', toolName: 'search_repos' })
+  })
+
+  it('resolves namespaced id to serverId and toolName', () => {
+    syncToolMapFromTools([
+      {
+        id: 'github__search_repos',
+        name: 'search_repos',
+        serverId: 'github',
+        serverName: 'GitHub',
+        description: '',
+        inputSchema: { type: 'object' as const },
+        type: 'mcp'
+      }
+    ])
+
+    const result = resolveHubToolName('github__search_repos')
+    expect(result).toEqual({ serverId: 'github', toolName: 'search_repos' })
+  })
+
+  it('returns null for unknown tool name', () => {
+    syncToolMapFromTools([
+      {
+        id: 'github__search_repos',
+        name: 'search_repos',
+        serverId: 'github',
+        serverName: 'GitHub',
+        description: '',
+        inputSchema: { type: 'object' as const },
+        type: 'mcp'
+      }
+    ])
+
+    expect(resolveHubToolName('unknownTool')).toBeNull()
+  })
+
+  it('handles serverId with multiple underscores', () => {
+    syncToolMapFromTools([
+      {
+        id: 'my_server__do_thing',
+        name: 'do_thing',
+        serverId: 'my_server',
+        serverName: 'My Server',
+        description: '',
+        inputSchema: { type: 'object' as const },
+        type: 'mcp'
+      }
+    ])
+
+    const result = resolveHubToolName('my_server__do_thing')
+    expect(result).toEqual({ serverId: 'my_server', toolName: 'do_thing' })
+  })
+})

--- a/src/main/mcpServers/hub/__tests__/toolname.test.ts
+++ b/src/main/mcpServers/hub/__tests__/toolname.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ToolIdentity, ToolNameMapping } from '../toolname'
+import { buildHubJsToolName, buildToolNameMapping, isNamespacedToolId, resolveToolId } from '../toolname'
+
+describe('toolname', () => {
+  describe('isNamespacedToolId', () => {
+    it('returns true for namespaced ids', () => {
+      expect(isNamespacedToolId('github__search_repos')).toBe(true)
+      expect(isNamespacedToolId('db__query')).toBe(true)
+    })
+
+    it('returns false for JS names', () => {
+      expect(isNamespacedToolId('githubSearchRepos')).toBe(false)
+      expect(isNamespacedToolId('query')).toBe(false)
+    })
+  })
+
+  describe('buildHubJsToolName', () => {
+    it('combines server and tool names in camelCase', () => {
+      expect(buildHubJsToolName('GitHub', 'search_repos')).toBe('githubSearchRepos')
+    })
+
+    it('handles empty server name', () => {
+      expect(buildHubJsToolName(undefined, 'search_repos')).toBe('searchRepos')
+      expect(buildHubJsToolName('', 'search_repos')).toBe('searchRepos')
+    })
+  })
+
+  describe('buildToolNameMapping', () => {
+    const tools: ToolIdentity[] = [
+      { id: 'github__search_repos', serverName: 'GitHub', toolName: 'search_repos' },
+      { id: 'github__get_user', serverName: 'GitHub', toolName: 'get_user' },
+      { id: 'database__query', serverName: 'Database', toolName: 'query' }
+    ]
+
+    it('builds bidirectional mapping', () => {
+      const mapping = buildToolNameMapping(tools)
+
+      expect(mapping.toJs.get('github__search_repos')).toBe('githubSearchRepos')
+      expect(mapping.toJs.get('github__get_user')).toBe('githubGetUser')
+      expect(mapping.toJs.get('database__query')).toBe('databaseQuery')
+
+      expect(mapping.toOriginal.get('githubSearchRepos')).toBe('github__search_repos')
+      expect(mapping.toOriginal.get('githubGetUser')).toBe('github__get_user')
+      expect(mapping.toOriginal.get('databaseQuery')).toBe('database__query')
+    })
+
+    it('handles name collisions with suffix', () => {
+      const collisionTools: ToolIdentity[] = [
+        { id: 'a__search', serverName: 'GitHub', toolName: 'search' },
+        { id: 'b__search', serverName: 'GitHub', toolName: 'search' }
+      ]
+
+      const mapping = buildToolNameMapping(collisionTools)
+      const jsNames = [...mapping.toOriginal.keys()]
+
+      expect(jsNames).toContain('githubSearch')
+      expect(jsNames).toContain('githubSearch_2')
+    })
+
+    it('handles empty input', () => {
+      const mapping = buildToolNameMapping([])
+      expect(mapping.toJs.size).toBe(0)
+      expect(mapping.toOriginal.size).toBe(0)
+    })
+  })
+
+  describe('resolveToolId', () => {
+    let mapping: ToolNameMapping
+
+    beforeAll(() => {
+      mapping = buildToolNameMapping([
+        { id: 'github__search_repos', serverName: 'GitHub', toolName: 'search_repos' },
+        { id: 'database__query', serverName: 'Database', toolName: 'query' }
+      ])
+    })
+
+    it('returns namespaced id as-is', () => {
+      expect(resolveToolId(mapping, 'github__search_repos')).toBe('github__search_repos')
+      expect(resolveToolId(mapping, 'unknown__tool')).toBe('unknown__tool')
+    })
+
+    it('resolves JS name to namespaced id', () => {
+      expect(resolveToolId(mapping, 'githubSearchRepos')).toBe('github__search_repos')
+      expect(resolveToolId(mapping, 'databaseQuery')).toBe('database__query')
+    })
+
+    it('returns undefined for unknown JS name', () => {
+      expect(resolveToolId(mapping, 'unknownTool')).toBeUndefined()
+    })
+
+    it('returns undefined for empty input', () => {
+      expect(resolveToolId(mapping, '')).toBeUndefined()
+    })
+  })
+})

--- a/src/main/mcpServers/hub/mcp-bridge.ts
+++ b/src/main/mcpServers/hub/mcp-bridge.ts
@@ -40,6 +40,25 @@ export function clearToolMap(): void {
 }
 
 /**
+ * Resolve a hub tool JS name (or namespaced id) to its original serverId and toolName.
+ * Returns null if the mapping is not initialized or the name cannot be resolved.
+ */
+export function resolveHubToolName(nameOrId: string): { serverId: string; toolName: string } | null {
+  if (!toolNameMapping) return null
+
+  const toolId = resolveToolId(toolNameMapping, nameOrId)
+  if (!toolId) return null
+
+  const separatorIndex = toolId.indexOf('__')
+  if (separatorIndex === -1) return null
+
+  return {
+    serverId: toolId.substring(0, separatorIndex),
+    toolName: toolId.substring(separatorIndex + 2)
+  }
+}
+
+/**
  * Call a tool by either:
  * - JS name (camelCase), e.g. "githubSearchRepos"
  * - original tool id (namespaced), e.g. "github__search_repos"

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -417,6 +417,8 @@ const api = {
       return ipcRenderer.invoke(IpcChannel.Mcp_UploadDxt, buffer, file.name)
     },
     abortTool: (callId: string) => ipcRenderer.invoke(IpcChannel.Mcp_AbortTool, callId),
+    resolveHubTool: (nameOrId: string): Promise<{ serverId: string; toolName: string } | null> =>
+      ipcRenderer.invoke(IpcChannel.Mcp_ResolveHubTool, nameOrId),
     getServerVersion: (server: MCPServer): Promise<string | null> =>
       ipcRenderer.invoke(IpcChannel.Mcp_GetServerVersion, server),
     getServerLogs: (server: MCPServer): Promise<MCPServerLogEntry[]> =>

--- a/src/renderer/src/aiCore/utils/mcp.ts
+++ b/src/renderer/src/aiCore/utils/mcp.ts
@@ -1,4 +1,5 @@
 import { loggerService } from '@logger'
+import store from '@renderer/store'
 import type { MCPCallToolResponse, MCPTool, MCPToolResponse } from '@renderer/types'
 import { callMCPTool, getMcpServerByTool, isToolAutoApproved } from '@renderer/utils/mcp-tools'
 import { requestToolConfirmation } from '@renderer/utils/userConfirmation'
@@ -91,7 +92,29 @@ export function convertMcpToolsToAiSdkTools(mcpTools: MCPTool[], allowedTools?: 
       execute: async (params, { toolCallId }) => {
         // 检查是否启用自动批准
         const server = getMcpServerByTool(mcpTool)
-        const isAutoApproveEnabled = isToolAutoApproved(mcpTool, server, allowedTools)
+        let isAutoApproveEnabled = isToolAutoApproved(mcpTool, server, allowedTools)
+
+        // For hub invoke/exec, resolve the underlying tool and check its server's auto-approve config
+        if (
+          !isAutoApproveEnabled &&
+          mcpTool.serverId === 'hub' &&
+          (mcpTool.name === 'invoke' || mcpTool.name === 'exec')
+        ) {
+          const underlyingToolName = (params as Record<string, unknown>)?.name as string | undefined
+          if (underlyingToolName) {
+            try {
+              const resolved = await window.api.mcp.resolveHubTool(underlyingToolName)
+              if (resolved) {
+                const underlyingServer = store.getState().mcp.servers.find((s) => s.id === resolved.serverId)
+                if (underlyingServer) {
+                  isAutoApproveEnabled = !underlyingServer.disabledAutoApproveTools?.includes(resolved.toolName)
+                }
+              }
+            } catch (err) {
+              logger.warn('Failed to resolve hub tool for auto-approve check', err as Error)
+            }
+          }
+        }
 
         let confirmed = true
 

--- a/src/renderer/src/utils/__tests__/mcp-tools-approval.test.ts
+++ b/src/renderer/src/utils/__tests__/mcp-tools-approval.test.ts
@@ -1,0 +1,150 @@
+import type { MCPServer, MCPTool } from '@renderer/types'
+import { describe, expect, it, vi } from 'vitest'
+
+// Mock all transitive dependencies that cause initialization errors
+vi.mock('@renderer/store', () => ({
+  default: {
+    getState: vi.fn(() => ({ mcp: { servers: [] } })),
+    dispatch: vi.fn(),
+    subscribe: vi.fn()
+  }
+}))
+
+vi.mock('@renderer/store/mcp', () => ({
+  hubMCPServer: { id: 'hub', name: 'MCP Hub', type: 'inMemory', isActive: true },
+  addMCPServer: vi.fn()
+}))
+
+vi.mock('@renderer/store/assistants', () => ({
+  default: vi.fn(),
+  setDefaultAssistant: vi.fn()
+}))
+
+vi.mock('@renderer/services/AssistantService', () => ({
+  getDefaultAssistant: vi.fn(() => ({})),
+  getDefaultTopic: vi.fn(() => ({}))
+}))
+
+vi.mock('@renderer/i18n', () => ({
+  default: { t: vi.fn((key: string) => key) }
+}))
+
+vi.mock('@renderer/services/SpanManagerService', () => ({
+  currentSpan: vi.fn()
+}))
+
+vi.mock('@renderer/config/models', () => ({
+  isFunctionCallingModel: vi.fn(),
+  isVisionModel: vi.fn()
+}))
+
+import { isToolAutoApproved } from '../mcp-tools'
+
+function makeTool(overrides: Partial<MCPTool> = {}): MCPTool {
+  return {
+    id: 'server1__tool1',
+    name: 'tool1',
+    serverId: 'server1',
+    serverName: 'Server 1',
+    description: 'A test tool',
+    inputSchema: { type: 'object' },
+    type: 'mcp',
+    ...overrides
+  }
+}
+
+function makeServer(overrides: Partial<MCPServer> = {}): MCPServer {
+  return {
+    id: 'server1',
+    name: 'Server 1',
+    type: 'stdio',
+    isActive: true,
+    command: 'test',
+    ...overrides
+  } as MCPServer
+}
+
+describe('isToolAutoApproved', () => {
+  describe('built-in tools', () => {
+    it('returns true for built-in tools', () => {
+      const tool = makeTool({ isBuiltIn: true })
+      expect(isToolAutoApproved(tool)).toBe(true)
+    })
+  })
+
+  describe('agent allowed_tools', () => {
+    it('returns true when tool.id is in allowedTools', () => {
+      const tool = makeTool({ id: 'server1__tool1' })
+      expect(isToolAutoApproved(tool, undefined, ['server1__tool1'])).toBe(true)
+    })
+
+    it('returns false when tool.id is not in allowedTools', () => {
+      const tool = makeTool({ id: 'server1__tool1' })
+      const server = makeServer({ disabledAutoApproveTools: ['tool1'] })
+      expect(isToolAutoApproved(tool, server, ['other_tool'])).toBe(false)
+    })
+  })
+
+  describe('server-level auto-approve', () => {
+    it('returns true when tool is not in disabledAutoApproveTools', () => {
+      const tool = makeTool({ name: 'tool1' })
+      const server = makeServer({ disabledAutoApproveTools: ['other_tool'] })
+      expect(isToolAutoApproved(tool, server)).toBe(true)
+    })
+
+    it('returns false when tool is in disabledAutoApproveTools', () => {
+      const tool = makeTool({ name: 'tool1' })
+      const server = makeServer({ disabledAutoApproveTools: ['tool1'] })
+      expect(isToolAutoApproved(tool, server)).toBe(false)
+    })
+
+    it('returns true when disabledAutoApproveTools is undefined', () => {
+      const tool = makeTool({ name: 'tool1' })
+      const server = makeServer({ disabledAutoApproveTools: undefined })
+      expect(isToolAutoApproved(tool, server)).toBe(true)
+    })
+
+    it('returns false when server is not found', () => {
+      const tool = makeTool({ serverId: 'nonexistent' })
+      expect(isToolAutoApproved(tool)).toBe(false)
+    })
+  })
+
+  describe('hub server', () => {
+    it('auto-approves list meta-tool', () => {
+      const tool = makeTool({ serverId: 'hub', name: 'list' })
+      const hubServer = makeServer({ id: 'hub' })
+      expect(isToolAutoApproved(tool, hubServer)).toBe(true)
+    })
+
+    it('auto-approves inspect meta-tool', () => {
+      const tool = makeTool({ serverId: 'hub', name: 'inspect' })
+      const hubServer = makeServer({ id: 'hub' })
+      expect(isToolAutoApproved(tool, hubServer)).toBe(true)
+    })
+
+    it('requires approval for invoke meta-tool', () => {
+      const tool = makeTool({ serverId: 'hub', name: 'invoke' })
+      const hubServer = makeServer({ id: 'hub' })
+      expect(isToolAutoApproved(tool, hubServer)).toBe(false)
+    })
+
+    it('requires approval for exec meta-tool', () => {
+      const tool = makeTool({ serverId: 'hub', name: 'exec' })
+      const hubServer = makeServer({ id: 'hub' })
+      expect(isToolAutoApproved(tool, hubServer)).toBe(false)
+    })
+
+    it('still allows built-in hub tools', () => {
+      const tool = makeTool({ serverId: 'hub', name: 'invoke', isBuiltIn: true })
+      const hubServer = makeServer({ id: 'hub' })
+      expect(isToolAutoApproved(tool, hubServer)).toBe(true)
+    })
+
+    it('still allows agent allowed_tools for hub', () => {
+      const tool = makeTool({ id: 'hub__invoke', serverId: 'hub', name: 'invoke' })
+      const hubServer = makeServer({ id: 'hub' })
+      expect(isToolAutoApproved(tool, hubServer, ['hub__invoke'])).toBe(true)
+    })
+  })
+})

--- a/src/renderer/src/utils/mcp-tools.ts
+++ b/src/renderer/src/utils/mcp-tools.ts
@@ -347,7 +347,13 @@ export function isToolAutoApproved(tool: MCPTool, server?: MCPServer, allowedToo
   }
   // Fall back to server-level auto-approve setting
   const effectiveServer = server ?? getMcpServerByTool(tool)
-  return effectiveServer ? !effectiveServer.disabledAutoApproveTools?.includes(tool.name) : false
+  if (!effectiveServer) return false
+  // Hub meta-tools: read-only tools (list, inspect) are auto-approved;
+  // execution tools (invoke, exec) require approval.
+  if (effectiveServer.id === 'hub') {
+    return tool.name === 'list' || tool.name === 'inspect'
+  }
+  return !effectiveServer.disabledAutoApproveTools?.includes(tool.name)
 }
 
 export function parseToolUse(


### PR DESCRIPTION
### What this PR does

Before this PR:
- In MCP hub/auto-discovery mode, **all tools were auto-approved**, bypassing the permission system entirely. Hub tools get `serverId: 'hub'`, and `isToolAutoApproved()` always returned `true` because the hub server object has no `disabledAutoApproveTools` field.

After this PR:
- Hub meta-tools `list` and `inspect` remain auto-approved (read-only, safe)
- Hub meta-tools `invoke` and `exec` require approval by default
- For `invoke`/`exec`, the underlying tool's server auto-approve configuration is checked via IPC, so tools that are individually auto-approved on their original server still auto-execute through the hub

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Added a new IPC channel (`Mcp_ResolveHubTool`) to resolve hub JS tool names back to their original `serverId`/`toolName` pairs, since the tool name mapping only exists in the main process
- `isToolAutoApproved()` returns `false` for hub `invoke`/`exec` by default; the execute callback in `mcp.ts` performs the IPC resolution to check the underlying tool's auto-approve setting

The following alternatives were considered:
- Embedding original server metadata in the hub tool response — rejected because the MCP protocol doesn't carry custom metadata
- Simply blocking all hub tools — rejected because `list`/`inspect` are safe read-only operations and should remain fast

### Breaking changes

None. This is a security fix — tools that previously bypassed approval will now correctly require it (unless their underlying server has auto-approve enabled).

### Special notes for your reviewer

- `mcp-bridge.ts`: Added `resolveHubToolName()` to resolve JS tool names to original `{serverId, toolName}`
- `IpcChannel.ts` / `ipc.ts` / `preload/index.ts`: New IPC channel for the resolution
- `mcp-tools.ts`: Hub-specific check in `isToolAutoApproved` — `list`/`inspect` auto-approve, others don't
- `mcp.ts`: For hub `invoke`/`exec`, resolves underlying tool and checks its server's auto-approve config
- Includes 31 unit tests across 3 test files (toolname, mcp-bridge, mcp-tools-approval)

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix hub/auto-discovery mode bypassing tool permission checks. Hub tools now correctly respect per-tool auto-approve settings from their original MCP server configuration.
```
