### PR TITLE
fix: ensure temp directory exists before document parsing

### DIFF
--- a/src/main/services/FileStorage.ts
+++ b/src/main/services/FileStorage.ts
@@ -27,7 +27,6 @@ import { isBinaryFile } from 'isbinaryfile'
 import officeParser from 'officeparser'
 import * as path from 'path'
 import { PDFDocument } from 'pdf-lib'
-import { chdir } from 'process'
 import { v4 as uuidv4 } from 'uuid'
 import WordExtractor from 'word-extractor'
 
@@ -149,13 +148,20 @@ const DEFAULT_DIRECTORY_LIST_OPTIONS: Required<DirectoryListOptions> = {
 class FileStorage {
   private storageDir = getFilesDir()
   private notesDir = getNotesDir()
-  private tempDir = getTempDir()
+  private _tempDir = getTempDir()
   private watcher?: FSWatcher
   private watcherSender?: Electron.WebContents
   private currentWatchPath?: string
   private debounceTimer?: NodeJS.Timeout
   private watcherConfig: Required<FileWatcherConfig> = DEFAULT_WATCHER_CONFIG
   private isPaused = false
+
+  private get tempDir(): string {
+    if (!fs.existsSync(this._tempDir)) {
+      fs.mkdirSync(this._tempDir, { recursive: true })
+    }
+    return this._tempDir
+  }
 
   constructor() {
     this.initStorageDir()
@@ -168,9 +174,6 @@ class FileStorage {
       }
       if (!fs.existsSync(this.notesDir)) {
         fs.mkdirSync(this.notesDir, { recursive: true })
-      }
-      if (!fs.existsSync(this.tempDir)) {
-        fs.mkdirSync(this.tempDir, { recursive: true })
       }
     } catch (error) {
       logger.error('Failed to initialize storage directories:', error as Error)
@@ -504,22 +507,18 @@ class FileStorage {
     const fileExtension = path.extname(filePath)
 
     if (documentExts.includes(fileExtension)) {
-      const originalCwd = process.cwd()
       try {
-        chdir(this.tempDir)
-
         if (fileExtension === '.doc') {
           const extractor = new WordExtractor()
           const extracted = await extractor.extract(filePath)
-          chdir(originalCwd)
           return extracted.getBody()
         }
 
-        const data = await officeParser.parseOfficeAsync(filePath)
-        chdir(originalCwd)
+        const data = await officeParser.parseOfficeAsync(filePath, {
+          tempFilesLocation: this.tempDir
+        })
         return data
       } catch (error) {
-        chdir(originalCwd)
         logger.error('Failed to read document file:', error as Error)
         throw error
       }
@@ -611,10 +610,6 @@ class FileStorage {
   }
 
   public createTempFile = async (_: Electron.IpcMainInvokeEvent, fileName: string): Promise<string> => {
-    if (!fs.existsSync(this.tempDir)) {
-      fs.mkdirSync(this.tempDir, { recursive: true })
-    }
-
     return path.join(this.tempDir, `temp_file_${uuidv4()}_${fileName}`)
   }
 


### PR DESCRIPTION
### What this PR does

Before this PR:

When the OS or cleanup tools delete the temp directory (`%TEMP%/CherryStudio`) at runtime (commonly at midnight on Windows), all document parsing (PDF, DOCX, etc.) fails with `ENOENT: no such file or directory, chdir` because `readFileCore` calls `process.chdir()` to a non-existent directory.

After this PR:

The temp directory is guaranteed to exist before every access via a self-healing getter. The `process.chdir()` hack is replaced with officeparser's native `tempFilesLocation` config option, eliminating global state mutation entirely.

Fixes #13222

### Why we need it and why it was done in this way

The root cause is that `officeparser` needs a temp directory to decompress Office/PDF files. The previous code used `process.chdir(tempDir)` to set the working directory before calling `parseOfficeAsync`, but `chdir` throws `ENOENT` if the directory doesn't exist.

The following tradeoffs were made:

- Used a getter with auto-creation instead of explicit `ensureTempDir()` calls at each use site, so future code cannot forget to check.

The following alternatives were considered:

- Adding `ensureTempDir()` before each `chdir()` call — rejected because it's easy to forget in future methods.
- Keeping `chdir()` with a directory check — rejected because `chdir()` mutates global process state and is unnecessary since officeparser supports `tempFilesLocation` natively.

### Breaking changes

None.

### Special notes for your reviewer

- `officeparser` supports a `tempFilesLocation` config option (see [officeparser docs](https://github.com/harshankur/officeparser)), making `process.chdir()` entirely unnecessary.
- The `private get tempDir()` getter ensures the directory exists on every access, protecting all current and future methods.
- Net result: 11 additions, 16 deletions — simpler and more robust.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: N/A — internal fix, no user-facing feature or behavior change
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix: document parsing (PDF, DOCX, etc.) no longer breaks after the system temp directory is cleaned at runtime
```
