### PR TITLE
feat: add timestamps to markdown export

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -58,7 +58,7 @@
       "found": {
         "title": "Git Bash configured"
       },
-      "notFound": "Git Bash not found. Please install it first.",
+      "notFound": "Git Bash not found. Please install it first."，
       "pick": {
         "button": "Select Git Bash Path",
         "failed": "Failed to set Git Bash path",
@@ -84,7 +84,7 @@
     },
     "session": {
       "accessible_paths": {
-        "add": "Add directory",
+        "add": "Add directory"，
         "default_hint": "A default workspace will be created automatically if not specified.",
         "duplicate": "This directory is already included.",
         "empty": "Select at least one directory that the agent can access.",
@@ -3543,7 +3543,7 @@
     "advanced": {
       "auto_switch_to_topics": "Auto switch to topic",
       "title": "Advanced Settings"
-    },
+    }，
     "assistant": {
       "icon": {
         "type": {
@@ -3828,6 +3828,10 @@
         "standardize_citations": {
           "help": "When enabled, citation markers will be converted to standard Markdown footnote format [^1] and citation lists will be formatted.",
           "title": "Standardize Citation Format"
+        },
+        "show_timestamp": {  
+          "title": "Show message timestamps on export",  
+          "help": "When enabled, the creation time of each message will be appended to its heading in the format YYYY-MM-DD HH:mm."  
         },
         "title": "Markdown Export"
       },

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -58,7 +58,7 @@
       "found": {
         "title": "Git Bash configured"
       },
-      "notFound": "Git Bash not found. Please install it first."，
+      "notFound": "Git Bash not found. Please install it first.",
       "pick": {
         "button": "Select Git Bash Path",
         "failed": "Failed to set Git Bash path",
@@ -84,7 +84,7 @@
     },
     "session": {
       "accessible_paths": {
-        "add": "Add directory"，
+        "add": "Add directory",
         "default_hint": "A default workspace will be created automatically if not specified.",
         "duplicate": "This directory is already included.",
         "empty": "Select at least one directory that the agent can access.",
@@ -3543,7 +3543,7 @@
     "advanced": {
       "auto_switch_to_topics": "Auto switch to topic",
       "title": "Advanced Settings"
-    }，
+    },
     "assistant": {
       "icon": {
         "type": {

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -3825,13 +3825,13 @@
           "help": "Display the model provider (e.g., OpenAI, Gemini) when exporting to Markdown",
           "title": "Show Model Provider"
         },
-        "standardize_citations": {
-          "help": "When enabled, citation markers will be converted to standard Markdown footnote format [^1] and citation lists will be formatted.",
-          "title": "Standardize Citation Format"
-        },
         "show_timestamp": {  
           "title": "Show message timestamps on export",  
           "help": "When enabled, the creation time of each message will be appended to its heading in the format YYYY-MM-DD HH:mm."  
+        },
+        "standardize_citations": {
+          "help": "When enabled, citation markers will be converted to standard Markdown footnote format [^1] and citation lists will be formatted.",
+          "title": "Standardize Citation Format"
         },
         "title": "Markdown Export"
       },

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -58,7 +58,7 @@
       "found": {
         "title": "已配置 Git Bash"
       },
-      "notFound": "未找到 Git Bash。请先安装。",
+      "notFound": "未找到 Git Bash。请先安装。"，
       "pick": {
         "button": "选择 Git Bash 路径",
         "failed": "设置 Git Bash 路径失败",
@@ -2529,7 +2529,7 @@
   "ocr": {
     "builtin": {
       "system": "系统 OCR"
-    },
+    }，
     "error": {
       "provider": {
         "cannot_remove_builtin": "不能删除内置提供商",
@@ -2987,7 +2987,7 @@
     "copy": {
       "image": "复制为图片",
       "src": "复制图片源"
-    },
+    }，
     "dialog": "打开预览窗口",
     "label": "预览",
     "pan": "移动",
@@ -3426,7 +3426,7 @@
           "description_note": {
             "mac": "若使用了快捷键或键盘映射工具对 ⌘ 键进行了重映射，可能导致部分应用无法划词。",
             "windows": "少数应用不支持通过 Ctrl 键划词。若使用了AHK等按键映射工具对 Ctrl 键进行了重映射，可能导致部分应用无法划词。"
-          },
+          }，
           "selected": "划词",
           "selected_note": "划词后立即显示工具栏",
           "shortcut": "快捷键",
@@ -3828,6 +3828,10 @@
         "standardize_citations": {
           "help": "开启后，导出 Markdown 时会将引用标记转换为标准 Markdown 脚注格式 [^1]，并格式化引用列表",
           "title": "标准化引用格式"
+        },
+        "show_timestamp": {  
+          "title": "导出时显示消息时间戳",  
+          "help": "开启后，导出 Markdown 时每条消息标题后会附加发送时间，格式为 YYYY-MM-DD HH:mm"  
         },
         "title": "Markdown 导出"
       },

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -58,7 +58,7 @@
       "found": {
         "title": "已配置 Git Bash"
       },
-      "notFound": "未找到 Git Bash。请先安装。"，
+      "notFound": "未找到 Git Bash。请先安装。",
       "pick": {
         "button": "选择 Git Bash 路径",
         "failed": "设置 Git Bash 路径失败",
@@ -2529,7 +2529,7 @@
   "ocr": {
     "builtin": {
       "system": "系统 OCR"
-    }，
+    },
     "error": {
       "provider": {
         "cannot_remove_builtin": "不能删除内置提供商",
@@ -2987,7 +2987,7 @@
     "copy": {
       "image": "复制为图片",
       "src": "复制图片源"
-    }，
+    },
     "dialog": "打开预览窗口",
     "label": "预览",
     "pan": "移动",
@@ -3426,7 +3426,7 @@
           "description_note": {
             "mac": "若使用了快捷键或键盘映射工具对 ⌘ 键进行了重映射，可能导致部分应用无法划词。",
             "windows": "少数应用不支持通过 Ctrl 键划词。若使用了AHK等按键映射工具对 Ctrl 键进行了重映射，可能导致部分应用无法划词。"
-          }，
+          },
           "selected": "划词",
           "selected_note": "划词后立即显示工具栏",
           "shortcut": "快捷键",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -3825,13 +3825,13 @@
           "help": "在导出 Markdown 时显示模型供应商，如 OpenAI、Gemini 等",
           "title": "显示模型供应商"
         },
-        "standardize_citations": {
-          "help": "开启后，导出 Markdown 时会将引用标记转换为标准 Markdown 脚注格式 [^1]，并格式化引用列表",
-          "title": "标准化引用格式"
-        },
         "show_timestamp": {  
           "title": "导出时显示消息时间戳",  
           "help": "开启后，导出 Markdown 时每条消息标题后会附加发送时间，格式为 YYYY-MM-DD HH:mm"  
+        },
+        "standardize_citations": {
+          "help": "开启后，导出 Markdown 时会将引用标记转换为标准 Markdown 脚注格式 [^1]，并格式化引用列表",
+          "title": "标准化引用格式"
         },
         "title": "Markdown 导出"
       },

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -3825,6 +3825,10 @@
           "help": "在匯出 Markdown 時顯示模型供應商，如 OpenAI、Gemini 等",
           "title": "顯示模型供應商"
         },
+        "show_timestamp": {  
+          "title": "匯出時顯示訊息時間戳記",  
+          "help": "開啟後，匯出 Markdown 時每條訊息標題後會附加傳送時間，格式為 YYYY-MM-DD HH:mm"  
+        },
         "standardize_citations": {
           "help": "將引用標記轉換為標準 Markdown 腳註格式 [^1]，並格式化引用列表",
           "title": "標準化引用格式"

--- a/src/renderer/src/pages/settings/DataSettings/MarkdownExportSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/MarkdownExportSettings.tsx
@@ -1,10 +1,4 @@
 import { DeleteOutlined, FolderOpenOutlined } from '@ant-design/icons'
-import { Button, Switch } from 'antd'
-import Input from 'antd/es/input/Input'
-import type { FC } from 'react'
-import { useTranslation } from 'react-i18next'
-import { useSelector } from 'react-redux'
-
 import { HStack } from '@renderer/components/Layout'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import type { RootState } from '@renderer/store'
@@ -19,15 +13,13 @@ import {
   setStandardizeCitationsInExport,
   setUseTopicNamingForMessageTitle
 } from '@renderer/store/settings'
+import { Button, Switch } from 'antd'
+import Input from 'antd/es/input/Input'
+import type { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
 
-import {
-  SettingDivider,
-  SettingGroup,
-  SettingHelpText,
-  SettingRow,
-  SettingRowTitle,
-  SettingTitle
-} from '..'
+import { SettingDivider, SettingGroup, SettingHelpText, SettingRow, SettingRowTitle, SettingTitle } from '..'
 
 const MarkdownExportSettings: FC = () => {
   const { t } = useTranslation()

--- a/src/renderer/src/pages/settings/DataSettings/MarkdownExportSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/MarkdownExportSettings.tsx
@@ -10,6 +10,7 @@ import {
   setShowModelNameInMarkdown,
   setShowModelProviderInMarkdown,
   setStandardizeCitationsInExport,
+  setShowTimestampInMarkdown,
   setUseTopicNamingForMessageTitle
 } from '@renderer/store/settings'
 import { Button, Switch } from 'antd'
@@ -30,6 +31,7 @@ const MarkdownExportSettings: FC = () => {
   const useTopicNamingForMessageTitle = useSelector((state: RootState) => state.settings.useTopicNamingForMessageTitle)
   const showModelNameInExport = useSelector((state: RootState) => state.settings.showModelNameInMarkdown)
   const showModelProviderInMarkdown = useSelector((state: RootState) => state.settings.showModelProviderInMarkdown)
+  const showTimestampInMarkdown = useSelector((state: RootState) => state.settings.showTimestampInMarkdown)
   const excludeCitationsInExport = useSelector((state: RootState) => state.settings.excludeCitationsInExport)
   const standardizeCitationsInExport = useSelector((state: RootState) => state.settings.standardizeCitationsInExport)
 
@@ -59,7 +61,11 @@ const MarkdownExportSettings: FC = () => {
   const handleToggleShowModelProvider = (checked: boolean) => {
     dispatch(setShowModelProviderInMarkdown(checked))
   }
-
+  
+  const handleToggleShowTimestamp = (checked: boolean) => {  
+  dispatch(setShowTimestampInMarkdown(checked))  
+  }
+  
   const handleToggleExcludeCitations = (checked: boolean) => {
     dispatch(setExcludeCitationsInExport(checked))
   }
@@ -126,6 +132,14 @@ const MarkdownExportSettings: FC = () => {
       </SettingRow>
       <SettingRow>
         <SettingHelpText>{t('settings.data.markdown_export.show_model_provider.help')}</SettingHelpText>
+      </SettingRow>
+      <SettingDivider />  
+      <SettingRow>  
+        <SettingRowTitle>{t('settings.data.markdown_export.show_timestamp.title')}</SettingRowTitle>  
+        <Switch checked={showTimestampInMarkdown} onChange={handleToggleShowTimestamp} />  
+      </SettingRow>  
+      <SettingRow>  
+        <SettingHelpText>{t('settings.data.markdown_export.show_timestamp.help')}</SettingHelpText>  
       </SettingRow>
       <SettingDivider />
       <SettingRow>

--- a/src/renderer/src/pages/settings/DataSettings/MarkdownExportSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/MarkdownExportSettings.tsx
@@ -1,4 +1,10 @@
 import { DeleteOutlined, FolderOpenOutlined } from '@ant-design/icons'
+import { Button, Switch } from 'antd'
+import Input from 'antd/es/input/Input'
+import type { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
+
 import { HStack } from '@renderer/components/Layout'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import type { RootState } from '@renderer/store'
@@ -9,17 +15,19 @@ import {
   setmarkdownExportPath,
   setShowModelNameInMarkdown,
   setShowModelProviderInMarkdown,
-  setStandardizeCitationsInExport,
   setShowTimestampInMarkdown,
+  setStandardizeCitationsInExport,
   setUseTopicNamingForMessageTitle
 } from '@renderer/store/settings'
-import { Button, Switch } from 'antd'
-import Input from 'antd/es/input/Input'
-import type { FC } from 'react'
-import { useTranslation } from 'react-i18next'
-import { useSelector } from 'react-redux'
 
-import { SettingDivider, SettingGroup, SettingHelpText, SettingRow, SettingRowTitle, SettingTitle } from '..'
+import {
+  SettingDivider,
+  SettingGroup,
+  SettingHelpText,
+  SettingRow,
+  SettingRowTitle,
+  SettingTitle
+} from '..'
 
 const MarkdownExportSettings: FC = () => {
   const { t } = useTranslation()

--- a/src/renderer/src/store/settings.ts
+++ b/src/renderer/src/store/settings.ts
@@ -172,6 +172,7 @@ export interface SettingsState {
   notionExportReasoning: boolean
   excludeCitationsInExport: boolean
   standardizeCitationsInExport: boolean
+  showTimestampInMarkdown: boolean
   yuqueToken: string | null
   yuqueUrl: string | null
   yuqueRepoId: string | null

--- a/src/renderer/src/store/settings.ts
+++ b/src/renderer/src/store/settings.ts
@@ -422,7 +422,7 @@ export const initialState: SettingsState = {
   },
   // Local backup settings
   localBackupDir: '',
-  localBackupAutoSync: false，
+  localBackupAutoSync: false,
   localBackupSyncInterval: 0,
   localBackupMaxBackups: 0,
   localBackupSkipBackupFile: false,
@@ -430,8 +430,8 @@ export const initialState: SettingsState = {
   s3: {
     endpoint: '',
     region: '',
-    bucket: ''，
-    accessKeyId: ''，
+    bucket: '',
+    accessKeyId: '',
     secretAccessKey: '',
     root: '',
     autoSync: false,
@@ -441,14 +441,14 @@ export const initialState: SettingsState = {
   },
 
   // Developer mode
-  enableDeveloperMode: false，
+  enableDeveloperMode: false,
   // UI
   navbarPosition: 'top',
   // API Server
   apiServer: {
     enabled: false,
-    host: API_SERVER_DEFAULTS。HOST，
-    port: API_SERVER_DEFAULTS。PORT,
+    host: API_SERVER_DEFAULTS.HOST,
+    port: API_SERVER_DEFAULTS.PORT,
     apiKey: `cs-sk-${uuid()}`
   },
   showMessageOutline: false
@@ -475,7 +475,7 @@ const settingsSlice = createSlice({
     },
     setSendMessageShortcut: (state, action: PayloadAction<SendMessageShortcut>) => {
       state.sendMessageShortcut = action.payload
-    }，
+    },
     setLanguage: (state, action: PayloadAction<LanguageVarious>) => {
       state.language = action.payload
     },
@@ -490,7 +490,7 @@ const settingsSlice = createSlice({
     },
     setProxyBypassRules: (state, action: PayloadAction<string | undefined>) => {
       state.proxyBypassRules = action.payload
-    }，
+    },
     setUserName: (state, action: PayloadAction<string>) => {
       state.userName = action.payload
     },
@@ -535,7 +535,7 @@ const settingsSlice = createSlice({
     },
     setTopicPosition: (state, action: PayloadAction<'left' | 'right'>) => {
       state.topicPosition = action.payload
-    }，
+    },
     setShowTopicTime: (state, action: PayloadAction<boolean>) => {
       state.showTopicTime = action.payload
     },
@@ -582,7 +582,7 @@ const settingsSlice = createSlice({
       state.webdavAutoSync = action.payload
     },
     setWebdavSyncInterval: (state, action: PayloadAction<number>) => {
-      state。webdavSyncInterval = action.payload
+      state.webdavSyncInterval = action.payload
     },
     setWebdavMaxBackups: (state, action: PayloadAction<number>) => {
       state.webdavMaxBackups = action.payload
@@ -674,7 +674,7 @@ const settingsSlice = createSlice({
       state.gridPopoverTrigger = action.payload
     },
     setMessageStyle: (state, action: PayloadAction<'plain' | 'bubble'>) => {
-      state。messageStyle = action.payload
+      state.messageStyle = action.payload
     },
     setTranslateModelPrompt: (state, action: PayloadAction<string>) => {
       state.translateModelPrompt = action.payload
@@ -733,7 +733,7 @@ const settingsSlice = createSlice({
       state.forceDollarMathInMarkdown = action.payload
     },
     setUseTopicNamingForMessageTitle: (state, action: PayloadAction<boolean>) => {
-      state。useTopicNamingForMessageTitle = action.payload
+      state.useTopicNamingForMessageTitle = action.payload
     },
     setShowModelNameInMarkdown: (state, action: PayloadAction<boolean>) => {
       state.showModelNameInMarkdown = action.payload
@@ -820,7 +820,7 @@ const settingsSlice = createSlice({
       state.spellCheckLanguages = action.payload
     },
     setExportMenuOptions: (state, action: PayloadAction<typeof initialState.exportMenuOptions>) => {
-      state。exportMenuOptions = action.payload
+      state.exportMenuOptions = action.payload
     },
     setEnableQuickPanelTriggers: (state, action: PayloadAction<boolean>) => {
       state.enableQuickPanelTriggers = action.payload
@@ -829,10 +829,10 @@ const settingsSlice = createSlice({
       state.confirmDeleteMessage = action.payload
     },
     setConfirmRegenerateMessage: (state, action: PayloadAction<boolean>) => {
-      state。confirmRegenerateMessage = action.payload
+      state.confirmRegenerateMessage = action.payload
     },
     setDisableHardwareAcceleration: (state, action: PayloadAction<boolean>) => {
-      state。disableHardwareAcceleration = action.payload
+      state.disableHardwareAcceleration = action.payload
     },
     setUseSystemTitleBar: (state, action: PayloadAction<boolean>) => {
       state.useSystemTitleBar = action.payload
@@ -844,14 +844,14 @@ const settingsSlice = createSlice({
       state.openAI.verbosity = action.payload
     },
     setOpenAIStreamOptionsIncludeUsage: (
-      state，
+      state,
       action: PayloadAction<OpenAICompletionsStreamOptions['include_usage']>
     ) => {
       state.openAI.streamOptions.includeUsage = action.payload
     },
     setNotificationSettings: (state, action: PayloadAction<SettingsState['notification']>) => {
       state.notification = action.payload
-    }，
+    },
     // Local backup settings
     setLocalBackupDir: (state, action: PayloadAction<string>) => {
       state.localBackupDir = action.payload
@@ -863,7 +863,7 @@ const settingsSlice = createSlice({
       state.localBackupSyncInterval = action.payload
     },
     setLocalBackupMaxBackups: (state, action: PayloadAction<number>) => {
-      state。localBackupMaxBackups = action.payload
+      state.localBackupMaxBackups = action.payload
     },
     setLocalBackupSkipBackupFile: (state, action: PayloadAction<boolean>) => {
       state.localBackupSkipBackupFile = action.payload
@@ -881,7 +881,7 @@ const settingsSlice = createSlice({
       state.enableDeveloperMode = action.payload
     },
     setNavbarPosition: (state, action: PayloadAction<'left' | 'top'>) => {
-      state。navbarPosition = action.payload
+      state.navbarPosition = action.payload
     },
     // API Server actions
     setApiServerEnabled: (state, action: PayloadAction<boolean>) => {
@@ -892,7 +892,7 @@ const settingsSlice = createSlice({
     },
     setApiServerPort: (state, action: PayloadAction<number>) => {
       state.apiServer = {
-        ...state。apiServer,
+        ...state.apiServer,
         port: action.payload
       }
     },

--- a/src/renderer/src/store/settings.ts
+++ b/src/renderer/src/store/settings.ts
@@ -362,6 +362,7 @@ export const initialState: SettingsState = {
   thoughtAutoCollapse: true,
   notionExportReasoning: false,
   excludeCitationsInExport: false,
+  showTimestampInMarkdown: false,
   standardizeCitationsInExport: false,
   yuqueToken: '',
   yuqueUrl: '',
@@ -421,7 +422,7 @@ export const initialState: SettingsState = {
   },
   // Local backup settings
   localBackupDir: '',
-  localBackupAutoSync: false,
+  localBackupAutoSync: false，
   localBackupSyncInterval: 0,
   localBackupMaxBackups: 0,
   localBackupSkipBackupFile: false,
@@ -429,8 +430,8 @@ export const initialState: SettingsState = {
   s3: {
     endpoint: '',
     region: '',
-    bucket: '',
-    accessKeyId: '',
+    bucket: ''，
+    accessKeyId: ''，
     secretAccessKey: '',
     root: '',
     autoSync: false,
@@ -440,14 +441,14 @@ export const initialState: SettingsState = {
   },
 
   // Developer mode
-  enableDeveloperMode: false,
+  enableDeveloperMode: false，
   // UI
   navbarPosition: 'top',
   // API Server
   apiServer: {
     enabled: false,
-    host: API_SERVER_DEFAULTS.HOST,
-    port: API_SERVER_DEFAULTS.PORT,
+    host: API_SERVER_DEFAULTS。HOST，
+    port: API_SERVER_DEFAULTS。PORT,
     apiKey: `cs-sk-${uuid()}`
   },
   showMessageOutline: false
@@ -474,7 +475,7 @@ const settingsSlice = createSlice({
     },
     setSendMessageShortcut: (state, action: PayloadAction<SendMessageShortcut>) => {
       state.sendMessageShortcut = action.payload
-    },
+    }，
     setLanguage: (state, action: PayloadAction<LanguageVarious>) => {
       state.language = action.payload
     },
@@ -489,7 +490,7 @@ const settingsSlice = createSlice({
     },
     setProxyBypassRules: (state, action: PayloadAction<string | undefined>) => {
       state.proxyBypassRules = action.payload
-    },
+    }，
     setUserName: (state, action: PayloadAction<string>) => {
       state.userName = action.payload
     },
@@ -534,7 +535,7 @@ const settingsSlice = createSlice({
     },
     setTopicPosition: (state, action: PayloadAction<'left' | 'right'>) => {
       state.topicPosition = action.payload
-    },
+    }，
     setShowTopicTime: (state, action: PayloadAction<boolean>) => {
       state.showTopicTime = action.payload
     },
@@ -581,7 +582,7 @@ const settingsSlice = createSlice({
       state.webdavAutoSync = action.payload
     },
     setWebdavSyncInterval: (state, action: PayloadAction<number>) => {
-      state.webdavSyncInterval = action.payload
+      state。webdavSyncInterval = action.payload
     },
     setWebdavMaxBackups: (state, action: PayloadAction<number>) => {
       state.webdavMaxBackups = action.payload
@@ -673,7 +674,7 @@ const settingsSlice = createSlice({
       state.gridPopoverTrigger = action.payload
     },
     setMessageStyle: (state, action: PayloadAction<'plain' | 'bubble'>) => {
-      state.messageStyle = action.payload
+      state。messageStyle = action.payload
     },
     setTranslateModelPrompt: (state, action: PayloadAction<string>) => {
       state.translateModelPrompt = action.payload
@@ -732,13 +733,16 @@ const settingsSlice = createSlice({
       state.forceDollarMathInMarkdown = action.payload
     },
     setUseTopicNamingForMessageTitle: (state, action: PayloadAction<boolean>) => {
-      state.useTopicNamingForMessageTitle = action.payload
+      state。useTopicNamingForMessageTitle = action.payload
     },
     setShowModelNameInMarkdown: (state, action: PayloadAction<boolean>) => {
       state.showModelNameInMarkdown = action.payload
     },
     setShowModelProviderInMarkdown: (state, action: PayloadAction<boolean>) => {
       state.showModelProviderInMarkdown = action.payload
+    },
+    setShowTimestampInMarkdown: (state, action: PayloadAction<boolean>) => {  
+      state.showTimestampInMarkdown = action.payload  
     },
     setThoughtAutoCollapse: (state, action: PayloadAction<boolean>) => {
       state.thoughtAutoCollapse = action.payload
@@ -816,7 +820,7 @@ const settingsSlice = createSlice({
       state.spellCheckLanguages = action.payload
     },
     setExportMenuOptions: (state, action: PayloadAction<typeof initialState.exportMenuOptions>) => {
-      state.exportMenuOptions = action.payload
+      state。exportMenuOptions = action.payload
     },
     setEnableQuickPanelTriggers: (state, action: PayloadAction<boolean>) => {
       state.enableQuickPanelTriggers = action.payload
@@ -825,10 +829,10 @@ const settingsSlice = createSlice({
       state.confirmDeleteMessage = action.payload
     },
     setConfirmRegenerateMessage: (state, action: PayloadAction<boolean>) => {
-      state.confirmRegenerateMessage = action.payload
+      state。confirmRegenerateMessage = action.payload
     },
     setDisableHardwareAcceleration: (state, action: PayloadAction<boolean>) => {
-      state.disableHardwareAcceleration = action.payload
+      state。disableHardwareAcceleration = action.payload
     },
     setUseSystemTitleBar: (state, action: PayloadAction<boolean>) => {
       state.useSystemTitleBar = action.payload
@@ -840,14 +844,14 @@ const settingsSlice = createSlice({
       state.openAI.verbosity = action.payload
     },
     setOpenAIStreamOptionsIncludeUsage: (
-      state,
+      state，
       action: PayloadAction<OpenAICompletionsStreamOptions['include_usage']>
     ) => {
       state.openAI.streamOptions.includeUsage = action.payload
     },
     setNotificationSettings: (state, action: PayloadAction<SettingsState['notification']>) => {
       state.notification = action.payload
-    },
+    }，
     // Local backup settings
     setLocalBackupDir: (state, action: PayloadAction<string>) => {
       state.localBackupDir = action.payload
@@ -859,7 +863,7 @@ const settingsSlice = createSlice({
       state.localBackupSyncInterval = action.payload
     },
     setLocalBackupMaxBackups: (state, action: PayloadAction<number>) => {
-      state.localBackupMaxBackups = action.payload
+      state。localBackupMaxBackups = action.payload
     },
     setLocalBackupSkipBackupFile: (state, action: PayloadAction<boolean>) => {
       state.localBackupSkipBackupFile = action.payload
@@ -877,7 +881,7 @@ const settingsSlice = createSlice({
       state.enableDeveloperMode = action.payload
     },
     setNavbarPosition: (state, action: PayloadAction<'left' | 'top'>) => {
-      state.navbarPosition = action.payload
+      state。navbarPosition = action.payload
     },
     // API Server actions
     setApiServerEnabled: (state, action: PayloadAction<boolean>) => {
@@ -888,7 +892,7 @@ const settingsSlice = createSlice({
     },
     setApiServerPort: (state, action: PayloadAction<number>) => {
       state.apiServer = {
-        ...state.apiServer,
+        ...state。apiServer,
         port: action.payload
       }
     },
@@ -905,6 +909,7 @@ const settingsSlice = createSlice({
 })
 
 export const {
+  setShowTimestampInMarkdown,
   setShowModelNameInMarkdown,
   setShowModelProviderInMarkdown,
   setShowAssistants,

--- a/src/renderer/src/utils/export.ts
+++ b/src/renderer/src/utils/export.ts
@@ -42,7 +42,7 @@ const setExportingState = (isExporting: boolean) => {
  */
 const sanitizeReasoningContent = (content: string): string => {
   // 先处理换行符转换为 <br>
-  const contentWithBr = content.替换(/\n/g, '<br>')
+  const contentWithBr = content.replace(/\n/g, '<br>')
 
   // 使用 DOMPurify 清理内容，保留常用的安全标签和属性
   return DOMPurify.sanitize(contentWithBr, {
@@ -60,8 +60,8 @@ const sanitizeReasoningContent = (content: string): string => {
       'u',
       's',
       'del',
-      'mark'，
-      'small'，
+      'mark',
+      'small',
       // 上标下标（数学公式、引用等）
       'sup',
       'sub',
@@ -85,8 +85,8 @@ const sanitizeReasoningContent = (content: string): string => {
       'var',
       'samp',
       // 表格（AI输出中可能包含表格）
-      'table'，
-      'thead'，
+      'table',
+      'thead',
       'tbody',
       'tfoot',
       'tr',
@@ -94,7 +94,7 @@ const sanitizeReasoningContent = (content: string): string => {
       'th',
       // 分隔线
       'hr'
-    ]，
+    ],
     ALLOWED_ATTR: [
       // 安全的通用属性
       'class',
@@ -107,7 +107,7 @@ const sanitizeReasoningContent = (content: string): string => {
       'colspan',
       'rowspan',
       // 列表属性
-      'start'，
+      'start',
       'type'
     ],
     KEEP_CONTENT: true, // 保留被移除标签的文本内容

--- a/src/renderer/src/utils/export.ts
+++ b/src/renderer/src/utils/export.ts
@@ -42,7 +42,7 @@ const setExportingState = (isExporting: boolean) => {
  */
 const sanitizeReasoningContent = (content: string): string => {
   // 先处理换行符转换为 <br>
-  const contentWithBr = content.replace(/\n/g, '<br>')
+  const contentWithBr = content.替换(/\n/g, '<br>')
 
   // 使用 DOMPurify 清理内容，保留常用的安全标签和属性
   return DOMPurify.sanitize(contentWithBr, {
@@ -60,8 +60,8 @@ const sanitizeReasoningContent = (content: string): string => {
       'u',
       's',
       'del',
-      'mark',
-      'small',
+      'mark'，
+      'small'，
       // 上标下标（数学公式、引用等）
       'sup',
       'sub',
@@ -85,8 +85,8 @@ const sanitizeReasoningContent = (content: string): string => {
       'var',
       'samp',
       // 表格（AI输出中可能包含表格）
-      'table',
-      'thead',
+      'table'，
+      'thead'，
       'tbody',
       'tfoot',
       'tr',
@@ -94,7 +94,7 @@ const sanitizeReasoningContent = (content: string): string => {
       'th',
       // 分隔线
       'hr'
-    ],
+    ]，
     ALLOWED_ATTR: [
       // 安全的通用属性
       'class',
@@ -107,7 +107,7 @@ const sanitizeReasoningContent = (content: string): string => {
       'colspan',
       'rowspan',
       // 列表属性
-      'start',
+      'start'，
       'type'
     ],
     KEEP_CONTENT: true, // 保留被移除标签的文本内容
@@ -269,9 +269,10 @@ const createBaseMarkdown = (
   excludeCitations: boolean = false,
   normalizeCitations: boolean = true
 ): { titleSection: string; reasoningSection: string; contentSection: string; citation: string } => {
-  const { forceDollarMathInMarkdown } = store.getState().settings
-  const roleText = getRoleText(message.role, message.model?.name, message.model?.provider)
-  const titleSection = `## ${roleText}`
+  const { forceDollarMathInMarkdown, showTimestampInMarkdown } = store.getState().settings  
+  const roleText = getRoleText(message.role, message.model?.name, message.model?.provider)  
+  const timestamp = showTimestampInMarkdown ? ` (${dayjs(message.createdAt).format('YYYY-MM-DD HH:mm')})` : ''  
+  const titleSection = `## ${roleText}${timestamp}`
   let reasoningSection = ''
 
   if (includeReasoning) {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

⚠️ Important: Redux/IndexedDB Data-Changing Feature PRs Temporarily On Hold ⚠️

Please note: For our current development cycle, we are not accepting feature Pull Requests that introduce changes to Redux data models or IndexedDB schemas.

While we value your contributions, PRs of this nature will be blocked without merge. We welcome all other contributions (bug fixes, perf enhancements, docs, etc.). Thank you!

Once version 2.0.0 is released, we will resume reviewing feature PRs.

-->

### What this PR does

Before this PR:
Exported Markdown conversations do not include timestamps for each message.

After this PR:
Each message in the exported Markdown now includes its timestamp, making it easier to understand the conversation timeline.

Fixes #13272

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note

```
