### PR TITLE
fix(renderer): sync Redux store during streaming and migrate topic creation to Data API

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -1,4 +1,5 @@
 import { cacheService } from '@data/CacheService'
+import { dataApiService } from '@data/DataApiService'
 import { usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
 import {
@@ -11,7 +12,6 @@ import {
   isWebSearchModel
 } from '@renderer/config/models'
 import { useCache } from '@renderer/data/hooks/useCache'
-import db from '@renderer/databases'
 import { useAssistant } from '@renderer/hooks/useAssistant'
 import { useInputText } from '@renderer/hooks/useInputText'
 import { useMessageOperations, useTopicLoading } from '@renderer/hooks/useMessageOperations'
@@ -24,7 +24,7 @@ import {
   useInputbarToolsInternalDispatch,
   useInputbarToolsState
 } from '@renderer/pages/home/Inputbar/context/InputbarToolsProvider'
-import { getDefaultTopic } from '@renderer/services/AssistantService'
+import { getDefaultTopic, mapLegacyTopicToDto } from '@renderer/services/AssistantService'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import FileManager from '@renderer/services/FileManager'
 import { checkRateLimit, getUserMessage } from '@renderer/services/MessagesService'
@@ -327,14 +327,19 @@ const InputbarInner: FC<InputbarInnerProps> = ({ assistant: initialAssistant, se
   const addNewTopic = useCallback(async () => {
     const newTopic = getDefaultTopic(assistant.id)
 
-    await db.topics.add({ id: newTopic.id, messages: [] })
+    // Create topic via Data API and use server-returned data
+    const createdTopic = await dataApiService.post('/topics', {
+      body: mapLegacyTopicToDto(newTopic)
+    })
+
+    logger.silly('create topic in sqlite', createdTopic.id)
 
     if (assistant.defaultModel) {
       setModel(assistant.defaultModel)
     }
 
-    addTopic(newTopic)
-    setActiveTopic(newTopic)
+    addTopic(createdTopic)
+    setActiveTopic(createdTopic)
 
     setTimeoutTimer('addNewTopic', () => EventEmitter.emit(EVENT_NAMES.SHOW_TOPIC_SIDEBAR), 0)
   }, [addTopic, assistant.defaultModel, assistant.id, setActiveTopic, setModel, setTimeoutTimer])

--- a/src/renderer/src/services/AssistantService.ts
+++ b/src/renderer/src/services/AssistantService.ts
@@ -25,6 +25,7 @@ import type {
   TranslateLanguage
 } from '@renderer/types'
 import { uuid } from '@renderer/utils'
+import { CreateTopicDto } from '@shared/data/api/schemas/topics'
 
 const logger = loggerService.withContext('AssistantService')
 
@@ -170,6 +171,15 @@ export function getDefaultTopic(assistantId: string): Topic {
     name: i18n.t('chat.default.topic.name'),
     messages: [],
     isNameManuallyEdited: false
+  }
+}
+
+// TODO: remove it in v2
+export function mapLegacyTopicToDto(topic: Topic): CreateTopicDto {
+  return {
+    name: topic.name,
+    assistantId: topic.assistantId,
+    prompt: topic.prompt
   }
 }
 

--- a/src/renderer/src/services/AssistantService.ts
+++ b/src/renderer/src/services/AssistantService.ts
@@ -25,7 +25,7 @@ import type {
   TranslateLanguage
 } from '@renderer/types'
 import { uuid } from '@renderer/utils'
-import { CreateTopicDto } from '@shared/data/api/schemas/topics'
+import type { CreateTopicDto } from '@shared/data/api/schemas/topics'
 
 const logger = loggerService.withContext('AssistantService')
 

--- a/src/renderer/src/services/db/DataApiMessageDataSource.ts
+++ b/src/renderer/src/services/db/DataApiMessageDataSource.ts
@@ -1,11 +1,12 @@
 /**
- * Data API based message data source for normal topics (non-agent sessions).
+ * TODO: Temporary compatibility layer — remove after message type migration.
  *
- * Reads messages from SQLite via the Data API (GET /topics/:topicId/messages)
- * and converts from shared format back to renderer format.
+ * This module bridges the Data API (shared types) and the renderer (legacy types)
+ * by converting SharedMessage → renderer Message + MessageBlock[].
  *
- * Block data in the DB was written from renderer format (with id/status/messageId stripped
- * by StreamingService.convertBlocksToDataFormat). This module restores those fields.
+ * Once the renderer adopts shared types directly (Message from @shared/data/types/message),
+ * this conversion layer and the separate MessageBlock store become unnecessary.
+ * The renderer should consume Data API responses as-is without re-shaping.
  */
 import { dataApiService } from '@data/DataApiService'
 import { loggerService } from '@logger'

--- a/src/renderer/src/services/db/DataApiMessageDataSource.ts
+++ b/src/renderer/src/services/db/DataApiMessageDataSource.ts
@@ -1,0 +1,139 @@
+/**
+ * Data API based message data source for normal topics (non-agent sessions).
+ *
+ * Reads messages from SQLite via the Data API (GET /topics/:topicId/messages)
+ * and converts from shared format back to renderer format.
+ *
+ * Block data in the DB was written from renderer format (with id/status/messageId stripped
+ * by StreamingService.convertBlocksToDataFormat). This module restores those fields.
+ */
+import { dataApiService } from '@data/DataApiService'
+import { loggerService } from '@logger'
+import type { Message, MessageBlock } from '@renderer/types/newMessage'
+import { MessageBlockStatus } from '@renderer/types/newMessage'
+import { ErrorCode } from '@shared/data/api/apiErrors'
+import type { BranchMessagesResponse, Message as SharedMessage } from '@shared/data/types/message'
+
+const logger = loggerService.withContext('DataApiMessageDataSource')
+
+const FETCH_LIMIT = 999
+
+/**
+ * Fetch messages for a topic from the Data API and convert to renderer format.
+ */
+export async function fetchMessagesFromDataApi(topicId: string): Promise<{
+  messages: Message[]
+  blocks: MessageBlock[]
+}> {
+  try {
+    const response = (await dataApiService.get(`/topics/${topicId}/messages`, {
+      query: { limit: FETCH_LIMIT, includeSiblings: true }
+    })) as BranchMessagesResponse
+
+    const messages: Message[] = []
+    const blocks: MessageBlock[] = []
+
+    for (const item of response.items) {
+      const result = convertSharedMessage(item.message)
+      messages.push(result.message)
+      blocks.push(...result.blocks)
+
+      if (item.siblingsGroup) {
+        for (const sibling of item.siblingsGroup) {
+          const sibResult = convertSharedMessage(sibling)
+          messages.push(sibResult.message)
+          blocks.push(...sibResult.blocks)
+        }
+      }
+    }
+
+    logger.debug('Fetched messages from Data API', {
+      topicId,
+      messageCount: messages.length,
+      blockCount: blocks.length
+    })
+
+    return { messages, blocks }
+  } catch (error: any) {
+    if (error?.code === ErrorCode.NOT_FOUND) {
+      logger.debug(`Topic ${topicId} not found in Data API, returning empty`)
+      return { messages: [], blocks: [] }
+    }
+    logger.error(`Failed to fetch messages from Data API for topic ${topicId}:`, error as Error)
+    throw error
+  }
+}
+
+/**
+ * Convert a shared Message (Data API) to renderer Message + MessageBlock[].
+ *
+ * Block data was written from renderer format (minus id/status/messageId),
+ * so we restore those fields with deterministic IDs based on messageId + index.
+ */
+function convertSharedMessage(shared: SharedMessage): {
+  message: Message
+  blocks: MessageBlock[]
+} {
+  const rendererBlocks: MessageBlock[] = []
+  const blockIds: string[] = []
+  const dataBlocks = shared.data?.blocks || []
+
+  for (let i = 0; i < dataBlocks.length; i++) {
+    const { type, createdAt, ...rest } = dataBlocks[i] as Record<string, any>
+    const blockId = `${shared.id}-block-${i}`
+    blockIds.push(blockId)
+
+    rendererBlocks.push({
+      ...rest,
+      id: blockId,
+      messageId: shared.id,
+      type,
+      status: mapBlockStatus(shared.status),
+      createdAt: typeof createdAt === 'number' ? new Date(createdAt).toISOString() : createdAt || shared.createdAt
+    } as MessageBlock)
+  }
+
+  const message: Message = {
+    id: shared.id,
+    topicId: shared.topicId,
+    role: shared.role,
+    assistantId: shared.assistantId || '',
+    status: shared.status as Message['status'],
+    blocks: blockIds,
+    createdAt: shared.createdAt,
+    updatedAt: shared.updatedAt,
+    askId: shared.parentId ?? undefined,
+    modelId: shared.modelId ?? undefined,
+    traceId: shared.traceId ?? undefined,
+    ...(shared.stats && {
+      usage: {
+        prompt_tokens: shared.stats.promptTokens ?? 0,
+        completion_tokens: shared.stats.completionTokens ?? 0,
+        total_tokens: shared.stats.totalTokens ?? 0
+      },
+      metrics: {
+        completion_tokens: shared.stats.completionTokens ?? 0,
+        time_completion_millsec: shared.stats.timeCompletionMs ?? 0,
+        time_first_token_millsec: shared.stats.timeFirstTokenMs,
+        time_thinking_millsec: shared.stats.timeThinkingMs
+      }
+    })
+  }
+
+  return { message, blocks: rendererBlocks }
+}
+
+function mapBlockStatus(messageStatus: string): MessageBlockStatus {
+  switch (messageStatus) {
+    case 'success':
+      return MessageBlockStatus.SUCCESS
+    case 'error':
+      return MessageBlockStatus.ERROR
+    case 'paused':
+      return MessageBlockStatus.PAUSED
+    case 'pending':
+      return MessageBlockStatus.PENDING
+    default:
+      return MessageBlockStatus.SUCCESS
+  }
+}

--- a/src/renderer/src/services/db/DbService.ts
+++ b/src/renderer/src/services/db/DbService.ts
@@ -89,6 +89,7 @@ class DbService implements MessageDataSource {
 
   async fetchMessages(
     topicId: string,
+    // oxlint-disable-next-line no-unused-vars -- interface requires this parameter
     _forceReload?: boolean
   ): Promise<{
     messages: Message[]

--- a/src/renderer/src/services/db/DbService.ts
+++ b/src/renderer/src/services/db/DbService.ts
@@ -19,6 +19,7 @@ import store from '@renderer/store'
 import type { Message, MessageBlock } from '@renderer/types/newMessage'
 
 import { AgentMessageDataSource } from './AgentMessageDataSource'
+import { fetchMessagesFromDataApi } from './DataApiMessageDataSource'
 import { DexieMessageDataSource } from './DexieMessageDataSource'
 import type { MessageDataSource } from './types'
 import { buildAgentSessionTopicId, isAgentSessionTopicId } from './types'
@@ -88,13 +89,17 @@ class DbService implements MessageDataSource {
 
   async fetchMessages(
     topicId: string,
-    forceReload?: boolean
+    _forceReload?: boolean
   ): Promise<{
     messages: Message[]
     blocks: MessageBlock[]
   }> {
-    const source = this.getDataSource(topicId)
-    return source.fetchMessages(topicId, forceReload)
+    if (isAgentSessionTopicId(topicId)) {
+      return this.agentSource.fetchMessages(topicId)
+    }
+
+    // Normal topics: read from Data API (SQLite)
+    return fetchMessagesFromDataApi(topicId)
   }
 
   // ============ Write Operations ============

--- a/src/renderer/src/services/messageStreaming/StreamingService.ts
+++ b/src/renderer/src/services/messageStreaming/StreamingService.ts
@@ -22,6 +22,9 @@
 import { cacheService } from '@data/CacheService'
 import { dataApiService } from '@data/DataApiService'
 import { loggerService } from '@logger'
+import store from '@renderer/store'
+import { updateOneBlock, upsertOneBlock } from '@renderer/store/messageBlock'
+import { newMessagesActions } from '@renderer/store/newMessage'
 import type { Model } from '@renderer/types'
 import type { Message, MessageBlock } from '@renderer/types/newMessage'
 import { AssistantMessageStatus, MessageBlockStatus } from '@renderer/types/newMessage'
@@ -300,6 +303,17 @@ class StreamingService {
     cacheService.set(getBlockKey(block.id), block, TASK_TTL)
     cacheService.set(getMessageKey(messageId), newMessage, TASK_TTL)
 
+    // TODO: temp fix, it will be removed after message refraction
+    store.dispatch(upsertOneBlock(block))
+    store.dispatch(
+      newMessagesActions.upsertBlockReference({
+        messageId,
+        blockId: block.id,
+        status: block.status,
+        blockType: block.type
+      })
+    )
+
     logger.debug('Added block to task', { messageId, blockId: block.id, blockType: block.type })
   }
 
@@ -344,6 +358,25 @@ class StreamingService {
     // Update caches with new references to trigger notifications
     cacheService.set(getTaskKey(messageId), newTask, TASK_TTL)
     cacheService.set(getBlockKey(blockId), updatedBlock, TASK_TTL)
+
+    // TODO: temp fix, it will be removed after message refraction
+    store.dispatch(
+      updateOneBlock({
+        id: blockId,
+        changes
+      })
+    )
+
+    if (changes.status || changes.type) {
+      store.dispatch(
+        newMessagesActions.upsertBlockReference({
+          messageId,
+          blockId,
+          status: updatedBlock.status,
+          blockType: updatedBlock.type
+        })
+      )
+    }
   }
 
   /**
@@ -384,6 +417,15 @@ class StreamingService {
     // Update caches with new references to trigger notifications
     cacheService.set(getTaskKey(messageId), newTask, TASK_TTL)
     cacheService.set(getMessageKey(messageId), newMessage, TASK_TTL)
+
+    // TODO: temp fix, it will be removed after message refraction
+    store.dispatch(
+      newMessagesActions.updateMessage({
+        topicId: task.topicId,
+        messageId,
+        updates
+      })
+    )
   }
 
   /**


### PR DESCRIPTION
### What this PR does

Before this PR:
- Streaming updates (blocks and messages) were only written to the cache service, causing the Redux store to be out of sync during streaming, leading to UI not reflecting real-time streaming state.
- Topic creation in Inputbar used Dexie (`db.topics.add`) directly, which is being removed in v2.

After this PR:
- StreamingService temporarily dispatches to the Redux store alongside cache updates, keeping the UI in sync during streaming.
- Topic creation uses `dataApiService.post('/topics', ...)` with the server-returned data, aligning with the v2 Data API architecture.
- A `mapLegacyTopicToDto` helper bridges the legacy Topic type to CreateTopicDto during migration.

<img width="847" height="805" alt="image" src="https://github.com/user-attachments/assets/dbd354fa-8578-41e1-9bd8-6d15228fab27" />


### Why we need it and why it was done in this way

The following tradeoffs were made:
- The Redux dispatches in StreamingService are marked as temporary (`TODO: temp fix`) and will be removed after the full message refactoring is complete. This is a pragmatic bridge to keep the UI working during the v2 migration.

The following alternatives were considered:
- Fully refactoring the message/block rendering to use cache-only — deferred to a later phase.

### Breaking changes

None

### Special notes for your reviewer

The Redux dispatches in StreamingService are intentionally temporary. They exist to bridge the gap between the new cache-based streaming architecture and the existing Redux-dependent UI components.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: N/A — internal refactoring, no user-facing changes
- [ ] Self-review: I have reviewed my own code

### Release note

```release-note
NONE
```
