### PR TITLE
feat(skills): add v2 data refactoring skills (migrator, data-api, renderer)

### DIFF
--- a/.agents/skills/.gitignore
+++ b/.agents/skills/.gitignore
@@ -14,3 +14,9 @@
 !gh-pr-review/**
 !prepare-release/
 !prepare-release/**
+!v2-data-api/
+!v2-data-api/**
+!v2-migrator/
+!v2-migrator/**
+!v2-renderer/
+!v2-renderer/**

--- a/.agents/skills/public-skills.txt
+++ b/.agents/skills/public-skills.txt
@@ -5,3 +5,6 @@ prepare-release
 create-skill
 gh-create-issue
 gh-pr-review
+v2-migrator
+v2-data-api
+v2-renderer

--- a/.agents/skills/v2-data-api/SKILL.md
+++ b/.agents/skills/v2-data-api/SKILL.md
@@ -1,0 +1,520 @@
+---
+name: v2-data-api
+description: Build Main-process services and APIs that expose data from SQLite to renderers. Covers the Handler -> Service -> Repository layered architecture, API schema design, database patterns, preference schema, and business logic implementation. Use when adding endpoints, creating services, designing schemas, or refactoring business logic in the v2 data layer.
+---
+
+# V2 Data API: Main-Process Services (Phase 2 of 3)
+
+Design and implement the Main-process layer that exposes SQLite data to renderers via type-safe IPC. This covers business logic, service architecture, and database access patterns.
+
+**This skill enforces strict TDD (red-green-refactor).** For every unit of work: (1) write ONE failing test (red), (2) write the minimum code to make it pass (green), (3) refactor while keeping tests green. Repeat. Run `pnpm test:main` to verify.
+
+**Related skills:**
+- `v2-migrator` - Phase 1: Migrating legacy data into SQLite
+- `v2-renderer` - Phase 3: Renderer hooks that consume these APIs
+
+## System Selection
+
+Before building a service, determine the right system:
+
+| System | When to Use | Loss Impact | Example |
+|--------|------------|-------------|---------|
+| **DataApiService** | User-created business data, structured, can grow | **Severe** | Topics, messages, assistants, files |
+| **PreferenceService** | User settings, fixed keys, stable values | Low | Theme, language, shortcuts, proxy config |
+| **CacheService** | Regenerable/temporary, no backup needed | None | API responses, scroll positions |
+
+**Decision flow:**
+1. Can data be lost without user impact? -> CacheService (no Main service needed)
+2. Is it a user setting with a fixed key? -> PreferenceService (schema-based)
+3. Is it user-created data that grows unbounded? -> DataApiService (full service stack)
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ Main Process                                                  │
+│                                                                │
+│  Handler (thin)                                                │
+│    - Extract params from request                               │
+│    - Call service, return result                                │
+│    - NO business logic                                         │
+│         │                                                      │
+│         v                                                      │
+│  Service (business logic)                                      │
+│    - Validation, authorization                                 │
+│    - Transaction coordination                                  │
+│    - Domain workflows                                          │
+│    - Orchestrates repositories or direct Drizzle               │
+│         │                                                      │
+│    ┌────┴────┐                                                 │
+│    v         v                                                 │
+│  Repository    Direct Drizzle                                  │
+│  (complex)     (simple CRUD)                                   │
+│    │              │                                            │
+│    └──────┬───────┘                                            │
+│           v                                                    │
+│  SQLite (Drizzle ORM)                                          │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**When to use Repository vs Direct Drizzle:**
+
+| Use Repository | Use Direct Drizzle |
+|---|---|
+| Complex queries (joins, subqueries, aggregations) | Simple CRUD |
+| GB-scale data with pagination | Small datasets (< 100MB) |
+| Complex multi-table transactions | Single-table operations |
+| Reusable data access patterns | Domain-specific one-off queries |
+
+## File Locations
+
+| Layer | Location |
+|-------|----------|
+| Shared API types/schemas | `packages/shared/data/api/schemas/` |
+| Handlers | `src/main/data/api/handlers/` |
+| Services | `src/main/data/services/` |
+| Repositories | `src/main/data/repositories/` (optional) |
+| DB schemas | `src/main/data/db/schemas/` |
+| Preference types | `packages/shared/data/preference/` |
+| Cache schemas | `packages/shared/data/cache/cacheSchemas.ts` |
+
+## Adding a DataApi Endpoint (Step-by-Step)
+
+### Step 1: Define SQLite Schema
+
+```typescript
+// src/main/data/db/schemas/myDomain.ts
+import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core'
+import { uuidPrimaryKey, timestamps } from './helpers'
+
+export const myDomainTable = sqliteTable('my_domain', {
+  ...uuidPrimaryKey(),        // id: text, primary key, auto-generated UUID
+  name: text('name').notNull(),
+  description: text('description'),
+  config: text('config', { mode: 'json' }).$type<MyConfig>(),
+  ...timestamps(),            // createdAt, updatedAt (auto-managed)
+})
+```
+
+**Schema conventions:**
+- Table name: singular, snake_case (`my_domain` not `myDomains`)
+- Export name: `xxxTable` (e.g., `myDomainTable`)
+- Use helpers: `uuidPrimaryKey()`, `uuidPrimaryKeyOrdered()`, `timestamps()`
+- JSON fields: `text('col', { mode: 'json' }).$type<T>()`
+- Foreign keys: use `references(() => otherTable.id)` or `foreignKey` for self-referencing
+- Soft delete: add `deletedAt` column when needed
+- After changes: run `yarn db:migrations:generate`
+
+See `docs/en/references/data/database-patterns.md` for full conventions.
+
+### Step 2: Define API Schema (Shared Types)
+
+```typescript
+// packages/shared/data/api/schemas/myDomain.ts
+export interface MyDomainSchemas {
+  '/my-domains': {
+    GET: {
+      query?: { page?: number; limit?: number }
+      response: PaginatedResponse<MyDomain>
+    }
+    POST: {
+      body: CreateMyDomainDto
+      response: MyDomain
+    }
+  }
+  '/my-domains/:id': {
+    GET: { response: MyDomain }
+    PATCH: { body: Partial<UpdateMyDomainDto>; response: MyDomain }
+    DELETE: { response: void }
+  }
+}
+```
+
+Register in `packages/shared/data/api/schemas/index.ts`:
+```typescript
+export type ApiSchemas = AssertValidSchemas<TopicSchemas & MessageSchemas & MyDomainSchemas>
+```
+
+**Path conventions:**
+- Plural nouns, kebab-case: `/my-domains`, `/knowledge-bases`
+- Nested resources: `/topics/:topicId/messages`
+- Non-CRUD actions: `POST /topics/:id/archive`
+- Query params for filtering/sorting: `?page=1&limit=20&sort=name&order=asc`
+
+See `docs/en/references/data/api-design-guidelines.md` for full rules.
+
+### Step 3: Write Service Tests (TDD Red Phase)
+
+Write failing tests for the service before implementing it. Each test must fail (red) before you proceed to Step 4. Use the main-process test mocks.
+
+```typescript
+// src/main/data/services/__tests__/MyDomainService.test.ts
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { MyDomainService } from '../MyDomainService'
+
+// Mock DbService
+vi.mock('@data/db/DbService', () => ({
+  DbService: {
+    db: {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+          orderBy: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({ offset: vi.fn().mockResolvedValue([]) })
+          }),
+        })
+      }),
+      insert: vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: '1', name: 'Test' }]) })
+      }),
+      update: vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: '1', name: 'Updated' }]) })
+        })
+      }),
+      delete: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined)
+      }),
+    },
+    transaction: vi.fn(async (fn) => fn(/* tx mock */)),
+  }
+}))
+
+describe('MyDomainService', () => {
+  let service: MyDomainService
+
+  beforeEach(() => {
+    service = MyDomainService.getInstance()
+    vi.clearAllMocks()
+  })
+
+  describe('create', () => {
+    it('should validate required fields', async () => {
+      await expect(service.create({ name: '' })).rejects.toThrow()
+    })
+
+    it('should create and return item', async () => {
+      const result = await service.create({ name: 'Test' })
+      expect(result.id).toBeDefined()
+      expect(result.name).toBe('Test')
+    })
+  })
+
+  describe('getById', () => {
+    it('should throw NotFound for non-existent id', async () => {
+      await expect(service.getById('non-existent')).rejects.toThrow()
+    })
+  })
+})
+```
+
+**What to test:**
+- Validation logic (required fields, format checks)
+- Error cases (not found, conflicts, invalid operations)
+- Business rules and domain workflows
+- Transaction coordination (multi-table operations)
+- Service method contracts (input -> output)
+
+### Step 4: Implement the Service (TDD Green Phase + Refactor)
+
+```typescript
+// src/main/data/services/MyDomainService.ts
+import { eq, desc, sql } from 'drizzle-orm'
+import { DbService } from '@data/db/DbService'
+import { myDomainTable } from '@data/db/schemas/myDomain'
+import { DataApiErrorFactory } from '@shared/data/api'
+import { loggerService } from '@logger'
+
+const logger = loggerService.withContext('MyDomainService')
+
+export class MyDomainService {
+  private static instance: MyDomainService
+  static getInstance() {
+    return (this.instance ??= new MyDomainService())
+  }
+
+  async list({ page = 1, limit = 20 }) {
+    const offset = (page - 1) * limit
+    const [items, [{ count }]] = await Promise.all([
+      DbService.db.select().from(myDomainTable)
+        .orderBy(desc(myDomainTable.updatedAt))
+        .limit(limit).offset(offset),
+      DbService.db.select({ count: sql<number>`count(*)` }).from(myDomainTable)
+    ])
+    return { items, total: count, page, limit }
+  }
+
+  async getById(id: string) {
+    const [item] = await DbService.db.select().from(myDomainTable)
+      .where(eq(myDomainTable.id, id)).limit(1)
+    if (!item) throw DataApiErrorFactory.notFound('MyDomain', id)
+    return item
+  }
+
+  async create(data: CreateMyDomainDto) {
+    this.validate(data)
+    const [item] = await DbService.db.insert(myDomainTable).values(data).returning()
+    logger.info(`Created ${item.id}`)
+    return item
+  }
+
+  async update(id: string, data: Partial<UpdateMyDomainDto>) {
+    await this.getById(id) // throws if not found
+    const [item] = await DbService.db.update(myDomainTable)
+      .set(data).where(eq(myDomainTable.id, id)).returning()
+    return item
+  }
+
+  async delete(id: string) {
+    await this.getById(id)
+    await DbService.db.delete(myDomainTable).where(eq(myDomainTable.id, id))
+  }
+
+  private validate(data: CreateMyDomainDto) {
+    if (!data.name?.trim()) {
+      throw DataApiErrorFactory.validation({ name: ['Name is required'] })
+    }
+  }
+}
+```
+
+**Service responsibilities:**
+- Business validation and authorization
+- Transaction coordination (`DbService.transaction()`)
+- Domain-specific workflows and orchestration
+- Error handling with `DataApiErrorFactory`
+- Logging via `loggerService`
+
+**Transactions:**
+```typescript
+async createWithChildren(data: CreateWithChildrenDto) {
+  return await DbService.transaction(async (tx) => {
+    const [parent] = await tx.insert(parentTable).values(data.parent).returning()
+    await tx.insert(childTable).values(
+      data.children.map(c => ({ ...c, parentId: parent.id }))
+    )
+    return parent
+  })
+}
+```
+
+**When refactoring business logic from Redux:**
+- Old Redux: business logic lived in thunks, selectors, and React components
+- New v2: business logic lives in Services (Main process)
+- Extract validation, computation, and side effects from Redux thunks into Service methods
+- Services can call other services for cross-domain workflows
+- Keep services stateless - state lives in SQLite
+
+### Step 5: Implement the Handler
+
+```typescript
+// src/main/data/api/handlers/myDomain.ts
+import type { ApiImplementation } from '@shared/data/api'
+import { MyDomainService } from '@data/services/MyDomainService'
+
+export const myDomainHandlers: Partial<ApiImplementation> = {
+  '/my-domains': {
+    GET: async ({ query }) => MyDomainService.getInstance().list(query ?? {}),
+    POST: async ({ body }) => MyDomainService.getInstance().create(body),
+  },
+  '/my-domains/:id': {
+    GET: async ({ params }) => MyDomainService.getInstance().getById(params.id),
+    PATCH: async ({ params, body }) => MyDomainService.getInstance().update(params.id, body),
+    DELETE: async ({ params }) => { await MyDomainService.getInstance().delete(params.id) },
+  }
+}
+```
+
+Register in `src/main/data/api/handlers/index.ts`:
+```typescript
+export const allHandlers: ApiImplementation = {
+  ...topicHandlers,
+  ...myDomainHandlers,  // <-- add
+}
+```
+
+**Handler rules:**
+- THIN: extract params -> call service -> return result
+- NO business logic, validation, or error handling (service does that)
+- Status codes inferred automatically (200 for data, 204 for void)
+
+### Step 6: Repository (optional, for complex domains)
+
+```typescript
+// src/main/data/repositories/MyDomainRepository.ts
+import { eq, desc, sql, and, like } from 'drizzle-orm'
+import { DbService } from '@data/db/DbService'
+import { myDomainTable } from '@data/db/schemas/myDomain'
+
+export class MyDomainRepository {
+  async findWithRelations(id: string, tx?: Transaction) {
+    const db = tx || DbService.db
+    // Complex join query...
+  }
+
+  async search(query: string, options: SearchOptions, tx?: Transaction) {
+    const db = tx || DbService.db
+    // Full-text search, aggregations...
+  }
+}
+```
+
+Always accept optional `tx` parameter for transaction support.
+
+## Adding a Preference Key
+
+For user settings that don't need full DataApi:
+
+### Step 1: Define Type (if custom)
+```typescript
+// packages/shared/data/preference/preferenceTypes.ts
+export enum MyFeatureMode { auto = 'auto', manual = 'manual', disabled = 'disabled' }
+```
+
+### Step 2: Add to Schema
+```typescript
+// packages/shared/data/preference/preferenceSchemas.ts
+export interface PreferenceSchemas {
+  default: {
+    // ... existing keys (alphabetically sorted)
+    'feature.my_feature.enabled': boolean
+    'feature.my_feature.mode': PreferenceTypes.MyFeatureMode
+  }
+}
+
+export const DefaultPreferences: PreferenceSchemas = {
+  default: {
+    // ... existing defaults (alphabetically sorted)
+    'feature.my_feature.enabled': true,
+    'feature.my_feature.mode': PreferenceTypes.MyFeatureMode.auto,
+  }
+}
+```
+
+**Key naming:** `namespace.category.key_name`
+- At least 2 dot-separated segments
+- Lowercase letters, numbers, underscores only
+- Pattern: `/^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$/`
+- Namespaces: `app.*`, `chat.*`, `feature.*`, `ui.*`, `data.*`, `shortcut.*`
+- Boolean keys: use `.enabled` suffix
+
+**Design principles:**
+- Prefer flat over nested (split objects into individual keys)
+- Keep values atomic (one preference = one logical setting)
+- Provide sensible defaults in `DefaultPreferences`
+
+See `docs/en/references/data/preference-schema-guide.md` for full guide.
+
+## Cross-Domain References (Stale Object Bug)
+
+### The Legacy Problem
+
+In Redux, domains often stored **full copies** of objects from other domains instead of just IDs. When the original was deleted, the copy became stale — a phantom reference the user couldn't fix.
+
+**Inventory of problematic embeddings in Redux:**
+
+| Host Domain | Embedded Guest | Field | Impact |
+|-------------|---------------|-------|--------|
+| Assistant | `Model` (full) | `model`, `defaultModel` | Model deleted → assistant shows stale model info |
+| Assistant | `Topic[]` (full) | `topics` | Topic deleted → assistant still has copy |
+| Assistant | `KnowledgeBase[]` (full) | `knowledge_bases` | KB deleted → assistant shows deleted KB |
+| Assistant | `MCPServer[]` (full) | `mcpServers` | Server removed → assistant still references it |
+| Message | `Model` (full) | `model`, `mentions` | Model removed → stale metadata in history |
+| MessageBlock | `Model` (full) | `model` | Same as above, per-block level |
+| LLM store | `Model` (full) | `defaultModel`, `quickModel`, etc. | 4+ full model copies go stale |
+
+### v2 Solution: FK IDs Only
+
+The v2 database replaces full-object embeddings with **FK ID references**. The full object can always be fetched via the FK ID — no need to store redundant copies or maintain separate snapshot types.
+
+```typescript
+// message table:
+assistantId: text(),  // FK → query assistant table for full object
+modelId: text(),      // FK → query model/provider for full object
+```
+
+### When to Use Which Pattern
+
+| Scenario | Pattern | Example |
+|----------|---------|---------|
+| **Reference can be deleted** and host must survive | FK ID with `onDelete: 'set null'` | topic→assistant, message→model |
+| **Reference is owned** by host (cascade delete) | FK with `onDelete: 'cascade'` | topic→messages |
+| **Reference is organizational** (grouping) | FK with `onDelete: 'set null'` | topic→group |
+| **Reference is config** (list of IDs) | JSON array of IDs | assistant→knowledgeBaseIds |
+| **Data is immutable history** (citations, tool results) | Embedded JSON (full copy OK) | message→citation data |
+
+### API Response Design
+
+APIs should **not** re-embed full referenced objects. Return FK IDs and let the renderer fetch full objects via separate queries when needed.
+
+```typescript
+// API schema - topic response includes FK ID, not full assistant
+'/topics/:id': {
+  GET: {
+    response: {
+      id: string
+      name: string
+      assistantId: string | null  // FK — renderer queries assistant separately
+      // NOT: assistant: Assistant  ← don't embed full objects
+    }
+  }
+}
+```
+
+## Error Handling
+
+```typescript
+import { DataApiErrorFactory } from '@shared/data/api'
+
+// Standard error factories
+throw DataApiErrorFactory.notFound('Topic', id)
+throw DataApiErrorFactory.validation({ name: ['Required'], email: ['Invalid format'] })
+throw DataApiErrorFactory.conflict('Name already exists')
+throw DataApiErrorFactory.database(error, 'insert topic')
+throw DataApiErrorFactory.invalidOperation('delete root message', 'cascade=true required')
+throw DataApiErrorFactory.timeout('fetch topics', 3000)
+```
+
+## Checklist
+
+### TDD Cycle (red-green-refactor)
+- [ ] Service tests written and **failing** (red) in `src/main/data/services/__tests__/`
+- [ ] Minimum service code written to make tests pass (green)
+- [ ] Validation logic tests added (red), then implemented (green)
+- [ ] Error case tests added (red): not found, invalid operations, then handled (green)
+- [ ] Business rule tests added (red): domain workflows, transaction coordination
+- [ ] Code refactored with all tests still passing
+- [ ] Tests pass: `pnpm test:main`
+
+### DataApi Endpoint (implementation details)
+- [ ] SQLite schema in `src/main/data/db/schemas/` + migrations generated
+- [ ] API schema in `packages/shared/data/api/schemas/` + registered in index
+- [ ] Service with business logic in `src/main/data/services/`
+- [ ] Handler (thin) in `src/main/data/api/handlers/` + registered in index
+- [ ] Repository (if complex domain) in `src/main/data/repositories/`
+- [ ] Error handling via `DataApiErrorFactory`
+- [ ] Logging via `loggerService` with context
+- [ ] Business logic extracted from Redux thunks/selectors into Service
+
+### Preference Key
+- [ ] Custom type in `preferenceTypes.ts` (if needed)
+- [ ] Key + type in `PreferenceSchemas` interface
+- [ ] Default value in `DefaultPreferences`
+- [ ] Key naming follows conventions
+
+### Quality
+- [ ] All tests pass: `pnpm test`
+- [ ] `pnpm lint && pnpm format` pass
+- [ ] `pnpm build:check` passes
+
+## Documentation References
+
+- `docs/en/references/data/README.md` - System selection guide
+- `docs/en/references/data/data-api-overview.md` - DataApi architecture
+- `docs/en/references/data/data-api-in-main.md` - Main-process patterns
+- `docs/en/references/data/api-design-guidelines.md` - RESTful conventions
+- `docs/en/references/data/api-types.md` - Type system
+- `docs/en/references/data/database-patterns.md` - Schema conventions
+- `docs/en/references/data/preference-overview.md` - Preference architecture
+- `docs/en/references/data/preference-schema-guide.md` - Adding preference keys
+- `docs/en/references/data/best-practice-layered-preset-pattern.md` - Layered presets

--- a/.agents/skills/v2-migrator/SKILL.md
+++ b/.agents/skills/v2-migrator/SKILL.md
@@ -1,0 +1,662 @@
+---
+name: v2-migrator
+description: Implement migrators that move legacy Redux/Dexie/ElectronStore data into SQLite. Use when creating or modifying migrators in the v2 migration pipeline. This skill only covers data migration - for Main-process services see v2-data-api, for Renderer consumption see v2-renderer.
+---
+
+# V2 Migration: Data Migration (Phase 1 of 3)
+
+Move legacy data (Redux Persist, Dexie IndexedDB, ElectronStore) into SQLite tables. This is a one-shot migration that runs before the app switches to the v2 architecture.
+
+**This skill enforces strict TDD (red-green-refactor).** For every unit of work: (1) write ONE failing test (red), (2) write the minimum code to make it pass (green), (3) refactor while keeping tests green. Repeat. Run `pnpm test:main` to verify.
+
+**Related skills:**
+- `v2-data-api` - Phase 2: Main-process services that expose migrated data
+- `v2-renderer` - Phase 3: Renderer hooks and services that consume data
+
+## Data Source Classification
+
+Before writing a migrator, confirm which data needs migration:
+
+| Category | v2 Target | Migrate? |
+|----------|-----------|----------|
+| **preferences** (settings) | `preferenceTable` | Yes - via PreferencesMigrator |
+| **user_data** (topics, messages, assistants) | Domain SQLite tables | Yes - domain migrators |
+| **cache** (favicon, computed results) | CacheService | No - regenerable |
+| **runtime** (selected topic, UI state) | CacheService or React state | No - session only |
+
+**Cross-category migration:** In the legacy Redux store, some data that is logically a user preference lives under domain slices (e.g., `knowledge`, `memory`, `nutstore`) rather than `settings`. During migration, these fields must be reclassified and routed to `preferenceTable` instead of domain tables. Examples:
+
+| Redux Slice | Legacy Key | v2 Target | Rationale |
+|---|---|---|---|
+| `memory` | `memory.embedderModel` | `preference: feature.memory.embedder_model_id` | Full `Model` object → extract and store only model ID |
+| `nutstore` | `nutstore.autoSyncEnabled` | `preference: data.nutstore.auto_sync_enabled` | Toggle setting |
+| `knowledge` | `knowledge.defaultEmbedModel` | `preference: feature.knowledge.default_embed_model_id` | Full `Model` object → extract and store only model ID |
+| `selectionStore` | `selectionStore.quickAssistantId` | `preference: feature.quick_assistant.id` | User selection |
+
+When implementing a domain migrator, always check whether each field is truly user data (belongs in a domain table) or actually a user preference (belongs in `preferenceTable`). Consult `v2-refactor-temp/tools/data-classify/classification.json` for the authoritative classification. Preference-type fields from domain slices should be added to the PreferencesMigrator's `REDUX_STORE_MAPPINGS` (which already supports non-settings categories like `memory`, `nutstore`, `shortcuts`, `note`, `selectionStore`).
+
+Full inventory: `v2-refactor-temp/tools/data-classify/classification.json` (391 items)
+
+## Architecture
+
+```
+Renderer Process                          Main Process
++-----------------------+                 +---------------------------+
+| Redux Persist Store   |---IPC export--->| ReduxStateReader          |
+| (localStorage)        |                 |   .get(category, key)     |
++-----------------------+                 +---------------------------+
+                                                    |
++-----------------------+                           v
+| Dexie IndexedDB       |---JSON export-->| DexieFileReader            |
+| (topics, messages,    |                 |   .readTable() / stream    |
+|  blocks, files...)    |                 +---------------------------+
++-----------------------+                           |
+                                                    v
++-----------------------+                 +---------------------------+
+| ElectronStore         |---direct------->| ConfigManager             |
+| (electron-store.json) |                 |   .get(key)               |
++-----------------------+                 +---------------------------+
+                                                    |
+                                                    v
+                                          +---------------------------+
+                                          | MigrationEngine           |
+                                          |   prepare/execute/validate|
+                                          +---------------------------+
+                                                    |
+                                                    v
+                                          +---------------------------+
+                                          | SQLite (Drizzle ORM)      |
+                                          +---------------------------+
+```
+
+**Multi-renderer note:** Cherry Studio has multiple renderer windows (main app, mini window, selection toolbar). Only the dedicated migration window triggers migration. Main process owns all migration logic; renderers receive progress via IPC.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/main/data/migration/v2/core/MigrationEngine.ts` | Orchestrator: 3-phase pipeline, progress tracking |
+| `src/main/data/migration/v2/core/MigrationContext.ts` | Shared context: sources, db, sharedData, logger |
+| `src/main/data/migration/v2/migrators/BaseMigrator.ts` | Abstract base class |
+| `src/main/data/migration/v2/migrators/index.ts` | Migrator registration (execution order) |
+| `src/main/data/migration/v2/migrators/PreferencesMigrator.ts` | Reference impl: settings migration |
+| `src/main/data/migration/v2/migrators/ChatMigrator.ts` | Reference impl: complex multi-source migration |
+| `src/main/data/migration/v2/migrators/mappings/` | Mapping definitions and transform functions |
+| `src/main/data/migration/v2/utils/ReduxStateReader.ts` | Dot-path accessor for Redux state |
+| `src/main/data/migration/v2/utils/DexieFileReader.ts` | JSON table reader with streaming |
+| `src/main/data/migration/v2/utils/JSONStreamReader.ts` | Memory-efficient batch streaming |
+| `packages/shared/data/migration/v2/types.ts` | Shared types: stages, results, stats |
+| `src/main/data/migration/v2/window/MigrationIpcHandler.ts` | IPC flow control |
+| `src/renderer/src/store/` | Redux slices (source data shapes) |
+
+## Migrator Contract
+
+Every migrator extends `BaseMigrator` with a **three-phase lifecycle**:
+
+```typescript
+import { BaseMigrator } from './BaseMigrator'
+import type { MigrationContext } from '../core/MigrationContext'
+import type { PrepareResult, ExecuteResult, ValidateResult } from '@shared/data/migration/v2/types'
+
+export class MyDomainMigrator extends BaseMigrator {
+  id = 'my_domain'
+  name = 'My Domain Migrator'
+  description = 'Migrates X from legacy stores to SQLite'
+  order = 5 // Lower runs first
+
+  async prepare(ctx: MigrationContext): Promise<PrepareResult> {
+    // Phase 1: Dry-run - count items, check source availability, NO DB writes
+    // Return { success, itemCount, warnings? }
+  }
+
+  async execute(ctx: MigrationContext): Promise<ExecuteResult> {
+    // Phase 2: Batch inserts with transactions, report progress
+    // Return { success, processedCount, error? }
+  }
+
+  async validate(ctx: MigrationContext): Promise<ValidateResult> {
+    // Phase 3: Compare source vs target counts, sample-check records
+    // Return { success, errors[], stats: { sourceCount, targetCount, skippedCount } }
+    // Engine fails if targetCount < sourceCount - skippedCount
+  }
+}
+```
+
+## Data Access in Migrators
+
+```typescript
+// Redux state
+const settings = ctx.sources.redux.getCategory('settings')
+const theme = ctx.sources.redux.get('settings', 'theme')
+const editorEnabled = ctx.sources.redux.get('settings', 'codeEditor.enabled')
+if (ctx.sources.redux.hasCategory('knowledge')) { /* ... */ }
+
+// Dexie - small table (load all at once)
+const notes = await ctx.sources.dexie.readTable<OldNote>('knowledge_notes')
+
+// Dexie - large table (streaming)
+const reader = ctx.sources.dexie.createStreamReader('topics')
+const count = await reader.count()
+await reader.readInBatches(50, async (batch) => { /* process */ })
+const sample = await reader.readSample(5)  // validation sampling
+
+// ElectronStore
+const zoomFactor = ctx.sources.config.get('ZoomFactor')
+
+// Cross-migrator data sharing
+ctx.sharedData.set('assistantIdMap', idMap)  // producer (earlier migrator)
+const idMap = ctx.sharedData.get('assistantIdMap')  // consumer (later migrator)
+```
+
+## Step-by-Step: New Migrator
+
+### 1. Understand Source Data
+- Read the Redux slice in `src/renderer/src/store/` for data shape
+- Check Dexie tables in `src/renderer/src/services/db.ts` if applicable
+- Confirm classification in `v2-refactor-temp/tools/data-classify/classification.json`
+
+### 2. Understand Target Schema
+- Read target SQLite schema in `src/main/data/db/schemas/`
+- Map source fields to target columns
+- Identify transformations (type conversions, restructuring, merging)
+
+### 3. Create Mapping File (if needed)
+
+**Simple 1:1 mapping** (like PreferencesMappings):
+```typescript
+// src/main/data/migration/v2/migrators/mappings/MyDomainMappings.ts
+export interface FieldMapping {
+  originalKey: string   // Source field path (dot notation)
+  targetKey: string     // Target column or key
+  transform?: (value: unknown) => unknown
+}
+
+export const MY_DOMAIN_MAPPINGS: FieldMapping[] = [
+  { originalKey: 'name', targetKey: 'display_name' },
+  { originalKey: 'config.enabled', targetKey: 'is_enabled', transform: Boolean },
+]
+```
+
+**Complex mapping** (like ComplexPreferenceMappings - 1:N, N:1, or cross-source):
+```typescript
+export interface ComplexMapping {
+  id: string
+  description: string
+  sources: Record<string, SourceDefinition>
+  targetKeys: string[]
+  transform: (sources: Record<string, unknown>) => Record<string, unknown>
+}
+```
+
+### 4. Write Tests for Transformation Functions (TDD Red Phase)
+
+**Write failing tests first.** Each test should fail (red) before you write any transformation code. Only write enough code to make each test pass (green), then refactor.
+
+Test location: colocated `__tests__/` directories next to the code being tested (e.g., `migrators/mappings/__tests__/MyDomainMappings.test.ts`).
+
+```typescript
+// src/main/data/migration/v2/migrators/mappings/__tests__/MyDomainMappings.test.ts
+import { describe, expect, it } from 'vitest'
+import { transformRecord } from '../MyDomainMappings'
+
+describe('MyDomainMappings', () => {
+  describe('transformRecord', () => {
+    it('should transform basic fields', () => {
+      const old = { id: 'abc', name: 'Test', createdAt: 1700000000000 }
+      const result = transformRecord(old)
+      expect(result.id).toBe('abc')
+      expect(result.display_name).toBe('Test')
+      expect(result.created_at).toBe('2023-11-14T22:13:20.000Z')
+    })
+
+    it('should handle missing optional fields', () => {
+      const old = { id: 'abc', name: 'Test' }
+      const result = transformRecord(old)
+      expect(result.created_at).toBeDefined() // falls back to now
+    })
+
+    it('should handle null/undefined input gracefully', () => {
+      const old = { id: 'abc', name: null, createdAt: undefined }
+      const result = transformRecord(old)
+      expect(result.display_name).toBe('') // or whatever default
+    })
+
+    it('should generate new ID for duplicates', () => {
+      // Test with duplicate detection logic
+    })
+  })
+})
+```
+
+**What to test:**
+- Each transformation function (pure, no DB dependency)
+- Edge cases: null/undefined fields, empty strings, invalid dates
+- Mapping completeness: all source fields accounted for
+- Complex mappings: multi-source merging, conditional logic
+- ID deduplication logic
+
+### 5. Write Transformation Functions (TDD Green Phase)
+
+Implement the minimum code to make the tests from step 4 pass. Pure functions in a separate mappings file:
+```typescript
+interface OldRecord { /* legacy shape */ }
+interface NewRecord { /* SQLite shape */ }
+
+export function transformRecord(old: OldRecord, lookupData?: Map<string, any>): NewRecord {
+  return {
+    id: old.id,
+    created_at: old.createdAt ? new Date(old.createdAt).toISOString() : new Date().toISOString(),
+    // ... field transformations
+  }
+}
+```
+
+### 6. Write Tests for Migrator Phases (TDD Red Phase)
+
+Write failing tests for the migrator's prepare/execute/validate phases by mocking `MigrationContext`. Each test must fail before you proceed to step 7:
+
+```typescript
+// src/main/data/migration/v2/migrators/__tests__/MyDomainMigrator.test.ts
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { MyDomainMigrator } from '../MyDomainMigrator'
+
+// Mock MigrationContext
+function createMockContext(reduxData: Record<string, any> = {}, dbRows: any[] = []) {
+  return {
+    sources: {
+      redux: {
+        get: vi.fn((category, key) => {
+          const cat = reduxData[category]
+          if (!cat || !key) return cat
+          return key.split('.').reduce((o, k) => o?.[k], cat)
+        }),
+        getCategory: vi.fn((cat) => reduxData[cat]),
+        hasCategory: vi.fn((cat) => cat in reduxData),
+      },
+      dexie: { readTable: vi.fn(), createStreamReader: vi.fn(), tableExists: vi.fn() },
+      config: { get: vi.fn() },
+    },
+    db: {
+      transaction: vi.fn(async (fn) => fn({
+        insert: vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) })
+      })),
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockResolvedValue([{ count: dbRows.length }])
+      }),
+    },
+    sharedData: new Map(),
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  }
+}
+
+describe('MyDomainMigrator', () => {
+  let migrator: MyDomainMigrator
+
+  beforeEach(() => {
+    migrator = new MyDomainMigrator()
+    migrator.reportProgress = vi.fn()
+  })
+
+  describe('prepare', () => {
+    it('should count source items', async () => {
+      const ctx = createMockContext({ mySlice: { items: [{id:'1'}, {id:'2'}] } })
+      const result = await migrator.prepare(ctx as any)
+      expect(result.success).toBe(true)
+      expect(result.itemCount).toBe(2)
+    })
+
+    it('should handle empty source', async () => {
+      const ctx = createMockContext({})
+      const result = await migrator.prepare(ctx as any)
+      expect(result.success).toBe(true)
+      expect(result.itemCount).toBe(0)
+    })
+  })
+
+  describe('validate', () => {
+    it('should pass when counts match', async () => {
+      const ctx = createMockContext(
+        { mySlice: { items: [{id:'1'}, {id:'2'}] } },
+        [{}, {}] // 2 rows in DB
+      )
+      const result = await migrator.validate(ctx as any)
+      expect(result.success).toBe(true)
+      expect(result.stats.sourceCount).toBe(2)
+      expect(result.stats.targetCount).toBe(2)
+    })
+  })
+})
+```
+
+### 7. Implement the Migrator (TDD Green Phase)
+
+Write the minimum code to make the tests from step 6 pass. Then refactor while keeping all tests green.
+
+**Template - small dataset (fits in memory):**
+```typescript
+import { loggerService } from '@logger'
+import { BaseMigrator } from './BaseMigrator'
+
+const logger = loggerService.withContext('MyDomainMigrator')
+
+export class MyDomainMigrator extends BaseMigrator {
+  id = 'my_domain'; name = 'My Domain'; description = '...'; order = 5
+
+  async prepare(ctx) {
+    const items = ctx.sources.redux.get('mySlice', 'items') ?? []
+    return { success: true, itemCount: items.length }
+  }
+
+  async execute(ctx) {
+    const items = ctx.sources.redux.get('mySlice', 'items') ?? []
+    const BATCH = 100; let processed = 0; let skipped = 0
+
+    for (let i = 0; i < items.length; i += BATCH) {
+      const batch = items.slice(i, i + BATCH)
+      const rows = []
+      for (const item of batch) {
+        try { rows.push(transform(item)) }
+        catch (e) { logger.warn(`Skip ${item.id}: ${e}`); skipped++ }
+      }
+      await ctx.db.transaction(async (tx) => {
+        await tx.insert(targetTable).values(rows)
+      })
+      processed += rows.length
+      this.reportProgress(Math.round(((processed + skipped) / items.length) * 100),
+        `Migrated ${processed}/${items.length}`)
+    }
+    return { success: true, processedCount: processed }
+  }
+
+  async validate(ctx) {
+    const sourceCount = (ctx.sources.redux.get('mySlice', 'items') ?? []).length
+    const [{ count }] = await ctx.db.select({ count: sql`count(*)` }).from(targetTable)
+    return {
+      success: Number(count) >= sourceCount,
+      errors: [], stats: { sourceCount, targetCount: Number(count), skippedCount: 0 }
+    }
+  }
+}
+```
+
+**Template - large dataset (streaming):**
+```typescript
+async execute(ctx) {
+  const reader = ctx.sources.dexie.createStreamReader('myLargeTable')
+  const total = await reader.count()
+  let processed = 0
+
+  await reader.readInBatches(50, async (batch) => {
+    const rows = batch.map(item => transform(item))
+    await ctx.db.transaction(async (tx) => {
+      await tx.insert(targetTable).values(rows)
+    })
+    processed += rows.length
+    this.reportProgress(Math.round((processed / total) * 100),
+      `Migrated ${processed}/${total}`)
+  })
+  return { success: true, processedCount: processed }
+}
+```
+
+### 8. Register
+
+1. Add to `src/main/data/migration/v2/migrators/index.ts` with correct `order`
+2. Add target table to `MigrationEngine.verifyAndClearNewTables` (child tables before parents)
+
+### 9. Document
+
+Create `src/main/data/migration/v2/migrators/README-<MigratorName>.md`:
+- Data sources and target tables
+- Field mappings (source -> target)
+- Key transformations
+- Dropped fields and rationale
+- Edge cases and data quality handling
+
+## Common Transformation Patterns
+
+### ID Handling
+```typescript
+import { v4 as uuidv4 } from 'uuid'
+const seenIds = new Set<string>()
+function ensureUniqueId(id: string): string {
+  if (seenIds.has(id)) {
+    const newId = uuidv4()
+    logger.warn(`Duplicate ID ${id}, generated new: ${newId}`)
+    return newId
+  }
+  seenIds.add(id)
+  return id
+}
+```
+
+### Timestamp Normalization
+```typescript
+function normalizeTimestamp(value: unknown): string {
+  if (typeof value === 'number') return new Date(value).toISOString()
+  if (typeof value === 'string') return new Date(value).toISOString()
+  return new Date().toISOString()
+}
+```
+
+### Data Merging (Multiple Sources)
+```typescript
+// Merge Redux metadata with Dexie content (pattern from ChatMigrator)
+function mergeTopicData(reduxTopic: ReduxTopic, dexieTopic: DexieTopic): MergedTopic {
+  return {
+    id: dexieTopic.id,
+    name: reduxTopic.name || dexieTopic.name || 'Unnamed',
+    messages: dexieTopic.messages,
+    assistantId: reduxTopic.assistantId,
+    createdAt: reduxTopic.createdAt,
+  }
+}
+```
+
+## Cross-Domain References & Foreign Keys
+
+### The Legacy Problem: Embedded Full Objects
+
+In Redux, domains store **full copies** of objects from other domains instead of just IDs. When the original is deleted, the copy becomes stale — a phantom that the user can't remove.
+
+**Known problematic embeddings:**
+
+| Host | Embedded Guest (full copy) | Field | Stale Data Risk |
+|------|---------------------------|-------|-----------------|
+| Assistant | `Model` | `model`, `defaultModel` | Model deleted → assistant shows phantom model |
+| Assistant | `Topic[]` | `topics` | Topic deleted → assistant still holds copy |
+| Assistant | `KnowledgeBase[]` | `knowledge_bases` | KB removed → assistant still references it |
+| Assistant | `MCPServer[]` | `mcpServers` | Server removed → assistant still lists it |
+| Message | `Model` | `model`, `mentions` | Model removed → stale metadata in history |
+| MessageBlock | `Model` | `model` | Same, per-block level |
+| LLM store | `Model` (x4) | `defaultModel`, `quickModel`, `translateModel`, `topicNamingModel` | 4 full Model copies go stale |
+| WebSearch | `Model` | `compressionConfig.embeddingModel` | Model deleted → RAG compression broken |
+| WebSearch | `Model` | `compressionConfig.rerankModel` | Model deleted → reranking broken |
+
+### The v2 Solution: FK IDs Only
+
+The v2 database replaces full-object embeddings with **FK ID references**. The full object can always be fetched via the ID — no need to store redundant copies.
+
+```typescript
+// Before (Redux): topic.assistant = { id: 'a1', name: '...', model: {...}, ... }
+// After (v2):     topic.assistantId = 'a1'  (query assistant table for full object)
+
+// Before (Redux): message.model = { id: 'm1', name: 'GPT-4', provider: 'openai', ... }
+// After (v2):     message.modelId = 'm1'   (query model/provider for full object)
+```
+
+### Migration Transform: Full Object → ID
+
+When migrating, extract just the ID from embedded full objects:
+
+```typescript
+// Extract ID from full embedded object
+function extractId(embedded: any): string | null {
+  return embedded?.id ?? null
+}
+
+// Usage in a topic transform:
+function transformTopic(reduxTopic: any): DbTopicRow {
+  return {
+    id: reduxTopic.id,
+    name: reduxTopic.name,
+    assistantId: reduxTopic.assistantId ?? reduxTopic.assistant?.id ?? null,
+    // ... other fields
+  }
+}
+
+// Usage in a message transform:
+function transformMessage(msg: any): DbMessageRow {
+  return {
+    id: msg.id,
+    modelId: msg.modelId ?? msg.model?.id ?? null,
+    assistantId: msg.assistantId,
+    // ... other fields
+  }
+}
+```
+
+### Array References: Full Objects → ID Arrays
+
+For fields that embed arrays of full objects (e.g., `assistant.mcpServers`, `assistant.knowledge_bases`), migrate to arrays of IDs:
+
+```typescript
+// Before (Redux): assistant.mcpServers = [{ id: 'srv1', name: '...', url: '...' }, ...]
+// After (v2):     assistant.mcpServerIds = ['srv1', 'srv2']  (or a join table)
+
+function extractIds(embedded: any[] | undefined): string[] {
+  if (!Array.isArray(embedded)) return []
+  return embedded.map(item => item.id).filter(Boolean)
+}
+```
+
+### Migration Order & Foreign Keys
+
+SQLite enforces FK constraints. Migrators must run in dependency order — referenced tables before referencing tables:
+
+```
+order=1  GroupMigrator        → group table (no FKs)
+order=2  AssistantMigrator    → assistant table (no FKs to other migrated tables)
+order=3  TopicMigrator        → topic table (FK → group, FK → assistant)
+order=4  MessageMigrator      → message table (FK → topic, self-ref parentId)
+```
+
+**Key rules:**
+- **Set `order` so parent tables are populated first** — e.g., topics before messages
+- **`MigrationEngine.verifyAndClearNewTables`** must list child tables before parents (reverse order) so DELETE cascades correctly during cleanup
+- **Orphan references are expected** — the original entity may have been deleted in Redux while the embedding survived. Set the FK to `null`
+- **Share ID maps via `ctx.sharedData`** when a later migrator needs to look up IDs from an earlier one
+
+### Handling Orphan References
+
+When migrating, the embedded object may reference an entity that no longer exists (was deleted by user). The migrator should:
+
+1. **Check if the referenced entity exists** in the already-migrated target table
+2. **Set `entityId` to `null` if the FK target doesn't exist** — don't insert a dangling FK
+
+```typescript
+async execute(ctx) {
+  // Earlier migrator shared the set of valid assistant IDs
+  const validAssistantIds = ctx.sharedData.get('assistantIds') as Set<string>
+
+  for (const topic of topics) {
+    const row = transformTopic(topic)
+
+    // Validate FK — don't insert dangling reference
+    if (row.assistantId && !validAssistantIds.has(row.assistantId)) {
+      logger.warn(`Topic ${row.id}: assistant ${row.assistantId} not found, setting to null`)
+      row.assistantId = null
+    }
+
+    rows.push(row)
+  }
+}
+```
+
+### What to Test (FK-related)
+
+Add these to TDD tests for any migrator that handles cross-domain references:
+
+```typescript
+it('should extract ID from full embedded object', () => {
+  const embedded = { id: 'm1', name: 'GPT-4', provider: 'openai' }
+  expect(extractId(embedded)).toBe('m1')
+})
+
+it('should return null for missing embedded object', () => {
+  expect(extractId(null)).toBeNull()
+  expect(extractId(undefined)).toBeNull()
+  expect(extractId({})).toBeNull()
+})
+
+it('should set FK to null when referenced entity is deleted', () => {
+  const validIds = new Set(['a1'])
+  const topic = { id: 't1', assistantId: 'a-deleted', assistant: { id: 'a-deleted', name: 'Old' } }
+  const row = transformTopic(topic)
+  if (!validIds.has(row.assistantId!)) row.assistantId = null
+  expect(row.assistantId).toBeNull()
+})
+
+it('should extract ID array from full object array', () => {
+  const servers = [{ id: 's1', name: 'MCP1' }, { id: 's2', name: 'MCP2' }]
+  expect(extractIds(servers)).toEqual(['s1', 's2'])
+  expect(extractIds(undefined)).toEqual([])
+  expect(extractIds([])).toEqual([])
+})
+```
+
+## Error Handling
+
+1. **Never abort for one bad record** - skip it, log warning, increment `skippedCount`
+2. **Log with context** - `loggerService.withContext('MigratorName')`
+3. **Transaction per batch** - if a batch fails, only that batch rolls back
+4. **Provide mismatchReason** - explain count mismatches in `stats.mismatchReason`
+
+```typescript
+try {
+  rows.push(transformRecord(item))
+} catch (err) {
+  logger.warn(`Skipping item ${item.id}: ${(err as Error).message}`)
+  skippedCount++
+}
+```
+
+## Checklist
+
+### TDD Cycle (red-green-refactor)
+- [ ] Transformation function tests written and **failing** (red) before any implementation
+- [ ] Minimum transformation code written to make tests pass (green)
+- [ ] Migrator phase tests (prepare/execute/validate) written and **failing** (red)
+- [ ] Minimum migrator code written to make phase tests pass (green)
+- [ ] Edge case tests: empty data, null fields, duplicate IDs, missing sources
+- [ ] Code refactored with all tests still passing
+- [ ] Tests pass: `pnpm test:main`
+
+### Implementation details
+- [ ] Source data shape understood (Redux slice + Dexie schema)
+- [ ] Classification confirmed in `classification.json`
+- [ ] Target SQLite schema exists in `src/main/data/db/schemas/`
+- [ ] Mapping/transformation file created (if needed)
+- [ ] All three phases: prepare, execute, validate
+- [ ] Batch inserts + transactions (50-100 per batch)
+- [ ] Streaming for large tables (>1000 records)
+- [ ] Duplicate ID handling
+- [ ] Progress via `reportProgress`
+- [ ] Registered in `migrators/index.ts` with correct `order`
+- [ ] Target table added to `MigrationEngine.verifyAndClearNewTables`
+- [ ] Cross-migrator data via `ctx.sharedData` (if applicable)
+- [ ] `README-<MigratorName>.md` created
+- [ ] All logging via `loggerService` (no `console.log`)
+
+### Cross-domain references & FK integrity
+- [ ] Embedded full objects → extracted to FK ID only (discard the rest)
+- [ ] Array of full objects → array of IDs (or join table)
+- [ ] `order` set so parent tables populate before child tables
+- [ ] Orphan references handled: FK set to `null`
+- [ ] Valid ID sets shared via `ctx.sharedData` for FK validation
+- [ ] `verifyAndClearNewTables` lists child tables before parents (reverse delete order)
+
+## Documentation References
+
+- `docs/en/references/data/v2-migration-guide.md` - Migration engine architecture
+- `docs/en/references/data/database-patterns.md` - SQLite schema conventions

--- a/.agents/skills/v2-renderer/SKILL.md
+++ b/.agents/skills/v2-renderer/SKILL.md
@@ -1,0 +1,514 @@
+---
+name: v2-renderer
+description: Wire up Renderer-process consumption of v2 data via React hooks and services. Covers replacing Redux useAppSelector/dispatch with useQuery/useMutation (DataApi), usePreference (settings), and useCache (temporary data), with multi-window sync considerations. Use when migrating React components from Redux to the v2 data layer.
+---
+
+# V2 Renderer: UI Data Consumption (Phase 3 of 3)
+
+Replace Redux `useAppSelector` / `dispatch` in React components with v2 hooks (`useQuery`, `usePreference`, `useCache`) that talk to Main-process services via IPC.
+
+**This skill enforces strict TDD (red-green-refactor).** For every unit of work: (1) write ONE failing test (red), (2) write the minimum code to make it pass (green), (3) refactor while keeping tests green. Repeat. Run `pnpm test:renderer` to verify.
+
+**Related skills:**
+- `v2-migrator` - Phase 1: Migrating legacy data into SQLite
+- `v2-data-api` - Phase 2: Main-process services that expose data
+
+## Multi-Window Architecture
+
+Cherry Studio has multiple renderer windows (main app, mini window, selection toolbar). Each system handles cross-window sync differently:
+
+| System | Sync Strategy | Notes |
+|--------|--------------|-------|
+| **DataApiService** | No auto-sync; fetch on demand | Each window fetches fresh data independently |
+| **PreferenceService** | Auto-broadcasts to all windows | Main process is source of truth; optimistic updates with rollback |
+| **CacheService (shared)** | Auto-broadcasts to all windows | Main maintains authoritative copy; new windows get init-sync |
+| **CacheService (persist)** | Auto-broadcasts + localStorage | Survives restarts; Main-priority override on sync |
+| **CacheService (memory)** | No sync (process-local) | Isolated per renderer process |
+
+## Migration Pattern: Redux -> v2
+
+### Before (Redux)
+```typescript
+import { useAppSelector, useAppDispatch } from '@/store'
+import { updateSettings } from '@/store/settings'
+
+function SettingsPage() {
+  const theme = useAppSelector(state => state.settings.theme)
+  const dispatch = useAppDispatch()
+
+  const handleThemeChange = (value: string) => {
+    dispatch(updateSettings({ theme: value }))
+  }
+}
+```
+
+### After (v2 - depends on data type)
+
+**User settings -> usePreference:**
+```typescript
+import { usePreference } from '@data/hooks/usePreference'
+
+function SettingsPage() {
+  const [theme, setTheme] = usePreference('app.theme.mode')
+  const handleThemeChange = (value: string) => setTheme(value)
+}
+```
+
+**Business data -> useQuery/useMutation:**
+```typescript
+import { useQuery, useMutation } from '@data/hooks/useDataApi'
+
+function TopicList() {
+  const { data: topics, isLoading } = useQuery('/topics')
+  const { trigger: createTopic } = useMutation('POST', '/topics', {
+    refresh: ['/topics']
+  })
+}
+```
+
+**Temporary/UI state -> useCache:**
+```typescript
+import { useSharedCache } from '@data/hooks/useCache'
+
+function Sidebar() {
+  const [collapsed, setCollapsed] = useSharedCache('ui.sidebar.collapsed', false)
+}
+```
+
+## DataApi Hooks (Business Data)
+
+Import from `@data/hooks/useDataApi`.
+
+### useQuery (GET)
+
+```typescript
+// Basic list
+const { data, isLoading, error, refetch } = useQuery('/topics')
+
+// With query params
+const { data } = useQuery('/messages', { query: { topicId, page: 1, limit: 20 } })
+
+// Single resource
+const { data: topic } = useQuery('/topics/abc123')
+
+// Conditional fetching (null key = skip)
+const { data } = useQuery(topicId ? `/topics/${topicId}/messages` : null)
+
+// Polling
+const { data } = useQuery('/topics', { refreshInterval: 5000 })
+```
+
+### useMutation (POST/PUT/PATCH/DELETE)
+
+```typescript
+// Create
+const { trigger: create, isLoading } = useMutation('POST', '/topics', {
+  refresh: ['/topics'],  // Auto-refresh these queries after success
+  onSuccess: (data) => toast.success('Created'),
+})
+await create({ body: { name: 'New Topic' } })
+
+// Update (full replace)
+const { trigger: replace } = useMutation('PUT', `/topics/${id}`)
+await replace({ body: { name: 'Updated', description: '...' } })
+
+// Partial update
+const { trigger: update } = useMutation('PATCH', `/topics/${id}`)
+await update({ body: { name: 'New Name' } })
+
+// Delete
+const { trigger: remove } = useMutation('DELETE', `/topics/${id}`, {
+  refresh: ['/topics']
+})
+await remove()
+
+// Optimistic update (instant UI, auto-rollback on failure)
+const { trigger: toggleStar } = useMutation('PATCH', `/topics/${id}`, {
+  optimisticData: { ...topic, starred: !topic.starred }
+})
+```
+
+### useInfiniteQuery (Cursor-based Infinite Scroll)
+
+```typescript
+const { items, isLoading, hasNext, loadNext } = useInfiniteQuery('/messages', {
+  query: { topicId },
+  limit: 20
+})
+// items: all loaded items flattened
+// loadNext(): load next page
+```
+
+### usePaginatedQuery (Offset-based Pagination)
+
+```typescript
+const { items, page, total, hasNext, hasPrev, nextPage, prevPage } =
+  usePaginatedQuery('/topics', { limit: 10 })
+```
+
+### Direct Service (non-React)
+
+```typescript
+import { dataApiService } from '@data/DataApiService'
+
+const topics = await dataApiService.get('/topics')
+const topic = await dataApiService.get('/topics/abc123')
+const newTopic = await dataApiService.post('/topics', { body: { name: 'New' } })
+await dataApiService.patch('/topics/abc123', { body: { name: 'Updated' } })
+await dataApiService.delete('/topics/abc123')
+```
+
+### Error Handling
+
+```typescript
+// In hooks
+const { data, error } = useQuery('/topics')
+if (error?.code === ErrorCode.NOT_FOUND) return <NotFound />
+
+// In try-catch
+import { DataApiError, ErrorCode } from '@shared/data/api'
+try {
+  await dataApiService.post('/topics', { body: data })
+} catch (error) {
+  if (error instanceof DataApiError) {
+    if (error.code === ErrorCode.VALIDATION_ERROR) {
+      const fieldErrors = error.details?.fieldErrors
+    }
+    if (error.isRetryable) { /* safe to retry */ }
+  }
+}
+```
+
+## Preference Hooks (User Settings)
+
+Import from `@data/hooks/usePreference`.
+
+### usePreference (Single)
+
+```typescript
+// Optimistic (default) - UI updates immediately, syncs to DB
+const [theme, setTheme] = usePreference('app.theme.mode')
+await setTheme('dark')
+
+// Pessimistic - waits for DB confirmation before UI update
+const [apiKey, setApiKey] = usePreference('api.key', { optimistic: false })
+await setApiKey('sk-...')
+```
+
+**When to use which:**
+- **Optimistic** (default): frequent, non-critical changes (theme, font size)
+- **Pessimistic**: security-sensitive or external-service settings (API keys)
+
+### usePreferences (Multiple)
+
+```typescript
+const { theme, language, fontSize } = usePreferences([
+  'app.theme.mode',
+  'app.language',
+  'chat.message.font_size'
+])
+```
+
+### Direct Service (non-React)
+
+```typescript
+import { preferenceService } from '@data/PreferenceService'
+
+// Read
+const theme = await preferenceService.get('app.theme.mode')
+const settings = await preferenceService.getMultiple(['app.theme.mode', 'app.language'])
+
+// Write
+await preferenceService.set('app.theme.mode', 'dark')
+await preferenceService.setMultiple({ 'app.theme.mode': 'dark', 'app.language': 'en' })
+
+// Subscribe (useful in services, not components)
+const unsub = preferenceService.subscribe('app.theme.mode', (newValue) => {
+  // Called when preference changes in any window
+})
+unsub() // cleanup
+```
+
+## Cache Hooks (Temporary/Regenerable Data)
+
+Import from `@data/hooks/useCache`.
+
+### Three Tiers
+
+| Tier | Hook | Scope | Survives Restart | Cross-Window Sync | Use When |
+|------|------|-------|-----------------|-------------------|----------|
+| **Memory** | `useCache` | Single renderer process | No | No | Computed results, search results, scroll positions — data local to one window that can be recomputed |
+| **Shared** | `useSharedCache` | All renderer windows | No | Yes (via Main) | UI state that must stay in sync across windows (sidebar collapsed, active panel, selection state) |
+| **Persist** | `usePersistCache` | All renderer windows | Yes (localStorage) | Yes (via Main) | User-specific ephemeral data worth keeping across restarts but not critical enough for Preference (recent files, last-used filters, draft text) |
+
+**Decision flow:**
+1. Does this state need to survive app restart? → `usePersistCache`
+2. Does this state need to sync across windows? → `useSharedCache`
+3. Otherwise → `useCache` (memory-only, cheapest)
+
+```typescript
+// Memory cache - lost on restart, single-window only
+const [results, setResults] = useCache('search.results', [])
+const [results, setResults] = useCache('search.results', [], { ttl: 30000 }) // with TTL
+
+// Shared cache - cross-window sync via Main, lost on restart
+const [collapsed, setCollapsed] = useSharedCache('ui.sidebar.collapsed', false)
+
+// Persist cache - cross-window sync + survives restart via localStorage
+const [recent, setRecent] = usePersistCache('app.recent_files', [])
+```
+
+### Type-Safe vs Casual vs Template Keys
+
+```typescript
+// Type-safe (schema key) - auto-completion, compile-time validation
+const [counter, setCounter] = useCache('ui.counter', 0)
+
+// Template key (dynamic pattern, auto type inference)
+const [scrollPos, setScrollPos] = useCache('scroll.position.topic123') // inferred: number
+
+// Casual (fully dynamic, manual type)
+cacheService.setCasual<TopicCache>(`topic:${id}`, data)
+const topic = cacheService.getCasual<TopicCache>(`topic:${id}`)
+```
+
+### Direct Service (non-React)
+
+```typescript
+import { cacheService } from '@data/CacheService'
+
+// Memory
+cacheService.set('search.results', data)
+cacheService.set('search.results', data, 30000) // with TTL
+const data = cacheService.get('search.results')
+cacheService.delete('search.results')
+
+// Shared
+cacheService.setShared('window.layout', config)
+const layout = cacheService.getShared('window.layout')
+
+// Persist
+cacheService.setPersist('app.recent_files', files)
+const files = cacheService.getPersist('app.recent_files')
+```
+
+### Shared Cache Ready State
+
+```typescript
+// SharedCache syncs from Main on window init (async)
+if (cacheService.isSharedCacheReady()) { /* synced */ }
+
+const unsub = cacheService.onSharedCacheReady(() => {
+  // Called immediately if already ready, or when sync completes
+})
+
+// getShared() returns undefined before ready
+// setShared() works immediately (broadcasts to Main)
+// Hooks work normally - update when sync completes
+```
+
+## Testing (Strict TDD)
+
+Follow the red-green-refactor cycle for every component migration. For each piece of UI:
+1. **Red**: Write a failing test for the new hook/component behavior
+2. **Green**: Write the minimum code to make it pass (replace Redux with v2 hook)
+3. **Refactor**: Clean up while keeping tests green
+
+Use the unified mocks in `tests/__mocks__/renderer/`.
+
+### Test Setup
+
+Mocks are globally configured in `tests/renderer.setup.ts`. Import mock utilities via `@test-mocks/*`:
+
+```typescript
+import { MockCacheUtils } from '@test-mocks/renderer/CacheService'
+import { MockDataApiUtils } from '@test-mocks/renderer/DataApiService'
+import { MockUseDataApiUtils } from '@test-mocks/renderer/useDataApi'
+```
+
+### Testing DataApi Components
+
+```typescript
+import { describe, expect, it, beforeEach } from 'vitest'
+import { useQuery, useMutation } from '@data/hooks/useDataApi'
+import { MockUseDataApiUtils } from '@test-mocks/renderer/useDataApi'
+
+describe('TopicList', () => {
+  beforeEach(() => MockUseDataApiUtils.resetMocks())
+
+  it('should fetch topics via useQuery', () => {
+    MockUseDataApiUtils.mockQueryData('/topics', { items: [{ id: '1', name: 'Test' }] })
+    const { data } = useQuery('/topics')
+    expect(data.items).toHaveLength(1)
+  })
+
+  it('should handle loading state', () => {
+    const { loading } = useQuery('/topics')
+    expect(loading).toBe(false) // mock returns immediately
+  })
+
+  it('should create topic via useMutation', async () => {
+    const { mutate } = useMutation('POST', '/topics')
+    const result = await mutate({ body: { name: 'New' } })
+    expect(result.created).toBe(true)
+  })
+
+  it('should handle API errors', async () => {
+    MockDataApiUtils.setErrorResponse('/topics', 'GET', new Error('Network error'))
+    // Test error handling in component
+  })
+})
+```
+
+### Testing Preference Components
+
+```typescript
+import { usePreference } from '@data/hooks/usePreference'
+
+it('should read and update preference', async () => {
+  const [theme, setTheme] = usePreference('app.theme.mode')
+  expect(theme).toBeDefined()
+  await setTheme('dark')
+})
+```
+
+### Testing Cache Components
+
+```typescript
+import { useCache } from '@data/hooks/useCache'
+import { MockCacheUtils } from '@test-mocks/renderer/CacheService'
+
+beforeEach(() => MockCacheUtils.resetMocks())
+
+it('should use cache with initial value', () => {
+  const [value, setValue] = useCache('search.results', [])
+  expect(value).toEqual([])
+})
+
+it('should pre-populate cache for testing', () => {
+  MockCacheUtils.setInitialState({
+    memory: [['search.results', [{ id: '1' }]]],
+  })
+  const [value] = useCache('search.results', [])
+  expect(value).toHaveLength(1)
+})
+```
+
+### What to Test
+
+- Component renders correctly with data from hooks
+- Loading and error states display properly
+- User interactions trigger correct mutations/updates
+- Multi-window behavior: shared cache syncs, local cache doesn't
+- Old Redux imports are removed (no `useAppSelector`/`dispatch`)
+
+## Common Migration Patterns
+
+### Settings Page
+```typescript
+// Before: Redux
+const theme = useAppSelector(s => s.settings.theme)
+dispatch(updateSettings({ theme: 'dark' }))
+
+// After: Preference
+const [theme, setTheme] = usePreference('app.theme.mode')
+await setTheme('dark')
+```
+
+### Data List with CRUD
+```typescript
+// Before: Redux + Dexie
+const topics = useAppSelector(s => s.topics.items)
+dispatch(addTopic(data))
+
+// After: DataApi
+const { data: topics, isLoading } = useQuery('/topics')
+const { trigger: addTopic } = useMutation('POST', '/topics', { refresh: ['/topics'] })
+await addTopic({ body: data })
+```
+
+### UI State (Sidebar, Panels)
+```typescript
+// Before: Redux
+const collapsed = useAppSelector(s => s.runtime.sidebarCollapsed)
+dispatch(setSidebarCollapsed(true))
+
+// After: SharedCache (cross-window) or local state
+const [collapsed, setCollapsed] = useSharedCache('ui.sidebar.collapsed', false)
+```
+
+### Computed/Derived Data
+```typescript
+// Before: Redux selector
+const stats = useAppSelector(selectTopicStats)
+
+// After: useQuery (computed on server) or useCache (computed on client)
+const { data: stats } = useQuery('/topics/stats')
+// or
+const [stats, setStats] = useCache('topics.stats', null)
+```
+
+### Feature Toggles
+```typescript
+// Before: Redux
+const showTimestamp = useAppSelector(s => s.settings.showMessageTimestamp)
+
+// After: Preference
+const [showTimestamp] = usePreference('chat.display.show_timestamp')
+```
+
+## Adding New Schema Keys
+
+### New Cache Key
+1. Add to `packages/shared/data/cache/cacheSchemas.ts`:
+   ```typescript
+   export type UseCacheSchema = {
+     'myFeature.data': MyDataType
+   }
+   export const DefaultUseCache = {
+     'myFeature.data': { items: [], lastUpdated: 0 }
+   }
+   ```
+2. Template key for dynamic patterns:
+   ```typescript
+   'scroll.position.${topicId}': number  // matches scroll.position.topic123
+   ```
+
+### New Preference Key
+See `v2-data-api` skill, "Adding a Preference Key" section.
+
+## Checklist
+
+### TDD Cycle (red-green-refactor)
+- [ ] Component/hook tests written and **failing** (red) with mocked services (`@test-mocks/renderer/*`)
+- [ ] Minimum hook/component code written to make tests pass (green)
+- [ ] Loading and error state tests added (red), then handled (green)
+- [ ] User interaction tests added (red): mutations, preference updates
+- [ ] Code refactored with all tests still passing
+- [ ] Mock utilities reset in `beforeEach`
+- [ ] Tests pass: `pnpm test:renderer`
+
+### Implementation details
+- [ ] Identified correct system for each piece of data (DataApi vs Preference vs Cache)
+- [ ] Old `useAppSelector` / `dispatch` calls removed
+- [ ] New hooks wired up with proper types
+- [ ] Loading states handled (`isLoading` for DataApi)
+- [ ] Error states handled (DataApi error codes)
+- [ ] Mutation callbacks set up (`refresh`, `onSuccess`)
+- [ ] Multi-window behavior verified (shared data syncs, local data doesn't)
+- [ ] Optimistic vs pessimistic update strategy chosen for preferences
+- [ ] Cache tier chosen correctly (memory vs shared vs persist)
+- [ ] New cache/preference keys added to schemas
+
+### Quality
+- [ ] All tests pass: `pnpm test`
+- [ ] `pnpm lint && pnpm format` pass
+- [ ] `pnpm build:check` passes
+
+## Documentation References
+
+- `docs/en/references/data/README.md` - System selection guide
+- `docs/en/references/data/data-api-in-renderer.md` - DataApi hooks and patterns
+- `docs/en/references/data/preference-usage.md` - Preference hooks and service
+- `docs/en/references/data/cache-overview.md` - Cache architecture
+- `docs/en/references/data/cache-usage.md` - Cache hooks and patterns

--- a/.claude/skills/.gitignore
+++ b/.claude/skills/.gitignore
@@ -13,3 +13,9 @@
 !gh-pr-review/**
 !prepare-release/
 !prepare-release/**
+!v2-data-api/
+!v2-data-api/**
+!v2-migrator/
+!v2-migrator/**
+!v2-renderer/
+!v2-renderer/**

--- a/.claude/skills/v2-data-api/SKILL.md
+++ b/.claude/skills/v2-data-api/SKILL.md
@@ -1,0 +1,520 @@
+---
+name: v2-data-api
+description: Build Main-process services and APIs that expose data from SQLite to renderers. Covers the Handler -> Service -> Repository layered architecture, API schema design, database patterns, preference schema, and business logic implementation. Use when adding endpoints, creating services, designing schemas, or refactoring business logic in the v2 data layer.
+---
+
+# V2 Data API: Main-Process Services (Phase 2 of 3)
+
+Design and implement the Main-process layer that exposes SQLite data to renderers via type-safe IPC. This covers business logic, service architecture, and database access patterns.
+
+**This skill enforces strict TDD (red-green-refactor).** For every unit of work: (1) write ONE failing test (red), (2) write the minimum code to make it pass (green), (3) refactor while keeping tests green. Repeat. Run `pnpm test:main` to verify.
+
+**Related skills:**
+- `v2-migrator` - Phase 1: Migrating legacy data into SQLite
+- `v2-renderer` - Phase 3: Renderer hooks that consume these APIs
+
+## System Selection
+
+Before building a service, determine the right system:
+
+| System | When to Use | Loss Impact | Example |
+|--------|------------|-------------|---------|
+| **DataApiService** | User-created business data, structured, can grow | **Severe** | Topics, messages, assistants, files |
+| **PreferenceService** | User settings, fixed keys, stable values | Low | Theme, language, shortcuts, proxy config |
+| **CacheService** | Regenerable/temporary, no backup needed | None | API responses, scroll positions |
+
+**Decision flow:**
+1. Can data be lost without user impact? -> CacheService (no Main service needed)
+2. Is it a user setting with a fixed key? -> PreferenceService (schema-based)
+3. Is it user-created data that grows unbounded? -> DataApiService (full service stack)
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ Main Process                                                  │
+│                                                                │
+│  Handler (thin)                                                │
+│    - Extract params from request                               │
+│    - Call service, return result                                │
+│    - NO business logic                                         │
+│         │                                                      │
+│         v                                                      │
+│  Service (business logic)                                      │
+│    - Validation, authorization                                 │
+│    - Transaction coordination                                  │
+│    - Domain workflows                                          │
+│    - Orchestrates repositories or direct Drizzle               │
+│         │                                                      │
+│    ┌────┴────┐                                                 │
+│    v         v                                                 │
+│  Repository    Direct Drizzle                                  │
+│  (complex)     (simple CRUD)                                   │
+│    │              │                                            │
+│    └──────┬───────┘                                            │
+│           v                                                    │
+│  SQLite (Drizzle ORM)                                          │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**When to use Repository vs Direct Drizzle:**
+
+| Use Repository | Use Direct Drizzle |
+|---|---|
+| Complex queries (joins, subqueries, aggregations) | Simple CRUD |
+| GB-scale data with pagination | Small datasets (< 100MB) |
+| Complex multi-table transactions | Single-table operations |
+| Reusable data access patterns | Domain-specific one-off queries |
+
+## File Locations
+
+| Layer | Location |
+|-------|----------|
+| Shared API types/schemas | `packages/shared/data/api/schemas/` |
+| Handlers | `src/main/data/api/handlers/` |
+| Services | `src/main/data/services/` |
+| Repositories | `src/main/data/repositories/` (optional) |
+| DB schemas | `src/main/data/db/schemas/` |
+| Preference types | `packages/shared/data/preference/` |
+| Cache schemas | `packages/shared/data/cache/cacheSchemas.ts` |
+
+## Adding a DataApi Endpoint (Step-by-Step)
+
+### Step 1: Define SQLite Schema
+
+```typescript
+// src/main/data/db/schemas/myDomain.ts
+import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core'
+import { uuidPrimaryKey, timestamps } from './helpers'
+
+export const myDomainTable = sqliteTable('my_domain', {
+  ...uuidPrimaryKey(),        // id: text, primary key, auto-generated UUID
+  name: text('name').notNull(),
+  description: text('description'),
+  config: text('config', { mode: 'json' }).$type<MyConfig>(),
+  ...timestamps(),            // createdAt, updatedAt (auto-managed)
+})
+```
+
+**Schema conventions:**
+- Table name: singular, snake_case (`my_domain` not `myDomains`)
+- Export name: `xxxTable` (e.g., `myDomainTable`)
+- Use helpers: `uuidPrimaryKey()`, `uuidPrimaryKeyOrdered()`, `timestamps()`
+- JSON fields: `text('col', { mode: 'json' }).$type<T>()`
+- Foreign keys: use `references(() => otherTable.id)` or `foreignKey` for self-referencing
+- Soft delete: add `deletedAt` column when needed
+- After changes: run `yarn db:migrations:generate`
+
+See `docs/en/references/data/database-patterns.md` for full conventions.
+
+### Step 2: Define API Schema (Shared Types)
+
+```typescript
+// packages/shared/data/api/schemas/myDomain.ts
+export interface MyDomainSchemas {
+  '/my-domains': {
+    GET: {
+      query?: { page?: number; limit?: number }
+      response: PaginatedResponse<MyDomain>
+    }
+    POST: {
+      body: CreateMyDomainDto
+      response: MyDomain
+    }
+  }
+  '/my-domains/:id': {
+    GET: { response: MyDomain }
+    PATCH: { body: Partial<UpdateMyDomainDto>; response: MyDomain }
+    DELETE: { response: void }
+  }
+}
+```
+
+Register in `packages/shared/data/api/schemas/index.ts`:
+```typescript
+export type ApiSchemas = AssertValidSchemas<TopicSchemas & MessageSchemas & MyDomainSchemas>
+```
+
+**Path conventions:**
+- Plural nouns, kebab-case: `/my-domains`, `/knowledge-bases`
+- Nested resources: `/topics/:topicId/messages`
+- Non-CRUD actions: `POST /topics/:id/archive`
+- Query params for filtering/sorting: `?page=1&limit=20&sort=name&order=asc`
+
+See `docs/en/references/data/api-design-guidelines.md` for full rules.
+
+### Step 3: Write Service Tests (TDD Red Phase)
+
+Write failing tests for the service before implementing it. Each test must fail (red) before you proceed to Step 4. Use the main-process test mocks.
+
+```typescript
+// src/main/data/services/__tests__/MyDomainService.test.ts
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { MyDomainService } from '../MyDomainService'
+
+// Mock DbService
+vi.mock('@data/db/DbService', () => ({
+  DbService: {
+    db: {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+          orderBy: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({ offset: vi.fn().mockResolvedValue([]) })
+          }),
+        })
+      }),
+      insert: vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: '1', name: 'Test' }]) })
+      }),
+      update: vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: '1', name: 'Updated' }]) })
+        })
+      }),
+      delete: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined)
+      }),
+    },
+    transaction: vi.fn(async (fn) => fn(/* tx mock */)),
+  }
+}))
+
+describe('MyDomainService', () => {
+  let service: MyDomainService
+
+  beforeEach(() => {
+    service = MyDomainService.getInstance()
+    vi.clearAllMocks()
+  })
+
+  describe('create', () => {
+    it('should validate required fields', async () => {
+      await expect(service.create({ name: '' })).rejects.toThrow()
+    })
+
+    it('should create and return item', async () => {
+      const result = await service.create({ name: 'Test' })
+      expect(result.id).toBeDefined()
+      expect(result.name).toBe('Test')
+    })
+  })
+
+  describe('getById', () => {
+    it('should throw NotFound for non-existent id', async () => {
+      await expect(service.getById('non-existent')).rejects.toThrow()
+    })
+  })
+})
+```
+
+**What to test:**
+- Validation logic (required fields, format checks)
+- Error cases (not found, conflicts, invalid operations)
+- Business rules and domain workflows
+- Transaction coordination (multi-table operations)
+- Service method contracts (input -> output)
+
+### Step 4: Implement the Service (TDD Green Phase + Refactor)
+
+```typescript
+// src/main/data/services/MyDomainService.ts
+import { eq, desc, sql } from 'drizzle-orm'
+import { DbService } from '@data/db/DbService'
+import { myDomainTable } from '@data/db/schemas/myDomain'
+import { DataApiErrorFactory } from '@shared/data/api'
+import { loggerService } from '@logger'
+
+const logger = loggerService.withContext('MyDomainService')
+
+export class MyDomainService {
+  private static instance: MyDomainService
+  static getInstance() {
+    return (this.instance ??= new MyDomainService())
+  }
+
+  async list({ page = 1, limit = 20 }) {
+    const offset = (page - 1) * limit
+    const [items, [{ count }]] = await Promise.all([
+      DbService.db.select().from(myDomainTable)
+        .orderBy(desc(myDomainTable.updatedAt))
+        .limit(limit).offset(offset),
+      DbService.db.select({ count: sql<number>`count(*)` }).from(myDomainTable)
+    ])
+    return { items, total: count, page, limit }
+  }
+
+  async getById(id: string) {
+    const [item] = await DbService.db.select().from(myDomainTable)
+      .where(eq(myDomainTable.id, id)).limit(1)
+    if (!item) throw DataApiErrorFactory.notFound('MyDomain', id)
+    return item
+  }
+
+  async create(data: CreateMyDomainDto) {
+    this.validate(data)
+    const [item] = await DbService.db.insert(myDomainTable).values(data).returning()
+    logger.info(`Created ${item.id}`)
+    return item
+  }
+
+  async update(id: string, data: Partial<UpdateMyDomainDto>) {
+    await this.getById(id) // throws if not found
+    const [item] = await DbService.db.update(myDomainTable)
+      .set(data).where(eq(myDomainTable.id, id)).returning()
+    return item
+  }
+
+  async delete(id: string) {
+    await this.getById(id)
+    await DbService.db.delete(myDomainTable).where(eq(myDomainTable.id, id))
+  }
+
+  private validate(data: CreateMyDomainDto) {
+    if (!data.name?.trim()) {
+      throw DataApiErrorFactory.validation({ name: ['Name is required'] })
+    }
+  }
+}
+```
+
+**Service responsibilities:**
+- Business validation and authorization
+- Transaction coordination (`DbService.transaction()`)
+- Domain-specific workflows and orchestration
+- Error handling with `DataApiErrorFactory`
+- Logging via `loggerService`
+
+**Transactions:**
+```typescript
+async createWithChildren(data: CreateWithChildrenDto) {
+  return await DbService.transaction(async (tx) => {
+    const [parent] = await tx.insert(parentTable).values(data.parent).returning()
+    await tx.insert(childTable).values(
+      data.children.map(c => ({ ...c, parentId: parent.id }))
+    )
+    return parent
+  })
+}
+```
+
+**When refactoring business logic from Redux:**
+- Old Redux: business logic lived in thunks, selectors, and React components
+- New v2: business logic lives in Services (Main process)
+- Extract validation, computation, and side effects from Redux thunks into Service methods
+- Services can call other services for cross-domain workflows
+- Keep services stateless - state lives in SQLite
+
+### Step 5: Implement the Handler
+
+```typescript
+// src/main/data/api/handlers/myDomain.ts
+import type { ApiImplementation } from '@shared/data/api'
+import { MyDomainService } from '@data/services/MyDomainService'
+
+export const myDomainHandlers: Partial<ApiImplementation> = {
+  '/my-domains': {
+    GET: async ({ query }) => MyDomainService.getInstance().list(query ?? {}),
+    POST: async ({ body }) => MyDomainService.getInstance().create(body),
+  },
+  '/my-domains/:id': {
+    GET: async ({ params }) => MyDomainService.getInstance().getById(params.id),
+    PATCH: async ({ params, body }) => MyDomainService.getInstance().update(params.id, body),
+    DELETE: async ({ params }) => { await MyDomainService.getInstance().delete(params.id) },
+  }
+}
+```
+
+Register in `src/main/data/api/handlers/index.ts`:
+```typescript
+export const allHandlers: ApiImplementation = {
+  ...topicHandlers,
+  ...myDomainHandlers,  // <-- add
+}
+```
+
+**Handler rules:**
+- THIN: extract params -> call service -> return result
+- NO business logic, validation, or error handling (service does that)
+- Status codes inferred automatically (200 for data, 204 for void)
+
+### Step 6: Repository (optional, for complex domains)
+
+```typescript
+// src/main/data/repositories/MyDomainRepository.ts
+import { eq, desc, sql, and, like } from 'drizzle-orm'
+import { DbService } from '@data/db/DbService'
+import { myDomainTable } from '@data/db/schemas/myDomain'
+
+export class MyDomainRepository {
+  async findWithRelations(id: string, tx?: Transaction) {
+    const db = tx || DbService.db
+    // Complex join query...
+  }
+
+  async search(query: string, options: SearchOptions, tx?: Transaction) {
+    const db = tx || DbService.db
+    // Full-text search, aggregations...
+  }
+}
+```
+
+Always accept optional `tx` parameter for transaction support.
+
+## Adding a Preference Key
+
+For user settings that don't need full DataApi:
+
+### Step 1: Define Type (if custom)
+```typescript
+// packages/shared/data/preference/preferenceTypes.ts
+export enum MyFeatureMode { auto = 'auto', manual = 'manual', disabled = 'disabled' }
+```
+
+### Step 2: Add to Schema
+```typescript
+// packages/shared/data/preference/preferenceSchemas.ts
+export interface PreferenceSchemas {
+  default: {
+    // ... existing keys (alphabetically sorted)
+    'feature.my_feature.enabled': boolean
+    'feature.my_feature.mode': PreferenceTypes.MyFeatureMode
+  }
+}
+
+export const DefaultPreferences: PreferenceSchemas = {
+  default: {
+    // ... existing defaults (alphabetically sorted)
+    'feature.my_feature.enabled': true,
+    'feature.my_feature.mode': PreferenceTypes.MyFeatureMode.auto,
+  }
+}
+```
+
+**Key naming:** `namespace.category.key_name`
+- At least 2 dot-separated segments
+- Lowercase letters, numbers, underscores only
+- Pattern: `/^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$/`
+- Namespaces: `app.*`, `chat.*`, `feature.*`, `ui.*`, `data.*`, `shortcut.*`
+- Boolean keys: use `.enabled` suffix
+
+**Design principles:**
+- Prefer flat over nested (split objects into individual keys)
+- Keep values atomic (one preference = one logical setting)
+- Provide sensible defaults in `DefaultPreferences`
+
+See `docs/en/references/data/preference-schema-guide.md` for full guide.
+
+## Cross-Domain References (Stale Object Bug)
+
+### The Legacy Problem
+
+In Redux, domains often stored **full copies** of objects from other domains instead of just IDs. When the original was deleted, the copy became stale — a phantom reference the user couldn't fix.
+
+**Inventory of problematic embeddings in Redux:**
+
+| Host Domain | Embedded Guest | Field | Impact |
+|-------------|---------------|-------|--------|
+| Assistant | `Model` (full) | `model`, `defaultModel` | Model deleted → assistant shows stale model info |
+| Assistant | `Topic[]` (full) | `topics` | Topic deleted → assistant still has copy |
+| Assistant | `KnowledgeBase[]` (full) | `knowledge_bases` | KB deleted → assistant shows deleted KB |
+| Assistant | `MCPServer[]` (full) | `mcpServers` | Server removed → assistant still references it |
+| Message | `Model` (full) | `model`, `mentions` | Model removed → stale metadata in history |
+| MessageBlock | `Model` (full) | `model` | Same as above, per-block level |
+| LLM store | `Model` (full) | `defaultModel`, `quickModel`, etc. | 4+ full model copies go stale |
+
+### v2 Solution: FK IDs Only
+
+The v2 database replaces full-object embeddings with **FK ID references**. The full object can always be fetched via the FK ID — no need to store redundant copies or maintain separate snapshot types.
+
+```typescript
+// message table:
+assistantId: text(),  // FK → query assistant table for full object
+modelId: text(),      // FK → query model/provider for full object
+```
+
+### When to Use Which Pattern
+
+| Scenario | Pattern | Example |
+|----------|---------|---------|
+| **Reference can be deleted** and host must survive | FK ID with `onDelete: 'set null'` | topic→assistant, message→model |
+| **Reference is owned** by host (cascade delete) | FK with `onDelete: 'cascade'` | topic→messages |
+| **Reference is organizational** (grouping) | FK with `onDelete: 'set null'` | topic→group |
+| **Reference is config** (list of IDs) | JSON array of IDs | assistant→knowledgeBaseIds |
+| **Data is immutable history** (citations, tool results) | Embedded JSON (full copy OK) | message→citation data |
+
+### API Response Design
+
+APIs should **not** re-embed full referenced objects. Return FK IDs and let the renderer fetch full objects via separate queries when needed.
+
+```typescript
+// API schema - topic response includes FK ID, not full assistant
+'/topics/:id': {
+  GET: {
+    response: {
+      id: string
+      name: string
+      assistantId: string | null  // FK — renderer queries assistant separately
+      // NOT: assistant: Assistant  ← don't embed full objects
+    }
+  }
+}
+```
+
+## Error Handling
+
+```typescript
+import { DataApiErrorFactory } from '@shared/data/api'
+
+// Standard error factories
+throw DataApiErrorFactory.notFound('Topic', id)
+throw DataApiErrorFactory.validation({ name: ['Required'], email: ['Invalid format'] })
+throw DataApiErrorFactory.conflict('Name already exists')
+throw DataApiErrorFactory.database(error, 'insert topic')
+throw DataApiErrorFactory.invalidOperation('delete root message', 'cascade=true required')
+throw DataApiErrorFactory.timeout('fetch topics', 3000)
+```
+
+## Checklist
+
+### TDD Cycle (red-green-refactor)
+- [ ] Service tests written and **failing** (red) in `src/main/data/services/__tests__/`
+- [ ] Minimum service code written to make tests pass (green)
+- [ ] Validation logic tests added (red), then implemented (green)
+- [ ] Error case tests added (red): not found, invalid operations, then handled (green)
+- [ ] Business rule tests added (red): domain workflows, transaction coordination
+- [ ] Code refactored with all tests still passing
+- [ ] Tests pass: `pnpm test:main`
+
+### DataApi Endpoint (implementation details)
+- [ ] SQLite schema in `src/main/data/db/schemas/` + migrations generated
+- [ ] API schema in `packages/shared/data/api/schemas/` + registered in index
+- [ ] Service with business logic in `src/main/data/services/`
+- [ ] Handler (thin) in `src/main/data/api/handlers/` + registered in index
+- [ ] Repository (if complex domain) in `src/main/data/repositories/`
+- [ ] Error handling via `DataApiErrorFactory`
+- [ ] Logging via `loggerService` with context
+- [ ] Business logic extracted from Redux thunks/selectors into Service
+
+### Preference Key
+- [ ] Custom type in `preferenceTypes.ts` (if needed)
+- [ ] Key + type in `PreferenceSchemas` interface
+- [ ] Default value in `DefaultPreferences`
+- [ ] Key naming follows conventions
+
+### Quality
+- [ ] All tests pass: `pnpm test`
+- [ ] `pnpm lint && pnpm format` pass
+- [ ] `pnpm build:check` passes
+
+## Documentation References
+
+- `docs/en/references/data/README.md` - System selection guide
+- `docs/en/references/data/data-api-overview.md` - DataApi architecture
+- `docs/en/references/data/data-api-in-main.md` - Main-process patterns
+- `docs/en/references/data/api-design-guidelines.md` - RESTful conventions
+- `docs/en/references/data/api-types.md` - Type system
+- `docs/en/references/data/database-patterns.md` - Schema conventions
+- `docs/en/references/data/preference-overview.md` - Preference architecture
+- `docs/en/references/data/preference-schema-guide.md` - Adding preference keys
+- `docs/en/references/data/best-practice-layered-preset-pattern.md` - Layered presets

--- a/.claude/skills/v2-migrator/SKILL.md
+++ b/.claude/skills/v2-migrator/SKILL.md
@@ -1,0 +1,662 @@
+---
+name: v2-migrator
+description: Implement migrators that move legacy Redux/Dexie/ElectronStore data into SQLite. Use when creating or modifying migrators in the v2 migration pipeline. This skill only covers data migration - for Main-process services see v2-data-api, for Renderer consumption see v2-renderer.
+---
+
+# V2 Migration: Data Migration (Phase 1 of 3)
+
+Move legacy data (Redux Persist, Dexie IndexedDB, ElectronStore) into SQLite tables. This is a one-shot migration that runs before the app switches to the v2 architecture.
+
+**This skill enforces strict TDD (red-green-refactor).** For every unit of work: (1) write ONE failing test (red), (2) write the minimum code to make it pass (green), (3) refactor while keeping tests green. Repeat. Run `pnpm test:main` to verify.
+
+**Related skills:**
+- `v2-data-api` - Phase 2: Main-process services that expose migrated data
+- `v2-renderer` - Phase 3: Renderer hooks and services that consume data
+
+## Data Source Classification
+
+Before writing a migrator, confirm which data needs migration:
+
+| Category | v2 Target | Migrate? |
+|----------|-----------|----------|
+| **preferences** (settings) | `preferenceTable` | Yes - via PreferencesMigrator |
+| **user_data** (topics, messages, assistants) | Domain SQLite tables | Yes - domain migrators |
+| **cache** (favicon, computed results) | CacheService | No - regenerable |
+| **runtime** (selected topic, UI state) | CacheService or React state | No - session only |
+
+**Cross-category migration:** In the legacy Redux store, some data that is logically a user preference lives under domain slices (e.g., `knowledge`, `memory`, `nutstore`) rather than `settings`. During migration, these fields must be reclassified and routed to `preferenceTable` instead of domain tables. Examples:
+
+| Redux Slice | Legacy Key | v2 Target | Rationale |
+|---|---|---|---|
+| `memory` | `memory.embedderModel` | `preference: feature.memory.embedder_model_id` | Full `Model` object → extract and store only model ID |
+| `nutstore` | `nutstore.autoSyncEnabled` | `preference: data.nutstore.auto_sync_enabled` | Toggle setting |
+| `knowledge` | `knowledge.defaultEmbedModel` | `preference: feature.knowledge.default_embed_model_id` | Full `Model` object → extract and store only model ID |
+| `selectionStore` | `selectionStore.quickAssistantId` | `preference: feature.quick_assistant.id` | User selection |
+
+When implementing a domain migrator, always check whether each field is truly user data (belongs in a domain table) or actually a user preference (belongs in `preferenceTable`). Consult `v2-refactor-temp/tools/data-classify/classification.json` for the authoritative classification. Preference-type fields from domain slices should be added to the PreferencesMigrator's `REDUX_STORE_MAPPINGS` (which already supports non-settings categories like `memory`, `nutstore`, `shortcuts`, `note`, `selectionStore`).
+
+Full inventory: `v2-refactor-temp/tools/data-classify/classification.json` (391 items)
+
+## Architecture
+
+```
+Renderer Process                          Main Process
++-----------------------+                 +---------------------------+
+| Redux Persist Store   |---IPC export--->| ReduxStateReader          |
+| (localStorage)        |                 |   .get(category, key)     |
++-----------------------+                 +---------------------------+
+                                                    |
++-----------------------+                           v
+| Dexie IndexedDB       |---JSON export-->| DexieFileReader            |
+| (topics, messages,    |                 |   .readTable() / stream    |
+|  blocks, files...)    |                 +---------------------------+
++-----------------------+                           |
+                                                    v
++-----------------------+                 +---------------------------+
+| ElectronStore         |---direct------->| ConfigManager             |
+| (electron-store.json) |                 |   .get(key)               |
++-----------------------+                 +---------------------------+
+                                                    |
+                                                    v
+                                          +---------------------------+
+                                          | MigrationEngine           |
+                                          |   prepare/execute/validate|
+                                          +---------------------------+
+                                                    |
+                                                    v
+                                          +---------------------------+
+                                          | SQLite (Drizzle ORM)      |
+                                          +---------------------------+
+```
+
+**Multi-renderer note:** Cherry Studio has multiple renderer windows (main app, mini window, selection toolbar). Only the dedicated migration window triggers migration. Main process owns all migration logic; renderers receive progress via IPC.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/main/data/migration/v2/core/MigrationEngine.ts` | Orchestrator: 3-phase pipeline, progress tracking |
+| `src/main/data/migration/v2/core/MigrationContext.ts` | Shared context: sources, db, sharedData, logger |
+| `src/main/data/migration/v2/migrators/BaseMigrator.ts` | Abstract base class |
+| `src/main/data/migration/v2/migrators/index.ts` | Migrator registration (execution order) |
+| `src/main/data/migration/v2/migrators/PreferencesMigrator.ts` | Reference impl: settings migration |
+| `src/main/data/migration/v2/migrators/ChatMigrator.ts` | Reference impl: complex multi-source migration |
+| `src/main/data/migration/v2/migrators/mappings/` | Mapping definitions and transform functions |
+| `src/main/data/migration/v2/utils/ReduxStateReader.ts` | Dot-path accessor for Redux state |
+| `src/main/data/migration/v2/utils/DexieFileReader.ts` | JSON table reader with streaming |
+| `src/main/data/migration/v2/utils/JSONStreamReader.ts` | Memory-efficient batch streaming |
+| `packages/shared/data/migration/v2/types.ts` | Shared types: stages, results, stats |
+| `src/main/data/migration/v2/window/MigrationIpcHandler.ts` | IPC flow control |
+| `src/renderer/src/store/` | Redux slices (source data shapes) |
+
+## Migrator Contract
+
+Every migrator extends `BaseMigrator` with a **three-phase lifecycle**:
+
+```typescript
+import { BaseMigrator } from './BaseMigrator'
+import type { MigrationContext } from '../core/MigrationContext'
+import type { PrepareResult, ExecuteResult, ValidateResult } from '@shared/data/migration/v2/types'
+
+export class MyDomainMigrator extends BaseMigrator {
+  id = 'my_domain'
+  name = 'My Domain Migrator'
+  description = 'Migrates X from legacy stores to SQLite'
+  order = 5 // Lower runs first
+
+  async prepare(ctx: MigrationContext): Promise<PrepareResult> {
+    // Phase 1: Dry-run - count items, check source availability, NO DB writes
+    // Return { success, itemCount, warnings? }
+  }
+
+  async execute(ctx: MigrationContext): Promise<ExecuteResult> {
+    // Phase 2: Batch inserts with transactions, report progress
+    // Return { success, processedCount, error? }
+  }
+
+  async validate(ctx: MigrationContext): Promise<ValidateResult> {
+    // Phase 3: Compare source vs target counts, sample-check records
+    // Return { success, errors[], stats: { sourceCount, targetCount, skippedCount } }
+    // Engine fails if targetCount < sourceCount - skippedCount
+  }
+}
+```
+
+## Data Access in Migrators
+
+```typescript
+// Redux state
+const settings = ctx.sources.redux.getCategory('settings')
+const theme = ctx.sources.redux.get('settings', 'theme')
+const editorEnabled = ctx.sources.redux.get('settings', 'codeEditor.enabled')
+if (ctx.sources.redux.hasCategory('knowledge')) { /* ... */ }
+
+// Dexie - small table (load all at once)
+const notes = await ctx.sources.dexie.readTable<OldNote>('knowledge_notes')
+
+// Dexie - large table (streaming)
+const reader = ctx.sources.dexie.createStreamReader('topics')
+const count = await reader.count()
+await reader.readInBatches(50, async (batch) => { /* process */ })
+const sample = await reader.readSample(5)  // validation sampling
+
+// ElectronStore
+const zoomFactor = ctx.sources.config.get('ZoomFactor')
+
+// Cross-migrator data sharing
+ctx.sharedData.set('assistantIdMap', idMap)  // producer (earlier migrator)
+const idMap = ctx.sharedData.get('assistantIdMap')  // consumer (later migrator)
+```
+
+## Step-by-Step: New Migrator
+
+### 1. Understand Source Data
+- Read the Redux slice in `src/renderer/src/store/` for data shape
+- Check Dexie tables in `src/renderer/src/services/db.ts` if applicable
+- Confirm classification in `v2-refactor-temp/tools/data-classify/classification.json`
+
+### 2. Understand Target Schema
+- Read target SQLite schema in `src/main/data/db/schemas/`
+- Map source fields to target columns
+- Identify transformations (type conversions, restructuring, merging)
+
+### 3. Create Mapping File (if needed)
+
+**Simple 1:1 mapping** (like PreferencesMappings):
+```typescript
+// src/main/data/migration/v2/migrators/mappings/MyDomainMappings.ts
+export interface FieldMapping {
+  originalKey: string   // Source field path (dot notation)
+  targetKey: string     // Target column or key
+  transform?: (value: unknown) => unknown
+}
+
+export const MY_DOMAIN_MAPPINGS: FieldMapping[] = [
+  { originalKey: 'name', targetKey: 'display_name' },
+  { originalKey: 'config.enabled', targetKey: 'is_enabled', transform: Boolean },
+]
+```
+
+**Complex mapping** (like ComplexPreferenceMappings - 1:N, N:1, or cross-source):
+```typescript
+export interface ComplexMapping {
+  id: string
+  description: string
+  sources: Record<string, SourceDefinition>
+  targetKeys: string[]
+  transform: (sources: Record<string, unknown>) => Record<string, unknown>
+}
+```
+
+### 4. Write Tests for Transformation Functions (TDD Red Phase)
+
+**Write failing tests first.** Each test should fail (red) before you write any transformation code. Only write enough code to make each test pass (green), then refactor.
+
+Test location: colocated `__tests__/` directories next to the code being tested (e.g., `migrators/mappings/__tests__/MyDomainMappings.test.ts`).
+
+```typescript
+// src/main/data/migration/v2/migrators/mappings/__tests__/MyDomainMappings.test.ts
+import { describe, expect, it } from 'vitest'
+import { transformRecord } from '../MyDomainMappings'
+
+describe('MyDomainMappings', () => {
+  describe('transformRecord', () => {
+    it('should transform basic fields', () => {
+      const old = { id: 'abc', name: 'Test', createdAt: 1700000000000 }
+      const result = transformRecord(old)
+      expect(result.id).toBe('abc')
+      expect(result.display_name).toBe('Test')
+      expect(result.created_at).toBe('2023-11-14T22:13:20.000Z')
+    })
+
+    it('should handle missing optional fields', () => {
+      const old = { id: 'abc', name: 'Test' }
+      const result = transformRecord(old)
+      expect(result.created_at).toBeDefined() // falls back to now
+    })
+
+    it('should handle null/undefined input gracefully', () => {
+      const old = { id: 'abc', name: null, createdAt: undefined }
+      const result = transformRecord(old)
+      expect(result.display_name).toBe('') // or whatever default
+    })
+
+    it('should generate new ID for duplicates', () => {
+      // Test with duplicate detection logic
+    })
+  })
+})
+```
+
+**What to test:**
+- Each transformation function (pure, no DB dependency)
+- Edge cases: null/undefined fields, empty strings, invalid dates
+- Mapping completeness: all source fields accounted for
+- Complex mappings: multi-source merging, conditional logic
+- ID deduplication logic
+
+### 5. Write Transformation Functions (TDD Green Phase)
+
+Implement the minimum code to make the tests from step 4 pass. Pure functions in a separate mappings file:
+```typescript
+interface OldRecord { /* legacy shape */ }
+interface NewRecord { /* SQLite shape */ }
+
+export function transformRecord(old: OldRecord, lookupData?: Map<string, any>): NewRecord {
+  return {
+    id: old.id,
+    created_at: old.createdAt ? new Date(old.createdAt).toISOString() : new Date().toISOString(),
+    // ... field transformations
+  }
+}
+```
+
+### 6. Write Tests for Migrator Phases (TDD Red Phase)
+
+Write failing tests for the migrator's prepare/execute/validate phases by mocking `MigrationContext`. Each test must fail before you proceed to step 7:
+
+```typescript
+// src/main/data/migration/v2/migrators/__tests__/MyDomainMigrator.test.ts
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { MyDomainMigrator } from '../MyDomainMigrator'
+
+// Mock MigrationContext
+function createMockContext(reduxData: Record<string, any> = {}, dbRows: any[] = []) {
+  return {
+    sources: {
+      redux: {
+        get: vi.fn((category, key) => {
+          const cat = reduxData[category]
+          if (!cat || !key) return cat
+          return key.split('.').reduce((o, k) => o?.[k], cat)
+        }),
+        getCategory: vi.fn((cat) => reduxData[cat]),
+        hasCategory: vi.fn((cat) => cat in reduxData),
+      },
+      dexie: { readTable: vi.fn(), createStreamReader: vi.fn(), tableExists: vi.fn() },
+      config: { get: vi.fn() },
+    },
+    db: {
+      transaction: vi.fn(async (fn) => fn({
+        insert: vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) })
+      })),
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockResolvedValue([{ count: dbRows.length }])
+      }),
+    },
+    sharedData: new Map(),
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  }
+}
+
+describe('MyDomainMigrator', () => {
+  let migrator: MyDomainMigrator
+
+  beforeEach(() => {
+    migrator = new MyDomainMigrator()
+    migrator.reportProgress = vi.fn()
+  })
+
+  describe('prepare', () => {
+    it('should count source items', async () => {
+      const ctx = createMockContext({ mySlice: { items: [{id:'1'}, {id:'2'}] } })
+      const result = await migrator.prepare(ctx as any)
+      expect(result.success).toBe(true)
+      expect(result.itemCount).toBe(2)
+    })
+
+    it('should handle empty source', async () => {
+      const ctx = createMockContext({})
+      const result = await migrator.prepare(ctx as any)
+      expect(result.success).toBe(true)
+      expect(result.itemCount).toBe(0)
+    })
+  })
+
+  describe('validate', () => {
+    it('should pass when counts match', async () => {
+      const ctx = createMockContext(
+        { mySlice: { items: [{id:'1'}, {id:'2'}] } },
+        [{}, {}] // 2 rows in DB
+      )
+      const result = await migrator.validate(ctx as any)
+      expect(result.success).toBe(true)
+      expect(result.stats.sourceCount).toBe(2)
+      expect(result.stats.targetCount).toBe(2)
+    })
+  })
+})
+```
+
+### 7. Implement the Migrator (TDD Green Phase)
+
+Write the minimum code to make the tests from step 6 pass. Then refactor while keeping all tests green.
+
+**Template - small dataset (fits in memory):**
+```typescript
+import { loggerService } from '@logger'
+import { BaseMigrator } from './BaseMigrator'
+
+const logger = loggerService.withContext('MyDomainMigrator')
+
+export class MyDomainMigrator extends BaseMigrator {
+  id = 'my_domain'; name = 'My Domain'; description = '...'; order = 5
+
+  async prepare(ctx) {
+    const items = ctx.sources.redux.get('mySlice', 'items') ?? []
+    return { success: true, itemCount: items.length }
+  }
+
+  async execute(ctx) {
+    const items = ctx.sources.redux.get('mySlice', 'items') ?? []
+    const BATCH = 100; let processed = 0; let skipped = 0
+
+    for (let i = 0; i < items.length; i += BATCH) {
+      const batch = items.slice(i, i + BATCH)
+      const rows = []
+      for (const item of batch) {
+        try { rows.push(transform(item)) }
+        catch (e) { logger.warn(`Skip ${item.id}: ${e}`); skipped++ }
+      }
+      await ctx.db.transaction(async (tx) => {
+        await tx.insert(targetTable).values(rows)
+      })
+      processed += rows.length
+      this.reportProgress(Math.round(((processed + skipped) / items.length) * 100),
+        `Migrated ${processed}/${items.length}`)
+    }
+    return { success: true, processedCount: processed }
+  }
+
+  async validate(ctx) {
+    const sourceCount = (ctx.sources.redux.get('mySlice', 'items') ?? []).length
+    const [{ count }] = await ctx.db.select({ count: sql`count(*)` }).from(targetTable)
+    return {
+      success: Number(count) >= sourceCount,
+      errors: [], stats: { sourceCount, targetCount: Number(count), skippedCount: 0 }
+    }
+  }
+}
+```
+
+**Template - large dataset (streaming):**
+```typescript
+async execute(ctx) {
+  const reader = ctx.sources.dexie.createStreamReader('myLargeTable')
+  const total = await reader.count()
+  let processed = 0
+
+  await reader.readInBatches(50, async (batch) => {
+    const rows = batch.map(item => transform(item))
+    await ctx.db.transaction(async (tx) => {
+      await tx.insert(targetTable).values(rows)
+    })
+    processed += rows.length
+    this.reportProgress(Math.round((processed / total) * 100),
+      `Migrated ${processed}/${total}`)
+  })
+  return { success: true, processedCount: processed }
+}
+```
+
+### 8. Register
+
+1. Add to `src/main/data/migration/v2/migrators/index.ts` with correct `order`
+2. Add target table to `MigrationEngine.verifyAndClearNewTables` (child tables before parents)
+
+### 9. Document
+
+Create `src/main/data/migration/v2/migrators/README-<MigratorName>.md`:
+- Data sources and target tables
+- Field mappings (source -> target)
+- Key transformations
+- Dropped fields and rationale
+- Edge cases and data quality handling
+
+## Common Transformation Patterns
+
+### ID Handling
+```typescript
+import { v4 as uuidv4 } from 'uuid'
+const seenIds = new Set<string>()
+function ensureUniqueId(id: string): string {
+  if (seenIds.has(id)) {
+    const newId = uuidv4()
+    logger.warn(`Duplicate ID ${id}, generated new: ${newId}`)
+    return newId
+  }
+  seenIds.add(id)
+  return id
+}
+```
+
+### Timestamp Normalization
+```typescript
+function normalizeTimestamp(value: unknown): string {
+  if (typeof value === 'number') return new Date(value).toISOString()
+  if (typeof value === 'string') return new Date(value).toISOString()
+  return new Date().toISOString()
+}
+```
+
+### Data Merging (Multiple Sources)
+```typescript
+// Merge Redux metadata with Dexie content (pattern from ChatMigrator)
+function mergeTopicData(reduxTopic: ReduxTopic, dexieTopic: DexieTopic): MergedTopic {
+  return {
+    id: dexieTopic.id,
+    name: reduxTopic.name || dexieTopic.name || 'Unnamed',
+    messages: dexieTopic.messages,
+    assistantId: reduxTopic.assistantId,
+    createdAt: reduxTopic.createdAt,
+  }
+}
+```
+
+## Cross-Domain References & Foreign Keys
+
+### The Legacy Problem: Embedded Full Objects
+
+In Redux, domains store **full copies** of objects from other domains instead of just IDs. When the original is deleted, the copy becomes stale — a phantom that the user can't remove.
+
+**Known problematic embeddings:**
+
+| Host | Embedded Guest (full copy) | Field | Stale Data Risk |
+|------|---------------------------|-------|-----------------|
+| Assistant | `Model` | `model`, `defaultModel` | Model deleted → assistant shows phantom model |
+| Assistant | `Topic[]` | `topics` | Topic deleted → assistant still holds copy |
+| Assistant | `KnowledgeBase[]` | `knowledge_bases` | KB removed → assistant still references it |
+| Assistant | `MCPServer[]` | `mcpServers` | Server removed → assistant still lists it |
+| Message | `Model` | `model`, `mentions` | Model removed → stale metadata in history |
+| MessageBlock | `Model` | `model` | Same, per-block level |
+| LLM store | `Model` (x4) | `defaultModel`, `quickModel`, `translateModel`, `topicNamingModel` | 4 full Model copies go stale |
+| WebSearch | `Model` | `compressionConfig.embeddingModel` | Model deleted → RAG compression broken |
+| WebSearch | `Model` | `compressionConfig.rerankModel` | Model deleted → reranking broken |
+
+### The v2 Solution: FK IDs Only
+
+The v2 database replaces full-object embeddings with **FK ID references**. The full object can always be fetched via the ID — no need to store redundant copies.
+
+```typescript
+// Before (Redux): topic.assistant = { id: 'a1', name: '...', model: {...}, ... }
+// After (v2):     topic.assistantId = 'a1'  (query assistant table for full object)
+
+// Before (Redux): message.model = { id: 'm1', name: 'GPT-4', provider: 'openai', ... }
+// After (v2):     message.modelId = 'm1'   (query model/provider for full object)
+```
+
+### Migration Transform: Full Object → ID
+
+When migrating, extract just the ID from embedded full objects:
+
+```typescript
+// Extract ID from full embedded object
+function extractId(embedded: any): string | null {
+  return embedded?.id ?? null
+}
+
+// Usage in a topic transform:
+function transformTopic(reduxTopic: any): DbTopicRow {
+  return {
+    id: reduxTopic.id,
+    name: reduxTopic.name,
+    assistantId: reduxTopic.assistantId ?? reduxTopic.assistant?.id ?? null,
+    // ... other fields
+  }
+}
+
+// Usage in a message transform:
+function transformMessage(msg: any): DbMessageRow {
+  return {
+    id: msg.id,
+    modelId: msg.modelId ?? msg.model?.id ?? null,
+    assistantId: msg.assistantId,
+    // ... other fields
+  }
+}
+```
+
+### Array References: Full Objects → ID Arrays
+
+For fields that embed arrays of full objects (e.g., `assistant.mcpServers`, `assistant.knowledge_bases`), migrate to arrays of IDs:
+
+```typescript
+// Before (Redux): assistant.mcpServers = [{ id: 'srv1', name: '...', url: '...' }, ...]
+// After (v2):     assistant.mcpServerIds = ['srv1', 'srv2']  (or a join table)
+
+function extractIds(embedded: any[] | undefined): string[] {
+  if (!Array.isArray(embedded)) return []
+  return embedded.map(item => item.id).filter(Boolean)
+}
+```
+
+### Migration Order & Foreign Keys
+
+SQLite enforces FK constraints. Migrators must run in dependency order — referenced tables before referencing tables:
+
+```
+order=1  GroupMigrator        → group table (no FKs)
+order=2  AssistantMigrator    → assistant table (no FKs to other migrated tables)
+order=3  TopicMigrator        → topic table (FK → group, FK → assistant)
+order=4  MessageMigrator      → message table (FK → topic, self-ref parentId)
+```
+
+**Key rules:**
+- **Set `order` so parent tables are populated first** — e.g., topics before messages
+- **`MigrationEngine.verifyAndClearNewTables`** must list child tables before parents (reverse order) so DELETE cascades correctly during cleanup
+- **Orphan references are expected** — the original entity may have been deleted in Redux while the embedding survived. Set the FK to `null`
+- **Share ID maps via `ctx.sharedData`** when a later migrator needs to look up IDs from an earlier one
+
+### Handling Orphan References
+
+When migrating, the embedded object may reference an entity that no longer exists (was deleted by user). The migrator should:
+
+1. **Check if the referenced entity exists** in the already-migrated target table
+2. **Set `entityId` to `null` if the FK target doesn't exist** — don't insert a dangling FK
+
+```typescript
+async execute(ctx) {
+  // Earlier migrator shared the set of valid assistant IDs
+  const validAssistantIds = ctx.sharedData.get('assistantIds') as Set<string>
+
+  for (const topic of topics) {
+    const row = transformTopic(topic)
+
+    // Validate FK — don't insert dangling reference
+    if (row.assistantId && !validAssistantIds.has(row.assistantId)) {
+      logger.warn(`Topic ${row.id}: assistant ${row.assistantId} not found, setting to null`)
+      row.assistantId = null
+    }
+
+    rows.push(row)
+  }
+}
+```
+
+### What to Test (FK-related)
+
+Add these to TDD tests for any migrator that handles cross-domain references:
+
+```typescript
+it('should extract ID from full embedded object', () => {
+  const embedded = { id: 'm1', name: 'GPT-4', provider: 'openai' }
+  expect(extractId(embedded)).toBe('m1')
+})
+
+it('should return null for missing embedded object', () => {
+  expect(extractId(null)).toBeNull()
+  expect(extractId(undefined)).toBeNull()
+  expect(extractId({})).toBeNull()
+})
+
+it('should set FK to null when referenced entity is deleted', () => {
+  const validIds = new Set(['a1'])
+  const topic = { id: 't1', assistantId: 'a-deleted', assistant: { id: 'a-deleted', name: 'Old' } }
+  const row = transformTopic(topic)
+  if (!validIds.has(row.assistantId!)) row.assistantId = null
+  expect(row.assistantId).toBeNull()
+})
+
+it('should extract ID array from full object array', () => {
+  const servers = [{ id: 's1', name: 'MCP1' }, { id: 's2', name: 'MCP2' }]
+  expect(extractIds(servers)).toEqual(['s1', 's2'])
+  expect(extractIds(undefined)).toEqual([])
+  expect(extractIds([])).toEqual([])
+})
+```
+
+## Error Handling
+
+1. **Never abort for one bad record** - skip it, log warning, increment `skippedCount`
+2. **Log with context** - `loggerService.withContext('MigratorName')`
+3. **Transaction per batch** - if a batch fails, only that batch rolls back
+4. **Provide mismatchReason** - explain count mismatches in `stats.mismatchReason`
+
+```typescript
+try {
+  rows.push(transformRecord(item))
+} catch (err) {
+  logger.warn(`Skipping item ${item.id}: ${(err as Error).message}`)
+  skippedCount++
+}
+```
+
+## Checklist
+
+### TDD Cycle (red-green-refactor)
+- [ ] Transformation function tests written and **failing** (red) before any implementation
+- [ ] Minimum transformation code written to make tests pass (green)
+- [ ] Migrator phase tests (prepare/execute/validate) written and **failing** (red)
+- [ ] Minimum migrator code written to make phase tests pass (green)
+- [ ] Edge case tests: empty data, null fields, duplicate IDs, missing sources
+- [ ] Code refactored with all tests still passing
+- [ ] Tests pass: `pnpm test:main`
+
+### Implementation details
+- [ ] Source data shape understood (Redux slice + Dexie schema)
+- [ ] Classification confirmed in `classification.json`
+- [ ] Target SQLite schema exists in `src/main/data/db/schemas/`
+- [ ] Mapping/transformation file created (if needed)
+- [ ] All three phases: prepare, execute, validate
+- [ ] Batch inserts + transactions (50-100 per batch)
+- [ ] Streaming for large tables (>1000 records)
+- [ ] Duplicate ID handling
+- [ ] Progress via `reportProgress`
+- [ ] Registered in `migrators/index.ts` with correct `order`
+- [ ] Target table added to `MigrationEngine.verifyAndClearNewTables`
+- [ ] Cross-migrator data via `ctx.sharedData` (if applicable)
+- [ ] `README-<MigratorName>.md` created
+- [ ] All logging via `loggerService` (no `console.log`)
+
+### Cross-domain references & FK integrity
+- [ ] Embedded full objects → extracted to FK ID only (discard the rest)
+- [ ] Array of full objects → array of IDs (or join table)
+- [ ] `order` set so parent tables populate before child tables
+- [ ] Orphan references handled: FK set to `null`
+- [ ] Valid ID sets shared via `ctx.sharedData` for FK validation
+- [ ] `verifyAndClearNewTables` lists child tables before parents (reverse delete order)
+
+## Documentation References
+
+- `docs/en/references/data/v2-migration-guide.md` - Migration engine architecture
+- `docs/en/references/data/database-patterns.md` - SQLite schema conventions

--- a/.claude/skills/v2-renderer/SKILL.md
+++ b/.claude/skills/v2-renderer/SKILL.md
@@ -1,0 +1,514 @@
+---
+name: v2-renderer
+description: Wire up Renderer-process consumption of v2 data via React hooks and services. Covers replacing Redux useAppSelector/dispatch with useQuery/useMutation (DataApi), usePreference (settings), and useCache (temporary data), with multi-window sync considerations. Use when migrating React components from Redux to the v2 data layer.
+---
+
+# V2 Renderer: UI Data Consumption (Phase 3 of 3)
+
+Replace Redux `useAppSelector` / `dispatch` in React components with v2 hooks (`useQuery`, `usePreference`, `useCache`) that talk to Main-process services via IPC.
+
+**This skill enforces strict TDD (red-green-refactor).** For every unit of work: (1) write ONE failing test (red), (2) write the minimum code to make it pass (green), (3) refactor while keeping tests green. Repeat. Run `pnpm test:renderer` to verify.
+
+**Related skills:**
+- `v2-migrator` - Phase 1: Migrating legacy data into SQLite
+- `v2-data-api` - Phase 2: Main-process services that expose data
+
+## Multi-Window Architecture
+
+Cherry Studio has multiple renderer windows (main app, mini window, selection toolbar). Each system handles cross-window sync differently:
+
+| System | Sync Strategy | Notes |
+|--------|--------------|-------|
+| **DataApiService** | No auto-sync; fetch on demand | Each window fetches fresh data independently |
+| **PreferenceService** | Auto-broadcasts to all windows | Main process is source of truth; optimistic updates with rollback |
+| **CacheService (shared)** | Auto-broadcasts to all windows | Main maintains authoritative copy; new windows get init-sync |
+| **CacheService (persist)** | Auto-broadcasts + localStorage | Survives restarts; Main-priority override on sync |
+| **CacheService (memory)** | No sync (process-local) | Isolated per renderer process |
+
+## Migration Pattern: Redux -> v2
+
+### Before (Redux)
+```typescript
+import { useAppSelector, useAppDispatch } from '@/store'
+import { updateSettings } from '@/store/settings'
+
+function SettingsPage() {
+  const theme = useAppSelector(state => state.settings.theme)
+  const dispatch = useAppDispatch()
+
+  const handleThemeChange = (value: string) => {
+    dispatch(updateSettings({ theme: value }))
+  }
+}
+```
+
+### After (v2 - depends on data type)
+
+**User settings -> usePreference:**
+```typescript
+import { usePreference } from '@data/hooks/usePreference'
+
+function SettingsPage() {
+  const [theme, setTheme] = usePreference('app.theme.mode')
+  const handleThemeChange = (value: string) => setTheme(value)
+}
+```
+
+**Business data -> useQuery/useMutation:**
+```typescript
+import { useQuery, useMutation } from '@data/hooks/useDataApi'
+
+function TopicList() {
+  const { data: topics, isLoading } = useQuery('/topics')
+  const { trigger: createTopic } = useMutation('POST', '/topics', {
+    refresh: ['/topics']
+  })
+}
+```
+
+**Temporary/UI state -> useCache:**
+```typescript
+import { useSharedCache } from '@data/hooks/useCache'
+
+function Sidebar() {
+  const [collapsed, setCollapsed] = useSharedCache('ui.sidebar.collapsed', false)
+}
+```
+
+## DataApi Hooks (Business Data)
+
+Import from `@data/hooks/useDataApi`.
+
+### useQuery (GET)
+
+```typescript
+// Basic list
+const { data, isLoading, error, refetch } = useQuery('/topics')
+
+// With query params
+const { data } = useQuery('/messages', { query: { topicId, page: 1, limit: 20 } })
+
+// Single resource
+const { data: topic } = useQuery('/topics/abc123')
+
+// Conditional fetching (null key = skip)
+const { data } = useQuery(topicId ? `/topics/${topicId}/messages` : null)
+
+// Polling
+const { data } = useQuery('/topics', { refreshInterval: 5000 })
+```
+
+### useMutation (POST/PUT/PATCH/DELETE)
+
+```typescript
+// Create
+const { trigger: create, isLoading } = useMutation('POST', '/topics', {
+  refresh: ['/topics'],  // Auto-refresh these queries after success
+  onSuccess: (data) => toast.success('Created'),
+})
+await create({ body: { name: 'New Topic' } })
+
+// Update (full replace)
+const { trigger: replace } = useMutation('PUT', `/topics/${id}`)
+await replace({ body: { name: 'Updated', description: '...' } })
+
+// Partial update
+const { trigger: update } = useMutation('PATCH', `/topics/${id}`)
+await update({ body: { name: 'New Name' } })
+
+// Delete
+const { trigger: remove } = useMutation('DELETE', `/topics/${id}`, {
+  refresh: ['/topics']
+})
+await remove()
+
+// Optimistic update (instant UI, auto-rollback on failure)
+const { trigger: toggleStar } = useMutation('PATCH', `/topics/${id}`, {
+  optimisticData: { ...topic, starred: !topic.starred }
+})
+```
+
+### useInfiniteQuery (Cursor-based Infinite Scroll)
+
+```typescript
+const { items, isLoading, hasNext, loadNext } = useInfiniteQuery('/messages', {
+  query: { topicId },
+  limit: 20
+})
+// items: all loaded items flattened
+// loadNext(): load next page
+```
+
+### usePaginatedQuery (Offset-based Pagination)
+
+```typescript
+const { items, page, total, hasNext, hasPrev, nextPage, prevPage } =
+  usePaginatedQuery('/topics', { limit: 10 })
+```
+
+### Direct Service (non-React)
+
+```typescript
+import { dataApiService } from '@data/DataApiService'
+
+const topics = await dataApiService.get('/topics')
+const topic = await dataApiService.get('/topics/abc123')
+const newTopic = await dataApiService.post('/topics', { body: { name: 'New' } })
+await dataApiService.patch('/topics/abc123', { body: { name: 'Updated' } })
+await dataApiService.delete('/topics/abc123')
+```
+
+### Error Handling
+
+```typescript
+// In hooks
+const { data, error } = useQuery('/topics')
+if (error?.code === ErrorCode.NOT_FOUND) return <NotFound />
+
+// In try-catch
+import { DataApiError, ErrorCode } from '@shared/data/api'
+try {
+  await dataApiService.post('/topics', { body: data })
+} catch (error) {
+  if (error instanceof DataApiError) {
+    if (error.code === ErrorCode.VALIDATION_ERROR) {
+      const fieldErrors = error.details?.fieldErrors
+    }
+    if (error.isRetryable) { /* safe to retry */ }
+  }
+}
+```
+
+## Preference Hooks (User Settings)
+
+Import from `@data/hooks/usePreference`.
+
+### usePreference (Single)
+
+```typescript
+// Optimistic (default) - UI updates immediately, syncs to DB
+const [theme, setTheme] = usePreference('app.theme.mode')
+await setTheme('dark')
+
+// Pessimistic - waits for DB confirmation before UI update
+const [apiKey, setApiKey] = usePreference('api.key', { optimistic: false })
+await setApiKey('sk-...')
+```
+
+**When to use which:**
+- **Optimistic** (default): frequent, non-critical changes (theme, font size)
+- **Pessimistic**: security-sensitive or external-service settings (API keys)
+
+### usePreferences (Multiple)
+
+```typescript
+const { theme, language, fontSize } = usePreferences([
+  'app.theme.mode',
+  'app.language',
+  'chat.message.font_size'
+])
+```
+
+### Direct Service (non-React)
+
+```typescript
+import { preferenceService } from '@data/PreferenceService'
+
+// Read
+const theme = await preferenceService.get('app.theme.mode')
+const settings = await preferenceService.getMultiple(['app.theme.mode', 'app.language'])
+
+// Write
+await preferenceService.set('app.theme.mode', 'dark')
+await preferenceService.setMultiple({ 'app.theme.mode': 'dark', 'app.language': 'en' })
+
+// Subscribe (useful in services, not components)
+const unsub = preferenceService.subscribe('app.theme.mode', (newValue) => {
+  // Called when preference changes in any window
+})
+unsub() // cleanup
+```
+
+## Cache Hooks (Temporary/Regenerable Data)
+
+Import from `@data/hooks/useCache`.
+
+### Three Tiers
+
+| Tier | Hook | Scope | Survives Restart | Cross-Window Sync | Use When |
+|------|------|-------|-----------------|-------------------|----------|
+| **Memory** | `useCache` | Single renderer process | No | No | Computed results, search results, scroll positions — data local to one window that can be recomputed |
+| **Shared** | `useSharedCache` | All renderer windows | No | Yes (via Main) | UI state that must stay in sync across windows (sidebar collapsed, active panel, selection state) |
+| **Persist** | `usePersistCache` | All renderer windows | Yes (localStorage) | Yes (via Main) | User-specific ephemeral data worth keeping across restarts but not critical enough for Preference (recent files, last-used filters, draft text) |
+
+**Decision flow:**
+1. Does this state need to survive app restart? → `usePersistCache`
+2. Does this state need to sync across windows? → `useSharedCache`
+3. Otherwise → `useCache` (memory-only, cheapest)
+
+```typescript
+// Memory cache - lost on restart, single-window only
+const [results, setResults] = useCache('search.results', [])
+const [results, setResults] = useCache('search.results', [], { ttl: 30000 }) // with TTL
+
+// Shared cache - cross-window sync via Main, lost on restart
+const [collapsed, setCollapsed] = useSharedCache('ui.sidebar.collapsed', false)
+
+// Persist cache - cross-window sync + survives restart via localStorage
+const [recent, setRecent] = usePersistCache('app.recent_files', [])
+```
+
+### Type-Safe vs Casual vs Template Keys
+
+```typescript
+// Type-safe (schema key) - auto-completion, compile-time validation
+const [counter, setCounter] = useCache('ui.counter', 0)
+
+// Template key (dynamic pattern, auto type inference)
+const [scrollPos, setScrollPos] = useCache('scroll.position.topic123') // inferred: number
+
+// Casual (fully dynamic, manual type)
+cacheService.setCasual<TopicCache>(`topic:${id}`, data)
+const topic = cacheService.getCasual<TopicCache>(`topic:${id}`)
+```
+
+### Direct Service (non-React)
+
+```typescript
+import { cacheService } from '@data/CacheService'
+
+// Memory
+cacheService.set('search.results', data)
+cacheService.set('search.results', data, 30000) // with TTL
+const data = cacheService.get('search.results')
+cacheService.delete('search.results')
+
+// Shared
+cacheService.setShared('window.layout', config)
+const layout = cacheService.getShared('window.layout')
+
+// Persist
+cacheService.setPersist('app.recent_files', files)
+const files = cacheService.getPersist('app.recent_files')
+```
+
+### Shared Cache Ready State
+
+```typescript
+// SharedCache syncs from Main on window init (async)
+if (cacheService.isSharedCacheReady()) { /* synced */ }
+
+const unsub = cacheService.onSharedCacheReady(() => {
+  // Called immediately if already ready, or when sync completes
+})
+
+// getShared() returns undefined before ready
+// setShared() works immediately (broadcasts to Main)
+// Hooks work normally - update when sync completes
+```
+
+## Testing (Strict TDD)
+
+Follow the red-green-refactor cycle for every component migration. For each piece of UI:
+1. **Red**: Write a failing test for the new hook/component behavior
+2. **Green**: Write the minimum code to make it pass (replace Redux with v2 hook)
+3. **Refactor**: Clean up while keeping tests green
+
+Use the unified mocks in `tests/__mocks__/renderer/`.
+
+### Test Setup
+
+Mocks are globally configured in `tests/renderer.setup.ts`. Import mock utilities via `@test-mocks/*`:
+
+```typescript
+import { MockCacheUtils } from '@test-mocks/renderer/CacheService'
+import { MockDataApiUtils } from '@test-mocks/renderer/DataApiService'
+import { MockUseDataApiUtils } from '@test-mocks/renderer/useDataApi'
+```
+
+### Testing DataApi Components
+
+```typescript
+import { describe, expect, it, beforeEach } from 'vitest'
+import { useQuery, useMutation } from '@data/hooks/useDataApi'
+import { MockUseDataApiUtils } from '@test-mocks/renderer/useDataApi'
+
+describe('TopicList', () => {
+  beforeEach(() => MockUseDataApiUtils.resetMocks())
+
+  it('should fetch topics via useQuery', () => {
+    MockUseDataApiUtils.mockQueryData('/topics', { items: [{ id: '1', name: 'Test' }] })
+    const { data } = useQuery('/topics')
+    expect(data.items).toHaveLength(1)
+  })
+
+  it('should handle loading state', () => {
+    const { loading } = useQuery('/topics')
+    expect(loading).toBe(false) // mock returns immediately
+  })
+
+  it('should create topic via useMutation', async () => {
+    const { mutate } = useMutation('POST', '/topics')
+    const result = await mutate({ body: { name: 'New' } })
+    expect(result.created).toBe(true)
+  })
+
+  it('should handle API errors', async () => {
+    MockDataApiUtils.setErrorResponse('/topics', 'GET', new Error('Network error'))
+    // Test error handling in component
+  })
+})
+```
+
+### Testing Preference Components
+
+```typescript
+import { usePreference } from '@data/hooks/usePreference'
+
+it('should read and update preference', async () => {
+  const [theme, setTheme] = usePreference('app.theme.mode')
+  expect(theme).toBeDefined()
+  await setTheme('dark')
+})
+```
+
+### Testing Cache Components
+
+```typescript
+import { useCache } from '@data/hooks/useCache'
+import { MockCacheUtils } from '@test-mocks/renderer/CacheService'
+
+beforeEach(() => MockCacheUtils.resetMocks())
+
+it('should use cache with initial value', () => {
+  const [value, setValue] = useCache('search.results', [])
+  expect(value).toEqual([])
+})
+
+it('should pre-populate cache for testing', () => {
+  MockCacheUtils.setInitialState({
+    memory: [['search.results', [{ id: '1' }]]],
+  })
+  const [value] = useCache('search.results', [])
+  expect(value).toHaveLength(1)
+})
+```
+
+### What to Test
+
+- Component renders correctly with data from hooks
+- Loading and error states display properly
+- User interactions trigger correct mutations/updates
+- Multi-window behavior: shared cache syncs, local cache doesn't
+- Old Redux imports are removed (no `useAppSelector`/`dispatch`)
+
+## Common Migration Patterns
+
+### Settings Page
+```typescript
+// Before: Redux
+const theme = useAppSelector(s => s.settings.theme)
+dispatch(updateSettings({ theme: 'dark' }))
+
+// After: Preference
+const [theme, setTheme] = usePreference('app.theme.mode')
+await setTheme('dark')
+```
+
+### Data List with CRUD
+```typescript
+// Before: Redux + Dexie
+const topics = useAppSelector(s => s.topics.items)
+dispatch(addTopic(data))
+
+// After: DataApi
+const { data: topics, isLoading } = useQuery('/topics')
+const { trigger: addTopic } = useMutation('POST', '/topics', { refresh: ['/topics'] })
+await addTopic({ body: data })
+```
+
+### UI State (Sidebar, Panels)
+```typescript
+// Before: Redux
+const collapsed = useAppSelector(s => s.runtime.sidebarCollapsed)
+dispatch(setSidebarCollapsed(true))
+
+// After: SharedCache (cross-window) or local state
+const [collapsed, setCollapsed] = useSharedCache('ui.sidebar.collapsed', false)
+```
+
+### Computed/Derived Data
+```typescript
+// Before: Redux selector
+const stats = useAppSelector(selectTopicStats)
+
+// After: useQuery (computed on server) or useCache (computed on client)
+const { data: stats } = useQuery('/topics/stats')
+// or
+const [stats, setStats] = useCache('topics.stats', null)
+```
+
+### Feature Toggles
+```typescript
+// Before: Redux
+const showTimestamp = useAppSelector(s => s.settings.showMessageTimestamp)
+
+// After: Preference
+const [showTimestamp] = usePreference('chat.display.show_timestamp')
+```
+
+## Adding New Schema Keys
+
+### New Cache Key
+1. Add to `packages/shared/data/cache/cacheSchemas.ts`:
+   ```typescript
+   export type UseCacheSchema = {
+     'myFeature.data': MyDataType
+   }
+   export const DefaultUseCache = {
+     'myFeature.data': { items: [], lastUpdated: 0 }
+   }
+   ```
+2. Template key for dynamic patterns:
+   ```typescript
+   'scroll.position.${topicId}': number  // matches scroll.position.topic123
+   ```
+
+### New Preference Key
+See `v2-data-api` skill, "Adding a Preference Key" section.
+
+## Checklist
+
+### TDD Cycle (red-green-refactor)
+- [ ] Component/hook tests written and **failing** (red) with mocked services (`@test-mocks/renderer/*`)
+- [ ] Minimum hook/component code written to make tests pass (green)
+- [ ] Loading and error state tests added (red), then handled (green)
+- [ ] User interaction tests added (red): mutations, preference updates
+- [ ] Code refactored with all tests still passing
+- [ ] Mock utilities reset in `beforeEach`
+- [ ] Tests pass: `pnpm test:renderer`
+
+### Implementation details
+- [ ] Identified correct system for each piece of data (DataApi vs Preference vs Cache)
+- [ ] Old `useAppSelector` / `dispatch` calls removed
+- [ ] New hooks wired up with proper types
+- [ ] Loading states handled (`isLoading` for DataApi)
+- [ ] Error states handled (DataApi error codes)
+- [ ] Mutation callbacks set up (`refresh`, `onSuccess`)
+- [ ] Multi-window behavior verified (shared data syncs, local data doesn't)
+- [ ] Optimistic vs pessimistic update strategy chosen for preferences
+- [ ] Cache tier chosen correctly (memory vs shared vs persist)
+- [ ] New cache/preference keys added to schemas
+
+### Quality
+- [ ] All tests pass: `pnpm test`
+- [ ] `pnpm lint && pnpm format` pass
+- [ ] `pnpm build:check` passes
+
+## Documentation References
+
+- `docs/en/references/data/README.md` - System selection guide
+- `docs/en/references/data/data-api-in-renderer.md` - DataApi hooks and patterns
+- `docs/en/references/data/preference-usage.md` - Preference hooks and service
+- `docs/en/references/data/cache-overview.md` - Cache architecture
+- `docs/en/references/data/cache-usage.md` - Cache hooks and patterns


### PR DESCRIPTION
### What this PR does

Before this PR:

No structured guidance existed for Claude agents working on the v2 data layer migration. Each migration task required re-explaining the architecture, patterns, and constraints from scratch.

After this PR:

Three new skills guide the full v2 data refactoring lifecycle:
- **`v2-migrator`** (Phase 1): Moving legacy Redux/Dexie/ElectronStore data into SQLite — covers source classification, migrator contract, cross-domain references & FK design, orphan handling, and streaming patterns
- **`v2-data-api`** (Phase 2): Building Main-process services — covers Handler→Service→Repository layered architecture, API schema design, preference schema, and database patterns
- **`v2-renderer`** (Phase 3): Wiring up Renderer-process hooks — covers `useQuery`/`useMutation` (DataApi), `usePreference` (settings), and `useCache`/`useSharedCache`/`usePersistCache` (temporary data) with cache tier selection guidance and multi-window sync considerations

All three skills enforce strict TDD (red-green-refactor).

### Why we need it and why it was done in this way

The v2 data refactoring involves migrating ~391 classified data items across Redux, Dexie, and ElectronStore into a unified SQLite + Preference + Cache architecture. Without structured skills, agents repeatedly make mistakes around:

- **Cross-domain references**: Redux stores full object copies (e.g., `Model`, `KnowledgeBase[]`) instead of IDs, leading to stale phantom data when originals are deleted. Skills document the FK-IDs-only pattern and orphan reference handling.
- **Cross-category migration**: Some preferences live in domain slices (`memory.embedderModel`, `websearch.compressionConfig.embeddingModel`) rather than settings. Skills guide correct reclassification.
- **Cache tier selection**: Three cache tiers (memory/shared/persist) have different scope, sync, and persistence characteristics. Skills provide a decision flow.

The following tradeoffs were made:

Skills are split into 3 phases (migrator → data-api → renderer) matching the natural dependency order, rather than one monolithic skill.

The following alternatives were considered:

A single combined skill was considered but rejected — each phase has distinct concerns, file locations, and testing strategies.

### Breaking changes

None. This PR only adds new skill files and updates `.gitignore`/`public-skills.txt`.

### Special notes for your reviewer

- All skills passed `pnpm skills:check` (8 public skills validated)
- The skills reference existing documentation in `docs/en/references/data/` and existing migration code in `src/main/data/migration/v2/`
- The cross-domain reference tables in `v2-migrator` were built from actual Redux store analysis (`src/renderer/src/store/`)

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
