### PR TITLE
fix(backup): defer auto backup during streaming response

### DIFF
--- a/src/renderer/src/services/BackupService.ts
+++ b/src/renderer/src/services/BackupService.ts
@@ -657,6 +657,16 @@ export function startAutoSync(immediate = false, type?: BackupType) {
       return
     }
 
+    // Check if any topic is currently streaming/loading
+    const state = store.getState()
+    const anyTopicLoading = Object.values(state.messages.loadingByTopic).some((loading) => loading === true)
+
+    if (anyTopicLoading) {
+      logger.info(`${logPrefix} Streaming in progress, deferring backup`)
+      scheduleNextBackup('fromNow', backupType)
+      return
+    }
+
     // 设置运行状态
     if (backupType === 'webdav') {
       isWebdavAutoBackupRunning = true


### PR DESCRIPTION
### What this PR does

Before this PR:
- Auto backup (WebDAV, S3, local) could trigger during an ongoing streaming response
- This caused incomplete conversation state to be saved
- Synced devices would receive truncated/unusable conversations
- Users experienced "half-response" frozen state with no way to recover

After this PR:
- Auto backup checks if any topic is currently streaming before starting
- Backup is deferred until all streaming responses complete
- Conversations are only backed up in consistent states
- No more conversation truncation or freeze issues during backup

Fixes #13216

### Why we need it and why it was done in this way

The issue occurs when auto backup triggers during an active streaming response. The backup captures an incomplete state of the conversation, which then syncs to other devices and causes permanent corruption.

**Tradeoffs made:**
- Backup is deferred rather than cancelled - ensures backup still happens eventually
- Simple state check (`loadingByTopic`) rather than complex queuing mechanism
- Minimal code change to reduce risk

**Alternatives considered:**
- Pause streaming during backup - would affect user experience
- Queue backup requests - more complex implementation
- Skip backup entirely if streaming - could miss backup window

### Breaking changes

None

### Special notes for your reviewer

The fix adds a streaming detection check in `performAutoBackup` function. It checks the Redux state `loadingByTopic` to determine if any topic is currently receiving a streaming response. If streaming is detected, the backup is deferred (the next scheduled backup will handle it).

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [ ] Refactor: N/A - minimal bug fix
- [ ] Upgrade: N/A - no data schema changes
- [ ] Documentation: N/A - internal bug fix, no user-facing changes to document
- [x] Self-review: Completed

### Release note

```release-note
Fix auto backup interrupting streaming responses, preventing conversation truncation and freeze issues
```