### PR TITLE
fix: respect pasteLongTextAsFile setting in MessageEditor

### DIFF
--- a/src/renderer/src/pages/home/Messages/MessageEditor.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageEditor.tsx
@@ -143,7 +143,7 @@ const MessageBlockEditor: FC<Props> = ({ message, topicId, onSave, onResend, onC
         t
       )
     },
-    [extensions, pasteLongTextThreshold, t]
+    [extensions, pasteLongTextThreshold, t, pasteLongTextAsFile]
   )
 
   // 添加全局粘贴事件处理


### PR DESCRIPTION
Fix #13299 

The message editor's paste handler had pasteLongTextAsFile hardcoded to false, preventing long text from being pasted as a file attachment. This makes the message editor respect the user's setting, consistent with the bottom input bar behavior.


<img width="905" height="648" alt="image" src="https://github.com/user-attachments/assets/cae3c273-ab91-425c-b2de-0ccf09d19f99" />
