### PR TITLE
fix: remove scrollbar width override in responsive.css

### DIFF
--- a/src/renderer/src/assets/styles/responsive.css
+++ b/src/renderer/src/assets/styles/responsive.css
@@ -8,8 +8,6 @@
   --assistants-width: 275px;
   --topic-list-width: 275px;
   --settings-width: 250px;
-
-  --scrollbar-width: 5px;
 }
 
 [navbar-position='left'] {


### PR DESCRIPTION
### What this PR does

Before this PR:
`responsive.css` overrides the `--scrollbar-width` CSS variable to `5px`, which completely shadows any value set in `scrollbar.css`. This makes it impossible to adjust scrollbar width through `scrollbar.css`.

After this PR:
The redundant `--scrollbar-width: 5px` override in `responsive.css` is removed. The scrollbar width is now solely controlled by `scrollbar.css` (default `6px`), which is 1px wider than before — addressing user feedback that the scrollbar was too thin.

Related discussion: #9098

### Why we need it and why it was done in this way

Many users have reported that the scrollbar is too thin and hard to grab (see #9098). The root cause is that `responsive.css` was overriding the CSS variable defined in `scrollbar.css`, making any width adjustments in `scrollbar.css` ineffective.

The following tradeoffs were made:
The default scrollbar width increases from 5px to 6px. This is a minor visual change that improves usability.

The following alternatives were considered:
Increasing the value in `responsive.css` instead, but removing the override entirely is cleaner — it eliminates the hidden dependency and lets `scrollbar.css` be the single source of truth.

### Breaking changes

None.

### Special notes for your reviewer

This is a one-line CSS deletion. The net effect is that `--scrollbar-width` goes from `5px` (overridden by `responsive.css`) to `6px` (the value already defined in `scrollbar.css`).

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Scrollbar width increased from 5px to 6px for better usability, and fixed an issue where scrollbar width customization in `scrollbar.css` was being overridden by `responsive.css`.
```
