### PR TITLE
docs(skills): add Layered Preset pattern and ReduxExporter guidance to v2 skills

### DIFF
--- a/.agents/skills/v2-data-api/SKILL.md
+++ b/.agents/skills/v2-data-api/SKILL.md
@@ -405,6 +405,76 @@ export const DefaultPreferences: PreferenceSchemas = {
 
 See `docs/en/references/data/preference-schema-guide.md` for full guide.
 
+## Layered Preset Pattern (Predefined Config + User Overrides)
+
+Use this pattern when a feature has a **predefined list of items** (tools, providers, templates) with **user-customizable settings per item**. Instead of storing full config for every item, store only the user's deviations from defaults.
+
+**When to use:**
+- Feature has a fixed, code-defined list of options (e.g., CLI tools, AI providers)
+- Users can customize per-item settings (model, API key, env vars)
+- Most items keep default values — only a few are customized
+
+**Architecture:**
+
+```
+packages/shared/data/presets/<domain>.ts    → Preset definitions (code, not DB)
+packages/shared/data/preference/            → Overrides preference key (DB)
+```
+
+### Step 1: Define Presets (Shared Package)
+
+```typescript
+// packages/shared/data/presets/my-feature.ts
+export interface MyFeaturePreset {
+  id: string
+  name: string
+  modelId: string | null
+  config: string
+}
+
+export const PRESETS_MY_FEATURE: MyFeaturePreset[] = [
+  { id: 'option-a', name: 'Option A', modelId: null, config: '' },
+  { id: 'option-b', name: 'Option B', modelId: null, config: '' },
+]
+
+// Override = partial preset (only non-default fields)
+export type MyFeatureOverride = Partial<Omit<MyFeaturePreset, 'id' | 'name'>>
+export type MyFeatureOverrides = Record<string, MyFeatureOverride>
+```
+
+### Step 2: Add Overrides Preference Key
+
+```typescript
+// packages/shared/data/preference/preferenceSchemas.ts
+import type { MyFeatureOverrides } from '@shared/data/presets/my-feature'
+
+// In PreferenceSchemas interface:
+'feature.my_feature.overrides': MyFeatureOverrides  // default: {}
+
+// In DefaultPreferences:
+'feature.my_feature.overrides': {},
+```
+
+**Key design principles:**
+- Presets are **immutable code** — updated via app releases, not user action
+- Overrides store **delta only** — empty `{}` means all defaults
+- Override keys match preset IDs — `{ 'option-a': { modelId: 'm1' } }`
+- The merge happens at read time (renderer), not write time
+
+### Step 3: Merge Logic (Service or Hook)
+
+The effective config for an item = preset defaults merged with user overrides:
+
+```typescript
+function getEffectiveConfig(presetId: string, overrides: MyFeatureOverrides): MyFeaturePreset {
+  const preset = PRESETS_MY_FEATURE.find(p => p.id === presetId)
+  if (!preset) throw new Error(`Unknown preset: ${presetId}`)
+  return { ...preset, ...overrides[presetId] }
+}
+```
+
+See `docs/en/references/data/best-practice-layered-preset-pattern.md` for full documentation and `packages/shared/data/presets/code-tools.ts` for a reference implementation.
+
 ## Cross-Domain References (Stale Object Bug)
 
 ### The Legacy Problem
@@ -501,6 +571,8 @@ throw DataApiErrorFactory.timeout('fetch topics', 3000)
 - [ ] Key + type in `PreferenceSchemas` interface
 - [ ] Default value in `DefaultPreferences`
 - [ ] Key naming follows conventions
+- [ ] Layered Preset pattern applied (if feature has predefined list + per-item overrides)
+- [ ] Preset definitions in `packages/shared/data/presets/` (if using Layered Preset)
 
 ### Quality
 - [ ] All tests pass: `pnpm test`

--- a/.agents/skills/v2-migrator/SKILL.md
+++ b/.agents/skills/v2-migrator/SKILL.md
@@ -399,12 +399,30 @@ async execute(ctx) {
 }
 ```
 
-### 8. Register
+### 8. Register ReduxExporter (if migrating a Redux slice)
+
+If the migrator reads from a Redux slice, the slice must be exported by the renderer during migration. Register it in:
+
+```typescript
+// src/renderer/src/windows/migrationV2/exporters/ReduxExporter.ts
+const SLICES_TO_EXPORT = [
+  'settings',
+  'llm',
+  // ... existing slices
+  'myNewSlice',  // <-- add your slice here
+]
+```
+
+**Why:** The migration runs in the Main process, but Redux state lives in the renderer's localStorage. `ReduxExporter` serializes registered slices and sends them to Main via IPC. If you forget this step, `ctx.sources.redux.get('mySlice', ...)` will return `undefined` for all keys.
+
+**When to skip:** If your migrator only reads from Dexie or ElectronStore (not Redux), skip this step.
+
+### 9. Register Migrator
 
 1. Add to `src/main/data/migration/v2/migrators/index.ts` with correct `order`
 2. Add target table to `MigrationEngine.verifyAndClearNewTables` (child tables before parents)
 
-### 9. Document
+### 10. Document
 
 Create `src/main/data/migration/v2/migrators/README-<MigratorName>.md`:
 - Data sources and target tables
@@ -452,6 +470,39 @@ function mergeTopicData(reduxTopic: ReduxTopic, dexieTopic: DexieTopic): MergedT
   }
 }
 ```
+
+## Layered Preset Pattern Recognition
+
+When analyzing a Redux slice for migration, check if the data follows the **Layered Preset** pattern — a predefined list of items with user customizations stored per-item. This is common for features with a fixed set of options (tools, providers, templates) where users can override individual settings.
+
+**How to recognize it in Redux:**
+- A hardcoded list of items in code (e.g., `CLI_TOOLS`, `PROVIDER_LIST`)
+- Per-item user state stored in Redux as `Record<itemId, value>` maps (e.g., `selectedModels: { 'tool-a': Model, 'tool-b': null }`)
+- Multiple such maps that share the same item keys
+
+**v2 migration strategy:** Convert to a single `overrides` preference key using delta-only storage:
+
+```typescript
+// Before (Redux): Multiple per-tool maps
+// codeTools.selectedModels = { 'tool-a': { id: 'm1', ... }, 'tool-b': null }
+// codeTools.environmentVariables = { 'tool-a': 'KEY=val', 'tool-b': '' }
+
+// After (v2): Single overrides preference (delta-only, non-default values only)
+// preference: 'feature.code_tools.overrides' = { 'tool-a': { modelId: 'm1', envVars: 'KEY=val' } }
+```
+
+**Implementation steps:**
+1. Define preset types and defaults in `packages/shared/data/presets/<domain>.ts`
+2. Add the overrides preference key to `preferenceSchemas.ts` with `{}` as default
+3. Use a `ComplexMapping` in `ComplexPreferenceMappings.ts` to merge multiple Redux maps into a single overrides object
+4. Write pure transform functions in a separate file (e.g., `CodeToolsTransforms.ts`)
+
+**Key principles:**
+- Store only non-default values (delta) — if a tool's settings all match the preset defaults, omit it entirely
+- Extract FK IDs from embedded full objects (e.g., `Model` → `modelId`)
+- Presets live in code (`packages/shared/data/presets/`), overrides live in preferences
+
+See `docs/en/references/data/best-practice-layered-preset-pattern.md` for full pattern documentation, and `packages/shared/data/presets/code-tools.ts` for a reference implementation.
 
 ## Cross-Domain References & Foreign Keys
 
@@ -642,6 +693,8 @@ try {
 - [ ] Streaming for large tables (>1000 records)
 - [ ] Duplicate ID handling
 - [ ] Progress via `reportProgress`
+- [ ] Redux slice registered in `ReduxExporter.SLICES_TO_EXPORT` (if reading from Redux)
+- [ ] Layered Preset pattern identified and applied (if source has predefined list + per-item overrides)
 - [ ] Registered in `migrators/index.ts` with correct `order`
 - [ ] Target table added to `MigrationEngine.verifyAndClearNewTables`
 - [ ] Cross-migrator data via `ctx.sharedData` (if applicable)

--- a/.agents/skills/v2-renderer/SKILL.md
+++ b/.agents/skills/v2-renderer/SKILL.md
@@ -457,6 +457,59 @@ const showTimestamp = useAppSelector(s => s.settings.showMessageTimestamp)
 const [showTimestamp] = usePreference('chat.display.show_timestamp')
 ```
 
+## Consuming Layered Presets (Predefined Config + User Overrides)
+
+When a feature uses the Layered Preset pattern (see `v2-data-api` skill), the renderer merges presets with user overrides at read time.
+
+### Reading Effective Config
+
+```typescript
+import { PRESETS_MY_FEATURE, type MyFeaturePreset } from '@shared/data/presets/my-feature'
+import { usePreference } from '@data/hooks/usePreference'
+
+function useMyFeatureConfig(presetId: string): MyFeaturePreset {
+  const [overrides] = usePreference('feature.my_feature.overrides')
+  const preset = PRESETS_MY_FEATURE.find(p => p.id === presetId)!
+  return { ...preset, ...overrides[presetId] }
+}
+```
+
+### Updating Per-Item Overrides
+
+Write only the changed fields — keep the delta minimal:
+
+```typescript
+function useMyFeatureOverride(presetId: string) {
+  const [overrides, setOverrides] = usePreference('feature.my_feature.overrides')
+
+  const updateOverride = async (patch: Partial<MyFeatureOverride>) => {
+    const current = overrides[presetId] ?? {}
+    await setOverrides({ ...overrides, [presetId]: { ...current, ...patch } })
+  }
+
+  const resetOverride = async () => {
+    const { [presetId]: _, ...rest } = overrides
+    await setOverrides(rest)
+  }
+
+  return { override: overrides[presetId] ?? {}, updateOverride, resetOverride }
+}
+```
+
+### Migration Pattern: Redux Per-Item Maps -> Layered Preset
+
+```typescript
+// Before (Redux): separate maps per field
+const selectedModels = useAppSelector(s => s.codeTools.selectedModels)   // Record<toolId, Model>
+const envVars = useAppSelector(s => s.codeTools.environmentVariables)    // Record<toolId, string>
+
+// After (v2): single overrides preference + preset merge
+const [overrides] = usePreference('feature.code_tools.overrides')
+const effectiveConfig = { ...PRESETS_CODE_TOOLS.find(p => p.id === toolId)!, ...overrides[toolId] }
+```
+
+See `packages/shared/data/presets/code-tools.ts` for a reference implementation.
+
 ## Adding New Schema Keys
 
 ### New Cache Key
@@ -499,6 +552,7 @@ See `v2-data-api` skill, "Adding a Preference Key" section.
 - [ ] Optimistic vs pessimistic update strategy chosen for preferences
 - [ ] Cache tier chosen correctly (memory vs shared vs persist)
 - [ ] New cache/preference keys added to schemas
+- [ ] Layered Preset merge logic implemented (if feature uses presets + overrides)
 
 ### Quality
 - [ ] All tests pass: `pnpm test`

--- a/.claude/skills/v2-data-api/SKILL.md
+++ b/.claude/skills/v2-data-api/SKILL.md
@@ -405,6 +405,76 @@ export const DefaultPreferences: PreferenceSchemas = {
 
 See `docs/en/references/data/preference-schema-guide.md` for full guide.
 
+## Layered Preset Pattern (Predefined Config + User Overrides)
+
+Use this pattern when a feature has a **predefined list of items** (tools, providers, templates) with **user-customizable settings per item**. Instead of storing full config for every item, store only the user's deviations from defaults.
+
+**When to use:**
+- Feature has a fixed, code-defined list of options (e.g., CLI tools, AI providers)
+- Users can customize per-item settings (model, API key, env vars)
+- Most items keep default values — only a few are customized
+
+**Architecture:**
+
+```
+packages/shared/data/presets/<domain>.ts    → Preset definitions (code, not DB)
+packages/shared/data/preference/            → Overrides preference key (DB)
+```
+
+### Step 1: Define Presets (Shared Package)
+
+```typescript
+// packages/shared/data/presets/my-feature.ts
+export interface MyFeaturePreset {
+  id: string
+  name: string
+  modelId: string | null
+  config: string
+}
+
+export const PRESETS_MY_FEATURE: MyFeaturePreset[] = [
+  { id: 'option-a', name: 'Option A', modelId: null, config: '' },
+  { id: 'option-b', name: 'Option B', modelId: null, config: '' },
+]
+
+// Override = partial preset (only non-default fields)
+export type MyFeatureOverride = Partial<Omit<MyFeaturePreset, 'id' | 'name'>>
+export type MyFeatureOverrides = Record<string, MyFeatureOverride>
+```
+
+### Step 2: Add Overrides Preference Key
+
+```typescript
+// packages/shared/data/preference/preferenceSchemas.ts
+import type { MyFeatureOverrides } from '@shared/data/presets/my-feature'
+
+// In PreferenceSchemas interface:
+'feature.my_feature.overrides': MyFeatureOverrides  // default: {}
+
+// In DefaultPreferences:
+'feature.my_feature.overrides': {},
+```
+
+**Key design principles:**
+- Presets are **immutable code** — updated via app releases, not user action
+- Overrides store **delta only** — empty `{}` means all defaults
+- Override keys match preset IDs — `{ 'option-a': { modelId: 'm1' } }`
+- The merge happens at read time (renderer), not write time
+
+### Step 3: Merge Logic (Service or Hook)
+
+The effective config for an item = preset defaults merged with user overrides:
+
+```typescript
+function getEffectiveConfig(presetId: string, overrides: MyFeatureOverrides): MyFeaturePreset {
+  const preset = PRESETS_MY_FEATURE.find(p => p.id === presetId)
+  if (!preset) throw new Error(`Unknown preset: ${presetId}`)
+  return { ...preset, ...overrides[presetId] }
+}
+```
+
+See `docs/en/references/data/best-practice-layered-preset-pattern.md` for full documentation and `packages/shared/data/presets/code-tools.ts` for a reference implementation.
+
 ## Cross-Domain References (Stale Object Bug)
 
 ### The Legacy Problem
@@ -501,6 +571,8 @@ throw DataApiErrorFactory.timeout('fetch topics', 3000)
 - [ ] Key + type in `PreferenceSchemas` interface
 - [ ] Default value in `DefaultPreferences`
 - [ ] Key naming follows conventions
+- [ ] Layered Preset pattern applied (if feature has predefined list + per-item overrides)
+- [ ] Preset definitions in `packages/shared/data/presets/` (if using Layered Preset)
 
 ### Quality
 - [ ] All tests pass: `pnpm test`

--- a/.claude/skills/v2-migrator/SKILL.md
+++ b/.claude/skills/v2-migrator/SKILL.md
@@ -399,12 +399,30 @@ async execute(ctx) {
 }
 ```
 
-### 8. Register
+### 8. Register ReduxExporter (if migrating a Redux slice)
+
+If the migrator reads from a Redux slice, the slice must be exported by the renderer during migration. Register it in:
+
+```typescript
+// src/renderer/src/windows/migrationV2/exporters/ReduxExporter.ts
+const SLICES_TO_EXPORT = [
+  'settings',
+  'llm',
+  // ... existing slices
+  'myNewSlice',  // <-- add your slice here
+]
+```
+
+**Why:** The migration runs in the Main process, but Redux state lives in the renderer's localStorage. `ReduxExporter` serializes registered slices and sends them to Main via IPC. If you forget this step, `ctx.sources.redux.get('mySlice', ...)` will return `undefined` for all keys.
+
+**When to skip:** If your migrator only reads from Dexie or ElectronStore (not Redux), skip this step.
+
+### 9. Register Migrator
 
 1. Add to `src/main/data/migration/v2/migrators/index.ts` with correct `order`
 2. Add target table to `MigrationEngine.verifyAndClearNewTables` (child tables before parents)
 
-### 9. Document
+### 10. Document
 
 Create `src/main/data/migration/v2/migrators/README-<MigratorName>.md`:
 - Data sources and target tables
@@ -452,6 +470,39 @@ function mergeTopicData(reduxTopic: ReduxTopic, dexieTopic: DexieTopic): MergedT
   }
 }
 ```
+
+## Layered Preset Pattern Recognition
+
+When analyzing a Redux slice for migration, check if the data follows the **Layered Preset** pattern — a predefined list of items with user customizations stored per-item. This is common for features with a fixed set of options (tools, providers, templates) where users can override individual settings.
+
+**How to recognize it in Redux:**
+- A hardcoded list of items in code (e.g., `CLI_TOOLS`, `PROVIDER_LIST`)
+- Per-item user state stored in Redux as `Record<itemId, value>` maps (e.g., `selectedModels: { 'tool-a': Model, 'tool-b': null }`)
+- Multiple such maps that share the same item keys
+
+**v2 migration strategy:** Convert to a single `overrides` preference key using delta-only storage:
+
+```typescript
+// Before (Redux): Multiple per-tool maps
+// codeTools.selectedModels = { 'tool-a': { id: 'm1', ... }, 'tool-b': null }
+// codeTools.environmentVariables = { 'tool-a': 'KEY=val', 'tool-b': '' }
+
+// After (v2): Single overrides preference (delta-only, non-default values only)
+// preference: 'feature.code_tools.overrides' = { 'tool-a': { modelId: 'm1', envVars: 'KEY=val' } }
+```
+
+**Implementation steps:**
+1. Define preset types and defaults in `packages/shared/data/presets/<domain>.ts`
+2. Add the overrides preference key to `preferenceSchemas.ts` with `{}` as default
+3. Use a `ComplexMapping` in `ComplexPreferenceMappings.ts` to merge multiple Redux maps into a single overrides object
+4. Write pure transform functions in a separate file (e.g., `CodeToolsTransforms.ts`)
+
+**Key principles:**
+- Store only non-default values (delta) — if a tool's settings all match the preset defaults, omit it entirely
+- Extract FK IDs from embedded full objects (e.g., `Model` → `modelId`)
+- Presets live in code (`packages/shared/data/presets/`), overrides live in preferences
+
+See `docs/en/references/data/best-practice-layered-preset-pattern.md` for full pattern documentation, and `packages/shared/data/presets/code-tools.ts` for a reference implementation.
 
 ## Cross-Domain References & Foreign Keys
 
@@ -642,6 +693,8 @@ try {
 - [ ] Streaming for large tables (>1000 records)
 - [ ] Duplicate ID handling
 - [ ] Progress via `reportProgress`
+- [ ] Redux slice registered in `ReduxExporter.SLICES_TO_EXPORT` (if reading from Redux)
+- [ ] Layered Preset pattern identified and applied (if source has predefined list + per-item overrides)
 - [ ] Registered in `migrators/index.ts` with correct `order`
 - [ ] Target table added to `MigrationEngine.verifyAndClearNewTables`
 - [ ] Cross-migrator data via `ctx.sharedData` (if applicable)

--- a/.claude/skills/v2-renderer/SKILL.md
+++ b/.claude/skills/v2-renderer/SKILL.md
@@ -457,6 +457,59 @@ const showTimestamp = useAppSelector(s => s.settings.showMessageTimestamp)
 const [showTimestamp] = usePreference('chat.display.show_timestamp')
 ```
 
+## Consuming Layered Presets (Predefined Config + User Overrides)
+
+When a feature uses the Layered Preset pattern (see `v2-data-api` skill), the renderer merges presets with user overrides at read time.
+
+### Reading Effective Config
+
+```typescript
+import { PRESETS_MY_FEATURE, type MyFeaturePreset } from '@shared/data/presets/my-feature'
+import { usePreference } from '@data/hooks/usePreference'
+
+function useMyFeatureConfig(presetId: string): MyFeaturePreset {
+  const [overrides] = usePreference('feature.my_feature.overrides')
+  const preset = PRESETS_MY_FEATURE.find(p => p.id === presetId)!
+  return { ...preset, ...overrides[presetId] }
+}
+```
+
+### Updating Per-Item Overrides
+
+Write only the changed fields — keep the delta minimal:
+
+```typescript
+function useMyFeatureOverride(presetId: string) {
+  const [overrides, setOverrides] = usePreference('feature.my_feature.overrides')
+
+  const updateOverride = async (patch: Partial<MyFeatureOverride>) => {
+    const current = overrides[presetId] ?? {}
+    await setOverrides({ ...overrides, [presetId]: { ...current, ...patch } })
+  }
+
+  const resetOverride = async () => {
+    const { [presetId]: _, ...rest } = overrides
+    await setOverrides(rest)
+  }
+
+  return { override: overrides[presetId] ?? {}, updateOverride, resetOverride }
+}
+```
+
+### Migration Pattern: Redux Per-Item Maps -> Layered Preset
+
+```typescript
+// Before (Redux): separate maps per field
+const selectedModels = useAppSelector(s => s.codeTools.selectedModels)   // Record<toolId, Model>
+const envVars = useAppSelector(s => s.codeTools.environmentVariables)    // Record<toolId, string>
+
+// After (v2): single overrides preference + preset merge
+const [overrides] = usePreference('feature.code_tools.overrides')
+const effectiveConfig = { ...PRESETS_CODE_TOOLS.find(p => p.id === toolId)!, ...overrides[toolId] }
+```
+
+See `packages/shared/data/presets/code-tools.ts` for a reference implementation.
+
 ## Adding New Schema Keys
 
 ### New Cache Key
@@ -499,6 +552,7 @@ See `v2-data-api` skill, "Adding a Preference Key" section.
 - [ ] Optimistic vs pessimistic update strategy chosen for preferences
 - [ ] Cache tier chosen correctly (memory vs shared vs persist)
 - [ ] New cache/preference keys added to schemas
+- [ ] Layered Preset merge logic implemented (if feature uses presets + overrides)
 
 ### Quality
 - [ ] All tests pass: `pnpm test`

--- a/packages/shared/data/preference/preferenceSchemas.ts
+++ b/packages/shared/data/preference/preferenceSchemas.ts
@@ -28,6 +28,7 @@
 
 import { MEMORY_FACT_EXTRACTION_PROMPT, MEMORY_UPDATE_SYSTEM_PROMPT, TRANSLATE_PROMPT } from '@shared/config/prompts'
 import * as PreferenceTypes from '@shared/data/preference/preferenceTypes'
+import type { CodeToolOverrides } from '@shared/data/presets/code-tools'
 
 /* eslint @typescript-eslint/member-ordering: ["error", {
   "interfaces": { "order": "alphabetically" },
@@ -304,6 +305,12 @@ export interface PreferenceSchemas {
     'data.integration.yuque.token': string
     // redux/settings/yuqueUrl
     'data.integration.yuque.url': string
+    // redux/codeTools - per-tool overrides (layered preset pattern)
+    'feature.code_tools.overrides': CodeToolOverrides
+    // redux/codeTools/selectedCliTool
+    'feature.code_tools.selected_cli_tool': string
+    // redux/codeTools/selectedTerminal
+    'feature.code_tools.selected_terminal': string
     // redux/settings/apiServer.apiKey
     'feature.csaas.api_key': string | null
     // redux/settings/apiServer.enabled
@@ -584,6 +591,9 @@ export const DefaultPreferences: PreferenceSchemas = {
     'data.integration.yuque.repo_id': '',
     'data.integration.yuque.token': '',
     'data.integration.yuque.url': '',
+    'feature.code_tools.overrides': {},
+    'feature.code_tools.selected_cli_tool': 'qwen-code',
+    'feature.code_tools.selected_terminal': 'Terminal',
     'feature.csaas.api_key': null,
     'feature.csaas.enabled': false,
     'feature.csaas.host': '127.0.0.1',

--- a/packages/shared/data/presets/code-tools.ts
+++ b/packages/shared/data/presets/code-tools.ts
@@ -1,0 +1,46 @@
+/**
+ * Code Tools preset definitions
+ *
+ * Defines the list of supported CLI coding tools and their default per-tool config.
+ * User customizations are stored as overrides via the preference key
+ * `feature.code_tools.overrides`.
+ *
+ * @see docs/en/references/data/best-practice-layered-preset-pattern.md
+ */
+
+export interface CodeToolPreset {
+  id: string
+  name: string
+  modelId: string | null
+  envVars: string
+  currentDirectory: string
+  directories: string[]
+}
+
+export const PRESETS_CODE_TOOLS: CodeToolPreset[] = [
+  { id: 'qwen-code', name: 'Qwen Code', modelId: null, envVars: '', currentDirectory: '', directories: [] },
+  { id: 'claude-code', name: 'Claude Code', modelId: null, envVars: '', currentDirectory: '', directories: [] },
+  { id: 'gemini-cli', name: 'Gemini CLI', modelId: null, envVars: '', currentDirectory: '', directories: [] },
+  { id: 'openai-codex', name: 'OpenAI Codex', modelId: null, envVars: '', currentDirectory: '', directories: [] },
+  { id: 'iflow-cli', name: 'iFlow CLI', modelId: null, envVars: '', currentDirectory: '', directories: [] },
+  {
+    id: 'github-copilot-cli',
+    name: 'GitHub Copilot CLI',
+    modelId: null,
+    envVars: '',
+    currentDirectory: '',
+    directories: []
+  },
+  { id: 'kimi-cli', name: 'Kimi CLI', modelId: null, envVars: '', currentDirectory: '', directories: [] },
+  { id: 'opencode', name: 'OpenCode', modelId: null, envVars: '', currentDirectory: '', directories: [] }
+]
+
+/**
+ * User-overridable fields per tool (delta only — omitted fields use preset defaults).
+ */
+export type CodeToolOverride = Partial<Omit<CodeToolPreset, 'id' | 'name'>>
+
+/**
+ * Map of tool ID to its user overrides.
+ */
+export type CodeToolOverrides = Record<string, CodeToolOverride>

--- a/src/main/data/migration/v2/migrators/mappings/CodeToolsTransforms.ts
+++ b/src/main/data/migration/v2/migrators/mappings/CodeToolsTransforms.ts
@@ -1,0 +1,106 @@
+/**
+ * Transform functions for codeTools migration
+ *
+ * Converts legacy Redux codeTools state into v2 preference values
+ * using the Layered Preset pattern (overrides per tool).
+ */
+
+import type { CodeToolOverrides } from '@shared/data/presets/code-tools'
+
+/**
+ * Extract model IDs from a Record of full Model objects.
+ *
+ * Legacy Redux stores full Model objects per CLI tool:
+ *   { 'qwen-code': { id: 'model-1', name: '...', provider: '...' }, ... }
+ *
+ * v2 stores only model IDs:
+ *   { 'qwen-code': 'model-1', 'claude-code': null, ... }
+ */
+export function transformSelectedModelsToIds(
+  selectedModels: Record<string, unknown> | null | undefined
+): Record<string, string | null> {
+  if (!selectedModels || typeof selectedModels !== 'object') {
+    return {}
+  }
+
+  const result: Record<string, string | null> = {}
+
+  for (const [toolKey, model] of Object.entries(selectedModels)) {
+    if (model === null || model === undefined) {
+      result[toolKey] = null
+    } else if (typeof model === 'object' && 'id' in model && typeof (model as any).id === 'string') {
+      result[toolKey] = (model as any).id
+    } else {
+      result[toolKey] = null
+    }
+  }
+
+  return result
+}
+
+interface CodeToolsSourceData {
+  selectedModels?: Record<string, unknown> | null
+  environmentVariables?: Record<string, string> | null
+  directories?: string[] | null
+  currentDirectory?: string | null
+  selectedCliTool?: string | null
+}
+
+/**
+ * Transform legacy Redux codeTools state into per-tool overrides.
+ *
+ * Merges selectedModels (Model→ID), environmentVariables, and global
+ * directories/currentDirectory into a single CodeToolOverrides record.
+ *
+ * Only non-default values are included (delta-only overrides).
+ * Global directories/currentDirectory are assigned to every tool that has
+ * other overrides, plus the selectedCliTool if it has dirs but no other overrides.
+ */
+export function transformCodeToolsToOverrides(sources: CodeToolsSourceData): CodeToolOverrides {
+  const modelIds = transformSelectedModelsToIds(sources.selectedModels)
+  const envVars = sources.environmentVariables ?? {}
+  const directories = sources.directories ?? []
+  const currentDirectory = sources.currentDirectory ?? ''
+  const hasDirs = directories.length > 0 || currentDirectory !== ''
+
+  // Collect all tool keys that appear in either models or env vars
+  const allToolKeys = new Set<string>([...Object.keys(modelIds), ...Object.keys(envVars)])
+
+  const overrides: CodeToolOverrides = {}
+
+  for (const toolKey of allToolKeys) {
+    const modelId = modelIds[toolKey] ?? null
+    const env = envVars[toolKey] ?? ''
+
+    const hasModel = modelId !== null
+    const hasEnv = env !== ''
+
+    if (!hasModel && !hasEnv) continue
+
+    const override: Record<string, unknown> = {}
+    if (hasModel) override.modelId = modelId
+    if (hasEnv) override.envVars = env
+
+    overrides[toolKey] = override
+  }
+
+  // Assign global directories to all tools that have overrides
+  if (hasDirs) {
+    for (const toolKey of Object.keys(overrides)) {
+      if (directories.length > 0) overrides[toolKey].directories = directories
+      if (currentDirectory) overrides[toolKey].currentDirectory = currentDirectory
+    }
+
+    // Also ensure the selectedCliTool gets dirs even if it has no model/env overrides
+    if (sources.selectedCliTool && !overrides[sources.selectedCliTool]) {
+      const dirOverride: Record<string, unknown> = {}
+      if (directories.length > 0) dirOverride.directories = directories
+      if (currentDirectory) dirOverride.currentDirectory = currentDirectory
+      if (Object.keys(dirOverride).length > 0) {
+        overrides[sources.selectedCliTool] = dirOverride
+      }
+    }
+  }
+
+  return overrides
+}

--- a/src/main/data/migration/v2/migrators/mappings/ComplexPreferenceMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/ComplexPreferenceMappings.ts
@@ -18,6 +18,8 @@
  * The system uses strict mode - conflicts will cause errors at runtime.
  */
 
+import { transformCodeToolsToOverrides } from './CodeToolsTransforms'
+
 // ============================================================================
 // Type Definitions
 // ============================================================================
@@ -78,34 +80,28 @@ export interface ComplexMapping {
  * Remember to also define the target keys in target-key-definitions.json!
  */
 export const COMPLEX_PREFERENCE_MAPPINGS: ComplexMapping[] = [
-  // Example mappings (commented out - uncomment when needed):
-  //
-  // {
-  //   id: 'window_bounds_split',
-  //   description: 'Split windowBounds object into separate position and size keys',
-  //   sources: {
-  //     windowBounds: { source: 'electronStore', key: 'windowBounds' }
-  //   },
-  //   targetKeys: [
-  //     'app.window.position.x',
-  //     'app.window.position.y',
-  //     'app.window.size.width',
-  //     'app.window.size.height'
-  //   ],
-  //   transform: splitWindowBounds
-  // },
-  //
-  // {
-  //   id: 'proxy_config_merge',
-  //   description: 'Merge proxy configuration from multiple sources',
-  //   sources: {
-  //     proxyEnabled: { source: 'redux', category: 'settings', key: 'proxyEnabled' },
-  //     proxyHost: { source: 'redux', category: 'settings', key: 'proxyHost' },
-  //     proxyPort: { source: 'electronStore', key: 'ProxyPort' }
-  //   },
-  //   targetKeys: ['network.proxy.enabled', 'network.proxy.host', 'network.proxy.port'],
-  //   transform: mergeProxyConfig
-  // }
+  {
+    id: 'code_tools_overrides',
+    description: 'Merge codeTools per-tool data (models, env vars, directories) into layered preset overrides',
+    sources: {
+      selectedModels: { source: 'redux', category: 'codeTools', key: 'selectedModels' },
+      environmentVariables: { source: 'redux', category: 'codeTools', key: 'environmentVariables' },
+      directories: { source: 'redux', category: 'codeTools', key: 'directories' },
+      currentDirectory: { source: 'redux', category: 'codeTools', key: 'currentDirectory' },
+      selectedCliTool: { source: 'redux', category: 'codeTools', key: 'selectedCliTool' }
+    },
+    targetKeys: ['feature.code_tools.overrides'],
+    transform: (sources) => {
+      const overrides = transformCodeToolsToOverrides({
+        selectedModels: sources.selectedModels as Record<string, unknown> | null,
+        environmentVariables: sources.environmentVariables as Record<string, string> | null,
+        directories: sources.directories as string[] | null,
+        currentDirectory: sources.currentDirectory as string | null,
+        selectedCliTool: sources.selectedCliTool as string | null
+      })
+      return { 'feature.code_tools.overrides': overrides }
+    }
+  }
 ]
 
 // ============================================================================

--- a/src/main/data/migration/v2/migrators/mappings/PreferencesMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/PreferencesMappings.ts
@@ -852,6 +852,16 @@ export const REDUX_STORE_MAPPINGS = {
       originalKey: 'sortType',
       targetKey: 'feature.notes.sort_type'
     }
+  ],
+  codeTools: [
+    {
+      originalKey: 'selectedCliTool',
+      targetKey: 'feature.code_tools.selected_cli_tool'
+    },
+    {
+      originalKey: 'selectedTerminal',
+      targetKey: 'feature.code_tools.selected_terminal'
+    }
   ]
 } as const
 
@@ -860,9 +870,9 @@ export const REDUX_STORE_MAPPINGS = {
 /**
  * 映射统计:
  * - ElectronStore项: 1
- * - Redux Store项: 203
- * - Redux分类: settings, selectionStore, memory, nutstore, shortcuts, note
- * - 总配置项: 204
+ * - Redux Store项: 208
+ * - Redux分类: settings, selectionStore, memory, nutstore, shortcuts, note, codeTools
+ * - 总配置项: 209
  *
  * 使用说明:
  * 1. ElectronStore读取: configManager.get(mapping.originalKey)

--- a/src/main/data/migration/v2/migrators/mappings/__tests__/CodeToolsTransforms.test.ts
+++ b/src/main/data/migration/v2/migrators/mappings/__tests__/CodeToolsTransforms.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest'
+
+import { transformCodeToolsToOverrides, transformSelectedModelsToIds } from '../CodeToolsTransforms'
+
+describe('CodeToolsTransforms', () => {
+  describe('transformSelectedModelsToIds', () => {
+    it('should extract model IDs from full Model objects', () => {
+      const selectedModels = {
+        'qwen-code': { id: 'model-1', provider: 'openai', name: 'GPT-4', group: 'default' },
+        'claude-code': { id: 'model-2', provider: 'anthropic', name: 'Claude', group: 'default' },
+        'gemini-cli': null
+      }
+
+      const result = transformSelectedModelsToIds(selectedModels)
+      expect(result).toEqual({
+        'qwen-code': 'model-1',
+        'claude-code': 'model-2',
+        'gemini-cli': null
+      })
+    })
+
+    it('should handle all null models', () => {
+      const selectedModels = {
+        'qwen-code': null,
+        'claude-code': null,
+        'gemini-cli': null
+      }
+
+      const result = transformSelectedModelsToIds(selectedModels)
+      expect(result).toEqual({
+        'qwen-code': null,
+        'claude-code': null,
+        'gemini-cli': null
+      })
+    })
+
+    it('should handle empty object', () => {
+      const result = transformSelectedModelsToIds({})
+      expect(result).toEqual({})
+    })
+
+    it('should handle undefined/null input', () => {
+      expect(transformSelectedModelsToIds(undefined)).toEqual({})
+      expect(transformSelectedModelsToIds(null)).toEqual({})
+    })
+
+    it('should handle models without id field', () => {
+      const selectedModels = {
+        'qwen-code': { name: 'No ID Model', provider: 'test', group: 'default' },
+        'claude-code': { id: 'valid-id', provider: 'anthropic', name: 'Claude', group: 'default' }
+      }
+
+      const result = transformSelectedModelsToIds(selectedModels as any)
+      expect(result).toEqual({
+        'qwen-code': null,
+        'claude-code': 'valid-id'
+      })
+    })
+
+    it('should handle non-object model values gracefully', () => {
+      const selectedModels = {
+        'qwen-code': 'string-value',
+        'claude-code': 42,
+        'gemini-cli': { id: 'valid', provider: 'test', name: 'Test', group: 'default' }
+      }
+
+      const result = transformSelectedModelsToIds(selectedModels as any)
+      expect(result).toEqual({
+        'qwen-code': null,
+        'claude-code': null,
+        'gemini-cli': 'valid'
+      })
+    })
+  })
+
+  describe('transformCodeToolsToOverrides', () => {
+    it('should merge selectedModels and environmentVariables into per-tool overrides', () => {
+      const result = transformCodeToolsToOverrides({
+        selectedModels: {
+          'qwen-code': { id: 'model-1', provider: 'openai', name: 'GPT-4', group: 'default' },
+          'claude-code': null
+        },
+        environmentVariables: {
+          'qwen-code': 'KEY=val',
+          'claude-code': ''
+        },
+        directories: ['/project-a', '/project-b'],
+        currentDirectory: '/project-a'
+      })
+
+      // claude-code has null model and empty env → no override (all defaults)
+      // Only qwen-code has non-default values → gets directories too
+      expect(result).toEqual({
+        'qwen-code': {
+          modelId: 'model-1',
+          envVars: 'KEY=val',
+          directories: ['/project-a', '/project-b'],
+          currentDirectory: '/project-a'
+        }
+      })
+    })
+
+    it('should skip tools where all fields are default (null model, empty env)', () => {
+      const result = transformCodeToolsToOverrides({
+        selectedModels: {
+          'qwen-code': null,
+          'claude-code': null
+        },
+        environmentVariables: {
+          'qwen-code': '',
+          'claude-code': ''
+        },
+        directories: [],
+        currentDirectory: ''
+      })
+
+      expect(result).toEqual({})
+    })
+
+    it('should handle missing sources gracefully', () => {
+      const result = transformCodeToolsToOverrides({
+        selectedModels: undefined,
+        environmentVariables: undefined,
+        directories: undefined,
+        currentDirectory: undefined
+      })
+
+      expect(result).toEqual({})
+    })
+
+    it('should include tool override even if only model is set', () => {
+      const result = transformCodeToolsToOverrides({
+        selectedModels: {
+          'gemini-cli': { id: 'gem-1', provider: 'google', name: 'Gemini', group: 'default' }
+        },
+        environmentVariables: {},
+        directories: [],
+        currentDirectory: ''
+      })
+
+      expect(result).toEqual({
+        'gemini-cli': { modelId: 'gem-1' }
+      })
+    })
+
+    it('should include tool override even if only envVars is set', () => {
+      const result = transformCodeToolsToOverrides({
+        selectedModels: {},
+        environmentVariables: { opencode: 'API_KEY=123' },
+        directories: [],
+        currentDirectory: ''
+      })
+
+      expect(result).toEqual({
+        opencode: { envVars: 'API_KEY=123' }
+      })
+    })
+
+    it('should assign global directories/currentDirectory to all tools that have other overrides', () => {
+      const result = transformCodeToolsToOverrides({
+        selectedModels: { 'qwen-code': { id: 'm1', provider: 'p', name: 'n', group: 'g' } },
+        environmentVariables: { 'claude-code': 'X=1' },
+        directories: ['/dir1'],
+        currentDirectory: '/dir1'
+      })
+
+      // Both tools that have overrides also get the global dirs
+      expect(result['qwen-code']?.directories).toEqual(['/dir1'])
+      expect(result['qwen-code']?.currentDirectory).toBe('/dir1')
+      expect(result['claude-code']?.directories).toEqual(['/dir1'])
+      expect(result['claude-code']?.currentDirectory).toBe('/dir1')
+    })
+
+    it('should create override for selectedCliTool even if no model/env set, when dirs exist', () => {
+      const result = transformCodeToolsToOverrides({
+        selectedModels: { 'qwen-code': null },
+        environmentVariables: { 'qwen-code': '' },
+        directories: ['/project'],
+        currentDirectory: '/project',
+        selectedCliTool: 'qwen-code'
+      })
+
+      // The selected tool gets dirs even though model/env are default
+      expect(result).toEqual({
+        'qwen-code': { directories: ['/project'], currentDirectory: '/project' }
+      })
+    })
+  })
+})

--- a/src/main/data/migration/v2/migrators/mappings/__tests__/ComplexPreferenceMappings.test.ts
+++ b/src/main/data/migration/v2/migrators/mappings/__tests__/ComplexPreferenceMappings.test.ts
@@ -64,16 +64,18 @@ describe('ComplexPreferenceMappings', () => {
       expect(Array.isArray(COMPLEX_PREFERENCE_MAPPINGS)).toBe(true)
     })
 
-    it('should initially be empty (no mappings configured yet)', () => {
-      // This test documents the current state - update when mappings are added
-      expect(COMPLEX_PREFERENCE_MAPPINGS.length).toBe(0)
+    it('should contain the code_tools_overrides mapping', () => {
+      expect(COMPLEX_PREFERENCE_MAPPINGS.length).toBeGreaterThanOrEqual(1)
+      const codeToolsMapping = COMPLEX_PREFERENCE_MAPPINGS.find((m) => m.id === 'code_tools_overrides')
+      expect(codeToolsMapping).toBeDefined()
+      expect(codeToolsMapping!.targetKeys).toEqual(['feature.code_tools.overrides'])
     })
   })
 
   describe('getComplexMappingTargetKeys', () => {
-    it('should return empty array when no mappings exist', () => {
+    it('should return target keys from registered mappings', () => {
       const keys = getComplexMappingTargetKeys()
-      expect(keys).toEqual([])
+      expect(keys).toContain('feature.code_tools.overrides')
     })
 
     it('should flatten target keys from all mappings', () => {

--- a/src/renderer/src/windows/migrationV2/exporters/ReduxExporter.ts
+++ b/src/renderer/src/windows/migrationV2/exporters/ReduxExporter.ts
@@ -12,7 +12,8 @@ const SLICES_TO_EXPORT = [
   'knowledge', // Knowledge base metadata
   'llm', // LLM provider and model configurations
   'note', // Note-related settings
-  'selectionStore' // Selection assistant settings
+  'selectionStore', // Selection assistant settings
+  'codeTools' // Code tools settings (CLI tool, models, terminal)
 ]
 
 export interface ReduxExportResult {


### PR DESCRIPTION
### What this PR does

Before this PR:
The three v2 skills (`v2-migrator`, `v2-data-api`, `v2-renderer`) had no guidance on:
1. **ReduxExporter** `SLICES_TO_EXPORT` registration — a required step when migrating Redux slices that was easy to forget
2. **Layered Preset pattern** — a common data shape (predefined list + user overrides) that requires specific migration, API design, and renderer consumption patterns

After this PR:
All three skills now include targeted guidance for these patterns:
- **v2-migrator**: New step 8 (ReduxExporter registration), Layered Preset recognition section, and two new checklist items
- **v2-data-api**: New "Layered Preset Pattern" section with step-by-step preset definition, overrides preference key, and merge logic; two new checklist items
- **v2-renderer**: New "Consuming Layered Presets" section with `usePreference` merge hooks, per-item override updates, and migration pattern from Redux per-item maps; one new checklist item

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Added guidance inline in each skill rather than creating a separate cross-cutting skill, since the context is phase-specific

The following alternatives were considered:
- Creating a standalone `layered-preset` skill — rejected because the guidance is tightly coupled to each phase's workflow

### Breaking changes

None

### Special notes for your reviewer

- Both `.agents/skills/` and `.claude/skills/` copies are updated identically
- The code-tools migration (parent branch `DeJeune/migrate-codetools-v2`) serves as the reference implementation cited in these skill updates

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: N/A — this PR *is* the documentation update
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
