### PR TITLE
docs(skills): add Layered Preset pattern and ReduxExporter guidance to v2 skills

### DIFF
--- a/.agents/skills/v2-data-api/SKILL.md
+++ b/.agents/skills/v2-data-api/SKILL.md
@@ -405,6 +405,76 @@ export const DefaultPreferences: PreferenceSchemas = {
 
 See `docs/en/references/data/preference-schema-guide.md` for full guide.
 
+## Layered Preset Pattern (Predefined Config + User Overrides)
+
+Use this pattern when a feature has a **predefined list of items** (tools, providers, templates) with **user-customizable settings per item**. Instead of storing full config for every item, store only the user's deviations from defaults.
+
+**When to use:**
+- Feature has a fixed, code-defined list of options (e.g., CLI tools, AI providers)
+- Users can customize per-item settings (model, API key, env vars)
+- Most items keep default values — only a few are customized
+
+**Architecture:**
+
+```
+packages/shared/data/presets/<domain>.ts    → Preset definitions (code, not DB)
+packages/shared/data/preference/            → Overrides preference key (DB)
+```
+
+### Step 1: Define Presets (Shared Package)
+
+```typescript
+// packages/shared/data/presets/my-feature.ts
+export interface MyFeaturePreset {
+  id: string
+  name: string
+  modelId: string | null
+  config: string
+}
+
+export const PRESETS_MY_FEATURE: MyFeaturePreset[] = [
+  { id: 'option-a', name: 'Option A', modelId: null, config: '' },
+  { id: 'option-b', name: 'Option B', modelId: null, config: '' },
+]
+
+// Override = partial preset (only non-default fields)
+export type MyFeatureOverride = Partial<Omit<MyFeaturePreset, 'id' | 'name'>>
+export type MyFeatureOverrides = Record<string, MyFeatureOverride>
+```
+
+### Step 2: Add Overrides Preference Key
+
+```typescript
+// packages/shared/data/preference/preferenceSchemas.ts
+import type { MyFeatureOverrides } from '@shared/data/presets/my-feature'
+
+// In PreferenceSchemas interface:
+'feature.my_feature.overrides': MyFeatureOverrides  // default: {}
+
+// In DefaultPreferences:
+'feature.my_feature.overrides': {},
+```
+
+**Key design principles:**
+- Presets are **immutable code** — updated via app releases, not user action
+- Overrides store **delta only** — empty `{}` means all defaults
+- Override keys match preset IDs — `{ 'option-a': { modelId: 'm1' } }`
+- The merge happens at read time (renderer), not write time
+
+### Step 3: Merge Logic (Service or Hook)
+
+The effective config for an item = preset defaults merged with user overrides:
+
+```typescript
+function getEffectiveConfig(presetId: string, overrides: MyFeatureOverrides): MyFeaturePreset {
+  const preset = PRESETS_MY_FEATURE.find(p => p.id === presetId)
+  if (!preset) throw new Error(`Unknown preset: ${presetId}`)
+  return { ...preset, ...overrides[presetId] }
+}
+```
+
+See `docs/en/references/data/best-practice-layered-preset-pattern.md` for full documentation and `packages/shared/data/presets/code-tools.ts` for a reference implementation.
+
 ## Cross-Domain References (Stale Object Bug)
 
 ### The Legacy Problem
@@ -501,6 +571,8 @@ throw DataApiErrorFactory.timeout('fetch topics', 3000)
 - [ ] Key + type in `PreferenceSchemas` interface
 - [ ] Default value in `DefaultPreferences`
 - [ ] Key naming follows conventions
+- [ ] Layered Preset pattern applied (if feature has predefined list + per-item overrides)
+- [ ] Preset definitions in `packages/shared/data/presets/` (if using Layered Preset)
 
 ### Quality
 - [ ] All tests pass: `pnpm test`

--- a/.agents/skills/v2-data-api/SKILL.md
+++ b/.agents/skills/v2-data-api/SKILL.md
@@ -363,35 +363,83 @@ Always accept optional `tx` parameter for transaction support.
 
 ## Adding a Preference Key
 
-For user settings that don't need full DataApi:
+For user settings that don't need full DataApi.
 
-### Step 1: Define Type (if custom)
+**IMPORTANT:** `preferenceSchemas.ts` and `PreferencesMappings.ts` are **auto-generated** by the `v2-refactor-temp/tools/data-classify` toolchain. Do NOT edit them directly for migrated keys — use the toolchain instead. However, for keys that use custom types (e.g., `CodeToolOverrides`) or complex defaults (e.g., Layered Preset overrides), you may need to manually add them because the code generator only handles primitive types and simple `VALUE:` references.
+
+### Understanding the Toolchain
+
+The `v2-refactor-temp/tools/data-classify/` directory contains scripts that manage the full preference lifecycle:
+
+```
+v2-refactor-temp/tools/data-classify/
+├── data/
+│   ├── classification.json          # All legacy data items classified (391 items)
+│   ├── inventory.json               # Auto-extracted from source code
+│   └── target-key-definitions.json  # Complex mapping + v2-new-only target keys
+├── scripts/
+│   ├── extract-inventory.js         # Scan source code for data items
+│   ├── generate-preferences.js      # Generate preferenceSchemas.ts
+│   ├── generate-migration.js        # Generate PreferencesMappings.ts
+│   ├── generate-all.js              # Run all generators
+│   ├── validate-consistency.js      # Check classification consistency
+│   └── validate-generation.js       # Verify generated code quality
+```
+
+**Generated files** (do not manually edit for simple migrated keys):
+- `packages/shared/data/preference/preferenceSchemas.ts` — types + defaults
+- `src/main/data/migration/v2/migrators/mappings/PreferencesMappings.ts` — simple 1:1 mappings
+
+### How to Add a Preference Key
+
+There are **two paths** depending on whether the key migrates from legacy data or is brand new:
+
+#### Path A: Migrating from Legacy Data (Simple 1:1 Mapping)
+
+1. Edit `v2-refactor-temp/tools/data-classify/data/classification.json`
+2. Set `status: "classified"`, `category: "preferences"`, `targetKey: "feature.my_feature.enabled"`
+3. Run `cd v2-refactor-temp/tools/data-classify && npm run generate`
+4. The toolchain generates both `preferenceSchemas.ts` and `PreferencesMappings.ts`
+
+#### Path B: Complex Mapping or v2-New-Only Key
+
+For keys that come from complex migration transforms (N→1, 1→N) or are entirely new in v2:
+
+1. Add the key definition to `v2-refactor-temp/tools/data-classify/data/target-key-definitions.json`:
+```json
+{
+  "targetKey": "feature.my_feature.enabled",
+  "type": "boolean",
+  "defaultValue": false,
+  "status": "classified",
+  "description": "Enable my feature (v2 new, non-migration)"
+}
+```
+2. Run `cd v2-refactor-temp/tools/data-classify && npm run generate:preferences`
+3. For complex migrations, also implement transform in `ComplexPreferenceMappings.ts`
+
+#### Path C: Keys with Custom Types (Manual)
+
+When the preference uses a custom TypeScript type (e.g., `CodeToolOverrides`, a Record type), the code generator cannot handle it. Manually add:
+
+1. Define custom type (if needed):
 ```typescript
 // packages/shared/data/preference/preferenceTypes.ts
 export enum MyFeatureMode { auto = 'auto', manual = 'manual', disabled = 'disabled' }
 ```
 
-### Step 2: Add to Schema
+2. Manually add to `preferenceSchemas.ts` (keep alphabetical order):
 ```typescript
-// packages/shared/data/preference/preferenceSchemas.ts
-export interface PreferenceSchemas {
-  default: {
-    // ... existing keys (alphabetically sorted)
-    'feature.my_feature.enabled': boolean
-    'feature.my_feature.mode': PreferenceTypes.MyFeatureMode
-  }
-}
+// In PreferenceSchemas interface:
+'feature.my_feature.overrides': MyFeatureOverrides
 
-export const DefaultPreferences: PreferenceSchemas = {
-  default: {
-    // ... existing defaults (alphabetically sorted)
-    'feature.my_feature.enabled': true,
-    'feature.my_feature.mode': PreferenceTypes.MyFeatureMode.auto,
-  }
-}
+// In DefaultPreferences:
+'feature.my_feature.overrides': {},
 ```
 
-**Key naming:** `namespace.category.key_name`
+### Key Naming Conventions
+
+**Format:** `namespace.category.key_name`
 - At least 2 dot-separated segments
 - Lowercase letters, numbers, underscores only
 - Pattern: `/^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$/`

--- a/.agents/skills/v2-migrator/SKILL.md
+++ b/.agents/skills/v2-migrator/SKILL.md
@@ -88,6 +88,9 @@ Renderer Process                          Main Process
 | `packages/shared/data/migration/v2/types.ts` | Shared types: stages, results, stats |
 | `src/main/data/migration/v2/window/MigrationIpcHandler.ts` | IPC flow control |
 | `src/renderer/src/store/` | Redux slices (source data shapes) |
+| `v2-refactor-temp/tools/data-classify/` | Toolchain: classification, code generation, validation |
+| `v2-refactor-temp/tools/data-classify/data/classification.json` | Authoritative classification of all 391 legacy data items |
+| `v2-refactor-temp/tools/data-classify/data/target-key-definitions.json` | Target keys for complex mappings and v2-new-only preferences |
 
 ## Migrator Contract
 
@@ -153,14 +156,17 @@ const idMap = ctx.sharedData.get('assistantIdMap')  // consumer (later migrator)
 ### 1. Understand Source Data
 - Read the Redux slice in `src/renderer/src/store/` for data shape
 - Check Dexie tables in `src/renderer/src/services/db.ts` if applicable
-- Confirm classification in `v2-refactor-temp/tools/data-classify/classification.json`
+- Confirm classification in `v2-refactor-temp/tools/data-classify/data/classification.json`
 
 ### 2. Understand Target Schema
 - Read target SQLite schema in `src/main/data/db/schemas/`
 - Map source fields to target columns
 - Identify transformations (type conversions, restructuring, merging)
+- For preference migrations: check if target keys already exist in `v2-refactor-temp/tools/data-classify/data/target-key-definitions.json`
 
 ### 3. Create Mapping File (if needed)
+
+**For preference migrations:** `PreferencesMappings.ts` and `preferenceSchemas.ts` are **auto-generated** by the `v2-refactor-temp/tools/data-classify` toolchain. For simple 1:1 preference mappings, update `classification.json` and run `npm run generate` instead of editing the generated files directly. See the `v2-data-api` skill for the full workflow. For complex mappings or keys with custom types, you may need to add entries manually.
 
 **Simple 1:1 mapping** (like PreferencesMappings):
 ```typescript
@@ -187,6 +193,8 @@ export interface ComplexMapping {
   transform: (sources: Record<string, unknown>) => Record<string, unknown>
 }
 ```
+
+For complex mapping target keys, add them to `v2-refactor-temp/tools/data-classify/data/target-key-definitions.json` so that the generated `preferenceSchemas.ts` includes their type and default value.
 
 ### 4. Write Tests for Transformation Functions (TDD Red Phase)
 

--- a/.agents/skills/v2-migrator/SKILL.md
+++ b/.agents/skills/v2-migrator/SKILL.md
@@ -399,12 +399,30 @@ async execute(ctx) {
 }
 ```
 
-### 8. Register
+### 8. Register ReduxExporter (if migrating a Redux slice)
+
+If the migrator reads from a Redux slice, the slice must be exported by the renderer during migration. Register it in:
+
+```typescript
+// src/renderer/src/windows/migrationV2/exporters/ReduxExporter.ts
+const SLICES_TO_EXPORT = [
+  'settings',
+  'llm',
+  // ... existing slices
+  'myNewSlice',  // <-- add your slice here
+]
+```
+
+**Why:** The migration runs in the Main process, but Redux state lives in the renderer's localStorage. `ReduxExporter` serializes registered slices and sends them to Main via IPC. If you forget this step, `ctx.sources.redux.get('mySlice', ...)` will return `undefined` for all keys.
+
+**When to skip:** If your migrator only reads from Dexie or ElectronStore (not Redux), skip this step.
+
+### 9. Register Migrator
 
 1. Add to `src/main/data/migration/v2/migrators/index.ts` with correct `order`
 2. Add target table to `MigrationEngine.verifyAndClearNewTables` (child tables before parents)
 
-### 9. Document
+### 10. Document
 
 Create `src/main/data/migration/v2/migrators/README-<MigratorName>.md`:
 - Data sources and target tables
@@ -452,6 +470,39 @@ function mergeTopicData(reduxTopic: ReduxTopic, dexieTopic: DexieTopic): MergedT
   }
 }
 ```
+
+## Layered Preset Pattern Recognition
+
+When analyzing a Redux slice for migration, check if the data follows the **Layered Preset** pattern — a predefined list of items with user customizations stored per-item. This is common for features with a fixed set of options (tools, providers, templates) where users can override individual settings.
+
+**How to recognize it in Redux:**
+- A hardcoded list of items in code (e.g., `CLI_TOOLS`, `PROVIDER_LIST`)
+- Per-item user state stored in Redux as `Record<itemId, value>` maps (e.g., `selectedModels: { 'tool-a': Model, 'tool-b': null }`)
+- Multiple such maps that share the same item keys
+
+**v2 migration strategy:** Convert to a single `overrides` preference key using delta-only storage:
+
+```typescript
+// Before (Redux): Multiple per-tool maps
+// codeTools.selectedModels = { 'tool-a': { id: 'm1', ... }, 'tool-b': null }
+// codeTools.environmentVariables = { 'tool-a': 'KEY=val', 'tool-b': '' }
+
+// After (v2): Single overrides preference (delta-only, non-default values only)
+// preference: 'feature.code_tools.overrides' = { 'tool-a': { modelId: 'm1', envVars: 'KEY=val' } }
+```
+
+**Implementation steps:**
+1. Define preset types and defaults in `packages/shared/data/presets/<domain>.ts`
+2. Add the overrides preference key to `preferenceSchemas.ts` with `{}` as default
+3. Use a `ComplexMapping` in `ComplexPreferenceMappings.ts` to merge multiple Redux maps into a single overrides object
+4. Write pure transform functions in a separate file (e.g., `CodeToolsTransforms.ts`)
+
+**Key principles:**
+- Store only non-default values (delta) — if a tool's settings all match the preset defaults, omit it entirely
+- Extract FK IDs from embedded full objects (e.g., `Model` → `modelId`)
+- Presets live in code (`packages/shared/data/presets/`), overrides live in preferences
+
+See `docs/en/references/data/best-practice-layered-preset-pattern.md` for full pattern documentation, and `packages/shared/data/presets/code-tools.ts` for a reference implementation.
 
 ## Cross-Domain References & Foreign Keys
 
@@ -642,6 +693,8 @@ try {
 - [ ] Streaming for large tables (>1000 records)
 - [ ] Duplicate ID handling
 - [ ] Progress via `reportProgress`
+- [ ] Redux slice registered in `ReduxExporter.SLICES_TO_EXPORT` (if reading from Redux)
+- [ ] Layered Preset pattern identified and applied (if source has predefined list + per-item overrides)
 - [ ] Registered in `migrators/index.ts` with correct `order`
 - [ ] Target table added to `MigrationEngine.verifyAndClearNewTables`
 - [ ] Cross-migrator data via `ctx.sharedData` (if applicable)

--- a/.agents/skills/v2-renderer/SKILL.md
+++ b/.agents/skills/v2-renderer/SKILL.md
@@ -528,7 +528,7 @@ See `packages/shared/data/presets/code-tools.ts` for a reference implementation.
    ```
 
 ### New Preference Key
-See `v2-data-api` skill, "Adding a Preference Key" section.
+See `v2-data-api` skill, "Adding a Preference Key" section. Note that `preferenceSchemas.ts` is **auto-generated** by the `v2-refactor-temp/tools/data-classify` toolchain — for simple keys, use the toolchain (update `classification.json` or `target-key-definitions.json`, then run `npm run generate`) instead of editing the generated file directly.
 
 ## Checklist
 

--- a/.agents/skills/v2-renderer/SKILL.md
+++ b/.agents/skills/v2-renderer/SKILL.md
@@ -457,6 +457,59 @@ const showTimestamp = useAppSelector(s => s.settings.showMessageTimestamp)
 const [showTimestamp] = usePreference('chat.display.show_timestamp')
 ```
 
+## Consuming Layered Presets (Predefined Config + User Overrides)
+
+When a feature uses the Layered Preset pattern (see `v2-data-api` skill), the renderer merges presets with user overrides at read time.
+
+### Reading Effective Config
+
+```typescript
+import { PRESETS_MY_FEATURE, type MyFeaturePreset } from '@shared/data/presets/my-feature'
+import { usePreference } from '@data/hooks/usePreference'
+
+function useMyFeatureConfig(presetId: string): MyFeaturePreset {
+  const [overrides] = usePreference('feature.my_feature.overrides')
+  const preset = PRESETS_MY_FEATURE.find(p => p.id === presetId)!
+  return { ...preset, ...overrides[presetId] }
+}
+```
+
+### Updating Per-Item Overrides
+
+Write only the changed fields — keep the delta minimal:
+
+```typescript
+function useMyFeatureOverride(presetId: string) {
+  const [overrides, setOverrides] = usePreference('feature.my_feature.overrides')
+
+  const updateOverride = async (patch: Partial<MyFeatureOverride>) => {
+    const current = overrides[presetId] ?? {}
+    await setOverrides({ ...overrides, [presetId]: { ...current, ...patch } })
+  }
+
+  const resetOverride = async () => {
+    const { [presetId]: _, ...rest } = overrides
+    await setOverrides(rest)
+  }
+
+  return { override: overrides[presetId] ?? {}, updateOverride, resetOverride }
+}
+```
+
+### Migration Pattern: Redux Per-Item Maps -> Layered Preset
+
+```typescript
+// Before (Redux): separate maps per field
+const selectedModels = useAppSelector(s => s.codeTools.selectedModels)   // Record<toolId, Model>
+const envVars = useAppSelector(s => s.codeTools.environmentVariables)    // Record<toolId, string>
+
+// After (v2): single overrides preference + preset merge
+const [overrides] = usePreference('feature.code_tools.overrides')
+const effectiveConfig = { ...PRESETS_CODE_TOOLS.find(p => p.id === toolId)!, ...overrides[toolId] }
+```
+
+See `packages/shared/data/presets/code-tools.ts` for a reference implementation.
+
 ## Adding New Schema Keys
 
 ### New Cache Key
@@ -499,6 +552,7 @@ See `v2-data-api` skill, "Adding a Preference Key" section.
 - [ ] Optimistic vs pessimistic update strategy chosen for preferences
 - [ ] Cache tier chosen correctly (memory vs shared vs persist)
 - [ ] New cache/preference keys added to schemas
+- [ ] Layered Preset merge logic implemented (if feature uses presets + overrides)
 
 ### Quality
 - [ ] All tests pass: `pnpm test`

--- a/.claude/skills/v2-data-api/SKILL.md
+++ b/.claude/skills/v2-data-api/SKILL.md
@@ -405,6 +405,76 @@ export const DefaultPreferences: PreferenceSchemas = {
 
 See `docs/en/references/data/preference-schema-guide.md` for full guide.
 
+## Layered Preset Pattern (Predefined Config + User Overrides)
+
+Use this pattern when a feature has a **predefined list of items** (tools, providers, templates) with **user-customizable settings per item**. Instead of storing full config for every item, store only the user's deviations from defaults.
+
+**When to use:**
+- Feature has a fixed, code-defined list of options (e.g., CLI tools, AI providers)
+- Users can customize per-item settings (model, API key, env vars)
+- Most items keep default values — only a few are customized
+
+**Architecture:**
+
+```
+packages/shared/data/presets/<domain>.ts    → Preset definitions (code, not DB)
+packages/shared/data/preference/            → Overrides preference key (DB)
+```
+
+### Step 1: Define Presets (Shared Package)
+
+```typescript
+// packages/shared/data/presets/my-feature.ts
+export interface MyFeaturePreset {
+  id: string
+  name: string
+  modelId: string | null
+  config: string
+}
+
+export const PRESETS_MY_FEATURE: MyFeaturePreset[] = [
+  { id: 'option-a', name: 'Option A', modelId: null, config: '' },
+  { id: 'option-b', name: 'Option B', modelId: null, config: '' },
+]
+
+// Override = partial preset (only non-default fields)
+export type MyFeatureOverride = Partial<Omit<MyFeaturePreset, 'id' | 'name'>>
+export type MyFeatureOverrides = Record<string, MyFeatureOverride>
+```
+
+### Step 2: Add Overrides Preference Key
+
+```typescript
+// packages/shared/data/preference/preferenceSchemas.ts
+import type { MyFeatureOverrides } from '@shared/data/presets/my-feature'
+
+// In PreferenceSchemas interface:
+'feature.my_feature.overrides': MyFeatureOverrides  // default: {}
+
+// In DefaultPreferences:
+'feature.my_feature.overrides': {},
+```
+
+**Key design principles:**
+- Presets are **immutable code** — updated via app releases, not user action
+- Overrides store **delta only** — empty `{}` means all defaults
+- Override keys match preset IDs — `{ 'option-a': { modelId: 'm1' } }`
+- The merge happens at read time (renderer), not write time
+
+### Step 3: Merge Logic (Service or Hook)
+
+The effective config for an item = preset defaults merged with user overrides:
+
+```typescript
+function getEffectiveConfig(presetId: string, overrides: MyFeatureOverrides): MyFeaturePreset {
+  const preset = PRESETS_MY_FEATURE.find(p => p.id === presetId)
+  if (!preset) throw new Error(`Unknown preset: ${presetId}`)
+  return { ...preset, ...overrides[presetId] }
+}
+```
+
+See `docs/en/references/data/best-practice-layered-preset-pattern.md` for full documentation and `packages/shared/data/presets/code-tools.ts` for a reference implementation.
+
 ## Cross-Domain References (Stale Object Bug)
 
 ### The Legacy Problem
@@ -501,6 +571,8 @@ throw DataApiErrorFactory.timeout('fetch topics', 3000)
 - [ ] Key + type in `PreferenceSchemas` interface
 - [ ] Default value in `DefaultPreferences`
 - [ ] Key naming follows conventions
+- [ ] Layered Preset pattern applied (if feature has predefined list + per-item overrides)
+- [ ] Preset definitions in `packages/shared/data/presets/` (if using Layered Preset)
 
 ### Quality
 - [ ] All tests pass: `pnpm test`

--- a/.claude/skills/v2-data-api/SKILL.md
+++ b/.claude/skills/v2-data-api/SKILL.md
@@ -363,35 +363,83 @@ Always accept optional `tx` parameter for transaction support.
 
 ## Adding a Preference Key
 
-For user settings that don't need full DataApi:
+For user settings that don't need full DataApi.
 
-### Step 1: Define Type (if custom)
+**IMPORTANT:** `preferenceSchemas.ts` and `PreferencesMappings.ts` are **auto-generated** by the `v2-refactor-temp/tools/data-classify` toolchain. Do NOT edit them directly for migrated keys — use the toolchain instead. However, for keys that use custom types (e.g., `CodeToolOverrides`) or complex defaults (e.g., Layered Preset overrides), you may need to manually add them because the code generator only handles primitive types and simple `VALUE:` references.
+
+### Understanding the Toolchain
+
+The `v2-refactor-temp/tools/data-classify/` directory contains scripts that manage the full preference lifecycle:
+
+```
+v2-refactor-temp/tools/data-classify/
+├── data/
+│   ├── classification.json          # All legacy data items classified (391 items)
+│   ├── inventory.json               # Auto-extracted from source code
+│   └── target-key-definitions.json  # Complex mapping + v2-new-only target keys
+├── scripts/
+│   ├── extract-inventory.js         # Scan source code for data items
+│   ├── generate-preferences.js      # Generate preferenceSchemas.ts
+│   ├── generate-migration.js        # Generate PreferencesMappings.ts
+│   ├── generate-all.js              # Run all generators
+│   ├── validate-consistency.js      # Check classification consistency
+│   └── validate-generation.js       # Verify generated code quality
+```
+
+**Generated files** (do not manually edit for simple migrated keys):
+- `packages/shared/data/preference/preferenceSchemas.ts` — types + defaults
+- `src/main/data/migration/v2/migrators/mappings/PreferencesMappings.ts` — simple 1:1 mappings
+
+### How to Add a Preference Key
+
+There are **two paths** depending on whether the key migrates from legacy data or is brand new:
+
+#### Path A: Migrating from Legacy Data (Simple 1:1 Mapping)
+
+1. Edit `v2-refactor-temp/tools/data-classify/data/classification.json`
+2. Set `status: "classified"`, `category: "preferences"`, `targetKey: "feature.my_feature.enabled"`
+3. Run `cd v2-refactor-temp/tools/data-classify && npm run generate`
+4. The toolchain generates both `preferenceSchemas.ts` and `PreferencesMappings.ts`
+
+#### Path B: Complex Mapping or v2-New-Only Key
+
+For keys that come from complex migration transforms (N→1, 1→N) or are entirely new in v2:
+
+1. Add the key definition to `v2-refactor-temp/tools/data-classify/data/target-key-definitions.json`:
+```json
+{
+  "targetKey": "feature.my_feature.enabled",
+  "type": "boolean",
+  "defaultValue": false,
+  "status": "classified",
+  "description": "Enable my feature (v2 new, non-migration)"
+}
+```
+2. Run `cd v2-refactor-temp/tools/data-classify && npm run generate:preferences`
+3. For complex migrations, also implement transform in `ComplexPreferenceMappings.ts`
+
+#### Path C: Keys with Custom Types (Manual)
+
+When the preference uses a custom TypeScript type (e.g., `CodeToolOverrides`, a Record type), the code generator cannot handle it. Manually add:
+
+1. Define custom type (if needed):
 ```typescript
 // packages/shared/data/preference/preferenceTypes.ts
 export enum MyFeatureMode { auto = 'auto', manual = 'manual', disabled = 'disabled' }
 ```
 
-### Step 2: Add to Schema
+2. Manually add to `preferenceSchemas.ts` (keep alphabetical order):
 ```typescript
-// packages/shared/data/preference/preferenceSchemas.ts
-export interface PreferenceSchemas {
-  default: {
-    // ... existing keys (alphabetically sorted)
-    'feature.my_feature.enabled': boolean
-    'feature.my_feature.mode': PreferenceTypes.MyFeatureMode
-  }
-}
+// In PreferenceSchemas interface:
+'feature.my_feature.overrides': MyFeatureOverrides
 
-export const DefaultPreferences: PreferenceSchemas = {
-  default: {
-    // ... existing defaults (alphabetically sorted)
-    'feature.my_feature.enabled': true,
-    'feature.my_feature.mode': PreferenceTypes.MyFeatureMode.auto,
-  }
-}
+// In DefaultPreferences:
+'feature.my_feature.overrides': {},
 ```
 
-**Key naming:** `namespace.category.key_name`
+### Key Naming Conventions
+
+**Format:** `namespace.category.key_name`
 - At least 2 dot-separated segments
 - Lowercase letters, numbers, underscores only
 - Pattern: `/^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$/`

--- a/.claude/skills/v2-migrator/SKILL.md
+++ b/.claude/skills/v2-migrator/SKILL.md
@@ -88,6 +88,9 @@ Renderer Process                          Main Process
 | `packages/shared/data/migration/v2/types.ts` | Shared types: stages, results, stats |
 | `src/main/data/migration/v2/window/MigrationIpcHandler.ts` | IPC flow control |
 | `src/renderer/src/store/` | Redux slices (source data shapes) |
+| `v2-refactor-temp/tools/data-classify/` | Toolchain: classification, code generation, validation |
+| `v2-refactor-temp/tools/data-classify/data/classification.json` | Authoritative classification of all 391 legacy data items |
+| `v2-refactor-temp/tools/data-classify/data/target-key-definitions.json` | Target keys for complex mappings and v2-new-only preferences |
 
 ## Migrator Contract
 
@@ -153,14 +156,17 @@ const idMap = ctx.sharedData.get('assistantIdMap')  // consumer (later migrator)
 ### 1. Understand Source Data
 - Read the Redux slice in `src/renderer/src/store/` for data shape
 - Check Dexie tables in `src/renderer/src/services/db.ts` if applicable
-- Confirm classification in `v2-refactor-temp/tools/data-classify/classification.json`
+- Confirm classification in `v2-refactor-temp/tools/data-classify/data/classification.json`
 
 ### 2. Understand Target Schema
 - Read target SQLite schema in `src/main/data/db/schemas/`
 - Map source fields to target columns
 - Identify transformations (type conversions, restructuring, merging)
+- For preference migrations: check if target keys already exist in `v2-refactor-temp/tools/data-classify/data/target-key-definitions.json`
 
 ### 3. Create Mapping File (if needed)
+
+**For preference migrations:** `PreferencesMappings.ts` and `preferenceSchemas.ts` are **auto-generated** by the `v2-refactor-temp/tools/data-classify` toolchain. For simple 1:1 preference mappings, update `classification.json` and run `npm run generate` instead of editing the generated files directly. See the `v2-data-api` skill for the full workflow. For complex mappings or keys with custom types, you may need to add entries manually.
 
 **Simple 1:1 mapping** (like PreferencesMappings):
 ```typescript
@@ -187,6 +193,8 @@ export interface ComplexMapping {
   transform: (sources: Record<string, unknown>) => Record<string, unknown>
 }
 ```
+
+For complex mapping target keys, add them to `v2-refactor-temp/tools/data-classify/data/target-key-definitions.json` so that the generated `preferenceSchemas.ts` includes their type and default value.
 
 ### 4. Write Tests for Transformation Functions (TDD Red Phase)
 

--- a/.claude/skills/v2-migrator/SKILL.md
+++ b/.claude/skills/v2-migrator/SKILL.md
@@ -399,12 +399,30 @@ async execute(ctx) {
 }
 ```
 
-### 8. Register
+### 8. Register ReduxExporter (if migrating a Redux slice)
+
+If the migrator reads from a Redux slice, the slice must be exported by the renderer during migration. Register it in:
+
+```typescript
+// src/renderer/src/windows/migrationV2/exporters/ReduxExporter.ts
+const SLICES_TO_EXPORT = [
+  'settings',
+  'llm',
+  // ... existing slices
+  'myNewSlice',  // <-- add your slice here
+]
+```
+
+**Why:** The migration runs in the Main process, but Redux state lives in the renderer's localStorage. `ReduxExporter` serializes registered slices and sends them to Main via IPC. If you forget this step, `ctx.sources.redux.get('mySlice', ...)` will return `undefined` for all keys.
+
+**When to skip:** If your migrator only reads from Dexie or ElectronStore (not Redux), skip this step.
+
+### 9. Register Migrator
 
 1. Add to `src/main/data/migration/v2/migrators/index.ts` with correct `order`
 2. Add target table to `MigrationEngine.verifyAndClearNewTables` (child tables before parents)
 
-### 9. Document
+### 10. Document
 
 Create `src/main/data/migration/v2/migrators/README-<MigratorName>.md`:
 - Data sources and target tables
@@ -452,6 +470,39 @@ function mergeTopicData(reduxTopic: ReduxTopic, dexieTopic: DexieTopic): MergedT
   }
 }
 ```
+
+## Layered Preset Pattern Recognition
+
+When analyzing a Redux slice for migration, check if the data follows the **Layered Preset** pattern — a predefined list of items with user customizations stored per-item. This is common for features with a fixed set of options (tools, providers, templates) where users can override individual settings.
+
+**How to recognize it in Redux:**
+- A hardcoded list of items in code (e.g., `CLI_TOOLS`, `PROVIDER_LIST`)
+- Per-item user state stored in Redux as `Record<itemId, value>` maps (e.g., `selectedModels: { 'tool-a': Model, 'tool-b': null }`)
+- Multiple such maps that share the same item keys
+
+**v2 migration strategy:** Convert to a single `overrides` preference key using delta-only storage:
+
+```typescript
+// Before (Redux): Multiple per-tool maps
+// codeTools.selectedModels = { 'tool-a': { id: 'm1', ... }, 'tool-b': null }
+// codeTools.environmentVariables = { 'tool-a': 'KEY=val', 'tool-b': '' }
+
+// After (v2): Single overrides preference (delta-only, non-default values only)
+// preference: 'feature.code_tools.overrides' = { 'tool-a': { modelId: 'm1', envVars: 'KEY=val' } }
+```
+
+**Implementation steps:**
+1. Define preset types and defaults in `packages/shared/data/presets/<domain>.ts`
+2. Add the overrides preference key to `preferenceSchemas.ts` with `{}` as default
+3. Use a `ComplexMapping` in `ComplexPreferenceMappings.ts` to merge multiple Redux maps into a single overrides object
+4. Write pure transform functions in a separate file (e.g., `CodeToolsTransforms.ts`)
+
+**Key principles:**
+- Store only non-default values (delta) — if a tool's settings all match the preset defaults, omit it entirely
+- Extract FK IDs from embedded full objects (e.g., `Model` → `modelId`)
+- Presets live in code (`packages/shared/data/presets/`), overrides live in preferences
+
+See `docs/en/references/data/best-practice-layered-preset-pattern.md` for full pattern documentation, and `packages/shared/data/presets/code-tools.ts` for a reference implementation.
 
 ## Cross-Domain References & Foreign Keys
 
@@ -642,6 +693,8 @@ try {
 - [ ] Streaming for large tables (>1000 records)
 - [ ] Duplicate ID handling
 - [ ] Progress via `reportProgress`
+- [ ] Redux slice registered in `ReduxExporter.SLICES_TO_EXPORT` (if reading from Redux)
+- [ ] Layered Preset pattern identified and applied (if source has predefined list + per-item overrides)
 - [ ] Registered in `migrators/index.ts` with correct `order`
 - [ ] Target table added to `MigrationEngine.verifyAndClearNewTables`
 - [ ] Cross-migrator data via `ctx.sharedData` (if applicable)

--- a/.claude/skills/v2-renderer/SKILL.md
+++ b/.claude/skills/v2-renderer/SKILL.md
@@ -528,7 +528,7 @@ See `packages/shared/data/presets/code-tools.ts` for a reference implementation.
    ```
 
 ### New Preference Key
-See `v2-data-api` skill, "Adding a Preference Key" section.
+See `v2-data-api` skill, "Adding a Preference Key" section. Note that `preferenceSchemas.ts` is **auto-generated** by the `v2-refactor-temp/tools/data-classify` toolchain — for simple keys, use the toolchain (update `classification.json` or `target-key-definitions.json`, then run `npm run generate`) instead of editing the generated file directly.
 
 ## Checklist
 

--- a/.claude/skills/v2-renderer/SKILL.md
+++ b/.claude/skills/v2-renderer/SKILL.md
@@ -457,6 +457,59 @@ const showTimestamp = useAppSelector(s => s.settings.showMessageTimestamp)
 const [showTimestamp] = usePreference('chat.display.show_timestamp')
 ```
 
+## Consuming Layered Presets (Predefined Config + User Overrides)
+
+When a feature uses the Layered Preset pattern (see `v2-data-api` skill), the renderer merges presets with user overrides at read time.
+
+### Reading Effective Config
+
+```typescript
+import { PRESETS_MY_FEATURE, type MyFeaturePreset } from '@shared/data/presets/my-feature'
+import { usePreference } from '@data/hooks/usePreference'
+
+function useMyFeatureConfig(presetId: string): MyFeaturePreset {
+  const [overrides] = usePreference('feature.my_feature.overrides')
+  const preset = PRESETS_MY_FEATURE.find(p => p.id === presetId)!
+  return { ...preset, ...overrides[presetId] }
+}
+```
+
+### Updating Per-Item Overrides
+
+Write only the changed fields — keep the delta minimal:
+
+```typescript
+function useMyFeatureOverride(presetId: string) {
+  const [overrides, setOverrides] = usePreference('feature.my_feature.overrides')
+
+  const updateOverride = async (patch: Partial<MyFeatureOverride>) => {
+    const current = overrides[presetId] ?? {}
+    await setOverrides({ ...overrides, [presetId]: { ...current, ...patch } })
+  }
+
+  const resetOverride = async () => {
+    const { [presetId]: _, ...rest } = overrides
+    await setOverrides(rest)
+  }
+
+  return { override: overrides[presetId] ?? {}, updateOverride, resetOverride }
+}
+```
+
+### Migration Pattern: Redux Per-Item Maps -> Layered Preset
+
+```typescript
+// Before (Redux): separate maps per field
+const selectedModels = useAppSelector(s => s.codeTools.selectedModels)   // Record<toolId, Model>
+const envVars = useAppSelector(s => s.codeTools.environmentVariables)    // Record<toolId, string>
+
+// After (v2): single overrides preference + preset merge
+const [overrides] = usePreference('feature.code_tools.overrides')
+const effectiveConfig = { ...PRESETS_CODE_TOOLS.find(p => p.id === toolId)!, ...overrides[toolId] }
+```
+
+See `packages/shared/data/presets/code-tools.ts` for a reference implementation.
+
 ## Adding New Schema Keys
 
 ### New Cache Key
@@ -499,6 +552,7 @@ See `v2-data-api` skill, "Adding a Preference Key" section.
 - [ ] Optimistic vs pessimistic update strategy chosen for preferences
 - [ ] Cache tier chosen correctly (memory vs shared vs persist)
 - [ ] New cache/preference keys added to schemas
+- [ ] Layered Preset merge logic implemented (if feature uses presets + overrides)
 
 ### Quality
 - [ ] All tests pass: `pnpm test`


### PR DESCRIPTION
### What this PR does

Before this PR:
The three v2 skills (`v2-migrator`, `v2-data-api`, `v2-renderer`) had no guidance on:
1. **ReduxExporter** `SLICES_TO_EXPORT` registration — a required step when migrating Redux slices that was easy to forget
2. **Layered Preset pattern** — a common data shape (predefined list + user overrides) that requires specific migration, API design, and renderer consumption patterns

After this PR:
All three skills now include targeted guidance for these patterns:
- **v2-migrator**: New step 8 (ReduxExporter registration), Layered Preset recognition section, and two new checklist items
- **v2-data-api**: New "Layered Preset Pattern" section with step-by-step preset definition, overrides preference key, and merge logic; two new checklist items
- **v2-renderer**: New "Consuming Layered Presets" section with `usePreference` merge hooks, per-item override updates, and migration pattern from Redux per-item maps; one new checklist item

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Added guidance inline in each skill rather than creating a separate cross-cutting skill, since the context is phase-specific

The following alternatives were considered:
- Creating a standalone `layered-preset` skill — rejected because the guidance is tightly coupled to each phase's workflow

### Breaking changes

None

### Special notes for your reviewer

- Both `.agents/skills/` and `.claude/skills/` copies are updated identically
- The code-tools migration (`DeJeune/migrate-codetools-v2` branch) serves as the reference implementation cited in these skill updates

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: N/A — this PR *is* the documentation update
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
