### PR TITLE
fix: replace `p` with `span` to resolve invalid nesting warning

### DIFF
--- a/src/renderer/src/pages/settings/AgentSettings/components/PluginsSettings/components/PluginBrowser.tsx
+++ b/src/renderer/src/pages/settings/AgentSettings/components/PluginsSettings/components/PluginBrowser.tsx
@@ -312,7 +312,7 @@ export const PluginBrowser: FC<PluginBrowserProps> = ({ installedPlugins, onInst
 
       {/* Result Count */}
       <div className="flex items-center gap-2">
-        <p className="text-default-500 text-small">
+        <span className="text-default-500 text-small">
           {isInitialLoading ? (
             <>
               {showingResultsParts.prefix}
@@ -322,7 +322,7 @@ export const PluginBrowser: FC<PluginBrowserProps> = ({ installedPlugins, onInst
           ) : (
             t(showingResultsKey, { count: total })
           )}
-        </p>
+        </span>
       </div>
 
       {/* Plugin Grid */}


### PR DESCRIPTION
The `<SkeletonSpan>` renders Ant Design's `SkeletonInput` which is a `<div>`, and HTML spec doesn't allow block-level elements (`<div>`) inside `<p>`. Using `<span>` instead resolves the nesting violation while keeping the same styling via the existing classes.

<img width="2658" height="1972" alt="CleanShot 2026-03-10 at 10 45 15@2x" src="https://github.com/user-attachments/assets/6351e77e-03c7-42ac-96e8-65d9f162fa22" />
