### PR TITLE
fix: use consistent OpenClaw icon in sidebar settings

### DIFF
--- a/src/renderer/src/pages/settings/DisplaySettings/SidebarIconsManager.tsx
+++ b/src/renderer/src/pages/settings/DisplaySettings/SidebarIconsManager.tsx
@@ -1,13 +1,13 @@
 import { CloseOutlined } from '@ant-design/icons'
 import type { DraggableProvided, DroppableProvided, DropResult } from '@hello-pangea/dnd'
 import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd'
+import { OpenClawSidebarIcon } from '@renderer/components/Icons/SVGIcon'
 import { getSidebarIconLabel } from '@renderer/i18n/label'
 import { useAppDispatch } from '@renderer/store'
 import { setSidebarIcons } from '@renderer/store/settings'
 import type { SidebarIcon } from '@renderer/types'
 import { message } from 'antd'
 import {
-  Bot,
   Code,
   FileSearch,
   Folder,
@@ -125,7 +125,7 @@ const SidebarIconsManager: FC<SidebarIconsManagerProps> = ({
         files: <Folder size={16} />,
         notes: <NotepadText size={16} />,
         code_tools: <Code size={16} />,
-        openclaw: <Bot size={16} />
+        openclaw: <OpenClawSidebarIcon style={{ width: 16, height: 16 }} />
       }) satisfies Record<SidebarIcon, ReactNode>,
     []
   )


### PR DESCRIPTION
### What this PR does

Before this PR:
The OpenClaw icon in Display Settings > Sidebar Settings used a generic `Bot` icon from lucide-react, which was different from the actual OpenClaw icon shown in the left sidebar.

<img width="1239" height="906" alt="image" src="https://github.com/user-attachments/assets/6b429291-103f-492a-bfd2-6525120ffcde" />


After this PR:
The OpenClaw icon in Sidebar Settings now uses `OpenClawSidebarIcon` (the same custom SVG icon used in the main sidebar), making both icons consistent.

<img width="746" height="545" alt="image" src="https://github.com/user-attachments/assets/64f61bdd-eac1-4e4c-99ce-9ae223ba25ed" />


### Why we need it and why it was done in this way

The sidebar settings panel should display the same icons as the actual sidebar so users can easily identify which item they are configuring. The fix simply replaces the incorrect `Bot` icon import with the existing `OpenClawSidebarIcon` component that is already used in `Sidebar.tsx`.

The following tradeoffs were made: None — this is a straightforward icon replacement.

The following alternatives were considered: None — using the same icon component is the obvious correct approach.

### Breaking changes

None.

### Special notes for your reviewer

Single-file change. Only the icon mapping in `SidebarIconsManager.tsx` was modified.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: Not required — no user-facing feature change, only icon consistency fix
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
fix: use consistent OpenClaw icon in Display Settings sidebar configuration
```