### PR TITLE
refactor(OGCard): adjust layout and migrate to TailwindCSS

### DIFF
--- a/src/renderer/src/components/OGCard.tsx
+++ b/src/renderer/src/components/OGCard.tsx
@@ -46,7 +46,7 @@ export const OGCard = ({ link, show }: Props) => {
   return (
     <Container>
       {hasImage && (
-        <div className="flex overflow:hidden min-h-48 items-center justify-center">
+        <div className="flex overflow:hidden h-48 min-h-48 items-center justify-center">
           <img src={metadata['og:image']} alt={metadata['og:imageAlt'] || link} className="max-h-full object-contain" />
         </div>
       )}


### PR DESCRIPTION
### What this PR does

Before this PR:
- OGCard used styled-components for styling with a fixed image area height of `9rem` (144px), resulting in a 2.67:1 aspect ratio that heavily crops standard og:image (1.91:1)
- Used antd `Typography` components for title and description

<!-- 📸 Before screenshot -->
<img width="562" height="322" alt="image" src="https://github.com/user-attachments/assets/38537b62-d895-4653-a3a2-ad23d472af49" />
<img width="461" height="303" alt="image" src="https://github.com/user-attachments/assets/b4325e4d-1034-4399-9d4a-6fbcd775e4fd" />


After this PR:
- Migrated OGCard styling from styled-components to TailwindCSS utility classes
- Increased image area height to `min-h-48` (192px), giving a ~2:1 aspect ratio that better fits standard og:image dimensions (1200×630, 1.91:1)
- Replaced antd `Typography.Title` with `MarqueeText` component for title overflow handling
- Replaced antd `Typography.Paragraph` with native `div` using `line-clamp-3` for description truncation
- Unified `Container` component for both card and skeleton states

<!-- 📸 After screenshot -->
<img width="593" height="337" alt="image" src="https://github.com/user-attachments/assets/afa15961-2084-4882-9f88-f3255934f8b6" />
<img width="440" height="336" alt="image" src="https://github.com/user-attachments/assets/0ca7a16b-3dcc-4f23-bd48-1c0e9d4d90c7" />



Fixes #13352

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Chose `min-h-48` (192px) as the image height to approximate the 1.91:1 standard og:image ratio within the `w-96` (384px) container width
- Migrated to TailwindCSS to reduce styled-components boilerplate (91 deletions, 36 additions)

The following alternatives were considered:
- Using `object-fit: contain` instead of adjusting container size — rejected because it would leave blank space around landscape images

### Breaking changes

None

### Special notes for your reviewer

- The overall card height changed from `h-64` (256px) to `h-72` (288px) to accommodate the taller image area
- Description truncation changed from 2 lines to 3 lines

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
