### PR TITLE
fix: prepend node directory to PATH for sudo OpenClaw install/uninstall

### DIFF
--- a/src/main/services/OpenClawService.ts
+++ b/src/main/services/OpenClawService.ts
@@ -248,15 +248,10 @@ class OpenClawService {
     // On macOS/Linux, prepend npm's parent dir to PATH so that sudo (which runs in a
     // clean environment without user PATH) can resolve `node` via npm's shebang
     // (#!/usr/bin/env node).
-    // Only prepend when npmPath is absolute — if it fell back to literal 'npm',
-    // path.dirname would be '.', which doesn't help in a clean sudo env.
     const nodeDir = path.dirname(npmPath)
-    const needsPathFix = !isWin && path.isAbsolute(npmPath)
     const npmCommand = isWin
       ? `"${npmPath}" install -g ${packageName} ${registryArg}`.trim()
-      : needsPathFix
-        ? `PATH="${nodeDir}:$PATH" "${npmPath}" install -g ${packageName} ${registryArg}`.trim()
-        : `"${npmPath}" install -g ${packageName} ${registryArg}`.trim()
+      : `PATH="${nodeDir}:$PATH" "${npmPath}" install -g ${packageName} ${registryArg}`.trim()
 
     // On Windows, wrap npm path in quotes if it contains spaces and is not already quoted
     const needsQuotes = isWin && npmPath.includes(' ') && !npmPath.startsWith('"')
@@ -360,14 +355,10 @@ class OpenClawService {
 
     // Keep the command string for logging and sudo retry.
     // On macOS/Linux, prepend npm's parent dir to PATH so that sudo can resolve `node`.
-    // Only prepend when npmPath is absolute — literal 'npm' fallback yields '.' which is useless.
     const nodeDir = path.dirname(npmPath)
-    const needsPathFix = !isWin && path.isAbsolute(npmPath)
     const npmCommand = isWin
       ? `"${npmPath}" uninstall -g openclaw @qingchencloud/openclaw-zh`
-      : needsPathFix
-        ? `PATH="${nodeDir}:$PATH" "${npmPath}" uninstall -g openclaw @qingchencloud/openclaw-zh`
-        : `"${npmPath}" uninstall -g openclaw @qingchencloud/openclaw-zh`
+      : `PATH="${nodeDir}:$PATH" "${npmPath}" uninstall -g openclaw @qingchencloud/openclaw-zh`
 
     // On Windows, wrap npm path in quotes if it contains spaces and is not already quoted
     const needsQuotes = isWin && npmPath.includes(' ') && !npmPath.startsWith('"')


### PR DESCRIPTION
### What this PR does

Before this PR:
When OpenClaw one-click install fails and retries with `sudo` via `@expo/sudo-prompt`, the root user's PATH doesn't include nvm/homebrew directories where `node` lives. Since npm's shebang is `#!/usr/bin/env node`, this causes `env: node: No such file or directory` (exit code 127).

After this PR:
Prepend npm's parent directory to PATH in the sudo command string on macOS/Linux. Windows is unaffected (npm uses `.cmd` shims without shebangs).

Fixes #13333

### Why we need it and why it was done in this way

N/A

### Breaking changes

N/A

### Special notes for your reviewer

- `install()`: Prepend `nodeDir` to PATH in sudo retry command
- `uninstall()`: Same fix for sudo retry command

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix: prepend node directory to PATH for sudo OpenClaw install/uninstall
```