### PR TITLE
feat(websearch): add DuckDuckGo as free local web search provider

### DIFF
--- a/src/renderer/src/assets/images/search/duckduckgo.svg
+++ b/src/renderer/src/assets/images/search/duckduckgo.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- DuckDuckGo logo, adjusted: outer circle as ring so the duck isn't fully filled by a solid disc. -->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  aria-label="DuckDuckGo"
+  role="img"
+  viewBox="-128 -128 256 256"
+  fill="#ffffff">
+  <!-- Outer circle: transparent (ring not visible) -->
+  <circle r="108" fill="none" stroke="none" />
+  <!-- Inner white ring -->
+  <circle r="96" fill="none" stroke="#ffffff" stroke-width="7" />
+  <!-- Duck details (keep brand colors) -->
+  <path
+    d="M-32-55C-62-48-51-6-51-6l19 93 7 3M-39-73h-8l11 4s-11 0-11 7c24-1 35 5 35 5"
+    fill="#ddd"
+  />
+  <path
+    d="M25 95S1 57 1 32c0-47 31-7 31-44S1-58 1-58c-15-19-44-15-44-15l7 4s-7 2-9 4 19-3 28 5c-37 3-31 33-31 33l21 120"
+  />
+  <path
+    d="M25-1l38-10c34 5-29 24-33 23C0 7 9 32 45 24s9 20-24 9C-26 20-1-3 25-1"
+    fill="#fc0"
+  />
+  <path
+    d="M15 78l2-3c22 8 23 11 22-9s0-20-23-3c0-5-13-3-15 0-21-9-23-12-22 2 2 29 1 24 21 14"
+    fill="#6b5"
+  />
+  <path
+    d="M-1 67v12c1 2 17 2 17-2s-8 3-13 1-2-13-2-13"
+    fill="#4a4"
+  />
+  <path
+    d="M-23-32c-5-6-18-1-15 7 1-4 8-10 15-7m32 0c1-6 11-7 14-1-4-2-10-2-14 1m-33 16a2 2 0 1 1 0 1m-8 3a7 7 0 1 0 0-1m52-6a2 2 0 1 1 0 1m-6 3a6 6 0 1 0 0-1"
+    fill="#148"
+  />
+</svg>

--- a/src/renderer/src/components/Icons/SVGIcon.tsx
+++ b/src/renderer/src/components/Icons/SVGIcon.tsx
@@ -140,6 +140,32 @@ export function BingLogo(props: SVGProps<SVGSVGElement>) {
   )
 }
 
+/** DuckDuckGo logo as inline SVG with currentColor. Ring + duck silhouette so the duck stays visible when active. */
+export function DuckDuckGoLogo(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      aria-label="DuckDuckGo"
+      role="img"
+      viewBox="-128 -128 256 256"
+      fill="currentColor"
+      width="1em"
+      height="1em"
+      {...props}>
+      {/* Outer circle: transparent so the duck is the main shape */}
+      <circle r="108" fill="none" stroke="none" />
+      <circle r="96" fill="none" stroke="currentColor" strokeWidth="4" />
+      {/* Duck silhouette — single color so it reads clearly when active */}
+      <path d="M-32-55C-62-48-51-6-51-6l19 93 7 3M-39-73h-8l11 4s-11 0-11 7c24-1 35 5 35 5" />
+      <path d="M25 95S1 57 1 32c0-47 31-7 31-44S1-58 1-58c-15-19-44-15-44-15l7 4s-7 2-9 4 19-3 28 5c-37 3-31 33-31 33l21 120" />
+      <path d="M25-1l38-10c34 5-29 24-33 23C0 7 9 32 45 24s9 20-24 9C-26 20-1-3 25-1" />
+      <path d="M15 78l2-3c22 8 23 11 22-9s0-20-23-3c0-5-13-3-15 0-21-9-23-12-22 2 2 29 1 24 21 14" />
+      <path d="M-1 67v12c1 2 17 2 17-2s-8 3-13 1-2-13-2-13" />
+      <path d="M-23-32c-5-6-18-1-15 7 1-4 8-10 15-7m32 0c1-6 11-7 14-1-4-2-10-2-14 1m-33 16a2 2 0 1 1 0 1m-8 3a7 7 0 1 0 0-1m52-6a2 2 0 1 1 0 1m-6 3a6 6 0 1 0 0-1" />
+    </svg>
+  )
+}
+
 export function SearXNGLogo(props: SVGProps<SVGSVGElement>) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 265 265" style={{ display: 'block' }} {...props}>

--- a/src/renderer/src/config/webSearchProviders.ts
+++ b/src/renderer/src/config/webSearchProviders.ts
@@ -56,6 +56,11 @@ export const WEB_SEARCH_PROVIDER_CONFIG: Record<WebSearchProviderId, WebSearchPr
     websites: {
       official: 'https://www.baidu.com'
     }
+  },
+  'local-duckduckgo': {
+    websites: {
+      official: 'https://duckduckgo.com'
+    }
   }
 }
 
@@ -110,5 +115,10 @@ export const WEB_SEARCH_PROVIDERS: WebSearchProvider[] = [
     id: 'local-baidu',
     name: 'Baidu',
     url: 'https://www.baidu.com/s?wd=%s'
+  },
+  {
+    id: 'local-duckduckgo',
+    name: 'DuckDuckGo',
+    url: 'https://html.duckduckgo.com/html/?q=%s'
   }
 ] as const

--- a/src/renderer/src/pages/home/Inputbar/tools/components/WebSearchQuickPanelManager.tsx
+++ b/src/renderer/src/pages/home/Inputbar/tools/components/WebSearchQuickPanelManager.tsx
@@ -1,6 +1,14 @@
 import { BaiduOutlined, GoogleOutlined } from '@ant-design/icons'
 import { loggerService } from '@logger'
-import { BingLogo, BochaLogo, ExaLogo, SearXNGLogo, TavilyLogo, ZhipuLogo } from '@renderer/components/Icons'
+import {
+  BingLogo,
+  BochaLogo,
+  DuckDuckGoLogo,
+  ExaLogo,
+  SearXNGLogo,
+  TavilyLogo,
+  ZhipuLogo
+} from '@renderer/components/Icons'
 import type { QuickPanelListItem } from '@renderer/components/QuickPanel'
 import { QuickPanelReservedSymbol } from '@renderer/components/QuickPanel'
 import {
@@ -53,6 +61,8 @@ export const WebSearchProviderIcon = ({
       return <BingLogo className="icon" width={size} height={size} color={color} />
     case 'local-google':
       return <GoogleOutlined size={size} style={{ color, fontSize: size }} />
+    case 'local-duckduckgo':
+      return <DuckDuckGoLogo className="icon" width={size} height={size} color={color} />
     default:
       return <Globe className="icon" size={size} style={{ color, fontSize: size }} />
   }

--- a/src/renderer/src/pages/settings/WebSearchSettings/BasicSettings.tsx
+++ b/src/renderer/src/pages/settings/WebSearchSettings/BasicSettings.tsx
@@ -1,6 +1,7 @@
 import BaiduLogo from '@renderer/assets/images/search/baidu.svg'
 import BingLogo from '@renderer/assets/images/search/bing.svg'
 import BochaLogo from '@renderer/assets/images/search/bocha.webp'
+import DuckDuckGoLogo from '@renderer/assets/images/search/duckduckgo.svg'
 import ExaLogo from '@renderer/assets/images/search/exa.png'
 import GoogleLogo from '@renderer/assets/images/search/google.svg'
 import SearxngLogo from '@renderer/assets/images/search/searxng.svg'
@@ -45,6 +46,8 @@ const getProviderLogo = (providerId: WebSearchProviderId): string | undefined =>
       return BingLogo
     case 'local-baidu':
       return BaiduLogo
+    case 'local-duckduckgo':
+      return DuckDuckGoLogo
     default:
       return undefined
   }

--- a/src/renderer/src/pages/settings/WebSearchSettings/WebSearchProviderSetting.tsx
+++ b/src/renderer/src/pages/settings/WebSearchSettings/WebSearchProviderSetting.tsx
@@ -3,6 +3,7 @@ import { loggerService } from '@logger'
 import BaiduLogo from '@renderer/assets/images/search/baidu.svg'
 import BingLogo from '@renderer/assets/images/search/bing.svg'
 import BochaLogo from '@renderer/assets/images/search/bocha.webp'
+import DuckDuckGoLogo from '@renderer/assets/images/search/duckduckgo.svg'
 import ExaLogo from '@renderer/assets/images/search/exa.png'
 import GoogleLogo from '@renderer/assets/images/search/google.svg'
 import SearxngLogo from '@renderer/assets/images/search/searxng.svg'
@@ -159,6 +160,8 @@ const WebSearchProviderSetting: FC<Props> = ({ providerId }) => {
         return BingLogo
       case 'local-baidu':
         return BaiduLogo
+      case 'local-duckduckgo':
+        return DuckDuckGoLogo
       default:
         return undefined
     }

--- a/src/renderer/src/pages/settings/WebSearchSettings/index.tsx
+++ b/src/renderer/src/pages/settings/WebSearchSettings/index.tsx
@@ -1,6 +1,7 @@
 import BaiduLogo from '@renderer/assets/images/search/baidu.svg'
 import BingLogo from '@renderer/assets/images/search/bing.svg'
 import BochaLogo from '@renderer/assets/images/search/bocha.webp'
+import DuckDuckGoLogo from '@renderer/assets/images/search/duckduckgo.svg'
 import ExaLogo from '@renderer/assets/images/search/exa.png'
 import GoogleLogo from '@renderer/assets/images/search/google.svg'
 import SearxngLogo from '@renderer/assets/images/search/searxng.svg'
@@ -73,6 +74,8 @@ const WebSearchSettings: FC = () => {
         return BingLogo
       case 'local-baidu':
         return BaiduLogo
+      case 'local-duckduckgo':
+        return DuckDuckGoLogo
       default:
         return undefined
     }

--- a/src/renderer/src/providers/WebSearchProvider/LocalDuckDuckGoProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/LocalDuckDuckGoProvider.ts
@@ -1,0 +1,72 @@
+import { loggerService } from '@logger'
+
+import type { SearchItem } from './LocalSearchProvider'
+import LocalSearchProvider from './LocalSearchProvider'
+
+const logger = loggerService.withContext('LocalDuckDuckGoProvider')
+
+export default class LocalDuckDuckGoProvider extends LocalSearchProvider {
+  protected parseValidUrls(htmlContent: string): SearchItem[] {
+    const results: SearchItem[] = []
+
+    try {
+      const parser = new DOMParser()
+      const doc = parser.parseFromString(htmlContent, 'text/html')
+
+      const items = doc.querySelectorAll('.result')
+      items.forEach((resultEl) => {
+        const titleEl = resultEl.querySelector('.result__title a')
+        if (!titleEl) {
+          return
+        }
+
+        const link = (titleEl as HTMLAnchorElement).href
+        // Skip ad results
+        if (link.includes('y.js')) {
+          return
+        }
+
+        const resolvedUrl = this.decodeDuckDuckGoUrl(link)
+        results.push({
+          title: titleEl.textContent?.trim() ?? '',
+          url: resolvedUrl
+        })
+      })
+    } catch (error) {
+      logger.error('Failed to parse DuckDuckGo search HTML:', error as Error)
+    }
+    logger.info('Parsed DuckDuckGo search results:', results)
+    return results
+  }
+
+  /**
+   * Decode DuckDuckGo redirect URL to get the actual destination.
+   * Links may be in format: //duckduckgo.com/l/?uddg=https%3A%2F%2F...
+   * The 'uddg' parameter contains the URL-encoded destination.
+   */
+  private decodeDuckDuckGoUrl(ddgUrl: string): string {
+    try {
+      // Handle protocol-relative or absolute redirect URL
+      const normalized = ddgUrl.startsWith('//') ? `https:${ddgUrl}` : ddgUrl
+      const url = new URL(normalized)
+      if (!url.pathname.includes('/l/')) {
+        return ddgUrl
+      }
+
+      const encodedUrl = url.searchParams.get('uddg')
+      if (!encodedUrl) {
+        return ddgUrl
+      }
+
+      const decoded = decodeURIComponent(encodedUrl)
+      if (decoded.startsWith('http')) {
+        return decoded
+      }
+
+      return ddgUrl
+    } catch (error) {
+      logger.warn('Failed to decode DuckDuckGo URL:', error as Error)
+      return ddgUrl
+    }
+  }
+}

--- a/src/renderer/src/providers/WebSearchProvider/WebSearchProviderFactory.ts
+++ b/src/renderer/src/providers/WebSearchProvider/WebSearchProviderFactory.ts
@@ -7,6 +7,7 @@ import ExaMcpProvider from './ExaMcpProvider'
 import ExaProvider from './ExaProvider'
 import LocalBaiduProvider from './LocalBaiduProvider'
 import LocalBingProvider from './LocalBingProvider'
+import LocalDuckDuckGoProvider from './LocalDuckDuckGoProvider'
 import LocalGoogleProvider from './LocalGoogleProvider'
 import SearxngProvider from './SearxngProvider'
 import TavilyProvider from './TavilyProvider'
@@ -33,6 +34,8 @@ export default class WebSearchProviderFactory {
         return new LocalBaiduProvider(provider)
       case 'local-bing':
         return new LocalBingProvider(provider)
+      case 'local-duckduckgo':
+        return new LocalDuckDuckGoProvider(provider)
       default:
         return new DefaultProvider(provider)
     }

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -86,7 +86,7 @@ const persistedReducer = persistReducer(
   {
     key: 'cherry-studio',
     storage,
-    version: 199,
+    version: 200,
     blacklist: ['runtime', 'messages', 'messageBlocks', 'tabs', 'toolPermissions'],
     migrate
   },

--- a/src/renderer/src/store/migrate.ts
+++ b/src/renderer/src/store/migrate.ts
@@ -3255,6 +3255,15 @@ const migrateConfig = {
       logger.error('migrate 199 error', error as Error)
       return state
     }
+  },
+  '200': (state: RootState) => {
+    try {
+      addWebSearchProvider(state, 'local-duckduckgo')
+      return state
+    } catch (error) {
+      logger.error('migrate 200 error', error as Error)
+      return state
+    }
   }
 }
 

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -682,7 +682,8 @@ export const WebSearchProviderIds = {
   bocha: 'bocha',
   'local-google': 'local-google',
   'local-bing': 'local-bing',
-  'local-baidu': 'local-baidu'
+  'local-baidu': 'local-baidu',
+  'local-duckduckgo': 'local-duckduckgo'
 } as const
 
 export type WebSearchProviderId = keyof typeof WebSearchProviderIds


### PR DESCRIPTION
Add DuckDuckGo as a new web search provider option. DuckDuckGo is a **free** local provider following the same pattern as Baidu and Bing.
https://github.com/CherryHQ/cherry-studio/issues/13373

Changes:

- Add LocalDuckDuckGoProvider implementation
- Add DuckDuckGo logo asset
- Register DuckDuckGo in WebSearchProviderFactory
- Add DuckDuckGo configuration in webSearchProviders.ts
- Add migration (v200) to add DuckDuckGo provider for existing users
- Update UI components to display DuckDuckGo logo

### What this PR does

**Before this PR:**

Cherry Studio did not support DuckDuckGo as a web search provider.

**After this PR:**

Users can now select DuckDuckGo as a web search provider in settings. DuckDuckGo is a **free** local provider. It is a good option for users who want a free, privacy-oriented search backend alongside existing options like Baidu and Bing.

Fixes #

### Why we need it and why it was done in this way

**The following tradeoffs were made:**

- Added migration (v200) to automatically add the DuckDuckGo provider for existing users, following the same pattern as other local providers.

**The following alternatives were considered:**

- None

Links to places where the discussion took place: N/A

### Breaking changes

None

### Special notes for your reviewer

N/A

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [X] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [X] Self-review: I have reviewed my own code (e.g., via `/gh-pr-review`, `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Add DuckDuckGo as a new free web search provider option. No API key required; uses local browser-based search like Baidu and Bing.