### PR TITLE
fix: preserve emoji when saving assistant to library

### DIFF
--- a/src/renderer/src/pages/home/Tabs/components/AssistantItem.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/AssistantItem.tsx
@@ -314,7 +314,7 @@ function getMenuItems({
       key: 'save-to-agent',
       icon: <Save size={14} />,
       onClick: async () => {
-        const preset = omit(assistant, ['model', 'emoji'])
+        const preset = omit(assistant, ['model'])
         preset.id = uuid()
         preset.type = 'agent'
         addPreset(preset)


### PR DESCRIPTION
Fixes #13367

- Migration v73 moves leading emoji from `assistant.name` into `assistant.emoji` and trims the
name.
- The save-to-library flow still omits `emoji`, which now drops the migrated value.