### PR TITLE
fix: strip proxy env vars from OpenClaw gateway process

### DIFF
--- a/src/main/services/OpenClawService.ts
+++ b/src/main/services/OpenClawService.ts
@@ -491,22 +491,13 @@ class OpenClawService {
     let startupError: string | null = null
     let processExited = false
 
-    // Strip proxy env vars so Cherry Studio's proxy settings don't bleed into
-    // the gateway process. OpenClaw's undici crashes if HTTP_PROXY is set to a
-    // non-http(s) URL (e.g. socks5://). See #13140.
+    // Strip non-http(s) proxy URLs that crash OpenClaw's undici. See #13140.
     const gatewayEnv = { ...shellEnv, OPENCLAW_CONFIG_PATH }
-    for (const key of [
-      'HTTP_PROXY',
-      'HTTPS_PROXY',
-      'http_proxy',
-      'https_proxy',
-      'SOCKS_PROXY',
-      'ALL_PROXY',
-      'grpc_proxy',
-      'no_proxy',
-      'NO_PROXY'
-    ]) {
-      delete gatewayEnv[key]
+    for (const key of ['HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy']) {
+      const val = gatewayEnv[key]
+      if (val && !val.startsWith('http://') && !val.startsWith('https://')) {
+        delete gatewayEnv[key]
+      }
     }
 
     logger.info(`Spawning gateway process: ${openclawPath} gateway --port ${this.gatewayPort}`)

--- a/src/main/services/OpenClawService.ts
+++ b/src/main/services/OpenClawService.ts
@@ -491,9 +491,27 @@ class OpenClawService {
     let startupError: string | null = null
     let processExited = false
 
+    // Strip proxy env vars so Cherry Studio's proxy settings don't bleed into
+    // the gateway process. OpenClaw's undici crashes if HTTP_PROXY is set to a
+    // non-http(s) URL (e.g. socks5://). See #13140.
+    const gatewayEnv = { ...shellEnv, OPENCLAW_CONFIG_PATH }
+    for (const key of [
+      'HTTP_PROXY',
+      'HTTPS_PROXY',
+      'http_proxy',
+      'https_proxy',
+      'SOCKS_PROXY',
+      'ALL_PROXY',
+      'grpc_proxy',
+      'no_proxy',
+      'NO_PROXY'
+    ]) {
+      delete gatewayEnv[key]
+    }
+
     logger.info(`Spawning gateway process: ${openclawPath} gateway --port ${this.gatewayPort}`)
     this.gatewayProcess = crossPlatformSpawn(openclawPath, ['gateway', '--port', String(this.gatewayPort)], {
-      env: { ...shellEnv, OPENCLAW_CONFIG_PATH }
+      env: gatewayEnv
     })
     logger.info(`Gateway process spawned with pid: ${this.gatewayProcess.pid}`)
 

--- a/src/main/services/OpenClawService.ts
+++ b/src/main/services/OpenClawService.ts
@@ -8,7 +8,7 @@ import { exec } from '@expo/sudo-prompt'
 import { loggerService } from '@logger'
 import { isLinux, isMac, isWin } from '@main/constant'
 import { isUserInChina } from '@main/utils/ipService'
-import { crossPlatformSpawn, executeCommand, findExecutableInEnv } from '@main/utils/process'
+import { crossPlatformSpawn, executeCommand, findExecutableInEnv, stripProxyEnvVars } from '@main/utils/process'
 import getShellEnv, { refreshShellEnv } from '@main/utils/shell-env'
 import type { NodeCheckResult } from '@shared/config/types'
 import { IpcChannel } from '@shared/IpcChannel'
@@ -491,14 +491,8 @@ class OpenClawService {
     let startupError: string | null = null
     let processExited = false
 
-    // Strip non-http(s) proxy URLs that crash OpenClaw's undici. See #13140.
-    const gatewayEnv = { ...shellEnv, OPENCLAW_CONFIG_PATH }
-    for (const key of ['HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy']) {
-      const val = gatewayEnv[key]
-      if (val && !val.startsWith('http://') && !val.startsWith('https://')) {
-        delete gatewayEnv[key]
-      }
-    }
+    // Strip proxy env vars that crash OpenClaw's undici (e.g. socks5://). See #13140.
+    const gatewayEnv = { ...stripProxyEnvVars(shellEnv), OPENCLAW_CONFIG_PATH }
 
     logger.info(`Spawning gateway process: ${openclawPath} gateway --port ${this.gatewayPort}`)
     this.gatewayProcess = crossPlatformSpawn(openclawPath, ['gateway', '--port', String(this.gatewayPort)], {

--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -19,7 +19,7 @@ import { validateModelId } from '@main/apiServer/utils'
 import { isWin } from '@main/constant'
 import { pluginService } from '@main/services/agents/plugins/PluginService'
 import { configManager } from '@main/services/ConfigManager'
-import { autoDiscoverGitBash } from '@main/utils/process'
+import { autoDiscoverGitBash, stripProxyEnvVars } from '@main/utils/process'
 import getLoginShellEnvironment from '@main/utils/shell-env'
 import { languageEnglishNameMap } from '@shared/config/languages'
 import { withoutTrailingApiVersion } from '@shared/utils'
@@ -125,9 +125,7 @@ class ClaudeCodeService implements AgentServiceInterface {
 
     const apiConfig = await apiConfigService.get()
     const loginShellEnv = await getLoginShellEnvironment()
-    const loginShellEnvWithoutProxies = Object.fromEntries(
-      Object.entries(loginShellEnv).filter(([key]) => !key.toLowerCase().endsWith('_proxy'))
-    ) as Record<string, string>
+    const loginShellEnvWithoutProxies = stripProxyEnvVars(loginShellEnv)
 
     // Auto-discover Git Bash path on Windows (already logs internally)
     const customGitBashPath = isWin ? autoDiscoverGitBash() : null

--- a/src/main/utils/process.ts
+++ b/src/main/utils/process.ts
@@ -667,3 +667,12 @@ export function getGitBashPathInfo(): GitBashPathInfo {
 
   return { path, source }
 }
+
+/**
+ * Strip proxy-related environment variables from an env object.
+ * Prevents child processes from inheriting proxy settings that may cause crashes
+ * (e.g. undici does not support socks5:// protocol).
+ */
+export function stripProxyEnvVars<T extends Record<string, string>>(env: T): T {
+  return Object.fromEntries(Object.entries(env).filter(([key]) => !key.toLowerCase().endsWith('_proxy'))) as T
+}


### PR DESCRIPTION
## Summary
- Strip all proxy-related environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `SOCKS_PROXY`, etc.) before spawning the OpenClaw gateway process
- Cherry Studio's `ProxyManager` sets `process.env.HTTP_PROXY` which gets inherited by the gateway child process via `getShellEnv()`. OpenClaw's `undici` crashes with `InvalidArgumentError: Invalid URL protocol` when the proxy URL uses a non-http(s) protocol (e.g. `socks5://`), causing gateway to exit with code 1

## Root cause
```
ProxyManager.setEnvironment(url)     → process.env.HTTP_PROXY = "socks5://127.0.0.1:1080"
getShellEnv() (Windows: copies process.env) → shellEnv includes HTTP_PROXY
crossPlatformSpawn(gateway, { env: shellEnv })  → gateway inherits proxy
undici EnvHttpProxyAgent reads HTTP_PROXY       → InvalidArgumentError → exit code 1
```

## Test plan
- [ ] Set proxy to `socks5://127.0.0.1:1080` in Cherry Studio settings → start OpenClaw gateway → should start successfully
- [ ] Set proxy to `http://127.0.0.1:7897` → gateway should still work
- [ ] No proxy set → gateway works as before

Closes #13140

🤖 Generated with [Claude Code](https://claude.com/claude-code)