### PR TITLE
fix: unify agents.db path between dev and prod environments

### DIFF
--- a/src/main/services/agents/drizzle.config.ts
+++ b/src/main/services/agents/drizzle.config.ts
@@ -18,16 +18,12 @@
  * Drizzle Kit configuration for agents database
  */
 
-import os from 'node:os'
 import path from 'node:path'
 
 import { defineConfig } from 'drizzle-kit'
 import { app } from 'electron'
 
 function getDbPath() {
-  if (process.env.NODE_ENV === 'development') {
-    return path.join(os.homedir(), '.cherrystudio', 'data', 'agents.db')
-  }
   return path.join(app.getPath('userData'), 'Data', 'agents.db')
 }
 


### PR DESCRIPTION
### What this PR does

Before this PR:

In development environment, `agents.db` was stored at `~/.cherrystudio/data/agents.db`, while production used `{userData}/Data/agents.db`. This inconsistency could cause issues when switching between environments.

After this PR:

Both development and production environments use the same path: `{userData}/Data/agents.db`.

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

None. This is a straightforward path unification.

The following alternatives were considered:

None. Unifying to the production path is the correct approach.

Links to places where the discussion took place:

N/A

### Breaking changes

None. The existing migration logic in `DatabaseManager.ts` already handles migrating from old paths.

### Special notes for your reviewer

This is a simple bug fix that removes the environment-specific path logic. The `getOldDbPath()` function is preserved for the existing migration logic.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
