### PR TITLE
fix(ui): fix Move To submenu overflow and hide scrollbar

### DIFF
--- a/src/renderer/src/assets/styles/ant.css
+++ b/src/renderer/src/assets/styles/ant.css
@@ -151,6 +151,16 @@
   overflow-x: hidden;
 }
 
+/* Hide scrollbar for Move To submenu only */
+.move-to-submenu .ant-dropdown-menu {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.move-to-submenu .ant-dropdown-menu::-webkit-scrollbar {
+  display: none;
+}
+
 .ant-dropdown-menu-submenu .ant-dropdown-menu-submenu-title {
   align-items: center;
 }

--- a/src/renderer/src/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/Topics.tsx
@@ -479,6 +479,7 @@ export const Topics: React.FC<Props> = ({ assistant: _assistant, activeTopic, se
         label: t('chat.topics.move_to'),
         key: 'move',
         icon: <FolderOpen size={14} />,
+        popupClassName: 'move-to-submenu',
         children: assistants
           .filter((a) => a.id !== assistant.id)
           .map((a) => ({


### PR DESCRIPTION
### What this PR does

Before this PR:
The "Move To" submenu in the topic context menu could not scroll when the list of assistants was long, causing overflow issues (reported in #13350).

After this PR:
The "Move To" submenu now:
- Limits its height to 60vh to prevent overflow
- Allows vertical scrolling for long assistant lists
- Hides the scrollbar for a cleaner UI while maintaining scroll functionality

![PixPin_2026-03-12_00-18-17](https://github.com/user-attachments/assets/68f7e6a9-2b6b-47d4-97de-e3927ea8ac90)


Fixes #13350

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Used CSS to hide the scrollbar instead of using a custom scroll component. This keeps the implementation simple and consistent with Ant Design's native behavior while improving visual aesthetics.

The following alternatives were considered:
- Using a virtual list for very long assistant lists - deemed unnecessary complexity for this use case
- Keeping the scrollbar visible - rejected in favor of cleaner UI per user feedback

Links to places where the discussion took place: N/A

### Breaking changes

None

### Special notes for your reviewer

This PR consists of 3 commits that work together:
1. `fix(ui): limit Move To submenu height to prevent overflow` - Adds max-height and enables scrolling
2. `fix(dropdown): allow scrolling in Move To submenu for topics` - Ensures scroll functionality works
3. `fix(ui): hide scrollbar for Move To submenu` - Hides scrollbar for cleaner UI

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting reviewers

### Release note

```release-note
Fixed the "Move To" submenu overflow issue by limiting its height and enabling scrolling when the list of assistants is long.
```
