### PR TITLE
docs: update issue templates to use type instead of label

### DIFF
--- a/.github/ISSUE_TEMPLATE/0_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/0_bug_report.yml
@@ -1,7 +1,8 @@
 name: 🐛 Bug Report
 description: Create a report to help us improve
-title: '[Bug]: '
-labels: ['BUG']
+title: "[Bug]: "
+labels: []
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/1_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/1_feature_request.yml
@@ -1,7 +1,8 @@
 name: 💡 Feature Request
 description: Suggest an idea for this project
-title: '[Feature]: '
-labels: ['feature']
+title: "[Feature]: "
+labels: []
+type: Feature
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
### What this PR does

Before this PR:
Issue templates used `labels` field (e.g., `labels: ['BUG']`, `labels: ['feature']`) to categorize issues.

After this PR:
Issue templates use GitHub's native `type` field (`type: Bug`, `type: Feature`) instead of labels, and `labels` is set to an empty array.

### Why we need it and why it was done in this way

GitHub now supports issue types as a first-class feature, which provides better categorization than labels for issue classification. Migrating to `type` aligns with GitHub's recommended approach.

The following tradeoffs were made: N/A

The following alternatives were considered: N/A

### Breaking changes

None

### Special notes for your reviewer

This is a simple metadata change in issue templates. No functional impact on the application itself.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
