### PR TITLE
docs: add DeJeune as v2 data layer code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,13 +4,13 @@
 /packages/shared/IpcChannel.ts @0xfullex
 /src/main/ipc.ts @0xfullex
 
-/migrations/ @0xfullex
-/packages/shared/data/ @0xfullex
-/src/main/data/ @0xfullex
-/src/renderer/src/data/ @0xfullex
-/v2-refactor-temp/ @0xfullex
-/docs/en/references/data/ @0xfullex
-/docs/zh/references/data/ @0xfullex
+/migrations/ @0xfullex @DeJeune
+/packages/shared/data/ @0xfullex @DeJeune
+/src/main/data/ @0xfullex @DeJeune
+/src/renderer/src/data/ @0xfullex @DeJeune
+/v2-refactor-temp/ @0xfullex @DeJeune
+/docs/en/references/data/ @0xfullex @DeJeune
+/docs/zh/references/data/ @0xfullex @DeJeune
 
 /packages/ui/ @MyPrototypeWhat
 


### PR DESCRIPTION
### What this PR does

Before this PR: Only `@0xfullex` is listed as code owner for the v2 data layer paths.

After this PR: `@DeJeune` is added as a co-owner for all v2 data layer paths in CODEOWNERS.

### Why we need it and why it was done in this way

DeJeune is actively contributing to the v2 data layer and should receive review requests for changes in those paths.

### Breaking changes

None

### Special notes for your reviewer

N/A

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: N/A — no user-facing change
- [ ] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
