### PR TITLE
docs: add DeJeune as code owner for core data paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
-/src/renderer/src/store/ @0xfullex
-/src/renderer/src/databases/ @0xfullex
-/src/main/services/ConfigManager.ts @0xfullex
-/packages/shared/IpcChannel.ts @0xfullex
-/src/main/ipc.ts @0xfullex
+/src/renderer/src/store/ @0xfullex @DeJeune
+/src/renderer/src/databases/ @0xfullex @DeJeune
+/src/main/services/ConfigManager.ts @0xfullex @DeJeune
+/packages/shared/IpcChannel.ts @0xfullex @DeJeune
+/src/main/ipc.ts @0xfullex @DeJeune
 /app-upgrade-config.json @kangfenmao


### PR DESCRIPTION
### What this PR does

Before this PR:
Only `@0xfullex` was listed as code owner for store, databases, ConfigManager, IpcChannel, and ipc paths.

After this PR:
`@DeJeune` is added as an additional code owner for the same five paths in `.github/CODEOWNERS`.

Fixes # N/A

### Why we need it and why it was done in this way

Adding `@DeJeune` as a code owner ensures they receive review requests for changes to these critical data paths.

The following tradeoffs were made: None

The following alternatives were considered: None

### Breaking changes

None

### Special notes for your reviewer

Simple CODEOWNERS update — no code changes.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
