### PR TITLE
fix: remove 32-char truncation for user-defined filter paths

### DIFF
--- a/src/renderer/src/pages/settings/SelectionAssistantSettings/components/SelectionFilterListModal.tsx
+++ b/src/renderer/src/pages/settings/SelectionAssistantSettings/components/SelectionFilterListModal.tsx
@@ -31,7 +31,7 @@ const SelectionFilterListModal: FC<SelectionFilterListModalProps> = ({ open, onC
         .trim()
         .toLowerCase()
         .split('\n')
-        .map((line: string) => line.trim().slice(0, 32))
+        .map((line: string) => line.trim())
         .filter((line: string) => line.length > 0)
       onSave([...new Set(newList)])
       onClose()


### PR DESCRIPTION
## Summary

Previously, user-defined application paths in the Selection Toolbar filter list were being truncated to 32 characters due to `.slice(0, 32)`. This caused paths with spaces like `C:\Program Files\Microsoft Office\...` to be saved incorrectly as `c:\program files\microsoft offi`.

## Fix

This fix removes the arbitrary character limit to allow full Windows/Mac application paths to be stored correctly.

## Testing

Manual testing:
1. Open Selection Toolbar
2. Go to Application Filter > Blacklist > Edit
3. Enter a path with spaces: `C:\Program Files\Microsoft Office\root\Office16\WINWORD.EXE`
4. Click Confirm
5. Re-open Edit - full path should now be preserved

## Related Issue

Fixes #13372