### PR TITLE
fix: render xml fenced svg blocks as svg previews

### DIFF
--- a/src/renderer/src/pages/home/Markdown/CodeBlock.tsx
+++ b/src/renderer/src/pages/home/Markdown/CodeBlock.tsx
@@ -19,7 +19,14 @@ interface Props {
 const CodeBlock: React.FC<Props> = ({ children, className, node, blockId }) => {
   const languageMatch = /language-([\w-+]+)/.exec(className || '')
   const isMultiline = children?.includes('\n')
-  const language = languageMatch?.[1] ?? (isMultiline ? 'text' : null)
+  const detectedLanguage = languageMatch?.[1] ?? (isMultiline ? 'text' : null)
+  const language = useMemo(() => {
+    return detectedLanguage !== 'xml'
+      ? detectedLanguage
+      : /^\s*(?:<\?xml[\s\S]*?\?>\s*)?<svg[\s>]/i.test(children)
+        ? 'svg'
+        : detectedLanguage
+  }, [children, detectedLanguage])
   const { codeFancyBlock } = useSettings()
 
   // 代码块 id


### PR DESCRIPTION
Fix #13409 


After:

<img width="462" alt="CleanShot 2026-03-13 at 10 54 11@2x" src="https://github.com/user-attachments/assets/25c336c4-74c8-4532-9533-30911db93608" />
