### PR TITLE
refactor(openclaw): unify package to openclaw, remove openclaw-zh

### DIFF
--- a/src/main/services/OpenClawService.ts
+++ b/src/main/services/OpenClawService.ts
@@ -230,13 +230,11 @@ class OpenClawService {
   }
 
   /**
-   * Install OpenClaw using npm with China mirror acceleration
-   * For users in China, install @qingchencloud/openclaw-zh package instead
+   * Install OpenClaw using npm with China mirror acceleration for users in China
    */
   public async install(): Promise<{ success: boolean; message: string }> {
     const inChina = await isUserInChina()
-
-    const packageName = inChina ? '@qingchencloud/openclaw-zh@latest' : 'openclaw@latest'
+    const packageName = 'openclaw@latest'
     const registryArg = inChina ? `--registry=${NPM_MIRROR_CN}` : ''
 
     const npmPath = (await findExecutableInEnv('npm')) || 'npm'
@@ -341,7 +339,7 @@ class OpenClawService {
 
   /**
    * Uninstall OpenClaw using npm
-   * Uninstalls both the standard and Chinese packages to ensure clean removal
+   * Uninstalls both openclaw and legacy @qingchencloud/openclaw-zh package
    */
   public async uninstall(): Promise<{ success: boolean; message: string }> {
     // First stop the gateway if running


### PR DESCRIPTION
### What this PR does

Before this PR:
- OpenClaw installation used different npm packages based on user location: `@qingchencloud/openclaw-zh@latest` for China users and `openclaw@latest` for others

After this PR:
- All users install the unified `openclaw@latest` package
- China users still get npm mirror acceleration via `--registry` flag
- Uninstall removes both `openclaw` and legacy `@qingchencloud/openclaw-zh` packages to clean up old installations

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Simplified package management by using a single package for all regions

The following alternatives were considered:
- N/A

### Breaking changes

None.

### Special notes for your reviewer

N/A

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required.
- [ ] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
