### PR TITLE
feat: Add configurable web-search timeout setting

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -4943,6 +4943,10 @@
         "label": "API Key",
         "tip": "Use commas to separate multiple keys"
       },
+      "timeout": {
+        "label": "Request Timeout (ms)",
+        "tip": "Request timeout for web search in milliseconds (default: 10000)"
+      },
       "api_version": "API Version",
       "aws-bedrock": {
         "access_key_id": "AWS Access Key ID",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -4943,6 +4943,10 @@
         "label": "API 密钥",
         "tip": "多个密钥使用逗号分隔"
       },
+      "timeout": {
+        "label": "请求超时（毫秒）",
+        "tip": "网络搜索请求的超时时间，默认 10000 毫秒"
+      },
       "api_version": "API 版本",
       "aws-bedrock": {
         "access_key_id": "AWS 访问密钥 ID",

--- a/src/renderer/src/pages/settings/WebSearchSettings/WebSearchProviderSetting.tsx
+++ b/src/renderer/src/pages/settings/WebSearchSettings/WebSearchProviderSetting.tsx
@@ -42,6 +42,7 @@ const WebSearchProviderSetting: FC<Props> = ({ providerId }) => {
   const [basicAuthUsername, setBasicAuthUsername] = useState(provider.basicAuthUsername || '')
   const [basicAuthPassword, setBasicAuthPassword] = useState(provider.basicAuthPassword || '')
   const [apiValid, setApiValid] = useState(false)
+  const [timeout, setTimeout] = useState(provider.timeout || 10000)
   const { setTimeoutTimer } = useTimer()
 
   const webSearchProviderConfig = WEB_SEARCH_PROVIDER_CONFIG[provider.id]
@@ -83,6 +84,17 @@ const WebSearchProviderSetting: FC<Props> = ({ providerId }) => {
       updateProvider({ basicAuthPassword })
     } else {
       setBasicAuthPassword(provider.basicAuthPassword || '')
+    }
+  }
+
+  const onUpdateTimeout = () => {
+    const timeoutValue = Number(timeout)
+    if (timeoutValue > 0 && timeoutValue !== provider.timeout) {
+      updateProvider({ timeout: timeoutValue })
+    } else if (!timeoutValue && provider.timeout) {
+      updateProvider({ timeout: undefined })
+    } else {
+      setTimeout(provider.timeout || 10000)
     }
   }
 
@@ -139,7 +151,8 @@ const WebSearchProviderSetting: FC<Props> = ({ providerId }) => {
     setApiHost(provider.apiHost ?? '')
     setBasicAuthUsername(provider.basicAuthUsername ?? '')
     setBasicAuthPassword(provider.basicAuthPassword ?? '')
-  }, [provider.apiKey, provider.apiHost, provider.basicAuthUsername, provider.basicAuthPassword])
+    setTimeout(provider.timeout ?? 10000)
+  }, [provider.apiKey, provider.apiHost, provider.basicAuthUsername, provider.basicAuthPassword, provider.timeout])
 
   const getWebSearchProviderLogo = (providerId: WebSearchProviderId) => {
     switch (providerId) {
@@ -342,6 +355,28 @@ const WebSearchProviderSetting: FC<Props> = ({ providerId }) => {
               </Form.Item>
             </Form>
           </Flex>
+        </>
+      )}
+      {!isLocalProvider && (
+        <>
+          <SettingDivider style={{ marginTop: 12, marginBottom: 12 }} />
+          <SettingSubtitle style={{ marginTop: 5, marginBottom: 10 }}>
+            {t('settings.provider.timeout.label')}
+          </SettingSubtitle>
+          <Flex gap={8}>
+            <Input
+              type="number"
+              value={timeout}
+              placeholder="10000"
+              onChange={(e) => setTimeout(Number(e.target.value))}
+              onBlur={onUpdateTimeout}
+              min="1000"
+              step="1000"
+            />
+          </Flex>
+          <SettingHelpTextRow style={{ justifyContent: 'space-between', marginTop: 5 }}>
+            <SettingHelpText>{t('settings.provider.timeout.tip')}</SettingHelpText>
+          </SettingHelpTextRow>
         </>
       )}
     </>

--- a/src/renderer/src/providers/WebSearchProvider/ExaMcpProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/ExaMcpProvider.ts
@@ -43,7 +43,7 @@ interface ExaSearchResults {
 
 const DEFAULT_API_HOST = 'https://mcp.exa.ai/mcp'
 const DEFAULT_NUM_RESULTS = 8
-const REQUEST_TIMEOUT_MS = 25000
+const DEFAULT_REQUEST_TIMEOUT_MS = 25000
 
 export default class ExaMcpProvider extends BaseWebSearchProvider {
   constructor(provider: WebSearchProvider) {
@@ -78,8 +78,9 @@ export default class ExaMcpProvider extends BaseWebSearchProvider {
         }
       }
 
+      const requestTimeoutMs = this.provider.timeout || DEFAULT_REQUEST_TIMEOUT_MS
       const controller = new AbortController()
-      const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+      const timeoutId = setTimeout(() => controller.abort(), requestTimeoutMs)
 
       try {
         const response = await fetch(this.apiHost!, {

--- a/src/renderer/src/providers/WebSearchProvider/SearxngProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/SearxngProvider.ts
@@ -123,8 +123,32 @@ export default class SearxngProvider extends BaseWebSearchProvider {
 
       // Fetch content for each URL concurrently
       const fetchPromises = validItems.map(async (item) => {
-        // Logger.log(`Fetching content for ${item.url}...`)
-        return await fetchWebContent(item.url, 'markdown', this.provider.usingBrowser)
+        // Create timeout for each URL fetch
+        const timeoutMs = this.provider.timeout || 10000 // Default 10 seconds
+        const controller = new AbortController()
+        const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+
+        try {
+          // Logger.log(`Fetching content for ${item.url}...`)
+          const result = await fetchWebContent(
+            item.url,
+            'markdown',
+            this.provider.usingBrowser,
+            {
+              signal: controller.signal
+            }
+          )
+          clearTimeout(timeoutId)
+          return result
+        } catch (error) {
+          clearTimeout(timeoutId)
+          logger.warn(`Failed to fetch ${item.url} after ${timeoutMs}ms`, error)
+          return {
+            title: item.title || 'Error',
+            content: noContent,
+            url: item.url
+          }
+        }
       })
 
       // Wait for all fetches to complete

--- a/src/renderer/src/providers/WebSearchProvider/SearxngProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/SearxngProvider.ts
@@ -130,14 +130,9 @@ export default class SearxngProvider extends BaseWebSearchProvider {
 
         try {
           // Logger.log(`Fetching content for ${item.url}...`)
-          const result = await fetchWebContent(
-            item.url,
-            'markdown',
-            this.provider.usingBrowser,
-            {
-              signal: controller.signal
-            }
-          )
+          const result = await fetchWebContent(item.url, 'markdown', this.provider.usingBrowser, {
+            signal: controller.signal
+          })
           clearTimeout(timeoutId)
           return result
         } catch (error) {

--- a/src/renderer/src/providers/WebSearchProvider/SearxngProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/SearxngProvider.ts
@@ -154,7 +154,8 @@ export default class SearxngProvider extends BaseWebSearchProvider {
         results: results.filter((result) => result.content != noContent)
       }
     } catch (error) {
-      logger.error('Searxng search failed:', error as Error)
+      const logError = error instanceof Error ? error : { error }
+      logger.error('Searxng search failed:', logError)
       throw new Error(`Search failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
     }
   }

--- a/src/renderer/src/providers/WebSearchProvider/SearxngProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/SearxngProvider.ts
@@ -137,7 +137,7 @@ export default class SearxngProvider extends BaseWebSearchProvider {
           return result
         } catch (error) {
           clearTimeout(timeoutId)
-          logger.warn(`Failed to fetch ${item.url} after ${timeoutMs}ms`, error)
+          logger.warn(`Failed to fetch ${item.url} after ${timeoutMs}ms`, error as Error)
           return {
             title: item.title || 'Error',
             content: noContent,

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -706,6 +706,7 @@ export type WebSearchProvider = {
   allowedTools?: string[]
   parentSpanId?: string
   modelName?: string
+  timeout?: number
 }
 
 export type WebSearchProviderResult = {


### PR DESCRIPTION
## Summary

This PR implements configurable timeout settings for web-search providers, addressing issue #13426.

## Changes

### Core Implementation
- **Type Definition**: Added `timeout?: number` field to `WebSearchProvider` type
- **ExaMcpProvider**: Now uses provider-specific timeout with fallback to 25000ms
- **SearxngProvider**: Implements per-request timeout with error handling (default 10000ms)

### User Interface
- **Settings Page**: Added timeout input field in `WebSearchProviderSetting` component
  - Only shown for non-local providers
  - Number input with min 1000ms and step 1000ms
  - Validates and saves timeout values

### Internationalization
- **Chinese (zh-cn)**: Added timeout label and tip translations
- **English (en-us)**: Added timeout label and tip translations

## Backward Compatibility
- Existing providers without timeout config continue to work with defaults
- Timeout field is optional, maintaining compatibility

## Testing
- Manual testing with SearxNG provider
- Verified timeout configuration saves and persists
- Confirmed error handling for timeout failures

## Related Issue
Fixes #13426