### PR TITLE
fix(ui): reset thinking time display when new session starts

### DIFF
--- a/src/renderer/src/pages/home/Messages/Blocks/ThinkingBlock.tsx
+++ b/src/renderer/src/pages/home/Messages/Blocks/ThinkingBlock.tsx
@@ -113,6 +113,10 @@ const ThinkingTimeSeconds = memo(
 
     useEffect(() => {
       if (isThinking) {
+        // Reset displayTime when starting new thinking session
+        if (blockThinkingTime === 0) {
+          setDisplayTime(0)
+        }
         if (!timer.current) {
           timer.current = setInterval(() => {
             setDisplayTime((prev) => prev + 100)

--- a/src/renderer/src/pages/home/Messages/Blocks/__tests__/ThinkingBlock.test.tsx
+++ b/src/renderer/src/pages/home/Messages/Blocks/__tests__/ThinkingBlock.test.tsx
@@ -238,6 +238,31 @@ describe('ThinkingBlock', () => {
       expect(activeTimeText).toHaveTextContent('Thinking...')
     })
 
+    it('should reset display time when new thinking session starts', () => {
+      // Arrange: render a completed thinking block with 5s of thinking time
+      const completedBlock = createThinkingBlock({
+        thinking_millsec: 5000,
+        status: MessageBlockStatus.SUCCESS,
+        id: 'completed-block'
+      })
+      const { rerender } = renderThinkingBlock(completedBlock)
+
+      // Assert: verify it shows 5.0s
+      expect(getThinkingTimeText()).toHaveTextContent('5.0s')
+
+      // Act: switch to a new thinking session with 0ms thinking time
+      const newThinkingBlock = createThinkingBlock({
+        thinking_millsec: 0,
+        status: MessageBlockStatus.STREAMING,
+        id: 'new-thinking-block'
+      })
+      rerender(<ThinkingBlock block={newThinkingBlock} />)
+
+      // Assert: verify it shows 0.1s (minimum display value), confirming reset
+      expect(getThinkingTimeText()).toHaveTextContent('0.1s')
+      expect(getThinkingTimeText()).toHaveTextContent('Thinking...')
+    })
+
     it('should handle extreme thinking times correctly', () => {
       const testCases = [
         { thinking_millsec: 0, expectedTime: '0.1s' }, // New logic: values < 1000ms display as 0.1s


### PR DESCRIPTION
### What this PR does

**Before this PR:**
When sending a prompt with a thinking model, the displayed thinking time counter doesn't start from 0s on subsequent prompts. Instead, it accumulates from the previous thinking session's value because the `displayTime` state in `ThinkingTimeSeconds` component is not reset when a new thinking session starts.

**After this PR:**
Added logic to reset `displayTime` to 0 when `isThinking` becomes `true` and `blockThinkingTime === 0` (indicating a new thinking session). This ensures the thinking time counter starts fresh from 0s for each new prompt.

Fixes #13449

### Why we need it and why it was done in this way

**Root cause:** The `ThinkingTimeSeconds` component uses `useState` to track `displayTime`, which is only initialized once when the component mounts. When React reuses the component instance for a new thinking block, the previous `displayTime` value persists, causing the timer to accumulate from the old value.

**The fix:** Added a conditional reset in the `useEffect` that handles the `isThinking` state change:
```typescript
if (isThinking) {
  // Reset displayTime when starting new thinking session
  if (blockThinkingTime === 0) {
    setDisplayTime(0)
  }
  // ...
}
```

**Tradeoffs made:**
- Minimal change to avoid disrupting existing timer logic
- Reset only when `blockThinkingTime === 0` to preserve behavior for resumed/in-progress sessions

**Alternatives considered:**
- Using a `useRef` to track timer start time: rejected as it would require more extensive refactoring
- Adding a unique session ID dependency: rejected as unnecessary complexity for this bug fix

### Breaking changes

None. This is a bug fix that only affects the display behavior of the thinking time counter.

### Special notes for your reviewer

- The fix targets the specific case where a new thinking session starts (`isThinking` transitions from `false` to `true`)
- The condition `blockThinkingTime === 0` ensures we only reset for genuinely new sessions, not resumed ones
- Verified with Vercel React Best Practices - follows `rerender-dependencies` and `rerender-functional-setstate` guidelines

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed thinking time display bug where the timer would accumulate from previous sessions instead of starting from 0s for each new prompt.
```
