### PR TITLE
fix: increase default request timeout from 10 to 30 minutes

### DIFF
--- a/packages/shared/config/constant.ts
+++ b/packages/shared/config/constant.ts
@@ -218,7 +218,7 @@ export enum UpdateMirror {
   GITCODE = 'gitcode'
 }
 
-export const DEFAULT_TIMEOUT = 10 * 1000 * 60
+export const DEFAULT_TIMEOUT = 30 * 1000 * 60
 
 export const occupiedDirs = ['logs', 'Network', 'Partitions/webview/Network']
 


### PR DESCRIPTION
### What this PR does

Before this PR:

The default request timeout for LLM API calls was 10 minutes. When using local models (e.g., LM Studio with Qwen 3.5 28b), the model may take longer than 10 minutes to process input data, causing a `TimeoutError` / `AbortError` before the model finishes responding.

After this PR:

The default request timeout is increased to 30 minutes, giving local models enough time to complete inference.

Fixes #13452

### Why we need it and why it was done in this way

Local models running on consumer hardware (e.g., via LM Studio, Ollama) can take significantly longer to process requests compared to cloud APIs. The previous 10-minute timeout was insufficient for large local models like Qwen 3.5 28b.

The following tradeoffs were made:

This is a temporary fix as discussed in the issue. User-configurable timeout settings will be available after v2.0.0.

The following alternatives were considered:

- Per-provider timeout configuration (deferred to v2)
- Separate timeout for local vs cloud providers (unnecessary complexity for a temporary fix)

### Breaking changes

None.

### Special notes for your reviewer

The `DEFAULT_TIMEOUT` constant is used across both the new AI Core path (`parameterBuilder.ts`) and the legacy client path (`BaseApiClient.ts`). The flex service tier timeout (15 min) is now shorter than the default (30 min), but flex tier models are cloud-hosted and unlikely to need more than 15 minutes.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Increased the default request timeout from 10 minutes to 30 minutes, preventing premature timeout errors when using slow local models (e.g., LM Studio, Ollama).
```
