### PR TITLE
chore: release v1.7.26

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -140,64 +140,28 @@ artifactBuildCompleted: scripts/artifact-build-completed.js
 releaseInfo:
   releaseNotes: |
     <!--LANG:en-->
-    Cherry Studio 1.7.25 - Security & Stability
+    Cherry Studio 1.7.26 - Discoverability & Performance
 
     ✨ New Features
-    - [Web Search] Add Querit search provider (1,000 free requests for new users)
-    - [Provider] Add MiniMax Global and Z.ai providers
-    - [Mini Apps] Add MiniMax Agent and IMA mini apps
-    - [Provider] Add agent support filter in provider settings
-    - [Agent] Add custom environment variables support
-    - [Models] Add GPT-5.4 support
+    - [Agent] Added dedicated Agents page accessible from sidebar, separating Agents from Assistants for improved discoverability
+    - [Assistant] Added configurable max tool calls setting (1-100 limit) in Model Settings
+    - [OpenClaw] Switched to binary download install and added auto update check
 
     🐛 Bug Fixes
-    - [Security] Built-in filesystem MCP now requires manual approval for write/edit/delete operations
-    - [Security] Fix MCP hub mode bypassing tool permission checks
-    - [Security] Remove auto-execution countdown - tools now wait for user confirmation
-    - [Agent] Fix tool status not stopping when aborting on Windows
-    - [Chat] Fix auto backup interrupting streaming responses
-    - [Chat] Fix topic renaming errors with image-capable models
-    - [UI] Fix "Move To" submenu overflow with long assistant lists
-    - [Editor] Render SVG code blocks as previews
-    - [Models] Fix Gemini 3 and Qwen 3.5 reasoning parameter issues
-    - [xAI] Upgrade to new Responses API with X/Twitter search support
-    - [API Server] Fix tool calling message validation
-    - [Plugins] Fix install/uninstall button state issues
-    - [Update] Fix update dialog not showing on manual check
-    - [Update] Prevent unexpected auto-updates on app quit
-
-    💄 Improvements
-    - [Provider] Improve agent model selector ordering and highlighting
-    - [MCP] Add system notifications when tool approval is required
+    - [aiCore] Fix deep thinking mode not working with some OpenAI-compatible providers
+    - [Timeout] Increased default request timeout from 10 to 30 minutes for slow local models
+    - [Poe] Fix web search not working correctly when built-in search is enabled
 
     <!--LANG:zh-CN-->
-    Cherry Studio 1.7.25 - 安全与稳定性
+    Cherry Studio 1.7.26 - 可发现性与性能
 
     ✨ 新功能
-    - [网络搜索] 新增 Querit 搜索引擎（新用户 1,000 次免费请求）
-    - [服务商] 新增 MiniMax Global 和 Z.ai 服务商
-    - [小程序] 新增 MiniMax Agent 和 IMA 小程序
-    - [服务商] 添加智能体支持筛选器
-    - [智能体] 支持自定义环境变量配置
-    - [模型] 新增 GPT-5.4 支持
+    - [智能体] 新增独立的智能体页面，可通过侧边栏访问，与助手列表分离以便于发现
+    - [助手] 新增可配置的最大工具调用次数设置（1-100 次限制），可在模型设置中调整
+    - [OpenClaw] 切换到二进制下载安装，并添加自动更新检查
 
     🐛 问题修复
-    - [安全] 内置文件系统 MCP 的写入/编辑/删除操作现需手动批准
-    - [安全] 修复 MCP Hub 模式绕过工具权限检查的问题
-    - [安全] 移除自动执行倒计时 - 工具现在等待用户确认
-    - [智能体] 修复 Windows 上中止时工具状态未停止的问题
-    - [对话] 修复自动备份中断流式响应的问题
-    - [对话] 修复使用图像模型时话题重命名出错的问题
-    - [UI] 修复助手列表过长时"移动到"子菜单溢出
-    - [编辑器] SVG 代码块现在显示为预览图
-    - [模型] 修复 Gemini 3 和 Qwen 3.5 推理参数问题
-    - [xAI] 升级到新版 Responses API，支持 X/Twitter 搜索
-    - [API 服务] 修复工具调用消息验证问题
-    - [插件] 修复安装/卸载按钮状态问题
-    - [更新] 修复手动检查更新时对话框不显示的问题
-    - [更新] 防止退出应用时意外自动更新
-
-    💄 改进
-    - [服务商] 优化智能体模型选择器排序和高亮
-    - [MCP] 工具需要批准时发送系统通知
+    - [aiCore] 修复深度思考模式在某些 OpenAI 兼容服务商上无法正常工作的问题
+    - [超时] 将默认请求超时从 10 分钟增加到 30 分钟，以支持较慢的本地模型
+    - [Poe] 修复启用内置搜索时网络搜索无法正常工作的问题
     <!--LANG:END-->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CherryStudio",
-  "version": "1.7.25",
+  "version": "1.7.26",
   "private": true,
   "description": "A powerful AI assistant for producer.",
   "desktopName": "CherryStudio.desktop",


### PR DESCRIPTION
### What this PR does

Before this PR:
- Version was at 1.7.25
- Release notes for 1.7.26 were not published

After this PR:
- Version bumped to 1.7.26
- Bilingual release notes (English/Chinese) published in `electron-builder.yml`
- Release branch `release/v1.7.26` ready for merge

Fixes #

### Why we need it and why it was done in this way

This is a release preparation PR for version 1.7.26. The release includes:

**New Features:**
- Dedicated Agents page accessible from sidebar, separating Agents from Assistants for improved discoverability
- Configurable max tool calls setting (1-100 limit) in Model Settings
- OpenClaw binary download install and auto update check

**Bug Fixes:**
- Fix deep thinking mode not working with some OpenAI-compatible providers
- Increased default request timeout from 10 to 30 minutes for slow local models
- Fix Poe web search not working correctly when built-in search is enabled

The following tradeoffs were made:
- N/A

The following alternatives were considered:
- N/A

Links to places where the discussion took place:
- N/A

### Breaking changes

None

### Special notes for your reviewer

This PR follows the release workflow:
1. Version bump in `package.json`: 1.7.25 → 1.7.26
2. Bilingual release notes in `electron-builder.yml`
3. Merging this PR will trigger `release.yml` CI workflow to build artifacts and create a draft GitHub Release

### Included Commits

- f3244c3e9 fix(aiCore): bypass AI SDK model ID allowlist for reasoning detection (#13463)
- aeae3be69 fix: increase default request timeout from 10 to 30 minutes (#13453)
- 9c3c99036 feat: separate Agent into independent module with dedicated page and route (#13420)
- ea694c630 feat(assistant): add configurable max tool calls setting (#13398)
- 97011c8bb feat(openclaw): binary download install, auto update check, and gateway refactor (#13440)
- 4aef24915 fix: correctly pass poe web_search via extra_body when built-in search is enabled (#13434)

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release Review Checklist

- [ ] Review generated release notes in `electron-builder.yml`
- [ ] Verify version bump in `package.json`
- [ ] CI passes
- [ ] Merge to trigger release build

### Release note

```release-note
Cherry Studio 1.7.26 - Discoverability & Performance

✨ New Features
- [Agent] Added dedicated Agents page accessible from sidebar, separating Agents from Assistants for improved discoverability
- [Assistant] Added configurable max tool calls setting (1-100 limit) in Model Settings
- [OpenClaw] Switched to binary download install and added auto update check

🐛 Bug Fixes
- [aiCore] Fix deep thinking mode not working with some OpenAI-compatible providers
- [Timeout] Increased default request timeout from 10 to 30 minutes for slow local models
- [Poe] Fix web search not working correctly when built-in search is enabled
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)