### PR TITLE
feat: add MiniMax-M2.5-highspeed model

### DIFF
--- a/src/renderer/src/config/models/default.ts
+++ b/src/renderer/src/config/models/default.ts
@@ -1055,6 +1055,12 @@ export const SYSTEM_MODELS: Record<SystemProviderId | 'defaultModel', Model[]> =
       group: 'M2.5'
     },
     {
+      id: 'MiniMax-M2.5-highspeed',
+      provider: 'minimax',
+      name: 'MiniMax-M2.5-highspeed',
+      group: 'M2.5'
+    },
+    {
       id: 'MiniMax-M2.5-lightning',
       provider: 'minimax',
       name: 'MiniMax-M2.5-lightning',
@@ -1090,6 +1096,12 @@ export const SYSTEM_MODELS: Record<SystemProviderId | 'defaultModel', Model[]> =
       id: 'MiniMax-M2.5',
       provider: 'minimax-global',
       name: 'MiniMax-M2.5',
+      group: 'M2.5'
+    },
+    {
+      id: 'MiniMax-M2.5-highspeed',
+      provider: 'minimax-global',
+      name: 'MiniMax-M2.5-highspeed',
       group: 'M2.5'
     },
     {


### PR DESCRIPTION
## Summary

Add the `MiniMax-M2.5-highspeed` model to both `minimax` (CN) and `minimax-global` provider model lists.

## Changes

- Add `MiniMax-M2.5-highspeed` model entry to the `minimax` provider model list
- Add `MiniMax-M2.5-highspeed` model entry to the `minimax-global` provider model list

## Context

`MiniMax-M2.5-highspeed` is an officially available MiniMax model that offers the same performance as `MiniMax-M2.5` but with faster inference speed and more agility. It supports 204,800 tokens context window.

- API Documentation: https://platform.minimax.io/docs/api-reference/text-openai-api