### PR TITLE
docs: update agents.db path in CLAUDE.md after #13392

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ Slices (redux-persist enabled):
   - **BLOCKED**: Do not modify schema until v2.0.0.
 - **SQLite** (Drizzle ORM + LibSQL): `src/main/services/agents/`
   - Used for the agents subsystem
-  - DB path: `~/.cherrystudio/data/agents.db` (dev) / `userData/agents.db` (prod)
+  - DB path: `{userData}/Data/agents.db` (e.g., on macOS: `~/Library/Application Support/CherryStudioDev/Data/agents.db` in dev, `~/Library/Application Support/CherryStudio/Data/agents.db` in prod)
 
 ### IPC Communication
 


### PR DESCRIPTION
### What this PR does

Before this PR:

CLAUDE.md described agents.db path as `~/.cherrystudio/data/agents.db` (dev) / `userData/agents.db` (prod), which is outdated after #13392.

After this PR:

Updated to reflect the unified path `{userData}/Data/agents.db` with macOS examples for both dev and prod.

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

None. Straightforward documentation update.

The following alternatives were considered:

N/A

Links to places where the discussion took place:

https://github.com/CherryHQ/cherry-studio/pull/13392

### Breaking changes

None.

### Special notes for your reviewer

N/A

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
