### PR TITLE
feat: add site adapter support to browser MCP server

### DIFF
--- a/src/main/mcpServers/browser/__tests__/registry.test.ts
+++ b/src/main/mcpServers/browser/__tests__/registry.test.ts
@@ -1,0 +1,466 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock node:fs before importing the module under test
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+    readdirSync: vi.fn(),
+    statSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn()
+  }
+})
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+  spawn: vi.fn(() => ({ unref: vi.fn() }))
+}))
+
+// Mock the logger
+vi.mock('../types', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+import { execFile, spawn } from 'node:child_process'
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+
+import {
+  backgroundUpdate,
+  ensureSitesAvailable,
+  findSite,
+  getAllSites,
+  invalidateCache,
+  parseSiteMeta,
+  scanSites,
+  searchSites
+} from '../sites/registry'
+
+const BB_DIR = join(homedir(), '.bb-browser')
+const LOCAL_SITES_DIR = join(BB_DIR, 'sites')
+const COMMUNITY_SITES_DIR = join(BB_DIR, 'bb-sites')
+
+describe('parseSiteMeta', () => {
+  it('parses @meta JSON block', () => {
+    const content = `/* @meta
+{
+  "name": "twitter/search",
+  "description": "Search tweets",
+  "domain": "x.com",
+  "args": { "query": { "required": true, "description": "Search query" } },
+  "example": "site twitter/search --query cats"
+}
+*/
+async function(args) { return []; }`
+
+    const result = parseSiteMeta(content, join(COMMUNITY_SITES_DIR, 'twitter/search.js'), 'community')
+
+    expect(result).not.toBeNull()
+    expect(result!.name).toBe('twitter/search')
+    expect(result!.description).toBe('Search tweets')
+    expect(result!.domain).toBe('x.com')
+    expect(result!.args).toEqual({ query: { required: true, description: 'Search query' } })
+    expect(result!.example).toBe('site twitter/search --query cats')
+    expect(result!.source).toBe('community')
+  })
+
+  it('uses default name from file path when @meta has no name', () => {
+    const content = `/* @meta
+{ "description": "Popular videos", "domain": "bilibili.com" }
+*/
+async function(args) { return []; }`
+
+    const result = parseSiteMeta(content, join(COMMUNITY_SITES_DIR, 'bilibili/popular.js'), 'community')
+
+    expect(result).not.toBeNull()
+    expect(result!.name).toBe('bilibili/popular')
+  })
+
+  it('parses @tag fallback format', () => {
+    const content = `// @name hackernews/top
+// @description Top stories from Hacker News
+// @domain news.ycombinator.com
+// @args count
+// @example site hackernews/top 10
+async function(args) { return []; }`
+
+    const result = parseSiteMeta(content, join(COMMUNITY_SITES_DIR, 'hackernews/top.js'), 'community')
+
+    expect(result).not.toBeNull()
+    expect(result!.name).toBe('hackernews/top')
+    expect(result!.description).toBe('Top stories from Hacker News')
+    expect(result!.domain).toBe('news.ycombinator.com')
+    expect(result!.args).toEqual({ count: { required: true } })
+    expect(result!.example).toBe('site hackernews/top 10')
+  })
+
+  it('handles malformed @meta JSON by falling back to @tag parsing', () => {
+    const content = `/* @meta
+{ this is not valid JSON }
+*/
+// @description Fallback desc
+// @domain example.com
+async function(args) { return []; }`
+
+    const result = parseSiteMeta(content, join(COMMUNITY_SITES_DIR, 'test/broken.js'), 'community')
+
+    expect(result).not.toBeNull()
+    expect(result!.name).toBe('test/broken')
+    expect(result!.description).toBe('Fallback desc')
+    expect(result!.domain).toBe('example.com')
+  })
+
+  it('handles content with no @meta and no @tag', () => {
+    const content = `async function(args) { return []; }`
+
+    const result = parseSiteMeta(content, join(LOCAL_SITES_DIR, 'custom/tool.js'), 'local')
+
+    expect(result).not.toBeNull()
+    expect(result!.name).toBe('custom/tool')
+    expect(result!.description).toBe('')
+    expect(result!.domain).toBe('')
+    expect(result!.args).toEqual({})
+    expect(result!.source).toBe('local')
+  })
+
+  it('parses multiple @args from comma-separated values', () => {
+    const content = `// @args query, count, sort`
+
+    const result = parseSiteMeta(content, join(COMMUNITY_SITES_DIR, 'test/multi.js'), 'community')
+
+    expect(result).not.toBeNull()
+    expect(result!.args).toEqual({
+      query: { required: true },
+      count: { required: true },
+      sort: { required: true }
+    })
+  })
+})
+
+describe('scanSites', () => {
+  beforeEach(() => {
+    vi.mocked(existsSync).mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    invalidateCache()
+  })
+
+  it('returns empty array when directory does not exist', () => {
+    vi.mocked(existsSync).mockReturnValue(false)
+    const result = scanSites('/nonexistent', 'community')
+    expect(result).toEqual([])
+  })
+
+  it('scans directory recursively for .js files', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readdirSync).mockImplementation(((dirPath: string) => {
+      const dir = String(dirPath)
+      if (dir === COMMUNITY_SITES_DIR) {
+        return [
+          { name: 'twitter', isDirectory: () => true, isFile: () => false },
+          { name: '.git', isDirectory: () => true, isFile: () => false }
+        ] as unknown as ReturnType<typeof readdirSync>
+      }
+      if (dir.endsWith('twitter')) {
+        return [{ name: 'search.js', isDirectory: () => false, isFile: () => true }] as unknown as ReturnType<
+          typeof readdirSync
+        >
+      }
+      return [] as unknown as ReturnType<typeof readdirSync>
+    }) as typeof readdirSync)
+
+    vi.mocked(readFileSync).mockReturnValue(`/* @meta
+{ "description": "Search tweets", "domain": "x.com" }
+*/
+async function(args) { return []; }`)
+
+    const result = scanSites(COMMUNITY_SITES_DIR, 'community')
+
+    expect(result).toHaveLength(1)
+    expect(result[0].description).toBe('Search tweets')
+    // Skips .git directory
+  })
+})
+
+describe('getAllSites', () => {
+  beforeEach(() => {
+    invalidateCache()
+    vi.mocked(existsSync).mockReturnValue(false)
+    vi.mocked(statSync).mockReturnValue({ mtimeMs: 0 } as ReturnType<typeof statSync>)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    invalidateCache()
+  })
+
+  it('local adapter overrides community adapter with same name', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+
+    let callCount = 0
+    vi.mocked(statSync).mockImplementation(() => {
+      callCount++
+      return { mtimeMs: callCount } as ReturnType<typeof statSync>
+    })
+
+    vi.mocked(readdirSync).mockImplementation(((dirPath: string) => {
+      const dir = String(dirPath)
+      if (dir === COMMUNITY_SITES_DIR || dir === LOCAL_SITES_DIR) {
+        return [{ name: 'twitter', isDirectory: () => true, isFile: () => false }] as unknown as ReturnType<
+          typeof readdirSync
+        >
+      }
+      if (dir.includes('twitter')) {
+        return [{ name: 'search.js', isDirectory: () => false, isFile: () => true }] as unknown as ReturnType<
+          typeof readdirSync
+        >
+      }
+      return [] as unknown as ReturnType<typeof readdirSync>
+    }) as typeof readdirSync)
+
+    vi.mocked(readFileSync).mockImplementation(((filePath: string) => {
+      const path = String(filePath)
+      if (path.includes('bb-sites')) {
+        return `/* @meta
+{ "description": "Community version", "domain": "x.com" }
+*/`
+      }
+      return `/* @meta
+{ "description": "Local version", "domain": "x.com" }
+*/`
+    }) as typeof readFileSync)
+
+    const sites = getAllSites()
+
+    expect(sites).toHaveLength(1)
+    expect(sites[0].description).toBe('Local version')
+    expect(sites[0].source).toBe('local')
+  })
+
+  it('returns cached results when mtimes have not changed', () => {
+    vi.mocked(statSync).mockReturnValue({ mtimeMs: 100 } as ReturnType<typeof statSync>)
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readdirSync).mockReturnValue([] as unknown as ReturnType<typeof readdirSync>)
+
+    const first = getAllSites()
+    const second = getAllSites()
+
+    expect(first).toBe(second) // Same reference = cached
+    // readdirSync should only be called for the first scan (2 dirs)
+    // Second call returns cached result
+  })
+})
+
+describe('findSite', () => {
+  beforeEach(() => {
+    invalidateCache()
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(statSync).mockReturnValue({ mtimeMs: Date.now() } as ReturnType<typeof statSync>)
+    vi.mocked(readdirSync).mockImplementation(((dirPath: string) => {
+      const dir = String(dirPath)
+      if (dir === COMMUNITY_SITES_DIR) {
+        return [{ name: 'hackernews', isDirectory: () => true, isFile: () => false }] as unknown as ReturnType<
+          typeof readdirSync
+        >
+      }
+      if (dir.includes('hackernews')) {
+        return [{ name: 'top.js', isDirectory: () => false, isFile: () => true }] as unknown as ReturnType<
+          typeof readdirSync
+        >
+      }
+      return [] as unknown as ReturnType<typeof readdirSync>
+    }) as typeof readdirSync)
+    vi.mocked(readFileSync).mockReturnValue(`/* @meta
+{ "name": "hackernews/top", "description": "Top HN stories", "domain": "news.ycombinator.com" }
+*/`)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    invalidateCache()
+  })
+
+  it('finds adapter by exact name', () => {
+    const site = findSite('hackernews/top')
+    expect(site).toBeDefined()
+    expect(site!.name).toBe('hackernews/top')
+  })
+
+  it('returns undefined for non-existent adapter', () => {
+    const site = findSite('nonexistent/tool')
+    expect(site).toBeUndefined()
+  })
+})
+
+describe('searchSites', () => {
+  beforeEach(() => {
+    invalidateCache()
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(statSync).mockReturnValue({ mtimeMs: Date.now() } as ReturnType<typeof statSync>)
+    vi.mocked(readdirSync).mockImplementation(((dirPath: string) => {
+      const dir = String(dirPath)
+      if (dir === COMMUNITY_SITES_DIR) {
+        return [
+          { name: 'twitter', isDirectory: () => true, isFile: () => false },
+          { name: 'reddit', isDirectory: () => true, isFile: () => false }
+        ] as unknown as ReturnType<typeof readdirSync>
+      }
+      if (dir.includes('twitter')) {
+        return [{ name: 'search.js', isDirectory: () => false, isFile: () => true }] as unknown as ReturnType<
+          typeof readdirSync
+        >
+      }
+      if (dir.includes('reddit')) {
+        return [{ name: 'thread.js', isDirectory: () => false, isFile: () => true }] as unknown as ReturnType<
+          typeof readdirSync
+        >
+      }
+      return [] as unknown as ReturnType<typeof readdirSync>
+    }) as typeof readdirSync)
+
+    vi.mocked(readFileSync).mockImplementation(((filePath: string) => {
+      const path = String(filePath)
+      if (path.includes('twitter')) {
+        return `/* @meta
+{ "name": "twitter/search", "description": "Search tweets", "domain": "x.com" }
+*/`
+      }
+      return `/* @meta
+{ "name": "reddit/thread", "description": "Read Reddit thread", "domain": "www.reddit.com" }
+*/`
+    }) as typeof readFileSync)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    invalidateCache()
+  })
+
+  it('searches by name', () => {
+    const results = searchSites('twitter')
+    expect(results).toHaveLength(1)
+    expect(results[0].name).toBe('twitter/search')
+  })
+
+  it('searches by description', () => {
+    const results = searchSites('tweets')
+    expect(results).toHaveLength(1)
+    expect(results[0].name).toBe('twitter/search')
+  })
+
+  it('searches by domain', () => {
+    const results = searchSites('reddit.com')
+    expect(results).toHaveLength(1)
+    expect(results[0].name).toBe('reddit/thread')
+  })
+
+  it('is case-insensitive', () => {
+    const results = searchSites('TWITTER')
+    expect(results).toHaveLength(1)
+  })
+
+  it('returns empty array for no matches', () => {
+    const results = searchSites('nonexistent')
+    expect(results).toHaveLength(0)
+  })
+})
+
+describe('ensureSitesAvailable', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    invalidateCache()
+  })
+
+  it('returns immediately if .git dir already exists', async () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    const result = await ensureSitesAvailable()
+    expect(result).toBe('Community adapters already available.')
+  })
+
+  it('clones repo when bb-sites dir does not exist', async () => {
+    vi.mocked(existsSync).mockImplementation(((p: string) => {
+      const path = String(p)
+      if (path.endsWith('.git')) return false
+      return false
+    }) as typeof existsSync)
+
+    vi.mocked(readdirSync).mockReturnValue([] as unknown as ReturnType<typeof readdirSync>)
+
+    vi.mocked(execFile).mockImplementation(((_cmd: unknown, _args: unknown, _opts: unknown, callback: unknown) => {
+      ;(callback as (err: null, stdout: string, stderr: string) => void)(null, '', '')
+      return {} as ReturnType<typeof execFile>
+    }) as typeof execFile)
+
+    const result = await ensureSitesAvailable()
+    expect(result).toMatch(/Cloned \d+ community adapters/)
+  })
+
+  it('returns error message when git clone fails', async () => {
+    vi.mocked(existsSync).mockReturnValue(false)
+
+    vi.mocked(execFile).mockImplementation(((_cmd: unknown, _args: unknown, _opts: unknown, callback: unknown) => {
+      ;(callback as (err: Error, stdout: string, stderr: string) => void)(
+        new Error('git not found'),
+        '',
+        'git not found'
+      )
+      return {} as ReturnType<typeof execFile>
+    }) as typeof execFile)
+
+    const result = await ensureSitesAvailable()
+    expect(result).toContain('Failed to clone')
+    expect(result).toContain('manually clone')
+  })
+})
+
+describe('backgroundUpdate', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    invalidateCache()
+  })
+
+  it('does nothing when .git dir does not exist', () => {
+    vi.mocked(existsSync).mockReturnValue(false)
+    backgroundUpdate()
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when last update was recent', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readFileSync).mockReturnValue(String(Date.now()))
+    backgroundUpdate()
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
+  it('spawns git pull when last update was >24h ago', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readFileSync).mockReturnValue(String(Date.now() - 25 * 60 * 60 * 1000))
+
+    backgroundUpdate()
+
+    expect(spawn).toHaveBeenCalledWith('git', ['pull', '--ff-only'], expect.objectContaining({ detached: true }))
+    expect(writeFileSync).toHaveBeenCalled()
+  })
+
+  it('spawns git pull when .last-update file does not exist', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readFileSync).mockImplementation(() => {
+      throw new Error('ENOENT')
+    })
+
+    backgroundUpdate()
+
+    expect(spawn).toHaveBeenCalledWith('git', ['pull', '--ff-only'], expect.objectContaining({ detached: true }))
+  })
+})

--- a/src/main/mcpServers/browser/__tests__/registry.test.ts
+++ b/src/main/mcpServers/browser/__tests__/registry.test.ts
@@ -170,15 +170,13 @@ describe('scanSites', () => {
         return [
           { name: 'twitter', isDirectory: () => true, isFile: () => false },
           { name: '.git', isDirectory: () => true, isFile: () => false }
-        ] as unknown as ReturnType<typeof readdirSync>
+        ]
       }
       if (dir.endsWith('twitter')) {
-        return [{ name: 'search.js', isDirectory: () => false, isFile: () => true }] as unknown as ReturnType<
-          typeof readdirSync
-        >
+        return [{ name: 'search.js', isDirectory: () => false, isFile: () => true }]
       }
-      return [] as unknown as ReturnType<typeof readdirSync>
-    }) as typeof readdirSync)
+      return []
+    }) as unknown as typeof readdirSync)
 
     vi.mocked(readFileSync).mockReturnValue(`/* @meta
 { "description": "Search tweets", "domain": "x.com" }
@@ -217,17 +215,13 @@ describe('getAllSites', () => {
     vi.mocked(readdirSync).mockImplementation(((dirPath: string) => {
       const dir = String(dirPath)
       if (dir === COMMUNITY_SITES_DIR || dir === LOCAL_SITES_DIR) {
-        return [{ name: 'twitter', isDirectory: () => true, isFile: () => false }] as unknown as ReturnType<
-          typeof readdirSync
-        >
+        return [{ name: 'twitter', isDirectory: () => true, isFile: () => false }]
       }
       if (dir.includes('twitter')) {
-        return [{ name: 'search.js', isDirectory: () => false, isFile: () => true }] as unknown as ReturnType<
-          typeof readdirSync
-        >
+        return [{ name: 'search.js', isDirectory: () => false, isFile: () => true }]
       }
-      return [] as unknown as ReturnType<typeof readdirSync>
-    }) as typeof readdirSync)
+      return []
+    }) as unknown as typeof readdirSync)
 
     vi.mocked(readFileSync).mockImplementation(((filePath: string) => {
       const path = String(filePath)
@@ -270,17 +264,13 @@ describe('findSite', () => {
     vi.mocked(readdirSync).mockImplementation(((dirPath: string) => {
       const dir = String(dirPath)
       if (dir === COMMUNITY_SITES_DIR) {
-        return [{ name: 'hackernews', isDirectory: () => true, isFile: () => false }] as unknown as ReturnType<
-          typeof readdirSync
-        >
+        return [{ name: 'hackernews', isDirectory: () => true, isFile: () => false }]
       }
       if (dir.includes('hackernews')) {
-        return [{ name: 'top.js', isDirectory: () => false, isFile: () => true }] as unknown as ReturnType<
-          typeof readdirSync
-        >
+        return [{ name: 'top.js', isDirectory: () => false, isFile: () => true }]
       }
-      return [] as unknown as ReturnType<typeof readdirSync>
-    }) as typeof readdirSync)
+      return []
+    }) as unknown as typeof readdirSync)
     vi.mocked(readFileSync).mockReturnValue(`/* @meta
 { "name": "hackernews/top", "description": "Top HN stories", "domain": "news.ycombinator.com" }
 */`)
@@ -314,20 +304,16 @@ describe('searchSites', () => {
         return [
           { name: 'twitter', isDirectory: () => true, isFile: () => false },
           { name: 'reddit', isDirectory: () => true, isFile: () => false }
-        ] as unknown as ReturnType<typeof readdirSync>
+        ]
       }
       if (dir.includes('twitter')) {
-        return [{ name: 'search.js', isDirectory: () => false, isFile: () => true }] as unknown as ReturnType<
-          typeof readdirSync
-        >
+        return [{ name: 'search.js', isDirectory: () => false, isFile: () => true }]
       }
       if (dir.includes('reddit')) {
-        return [{ name: 'thread.js', isDirectory: () => false, isFile: () => true }] as unknown as ReturnType<
-          typeof readdirSync
-        >
+        return [{ name: 'thread.js', isDirectory: () => false, isFile: () => true }]
       }
-      return [] as unknown as ReturnType<typeof readdirSync>
-    }) as typeof readdirSync)
+      return []
+    }) as unknown as typeof readdirSync)
 
     vi.mocked(readFileSync).mockImplementation(((filePath: string) => {
       const path = String(filePath)

--- a/src/main/mcpServers/browser/__tests__/runner.test.ts
+++ b/src/main/mcpServers/browser/__tests__/runner.test.ts
@@ -264,7 +264,8 @@ describe('runSiteAdapter', () => {
       'Login required',
       'unauthorized',
       'Please sign in to continue',
-      'auth token expired'
+      'auth token expired',
+      'auth failed'
     ]
 
     for (const pattern of authPatterns) {
@@ -283,7 +284,27 @@ describe('runSiteAdapter', () => {
       })
     }
 
-    const nonAuthPatterns = ['author not found', 'authentication successful', 'normal content with no errors']
+    const nonAuthPatterns = [
+      'author not found',
+      'authentication successful',
+      'normal content with no errors',
+      'authorize user'
+    ]
+
+    // Test that non-auth errors don't get login hints
+    it('does NOT add login hint for error "author not found"', async () => {
+      const site = makeSite({ domain: 'x.com' })
+      const controller = makeController({
+        listTabs: vi.fn().mockResolvedValue([{ tabId: 't1', url: 'https://x.com', title: 'X' }]),
+        execute: vi.fn().mockResolvedValue({ error: 'author not found' })
+      })
+
+      const result = await runSiteAdapter(controller, site, {})
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('author not found')
+      expect(result.hint).toBeUndefined()
+    })
 
     for (const pattern of nonAuthPatterns) {
       it(`does NOT false-positive on: "${pattern}"`, async () => {

--- a/src/main/mcpServers/browser/__tests__/runner.test.ts
+++ b/src/main/mcpServers/browser/__tests__/runner.test.ts
@@ -1,0 +1,372 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock node:fs
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return {
+    ...actual,
+    readFileSync: vi.fn()
+  }
+})
+
+// Mock the logger
+vi.mock('../types', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+import { readFileSync } from 'node:fs'
+
+import { domainMatches, runSiteAdapter } from '../sites/runner'
+import type { SiteMeta } from '../types'
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function makeSite(overrides: Partial<SiteMeta> = {}): SiteMeta {
+  return {
+    name: 'test/adapter',
+    description: 'Test adapter',
+    domain: 'example.com',
+    args: {},
+    filePath: '/tmp/test/adapter.js',
+    source: 'community',
+    ...overrides
+  }
+}
+
+function makeController(overrides: Record<string, unknown> = {}) {
+  return {
+    listTabs: vi.fn().mockResolvedValue([]),
+    open: vi.fn().mockResolvedValue({ currentUrl: 'https://example.com', title: 'Example', tabId: 'tab-1' }),
+    execute: vi.fn().mockResolvedValue(null),
+    ...overrides
+  } as any
+}
+
+const ADAPTER_JS = `/* @meta
+{ "name": "test/adapter", "description": "Test", "domain": "example.com" }
+*/
+async function(args) { return { items: [] }; }`
+
+const ADAPTER_JS_BODY = 'async function(args) { return { items: [] }; }'
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe('domainMatches', () => {
+  it('matches exact domain', () => {
+    expect(domainMatches('https://x.com/home', 'x.com')).toBe(true)
+  })
+
+  it('matches subdomain', () => {
+    expect(domainMatches('https://api.twitter.com/v2', 'twitter.com')).toBe(true)
+  })
+
+  it('does not match partial domain name', () => {
+    expect(domainMatches('https://nottwitter.com', 'twitter.com')).toBe(false)
+  })
+
+  it('returns false for invalid URL', () => {
+    expect(domainMatches('not-a-url', 'example.com')).toBe(false)
+  })
+
+  it('matches www subdomain', () => {
+    expect(domainMatches('https://www.bilibili.com/hot', 'bilibili.com')).toBe(true)
+  })
+})
+
+describe('runSiteAdapter', () => {
+  beforeEach(() => {
+    vi.mocked(readFileSync).mockReturnValue(ADAPTER_JS)
+  })
+
+  describe('required args validation', () => {
+    it('returns error when required args are missing', async () => {
+      const site = makeSite({
+        args: {
+          query: { required: true, description: 'Search query' },
+          count: { required: false, description: 'Result count' }
+        }
+      })
+      const controller = makeController()
+
+      const result = await runSiteAdapter(controller, site, {})
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Missing required args')
+      expect(result.error).toContain('query')
+      expect(result.hint).toContain('query (required)')
+      expect(result.hint).toContain('Search query')
+    })
+
+    it('passes when all required args are provided', async () => {
+      const site = makeSite({
+        args: {
+          query: { required: true, description: 'Search query' }
+        }
+      })
+      const controller = makeController({
+        execute: vi.fn().mockResolvedValue({ items: ['a'] })
+      })
+
+      const result = await runSiteAdapter(controller, site, { query: 'cats' })
+
+      expect(result.success).toBe(true)
+    })
+
+    it('includes example in hint when available', async () => {
+      const site = makeSite({
+        args: { query: { required: true } },
+        example: 'site test/adapter --query cats'
+      })
+      const controller = makeController()
+
+      const result = await runSiteAdapter(controller, site, {})
+
+      expect(result.hint).toContain('Example: site test/adapter --query cats')
+    })
+  })
+
+  describe('IIFE wrapping', () => {
+    it('produces correct script from adapter body and args', async () => {
+      const site = makeSite()
+      const controller = makeController()
+
+      await runSiteAdapter(controller, site, { count: '10' })
+
+      expect(controller.execute).toHaveBeenCalledWith(`(${ADAPTER_JS_BODY})({"count":"10"})`, 30_000, false, 'tab-1')
+    })
+
+    it('strips @meta block before wrapping', async () => {
+      const site = makeSite()
+      const controller = makeController()
+
+      await runSiteAdapter(controller, site, {})
+
+      const script = controller.execute.mock.calls[0][0] as string
+      expect(script).not.toContain('@meta')
+      expect(script).toContain('async function')
+    })
+  })
+
+  describe('domain tab resolution', () => {
+    it('reuses existing tab matching domain', async () => {
+      const site = makeSite({ domain: 'x.com' })
+      const controller = makeController({
+        listTabs: vi.fn().mockResolvedValue([{ tabId: 'existing-tab', url: 'https://x.com/home', title: 'X' }]),
+        execute: vi.fn().mockResolvedValue({ tweets: [] })
+      })
+
+      await runSiteAdapter(controller, site, {})
+
+      expect(controller.open).not.toHaveBeenCalled()
+      expect(controller.execute).toHaveBeenCalledWith(expect.any(String), 30_000, false, 'existing-tab')
+    })
+
+    it('opens new tab when no matching domain tab exists', async () => {
+      const site = makeSite({ domain: 'bilibili.com' })
+      const controller = makeController({
+        listTabs: vi.fn().mockResolvedValue([]),
+        open: vi.fn().mockResolvedValue({ tabId: 'new-tab' }),
+        execute: vi.fn().mockResolvedValue(null)
+      })
+
+      await runSiteAdapter(controller, site, {})
+
+      expect(controller.open).toHaveBeenCalledWith('https://bilibili.com', 30_000, false, true, false)
+      expect(controller.execute).toHaveBeenCalledWith(expect.any(String), 30_000, false, 'new-tab')
+    })
+
+    it('returns error when no domain and no active tab', async () => {
+      const site = makeSite({ domain: '' })
+      const controller = makeController({
+        listTabs: vi.fn().mockResolvedValue([])
+      })
+
+      const result = await runSiteAdapter(controller, site, {})
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('No page open')
+    })
+
+    it('uses active tab when no domain but tabs exist', async () => {
+      const site = makeSite({ domain: '' })
+      const controller = makeController({
+        listTabs: vi.fn().mockResolvedValue([{ tabId: 'active-tab', url: 'https://something.com', title: 'Page' }]),
+        execute: vi.fn().mockResolvedValue('result data')
+      })
+
+      const result = await runSiteAdapter(controller, site, {})
+
+      expect(result.success).toBe(true)
+      // tabId should be undefined (uses active tab)
+      expect(controller.execute).toHaveBeenCalledWith(expect.any(String), 30_000, false, undefined)
+    })
+  })
+
+  describe('result parsing', () => {
+    it('passes through object result as data', async () => {
+      const site = makeSite()
+      const controller = makeController({
+        execute: vi.fn().mockResolvedValue({ items: [1, 2, 3] })
+      })
+
+      const result = await runSiteAdapter(controller, site, {})
+
+      expect(result.success).toBe(true)
+      expect(result.data).toEqual({ items: [1, 2, 3] })
+    })
+
+    it('parses JSON string result', async () => {
+      const site = makeSite()
+      const controller = makeController({
+        execute: vi.fn().mockResolvedValue('{"count":42}')
+      })
+
+      const result = await runSiteAdapter(controller, site, {})
+
+      expect(result.success).toBe(true)
+      expect(result.data).toEqual({ count: 42 })
+    })
+
+    it('passes through non-JSON string as data', async () => {
+      const site = makeSite()
+      const controller = makeController({
+        execute: vi.fn().mockResolvedValue('Hello world')
+      })
+
+      const result = await runSiteAdapter(controller, site, {})
+
+      expect(result.success).toBe(true)
+      expect(result.data).toBe('Hello world')
+    })
+
+    it('handles null result', async () => {
+      const site = makeSite()
+      const controller = makeController({
+        execute: vi.fn().mockResolvedValue(null)
+      })
+
+      const result = await runSiteAdapter(controller, site, {})
+
+      expect(result.success).toBe(true)
+      expect(result.data).toBeNull()
+    })
+  })
+
+  describe('auth error detection', () => {
+    const authPatterns = [
+      '401',
+      '403 Forbidden',
+      'Not logged in',
+      'Login required',
+      'unauthorized',
+      'Please sign in to continue',
+      'auth token expired'
+    ]
+
+    for (const pattern of authPatterns) {
+      it(`detects auth error: "${pattern}"`, async () => {
+        const site = makeSite({ domain: 'x.com' })
+        const controller = makeController({
+          listTabs: vi.fn().mockResolvedValue([{ tabId: 't1', url: 'https://x.com', title: 'X' }]),
+          execute: vi.fn().mockResolvedValue({ error: pattern })
+        })
+
+        const result = await runSiteAdapter(controller, site, {})
+
+        expect(result.success).toBe(false)
+        expect(result.error).toBe(pattern)
+        expect(result.hint).toContain('Please log in to https://x.com')
+      })
+    }
+
+    const nonAuthPatterns = ['author not found', 'authentication successful', 'normal content with no errors']
+
+    for (const pattern of nonAuthPatterns) {
+      it(`does NOT false-positive on: "${pattern}"`, async () => {
+        const site = makeSite()
+        const controller = makeController({
+          execute: vi.fn().mockResolvedValue({ items: [pattern] })
+        })
+
+        const result = await runSiteAdapter(controller, site, {})
+
+        expect(result.success).toBe(true)
+      })
+    }
+
+    it('detects error object without auth and returns without login hint', async () => {
+      const site = makeSite()
+      const controller = makeController({
+        execute: vi.fn().mockResolvedValue({ error: 'Rate limit exceeded' })
+      })
+
+      const result = await runSiteAdapter(controller, site, {})
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Rate limit exceeded')
+      expect(result.hint).toBeUndefined()
+    })
+  })
+
+  describe('execution errors', () => {
+    it('returns error when controller.execute throws', async () => {
+      const site = makeSite()
+      const controller = makeController({
+        execute: vi.fn().mockRejectedValue(new Error('Execution timed out'))
+      })
+
+      const result = await runSiteAdapter(controller, site, {})
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Execution timed out')
+    })
+
+    it('returns error when adapter file cannot be read', async () => {
+      vi.mocked(readFileSync).mockImplementation(() => {
+        throw new Error('ENOENT: no such file')
+      })
+
+      const site = makeSite()
+      const controller = makeController()
+
+      const result = await runSiteAdapter(controller, site, {})
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Failed to read adapter file')
+    })
+  })
+
+  describe('options', () => {
+    it('passes custom timeout and privateMode', async () => {
+      const site = makeSite()
+      const controller = makeController({
+        listTabs: vi.fn().mockResolvedValue([]),
+        open: vi.fn().mockResolvedValue({ tabId: 'tab-p' }),
+        execute: vi.fn().mockResolvedValue(null)
+      })
+
+      await runSiteAdapter(controller, site, {}, { timeout: 60_000, privateMode: true })
+
+      expect(controller.listTabs).toHaveBeenCalledWith(true)
+      expect(controller.open).toHaveBeenCalledWith('https://example.com', 60_000, true, true, false)
+      expect(controller.execute).toHaveBeenCalledWith(expect.any(String), 60_000, true, 'tab-p')
+    })
+
+    it('passes showWindow to controller.open', async () => {
+      const site = makeSite()
+      const controller = makeController({
+        listTabs: vi.fn().mockResolvedValue([]),
+        open: vi.fn().mockResolvedValue({ tabId: 'tab-v' }),
+        execute: vi.fn().mockResolvedValue(null)
+      })
+
+      await runSiteAdapter(controller, site, {}, { showWindow: true })
+
+      expect(controller.open).toHaveBeenCalledWith('https://example.com', 30_000, false, true, true)
+    })
+  })
+})

--- a/src/main/mcpServers/browser/__tests__/site-tool.test.ts
+++ b/src/main/mcpServers/browser/__tests__/site-tool.test.ts
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock registry
+vi.mock('../sites/registry', () => ({
+  getAllSites: vi.fn(),
+  findSite: vi.fn(),
+  searchSites: vi.fn(),
+  ensureSitesAvailable: vi.fn(),
+  backgroundUpdate: vi.fn()
+}))
+
+// Mock runner
+vi.mock('../sites/runner', () => ({
+  runSiteAdapter: vi.fn()
+}))
+
+// Mock logger
+vi.mock('../types', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+import { backgroundUpdate, ensureSitesAvailable, findSite, getAllSites, searchSites } from '../sites/registry'
+import { runSiteAdapter } from '../sites/runner'
+import { handleSite } from '../tools/site'
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function makeController() {
+  return {} as any
+}
+
+function makeSiteMeta(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'twitter/search',
+    description: 'Search Twitter',
+    domain: 'x.com',
+    args: { query: { required: true, description: 'Search query' } },
+    filePath: '/tmp/twitter/search.js',
+    source: 'community',
+    ...overrides
+  }
+}
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe('handleSite', () => {
+  const controller = makeController()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(ensureSitesAvailable).mockResolvedValue('Community adapters already available.')
+  })
+
+  // ── backgroundUpdate is called on every action ──
+
+  it('calls backgroundUpdate on every action', async () => {
+    vi.mocked(getAllSites).mockReturnValue([])
+    await handleSite(controller, { action: 'list' })
+    expect(backgroundUpdate).toHaveBeenCalled()
+  })
+
+  it('calls backgroundUpdate for search action', async () => {
+    vi.mocked(searchSites).mockReturnValue([])
+    await handleSite(controller, { action: 'search', query: 'test' })
+    expect(backgroundUpdate).toHaveBeenCalled()
+  })
+
+  it('calls backgroundUpdate for info action', async () => {
+    vi.mocked(findSite).mockReturnValue(makeSiteMeta() as any)
+    await handleSite(controller, { action: 'info', name: 'twitter/search' })
+    expect(backgroundUpdate).toHaveBeenCalled()
+  })
+
+  it('calls backgroundUpdate for run action', async () => {
+    vi.mocked(findSite).mockReturnValue(makeSiteMeta() as any)
+    vi.mocked(runSiteAdapter).mockResolvedValue({ success: true, data: {} })
+    await handleSite(controller, { action: 'run', name: 'twitter/search', args: { query: 'test' } })
+    expect(backgroundUpdate).toHaveBeenCalled()
+  })
+
+  // ── action: list ──
+
+  describe('action: list', () => {
+    it('returns grouped platforms', async () => {
+      vi.mocked(getAllSites).mockReturnValue([
+        makeSiteMeta({ name: 'twitter/search' }) as any,
+        makeSiteMeta({ name: 'twitter/timeline', description: 'Timeline' }) as any,
+        makeSiteMeta({ name: 'github/trending', domain: 'github.com', description: 'Trending repos' }) as any
+      ])
+
+      const result = await handleSite(controller, { action: 'list' })
+      expect(result.isError).toBe(false)
+
+      const body = JSON.parse(result.content[0].text)
+      expect(body.total).toBe(3)
+      expect(body.platforms.twitter).toHaveLength(2)
+      expect(body.platforms.github).toHaveLength(1)
+    })
+
+    it('calls ensureSitesAvailable before listing', async () => {
+      vi.mocked(getAllSites).mockReturnValue([])
+      await handleSite(controller, { action: 'list' })
+      expect(ensureSitesAvailable).toHaveBeenCalled()
+    })
+
+    it('returns empty list when no adapters', async () => {
+      vi.mocked(getAllSites).mockReturnValue([])
+      const result = await handleSite(controller, { action: 'list' })
+      const body = JSON.parse(result.content[0].text)
+      expect(body.total).toBe(0)
+      expect(body.platforms).toEqual({})
+    })
+  })
+
+  // ── action: search ──
+
+  describe('action: search', () => {
+    it('returns matching adapters', async () => {
+      vi.mocked(searchSites).mockReturnValue([makeSiteMeta() as any])
+      const result = await handleSite(controller, { action: 'search', query: 'twitter' })
+      expect(result.isError).toBe(false)
+
+      const body = JSON.parse(result.content[0].text)
+      expect(body).toHaveLength(1)
+      expect(body[0].name).toBe('twitter/search')
+    })
+
+    it('returns empty array when no results', async () => {
+      vi.mocked(searchSites).mockReturnValue([])
+      const result = await handleSite(controller, { action: 'search', query: 'nonexistent' })
+      expect(result.isError).toBe(false)
+
+      const body = JSON.parse(result.content[0].text)
+      expect(body).toHaveLength(0)
+    })
+
+    it('returns error when query is missing', async () => {
+      const result = await handleSite(controller, { action: 'search' })
+      expect(result.isError).toBe(true)
+      expect(result.content[0].text).toContain('query')
+    })
+  })
+
+  // ── action: info ──
+
+  describe('action: info', () => {
+    it('returns adapter metadata', async () => {
+      const site = makeSiteMeta({
+        capabilities: ['read'],
+        readOnly: true,
+        example: 'site run twitter/search --query test'
+      })
+      vi.mocked(findSite).mockReturnValue(site as any)
+
+      const result = await handleSite(controller, { action: 'info', name: 'twitter/search' })
+      expect(result.isError).toBe(false)
+
+      const body = JSON.parse(result.content[0].text)
+      expect(body.name).toBe('twitter/search')
+      expect(body.domain).toBe('x.com')
+      expect(body.args.query.required).toBe(true)
+      expect(body.capabilities).toEqual(['read'])
+      expect(body.readOnly).toBe(true)
+      expect(body.example).toBe('site run twitter/search --query test')
+      expect(body.source).toBe('community')
+    })
+
+    it('returns error when adapter not found', async () => {
+      vi.mocked(findSite).mockReturnValue(undefined)
+      const result = await handleSite(controller, { action: 'info', name: 'nonexistent/adapter' })
+      expect(result.isError).toBe(true)
+      expect(result.content[0].text).toContain('not found')
+    })
+
+    it('returns error when name is missing', async () => {
+      const result = await handleSite(controller, { action: 'info' })
+      expect(result.isError).toBe(true)
+      expect(result.content[0].text).toContain('name')
+    })
+  })
+
+  // ── action: run ──
+
+  describe('action: run', () => {
+    it('calls runner and returns result', async () => {
+      const site = makeSiteMeta()
+      vi.mocked(findSite).mockReturnValue(site as any)
+      vi.mocked(runSiteAdapter).mockResolvedValue({ success: true, data: { items: [1, 2, 3] } })
+
+      const result = await handleSite(controller, { action: 'run', name: 'twitter/search', args: { query: 'test' } })
+      expect(result.isError).toBe(false)
+
+      const body = JSON.parse(result.content[0].text)
+      expect(body.success).toBe(true)
+      expect(body.data.items).toEqual([1, 2, 3])
+
+      expect(runSiteAdapter).toHaveBeenCalledWith(
+        controller,
+        site,
+        { query: 'test' },
+        {
+          timeout: undefined,
+          privateMode: undefined,
+          showWindow: undefined
+        }
+      )
+    })
+
+    it('passes options to runner', async () => {
+      vi.mocked(findSite).mockReturnValue(makeSiteMeta() as any)
+      vi.mocked(runSiteAdapter).mockResolvedValue({ success: true, data: {} })
+
+      await handleSite(controller, {
+        action: 'run',
+        name: 'twitter/search',
+        args: { query: 'test' },
+        timeout: 60000,
+        privateMode: true,
+        showWindow: true
+      })
+
+      expect(runSiteAdapter).toHaveBeenCalledWith(
+        controller,
+        expect.anything(),
+        { query: 'test' },
+        { timeout: 60000, privateMode: true, showWindow: true }
+      )
+    })
+
+    it('returns error when name is missing', async () => {
+      const result = await handleSite(controller, { action: 'run' })
+      expect(result.isError).toBe(true)
+      expect(result.content[0].text).toContain('name')
+    })
+
+    it('returns error when adapter not found', async () => {
+      vi.mocked(findSite).mockReturnValue(undefined)
+      const result = await handleSite(controller, { action: 'run', name: 'nonexistent/adapter' })
+      expect(result.isError).toBe(true)
+      expect(result.content[0].text).toContain('not found')
+    })
+
+    it('uses empty args when none provided', async () => {
+      vi.mocked(findSite).mockReturnValue(makeSiteMeta() as any)
+      vi.mocked(runSiteAdapter).mockResolvedValue({ success: true, data: {} })
+
+      await handleSite(controller, { action: 'run', name: 'twitter/search' })
+      expect(runSiteAdapter).toHaveBeenCalledWith(controller, expect.anything(), {}, expect.anything())
+    })
+  })
+
+  // ── error handling ──
+
+  describe('error handling', () => {
+    it('returns error for invalid action', async () => {
+      const result = await handleSite(controller, { action: 'invalid' })
+      expect(result.isError).toBe(true)
+    })
+
+    it('returns error for invalid args schema', async () => {
+      const result = await handleSite(controller, { action: 'run', args: 'not-an-object' })
+      expect(result.isError).toBe(true)
+    })
+  })
+})

--- a/src/main/mcpServers/browser/sites/registry.ts
+++ b/src/main/mcpServers/browser/sites/registry.ts
@@ -29,7 +29,7 @@ export function parseSiteMeta(content: string, filePath: string, source: 'local'
   const defaultName = relPath.replace(/\.js$/, '').replace(/\\/g, '/')
 
   // Parse /* @meta { ... } */ block
-  const metaMatch = content.match(/\/\*\s*@meta\s*\n([\s\S]*?)\*\//)
+  const metaMatch = content.match(/\/\*\s*@meta\s*[\r\n]([\s\S]*?)\*\//)
   if (metaMatch) {
     try {
       const metaJson = JSON.parse(metaMatch[1])
@@ -268,8 +268,7 @@ export function backgroundUpdate(): void {
       detached: true
     })
     child.unref()
-    // Invalidate cache so next getAllSites() picks up changes
-    invalidateCache()
+    // Cache invalidation happens naturally via mtime change after git pull completes
   } catch (error) {
     logger.warn('Background update spawn failed', {
       error: error instanceof Error ? error.message : String(error)

--- a/src/main/mcpServers/browser/sites/registry.ts
+++ b/src/main/mcpServers/browser/sites/registry.ts
@@ -60,7 +60,7 @@ export function parseSiteMeta(content: string, filePath: string, source: 'local'
   }
 
   const tagPattern = /\/\/\s*@(\w+)[ \t]+(.*)/g
-  let match
+  let match: RegExpExecArray | null
   while ((match = tagPattern.exec(content)) !== null) {
     const [, key, value] = match
     switch (key) {
@@ -98,7 +98,7 @@ export function scanSites(dir: string, source: 'local' | 'community'): SiteMeta[
   const sites: SiteMeta[] = []
 
   function walk(currentDir: string): void {
-    let entries
+    let entries: import('node:fs').Dirent[]
     try {
       entries = readdirSync(currentDir, { withFileTypes: true })
     } catch {

--- a/src/main/mcpServers/browser/sites/registry.ts
+++ b/src/main/mcpServers/browser/sites/registry.ts
@@ -1,0 +1,278 @@
+import { execFile } from 'node:child_process'
+import { spawn } from 'node:child_process'
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join, relative } from 'node:path'
+
+import type { SiteMeta } from '../types'
+import { logger } from '../types'
+
+const BB_DIR = join(homedir(), '.bb-browser')
+const LOCAL_SITES_DIR = join(BB_DIR, 'sites')
+const COMMUNITY_SITES_DIR = join(BB_DIR, 'bb-sites')
+const COMMUNITY_REPO = 'https://github.com/epiral/bb-sites.git'
+const LAST_UPDATE_FILE = join(BB_DIR, '.last-update')
+const UPDATE_INTERVAL_MS = 24 * 60 * 60 * 1000
+
+// Mtime-based cache
+let cachedSites: SiteMeta[] | null = null
+let cachedLocalMtime = 0
+let cachedCommunityMtime = 0
+
+/**
+ * Parse adapter metadata from JS file content.
+ * Supports `/* @meta JSON * /` block with `// @tag value` fallback.
+ */
+export function parseSiteMeta(content: string, filePath: string, source: 'local' | 'community'): SiteMeta | null {
+  const sitesDir = source === 'local' ? LOCAL_SITES_DIR : COMMUNITY_SITES_DIR
+  const relPath = relative(sitesDir, filePath)
+  const defaultName = relPath.replace(/\.js$/, '').replace(/\\/g, '/')
+
+  // Parse /* @meta { ... } */ block
+  const metaMatch = content.match(/\/\*\s*@meta\s*\n([\s\S]*?)\*\//)
+  if (metaMatch) {
+    try {
+      const metaJson = JSON.parse(metaMatch[1])
+      return {
+        name: metaJson.name || defaultName,
+        description: metaJson.description || '',
+        domain: metaJson.domain || '',
+        args: metaJson.args || {},
+        capabilities: metaJson.capabilities,
+        readOnly: metaJson.readOnly,
+        example: metaJson.example,
+        filePath,
+        source
+      }
+    } catch {
+      // JSON parse failed, fall through to @tag mode
+    }
+  }
+
+  // Fallback: parse // @tag format
+  const meta: SiteMeta = {
+    name: defaultName,
+    description: '',
+    domain: '',
+    args: {},
+    filePath,
+    source
+  }
+
+  const tagPattern = /\/\/\s*@(\w+)[ \t]+(.*)/g
+  let match
+  while ((match = tagPattern.exec(content)) !== null) {
+    const [, key, value] = match
+    switch (key) {
+      case 'name':
+        meta.name = value.trim()
+        break
+      case 'description':
+        meta.description = value.trim()
+        break
+      case 'domain':
+        meta.domain = value.trim()
+        break
+      case 'args':
+        for (const arg of value
+          .trim()
+          .split(/[,\s]+/)
+          .filter(Boolean)) {
+          meta.args[arg] = { required: true }
+        }
+        break
+      case 'example':
+        meta.example = value.trim()
+        break
+    }
+  }
+
+  return meta
+}
+
+/**
+ * Recursively scan a directory for .js adapter files.
+ */
+export function scanSites(dir: string, source: 'local' | 'community'): SiteMeta[] {
+  if (!existsSync(dir)) return []
+  const sites: SiteMeta[] = []
+
+  function walk(currentDir: string): void {
+    let entries
+    try {
+      entries = readdirSync(currentDir, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      const fullPath = join(currentDir, entry.name)
+      if (entry.isDirectory() && !entry.name.startsWith('.')) {
+        walk(fullPath)
+      } else if (entry.isFile() && entry.name.endsWith('.js')) {
+        let content: string
+        try {
+          content = readFileSync(fullPath, 'utf-8')
+        } catch {
+          continue
+        }
+        const meta = parseSiteMeta(content, fullPath, source)
+        if (meta) sites.push(meta)
+      }
+    }
+  }
+
+  walk(dir)
+  return sites
+}
+
+/**
+ * Get directory mtime safely (returns 0 if dir does not exist).
+ */
+function getDirMtime(dir: string): number {
+  try {
+    return statSync(dir).mtimeMs
+  } catch {
+    return 0
+  }
+}
+
+/**
+ * Get all available site adapters (local overrides community by name).
+ * Uses mtime-based caching to avoid rescanning on every call.
+ */
+export function getAllSites(): SiteMeta[] {
+  const localMtime = getDirMtime(LOCAL_SITES_DIR)
+  const communityMtime = getDirMtime(COMMUNITY_SITES_DIR)
+
+  if (cachedSites && localMtime === cachedLocalMtime && communityMtime === cachedCommunityMtime) {
+    return cachedSites
+  }
+
+  const community = scanSites(COMMUNITY_SITES_DIR, 'community')
+  const local = scanSites(LOCAL_SITES_DIR, 'local')
+
+  const byName = new Map<string, SiteMeta>()
+  for (const s of community) byName.set(s.name, s)
+  for (const s of local) byName.set(s.name, s) // local overrides community
+
+  const result = Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name))
+
+  cachedSites = result
+  cachedLocalMtime = localMtime
+  cachedCommunityMtime = communityMtime
+
+  return result
+}
+
+/**
+ * Find an adapter by exact name.
+ */
+export function findSite(name: string): SiteMeta | undefined {
+  return getAllSites().find((s) => s.name === name)
+}
+
+/**
+ * Search adapters by fuzzy match on name, description, and domain.
+ */
+export function searchSites(query: string): SiteMeta[] {
+  const q = query.toLowerCase()
+  return getAllSites().filter(
+    (s) =>
+      s.name.toLowerCase().includes(q) || s.description.toLowerCase().includes(q) || s.domain.toLowerCase().includes(q)
+  )
+}
+
+/**
+ * Invalidate the mtime cache so the next getAllSites() rescans.
+ */
+export function invalidateCache(): void {
+  cachedSites = null
+  cachedLocalMtime = 0
+  cachedCommunityMtime = 0
+}
+
+// ── Auto-update ──────────────────────────────────────────────────
+
+/**
+ * Promisified execFile helper.
+ */
+function execFileAsync(cmd: string, args: string[], options: { cwd?: string } = {}): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(cmd, args, { ...options, timeout: 60_000 }, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(`${cmd} ${args.join(' ')} failed: ${stderr || error.message}`))
+      } else {
+        resolve(stdout)
+      }
+    })
+  })
+}
+
+/**
+ * Ensure the community sites directory is available.
+ * Clones the repo if it does not exist.
+ */
+export async function ensureSitesAvailable(): Promise<string> {
+  if (existsSync(join(COMMUNITY_SITES_DIR, '.git'))) {
+    return 'Community adapters already available.'
+  }
+
+  logger.info('Cloning community site adapters...', { repo: COMMUNITY_REPO })
+  mkdirSync(BB_DIR, { recursive: true })
+
+  try {
+    await execFileAsync('git', ['clone', COMMUNITY_REPO, COMMUNITY_SITES_DIR])
+    invalidateCache()
+    const sites = scanSites(COMMUNITY_SITES_DIR, 'community')
+    logger.info('Community adapters cloned', { count: sites.length })
+    return `Cloned ${sites.length} community adapters.`
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error)
+    logger.error('Failed to clone community adapters', { error: msg })
+    return `Failed to clone community adapters: ${msg}. You can manually clone: git clone ${COMMUNITY_REPO} ~/.bb-browser/bb-sites`
+  }
+}
+
+/**
+ * Background update: async pull if last update was >24h ago.
+ * Non-blocking — spawns detached git process.
+ */
+export function backgroundUpdate(): void {
+  const gitDir = join(COMMUNITY_SITES_DIR, '.git')
+  if (!existsSync(gitDir)) return
+
+  // Check last update timestamp
+  let lastUpdate = 0
+  try {
+    const content = readFileSync(LAST_UPDATE_FILE, 'utf-8').trim()
+    lastUpdate = Number(content)
+  } catch {
+    // File doesn't exist or can't be read — treat as never updated
+  }
+
+  if (Date.now() - lastUpdate < UPDATE_INTERVAL_MS) return
+
+  logger.info('Starting background update of community adapters')
+
+  try {
+    // Write timestamp first to avoid repeated triggers
+    writeFileSync(LAST_UPDATE_FILE, String(Date.now()))
+  } catch {
+    // Non-critical
+  }
+
+  try {
+    const child = spawn('git', ['pull', '--ff-only'], {
+      cwd: COMMUNITY_SITES_DIR,
+      stdio: 'ignore',
+      detached: true
+    })
+    child.unref()
+    // Invalidate cache so next getAllSites() picks up changes
+    invalidateCache()
+  } catch (error) {
+    logger.warn('Background update spawn failed', {
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+}

--- a/src/main/mcpServers/browser/sites/runner.ts
+++ b/src/main/mcpServers/browser/sites/runner.ts
@@ -4,7 +4,8 @@ import type { CdpBrowserController } from '../controller'
 import type { SiteMeta } from '../types'
 import { logger } from '../types'
 
-const AUTH_ERROR_RE = /401|403|unauthorized|forbidden|not.?logged|login.?required|sign.?in|auth/i
+const AUTH_ERROR_RE =
+  /401|403|unauthorized|forbidden|not.?logged|login.?required|sign.?in|auth.?(?:failed|expired|required|error|token)/i
 
 type RunResult = {
   success: boolean

--- a/src/main/mcpServers/browser/sites/runner.ts
+++ b/src/main/mcpServers/browser/sites/runner.ts
@@ -1,0 +1,141 @@
+import { readFileSync } from 'node:fs'
+
+import type { CdpBrowserController } from '../controller'
+import type { SiteMeta } from '../types'
+import { logger } from '../types'
+
+const AUTH_ERROR_RE = /401|403|unauthorized|forbidden|not.?logged|login.?required|sign.?in|auth/i
+
+type RunResult = {
+  success: boolean
+  data?: unknown
+  error?: string
+  hint?: string
+}
+
+/**
+ * Check whether a tab URL's hostname matches the adapter domain.
+ * `x.com` matches `https://x.com/home`; `api.twitter.com` matches domain `twitter.com`.
+ */
+export function domainMatches(tabUrl: string, domain: string): boolean {
+  try {
+    const hostname = new URL(tabUrl).hostname
+    return hostname === domain || hostname.endsWith('.' + domain)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Run a site adapter in the browser via the CDP controller.
+ *
+ * Steps:
+ * 1. Validate required args
+ * 2. Read adapter JS file and strip @meta block
+ * 3. Resolve domain tab (reuse existing or open new)
+ * 4. Build IIFE and execute via controller
+ * 5. Parse result and detect auth errors
+ */
+export async function runSiteAdapter(
+  controller: CdpBrowserController,
+  site: SiteMeta,
+  args: Record<string, string>,
+  options?: { timeout?: number; privateMode?: boolean; showWindow?: boolean }
+): Promise<RunResult> {
+  const timeout = options?.timeout ?? 30_000
+  const privateMode = options?.privateMode ?? false
+  const showWindow = options?.showWindow ?? false
+
+  // 1. Validate required args
+  const missing: string[] = []
+  for (const [name, def] of Object.entries(site.args)) {
+    if (def.required && !(name in args)) {
+      missing.push(name)
+    }
+  }
+  if (missing.length > 0) {
+    const usage = Object.entries(site.args)
+      .map(([name, def]) => `  ${name}${def.required ? ' (required)' : ''}: ${def.description || 'no description'}`)
+      .join('\n')
+    return {
+      success: false,
+      error: `Missing required args: ${missing.join(', ')}`,
+      hint: `Usage for ${site.name}:\n${usage}${site.example ? `\nExample: ${site.example}` : ''}`
+    }
+  }
+
+  // 2. Read adapter file and strip @meta block
+  let content: string
+  try {
+    content = readFileSync(site.filePath, 'utf-8')
+  } catch (error) {
+    logger.error('Failed to read adapter file', { filePath: site.filePath, error })
+    return { success: false, error: `Failed to read adapter file: ${site.filePath}` }
+  }
+
+  const jsBody = content.replace(/\/\*\s*@meta[\s\S]*?\*\//, '').trim()
+
+  // 3. Domain tab resolution
+  let tabId: string | undefined
+
+  if (site.domain) {
+    const tabs = await controller.listTabs(privateMode)
+    const existing = tabs.find((t) => domainMatches(t.url, site.domain))
+
+    if (existing) {
+      tabId = existing.tabId
+      logger.info('Reusing existing tab for domain', { domain: site.domain, tabId })
+    } else {
+      const opened = await controller.open(`https://${site.domain}`, timeout, privateMode, true, showWindow)
+      tabId = opened.tabId
+      logger.info('Opened new tab for domain', { domain: site.domain, tabId })
+    }
+  } else {
+    // No domain — check if there is an active tab
+    const tabs = await controller.listTabs(privateMode)
+    if (tabs.length === 0) {
+      return {
+        success: false,
+        error: 'No page open. Use an adapter with a domain or open a page first.'
+      }
+    }
+    // Use active tab (don't pass tabId — controller.execute uses active tab)
+  }
+
+  // 4. Build IIFE and execute
+  const script = `(${jsBody})(${JSON.stringify(args)})`
+
+  let rawResult: unknown
+  try {
+    rawResult = await controller.execute(script, timeout, privateMode, tabId)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    logger.error('Adapter execution failed', { name: site.name, error: message })
+    return { success: false, error: message }
+  }
+
+  // 5. Parse result
+  let data: unknown = rawResult
+  if (typeof rawResult === 'string') {
+    try {
+      data = JSON.parse(rawResult)
+    } catch {
+      // Not JSON — pass through as string
+    }
+  }
+
+  // 6. Error detection
+  if (data && typeof data === 'object' && 'error' in data) {
+    const errorObj = data as { error: string; hint?: string }
+    const errorMsg = String(errorObj.error)
+
+    let hint = errorObj.hint
+    if (AUTH_ERROR_RE.test(errorMsg)) {
+      hint = `Please log in to https://${site.domain || 'the site'} in the browser first.${hint ? ' ' + hint : ''}`
+    }
+
+    return { success: false, error: errorMsg, hint }
+  }
+
+  return { success: true, data }
+}

--- a/src/main/mcpServers/browser/tools/index.ts
+++ b/src/main/mcpServers/browser/tools/index.ts
@@ -1,13 +1,15 @@
 export { ExecuteSchema, executeToolDefinition, handleExecute } from './execute'
 export { handleOpen, OpenSchema, openToolDefinition } from './open'
 export { handleReset, resetToolDefinition } from './reset'
+export { handleSite, SiteSchema, siteToolDefinition } from './site'
 
 import type { CdpBrowserController } from '../controller'
 import { executeToolDefinition, handleExecute } from './execute'
 import { handleOpen, openToolDefinition } from './open'
 import { handleReset, resetToolDefinition } from './reset'
+import { handleSite, siteToolDefinition } from './site'
 
-export const toolDefinitions = [openToolDefinition, executeToolDefinition, resetToolDefinition]
+export const toolDefinitions = [openToolDefinition, executeToolDefinition, resetToolDefinition, siteToolDefinition]
 
 export const toolHandlers: Record<
   string,
@@ -18,5 +20,6 @@ export const toolHandlers: Record<
 > = {
   open: handleOpen,
   execute: handleExecute,
-  reset: handleReset
+  reset: handleReset,
+  site: handleSite
 }

--- a/src/main/mcpServers/browser/tools/site.ts
+++ b/src/main/mcpServers/browser/tools/site.ts
@@ -1,0 +1,156 @@
+import * as z from 'zod'
+
+import type { CdpBrowserController } from '../controller'
+import { backgroundUpdate, ensureSitesAvailable, findSite, getAllSites, searchSites } from '../sites/registry'
+import { runSiteAdapter } from '../sites/runner'
+import type { SiteMeta } from '../types'
+import { logger } from '../types'
+import { errorResponse, successResponse } from './utils'
+
+export const SiteSchema = z.object({
+  action: z.enum(['list', 'search', 'run', 'info']).describe('Action to perform'),
+  name: z.string().optional().describe('Adapter name (e.g. "twitter/search"). Required for run and info.'),
+  args: z.record(z.string(), z.string()).optional().describe('Arguments for the adapter (for action=run)'),
+  query: z.string().optional().describe('Search query (for action=search)'),
+  timeout: z.number().optional().describe('Execution timeout in ms (default: 30000)'),
+  privateMode: z.boolean().optional().describe('Use private browsing mode (default: false)'),
+  showWindow: z.boolean().optional().describe('Show browser window (default: false)')
+})
+
+export const siteToolDefinition = {
+  name: 'site',
+  description:
+    "Run pre-built site adapters to extract structured data from websites (Twitter, GitHub, Reddit, Bilibili, etc.). Use action='list' to discover available adapters. The browser has persistent sessions for authenticated access.\n\nActions:\n- list: Show all available adapters grouped by platform\n- search: Find adapters by keyword (requires 'query')\n- info: Show adapter details and args (requires 'name')\n- run: Execute an adapter (requires 'name', optional 'args')",
+  inputSchema: {
+    type: 'object',
+    properties: {
+      action: {
+        type: 'string',
+        enum: ['list', 'search', 'run', 'info'],
+        description: 'Action to perform'
+      },
+      name: {
+        type: 'string',
+        description: 'Adapter name (e.g. "twitter/search"). Required for run and info.'
+      },
+      args: {
+        type: 'object',
+        additionalProperties: { type: 'string' },
+        description: 'Arguments for the adapter (for action=run)'
+      },
+      query: {
+        type: 'string',
+        description: 'Search query (for action=search)'
+      },
+      timeout: {
+        type: 'number',
+        description: 'Execution timeout in ms (default: 30000)'
+      },
+      privateMode: {
+        type: 'boolean',
+        description: 'Use private browsing mode (default: false)'
+      },
+      showWindow: {
+        type: 'boolean',
+        description: 'Show browser window (default: false)'
+      }
+    },
+    required: ['action']
+  }
+}
+
+function groupByPlatform(
+  sites: SiteMeta[]
+): Record<string, { name: string; description: string; domain: string; args: Record<string, unknown> }[]> {
+  const platforms: Record<
+    string,
+    { name: string; description: string; domain: string; args: Record<string, unknown> }[]
+  > = {}
+  for (const site of sites) {
+    const platform = site.name.split('/')[0] || 'other'
+    if (!platforms[platform]) platforms[platform] = []
+    platforms[platform].push({
+      name: site.name,
+      description: site.description,
+      domain: site.domain,
+      args: site.args
+    })
+  }
+  return platforms
+}
+
+export async function handleSite(controller: CdpBrowserController, args: unknown) {
+  try {
+    const parsed = SiteSchema.parse(args)
+
+    // Trigger background update on every call (non-blocking)
+    backgroundUpdate()
+
+    switch (parsed.action) {
+      case 'list': {
+        await ensureSitesAvailable()
+        const sites = getAllSites()
+        const platforms = groupByPlatform(sites)
+        return successResponse(JSON.stringify({ platforms, total: sites.length }))
+      }
+
+      case 'search': {
+        if (!parsed.query) {
+          return errorResponse('Missing required parameter: query')
+        }
+        const matches = searchSites(parsed.query)
+        return successResponse(
+          JSON.stringify(
+            matches.map((s) => ({
+              name: s.name,
+              description: s.description,
+              domain: s.domain,
+              args: s.args
+            }))
+          )
+        )
+      }
+
+      case 'info': {
+        if (!parsed.name) {
+          return errorResponse('Missing required parameter: name')
+        }
+        const site = findSite(parsed.name)
+        if (!site) {
+          return errorResponse(`Adapter not found: ${parsed.name}`)
+        }
+        return successResponse(
+          JSON.stringify({
+            name: site.name,
+            description: site.description,
+            domain: site.domain,
+            args: site.args,
+            capabilities: site.capabilities,
+            readOnly: site.readOnly,
+            example: site.example,
+            source: site.source
+          })
+        )
+      }
+
+      case 'run': {
+        if (!parsed.name) {
+          return errorResponse('Missing required parameter: name')
+        }
+        const site = findSite(parsed.name)
+        if (!site) {
+          return errorResponse(`Adapter not found: ${parsed.name}`)
+        }
+        const result = await runSiteAdapter(controller, site, parsed.args ?? {}, {
+          timeout: parsed.timeout,
+          privateMode: parsed.privateMode,
+          showWindow: parsed.showWindow
+        })
+        return successResponse(JSON.stringify(result))
+      }
+    }
+  } catch (error) {
+    logger.error('Site tool failed', { error })
+    return errorResponse(error instanceof Error ? error : String(error))
+  }
+}

--- a/src/main/mcpServers/browser/types.ts
+++ b/src/main/mcpServers/browser/types.ts
@@ -22,3 +22,22 @@ export interface WindowInfo {
   lastActive: number
   tabBarView?: BrowserView
 }
+
+/** Adapter argument definition */
+export type ArgDef = {
+  required?: boolean
+  description?: string
+}
+
+/** Adapter metadata parsed from .js files */
+export type SiteMeta = {
+  name: string
+  description: string
+  domain: string
+  args: Record<string, ArgDef>
+  capabilities?: string[]
+  readOnly?: boolean
+  example?: string
+  filePath: string
+  source: 'local' | 'community'
+}


### PR DESCRIPTION
### What this PR does

Before this PR:

The `@cherry/browser` MCP server only had three generic tools (`open`, `execute`, `reset`) — AI agents had to manually navigate to sites, figure out DOM structure or API endpoints, and write custom JS for every data extraction task.

After this PR:

Adds a `site` MCP tool that reuses the [bb-sites](https://github.com/epiral/bb-sites) adapter ecosystem — 104 pre-built JavaScript adapters across 36 platforms (Twitter, GitHub, Reddit, Bilibili, Hacker News, YouTube, etc.). AI agents can now:
- `site(action='list')` — discover available adapters grouped by platform
- `site(action='search', query='twitter')` — find adapters by keyword
- `site(action='info', name='twitter/search')` — get adapter metadata and args
- `site(action='run', name='hackernews/top', args={count:'10'})` — execute and get structured JSON

Key features:
- **Domain-aware tab reuse** — automatically finds/opens tabs matching the adapter's target domain
- **Auto-clone** — clones the community adapter repo on first use if not present
- **Background auto-update** — pulls latest adapters every 24h (non-blocking detached process)
- **Auth error detection** — detects 401/403/login-required patterns and provides login hints
- **Persistent sessions** — leverages Electron's `persist:default` partition for logged-in access

### Why we need it and why it was done in this way

The bb-sites adapter pattern (`/* @meta { ... } */` + bare JS function) is already proven with 104 adapters. Reusing it gives Cherry Studio instant access to structured data extraction for dozens of platforms without writing custom code.

The following tradeoffs were made:
- Single `site` tool with `action` parameter instead of 104 individual MCP tools — keeps the tool list manageable
- Adapters are not bundled — they live in `~/.bb-browser/bb-sites/` (community) and `~/.bb-browser/sites/` (local), updating independently via git
- `showWindow` defaults to `false` for site tool (unlike `open` which defaults to `true`) since adapter execution is programmatic, not interactive

The following alternatives were considered:
- Running bb-browser as a separate MCP server — rejected because it requires the user to install bb-browser + Chrome extension separately, and can't leverage Cherry Studio's persistent Electron sessions
- Bundling adapter JS in the app — rejected because adapters update frequently in the community repo

### Breaking changes

None. This is purely additive — new `site` tool alongside existing `open`/`execute`/`reset` tools. No existing APIs or behavior changed.

### Special notes for your reviewer

- **No changes to `controller.ts`** — all execution flows through existing `open()`, `execute()`, `listTabs()` methods
- The adapter execution path: read `.js` file → strip `@meta` block → wrap as IIFE `(${jsBody})(${argsJson})` → CDP `Runtime.evaluate` with `awaitPromise: true` — identical to how bb-browser runs adapters
- All git operations (clone/pull) use async `execFile`/`spawn`, never `execSync`, to avoid blocking Electron's main process
- 80 new tests across 3 test files (registry: 24, runner: 36, tool integration: 20)

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Added `site` tool to the built-in browser MCP server, enabling AI agents to run pre-built site adapters for structured data extraction from 36+ platforms (Twitter, GitHub, Reddit, Bilibili, etc.). Supports adapter discovery, search, and execution with domain-aware tab reuse, auto-update, and auth error detection.
```
