### PR TITLE
fix: prevent horizontal scroll in agent chat messages container

### DIFF
--- a/src/renderer/src/pages/agents/AgentChat.tsx
+++ b/src/renderer/src/pages/agents/AgentChat.tsx
@@ -93,7 +93,7 @@ const AgentChat = () => {
           </div>
 
           {/* Messages */}
-          <div className="translate-z-0 relative flex w-full flex-1 flex-col justify-between overflow-y-auto">
+          <div className="translate-z-0 relative flex w-full flex-1 flex-col justify-between overflow-y-auto overflow-x-hidden">
             <AgentSessionMessages agentId={activeAgentId} sessionId={activeSessionId} />
             <div className="mt-auto px-4.5 pb-2">
               <NarrowLayout>


### PR DESCRIPTION
### What this PR does

Before this PR:
The `ChatNavigation` component at `AgentChat.tsx:103` causes an unwanted horizontal scrollbar to appear in the agent chat messages container.

After this PR:
Added `overflow-x-hidden` to the messages container to prevent the horizontal scrollbar caused by `ChatNavigation`.

### Why we need it and why it was done in this way

The messages container already had `overflow-y-auto` for vertical scrolling, but lacked `overflow-x-hidden` to suppress the horizontal scrollbar introduced by the `ChatNavigation` component. Adding this single utility class is the minimal fix.

The following tradeoffs were made:
N/A

The following alternatives were considered:
N/A

### Breaking changes

None

### Special notes for your reviewer

One-line CSS change — adds `overflow-x-hidden` to the agent chat messages container div.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
