### PR TITLE
fix(ci): only trigger release build on PR merge, not on every push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v'))
+      (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.event.pull_request.head.ref, 'release/v'))
     runs-on: ${{ matrix.os }}
 
     strategy:


### PR DESCRIPTION
### What this PR does

Before this PR:
The `release.yml` workflow triggers on `pull_request_target` with `opened` and `synchronize` event types. Every commit pushed to a release PR (e.g. editing release notes in `electron-builder.yml`) re-triggers the full 3-platform release build (macOS + Windows + Linux), wasting significant CI resources.

After this PR:
The workflow only triggers when the release PR is **merged** into `main`, not on every push. This is achieved by:
1. Changing `pull_request_target` types from `opened`/`synchronize` to `closed`
2. Adding `github.event.pull_request.merged == true` to the job condition

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Release builds no longer run during PR review phase. If a pre-merge test build is needed, `workflow_dispatch` can be used manually.

The following alternatives were considered:
- **Remove `synchronize` only (keep `opened`)**: Would still trigger on PR creation but not subsequent pushes. However, this loses automation on merge.
- **Path filtering**: `pull_request_target` doesn't support `paths` filter, would require a separate job to check changed files — more complex for the same result.
- **Label-based triggering**: Adds manual steps, defeats automation purpose.

### Breaking changes

None. The `tag push` and `workflow_dispatch` triggers remain unchanged. The only behavioral change is that release builds now happen on merge instead of on PR open/push.

### Special notes for your reviewer

- The `workflow_dispatch` trigger still allows manual release builds at any time
- The `push: tags: v*.*.*` trigger is unaffected
- The removed `head.repo.full_name == github.repository` check is redundant since `merged == true` already implies the PR was accepted

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
