### PR TITLE
fix: keep navbar settings visible in top mode

### DIFF
--- a/src/renderer/src/components/Tab/TabContainer.tsx
+++ b/src/renderer/src/components/Tab/TabContainer.tsx
@@ -46,6 +46,7 @@ import MinAppIcon from '../Icons/MinAppIcon'
 import { OpenClawIcon } from '../Icons/SVGIcon'
 import MinAppTabsPool from '../MinApp/MinAppTabsPool'
 import WindowControls from '../WindowControls'
+import { isNavbarTabVisible } from './navigationVisibility'
 
 interface TabsContainerProps {
   children: React.ReactNode
@@ -131,7 +132,7 @@ const TabsContainer: React.FC<TabsContainerProps> = ({ children }) => {
   const { settedTheme, toggleTheme } = useTheme()
   const { hideMinappPopup, minAppsCache } = useMinappPopup()
   const { minapps } = useMinapps()
-  const { useSystemTitleBar } = useSettings()
+  const { useSystemTitleBar, sidebarIcons } = useSettings()
   const { t } = useTranslation()
 
   const getTabId = (path: string): string => {
@@ -172,7 +173,11 @@ const TabsContainer: React.FC<TabsContainerProps> = ({ children }) => {
   const shouldCreateTab = (path: string) => {
     if (path === '/') return false
     if (path === '/settings') return false
-    return !tabs.some((tab) => tab.id === getTabId(path))
+    const tabId = getTabId(path)
+    if (!isNavbarTabVisible(tabId, sidebarIcons.visible)) {
+      return false
+    }
+    return !tabs.some((tab) => tab.id === tabId)
   }
 
   const removeSpecialTabs = useCallback(() => {
@@ -223,7 +228,10 @@ const TabsContainer: React.FC<TabsContainerProps> = ({ children }) => {
     navigate(tab.path)
   }
 
-  const visibleTabs = useMemo(() => tabs.filter((tab) => !specialTabs.includes(tab.id)), [tabs])
+  const visibleTabs = useMemo(
+    () => tabs.filter((tab) => !specialTabs.includes(tab.id) && isNavbarTabVisible(tab.id, sidebarIcons.visible)),
+    [sidebarIcons.visible, tabs]
+  )
 
   const { onSortEnd } = useDndReorder<Tab>({
     originalList: tabs,

--- a/src/renderer/src/components/Tab/__tests__/navigationVisibility.test.ts
+++ b/src/renderer/src/components/Tab/__tests__/navigationVisibility.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { isNavbarTabVisible } from '../navigationVisibility'
+
+describe('isNavbarTabVisible', () => {
+  it('keeps the home tab visible when assistants are enabled', () => {
+    expect(isNavbarTabVisible('home', ['assistants', 'agents'])).toBe(true)
+  })
+
+  it('hides the agents tab when agents is removed from visible sidebar icons', () => {
+    expect(isNavbarTabVisible('agents', ['assistants', 'store'])).toBe(false)
+  })
+
+  it('does not hide tabs that are not controlled by sidebar icon settings', () => {
+    expect(isNavbarTabVisible('settings', ['assistants'])).toBe(true)
+    expect(isNavbarTabVisible('apps:custom-minapp', ['assistants'])).toBe(true)
+  })
+})

--- a/src/renderer/src/components/Tab/navigationVisibility.ts
+++ b/src/renderer/src/components/Tab/navigationVisibility.ts
@@ -1,0 +1,24 @@
+import type { SidebarIcon } from '@renderer/types'
+
+const TAB_TO_SIDEBAR_ICON: Partial<Record<string, SidebarIcon>> = {
+  home: 'assistants',
+  agents: 'agents',
+  store: 'store',
+  paintings: 'paintings',
+  translate: 'translate',
+  apps: 'minapp',
+  knowledge: 'knowledge',
+  files: 'files',
+  notes: 'notes',
+  code: 'code_tools',
+  openclaw: 'openclaw'
+}
+
+export const isNavbarTabVisible = (tabId: string, visibleIcons: SidebarIcon[]): boolean => {
+  const sidebarIcon = TAB_TO_SIDEBAR_ICON[tabId]
+  if (!sidebarIcon) {
+    return true
+  }
+
+  return visibleIcons.includes(sidebarIcon)
+}

--- a/src/renderer/src/pages/settings/DisplaySettings/DisplaySettings.tsx
+++ b/src/renderer/src/pages/settings/DisplaySettings/DisplaySettings.tsx
@@ -451,24 +451,22 @@ const DisplaySettings: FC = () => {
           />
         </SettingRow>
       </SettingGroup>
-      {navbarPosition === 'left' && (
-        <SettingGroup theme={theme}>
-          <SettingTitle
-            style={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
-            <span>{t('settings.display.sidebar.title')}</span>
-            <ResetButtonWrapper>
-              <Button onClick={handleReset}>{t('common.reset')}</Button>
-            </ResetButtonWrapper>
-          </SettingTitle>
-          <SettingDivider />
-          <SidebarIconsManager
-            visibleIcons={visibleIcons}
-            disabledIcons={disabledIcons}
-            setVisibleIcons={setVisibleIcons}
-            setDisabledIcons={setDisabledIcons}
-          />
-        </SettingGroup>
-      )}
+      <SettingGroup theme={theme}>
+        <SettingTitle
+          style={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span>{t('settings.display.sidebar.title')}</span>
+          <ResetButtonWrapper>
+            <Button onClick={handleReset}>{t('common.reset')}</Button>
+          </ResetButtonWrapper>
+        </SettingTitle>
+        <SettingDivider />
+        <SidebarIconsManager
+          visibleIcons={visibleIcons}
+          disabledIcons={disabledIcons}
+          setVisibleIcons={setVisibleIcons}
+          setDisabledIcons={setDisabledIcons}
+        />
+      </SettingGroup>
       <SettingGroup theme={theme}>
         <SettingTitle>
           {t('settings.display.custom.css.label')}

--- a/src/renderer/src/pages/settings/DisplaySettings/__tests__/DisplaySettings.test.tsx
+++ b/src/renderer/src/pages/settings/DisplaySettings/__tests__/DisplaySettings.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  navbarPosition: 'top' as 'left' | 'top',
+  dispatch: vi.fn(),
+  setTimeoutTimer: vi.fn(),
+  setUserTheme: vi.fn(),
+  setWindowStyle: vi.fn(),
+  setTopicPosition: vi.fn(),
+  setTheme: vi.fn(),
+  setUseSystemTitleBar: vi.fn(),
+  t: vi.fn((key: string) => key)
+}))
+
+vi.mock('@renderer/components/CodeEditor', () => ({
+  default: () => <div data-testid="code-editor" />
+}))
+
+vi.mock('@renderer/components/Icons', () => ({
+  ResetIcon: () => <span data-testid="reset-icon" />
+}))
+
+vi.mock('@renderer/components/Layout', () => ({
+  HStack: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+}))
+
+vi.mock('@renderer/components/TextBadge', () => ({
+  default: ({ text }: { text: string }) => <span>{text}</span>
+}))
+
+vi.mock('@renderer/config/constant', () => ({
+  isLinux: false,
+  isMac: false,
+  THEME_COLOR_PRESETS: ['#1677ff']
+}))
+
+vi.mock('@renderer/config/sidebar', () => ({
+  DEFAULT_SIDEBAR_ICONS: ['assistants', 'agents', 'store']
+}))
+
+vi.mock('@renderer/context/ThemeProvider', () => ({
+  useTheme: () => ({ theme: 'light', settedTheme: 'light' })
+}))
+
+vi.mock('@renderer/hooks/useSettings', () => ({
+  useNavbarPosition: () => ({
+    navbarPosition: mocks.navbarPosition,
+    setNavbarPosition: vi.fn()
+  }),
+  useSettings: () => ({
+    windowStyle: 'opaque',
+    setWindowStyle: mocks.setWindowStyle,
+    topicPosition: 'right',
+    setTopicPosition: mocks.setTopicPosition,
+    clickAssistantToShowTopic: false,
+    showTopicTime: true,
+    pinTopicsToTop: false,
+    customCss: '',
+    sidebarIcons: {
+      visible: ['assistants', 'agents', 'store'],
+      disabled: []
+    },
+    setTheme: mocks.setTheme,
+    assistantIconType: 'model',
+    userTheme: {
+      colorPrimary: '#1677ff',
+      userFontFamily: '',
+      userCodeFontFamily: ''
+    },
+    useSystemTitleBar: false,
+    setUseSystemTitleBar: mocks.setUseSystemTitleBar
+  })
+}))
+
+vi.mock('@renderer/hooks/useTimer', () => ({
+  useTimer: () => ({ setTimeoutTimer: mocks.setTimeoutTimer })
+}))
+
+vi.mock('@renderer/hooks/useUserTheme', () => ({
+  default: () => ({ setUserTheme: mocks.setUserTheme })
+}))
+
+vi.mock('@renderer/store', () => ({
+  useAppDispatch: () => mocks.dispatch
+}))
+
+vi.mock('@renderer/store/settings', () => ({
+  setAssistantIconType: (payload: unknown) => ({ type: 'setAssistantIconType', payload }),
+  setClickAssistantToShowTopic: (payload: unknown) => ({ type: 'setClickAssistantToShowTopic', payload }),
+  setCustomCss: (payload: unknown) => ({ type: 'setCustomCss', payload }),
+  setPinTopicsToTop: (payload: unknown) => ({ type: 'setPinTopicsToTop', payload }),
+  setShowTopicTime: (payload: unknown) => ({ type: 'setShowTopicTime', payload }),
+  setSidebarIcons: (payload: unknown) => ({ type: 'setSidebarIcons', payload })
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: mocks.t })
+}))
+
+vi.mock('antd', () => ({
+  Button: ({ children, onClick }: any) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  ColorPicker: () => <div data-testid="color-picker" />,
+  Divider: () => <div data-testid="divider" />,
+  Segmented: () => <div data-testid="segmented" />,
+  Select: () => <div data-testid="select" />,
+  Switch: () => <input type="checkbox" readOnly />,
+  Tooltip: ({ children }: any) => <>{children}</>
+}))
+
+vi.mock('antd/es/typography/Link', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <a>{children}</a>
+}))
+
+vi.mock('../SidebarIconsManager', () => ({
+  default: () => <div data-testid="sidebar-icons-manager" />
+}))
+
+import DisplaySettings from '../DisplaySettings'
+
+describe('DisplaySettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.defineProperty(window, 'api', {
+      value: {
+        getSystemFonts: vi.fn().mockResolvedValue([]),
+        handleZoomFactor: vi.fn().mockResolvedValue(1),
+        relaunchApp: vi.fn()
+      },
+      configurable: true
+    })
+  })
+
+  it('shows the sidebar icon manager even when navbar position is top', async () => {
+    mocks.navbarPosition = 'top'
+
+    render(<DisplaySettings />)
+
+    expect(await screen.findByTestId('sidebar-icons-manager')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

⚠️ Important: Redux/IndexedDB Data-Changing Feature PRs Temporarily On Hold ⚠️

Please note: For our current development cycle, we are not accepting feature Pull Requests that introduce changes to Redux data models or IndexedDB schemas.

While we value your contributions, PRs of this nature will be blocked without merge. We welcome all other contributions (bug fixes, perf enhancements, docs, etc.). Thank you!

Once version 2.0.0 is released, we will resume reviewing feature PRs.

-->

### What this PR does

Before this PR:

- When `Navigation Bar Position` was set to `Top`, the sidebar icon settings section disappeared from `Display Settings`.
- In top navbar mode, the visible navigation entries were not fully synchronized with `sidebarIcons.visible`.
- Hiding items such as `Agents` in sidebar settings could still leave the corresponding entry visible in the top navigation.

After this PR:

- The sidebar icon settings section remains available in `Display Settings` for both `Left` and `Top` navbar modes.
- Top navbar tab visibility now follows the same `sidebarIcons.visible` configuration used by the left sidebar.
- Hidden navigation items no longer remain visible in top navbar mode.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #13549

### Why we need it and why it was done in this way

This bug came from two inconsistent UI paths:

1. The settings UI incorrectly tied the sidebar icon manager to `navbarPosition === 'left'`, so switching to top mode removed the configuration entry entirely.
2. The left sidebar respected `sidebarIcons.visible`, but the top navbar tab flow used a separate rendering path and did not consistently apply the same visibility rules.

This was fixed by:

- removing the `left`-only condition around the sidebar icon settings section in `DisplaySettings`
- centralizing top-navbar visibility checks in a small helper used by `TabContainer`
- adding regression tests for both the settings visibility and the top-navbar visibility mapping

The following tradeoffs were made:

- Top navbar visibility is now explicitly mapped to sidebar icon configuration, which adds a small helper layer but keeps the behavior consistent across both navbar layouts.
- The change is scoped to the current navigation implementation rather than attempting a broader refactor during the v2 transition period.

The following alternatives were considered:

- Fixing only the missing settings panel. This was rejected because it would leave top navbar visibility inconsistent with the saved sidebar configuration.
- Duplicating ad hoc visibility checks directly inside the top navbar/tab components. This was rejected in favor of a centralized helper to avoid drift.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/13549

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

- This is a bug fix only. No Redux data model or IndexedDB schema changes were made.
- Local validation completed with `pnpm format`, `pnpm test`, and `pnpm lint`.
- Added focused regression tests for:
  - `DisplaySettings` rendering in top navbar mode
  - top navbar visibility behavior derived from `sidebarIcons.visible`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed an issue where setting the navigation bar position to Top could hide sidebar icon settings and leave hidden navigation items visible in the top navbar.
```
