### PR TITLE
fix: quote windows launch scripts for claude code

### DIFF
--- a/packages/shared/__tests__/constant.test.ts
+++ b/packages/shared/__tests__/constant.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { terminalApps, WINDOWS_TERMINALS_WITH_COMMANDS } from '../config/constant'
+
+describe('WINDOWS_TERMINALS_WITH_COMMANDS', () => {
+  const batPath = 'C:\\Users\\Test User\\AppData\\Local\\Temp\\cherrystudio\\launch_claude-code_1.bat'
+
+  it('quotes the command prompt launch script path', () => {
+    const config = WINDOWS_TERMINALS_WITH_COMMANDS.find((item) => item.id === terminalApps.cmd)
+    expect(config?.command('', batPath)).toEqual({
+      command: 'cmd',
+      args: ['/c', `"${batPath}"`]
+    })
+  })
+
+  it('quotes the windows terminal launch script path', () => {
+    const config = WINDOWS_TERMINALS_WITH_COMMANDS.find((item) => item.id === terminalApps.windowsTerminal)
+    expect(config?.command('', batPath)).toEqual({
+      command: 'wt',
+      args: ['-p', 'Command Prompt', '--', 'cmd', '/c', `"${batPath}"`]
+    })
+  })
+
+  it('quotes the alternative terminal launch script path', () => {
+    const alacritty = WINDOWS_TERMINALS_WITH_COMMANDS.find((item) => item.id === terminalApps.alacritty)
+    const wezterm = WINDOWS_TERMINALS_WITH_COMMANDS.find((item) => item.id === terminalApps.wezterm)
+
+    expect(alacritty?.command('', batPath)).toEqual({
+      command: 'alacritty',
+      args: ['-e', 'cmd', '/c', `"${batPath}"`]
+    })
+    expect(wezterm?.command('', batPath)).toEqual({
+      command: 'wezterm',
+      args: ['start', '--', 'cmd', '/c', `"${batPath}"`]
+    })
+  })
+
+  it('quotes the wsl launch script path before delegating to cmd.exe', () => {
+    const config = WINDOWS_TERMINALS_WITH_COMMANDS.find((item) => item.id === terminalApps.wsl)
+    expect(config?.command('', batPath)).toEqual({
+      command: 'wsl',
+      args: ['bash', '-c', `cmd.exe /c "${batPath}" ; read -p 'Press Enter to exit'`]
+    })
+  })
+})

--- a/packages/shared/config/constant.ts
+++ b/packages/shared/config/constant.ts
@@ -329,13 +329,17 @@ export const WINDOWS_TERMINALS: TerminalConfig[] = [
   }
 ]
 
+const quoteWindowsCommand = (command: string): string => {
+  return `"${command.replace(/"/g, '""')}"`
+}
+
 export const WINDOWS_TERMINALS_WITH_COMMANDS: TerminalConfigWithCommand[] = [
   {
     id: terminalApps.cmd,
     name: 'Command Prompt',
     command: (_: string, fullCommand: string) => ({
       command: 'cmd',
-      args: ['/c', fullCommand]
+      args: ['/c', quoteWindowsCommand(fullCommand)]
     })
   },
   {
@@ -351,7 +355,7 @@ export const WINDOWS_TERMINALS_WITH_COMMANDS: TerminalConfigWithCommand[] = [
     name: 'Windows Terminal',
     command: (_: string, fullCommand: string) => ({
       command: 'wt',
-      args: ['-p', 'Command Prompt', '--', 'cmd', '/c', `"${fullCommand}"`]
+      args: ['-p', 'Command Prompt', '--', 'cmd', '/c', quoteWindowsCommand(fullCommand)]
     })
   },
   {
@@ -359,7 +363,7 @@ export const WINDOWS_TERMINALS_WITH_COMMANDS: TerminalConfigWithCommand[] = [
     name: 'WSL (Ubuntu/Debian)',
     command: (_: string, fullCommand: string) => ({
       command: 'wsl',
-      args: ['bash', '-c', `cmd.exe /c '${fullCommand}' ; read -p 'Press Enter to exit'`]
+      args: ['bash', '-c', `cmd.exe /c ${quoteWindowsCommand(fullCommand)} ; read -p 'Press Enter to exit'`]
     })
   },
   {
@@ -368,7 +372,7 @@ export const WINDOWS_TERMINALS_WITH_COMMANDS: TerminalConfigWithCommand[] = [
     customPath: '',
     command: (_: string, fullCommand: string) => ({
       command: 'alacritty',
-      args: ['-e', 'cmd', '/c', fullCommand]
+      args: ['-e', 'cmd', '/c', quoteWindowsCommand(fullCommand)]
     })
   },
   {
@@ -377,7 +381,7 @@ export const WINDOWS_TERMINALS_WITH_COMMANDS: TerminalConfigWithCommand[] = [
     customPath: '',
     command: (_: string, fullCommand: string) => ({
       command: 'wezterm',
-      args: ['start', '--', 'cmd', '/c', fullCommand]
+      args: ['start', '--', 'cmd', '/c', quoteWindowsCommand(fullCommand)]
     })
   }
 ]


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

⚠️ Important: Redux/IndexedDB Data-Changing Feature PRs Temporarily On Hold ⚠️

Please note: For our current development cycle, we are not accepting feature Pull Requests that introduce changes to Redux data models or IndexedDB schemas.

While we value your contributions, PRs of this nature will be blocked without merge. We welcome all other contributions (bug fixes, perf enhancements, docs, etc.). Thank you!

Once version 2.0.0 is released, we will resume reviewing feature PRs.

-->

### What this PR does

Before this PR:

- On Windows, starting Claude Code could fail with `0x80070002` / "The system cannot find the file specified".
- Cherry Studio generated a temporary `.bat` launcher under `%LOCALAPPDATA%\\Temp\\cherrystudio\\`, but several Windows terminal launch configurations passed that path to `cmd /c` without consistently quoting it.
- When the generated path contained spaces, Windows could split the path incorrectly and fail before Claude Code actually started.

After this PR:

- Windows terminal launch commands now consistently quote the generated launcher script path before passing it to `cmd /c`.
- This fix covers `Command Prompt`, `Windows Terminal`, `WSL`, `Alacritty`, and `WezTerm` launch paths.
- Added regression tests to lock the quoting behavior for these Windows terminal configurations.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #13546

### Why we need it and why it was done in this way

The failure happened before Claude Code itself was launched. The real issue was Windows command-line argument handling for the temporary `.bat` script path.

This PR fixes the problem at the shared terminal command construction layer so every Windows terminal entry uses the same quoting behavior. That keeps the change small, predictable, and easy to validate.

The following tradeoffs were made:

- A small helper was added in the shared Windows terminal configuration to centralize quoting behavior.
- The fix is intentionally limited to launch script quoting and does not change Claude Code SDK logic or temp script generation flow.

The following alternatives were considered:

- Changing only the `Command Prompt` entry. This was rejected because the same quoting issue could affect other Windows terminal launchers that also delegate to `cmd /c`.
- Reworking the temp `.bat` generation flow. This was rejected because the generated script itself was valid; the bug was in how its path was passed to terminal commands.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/13546

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

- Scope is limited to Windows terminal command argument construction.
- No Redux data model, IndexedDB schema, or Claude Code session logic changes were made.
- Validation completed with local `pnpm format`, `pnpm test`, and `pnpm lint`.
- Added focused shared-layer regression tests for Windows terminal launcher argument quoting.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
