### PR TITLE
fix: allow Ctrl+Enter to insert newline when send key is Enter

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/components/InputbarCore.tsx
+++ b/src/renderer/src/pages/home/Inputbar/components/InputbarCore.tsx
@@ -326,7 +326,8 @@ export const InputbarCore: FC<InputbarCoreProps> = ({
           return
         }
 
-        if (event.shiftKey) {
+        // Any Enter combination that is not the send shortcut should insert a newline
+        if (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey) {
           return
         }
       }


### PR DESCRIPTION
## Summary
- When send shortcut is set to Enter, Ctrl+Enter (and other modifier+Enter combos) could not insert newlines on Windows
- Only Shift+Enter was explicitly allowed to pass through for newline insertion
- Now any modifier+Enter that does not match the send shortcut will insert a newline

## Change


Closes #13555

## Test plan
- [ ] Send key = Enter: Ctrl+Enter inserts newline (previously broken)
- [ ] Send key = Enter: Shift+Enter inserts newline (no regression)
- [ ] Send key = Enter: Enter sends message (no regression)
- [ ] Send key = Ctrl+Enter: Ctrl+Enter sends message (no regression)
- [ ] Send key = Ctrl+Enter: Enter inserts newline (no regression)