### PR TITLE
chore: Add CI check scripts to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,10 @@
     "release:aicore:alpha": "pnpm --filter @cherrystudio/ai-core version prerelease --preid alpha && pnpm --filter @cherrystudio/ai-core build && pnpm --filter @cherrystudio/ai-core publish --tag alpha --access public",
     "release:aicore:beta": "pnpm --filter @cherrystudio/ai-core version prerelease --preid beta && pnpm --filter @cherrystudio/ai-core build && pnpm --filter @cherrystudio/ai-core publish --tag beta --access public",
     "release:aicore": "pnpm --filter @cherrystudio/ai-core version patch && pnpm --filter @cherrystudio/ai-core build && pnpm --filter @cherrystudio/ai-core publish --access public",
-    "release:ai-sdk-provider": "pnpm --filter @cherrystudio/ai-sdk-provider version patch && pnpm --filter @cherrystudio/ai-sdk-provider build && pnpm --filter @cherrystudio/ai-sdk-provider publish --access public"
+    "release:ai-sdk-provider": "pnpm --filter @cherrystudio/ai-sdk-provider version patch && pnpm --filter @cherrystudio/ai-sdk-provider build && pnpm --filter @cherrystudio/ai-sdk-provider publish --access public",
+    "ci:basic-check": "pnpm test:lint && pnpm format:check && pnpm typecheck && pnpm i18n:check && pnpm i18n:hardcoded:strict && pnpm openapi:check && pnpm skills:check",
+    "ci:test-check": "pnpm test:main && pnpm test:renderer && pnpm test:aicore && pnpm test:shared && pnpm test:scripts",
+    "ci": "pnpm ci:basic-check && pnpm ci:test-check"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.2.71",


### PR DESCRIPTION
### What this PR does

Before this PR:
CI checks had no single-command entry points; each check step had to be invoked individually.

After this PR:
Three convenience scripts (`ci:basic-check`, `ci:test-check`, `ci:all-check`) are available in `package.json` to run CI checks locally with a single command.

Fixes # N/A

### Why we need it and why it was done in this way

These scripts mirror the CI pipeline steps so contributors can reproduce the full CI check suite locally before pushing. Grouping them into composite scripts reduces friction and prevents forgotten steps.

The following tradeoffs were made: None

The following alternatives were considered: None

### Breaking changes

None

### Special notes for your reviewer

N/A

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: Not required — no user-facing change
- [ ] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
