### PR TITLE
fix: disable thinking mode for LLM language detection

### DIFF
--- a/src/renderer/src/utils/translate.ts
+++ b/src/renderer/src/utils/translate.ts
@@ -5,7 +5,8 @@ import { builtinLanguages, LanguagesEnum, UNKNOWN } from '@renderer/config/trans
 import db from '@renderer/databases'
 import i18n from '@renderer/i18n'
 import { fetchChatCompletion } from '@renderer/services/ApiService'
-import { getDefaultAssistant, getDefaultModel, getQuickModel } from '@renderer/services/AssistantService'
+import { getDefaultAssistant, getQuickModel } from '@renderer/services/AssistantService'
+import { hasModel } from '@renderer/services/ModelService'
 import { estimateTextTokens } from '@renderer/services/TokenService'
 import { getAllCustomLanguages } from '@renderer/services/TranslateService'
 import type { Assistant, TranslateLanguage, TranslateLanguageCode } from '@renderer/types'
@@ -68,8 +69,8 @@ const detectLanguageByLLM = async (inputText: string): Promise<TranslateLanguage
   const listLang = translateLanguageOptions.map((item) => item.langCode)
   const listLangText = JSON.stringify(listLang)
 
-  const model = getQuickModel() || getDefaultModel()
-  if (!model) {
+  const model = getQuickModel()
+  if (!model || !hasModel(model)) {
     throw new Error(i18n.t('error.model.not_exists'))
   }
 
@@ -83,7 +84,9 @@ const detectLanguageByLLM = async (inputText: string): Promise<TranslateLanguage
   const assistant: Assistant = getDefaultAssistant()
 
   assistant.model = model
-  assistant.settings = {}
+  assistant.settings = {
+    reasoning_effort: 'none'
+  }
   assistant.prompt = LANG_DETECT_PROMPT.replace('{{list_lang}}', listLangText).replace('{{input}}', text)
 
   const onChunk: (chunk: Chunk) => void = (chunk: Chunk) => {


### PR DESCRIPTION
### What this PR does

Before this PR:
Language detection via LLM used `getQuickModel() || getDefaultModel()` without validating model availability, and did not disable thinking/reasoning mode. This caused issues when most modern models default to thinking mode, making model selection difficult for language detection.

After this PR:
- Only uses the quick model (falls back to error if unavailable) and validates it exists via `hasModel()`
- Sets `reasoning_effort: 'none'` to explicitly disable thinking mode for language detection
- Removes unused `getDefaultModel` import

Fixes #13562

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Removed the `getDefaultModel()` fallback — language detection should only use the explicitly configured quick model, not silently fall back to the default model which may be slow/expensive.

The following alternatives were considered:
- Passing thinking mode parameters at the API level — rejected because `reasoning_effort: 'none'` in assistant settings is the existing pattern used elsewhere in the codebase.

### Breaking changes

None.

### Special notes for your reviewer

Small, focused fix. Only modifies `src/renderer/src/utils/translate.ts`.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix: Disable thinking/reasoning mode for LLM-based language detection to improve compatibility with modern models that default to thinking mode
```
