### PR TITLE
fix(agent): stop thinking timer on abort by emitting abort stream part

### DIFF
--- a/src/renderer/src/store/thunk/messageThunk.ts
+++ b/src/renderer/src/store/thunk/messageThunk.ts
@@ -358,7 +358,7 @@ const withAbortStreamPart = (
           return
         }
         controller.enqueue(value)
-      } catch {
+      } catch (error) {
         // When the source errors due to abort, emit the abort stream part
         // so downstream consumers (AiSdkToChunkAdapter) can fire onError.
         if (signal.aborted) {
@@ -367,8 +367,10 @@ const withAbortStreamPart = (
           } catch {
             // Controller may already be closed
           }
+          controller.close()
+        } else {
+          controller.error(error)
         }
-        controller.close()
       }
     },
     cancel(reason) {


### PR DESCRIPTION
### What this PR does

Before this PR:

After force-stopping an Agent while it is thinking, the thinking time counter continues running indefinitely because `callbacks.onError` is never called for agent streams on abort.

After this PR:

The thinking timer stops correctly when the user force-stops an Agent, because the agent SSE stream now emits an `'abort'` stream part before erroring — matching AI SDK stream behavior — so `callbacks.onError` fires and updates block statuses.

Fixes #13566

<img width="919" height="339" alt="image" src="https://github.com/user-attachments/assets/03ca5643-4900-44a0-81d5-b79047bd5772" />


### Why we need it and why it was done in this way

The root cause is in `createSSEReadableStream` (used only for agent streams). Its abort handler called `controller.error()` directly without first enqueuing an `'abort'` TextStreamPart. The standard AI SDK streams emit an `'abort'` part before erroring, which `AiSdkToChunkAdapter.convertAndEmitChunk` converts to a `ChunkType.ERROR` chunk, triggering `callbacks.onError` to update block statuses (STREAMING → PAUSED). Without that stream part, the adapter's `processStream` catch silently swallowed the AbortError, and `onError` was never invoked.

The following tradeoffs were made:

A try/catch wraps the `controller.enqueue()` in case the controller is already closed. This is defensive but necessary since the abort handler can race with a natural stream close.

The following alternatives were considered:

- Patching `AiSdkToChunkAdapter.processStream` to emit the ERROR chunk in the catch block when no error chunk was emitted. Rejected because fixing the upstream source (`createSSEReadableStream`) is cleaner and makes agent streams consistent with AI SDK streams.

### Breaking changes

None.

### Special notes for your reviewer

Single-line root cause: `createSSEReadableStream`'s abort handler → `controller.error()` without prior `controller.enqueue({ type: 'abort' })` → `AiSdkToChunkAdapter` never emits ERROR chunk → `onError` never called → thinking block stays STREAMING.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: Not required — bug fix, no user-facing behavior change
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
fix: Agent thinking timer no longer continues counting after force-stopping the Agent
```
