### PR TITLE
fix(agents): show reasoning effort button for agent session reasoning models

### DIFF
--- a/src/renderer/src/pages/agents/components/AgentSessionInputbar.tsx
+++ b/src/renderer/src/pages/agents/components/AgentSessionInputbar.tsx
@@ -480,10 +480,12 @@ const AgentSessionInputbarInner: FC<InnerProps> = ({ assistant, agentId, session
   const leftToolbar = useMemo(
     () => (
       <ToolbarGroup>
-        {config.showTools && <InputbarTools scope={scope} assistantId={assistant.id} session={toolsSession} />}
+        {config.showTools && (
+          <InputbarTools scope={scope} assistant={assistant} model={assistant.model!} session={toolsSession} />
+        )}
       </ToolbarGroup>
     ),
-    [config.showTools, scope, assistant.id, toolsSession]
+    [config.showTools, scope, assistant, toolsSession]
   )
   const placeholderText = useMemo(
     () =>

--- a/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/src/pages/home/Inputbar/Inputbar.tsx
@@ -478,7 +478,7 @@ const InputbarInner: FC<InputbarInnerProps> = ({ assistant: initialAssistant, se
   )
 
   // leftToolbar: 左侧工具栏
-  const leftToolbar = config.showTools ? <InputbarTools scope={scope} assistantId={assistant.id} /> : null
+  const leftToolbar = config.showTools ? <InputbarTools scope={scope} assistant={assistant} model={model} /> : null
 
   // rightToolbar: 右侧工具栏
   const rightToolbar = (

--- a/src/renderer/src/pages/home/Inputbar/InputbarTools.tsx
+++ b/src/renderer/src/pages/home/Inputbar/InputbarTools.tsx
@@ -5,7 +5,6 @@ import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd'
 import { ActionIconButton } from '@renderer/components/Buttons'
 import type { QuickPanelListItem, QuickPanelReservedSymbol } from '@renderer/components/QuickPanel'
 import { useQuickPanel } from '@renderer/components/QuickPanel'
-import { useAssistant } from '@renderer/hooks/useAssistant'
 import { useInputbarTools } from '@renderer/pages/home/Inputbar/context/InputbarToolsProvider'
 import type {
   InputbarScope,
@@ -22,6 +21,7 @@ import type {
 import { getToolsForScope } from '@renderer/pages/home/Inputbar/types'
 import { useAppDispatch, useAppSelector } from '@renderer/store'
 import { selectToolOrderForScope, setIsCollapsed, setToolOrder } from '@renderer/store/inputTools'
+import type { Assistant, Model } from '@renderer/types'
 import type { InputBarToolType } from '@renderer/types/chat'
 import { classNames } from '@renderer/utils'
 import { Divider, Dropdown } from 'antd'
@@ -34,7 +34,8 @@ import styled from 'styled-components'
 
 export interface InputbarToolsNewProps {
   scope: InputbarScope
-  assistantId: string
+  assistant: Assistant
+  model: Model
   session?: ToolContext['session']
 }
 
@@ -49,10 +50,9 @@ const DraggablePortal = ({ children, isDragging }: { children: React.ReactNode; 
   return isDragging ? createPortal(children, document.body) : children
 }
 
-const InputbarTools = ({ scope, assistantId, session }: InputbarToolsNewProps) => {
+const InputbarTools = ({ scope, assistant, model, session }: InputbarToolsNewProps) => {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
-  const { assistant, model } = useAssistant(assistantId)
   const toolsContext = useInputbarTools()
   const quickPanelContext = useQuickPanel()
   const quickPanelApiCacheRef = useRef(new Map<string, ToolQuickPanelApi>())


### PR DESCRIPTION
### What this PR does

Before this PR:

When selecting a reasoning model (e.g., Claude with extended thinking, o3) in an agent session, the reasoning effort / thinking button was invisible — users could not configure thinking intensity.

After this PR:

The reasoning effort button correctly appears for reasoning models in agent sessions, matching the behavior in normal chat.

<img width="691" height="137" alt="image" src="https://github.com/user-attachments/assets/897d990f-9ee9-46d1-89f7-8fde6ee4b727" />


### Why we need it and why it was done in this way

**Root cause**: `InputbarTools` internally called `useAssistant(assistantId)` to resolve the assistant and model. For agent sessions, the `assistantId` is an agent ID that doesn't exist in the Redux `state.assistants.assistants` array. This caused:
1. `assistant` resolved to `undefined` (cast as `Assistant`)
2. `model` fell back to the global `defaultModel` (e.g., gpt-4o)
3. The thinking tool's `condition: isReasoningModel(model)` returned `false`
4. The button was filtered out of `availableTools` entirely

**The fix**: Pass `assistant` and `model` as props from the caller (which already has the correct data) instead of having `InputbarTools` fetch them internally via `useAssistant`.

The following tradeoffs were made:

- Removes `useAssistant` from `InputbarTools`, making it a controlled component that relies on the caller to provide assistant/model data. This is a minor interface change but makes the component more predictable and reusable.

The following alternatives were considered:

1. **Add `modelOverride` prop as a fallback** — Would keep `useAssistant` as the primary source and only override when needed. Rejected because it's a band-aid that doesn't address the root cause: `useAssistant` is being called with an ID that fundamentally cannot exist in Redux for agent sessions.

2. **Dispatch agent assistant stub into Redux store** — Would make `useAssistant(agentId)` find the assistant naturally. Rejected because:
   - The stub would appear in the assistants sidebar UI (no `type`-based filtering exists)
   - It would be persisted by `redux-persist`, polluting storage
   - `useAssistant`'s `useEffect` would sync reasoning effort settings back to Redux, conflicting with agent session's local state management
   - Requires cleanup on unmount with potential race conditions
   - Redux data model changes are currently blocked until v2.0.0

3. **Pass props from caller** (chosen approach) — The simplest fix. Both callers (`Inputbar` and `AgentSessionInputbar`) already have the correct `assistant` and `model`. Three files changed, ~9 lines added / ~7 removed.

### Breaking changes

None. Internal component interface change only — `InputbarTools` is not exported as a public API.

### Special notes for your reviewer

The `assistantId` prop was removed from `InputbarToolsNewProps` since `assistant.id` provides the same information. No external consumers exist.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix: reasoning effort button now appears correctly when using reasoning models in agent sessions
```
