### PR TITLE
fix(api): resolve request body validation gaps in agents endpoints

### DIFF
--- a/src/main/apiServer/routes/agents/handlers/agents.ts
+++ b/src/main/apiServer/routes/agents/handlers/agents.ts
@@ -53,9 +53,10 @@ const modelValidationErrorBody = (error: AgentModelValidationError) => ({
 export const createAgent = async (req: Request, res: Response): Promise<Response> => {
   try {
     logger.debug('Creating agent')
-    logger.debug('Agent payload', { body: req.body })
+    const { validatedBody } = req as ValidationRequest
+    logger.debug('Agent payload', { body: validatedBody })
 
-    const agent = await agentService.createAgent(req.body)
+    const agent = await agentService.createAgent(validatedBody)
 
     try {
       logger.info('Agent created', { agentId: agent.id })
@@ -183,10 +184,12 @@ export const createAgent = async (req: Request, res: Response): Promise<Response
  */
 export const listAgents = async (req: Request, res: Response): Promise<Response> => {
   try {
-    const limit = req.query.limit ? parseInt(req.query.limit as string) : 20
-    const offset = req.query.offset ? parseInt(req.query.offset as string) : 0
-    const sortBy = (req.query.sortBy as 'created_at' | 'updated_at' | 'name' | 'sort_order') || 'sort_order'
-    const orderBy = (req.query.orderBy as 'asc' | 'desc') || (sortBy === 'sort_order' ? 'asc' : 'desc')
+    const { validatedQuery } = req as ValidationRequest
+
+    const limit = validatedQuery?.limit ?? 20
+    const offset = validatedQuery?.offset ?? 0
+    const sortBy = validatedQuery?.sortBy ?? 'sort_order'
+    const orderBy = validatedQuery?.orderBy ?? (sortBy === 'sort_order' ? 'asc' : 'desc')
 
     logger.debug('Listing agents', { limit, offset, sortBy, orderBy })
 
@@ -332,10 +335,22 @@ export const updateAgent = async (req: Request, res: Response): Promise<Response
   const { agentId } = req.params
   try {
     logger.debug('Updating agent', { agentId })
-    logger.debug('Replace payload', { body: req.body })
 
     const { validatedBody } = req as ValidationRequest
-    const replacePayload = (validatedBody ?? {}) as ReplaceAgentRequest
+
+    if (!validatedBody) {
+      logger.warn('Missing validated body for agent update', { agentId })
+      return res.status(400).json({
+        error: {
+          message: 'Request body is required for replace operation',
+          type: 'invalid_request_error',
+          code: 'missing_request_body'
+        }
+      })
+    }
+
+    const replacePayload = validatedBody as ReplaceAgentRequest
+    logger.debug('Replace payload', { body: replacePayload })
 
     const agent = await agentService.updateAgent(agentId, replacePayload, { replace: true })
 
@@ -478,10 +493,22 @@ export const patchAgent = async (req: Request, res: Response): Promise<Response>
   const { agentId } = req.params
   try {
     logger.debug('Partially updating agent', { agentId })
-    logger.debug('Patch payload', { body: req.body })
 
     const { validatedBody } = req as ValidationRequest
-    const updatePayload = (validatedBody ?? {}) as UpdateAgentRequest
+
+    if (!validatedBody) {
+      logger.warn('Missing validated body for agent patch', { agentId })
+      return res.status(400).json({
+        error: {
+          message: 'Request body is required for patch operation',
+          type: 'invalid_request_error',
+          code: 'missing_request_body'
+        }
+      })
+    }
+
+    const updatePayload = validatedBody as UpdateAgentRequest
+    logger.debug('Patch payload', { body: updatePayload })
 
     const agent = await agentService.updateAgent(agentId, updatePayload)
 
@@ -622,21 +649,9 @@ export const deleteAgent = async (req: Request, res: Response): Promise<Response
  */
 export const reorderAgents = async (req: Request, res: Response): Promise<Response> => {
   try {
-    const { ordered_ids } = req.body
+    const { validatedBody } = req as ValidationRequest
 
-    if (
-      !Array.isArray(ordered_ids) ||
-      ordered_ids.length === 0 ||
-      !ordered_ids.every((id: unknown) => typeof id === 'string' && id.length > 0)
-    ) {
-      return res.status(400).json({
-        error: {
-          message: 'ordered_ids must be a non-empty array of agent IDs',
-          type: 'invalid_request_error',
-          code: 'invalid_ordered_ids'
-        }
-      })
-    }
+    const ordered_ids = validatedBody?.ordered_ids
 
     logger.debug('Reordering agents', { count: ordered_ids.length })
     await agentService.reorderAgents(ordered_ids)

--- a/src/main/apiServer/routes/agents/handlers/sessions.ts
+++ b/src/main/apiServer/routes/agents/handlers/sessions.ts
@@ -334,21 +334,9 @@ export const deleteSession = async (req: Request, res: Response): Promise<Respon
 export const reorderSessions = async (req: Request, res: Response): Promise<Response> => {
   const { agentId } = req.params
   try {
-    const { ordered_ids } = req.body
+    const { validatedBody } = req as ValidationRequest
 
-    if (
-      !Array.isArray(ordered_ids) ||
-      ordered_ids.length === 0 ||
-      !ordered_ids.every((id: unknown) => typeof id === 'string' && id.length > 0)
-    ) {
-      return res.status(400).json({
-        error: {
-          message: 'ordered_ids must be a non-empty array of session IDs',
-          type: 'invalid_request_error',
-          code: 'invalid_ordered_ids'
-        }
-      })
-    }
+    const ordered_ids = validatedBody?.ordered_ids
 
     logger.debug('Reordering sessions', { agentId, count: ordered_ids.length })
     await sessionService.reorderSessions(agentId, ordered_ids)

--- a/src/main/apiServer/routes/agents/index.ts
+++ b/src/main/apiServer/routes/agents/index.ts
@@ -8,6 +8,8 @@ import {
   validateAgentReplace,
   validateAgentUpdate,
   validatePagination,
+  validateReorderAgents,
+  validateReorderSessions,
   validateSession,
   validateSessionId,
   validateSessionMessage,
@@ -388,7 +390,7 @@ const agentsRouter = express.Router()
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 // Reorder route — must be before /:agentId to avoid treating "reorder" as an agentId
-agentsRouter.put('/reorder', agentHandlers.reorderAgents)
+agentsRouter.put('/reorder', validateReorderAgents, handleValidationErrors, agentHandlers.reorderAgents)
 
 // Agent CRUD routes
 agentsRouter.post('/', validateAgent, handleValidationErrors, agentHandlers.createAgent)
@@ -653,7 +655,7 @@ const createSessionsRouter = (): express.Router => {
    *             schema:
    *               $ref: '#/components/schemas/ErrorResponse'
    */
-  sessionsRouter.put('/reorder', sessionHandlers.reorderSessions)
+  sessionsRouter.put('/reorder', validateReorderSessions, handleValidationErrors, sessionHandlers.reorderSessions)
 
   sessionsRouter.post('/', validateSession, handleValidationErrors, sessionHandlers.createSession)
 

--- a/src/main/apiServer/routes/agents/validators/agents.ts
+++ b/src/main/apiServer/routes/agents/validators/agents.ts
@@ -1,6 +1,7 @@
 import {
   AgentIdParamSchema,
   CreateAgentRequestSchema,
+  ReorderAgentsRequestSchema,
   ReplaceAgentRequestSchema,
   UpdateAgentRequestSchema
 } from '@types'
@@ -21,4 +22,8 @@ export const validateAgentUpdate = createZodValidator({
 
 export const validateAgentId = createZodValidator({
   params: AgentIdParamSchema
+})
+
+export const validateReorderAgents = createZodValidator({
+  body: ReorderAgentsRequestSchema
 })

--- a/src/main/apiServer/routes/agents/validators/sessions.ts
+++ b/src/main/apiServer/routes/agents/validators/sessions.ts
@@ -1,5 +1,6 @@
 import {
   CreateSessionRequestSchema,
+  ReorderSessionsRequestSchema,
   ReplaceSessionRequestSchema,
   SessionIdParamSchema,
   UpdateSessionRequestSchema
@@ -21,4 +22,8 @@ export const validateSessionUpdate = createZodValidator({
 
 export const validateSessionId = createZodValidator({
   params: SessionIdParamSchema
+})
+
+export const validateReorderSessions = createZodValidator({
+  body: ReorderSessionsRequestSchema
 })

--- a/src/renderer/src/types/agent.ts
+++ b/src/renderer/src/types/agent.ts
@@ -347,7 +347,9 @@ export const SessionMessageIdParamSchema = z.object({
 export const PaginationQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).optional().default(20),
   offset: z.coerce.number().int().min(0).optional().default(0),
-  status: z.enum(['idle', 'running', 'completed', 'failed', 'stopped']).optional()
+  status: z.enum(['idle', 'running', 'completed', 'failed', 'stopped']).optional(),
+  sortBy: z.enum(['created_at', 'updated_at', 'name', 'sort_order']).optional().default('sort_order'),
+  orderBy: z.enum(['asc', 'desc']).optional()
 })
 
 // Request body validation schemas derived from shared bases
@@ -363,6 +365,15 @@ export const CreateAgentRequestSchema = agentCreatableSchema.extend({
 export const UpdateAgentRequestSchema = AgentBaseSchema.partial()
 
 export const ReplaceAgentRequestSchema = AgentBaseSchema
+
+// Reorder request schemas
+export const ReorderAgentsRequestSchema = z.object({
+  ordered_ids: z.array(z.string().min(1, 'Agent ID cannot be empty')).min(1, 'ordered_ids must be a non-empty array')
+})
+
+export const ReorderSessionsRequestSchema = z.object({
+  ordered_ids: z.array(z.string().min(1, 'Session ID cannot be empty')).min(1, 'ordered_ids must be a non-empty array')
+})
 
 const sessionCreatableSchema = AgentBaseSchema.extend({
   model: z.string().min(1, 'Model is required')


### PR DESCRIPTION
## Summary

This PR fixes several security-relevant validation issues in the API server's agents endpoints that could allow unvalidated data to reach the service layer, as detailed in issue #13532.

## Issues Fixed

### 1. createAgent bypasses Zod-validated body
**Before:** Handler passed raw `req.body` directly to `agentService.createAgent()`, ignoring the Zod-validated result.

**After:** Now uses `req.validatedBody` like `updateAgent` and `patchAgent` do.

### 2. listAgents query params sortBy/orderBy lack Zod validation
**Before:** `sortBy` and `orderBy` were read from `req.query` with TypeScript `as` assertions, with no runtime validation.

**After:** Added `sortBy` and `orderBy` to `PaginationQuerySchema` with proper enum validation.

### 3. reorderAgents and reorderSessions endpoints lack Zod middleware
**Before:** No Zod validation middleware; only manual inline validation in handlers.

**After:** Created `ReorderAgentsRequestSchema` and `ReorderSessionsRequestSchema`, added validation middleware, and updated handlers to use `validatedBody`.

### 4. validatedBody ?? {} fallback silently bypasses validation
**Before:** `validatedBody ?? {}` in `updateAgent` and `patchAgent` could fall back to empty object.

**After:** Now returns 400 error if `validatedBody` is missing.

## Files Modified

- `src/renderer/src/types/agent.ts`: Added `sortBy`/`orderBy` to pagination schema, added reorder request schemas
- `src/main/apiServer/routes/agents/handlers/agents.ts`: Use `validatedBody`, remove unsafe fallback
- `src/main/apiServer/routes/agents/handlers/sessions.ts`: Use `validatedBody`
- `src/main/apiServer/routes/agents/validators/agents.ts`: Add `validateReorderAgents`
- `src/main/apiServer/routes/agents/validators/sessions.ts`: Add `validateReorderSessions`
- `src/main/apiServer/routes/agents/index.ts`: Apply validation middleware to reorder routes

## Testing

All modified files pass TypeScript syntax validation.

Closes #13532

🤖 Generated with [Claude Code](https://claude.com/claude-code)