### PR TITLE
fix(websearch): preserve searxng results when fetch fails

### DIFF
--- a/src/renderer/src/providers/WebSearchProvider/SearxngProvider.test.ts
+++ b/src/renderer/src/providers/WebSearchProvider/SearxngProvider.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { searchMock, kyCreateMock, axiosGetMock, fetchWebContentMock } = vi.hoisted(() => ({
+  searchMock: vi.fn(),
+  kyCreateMock: vi.fn(() => ({ extend: vi.fn(() => ({})) })),
+  axiosGetMock: vi.fn(),
+  fetchWebContentMock: vi.fn()
+}))
+
+vi.mock('@agentic/searxng', () => ({
+  SearxngClient: vi.fn(() => ({
+    search: searchMock
+  }))
+}))
+
+vi.mock('ky', () => ({
+  default: {
+    create: kyCreateMock
+  }
+}))
+
+vi.mock('axios', () => ({
+  default: {
+    get: axiosGetMock
+  }
+}))
+
+vi.mock('@renderer/utils/fetch', () => ({
+  fetchWebContent: fetchWebContentMock,
+  noContent: 'No content found'
+}))
+
+import SearxngProvider from './SearxngProvider'
+
+describe('SearxngProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    global.window = {
+      keyv: {
+        get: vi.fn(),
+        set: vi.fn()
+      }
+    } as any
+
+    axiosGetMock.mockResolvedValue({
+      data: {
+        engines: [{ enabled: true, categories: ['general', 'web'], name: 'google' }]
+      }
+    })
+
+    searchMock.mockResolvedValue({
+      results: [
+        {
+          title: 'Relevant result',
+          url: 'https://example.com/result',
+          content: 'Snippet from SearXNG'
+        }
+      ]
+    })
+  })
+
+  it('falls back to the SearXNG snippet when page fetching returns no content', async () => {
+    fetchWebContentMock.mockResolvedValue({
+      title: 'Fetched page',
+      url: 'https://example.com/result',
+      content: 'No content found'
+    })
+
+    const provider = new SearxngProvider({
+      id: 'searxng',
+      name: 'SearXNG',
+      apiHost: 'https://searx.example.com'
+    })
+
+    const response = await provider.search('test query', { maxResults: 10 } as any)
+
+    expect(response.results).toEqual([
+      {
+        title: 'Relevant result',
+        url: 'https://example.com/result',
+        content: 'Snippet from SearXNG'
+      }
+    ])
+  })
+
+  it('falls back to the SearXNG snippet when page fetching throws', async () => {
+    fetchWebContentMock.mockRejectedValue(new Error('timeout'))
+
+    const provider = new SearxngProvider({
+      id: 'searxng',
+      name: 'SearXNG',
+      apiHost: 'https://searx.example.com'
+    })
+
+    const response = await provider.search('test query', { maxResults: 10 } as any)
+
+    expect(response.results).toEqual([
+      {
+        title: 'Relevant result',
+        url: 'https://example.com/result',
+        content: 'Snippet from SearXNG'
+      }
+    ])
+  })
+
+  it('keeps fetched content when readable page extraction succeeds', async () => {
+    fetchWebContentMock.mockResolvedValue({
+      title: 'Fetched page',
+      url: 'https://example.com/result',
+      content: 'Fetched markdown content'
+    })
+
+    const provider = new SearxngProvider({
+      id: 'searxng',
+      name: 'SearXNG',
+      apiHost: 'https://searx.example.com'
+    })
+
+    const response = await provider.search('test query', { maxResults: 10 } as any)
+
+    expect(response.results).toEqual([
+      {
+        title: 'Fetched page',
+        url: 'https://example.com/result',
+        content: 'Fetched markdown content'
+      }
+    ])
+  })
+})

--- a/src/renderer/src/providers/WebSearchProvider/SearxngProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/SearxngProvider.ts
@@ -1,7 +1,7 @@
 import { SearxngClient } from '@agentic/searxng'
 import { loggerService } from '@logger'
 import type { WebSearchState } from '@renderer/store/websearch'
-import type { WebSearchProvider, WebSearchProviderResponse } from '@renderer/types'
+import type { WebSearchProvider, WebSearchProviderResponse, WebSearchProviderResult } from '@renderer/types'
 import { fetchWebContent, noContent } from '@renderer/utils/fetch'
 import axios from 'axios'
 import ky from 'ky'
@@ -45,6 +45,15 @@ export default class SearxngProvider extends BaseWebSearchProvider {
     }
     this.initEngines().catch((err) => logger.error('Failed to initialize SearxNG engines:', err))
   }
+
+  private buildFallbackResult(item: { title?: string; content?: string; url: string }): WebSearchProviderResult {
+    return {
+      title: item.title || item.url,
+      url: item.url,
+      content: item.content?.trim() || item.title || item.url
+    }
+  }
+
   private async initEngines(): Promise<void> {
     try {
       logger.info(`Initializing SearxNG with API host: ${this.apiHost}`)
@@ -56,7 +65,7 @@ export default class SearxngProvider extends BaseWebSearchProvider {
         : undefined
       const response = await axios.get(`${this.apiHost}/config`, {
         timeout: 5000,
-        validateStatus: (status) => status === 200, // 仅接受 200 状态码
+        validateStatus: (status) => status === 200,
         auth
       })
 
@@ -101,9 +110,8 @@ export default class SearxngProvider extends BaseWebSearchProvider {
         throw new Error('Search query cannot be empty')
       }
 
-      // Wait for initialization if it's the first search
       if (!this.isInitialized) {
-        await this.initEngines().catch(() => {}) // Ignore errors
+        await this.initEngines().catch(() => {})
       }
 
       const result = await this.searxng.search({
@@ -119,20 +127,35 @@ export default class SearxngProvider extends BaseWebSearchProvider {
       const validItems = result.results
         .filter((item) => item.url.startsWith('http') || item.url.startsWith('https'))
         .slice(0, websearch.maxResults)
-      // Logger.log('Valid search items:', validItems)
 
-      // Fetch content for each URL concurrently
       const fetchPromises = validItems.map(async (item) => {
-        // Logger.log(`Fetching content for ${item.url}...`)
-        return await fetchWebContent(item.url, 'markdown', this.provider.usingBrowser)
+        const timeoutMs = this.provider.timeout || 10000
+        const controller = new AbortController()
+        const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+
+        try {
+          const fetched = await fetchWebContent(item.url, 'markdown', this.provider.usingBrowser, {
+            signal: controller.signal
+          })
+          clearTimeout(timeoutId)
+
+          if (fetched.content === noContent) {
+            return this.buildFallbackResult(item)
+          }
+
+          return fetched
+        } catch (error) {
+          clearTimeout(timeoutId)
+          logger.warn(`Failed to fetch ${item.url} after ${timeoutMs}ms`, error as Error)
+          return this.buildFallbackResult(item)
+        }
       })
 
-      // Wait for all fetches to complete
       const results = await Promise.all(fetchPromises)
 
       return {
         query: query,
-        results: results.filter((result) => result.content != noContent)
+        results: results.filter((result) => result.content.trim().length > 0)
       }
     } catch (error) {
       const logError = error instanceof Error ? error : { error }

--- a/src/renderer/src/providers/WebSearchProvider/SearxngProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/SearxngProvider.ts
@@ -135,7 +135,8 @@ export default class SearxngProvider extends BaseWebSearchProvider {
         results: results.filter((result) => result.content != noContent)
       }
     } catch (error) {
-      logger.error('Searxng search failed:', error as Error)
+      const logError = error instanceof Error ? error : { error }
+      logger.error('Searxng search failed:', logError)
       throw new Error(`Search failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
     }
   }

--- a/src/renderer/src/providers/WebSearchProvider/SearxngProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/SearxngProvider.ts
@@ -129,15 +129,8 @@ export default class SearxngProvider extends BaseWebSearchProvider {
         .slice(0, websearch.maxResults)
 
       const fetchPromises = validItems.map(async (item) => {
-        const timeoutMs = this.provider.timeout || 10000
-        const controller = new AbortController()
-        const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
-
         try {
-          const fetched = await fetchWebContent(item.url, 'markdown', this.provider.usingBrowser, {
-            signal: controller.signal
-          })
-          clearTimeout(timeoutId)
+          const fetched = await fetchWebContent(item.url, 'markdown', this.provider.usingBrowser)
 
           if (fetched.content === noContent) {
             return this.buildFallbackResult(item)
@@ -145,8 +138,8 @@ export default class SearxngProvider extends BaseWebSearchProvider {
 
           return fetched
         } catch (error) {
-          clearTimeout(timeoutId)
-          logger.warn(`Failed to fetch ${item.url} after ${timeoutMs}ms`, error as Error)
+          const logError = error instanceof Error ? error : { error }
+          logger.warn(`Failed to fetch ${item.url}, using SearXNG snippet fallback`, logError)
           return this.buildFallbackResult(item)
         }
       })


### PR DESCRIPTION
## Summary

- preserve SearXNG search results when page content fetching fails
- fall back to the original SearXNG snippet instead of dropping the result
- add tests covering fetch failure and no-content fallback behavior

## Problem

Fixes #12954.

SearXNG may return relevant search results, but Cherry Studio currently fetches each result page and drops items when readable content extraction fails. In practice, this can make the LLM receive a smaller, distorted, or seemingly fixed set of results even though SearXNG itself returned useful matches.

## Fix

When `fetchWebContent()` fails or returns `No content found`, keep the original SearXNG result by falling back to its existing `title/content/url` fields.

This keeps successful page extraction behavior unchanged, while avoiding loss of relevant search results when downstream fetching fails.

## Testing

- added unit tests for fallback when page fetching returns `No content found`
- added unit tests for fallback when page fetching throws
- added unit tests to confirm fetched page content is still preferred when available
- ran:
  - `node node_modules/vitest/vitest.mjs run src/renderer/src/providers/WebSearchProvider/SearxngProvider.test.ts`
