### PR TITLE
feat(model): add support for MiMo-V2-Pro and MiMo-V2-Omni models

### DIFF
--- a/src/renderer/src/config/models/default.ts
+++ b/src/renderer/src/config/models/default.ts
@@ -2015,6 +2015,18 @@ export const SYSTEM_MODELS: Record<SystemProviderId | 'defaultModel', Model[]> =
       name: 'Mimo V2 Flash',
       provider: 'mimo',
       group: 'Mimo'
+    },
+    {
+      id: 'mimo-v2-pro',
+      name: 'Mimo V2 Pro',
+      provider: 'mimo',
+      group: 'Mimo'
+    },
+    {
+      id: 'mimo-v2-omni',
+      name: 'Mimo V2 Omni',
+      provider: 'mimo',
+      group: 'Mimo'
     }
   ],
   zai: [

--- a/src/renderer/src/config/models/reasoning.ts
+++ b/src/renderer/src/config/models/reasoning.ts
@@ -593,7 +593,7 @@ export const isSupportedThinkingTokenZhipuModel = (model: Model): boolean => {
 
 export const isSupportedThinkingTokenMiMoModel = (model: Model): boolean => {
   const modelId = getLowerBaseModelName(model.id, '/')
-  return ['mimo-v2-flash'].some((id) => modelId.includes(id))
+  return ['mimo-v2-flash', 'mimo-v2-pro', 'mimo-v2-omni'].some((id) => modelId.includes(id))
 }
 
 /**

--- a/src/renderer/src/config/models/tooluse.ts
+++ b/src/renderer/src/config/models/tooluse.ts
@@ -35,7 +35,9 @@ export const FUNCTION_CALLING_MODELS = [
   'ling-\\w+(?:-[\\w-]+)?',
   'ring-\\w+(?:-[\\w-]+)?',
   'minimax-m2(?:\\.\\d+)?(?:-[\\w-]+)?',
-  'mimo-v2-flash'
+  'mimo-v2-flash',
+  'mimo-v2-pro',
+  'mimo-v2-omni'
 ] as const
 
 const FUNCTION_CALLING_EXCLUDED_MODELS = [

--- a/src/renderer/src/config/models/vision.ts
+++ b/src/renderer/src/config/models/vision.ts
@@ -60,7 +60,8 @@ const visionAllowedModels = [
   'qwen-omni(?:-[\\w-]+)?',
   'mistral-large-(2512|latest)',
   'mistral-medium-(2508|latest)',
-  'mistral-small-(2506|latest)'
+  'mistral-small-(2506|latest)',
+  'mimo-v2-omni(?:-[\\w-]+)?'
 ]
 
 const visionExcludedModels = [


### PR DESCRIPTION
What this PR does

  Before this PR:

  • Cherry Studio only supported the MiMo-V2-Flash model
  • Users could not use the newly released MiMo-V2-Pro and MiMo-V2-Omni models with proper capability detection

  After this PR:

  • Added support for MiMo-V2-Pro: reasoning control and tool use capabilities
  • Added support for MiMo-V2-Omni: reasoning control, tool use, and vision capabilities
  • Kept MiMo-V2-Flash as the first default model for backward compatibility
  • Updated model detection logic to recognize all three MiMo V2 variants

  Why we need it and why it was done in this way

  Xiaomi released two new models (MiMo-V2-Pro and MiMo-V2-Omni) on March 18, 2026. This PR adds support for these models to ensure Ch
  erry Studio users can leverage the latest MiMo model capabilities.

  Tradeoffs made:

  • Used exact model ID matching (mimo-v2-omni) for vision detection to avoid false positives with future non-vision "omni" models
  • Maintained backward compatibility by keeping Flash model as the first default

  Alternatives considered:

  • Using regex pattern .*mimo.*omni.* for more flexible matching, but rejected to avoid potential false matches

  Breaking changes

  NONE - This is an additive feature that extends existing MiMo model support without affecting current functionality.

  Checklist

  • [x] PR: The PR description is expressive enough and will help future contributors
  • [x] Code: Write code that humans can understand and Keep it simple
  • [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
  • [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
  • [ ] Documentation: A user-guide update was considered and is present (link) or not required.
  • [x] Self-review: I have reviewed my own code before requesting review from others

  Release note

  feat: Add support for Xiaomi MiMo-V2-Pro and MiMo-V2-Omni models

  - MiMo-V2-Pro: Supports reasoning control and tool use
  - MiMo-V2-Omni: Supports reasoning control, tool use, and vision input