### PR TITLE
fix: Set dev userData path before service initialization

### DIFF
--- a/src/main/bootstrap.ts
+++ b/src/main/bootstrap.ts
@@ -7,6 +7,13 @@ import { initAppDataDir } from './utils/init'
 
 app.isPackaged && initAppDataDir()
 
+if (process.env.NODE_ENV === 'development') {
+  const current = app.getPath('userData')
+  if (!current.endsWith('Dev')) {
+    app.setPath('userData', `${current}Dev`)
+  }
+}
+
 // 在主进程中复制 appData 中某些一直被占用的文件
 // 在renderer进程还没有启动时，主进程可以复制这些文件到新的appData中
 function copyOccupiedDirsInMainProcess() {

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -1,11 +1,6 @@
-import { isDev, isWin } from '@main/constant'
-import { app } from 'electron'
+import { isWin } from '@main/constant'
 
 import { getDataPath } from './utils'
-
-if (isDev) {
-  app.setPath('userData', app.getPath('userData') + 'Dev')
-}
 
 export const DATA_PATH = getDataPath()
 


### PR DESCRIPTION
在开发模式下启动应用（pnpm dev 或 NODE_ENV=development pnpm dev）时，主数据库实际连接到了生产目
录：
/Users/xxx/Library/Application Support/CherryStudio/cherrystudio.sqlite
而不是预期的开发目录：
/Users/xxx/Library/Application Support/CherryStudioDev/cherrystudio.sqlite
这导致开发环境下看不到 CherryStudioDev/cherrystudio.sqlite，并且出现“明明是 dev 启动，却读写了非
Dev 数据”的现象。

### 最小修复方案

采用最小改动，只修复时序：

1. 在 src/main/bootstrap.ts 最早阶段设置开发环境 userData 为 ...Dev
2. 在 src/main/config.ts 移除晚执行的 Dev 路径设置，避免重复或时序冲突
3. 增加防重复保护：若已以 Dev 结尾则不再追加
