### PR TITLE
fix(MessageHeader): crash when clicking topic in message search

### DIFF
--- a/src/renderer/src/pages/home/Messages/MessageHeader.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageHeader.tsx
@@ -21,7 +21,6 @@ import { Sparkle } from 'lucide-react'
 import type { FC } from 'react'
 import { memo, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useLocation } from 'react-router-dom'
 import styled from 'styled-components'
 
 import MessageTokens from './MessageTokens'
@@ -46,8 +45,7 @@ const MessageHeader: FC<Props> = memo(({ assistant, model, message, topic, isGro
   const { chat } = useRuntime()
   const { activeAgentId } = chat
   const { agent } = useAgent(activeAgentId)
-  const { pathname } = useLocation()
-  const isAgentView = pathname.startsWith('/agents')
+  const isAgentView = window.location.pathname.startsWith('/agents')
   const { t } = useTranslation()
   const { isBubbleStyle } = useMessageStyle()
   const { openMinappById } = useMinappPopup()


### PR DESCRIPTION
### What this PR does

Before this PR:
Clicking on a topic title in the message search results would crash the app with error: `useLocation() may be used only in the context of a <Router> component`.

<img width="1409" height="923" alt="image" src="https://github.com/user-attachments/assets/79a151e6-f066-472a-9fed-172b1ea435bb" />

<img width="1409" height="923" alt="image" src="https://github.com/user-attachments/assets/8ba02fde-74e1-4145-bd95-b783b5e1ed48" />

After this PR:
The app works correctly when clicking topic titles in message search results.

### Why we need it and why it was done in this way

The `MessageHeader` component uses `useLocation()` hook from react-router-dom to check if the current view is an agent view. However, when the component is rendered in the message search popup, it's outside of the Router context, causing the hook to throw an error.

The fix replaces `useLocation().pathname` with `window.location.pathname`, which works in any context without requiring a Router wrapper.

The following tradeoffs were made:
- Using `window.location.pathname` instead of `useLocation()` means we lose React Router's reactivity for pathname changes. However, this is acceptable because the `isAgentView` check only needs the current pathname at render time, and route changes would trigger a re-render anyway.

The following alternatives were considered:
- Wrapping the search popup with a Router - rejected as it adds unnecessary complexity
- Using `useInRouterContext()` to conditionally use `useLocation()` - rejected as it's more verbose and `window.location` is simpler

### Breaking changes

None.

### Special notes for your reviewer

This is a minimal fix that addresses the crash without changing the component's behavior.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix crash when clicking topic title in message search results
```

fixed: #13620
