### PR TITLE
fix: prevent infinite re-render loop in TopicMessages after global search

### DIFF
--- a/src/renderer/src/pages/history/components/TopicMessages.tsx
+++ b/src/renderer/src/pages/history/components/TopicMessages.tsx
@@ -40,7 +40,7 @@ const TopicMessages: FC<Props> = ({ topic: _topic, ...props }) => {
       const topic = await getTopicById(_topic.id)
       setTopic(topic)
     })
-  }, [_topic, topic])
+  }, [_topic?.id])
 
   const isEmpty = (topic?.messages || []).length === 0
 


### PR DESCRIPTION
### What this PR does

Before this PR:
- Opening a conversation from global search (Cmd+Shift+F) caused an infinite re-render loop in `TopicMessages`, leading to a white screen crash that could not be recovered without reloading the app.

After this PR:
- The `useEffect` dependency is corrected to `[_topic?.id]`, so topic messages are loaded once per topic selection without looping.

Fixes #13620

### Why we need it and why it was done in this way

The `useEffect` in `TopicMessages.tsx` had `[_topic, topic]` as its dependency array. `getTopicById` always returns a new object reference via `{ ...topic, messages }`, so every `setTopic(topic)` call changed the `topic` state, which re-triggered the effect, creating an infinite loop of IndexedDB reads and React state updates. This eventually exhausted memory/CPU and crashed the renderer process (white screen).

The following tradeoffs were made:
- Using `_topic?.id` instead of `_topic` as dependency to avoid re-triggering on object reference changes while still reacting to actual topic changes.

The following alternatives were considered:
- Using `[_topic]` alone — rejected because `_topic` could also be a new object reference from the parent on each render.

### Breaking changes

None

### Special notes for your reviewer

The one-line change is at `src/renderer/src/pages/history/components/TopicMessages.tsx:43`:
```diff
-  }, [_topic, topic])
+  }, [_topic?.id])
```

The root cause is that `getTopicById` (in `useTopic.ts:74-80`) always creates a new object:
```ts
return { ...topic, messages } as Topic
```

This means the `topic` state variable is never referentially equal to the previous value, so including it in the dependency array guarantees an infinite loop.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed white screen crash when clicking a conversation from global search results (Cmd+Shift+F).
```
