### PR TITLE
fix(mcp): create fresh MCP Server per transport session

### DIFF
--- a/src/main/apiServer/services/mcp.ts
+++ b/src/main/apiServer/services/mcp.ts
@@ -9,7 +9,7 @@ import type { Request, Response } from 'express'
 import type { IncomingMessage, ServerResponse } from 'http'
 
 import { loggerService } from '../../services/LoggerService'
-import { getMcpServerById, getMCPServersFromRedux } from '../utils/mcp'
+import { createMcpServerForTransport, getMCPServersFromRedux } from '../utils/mcp'
 
 const logger = loggerService.withContext('MCPApiService')
 const transports: Record<string, StreamableHTTPServerTransport> = {}
@@ -139,10 +139,8 @@ class MCPApiService extends EventEmitter {
           delete transports[transport.sessionId]
         }
       }
-      const mcpServer = await getMcpServerById(server.id)
-      if (mcpServer) {
-        await mcpServer.connect(transport)
-      }
+      const mcpServer = await createMcpServerForTransport(server.id)
+      await mcpServer.connect(transport)
     }
     const jsonpayload = req.body
     const messages: JSONRPCMessage[] = []

--- a/src/main/apiServer/utils/mcp.ts
+++ b/src/main/apiServer/utils/mcp.ts
@@ -14,8 +14,6 @@ const logger = loggerService.withContext('MCPApiService')
 const MCP_SERVERS_CACHE_KEY = 'api-server:mcp-servers'
 const MCP_SERVERS_CACHE_TTL = 5 * 60 * 1000 // 5 minutes
 
-const cachedServers: Record<string, Server> = {}
-
 async function handleListToolsRequest(request: any, extra: any): Promise<ListToolsResult> {
   logger.debug('Handling list tools request', { request: request, extra: extra })
   const serverId: string = request.params._meta.serverId
@@ -72,26 +70,24 @@ export async function getMCPServersFromRedux(): Promise<MCPServer[]> {
   }
 }
 
-export async function getMcpServerById(id: string): Promise<Server> {
-  const server = cachedServers[id]
-  if (!server) {
-    const servers = await getMCPServersFromRedux()
-    const mcpServer = servers.find((s) => s.id === id || s.name === id)
-    if (!mcpServer) {
-      throw new Error(`Server not found: ${id}`)
-    }
-
-    const createMcpServer = (name: string, version: string): Server => {
-      const server = new Server({ name: name, version }, { capabilities: { tools: {} } })
-      server.setRequestHandler(ListToolsRequestSchema, handleListToolsRequest)
-      server.setRequestHandler(CallToolRequestSchema, handleCallToolRequest)
-      return server
-    }
-
-    const newServer = createMcpServer(mcpServer.name, '0.1.0')
-    cachedServers[id] = newServer
-    return newServer
+/**
+ * Creates a fresh MCP Server instance for a given server ID.
+ *
+ * A new Server is created for each transport session because the MCP SDK's
+ * Protocol.connect() throws "Already connected" if the Server is already
+ * bound to a transport. Since the Claude Agent SDK spawns a new CLI process
+ * per query (including resumes), each process establishes a new HTTP
+ * transport, so the proxy must provide a fresh Server instance every time.
+ */
+export async function createMcpServerForTransport(id: string): Promise<Server> {
+  const servers = await getMCPServersFromRedux()
+  const mcpServer = servers.find((s) => s.id === id || s.name === id)
+  if (!mcpServer) {
+    throw new Error(`Server not found: ${id}`)
   }
-  logger.debug('Returning cached MCP server', { id, hasHandlers: Boolean(server) })
+
+  const server = new Server({ name: mcpServer.name, version: '0.1.0' }, { capabilities: { tools: {} } })
+  server.setRequestHandler(ListToolsRequestSchema, handleListToolsRequest)
+  server.setRequestHandler(CallToolRequestSchema, handleCallToolRequest)
   return server
 }


### PR DESCRIPTION
### What this PR does

Before this PR:
MCP tools only worked on the first user prompt when using the Claude Agent SDK. Subsequent prompts failed silently because the cached MCP Server was already bound to a previous transport.

After this PR:
A fresh MCP Server instance is created for each transport session, so MCP tools work correctly on every prompt.

### Why we need it and why it was done in this way

The MCP SDK's `Protocol.connect()` throws "Already connected" if the Server is already bound to a transport. The Claude Agent SDK spawns a new CLI process per query (including resumes), and each process establishes a new HTTP transport. The previous code cached the Server instance and tried to reuse it, which caused the "Already connected" error on the second and subsequent prompts.

The following tradeoffs were made:
- Removed the server cache entirely. Creating a new `Server` instance per session is lightweight (just an object with two request handlers), so caching provides no meaningful benefit.

The following alternatives were considered:
- Disconnecting the old transport before connecting the new one — rejected because the MCP SDK `Server` class doesn't expose a clean disconnect/reset API.

### Breaking changes

None.

### Special notes for your reviewer

The key insight is in `src/main/apiServer/utils/mcp.ts`: `getMcpServerById` (cached) → `createMcpServerForTransport` (fresh instance per session).

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: N/A
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed MCP tools only working on the first prompt when using the Claude Agent SDK API server.
```