### PR TITLE
fix: align agent chat bubble layout with shared chat styles

### DIFF
--- a/src/renderer/src/pages/agents/AgentChat.tsx
+++ b/src/renderer/src/pages/agents/AgentChat.tsx
@@ -23,10 +23,10 @@ import Sessions from './components/Sessions'
 
 const AgentChat = () => {
   const { t } = useTranslation()
-  const { messageNavigation, topicPosition } = useSettings()
+  const { messageNavigation, messageStyle, topicPosition } = useSettings()
   const { showTopics } = useShowTopics()
   const { chat } = useRuntime()
-  const { activeAgentId, activeSessionIdMap } = chat
+  const { activeAgentId, activeSessionIdMap, isMultiSelectMode } = chat
   const activeSessionId = activeAgentId ? activeSessionIdMap[activeAgentId] : null
   // undefined = session not yet initialized, null = initialized but no sessions
   const isSessionInitialized = !activeAgentId || activeAgentId in activeSessionIdMap
@@ -83,7 +83,10 @@ const AgentChat = () => {
   }
 
   return (
-    <Container>
+    <Container
+      // AgentChat doesn't support multi-select
+      // But we want to apply the message style for consistency
+      className={cn(messageStyle, { 'multi-select-mode': isMultiSelectMode })}>
       <QuickPanelProvider>
         {/* Main Chat */}
         <div className="flex min-w-0 flex-1 flex-col">


### PR DESCRIPTION
Fix #13630 

<table>
<tr>
 <td>
 Before
 <td>
After
<tr>
 <td>
<img width="1177" height="617" alt="image" src="https://github.com/user-attachments/assets/f139663d-40cc-4e84-9448-3ea499db43e9" />
 <td>
<img width="1736" height="770" alt="CleanShot 2026-03-19 at 16 58 40@2x" src="https://github.com/user-attachments/assets/bf2d3cd0-f744-4bd6-8ff9-67016aee78f9" />

</table>



