### PR TITLE
fix: correct parameter order in knowledgeSearchTool call

### DIFF
--- a/src/renderer/src/aiCore/plugins/searchOrchestrationPlugin.ts
+++ b/src/renderer/src/aiCore/plugins/searchOrchestrationPlugin.ts
@@ -355,8 +355,8 @@ export const searchOrchestrationPlugin = (
             params.tools['builtin_knowledge_search'] = knowledgeSearchTool(
               assistant,
               analysisResult.knowledge,
-              getMessageContent(userMessage),
-              topicId
+              topicId,
+              getMessageContent(userMessage)
             )
           }
         }


### PR DESCRIPTION
### What this PR does

Before this PR:
The `knowledgeSearchTool()` function in `searchOrchestrationPlugin.ts` was called with the 3rd and 4th parameters swapped — `userMessage` was passed as `topicId` and vice versa. This caused knowledge base searches to use corrupted tracing context and incorrect query text, resulting in knowledge base content not being delivered to the model.

After this PR:
The parameters are passed in the correct order matching the function signature in `KnowledgeSearchTool.ts`, restoring proper knowledge base search functionality.

Fixes #13609

### Why we need it and why it was done in this way

The parameter order bug was introduced in commit `e10042a43` (Feat/provider options and built-in tools #10068) and has persisted through v1.8.0 and v1.8.1. The fix is a simple parameter swap — no logic changes needed.

The following tradeoffs were made: None — this is a straightforward bug fix.

The following alternatives were considered: None — the root cause is clear.

### Breaking changes

None.

### Special notes for your reviewer

The function signature in `KnowledgeSearchTool.ts:13-18` expects:
```typescript
knowledgeSearchTool(assistant, extractedKeywords, topicId, userMessage?)
```

But the call site had `getMessageContent(userMessage)` and `topicId` swapped.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: N/A — bug fix, no user-facing documentation change needed
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix knowledge base content not being delivered to the model when selected in conversation
```