### PR TITLE
fix: move router ownership above TopView overlays

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -4,6 +4,7 @@ import { loggerService } from '@logger'
 import store, { persistor } from '@renderer/store'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Provider } from 'react-redux'
+import { HashRouter } from 'react-router-dom'
 import { PersistGate } from 'redux-persist/integration/react'
 
 import TopViewContainer from './components/TopView'
@@ -38,9 +39,11 @@ function App(): React.ReactElement {
               <NotificationProvider>
                 <CodeStyleProvider>
                   <PersistGate loading={null} persistor={persistor}>
-                    <TopViewContainer>
-                      <Router />
-                    </TopViewContainer>
+                    <HashRouter>
+                      <TopViewContainer>
+                        <Router />
+                      </TopViewContainer>
+                    </HashRouter>
                   </PersistGate>
                 </CodeStyleProvider>
               </NotificationProvider>

--- a/src/renderer/src/Router.tsx
+++ b/src/renderer/src/Router.tsx
@@ -2,7 +2,7 @@ import '@renderer/databases'
 
 import type { FC } from 'react'
 import { useMemo } from 'react'
-import { HashRouter, Route, Routes } from 'react-router-dom'
+import { Route, Routes } from 'react-router-dom'
 
 import Sidebar from './components/app/Sidebar'
 import { ErrorBoundary } from './components/ErrorBoundary'
@@ -52,19 +52,19 @@ const Router: FC = () => {
 
   if (navbarPosition === 'left') {
     return (
-      <HashRouter>
+      <>
         <Sidebar />
         {routes}
         <NavigationHandler />
-      </HashRouter>
+      </>
     )
   }
 
   return (
-    <HashRouter>
+    <>
       <NavigationHandler />
       <TabsContainer>{routes}</TabsContainer>
-    </HashRouter>
+    </>
   )
 }
 


### PR DESCRIPTION
Fix #13645 

### Before

```
TopViewContainer
  ├─ Router
  │    └─ HashRouter
  │           └─ MainPage
  └─ TopView.show() 
```

### After

```
HashRouter
  └─ TopViewContainer
        ├─ Router
        │    └─ MainPage
        └─ TopView.show() 
```

https://github.com/user-attachments/assets/c461d7f9-4c85-4d44-8505-dfa27ec48c2c

