### PR TITLE
fix: properly handle multi-element MCP tool results in OpenAI clients

### DIFF
--- a/src/renderer/src/aiCore/legacy/clients/openai/OpenAIApiClient.ts
+++ b/src/renderer/src/aiCore/legacy/clients/openai/OpenAIApiClient.ts
@@ -71,6 +71,7 @@ import type {
   ReasoningEffortOptionalParams
 } from '@renderer/types/sdk'
 import { addImageFileToContents } from '@renderer/utils/formats'
+import { mcpToolCallResponseToOpenAIChatToolContent } from '@renderer/utils/mcp-tool-content'
 import {
   isSupportedToolUse,
   mcpToolCallResponseToOpenAICompatibleMessage,
@@ -513,7 +514,7 @@ export class OpenAIAPIClient extends OpenAIBaseClient<
       return {
         role: 'tool',
         tool_call_id: mcpToolResponse.toolCallId,
-        content: JSON.stringify(resp.content)
+        content: mcpToolCallResponseToOpenAIChatToolContent(resp, isVisionModel(model))
       } as OpenAI.Chat.Completions.ChatCompletionToolMessageParam
     }
     return undefined

--- a/src/renderer/src/aiCore/legacy/clients/openai/OpenAIResponseAPIClient.ts
+++ b/src/renderer/src/aiCore/legacy/clients/openai/OpenAIResponseAPIClient.ts
@@ -35,6 +35,7 @@ import type {
   OpenAIResponseSdkToolCall
 } from '@renderer/types/sdk'
 import { addImageFileToContents } from '@renderer/utils/formats'
+import { mcpToolCallResponseToOpenAIResponsesOutput } from '@renderer/utils/mcp-tool-content'
 import {
   isSupportedToolUse,
   mcpToolCallResponseToOpenAIMessage,
@@ -290,7 +291,7 @@ export class OpenAIResponseAPIClient extends OpenAIBaseClient<
       return {
         type: 'function_call_output',
         call_id: mcpToolResponse.toolCallId,
-        output: JSON.stringify(resp.content)
+        output: mcpToolCallResponseToOpenAIResponsesOutput(resp, isVisionModel(model))
       }
     }
     return

--- a/src/renderer/src/utils/__tests__/mcp-tool-content.test.ts
+++ b/src/renderer/src/utils/__tests__/mcp-tool-content.test.ts
@@ -1,0 +1,146 @@
+import type { MCPCallToolResponse } from '@renderer/types'
+import { describe, expect, it } from 'vitest'
+
+import {
+  mcpToolCallResponseToOpenAIChatToolContent,
+  mcpToolCallResponseToOpenAIResponsesOutput
+} from '../mcp-tool-content'
+
+describe('mcpToolCallResponseToOpenAIResponsesOutput', () => {
+  it('returns structured array with input_text and input_image for vision model', () => {
+    const resp: MCPCallToolResponse = {
+      content: [
+        { type: 'text', text: 'Analysis complete' },
+        { type: 'image', data: 'iVBORw0KGgo=', mimeType: 'image/png' }
+      ]
+    }
+    const result = mcpToolCallResponseToOpenAIResponsesOutput(resp, true)
+    expect(Array.isArray(result)).toBe(true)
+    const parts = result as Array<any>
+    expect(parts).toHaveLength(2)
+    expect(parts[0]).toEqual({ type: 'input_text', text: 'Analysis complete' })
+    expect(parts[1]).toEqual({
+      type: 'input_image',
+      image_url: 'data:image/png;base64,iVBORw0KGgo=',
+      detail: 'auto'
+    })
+  })
+
+  it('returns JSON string for non-vision model', () => {
+    const resp: MCPCallToolResponse = {
+      content: [
+        { type: 'text', text: 'hello' },
+        { type: 'image', data: 'abc', mimeType: 'image/png' }
+      ]
+    }
+    const result = mcpToolCallResponseToOpenAIResponsesOutput(resp, false)
+    expect(typeof result).toBe('string')
+    expect(result).toBe(JSON.stringify(resp.content))
+  })
+
+  it('returns JSON string for error response', () => {
+    const resp: MCPCallToolResponse = {
+      isError: true,
+      content: [{ type: 'text', text: 'Something failed' }]
+    }
+    const result = mcpToolCallResponseToOpenAIResponsesOutput(resp, true)
+    expect(typeof result).toBe('string')
+    expect(result).toBe(JSON.stringify(resp.content))
+  })
+
+  it('returns text placeholder when image data is missing', () => {
+    const resp: MCPCallToolResponse = {
+      content: [{ type: 'image', mimeType: 'image/png' }]
+    }
+    const result = mcpToolCallResponseToOpenAIResponsesOutput(resp, true)
+    expect(Array.isArray(result)).toBe(true)
+    const parts = result as Array<any>
+    expect(parts[0]).toEqual({ type: 'input_text', text: '[Image result omitted: missing image data]' })
+  })
+
+  it('summarizes audio content as text for vision model', () => {
+    const resp: MCPCallToolResponse = {
+      content: [{ type: 'audio', data: 'audiodata', mimeType: 'audio/mp3' }]
+    }
+    const result = mcpToolCallResponseToOpenAIResponsesOutput(resp, true)
+    expect(Array.isArray(result)).toBe(true)
+    const parts = result as Array<any>
+    expect(parts[0]).toEqual({ type: 'input_text', text: '[Audio result: audio/mp3, base64 payload present]' })
+  })
+
+  it('summarizes resource content with text for vision model', () => {
+    const resp: MCPCallToolResponse = {
+      content: [{ type: 'resource', resource: { text: 'resource content', uri: 'file://test.txt' } }]
+    }
+    const result = mcpToolCallResponseToOpenAIResponsesOutput(resp, true)
+    expect(Array.isArray(result)).toBe(true)
+    const parts = result as Array<any>
+    expect(parts[0]).toEqual({ type: 'input_text', text: 'resource content' })
+  })
+
+  it('summarizes resource without text for vision model', () => {
+    const resp: MCPCallToolResponse = {
+      content: [{ type: 'resource', resource: { uri: 'file://data.bin', mimeType: 'application/octet-stream' } }]
+    }
+    const result = mcpToolCallResponseToOpenAIResponsesOutput(resp, true)
+    expect(Array.isArray(result)).toBe(true)
+    const parts = result as Array<any>
+    expect(parts[0]).toEqual({
+      type: 'input_text',
+      text: '[Resource result: file://data.bin (application/octet-stream)]'
+    })
+  })
+})
+
+describe('mcpToolCallResponseToOpenAIChatToolContent', () => {
+  it('joins multiple text items with newlines', () => {
+    const resp: MCPCallToolResponse = {
+      content: [
+        { type: 'text', text: 'line one' },
+        { type: 'text', text: 'line two' }
+      ]
+    }
+    const result = mcpToolCallResponseToOpenAIChatToolContent(resp, false)
+    expect(result).toBe('line one\nline two')
+  })
+
+  it('returns summarized text for vision model with mixed content', () => {
+    const resp: MCPCallToolResponse = {
+      content: [
+        { type: 'text', text: 'Description' },
+        { type: 'image', data: 'abc', mimeType: 'image/jpeg' }
+      ]
+    }
+    const result = mcpToolCallResponseToOpenAIChatToolContent(resp, true)
+    expect(result).toBe('Description\n[Image result: image/jpeg, base64 payload present]')
+  })
+
+  it('returns JSON string for error response', () => {
+    const resp: MCPCallToolResponse = {
+      isError: true,
+      content: [{ type: 'text', text: 'Error occurred' }]
+    }
+    const result = mcpToolCallResponseToOpenAIChatToolContent(resp, false)
+    expect(result).toBe(JSON.stringify(resp.content))
+  })
+
+  it('stringifies non-text items for non-vision model', () => {
+    const resp: MCPCallToolResponse = {
+      content: [
+        { type: 'text', text: 'hello' },
+        { type: 'image', data: 'img', mimeType: 'image/png' }
+      ]
+    }
+    const result = mcpToolCallResponseToOpenAIChatToolContent(resp, false)
+    expect(result).toContain('hello')
+    expect(result).toContain('"type":"image"')
+  })
+
+  it('handles empty text gracefully', () => {
+    const resp: MCPCallToolResponse = {
+      content: [{ type: 'text' }]
+    }
+    const result = mcpToolCallResponseToOpenAIChatToolContent(resp, false)
+    expect(result).toBe('')
+  })
+})

--- a/src/renderer/src/utils/mcp-tool-content.ts
+++ b/src/renderer/src/utils/mcp-tool-content.ts
@@ -1,0 +1,76 @@
+import type OpenAI from '@cherrystudio/openai'
+import type { MCPCallToolResponse, MCPToolResultContent } from '@renderer/types'
+
+function summarizeMcpToolResultItem(item: MCPToolResultContent): string {
+  switch (item.type) {
+    case 'text':
+      return item.text || ''
+    case 'image':
+      return `[Image result: ${item.mimeType || 'unknown'}, base64 payload present]`
+    case 'audio':
+      return `[Audio result: ${item.mimeType || 'unknown'}, base64 payload present]`
+    case 'resource':
+      if (item.resource?.text) {
+        return item.resource.text
+      }
+      return `[Resource result: ${item.resource?.uri || 'unknown'} (${item.resource?.mimeType || item.mimeType || 'unknown'})]`
+    default:
+      return JSON.stringify(item)
+  }
+}
+
+export function mcpToolCallResponseToOpenAIResponsesOutput(
+  resp: MCPCallToolResponse,
+  isVision: boolean
+): string | OpenAI.Responses.ResponseFunctionCallOutputItemList {
+  if (resp.isError) {
+    return JSON.stringify(resp.content)
+  }
+
+  if (isVision) {
+    const parts: OpenAI.Responses.ResponseFunctionCallOutputItemList = []
+    for (const item of resp.content) {
+      switch (item.type) {
+        case 'text':
+          parts.push({ type: 'input_text', text: item.text || 'no content' })
+          break
+        case 'image':
+          if (item.data) {
+            parts.push({
+              type: 'input_image',
+              image_url: `data:${item.mimeType || 'image/png'};base64,${item.data}`,
+              detail: 'auto'
+            })
+          } else {
+            parts.push({ type: 'input_text', text: '[Image result omitted: missing image data]' })
+          }
+          break
+        default:
+          parts.push({ type: 'input_text', text: summarizeMcpToolResultItem(item) })
+          break
+      }
+    }
+    return parts
+  }
+
+  return JSON.stringify(resp.content)
+}
+
+export function mcpToolCallResponseToOpenAIChatToolContent(resp: MCPCallToolResponse, isVision: boolean): string {
+  if (resp.isError) {
+    return JSON.stringify(resp.content)
+  }
+
+  if (isVision) {
+    return resp.content.map((item) => summarizeMcpToolResultItem(item)).join('\n')
+  }
+
+  return resp.content
+    .map((item) => {
+      if (item.type === 'text') {
+        return item.text || ''
+      }
+      return JSON.stringify(item)
+    })
+    .join('\n')
+}


### PR DESCRIPTION
Fixes #13292

## Summary

MCP tool results with multiple content elements (text + images, audio, resources) were being passed through `JSON.stringify(resp.content)`, producing a raw JSON string instead of properly structured content. This affected both OpenAI API clients.

## Changes

- **`src/renderer/src/utils/mcp-tool-content.ts`** — New utility with two conversion functions:
  - `mcpToolCallResponseToOpenAIResponsesOutput()` for the Responses API (returns structured `input_image` parts for vision models)
  - `mcpToolCallResponseToOpenAIChatToolContent()` for the Chat API (returns text with descriptive placeholders for non-text content)
  - Private helper `summarizeMcpToolResultItem()` for consistent non-text content summarization

- **`OpenAIResponseAPIClient.ts`** — Replace `JSON.stringify(resp.content)` with `mcpToolCallResponseToOpenAIResponsesOutput(resp, isVisionModel(model))`

- **`OpenAIApiClient.ts`** — Replace `JSON.stringify(resp.content)` with `mcpToolCallResponseToOpenAIChatToolContent(resp, isVisionModel(model))`

Other API clients (Anthropic, Bedrock, Gemini) already handle multi-element content correctly.

## Test Plan

- 12 unit tests covering both functions with various content types (text, image, audio, resource, error, mixed)
- All 2614 renderer tests pass
- Typecheck and lint clean