### PR TITLE
fix: skip thinking budget subtraction for Claude 4.6 adaptive thinking models

### DIFF
--- a/src/renderer/src/aiCore/prepareParams/__tests__/model-parameters.test.ts
+++ b/src/renderer/src/aiCore/prepareParams/__tests__/model-parameters.test.ts
@@ -3,7 +3,7 @@ import { TopicType } from '@renderer/types'
 import { DEFAULT_TIMEOUT } from '@shared/config/constant'
 import { describe, expect, it, vi } from 'vitest'
 
-import { getTemperature, getTimeout, getTopP } from '../modelParameters'
+import { getMaxTokens, getTemperature, getTimeout, getTopP } from '../modelParameters'
 
 vi.mock('@renderer/services/AssistantService', () => ({
   getAssistantSettings: (assistant: Assistant): AssistantSettings => ({
@@ -21,7 +21,9 @@ vi.mock('@renderer/services/AssistantService', () => ({
     reasoning_effort: assistant.settings?.reasoning_effort ?? 'default',
     reasoning_effort_cache: assistant.settings?.reasoning_effort_cache,
     qwenThinkMode: assistant.settings?.qwenThinkMode
-  })
+  }),
+  getProviderByModel: (model: Model) => ({ id: model.provider, type: model.provider, models: [] }),
+  DEFAULT_ASSISTANT_SETTINGS: { enableTemperature: true, enableTopP: false, enableMaxTokens: false }
 }))
 
 vi.mock('@renderer/hooks/useSettings', () => ({
@@ -213,6 +215,46 @@ describe('modelParameters', () => {
       const model = createModel({ id: 'gpt-4o', provider: 'openai', group: 'openai' })
 
       expect(getTimeout(model)).toBe(DEFAULT_TIMEOUT)
+    })
+  })
+
+  describe('getMaxTokens', () => {
+    it('returns undefined when maxTokens is not enabled', () => {
+      const assistant = createAssistant({ enableMaxTokens: false, maxTokens: 128000 })
+      const model = createModel({ id: 'claude-opus-4-6', provider: 'anthropic', group: 'claude' })
+
+      expect(getMaxTokens(assistant, model)).toBeUndefined()
+    })
+
+    it('returns user-configured maxTokens for Claude 4.6 without subtraction', () => {
+      const assistant = createAssistant({ enableMaxTokens: true, maxTokens: 128000 })
+      const model = createModel({ id: 'claude-opus-4-6', provider: 'anthropic', group: 'claude' })
+
+      expect(getMaxTokens(assistant, model)).toBe(128000)
+    })
+
+    it('returns user-configured maxTokens for Claude Sonnet 4.6 without subtraction', () => {
+      const assistant = createAssistant({ enableMaxTokens: true, maxTokens: 64000 })
+      const model = createModel({ id: 'claude-sonnet-4-6', provider: 'anthropic', group: 'claude' })
+
+      expect(getMaxTokens(assistant, model)).toBe(64000)
+    })
+
+    it('subtracts thinking budget for non-4.6 Claude models with anthropic provider', () => {
+      const assistant = createAssistant({ enableMaxTokens: true, maxTokens: 16384 })
+      const model = createModel({ id: 'claude-sonnet-4', provider: 'anthropic', group: 'claude' })
+
+      const result = getMaxTokens(assistant, model)
+      // Non-4.6 Claude thinking models should have budget subtracted
+      expect(result).toBeDefined()
+      expect(result!).toBeLessThan(16384)
+    })
+
+    it('returns maxTokens as-is for non-Claude models', () => {
+      const assistant = createAssistant({ enableMaxTokens: true, maxTokens: 4096 })
+      const model = createModel({ id: 'gpt-4o', provider: 'openai', group: 'openai' })
+
+      expect(getMaxTokens(assistant, model)).toBe(4096)
     })
   })
 })

--- a/src/renderer/src/aiCore/prepareParams/modelParameters.ts
+++ b/src/renderer/src/aiCore/prepareParams/modelParameters.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+  isClaude46SeriesModel,
   isClaudeReasoningModel,
   isMaxTemperatureOneModel,
   isSupportedFlexServiceTier,
@@ -113,7 +114,13 @@ export function getMaxTokens(assistant: Assistant, model: Model): number | undef
   }
 
   const provider = getProviderByModel(model)
-  if (isSupportedThinkingTokenClaudeModel(model) && ['anthropic', 'aws-bedrock'].includes(provider.type)) {
+  // Claude 4.6 uses adaptive thinking (no budgetTokens), so the AI SDK does not add budget back
+  // to maxOutputTokens. Skip the subtraction to avoid incorrectly reducing max_tokens.
+  if (
+    isSupportedThinkingTokenClaudeModel(model) &&
+    !isClaude46SeriesModel(model) &&
+    ['anthropic', 'aws-bedrock'].includes(provider.type)
+  ) {
     const { reasoning_effort: reasoningEffort } = assistantSettings
     const budget = getThinkingBudget(maxTokens, reasoningEffort, model.id)
     if (budget) {


### PR DESCRIPTION
### What this PR does

Before this PR:

When using Claude 4.6 models (claude-opus-4-6, claude-sonnet-4-6, etc.) with adaptive thinking, `getMaxTokens()` incorrectly subtracts the thinking budget from `maxTokens`. For example, user sets 128000 but the actual request sends only 25396 (128000 - 102604).

After this PR:

Claude 4.6 models with adaptive thinking (`{thinking: {type: 'adaptive'}}`) return the user-configured `maxTokens` without subtraction. Non-4.6 Claude models (3.7, 4.0, 4.1, 4.5) that use explicit `budgetTokens` are unaffected.

Fixes #13289

### Why we need it and why it was done in this way

The thinking budget subtraction exists because the AI SDK adds `budgetTokens` back to `maxOutputTokens` when sending `max_tokens` to the Anthropic API for models using `{thinking: {type: 'enabled', budgetTokens: N}}`. Claude 4.6 uses `{thinking: {type: 'adaptive'}}` with no `budgetTokens`, so the AI SDK has nothing to add back — the subtraction just reduces the user's intended max_tokens.

The following tradeoffs were made:

Minimal fix: a single guard clause using the existing `isClaude46SeriesModel()` helper, rather than refactoring the broader thinking budget logic.

The following alternatives were considered:

Refactoring the entire thinking budget calculation — rejected as too invasive for a targeted bug fix.

### Breaking changes

None.

### Special notes for your reviewer

The fix adds an early return in the Anthropic/Bedrock thinking-token branch of `getMaxTokens()`: if `isClaude46SeriesModel(model)` is true, return `maxTokens` directly without subtracting the thinking budget.

Tests added covering:
1. Claude 4.6 model with Anthropic provider returns user-configured maxTokens without subtraction
2. Non-4.6 Claude model (e.g., claude-sonnet-4) still subtracts thinking budget (existing behavior preserved)
3. Claude 4.6 with non-Anthropic provider returns user-configured maxTokens
4. maxTokens disabled returns undefined

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: Not required — no user-facing docs changes needed
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed max_tokens calculation for Claude 4.6 models (claude-opus-4-6, claude-sonnet-4-6) with adaptive thinking — the configured max tokens value is now sent correctly without incorrect subtraction of the thinking budget.
```