### PR TITLE
fix(main): avoid PDF startup crash in Electron main

### DIFF
--- a/packages/shared/utils/pdf.ts
+++ b/packages/shared/utils/pdf.ts
@@ -1,4 +1,44 @@
-import { PDFParse } from 'pdf-parse'
+type PDFParseConstructor = typeof import('pdf-parse').PDFParse
+
+let PDFParse: PDFParseConstructor | null = null
+
+function ensureNodeDOMMatrixPolyfill() {
+  if (typeof DOMMatrix !== 'undefined') {
+    return
+  }
+
+  // Minimal DOMMatrix shim for Node/Electron main process.
+  class NodeDOMMatrix {
+    multiplySelf() {
+      return this
+    }
+    preMultiplySelf() {
+      return this
+    }
+    invertSelf() {
+      return this
+    }
+    translate() {
+      return this
+    }
+    scale() {
+      return this
+    }
+  }
+
+  ;(globalThis as { DOMMatrix?: unknown }).DOMMatrix = NodeDOMMatrix
+}
+
+async function getPDFParse(): Promise<PDFParseConstructor> {
+  if (PDFParse) {
+    return PDFParse
+  }
+
+  ensureNodeDOMMatrixPolyfill()
+  const mod = await import('pdf-parse')
+  PDFParse = mod.PDFParse
+  return PDFParse
+}
 
 /**
  * Extract text content from PDF data.
@@ -8,6 +48,8 @@ import { PDFParse } from 'pdf-parse'
  * @returns Extracted text content
  */
 export async function extractPdfText(data: Uint8Array | ArrayBuffer | string | URL): Promise<string> {
+  const PDFParse = await getPDFParse()
+
   if (data instanceof URL) {
     const parser = new PDFParse({ url: data.href })
     try {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -22,7 +22,6 @@ import type { UpgradeChannel } from '@shared/config/constant'
 import { MIN_WINDOW_HEIGHT, MIN_WINDOW_WIDTH } from '@shared/config/constant'
 import type { LocalTransferConnectPayload } from '@shared/config/types'
 import { IpcChannel } from '@shared/IpcChannel'
-import { extractPdfText } from '@shared/utils/pdf'
 import type {
   AgentPersistedMessage,
   FileMetadata,
@@ -650,7 +649,10 @@ export async function registerIpc(mainWindow: BrowserWindow, app: Electron.App) 
   ipcMain.handle(IpcChannel.File_ShowInFolder, fileManager.showInFolder.bind(fileManager))
 
   // pdf
-  ipcMain.handle(IpcChannel.Pdf_ExtractText, (_, data: Uint8Array | ArrayBuffer | string) => extractPdfText(data))
+  ipcMain.handle(IpcChannel.Pdf_ExtractText, async (_, data: Uint8Array | ArrayBuffer | string) => {
+    const { extractPdfText } = await import('@shared/utils/pdf')
+    return extractPdfText(data)
+  })
 
   // file service
   ipcMain.handle(IpcChannel.FileService_Upload, async (_, provider: Provider, file: FileMetadata) => {


### PR DESCRIPTION
### What this PR does

Before this PR:
- The main process imported `@shared/utils/pdf` when registering IPC handlers.
- The shared PDF utility imported `pdf-parse` eagerly, which pulled in `pdfjs-dist` during app startup.
- On Electron main, that dependency chain referenced `DOMMatrix` and could crash the app before the PDF extraction IPC handler was ever called.

After this PR:
- The PDF extraction utility is loaded lazily inside `IpcChannel.Pdf_ExtractText`.
- The shared PDF utility loads `pdf-parse` on demand instead of at module initialization time.
- A minimal main-process `DOMMatrix` shim is added before loading `pdf-parse`, preventing startup crashes in Electron main.

Fixes #13682

### Why we need it and why it was done in this way

The following tradeoffs were made:
- The fix keeps the existing IPC-based PDF extraction flow intact instead of refactoring the renderer/main split in the same patch.
- The utility is loaded lazily in the IPC handler so the main process no longer initializes the PDF parsing dependency chain during startup.
- A minimal shim is used as a targeted compatibility layer for Electron main to prevent `pdfjs-dist` from crashing on missing `DOMMatrix`.

The following alternatives were considered:
- Reverting the PDF compatibility work entirely, which would have regressed the original aggregator-provider fix.
- Moving all PDF extraction work fully into the renderer, which is larger in scope than needed for this regression fix.
- Leaving the import eager and only wrapping the IPC handler, which would still allow runtime failures when the parser loads in main.

Links to places where the discussion took place: #13682

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- This is a regression fix for commit `fb42d4d0b5b40c3b0671d68905cad5322e857ff1`.
- The change is intentionally minimal and only touches the main-process import timing and PDF utility initialization path.
- Lint checks passed for the edited files. I did not run a full app startup smoke test in this automation flow.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed a startup crash on Windows and other Electron main-process environments where PDF parsing could fail with `DOMMatrix is not defined` after the recent PDF compatibility changes.
```
