### PR TITLE
fix(linkConverter): enhance link parsing to handle invalid parenthesized links

### DIFF
--- a/src/renderer/src/utils/__tests__/linkConverter.test.ts
+++ b/src/renderer/src/utils/__tests__/linkConverter.test.ts
@@ -31,6 +31,13 @@ describe('linkConverter', () => {
       expect(result.hasBufferedContent).toBe(false)
     })
 
+    it('should not handle impossible parenthesized grounding link', () => {
+      const input = 'await sendBatch([1], topicData.topicID, topicData.csrfToken);'
+      const result = convertLinks(input, true)
+      expect(result.text).toBe(input)
+      expect(result.hasBufferedContent).toBe(false)
+    })
+
     it('should use the same counter for duplicate URLs', () => {
       const input =
         '第一个链接 [example.com](https://example.com) 和第二个相同链接 [subdomain.example.com](https://example.com)'

--- a/src/renderer/src/utils/linkConverter.ts
+++ b/src/renderer/src/utils/linkConverter.ts
@@ -51,8 +51,13 @@ export function convertLinks(
         const match = /^\(\[([^\]]+)\]\(([^)]+)\)\)/.exec(substring)
 
         if (!match) {
-          safePoint = i
-          break
+          // [text] 已完整但后面没跟 (，永远无法形成合法的 ([text](url)) 格式
+          const definitelyNotLink = /^\(\[[^\]]+\][^(]/.test(substring)
+          if (!definitelyNotLink) {
+            safePoint = i
+            break
+          }
+          // fall through，按普通字符处理
         }
       }
     } else if (buffer[i] === '[') {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

⚠️ Important: Redux/IndexedDB Data-Changing Feature PRs Temporarily On Hold ⚠️

Please note: For our current development cycle, we are not accepting feature Pull Requests that introduce changes to Redux data models or IndexedDB schemas.

While we value your contributions, PRs of this nature will be blocked without merge. We welcome all other contributions (bug fixes, perf enhancements, docs, etc.). Thank you!

Once version 2.0.0 is released, we will resume reviewing feature PRs.

-->

### What this PR does

- Update the link conversion logic to correctly identify and skip over invalid parenthesized grounding links.
- Add a test case.

**Before this PR**:

Q:
```
Please output this code wrapped in a code block:
await sendBatch([1], topicData.topicID, topicData.csrfToken);
```

A:
```
await sendBatch
```

**After this PR**:

Q:
```
Please output this code wrapped in a code block:
await sendBatch([1], topicData.topicID, topicData.csrfToken);
```

A:
```
await sendBatch([1], topicData.topicID, topicData.csrfToken);
```

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #13612

### Why we need it and why it was done in this way

`linkConverter` operates at the raw stream chunk level and knows nothing about markdown semantics (e.g. code blocks). Protecting code blocks at this stage would require maintaining a stateful markdown parser across chunks, which adds significant complexity.

See review comments in #7724 for more information about this topic.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/pull/7724#discussion_r2177943378

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Enhance link parsing to handle invalid parenthesized links.
```
