### PR TITLE
fix(install): preserve lib/ directory structure when extracting Windows zip

### DIFF
--- a/resources/scripts/install-openclaw.js
+++ b/resources/scripts/install-openclaw.js
@@ -194,9 +194,12 @@ async function downloadOpenClawBinary(platform, arch, version = DEFAULT_VERSION,
 
       for (const entry of Object.values(entries)) {
         if (!entry.isDirectory) {
-          const filename = path.basename(entry.name)
-          const outputPath = path.join(binDir, filename)
-          console.log(`Extracting ${entry.name} -> ${filename}`)
+          const outputPath = path.join(binDir, entry.name)
+          const outputDir = path.dirname(outputPath)
+          if (!fs.existsSync(outputDir)) {
+            fs.mkdirSync(outputDir, { recursive: true })
+          }
+          console.log(`Extracting ${entry.name} -> ${outputPath}`)
           await zip.extract(entry.name, outputPath)
           console.log(`Extracted ${entry.name} -> ${outputPath}`)
         }


### PR DESCRIPTION
### What this PR does

Before this PR:

When installing OpenClaw on Windows, the zip extraction code used
`path.basename(entry.name)` to determine the output path, which stripped
all directory information and placed every file flat into `binDir`. Any
files inside `lib/` (e.g. `lib/playwright_core.node`) were extracted to
`binDir/playwright_core.node` instead of `binDir/lib/playwright_core.node`.

After this PR:

The zip extraction now uses `entry.name` directly as the relative output
path and creates intermediate directories with `mkdirSync({ recursive: true })`
as needed, matching the behaviour of the tar.gz extraction path used on
macOS/Linux.

Fixes #13671

### Why we need it and why it was done in this way

OpenClaw ships a `lib/` sidecar directory alongside its binary. The
tar.gz extractor (macOS/Linux) already handled this correctly by
preserving the `lib/` subdirectory. The zip extractor (Windows) did not,
causing the sidecar files to land in the wrong location.

As a result, when OpenClaw tried to load `playwright-core` via a relative
`lib/` path to execute browser actions (`fill`, `click`, etc.), the module
was not found and `chromium.connectOverCDP` was undefined. Snapshot
operations worked because they use a different code path that does not
require a CDP connection.

The fix is minimal: preserve the relative path from the zip entry instead
of only its basename, and ensure the target directory exists before
extraction.

The following tradeoffs were made: N/A

The following alternatives were considered: Extracting the whole zip to a
temp directory and then running the same `findAndMoveFiles` logic as
tar.gz — avoided to keep the change small.

### Breaking changes

None.

### Special notes for your reviewer

The fix is a 3-line change in `resources/scripts/install-openclaw.js`.
Users who already have OpenClaw installed on Windows can resolve the issue
by uninstalling and reinstalling OpenClaw from the Cherry Studio UI.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is not required (internal install script change).
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed a bug on Windows where installing OpenClaw did not correctly extract
the lib/ sidecar directory, causing browser actions (fill, click, etc.) to
fail with a `connectOverCDP` error while snapshot still worked.
```
