### PR TITLE
fix: avoid overriding Codex built-in OpenAI provider

### DIFF
--- a/src/main/services/CodeToolsConfig.ts
+++ b/src/main/services/CodeToolsConfig.ts
@@ -1,0 +1,36 @@
+export interface OpenAICodexConfigParams {
+  providerId: string
+  providerName?: string
+  baseUrl?: string
+  model: string
+}
+
+const OPENAI_CODEX_BUILT_IN_PROVIDER_CONFIG_KEYS: Record<string, string> = {
+  openai: 'openai_base_url'
+}
+
+const quoteCliValue = (value: string) => JSON.stringify(value)
+
+export const buildOpenAICodexConfigParams = ({
+  providerId,
+  providerName,
+  baseUrl,
+  model
+}: OpenAICodexConfigParams): string => {
+  const normalizedBaseUrl = baseUrl?.replace(/\/$/, '') ?? ''
+  const configParams = [`--config model_provider=${quoteCliValue(providerId)}`]
+  const builtInBaseUrlConfigKey = OPENAI_CODEX_BUILT_IN_PROVIDER_CONFIG_KEYS[providerId]
+
+  if (builtInBaseUrlConfigKey) {
+    configParams.push(`--config ${builtInBaseUrlConfigKey}=${quoteCliValue(normalizedBaseUrl)}`)
+  } else {
+    configParams.push(`--config model_providers.${providerId}.name=${quoteCliValue(providerName || providerId)}`)
+    configParams.push(`--config model_providers.${providerId}.base_url=${quoteCliValue(normalizedBaseUrl)}`)
+    configParams.push('--config model_providers.' + providerId + '.env_key="OPENAI_API_KEY"')
+    configParams.push('--config model_providers.' + providerId + '.wire_api="responses"')
+  }
+
+  configParams.push(`--config model=${quoteCliValue(model)}`)
+
+  return configParams.join(' ')
+}

--- a/src/main/services/CodeToolsService.ts
+++ b/src/main/services/CodeToolsService.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 
 import { loggerService } from '@logger'
 import { isMac, isWin } from '@main/constant'
+import { buildOpenAICodexConfigParams } from '@main/services/CodeToolsConfig'
 import { removeEnvProxy } from '@main/utils'
 import { isUserInChina } from '@main/utils/ipService'
 import { getBinaryName } from '@main/utils/process'
@@ -937,19 +938,12 @@ class CodeToolsService {
 
     // Add configuration parameters for OpenAI Codex using command line args
     if (cliTool === codeTools.openaiCodex && env.OPENAI_MODEL_PROVIDER) {
-      const providerId = env.OPENAI_MODEL_PROVIDER
-      const providerName = env.OPENAI_MODEL_PROVIDER_NAME || providerId
-      const normalizedBaseUrl = env.OPENAI_BASE_URL.replace(/\/$/, '')
-      const model = _model
-
-      const configParams = [
-        `--config model_provider="${providerId}"`,
-        `--config model_providers.${providerId}.name="${providerName}"`,
-        `--config model_providers.${providerId}.base_url="${normalizedBaseUrl}"`,
-        `--config model_providers.${providerId}.env_key="OPENAI_API_KEY"`,
-        `--config model_providers.${providerId}.wire_api="responses"`,
-        `--config model="${model}"`
-      ].join(' ')
+      const configParams = buildOpenAICodexConfigParams({
+        providerId: env.OPENAI_MODEL_PROVIDER,
+        providerName: env.OPENAI_MODEL_PROVIDER_NAME,
+        baseUrl: env.OPENAI_BASE_URL,
+        model: _model
+      })
       baseCommand = `${baseCommand} ${configParams}`
     }
 

--- a/src/main/services/__tests__/CodeToolsConfig.test.ts
+++ b/src/main/services/__tests__/CodeToolsConfig.test.ts
@@ -1,0 +1,33 @@
+import { buildOpenAICodexConfigParams } from '../CodeToolsConfig'
+
+describe('buildOpenAICodexConfigParams', () => {
+  it('uses the built-in openai provider config without overriding reserved IDs', () => {
+    const configParams = buildOpenAICodexConfigParams({
+      providerId: 'openai',
+      providerName: 'OpenAI',
+      baseUrl: 'https://api.openai.com/v1/',
+      model: 'gpt-5-codex'
+    })
+
+    expect(configParams).toContain('--config model_provider="openai"')
+    expect(configParams).toContain('--config openai_base_url="https://api.openai.com/v1"')
+    expect(configParams).toContain('--config model="gpt-5-codex"')
+    expect(configParams).not.toContain('model_providers.openai')
+  })
+
+  it('keeps custom providers in model_providers config', () => {
+    const configParams = buildOpenAICodexConfigParams({
+      providerId: 'openrouter',
+      providerName: 'OpenRouter',
+      baseUrl: 'https://openrouter.ai/api/v1/',
+      model: 'openai/gpt-5'
+    })
+
+    expect(configParams).toContain('--config model_provider="openrouter"')
+    expect(configParams).toContain('--config model_providers.openrouter.name="OpenRouter"')
+    expect(configParams).toContain('--config model_providers.openrouter.base_url="https://openrouter.ai/api/v1"')
+    expect(configParams).toContain('--config model_providers.openrouter.env_key="OPENAI_API_KEY"')
+    expect(configParams).toContain('--config model_providers.openrouter.wire_api="responses"')
+    expect(configParams).toContain('--config model="openai/gpt-5"')
+  })
+})


### PR DESCRIPTION
### What this PR does

Before this PR:
Launching OpenAI Codex with the built-in OpenAI provider passed `model_providers.openai.*` overrides to Codex CLI, which failed with a reserved built-in provider ID error.

After this PR:
Built-in OpenAI launches use Codex's `openai_base_url` config, while custom OpenAI-compatible providers still use `model_providers.<id>` overrides and keep working.

Fixes # None

### Why we need it and why it was done in this way

Codex CLI treats `openai` as a reserved built-in provider and rejects custom `model_providers.openai.*` overrides. This change moves OpenAI Codex config assembly into a small helper so built-in and custom providers follow the correct config path, and adds coverage for both launch paths.

The following tradeoffs were made:

A small helper and targeted main-process tests were added instead of keeping the command construction fully inline.

The following alternatives were considered:

Keeping the branching inline in `CodeToolsService`, or renaming the built-in provider ID in Cherry Studio. The inline approach would stay harder to test, and renaming the built-in provider would not match Codex CLI semantics.

Links to places where the discussion took place: None

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Verified locally with `pnpm lint`, `pnpm test`, and `pnpm format`.

No documentation update is required because this only fixes an existing OpenAI Codex launch failure in Code Tools.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed OpenAI Codex launches when the selected provider is the built-in OpenAI provider by using Codex's built-in OpenAI config path instead of overriding a reserved provider ID.
```
