### PR TITLE
fix: agent session auto renaming feedback

### DIFF
--- a/src/renderer/src/assets/styles/animation.css
+++ b/src/renderer/src/assets/styles/animation.css
@@ -111,20 +111,18 @@
   will-change: background-position;
 }
 
-/* 打字机动画 */
-@keyframes animation-typewriter {
+/* Reveal 动画 */
+@keyframes animation-reveal {
   from {
-    width: 0;
+    clip-path: inset(0 100% 0 0);
   }
   to {
-    width: 100%;
+    clip-path: inset(0 0 0 0);
   }
 }
 
-.animation-typewriter {
+.animation-reveal {
   display: block;
   white-space: nowrap;
-  overflow: hidden;
-  animation: animation-typewriter 0.5s steps(40, end);
-  will-change: width;
+  animation: animation-reveal 0.5s linear both;
 }

--- a/src/renderer/src/pages/agents/components/SessionItem.tsx
+++ b/src/renderer/src/pages/agents/components/SessionItem.tsx
@@ -201,7 +201,7 @@ const SessionItem = ({ session, agentId, onDelete, onPress }: SessionItemProps) 
               <div className="truncate text-[13px]">
                 <SessionLabel
                   session={session}
-                  className={isRenaming ? 'animation-shimmer' : isNewlyRenamed ? 'animation-typewriter' : ''}
+                  className={isRenaming ? 'animation-shimmer' : isNewlyRenamed ? 'animation-reveal' : ''}
                 />
               </div>
               <DeleteButton />

--- a/src/renderer/src/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/Topics.tsx
@@ -599,7 +599,7 @@ export const Topics: React.FC<Props> = ({ assistant: _assistant, activeTopic, se
 
           const getTopicNameClassName = () => {
             if (isRenaming(topic.id)) return 'animation-shimmer'
-            if (isNewlyRenamed(topic.id)) return 'animation-typewriter'
+            if (isNewlyRenamed(topic.id)) return 'animation-reveal'
             return ''
           }
 
@@ -796,11 +796,10 @@ const TopicName = styled.div`
   overflow: hidden;
   font-size: 13px;
   position: relative;
-  will-change: background-position, width;
   flex: 1;
   text-align: left;
 
-  &.animation-typewriter {
+  &.animation-reveal {
     -webkit-line-clamp: unset;
     -webkit-box-orient: unset;
   }

--- a/src/renderer/src/pages/notes/components/TreeNode.tsx
+++ b/src/renderer/src/pages/notes/components/TreeNode.tsx
@@ -71,7 +71,7 @@ const TreeNode = memo<TreeNodeProps>(({ node, depth, renderChildren = true, onHi
 
   const getNodeNameClassName = () => {
     if (isRenaming) return 'animation-shimmer'
-    if (isNewlyRenamed) return 'animation-typewriter'
+    if (isNewlyRenamed) return 'animation-reveal'
     return ''
   }
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

⚠️ Important: Redux/IndexedDB Data-Changing Feature PRs Temporarily On Hold ⚠️

Please note: For our current development cycle, we are not accepting feature Pull Requests that introduce changes to Redux data models or IndexedDB schemas.

While we value your contributions, PRs of this nature will be blocked without merge. We welcome all other contributions (bug fixes, perf enhancements, docs, etc.). Thank you!

Once version 2.0.0 is released, we will resume reviewing feature PRs.

-->

### What this PR does

Adds back the revealing animation to agent session renaming.

- Animation `typing` is improved using clip-path and renamed to `reveal`.
- `shimmer` and `reveal` animations are extracted to `animation.css`.
- These animiations are applied to agent session renaming.

**Before this PR**:

There is no feedback on agent session renaming.

**After this PR**:

Same animation feedbacks on renaming topic, session, and note items.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Add the revealing animation to agent session renaming.
```
