### PR TITLE
feat(agent): add OpenRouter support for Agent mode

### DIFF
--- a/src/renderer/src/config/providers.ts
+++ b/src/renderer/src/config/providers.ts
@@ -339,6 +339,9 @@ export const SYSTEM_PROVIDERS_CONFIG: Record<SystemProviderId, SystemProvider> =
     type: 'openai',
     apiKey: '',
     apiHost: 'https://openrouter.ai/api/v1/',
+    // Anthropic-compatible endpoint for Agent mode (Claude Code SDK)
+    // https://openrouter.ai/docs/guides/guides/coding-agents/claude-code-integration
+    anthropicApiHost: 'https://openrouter.ai/api',
     models: SYSTEM_MODELS.openrouter,
     isSystem: true,
     enabled: false


### PR DESCRIPTION
### What this PR does

Before this PR:
- OpenRouter provider could not be used with Agent mode (Claude Code SDK)
- Agent mode validation required `provider.type === 'anthropic'` or `anthropicApiHost` to be set
- OpenRouter was configured with `type: 'openai'` and no `anthropicApiHost`

After this PR:
- OpenRouter provider is now supported in Agent mode
- Users can select OpenRouter models (e.g., `anthropic/claude-sonnet-4`) for Agent sessions
- Leverages OpenRouter's native Anthropic-compatible endpoint ("Anthropic Skin") at `https://openrouter.ai/api`

Fixes #13662

### Why we need it and why it was done in this way

Users requested the ability to use OpenRouter with Agent mode. OpenRouter provides a native Anthropic-compatible API endpoint that fully supports Claude Code SDK features including tool use, thinking blocks, and the Agent SDK.

The implementation is minimal - a single configuration line adding `anthropicApiHost` to the OpenRouter provider config. The existing validation logic in `ClaudeCodeService` already handles providers with `anthropicApiHost` configured, so no code changes were needed beyond the configuration.

The following tradeoffs were made:
- Used OpenRouter's Anthropic endpoint (`https://openrouter.ai/api`) instead of the OpenAI-compatible endpoint (`https://openrouter.ai/api/v1/`)
- This ensures full compatibility with Claude Code SDK's native protocol

The following alternatives were considered:
- Creating a separate provider type for OpenRouter Anthropic - rejected as unnecessary complexity
- Modifying validation logic to special-case OpenRouter - rejected in favor of the existing `anthropicApiHost` pattern

Links to places where the discussion took place:
- Issue #13662
- OpenRouter documentation: https://openrouter.ai/docs/guides/guides/coding-agents/claude-code-integration

### Breaking changes

None. This is an additive feature that only adds configuration to an existing provider.

### Special notes for your reviewer

- The `anthropicApiHost` pattern is already used by other providers (LMStudio, Ollama, Minimax, Moonshot, etc.)
- No migration needed as this is a provider-level configuration, not a user setting
- TypeScript type checking, linting, and all tests pass

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Add OpenRouter support for Agent mode (Claude Code SDK). Users can now select OpenRouter as a provider for Agent sessions with Claude models.
```
