### PR TITLE
fix(groq): add dedicated @ai-sdk/groq provider to avoid reasoning_content errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "ci": "pnpm ci:basic-check && pnpm ci:test-check"
   },
   "dependencies": {
+    "@ai-sdk/groq": "^3.0.31",
     "@anthropic-ai/claude-agent-sdk": "0.2.81",
     "@expo/sudo-prompt": "^9.3.2",
     "@libsql/client": "0.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/groq':
+        specifier: ^3.0.31
+        version: 3.0.31(zod@4.3.4)
       '@anthropic-ai/claude-agent-sdk':
         specifier: 0.2.81
         version: 0.2.81(zod@4.3.4)
@@ -1397,6 +1400,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/groq@3.0.31':
+    resolution: {integrity: sha512-XbbugpnFmXGu2TlXiq8KUJskP6/VVbuFcnFIGDzDIB/Chg6XHsNnqrTF80Zxkh0Pd3+NvbM+2Uqrtsndk6bDAg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/huggingface@1.0.32':
     resolution: {integrity: sha512-2ucFTypb0liGO60dTn6sAMAn8Nkb7E4OHsXo6gm5pApaK7sLyM2vYNwvtFx0BqlZ0v6eZd0z7hjHszNG9sFV8g==}
     engines: {node: '>=18'}
@@ -1429,6 +1438,12 @@ packages:
 
   '@ai-sdk/provider-utils@4.0.15':
     resolution: {integrity: sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.21':
+    resolution: {integrity: sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -12269,6 +12284,12 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.15(zod@4.3.6)
       zod: 4.3.6
 
+  '@ai-sdk/groq@3.0.31(zod@4.3.4)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.21(zod@4.3.4)
+      zod: 4.3.4
+
   '@ai-sdk/huggingface@1.0.32(zod@4.3.4)':
     dependencies:
       '@ai-sdk/openai-compatible': 2.0.30(patch_hash=75058a2443f9c0eb3d44e09a419a2c9720e51329bbb174019c772e57521843f1)(zod@4.3.4)
@@ -12325,6 +12346,13 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 4.3.6
+
+  '@ai-sdk/provider-utils@4.0.21(zod@4.3.4)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.4
 
   '@ai-sdk/provider@3.0.8':
     dependencies:

--- a/src/renderer/src/aiCore/provider/factory.ts
+++ b/src/renderer/src/aiCore/provider/factory.ts
@@ -31,6 +31,7 @@ const STATIC_PROVIDER_MAPPING: Record<string, ProviderId> = {
   'azure-openai': 'azure', // Azure OpenAI -> azure
   'openai-response': 'openai', // OpenAI Responses -> openai
   grok: 'xai', // Grok -> xai
+  groq: 'groq', // Groq -> dedicated @ai-sdk/groq provider
   copilot: 'github-copilot-openai-compatible',
   tokenflux: 'openrouter' // TokenFlux -> openrouter (fully compatible)
 }

--- a/src/renderer/src/aiCore/provider/providerInitialization.ts
+++ b/src/renderer/src/aiCore/provider/providerInitialization.ts
@@ -102,6 +102,13 @@ export const NEW_PROVIDER_CONFIGS: ProviderConfig[] = [
     import: () => import('ollama-ai-provider-v2'),
     creatorFunctionName: 'createOllama',
     supportsImageGeneration: false
+  },
+  {
+    id: 'groq',
+    name: 'Groq',
+    import: () => import('@ai-sdk/groq'),
+    creatorFunctionName: 'createGroq',
+    supportsImageGeneration: false
   }
 ] as const
 


### PR DESCRIPTION
### What this PR does

Before this PR:
Groq uses the OpenAI-compatible provider (`type: 'openai'`). In AI SDK v6, the OpenAI provider sends `reasoning_content` in assistant messages by default, which Groq's API rejects on multi-turn conversations.

After this PR:
Groq uses the dedicated `@ai-sdk/groq` provider, which properly handles Groq's message format and does not send unsupported fields like `reasoning_content`.

Fixes #12327

### Why we need it and why it was done in this way

The following tradeoffs were made:
Added `@ai-sdk/groq` as a new dependency (~small bundle impact via dynamic import).

The following alternatives were considered:
- Stripping `reasoning_content` from messages before sending to Groq — fragile and would need to be maintained as message format evolves.
- Using the dedicated `@ai-sdk/groq` provider (chosen) — the SDK handles Groq's API format natively, consistent with how other providers (Anthropic, Google, DeepSeek, etc.) have dedicated packages.

### Breaking changes

None.

### Special notes for your reviewer

- Groq is registered as a dynamic provider in `providerInitialization.ts` (lazy-loaded), consistent with other non-core providers like Mistral, Cerebras, Perplexity.
- A static mapping `groq: 'groq'` is added in `factory.ts` to ensure the provider ID resolves to the dedicated provider instead of falling through to OpenAI compatible.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: N/A — internal provider routing change, no user-facing feature change.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix Groq multi-turn conversation errors caused by unsupported `reasoning_content` field by switching to the dedicated `@ai-sdk/groq` provider.
```
