### PR TITLE
feat(data): add translate history and language backend API with langCode PK

### DIFF
--- a/migrations/sqlite-drizzle/0004_volatile_madame_masque.sql
+++ b/migrations/sqlite-drizzle/0004_volatile_madame_masque.sql
@@ -1,0 +1,31 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_translate_language` (
+	`lang_code` text PRIMARY KEY NOT NULL,
+	`value` text NOT NULL,
+	`emoji` text NOT NULL,
+	`created_at` integer,
+	`updated_at` integer
+);
+--> statement-breakpoint
+INSERT INTO `__new_translate_language`("lang_code", "value", "emoji", "created_at", "updated_at") SELECT "lang_code", "value", "emoji", "created_at", "updated_at" FROM `translate_language`;--> statement-breakpoint
+DROP TABLE `translate_language`;--> statement-breakpoint
+ALTER TABLE `__new_translate_language` RENAME TO `translate_language`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE TABLE `__new_translate_history` (
+	`id` text PRIMARY KEY NOT NULL,
+	`source_text` text NOT NULL,
+	`target_text` text NOT NULL,
+	`source_language` text,
+	`target_language` text,
+	`star` integer DEFAULT false NOT NULL,
+	`created_at` integer,
+	`updated_at` integer,
+	FOREIGN KEY (`source_language`) REFERENCES `translate_language`(`lang_code`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`target_language`) REFERENCES `translate_language`(`lang_code`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+INSERT INTO `__new_translate_history`("id", "source_text", "target_text", "source_language", "target_language", "star", "created_at", "updated_at") SELECT "id", "source_text", "target_text", "source_language", "target_language", "star", "created_at", "updated_at" FROM `translate_history`;--> statement-breakpoint
+DROP TABLE `translate_history`;--> statement-breakpoint
+ALTER TABLE `__new_translate_history` RENAME TO `translate_history`;--> statement-breakpoint
+CREATE INDEX `translate_history_created_at_idx` ON `translate_history` (`created_at`);--> statement-breakpoint
+CREATE INDEX `translate_history_star_created_at_idx` ON `translate_history` (`star`,`created_at`);

--- a/migrations/sqlite-drizzle/meta/0004_snapshot.json
+++ b/migrations/sqlite-drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1002 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2eac4614-db61-4509-ab3a-962b57396871",
+  "prevId": "c736c8d5-58fa-4c17-9d28-c6dde07d439c",
+  "tables": {
+    "app_state": {
+      "name": "app_state",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group": {
+      "name": "group",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_entity_sort_idx": {
+          "name": "group_entity_sort_idx",
+          "columns": ["entity_type", "sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_server": {
+      "name": "mcp_server",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_url": {
+          "name": "provider_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "long_running": {
+          "name": "long_running",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dxt_version": {
+          "name": "dxt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dxt_path": {
+          "name": "dxt_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_key": {
+          "name": "search_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config_sample": {
+          "name": "config_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_tools": {
+          "name": "disabled_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_auto_approve_tools": {
+          "name": "disabled_auto_approve_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "should_config": {
+          "name": "should_config",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "install_source": {
+          "name": "install_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_trusted": {
+          "name": "is_trusted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trusted_at": {
+          "name": "trusted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_server_name_idx": {
+          "name": "mcp_server_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "mcp_server_is_active_idx": {
+          "name": "mcp_server_is_active_idx",
+          "columns": ["is_active"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "mcp_server_type_check": {
+          "name": "mcp_server_type_check",
+          "value": "\"mcp_server\".\"type\" IS NULL OR \"mcp_server\".\"type\" IN ('stdio', 'sse', 'streamableHttp', 'inMemory')"
+        },
+        "mcp_server_install_source_check": {
+          "name": "mcp_server_install_source_check",
+          "value": "\"mcp_server\".\"install_source\" IS NULL OR \"mcp_server\".\"install_source\" IN ('builtin', 'manual', 'protocol', 'unknown')"
+        }
+      }
+    },
+    "message": {
+      "name": "message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "searchable_text": {
+          "name": "searchable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "siblings_group_id": {
+          "name": "siblings_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assistant_meta": {
+          "name": "assistant_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_meta": {
+          "name": "model_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "message_parent_id_idx": {
+          "name": "message_parent_id_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "message_topic_created_idx": {
+          "name": "message_topic_created_idx",
+          "columns": ["topic_id", "created_at"],
+          "isUnique": false
+        },
+        "message_trace_id_idx": {
+          "name": "message_trace_id_idx",
+          "columns": ["trace_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "message_topic_id_topic_id_fk": {
+          "name": "message_topic_id_topic_id_fk",
+          "tableFrom": "message",
+          "tableTo": "topic",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_parent_id_message_id_fk": {
+          "name": "message_parent_id_message_id_fk",
+          "tableFrom": "message",
+          "tableTo": "message",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "message_role_check": {
+          "name": "message_role_check",
+          "value": "\"message\".\"role\" IN ('user', 'assistant', 'system')"
+        },
+        "message_status_check": {
+          "name": "message_status_check",
+          "value": "\"message\".\"status\" IN ('pending', 'success', 'error', 'paused')"
+        }
+      }
+    },
+    "preference": {
+      "name": "preference",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "preference_scope_key_pk": {
+          "columns": ["scope", "key"],
+          "name": "preference_scope_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "entity_tag": {
+      "name": "entity_tag",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "entity_tag_tag_id_idx": {
+          "name": "entity_tag_tag_id_idx",
+          "columns": ["tag_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "entity_tag_tag_id_tag_id_fk": {
+          "name": "entity_tag_tag_id_tag_id_fk",
+          "tableFrom": "entity_tag",
+          "tableTo": "tag",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "entity_tag_entity_type_entity_id_tag_id_pk": {
+          "columns": ["entity_type", "entity_id", "tag_id"],
+          "name": "entity_tag_entity_type_entity_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag": {
+      "name": "tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tag_name_unique": {
+          "name": "tag_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "topic": {
+      "name": "topic",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_name_manually_edited": {
+          "name": "is_name_manually_edited",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assistant_meta": {
+          "name": "assistant_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_node_id": {
+          "name": "active_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "pinned_order": {
+          "name": "pinned_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "topic_group_updated_idx": {
+          "name": "topic_group_updated_idx",
+          "columns": ["group_id", "updated_at"],
+          "isUnique": false
+        },
+        "topic_group_sort_idx": {
+          "name": "topic_group_sort_idx",
+          "columns": ["group_id", "sort_order"],
+          "isUnique": false
+        },
+        "topic_updated_at_idx": {
+          "name": "topic_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "topic_is_pinned_idx": {
+          "name": "topic_is_pinned_idx",
+          "columns": ["is_pinned", "pinned_order"],
+          "isUnique": false
+        },
+        "topic_assistant_id_idx": {
+          "name": "topic_assistant_id_idx",
+          "columns": ["assistant_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "topic_group_id_group_id_fk": {
+          "name": "topic_group_id_group_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translate_history": {
+      "name": "translate_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_text": {
+          "name": "target_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_language": {
+          "name": "source_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "star": {
+          "name": "star",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "translate_history_created_at_idx": {
+          "name": "translate_history_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "translate_history_star_created_at_idx": {
+          "name": "translate_history_star_created_at_idx",
+          "columns": ["star", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "translate_history_source_language_translate_language_lang_code_fk": {
+          "name": "translate_history_source_language_translate_language_lang_code_fk",
+          "tableFrom": "translate_history",
+          "tableTo": "translate_language",
+          "columnsFrom": ["source_language"],
+          "columnsTo": ["lang_code"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translate_history_target_language_translate_language_lang_code_fk": {
+          "name": "translate_history_target_language_translate_language_lang_code_fk",
+          "tableFrom": "translate_history",
+          "tableTo": "translate_language",
+          "columnsFrom": ["target_language"],
+          "columnsTo": ["lang_code"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translate_language": {
+      "name": "translate_language",
+      "columns": {
+        "lang_code": {
+          "name": "lang_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/sqlite-drizzle/meta/_journal.json
+++ b/migrations/sqlite-drizzle/meta/_journal.json
@@ -28,6 +28,13 @@
       "when": 1773896975667,
       "tag": "0003_material_pestilence",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1774262838467,
+      "tag": "0004_volatile_madame_masque",
+      "breakpoints": true
     }
   ],
   "version": "7"

--- a/packages/shared/data/api/schemas/index.ts
+++ b/packages/shared/data/api/schemas/index.ts
@@ -16,6 +16,7 @@
  * import type { TestItem, CreateTestItemDto } from '@shared/data/api/schemas/test'
  * import type { Topic, CreateTopicDto } from '@shared/data/api/schemas/topics'
  * import type { Message, CreateMessageDto } from '@shared/data/api/schemas/messages'
+ * import type { TranslateHistory, CreateTranslateHistoryDto } from '@shared/data/api/schemas/translate'
  * ```
  */
 
@@ -23,6 +24,7 @@ import type { AssertValidSchemas } from '../apiTypes'
 import type { MessageSchemas } from './messages'
 import type { TestSchemas } from './test'
 import type { TopicSchemas } from './topics'
+import type { TranslateSchemas } from './translate'
 
 /**
  * Merged API Schemas - single source of truth for all API endpoints
@@ -36,4 +38,4 @@ import type { TopicSchemas } from './topics'
  * 1. Create the schema file (e.g., topic.ts)
  * 2. Import and add to intersection below
  */
-export type ApiSchemas = AssertValidSchemas<TestSchemas & TopicSchemas & MessageSchemas>
+export type ApiSchemas = AssertValidSchemas<TestSchemas & TopicSchemas & MessageSchemas & TranslateSchemas>

--- a/packages/shared/data/api/schemas/translate.ts
+++ b/packages/shared/data/api/schemas/translate.ts
@@ -4,43 +4,19 @@
  * Contains endpoints for:
  * - Translate history CRUD with pagination/search/star filtering
  * - Translate language CRUD (builtin + user-defined)
+ *
+ * Entity schemas and types live in `@shared/data/types/translate`.
  */
 
 import * as z from 'zod'
 
+import type { TranslateHistory, TranslateLanguage } from '../../types/translate'
+import { LangCodeSchema } from '../../types/translate'
 import type { OffsetPaginationResponse } from '../apiTypes'
 
-/**
- * Language code pattern.
- * - 2–3 lowercase letters, optionally followed by `-` and 2–4 lowercase letters
- * - e.g. "en-us", "zh-cn", "ja", "ja-jp"
- */
-export const LangCodeSchema = z.string().regex(/^[a-z]{2,3}(-[a-z]{2,4})?$/)
-
 // ============================================================================
-// Translate History Types
+// Translate History DTOs & Query
 // ============================================================================
-
-export const TranslateHistorySchema = z.object({
-  /** UUIDv7 (time-ordered), auto-generated */
-  id: z.uuidv7(),
-  /** Original text, non-empty */
-  sourceText: z.string().min(1),
-  /** Translated text, non-empty */
-  targetText: z.string().min(1),
-  /** FK to translate_language.langCode, nullable (SET NULL on language delete) */
-  sourceLanguage: LangCodeSchema.nullable(),
-  /** FK to translate_language.langCode, nullable (SET NULL on language delete) */
-  targetLanguage: LangCodeSchema.nullable(),
-  /** Whether the record is starred */
-  star: z.boolean(),
-  /** ISO 8601 datetime */
-  createdAt: z.iso.datetime(),
-  /** ISO 8601 datetime */
-  updatedAt: z.iso.datetime()
-})
-/** Translate history entity. */
-export type TranslateHistory = z.infer<typeof TranslateHistorySchema>
 
 export const CreateTranslateHistorySchema = z.object({
   /** Non-empty string */
@@ -88,23 +64,8 @@ export const TranslateHistoryQuerySchema = z.object({
 export type TranslateHistoryQuery = z.infer<typeof TranslateHistoryQuerySchema>
 
 // ============================================================================
-// Translate Language Types
+// Translate Language DTOs
 // ============================================================================
-
-export const TranslateLanguageSchema = z.object({
-  /** PK, immutable, must match LangCodeSchema (`/^[a-z]{2,3}(-[a-z]{2,4})?$/`) */
-  langCode: LangCodeSchema,
-  /** Display name, non-empty (e.g. "English", "Chinese (Simplified)") */
-  value: z.string().min(1),
-  /** Flag emoji (e.g. "🇬🇧", "🇨🇳") */
-  emoji: z.emoji(),
-  /** ISO 8601 datetime */
-  createdAt: z.iso.datetime(),
-  /** ISO 8601 datetime */
-  updatedAt: z.iso.datetime()
-})
-/** Translate language entity. Both builtin and user-created languages share this schema. */
-export type TranslateLanguage = z.infer<typeof TranslateLanguageSchema>
 
 export const CreateTranslateLanguageSchema = z.object({
   /** Becomes the PK, immutable after creation. Normalized to lowercase before insert. */

--- a/packages/shared/data/api/schemas/translate.ts
+++ b/packages/shared/data/api/schemas/translate.ts
@@ -3,7 +3,7 @@
  *
  * Contains endpoints for:
  * - Translate history CRUD with pagination/search/star filtering
- * - Custom translate language CRUD
+ * - Translate language CRUD (builtin + user-defined)
  */
 
 import * as z from 'zod'
@@ -21,8 +21,8 @@ export const TranslateHistorySchema = z.object({
   id: z.uuid(),
   sourceText: z.string().min(1),
   targetText: z.string().min(1),
-  sourceLanguage: LangCodeSchema,
-  targetLanguage: LangCodeSchema,
+  sourceLanguage: LangCodeSchema.nullable(),
+  targetLanguage: LangCodeSchema.nullable(),
   star: z.boolean(),
   createdAt: z.iso.datetime(),
   updatedAt: z.iso.datetime()
@@ -55,11 +55,10 @@ export const TranslateHistoryQuerySchema = z.object({
 export type TranslateHistoryQuery = z.infer<typeof TranslateHistoryQuerySchema>
 
 // ============================================================================
-// Custom Translate Language Types
+// Translate Language Types
 // ============================================================================
 
 export const TranslateLanguageSchema = z.object({
-  id: z.uuid(),
   langCode: LangCodeSchema,
   value: z.string().min(1),
   emoji: z.string().min(1),
@@ -75,11 +74,12 @@ export const CreateTranslateLanguageSchema = z.object({
 })
 export type CreateTranslateLanguageDto = z.infer<typeof CreateTranslateLanguageSchema>
 
-export const UpdateTranslateLanguageSchema = z.object({
-  langCode: LangCodeSchema.optional(),
-  value: z.string().min(1).optional(),
-  emoji: z.string().min(1).optional()
-})
+export const UpdateTranslateLanguageSchema = z
+  .object({
+    value: z.string().min(1).optional(),
+    emoji: z.string().min(1).optional()
+  })
+  .strict()
 export type UpdateTranslateLanguageDto = z.infer<typeof UpdateTranslateLanguageSchema>
 
 // ============================================================================
@@ -124,32 +124,32 @@ export interface TranslateSchemas {
   }
 
   '/translate/languages': {
-    /** List all custom translate languages */
+    /** List all translate languages */
     GET: {
       response: TranslateLanguage[]
     }
-    /** Create a new custom translate language */
+    /** Create a new translate language */
     POST: {
       body: CreateTranslateLanguageDto
       response: TranslateLanguage
     }
   }
 
-  '/translate/languages/:id': {
-    /** Get a custom translate language by ID */
+  '/translate/languages/:langCode': {
+    /** Get a translate language by langCode */
     GET: {
-      params: { id: string }
+      params: { langCode: string }
       response: TranslateLanguage
     }
-    /** Update a custom translate language */
+    /** Update a translate language (value/emoji only, langCode is immutable) */
     PATCH: {
-      params: { id: string }
+      params: { langCode: string }
       body: UpdateTranslateLanguageDto
       response: TranslateLanguage
     }
-    /** Delete a custom translate language */
+    /** Delete a translate language */
     DELETE: {
-      params: { id: string }
+      params: { langCode: string }
       response: void
     }
   }

--- a/packages/shared/data/api/schemas/translate.ts
+++ b/packages/shared/data/api/schemas/translate.ts
@@ -10,7 +10,11 @@ import * as z from 'zod'
 
 import type { OffsetPaginationResponse } from '../apiTypes'
 
-/** Language code pattern: e.g. "en-us", "zh-cn", "ja-jp" */
+/**
+ * Language code pattern.
+ * - 2–3 lowercase letters, optionally followed by `-` and 2–4 lowercase letters
+ * - e.g. "en-us", "zh-cn", "ja", "ja-jp"
+ */
 export const LangCodeSchema = z.string().regex(/^[a-z]{2,3}(-[a-z]{2,4})?$/)
 
 // ============================================================================
@@ -18,40 +22,69 @@ export const LangCodeSchema = z.string().regex(/^[a-z]{2,3}(-[a-z]{2,4})?$/)
 // ============================================================================
 
 export const TranslateHistorySchema = z.object({
-  id: z.uuid(),
+  /** UUIDv7 (time-ordered), auto-generated */
+  id: z.uuidv7(),
+  /** Original text, non-empty */
   sourceText: z.string().min(1),
+  /** Translated text, non-empty */
   targetText: z.string().min(1),
+  /** FK to translate_language.langCode, nullable (SET NULL on language delete) */
   sourceLanguage: LangCodeSchema.nullable(),
+  /** FK to translate_language.langCode, nullable (SET NULL on language delete) */
   targetLanguage: LangCodeSchema.nullable(),
+  /** Whether the record is starred */
   star: z.boolean(),
+  /** ISO 8601 datetime */
   createdAt: z.iso.datetime(),
+  /** ISO 8601 datetime */
   updatedAt: z.iso.datetime()
 })
+/** Translate history entity. */
 export type TranslateHistory = z.infer<typeof TranslateHistorySchema>
 
 export const CreateTranslateHistorySchema = z.object({
+  /** Non-empty string */
   sourceText: z.string().min(1),
+  /** Non-empty string */
   targetText: z.string().min(1),
+  /** Required, must match LangCodeSchema (`/^[a-z]{2,3}(-[a-z]{2,4})?$/`) */
   sourceLanguage: LangCodeSchema,
+  /** Required, must match LangCodeSchema */
   targetLanguage: LangCodeSchema
 })
+/** DTO for creating a translate history record. */
 export type CreateTranslateHistoryDto = z.infer<typeof CreateTranslateHistorySchema>
 
 export const UpdateTranslateHistorySchema = z.object({
+  /** Non-empty string if provided */
   sourceText: z.string().min(1).optional(),
+  /** Non-empty string if provided */
   targetText: z.string().min(1).optional(),
+  /** Must match LangCodeSchema if provided */
   sourceLanguage: LangCodeSchema.optional(),
+  /** Must match LangCodeSchema if provided */
   targetLanguage: LangCodeSchema.optional(),
+  /** Boolean if provided */
   star: z.boolean().optional()
 })
+/** DTO for updating a translate history record. All fields optional. */
 export type UpdateTranslateHistoryDto = z.infer<typeof UpdateTranslateHistorySchema>
 
+export const TRANSLATE_HISTORY_DEFAULT_PAGE = 1
+export const TRANSLATE_HISTORY_DEFAULT_LIMIT = 20
+export const TRANSLATE_HISTORY_MAX_LIMIT = 100
+
 export const TranslateHistoryQuerySchema = z.object({
-  page: z.number().int().positive().optional(),
-  limit: z.number().int().positive().max(100).optional(),
+  /** Positive integer, defaults to {@link TRANSLATE_HISTORY_DEFAULT_PAGE} */
+  page: z.int().positive().default(TRANSLATE_HISTORY_DEFAULT_PAGE),
+  /** Positive integer, max {@link TRANSLATE_HISTORY_MAX_LIMIT}, defaults to {@link TRANSLATE_HISTORY_DEFAULT_LIMIT} */
+  limit: z.int().positive().max(TRANSLATE_HISTORY_MAX_LIMIT).default(TRANSLATE_HISTORY_DEFAULT_LIMIT),
+  /** LIKE search on sourceText and targetText (wildcards are escaped) */
   search: z.string().optional(),
+  /** Filter by starred status */
   star: z.boolean().optional()
 })
+/** Query parameters for listing translate histories. */
 export type TranslateHistoryQuery = z.infer<typeof TranslateHistoryQuerySchema>
 
 // ============================================================================
@@ -59,27 +92,43 @@ export type TranslateHistoryQuery = z.infer<typeof TranslateHistoryQuerySchema>
 // ============================================================================
 
 export const TranslateLanguageSchema = z.object({
+  /** PK, immutable, must match LangCodeSchema (`/^[a-z]{2,3}(-[a-z]{2,4})?$/`) */
   langCode: LangCodeSchema,
+  /** Display name, non-empty (e.g. "English", "Chinese (Simplified)") */
   value: z.string().min(1),
-  emoji: z.string().min(1),
+  /** Flag emoji (e.g. "🇬🇧", "🇨🇳") */
+  emoji: z.emoji(),
+  /** ISO 8601 datetime */
   createdAt: z.iso.datetime(),
+  /** ISO 8601 datetime */
   updatedAt: z.iso.datetime()
 })
+/** Translate language entity. Both builtin and user-created languages share this schema. */
 export type TranslateLanguage = z.infer<typeof TranslateLanguageSchema>
 
 export const CreateTranslateLanguageSchema = z.object({
+  /** Becomes the PK, immutable after creation. Normalized to lowercase before insert. */
   langCode: LangCodeSchema,
+  /** Display name, non-empty */
   value: z.string().min(1),
-  emoji: z.string().min(1)
+  /** Flag emoji */
+  emoji: z.emoji()
 })
+/** DTO for creating a translate language. */
 export type CreateTranslateLanguageDto = z.infer<typeof CreateTranslateLanguageSchema>
 
 export const UpdateTranslateLanguageSchema = z
   .object({
+    /** Display name, non-empty if provided */
     value: z.string().min(1).optional(),
-    emoji: z.string().min(1).optional()
+    /** Flag emoji if provided */
+    emoji: z.emoji().optional()
   })
   .strict()
+/**
+ * DTO for updating a translate language. Uses `.strict()` — unknown fields
+ * (including `langCode`) are rejected, not silently stripped.
+ */
 export type UpdateTranslateLanguageDto = z.infer<typeof UpdateTranslateLanguageSchema>
 
 // ============================================================================

--- a/packages/shared/data/api/schemas/translate.ts
+++ b/packages/shared/data/api/schemas/translate.ts
@@ -1,0 +1,156 @@
+/**
+ * Translate API Schema definitions
+ *
+ * Contains endpoints for:
+ * - Translate history CRUD with pagination/search/star filtering
+ * - Custom translate language CRUD
+ */
+
+import * as z from 'zod'
+
+import type { OffsetPaginationResponse } from '../apiTypes'
+
+/** Language code pattern: e.g. "en-us", "zh-cn", "ja-jp" */
+export const LangCodeSchema = z.string().regex(/^[a-z]{2,3}(-[a-z]{2,4})?$/)
+
+// ============================================================================
+// Translate History Types
+// ============================================================================
+
+export const TranslateHistorySchema = z.object({
+  id: z.uuid(),
+  sourceText: z.string().min(1),
+  targetText: z.string().min(1),
+  sourceLanguage: LangCodeSchema,
+  targetLanguage: LangCodeSchema,
+  star: z.boolean(),
+  createdAt: z.iso.datetime(),
+  updatedAt: z.iso.datetime()
+})
+export type TranslateHistory = z.infer<typeof TranslateHistorySchema>
+
+export const CreateTranslateHistorySchema = z.object({
+  sourceText: z.string().min(1),
+  targetText: z.string().min(1),
+  sourceLanguage: LangCodeSchema,
+  targetLanguage: LangCodeSchema
+})
+export type CreateTranslateHistoryDto = z.infer<typeof CreateTranslateHistorySchema>
+
+export const UpdateTranslateHistorySchema = z.object({
+  sourceText: z.string().min(1).optional(),
+  targetText: z.string().min(1).optional(),
+  sourceLanguage: LangCodeSchema.optional(),
+  targetLanguage: LangCodeSchema.optional(),
+  star: z.boolean().optional()
+})
+export type UpdateTranslateHistoryDto = z.infer<typeof UpdateTranslateHistorySchema>
+
+export const TranslateHistoryQuerySchema = z.object({
+  page: z.number().int().positive().optional(),
+  limit: z.number().int().positive().max(100).optional(),
+  search: z.string().optional(),
+  star: z.boolean().optional()
+})
+export type TranslateHistoryQuery = z.infer<typeof TranslateHistoryQuerySchema>
+
+// ============================================================================
+// Custom Translate Language Types
+// ============================================================================
+
+export const TranslateLanguageSchema = z.object({
+  id: z.uuid(),
+  langCode: LangCodeSchema,
+  value: z.string().min(1),
+  emoji: z.string().min(1),
+  createdAt: z.iso.datetime(),
+  updatedAt: z.iso.datetime()
+})
+export type TranslateLanguage = z.infer<typeof TranslateLanguageSchema>
+
+export const CreateTranslateLanguageSchema = z.object({
+  langCode: LangCodeSchema,
+  value: z.string().min(1),
+  emoji: z.string().min(1)
+})
+export type CreateTranslateLanguageDto = z.infer<typeof CreateTranslateLanguageSchema>
+
+export const UpdateTranslateLanguageSchema = z.object({
+  langCode: LangCodeSchema.optional(),
+  value: z.string().min(1).optional(),
+  emoji: z.string().min(1).optional()
+})
+export type UpdateTranslateLanguageDto = z.infer<typeof UpdateTranslateLanguageSchema>
+
+// ============================================================================
+// API Schema Definitions
+// ============================================================================
+
+export interface TranslateSchemas {
+  '/translate/histories': {
+    /** List translate histories with pagination, search, and star filter */
+    GET: {
+      query?: TranslateHistoryQuery
+      response: OffsetPaginationResponse<TranslateHistory>
+    }
+    /** Create a new translate history record */
+    POST: {
+      body: CreateTranslateHistoryDto
+      response: TranslateHistory
+    }
+    /** Clear all translate histories */
+    DELETE: {
+      response: void
+    }
+  }
+
+  '/translate/histories/:id': {
+    /** Get a translate history by ID */
+    GET: {
+      params: { id: string }
+      response: TranslateHistory
+    }
+    /** Update a translate history */
+    PATCH: {
+      params: { id: string }
+      body: UpdateTranslateHistoryDto
+      response: TranslateHistory
+    }
+    /** Delete a translate history */
+    DELETE: {
+      params: { id: string }
+      response: void
+    }
+  }
+
+  '/translate/languages': {
+    /** List all custom translate languages */
+    GET: {
+      response: TranslateLanguage[]
+    }
+    /** Create a new custom translate language */
+    POST: {
+      body: CreateTranslateLanguageDto
+      response: TranslateLanguage
+    }
+  }
+
+  '/translate/languages/:id': {
+    /** Get a custom translate language by ID */
+    GET: {
+      params: { id: string }
+      response: TranslateLanguage
+    }
+    /** Update a custom translate language */
+    PATCH: {
+      params: { id: string }
+      body: UpdateTranslateLanguageDto
+      response: TranslateLanguage
+    }
+    /** Delete a custom translate language */
+    DELETE: {
+      params: { id: string }
+      response: void
+    }
+  }
+}

--- a/packages/shared/data/presets/translate-languages.ts
+++ b/packages/shared/data/presets/translate-languages.ts
@@ -1,0 +1,32 @@
+/**
+ * Builtin translate languages — pure data, no i18n or renderer dependencies.
+ *
+ * Used by:
+ * - Main process seeding (insert into translate_language table on first run)
+ * - Renderer process (identify builtin vs user-created languages)
+ */
+
+export const BUILTIN_TRANSLATE_LANGUAGES = [
+  { langCode: 'en-us', value: 'English', emoji: '🇬🇧' },
+  { langCode: 'zh-cn', value: 'Chinese (Simplified)', emoji: '🇨🇳' },
+  { langCode: 'zh-tw', value: 'Chinese (Traditional)', emoji: '🇭🇰' },
+  { langCode: 'ja-jp', value: 'Japanese', emoji: '🇯🇵' },
+  { langCode: 'ko-kr', value: 'Korean', emoji: '🇰🇷' },
+  { langCode: 'fr-fr', value: 'French', emoji: '🇫🇷' },
+  { langCode: 'de-de', value: 'German', emoji: '🇩🇪' },
+  { langCode: 'it-it', value: 'Italian', emoji: '🇮🇹' },
+  { langCode: 'es-es', value: 'Spanish', emoji: '🇪🇸' },
+  { langCode: 'pt-pt', value: 'Portuguese', emoji: '🇵🇹' },
+  { langCode: 'ru-ru', value: 'Russian', emoji: '🇷🇺' },
+  { langCode: 'pl-pl', value: 'Polish', emoji: '🇵🇱' },
+  { langCode: 'ar-ar', value: 'Arabic', emoji: '🇸🇦' },
+  { langCode: 'tr-tr', value: 'Turkish', emoji: '🇹🇷' },
+  { langCode: 'th-th', value: 'Thai', emoji: '🇹🇭' },
+  { langCode: 'vi-vn', value: 'Vietnamese', emoji: '🇻🇳' },
+  { langCode: 'id-id', value: 'Indonesian', emoji: '🇮🇩' },
+  { langCode: 'ur-pk', value: 'Urdu', emoji: '🇵🇰' },
+  { langCode: 'ms-my', value: 'Malay', emoji: '🇲🇾' },
+  { langCode: 'uk-ua', value: 'Ukrainian', emoji: '🇺🇦' }
+] as const satisfies ReadonlyArray<{ langCode: string; value: string; emoji: string }>
+
+export type BuiltinLangCode = (typeof BUILTIN_TRANSLATE_LANGUAGES)[number]['langCode']

--- a/packages/shared/data/presets/translate-languages.ts
+++ b/packages/shared/data/presets/translate-languages.ts
@@ -7,7 +7,7 @@
  */
 
 export const BUILTIN_TRANSLATE_LANGUAGES = [
-  { langCode: 'en-us', value: 'English', emoji: '🇬🇧' },
+  { langCode: 'en-us', value: 'English', emoji: '🇺🇸' },
   { langCode: 'zh-cn', value: 'Chinese (Simplified)', emoji: '🇨🇳' },
   { langCode: 'zh-tw', value: 'Chinese (Traditional)', emoji: '🇭🇰' },
   { langCode: 'ja-jp', value: 'Japanese', emoji: '🇯🇵' },

--- a/packages/shared/data/presets/translate-languages.ts
+++ b/packages/shared/data/presets/translate-languages.ts
@@ -19,7 +19,7 @@ export const BUILTIN_TRANSLATE_LANGUAGES = [
   { langCode: 'pt-pt', value: 'Portuguese', emoji: '🇵🇹' },
   { langCode: 'ru-ru', value: 'Russian', emoji: '🇷🇺' },
   { langCode: 'pl-pl', value: 'Polish', emoji: '🇵🇱' },
-  { langCode: 'ar-ar', value: 'Arabic', emoji: '🇸🇦' },
+  { langCode: 'ar-sa', value: 'Arabic', emoji: '🇸🇦' },
   { langCode: 'tr-tr', value: 'Turkish', emoji: '🇹🇷' },
   { langCode: 'th-th', value: 'Thai', emoji: '🇹🇭' },
   { langCode: 'vi-vn', value: 'Vietnamese', emoji: '🇻🇳' },

--- a/packages/shared/data/types/translate.ts
+++ b/packages/shared/data/types/translate.ts
@@ -1,0 +1,59 @@
+/**
+ * Translate entity types
+ *
+ * Defines Zod schemas and inferred types for translate history and language entities.
+ * DTO/Query/API schemas live in `@shared/data/api/schemas/translate`.
+ */
+
+import * as z from 'zod'
+
+/**
+ * Language code pattern.
+ * - 2–3 lowercase letters, optionally followed by `-` and 2–4 lowercase letters
+ * - e.g. "en-us", "zh-cn", "ja", "ja-jp"
+ */
+export const LangCodeSchema = z.string().regex(/^[a-z]{2,3}(-[a-z]{2,4})?$/)
+
+// ============================================================================
+// Translate History
+// ============================================================================
+
+export const TranslateHistorySchema = z.object({
+  /** UUIDv7 (time-ordered), auto-generated */
+  id: z.uuidv7(),
+  /** Original text, non-empty */
+  sourceText: z.string().min(1),
+  /** Translated text, non-empty */
+  targetText: z.string().min(1),
+  /** FK to translate_language.langCode, nullable (SET NULL on language delete) */
+  sourceLanguage: LangCodeSchema.nullable(),
+  /** FK to translate_language.langCode, nullable (SET NULL on language delete) */
+  targetLanguage: LangCodeSchema.nullable(),
+  /** Whether the record is starred */
+  star: z.boolean(),
+  /** ISO 8601 datetime */
+  createdAt: z.iso.datetime(),
+  /** ISO 8601 datetime */
+  updatedAt: z.iso.datetime()
+})
+/** Translate history entity. */
+export type TranslateHistory = z.infer<typeof TranslateHistorySchema>
+
+// ============================================================================
+// Translate Language
+// ============================================================================
+
+export const TranslateLanguageSchema = z.object({
+  /** PK, immutable, must match LangCodeSchema (`/^[a-z]{2,3}(-[a-z]{2,4})?$/`) */
+  langCode: LangCodeSchema,
+  /** Display name, non-empty (e.g. "English", "Chinese (Simplified)") */
+  value: z.string().min(1),
+  /** Flag emoji (e.g. "🇬🇧", "🇨🇳") */
+  emoji: z.emoji(),
+  /** ISO 8601 datetime */
+  createdAt: z.iso.datetime(),
+  /** ISO 8601 datetime */
+  updatedAt: z.iso.datetime()
+})
+/** Translate language entity. Both builtin and user-created languages share this schema. */
+export type TranslateLanguage = z.infer<typeof TranslateLanguageSchema>

--- a/src/main/data/api/handlers/__tests__/translate.test.ts
+++ b/src/main/data/api/handlers/__tests__/translate.test.ts
@@ -126,8 +126,8 @@ describe('Translate handler validation (Zod schemas)', () => {
       expect(result.value).toBe('Updated')
     })
 
-    it('should reject invalid langCode format', () => {
-      expect(() => UpdateTranslateLanguageSchema.parse({ langCode: 'BAD' })).toThrow()
+    it('should reject langCode (immutable)', () => {
+      expect(() => UpdateTranslateLanguageSchema.parse({ langCode: 'ja-jp', value: 'Updated' })).toThrow()
     })
 
     it('should reject empty value', () => {

--- a/src/main/data/api/handlers/__tests__/translate.test.ts
+++ b/src/main/data/api/handlers/__tests__/translate.test.ts
@@ -1,0 +1,137 @@
+import {
+  CreateTranslateHistorySchema,
+  CreateTranslateLanguageSchema,
+  TranslateHistoryQuerySchema,
+  UpdateTranslateHistorySchema,
+  UpdateTranslateLanguageSchema
+} from '@shared/data/api/schemas/translate'
+import { describe, expect, it } from 'vitest'
+
+describe('Translate handler validation (Zod schemas)', () => {
+  describe('TranslateHistoryQuerySchema', () => {
+    it('should accept empty query', () => {
+      expect(() => TranslateHistoryQuerySchema.parse({})).not.toThrow()
+    })
+
+    it('should accept valid query', () => {
+      const result = TranslateHistoryQuerySchema.parse({ page: 1, limit: 20, star: true, search: 'hello' })
+      expect(result.page).toBe(1)
+      expect(result.star).toBe(true)
+    })
+
+    it('should reject negative page', () => {
+      expect(() => TranslateHistoryQuerySchema.parse({ page: -1 })).toThrow()
+    })
+
+    it('should reject limit over 100', () => {
+      expect(() => TranslateHistoryQuerySchema.parse({ limit: 101 })).toThrow()
+    })
+
+    it('should reject non-integer page', () => {
+      expect(() => TranslateHistoryQuerySchema.parse({ page: 1.5 })).toThrow()
+    })
+  })
+
+  describe('CreateTranslateHistorySchema', () => {
+    it('should accept valid dto', () => {
+      const result = CreateTranslateHistorySchema.parse({
+        sourceText: 'Hello',
+        targetText: 'Bonjour',
+        sourceLanguage: 'en-us',
+        targetLanguage: 'fr-fr'
+      })
+      expect(result.sourceText).toBe('Hello')
+    })
+
+    it('should reject empty sourceText', () => {
+      expect(() =>
+        CreateTranslateHistorySchema.parse({
+          sourceText: '',
+          targetText: 'Bonjour',
+          sourceLanguage: 'en-us',
+          targetLanguage: 'fr-fr'
+        })
+      ).toThrow()
+    })
+
+    it('should reject missing required fields', () => {
+      expect(() => CreateTranslateHistorySchema.parse({})).toThrow()
+    })
+
+    it('should reject invalid language code', () => {
+      expect(() =>
+        CreateTranslateHistorySchema.parse({
+          sourceText: 'Hello',
+          targetText: 'Bonjour',
+          sourceLanguage: 'INVALID',
+          targetLanguage: 'fr-fr'
+        })
+      ).toThrow()
+    })
+  })
+
+  describe('UpdateTranslateHistorySchema', () => {
+    it('should accept partial update', () => {
+      const result = UpdateTranslateHistorySchema.parse({ star: true })
+      expect(result.star).toBe(true)
+    })
+
+    it('should accept empty object', () => {
+      expect(() => UpdateTranslateHistorySchema.parse({})).not.toThrow()
+    })
+
+    it('should reject empty string fields', () => {
+      expect(() => UpdateTranslateHistorySchema.parse({ sourceText: '' })).toThrow()
+    })
+
+    it('should reject invalid language code', () => {
+      expect(() => UpdateTranslateHistorySchema.parse({ sourceLanguage: 'NOT_VALID' })).toThrow()
+    })
+  })
+
+  describe('CreateTranslateLanguageSchema', () => {
+    it('should accept valid dto', () => {
+      const result = CreateTranslateLanguageSchema.parse({
+        langCode: 'ja-jp',
+        value: 'Japanese',
+        emoji: '\uD83C\uDDEF\uD83C\uDDF5'
+      })
+      expect(result.langCode).toBe('ja-jp')
+    })
+
+    it('should reject empty langCode', () => {
+      expect(() =>
+        CreateTranslateLanguageSchema.parse({ langCode: '', value: 'Test', emoji: '\uD83C\uDDEF\uD83C\uDDF5' })
+      ).toThrow()
+    })
+
+    it('should reject invalid langCode format', () => {
+      expect(() =>
+        CreateTranslateLanguageSchema.parse({
+          langCode: 'INVALID-CODE',
+          value: 'Test',
+          emoji: '\uD83C\uDDEF\uD83C\uDDF5'
+        })
+      ).toThrow()
+    })
+
+    it('should reject missing required fields', () => {
+      expect(() => CreateTranslateLanguageSchema.parse({})).toThrow()
+    })
+  })
+
+  describe('UpdateTranslateLanguageSchema', () => {
+    it('should accept partial update', () => {
+      const result = UpdateTranslateLanguageSchema.parse({ value: 'Updated' })
+      expect(result.value).toBe('Updated')
+    })
+
+    it('should reject invalid langCode format', () => {
+      expect(() => UpdateTranslateLanguageSchema.parse({ langCode: 'BAD' })).toThrow()
+    })
+
+    it('should reject empty value', () => {
+      expect(() => UpdateTranslateLanguageSchema.parse({ value: '' })).toThrow()
+    })
+  })
+})

--- a/src/main/data/api/handlers/index.ts
+++ b/src/main/data/api/handlers/index.ts
@@ -8,6 +8,7 @@
  * - test.ts - Test API handlers
  * - topics.ts - Topic API handlers
  * - messages.ts - Message API handlers
+ * - translate.ts - Translate API handlers
  */
 
 import type { ApiImplementation } from '@shared/data/api/apiTypes'
@@ -15,6 +16,7 @@ import type { ApiImplementation } from '@shared/data/api/apiTypes'
 import { messageHandlers } from './messages'
 import { testHandlers } from './test'
 import { topicHandlers } from './topics'
+import { translateHandlers } from './translate'
 
 /**
  * Complete API handlers implementation
@@ -26,5 +28,6 @@ import { topicHandlers } from './topics'
 export const apiHandlers: ApiImplementation = {
   ...testHandlers,
   ...topicHandlers,
-  ...messageHandlers
+  ...messageHandlers,
+  ...translateHandlers
 }

--- a/src/main/data/api/handlers/translate.ts
+++ b/src/main/data/api/handlers/translate.ts
@@ -34,7 +34,8 @@ export const translateHandlers: {
       return await translateHistoryService.create(parsed)
     },
     DELETE: async () => {
-      return await translateHistoryService.clearAll()
+      await translateHistoryService.clearAll()
+      return undefined
     }
   },
 
@@ -47,7 +48,8 @@ export const translateHandlers: {
       return await translateHistoryService.update(params.id, parsed)
     },
     DELETE: async ({ params }) => {
-      return await translateHistoryService.delete(params.id)
+      await translateHistoryService.delete(params.id)
+      return undefined
     }
   },
 
@@ -70,7 +72,8 @@ export const translateHandlers: {
       return await translateLanguageService.update(params.langCode, parsed)
     },
     DELETE: async ({ params }) => {
-      return await translateLanguageService.delete(params.langCode)
+      await translateLanguageService.delete(params.langCode)
+      return undefined
     }
   }
 }

--- a/src/main/data/api/handlers/translate.ts
+++ b/src/main/data/api/handlers/translate.ts
@@ -1,0 +1,76 @@
+/**
+ * Translate API Handlers
+ *
+ * Implements translate history and custom language endpoints.
+ * All input validation happens here at the system boundary.
+ */
+
+import { translateHistoryService } from '@data/services/TranslateHistoryService'
+import { translateLanguageService } from '@data/services/TranslateLanguageService'
+import type { ApiHandler, ApiMethods } from '@shared/data/api/apiTypes'
+import type { TranslateSchemas } from '@shared/data/api/schemas/translate'
+import {
+  CreateTranslateHistorySchema,
+  CreateTranslateLanguageSchema,
+  TranslateHistoryQuerySchema,
+  UpdateTranslateHistorySchema,
+  UpdateTranslateLanguageSchema
+} from '@shared/data/api/schemas/translate'
+
+type TranslateHandler<Path extends keyof TranslateSchemas, Method extends ApiMethods<Path>> = ApiHandler<Path, Method>
+
+export const translateHandlers: {
+  [Path in keyof TranslateSchemas]: {
+    [Method in keyof TranslateSchemas[Path]]: TranslateHandler<Path, Method & ApiMethods<Path>>
+  }
+} = {
+  '/translate/histories': {
+    GET: async ({ query }) => {
+      const parsed = TranslateHistoryQuerySchema.parse(query ?? {})
+      return await translateHistoryService.list(parsed)
+    },
+    POST: async ({ body }) => {
+      const parsed = CreateTranslateHistorySchema.parse(body)
+      return await translateHistoryService.create(parsed)
+    },
+    DELETE: async () => {
+      return await translateHistoryService.clearAll()
+    }
+  },
+
+  '/translate/histories/:id': {
+    GET: async ({ params }) => {
+      return await translateHistoryService.getById(params.id)
+    },
+    PATCH: async ({ params, body }) => {
+      const parsed = UpdateTranslateHistorySchema.parse(body)
+      return await translateHistoryService.update(params.id, parsed)
+    },
+    DELETE: async ({ params }) => {
+      return await translateHistoryService.delete(params.id)
+    }
+  },
+
+  '/translate/languages': {
+    GET: async () => {
+      return await translateLanguageService.list()
+    },
+    POST: async ({ body }) => {
+      const parsed = CreateTranslateLanguageSchema.parse(body)
+      return await translateLanguageService.create(parsed)
+    }
+  },
+
+  '/translate/languages/:id': {
+    GET: async ({ params }) => {
+      return await translateLanguageService.getById(params.id)
+    },
+    PATCH: async ({ params, body }) => {
+      const parsed = UpdateTranslateLanguageSchema.parse(body)
+      return await translateLanguageService.update(params.id, parsed)
+    },
+    DELETE: async ({ params }) => {
+      return await translateLanguageService.delete(params.id)
+    }
+  }
+}

--- a/src/main/data/api/handlers/translate.ts
+++ b/src/main/data/api/handlers/translate.ts
@@ -61,16 +61,16 @@ export const translateHandlers: {
     }
   },
 
-  '/translate/languages/:id': {
+  '/translate/languages/:langCode': {
     GET: async ({ params }) => {
-      return await translateLanguageService.getById(params.id)
+      return await translateLanguageService.getByLangCode(params.langCode)
     },
     PATCH: async ({ params, body }) => {
       const parsed = UpdateTranslateLanguageSchema.parse(body)
-      return await translateLanguageService.update(params.id, parsed)
+      return await translateLanguageService.update(params.langCode, parsed)
     },
     DELETE: async ({ params }) => {
-      return await translateLanguageService.delete(params.id)
+      return await translateLanguageService.delete(params.langCode)
     }
   }
 }

--- a/src/main/data/db/schemas/translateHistory.ts
+++ b/src/main/data/db/schemas/translateHistory.ts
@@ -1,6 +1,7 @@
 import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
 import { createUpdateTimestamps, uuidPrimaryKeyOrdered } from './_columnHelpers'
+import { translateLanguageTable } from './translateLanguage'
 
 /**
  * Translate history table - stores translation records
@@ -11,6 +12,7 @@ import { createUpdateTimestamps, uuidPrimaryKeyOrdered } from './_columnHelpers'
  * - Text search (sourceText/targetText) uses SQL LIKE at DB layer,
  *   not client-side filtering.
  * - Star + createdAt compound index supports "starred only, sorted by time" queries.
+ * - sourceLanguage/targetLanguage are FK to translateLanguage.langCode (SET NULL on delete).
  */
 export const translateHistoryTable = sqliteTable(
   'translate_history',
@@ -18,8 +20,8 @@ export const translateHistoryTable = sqliteTable(
     id: uuidPrimaryKeyOrdered(),
     sourceText: text().notNull(),
     targetText: text().notNull(),
-    sourceLanguage: text().notNull(),
-    targetLanguage: text().notNull(),
+    sourceLanguage: text().references(() => translateLanguageTable.langCode, { onDelete: 'set null' }),
+    targetLanguage: text().references(() => translateLanguageTable.langCode, { onDelete: 'set null' }),
     star: integer({ mode: 'boolean' }).notNull().default(false),
     ...createUpdateTimestamps
   },

--- a/src/main/data/db/schemas/translateLanguage.ts
+++ b/src/main/data/db/schemas/translateLanguage.ts
@@ -1,17 +1,17 @@
 import { sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
-import { createUpdateTimestamps, uuidPrimaryKey } from './_columnHelpers'
+import { createUpdateTimestamps } from './_columnHelpers'
 
 /**
- * Custom translate language table - stores user-defined translation languages
+ * Translate language table - stores builtin and user-defined translation languages
  *
  * Design notes:
  * - Very small dataset (tens of records at most)
- * - langCode must be unique per language (UNIQUE constraint creates implicit index)
+ * - langCode is the primary key (natural key, e.g. "en-us", "zh-cn")
+ * - Referenced by translateHistory.sourceLanguage / targetLanguage as FK
  */
 export const translateLanguageTable = sqliteTable('translate_language', {
-  id: uuidPrimaryKey(),
-  langCode: text().notNull().unique(),
+  langCode: text().primaryKey().notNull(),
   value: text().notNull(),
   emoji: text().notNull(),
   ...createUpdateTimestamps

--- a/src/main/data/db/seeding/__tests__/translateLanguageSeeding.test.ts
+++ b/src/main/data/db/seeding/__tests__/translateLanguageSeeding.test.ts
@@ -1,0 +1,68 @@
+import { BUILTIN_TRANSLATE_LANGUAGES } from '@shared/data/presets/translate-languages'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockSelect = vi.fn()
+const mockInsert = vi.fn()
+
+vi.mock('@data/db/schemas/translateLanguage', () => ({
+  translateLanguageTable: { langCode: 'lang_code' }
+}))
+
+const TranslateLanguageSeed = (await import('../translateLanguageSeeding')).default
+
+function createMockDb() {
+  return {
+    select: mockSelect,
+    insert: mockInsert
+  }
+}
+
+describe('TranslateLanguageSeed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should insert all builtin languages into empty table', async () => {
+    mockSelect.mockReturnValue({
+      from: vi.fn().mockResolvedValue([])
+    })
+    const valuesArg = vi.fn().mockResolvedValue(undefined)
+    mockInsert.mockReturnValue({ values: valuesArg })
+
+    const seed = new TranslateLanguageSeed()
+    await seed.migrate(createMockDb() as any)
+
+    expect(mockInsert).toHaveBeenCalledTimes(1)
+    expect(valuesArg).toHaveBeenCalledWith(BUILTIN_TRANSLATE_LANGUAGES)
+  })
+
+  it('should only insert missing languages when some exist', async () => {
+    const existingCodes = [{ langCode: 'en-us' }, { langCode: 'zh-cn' }]
+    mockSelect.mockReturnValue({
+      from: vi.fn().mockResolvedValue(existingCodes)
+    })
+    const valuesArg = vi.fn().mockResolvedValue(undefined)
+    mockInsert.mockReturnValue({ values: valuesArg })
+
+    const seed = new TranslateLanguageSeed()
+    await seed.migrate(createMockDb() as any)
+
+    expect(mockInsert).toHaveBeenCalledTimes(1)
+    const inserted = valuesArg.mock.calls[0][0] as typeof BUILTIN_TRANSLATE_LANGUAGES
+    expect(inserted).toHaveLength(BUILTIN_TRANSLATE_LANGUAGES.length - 2)
+    expect(inserted.find((l) => l.langCode === 'en-us')).toBeUndefined()
+    expect(inserted.find((l) => l.langCode === 'zh-cn')).toBeUndefined()
+  })
+
+  it('should not insert when all languages exist', async () => {
+    const allCodes = BUILTIN_TRANSLATE_LANGUAGES.map((l) => ({ langCode: l.langCode }))
+    mockSelect.mockReturnValue({
+      from: vi.fn().mockResolvedValue(allCodes)
+    })
+
+    const seed = new TranslateLanguageSeed()
+    await seed.migrate(createMockDb() as any)
+
+    expect(mockInsert).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/data/db/seeding/index.ts
+++ b/src/main/data/db/seeding/index.ts
@@ -1,7 +1,9 @@
 import PreferenceSeeding from './preferenceSeeding'
+import TranslateLanguageSeeding from './translateLanguageSeeding'
 
 const seedingList = {
-  preference: PreferenceSeeding
+  preference: PreferenceSeeding,
+  translateLanguage: TranslateLanguageSeeding
 }
 
 export default seedingList

--- a/src/main/data/db/seeding/translateLanguageSeeding.ts
+++ b/src/main/data/db/seeding/translateLanguageSeeding.ts
@@ -1,0 +1,20 @@
+import { translateLanguageTable } from '@data/db/schemas/translateLanguage'
+import { BUILTIN_TRANSLATE_LANGUAGES } from '@shared/data/presets/translate-languages'
+
+import type { DbType, ISeed } from '../types'
+
+class TranslateLanguageSeed implements ISeed {
+  async migrate(db: DbType): Promise<void> {
+    const existing = await db.select({ langCode: translateLanguageTable.langCode }).from(translateLanguageTable)
+
+    const existingCodes = new Set(existing.map((r) => r.langCode))
+
+    const newLanguages = BUILTIN_TRANSLATE_LANGUAGES.filter((l) => !existingCodes.has(l.langCode))
+
+    if (newLanguages.length > 0) {
+      await db.insert(translateLanguageTable).values(newLanguages)
+    }
+  }
+}
+
+export default TranslateLanguageSeed

--- a/src/main/data/services/TranslateHistoryService.ts
+++ b/src/main/data/services/TranslateHistoryService.ts
@@ -9,10 +9,10 @@ import { DataApiErrorFactory } from '@shared/data/api'
 import type { OffsetPaginationResponse } from '@shared/data/api/apiTypes'
 import type {
   CreateTranslateHistoryDto,
-  TranslateHistory,
   TranslateHistoryQuery,
   UpdateTranslateHistoryDto
 } from '@shared/data/api/schemas/translate'
+import type { TranslateHistory } from '@shared/data/types/translate'
 import type { SQL } from 'drizzle-orm'
 import { and, desc, eq, or, sql } from 'drizzle-orm'
 

--- a/src/main/data/services/TranslateHistoryService.ts
+++ b/src/main/data/services/TranslateHistoryService.ts
@@ -1,0 +1,184 @@
+/**
+ * Translate History Service - handles translate history CRUD
+ */
+
+import { dbService } from '@data/db/DbService'
+import { translateHistoryTable } from '@data/db/schemas/translateHistory'
+import { loggerService } from '@logger'
+import { DataApiErrorFactory } from '@shared/data/api'
+import type { OffsetPaginationResponse } from '@shared/data/api/apiTypes'
+import type {
+  CreateTranslateHistoryDto,
+  TranslateHistory,
+  TranslateHistoryQuery,
+  UpdateTranslateHistoryDto
+} from '@shared/data/api/schemas/translate'
+import type { SQL } from 'drizzle-orm'
+import { and, desc, eq, or, sql } from 'drizzle-orm'
+
+const logger = loggerService.withContext('DataApi:TranslateHistoryService')
+
+const DEFAULT_PAGE = 1
+const DEFAULT_LIMIT = 20
+
+function rowToTranslateHistory(row: typeof translateHistoryTable.$inferSelect): TranslateHistory {
+  return {
+    id: row.id,
+    sourceText: row.sourceText,
+    targetText: row.targetText,
+    sourceLanguage: row.sourceLanguage,
+    targetLanguage: row.targetLanguage,
+    star: row.star,
+    createdAt: row.createdAt ? new Date(row.createdAt).toISOString() : new Date().toISOString(),
+    updatedAt: row.updatedAt ? new Date(row.updatedAt).toISOString() : new Date().toISOString()
+  }
+}
+
+export class TranslateHistoryService {
+  private static instance: TranslateHistoryService
+
+  private constructor() {}
+
+  public static getInstance(): TranslateHistoryService {
+    if (!TranslateHistoryService.instance) {
+      TranslateHistoryService.instance = new TranslateHistoryService()
+    }
+    return TranslateHistoryService.instance
+  }
+
+  async list(query?: TranslateHistoryQuery): Promise<OffsetPaginationResponse<TranslateHistory>> {
+    const db = dbService.getDb()
+    const page = query?.page ?? DEFAULT_PAGE
+    const limit = query?.limit ?? DEFAULT_LIMIT
+    const offset = (page - 1) * limit
+
+    const conditions: SQL[] = []
+
+    if (query?.star !== undefined) {
+      conditions.push(eq(translateHistoryTable.star, query.star))
+    }
+
+    if (query?.search) {
+      const escaped = query.search.replace(/[%_\\]/g, '\\$&')
+      const pattern = `%${escaped}%`
+      const searchCondition = or(
+        sql`${translateHistoryTable.sourceText} LIKE ${pattern} ESCAPE '\\'`,
+        sql`${translateHistoryTable.targetText} LIKE ${pattern} ESCAPE '\\'`
+      )
+      if (searchCondition) {
+        conditions.push(searchCondition)
+      }
+    }
+
+    const where = conditions.length > 0 ? and(...conditions) : undefined
+
+    const [items, [{ count }]] = await Promise.all([
+      db
+        .select()
+        .from(translateHistoryTable)
+        .where(where)
+        .orderBy(desc(translateHistoryTable.createdAt))
+        .limit(limit)
+        .offset(offset),
+      db.select({ count: sql<number>`count(*)` }).from(translateHistoryTable).where(where)
+    ])
+
+    return {
+      items: items.map(rowToTranslateHistory),
+      total: count,
+      page
+    }
+  }
+
+  async getById(id: string): Promise<TranslateHistory> {
+    const db = dbService.getDb()
+    const [row] = await db.select().from(translateHistoryTable).where(eq(translateHistoryTable.id, id)).limit(1)
+
+    if (!row) {
+      throw DataApiErrorFactory.notFound('TranslateHistory', id)
+    }
+
+    return rowToTranslateHistory(row)
+  }
+
+  async create(dto: CreateTranslateHistoryDto): Promise<TranslateHistory> {
+    const db = dbService.getDb()
+
+    const [row] = await db
+      .insert(translateHistoryTable)
+      .values({
+        sourceText: dto.sourceText,
+        targetText: dto.targetText,
+        sourceLanguage: dto.sourceLanguage,
+        targetLanguage: dto.targetLanguage
+      })
+      .returning()
+
+    if (!row) {
+      throw DataApiErrorFactory.database(new Error('Insert did not return a row'), 'create translate history')
+    }
+
+    logger.info('Created translate history', { id: row.id })
+    return rowToTranslateHistory(row)
+  }
+
+  async update(id: string, dto: UpdateTranslateHistoryDto): Promise<TranslateHistory> {
+    const db = dbService.getDb()
+
+    return await db.transaction(async (tx) => {
+      const [current] = await tx.select().from(translateHistoryTable).where(eq(translateHistoryTable.id, id)).limit(1)
+
+      if (!current) {
+        throw DataApiErrorFactory.notFound('TranslateHistory', id)
+      }
+
+      const updates: Partial<typeof translateHistoryTable.$inferInsert> = {}
+      if (dto.sourceText !== undefined) updates.sourceText = dto.sourceText
+      if (dto.targetText !== undefined) updates.targetText = dto.targetText
+      if (dto.sourceLanguage !== undefined) updates.sourceLanguage = dto.sourceLanguage
+      if (dto.targetLanguage !== undefined) updates.targetLanguage = dto.targetLanguage
+      if (dto.star !== undefined) updates.star = dto.star
+
+      if (Object.keys(updates).length === 0) {
+        return rowToTranslateHistory(current)
+      }
+
+      const [row] = await tx
+        .update(translateHistoryTable)
+        .set(updates)
+        .where(eq(translateHistoryTable.id, id))
+        .returning()
+
+      if (!row) {
+        throw DataApiErrorFactory.notFound('TranslateHistory', id)
+      }
+
+      logger.info('Updated translate history', { id, changes: Object.keys(dto) })
+      return rowToTranslateHistory(row)
+    })
+  }
+
+  async delete(id: string): Promise<void> {
+    const db = dbService.getDb()
+
+    await db.transaction(async (tx) => {
+      const [row] = await tx.select().from(translateHistoryTable).where(eq(translateHistoryTable.id, id)).limit(1)
+
+      if (!row) {
+        throw DataApiErrorFactory.notFound('TranslateHistory', id)
+      }
+
+      await tx.delete(translateHistoryTable).where(eq(translateHistoryTable.id, id))
+    })
+
+    logger.info('Deleted translate history', { id })
+  }
+
+  async clearAll(): Promise<void> {
+    const db = dbService.getDb()
+    await db.delete(translateHistoryTable)
+    logger.info('Cleared all translate histories')
+  }
+}
+
+export const translateHistoryService = TranslateHistoryService.getInstance()

--- a/src/main/data/services/TranslateHistoryService.ts
+++ b/src/main/data/services/TranslateHistoryService.ts
@@ -18,9 +18,6 @@ import { and, desc, eq, or, sql } from 'drizzle-orm'
 
 const logger = loggerService.withContext('DataApi:TranslateHistoryService')
 
-const DEFAULT_PAGE = 1
-const DEFAULT_LIMIT = 20
-
 function rowToTranslateHistory(row: typeof translateHistoryTable.$inferSelect): TranslateHistory {
   return {
     id: row.id,
@@ -46,10 +43,9 @@ export class TranslateHistoryService {
     return TranslateHistoryService.instance
   }
 
-  async list(query?: TranslateHistoryQuery): Promise<OffsetPaginationResponse<TranslateHistory>> {
+  async list(query: TranslateHistoryQuery): Promise<OffsetPaginationResponse<TranslateHistory>> {
     const db = dbService.getDb()
-    const page = query?.page ?? DEFAULT_PAGE
-    const limit = query?.limit ?? DEFAULT_LIMIT
+    const { page, limit } = query
     const offset = (page - 1) * limit
 
     const conditions: SQL[] = []

--- a/src/main/data/services/TranslateLanguageService.ts
+++ b/src/main/data/services/TranslateLanguageService.ts
@@ -1,5 +1,7 @@
 /**
- * Translate Language Service - handles custom translate language CRUD
+ * Translate Language Service - handles translate language CRUD
+ *
+ * langCode is the primary key (immutable after creation).
  */
 
 import { dbService } from '@data/db/DbService'
@@ -17,7 +19,6 @@ const logger = loggerService.withContext('DataApi:TranslateLanguageService')
 
 function rowToTranslateLanguage(row: typeof translateLanguageTable.$inferSelect): TranslateLanguage {
   return {
-    id: row.id,
     langCode: row.langCode,
     value: row.value,
     emoji: row.emoji,
@@ -44,12 +45,16 @@ export class TranslateLanguageService {
     return rows.map(rowToTranslateLanguage)
   }
 
-  async getById(id: string): Promise<TranslateLanguage> {
+  async getByLangCode(langCode: string): Promise<TranslateLanguage> {
     const db = dbService.getDb()
-    const [row] = await db.select().from(translateLanguageTable).where(eq(translateLanguageTable.id, id)).limit(1)
+    const [row] = await db
+      .select()
+      .from(translateLanguageTable)
+      .where(eq(translateLanguageTable.langCode, langCode))
+      .limit(1)
 
     if (!row) {
-      throw DataApiErrorFactory.notFound('TranslateLanguage', id)
+      throw DataApiErrorFactory.notFound('TranslateLanguage', langCode)
     }
 
     return rowToTranslateLanguage(row)
@@ -59,21 +64,8 @@ export class TranslateLanguageService {
     const db = dbService.getDb()
     const langCode = dto.langCode.toLowerCase()
 
-    return await db.transaction(async (tx) => {
-      const [existing] = await tx
-        .select()
-        .from(translateLanguageTable)
-        .where(eq(translateLanguageTable.langCode, langCode))
-        .limit(1)
-
-      if (existing) {
-        throw DataApiErrorFactory.invalidOperation(
-          'create translate language',
-          `Language with code '${langCode}' already exists`
-        )
-      }
-
-      const [row] = await tx
+    try {
+      const [row] = await db
         .insert(translateLanguageTable)
         .values({
           langCode,
@@ -86,24 +78,34 @@ export class TranslateLanguageService {
         throw DataApiErrorFactory.database(new Error('Insert did not return a row'), 'create translate language')
       }
 
-      logger.info('Created translate language', { id: row.id, langCode })
+      logger.info('Created translate language', { langCode })
       return rowToTranslateLanguage(row)
-    })
+    } catch (e: unknown) {
+      if (e instanceof Error && e.message.includes('UNIQUE constraint failed')) {
+        throw DataApiErrorFactory.invalidOperation(
+          'create translate language',
+          `Language with code '${langCode}' already exists`
+        )
+      }
+      throw e
+    }
   }
 
-  async update(id: string, dto: UpdateTranslateLanguageDto): Promise<TranslateLanguage> {
+  async update(langCode: string, dto: UpdateTranslateLanguageDto): Promise<TranslateLanguage> {
     const db = dbService.getDb()
 
     return await db.transaction(async (tx) => {
-      // Verify existence within transaction
-      const [current] = await tx.select().from(translateLanguageTable).where(eq(translateLanguageTable.id, id)).limit(1)
+      const [current] = await tx
+        .select()
+        .from(translateLanguageTable)
+        .where(eq(translateLanguageTable.langCode, langCode))
+        .limit(1)
 
       if (!current) {
-        throw DataApiErrorFactory.notFound('TranslateLanguage', id)
+        throw DataApiErrorFactory.notFound('TranslateLanguage', langCode)
       }
 
       const updates: Partial<typeof translateLanguageTable.$inferInsert> = {}
-      if (dto.langCode !== undefined) updates.langCode = dto.langCode.toLowerCase()
       if (dto.value !== undefined) updates.value = dto.value
       if (dto.emoji !== undefined) updates.emoji = dto.emoji
 
@@ -111,51 +113,39 @@ export class TranslateLanguageService {
         return rowToTranslateLanguage(current)
       }
 
-      // If updating langCode, check uniqueness within same transaction
-      if (updates.langCode !== undefined) {
-        const [existing] = await tx
-          .select()
-          .from(translateLanguageTable)
-          .where(eq(translateLanguageTable.langCode, updates.langCode))
-          .limit(1)
-
-        if (existing && existing.id !== id) {
-          throw DataApiErrorFactory.invalidOperation(
-            'update translate language',
-            `Language with code '${updates.langCode}' already exists`
-          )
-        }
-      }
-
       const [row] = await tx
         .update(translateLanguageTable)
         .set(updates)
-        .where(eq(translateLanguageTable.id, id))
+        .where(eq(translateLanguageTable.langCode, langCode))
         .returning()
 
       if (!row) {
-        throw DataApiErrorFactory.notFound('TranslateLanguage', id)
+        throw DataApiErrorFactory.notFound('TranslateLanguage', langCode)
       }
 
-      logger.info('Updated translate language', { id, changes: Object.keys(dto) })
+      logger.info('Updated translate language', { langCode, changes: Object.keys(dto) })
       return rowToTranslateLanguage(row)
     })
   }
 
-  async delete(id: string): Promise<void> {
+  async delete(langCode: string): Promise<void> {
     const db = dbService.getDb()
 
     await db.transaction(async (tx) => {
-      const [row] = await tx.select().from(translateLanguageTable).where(eq(translateLanguageTable.id, id)).limit(1)
+      const [row] = await tx
+        .select()
+        .from(translateLanguageTable)
+        .where(eq(translateLanguageTable.langCode, langCode))
+        .limit(1)
 
       if (!row) {
-        throw DataApiErrorFactory.notFound('TranslateLanguage', id)
+        throw DataApiErrorFactory.notFound('TranslateLanguage', langCode)
       }
 
-      await tx.delete(translateLanguageTable).where(eq(translateLanguageTable.id, id))
+      await tx.delete(translateLanguageTable).where(eq(translateLanguageTable.langCode, langCode))
     })
 
-    logger.info('Deleted translate language', { id })
+    logger.info('Deleted translate language', { langCode })
   }
 }
 

--- a/src/main/data/services/TranslateLanguageService.ts
+++ b/src/main/data/services/TranslateLanguageService.ts
@@ -1,0 +1,162 @@
+/**
+ * Translate Language Service - handles custom translate language CRUD
+ */
+
+import { dbService } from '@data/db/DbService'
+import { translateLanguageTable } from '@data/db/schemas/translateLanguage'
+import { loggerService } from '@logger'
+import { DataApiErrorFactory } from '@shared/data/api'
+import type {
+  CreateTranslateLanguageDto,
+  TranslateLanguage,
+  UpdateTranslateLanguageDto
+} from '@shared/data/api/schemas/translate'
+import { asc, eq } from 'drizzle-orm'
+
+const logger = loggerService.withContext('DataApi:TranslateLanguageService')
+
+function rowToTranslateLanguage(row: typeof translateLanguageTable.$inferSelect): TranslateLanguage {
+  return {
+    id: row.id,
+    langCode: row.langCode,
+    value: row.value,
+    emoji: row.emoji,
+    createdAt: row.createdAt ? new Date(row.createdAt).toISOString() : new Date().toISOString(),
+    updatedAt: row.updatedAt ? new Date(row.updatedAt).toISOString() : new Date().toISOString()
+  }
+}
+
+export class TranslateLanguageService {
+  private static instance: TranslateLanguageService
+
+  private constructor() {}
+
+  public static getInstance(): TranslateLanguageService {
+    if (!TranslateLanguageService.instance) {
+      TranslateLanguageService.instance = new TranslateLanguageService()
+    }
+    return TranslateLanguageService.instance
+  }
+
+  async list(): Promise<TranslateLanguage[]> {
+    const db = dbService.getDb()
+    const rows = await db.select().from(translateLanguageTable).orderBy(asc(translateLanguageTable.createdAt))
+    return rows.map(rowToTranslateLanguage)
+  }
+
+  async getById(id: string): Promise<TranslateLanguage> {
+    const db = dbService.getDb()
+    const [row] = await db.select().from(translateLanguageTable).where(eq(translateLanguageTable.id, id)).limit(1)
+
+    if (!row) {
+      throw DataApiErrorFactory.notFound('TranslateLanguage', id)
+    }
+
+    return rowToTranslateLanguage(row)
+  }
+
+  async create(dto: CreateTranslateLanguageDto): Promise<TranslateLanguage> {
+    const db = dbService.getDb()
+    const langCode = dto.langCode.toLowerCase()
+
+    return await db.transaction(async (tx) => {
+      const [existing] = await tx
+        .select()
+        .from(translateLanguageTable)
+        .where(eq(translateLanguageTable.langCode, langCode))
+        .limit(1)
+
+      if (existing) {
+        throw DataApiErrorFactory.invalidOperation(
+          'create translate language',
+          `Language with code '${langCode}' already exists`
+        )
+      }
+
+      const [row] = await tx
+        .insert(translateLanguageTable)
+        .values({
+          langCode,
+          value: dto.value,
+          emoji: dto.emoji
+        })
+        .returning()
+
+      if (!row) {
+        throw DataApiErrorFactory.database(new Error('Insert did not return a row'), 'create translate language')
+      }
+
+      logger.info('Created translate language', { id: row.id, langCode })
+      return rowToTranslateLanguage(row)
+    })
+  }
+
+  async update(id: string, dto: UpdateTranslateLanguageDto): Promise<TranslateLanguage> {
+    const db = dbService.getDb()
+
+    return await db.transaction(async (tx) => {
+      // Verify existence within transaction
+      const [current] = await tx.select().from(translateLanguageTable).where(eq(translateLanguageTable.id, id)).limit(1)
+
+      if (!current) {
+        throw DataApiErrorFactory.notFound('TranslateLanguage', id)
+      }
+
+      const updates: Partial<typeof translateLanguageTable.$inferInsert> = {}
+      if (dto.langCode !== undefined) updates.langCode = dto.langCode.toLowerCase()
+      if (dto.value !== undefined) updates.value = dto.value
+      if (dto.emoji !== undefined) updates.emoji = dto.emoji
+
+      if (Object.keys(updates).length === 0) {
+        return rowToTranslateLanguage(current)
+      }
+
+      // If updating langCode, check uniqueness within same transaction
+      if (updates.langCode !== undefined) {
+        const [existing] = await tx
+          .select()
+          .from(translateLanguageTable)
+          .where(eq(translateLanguageTable.langCode, updates.langCode))
+          .limit(1)
+
+        if (existing && existing.id !== id) {
+          throw DataApiErrorFactory.invalidOperation(
+            'update translate language',
+            `Language with code '${updates.langCode}' already exists`
+          )
+        }
+      }
+
+      const [row] = await tx
+        .update(translateLanguageTable)
+        .set(updates)
+        .where(eq(translateLanguageTable.id, id))
+        .returning()
+
+      if (!row) {
+        throw DataApiErrorFactory.notFound('TranslateLanguage', id)
+      }
+
+      logger.info('Updated translate language', { id, changes: Object.keys(dto) })
+      return rowToTranslateLanguage(row)
+    })
+  }
+
+  async delete(id: string): Promise<void> {
+    const db = dbService.getDb()
+
+    await db.transaction(async (tx) => {
+      const [row] = await tx.select().from(translateLanguageTable).where(eq(translateLanguageTable.id, id)).limit(1)
+
+      if (!row) {
+        throw DataApiErrorFactory.notFound('TranslateLanguage', id)
+      }
+
+      await tx.delete(translateLanguageTable).where(eq(translateLanguageTable.id, id))
+    })
+
+    logger.info('Deleted translate language', { id })
+  }
+}
+
+export const translateLanguageService = TranslateLanguageService.getInstance()

--- a/src/main/data/services/TranslateLanguageService.ts
+++ b/src/main/data/services/TranslateLanguageService.ts
@@ -79,10 +79,7 @@ export class TranslateLanguageService {
       return rowToTranslateLanguage(row)
     } catch (e: unknown) {
       if (e instanceof Error && e.message.includes('UNIQUE constraint failed')) {
-        throw DataApiErrorFactory.invalidOperation(
-          'create translate language',
-          `Language with code '${langCode}' already exists`
-        )
+        throw DataApiErrorFactory.conflict(`Language with code '${langCode}' already exists`, 'TranslateLanguage')
       }
       throw e
     }

--- a/src/main/data/services/TranslateLanguageService.ts
+++ b/src/main/data/services/TranslateLanguageService.ts
@@ -8,11 +8,8 @@ import { dbService } from '@data/db/DbService'
 import { translateLanguageTable } from '@data/db/schemas/translateLanguage'
 import { loggerService } from '@logger'
 import { DataApiErrorFactory } from '@shared/data/api'
-import type {
-  CreateTranslateLanguageDto,
-  TranslateLanguage,
-  UpdateTranslateLanguageDto
-} from '@shared/data/api/schemas/translate'
+import type { CreateTranslateLanguageDto, UpdateTranslateLanguageDto } from '@shared/data/api/schemas/translate'
+import type { TranslateLanguage } from '@shared/data/types/translate'
 import { asc, eq } from 'drizzle-orm'
 
 const logger = loggerService.withContext('DataApi:TranslateLanguageService')

--- a/src/main/data/services/__tests__/TranslateHistoryService.test.ts
+++ b/src/main/data/services/__tests__/TranslateHistoryService.test.ts
@@ -1,0 +1,204 @@
+import type { CreateTranslateHistoryDto, UpdateTranslateHistoryDto } from '@shared/data/api/schemas/translate'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock dbService - tx shares the same mocks since transaction passes tx to callback
+const mockSelect = vi.fn()
+const mockInsert = vi.fn()
+const mockUpdate = vi.fn()
+const mockDelete = vi.fn()
+
+const mockTx = {
+  select: mockSelect,
+  insert: mockInsert,
+  update: mockUpdate,
+  delete: mockDelete
+}
+
+vi.mock('@data/db/DbService', () => ({
+  dbService: {
+    getDb: vi.fn(() => ({
+      select: mockSelect,
+      insert: mockInsert,
+      update: mockUpdate,
+      delete: mockDelete,
+      transaction: vi.fn(async (fn: (tx: typeof mockTx) => Promise<unknown>) => fn(mockTx))
+    }))
+  }
+}))
+
+// Import after mocking
+const { TranslateHistoryService } = await import('../TranslateHistoryService')
+
+function createMockRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '550e8400-e29b-41d4-a716-446655440000',
+    sourceText: 'Hello',
+    targetText: 'Bonjour',
+    sourceLanguage: 'en-us',
+    targetLanguage: 'fr-fr',
+    star: false,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides
+  }
+}
+
+describe('TranslateHistoryService', () => {
+  let service: ReturnType<typeof TranslateHistoryService.getInstance>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    service = TranslateHistoryService.getInstance()
+  })
+
+  describe('list', () => {
+    function setupListMocks(rows: Record<string, unknown>[], count: number) {
+      // items query (first call)
+      mockSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                offset: vi.fn().mockResolvedValue(rows)
+              })
+            })
+          })
+        })
+      })
+      // count query (second call)
+      mockSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ count }])
+        })
+      })
+    }
+
+    it('should return paginated results with defaults', async () => {
+      const rows = [createMockRow()]
+      setupListMocks(rows, 1)
+
+      const result = await service.list()
+      expect(result.items).toHaveLength(1)
+      expect(result.total).toBe(1)
+      expect(result.page).toBe(1)
+    })
+
+    it('should return empty results', async () => {
+      setupListMocks([], 0)
+
+      const result = await service.list()
+      expect(result.items).toHaveLength(0)
+      expect(result.total).toBe(0)
+    })
+
+    it('should pass custom page and limit', async () => {
+      setupListMocks([], 0)
+
+      const result = await service.list({ page: 2, limit: 10 })
+      expect(result.page).toBe(2)
+    })
+  })
+
+  describe('getById', () => {
+    it('should return a translate history by id', async () => {
+      const row = createMockRow()
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([row])
+          })
+        })
+      })
+
+      const result = await service.getById(row.id as string)
+      expect(result.id).toBe(row.id)
+      expect(result.sourceText).toBe('Hello')
+      expect(result.targetText).toBe('Bonjour')
+    })
+
+    it('should throw NotFound for non-existent id', async () => {
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([])
+          })
+        })
+      })
+
+      await expect(service.getById('non-existent')).rejects.toThrow()
+    })
+  })
+
+  describe('create', () => {
+    it('should validate and create a translate history', async () => {
+      const row = createMockRow()
+      mockInsert.mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([row])
+        })
+      })
+
+      const dto: CreateTranslateHistoryDto = {
+        sourceText: 'Hello',
+        targetText: 'Bonjour',
+        sourceLanguage: 'en-us',
+        targetLanguage: 'fr-fr'
+      }
+
+      const result = await service.create(dto)
+      expect(result.sourceText).toBe('Hello')
+      expect(mockInsert).toHaveBeenCalled()
+    })
+  })
+
+  describe('update', () => {
+    it('should update a translate history', async () => {
+      const row = createMockRow()
+      // Mock getById
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([row])
+          })
+        })
+      })
+      mockUpdate.mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ ...row, star: true }])
+          })
+        })
+      })
+
+      const dto: UpdateTranslateHistoryDto = { star: true }
+      const result = await service.update(row.id as string, dto)
+      expect(result.star).toBe(true)
+    })
+  })
+
+  describe('delete', () => {
+    it('should delete an existing translate history', async () => {
+      const row = createMockRow()
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([row])
+          })
+        })
+      })
+      mockDelete.mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined)
+      })
+
+      await expect(service.delete(row.id as string)).resolves.toBeUndefined()
+    })
+  })
+
+  describe('clearAll', () => {
+    it('should clear all translate histories', async () => {
+      mockDelete.mockResolvedValue(undefined)
+
+      await expect(service.clearAll()).resolves.toBeUndefined()
+    })
+  })
+})

--- a/src/main/data/services/__tests__/TranslateHistoryService.test.ts
+++ b/src/main/data/services/__tests__/TranslateHistoryService.test.ts
@@ -77,7 +77,7 @@ describe('TranslateHistoryService', () => {
       const rows = [createMockRow()]
       setupListMocks(rows, 1)
 
-      const result = await service.list()
+      const result = await service.list({ page: 1, limit: 20 })
       expect(result.items).toHaveLength(1)
       expect(result.total).toBe(1)
       expect(result.page).toBe(1)
@@ -86,7 +86,7 @@ describe('TranslateHistoryService', () => {
     it('should return empty results', async () => {
       setupListMocks([], 0)
 
-      const result = await service.list()
+      const result = await service.list({ page: 1, limit: 20 })
       expect(result.items).toHaveLength(0)
       expect(result.total).toBe(0)
     })

--- a/src/main/data/services/__tests__/TranslateHistoryService.test.ts
+++ b/src/main/data/services/__tests__/TranslateHistoryService.test.ts
@@ -97,6 +97,30 @@ describe('TranslateHistoryService', () => {
       const result = await service.list({ page: 2, limit: 10 })
       expect(result.page).toBe(2)
     })
+
+    it('should pass search parameter to query', async () => {
+      setupListMocks([], 0)
+
+      await service.list({ page: 1, limit: 20, search: 'hello' })
+      // Verify select was called (items + count)
+      expect(mockSelect).toHaveBeenCalledTimes(2)
+    })
+
+    it('should escape LIKE wildcards in search', async () => {
+      setupListMocks([], 0)
+
+      // Should not throw when search contains LIKE wildcards
+      await expect(service.list({ page: 1, limit: 20, search: '100% off_sale\\test' })).resolves.toBeDefined()
+    })
+
+    it('should filter by star', async () => {
+      const rows = [createMockRow({ star: true })]
+      setupListMocks(rows, 1)
+
+      const result = await service.list({ page: 1, limit: 20, star: true })
+      expect(result.items).toHaveLength(1)
+      expect(result.items[0].star).toBe(true)
+    })
   })
 
   describe('getById', () => {
@@ -174,6 +198,21 @@ describe('TranslateHistoryService', () => {
       const result = await service.update(row.id as string, dto)
       expect(result.star).toBe(true)
     })
+
+    it('should return existing record on empty update', async () => {
+      const row = createMockRow()
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([row])
+          })
+        })
+      })
+
+      const result = await service.update(row.id as string, {})
+      expect(result.id).toBe(row.id)
+      expect(mockUpdate).not.toHaveBeenCalled()
+    })
   })
 
   describe('delete', () => {
@@ -191,6 +230,18 @@ describe('TranslateHistoryService', () => {
       })
 
       await expect(service.delete(row.id as string)).resolves.toBeUndefined()
+    })
+
+    it('should throw NotFound for non-existent id', async () => {
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([])
+          })
+        })
+      })
+
+      await expect(service.delete('non-existent')).rejects.toThrow()
     })
   })
 

--- a/src/main/data/services/__tests__/TranslateLanguageService.test.ts
+++ b/src/main/data/services/__tests__/TranslateLanguageService.test.ts
@@ -1,0 +1,214 @@
+import type { CreateTranslateLanguageDto } from '@shared/data/api/schemas/translate'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock dbService - tx shares the same mocks since transaction passes tx to callback
+const mockSelect = vi.fn()
+const mockInsert = vi.fn()
+const mockUpdate = vi.fn()
+const mockDelete = vi.fn()
+
+const mockTx = {
+  select: mockSelect,
+  insert: mockInsert,
+  update: mockUpdate,
+  delete: mockDelete
+}
+
+vi.mock('@data/db/DbService', () => ({
+  dbService: {
+    getDb: vi.fn(() => ({
+      select: mockSelect,
+      insert: mockInsert,
+      update: mockUpdate,
+      delete: mockDelete,
+      transaction: vi.fn(async (fn: (tx: typeof mockTx) => Promise<unknown>) => fn(mockTx))
+    }))
+  }
+}))
+
+const { TranslateLanguageService } = await import('../TranslateLanguageService')
+
+function createMockRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '550e8400-e29b-41d4-a716-446655440001',
+    langCode: 'ja',
+    value: 'Japanese',
+    emoji: '\uD83C\uDDEF\uD83C\uDDF5',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides
+  }
+}
+
+describe('TranslateLanguageService', () => {
+  let service: ReturnType<typeof TranslateLanguageService.getInstance>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    service = TranslateLanguageService.getInstance()
+  })
+
+  describe('list', () => {
+    it('should return all custom languages ordered by createdAt', async () => {
+      const rows = [createMockRow()]
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockResolvedValue(rows)
+        })
+      })
+
+      const result = await service.list()
+      expect(result).toHaveLength(1)
+      expect(result[0].langCode).toBe('ja')
+    })
+  })
+
+  describe('getById', () => {
+    it('should return a language by id', async () => {
+      const row = createMockRow()
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([row])
+          })
+        })
+      })
+
+      const result = await service.getById(row.id as string)
+      expect(result.langCode).toBe('ja')
+    })
+
+    it('should throw NotFound for non-existent id', async () => {
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([])
+          })
+        })
+      })
+
+      await expect(service.getById('non-existent')).rejects.toThrow()
+    })
+  })
+
+  describe('create', () => {
+    it('should create a language within transaction', async () => {
+      const row = createMockRow()
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([])
+          })
+        })
+      })
+      mockInsert.mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([row])
+        })
+      })
+
+      const dto: CreateTranslateLanguageDto = {
+        langCode: 'ja',
+        value: 'Japanese',
+        emoji: '\uD83C\uDDEF\uD83C\uDDF5'
+      }
+
+      const result = await service.create(dto)
+      expect(result.langCode).toBe('ja')
+    })
+
+    it('should reject duplicate langCode', async () => {
+      const existing = createMockRow()
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([existing])
+          })
+        })
+      })
+
+      const dto: CreateTranslateLanguageDto = {
+        langCode: 'ja',
+        value: 'Japanese',
+        emoji: '\uD83C\uDDEF\uD83C\uDDF5'
+      }
+
+      await expect(service.create(dto)).rejects.toThrow()
+    })
+  })
+
+  describe('update', () => {
+    it('should update a language within transaction', async () => {
+      const row = createMockRow()
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([row])
+          })
+        })
+      })
+      mockUpdate.mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ ...row, value: 'Updated' }])
+          })
+        })
+      })
+
+      const result = await service.update(row.id as string, { value: 'Updated' })
+      expect(result.value).toBe('Updated')
+    })
+
+    it('should return existing record on empty update', async () => {
+      const row = createMockRow()
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([row])
+          })
+        })
+      })
+
+      const result = await service.update(row.id as string, {})
+      expect(result.langCode).toBe('ja')
+      expect(mockUpdate).not.toHaveBeenCalled()
+    })
+
+    it('should reject duplicate langCode on update', async () => {
+      const row = createMockRow()
+      const other = createMockRow({ id: '550e8400-e29b-41d4-a716-446655440099', langCode: 'ko-kr' })
+
+      let callCount = 0
+      mockSelect.mockImplementation(() => {
+        callCount++
+        return {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([callCount === 1 ? row : other])
+            })
+          })
+        }
+      })
+
+      await expect(service.update(row.id as string, { langCode: 'ko-kr' })).rejects.toThrow()
+    })
+  })
+
+  describe('delete', () => {
+    it('should delete an existing language', async () => {
+      const row = createMockRow()
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([row])
+          })
+        })
+      })
+      mockDelete.mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined)
+      })
+
+      await expect(service.delete(row.id as string)).resolves.toBeUndefined()
+    })
+  })
+})

--- a/src/main/data/services/__tests__/TranslateLanguageService.test.ts
+++ b/src/main/data/services/__tests__/TranslateLanguageService.test.ts
@@ -30,8 +30,7 @@ const { TranslateLanguageService } = await import('../TranslateLanguageService')
 
 function createMockRow(overrides: Record<string, unknown> = {}) {
   return {
-    id: '550e8400-e29b-41d4-a716-446655440001',
-    langCode: 'ja',
+    langCode: 'ja-jp',
     value: 'Japanese',
     emoji: '\uD83C\uDDEF\uD83C\uDDF5',
     createdAt: '2024-01-01T00:00:00.000Z',
@@ -49,7 +48,7 @@ describe('TranslateLanguageService', () => {
   })
 
   describe('list', () => {
-    it('should return all custom languages ordered by createdAt', async () => {
+    it('should return all languages ordered by createdAt', async () => {
       const rows = [createMockRow()]
       mockSelect.mockReturnValue({
         from: vi.fn().mockReturnValue({
@@ -59,12 +58,12 @@ describe('TranslateLanguageService', () => {
 
       const result = await service.list()
       expect(result).toHaveLength(1)
-      expect(result[0].langCode).toBe('ja')
+      expect(result[0].langCode).toBe('ja-jp')
     })
   })
 
-  describe('getById', () => {
-    it('should return a language by id', async () => {
+  describe('getByLangCode', () => {
+    it('should return a language by langCode', async () => {
       const row = createMockRow()
       mockSelect.mockReturnValue({
         from: vi.fn().mockReturnValue({
@@ -74,11 +73,11 @@ describe('TranslateLanguageService', () => {
         })
       })
 
-      const result = await service.getById(row.id as string)
-      expect(result.langCode).toBe('ja')
+      const result = await service.getByLangCode('ja-jp')
+      expect(result.langCode).toBe('ja-jp')
     })
 
-    it('should throw NotFound for non-existent id', async () => {
+    it('should throw NotFound for non-existent langCode', async () => {
       mockSelect.mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
@@ -87,20 +86,13 @@ describe('TranslateLanguageService', () => {
         })
       })
 
-      await expect(service.getById('non-existent')).rejects.toThrow()
+      await expect(service.getByLangCode('xx-xx')).rejects.toThrow()
     })
   })
 
   describe('create', () => {
-    it('should create a language within transaction', async () => {
+    it('should create a language', async () => {
       const row = createMockRow()
-      mockSelect.mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([])
-          })
-        })
-      })
       mockInsert.mockReturnValue({
         values: vi.fn().mockReturnValue({
           returning: vi.fn().mockResolvedValue([row])
@@ -108,37 +100,34 @@ describe('TranslateLanguageService', () => {
       })
 
       const dto: CreateTranslateLanguageDto = {
-        langCode: 'ja',
+        langCode: 'ja-jp',
         value: 'Japanese',
         emoji: '\uD83C\uDDEF\uD83C\uDDF5'
       }
 
       const result = await service.create(dto)
-      expect(result.langCode).toBe('ja')
+      expect(result.langCode).toBe('ja-jp')
     })
 
-    it('should reject duplicate langCode', async () => {
-      const existing = createMockRow()
-      mockSelect.mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([existing])
-          })
+    it('should reject duplicate langCode via UNIQUE constraint', async () => {
+      mockInsert.mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockRejectedValue(new Error('UNIQUE constraint failed: translate_language.lang_code'))
         })
       })
 
       const dto: CreateTranslateLanguageDto = {
-        langCode: 'ja',
+        langCode: 'ja-jp',
         value: 'Japanese',
         emoji: '\uD83C\uDDEF\uD83C\uDDF5'
       }
 
-      await expect(service.create(dto)).rejects.toThrow()
+      await expect(service.create(dto)).rejects.toThrow(/already exists/)
     })
   })
 
   describe('update', () => {
-    it('should update a language within transaction', async () => {
+    it('should update value/emoji', async () => {
       const row = createMockRow()
       mockSelect.mockReturnValue({
         from: vi.fn().mockReturnValue({
@@ -155,7 +144,7 @@ describe('TranslateLanguageService', () => {
         })
       })
 
-      const result = await service.update(row.id as string, { value: 'Updated' })
+      const result = await service.update('ja-jp', { value: 'Updated' })
       expect(result.value).toBe('Updated')
     })
 
@@ -169,28 +158,21 @@ describe('TranslateLanguageService', () => {
         })
       })
 
-      const result = await service.update(row.id as string, {})
-      expect(result.langCode).toBe('ja')
+      const result = await service.update('ja-jp', {})
+      expect(result.langCode).toBe('ja-jp')
       expect(mockUpdate).not.toHaveBeenCalled()
     })
 
-    it('should reject duplicate langCode on update', async () => {
-      const row = createMockRow()
-      const other = createMockRow({ id: '550e8400-e29b-41d4-a716-446655440099', langCode: 'ko-kr' })
-
-      let callCount = 0
-      mockSelect.mockImplementation(() => {
-        callCount++
-        return {
-          from: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              limit: vi.fn().mockResolvedValue([callCount === 1 ? row : other])
-            })
+    it('should throw NotFound for non-existent langCode', async () => {
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([])
           })
-        }
+        })
       })
 
-      await expect(service.update(row.id as string, { langCode: 'ko-kr' })).rejects.toThrow()
+      await expect(service.update('xx-xx', { value: 'Test' })).rejects.toThrow()
     })
   })
 
@@ -208,7 +190,7 @@ describe('TranslateLanguageService', () => {
         where: vi.fn().mockResolvedValue(undefined)
       })
 
-      await expect(service.delete(row.id as string)).resolves.toBeUndefined()
+      await expect(service.delete('ja-jp')).resolves.toBeUndefined()
     })
   })
 })

--- a/src/main/data/services/__tests__/TranslateLanguageService.test.ts
+++ b/src/main/data/services/__tests__/TranslateLanguageService.test.ts
@@ -192,5 +192,17 @@ describe('TranslateLanguageService', () => {
 
       await expect(service.delete('ja-jp')).resolves.toBeUndefined()
     })
+
+    it('should throw NotFound for non-existent langCode', async () => {
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([])
+          })
+        })
+      })
+
+      await expect(service.delete('xx-xx')).rejects.toThrow()
+    })
   })
 })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -155,6 +155,7 @@ if (!app.requestSingleInstanceLock()) {
       await dbService.init()
       await dbService.migrateDb()
       await dbService.migrateSeed('preference')
+      await dbService.migrateSeed('translateLanguage')
     } catch (error) {
       logger.error('Failed to initialize database', error as Error)
       //TODO for v2 testing only:


### PR DESCRIPTION
### What this PR does

Before this PR:
- Translate history and custom language data only existed in renderer-side Dexie (IndexedDB)
- No Main-process API for translate data
- Builtin languages were hardcoded constants in renderer config only

After this PR:
- Full Main-process DataApi for translate history CRUD (paginated list, search, star filter)
- Full Main-process DataApi for translate language CRUD
- Builtin languages (20) are seeded into SQLite on app startup
- `langCode` is the primary key for `translate_language` (natural key, no UUID)
- `translate_history.sourceLanguage`/`targetLanguage` are FK references to `translate_language.langCode` with `ON DELETE SET NULL`
- Zod validation at handler boundary for all DTOs and query params (`z.emoji()`, `z.uuidv7()`, `z.int()`, `LangCodeSchema`)
- `langCode` is immutable after creation (not in UpdateDto, `.strict()` rejects unknown fields)
- Per-field JSDoc on all Zod schemas for IntelliSense
- Pagination defaults (`page=1`, `limit=20`, `max=100`) defined as named constants in schema
- Entity schemas and types extracted to `packages/shared/data/types/translate.ts`

### Why we need it and why it was done in this way

This is part of the v2 data layer migration (Redux/Dexie → SQLite/DataApi).

The following tradeoffs were made:
- **`langCode` as PK instead of UUID**: The language table is small (tens of records), `langCode` is the natural key (already UNIQUE), and it makes API paths more intuitive (`/translate/languages/zh-cn` vs UUID). The tradeoff is that `langCode` is immutable — to change it, delete and recreate.
- **Nullable FK with SET NULL**: When a language is deleted, history records retain their data but language references become null. This preserves history while allowing language cleanup.
- **Builtin languages in DB**: Instead of keeping builtins as code-only constants, they are seeded into the same table. This unifies the data source — renderer queries one API for all languages (builtin + custom). Users can also delete builtin languages they don't need.

The following alternatives were considered:
- Keeping UUID as PK: Rejected because it adds unnecessary indirection for a small, natural-key table.
- RESTRICT on FK delete: Rejected because it would prevent language cleanup when history exists.
- Separate tables for builtin vs custom languages: Rejected for unnecessary complexity.

### Breaking changes

None. This is a new API surface with no existing consumers.

### Special notes for your reviewer

- Migration `0004_volatile_madame_masque.sql` recreates both tables (SQLite limitation for PK/FK changes) with data preservation via `INSERT ... SELECT`.
- Seeding is idempotent — safe to run on every startup, only inserts missing languages.
- LIKE search escapes `%`, `_`, `\` to prevent wildcard injection.
- All multi-step operations (update, delete) use transactions to prevent TOCTOU races.
- Entity Zod schemas (`TranslateHistorySchema`, `TranslateLanguageSchema`, `LangCodeSchema`) live in `packages/shared/data/types/translate.ts`; DTOs, query schemas, and API route definitions remain in `schemas/translate.ts`.
- 44 unit tests covering services, handler validation, and seeding.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: Not required — internal data layer, no user-facing changes yet
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
