### PR TITLE
fix(agent): use containerRef from useScrollPosition to memorize scroll position

### DIFF
--- a/src/renderer/src/pages/agents/components/AgentSessionMessages.tsx
+++ b/src/renderer/src/pages/agents/components/AgentSessionMessages.tsx
@@ -14,7 +14,7 @@ import { getGroupedMessages } from '@renderer/services/MessagesService'
 import { type Topic, TopicType } from '@renderer/types'
 import { buildAgentSessionTopicId } from '@renderer/utils/agentSession'
 import { Spin } from 'antd'
-import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
+import { memo, useCallback, useEffect, useMemo } from 'react'
 
 const logger = loggerService.withContext('AgentSessionMessages')
 
@@ -29,9 +29,10 @@ const AgentSessionMessages = ({ agentId, sessionId }: Props) => {
   // Use the same hook as Messages.tsx for consistent behavior
   const messages = useTopicMessages(sessionTopicId)
   const { messageNavigation } = useSettings()
-  const scrollContainerRef = useRef<HTMLDivElement>(null)
 
-  const { handleScroll: handleScrollPosition } = useScrollPosition(`agent-session-${sessionId}`)
+  const { containerRef: scrollContainerRef, handleScroll: handleScrollPosition } = useScrollPosition(
+    `agent-session-${sessionId}`
+  )
 
   const displayMessages = useMemo(() => {
     if (!messages || messages.length === 0) return []


### PR DESCRIPTION
### What this PR does

Before this PR:

Agent chat page created a separate `useRef` for `scrollContainerRef` instead of using the one provided by `useScrollPosition`, causing the hook to never observe the actual scroll container. As a result, scroll positions were not memorized when switching between agent sessions.

After this PR:

Uses `containerRef` returned from `useScrollPosition` as the scroll container ref, so the hook correctly tracks and restores scroll positions for agent sessions.

### Why we need it and why it was done in this way

The `useScrollPosition` hook needs its own `containerRef` to be attached to the scrollable DOM element in order to read/write `scrollTop`. The previous code ignored this ref and created a standalone one, breaking the memorization mechanism.

The following tradeoffs were made: N/A

The following alternatives were considered: N/A

### Breaking changes

None

### Special notes for your reviewer

Minimal one-line fix — just replaced the standalone `useRef` with the `containerRef` from the hook.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix: Fixed agent chat page not memorizing scroll position when switching between sessions
```
