### PR TITLE
fix(data): resolve FK constraint failure in TranslateMigrator

### DIFF
--- a/src/main/data/migration/v2/migrators/TranslateMigrator.ts
+++ b/src/main/data/migration/v2/migrators/TranslateMigrator.ts
@@ -51,8 +51,8 @@ interface NewTranslateHistory {
   id: string
   sourceText: string
   targetText: string
-  sourceLanguage: string
-  targetLanguage: string
+  sourceLanguage: string | null
+  targetLanguage: string | null
   star: boolean
   createdAt: number
   updatedAt: number
@@ -75,14 +75,14 @@ function parseTimestamp(value: string): number {
   return !parsed || Number.isNaN(parsed) ? Date.now() : parsed
 }
 
-function transformHistoryRecord(old: OldTranslateHistory): NewTranslateHistory {
+function transformHistoryRecord(old: OldTranslateHistory, validLangCodes: Set<string>): NewTranslateHistory {
   const createdAt = parseTimestamp(old.createdAt)
   return {
     id: old.id,
     sourceText: old.sourceText,
     targetText: old.targetText,
-    sourceLanguage: old.sourceLanguage,
-    targetLanguage: old.targetLanguage,
+    sourceLanguage: validLangCodes.has(old.sourceLanguage) ? old.sourceLanguage : null,
+    targetLanguage: validLangCodes.has(old.targetLanguage) ? old.targetLanguage : null,
     star: old.star ?? false,
     createdAt,
     updatedAt: createdAt
@@ -168,44 +168,7 @@ export class TranslateMigrator extends BaseMigrator {
       const db = ctx.db
       let processedCount = 0
 
-      // ── Migrate translate history (batched) ──
-      if (this.historySourceCount > 0) {
-        const newHistoryRecords: NewTranslateHistory[] = []
-        for (const old of this.cachedHistoryRecords) {
-          if (!old.id || !old.sourceText || !old.targetText || !old.sourceLanguage || !old.targetLanguage) {
-            logger.warn(`Skipping invalid translate history record: ${old.id}`)
-            this.historySkippedCount++
-            continue
-          }
-          newHistoryRecords.push(transformHistoryRecord(old))
-        }
-
-        await db.transaction(async (tx) => {
-          for (let i = 0; i < newHistoryRecords.length; i += HISTORY_BATCH_SIZE) {
-            const batch = newHistoryRecords.slice(i, i + HISTORY_BATCH_SIZE)
-            await tx.insert(translateHistoryTable).values(batch)
-
-            const historyProcessed = Math.min(i + HISTORY_BATCH_SIZE, newHistoryRecords.length)
-            const progress = Math.round((historyProcessed / totalCount) * 100)
-            this.reportProgress(
-              progress,
-              `Migrated ${historyProcessed}/${newHistoryRecords.length} translate history records`,
-              {
-                key: 'migration.progress.migrated_translate_history',
-                params: { processed: historyProcessed, total: newHistoryRecords.length }
-              }
-            )
-          }
-        })
-
-        processedCount += newHistoryRecords.length
-        logger.info('Translate history migration completed', {
-          processedCount: newHistoryRecords.length,
-          skipped: this.historySkippedCount
-        })
-      }
-
-      // ── Migrate translate languages (single batch) ──
+      // ── Migrate translate languages first (history has FK references) ──
       if (this.languageSourceCount > 0) {
         const now = Date.now()
         const newLanguageRecords: NewTranslateLanguage[] = []
@@ -225,7 +188,8 @@ export class TranslateMigrator extends BaseMigrator {
           processedCount += newLanguageRecords.length
         }
 
-        this.reportProgress(100, `Migrated ${newLanguageRecords.length} custom translate languages`, {
+        const langProgress = Math.round((processedCount / totalCount) * 100)
+        this.reportProgress(langProgress, `Migrated ${newLanguageRecords.length} custom translate languages`, {
           key: 'migration.progress.migrated_translate_languages',
           params: { processed: newLanguageRecords.length, total: newLanguageRecords.length }
         })
@@ -233,6 +197,49 @@ export class TranslateMigrator extends BaseMigrator {
         logger.info('Translate language migration completed', {
           processedCount: newLanguageRecords.length,
           skipped: this.languageSkippedCount
+        })
+      }
+
+      // ── Migrate translate history (batched) ──
+      if (this.historySourceCount > 0) {
+        // Query all valid language codes to null-out dangling FK references
+        const existingLangs = await db
+          .select({ langCode: translateLanguageTable.langCode })
+          .from(translateLanguageTable)
+        const validLangCodes = new Set(existingLangs.map((r) => r.langCode))
+
+        const newHistoryRecords: NewTranslateHistory[] = []
+        for (const old of this.cachedHistoryRecords) {
+          if (!old.id || !old.sourceText || !old.targetText) {
+            logger.warn(`Skipping invalid translate history record: ${old.id}`)
+            this.historySkippedCount++
+            continue
+          }
+          newHistoryRecords.push(transformHistoryRecord(old, validLangCodes))
+        }
+
+        await db.transaction(async (tx) => {
+          for (let i = 0; i < newHistoryRecords.length; i += HISTORY_BATCH_SIZE) {
+            const batch = newHistoryRecords.slice(i, i + HISTORY_BATCH_SIZE)
+            await tx.insert(translateHistoryTable).values(batch)
+
+            const historyProcessed = Math.min(i + HISTORY_BATCH_SIZE, newHistoryRecords.length)
+            const progress = Math.round(((processedCount + historyProcessed) / totalCount) * 100)
+            this.reportProgress(
+              progress,
+              `Migrated ${historyProcessed}/${newHistoryRecords.length} translate history records`,
+              {
+                key: 'migration.progress.migrated_translate_history',
+                params: { processed: historyProcessed, total: newHistoryRecords.length }
+              }
+            )
+          }
+        })
+
+        processedCount += newHistoryRecords.length
+        logger.info('Translate history migration completed', {
+          processedCount: newHistoryRecords.length,
+          skipped: this.historySkippedCount
         })
       }
 


### PR DESCRIPTION
### What this PR does

Before this PR:

TranslateMigrator fails with `SQLITE_CONSTRAINT_FOREIGNKEY` when inserting translate_history records, because:
1. History records were inserted **before** language records, violating FK constraints (history.source_language/target_language → translate_language.lang_code).
2. Old history records may reference language codes that no longer exist in the translate_language table.

After this PR:

- Languages are migrated first, then history (respecting FK dependency order).
- Before inserting history, all valid `lang_code` values are queried from `translate_language`. History records referencing non-existent language codes get `source_language`/`target_language` set to `null` (consistent with the schema's `ON DELETE SET NULL` semantics).
- History records with missing language fields are no longer skipped entirely — only `id`, `sourceText`, and `targetText` are required.

### Why we need it and why it was done in this way

The following tradeoffs were made:

Setting dangling language references to `null` instead of skipping the entire history record. This preserves the user's translation history even when the referenced language no longer exists.

The following alternatives were considered:

- Disabling FK checks (`PRAGMA foreign_keys = OFF`) during migration — rejected because it bypasses the constraint entirely and could leave orphaned references.
- Skipping history records with invalid language references — rejected because it would lose user data unnecessarily.

### Breaking changes

None.

### Special notes for your reviewer

The seeding order guarantees that builtin languages are already present in `translate_language` before the v2 migrator runs (`migrateSeed('translateLanguage')` at `src/main/index.ts:158` runs before v2 migration at line 170+). This fix handles the edge case where old history references a language code that is neither builtin nor user-customized.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
