### PR TITLE
fix(data): add missing Method type argument to QueryParamsForPath usages

### DIFF
--- a/src/renderer/src/data/hooks/useDataApi.ts
+++ b/src/renderer/src/data/hooks/useDataApi.ts
@@ -195,7 +195,7 @@ export function useQuery<TPath extends ConcreteApiPaths>(
   path: TPath,
   options?: {
     /** Query parameters for filtering, pagination, etc. */
-    query?: QueryParamsForPath<TPath>
+    query?: QueryParamsForPath<TPath, 'GET'>
     /** Disable the request (default: true) */
     enabled?: boolean
     /** Override default SWR configuration */
@@ -416,7 +416,7 @@ export function useInvalidateCache() {
 export function prefetch<TPath extends ConcreteApiPaths>(
   path: TPath,
   options?: {
-    query?: QueryParamsForPath<TPath>
+    query?: QueryParamsForPath<TPath, 'GET'>
   }
 ): Promise<ResponseForPath<TPath, 'GET'>> {
   const key = buildSWRKey(path, options?.query)
@@ -463,7 +463,7 @@ export function useInfiniteQuery<TPath extends ConcreteApiPaths>(
   path: TPath,
   options?: {
     /** Additional query parameters (cursor/limit are managed internally) */
-    query?: Omit<QueryParamsForPath<TPath>, 'cursor' | 'limit'>
+    query?: Omit<QueryParamsForPath<TPath, 'GET'>, 'cursor' | 'limit'>
     /** Items per page (default: 10) */
     limit?: number
     /** Set to false to disable fetching (default: true) */
@@ -496,7 +496,7 @@ export function useInfiniteQuery<TPath extends ConcreteApiPaths>(
   )
 
   const infiniteFetcher = (key: [TPath, Record<string, unknown>]) => {
-    return getFetcher(key as unknown as [TPath, QueryParamsForPath<TPath>?]) as Promise<
+    return getFetcher(key as unknown as [TPath, QueryParamsForPath<TPath, 'GET'>?]) as Promise<
       CursorPaginationResponse<InferPaginatedItem<TPath>>
     >
   }
@@ -580,7 +580,7 @@ export function usePaginatedQuery<TPath extends ConcreteApiPaths>(
   path: TPath,
   options?: {
     /** Additional query parameters (page/limit are managed internally) */
-    query?: Omit<QueryParamsForPath<TPath>, 'page' | 'limit'>
+    query?: Omit<QueryParamsForPath<TPath, 'GET'>, 'page' | 'limit'>
     /** Items per page (default: 10) */
     limit?: number
     /** Set to false to disable fetching (default: true) */
@@ -607,7 +607,7 @@ export function usePaginatedQuery<TPath extends ConcreteApiPaths>(
 
   const { data, isLoading, isRefreshing, error, refetch } = useQuery(path, {
     // Type assertion needed: we're adding pagination params to a partial query type
-    query: queryWithPagination as QueryParamsForPath<TPath>,
+    query: queryWithPagination as QueryParamsForPath<TPath, 'GET'>,
     enabled: options?.enabled,
     swrOptions: options?.swrOptions
   })
@@ -718,7 +718,7 @@ function createApiFetcher<TPath extends ConcreteApiPaths, TMethod extends 'GET' 
  * @param query - Optional query parameters
  * @returns Tuple of [path, query?] for SWR cache key
  */
-function buildSWRKey<TPath extends ConcreteApiPaths, TQuery extends QueryParamsForPath<TPath>>(
+function buildSWRKey<TPath extends ConcreteApiPaths, TQuery extends QueryParamsForPath<TPath, 'GET'>>(
   path: TPath,
   query?: TQuery
 ): [TPath, TQuery?] {
@@ -736,7 +736,7 @@ function buildSWRKey<TPath extends ConcreteApiPaths, TQuery extends QueryParamsF
  * @param key - SWR cache key tuple [path, query?]
  * @returns Promise resolving to the API response
  */
-function getFetcher<TPath extends ConcreteApiPaths>([path, query]: [TPath, QueryParamsForPath<TPath>?]): Promise<
+function getFetcher<TPath extends ConcreteApiPaths>([path, query]: [TPath, QueryParamsForPath<TPath, 'GET'>?]): Promise<
   ResponseForPath<TPath, 'GET'>
 > {
   const apiFetcher = createApiFetcher<TPath, 'GET'>('GET')


### PR DESCRIPTION
### What this PR does

Before this PR:
`QueryParamsForPath` generic type in `useDataApi.ts` was called with only 1 type argument (`Path`), but the type definition requires 2 (`Path` and `Method`), causing 8 TypeScript errors.

After this PR:
All 8 usages now pass `'GET'` as the second type argument, fixing the typecheck errors.

Fixes #

### Why we need it and why it was done in this way

The `QueryParamsForPath` type was recently updated (in #13748) to require a `Method` type argument, but the consumer in `useDataApi.ts` was not updated accordingly.

All affected call sites are read-only SWR hooks (`useQuery`, `prefetch`, `useInfiniteQuery`, `usePaginatedQuery`) and their internal helpers (`buildSWRKey`, `getFetcher`), which exclusively perform GET requests — so `'GET'` is the correct method argument.

The following tradeoffs were made: N/A

The following alternatives were considered: N/A

### Breaking changes

None.

### Special notes for your reviewer

Pure type-level fix — no runtime behavior changes.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
