### PR TITLE
fix(deps): add @napi-rs/canvas platform binaries to fix startup crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -528,6 +528,14 @@
     "@napi-rs/system-ocr-darwin-x64": "1.0.2",
     "@napi-rs/system-ocr-win32-arm64-msvc": "1.0.2",
     "@napi-rs/system-ocr-win32-x64-msvc": "1.0.2",
-    "@strongtz/win32-arm64-msvc": "0.4.7"
+    "@strongtz/win32-arm64-msvc": "0.4.7",
+    "@napi-rs/canvas-linux-x64-gnu": "0.1.97",
+    "@napi-rs/canvas-linux-x64-musl": "0.1.97",
+    "@napi-rs/canvas-linux-arm64-gnu": "0.1.97",
+    "@napi-rs/canvas-linux-arm64-musl": "0.1.97",
+    "@napi-rs/canvas-darwin-x64": "0.1.97",
+    "@napi-rs/canvas-darwin-arm64": "0.1.97",
+    "@napi-rs/canvas-win32-x64-msvc": "0.1.97",
+    "@napi-rs/canvas-win32-arm64-msvc": "0.1.97"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1201,6 +1201,30 @@ importers:
       '@libsql/win32-x64-msvc':
         specifier: 0.4.7
         version: 0.4.7
+      '@napi-rs/canvas-darwin-arm64':
+        specifier: 0.1.97
+        version: 0.1.97
+      '@napi-rs/canvas-darwin-x64':
+        specifier: 0.1.97
+        version: 0.1.97
+      '@napi-rs/canvas-linux-arm64-gnu':
+        specifier: 0.1.97
+        version: 0.1.97
+      '@napi-rs/canvas-linux-arm64-musl':
+        specifier: 0.1.97
+        version: 0.1.97
+      '@napi-rs/canvas-linux-x64-gnu':
+        specifier: 0.1.97
+        version: 0.1.97
+      '@napi-rs/canvas-linux-x64-musl':
+        specifier: 0.1.97
+        version: 0.1.97
+      '@napi-rs/canvas-win32-arm64-msvc':
+        specifier: 0.1.97
+        version: 0.1.97
+      '@napi-rs/canvas-win32-x64-msvc':
+        specifier: 0.1.97
+        version: 0.1.97
       '@napi-rs/system-ocr-darwin-arm64':
         specifier: 1.0.2
         version: 1.0.2

--- a/scripts/before-pack.js
+++ b/scripts/before-pack.js
@@ -34,6 +34,14 @@ const packages = [
   '@napi-rs/system-ocr-darwin-x64',
   '@napi-rs/system-ocr-win32-arm64-msvc',
   '@napi-rs/system-ocr-win32-x64-msvc',
+  '@napi-rs/canvas-linux-x64-gnu',
+  '@napi-rs/canvas-linux-x64-musl',
+  '@napi-rs/canvas-linux-arm64-gnu',
+  '@napi-rs/canvas-linux-arm64-musl',
+  '@napi-rs/canvas-darwin-x64',
+  '@napi-rs/canvas-darwin-arm64',
+  '@napi-rs/canvas-win32-x64-msvc',
+  '@napi-rs/canvas-win32-arm64-msvc',
   '@strongtz/win32-arm64-msvc'
 ]
 


### PR DESCRIPTION
### What this PR does

Before this PR:
The app crashes on startup with `ReferenceError: DOMMatrix is not defined` because `@napi-rs/canvas` platform-specific binaries were missing from `optionalDependencies`.

<img width="620" height="587" alt="image" src="https://github.com/user-attachments/assets/20269613-cb89-460b-8854-2140ecac289c" />

After this PR:
Platform-specific binaries for `@napi-rs/canvas` are properly declared in `optionalDependencies` and handled in `before-pack.js`, fixing the startup crash.

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Only mainstream platforms are included (Linux x64/arm64 glibc/musl, macOS x64/arm64, Windows x64/arm64)
- Excluded rarely-used platforms: linux-arm-gnueabihf (32-bit ARM), linux-riscv64-gnu (RISC-V), android-arm64 (Android)

The following alternatives were considered:
None - this follows the existing pattern used for `@img/sharp`, `@libsql`, and `@napi-rs/system-ocr` packages.

### Breaking changes

None.

### Special notes for your reviewer

This change follows the existing pattern in `before-pack.js` for handling platform-specific native dependencies.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix: resolve app startup crash caused by missing @napi-rs/canvas platform binaries (DOMMatrix is not defined)
```
