### PR TITLE
fix: stabilize usePreference re-render and deduplicate API server status checks

### DIFF
--- a/src/renderer/src/data/hooks/usePreference.ts
+++ b/src/renderer/src/data/hooks/usePreference.ts
@@ -9,6 +9,7 @@ import type {
 import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react'
 
 const logger = loggerService.withContext('usePreference')
+const DEFAULT_PREFERENCE_OPTIONS: PreferenceUpdateOptions = { optimistic: true }
 
 /**
  * React hook for managing a single preference value with automatic synchronization
@@ -80,10 +81,8 @@ const logger = loggerService.withContext('usePreference')
  */
 export function usePreference<K extends PreferenceKeyType>(
   key: K,
-  options?: PreferenceUpdateOptions
+  options: PreferenceUpdateOptions = DEFAULT_PREFERENCE_OPTIONS
 ): [PreferenceDefaultScopeType[K], (value: PreferenceDefaultScopeType[K]) => Promise<void>] {
-  const optimistic = options?.optimistic ?? true
-
   // Subscribe to changes for this specific preference (raw value including undefined)
   const rawValue = useSyncExternalStore(
     useCallback((callback) => preferenceService.subscribeChange(key)(callback), [key]),
@@ -108,13 +107,13 @@ export function usePreference<K extends PreferenceKeyType>(
   const setValue = useCallback(
     async (newValue: PreferenceDefaultScopeType[K]) => {
       try {
-        await preferenceService.set(key, newValue, { optimistic })
+        await preferenceService.set(key, newValue, options)
       } catch (error) {
         logger.error(`Failed to set preference ${key}:`, error as Error)
         throw error
       }
     },
-    [key, optimistic]
+    [key, options]
   )
 
   return [exposedValue, setValue]
@@ -248,13 +247,11 @@ export function usePreference<K extends PreferenceKeyType>(
  */
 export function useMultiplePreferences<T extends Record<string, PreferenceKeyType>>(
   keys: T,
-  options?: PreferenceUpdateOptions
+  options: PreferenceUpdateOptions = DEFAULT_PREFERENCE_OPTIONS
 ): [
   { [P in keyof T]: PreferenceDefaultScopeType[T[P]] },
   (updates: Partial<{ [P in keyof T]: PreferenceDefaultScopeType[T[P]] }>) => Promise<void>
 ] {
-  const optimistic = options?.optimistic ?? true
-
   // Create stable key dependencies
   const keyList = useMemo(() => Object.values(keys), [keys])
 
@@ -340,13 +337,13 @@ export function useMultiplePreferences<T extends Record<string, PreferenceKeyTyp
           }
         }
 
-        await preferenceService.setMultiple(prefUpdates, { optimistic })
+        await preferenceService.setMultiple(prefUpdates, options)
       } catch (error) {
         logger.error('Failed to update preferences:', error as Error)
         throw error
       }
     },
-    [keys, optimistic]
+    [keys, options]
   )
 
   // Type-cast the values to the expected shape

--- a/src/renderer/src/data/hooks/usePreference.ts
+++ b/src/renderer/src/data/hooks/usePreference.ts
@@ -80,8 +80,10 @@ const logger = loggerService.withContext('usePreference')
  */
 export function usePreference<K extends PreferenceKeyType>(
   key: K,
-  options: PreferenceUpdateOptions = { optimistic: true }
+  options?: PreferenceUpdateOptions
 ): [PreferenceDefaultScopeType[K], (value: PreferenceDefaultScopeType[K]) => Promise<void>] {
+  const optimistic = options?.optimistic ?? true
+
   // Subscribe to changes for this specific preference (raw value including undefined)
   const rawValue = useSyncExternalStore(
     useCallback((callback) => preferenceService.subscribeChange(key)(callback), [key]),
@@ -106,13 +108,13 @@ export function usePreference<K extends PreferenceKeyType>(
   const setValue = useCallback(
     async (newValue: PreferenceDefaultScopeType[K]) => {
       try {
-        await preferenceService.set(key, newValue, options)
+        await preferenceService.set(key, newValue, { optimistic })
       } catch (error) {
         logger.error(`Failed to set preference ${key}:`, error as Error)
         throw error
       }
     },
-    [key, options]
+    [key, optimistic]
   )
 
   return [exposedValue, setValue]
@@ -246,11 +248,13 @@ export function usePreference<K extends PreferenceKeyType>(
  */
 export function useMultiplePreferences<T extends Record<string, PreferenceKeyType>>(
   keys: T,
-  options: PreferenceUpdateOptions = { optimistic: true }
+  options?: PreferenceUpdateOptions
 ): [
   { [P in keyof T]: PreferenceDefaultScopeType[T[P]] },
   (updates: Partial<{ [P in keyof T]: PreferenceDefaultScopeType[T[P]] }>) => Promise<void>
 ] {
+  const optimistic = options?.optimistic ?? true
+
   // Create stable key dependencies
   const keyList = useMemo(() => Object.values(keys), [keys])
 
@@ -336,13 +340,13 @@ export function useMultiplePreferences<T extends Record<string, PreferenceKeyTyp
           }
         }
 
-        await preferenceService.setMultiple(prefUpdates, options)
+        await preferenceService.setMultiple(prefUpdates, { optimistic })
       } catch (error) {
         logger.error('Failed to update preferences:', error as Error)
         throw error
       }
     },
-    [keys, options]
+    [keys, optimistic]
   )
 
   // Type-cast the values to the expected shape

--- a/src/renderer/src/hooks/useApiServer.ts
+++ b/src/renderer/src/hooks/useApiServer.ts
@@ -6,11 +6,18 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 const logger = loggerService.withContext('useApiServer')
+const API_SERVER_PREFERENCE_KEYS = {
+  enabled: 'feature.csaas.enabled',
+  host: 'feature.csaas.host',
+  port: 'feature.csaas.port',
+  apiKey: 'feature.csaas.api_key'
+} as const
 
 // Module-level single instance subscription to prevent EventEmitter memory leak
 // Only one IPC listener will be registered regardless of how many components use this hook
 const onReadyCallbacks = new Set<() => void>()
 let removeIpcListener: (() => void) | null = null
+let pendingStatusCheck: ReturnType<typeof window.api.apiServer.getStatus> | null = null
 
 const ensureIpcSubscribed = () => {
   if (!removeIpcListener) {
@@ -27,16 +34,22 @@ const cleanupIpcIfEmpty = () => {
   }
 }
 
+// Combine concurrent status checks into a single IPC request.
+const requestApiServerStatus = () => {
+  if (!pendingStatusCheck) {
+    pendingStatusCheck = window.api.apiServer.getStatus().finally(() => {
+      pendingStatusCheck = null
+    })
+  }
+
+  return pendingStatusCheck
+}
+
 export const useApiServer = () => {
   const { t } = useTranslation()
 
   // Use new preference system for API server configuration
-  const [apiServerConfig, setApiServerConfig] = useMultiplePreferences({
-    enabled: 'feature.csaas.enabled',
-    host: 'feature.csaas.host',
-    port: 'feature.csaas.port',
-    apiKey: 'feature.csaas.api_key'
-  })
+  const [apiServerConfig, setApiServerConfig] = useMultiplePreferences(API_SERVER_PREFERENCE_KEYS)
 
   const dispatch = useAppDispatch()
 
@@ -62,7 +75,7 @@ export const useApiServer = () => {
   const checkApiServerStatus = useCallback(async () => {
     setApiServerLoading(true)
     try {
-      const status = await window.api.apiServer.getStatus()
+      const status = await requestApiServerStatus()
       setApiServerRunning(status.running)
       if (status.running && !apiServerConfig.enabled) {
         setApiServerEnabled(true)
@@ -72,7 +85,7 @@ export const useApiServer = () => {
     } finally {
       setApiServerLoading(false)
     }
-  }, [apiServerConfig.enabled, setApiServerEnabled, setApiServerLoading, setApiServerRunning])
+  }, [apiServerConfig.enabled, setApiServerEnabled, setApiServerRunning])
 
   const startApiServer = useCallback(async () => {
     if (apiServerLoading) return

--- a/src/renderer/src/hooks/useApiServer.ts
+++ b/src/renderer/src/hooks/useApiServer.ts
@@ -104,7 +104,7 @@ export const useApiServer = () => {
     } finally {
       setApiServerLoading(false)
     }
-  }, [apiServerLoading, setApiServerEnabled, setApiServerLoading, setApiServerRunning, t])
+  }, [apiServerLoading, setApiServerEnabled, setApiServerRunning, t])
 
   const stopApiServer = useCallback(async () => {
     if (apiServerLoading) return
@@ -123,7 +123,7 @@ export const useApiServer = () => {
     } finally {
       setApiServerLoading(false)
     }
-  }, [apiServerLoading, setApiServerEnabled, setApiServerLoading, setApiServerRunning, t])
+  }, [apiServerLoading, setApiServerEnabled, setApiServerRunning, t])
 
   const restartApiServer = useCallback(async () => {
     if (apiServerLoading) return
@@ -142,7 +142,7 @@ export const useApiServer = () => {
     } finally {
       setApiServerLoading(false)
     }
-  }, [apiServerLoading, checkApiServerStatus, setApiServerEnabled, setApiServerLoading, t])
+  }, [apiServerLoading, checkApiServerStatus, setApiServerEnabled, t])
 
   useEffect(() => {
     checkApiServerStatus()


### PR DESCRIPTION
### Before this PR:

The options parameter in `usePreference` and `useMultiplePreferences` used a default object literal (`{ optimistic: true }`), which created a new reference on every render. This made the internal `useCallback` dependencies unstable and caused unnecessary re-renders.

In `useApiServer`, when multiple components mounted at the same time, duplicate getStatus IPC requests could be sent concurrently. The preference key object was also recreated on every render.

### After this PR:

The options parameter is now optional, and the hook extracts a primitive value with `options?.optimistic ?? true` for use in `useCallback` dependencies, ensuring stable references.

`useApiServer` now adds `requestApiServerStatus` to coalesce concurrent status checks into a single IPC request. The preference keys have been moved to a module-level constant, and an unnecessary dependency has been removed from `checkApiServerStatus`.

<table>
<tr>
 <td>
Before
 <td>
 After
<tr>
 <td>

https://github.com/user-attachments/assets/70ee1973-1112-403c-951d-12a24de94363


 <td>

https://github.com/user-attachments/assets/ddc7de33-6ce4-44a2-b62d-722cd5ccefad


</table>