### PR TITLE
fix(migration): handle fresh installs with no legacy data gracefully

### DIFF
--- a/src/main/data/migration/v2/core/MigrationEngine.ts
+++ b/src/main/data/migration/v2/core/MigrationEngine.ts
@@ -88,31 +88,27 @@ export class MigrationEngine {
 
   /**
    * Detect whether legacy v1 data exists on disk.
-   * Checks two independent indicators:
-   * 1. electron-store config.json file existence (app settings)
-   * 2. Any IndexedDB database in the userData directory (Dexie chat/message data)
-   * Returns true if ANY legacy data source is found.
+   * v2 removes Dexie/IndexedDB entirely in favor of SQLite, so the presence of
+   * any *.indexeddb.leveldb directory is a strong indicator of v1 legacy data.
+   *
+   * This is a best-effort optimization to avoid showing the migration window on
+   * fresh installs. Even if detection has a false positive, the migration pipeline
+   * handles empty data gracefully and completes successfully.
    */
   private hasLegacyData(): boolean {
     const userData = app.getPath('userData')
-
-    // electron-store creates config.json lazily on first write.
-    // v1 always writes settings; fresh v2 installs have no file yet
-    // (needsMigration runs before analyticsService.init which first writes clientId).
-    const configPath = path.join(userData, 'config.json')
-    const hasConfig = fsSync.existsSync(configPath)
-
-    // Check if any IndexedDB database exists (*.indexeddb.leveldb directories).
-    // Avoids hardcoding Chromium's internal origin-based naming convention.
     const indexedDbDir = path.join(userData, 'IndexedDB')
-    let hasIndexedDb = false
-    if (fsSync.existsSync(indexedDbDir)) {
-      const entries = fsSync.readdirSync(indexedDbDir)
-      hasIndexedDb = entries.some((e) => e.endsWith('.indexeddb.leveldb'))
+
+    if (!fsSync.existsSync(indexedDbDir)) {
+      logger.info('Legacy data detection: no IndexedDB directory found')
+      return false
     }
 
-    logger.info('Legacy data detection', { hasConfig, hasIndexedDb })
-    return hasConfig || hasIndexedDb
+    const entries = fsSync.readdirSync(indexedDbDir)
+    const hasIndexedDb = entries.some((e) => e.endsWith('.indexeddb.leveldb'))
+
+    logger.info('Legacy data detection', { hasIndexedDb, entries })
+    return hasIndexedDb
   }
 
   /**

--- a/src/main/data/migration/v2/core/MigrationEngine.ts
+++ b/src/main/data/migration/v2/core/MigrationEngine.ts
@@ -22,7 +22,9 @@ import type {
   ValidateResult
 } from '@shared/data/migration/v2/types'
 import { eq, sql } from 'drizzle-orm'
+import { app } from 'electron'
 import Store from 'electron-store'
+import fsSync from 'fs'
 import fs from 'fs/promises'
 import path from 'path'
 
@@ -74,15 +76,37 @@ export class MigrationEngine {
     }
 
     // No migration status record — check if this is a fresh install or an upgrade.
-    // Fresh installs have no legacy electron-store data, so migration is unnecessary.
-    const legacyStore = new Store()
-    if (legacyStore.size === 0) {
-      logger.info('Fresh install detected (empty electron-store), skipping migration')
+    // v1 users always have a Dexie IndexedDB and an electron-store config file.
+    // Fresh installs have neither, so migration is unnecessary.
+    if (!this.hasLegacyData()) {
+      logger.info('Fresh install detected (no legacy data found), skipping migration')
       await this.markCompleted()
       return false
     }
 
     return true
+  }
+
+  /**
+   * Detect whether legacy v1 data exists on disk.
+   * Checks two independent indicators:
+   * 1. Dexie IndexedDB directory (chat/message data)
+   * 2. electron-store config.json (app settings)
+   * Returns true if ANY legacy data source is found.
+   */
+  private hasLegacyData(): boolean {
+    const userData = app.getPath('userData')
+
+    // Dexie IndexedDB: v1 renderer uses file:// protocol → stored under "file__0.indexeddb.leveldb"
+    const dexieDbPath = path.join(userData, 'IndexedDB', 'file__0.indexeddb.leveldb')
+    const hasDexie = fsSync.existsSync(dexieDbPath)
+
+    // electron-store: v1 writes settings to config.json
+    const legacyStore = new Store()
+    const hasElectronStore = legacyStore.size > 0
+
+    logger.info('Legacy data detection', { hasDexie, hasElectronStore, dexieDbPath })
+    return hasDexie || hasElectronStore
   }
 
   /**

--- a/src/main/data/migration/v2/core/MigrationEngine.ts
+++ b/src/main/data/migration/v2/core/MigrationEngine.ts
@@ -22,6 +22,7 @@ import type {
   ValidateResult
 } from '@shared/data/migration/v2/types'
 import { eq, sql } from 'drizzle-orm'
+import Store from 'electron-store'
 import fs from 'fs/promises'
 import path from 'path'
 
@@ -63,16 +64,25 @@ export class MigrationEngine {
   /**
    * Check if migration is needed
    */
-  //TODO 不能仅仅判断数据库，如果是全新安装，而不是升级上来的用户，其实并不需要迁移，但是按现在的逻辑，还是会进行迁移，这不正确
   async needsMigration(): Promise<boolean> {
     const db = application.get('DbService').getDb()
     const status = await db.select().from(appStateTable).where(eq(appStateTable.key, MIGRATION_V2_STATUS)).get()
 
-    // Migration needed if: no status record, or status is not 'completed'
-    if (!status?.value) return true
+    if (status?.value) {
+      const statusValue = status.value as MigrationStatusValue
+      return statusValue.status !== 'completed'
+    }
 
-    const statusValue = status.value as MigrationStatusValue
-    return statusValue.status !== 'completed'
+    // No migration status record — check if this is a fresh install or an upgrade.
+    // Fresh installs have no legacy electron-store data, so migration is unnecessary.
+    const legacyStore = new Store()
+    if (legacyStore.size === 0) {
+      logger.info('Fresh install detected (empty electron-store), skipping migration')
+      await this.markCompleted()
+      return false
+    }
+
+    return true
   }
 
   /**

--- a/src/main/data/migration/v2/core/MigrationEngine.ts
+++ b/src/main/data/migration/v2/core/MigrationEngine.ts
@@ -66,6 +66,7 @@ export class MigrationEngine {
   /**
    * Check if migration is needed
    */
+  //TODO 不能仅仅判断数据库，如果是全新安装，而不是升级上来的用户，其实并不需要迁移，但是按现在的逻辑，还是会进行迁移，这不正确
   async needsMigration(): Promise<boolean> {
     const db = application.get('DbService').getDb()
     const status = await db.select().from(appStateTable).where(eq(appStateTable.key, MIGRATION_V2_STATUS)).get()

--- a/src/main/data/migration/v2/core/MigrationEngine.ts
+++ b/src/main/data/migration/v2/core/MigrationEngine.ts
@@ -23,7 +23,6 @@ import type {
 } from '@shared/data/migration/v2/types'
 import { eq, sql } from 'drizzle-orm'
 import { app } from 'electron'
-import Store from 'electron-store'
 import fsSync from 'fs'
 import fs from 'fs/promises'
 import path from 'path'
@@ -90,23 +89,30 @@ export class MigrationEngine {
   /**
    * Detect whether legacy v1 data exists on disk.
    * Checks two independent indicators:
-   * 1. Dexie IndexedDB directory (chat/message data)
-   * 2. electron-store config.json (app settings)
+   * 1. electron-store config.json file existence (app settings)
+   * 2. Any IndexedDB database in the userData directory (Dexie chat/message data)
    * Returns true if ANY legacy data source is found.
    */
   private hasLegacyData(): boolean {
     const userData = app.getPath('userData')
 
-    // Dexie IndexedDB: v1 renderer uses file:// protocol → stored under "file__0.indexeddb.leveldb"
-    const dexieDbPath = path.join(userData, 'IndexedDB', 'file__0.indexeddb.leveldb')
-    const hasDexie = fsSync.existsSync(dexieDbPath)
+    // electron-store creates config.json lazily on first write.
+    // v1 always writes settings; fresh v2 installs have no file yet
+    // (needsMigration runs before analyticsService.init which first writes clientId).
+    const configPath = path.join(userData, 'config.json')
+    const hasConfig = fsSync.existsSync(configPath)
 
-    // electron-store: v1 writes settings to config.json
-    const legacyStore = new Store()
-    const hasElectronStore = legacyStore.size > 0
+    // Check if any IndexedDB database exists (*.indexeddb.leveldb directories).
+    // Avoids hardcoding Chromium's internal origin-based naming convention.
+    const indexedDbDir = path.join(userData, 'IndexedDB')
+    let hasIndexedDb = false
+    if (fsSync.existsSync(indexedDbDir)) {
+      const entries = fsSync.readdirSync(indexedDbDir)
+      hasIndexedDb = entries.some((e) => e.endsWith('.indexeddb.leveldb'))
+    }
 
-    logger.info('Legacy data detection', { hasDexie, hasElectronStore, dexieDbPath })
-    return hasDexie || hasElectronStore
+    logger.info('Legacy data detection', { hasConfig, hasIndexedDb })
+    return hasConfig || hasIndexedDb
   }
 
   /**

--- a/src/main/data/migration/v2/core/MigrationEngine.ts
+++ b/src/main/data/migration/v2/core/MigrationEngine.ts
@@ -22,9 +22,7 @@ import type {
   ValidateResult
 } from '@shared/data/migration/v2/types'
 import { eq, sql } from 'drizzle-orm'
-import { app } from 'electron'
 import Store from 'electron-store'
-import fsSync from 'fs'
 import fs from 'fs/promises'
 import path from 'path'
 
@@ -87,47 +85,18 @@ export class MigrationEngine {
   }
 
   /**
-   * FIXME: 当前通过文件系统探测 electron-store / localStorage / IndexedDB 来判断是否有旧数据,
-   * 这是临时方案，存在以下局限:
-   * 1. electron-store (config.json) — v2 也可能在 needsMigration() 之前写入
-   * 2. localStorage (Local Storage/leveldb/*.ldb) — Electron 内部也会写少量数据
-   * 3. IndexedDB (*.indexeddb.leveldb) — v2 的 webview 也可能创建
-   * 三者任一不为空即视为有旧数据，宁可误触发迁移（空数据迁移可安全完成），也不漏掉真正的升级用户。
+   * FIXME: 当前仅通过 electron-store 判断是否有旧数据，这是临时方案。
+   * electron-store (config.json) 在 v2 中也可能被写入，导致误判。
+   * localStorage 和 IndexedDB 的文件系统路径不可靠（UserData 路径问题待迁移后期统一处理），暂不检测。
+   * 宁可误触发迁移（空数据迁移可安全完成），也不漏掉真正的升级用户。
    * 后续引入 version history 后可用精确的版本记录替代这些启发式检测。
    */
   private hasLegacyData(): boolean {
-    const userData = app.getPath('userData')
-
-    // 1. electron-store: v1 writes app settings to config.json
     const legacyStore = new Store()
-    if (legacyStore.size > 0) {
-      logger.info('Legacy data detected: electron-store has data')
-      return true
-    }
+    const hasData = legacyStore.size > 0
 
-    // 2. localStorage (Redux Persist): stored in Local Storage/leveldb/
-    // .ldb files contain compacted data; fresh Electron installs only have .log + MANIFEST
-    const localStorageDir = path.join(userData, 'Local Storage', 'leveldb')
-    if (fsSync.existsSync(localStorageDir)) {
-      const entries = fsSync.readdirSync(localStorageDir)
-      if (entries.some((e) => e.endsWith('.ldb'))) {
-        logger.info('Legacy data detected: localStorage has .ldb files')
-        return true
-      }
-    }
-
-    // 3. IndexedDB (Dexie): v1 stores chat/message data via Dexie
-    const indexedDbDir = path.join(userData, 'IndexedDB')
-    if (fsSync.existsSync(indexedDbDir)) {
-      const entries = fsSync.readdirSync(indexedDbDir)
-      if (entries.some((e) => e.endsWith('.indexeddb.leveldb'))) {
-        logger.info('Legacy data detected: IndexedDB has databases')
-        return true
-      }
-    }
-
-    logger.info('No legacy data found')
-    return false
+    logger.info('Legacy data detection', { hasElectronStore: hasData })
+    return hasData
   }
 
   /**

--- a/src/main/data/migration/v2/core/MigrationEngine.ts
+++ b/src/main/data/migration/v2/core/MigrationEngine.ts
@@ -23,6 +23,7 @@ import type {
 } from '@shared/data/migration/v2/types'
 import { eq, sql } from 'drizzle-orm'
 import { app } from 'electron'
+import Store from 'electron-store'
 import fsSync from 'fs'
 import fs from 'fs/promises'
 import path from 'path'
@@ -75,8 +76,6 @@ export class MigrationEngine {
     }
 
     // No migration status record — check if this is a fresh install or an upgrade.
-    // v1 users always have a Dexie IndexedDB and an electron-store config file.
-    // Fresh installs have neither, so migration is unnecessary.
     if (!this.hasLegacyData()) {
       logger.info('Fresh install detected (no legacy data found), skipping migration')
       await this.markCompleted()
@@ -87,28 +86,47 @@ export class MigrationEngine {
   }
 
   /**
-   * Detect whether legacy v1 data exists on disk.
-   * v2 removes Dexie/IndexedDB entirely in favor of SQLite, so the presence of
-   * any *.indexeddb.leveldb directory is a strong indicator of v1 legacy data.
-   *
-   * This is a best-effort optimization to avoid showing the migration window on
-   * fresh installs. Even if detection has a false positive, the migration pipeline
-   * handles empty data gracefully and completes successfully.
+   * FIXME: 当前通过文件系统探测 electron-store / localStorage / IndexedDB 来判断是否有旧数据,
+   * 这是临时方案，存在以下局限:
+   * 1. electron-store (config.json) — v2 也可能在 needsMigration() 之前写入
+   * 2. localStorage (Local Storage/leveldb/*.ldb) — Electron 内部也会写少量数据
+   * 3. IndexedDB (*.indexeddb.leveldb) — v2 的 webview 也可能创建
+   * 三者任一不为空即视为有旧数据，宁可误触发迁移（空数据迁移可安全完成），也不漏掉真正的升级用户。
+   * 后续引入 version history 后可用精确的版本记录替代这些启发式检测。
    */
   private hasLegacyData(): boolean {
     const userData = app.getPath('userData')
-    const indexedDbDir = path.join(userData, 'IndexedDB')
 
-    if (!fsSync.existsSync(indexedDbDir)) {
-      logger.info('Legacy data detection: no IndexedDB directory found')
-      return false
+    // 1. electron-store: v1 writes app settings to config.json
+    const legacyStore = new Store()
+    if (legacyStore.size > 0) {
+      logger.info('Legacy data detected: electron-store has data')
+      return true
     }
 
-    const entries = fsSync.readdirSync(indexedDbDir)
-    const hasIndexedDb = entries.some((e) => e.endsWith('.indexeddb.leveldb'))
+    // 2. localStorage (Redux Persist): stored in Local Storage/leveldb/
+    // .ldb files contain compacted data; fresh Electron installs only have .log + MANIFEST
+    const localStorageDir = path.join(userData, 'Local Storage', 'leveldb')
+    if (fsSync.existsSync(localStorageDir)) {
+      const entries = fsSync.readdirSync(localStorageDir)
+      if (entries.some((e) => e.endsWith('.ldb'))) {
+        logger.info('Legacy data detected: localStorage has .ldb files')
+        return true
+      }
+    }
 
-    logger.info('Legacy data detection', { hasIndexedDb, entries })
-    return hasIndexedDb
+    // 3. IndexedDB (Dexie): v1 stores chat/message data via Dexie
+    const indexedDbDir = path.join(userData, 'IndexedDB')
+    if (fsSync.existsSync(indexedDbDir)) {
+      const entries = fsSync.readdirSync(indexedDbDir)
+      if (entries.some((e) => e.endsWith('.indexeddb.leveldb'))) {
+        logger.info('Legacy data detected: IndexedDB has databases')
+        return true
+      }
+    }
+
+    logger.info('No legacy data found')
+    return false
   }
 
   /**

--- a/src/renderer/src/windows/migrationV2/exporters/DexieExporter.ts
+++ b/src/renderer/src/windows/migrationV2/exporters/DexieExporter.ts
@@ -35,19 +35,15 @@ export class DexieExporter {
    * @returns Export path
    */
   async exportAll(onProgress?: (progress: ExportProgress) => void): Promise<string> {
-    // Validate required tables exist
     const existingTables = db.tables.map((t) => t.name)
-    const missingTables = REQUIRED_TABLES.filter((t) => !existingTables.includes(t))
 
-    if (missingTables.length > 0) {
-      throw new Error(
-        `Required Dexie tables not found: ${missingTables.join(', ')}. ` +
-          `This may indicate an incompatible database version.`
-      )
+    // No Dexie tables at all — fresh install, nothing to export
+    if (existingTables.length === 0) {
+      return this.exportPath
     }
 
-    // Determine which tables to export
-    const tablesToExport = [...REQUIRED_TABLES, ...OPTIONAL_TABLES.filter((t) => existingTables.includes(t))]
+    // Determine which tables to export (skip missing ones gracefully)
+    const tablesToExport = [...REQUIRED_TABLES, ...OPTIONAL_TABLES].filter((t) => existingTables.includes(t))
 
     // Export each table
     for (let i = 0; i < tablesToExport.length; i++) {

--- a/src/renderer/src/windows/migrationV2/exporters/ReduxExporter.ts
+++ b/src/renderer/src/windows/migrationV2/exporters/ReduxExporter.ts
@@ -33,7 +33,11 @@ export class ReduxExporter {
     const rawData = localStorage.getItem(PERSIST_KEY)
 
     if (!rawData) {
-      throw new Error(`Redux Persist data not found in localStorage (key: ${PERSIST_KEY})`)
+      return {
+        data: {},
+        slicesFound: [],
+        slicesMissing: [...SLICES_TO_EXPORT]
+      }
     }
 
     // Parse the outer JSON


### PR DESCRIPTION
### What this PR does

Before this PR:

Fresh v2 installs (no legacy data) fail migration with error: `Redux Persist data not found in localStorage (key: persist:cherry-studio)`. The migration window opens and cannot proceed.

After this PR:

- Fresh installs are detected via empty electron-store and migration is skipped entirely
- If migration does run with no Redux data, `ReduxExporter` returns empty result instead of throwing, allowing migrators to complete harmlessly

### Why we need it and why it was done in this way

The fix addresses two layers:

1. **`MigrationEngine.needsMigration()`** only checked the DB for a migration status record. Fresh installs have no record → returned `true` → migration window opened. Now it also checks if the legacy electron-store has data. Empty store = fresh install = no migration needed.

2. **`ReduxExporter.export()`** threw on missing localStorage key. Now returns empty result as a safety net. All downstream migrators already handle empty source data gracefully (skip items with no data).

The following alternatives were considered:

- Checking for IndexedDB files on disk — more complex, less reliable across platforms
- Adding a dedicated "first run" flag — unnecessary when the electron-store emptiness already signals fresh install

### Breaking changes

None.

### Special notes for your reviewer

- The TODO comment on `needsMigration()` (line 66) explicitly acknowledged this bug: "不能仅仅判断数据库，如果是全新安装...其实并不需要迁移"
- `markCompleted()` is called for fresh installs so subsequent launches skip the check entirely

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
