### PR TITLE
fix: prevent CherryAI provider from using native PDF input in middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
     "sharp": "0.34.3",
     "swagger-ui-express": "5.0.1",
     "tesseract.js": "6.0.1",
-    "turndown": "7.2.0"
+    "turndown": "7.2.0",
+    "pdf-parse": "^2.4.5"
   },
   "devDependencies": {
     "@agentic/exa": "^7.3.3",
@@ -363,7 +364,6 @@
     "pako": "1.0.11",
     "partial-json": "0.1.7",
     "pdf-lib": "^1.17.1",
-    "pdf-parse": "^2.4.5",
     "prosemirror-model": "1.25.2",
     "proxy-agent": "^6.5.0",
     "rc-input": "1.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       os-proxy-config:
         specifier: 1.1.2
         version: 1.1.2
+      pdf-parse:
+        specifier: ^2.4.5
+        version: 2.4.5
       selection-hook:
         specifier: 1.0.12
         version: 1.0.12
@@ -927,9 +930,6 @@ importers:
       pdf-lib:
         specifier: ^1.17.1
         version: 1.17.1
-      pdf-parse:
-        specifier: ^2.4.5
-        version: 2.4.5
       prosemirror-model:
         specifier: 1.25.2
         version: 1.25.2

--- a/src/renderer/src/aiCore/plugins/pdfCompatibilityPlugin.ts
+++ b/src/renderer/src/aiCore/plugins/pdfCompatibilityPlugin.ts
@@ -43,7 +43,10 @@ function pdfCompatibilityMiddleware(provider: Provider): LanguageModelMiddleware
   return {
     specificationVersion: 'v3',
     transformParams: async ({ params }) => {
-      if (PDF_NATIVE_PROVIDER_TYPES.has(provider.type)) {
+      // CherryAI provider doesn't support native PDF input
+      const isCherryAI = provider.id === 'cherryai'
+
+      if (PDF_NATIVE_PROVIDER_TYPES.has(provider.type) && !isCherryAI) {
         return params
       }
 


### PR DESCRIPTION
### What this PR does

Before this PR:
1. CherryAI provider was incorrectly treated as supporting native PDF input because its provider type matches `PDF_NATIVE_PROVIDER_TYPES`, causing PDF files not being converted to text
2. PDF text extraction failed in production Electron builds with error: `Cannot find module '.../pdf.worker.mjs'` because `pdf-parse` was in devDependencies instead of dependencies

After this PR:
1. Added explicit check to exclude CherryAI provider from native PDF handling
2. Moved `pdf-parse` from devDependencies to dependencies so it's bundled correctly in Electron production builds

Fixes # N/A

### Why we need it and why it was done in this way

**Issue 1 - CherryAI provider:**
CherryAI is a proxy provider that doesn't actually support native PDF input like the underlying providers (Anthropic, Google) do. The middleware needs to convert PDFs to text before sending to CherryAI.

**Issue 2 - pdf-parse not found:**
In Electron apps, only `dependencies` are bundled into the production build (`app.asar`), while `devDependencies` are excluded. Since `pdf-parse` is required at runtime for PDF text extraction, it must be in `dependencies`.

The following tradeoffs were made:
- Used provider ID check (`provider.id === 'cherryai'`) rather than modifying the provider type set, as this is more explicit and maintainable

The following alternatives were considered:
- Removing CherryAI's provider type from `PDF_NATIVE_PROVIDER_TYPES` - rejected because CherryAI can proxy to multiple provider types

### Breaking changes

None

### Special notes for your reviewer

This is a bug fix that doesn't change Redux data models or IndexedDB schemas.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
fix: CherryAI provider now correctly converts PDF files to text instead of attempting native PDF input
fix: PDF text extraction now works in production builds (moved pdf-parse to dependencies)
```