### PR TITLE
fix(agents): add skill fallback for marketplace plugin installation

### DIFF
--- a/src/main/services/agents/plugins/PluginService.ts
+++ b/src/main/services/agents/plugins/PluginService.ts
@@ -258,6 +258,20 @@ export class PluginService {
             // Continue checking other roots
           }
         }
+
+        // Fallback: try skill directories when no plugin roots found
+        logger.info('No matching plugin roots, trying skill fallback', {
+          owner: identifier.owner,
+          repository: identifier.repository,
+          name: identifier.name
+        })
+        const skillDirs = await findAllSkillDirectories(tempDir, tempDir)
+        if (skillDirs.length > 0) {
+          const matchedSkill =
+            skillDirs.find((s) => path.basename(s.folderPath).toLowerCase() === targetPluginName) ?? skillDirs[0]
+          return await this.installMarketplaceSkillFromDirectory(matchedSkill.folderPath, context)
+        }
+
         throw {
           type: 'PLUGIN_MANIFEST_NOT_FOUND',
           reason: `Plugin '${identifier.name}' not found in repository`,


### PR DESCRIPTION
### What this PR does

Before this PR:

Installing marketplace items that are actually skills (with `SKILL.md`, no `.claude-plugin/plugin.json`) via the plugin browser fails with `plugin.json not found in .claude-plugin/` error.

After this PR:

`installMarketplacePlugin()` falls back to searching for skill directories when no plugin roots are found, mirroring the existing fallback pattern in `installFromSourceDir()`.

Fixes #12967

### Why we need it and why it was done in this way

The `installMarketplacePlugin()` method only searched for `.claude-plugin/plugin.json` (plugin packages). Many marketplace items are actually skills (identified by `SKILL.md`), which caused the installation to fail.

The following tradeoffs were made:

- The fix adds skill fallback only to the marketplace plugin install path, keeping the change minimal and focused.

The following alternatives were considered:

- Fixing marketplace metadata to correctly tag items as `skill` vs `plugin` — rejected because the backend fix is more robust and handles edge cases regardless of metadata accuracy.
- Refactoring both paths into a shared method — rejected as over-engineering for a targeted bug fix.

### Breaking changes

None.

### Special notes for your reviewer

- The same fallback pattern already exists in `installFromSourceDir()` (line 875-922), which handles ZIP/directory installs. This PR mirrors that pattern for marketplace installs.
- Existing methods `findAllSkillDirectories()` and `installMarketplaceSkillFromDirectory()` are reused — no new functions introduced.
- Repos with both `plugin.json` and `SKILL.md` still prefer the plugin path (tried first).

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix marketplace plugin installation failing with "plugin.json not found" when the marketplace item is a skill package
```
