### PR TITLE
feat: add OfoxAI as a new model provider

### DIFF
--- a/src/renderer/src/config/providers.ts
+++ b/src/renderer/src/config/providers.ts
@@ -736,6 +736,17 @@ export const SYSTEM_PROVIDERS_CONFIG: Record<SystemProviderId, SystemProvider> =
     models: SYSTEM_MODELS.mimo,
     isSystem: true,
     enabled: false
+  },
+  ofoxai: {
+    id: 'ofoxai',
+    name: 'OfoxAI',
+    type: 'openai',
+    apiKey: '',
+    apiHost: 'https://api.ofox.ai',
+    anthropicApiHost: 'https://api.ofox.ai',
+    models: [],
+    isSystem: true,
+    enabled: false
   }
 } as const
 
@@ -1510,6 +1521,17 @@ export const PROVIDER_URLS: Record<SystemProviderId, ProviderUrls> = {
       apiKey: 'https://platform.xiaomimimo.com/#/console/usage',
       docs: 'https://platform.xiaomimimo.com/#/docs/welcome',
       models: 'https://platform.xiaomimimo.com/'
+    }
+  },
+  ofoxai: {
+    api: {
+      url: 'https://api.ofox.ai'
+    },
+    websites: {
+      official: 'https://ofox.ai',
+      apiKey: 'https://ofox.ai',
+      docs: 'https://docs.ofox.ai/zh/api',
+      models: 'https://docs.ofox.ai/zh/api'
     }
   }
 }

--- a/src/renderer/src/types/provider.ts
+++ b/src/renderer/src/types/provider.ts
@@ -201,7 +201,8 @@ export const SystemProviderIdSchema = z.enum([
   'cerebras',
   'mimo',
   'minimax-global',
-  'zai'
+  'zai',
+  'ofoxai'
 ])
 
 export type SystemProviderId = z.infer<typeof SystemProviderIdSchema>
@@ -273,7 +274,8 @@ export const SystemProviderIds = {
   cerebras: 'cerebras',
   mimo: 'mimo',
   'minimax-global': 'minimax-global',
-  zai: 'zai'
+  zai: 'zai',
+  ofoxai: 'ofoxai'
 } as const satisfies Record<SystemProviderId, SystemProviderId>
 
 type SystemProviderIdTypeMap = typeof SystemProviderIds


### PR DESCRIPTION
## Summary

Add [OfoxAI](https://ofox.ai) as a new system provider.

**OfoxAI** is a unified API gateway for 100+ LLM models (Claude, GPT, Gemini, DeepSeek, etc.) with a single API key. OpenAI-compatible format.

- **Website**: https://ofox.ai
- **API Docs**: https://docs.ofox.ai/zh/api
- **Base URL**: `https://api.ofox.ai/v1`

## Changes

- `src/renderer/src/types/provider.ts` — Added `ofoxai` to `SystemProviderIdSchema` and `SystemProviderIds`
- `src/renderer/src/config/providers.ts` — Added OfoxAI provider config and URL config

No data model or IndexedDB schema changes.