### PR TITLE
fix(aiCore): move stream reading outside try-catch for correct abort flow

### DIFF
--- a/src/renderer/src/aiCore/chunk/AiSdkToChunkAdapter.ts
+++ b/src/renderer/src/aiCore/chunk/AiSdkToChunkAdapter.ts
@@ -72,18 +72,19 @@ export class AiSdkToChunkAdapter {
    * @returns 最终的文本内容
    */
   async processStream(aiSdkResult: any): Promise<string> {
-    try {
-      // 如果是流式且有 fullStream
-      if (aiSdkResult.fullStream) {
-        await this.readFullStream(aiSdkResult.fullStream)
-      }
+    // The stream is the single source of truth for abort handling.
+    // Both AI SDK (resilient stream) and the agent pipeline (withAbortStreamPart)
+    // guarantee: abort → enqueue { type: 'abort' } → close gracefully.
+    // convertAndEmitChunk processes the abort part and emits ChunkType.ERROR → onError.
+    if (aiSdkResult.fullStream) {
+      await this.readFullStream(aiSdkResult.fullStream)
+    }
 
-      // 使用 streamResult.text 获取最终结果
+    try {
       return await aiSdkResult.text
     } catch (error: any) {
-      // abort 时，AI SDK 通常会先通过流发送 'abort' chunk（在 readFullStream 中 convertAndEmitChunk
-      // 转为 ERROR chunk 发出）。随后 aiSdkResult.text 会抛出 AbortError
-      // 这里捕获它以避免 transformMessagesAndFetch 的 catch 再次发送重复的 ERROR chunk
+      // The text promise rejects when no steps completed (e.g. abort during thinking).
+      // The abort was already handled via the 'abort' stream part above.
       if (isAbortError(error)) {
         return ''
       }


### PR DESCRIPTION
### What this PR does

Before this PR:
`readFullStream()` was inside the `try` block alongside `aiSdkResult.text`. If the text promise rejected early (e.g. abort during thinking before any step completed), the stream was never consumed, so the `abort` stream part emitted by the AI SDK / agent pipeline was missed.

After this PR:
`readFullStream()` runs unconditionally before awaiting `aiSdkResult.text`. The abort stream part is always processed first, ensuring `convertAndEmitChunk` emits the `ChunkType.ERROR` → `onError` callback before the text promise rejection is handled.

### Why we need it and why it was done in this way

The stream is the single source of truth for abort handling. Both AI SDK (resilient stream) and the agent pipeline (`withAbortStreamPart`) guarantee: abort → enqueue `{ type: 'abort' }` → close gracefully. By reading the stream first, we ensure the abort chunk is always delivered to the UI before the text promise rejection is caught.

The following tradeoffs were made: None — this is a straightforward reordering with no behavioral change for the success path.

The following alternatives were considered: Wrapping `readFullStream` in its own try-catch, but that adds unnecessary complexity since the stream closes gracefully on abort.

### Breaking changes

None.

### Special notes for your reviewer

The only logic change is moving `readFullStream()` outside the `try` block. The `try-catch` now only wraps `aiSdkResult.text`, which is the part that can reject on abort. Comments were updated to English to explain the flow.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
