### PR TITLE
feat(api-server): add Ollama support for OpenAI chat completions

### DIFF
--- a/src/main/apiServer/services/chat-completion.ts
+++ b/src/main/apiServer/services/chat-completion.ts
@@ -54,12 +54,14 @@ export class ChatCompletionService {
 
     const provider = modelValidation.provider!
 
-    if (provider.type !== 'openai') {
+    // Support OpenAI-compatible providers (ollama provides /v1 compatible endpoint)
+    const openaiCompatibleTypes = ['openai', 'ollama']
+    if (!openaiCompatibleTypes.includes(provider.type)) {
       return {
         ok: false,
         error: {
           type: 'unsupported_provider_type',
-          message: `Provider '${provider.id}' of type '${provider.type}' is not supported for OpenAI chat completions`,
+          message: `Provider '${provider.id}' of type '${provider.type}' is not supported for OpenAI chat completions. Supported types: ${openaiCompatibleTypes.join(', ')}`,
           code: 'unsupported_provider_type'
         }
       }
@@ -67,9 +69,20 @@ export class ChatCompletionService {
 
     const modelId = modelValidation.modelId!
 
+    // For Ollama, use the OpenAI-compatible endpoint
+    // Handle both cases: apiHost with or without /api suffix
+    let baseURL: string
+    if (provider.type === 'ollama') {
+      const host = provider.apiHost || 'http://localhost:11434'
+      // Remove trailing /api if present, then add /v1
+      baseURL = host.replace(/\/api$/, '') + '/v1'
+    } else {
+      baseURL = provider.apiHost
+    }
+
     const client = new OpenAI({
-      baseURL: provider.apiHost,
-      apiKey: provider.apiKey
+      baseURL,
+      apiKey: provider.apiKey || 'ollama' // Ollama doesn't require API key, use placeholder
     })
 
     return {

--- a/src/renderer/src/services/MemoryProcessor.ts
+++ b/src/renderer/src/services/MemoryProcessor.ts
@@ -9,7 +9,7 @@ import {
   updateMemorySystemPrompt
 } from '@renderer/utils/memory-prompts'
 import type { MemoryConfig, MemoryItem } from '@types'
-import jaison from 'jaison/lib/index.js'
+import jaison from 'jaison'
 
 import { fetchGenerate } from './ApiService'
 import MemoryService from './MemoryService'


### PR DESCRIPTION
- Extend ChatCompletionService to support 'ollama' provider type
- Auto-handle Ollama apiHost configuration (remove /api suffix, add /v1)
- Fix jaison import path error (jaison/lib/index.js -> jaison)

This allows Ollama models to be used directly via /v1/chat/completions without requiring manual OpenAI-compatible provider configuration.

<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

⚠️ Important: Redux/IndexedDB Data-Changing Feature PRs Temporarily On Hold ⚠️

Please note: For our current development cycle, we are not accepting feature Pull Requests that introduce changes to Redux data models or IndexedDB schemas.

While we value your contributions, PRs of this nature will be blocked without merge. We welcome all other contributions (bug fixes, perf enhancements, docs, etc.). Thank you!

Once version 2.0.0 is released, we will resume reviewing feature PRs.

-->

### What this PR does

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note

```
