### PR TITLE
ci: restrict package release workflow to cherry-studio's main branch

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   release:
     name: Release Packages
+    if: github.repository == 'CherryHQ/cherry-studio' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
This CI had run in my fork, but it should only run in cherry studio's main branch.

<img width="1194" height="102" alt="CleanShot 2026-03-26 at 09 11 59@2x" src="https://github.com/user-attachments/assets/93cc496e-601e-40a4-a5d9-75cd056f7a66" />
