### PR TITLE
feat(data): add skill registry table with version tracking

### DIFF
--- a/migrations/sqlite-drizzle/0005_gray_giant_girl.sql
+++ b/migrations/sqlite-drizzle/0005_gray_giant_girl.sql
@@ -1,0 +1,40 @@
+CREATE TABLE `skill` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`slug` text NOT NULL,
+	`description` text,
+	`author` text,
+	`version` text,
+	`tags` text,
+	`tools` text,
+	`source` text NOT NULL,
+	`source_path` text NOT NULL,
+	`package_name` text,
+	`package_version` text,
+	`marketplace_id` text,
+	`content_hash` text,
+	`size` integer,
+	`is_enabled` integer DEFAULT true NOT NULL,
+	`version_dir_path` text,
+	`created_at` integer,
+	`updated_at` integer,
+	CONSTRAINT "skill_source_check" CHECK("skill"."source" IN ('builtin', 'project', 'marketplace', 'local', 'zip'))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `skill_slug_unique` ON `skill` (`slug`);--> statement-breakpoint
+CREATE INDEX `skill_name_idx` ON `skill` (`name`);--> statement-breakpoint
+CREATE INDEX `skill_source_idx` ON `skill` (`source`);--> statement-breakpoint
+CREATE INDEX `skill_is_enabled_idx` ON `skill` (`is_enabled`);--> statement-breakpoint
+CREATE TABLE `skill_version` (
+	`id` text PRIMARY KEY NOT NULL,
+	`skill_id` text NOT NULL,
+	`version` text,
+	`content_hash` text NOT NULL,
+	`diff_path` text NOT NULL,
+	`message` text,
+	`created_at` integer,
+	`updated_at` integer,
+	FOREIGN KEY (`skill_id`) REFERENCES `skill`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `skill_version_skill_id_idx` ON `skill_version` (`skill_id`,`created_at`);

--- a/migrations/sqlite-drizzle/meta/0005_snapshot.json
+++ b/migrations/sqlite-drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1254 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "27889a9d-5a61-4db0-9112-d8d7206e64f7",
+  "prevId": "2eac4614-db61-4509-ab3a-962b57396871",
+  "tables": {
+    "app_state": {
+      "name": "app_state",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group": {
+      "name": "group",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_entity_sort_idx": {
+          "name": "group_entity_sort_idx",
+          "columns": ["entity_type", "sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_server": {
+      "name": "mcp_server",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_url": {
+          "name": "provider_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "long_running": {
+          "name": "long_running",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dxt_version": {
+          "name": "dxt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dxt_path": {
+          "name": "dxt_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_key": {
+          "name": "search_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config_sample": {
+          "name": "config_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_tools": {
+          "name": "disabled_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_auto_approve_tools": {
+          "name": "disabled_auto_approve_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "should_config": {
+          "name": "should_config",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "install_source": {
+          "name": "install_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_trusted": {
+          "name": "is_trusted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trusted_at": {
+          "name": "trusted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_server_name_idx": {
+          "name": "mcp_server_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "mcp_server_is_active_idx": {
+          "name": "mcp_server_is_active_idx",
+          "columns": ["is_active"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "mcp_server_type_check": {
+          "name": "mcp_server_type_check",
+          "value": "\"mcp_server\".\"type\" IS NULL OR \"mcp_server\".\"type\" IN ('stdio', 'sse', 'streamableHttp', 'inMemory')"
+        },
+        "mcp_server_install_source_check": {
+          "name": "mcp_server_install_source_check",
+          "value": "\"mcp_server\".\"install_source\" IS NULL OR \"mcp_server\".\"install_source\" IN ('builtin', 'manual', 'protocol', 'unknown')"
+        }
+      }
+    },
+    "message": {
+      "name": "message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "searchable_text": {
+          "name": "searchable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "siblings_group_id": {
+          "name": "siblings_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assistant_meta": {
+          "name": "assistant_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_meta": {
+          "name": "model_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "message_parent_id_idx": {
+          "name": "message_parent_id_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "message_topic_created_idx": {
+          "name": "message_topic_created_idx",
+          "columns": ["topic_id", "created_at"],
+          "isUnique": false
+        },
+        "message_trace_id_idx": {
+          "name": "message_trace_id_idx",
+          "columns": ["trace_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "message_topic_id_topic_id_fk": {
+          "name": "message_topic_id_topic_id_fk",
+          "tableFrom": "message",
+          "tableTo": "topic",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_parent_id_message_id_fk": {
+          "name": "message_parent_id_message_id_fk",
+          "tableFrom": "message",
+          "tableTo": "message",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "message_role_check": {
+          "name": "message_role_check",
+          "value": "\"message\".\"role\" IN ('user', 'assistant', 'system')"
+        },
+        "message_status_check": {
+          "name": "message_status_check",
+          "value": "\"message\".\"status\" IN ('pending', 'success', 'error', 'paused')"
+        }
+      }
+    },
+    "preference": {
+      "name": "preference",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "preference_scope_key_pk": {
+          "columns": ["scope", "key"],
+          "name": "preference_scope_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skill": {
+      "name": "skill",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_version": {
+          "name": "package_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "marketplace_id": {
+          "name": "marketplace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "version_dir_path": {
+          "name": "version_dir_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "skill_slug_unique": {
+          "name": "skill_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        },
+        "skill_name_idx": {
+          "name": "skill_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "skill_source_idx": {
+          "name": "skill_source_idx",
+          "columns": ["source"],
+          "isUnique": false
+        },
+        "skill_is_enabled_idx": {
+          "name": "skill_is_enabled_idx",
+          "columns": ["is_enabled"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "skill_source_check": {
+          "name": "skill_source_check",
+          "value": "\"skill\".\"source\" IN ('builtin', 'project', 'marketplace', 'local', 'zip')"
+        }
+      }
+    },
+    "skill_version": {
+      "name": "skill_version",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "diff_path": {
+          "name": "diff_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "skill_version_skill_id_idx": {
+          "name": "skill_version_skill_id_idx",
+          "columns": ["skill_id", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "skill_version_skill_id_skill_id_fk": {
+          "name": "skill_version_skill_id_skill_id_fk",
+          "tableFrom": "skill_version",
+          "tableTo": "skill",
+          "columnsFrom": ["skill_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "entity_tag": {
+      "name": "entity_tag",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "entity_tag_tag_id_idx": {
+          "name": "entity_tag_tag_id_idx",
+          "columns": ["tag_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "entity_tag_tag_id_tag_id_fk": {
+          "name": "entity_tag_tag_id_tag_id_fk",
+          "tableFrom": "entity_tag",
+          "tableTo": "tag",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "entity_tag_entity_type_entity_id_tag_id_pk": {
+          "columns": ["entity_type", "entity_id", "tag_id"],
+          "name": "entity_tag_entity_type_entity_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag": {
+      "name": "tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tag_name_unique": {
+          "name": "tag_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "topic": {
+      "name": "topic",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_name_manually_edited": {
+          "name": "is_name_manually_edited",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assistant_meta": {
+          "name": "assistant_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_node_id": {
+          "name": "active_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "pinned_order": {
+          "name": "pinned_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "topic_group_updated_idx": {
+          "name": "topic_group_updated_idx",
+          "columns": ["group_id", "updated_at"],
+          "isUnique": false
+        },
+        "topic_group_sort_idx": {
+          "name": "topic_group_sort_idx",
+          "columns": ["group_id", "sort_order"],
+          "isUnique": false
+        },
+        "topic_updated_at_idx": {
+          "name": "topic_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "topic_is_pinned_idx": {
+          "name": "topic_is_pinned_idx",
+          "columns": ["is_pinned", "pinned_order"],
+          "isUnique": false
+        },
+        "topic_assistant_id_idx": {
+          "name": "topic_assistant_id_idx",
+          "columns": ["assistant_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "topic_group_id_group_id_fk": {
+          "name": "topic_group_id_group_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translate_history": {
+      "name": "translate_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_text": {
+          "name": "target_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_language": {
+          "name": "source_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "star": {
+          "name": "star",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "translate_history_created_at_idx": {
+          "name": "translate_history_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "translate_history_star_created_at_idx": {
+          "name": "translate_history_star_created_at_idx",
+          "columns": ["star", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "translate_history_source_language_translate_language_lang_code_fk": {
+          "name": "translate_history_source_language_translate_language_lang_code_fk",
+          "tableFrom": "translate_history",
+          "tableTo": "translate_language",
+          "columnsFrom": ["source_language"],
+          "columnsTo": ["lang_code"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translate_history_target_language_translate_language_lang_code_fk": {
+          "name": "translate_history_target_language_translate_language_lang_code_fk",
+          "tableFrom": "translate_history",
+          "tableTo": "translate_language",
+          "columnsFrom": ["target_language"],
+          "columnsTo": ["lang_code"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translate_language": {
+      "name": "translate_language",
+      "columns": {
+        "lang_code": {
+          "name": "lang_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/sqlite-drizzle/meta/_journal.json
+++ b/migrations/sqlite-drizzle/meta/_journal.json
@@ -35,6 +35,13 @@
       "when": 1774262838467,
       "tag": "0004_volatile_madame_masque",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1774503155809,
+      "tag": "0005_gray_giant_girl",
+      "breakpoints": true
     }
   ],
   "version": "7"

--- a/packages/shared/data/api/schemas/index.ts
+++ b/packages/shared/data/api/schemas/index.ts
@@ -23,6 +23,7 @@
 import type { AssertValidSchemas } from '../apiTypes'
 import type { FileProcessingSchemas } from './fileProcessing'
 import type { MessageSchemas } from './messages'
+import type { SkillSchemas } from './skills'
 import type { TestSchemas } from './test'
 import type { TopicSchemas } from './topics'
 import type { TranslateSchemas } from './translate'
@@ -40,5 +41,5 @@ import type { TranslateSchemas } from './translate'
  * 2. Import and add to intersection below
  */
 export type ApiSchemas = AssertValidSchemas<
-  TestSchemas & TopicSchemas & MessageSchemas & TranslateSchemas & FileProcessingSchemas
+  TestSchemas & TopicSchemas & MessageSchemas & TranslateSchemas & FileProcessingSchemas & SkillSchemas
 >

--- a/packages/shared/data/api/schemas/skills.ts
+++ b/packages/shared/data/api/schemas/skills.ts
@@ -1,0 +1,106 @@
+/**
+ * Skill API Schema definitions
+ *
+ * Contains all skill-related endpoints for the global skill registry.
+ */
+
+import type { Skill, SkillSource, SkillVersion } from '@shared/data/types/skill'
+
+// ============================================================================
+// DTOs
+// ============================================================================
+
+export interface CreateSkillDto {
+  name: string
+  slug: string
+  description?: string
+  author?: string
+  version?: string
+  tags?: string[]
+  tools?: string[]
+  source: SkillSource
+  sourcePath: string
+  packageName?: string
+  packageVersion?: string
+  marketplaceId?: string
+  contentHash?: string
+  size?: number
+}
+
+export interface UpdateSkillDto {
+  name?: string
+  description?: string
+  author?: string
+  version?: string
+  tags?: string[]
+  tools?: string[]
+  sourcePath?: string
+  packageName?: string
+  packageVersion?: string
+  marketplaceId?: string
+  contentHash?: string
+  size?: number
+  isEnabled?: boolean
+  versionDirPath?: string
+}
+
+// ============================================================================
+// API Schema Definitions
+// ============================================================================
+
+export interface SkillSchemas {
+  '/skills': {
+    /** List all registered skills */
+    GET: {
+      response: Skill[]
+    }
+    /** Register a new skill */
+    POST: {
+      body: CreateSkillDto
+      response: Skill
+    }
+  }
+
+  '/skills/:id': {
+    /** Get a skill by ID */
+    GET: {
+      params: { id: string }
+      response: Skill
+    }
+    /** Update a skill */
+    PATCH: {
+      params: { id: string }
+      body: UpdateSkillDto
+      response: Skill
+    }
+    /** Unregister a skill */
+    DELETE: {
+      params: { id: string }
+      response: void
+    }
+  }
+
+  '/skills/:id/enable': {
+    /** Enable a skill */
+    PUT: {
+      params: { id: string }
+      response: Skill
+    }
+  }
+
+  '/skills/:id/disable': {
+    /** Disable a skill */
+    PUT: {
+      params: { id: string }
+      response: Skill
+    }
+  }
+
+  '/skills/:id/versions': {
+    /** List version history for a skill */
+    GET: {
+      params: { id: string }
+      response: SkillVersion[]
+    }
+  }
+}

--- a/packages/shared/data/types/skill.ts
+++ b/packages/shared/data/types/skill.ts
@@ -1,0 +1,52 @@
+/**
+ * Skill entity types
+ *
+ * Skills are reusable instruction sets that can be assigned to agents.
+ * They are stored as directories containing a SKILL.md file.
+ */
+
+export type SkillSource = 'builtin' | 'project' | 'marketplace' | 'local' | 'zip'
+
+/**
+ * Complete skill entity as returned by the API
+ */
+export interface Skill {
+  id: string
+  name: string
+  slug: string
+  description?: string | null
+  author?: string | null
+  version?: string | null
+  tags?: string[] | null
+  tools?: string[] | null
+
+  source: SkillSource
+  sourcePath: string
+  packageName?: string | null
+  packageVersion?: string | null
+  marketplaceId?: string | null
+
+  contentHash?: string | null
+  size?: number | null
+
+  isEnabled: boolean
+
+  versionDirPath?: string | null
+
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * Skill version history entry
+ */
+export interface SkillVersion {
+  id: string
+  skillId: string
+  version?: string | null
+  contentHash: string
+  diffPath: string
+  message?: string | null
+  createdAt: string
+  updatedAt: string
+}

--- a/src/main/data/api/handlers/index.ts
+++ b/src/main/data/api/handlers/index.ts
@@ -15,6 +15,7 @@ import type { ApiImplementation } from '@shared/data/api/apiTypes'
 
 import { fileProcessingHandlers } from './fileProcessing'
 import { messageHandlers } from './messages'
+import { skillHandlers } from './skills'
 import { testHandlers } from './test'
 import { topicHandlers } from './topics'
 import { translateHandlers } from './translate'
@@ -28,6 +29,7 @@ import { translateHandlers } from './translate'
  */
 export const apiHandlers: ApiImplementation = {
   ...fileProcessingHandlers,
+  ...skillHandlers,
   ...testHandlers,
   ...topicHandlers,
   ...messageHandlers,

--- a/src/main/data/api/handlers/skills.ts
+++ b/src/main/data/api/handlers/skills.ts
@@ -1,0 +1,60 @@
+/**
+ * Skill API Handlers
+ *
+ * Implements all skill-related API endpoints including:
+ * - Skill CRUD (register, get, update, unregister)
+ * - Enable/disable toggle
+ * - Version history listing
+ */
+
+import { skillService } from '@data/services/SkillService'
+import type { ApiHandler, ApiMethods } from '@shared/data/api/apiTypes'
+import type { SkillSchemas } from '@shared/data/api/schemas/skills'
+
+type SkillHandler<Path extends keyof SkillSchemas, Method extends ApiMethods<Path>> = ApiHandler<Path, Method>
+
+export const skillHandlers: {
+  [Path in keyof SkillSchemas]: {
+    [Method in keyof SkillSchemas[Path]]: SkillHandler<Path, Method & ApiMethods<Path>>
+  }
+} = {
+  '/skills': {
+    GET: async () => {
+      return await skillService.list()
+    },
+    POST: async ({ body }) => {
+      return await skillService.create(body)
+    }
+  },
+
+  '/skills/:id': {
+    GET: async ({ params }) => {
+      return await skillService.getById(params.id)
+    },
+    PATCH: async ({ params, body }) => {
+      return await skillService.update(params.id, body)
+    },
+    DELETE: async ({ params }) => {
+      await skillService.delete(params.id)
+      return undefined
+    }
+  },
+
+  '/skills/:id/enable': {
+    PUT: async ({ params }) => {
+      return await skillService.enable(params.id)
+    }
+  },
+
+  '/skills/:id/disable': {
+    PUT: async ({ params }) => {
+      return await skillService.disable(params.id)
+    }
+  },
+
+  '/skills/:id/versions': {
+    GET: async ({ params }) => {
+      return await skillService.listVersions(params.id)
+    }
+  }
+}

--- a/src/main/data/db/schemas/skill.ts
+++ b/src/main/data/db/schemas/skill.ts
@@ -1,0 +1,92 @@
+import { sql } from 'drizzle-orm'
+import { check, index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+
+import { createUpdateTimestamps, uuidPrimaryKey, uuidPrimaryKeyOrdered } from './_columnHelpers'
+
+/**
+ * Skill source types
+ *
+ * - builtin: Ships with the app installation
+ * - project: `.agents/skills/` in the project directory
+ * - marketplace: Downloaded from the remote marketplace API
+ * - local: Installed from a user-specified local directory
+ * - zip: Installed from a ZIP package
+ */
+export type SkillSource = 'builtin' | 'project' | 'marketplace' | 'local' | 'zip'
+
+/**
+ * Skill table - global registry for all skills
+ *
+ * Centralizes metadata for skills from every source.
+ * Actual skill content (SKILL.md) is read from the filesystem via `sourcePath`.
+ */
+export const skillTable = sqliteTable(
+  'skill',
+  {
+    id: uuidPrimaryKey(),
+
+    // metadata
+    name: text().notNull(),
+    slug: text().notNull().unique(),
+    description: text(),
+    author: text(),
+    version: text(),
+    tags: text({ mode: 'json' }).$type<string[]>(),
+    tools: text({ mode: 'json' }).$type<string[]>(),
+
+    // source
+    source: text().$type<SkillSource>().notNull(),
+    sourcePath: text().notNull(),
+    packageName: text(),
+    packageVersion: text(),
+    marketplaceId: text(),
+
+    // content tracking
+    contentHash: text(),
+    size: integer(),
+
+    // state
+    isEnabled: integer({ mode: 'boolean' }).notNull().default(true),
+
+    // version history
+    versionDirPath: text(),
+
+    ...createUpdateTimestamps
+  },
+  (t) => [
+    index('skill_name_idx').on(t.name),
+    index('skill_source_idx').on(t.source),
+    index('skill_is_enabled_idx').on(t.isEnabled),
+    check('skill_source_check', sql`${t.source} IN ('builtin', 'project', 'marketplace', 'local', 'zip')`)
+  ]
+)
+
+export type SkillInsert = typeof skillTable.$inferInsert
+export type SkillSelect = typeof skillTable.$inferSelect
+
+/**
+ * Skill version table - tracks content changes as diffs
+ *
+ * Each row represents a historical snapshot. The actual diff content is stored
+ * as a unified-diff `.patch` file on the filesystem at `diffPath`.
+ */
+export const skillVersionTable = sqliteTable(
+  'skill_version',
+  {
+    id: uuidPrimaryKeyOrdered(),
+    skillId: text()
+      .notNull()
+      .references(() => skillTable.id, { onDelete: 'cascade' }),
+
+    version: text(),
+    contentHash: text().notNull(),
+    diffPath: text().notNull(),
+    message: text(),
+
+    ...createUpdateTimestamps
+  },
+  (t) => [index('skill_version_skill_id_idx').on(t.skillId, t.createdAt)]
+)
+
+export type SkillVersionInsert = typeof skillVersionTable.$inferInsert
+export type SkillVersionSelect = typeof skillVersionTable.$inferSelect

--- a/src/main/data/services/SkillService.ts
+++ b/src/main/data/services/SkillService.ts
@@ -1,0 +1,190 @@
+/**
+ * Skill Service - handles skill registry CRUD and version tracking
+ *
+ * Provides business logic for:
+ * - Skill registration and lookup
+ * - Enable/disable toggle
+ * - Version history (diff-based)
+ */
+
+import { skillTable, skillVersionTable } from '@data/db/schemas/skill'
+import { loggerService } from '@logger'
+import { application } from '@main/core/application'
+import { DataApiErrorFactory } from '@shared/data/api'
+import type { CreateSkillDto, UpdateSkillDto } from '@shared/data/api/schemas/skills'
+import type { Skill, SkillVersion } from '@shared/data/types/skill'
+import { desc, eq } from 'drizzle-orm'
+
+const logger = loggerService.withContext('DataApi:SkillService')
+
+function rowToSkill(row: typeof skillTable.$inferSelect): Skill {
+  return {
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    description: row.description,
+    author: row.author,
+    version: row.version,
+    tags: row.tags,
+    tools: row.tools,
+    source: row.source,
+    sourcePath: row.sourcePath,
+    packageName: row.packageName,
+    packageVersion: row.packageVersion,
+    marketplaceId: row.marketplaceId,
+    contentHash: row.contentHash,
+    size: row.size,
+    isEnabled: row.isEnabled ?? true,
+    versionDirPath: row.versionDirPath,
+    createdAt: row.createdAt ? new Date(row.createdAt).toISOString() : new Date().toISOString(),
+    updatedAt: row.updatedAt ? new Date(row.updatedAt).toISOString() : new Date().toISOString()
+  }
+}
+
+function rowToSkillVersion(row: typeof skillVersionTable.$inferSelect): SkillVersion {
+  return {
+    id: row.id,
+    skillId: row.skillId,
+    version: row.version,
+    contentHash: row.contentHash,
+    diffPath: row.diffPath,
+    message: row.message,
+    createdAt: row.createdAt ? new Date(row.createdAt).toISOString() : new Date().toISOString(),
+    updatedAt: row.updatedAt ? new Date(row.updatedAt).toISOString() : new Date().toISOString()
+  }
+}
+
+export class SkillService {
+  /**
+   * List all registered skills
+   */
+  async list(): Promise<Skill[]> {
+    const db = application.get('DbService').getDb()
+    const rows = await db.select().from(skillTable)
+    return rows.map(rowToSkill)
+  }
+
+  /**
+   * Get a skill by ID
+   */
+  async getById(id: string): Promise<Skill> {
+    const db = application.get('DbService').getDb()
+    const [row] = await db.select().from(skillTable).where(eq(skillTable.id, id)).limit(1)
+
+    if (!row) {
+      throw DataApiErrorFactory.notFound('Skill', id)
+    }
+
+    return rowToSkill(row)
+  }
+
+  /**
+   * Register a new skill
+   */
+  async create(dto: CreateSkillDto): Promise<Skill> {
+    const db = application.get('DbService').getDb()
+
+    const [row] = await db
+      .insert(skillTable)
+      .values({
+        name: dto.name,
+        slug: dto.slug,
+        description: dto.description,
+        author: dto.author,
+        version: dto.version,
+        tags: dto.tags,
+        tools: dto.tools,
+        source: dto.source,
+        sourcePath: dto.sourcePath,
+        packageName: dto.packageName,
+        packageVersion: dto.packageVersion,
+        marketplaceId: dto.marketplaceId,
+        contentHash: dto.contentHash,
+        size: dto.size
+      })
+      .returning()
+
+    logger.info('Registered skill', { id: row.id, slug: dto.slug, source: dto.source })
+
+    return rowToSkill(row)
+  }
+
+  /**
+   * Update a skill
+   */
+  async update(id: string, dto: UpdateSkillDto): Promise<Skill> {
+    const db = application.get('DbService').getDb()
+
+    await this.getById(id)
+
+    const updates: Partial<typeof skillTable.$inferInsert> = {}
+
+    if (dto.name !== undefined) updates.name = dto.name
+    if (dto.description !== undefined) updates.description = dto.description
+    if (dto.author !== undefined) updates.author = dto.author
+    if (dto.version !== undefined) updates.version = dto.version
+    if (dto.tags !== undefined) updates.tags = dto.tags
+    if (dto.tools !== undefined) updates.tools = dto.tools
+    if (dto.sourcePath !== undefined) updates.sourcePath = dto.sourcePath
+    if (dto.packageName !== undefined) updates.packageName = dto.packageName
+    if (dto.packageVersion !== undefined) updates.packageVersion = dto.packageVersion
+    if (dto.marketplaceId !== undefined) updates.marketplaceId = dto.marketplaceId
+    if (dto.contentHash !== undefined) updates.contentHash = dto.contentHash
+    if (dto.size !== undefined) updates.size = dto.size
+    if (dto.isEnabled !== undefined) updates.isEnabled = dto.isEnabled
+    if (dto.versionDirPath !== undefined) updates.versionDirPath = dto.versionDirPath
+
+    const [row] = await db.update(skillTable).set(updates).where(eq(skillTable.id, id)).returning()
+
+    logger.info('Updated skill', { id, changes: Object.keys(dto) })
+
+    return rowToSkill(row)
+  }
+
+  /**
+   * Unregister a skill and its version history
+   */
+  async delete(id: string): Promise<void> {
+    const db = application.get('DbService').getDb()
+
+    await this.getById(id)
+
+    // Versions are cascade-deleted via foreign key
+    await db.delete(skillTable).where(eq(skillTable.id, id))
+
+    logger.info('Unregistered skill', { id })
+  }
+
+  /**
+   * Enable a skill
+   */
+  async enable(id: string): Promise<Skill> {
+    return this.update(id, { isEnabled: true })
+  }
+
+  /**
+   * Disable a skill
+   */
+  async disable(id: string): Promise<Skill> {
+    return this.update(id, { isEnabled: false })
+  }
+
+  /**
+   * List version history for a skill, newest first
+   */
+  async listVersions(skillId: string): Promise<SkillVersion[]> {
+    const db = application.get('DbService').getDb()
+
+    await this.getById(skillId)
+
+    const rows = await db
+      .select()
+      .from(skillVersionTable)
+      .where(eq(skillVersionTable.skillId, skillId))
+      .orderBy(desc(skillVersionTable.createdAt))
+
+    return rows.map(rowToSkillVersion)
+  }
+}
+
+export const skillService = new SkillService()

--- a/src/main/data/services/__tests__/SkillService.test.ts
+++ b/src/main/data/services/__tests__/SkillService.test.ts
@@ -1,0 +1,243 @@
+import type { CreateSkillDto, UpdateSkillDto } from '@shared/data/api/schemas/skills'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockSelect = vi.fn()
+const mockInsert = vi.fn()
+const mockUpdate = vi.fn()
+const mockDelete = vi.fn()
+
+const mockDb = {
+  select: mockSelect,
+  insert: mockInsert,
+  update: mockUpdate,
+  delete: mockDelete
+}
+
+vi.mock('@main/core/application', async () => {
+  const { mockApplicationFactory } = await import('@test-mocks/main/application')
+  return mockApplicationFactory({
+    DbService: { getDb: () => mockDb }
+  })
+})
+
+const { skillService } = await import('../SkillService')
+
+const NOW = Date.now()
+
+function createMockRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'skill-001',
+    name: 'Test Skill',
+    slug: 'test-skill',
+    description: 'A test skill',
+    author: 'tester',
+    version: '1.0.0',
+    tags: ['test'],
+    tools: ['Read', 'Write'],
+    source: 'local',
+    sourcePath: '/path/to/skill',
+    packageName: null,
+    packageVersion: null,
+    marketplaceId: null,
+    contentHash: 'abc123',
+    size: 1024,
+    isEnabled: true,
+    versionDirPath: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides
+  }
+}
+
+function mockSelectChain(rows: unknown[]) {
+  mockSelect.mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows)
+      })
+    })
+  })
+}
+
+function mockSelectListChain(rows: unknown[]) {
+  mockSelect.mockReturnValue({
+    from: vi.fn().mockResolvedValue(rows)
+  })
+}
+
+function mockInsertChain(rows: unknown[]) {
+  mockInsert.mockReturnValue({
+    values: vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue(rows)
+    })
+  })
+}
+
+function mockUpdateChain(rows: unknown[]) {
+  mockUpdate.mockReturnValue({
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue(rows)
+      })
+    })
+  })
+}
+
+describe('SkillService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('list', () => {
+    it('should return all skills', async () => {
+      const rows = [createMockRow(), createMockRow({ id: 'skill-002', slug: 'other-skill' })]
+      mockSelectListChain(rows)
+
+      const result = await skillService.list()
+      expect(result).toHaveLength(2)
+      expect(result[0].slug).toBe('test-skill')
+      expect(result[1].slug).toBe('other-skill')
+    })
+
+    it('should return empty array when no skills', async () => {
+      mockSelectListChain([])
+
+      const result = await skillService.list()
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  describe('getById', () => {
+    it('should return a skill by ID', async () => {
+      mockSelectChain([createMockRow()])
+
+      const result = await skillService.getById('skill-001')
+      expect(result.id).toBe('skill-001')
+      expect(result.name).toBe('Test Skill')
+      expect(result.source).toBe('local')
+    })
+
+    it('should throw NotFound for non-existent ID', async () => {
+      mockSelectChain([])
+
+      await expect(skillService.getById('nonexistent')).rejects.toThrow()
+    })
+  })
+
+  describe('create', () => {
+    it('should register a new skill', async () => {
+      const row = createMockRow()
+      mockInsertChain([row])
+
+      const dto: CreateSkillDto = {
+        name: 'Test Skill',
+        slug: 'test-skill',
+        source: 'local',
+        sourcePath: '/path/to/skill',
+        version: '1.0.0',
+        tags: ['test'],
+        tools: ['Read', 'Write']
+      }
+
+      const result = await skillService.create(dto)
+      expect(result.slug).toBe('test-skill')
+      expect(result.source).toBe('local')
+    })
+  })
+
+  describe('update', () => {
+    it('should update skill fields', async () => {
+      const row = createMockRow()
+      mockSelectChain([row])
+      mockUpdateChain([{ ...row, name: 'Updated Skill' }])
+
+      const dto: UpdateSkillDto = { name: 'Updated Skill' }
+      const result = await skillService.update('skill-001', dto)
+      expect(result.name).toBe('Updated Skill')
+    })
+
+    it('should throw NotFound for non-existent ID', async () => {
+      mockSelectChain([])
+
+      await expect(skillService.update('nonexistent', { name: 'x' })).rejects.toThrow()
+    })
+  })
+
+  describe('delete', () => {
+    it('should unregister a skill', async () => {
+      mockSelectChain([createMockRow()])
+      mockDelete.mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined)
+      })
+
+      await expect(skillService.delete('skill-001')).resolves.toBeUndefined()
+    })
+
+    it('should throw NotFound for non-existent ID', async () => {
+      mockSelectChain([])
+
+      await expect(skillService.delete('nonexistent')).rejects.toThrow()
+    })
+  })
+
+  describe('enable/disable', () => {
+    it('should enable a skill', async () => {
+      const row = createMockRow({ isEnabled: false })
+      mockSelectChain([row])
+      mockUpdateChain([{ ...row, isEnabled: true }])
+
+      const result = await skillService.enable('skill-001')
+      expect(result.isEnabled).toBe(true)
+    })
+
+    it('should disable a skill', async () => {
+      const row = createMockRow({ isEnabled: true })
+      mockSelectChain([row])
+      mockUpdateChain([{ ...row, isEnabled: false }])
+
+      const result = await skillService.disable('skill-001')
+      expect(result.isEnabled).toBe(false)
+    })
+  })
+
+  describe('listVersions', () => {
+    it('should return version history for a skill', async () => {
+      const skillRow = createMockRow()
+      mockSelectChain([skillRow])
+
+      const versionRows = [
+        {
+          id: 'ver-001',
+          skillId: 'skill-001',
+          version: '1.0.0',
+          contentHash: 'hash1',
+          diffPath: '/path/to/diff.patch',
+          message: 'initial',
+          createdAt: NOW,
+          updatedAt: NOW
+        }
+      ]
+
+      // Second select call for versions
+      mockSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([skillRow])
+          })
+        })
+      })
+      mockSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockResolvedValue(versionRows)
+          })
+        })
+      })
+
+      const result = await skillService.listVersions('skill-001')
+      expect(result).toHaveLength(1)
+      expect(result[0].version).toBe('1.0.0')
+      expect(result[0].diffPath).toBe('/path/to/diff.patch')
+    })
+  })
+})


### PR DESCRIPTION
### What this PR does

Before this PR:
Skills are stored purely on the filesystem with a JSON cache (`plugins.json`), scattered across individual agent work directories. There is no centralized registry, no cross-agent visibility, and no version history.

After this PR:
A global `skill` table and `skill_version` table are added to SQLite (via Drizzle ORM), providing a centralized skill registry with full CRUD, enable/disable toggle, source tracking, and diff-based version history. DataApi endpoints are wired up for renderer consumption.

### Why we need it and why it was done in this way

The v2 architecture requires centralized skill management so that:
- All skills (builtin, project, marketplace, local, zip) are discoverable in one place
- Agents can reference skills by ID (JSON array field) instead of implicit filesystem discovery
- Version history is tracked via unified diffs stored on the filesystem (avoids DB bloat)

The following tradeoffs were made:
- **DB stores metadata only, filesystem stores content**: Keeps the DB lean and avoids sync issues. Skill content (SKILL.md) is read from `sourcePath` at runtime.
- **Diff files on filesystem**: Version diffs can be large text; storing them as `.patch` files is consistent with the content-on-filesystem strategy.
- **Named export singleton for service**: Follows the CLAUDE.md convention (`export const skillService = new SkillService()`) instead of the older `getInstance()` pattern.

The following alternatives were considered:
- Storing full skill content in the DB (rejected: sync issues, DB bloat)
- Storing diffs in the DB (rejected: can be large, filesystem is more appropriate)
- Lifecycle-managed service (rejected: SkillService has no long-lived resources or persistent side effects)

### Breaking changes

None. This is a new feature addition with no changes to existing code behavior.

### Special notes for your reviewer

- The `skill` table uses UUID v4 primary keys (standard for general tables)
- The `skill_version` table uses UUID v7 (time-ordered, for efficient chronological queries)
- Source types are constrained via SQL CHECK: `builtin`, `project`, `marketplace`, `local`, `zip`
- Migration file `0005_gray_giant_girl.sql` was auto-generated by `drizzle-kit generate`
- Agent-Skill association (JSON array on Agent table) will be added when the Agent table is created

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
