### PR TITLE
fix(aiCore): normalize model ID before looking up thinking token limits

### DIFF
--- a/src/renderer/src/aiCore/utils/reasoning.ts
+++ b/src/renderer/src/aiCore/utils/reasoning.ts
@@ -52,6 +52,7 @@ const logger = loggerService.withContext('reasoning')
 // The function is only for generic provider. May extract some logics to independent provider
 export function getReasoningEffort(assistant: Assistant, model: Model): ReasoningEffortOptionalParams {
   const provider = getProviderByModel(model)
+  const modelId = getLowerBaseModelName(model.id)
   if (provider.id === 'groq') {
     return {}
   }
@@ -245,7 +246,7 @@ export function getReasoningEffort(assistant: Assistant, model: Model): Reasonin
   }
 
   const effortRatio = EFFORT_RATIO[reasoningEffort]
-  const tokenLimit = findTokenLimit(model.id)
+  const tokenLimit = findTokenLimit(modelId)
   let budgetTokens: number | undefined
   if (tokenLimit) {
     budgetTokens = Math.floor((tokenLimit.max - tokenLimit.min) * effortRatio + tokenLimit.min)


### PR DESCRIPTION
### What this PR does

Before this PR:

`findTokenLimit()` in `getReasoningEffort()` was called with the raw `model.id`, which may contain provider prefixes or mixed casing (e.g., `openai/qwen3.5-397b-a17b`). This caused token limit lookups to fail, so `effort` was never correctly converted to `thinking_budget` for generic (OpenAI-compatible) providers.

After this PR:

The model ID is normalized via `getLowerBaseModelName()` before being passed to `findTokenLimit()`, ensuring correct token limit resolution and proper `effort → thinking_budget` conversion.

Fixes #13831

### Why we need it and why it was done in this way

The following tradeoffs were made:

The normalization is applied early in `getReasoningEffort()` and reuses the existing `getLowerBaseModelName()` utility, which is already used elsewhere in the same file. This is the minimal, consistent fix.

The following alternatives were considered:

- Modifying `findTokenLimit()` itself to normalize internally — rejected because it would change the contract for all callers, some of which may already pass normalized IDs.

### Breaking changes

None.

### Special notes for your reviewer

While this fix correctly resolves the token limit lookup, there is a known follow-up concern: for some models (e.g., Qwen3.5), even a correctly computed low `thinking_budget` can paradoxically cause **more** thinking than not passing the parameter at all. See the linked issue discussion for details. See #13844 for tracking improvements to the effort mapping strategy.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```