### PR TITLE
fix: update broken Awesome MCP Servers link

### DIFF
--- a/src/renderer/src/pages/settings/MCPSettings/McpMarketList.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/McpMarketList.tsx
@@ -63,7 +63,7 @@ const mcpMarkets = [
   },
   {
     name: 'Awesome MCP Servers',
-    url: 'https://github.com/punkpeye/awesome-mcp-servers',
+    url: 'https://github.com/wong2/awesome-mcp-servers',
     logo: 'https://github.githubassets.com/assets/github-logo-55c5b9a1fe52.png',
     descriptionKey: 'settings.mcp.more.awesome'
   }


### PR DESCRIPTION
## Description

Fixes #13827

The "Awesome MCP Servers" link in Settings > MCP Servers > Marketplaces was returning a 404 error. The original repository (punkpeye/awesome-mcp-servers) appears to have been removed or made private.

## Changes

Updated the URL to point to wong2/awesome-mcp-servers, which is an active and maintained fork of the original awesome-mcp-servers list.

## Verification

- [x] Verified the new URL returns 200 OK
- [x] Confirmed the repository contains a curated list of MCP servers
- [x] This is a minimal fix that doesn't affect Redux data models or IndexedDB schemas

## Related

- Issue: #13827
- Original broken URL: https://github.com/punkpeye/awesome-mcp-servers (404)
- New working URL: https://github.com/wong2/awesome-mcp-servers (200)