### PR TITLE
fix(ci): add Linux system deps for selection-hook native rebuild

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Build Linux
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get install -y rpm
+          sudo apt-get install -y rpm libevdev-dev libxtst-dev libx11-dev libxfixes-dev libwayland-dev
           pnpm build:linux
 
         env:


### PR DESCRIPTION
## Summary
- Install `libevdev-dev`, `libxtst-dev`, `libx11-dev`, `libxfixes-dev`, and `libwayland-dev` in the Linux release build step so the `selection-hook` native module compiles successfully.

## Test plan
- [ ] Trigger a Linux-only release build via `workflow_dispatch` and verify it completes without native module compilation errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)