### PR TITLE
fix(ci): narrow release-packages trigger to changeset-managed packages only

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -6,7 +6,9 @@ on:
       - main
     paths:
       - ".changeset/**"
-      - "packages/**"
+      - "packages/aiCore/**"
+      - "packages/ai-sdk-provider/**"
+      - "packages/extension-table-plus/**"
   workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### What this PR does

Before this PR:
The `release-packages` workflow triggered on **any** file change under `packages/**`, including internal packages (`shared`, `mcp-trace`, `ui`) that are not managed by changesets and never published to npm.

After this PR:
The workflow only triggers on changes to the three changeset-managed packages: `packages/aiCore/**`, `packages/ai-sdk-provider/**`, and `packages/extension-table-plus/**`.

### Why we need it and why it was done in this way

Only `@cherrystudio/ai-core`, `@cherrystudio/ai-sdk-provider`, and `@cherrystudio/extension-table-plus` have `package.json` with versions and are published via changesets. The other directories under `packages/` (`shared`, `mcp-trace`, `ui`) are internal modules with no `package.json` — changes to them should not trigger the release workflow.

The fix simply narrows the `paths` filter to explicitly list the three publishable packages instead of using a wildcard.

### Breaking changes

None.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: N/A — CI-only change, no user-facing impact
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
