### PR TITLE
fix(ci): run format after changeset version to satisfy pre-commit hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "claude": "dotenv -e .env -- claude",
     "changeset": "changeset",
     "changeset:status": "changeset status",
-    "changeset:version": "changeset version",
+    "changeset:version": "changeset version && pnpm format",
     "changeset:publish": "changeset publish",
     "packages:build": "pnpm --filter @cherrystudio/ai-sdk-provider build && pnpm --filter @cherrystudio/ai-core build && pnpm --filter @cherrystudio/extension-table-plus build",
     "packages:release": "pnpm packages:build && changeset publish",


### PR DESCRIPTION
### What this PR does

Before this PR:
The `release-packages` workflow fails because `changesets/action` runs `changeset version` which generates `package.json` and `CHANGELOG.md` files that don't conform to Biome formatting rules. When the action then runs `git commit`, the pre-commit hook (`biome-format-other`) reformats these files and rejects the commit.

After this PR:
The `changeset:version` script runs `pnpm format` after `changeset version`, ensuring all generated files are properly formatted before the commit.

Fixes the release workflow failure: https://github.com/CherryHQ/cherry-studio/actions/runs/23655599112/job/68911896452

### Why we need it and why it was done in this way

The simplest fix is to append `&& pnpm format` to the existing `changeset:version` script. This reuses the project's standard format command and ensures any files modified by `changeset version` are formatted before the changesets action attempts to commit them.

The following alternatives were considered:
- Disabling pre-commit hooks in CI — rejected because it bypasses safety checks
- Adding a separate CI step — not possible because `changesets/action` runs version + commit internally

### Breaking changes

None.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: N/A — CI/build tooling change, no user-facing impact
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
