### PR TITLE
chore(changeset): ignore @cherrystudio/ui in changeset checks

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
   "changelog": ["@changesets/changelog-github", { "repo": "CherryHQ/cherry-studio" }],
   "commit": false,
   "fixed": [],
-  "ignore": [],
+  "ignore": ["@cherrystudio/ui"],
   "linked": [],
   "updateInternalDependencies": "patch"
 }


### PR DESCRIPTION
### What this PR does

Before this PR:
`changeset-check` CI job fails on any PR that modifies files under `packages/ui/`, because changeset detects the `@cherrystudio/ui` package as changed but finds no corresponding changeset entry.

After this PR:
`@cherrystudio/ui` is added to the changeset `ignore` list, so changes to the UI package no longer require a changeset.

### Why we need it and why it was done in this way

The `@cherrystudio/ui` package is still in active development and has not been published to npm. Requiring changesets for it creates unnecessary friction for PRs that touch internal UI components.

The following tradeoffs were made:
N/A

The following alternatives were considered:
- Adding path filters to `changeset-check` CI job — more complex and doesn't address the root cause.
- Adding empty changesets per PR — tedious workaround.

### Breaking changes

None

### Special notes for your reviewer

Once `@cherrystudio/ui` is ready for publishing, remove it from the `ignore` list.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```