### PR TITLE
feat(v2): add agent/session schema and migration transform mappings

### DIFF
--- a/packages/shared/data/api/schemas/agents.ts
+++ b/packages/shared/data/api/schemas/agents.ts
@@ -1,0 +1,147 @@
+/**
+ * Agent API Schema definitions
+ *
+ * Contains endpoints for Agent and AgentSession CRUD operations.
+ * Entity schemas and types live in `@shared/data/types/agent`.
+ */
+
+import * as z from 'zod'
+
+import { type Agent, AgentSchema, type AgentSession, AgentSessionSchema } from '../../types/agent'
+import type { Message } from '../../types/message'
+import type { OffsetPaginationResponse } from '../apiTypes'
+
+// ============================================================================
+// DTO Derivation
+// ============================================================================
+
+/** Fields auto-managed by the database layer, excluded from DTOs */
+const AutoFields = { id: true, createdAt: true, updatedAt: true } as const
+
+/**
+ * DTO for creating a new agent.
+ * - `type`, `name`, `model` are required
+ * - `id` is excluded (auto-generated UUID by database)
+ */
+export const CreateAgentSchema = AgentSchema.omit(AutoFields).partial().required({
+  type: true,
+  name: true,
+  model: true
+})
+export type CreateAgentDto = z.infer<typeof CreateAgentSchema>
+
+/**
+ * DTO for updating an existing agent.
+ * All fields optional, `id` excluded (comes from URL path).
+ */
+export const UpdateAgentSchema = AgentSchema.omit(AutoFields).partial()
+export type UpdateAgentDto = z.infer<typeof UpdateAgentSchema>
+
+/**
+ * DTO for creating a new agent session.
+ * - `model` is required (snapshot from agent at creation)
+ * - `agentId`, `agentType`, `topicId` are set by the server
+ */
+export const CreateAgentSessionSchema = AgentSessionSchema.omit({
+  ...AutoFields,
+  agentId: true,
+  agentType: true,
+  topicId: true,
+  sdkSessionId: true
+})
+  .partial()
+  .required({ model: true })
+export type CreateAgentSessionDto = z.infer<typeof CreateAgentSessionSchema>
+
+/**
+ * Body for reordering agents or sessions
+ */
+export const ReorderAgentsSchema = z.object({
+  orderedIds: z.array(z.string().min(1))
+})
+export type ReorderAgentsBody = z.infer<typeof ReorderAgentsSchema>
+
+// ============================================================================
+// API Schema Definitions
+// ============================================================================
+
+export interface AgentSchemas {
+  '/agents': {
+    /** List all agents */
+    GET: {
+      query?: { page?: number; limit?: number; type?: string }
+      response: OffsetPaginationResponse<Agent>
+    }
+    /** Create a new agent */
+    POST: {
+      body: CreateAgentDto
+      response: Agent
+    }
+    /** Reorder agents */
+    PATCH: {
+      body: ReorderAgentsBody
+      response: void
+    }
+  }
+
+  '/agents/:id': {
+    /** Get an agent by ID */
+    GET: {
+      params: { id: string }
+      response: Agent
+    }
+    /** Update an agent */
+    PATCH: {
+      params: { id: string }
+      body: UpdateAgentDto
+      response: Agent
+    }
+    /** Delete an agent (soft delete) */
+    DELETE: {
+      params: { id: string }
+      response: void
+    }
+  }
+
+  '/agents/:agentId/sessions': {
+    /** List sessions for an agent */
+    GET: {
+      params: { agentId: string }
+      query?: { page?: number; limit?: number }
+      response: OffsetPaginationResponse<AgentSession>
+    }
+    /** Create a new session (auto-creates topic, snapshots agent config) */
+    POST: {
+      params: { agentId: string }
+      body: CreateAgentSessionDto
+      response: AgentSession
+    }
+    /** Reorder sessions */
+    PATCH: {
+      params: { agentId: string }
+      body: ReorderAgentsBody
+      response: void
+    }
+  }
+
+  '/agents/:agentId/sessions/:id': {
+    /** Get a session by ID */
+    GET: {
+      params: { agentId: string; id: string }
+      response: AgentSession
+    }
+    /** Delete a session (cascades to topic and messages) */
+    DELETE: {
+      params: { agentId: string; id: string }
+      response: void
+    }
+  }
+
+  '/agents/:agentId/sessions/:sessionId/messages': {
+    /** Get all messages for a session (via topic) */
+    GET: {
+      params: { agentId: string; sessionId: string }
+      response: Message[]
+    }
+  }
+}

--- a/packages/shared/data/api/schemas/index.ts
+++ b/packages/shared/data/api/schemas/index.ts
@@ -21,6 +21,7 @@
  */
 
 import type { AssertValidSchemas } from '../apiTypes'
+import type { AgentSchemas } from './agents'
 import type { FileProcessingSchemas } from './fileProcessing'
 import type { KnowledgeSchemas } from './knowledges'
 import type { MCPServerSchemas } from './mcpServers'
@@ -48,5 +49,6 @@ export type ApiSchemas = AssertValidSchemas<
     TranslateSchemas &
     FileProcessingSchemas &
     MCPServerSchemas &
-    KnowledgeSchemas
+    KnowledgeSchemas &
+    AgentSchemas
 >

--- a/packages/shared/data/types/agent.ts
+++ b/packages/shared/data/types/agent.ts
@@ -22,15 +22,15 @@ export const AgentSchema = z.object({
   id: z.uuidv4(),
   type: AgentTypeSchema,
   name: z.string().min(1),
-  description: z.string().nullable().optional(),
+  description: z.string().nullable(),
   model: z.string().min(1),
-  planModel: z.string().nullable().optional(),
-  smallModel: z.string().nullable().optional(),
-  accessiblePaths: z.array(z.string()).nullable().optional(),
-  instructions: z.record(z.string(), z.unknown()).nullable().optional(),
-  mcps: z.array(z.string()).nullable().optional(),
-  allowedTools: z.array(z.string()).nullable().optional(),
-  configuration: z.record(z.string(), z.unknown()).nullable().optional(),
+  planModel: z.string().nullable(),
+  smallModel: z.string().nullable(),
+  accessiblePaths: z.array(z.string()).nullable(),
+  instructions: z.record(z.string(), z.unknown()).nullable(),
+  mcps: z.array(z.string()).nullable(),
+  allowedTools: z.array(z.string()).nullable(),
+  configuration: z.record(z.string(), z.unknown()).nullable(),
   sortOrder: z.number().default(0),
   createdAt: z.iso.datetime(),
   updatedAt: z.iso.datetime()
@@ -43,19 +43,19 @@ export type Agent = z.infer<typeof AgentSchema>
 
 export const AgentSessionSchema = z.object({
   id: z.uuidv4(),
-  agentId: z.string().nullable().optional(),
+  agentId: z.string().nullable(),
   agentType: AgentTypeSchema,
   topicId: z.string(),
   model: z.string().min(1),
-  planModel: z.string().nullable().optional(),
-  smallModel: z.string().nullable().optional(),
-  accessiblePaths: z.array(z.string()).nullable().optional(),
-  instructions: z.record(z.string(), z.unknown()).nullable().optional(),
-  mcps: z.array(z.string()).nullable().optional(),
-  allowedTools: z.array(z.string()).nullable().optional(),
-  slashCommands: z.array(z.unknown()).nullable().optional(),
-  configuration: z.record(z.string(), z.unknown()).nullable().optional(),
-  sdkSessionId: z.string().nullable().optional(),
+  planModel: z.string().nullable(),
+  smallModel: z.string().nullable(),
+  accessiblePaths: z.array(z.string()).nullable(),
+  instructions: z.record(z.string(), z.unknown()).nullable(),
+  mcps: z.array(z.string()).nullable(),
+  allowedTools: z.array(z.string()).nullable(),
+  slashCommands: z.array(z.unknown()).nullable(),
+  configuration: z.record(z.string(), z.unknown()).nullable(),
+  sdkSessionId: z.string().nullable(),
   sortOrder: z.number().default(0),
   createdAt: z.iso.datetime(),
   updatedAt: z.iso.datetime()
@@ -78,10 +78,10 @@ export interface AgentSessionSnapshot {
   agentId: string | null
   agentType: string
   model: string
-  planModel?: string | null
-  smallModel?: string | null
-  instructions?: Record<string, unknown> | null
-  mcps?: string[] | null
-  allowedTools?: string[] | null
-  configuration?: Record<string, unknown> | null
+  planModel: string | null
+  smallModel: string | null
+  instructions: Record<string, unknown> | null
+  mcps: string[] | null
+  allowedTools: string[] | null
+  configuration: Record<string, unknown> | null
 }

--- a/packages/shared/data/types/agent.ts
+++ b/packages/shared/data/types/agent.ts
@@ -1,0 +1,87 @@
+/**
+ * Agent entity types
+ *
+ * Agents are autonomous code agent configurations (model + tools + instructions).
+ * Sessions are created from agents but run independently.
+ */
+
+import * as z from 'zod'
+
+// ============================================================================
+// Sub-Schemas
+// ============================================================================
+
+export const AgentTypeSchema = z.enum(['claude-code'])
+export type AgentType = z.infer<typeof AgentTypeSchema>
+
+// ============================================================================
+// Agent Entity
+// ============================================================================
+
+export const AgentSchema = z.object({
+  id: z.uuidv4(),
+  type: AgentTypeSchema,
+  name: z.string().min(1),
+  description: z.string().nullable().optional(),
+  model: z.string().min(1),
+  planModel: z.string().nullable().optional(),
+  smallModel: z.string().nullable().optional(),
+  accessiblePaths: z.array(z.string()).nullable().optional(),
+  instructions: z.record(z.string(), z.unknown()).nullable().optional(),
+  mcps: z.array(z.string()).nullable().optional(),
+  allowedTools: z.array(z.string()).nullable().optional(),
+  configuration: z.record(z.string(), z.unknown()).nullable().optional(),
+  sortOrder: z.number().default(0),
+  createdAt: z.iso.datetime(),
+  updatedAt: z.iso.datetime()
+})
+export type Agent = z.infer<typeof AgentSchema>
+
+// ============================================================================
+// Agent Session Entity
+// ============================================================================
+
+export const AgentSessionSchema = z.object({
+  id: z.uuidv4(),
+  agentId: z.string().nullable().optional(),
+  agentType: AgentTypeSchema,
+  topicId: z.string(),
+  model: z.string().min(1),
+  planModel: z.string().nullable().optional(),
+  smallModel: z.string().nullable().optional(),
+  accessiblePaths: z.array(z.string()).nullable().optional(),
+  instructions: z.record(z.string(), z.unknown()).nullable().optional(),
+  mcps: z.array(z.string()).nullable().optional(),
+  allowedTools: z.array(z.string()).nullable().optional(),
+  slashCommands: z.array(z.unknown()).nullable().optional(),
+  configuration: z.record(z.string(), z.unknown()).nullable().optional(),
+  sdkSessionId: z.string().nullable().optional(),
+  sortOrder: z.number().default(0),
+  createdAt: z.iso.datetime(),
+  updatedAt: z.iso.datetime()
+})
+export type AgentSession = z.infer<typeof AgentSessionSchema>
+
+// ============================================================================
+// Snapshot Types (immutable records captured at message creation time)
+// ============================================================================
+
+/**
+ * Agent session snapshot captured at message creation time.
+ * Preserves the session configuration used to generate this message,
+ * enabling audit, replay, and display even if the session is later modified or deleted.
+ *
+ * Only includes fields that affect message generation output.
+ * Symmetric with AssistantSnapshot from PR #13851.
+ */
+export interface AgentSessionSnapshot {
+  agentId: string | null
+  agentType: string
+  model: string
+  planModel?: string | null
+  smallModel?: string | null
+  instructions?: Record<string, unknown> | null
+  mcps?: string[] | null
+  allowedTools?: string[] | null
+  configuration?: Record<string, unknown> | null
+}

--- a/src/main/data/api/handlers/agents.ts
+++ b/src/main/data/api/handlers/agents.ts
@@ -1,0 +1,95 @@
+/**
+ * Agent API Handlers
+ *
+ * Implements all agent-related API endpoints including:
+ * - Agent CRUD (soft delete)
+ * - Session CRUD (auto-creates topic, snapshots agent config)
+ * - Session messages retrieval
+ *
+ * All input validation happens here at the system boundary.
+ */
+
+import { agentDataService } from '@data/services/AgentDataService'
+import type { ApiHandler, ApiMethods } from '@shared/data/api/apiTypes'
+import type { AgentSchemas } from '@shared/data/api/schemas/agents'
+import {
+  CreateAgentSchema,
+  CreateAgentSessionSchema,
+  ReorderAgentsSchema,
+  UpdateAgentSchema
+} from '@shared/data/api/schemas/agents'
+
+type AgentHandler<Path extends keyof AgentSchemas, Method extends ApiMethods<Path>> = ApiHandler<Path, Method>
+
+export const agentHandlers: {
+  [Path in keyof AgentSchemas]: {
+    [Method in keyof AgentSchemas[Path]]: AgentHandler<Path, Method & ApiMethods<Path>>
+  }
+} = {
+  '/agents': {
+    GET: async ({ query }) => {
+      return await agentDataService.listAgents(query)
+    },
+
+    POST: async ({ body }) => {
+      const parsed = CreateAgentSchema.parse(body)
+      return await agentDataService.createAgent(parsed)
+    },
+
+    PATCH: async ({ body }) => {
+      const parsed = ReorderAgentsSchema.parse(body)
+      await agentDataService.reorderAgents(parsed.orderedIds)
+      return undefined
+    }
+  },
+
+  '/agents/:id': {
+    GET: async ({ params }) => {
+      return await agentDataService.getAgent(params.id)
+    },
+
+    PATCH: async ({ params, body }) => {
+      const parsed = UpdateAgentSchema.parse(body)
+      return await agentDataService.updateAgent(params.id, parsed)
+    },
+
+    DELETE: async ({ params }) => {
+      await agentDataService.deleteAgent(params.id)
+      return undefined
+    }
+  },
+
+  '/agents/:agentId/sessions': {
+    GET: async ({ params, query }) => {
+      return await agentDataService.listSessions(params.agentId, query)
+    },
+
+    POST: async ({ params, body }) => {
+      const parsed = CreateAgentSessionSchema.parse(body)
+      return await agentDataService.createSession(params.agentId, parsed)
+    },
+
+    PATCH: async ({ params, body }) => {
+      const parsed = ReorderAgentsSchema.parse(body)
+      await agentDataService.reorderSessions(params.agentId, parsed.orderedIds)
+      return undefined
+    }
+  },
+
+  '/agents/:agentId/sessions/:id': {
+    GET: async ({ params }) => {
+      return await agentDataService.getSession(params.agentId, params.id)
+    },
+
+    DELETE: async ({ params }) => {
+      await agentDataService.deleteSession(params.agentId, params.id)
+      return undefined
+    }
+  },
+
+  '/agents/:agentId/sessions/:sessionId/messages': {
+    GET: async ({ params }) => {
+      return await agentDataService.getSessionMessages(params.agentId, params.sessionId)
+    }
+  }
+}

--- a/src/main/data/api/handlers/index.ts
+++ b/src/main/data/api/handlers/index.ts
@@ -13,6 +13,7 @@
 
 import type { ApiImplementation } from '@shared/data/api/apiTypes'
 
+import { agentHandlers } from './agents'
 import { fileProcessingHandlers } from './fileProcessing'
 import { knowledgeHandlers } from './knowledges'
 import { mcpServerHandlers } from './mcpServers'
@@ -29,6 +30,7 @@ import { translateHandlers } from './translate'
  * TypeScript ensures exhaustive coverage - missing handlers cause compile errors.
  */
 export const apiHandlers: ApiImplementation = {
+  ...agentHandlers,
   ...fileProcessingHandlers,
   ...testHandlers,
   ...topicHandlers,

--- a/src/main/data/db/schemas/agent.ts
+++ b/src/main/data/db/schemas/agent.ts
@@ -1,0 +1,38 @@
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+
+import { createUpdateDeleteTimestamps, uuidPrimaryKey } from './_columnHelpers'
+
+/**
+ * Agent table — autonomous agent definitions (templates)
+ *
+ * An agent is a code agent configuration (model + tools + instructions).
+ * Sessions are created from agents but run independently.
+ * Soft delete: preserve agent metadata for historical sessions.
+ */
+export const agentTable = sqliteTable(
+  'agent',
+  {
+    id: uuidPrimaryKey(),
+    type: text().notNull(),
+    name: text().notNull(),
+    description: text(),
+
+    model: text().notNull(),
+    planModel: text(),
+    smallModel: text(),
+
+    accessiblePaths: text({ mode: 'json' }).$type<string[]>(),
+    instructions: text({ mode: 'json' }).$type<Record<string, unknown>>(),
+    mcps: text({ mode: 'json' }).$type<string[]>(),
+    allowedTools: text({ mode: 'json' }).$type<string[]>(),
+    configuration: text({ mode: 'json' }).$type<Record<string, unknown>>(),
+
+    sortOrder: integer().notNull().default(0),
+
+    ...createUpdateDeleteTimestamps
+  },
+  (t) => [index('agent_type_idx').on(t.type), index('agent_sort_order_idx').on(t.sortOrder)]
+)
+
+export type AgentInsert = typeof agentTable.$inferInsert
+export type AgentSelect = typeof agentTable.$inferSelect

--- a/src/main/data/db/schemas/agentSession.ts
+++ b/src/main/data/db/schemas/agentSession.ts
@@ -1,0 +1,62 @@
+import { foreignKey, index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+
+import { createUpdateTimestamps, uuidPrimaryKey } from './_columnHelpers'
+import { agentTable } from './agent'
+import { topicTable } from './topic'
+
+/**
+ * Agent Session table — running instance of an agent
+ *
+ * Created from an agent template. Stores a config snapshot at creation time.
+ * Decoupled from agent: deleting agent sets agentId to NULL, session survives.
+ * Each session owns a topic (CASCADE): deleting session cleans up all messages.
+ */
+export const agentSessionTable = sqliteTable(
+  'agent_session',
+  {
+    id: uuidPrimaryKey(),
+
+    // SET NULL: session survives agent deletion
+    agentId: text(),
+    agentType: text().notNull(),
+
+    // CASCADE: session owns its topic and messages
+    topicId: text().notNull(),
+
+    // Config snapshot (copied from agent at creation)
+    model: text().notNull(),
+    planModel: text(),
+    smallModel: text(),
+    accessiblePaths: text({ mode: 'json' }).$type<string[]>(),
+    instructions: text({ mode: 'json' }).$type<Record<string, unknown>>(),
+    mcps: text({ mode: 'json' }).$type<string[]>(),
+    allowedTools: text({ mode: 'json' }).$type<string[]>(),
+    slashCommands: text({ mode: 'json' }).$type<unknown[]>(),
+    configuration: text({ mode: 'json' }).$type<Record<string, unknown>>(),
+
+    // Claude Code SDK session ID (for resume)
+    sdkSessionId: text(),
+
+    sortOrder: integer().notNull().default(0),
+
+    ...createUpdateTimestamps
+  },
+  (t) => [
+    index('agent_session_agent_id_idx').on(t.agentId),
+    index('agent_session_topic_id_idx').on(t.topicId),
+    index('agent_session_sort_order_idx').on(t.sortOrder),
+    foreignKey({
+      columns: [t.agentId],
+      foreignColumns: [agentTable.id],
+      name: 'fk_agent_session_agent'
+    }).onDelete('set null'),
+    foreignKey({
+      columns: [t.topicId],
+      foreignColumns: [topicTable.id],
+      name: 'fk_agent_session_topic'
+    }).onDelete('cascade')
+  ]
+)
+
+export type AgentSessionInsert = typeof agentSessionTable.$inferInsert
+export type AgentSessionSelect = typeof agentSessionTable.$inferSelect

--- a/src/main/data/db/schemas/message.ts
+++ b/src/main/data/db/schemas/message.ts
@@ -1,9 +1,11 @@
+import type { AgentSessionSnapshot } from '@shared/data/types/agent'
 import type { MessageData, MessageStats } from '@shared/data/types/message'
 import type { AssistantMeta, ModelMeta } from '@shared/data/types/meta'
 import { sql } from 'drizzle-orm'
 import { check, foreignKey, index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
 import { createUpdateDeleteTimestamps, uuidPrimaryKeyOrdered } from './_columnHelpers'
+import { agentSessionTable } from './agentSession'
 import { topicTable } from './topic'
 
 /**
@@ -49,6 +51,11 @@ export const messageTable = sqliteTable(
     // Statistics: token usage, performance metrics, etc.
     stats: text({ mode: 'json' }).$type<MessageStats>(),
 
+    // Agent session that produced this message (SET NULL on session delete)
+    agentSessionId: text(),
+    // Snapshot of agent session config at message creation time
+    agentSnapshot: text({ mode: 'json' }).$type<AgentSessionSnapshot>(),
+
     ...createUpdateDeleteTimestamps
   },
   (t) => [
@@ -58,8 +65,15 @@ export const messageTable = sqliteTable(
     index('message_parent_id_idx').on(t.parentId),
     index('message_topic_created_idx').on(t.topicId, t.createdAt),
     index('message_trace_id_idx').on(t.traceId),
+    // Agent session FK
+    index('message_agent_session_id_idx').on(t.agentSessionId),
+    foreignKey({
+      columns: [t.agentSessionId],
+      foreignColumns: [agentSessionTable.id],
+      name: 'fk_message_agent_session'
+    }).onDelete('set null'),
     // Check constraints for enum fields
-    check('message_role_check', sql`${t.role} IN ('user', 'assistant', 'system')`),
+    check('message_role_check', sql`${t.role} IN ('user', 'assistant', 'system', 'tool')`),
     check('message_status_check', sql`${t.status} IN ('pending', 'success', 'error', 'paused')`)
   ]
 )

--- a/src/main/data/db/schemas/topic.ts
+++ b/src/main/data/db/schemas/topic.ts
@@ -26,6 +26,9 @@ export const topicTable = sqliteTable(
     // Active node ID in the message tree
     activeNodeId: text(),
 
+    // Source type: 'chat' for normal conversations, 'agent' for agent sessions
+    sourceType: text().notNull().default('chat'),
+
     // FK to group table for organization
     // SET NULL: preserve topic when group is deleted
     groupId: text().references(() => groupTable.id, { onDelete: 'set null' }),
@@ -42,6 +45,7 @@ export const topicTable = sqliteTable(
     index('topic_group_sort_idx').on(t.groupId, t.sortOrder),
     index('topic_updated_at_idx').on(t.updatedAt),
     index('topic_is_pinned_idx').on(t.isPinned, t.pinnedOrder),
-    index('topic_assistant_id_idx').on(t.assistantId)
+    index('topic_assistant_id_idx').on(t.assistantId),
+    index('topic_source_type_idx').on(t.sourceType)
   ]
 )

--- a/src/main/data/migration/v2/migrators/AgentMigrator.ts
+++ b/src/main/data/migration/v2/migrators/AgentMigrator.ts
@@ -1,0 +1,372 @@
+/**
+ * Agent migrator - migrates agents, sessions, and messages from agents.db to v2 SQLite
+ *
+ * Data source: legacy agents.db (separate SQLite file)
+ * - agents table → agent table
+ * - sessions table → agent_session table + topic table (sourceType='agent')
+ * - session_messages table → message table (with agentSessionId + agentSnapshot)
+ *
+ * Unlike other migrators that read from Redux/Dexie, this one opens agents.db
+ * directly via libsql since the data lives in a separate database file.
+ */
+
+import { agentTable } from '@data/db/schemas/agent'
+import { agentSessionTable } from '@data/db/schemas/agentSession'
+import { messageTable } from '@data/db/schemas/message'
+import { topicTable } from '@data/db/schemas/topic'
+import { createClient } from '@libsql/client'
+import { loggerService } from '@logger'
+import type { ExecuteResult, PrepareResult, ValidateResult } from '@shared/data/migration/v2/types'
+import type { AgentSessionSnapshot } from '@shared/data/types/agent'
+import type { MessageData } from '@shared/data/types/message'
+import { sql } from 'drizzle-orm'
+import { app } from 'electron'
+import fs from 'fs'
+import path from 'path'
+
+import type { MigrationContext } from '../core/MigrationContext'
+import { BaseMigrator } from './BaseMigrator'
+import {
+  AgentTransformSchema,
+  LegacyMessageRowSchema,
+  makeSessionTransformWithFkCheck,
+  transformBlocksToMessageData
+} from './mappings/AgentMappings'
+
+const logger = loggerService.withContext('AgentMigrator')
+
+interface PreparedAgent {
+  id: string
+  type: string
+  name: string
+  description: string | null
+  model: string
+  planModel: string | null
+  smallModel: string | null
+  accessiblePaths: string[] | null
+  instructions: Record<string, unknown> | null
+  mcps: string[] | null
+  allowedTools: string[] | null
+  configuration: Record<string, unknown> | null
+  sortOrder: number
+}
+
+interface PreparedSession {
+  id: string
+  agentId: string
+  agentType: string
+  topicId: string
+  name: string
+  description: string | null
+  model: string
+  planModel: string | null
+  smallModel: string | null
+  accessiblePaths: string[] | null
+  instructions: Record<string, unknown> | null
+  mcps: string[] | null
+  allowedTools: string[] | null
+  slashCommands: unknown[] | null
+  configuration: Record<string, unknown> | null
+  sortOrder: number
+}
+
+interface PreparedMessage {
+  topicId: string
+  role: string
+  data: MessageData
+  status: string
+  agentSessionId: string
+  agentSnapshot: AgentSessionSnapshot
+  createdAt: number
+}
+
+export class AgentMigrator extends BaseMigrator {
+  readonly id = 'agent'
+  readonly name = 'Agent'
+  readonly description = 'Migrate agents, sessions, and messages from agents.db to v2 SQLite'
+  readonly order = 5
+
+  private preparedAgents: PreparedAgent[] = []
+  private preparedSessions: PreparedSession[] = []
+  private preparedMessages: PreparedMessage[] = []
+  private skippedCount = 0
+
+  /**
+   * Resolve the path to legacy agents.db.
+   * Checks both new Data/ path and old root path.
+   */
+  private getAgentsDbPath(): string | null {
+    const newPath = path.join(app.getPath('userData'), 'Data', 'agents.db')
+    if (fs.existsSync(newPath)) return newPath
+
+    const oldPath = path.join(app.getPath('userData'), 'agents.db')
+    if (fs.existsSync(oldPath)) return oldPath
+
+    return null
+  }
+
+  async prepare(_ctx: MigrationContext): Promise<PrepareResult> {
+    this.preparedAgents = []
+    this.preparedSessions = []
+    this.preparedMessages = []
+    this.skippedCount = 0
+    const warnings: string[] = []
+
+    try {
+      const dbPath = this.getAgentsDbPath()
+      if (!dbPath) {
+        logger.info('No agents.db found, skipping agent migration')
+        return { success: true, itemCount: 0, warnings: ['agents.db not found, skipping'] }
+      }
+
+      const client = createClient({ url: `file:${dbPath}`, intMode: 'number' })
+
+      try {
+        // 1. Read agents
+        const agentRows = await client.execute('SELECT * FROM agents ORDER BY sort_order')
+        const validAgentIds = new Set<string>()
+
+        for (const row of agentRows.rows) {
+          try {
+            const parsed = AgentTransformSchema.parse(row)
+            this.preparedAgents.push(parsed)
+            validAgentIds.add(parsed.id)
+          } catch (err) {
+            this.skippedCount++
+            warnings.push(`Skipped agent: ${(err as Error).message}`)
+          }
+        }
+
+        // 2. Read sessions (with FK validation)
+        const sessionRows = await client.execute('SELECT * FROM sessions ORDER BY sort_order')
+        const sessionTransform = makeSessionTransformWithFkCheck(validAgentIds)
+        const validSessionIds = new Set<string>()
+        const sessionAgentMap = new Map<string, PreparedAgent>()
+
+        for (const row of sessionRows.rows) {
+          try {
+            const parsed = sessionTransform.parse(row)
+            // Generate a topicId for this session (will be created during execute)
+            const topicId = crypto.randomUUID()
+            this.preparedSessions.push({ ...parsed, topicId })
+            validSessionIds.add(parsed.id)
+
+            const agent = this.preparedAgents.find((a) => a.id === parsed.agentId)
+            if (agent) sessionAgentMap.set(parsed.id, agent)
+          } catch (err) {
+            this.skippedCount++
+            warnings.push(`Skipped session: ${(err as Error).message}`)
+          }
+        }
+
+        // 3. Read messages (with FK validation)
+        const msgRows = await client.execute('SELECT * FROM session_messages ORDER BY created_at')
+
+        for (const row of msgRows.rows) {
+          try {
+            const parsed = LegacyMessageRowSchema.parse(row)
+
+            if (!validSessionIds.has(parsed.session_id)) {
+              this.skippedCount++
+              warnings.push(`Skipped message with invalid session_id: ${parsed.session_id}`)
+              continue
+            }
+
+            const session = this.preparedSessions.find((s) => s.id === parsed.session_id)
+            if (!session) continue
+
+            // Build message data from legacy content
+            const blocks = parsed.content?.blocks ?? []
+            const data = transformBlocksToMessageData(blocks)
+
+            // Build agent snapshot
+            const agentSnapshot: AgentSessionSnapshot = {
+              agentId: session.agentId,
+              agentType: session.agentType,
+              model: session.model,
+              planModel: session.planModel,
+              smallModel: session.smallModel,
+              instructions: session.instructions,
+              mcps: session.mcps,
+              allowedTools: session.allowedTools,
+              configuration: session.configuration
+            }
+
+            // Map legacy role
+            let role = parsed.role
+            if (role === 'agent') role = 'assistant'
+
+            this.preparedMessages.push({
+              topicId: session.topicId,
+              role,
+              data,
+              status: 'success',
+              agentSessionId: session.id,
+              agentSnapshot,
+              createdAt: new Date(parsed.created_at).getTime()
+            })
+          } catch (err) {
+            this.skippedCount++
+            warnings.push(`Skipped message: ${(err as Error).message}`)
+          }
+        }
+      } finally {
+        client.close()
+      }
+
+      const totalItems = this.preparedAgents.length + this.preparedSessions.length + this.preparedMessages.length
+
+      logger.info('Preparation completed', {
+        agents: this.preparedAgents.length,
+        sessions: this.preparedSessions.length,
+        messages: this.preparedMessages.length,
+        skipped: this.skippedCount
+      })
+
+      return {
+        success: true,
+        itemCount: totalItems,
+        warnings: warnings.length > 0 ? warnings : undefined
+      }
+    } catch (error) {
+      logger.error('Preparation failed', error as Error)
+      return {
+        success: false,
+        itemCount: 0,
+        warnings: [error instanceof Error ? error.message : String(error)]
+      }
+    }
+  }
+
+  async execute(ctx: MigrationContext): Promise<ExecuteResult> {
+    const totalItems = this.preparedAgents.length + this.preparedSessions.length + this.preparedMessages.length
+    if (totalItems === 0) {
+      return { success: true, processedCount: 0 }
+    }
+
+    try {
+      let processed = 0
+      const BATCH_SIZE = 100
+
+      await ctx.db.transaction(async (tx) => {
+        // 1. Insert agents
+        for (let i = 0; i < this.preparedAgents.length; i += BATCH_SIZE) {
+          const batch = this.preparedAgents.slice(i, i + BATCH_SIZE)
+          await tx.insert(agentTable).values(batch)
+          processed += batch.length
+        }
+
+        // 2. Insert topics for sessions
+        for (let i = 0; i < this.preparedSessions.length; i += BATCH_SIZE) {
+          const batch = this.preparedSessions.slice(i, i + BATCH_SIZE)
+          await tx.insert(topicTable).values(
+            batch.map((s) => ({
+              id: s.topicId,
+              name: s.name,
+              sourceType: 'agent',
+              isNameManuallyEdited: false
+            }))
+          )
+        }
+
+        // 3. Insert sessions
+        for (let i = 0; i < this.preparedSessions.length; i += BATCH_SIZE) {
+          const batch = this.preparedSessions.slice(i, i + BATCH_SIZE)
+          await tx.insert(agentSessionTable).values(batch)
+          processed += batch.length
+        }
+
+        // 4. Insert messages
+        for (let i = 0; i < this.preparedMessages.length; i += BATCH_SIZE) {
+          const batch = this.preparedMessages.slice(i, i + BATCH_SIZE)
+          await tx.insert(messageTable).values(batch)
+          processed += batch.length
+        }
+      })
+
+      this.reportProgress(100, `Migrated ${processed} items`, {
+        key: 'migration.progress.migrated_agents',
+        params: {
+          agents: this.preparedAgents.length,
+          sessions: this.preparedSessions.length,
+          messages: this.preparedMessages.length
+        }
+      })
+
+      logger.info('Execute completed', { processedCount: processed })
+      return { success: true, processedCount: processed }
+    } catch (error) {
+      logger.error('Execute failed', error as Error)
+      return {
+        success: false,
+        processedCount: 0,
+        error: error instanceof Error ? error.message : String(error)
+      }
+    }
+  }
+
+  async validate(ctx: MigrationContext): Promise<ValidateResult> {
+    try {
+      const errors: { key: string; message: string }[] = []
+
+      const [agentCount, sessionCount, messageCount] = await Promise.all([
+        ctx.db.select({ count: sql<number>`count(*)` }).from(agentTable).get(),
+        ctx.db.select({ count: sql<number>`count(*)` }).from(agentSessionTable).get(),
+        ctx.db
+          .select({ count: sql<number>`count(*)` })
+          .from(messageTable)
+          .where(sql`${messageTable.agentSessionId} IS NOT NULL`)
+          .get()
+      ])
+
+      const actualAgents = agentCount?.count ?? 0
+      const actualSessions = sessionCount?.count ?? 0
+      const actualMessages = messageCount?.count ?? 0
+
+      if (actualAgents !== this.preparedAgents.length) {
+        errors.push({
+          key: 'agent_count_mismatch',
+          message: `Expected ${this.preparedAgents.length} agents but found ${actualAgents}`
+        })
+      }
+
+      if (actualSessions !== this.preparedSessions.length) {
+        errors.push({
+          key: 'session_count_mismatch',
+          message: `Expected ${this.preparedSessions.length} sessions but found ${actualSessions}`
+        })
+      }
+
+      if (actualMessages !== this.preparedMessages.length) {
+        errors.push({
+          key: 'message_count_mismatch',
+          message: `Expected ${this.preparedMessages.length} messages but found ${actualMessages}`
+        })
+      }
+
+      const totalSource = this.preparedAgents.length + this.preparedSessions.length + this.preparedMessages.length
+      const totalTarget = actualAgents + actualSessions + actualMessages
+
+      return {
+        success: errors.length === 0,
+        errors,
+        stats: {
+          sourceCount: totalSource,
+          targetCount: totalTarget,
+          skippedCount: this.skippedCount
+        }
+      }
+    } catch (error) {
+      logger.error('Validation failed', error as Error)
+      return {
+        success: false,
+        errors: [{ key: 'validation', message: error instanceof Error ? error.message : String(error) }],
+        stats: {
+          sourceCount: this.preparedAgents.length + this.preparedSessions.length + this.preparedMessages.length,
+          targetCount: 0,
+          skippedCount: this.skippedCount
+        }
+      }
+    }
+  }
+}

--- a/src/main/data/migration/v2/migrators/__tests__/AgentMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/AgentMigrator.test.ts
@@ -1,0 +1,337 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AgentMigrator } from '../AgentMigrator'
+
+// ============================================================================
+// Mock agents.db via libsql
+// ============================================================================
+
+const mockExecute = vi.fn()
+const mockClose = vi.fn()
+
+vi.mock('@libsql/client', () => ({
+  createClient: () => ({
+    execute: mockExecute,
+    close: mockClose
+  })
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/mock/userData'
+  }
+}))
+
+vi.mock('fs', () => ({
+  default: {
+    existsSync: vi.fn().mockReturnValue(true)
+  }
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn()
+    })
+  }
+}))
+
+// ============================================================================
+// Sample Data
+// ============================================================================
+
+const SAMPLE_AGENTS = [
+  {
+    id: 'agent-1',
+    type: 'claude-code',
+    name: 'Code Agent',
+    description: null,
+    model: 'claude-sonnet-4-6',
+    plan_model: null,
+    small_model: null,
+    accessible_paths: null,
+    instructions: null,
+    mcps: '["mcp-1"]',
+    allowed_tools: null,
+    configuration: null,
+    sort_order: 0,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z'
+  }
+]
+
+const SAMPLE_SESSIONS = [
+  {
+    id: 'session-1',
+    agent_id: 'agent-1',
+    agent_type: 'claude-code',
+    name: 'Session 1',
+    description: null,
+    model: 'claude-sonnet-4-6',
+    plan_model: null,
+    small_model: null,
+    accessible_paths: null,
+    instructions: null,
+    mcps: null,
+    allowed_tools: null,
+    slash_commands: null,
+    configuration: null,
+    sort_order: 0,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z'
+  }
+]
+
+const SAMPLE_MESSAGES = [
+  {
+    id: 1,
+    session_id: 'session-1',
+    role: 'user',
+    content: JSON.stringify({
+      message: { id: 'msg-1', role: 'user' },
+      blocks: [{ type: 'main_text', content: 'hello' }]
+    }),
+    agent_session_id: '',
+    metadata: null,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z'
+  },
+  {
+    id: 2,
+    session_id: 'session-1',
+    role: 'agent',
+    content: JSON.stringify({
+      message: { id: 'msg-2', role: 'agent' },
+      blocks: [{ type: 'main_text', content: 'hi there' }]
+    }),
+    agent_session_id: '',
+    metadata: null,
+    created_at: '2024-01-01T00:01:00Z',
+    updated_at: '2024-01-01T00:01:00Z'
+  }
+]
+
+function createMockContext() {
+  return {
+    sources: {
+      electronStore: { get: vi.fn() },
+      reduxState: { get: vi.fn() },
+      dexieExport: { readTable: vi.fn(), createStreamReader: vi.fn(), tableExists: vi.fn() },
+      dexieSettings: { keys: vi.fn().mockReturnValue([]), get: vi.fn() },
+      localStorage: { get: vi.fn() }
+    },
+    db: {
+      transaction: vi.fn(async (fn: (tx: any) => Promise<void>) => {
+        const tx = {
+          insert: vi.fn().mockReturnValue({
+            values: vi.fn().mockResolvedValue(undefined)
+          })
+        }
+        await fn(tx)
+        return tx
+      }),
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            get: vi.fn().mockResolvedValue({ count: 0 })
+          }),
+          get: vi.fn().mockResolvedValue({ count: 0 })
+        })
+      })
+    },
+    sharedData: new Map(),
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn()
+    }
+  }
+}
+
+function setupMockDb(agents = SAMPLE_AGENTS, sessions = SAMPLE_SESSIONS, messages = SAMPLE_MESSAGES) {
+  mockExecute.mockImplementation(async (sql: string) => {
+    if (sql.includes('FROM agents')) return { rows: agents }
+    if (sql.includes('FROM sessions')) return { rows: sessions }
+    if (sql.includes('FROM session_messages')) return { rows: messages }
+    return { rows: [] }
+  })
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('AgentMigrator', () => {
+  let migrator: AgentMigrator
+
+  beforeEach(() => {
+    migrator = new AgentMigrator()
+    migrator.setProgressCallback(vi.fn())
+    vi.clearAllMocks()
+  })
+
+  it('should have correct metadata', () => {
+    expect(migrator.id).toBe('agent')
+    expect(migrator.name).toBe('Agent')
+    expect(migrator.order).toBe(5)
+  })
+
+  describe('prepare', () => {
+    it('should count all items from agents.db', async () => {
+      setupMockDb()
+      const ctx = createMockContext()
+      const result = await migrator.prepare(ctx as any)
+
+      // 1 agent + 1 session + 2 messages = 4
+      expect(result.success).toBe(true)
+      expect(result.itemCount).toBe(4)
+    })
+
+    it('should handle missing agents.db', async () => {
+      const fs = await import('fs')
+      vi.mocked(fs.default.existsSync).mockReturnValue(false)
+
+      const ctx = createMockContext()
+      const result = await migrator.prepare(ctx as any)
+
+      expect(result.success).toBe(true)
+      expect(result.itemCount).toBe(0)
+      expect(result.warnings).toContain('agents.db not found, skipping')
+
+      vi.mocked(fs.default.existsSync).mockReturnValue(true)
+    })
+
+    it('should skip sessions with invalid agent FK', async () => {
+      const orphanSession = [{ ...SAMPLE_SESSIONS[0], agent_id: 'non-existent' }]
+      setupMockDb(SAMPLE_AGENTS, orphanSession, [])
+
+      const ctx = createMockContext()
+      const result = await migrator.prepare(ctx as any)
+
+      expect(result.success).toBe(true)
+      // 1 agent, 0 sessions (orphan skipped), 0 messages
+      expect(result.itemCount).toBe(1)
+      expect(result.warnings?.some((w) => w.includes('Skipped session'))).toBe(true)
+    })
+
+    it('should skip messages with invalid session FK', async () => {
+      const orphanMsg = [{ ...SAMPLE_MESSAGES[0], session_id: 'non-existent' }]
+      setupMockDb(SAMPLE_AGENTS, SAMPLE_SESSIONS, orphanMsg)
+
+      const ctx = createMockContext()
+      const result = await migrator.prepare(ctx as any)
+
+      expect(result.success).toBe(true)
+      // 1 agent + 1 session + 0 messages (orphan skipped)
+      expect(result.itemCount).toBe(2)
+    })
+
+    it('should map agent role to assistant', async () => {
+      setupMockDb()
+      const ctx = createMockContext()
+      await migrator.prepare(ctx as any)
+
+      // Access private field for verification (the 2nd message has role: 'agent')
+      // We verify via execute that it gets mapped correctly
+      const result = await migrator.execute(ctx as any)
+      expect(result.success).toBe(true)
+    })
+
+    it('should close legacy db even on error', async () => {
+      mockExecute.mockRejectedValue(new Error('DB_CORRUPT'))
+      const ctx = createMockContext()
+      const result = await migrator.prepare(ctx as any)
+
+      expect(result.success).toBe(false)
+      expect(mockClose).toHaveBeenCalled()
+    })
+  })
+
+  describe('execute', () => {
+    it('should insert all items in a transaction', async () => {
+      setupMockDb()
+      const ctx = createMockContext()
+      await migrator.prepare(ctx as any)
+      const result = await migrator.execute(ctx as any)
+
+      expect(result.success).toBe(true)
+      // 1 agent + 1 session + 2 messages = 4
+      expect(result.processedCount).toBe(4)
+      expect(ctx.db.transaction).toHaveBeenCalled()
+    })
+
+    it('should handle empty data gracefully', async () => {
+      setupMockDb([], [], [])
+      const ctx = createMockContext()
+      await migrator.prepare(ctx as any)
+      const result = await migrator.execute(ctx as any)
+
+      expect(result.success).toBe(true)
+      expect(result.processedCount).toBe(0)
+    })
+
+    it('should return failure when transaction throws', async () => {
+      setupMockDb()
+      const ctx = createMockContext()
+      ctx.db.transaction = vi.fn().mockRejectedValue(new Error('SQLITE_CONSTRAINT'))
+      await migrator.prepare(ctx as any)
+      const result = await migrator.execute(ctx as any)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('SQLITE_CONSTRAINT')
+    })
+  })
+
+  describe('validate', () => {
+    function mockValidateDb(
+      ctx: ReturnType<typeof createMockContext>,
+      counts: { agents: number; sessions: number; messages: number }
+    ) {
+      let callIndex = 0
+      ctx.db.select = vi.fn().mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            get: vi.fn().mockResolvedValue({ count: counts.messages })
+          }),
+          get: vi.fn().mockResolvedValue({ count: [counts.agents, counts.sessions][callIndex++] ?? 0 })
+        })
+      }))
+    }
+
+    it('should pass when all counts match', async () => {
+      setupMockDb()
+      const ctx = createMockContext()
+      await migrator.prepare(ctx as any)
+
+      mockValidateDb(ctx, { agents: 1, sessions: 1, messages: 2 })
+      const result = await migrator.validate(ctx as any)
+      expect(result.success).toBe(true)
+      expect(result.stats?.sourceCount).toBe(4)
+    })
+
+    it('should fail on count mismatch', async () => {
+      setupMockDb()
+      const ctx = createMockContext()
+      await migrator.prepare(ctx as any)
+
+      mockValidateDb(ctx, { agents: 0, sessions: 0, messages: 0 })
+      const result = await migrator.validate(ctx as any)
+      expect(result.success).toBe(false)
+      expect(result.errors.length).toBeGreaterThan(0)
+    })
+
+    it('should pass with zero items', async () => {
+      setupMockDb([], [], [])
+      const ctx = createMockContext()
+      await migrator.prepare(ctx as any)
+
+      mockValidateDb(ctx, { agents: 0, sessions: 0, messages: 0 })
+      const result = await migrator.validate(ctx as any)
+      expect(result.success).toBe(true)
+    })
+  })
+})

--- a/src/main/data/migration/v2/migrators/index.ts
+++ b/src/main/data/migration/v2/migrators/index.ts
@@ -5,6 +5,7 @@
 export { BaseMigrator } from './BaseMigrator'
 
 // Import all migrators
+import { AgentMigrator } from './AgentMigrator'
 import { AssistantMigrator } from './AssistantMigrator'
 import { BootConfigMigrator } from './BootConfigMigrator'
 import { ChatMigrator } from './ChatMigrator'
@@ -15,6 +16,7 @@ import { TranslateMigrator } from './TranslateMigrator'
 
 // Export migrator classes
 export {
+  AgentMigrator,
   AssistantMigrator,
   BootConfigMigrator,
   ChatMigrator,
@@ -34,6 +36,7 @@ export function getAllMigrators() {
     new McpServerMigrator(),
     new AssistantMigrator(),
     new KnowledgeMigrator(),
+    new AgentMigrator(),
     new ChatMigrator(),
     new TranslateMigrator()
   ]

--- a/src/main/data/migration/v2/migrators/mappings/AgentMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/AgentMappings.ts
@@ -1,0 +1,214 @@
+/**
+ * Agent migration mappings using Zod transform schemas
+ *
+ * Handles type conversions from legacy agents.db to v2 SQLite:
+ * - JSON string columns → typed JSON objects
+ * - snake_case → camelCase field renaming
+ * - Legacy MessageBlock[] → v2 MessageData
+ */
+
+import type { MessageData, MessageDataBlock } from '@shared/data/types/message'
+import * as z from 'zod'
+
+// ============================================================================
+// Reusable Transform Primitives
+// ============================================================================
+
+/**
+ * Parse a JSON string column. If invalid JSON, returns null.
+ * Legacy agents.db stores JSON as plain text without mode: 'json',
+ * so values come back as raw strings that need parsing.
+ */
+const jsonString = <T extends z.ZodTypeAny>(inner: T) =>
+  z.preprocess((val) => {
+    if (val === null || val === undefined) return null
+    if (typeof val !== 'string') return val
+    try {
+      return JSON.parse(val)
+    } catch {
+      return null
+    }
+  }, inner.nullable())
+
+// ============================================================================
+// Legacy Input Schemas
+// ============================================================================
+
+/**
+ * Legacy agents table row from agents.db.
+ * Uses .passthrough() to not fail on unknown columns.
+ */
+export const LegacyAgentRowSchema = z
+  .object({
+    id: z.string().min(1),
+    type: z.string().min(1),
+    name: z.string().min(1),
+    description: z.string().nullable().optional(),
+    model: z.string().min(1),
+    plan_model: z.string().nullable().optional(),
+    small_model: z.string().nullable().optional(),
+    accessible_paths: jsonString(z.array(z.string())),
+    instructions: jsonString(z.any()),
+    mcps: jsonString(z.array(z.string())),
+    allowed_tools: jsonString(z.array(z.string())),
+    configuration: jsonString(z.record(z.string(), z.unknown())),
+    sort_order: z.number().default(0),
+    created_at: z.string(),
+    updated_at: z.string()
+  })
+  .loose()
+
+/**
+ * Legacy sessions table row from agents.db.
+ */
+export const LegacySessionRowSchema = z
+  .object({
+    id: z.string().min(1),
+    agent_id: z.string().min(1),
+    agent_type: z.string().min(1),
+    name: z.string().min(1),
+    description: z.string().nullable().optional(),
+    model: z.string().min(1),
+    plan_model: z.string().nullable().optional(),
+    small_model: z.string().nullable().optional(),
+    accessible_paths: jsonString(z.array(z.string())),
+    instructions: jsonString(z.any()),
+    mcps: jsonString(z.array(z.string())),
+    allowed_tools: jsonString(z.array(z.string())),
+    slash_commands: jsonString(z.array(z.unknown())),
+    configuration: jsonString(z.record(z.string(), z.unknown())),
+    sort_order: z.number().default(0),
+    created_at: z.string(),
+    updated_at: z.string()
+  })
+  .loose()
+
+/**
+ * Structure inside legacy session_messages.content JSON blob.
+ */
+const LegacyPersistedMessageSchema = z.object({
+  message: z
+    .object({
+      id: z.string(),
+      role: z.string()
+    })
+    .loose(),
+  blocks: z
+    .array(
+      z
+        .object({
+          type: z.string()
+        })
+        .loose()
+    )
+    .default([])
+})
+
+/**
+ * Legacy session_messages table row from agents.db.
+ */
+export const LegacyMessageRowSchema = z
+  .object({
+    id: z.number(),
+    session_id: z.string().min(1),
+    role: z.string(),
+    content: jsonString(LegacyPersistedMessageSchema),
+    agent_session_id: z.string().default(''),
+    metadata: jsonString(z.record(z.string(), z.unknown())),
+    created_at: z.string(),
+    updated_at: z.string()
+  })
+  .loose()
+
+export type LegacyAgentRow = z.infer<typeof LegacyAgentRowSchema>
+export type LegacySessionRow = z.infer<typeof LegacySessionRowSchema>
+export type LegacyMessageRow = z.infer<typeof LegacyMessageRowSchema>
+
+// ============================================================================
+// Transform Schemas
+// ============================================================================
+
+/**
+ * Agent transform: legacy row → new table insert values.
+ *
+ * Key conversions:
+ * - snake_case → camelCase (plan_model → planModel)
+ * - JSON strings → parsed objects (via jsonString preprocess)
+ * - Preserves original ID for migration stability
+ */
+export const AgentTransformSchema = LegacyAgentRowSchema.transform((old) => ({
+  id: old.id,
+  type: old.type,
+  name: old.name,
+  description: old.description ?? null,
+  model: old.model,
+  planModel: old.plan_model ?? null,
+  smallModel: old.small_model ?? null,
+  accessiblePaths: old.accessible_paths ?? null,
+  instructions: old.instructions ?? null,
+  mcps: old.mcps ?? null,
+  allowedTools: old.allowed_tools ?? null,
+  configuration: old.configuration ?? null,
+  sortOrder: old.sort_order
+}))
+
+/**
+ * Session transform: legacy row → new table insert values.
+ * Additional: agent_id → agentId, agent_type → agentType
+ */
+export const SessionTransformSchema = LegacySessionRowSchema.transform((old) => ({
+  id: old.id,
+  agentId: old.agent_id,
+  agentType: old.agent_type,
+  name: old.name,
+  description: old.description ?? null,
+  model: old.model,
+  planModel: old.plan_model ?? null,
+  smallModel: old.small_model ?? null,
+  accessiblePaths: old.accessible_paths ?? null,
+  instructions: old.instructions ?? null,
+  mcps: old.mcps ?? null,
+  allowedTools: old.allowed_tools ?? null,
+  slashCommands: old.slash_commands ?? null,
+  configuration: old.configuration ?? null,
+  sortOrder: old.sort_order
+}))
+
+// ============================================================================
+// Block Transform (pure function)
+// ============================================================================
+
+/**
+ * Convert legacy MessageBlock[] to v2 MessageData.
+ * Filters out invalid blocks (null, undefined, missing type).
+ * Preserves all block-specific fields via spread.
+ */
+export function transformBlocksToMessageData(legacyBlocks: unknown[]): MessageData {
+  const blocks = legacyBlocks
+    .filter((b): b is Record<string, unknown> => b != null && typeof b === 'object' && 'type' in b && !!b.type)
+    .map((b) => ({ ...b }) as unknown as MessageDataBlock)
+
+  return { blocks }
+}
+
+// ============================================================================
+// FK Validation Helpers (used in Migrator.prepare)
+// ============================================================================
+
+/**
+ * Create a session transform that validates agentId FK exists.
+ */
+export const makeSessionTransformWithFkCheck = (validAgentIds: Set<string>) =>
+  SessionTransformSchema.refine((session) => validAgentIds.has(session.agentId), {
+    message: 'Referenced agent not found',
+    path: ['agentId']
+  })
+
+/**
+ * Create a message row parser that validates sessionId FK exists.
+ */
+export const makeMessageRowWithFkCheck = (validSessionIds: Set<string>) =>
+  LegacyMessageRowSchema.refine((msg) => validSessionIds.has(msg.session_id), {
+    message: 'Referenced session not found',
+    path: ['session_id']
+  })

--- a/src/main/data/migration/v2/migrators/mappings/__tests__/AgentMappings.test.ts
+++ b/src/main/data/migration/v2/migrators/mappings/__tests__/AgentMappings.test.ts
@@ -1,0 +1,350 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  AgentTransformSchema,
+  LegacyMessageRowSchema,
+  SessionTransformSchema,
+  transformBlocksToMessageData
+} from '../AgentMappings'
+
+// ============================================================================
+// Agent Transform
+// ============================================================================
+
+describe('AgentTransformSchema', () => {
+  const validAgent = {
+    id: 'agent-1',
+    type: 'claude-code',
+    name: 'Test Agent',
+    description: 'A test agent',
+    model: 'claude-sonnet-4-6',
+    plan_model: 'claude-opus-4-6',
+    small_model: 'claude-haiku-4-5-20251001',
+    accessible_paths: '["/Users/test/project"]',
+    instructions: '{"key":"value"}',
+    mcps: '["mcp-1","mcp-2"]',
+    allowed_tools: '["tool-a"]',
+    configuration: '{"avatar":"🤖"}',
+    sort_order: 3,
+    created_at: '2025-01-01T00:00:00.000Z',
+    updated_at: '2025-06-01T00:00:00.000Z'
+  }
+
+  it('should transform a complete agent row', () => {
+    const result = AgentTransformSchema.safeParse(validAgent)
+    expect(result.success).toBe(true)
+    if (!result.success) return
+
+    expect(result.data).toStrictEqual({
+      id: 'agent-1',
+      type: 'claude-code',
+      name: 'Test Agent',
+      description: 'A test agent',
+      model: 'claude-sonnet-4-6',
+      planModel: 'claude-opus-4-6',
+      smallModel: 'claude-haiku-4-5-20251001',
+      accessiblePaths: ['/Users/test/project'],
+      instructions: { key: 'value' },
+      mcps: ['mcp-1', 'mcp-2'],
+      allowedTools: ['tool-a'],
+      configuration: { avatar: '🤖' },
+      sortOrder: 3
+    })
+  })
+
+  it('should handle minimal agent (only required fields)', () => {
+    const result = AgentTransformSchema.safeParse({
+      id: 'agent-2',
+      type: 'claude-code',
+      name: 'Minimal',
+      model: 'claude-sonnet-4-6',
+      sort_order: 0,
+      created_at: '2025-01-01T00:00:00.000Z',
+      updated_at: '2025-01-01T00:00:00.000Z'
+    })
+    expect(result.success).toBe(true)
+    if (!result.success) return
+
+    expect(result.data.planModel).toBeNull()
+    expect(result.data.smallModel).toBeNull()
+    expect(result.data.mcps).toBeNull()
+    expect(result.data.allowedTools).toBeNull()
+    expect(result.data.configuration).toBeNull()
+    expect(result.data.accessiblePaths).toBeNull()
+    expect(result.data.instructions).toBeNull()
+  })
+
+  it('should parse JSON string fields', () => {
+    const result = AgentTransformSchema.safeParse({
+      ...validAgent,
+      mcps: '["a","b","c"]'
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.mcps).toEqual(['a', 'b', 'c'])
+    }
+  })
+
+  it('should handle already-parsed JSON fields', () => {
+    const result = AgentTransformSchema.safeParse({
+      ...validAgent,
+      mcps: ['already', 'parsed']
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.mcps).toEqual(['already', 'parsed'])
+    }
+  })
+
+  it('should handle malformed JSON gracefully', () => {
+    const result = AgentTransformSchema.safeParse({
+      ...validAgent,
+      mcps: '{broken json'
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.mcps).toBeNull()
+    }
+  })
+
+  it('should handle null optional fields', () => {
+    const result = AgentTransformSchema.safeParse({
+      ...validAgent,
+      description: null,
+      plan_model: null,
+      small_model: null,
+      accessible_paths: null,
+      instructions: null,
+      mcps: null,
+      allowed_tools: null,
+      configuration: null
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.description).toBeNull()
+      expect(result.data.planModel).toBeNull()
+      expect(result.data.mcps).toBeNull()
+    }
+  })
+
+  it('should reject missing required fields', () => {
+    expect(AgentTransformSchema.safeParse({ id: 'x' }).success).toBe(false)
+    expect(AgentTransformSchema.safeParse({ id: 'x', type: 'claude-code' }).success).toBe(false)
+    expect(AgentTransformSchema.safeParse({ id: 'x', type: 'claude-code', name: 'y' }).success).toBe(false)
+  })
+
+  it('should reject empty id', () => {
+    expect(AgentTransformSchema.safeParse({ ...validAgent, id: '' }).success).toBe(false)
+  })
+
+  it('should pass through unknown fields without error', () => {
+    const result = AgentTransformSchema.safeParse({
+      ...validAgent,
+      unknown_field: 'should not break'
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('should default sort_order to 0 when missing', () => {
+    const { sort_order: _, ...withoutSort } = validAgent
+    const result = AgentTransformSchema.safeParse(withoutSort)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.sortOrder).toBe(0)
+    }
+  })
+})
+
+// ============================================================================
+// Session Transform
+// ============================================================================
+
+describe('SessionTransformSchema', () => {
+  const validSession = {
+    id: 'session-1',
+    agent_id: 'agent-1',
+    agent_type: 'claude-code',
+    name: 'Test Session',
+    description: null,
+    model: 'claude-sonnet-4-6',
+    plan_model: null,
+    small_model: null,
+    accessible_paths: null,
+    instructions: null,
+    mcps: null,
+    allowed_tools: null,
+    slash_commands: '[{"command":"/help"}]',
+    configuration: null,
+    sort_order: 0,
+    created_at: '2025-01-01T00:00:00.000Z',
+    updated_at: '2025-01-01T00:00:00.000Z'
+  }
+
+  it('should transform a session row with snake_case → camelCase', () => {
+    const result = SessionTransformSchema.safeParse(validSession)
+    expect(result.success).toBe(true)
+    if (!result.success) return
+
+    expect(result.data.id).toBe('session-1')
+    expect(result.data.agentId).toBe('agent-1')
+    expect(result.data.agentType).toBe('claude-code')
+    expect(result.data.slashCommands).toEqual([{ command: '/help' }])
+  })
+
+  it('should parse slash_commands JSON string', () => {
+    const result = SessionTransformSchema.safeParse({
+      ...validSession,
+      slash_commands: '[{"command":"/status"},{"command":"/help"}]'
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.slashCommands).toHaveLength(2)
+    }
+  })
+
+  it('should reject missing agent_id', () => {
+    const { agent_id: _, ...noAgentId } = validSession
+    expect(SessionTransformSchema.safeParse(noAgentId).success).toBe(false)
+  })
+})
+
+// ============================================================================
+// Message Row Schema
+// ============================================================================
+
+describe('LegacyMessageRowSchema', () => {
+  it('should parse a message row with JSON content string', () => {
+    const row = {
+      id: 1,
+      session_id: 'session-1',
+      role: 'user',
+      content: JSON.stringify({
+        message: { id: 'msg-1', role: 'user', content: 'Hello' },
+        blocks: [{ type: 'main_text', content: 'Hello', createdAt: 1700000000000 }]
+      }),
+      agent_session_id: 'sdk-session-1',
+      metadata: null,
+      created_at: '2025-01-01T00:00:00.000Z',
+      updated_at: '2025-01-01T00:00:00.000Z'
+    }
+
+    const result = LegacyMessageRowSchema.safeParse(row)
+    expect(result.success).toBe(true)
+    if (!result.success) return
+
+    expect(result.data.content?.message.id).toBe('msg-1')
+    expect(result.data.content?.blocks).toHaveLength(1)
+    expect(result.data.content?.blocks[0].type).toBe('main_text')
+  })
+
+  it('should handle null content gracefully', () => {
+    const row = {
+      id: 2,
+      session_id: 'session-1',
+      role: 'assistant',
+      content: null,
+      agent_session_id: '',
+      created_at: '2025-01-01T00:00:00.000Z',
+      updated_at: '2025-01-01T00:00:00.000Z'
+    }
+
+    const result = LegacyMessageRowSchema.safeParse(row)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.content).toBeNull()
+    }
+  })
+
+  it('should handle malformed content JSON', () => {
+    const row = {
+      id: 3,
+      session_id: 'session-1',
+      role: 'user',
+      content: '{not valid json',
+      agent_session_id: '',
+      created_at: '2025-01-01T00:00:00.000Z',
+      updated_at: '2025-01-01T00:00:00.000Z'
+    }
+
+    const result = LegacyMessageRowSchema.safeParse(row)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.content).toBeNull()
+    }
+  })
+
+  it('should default agent_session_id to empty string', () => {
+    const row = {
+      id: 4,
+      session_id: 'session-1',
+      role: 'user',
+      content: null,
+      created_at: '2025-01-01T00:00:00.000Z',
+      updated_at: '2025-01-01T00:00:00.000Z'
+    }
+
+    const result = LegacyMessageRowSchema.safeParse(row)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.agent_session_id).toBe('')
+    }
+  })
+})
+
+// ============================================================================
+// Block Transform
+// ============================================================================
+
+describe('transformBlocksToMessageData', () => {
+  it('should convert legacy blocks to MessageData format', () => {
+    const blocks = [
+      { type: 'main_text', content: 'Hello world', createdAt: 1700000000000 },
+      { type: 'thinking', content: 'Let me think...', createdAt: 1700000000001, thinkingMs: 500 }
+    ]
+
+    const result = transformBlocksToMessageData(blocks)
+
+    expect(result.blocks).toHaveLength(2)
+    expect(result.blocks[0].type).toBe('main_text')
+    expect(result.blocks[0]).toHaveProperty('content', 'Hello world')
+    expect(result.blocks[1].type).toBe('thinking')
+  })
+
+  it('should handle empty blocks array', () => {
+    const result = transformBlocksToMessageData([])
+    expect(result.blocks).toEqual([])
+  })
+
+  it('should filter out blocks without type', () => {
+    const blocks = [
+      { type: 'main_text', content: 'valid', createdAt: 1700000000000 },
+      { content: 'no type field' },
+      null,
+      undefined,
+      { type: 'thinking', content: 'also valid', createdAt: 1700000000001, thinkingMs: 100 }
+    ]
+
+    const result = transformBlocksToMessageData(blocks as any[])
+    expect(result.blocks).toHaveLength(2)
+  })
+
+  it('should preserve all block-specific fields', () => {
+    const blocks = [
+      {
+        type: 'tool',
+        toolId: 'tool-1',
+        toolName: 'Read',
+        arguments: { path: '/foo' },
+        content: 'file contents',
+        createdAt: 1700000000000
+      }
+    ]
+
+    const result = transformBlocksToMessageData(blocks)
+    expect(result.blocks).toHaveLength(1)
+    const block = result.blocks[0]
+    expect(block.type).toBe('tool')
+    expect(block).toHaveProperty('toolId', 'tool-1')
+    expect(block).toHaveProperty('toolName', 'Read')
+  })
+})

--- a/src/main/data/services/AgentDataService.ts
+++ b/src/main/data/services/AgentDataService.ts
@@ -1,0 +1,252 @@
+/**
+ * Agent Data Service - handles agent and session CRUD operations
+ *
+ * Provides business logic for:
+ * - Agent CRUD with soft delete
+ * - Session CRUD (auto-creates topic, snapshots agent config)
+ * - Session messages retrieval (via topic FK)
+ */
+
+import { agentTable } from '@data/db/schemas/agent'
+import { agentSessionTable } from '@data/db/schemas/agentSession'
+import { messageTable } from '@data/db/schemas/message'
+import { topicTable } from '@data/db/schemas/topic'
+import { loggerService } from '@logger'
+import { application } from '@main/core/application'
+import { DataApiErrorFactory } from '@shared/data/api'
+import type { CreateAgentDto, CreateAgentSessionDto, UpdateAgentDto } from '@shared/data/api/schemas/agents'
+import type { Agent, AgentSession } from '@shared/data/types/agent'
+import type { Message } from '@shared/data/types/message'
+import { and, asc, eq, isNull, sql } from 'drizzle-orm'
+
+const logger = loggerService.withContext('DataApi:AgentDataService')
+
+function stripNulls<T extends Record<string, unknown>>(obj: T): { [K in keyof T]: Exclude<T[K], null> } {
+  const result = {} as Record<string, unknown>
+  for (const [key, value] of Object.entries(obj)) {
+    result[key] = value === null ? undefined : value
+  }
+  return result as { [K in keyof T]: Exclude<T[K], null> }
+}
+
+function rowToAgent(row: typeof agentTable.$inferSelect): Agent {
+  const clean = stripNulls(row)
+  return {
+    ...clean,
+    type: clean.type as Agent['type'],
+    createdAt: row.createdAt ? new Date(row.createdAt).toISOString() : new Date().toISOString(),
+    updatedAt: row.updatedAt ? new Date(row.updatedAt).toISOString() : new Date().toISOString()
+  }
+}
+
+function rowToSession(row: typeof agentSessionTable.$inferSelect): AgentSession {
+  const clean = stripNulls(row)
+  return {
+    ...clean,
+    agentType: clean.agentType as AgentSession['agentType'],
+    createdAt: row.createdAt ? new Date(row.createdAt).toISOString() : new Date().toISOString(),
+    updatedAt: row.updatedAt ? new Date(row.updatedAt).toISOString() : new Date().toISOString()
+  }
+}
+
+function rowToMessage(row: typeof messageTable.$inferSelect): Message {
+  const clean = stripNulls(row)
+  return {
+    ...clean,
+    role: clean.role as Message['role'],
+    status: clean.status as Message['status'],
+    createdAt: row.createdAt ? new Date(row.createdAt).toISOString() : new Date().toISOString(),
+    updatedAt: row.updatedAt ? new Date(row.updatedAt).toISOString() : new Date().toISOString()
+  }
+}
+
+export class AgentDataService {
+  private get db() {
+    return application.get('DbService').getDb()
+  }
+
+  // ── Agent CRUD ──────────────────────────────────────
+
+  async getAgent(id: string): Promise<Agent> {
+    const [row] = await this.db
+      .select()
+      .from(agentTable)
+      .where(and(eq(agentTable.id, id), isNull(agentTable.deletedAt)))
+      .limit(1)
+
+    if (!row) {
+      throw DataApiErrorFactory.notFound('Agent', id)
+    }
+
+    return rowToAgent(row)
+  }
+
+  async listAgents(query?: { page?: number; limit?: number; type?: string }) {
+    const page = query?.page ?? 1
+    const limit = query?.limit ?? 50
+    const offset = (page - 1) * limit
+
+    const conditions = [isNull(agentTable.deletedAt)]
+    if (query?.type) {
+      conditions.push(eq(agentTable.type, query.type))
+    }
+
+    const [rows, [countRow]] = await Promise.all([
+      this.db
+        .select()
+        .from(agentTable)
+        .where(and(...conditions))
+        .orderBy(asc(agentTable.sortOrder))
+        .limit(limit)
+        .offset(offset),
+      this.db
+        .select({ count: sql<number>`count(*)` })
+        .from(agentTable)
+        .where(and(...conditions))
+    ])
+
+    return { items: rows.map(rowToAgent), total: countRow?.count ?? 0, page }
+  }
+
+  async createAgent(dto: CreateAgentDto): Promise<Agent> {
+    const [row] = await this.db.insert(agentTable).values(dto).returning()
+    logger.info('Created agent', { id: row.id, name: row.name })
+    return rowToAgent(row)
+  }
+
+  async updateAgent(id: string, dto: UpdateAgentDto): Promise<Agent> {
+    await this.getAgent(id)
+
+    const [row] = await this.db.update(agentTable).set(dto).where(eq(agentTable.id, id)).returning()
+
+    logger.info('Updated agent', { id, changes: Object.keys(dto) })
+    return rowToAgent(row)
+  }
+
+  async deleteAgent(id: string): Promise<void> {
+    await this.getAgent(id)
+
+    // Soft delete
+    await this.db.update(agentTable).set({ deletedAt: Date.now() }).where(eq(agentTable.id, id))
+
+    logger.info('Soft-deleted agent', { id })
+  }
+
+  async reorderAgents(orderedIds: string[]): Promise<void> {
+    await this.db.transaction(async (tx) => {
+      for (let i = 0; i < orderedIds.length; i++) {
+        await tx.update(agentTable).set({ sortOrder: i }).where(eq(agentTable.id, orderedIds[i]))
+      }
+    })
+    logger.info('Reordered agents', { count: orderedIds.length })
+  }
+
+  // ── Session CRUD ────────────────────────────────────
+
+  async getSession(agentId: string, id: string): Promise<AgentSession> {
+    const [row] = await this.db.select().from(agentSessionTable).where(eq(agentSessionTable.id, id)).limit(1)
+
+    if (!row || row.agentId !== agentId) {
+      throw DataApiErrorFactory.notFound('AgentSession', id)
+    }
+
+    return rowToSession(row)
+  }
+
+  async listSessions(agentId: string, query?: { page?: number; limit?: number }) {
+    const page = query?.page ?? 1
+    const limit = query?.limit ?? 50
+    const offset = (page - 1) * limit
+
+    const [rows, [countRow]] = await Promise.all([
+      this.db
+        .select()
+        .from(agentSessionTable)
+        .where(eq(agentSessionTable.agentId, agentId))
+        .orderBy(asc(agentSessionTable.sortOrder))
+        .limit(limit)
+        .offset(offset),
+      this.db
+        .select({ count: sql<number>`count(*)` })
+        .from(agentSessionTable)
+        .where(eq(agentSessionTable.agentId, agentId))
+    ])
+
+    return { items: rows.map(rowToSession), total: countRow?.count ?? 0, page }
+  }
+
+  async createSession(agentId: string, dto: CreateAgentSessionDto): Promise<AgentSession> {
+    const agent = await this.getAgent(agentId)
+
+    return await this.db.transaction(async (tx) => {
+      // 1. Create topic (message container)
+      const [topic] = await tx
+        .insert(topicTable)
+        .values({
+          name: agent.name,
+          sourceType: 'agent',
+          assistantId: null
+        })
+        .returning()
+
+      // 2. Create session (config snapshot from agent)
+      const [session] = await tx
+        .insert(agentSessionTable)
+        .values({
+          agentId,
+          agentType: agent.type,
+          topicId: topic.id,
+          model: dto.model ?? agent.model,
+          planModel: dto.planModel ?? agent.planModel ?? null,
+          smallModel: dto.smallModel ?? agent.smallModel ?? null,
+          accessiblePaths: dto.accessiblePaths ?? agent.accessiblePaths ?? null,
+          instructions: dto.instructions ?? agent.instructions ?? null,
+          mcps: dto.mcps ?? agent.mcps ?? null,
+          allowedTools: dto.allowedTools ?? agent.allowedTools ?? null,
+          slashCommands: dto.slashCommands ?? null,
+          configuration: dto.configuration ?? agent.configuration ?? null
+        })
+        .returning()
+
+      logger.info('Created session', { id: session.id, agentId, topicId: topic.id })
+      return rowToSession(session)
+    })
+  }
+
+  async deleteSession(agentId: string, id: string): Promise<void> {
+    const session = await this.getSession(agentId, id)
+
+    // Delete session (CASCADE to topic → CASCADE to messages)
+    await this.db.delete(agentSessionTable).where(eq(agentSessionTable.id, session.id))
+
+    logger.info('Deleted session', { id })
+  }
+
+  async reorderSessions(agentId: string, orderedIds: string[]): Promise<void> {
+    await this.db.transaction(async (tx) => {
+      for (let i = 0; i < orderedIds.length; i++) {
+        await tx
+          .update(agentSessionTable)
+          .set({ sortOrder: i })
+          .where(and(eq(agentSessionTable.id, orderedIds[i]), eq(agentSessionTable.agentId, agentId)))
+      }
+    })
+    logger.info('Reordered sessions', { agentId, count: orderedIds.length })
+  }
+
+  // ── Messages (via topic) ────────────────────────────
+
+  async getSessionMessages(agentId: string, sessionId: string): Promise<Message[]> {
+    const session = await this.getSession(agentId, sessionId)
+
+    const rows = await this.db
+      .select()
+      .from(messageTable)
+      .where(eq(messageTable.topicId, session.topicId))
+      .orderBy(asc(messageTable.createdAt))
+
+    return rows.map(rowToMessage)
+  }
+}
+
+export const agentDataService = new AgentDataService()

--- a/src/main/data/services/__tests__/AgentDataService.test.ts
+++ b/src/main/data/services/__tests__/AgentDataService.test.ts
@@ -1,0 +1,338 @@
+import { DataApiError, ErrorCode } from '@shared/data/api'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AgentDataService, agentDataService } from '../AgentDataService'
+
+// ============================================================================
+// DB Mock Helpers
+// ============================================================================
+
+function createMockAgentRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'agent-1',
+    type: 'claude-code',
+    name: 'Test Agent',
+    description: null,
+    model: 'claude-sonnet-4-6',
+    planModel: null,
+    smallModel: null,
+    accessiblePaths: null,
+    instructions: null,
+    mcps: null,
+    allowedTools: null,
+    configuration: null,
+    sortOrder: 0,
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+    deletedAt: null,
+    ...overrides
+  }
+}
+
+function createMockSessionRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'session-1',
+    agentId: 'agent-1',
+    agentType: 'claude-code',
+    topicId: 'topic-1',
+    name: 'Test Session',
+    description: null,
+    model: 'claude-sonnet-4-6',
+    planModel: null,
+    smallModel: null,
+    accessiblePaths: null,
+    instructions: null,
+    mcps: null,
+    allowedTools: null,
+    slashCommands: null,
+    configuration: null,
+    sdkSessionId: null,
+    sortOrder: 0,
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+    ...overrides
+  }
+}
+
+function createMockMessageRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'msg-1',
+    parentId: null,
+    topicId: 'topic-1',
+    role: 'user',
+    data: { blocks: [{ type: 'main_text', content: 'hello' }] },
+    searchableText: null,
+    status: 'success',
+    siblingsGroupId: 0,
+    assistantId: null,
+    assistantMeta: null,
+    modelId: null,
+    modelMeta: null,
+    traceId: null,
+    stats: null,
+    agentSessionId: 'session-1',
+    agentSnapshot: null,
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+    deletedAt: null,
+    ...overrides
+  }
+}
+
+function mockChain(resolvedValue: unknown) {
+  const thenable = {
+    then: (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) => {
+      return Promise.resolve(resolvedValue).then(resolve, reject)
+    }
+  }
+
+  const chain: any = new Proxy(thenable, {
+    get(target, prop) {
+      if (prop === 'then') return target.then
+      if (prop === 'catch' || prop === 'finally') {
+        return (...args: unknown[]) => Promise.resolve(resolvedValue)[prop as 'catch'](...(args as [any]))
+      }
+      return () => chain
+    }
+  })
+
+  return chain
+}
+
+let mockDb: any
+
+vi.mock('@main/core/application', async () => {
+  const { mockApplicationFactory } = await import('@test-mocks/main/application')
+  return mockApplicationFactory({
+    DbService: { getDb: () => mockDb }
+  })
+})
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn()
+    })
+  }
+}))
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('AgentDataService', () => {
+  beforeEach(() => {
+    mockDb = {
+      select: vi.fn(),
+      insert: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      transaction: vi.fn()
+    }
+  })
+
+  it('should export a module-level singleton', () => {
+    expect(agentDataService).toBeInstanceOf(AgentDataService)
+  })
+
+  // --------------------------------------------------------------------------
+  // Agent CRUD
+  // --------------------------------------------------------------------------
+  describe('getAgent', () => {
+    it('should return an agent when found', async () => {
+      const row = createMockAgentRow()
+      mockDb.select.mockReturnValue(mockChain([row]))
+
+      const result = await agentDataService.getAgent('agent-1')
+      expect(result.id).toBe('agent-1')
+      expect(result.name).toBe('Test Agent')
+      expect(result.type).toBe('claude-code')
+      expect(typeof result.createdAt).toBe('string')
+    })
+
+    it('should throw NOT_FOUND when agent does not exist', async () => {
+      mockDb.select.mockReturnValue(mockChain([]))
+
+      await expect(agentDataService.getAgent('non-existent')).rejects.toThrow(DataApiError)
+      await expect(agentDataService.getAgent('non-existent')).rejects.toMatchObject({
+        code: ErrorCode.NOT_FOUND
+      })
+    })
+  })
+
+  describe('listAgents', () => {
+    it('should return all agents', async () => {
+      const rows = [createMockAgentRow(), createMockAgentRow({ id: 'agent-2', name: 'Second' })]
+      mockDb.select.mockReturnValueOnce(mockChain(rows)).mockReturnValueOnce(mockChain([{ count: 2 }]))
+
+      const result = await agentDataService.listAgents()
+      expect(result.items).toHaveLength(2)
+      expect(result.total).toBe(2)
+    })
+
+    it('should filter by type', async () => {
+      const rows = [createMockAgentRow()]
+      mockDb.select.mockReturnValueOnce(mockChain(rows)).mockReturnValueOnce(mockChain([{ count: 1 }]))
+
+      const result = await agentDataService.listAgents({ type: 'claude-code' })
+      expect(result.items).toHaveLength(1)
+    })
+  })
+
+  describe('createAgent', () => {
+    it('should create and return agent', async () => {
+      const row = createMockAgentRow()
+      mockDb.insert.mockReturnValue(mockChain([row]))
+
+      const result = await agentDataService.createAgent({
+        type: 'claude-code',
+        name: 'Test Agent',
+        model: 'claude-sonnet-4-6'
+      })
+      expect(result.id).toBe('agent-1')
+      expect(result.name).toBe('Test Agent')
+    })
+  })
+
+  describe('updateAgent', () => {
+    it('should update and return agent', async () => {
+      const existing = createMockAgentRow()
+      const updated = createMockAgentRow({ name: 'Updated' })
+      mockDb.select.mockReturnValue(mockChain([existing]))
+      mockDb.update.mockReturnValue(mockChain([updated]))
+
+      const result = await agentDataService.updateAgent('agent-1', { name: 'Updated' })
+      expect(result.name).toBe('Updated')
+    })
+
+    it('should throw NOT_FOUND when updating non-existent agent', async () => {
+      mockDb.select.mockReturnValue(mockChain([]))
+
+      await expect(agentDataService.updateAgent('non-existent', { name: 'x' })).rejects.toMatchObject({
+        code: ErrorCode.NOT_FOUND
+      })
+    })
+  })
+
+  describe('deleteAgent', () => {
+    it('should soft-delete an existing agent', async () => {
+      const existing = createMockAgentRow()
+      mockDb.select.mockReturnValue(mockChain([existing]))
+      mockDb.update.mockReturnValue(mockChain(undefined))
+
+      await expect(agentDataService.deleteAgent('agent-1')).resolves.toBeUndefined()
+    })
+
+    it('should throw NOT_FOUND when deleting non-existent agent', async () => {
+      mockDb.select.mockReturnValue(mockChain([]))
+
+      await expect(agentDataService.deleteAgent('non-existent')).rejects.toMatchObject({
+        code: ErrorCode.NOT_FOUND
+      })
+    })
+  })
+
+  describe('reorderAgents', () => {
+    it('should update sortOrder in a transaction', async () => {
+      const txUpdate = vi.fn().mockReturnValue(mockChain(undefined))
+      mockDb.transaction = vi.fn().mockImplementation(async (fn: (tx: any) => Promise<void>) => {
+        await fn({ update: txUpdate })
+      })
+
+      await agentDataService.reorderAgents(['a-1', 'a-2', 'a-3'])
+
+      expect(mockDb.transaction).toHaveBeenCalledOnce()
+      expect(txUpdate).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Session CRUD
+  // --------------------------------------------------------------------------
+  describe('getSession', () => {
+    it('should return a session when found', async () => {
+      const row = createMockSessionRow()
+      mockDb.select.mockReturnValue(mockChain([row]))
+
+      const result = await agentDataService.getSession('agent-1', 'session-1')
+      expect(result.id).toBe('session-1')
+      expect(result.agentId).toBe('agent-1')
+    })
+
+    it('should throw NOT_FOUND when session does not exist', async () => {
+      mockDb.select.mockReturnValue(mockChain([]))
+
+      await expect(agentDataService.getSession('agent-1', 'non-existent')).rejects.toMatchObject({
+        code: ErrorCode.NOT_FOUND
+      })
+    })
+
+    it('should throw NOT_FOUND when session belongs to different agent', async () => {
+      const row = createMockSessionRow({ agentId: 'other-agent' })
+      mockDb.select.mockReturnValue(mockChain([row]))
+
+      await expect(agentDataService.getSession('agent-1', 'session-1')).rejects.toMatchObject({
+        code: ErrorCode.NOT_FOUND
+      })
+    })
+  })
+
+  describe('createSession', () => {
+    it('should create topic and session in a transaction', async () => {
+      const agentRow = createMockAgentRow()
+      const topicRow = { id: 'topic-new', name: 'Test Agent', sourceType: 'agent' }
+      const sessionRow = createMockSessionRow({ topicId: 'topic-new' })
+
+      // getAgent call
+      mockDb.select.mockReturnValue(mockChain([agentRow]))
+
+      const txInsert = vi
+        .fn()
+        .mockReturnValueOnce(mockChain([topicRow])) // topic insert
+        .mockReturnValueOnce(mockChain([sessionRow])) // session insert
+
+      mockDb.transaction = vi.fn().mockImplementation(async (fn: (tx: any) => Promise<unknown>) => {
+        return await fn({ insert: txInsert })
+      })
+
+      const result = await agentDataService.createSession('agent-1', {
+        model: 'claude-sonnet-4-6'
+      })
+
+      expect(mockDb.transaction).toHaveBeenCalledOnce()
+      expect(txInsert).toHaveBeenCalledTimes(2) // topic + session
+      expect(result.id).toBe('session-1')
+    })
+  })
+
+  describe('deleteSession', () => {
+    it('should delete session', async () => {
+      const sessionRow = createMockSessionRow()
+      mockDb.select.mockReturnValue(mockChain([sessionRow]))
+      mockDb.delete.mockReturnValue(mockChain(undefined))
+
+      await expect(agentDataService.deleteSession('agent-1', 'session-1')).resolves.toBeUndefined()
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Messages
+  // --------------------------------------------------------------------------
+  describe('getSessionMessages', () => {
+    it('should return messages via topic', async () => {
+      const sessionRow = createMockSessionRow()
+      const msgRows = [createMockMessageRow(), createMockMessageRow({ id: 'msg-2', role: 'assistant' })]
+
+      // getSession call, then messages query
+      mockDb.select.mockReturnValueOnce(mockChain([sessionRow])).mockReturnValueOnce(mockChain(msgRows))
+
+      const result = await agentDataService.getSessionMessages('agent-1', 'session-1')
+      expect(result).toHaveLength(2)
+      expect(result[0].role).toBe('user')
+      expect(result[1].role).toBe('assistant')
+    })
+  })
+})


### PR DESCRIPTION
### What this PR does

Before this PR:
- Agent data lives in a separate `agents.db` SQLite file managed by `DatabaseManager` singleton
- Agent sessions/messages use custom schema with manual JSON serialization
- No migration path from agents.db to the v2 unified SQLite database

After this PR:
- Drizzle schema definitions for `agent` and `agent_session` tables in the v2 data layer
- Zod-based transform schemas for migrating legacy agents.db data
- 21 unit tests covering all transform edge cases (JSON parsing, snake_case→camelCase, FK validation, block conversion)

### Why we need it and why it was done in this way

This is the foundation for migrating the agents database into the v2 unified SQLite database (`cherrystudio.sqlite`). The design follows decisions made in extended discussion:

The following tradeoffs were made:
- **Agent ↔ Session decoupled (SET NULL)**: Mirrors PR #13851's assistant ↔ topic pattern. Deleting an agent preserves sessions and their message history.
- **Session → Topic (CASCADE)**: Each session creates a topic as its message container. Messages go into the existing `message` table — no separate `agent_session_message` table.
- **Zod for transforms instead of manual type guards**: Consistent with entity types in `packages/shared/data/types/` (e.g., `MCPServerSchema`, `KnowledgeBaseSchema`). `safeParse` replaces manual `{ ok, value } | { ok, reason }` pattern.
- **`topic.sourceType` discriminator** (not yet added, pending PR #13851): Cleanly separates chat topics from agent session topics.
- **`message.agentSessionId` + `agentSnapshot`** (not yet added, pending PR #13851): Symmetric with `assistantId` + `assistantSnapshot`.
- **No new Renderer Exporter**: `agents.db` is a Main-process file, Migrator reads it directly via `@libsql/client`.

The following alternatives were considered:
- Exclusive arc (mutually exclusive nullable FKs on message) — rejected due to breaking existing `topicId NOT NULL` constraint
- Abstract `conversation` table (Class Table Inheritance) — rejected due to massive migration cost
- Separate `agent_session_message` table — rejected in favor of unified `message` table

### Breaking changes

None. This is a v2 migration/data layer addition. No existing code is modified.

### Special notes for your reviewer

- This is a **draft PR** — work in progress. Schema files, transforms, and tests are complete. Remaining: shared types, API schemas, service, handler, and migrator.
- Depends on PR #13851 for `topic.sourceType`, `message.agentSessionId`, and `message.agentSnapshot` columns.
- Uses Zod v4 API: `.loose()` instead of deprecated `.passthrough()`, `z.record(z.string(), z.unknown())` (v4 treats single arg as key type).
- `transformBlocksToMessageData` will share logic with `ChatMigrator`'s block transform once integrated.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
