### PR TITLE
fix: replace dots in provider name for opencode API key env var

### DIFF
--- a/src/main/services/CodeToolsService.ts
+++ b/src/main/services/CodeToolsService.ts
@@ -221,7 +221,7 @@ class CodeToolsService {
     this.openCodeConfigBackups.set(configPath, backupContent)
 
     // config with env variable Build CherryStudio provider reference for security
-    const envVarKey = `OPENCODE_API_KEY_${providerName.toUpperCase().replace(/-/g, '_')}`
+    const envVarKey = `OPENCODE_API_KEY_${providerName.toUpperCase().replace(/[-.]/g, '_')}`
     const cherryProviderConfig = {
       npm: npmPackage,
       name: dynamicProviderName,

--- a/src/renderer/src/pages/code/index.ts
+++ b/src/renderer/src/pages/code/index.ts
@@ -223,7 +223,7 @@ export const generateToolEnvironment = ({
         }
         env.OPENCODE_PROVIDER_TYPE = providerType
         env.OPENCODE_PROVIDER_NAME = providerName
-        const envVarKey = `OPENCODE_API_KEY_${providerName.toUpperCase().replace(/-/g, '_')}`
+        const envVarKey = `OPENCODE_API_KEY_${providerName.toUpperCase().replace(/[-.]/g, '_')}`
         env[envVarKey] = apiKey
       }
       break


### PR DESCRIPTION
### What this PR does

Before this PR:
Provider names containing dots (e.g. `z.ai`) generated invalid shell environment variable names like `OPENCODE_API_KEY_Z.AI`, which cannot be parsed correctly by shells.

After this PR:
Dots in provider names are replaced with underscores alongside hyphens, producing valid identifiers like `OPENCODE_API_KEY_Z_AI`.

Fixes #

### Why we need it and why it was done in this way

The dot character (`.`) is not valid in shell environment variable names. When generating the `OPENCODE_API_KEY_*` env var for providers like `z.ai`, the resulting `OPENCODE_API_KEY_Z.AI` is silently broken.

The following tradeoffs were made:
- Minimal regex change (`/[-.]/g`) to handle both hyphens and dots in a single replace call.

The following alternatives were considered:
- Adding a second `.replace(/\./g, '_')` call — rejected as less concise.

Links to places where the discussion took place:

### Breaking changes

None. Only providers with dots in their names (e.g. `z.ai`) are affected, and the previous behavior was already broken.

### Special notes for your reviewer

Two files changed with identical one-character regex fix:
- `src/main/services/CodeToolsService.ts:224`
- `src/renderer/src/pages/code/index.ts:226`

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.agents/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix invalid env variable names for providers with dots in their name (e.g. z.ai) when generating opencode configuration.
```
