### PR TITLE
fix: resolve uv binary not found error when running kimi-cli

### DIFF
--- a/src/main/services/CodeToolsService.ts
+++ b/src/main/services/CodeToolsService.ts
@@ -6,7 +6,8 @@ import { loggerService } from '@logger'
 import { isMac, isWin } from '@main/constant'
 import { removeEnvProxy } from '@main/utils'
 import { isUserInChina } from '@main/utils/ipService'
-import { getBinaryName } from '@main/utils/process'
+import { findCommandInShellEnv, getBinaryName, getBinaryPath, isBinaryExists } from '@main/utils/process'
+import getShellEnv from '@main/utils/shell-env'
 import type { TerminalConfig, TerminalConfigWithCommand } from '@shared/config/constant'
 import {
   codeTools,
@@ -921,7 +922,24 @@ class CodeToolsService {
 
     // Special handling for kimi-cli: use uvx instead of bun
     if (cliTool === codeTools.kimiCli) {
-      const uvPath = path.join(os.homedir(), HOME_CHERRY_DIR, 'bin', await getBinaryName('uv'))
+      const shellEnv = await getShellEnv()
+      let uvPath = await findCommandInShellEnv('uv', shellEnv)
+
+      if (!uvPath) {
+        if (await isBinaryExists('uv')) {
+          uvPath = await getBinaryPath('uv')
+          logger.info('Using bundled uv as fallback (not found in PATH)', { command: uvPath })
+        } else {
+          throw new Error(
+            'uv not found in PATH and bundled version is not available.\n' +
+              'Please either:\n' +
+              '1. Install uv from https://github.com/astral-sh/uv\n' +
+              '2. Run the MCP dependencies installer from Settings\n' +
+              '3. Restart the application if you recently installed uv'
+          )
+        }
+      }
+
       baseCommand = `${uvPath} tool run ${packageName}`
     }
 


### PR DESCRIPTION
### What this PR does

Before this PR:
Running kimi-cli would fail with `bash: line 1: /home/user/.cherrystudio/bin/uv: No such file or directory` because the uv binary path was hardcoded without checking if it exists.

After this PR:
kimi-cli now follows the same uv lookup pattern as MCPService:
1. Search for `uv` in the system PATH (via login shell environment)
2. Fallback to bundled `~/.cherrystudio/bin/uv` if available
3. Throw a clear error message with installation instructions if neither is found

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Reused the existing `findCommandInShellEnv` / `isBinaryExists` / `getBinaryPath` utilities from MCPService for consistency.

The following alternatives were considered:
- Auto-installing uv — rejected as too heavy-handed; users may already have uv installed via other means.
- Silently falling back to system `uv` only — rejected as bundled fallback is the existing pattern in the codebase.

Links to places where the discussion took place:

### Breaking changes

None. The previous behavior was broken (hardcoded path to non-existent binary).

### Special notes for your reviewer

Single file change: `src/main/services/CodeToolsService.ts`
- Added imports: `findCommandInShellEnv`, `getBinaryPath`, `isBinaryExists`, `getShellEnv`
- Replaced hardcoded path with 3-step lookup matching `MCPService.ts:460-488`

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.agents/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix kimi-cli crash when uv binary is not found in ~/.cherrystudio/bin by searching system PATH first, then falling back to bundled version, with clear installation instructions if neither is available.
```
