### PR TITLE
fix: use dynamic imports for native modules to prevent startup crash

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -162,7 +162,7 @@ if (!app.requestSingleInstanceLock()) {
     appMenuService?.setupApplicationMenu()
 
     nodeTraceService.init()
-    powerMonitorService.init()
+    void powerMonitorService.init()
     analyticsService.init()
 
     // Extract bundled rtk binary to ~/.cherrystudio/bin/ on first run

--- a/src/main/services/PowerMonitorService.ts
+++ b/src/main/services/PowerMonitorService.ts
@@ -1,6 +1,5 @@
 import { loggerService } from '@logger'
 import { isLinux, isMac, isWin } from '@main/constant'
-import ElectronShutdownHandler from '@paymoapp/electron-shutdown-handler'
 import { BrowserWindow } from 'electron'
 import { powerMonitor } from 'electron'
 
@@ -36,14 +35,14 @@ export class PowerMonitorService {
   /**
    * Initialize power monitor to listen for shutdown events
    */
-  public init(): void {
+  public async init(): Promise<void> {
     if (this.initialized) {
       logger.warn('PowerMonitorService already initialized')
       return
     }
 
     if (isWin) {
-      this.initWindowsShutdownHandler()
+      await this.initWindowsShutdownHandler()
     } else if (isMac || isLinux) {
       this.initElectronPowerMonitor()
     }
@@ -69,18 +68,15 @@ export class PowerMonitorService {
   /**
    * Initialize shutdown handler for Windows using @paymoapp/electron-shutdown-handler
    */
-  private initWindowsShutdownHandler(): void {
+  private async initWindowsShutdownHandler(): Promise<void> {
     try {
+      const { default: ElectronShutdownHandler } = await import('@paymoapp/electron-shutdown-handler')
       const zeroMemoryWindow = new BrowserWindow({ show: false })
-      // Set the window handle for the shutdown handler
       ElectronShutdownHandler.setWindowHandle(zeroMemoryWindow.getNativeWindowHandle())
 
-      // Listen for shutdown event
       ElectronShutdownHandler.on('shutdown', async () => {
         logger.info('System shutdown event detected (Windows)')
-        // Execute all registered shutdown handlers
         await this.executeShutdownHandlers()
-        // Release the shutdown block to allow the system to shut down
         ElectronShutdownHandler.releaseShutdown()
       })
 

--- a/src/main/services/ocr/builtin/SystemOcrService.ts
+++ b/src/main/services/ocr/builtin/SystemOcrService.ts
@@ -1,12 +1,10 @@
 import { isLinux, isWin } from '@main/constant'
 import { loadOcrImage } from '@main/utils/ocr'
-import { OcrAccuracy, recognize } from '@napi-rs/system-ocr'
 import type { ImageFileMetadata, OcrResult, OcrSystemConfig, SupportedOcrFile } from '@types'
 import { isImageFileMetadata } from '@types'
 
 import { OcrBaseService } from './OcrBaseService'
 
-// const logger = loggerService.withContext('SystemOcrService')
 export class SystemOcrService extends OcrBaseService {
   constructor() {
     super()
@@ -16,6 +14,7 @@ export class SystemOcrService extends OcrBaseService {
     if (isLinux) {
       return { text: '' }
     }
+    const { OcrAccuracy, recognize } = await import('@napi-rs/system-ocr')
     const buffer = await loadOcrImage(file)
     const langs = isWin ? options?.langs : undefined
     const result = await recognize(buffer, OcrAccuracy.Accurate, langs)


### PR DESCRIPTION
### What this PR does

Before this PR:
- `@paymoapp/electron-shutdown-handler` (native `.node` binary) and `@napi-rs/system-ocr` (native `.node` binary) were imported via static top-level `import` statements. If the native module failed to load (e.g., Windows Application Control / WDAC / AppLocker policy blocking unsigned `.node` binaries), the entire main process crashed with an uncaught exception at startup.

After this PR:
- Both native modules are loaded via dynamic `await import()` at the point of use, wrapped in try-catch. If loading fails, the error is logged and the feature gracefully degrades (Windows shutdown detection falls back to no-op; system OCR becomes unavailable) instead of crashing the app.

Fixes #13930

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Dynamic imports add a small async overhead at first use, but this is negligible compared to the cost of loading a native `.node` binary and is far better than crashing at startup.

The following alternatives were considered:
- Conditional static imports (not possible in ESM)
- Try-catch around `require()` at module scope (less idiomatic in the existing codebase, which already uses `await import()` for `sharp`)

Links to places where the discussion took place:
- #13930

### Breaking changes

None.

### Special notes for your reviewer

Changes in 3 files:
1. **`src/main/services/PowerMonitorService.ts`** — Removed static import, converted `initWindowsShutdownHandler()` to async with `await import()` + try-catch. `init()` is now async.
2. **`src/main/services/ocr/builtin/SystemOcrService.ts`** — Removed static import, moved `await import('@napi-rs/system-ocr')` into `ocrImage()` (already async).
3. **`src/main/index.ts`** — Added `void` prefix to `powerMonitorService.init()` call to satisfy `no-floating-promises` lint rule.

The `ansi-to-react` typecheck/test failures on `main` are pre-existing and unrelated to this PR.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: Left the code cleaner than found it (removed dead commented-out import)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: Not required (internal fix, no user-facing behavior change beyond crash prevention)
- [ ] Self-review: Performed via `git diff`

### Release note

```release-note
Fix main process crash on startup when Windows Application Control policies block native `.node` binaries (e.g., `@paymoapp/electron-shutdown-handler`). The app now gracefully degrades instead of crashing.
```
