### PR TITLE
fix: skip directory-based legacy knowledge stores in migration

### DIFF
--- a/src/main/data/migration/v2/migrators/KnowledgeMigrator.ts
+++ b/src/main/data/migration/v2/migrators/KnowledgeMigrator.ts
@@ -47,6 +47,7 @@ const LEGACY_VECTOR_TABLE_NAME = 'vectors'
 type DimensionResolutionReason =
   | 'ok'
   | 'vector_db_missing'
+  | 'legacy_vector_store_directory'
   | 'vector_db_empty'
   | 'invalid_vector_dimensions'
   | 'vector_db_invalid_path'
@@ -179,9 +180,16 @@ export class KnowledgeMigrator extends BaseMigrator {
       return { dimensions: null, reason: 'vector_db_missing' }
     }
 
-    const client = createClient({ url: pathToFileURL(dbPath).toString() })
+    let client: ReturnType<typeof createClient> | null = null
 
     try {
+      const dbStat = fs.statSync(dbPath)
+      if (dbStat.isDirectory()) {
+        return { dimensions: null, reason: 'legacy_vector_store_directory' }
+      }
+
+      client = createClient({ url: pathToFileURL(dbPath).toString() })
+
       const countResult = await client.execute(
         `SELECT count(*) AS total, sum(CASE WHEN vector IS NOT NULL THEN 1 ELSE 0 END) AS with_vector FROM ${LEGACY_VECTOR_TABLE_NAME}`
       )
@@ -209,14 +217,16 @@ export class KnowledgeMigrator extends BaseMigrator {
       this.warnings.push(warningMessage)
       return { dimensions: null, reason: 'vector_db_error' }
     } finally {
-      try {
-        client.close()
-      } catch (error) {
-        const warningMessage = `Failed to close legacy vector DB client for knowledge base ${base.id}: ${
-          error instanceof Error ? error.message : String(error)
-        }`
-        logger.warn(warningMessage)
-        this.warnings.push(warningMessage)
+      if (client) {
+        try {
+          client.close()
+        } catch (error) {
+          const warningMessage = `Failed to close legacy vector DB client for knowledge base ${base.id}: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+          logger.warn(warningMessage)
+          this.warnings.push(warningMessage)
+        }
       }
     }
   }

--- a/src/main/data/migration/v2/migrators/README-KnowledgeMigrator.md
+++ b/src/main/data/migration/v2/migrators/README-KnowledgeMigrator.md
@@ -83,6 +83,7 @@
 
 - `video` items are skipped.
 - `memory` items are skipped.
+- Legacy per-base knowledge store paths that resolve to directories are skipped as unsupported pre-v2 layouts.
 - Invalid/malformed items are skipped and recorded as warnings in `prepare`.
 - Invalid knowledge-base tuning fields are cleared during migration; they do not cause the base or its items to be skipped.
 
@@ -94,6 +95,7 @@
   - the per-base legacy vector DB file
   - the `vectors` table
   - a non-null vector blob whose byte length can be converted to a positive dimension count (`length(vector)/4`)
+- If the per-base legacy knowledge store path resolves to a directory instead of a SQLite file, that base is treated as an unsupported legacy layout and is skipped.
 - If the legacy vector DB is missing, empty, invalid, or the vector blob length cannot be parsed into a valid positive dimension count, that base is treated as unusable in V2 migration:
   - the base is skipped
   - all items under that base are skipped

--- a/src/main/data/migration/v2/migrators/__tests__/KnowledgeMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/KnowledgeMigrator.test.ts
@@ -27,6 +27,21 @@ vi.mock('@libsql/client', () => ({
 describe('KnowledgeMigrator dimensions resolution', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+
+    const existsSyncMock = fs.existsSync as unknown as {
+      mockReset?: () => void
+      mockReturnValue?: (value: boolean) => void
+    }
+    existsSyncMock.mockReset?.()
+
+    const statSyncMock = fs.statSync as unknown as {
+      mockReset?: () => void
+      mockReturnValue?: (value: unknown) => void
+    }
+    statSyncMock.mockReset?.()
+    statSyncMock.mockReturnValue?.({
+      isDirectory: () => false
+    })
   })
 
   it('resolves dimensions from vector blob even when legacy dimensions exists', async () => {
@@ -131,6 +146,27 @@ describe('KnowledgeMigrator dimensions resolution', () => {
     expect(createClient).not.toHaveBeenCalled()
   })
 
+  it('returns legacy_vector_store_directory when resolved path is a directory', async () => {
+    const migrator = new KnowledgeMigrator() as any
+    vi.spyOn(migrator, 'getLegacyKnowledgeDbPath').mockReturnValue('/mock/userData/Data/KnowledgeBase/kb-dir')
+
+    const existsSyncMock = fs.existsSync as unknown as { mockReturnValue: (value: boolean) => void }
+    existsSyncMock.mockReturnValue(true)
+
+    const statSyncMock = fs.statSync as unknown as { mockReturnValue: (value: unknown) => void }
+    statSyncMock.mockReturnValue({
+      isDirectory: () => true
+    })
+
+    const result = await migrator.resolveDimensionsForBase({
+      id: 'kb-dir',
+      name: 'Directory KB'
+    })
+
+    expect(result).toEqual({ dimensions: null, reason: 'legacy_vector_store_directory' })
+    expect(createClient).not.toHaveBeenCalled()
+  })
+
   it('records a warning when closing the legacy vector DB client fails', async () => {
     const migrator = new KnowledgeMigrator() as any
     vi.spyOn(migrator, 'getLegacyKnowledgeDbPath').mockReturnValue('/mock/userData/Data/KnowledgeBase/kb-close-error')
@@ -159,6 +195,34 @@ describe('KnowledgeMigrator dimensions resolution', () => {
     )
     expect(loggerWarnMock).toHaveBeenCalledWith(
       'Failed to close legacy vector DB client for knowledge base kb-close-error: close failed'
+    )
+  })
+
+  it('returns vector_db_error when createClient throws synchronously', async () => {
+    const migrator = new KnowledgeMigrator() as any
+    vi.spyOn(migrator, 'getLegacyKnowledgeDbPath').mockReturnValue('/mock/userData/Data/KnowledgeBase/kb-create-error')
+
+    const existsSyncMock = fs.existsSync as unknown as { mockReturnValue: (value: boolean) => void }
+    existsSyncMock.mockReturnValue(true)
+
+    const statSyncMock = fs.statSync as unknown as { mockReturnValue: (value: unknown) => void }
+    statSyncMock.mockReturnValue({
+      isDirectory: () => false
+    })
+
+    const createClientMock = createClient as unknown as { mockImplementation: (value: () => never) => void }
+    createClientMock.mockImplementation(() => {
+      throw new Error('open failed')
+    })
+
+    const result = await migrator.resolveDimensionsForBase({
+      id: 'kb-create-error',
+      name: 'Create Error KB'
+    })
+
+    expect(result).toEqual({ dimensions: null, reason: 'vector_db_error' })
+    expect(migrator.warnings).toContain(
+      'Failed to inspect legacy vector DB for knowledge base kb-create-error: open failed'
     )
   })
 
@@ -201,6 +265,51 @@ describe('KnowledgeMigrator dimensions resolution', () => {
     expect(migrator.skippedCount).toBe(3)
     expect(migrator.sourceCount).toBe(3)
     expect(result.warnings?.some((warning: string) => warning.includes('Skipped knowledge base kb-empty'))).toBe(true)
+  })
+
+  it('prepare skips base and items when legacy knowledge store path is a directory', async () => {
+    const migrator = new KnowledgeMigrator() as any
+    vi.spyOn(migrator, 'resolveDimensionsForBase').mockResolvedValue({
+      dimensions: null,
+      reason: 'legacy_vector_store_directory'
+    })
+
+    const ctx = {
+      sources: {
+        reduxState: {
+          getCategory: vi.fn().mockReturnValue({
+            bases: [
+              {
+                id: 'kb-dir',
+                name: 'Directory KB',
+                model: { id: 'm1', name: 'model-1', provider: 'openai' },
+                items: [
+                  { id: 'i1', type: 'url', content: 'https://example.com' },
+                  { id: 'i2', type: 'note', content: 'test' }
+                ]
+              }
+            ]
+          })
+        },
+        dexieExport: {
+          tableExists: vi.fn().mockResolvedValue(false),
+          readTable: vi.fn()
+        }
+      }
+    } as any
+
+    const result = await migrator.prepare(ctx)
+
+    expect(result.success).toBe(true)
+    expect(migrator.preparedBases).toHaveLength(0)
+    expect(migrator.preparedItems).toHaveLength(0)
+    expect(migrator.skippedCount).toBe(3)
+    expect(migrator.sourceCount).toBe(3)
+    expect(
+      result.warnings?.some((warning: string) =>
+        warning.includes('Skipped knowledge base kb-dir: legacy_vector_store_directory')
+      )
+    ).toBe(true)
   })
 
   it('prepare returns a warning when the knowledge Redux category is unavailable', async () => {


### PR DESCRIPTION
### What this PR does

Before this PR:

Legacy knowledge migration always treated `Data/KnowledgeBase/<baseId>` as a libsql file. If a beta backup contained a directory-based knowledge store layout at that path, migration could fail during `KnowledgeMigrator.prepare()` instead of skipping that unsupported base.

After this PR:

`KnowledgeMigrator` detects directory-based legacy knowledge store paths before opening libsql, skips those bases and their items, and keeps migration running. It also hardens the libsql open path so synchronous client creation failures are downgraded to warnings instead of aborting the whole prepare phase.

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- We treat any legacy knowledge store path that resolves to a directory as unsupported and skip it conservatively.
- We keep the fix scoped to migration behavior instead of mutating legacy Redux data or backup contents.
- We add regression tests around directory layouts and synchronous libsql open failures to lock the behavior in.

The following alternatives were considered:

- Detecting only FAISS-specific marker files such as `faiss.index` or `docstore.json`.
- Filtering or rewriting legacy knowledge entries earlier in Redux restore data.
- Trying to migrate directory-based stores through a separate compatibility path.

Links to places where the discussion took place: None

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- Base branch should be `v2`.
- I manually validated the backup/restore flow with a mocked directory-based knowledge store backup in addition to the automated tests.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed a v2 legacy backup migration failure where directory-based knowledge store layouts under `Data/KnowledgeBase/<baseId>` could abort migration instead of being skipped.
```
