### PR TITLE
fix: migrate epub to v2 async api

### DIFF
--- a/src/main/knowledge/embedjs/loader/epubLoader.ts
+++ b/src/main/knowledge/embedjs/loader/epubLoader.ts
@@ -82,40 +82,29 @@ export class EpubLoader extends BaseLoader<Record<string, string | number | bool
 
   /**
    * 等待 epub 文件初始化完成
-   * epub 库使用事件机制，需要等待 'end' 事件触发后才能访问文件内容
    * @param epub epub 实例
    * @returns 元数据和章节信息
    */
-  private waitForEpubInit(epub: any): Promise<{ metadata: EpubMetadata; chapters: EpubChapter[] }> {
-    return new Promise((resolve, reject) => {
-      epub.on('end', () => {
-        // 提取元数据
-        const metadata: EpubMetadata = {
-          creator: epub.metadata.creator,
-          creatorFileAs: epub.metadata.creatorFileAs,
-          title: epub.metadata.title,
-          language: epub.metadata.language,
-          subject: epub.metadata.subject,
-          date: epub.metadata.date,
-          description: epub.metadata.description
-        }
+  private async waitForEpubInit(epub: EPub): Promise<{ metadata: EpubMetadata; chapters: EpubChapter[] }> {
+    await epub.parse()
 
-        // 提取章节信息
-        const chapters: EpubChapter[] = epub.flow.map((chapter: any, index: number) => ({
-          id: chapter.id,
-          title: chapter.title || `Chapter ${index + 1}`,
-          order: index + 1
-        }))
+    const metadata: EpubMetadata = {
+      creator: epub.metadata.creator,
+      creatorFileAs: epub.metadata.creatorFileAs,
+      title: epub.metadata.title,
+      language: epub.metadata.language,
+      subject: epub.metadata.subject,
+      date: epub.metadata.date,
+      description: epub.metadata.description
+    }
 
-        resolve({ metadata, chapters })
-      })
+    const chapters: EpubChapter[] = epub.flow.map((chapter: any, index: number) => ({
+      id: chapter.id,
+      title: chapter.title || `Chapter ${index + 1}`,
+      order: index + 1
+    }))
 
-      epub.on('error', (error: Error) => {
-        reject(error)
-      })
-
-      epub.parse()
-    })
+    return { metadata, chapters }
   }
 
   /**
@@ -124,16 +113,8 @@ export class EpubLoader extends BaseLoader<Record<string, string | number | bool
    * @param chapterId 章节 ID
    * @returns 章节文本内容
    */
-  private getChapter(epub: any, chapterId: string): Promise<string> {
-    return new Promise((resolve, reject) => {
-      epub.getChapter(chapterId, (error: Error | null, text: string) => {
-        if (error) {
-          reject(error)
-        } else {
-          resolve(text)
-        }
-      })
-    })
+  private async getChapter(epub: EPub, chapterId: string): Promise<string> {
+    return epub.getChapter(chapterId)
   }
 
   /**


### PR DESCRIPTION
### What this PR does

Before this PR:

The epub loader used event-based callbacks (`epub.on('end')`, `epub.on('error')`) and callback-style `getChapter()` from epub v1 API, which caused `epub.on is not a function` errors with the patched epub v2 library.

After this PR:

Migrated to epub v2's promise-based async API (`epub.parse()`, `epub.getChapter()`), eliminating the event/callback wrappers and fixing epub embedding failures.

Fixes #13919

### Why we need it and why it was done in this way

The epub dependency was updated/patched to v2 which provides native async/promise APIs, but the loader code was still using the old v1 event-based API. This caused runtime errors (`epub.on is not a function`) preventing epub files from being embedded.

The migration replaces the manual Promise wrappers around event listeners and callbacks with direct `await` calls to the v2 async methods, which is simpler and more maintainable.

The following tradeoffs were made:

- Changed parameter types from `any` to `EPub` for better type safety.

The following alternatives were considered:

- None — this is a straightforward API migration to match the already-updated dependency.

### Breaking changes

None.

### Special notes for your reviewer

- The `waitForEpubInit` method now directly calls `await epub.parse()` instead of wrapping it in a Promise with event listeners.
- The `getChapter` method now directly returns `epub.getChapter(chapterId)` instead of wrapping the callback in a Promise.
- Both methods now use the typed `EPub` parameter instead of `any`.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix: resolve epub embedding failure (`epub.on is not a function`) by migrating to epub v2 async API
```