### PR TITLE
fix(migration): resolve dangling parentId in ChatMigrator for deleted user messages

### DIFF
--- a/src/main/data/migration/v2/migrators/ChatMigrator.ts
+++ b/src/main/data/migration/v2/migrators/ChatMigrator.ts
@@ -457,6 +457,22 @@ export class ChatMigrator extends BaseMigrator {
         })
       }
 
+      // Check for dangling parentId self-references (parentId points to non-existent message)
+      const danglingParentCheck = await db
+        .select({ count: sql<number>`count(*)` })
+        .from(messageTable)
+        .where(
+          sql`${messageTable.parentId} IS NOT NULL AND ${messageTable.parentId} NOT IN (SELECT id FROM ${messageTable})`
+        )
+        .get()
+
+      if (danglingParentCheck && danglingParentCheck.count > 0) {
+        errors.push({
+          key: 'dangling_parent_ids',
+          message: `Found ${danglingParentCheck.count} messages with dangling parentId`
+        })
+      }
+
       return {
         success: errors.length === 0,
         errors,
@@ -634,6 +650,25 @@ export class ChatMigrator extends BaseMigrator {
       } catch (error) {
         logger.warn(`Failed to transform message ${oldMsg.id}`, { error })
         this.skippedMessages++
+      }
+    }
+
+    // Fix dangling parentIds from second-pass skips (transform failure).
+    // resolveParentId only handles first-pass skips; if a message passed the first
+    // pass (had blocks) but failed transform, its children still reference it.
+    // Walk the ancestor chain to find the nearest migrated parent.
+    const migratedMessageIds = new Set(newMessages.map((m) => m.id))
+    for (const msg of newMessages) {
+      if (msg.parentId && !migratedMessageIds.has(msg.parentId)) {
+        let ancestor = messageParentMap.get(msg.parentId) ?? null
+        const visited = new Set<string>([msg.parentId])
+        while (ancestor && !migratedMessageIds.has(ancestor)) {
+          if (visited.has(ancestor)) break
+          visited.add(ancestor)
+          ancestor = messageParentMap.get(ancestor) ?? null
+        }
+        logger.warn(`Resolved dangling parentId for message ${msg.id}: ${msg.parentId} → ${ancestor}`)
+        msg.parentId = ancestor
       }
     }
 

--- a/src/main/data/migration/v2/migrators/ChatMigrator.ts
+++ b/src/main/data/migration/v2/migrators/ChatMigrator.ts
@@ -457,7 +457,7 @@ export class ChatMigrator extends BaseMigrator {
         })
       }
 
-      // Check for dangling parentId self-references (parentId points to non-existent message)
+      // Check for dangling parentId references (parentId points to non-existent message)
       const danglingParentCheck = await db
         .select({ count: sql<number>`count(*)` })
         .from(messageTable)
@@ -667,7 +667,13 @@ export class ChatMigrator extends BaseMigrator {
           visited.add(ancestor)
           ancestor = messageParentMap.get(ancestor) ?? null
         }
-        logger.warn(`Resolved dangling parentId for message ${msg.id}: ${msg.parentId} → ${ancestor}`)
+        if (ancestor) {
+          logger.warn(`Resolved dangling parentId for message ${msg.id}: ${msg.parentId} → ${ancestor}`)
+        } else {
+          logger.warn(
+            `No migrated ancestor found for message ${msg.id} (original parentId: ${msg.parentId}), setting as root`
+          )
+        }
         msg.parentId = ancestor
       }
     }

--- a/src/main/data/migration/v2/migrators/__tests__/ChatMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/ChatMigrator.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: vi.fn(() => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn()
+    }))
+  }
+}))
+
+import { ChatMigrator } from '../ChatMigrator'
+import type { NewMessage, NewTopic, OldBlock, OldMainTextBlock, OldMessage, OldTopic } from '../mappings/ChatMappings'
+
+interface PreparedTopicData {
+  topic: NewTopic
+  messages: NewMessage[]
+}
+
+/** Create a minimal OldMainTextBlock */
+function block(id: string, messageId: string): OldMainTextBlock {
+  return {
+    id,
+    messageId,
+    type: 'main_text',
+    createdAt: '2025-01-01T00:00:00.000Z',
+    status: 'success',
+    content: `Content of ${id}`
+  }
+}
+
+/** Create a minimal OldMessage */
+function msg(id: string, role: 'user' | 'assistant', blockIds: string[], extra: Partial<OldMessage> = {}): OldMessage {
+  return {
+    id,
+    role,
+    assistantId: 'ast-1',
+    topicId: 't1',
+    createdAt: '2025-01-01T00:00:00.000Z',
+    status: 'success',
+    blocks: blockIds,
+    ...extra
+  }
+}
+
+/** Create a minimal OldTopic */
+function topic(id: string, messages: OldMessage[]): OldTopic {
+  return {
+    id,
+    assistantId: 'ast-1',
+    name: 'Test Topic',
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: '2025-01-01T00:00:00.000Z',
+    messages
+  }
+}
+
+/**
+ * Set up ChatMigrator internal state and call prepareTopicData.
+ * Uses Reflect to access private members without `as any` cast.
+ */
+function prepareTopic(oldTopic: OldTopic, blocks: OldBlock[]): PreparedTopicData | null {
+  const migrator = new ChatMigrator()
+  // Access private fields via index signature to avoid `as any`
+  const m = migrator as unknown as Record<string, unknown>
+  m['blockLookup'] = new Map(blocks.map((b) => [b.id, b]))
+  m['assistantLookup'] = new Map()
+  m['topicMetaLookup'] = new Map()
+  m['topicAssistantLookup'] = new Map()
+  m['skippedMessages'] = 0
+  m['seenMessageIds'] = new Set()
+  m['blockStats'] = { requested: 0, resolved: 0, messagesWithMissingBlocks: 0, messagesWithEmptyBlocks: 0 }
+
+  const fn = m['prepareTopicData'] as (t: OldTopic) => PreparedTopicData | null
+  return fn.call(migrator, oldTopic)
+}
+
+/** Build a Map<id, message> from result messages for easy lookup */
+function toMsgMap(messages: NewMessage[]): Map<string, NewMessage> {
+  return new Map(messages.map((m) => [m.id, m]))
+}
+
+/** Assert no migrated message has a dangling parentId */
+function assertNoDanglingParentIds(messages: NewMessage[]): void {
+  const migratedIds = new Set(messages.map((m) => m.id))
+  for (const m of messages) {
+    if (m.parentId) {
+      expect(migratedIds.has(m.parentId), `message ${m.id} has dangling parentId ${m.parentId}`).toBe(true)
+    }
+  }
+}
+
+describe('ChatMigrator.prepareTopicData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('produces valid parentId chain for simple sequential messages', () => {
+    const b1 = block('b1', 'u1')
+    const b2 = block('b2', 'a1')
+    const messages = [msg('u1', 'user', ['b1']), msg('a1', 'assistant', ['b2'])]
+
+    const result = prepareTopic(topic('t1', messages), [b1, b2])
+
+    expect(result).not.toBeNull()
+    const msgMap = toMsgMap(result?.messages ?? [])
+    expect(msgMap.get('u1')?.parentId).toBeNull()
+    expect(msgMap.get('a1')?.parentId).toBe('u1')
+  })
+
+  it('resolves parentId through first-pass skipped messages (no blocks)', () => {
+    // u1 → a1 (no blocks, skipped) → u2
+    // u2's parentId should resolve through a1 to u1
+    const b1 = block('b1', 'u1')
+    const b3 = block('b3', 'u2')
+    const messages = [
+      msg('u1', 'user', ['b1']),
+      msg('a1', 'assistant', []), // no blocks → skipped in first pass
+      msg('u2', 'user', ['b3'])
+    ]
+
+    const result = prepareTopic(topic('t1', messages), [b1, b3])
+
+    expect(result).not.toBeNull()
+    const msgMap = toMsgMap(result?.messages ?? [])
+    // a1 should be skipped
+    expect(msgMap.has('a1')).toBe(false)
+    // u2's parentId should resolve through skipped a1 to u1
+    expect(msgMap.get('u2')?.parentId).toBe('u1')
+  })
+
+  it('resolves parentId through second-pass skipped messages (transform failure)', () => {
+    // u1 → a1 (has block IDs but blocks not in lookup → 0 resolved blocks → skipped) → u2
+    const b1 = block('b1', 'u1')
+    const b3 = block('b3', 'u2')
+    const messages = [
+      msg('u1', 'user', ['b1']),
+      msg('a1', 'assistant', ['missing-block']), // block ID exists but not in lookup → 0 resolved blocks → skipped
+      msg('u2', 'user', ['b3'])
+    ]
+
+    const result = prepareTopic(topic('t1', messages), [b1, b3])
+
+    expect(result).not.toBeNull()
+    const msgMap = toMsgMap(result?.messages ?? [])
+    expect(msgMap.has('a1')).toBe(false)
+    // u2's parentId should resolve to u1
+    expect(msgMap.get('u2')?.parentId).toBe('u1')
+  })
+
+  it('handles askId pointing to deleted user message (preserves sibling relationship)', () => {
+    // deleted-user-msg was the user message, a1 and a2 have askId pointing to it
+    const b0 = block('b0', 'prev')
+    const b1 = block('b1', 'a1')
+    const b2 = block('b2', 'a2')
+    const messages = [
+      msg('prev', 'assistant', ['b0']),
+      msg('a1', 'assistant', ['b1'], { askId: 'deleted-user-msg' }),
+      msg('a2', 'assistant', ['b2'], { askId: 'deleted-user-msg' })
+    ]
+
+    const result = prepareTopic(topic('t1', messages), [b0, b1, b2])
+
+    expect(result).not.toBeNull()
+    const msgMap = toMsgMap(result?.messages ?? [])
+    // Both orphaned siblings share 'prev' as common parent
+    expect(msgMap.get('a1')?.parentId).toBe('prev')
+    expect(msgMap.get('a2')?.parentId).toBe('prev')
+  })
+
+  it('no migrated message has a dangling parentId', () => {
+    // Mix of all edge cases: deleted askId target, missing blocks, valid messages
+    const b1 = block('b1', 'u1')
+    const b3 = block('b3', 'a2')
+    const b4 = block('b4', 'u2')
+    const messages = [
+      msg('u1', 'user', ['b1']),
+      msg('a1', 'assistant', [], { askId: 'u1' }), // no blocks → skipped
+      msg('a2', 'assistant', ['b3'], { askId: 'u1' }), // only one with askId survives → not a group
+      msg('u2', 'user', ['b4'])
+    ]
+
+    const result = prepareTopic(topic('t1', messages), [b1, b3, b4])
+
+    expect(result).not.toBeNull()
+    assertNoDanglingParentIds(result?.messages ?? [])
+  })
+
+  it('all parentIds reference migrated messages (comprehensive invariant)', () => {
+    // Complex scenario with multiple skip reasons
+    const b1 = block('b1', 'u1')
+    const b2 = block('b2', 'a1')
+    const b4 = block('b4', 'a3')
+    const b5 = block('b5', 'u2')
+    const b6 = block('b6', 'a4')
+    const messages = [
+      msg('u1', 'user', ['b1']),
+      msg('a1', 'assistant', ['b2'], { askId: 'u1', foldSelected: true }),
+      msg('a2', 'assistant', ['missing-block'], { askId: 'u1' }), // unresolved block → skipped
+      msg('a3', 'assistant', ['b4'], { askId: 'deleted-msg' }), // askId target missing
+      msg('u2', 'user', ['b5']),
+      msg('a4', 'assistant', ['b6'])
+    ]
+
+    const result = prepareTopic(topic('t1', messages), [b1, b2, b4, b5, b6])
+
+    expect(result).not.toBeNull()
+    assertNoDanglingParentIds(result?.messages ?? [])
+  })
+})

--- a/src/main/data/migration/v2/migrators/__tests__/ChatMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/ChatMigrator.test.ts
@@ -57,10 +57,7 @@ function topic(id: string, messages: OldMessage[]): OldTopic {
   }
 }
 
-/**
- * Set up ChatMigrator internal state and call prepareTopicData.
- * Uses Reflect to access private members without `as any` cast.
- */
+/** Set up ChatMigrator internal state and call prepareTopicData. */
 function prepareTopic(oldTopic: OldTopic, blocks: OldBlock[]): PreparedTopicData | null {
   const migrator = new ChatMigrator()
   // Access private fields via index signature to avoid `as any`
@@ -170,7 +167,7 @@ describe('ChatMigrator.prepareTopicData', () => {
     expect(msgMap.get('a2')?.parentId).toBe('prev')
   })
 
-  it('no migrated message has a dangling parentId', () => {
+  it('produces no dangling parentId across mixed edge cases', () => {
     // Mix of all edge cases: deleted askId target, missing blocks, valid messages
     const b1 = block('b1', 'u1')
     const b3 = block('b3', 'a2')
@@ -208,5 +205,27 @@ describe('ChatMigrator.prepareTopicData', () => {
 
     expect(result).not.toBeNull()
     assertNoDanglingParentIds(result?.messages ?? [])
+  })
+
+  it('resolves multi-hop ancestor chain when consecutive messages are skipped', () => {
+    // u1 → a1 (no blocks, skipped) → u2 (no blocks, skipped) → a2 (has blocks)
+    // a2's parentId should resolve through u2 → a1 → u1
+    const b1 = block('b1', 'u1')
+    const b4 = block('b4', 'a2')
+    const messages = [
+      msg('u1', 'user', ['b1']),
+      msg('a1', 'assistant', []), // skipped: no blocks
+      msg('u2', 'user', []), // skipped: no blocks
+      msg('a2', 'assistant', ['b4'])
+    ]
+
+    const result = prepareTopic(topic('t1', messages), [b1, b4])
+
+    expect(result).not.toBeNull()
+    const msgMap = toMsgMap(result?.messages ?? [])
+    expect(msgMap.has('a1')).toBe(false)
+    expect(msgMap.has('u2')).toBe(false)
+    // a2 should resolve through the chain to u1
+    expect(msgMap.get('a2')?.parentId).toBe('u1')
   })
 })

--- a/src/main/data/migration/v2/migrators/mappings/ChatMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/ChatMappings.ts
@@ -1050,6 +1050,14 @@ export function buildMessageTree(
     }
   }
 
+  // Build set of known message IDs for validating references
+  const knownIds = new Set(messages.map((m) => m.id))
+
+  // Track fallback parent for orphaned askId groups (user message deleted)
+  // All messages in the same orphaned group share the previousMessageId at the time
+  // the first group member is encountered, preserving sibling relationships.
+  const orphanedGroupParent = new Map<string, string | null>()
+
   // Second pass: build parent/sibling relationships
   let previousMessageId: string | null = null
   let lastNonGroupMessageId: string | null = null // Last message not in a group, for linking subsequent user messages
@@ -1060,9 +1068,18 @@ export function buildMessageTree(
     let siblingsGroupId = 0
 
     if (msg.askId && askIdToGroupId.has(msg.askId)) {
-      // This is part of a multi-model response group
-      parentId = msg.askId // Parent is the user message
       siblingsGroupId = askIdToGroupId.get(msg.askId)!
+
+      if (knownIds.has(msg.askId)) {
+        // Normal multi-model: parent is the user message
+        parentId = msg.askId
+      } else {
+        // Orphaned multi-model: user message deleted, share a common fallback parent
+        if (!orphanedGroupParent.has(msg.askId)) {
+          orphanedGroupParent.set(msg.askId, previousMessageId)
+        }
+        parentId = orphanedGroupParent.get(msg.askId) ?? null
+      }
 
       // If this is the selected response, update lastNonGroupMessageId for subsequent user messages
       if (msg.foldSelected) {

--- a/src/main/data/migration/v2/migrators/mappings/__tests__/ChatMappings.test.ts
+++ b/src/main/data/migration/v2/migrators/mappings/__tests__/ChatMappings.test.ts
@@ -120,7 +120,7 @@ describe('buildMessageTree', () => {
     expect(tree.get('a3')!.siblingsGroupId).toBe(tree.get('a4')!.siblingsGroupId)
   })
 
-  it('single askId reference does not form a group even when valid', () => {
+  it('does not form a group for single askId reference even when valid', () => {
     // Only one response with askId — not a multi-model group (count == 1)
     const messages = [msg('u1', 'user'), msg('a1', 'assistant', { askId: 'u1' })]
 
@@ -129,5 +129,22 @@ describe('buildMessageTree', () => {
     // Single askId doesn't create a group, falls through to sequential
     expect(tree.get('a1')!.parentId).toBe('u1')
     expect(tree.get('a1')!.siblingsGroupId).toBe(0)
+  })
+
+  it('links user message after orphaned foldSelected group to the selected response', () => {
+    const messages = [
+      msg('prev', 'assistant'),
+      msg('a1', 'assistant', { askId: 'deleted', foldSelected: true }),
+      msg('a2', 'assistant', { askId: 'deleted' }),
+      msg('u1', 'user')
+    ]
+
+    const tree = buildMessageTree(messages)
+
+    // Orphaned siblings share 'prev' as parent
+    expect(tree.get('a1')!.parentId).toBe('prev')
+    expect(tree.get('a2')!.parentId).toBe('prev')
+    // u1 should link to foldSelected response a1
+    expect(tree.get('u1')!.parentId).toBe('a1')
   })
 })

--- a/src/main/data/migration/v2/migrators/mappings/__tests__/ChatMappings.test.ts
+++ b/src/main/data/migration/v2/migrators/mappings/__tests__/ChatMappings.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildMessageTree, type OldMessage } from '../ChatMappings'
+
+/** Helper: create a minimal OldMessage stub */
+function msg(id: string, role: 'user' | 'assistant' = 'assistant', extra: Partial<OldMessage> = {}): OldMessage {
+  return {
+    id,
+    role,
+    assistantId: 'a1',
+    topicId: 't1',
+    createdAt: '2025-01-01T00:00:00.000Z',
+    status: 'success',
+    blocks: ['block-1'],
+    ...extra
+  }
+}
+
+describe('buildMessageTree', () => {
+  it('returns empty map for empty input', () => {
+    expect(buildMessageTree([])).toEqual(new Map())
+  })
+
+  it('builds a linear chain for sequential messages', () => {
+    const messages = [msg('u1', 'user'), msg('a1'), msg('u2', 'user'), msg('a2')]
+
+    const tree = buildMessageTree(messages)
+
+    expect(tree.get('u1')).toEqual({ parentId: null, siblingsGroupId: 0 })
+    expect(tree.get('a1')).toEqual({ parentId: 'u1', siblingsGroupId: 0 })
+    expect(tree.get('u2')).toEqual({ parentId: 'a1', siblingsGroupId: 0 })
+    expect(tree.get('a2')).toEqual({ parentId: 'u2', siblingsGroupId: 0 })
+  })
+
+  it('groups multi-model responses under the user message', () => {
+    const messages = [
+      msg('u1', 'user'),
+      msg('a1', 'assistant', { askId: 'u1', foldSelected: true }),
+      msg('a2', 'assistant', { askId: 'u1' })
+    ]
+
+    const tree = buildMessageTree(messages)
+
+    expect(tree.get('u1')).toEqual({ parentId: null, siblingsGroupId: 0 })
+    // Both responses share the same parent (user message) and siblingsGroupId
+    expect(tree.get('a1')!.parentId).toBe('u1')
+    expect(tree.get('a2')!.parentId).toBe('u1')
+    expect(tree.get('a1')!.siblingsGroupId).toBeGreaterThan(0)
+    expect(tree.get('a1')!.siblingsGroupId).toBe(tree.get('a2')!.siblingsGroupId)
+  })
+
+  it('links user message after multi-model group to foldSelected response', () => {
+    const messages = [
+      msg('u1', 'user'),
+      msg('a1', 'assistant', { askId: 'u1', foldSelected: true }),
+      msg('a2', 'assistant', { askId: 'u1' }),
+      msg('u2', 'user')
+    ]
+
+    const tree = buildMessageTree(messages)
+
+    // u2 should link to the foldSelected response (a1)
+    expect(tree.get('u2')!.parentId).toBe('a1')
+  })
+
+  // --- The fix: askId pointing to a deleted user message ---
+
+  it('falls back to previousMessageId when askId points to deleted message', () => {
+    // User message 'u1' was deleted, but assistant responses still have askId: 'u1'
+    const messages = [msg('a1', 'assistant', { askId: 'u1' }), msg('a2', 'assistant', { askId: 'u1' })]
+
+    const tree = buildMessageTree(messages)
+
+    // askId 'u1' doesn't exist in messages, siblings share a common fallback parent
+    expect(tree.get('a1')!.parentId).toBeNull() // first message, no previous → null
+    expect(tree.get('a2')!.parentId).toBeNull() // same shared parent as a1
+    expect(tree.get('a1')!.siblingsGroupId).toBeGreaterThan(0)
+    expect(tree.get('a1')!.siblingsGroupId).toBe(tree.get('a2')!.siblingsGroupId)
+  })
+
+  it('falls back to previousMessageId when askId points to deleted message (with prior context)', () => {
+    // There's a prior message, then the deleted user message's responses
+    const messages = [
+      msg('prev', 'assistant'),
+      msg('a1', 'assistant', { askId: 'deleted-user-msg' }),
+      msg('a2', 'assistant', { askId: 'deleted-user-msg' })
+    ]
+
+    const tree = buildMessageTree(messages)
+
+    // Orphaned siblings share 'prev' as common parent and keep siblingsGroupId
+    expect(tree.get('a1')!.parentId).toBe('prev')
+    expect(tree.get('a2')!.parentId).toBe('prev')
+    expect(tree.get('a1')!.siblingsGroupId).toBeGreaterThan(0)
+    expect(tree.get('a1')!.siblingsGroupId).toBe(tree.get('a2')!.siblingsGroupId)
+  })
+
+  it('handles mixed: some askIds valid, some pointing to deleted messages', () => {
+    const messages = [
+      msg('u1', 'user'),
+      // Valid multi-model group
+      msg('a1', 'assistant', { askId: 'u1', foldSelected: true }),
+      msg('a2', 'assistant', { askId: 'u1' }),
+      // Orphaned group (user message deleted)
+      msg('a3', 'assistant', { askId: 'deleted-msg' }),
+      msg('a4', 'assistant', { askId: 'deleted-msg' })
+    ]
+
+    const tree = buildMessageTree(messages)
+
+    // Valid group: siblings under u1
+    expect(tree.get('a1')!.parentId).toBe('u1')
+    expect(tree.get('a2')!.parentId).toBe('u1')
+    expect(tree.get('a1')!.siblingsGroupId).toBeGreaterThan(0)
+
+    // Orphaned group: siblings share common parent (a2, last before group) and keep groupId
+    expect(tree.get('a3')!.parentId).toBe('a2')
+    expect(tree.get('a4')!.parentId).toBe('a2')
+    expect(tree.get('a3')!.siblingsGroupId).toBeGreaterThan(0)
+    expect(tree.get('a3')!.siblingsGroupId).toBe(tree.get('a4')!.siblingsGroupId)
+  })
+
+  it('single askId reference does not form a group even when valid', () => {
+    // Only one response with askId — not a multi-model group (count == 1)
+    const messages = [msg('u1', 'user'), msg('a1', 'assistant', { askId: 'u1' })]
+
+    const tree = buildMessageTree(messages)
+
+    // Single askId doesn't create a group, falls through to sequential
+    expect(tree.get('a1')!.parentId).toBe('u1')
+    expect(tree.get('a1')!.siblingsGroupId).toBe(0)
+  })
+})


### PR DESCRIPTION
### What this PR does

Before this PR:

ChatMigrator produces foreign key violations (`message.parentId → message`) when the source data contains multi-model response messages whose originating user message has been deleted. This blocks the entire v2 migration with the error:
```
Foreign key check failed: 2 violation(s). Sample: message(rowid=6607)→message
```

After this PR:

All dangling `parentId` references are gracefully resolved during migration. Orphaned multi-model siblings preserve their branch structure (shared parent + `siblingsGroupId`) instead of being flattened into a linear chain.

### Why we need it and why it was done in this way

The root cause is that `buildMessageTree` used `msg.askId` as `parentId` without verifying the referenced user message still exists. In the old UI, users can delete any message — including the user prompt of a multi-model response group. The assistant replies retain their `askId` field pointing to the now-deleted message, creating an invalid `parentId` reference.

Three error paths were identified and fixed:

**Path 1 — `askId` → deleted user message (confirmed via production logs)**
- `buildMessageTree` assigns `parentId = msg.askId` for multi-model responses
- If the user message was deleted, this ID doesn't exist in the message set
- **Fix**: Validate `askId` against `knownIds`. When missing, orphaned siblings share `previousMessageId` as their common fallback parent while retaining `siblingsGroupId` for correct branch structure.

**Path 2 — `lastNonGroupMessageId` → second-pass skipped message**
- A user message after a multi-model group gets `parentId = lastNonGroupMessageId`
- If that message passes the first pass (has blocks) but fails `transformMessage`, the reference dangles
- **Fix**: Post-transform pass walks the ancestor chain via `messageParentMap` to find the nearest migrated parent.

**Path 3 — `previousMessageId` → second-pass skipped message**
- Normal sequential messages get `parentId = previousMessageId`
- Same second-pass skip scenario as Path 2
- **Fix**: Same post-transform ancestor chain resolution.

The following tradeoffs were made:

- Orphaned multi-model groups lose the explicit link to their (deleted) user prompt, but this is unavoidable since the prompt no longer exists. The sibling relationship between responses is preserved.

The following alternatives were considered:

- Setting all dangling `parentId` to `null` — rejected because it unnecessarily flattens the tree structure. Walking the ancestor chain preserves more of the original conversation topology.

### Breaking changes

None.

### Special notes for your reviewer

- The fix was diagnosed using real production migration logs. Only 2 violations were found across 2587 topics and 14342 messages, both from the same deleted user message in one topic.
- `ChatMigrator.validate` now includes a `parentId` self-reference check as a safety net, ensuring this class of error is caught at the migrator level rather than relying on the global FK check.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
