### PR TITLE
fix: preserve request headers on HTTP 3xx redirects

### DIFF
--- a/src/renderer/src/aiCore/provider/providerConfig.ts
+++ b/src/renderer/src/aiCore/provider/providerConfig.ts
@@ -500,7 +500,12 @@ function createRedirectSafeFetch(baseFetch?: typeof fetch): typeof fetch {
         }
 
         // Resolve relative redirect URLs
-        const currentUrl = typeof currentInput === 'string' ? currentInput : currentInput instanceof URL ? currentInput.href : currentInput.url
+        const currentUrl =
+          typeof currentInput === 'string'
+            ? currentInput
+            : currentInput instanceof URL
+              ? currentInput.href
+              : currentInput.url
         currentInput = new URL(location, currentUrl).href
 
         // For 303 See Other, switch method to GET and drop the body


### PR DESCRIPTION
## Summary

Fixes #13236

When an API provider returns an HTTP 3xx redirect, browsers/Chromium strip sensitive headers (e.g. `Authorization`, custom headers) from the redirected request due to cross-origin security policies. This causes authorization failures after redirects.

## Changes

Added a `createRedirectSafeFetch` wrapper in `src/renderer/src/aiCore/provider/providerConfig.ts` that:

- Uses `redirect: 'manual'` to prevent the browser from automatically following redirects
- Manually follows the redirect chain while preserving all original request headers
- Handles relative redirect URLs and `303 See Other` (switches to GET, drops body)
- Caps redirect depth at 10 to prevent infinite loops
- Respects callers that already set a custom redirect policy

The wrapper is applied to:
1. All AI SDK fetch paths via `providerToAiSdkConfig` (covers check, completions, models, etc.)
2. The CherryAI signature-based custom fetch in `prepareSpecialProviderConfig`

## Test plan

- [ ] Configure a Model Provider with an HTTP URL that 307-redirects to HTTPS
- [ ] Click "Check" in Settings → Model Provider and verify the request succeeds
- [ ] Verify custom request headers and Authorization are preserved after redirect
- [ ] Test with a provider that does NOT redirect to ensure no regression