### PR TITLE
fix(knowledge): invalidate RAG cache when embedding client config changes

### DIFF
--- a/src/main/services/KnowledgeService.ts
+++ b/src/main/services/KnowledgeService.ts
@@ -28,6 +28,7 @@ import { NoteLoader } from '@main/knowledge/embedjs/loader/noteLoader'
 import PreprocessProvider from '@main/knowledge/preprocess/PreprocessProvider'
 import Reranker from '@main/knowledge/reranker/Reranker'
 import { fileStorage } from '@main/services/FileStorage'
+import { getKnowledgeBaseEmbedCacheSignature } from '@main/services/knowledgeBaseEmbedSignature'
 import { windowService } from '@main/services/WindowService'
 import { getDataPath } from '@main/utils'
 import { getAllFiles, sanitizeFilename } from '@main/utils/file'
@@ -104,6 +105,8 @@ class KnowledgeService {
   private knowledgeItemProcessingQueueMappingPromise: Map<LoaderTaskOfSet, () => void> = new Map()
   private ragApplications: Map<string, RAGApplication> = new Map()
   private dbInstances: Map<string, LibSqlDb> = new Map()
+  /** Last embed client signature per KB id; used to invalidate cache when API key or embed settings change */
+  private ragEmbedCacheSignatures: Map<string, string> = new Map()
   private static MAXIMUM_WORKLOAD = 80 * MB
   private static MAXIMUM_PROCESSING_ITEM_COUNT = 30
   private static ERROR_LOADER_RETURN: LoaderReturn = {
@@ -143,6 +146,8 @@ class KnowledgeService {
         this.dbInstances.delete(id)
         logger.debug(`Removed database instance reference for id: ${id}`)
       }
+
+      this.ragEmbedCacheSignatures.delete(id)
     } catch (error) {
       logger.warn(`Failed to cleanup resources for id: ${id}`, error as Error)
     }
@@ -234,14 +239,43 @@ class KnowledgeService {
     logger.info(`Startup cleanup completed: ${deletedCount}/${pendingDeleteIds.length} knowledge bases deleted`)
   }
 
-  private getRagApplication = async ({
-    id,
-    embedApiClient,
-    dimensions,
-    documentCount
-  }: KnowledgeBaseParams): Promise<RAGApplication> => {
+  /**
+   * Drop in-memory RAG + DB handles without calling reset() on disk data.
+   * Used when embed API client changes (e.g. key rotation) so vectors are preserved.
+   */
+  private disposeCachedRagApplicationFromMemory = async (id: string): Promise<void> => {
+    this.ragEmbedCacheSignatures.delete(id)
+
+    const db = this.dbInstances.get(id)
+    if (db) {
+      try {
+        // LibSqlDb's client is private; match closeAll() until upstream exposes close().
+        const client = (db as any).client
+        if (client && typeof client.close === 'function') {
+          client.close()
+          logger.debug(`Closed database client for evicted cache id: ${id}`)
+        }
+      } catch (error) {
+        logger.warn(`Failed to close database instance for evicted id: ${id}`, error as Error)
+      }
+      this.dbInstances.delete(id)
+    }
+
     if (this.ragApplications.has(id)) {
-      return this.ragApplications.get(id)!
+      this.ragApplications.delete(id)
+      logger.debug(`Evicted RAG application from cache for id: ${id}`)
+    }
+  }
+
+  private getRagApplication = async (base: KnowledgeBaseParams): Promise<RAGApplication> => {
+    const { id, embedApiClient, dimensions, documentCount } = base
+    const signature = getKnowledgeBaseEmbedCacheSignature(base)
+
+    if (this.ragApplications.has(id)) {
+      if (this.ragEmbedCacheSignatures.get(id) === signature) {
+        return this.ragApplications.get(id)!
+      }
+      await this.disposeCachedRagApplicationFromMemory(id)
     }
 
     let ragApplication: RAGApplication
@@ -262,8 +296,10 @@ class KnowledgeService {
         .setSearchResultCount(documentCount || 30)
         .build()
       this.ragApplications.set(id, ragApplication)
+      this.ragEmbedCacheSignatures.set(id, signature)
     } catch (e) {
       logger.error('Failed to create RAGApplication:', e as Error)
+      this.ragEmbedCacheSignatures.delete(id)
       throw new Error(`Failed to create RAGApplication: ${e}`)
     }
 
@@ -709,6 +745,7 @@ class KnowledgeService {
 
     this.dbInstances.clear()
     this.ragApplications.clear()
+    this.ragEmbedCacheSignatures.clear()
 
     if (failed.length > 0) {
       throw new Error(`Failed to close KnowledgeBase connections: ${failed.join(', ')}`)

--- a/src/main/services/__tests__/knowledgeBaseEmbedSignature.test.ts
+++ b/src/main/services/__tests__/knowledgeBaseEmbedSignature.test.ts
@@ -1,0 +1,70 @@
+import type { KnowledgeBaseParams } from '@types'
+import { describe, expect, it } from 'vitest'
+
+import { getKnowledgeBaseEmbedCacheSignature } from '../knowledgeBaseEmbedSignature'
+
+function makeBase(overrides: Partial<KnowledgeBaseParams> = {}): KnowledgeBaseParams {
+  return {
+    id: 'kb-1',
+    dimensions: 1024,
+    documentCount: 10,
+    embedApiClient: {
+      model: 'bge-m3',
+      provider: 'silicon',
+      apiKey: 'key-a',
+      baseURL: 'https://api.example.com/v1'
+    },
+    ...overrides
+  }
+}
+
+describe('getKnowledgeBaseEmbedCacheSignature', () => {
+  it('returns the same string for identical configs', () => {
+    const a = makeBase()
+    const b = makeBase()
+    expect(getKnowledgeBaseEmbedCacheSignature(a)).toBe(getKnowledgeBaseEmbedCacheSignature(b))
+  })
+
+  it('changes when apiKey changes', () => {
+    const a = makeBase()
+    const b = makeBase({
+      embedApiClient: {
+        ...a.embedApiClient,
+        apiKey: 'key-b'
+      }
+    })
+    expect(getKnowledgeBaseEmbedCacheSignature(a)).not.toBe(getKnowledgeBaseEmbedCacheSignature(b))
+  })
+
+  it('changes when baseURL changes', () => {
+    const a = makeBase()
+    const b = makeBase({
+      embedApiClient: {
+        ...a.embedApiClient,
+        baseURL: 'https://other.example.com/v1'
+      }
+    })
+    expect(getKnowledgeBaseEmbedCacheSignature(a)).not.toBe(getKnowledgeBaseEmbedCacheSignature(b))
+  })
+
+  it('changes when embedding model id changes', () => {
+    const a = makeBase()
+    const b = makeBase({
+      embedApiClient: {
+        ...a.embedApiClient,
+        model: 'other-model'
+      }
+    })
+    expect(getKnowledgeBaseEmbedCacheSignature(a)).not.toBe(getKnowledgeBaseEmbedCacheSignature(b))
+  })
+
+  it('changes when dimensions or documentCount change', () => {
+    const base = makeBase()
+    expect(getKnowledgeBaseEmbedCacheSignature(base)).not.toBe(
+      getKnowledgeBaseEmbedCacheSignature({ ...base, dimensions: 512 })
+    )
+    expect(getKnowledgeBaseEmbedCacheSignature(base)).not.toBe(
+      getKnowledgeBaseEmbedCacheSignature({ ...base, documentCount: 20 })
+    )
+  })
+})

--- a/src/main/services/knowledgeBaseEmbedSignature.ts
+++ b/src/main/services/knowledgeBaseEmbedSignature.ts
@@ -1,0 +1,18 @@
+import type { KnowledgeBaseParams } from '@types'
+
+/**
+ * Stable signature for main-process RAG cache invalidation when embedding client
+ * configuration changes (e.g. API key rotation). Not for logging.
+ */
+export function getKnowledgeBaseEmbedCacheSignature(base: KnowledgeBaseParams): string {
+  const { embedApiClient, dimensions, documentCount } = base
+  return JSON.stringify({
+    d: dimensions ?? null,
+    dc: documentCount ?? null,
+    m: embedApiClient.model,
+    p: embedApiClient.provider,
+    k: embedApiClient.apiKey,
+    u: embedApiClient.baseURL,
+    v: embedApiClient.apiVersion ?? null
+  })
+}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

⚠️ Important: Redux/IndexedDB Data-Changing Feature PRs Temporarily On Hold ⚠️

Please note: For our current development cycle, we are not accepting feature Pull Requests that introduce changes to Redux data models or IndexedDB schemas.

While we value your contributions, PRs of this nature will be blocked without merge. We welcome all other contributions (bug fixes, perf enhancements, docs, etc.). Thank you!

Once version 2.0.0 is released, we will resume reviewing feature PRs.

-->

### What this PR does

Before this PR:

The Electron main process cached `RAGApplication` instances per knowledge base id only. The embedded `Embeddings` client was created on first use and kept the first-seen API key/base URL. After rotating the embedding provider API key in settings, IPC calls could include the updated credentials while the cached instance still authenticated with stale values, leading to `401` / `Api key is invalid` on `knowledge-base:search` until the knowledge base was recreated.

After this PR:

When the embedding client configuration changes (API key, base URL, model, provider, dimensions, or document count), the in-memory RAG/LibSQL handles are evicted without calling `reset()` on disk data, and a new `RAGApplication` is built with the current `embedApiClient`. A small helper computes a stable signature; unit tests cover signature stability.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

N/A — This PR is **related to** [#12799](https://github.com/CherryHQ/cherry-studio/issues/12799) but **does not claim** to match the original reporter’s reproduction (web search only, no user knowledge base). Maintainers should confirm whether the same root cause applies before closing that issue.

### Why we need it and why it was done in this way

The renderer already resolves the latest provider credentials when building `KnowledgeBaseParams`; the bug was main-process cache invalidation keyed solely by id.

The following tradeoffs were made:

- Signature includes embedding-relevant fields (including API key material) only for in-process equality checks; it is not logged and is cleared on eviction/delete.

The following alternatives were considered:

- Clearing cache on any provider update from Redux (would require broader wiring); per-request signature comparison is localized to `KnowledgeService`.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

N/A

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

<!-- optional -->

Manual verification: rotating the embedding provider API key (e.g. SiliconFlow) without deleting the knowledge base; assistant retrieval should no longer fail with `401` from stale credentials. Issue [#12799](https://github.com/CherryHQ/cherry-studio/issues/12799) describes a similar error with web search; this change may help any path that calls `knowledge-base:search` with a reused cache entry, but the original steps were not reproduced here.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed an issue where the main process could keep using a stale embedding API client after the provider API key or embedding endpoint settings changed, causing knowledge base search to fail with 401 until the knowledge base was recreated.
```
