### PR TITLE
fix: extend Qwen3.5 model detection to support Qwen3.5–3.9 series

### DIFF
--- a/src/renderer/src/aiCore/plugins/PluginBuilder.ts
+++ b/src/renderer/src/aiCore/plugins/PluginBuilder.ts
@@ -1,7 +1,7 @@
 import type { AiPlugin } from '@cherrystudio/ai-core'
 import { createPromptToolUsePlugin, providerToolPlugin } from '@cherrystudio/ai-core/built-in/plugins'
 import { loggerService } from '@logger'
-import { isGemini3Model, isQwen35Model, isSupportedThinkingTokenQwenModel } from '@renderer/config/models'
+import { isGemini3Model, isQwen35to39Model, isSupportedThinkingTokenQwenModel } from '@renderer/config/models'
 import { getEnableDeveloperMode } from '@renderer/hooks/useSettings'
 import type { Assistant, Model, Provider } from '@renderer/types'
 import { SystemProviderIds } from '@renderer/types'
@@ -93,7 +93,7 @@ export function buildPlugins({ provider, model, config }: BuildPluginsContext): 
   if (
     !isOllamaProvider(provider) &&
     isSupportedThinkingTokenQwenModel(model) &&
-    !isQwen35Model(model) &&
+    !isQwen35to39Model(model) &&
     !isSupportEnableThinkingProvider(provider)
   ) {
     const enableThinking = config.assistant?.settings?.reasoning_effort !== undefined

--- a/src/renderer/src/aiCore/utils/reasoning.ts
+++ b/src/renderer/src/aiCore/utils/reasoning.ts
@@ -21,7 +21,7 @@ import {
   isOpenAIModel,
   isOpenAIOpenWeightModel,
   isOpenAIReasoningModel,
-  isQwen35Model,
+  isQwen35to39Model,
   isQwenAlwaysThinkModel,
   isQwenReasoningModel,
   isReasoningModel,
@@ -198,7 +198,7 @@ export function getReasoningEffort(assistant: Assistant, model: Model): Reasonin
 
     // Qwen 3.5 without direct enable_thinking
     // https://huggingface.co/Qwen/Qwen3.5-397B-A17B#instruct-or-non-thinking-mode
-    if (isQwen35Model(model)) {
+    if (isQwen35to39Model(model)) {
       return {
         chat_template_kwargs: {
           enable_thinking: false

--- a/src/renderer/src/config/models/__tests__/models.test.ts
+++ b/src/renderer/src/config/models/__tests__/models.test.ts
@@ -4,7 +4,7 @@ import {
   isSupportedThinkingTokenQwenModel,
   isVisionModel
 } from '@renderer/config/models'
-import { isQwen35Model } from '@renderer/config/models/qwen'
+import { isQwen35to39Model } from '@renderer/config/models/qwen'
 import type { Model } from '@renderer/types'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
@@ -105,19 +105,24 @@ describe('Qwen Model Detection', () => {
     expect(isVisionModel({ id: 'qwen-omni-turbo' } as Model)).toBe(true)
   })
 
-  test('isQwen35Model', () => {
+  test('isQwen35to39Model', () => {
     // Qwen 3.5 series
-    expect(isQwen35Model({ id: 'qwen3.5-plus' } as Model)).toBe(true)
-    expect(isQwen35Model({ id: 'qwen3.5-plus-2026-02-15' } as Model)).toBe(true)
-    expect(isQwen35Model({ id: 'qwen3.5-flash' } as Model)).toBe(true)
-    expect(isQwen35Model({ id: 'qwen3.5-397b-a17b' } as Model)).toBe(true)
-    expect(isQwen35Model({ id: 'qwen3.5-thinking' } as Model)).toBe(true)
-    expect(isQwen35Model({ id: 'qwen3.5-instruct' } as Model)).toBe(true)
-    // Not Qwen 3.5
-    expect(isQwen35Model({ id: 'qwen3-max' } as Model)).toBe(false)
-    expect(isQwen35Model({ id: 'qwen3-8b' } as Model)).toBe(false)
-    expect(isQwen35Model({ id: 'qwen-plus' } as Model)).toBe(false)
-    expect(isQwen35Model(undefined)).toBe(false)
+    expect(isQwen35to39Model({ id: 'qwen3.5-plus' } as Model)).toBe(true)
+    expect(isQwen35to39Model({ id: 'qwen3.5-plus-2026-02-15' } as Model)).toBe(true)
+    expect(isQwen35to39Model({ id: 'qwen3.5-flash' } as Model)).toBe(true)
+    expect(isQwen35to39Model({ id: 'qwen3.5-397b-a17b' } as Model)).toBe(true)
+    expect(isQwen35to39Model({ id: 'qwen3.5-thinking' } as Model)).toBe(true)
+    expect(isQwen35to39Model({ id: 'qwen3.5-instruct' } as Model)).toBe(true)
+    // Qwen 3.6+ series (future-proof)
+    expect(isQwen35to39Model({ id: 'qwen3.6-plus' } as Model)).toBe(true)
+    expect(isQwen35to39Model({ id: 'qwen3.6-flash' } as Model)).toBe(true)
+    expect(isQwen35to39Model({ id: 'qwen3.7-200b' } as Model)).toBe(true)
+    expect(isQwen35to39Model({ id: 'qwen3.9-thinking' } as Model)).toBe(true)
+    // Not Qwen 3.5~3.9
+    expect(isQwen35to39Model({ id: 'qwen3-max' } as Model)).toBe(false)
+    expect(isQwen35to39Model({ id: 'qwen3-8b' } as Model)).toBe(false)
+    expect(isQwen35to39Model({ id: 'qwen-plus' } as Model)).toBe(false)
+    expect(isQwen35to39Model(undefined)).toBe(false)
   })
 })
 

--- a/src/renderer/src/config/models/qwen.ts
+++ b/src/renderer/src/config/models/qwen.ts
@@ -7,18 +7,19 @@ export const isQwenMTModel = (model: Model): boolean => {
 }
 
 /**
- * Checks if the model is a Qwen 3.5 series model.
+ * Checks if the model is a Qwen 3.5~3.9 series model.
  *
- * This function determines whether the given model belongs to the Qwen 3.5 series
- * by checking if its ID starts with 'qwen3.5'. The check is case-insensitive.
+ * This function determines whether the given model belongs to the Qwen 3.5–3.9 series
+ * by checking if its ID starts with 'qwen3.' followed by a single digit 5–9.
+ * The check is case-insensitive.
  *
  * @param model - The model to check, can be undefined.
- * @returns `true` if the model is a Qwen 3.5 series model, `false` otherwise.
+ * @returns `true` if the model is a Qwen 3.5–3.9 series model, `false` otherwise.
  */
-export function isQwen35Model(model?: Model): boolean {
+export function isQwen35to39Model(model?: Model): boolean {
   if (!model) {
     return false
   }
   const modelId = getLowerBaseModelName(model.id, '/')
-  return modelId.startsWith('qwen3.5')
+  return /^qwen3\.[5-9]/.test(modelId)
 }

--- a/src/renderer/src/config/models/reasoning.ts
+++ b/src/renderer/src/config/models/reasoning.ts
@@ -451,8 +451,8 @@ export function isSupportedThinkingTokenQwenModel(model?: Model): boolean {
     return false
   }
 
-  // qwen 3.5 series models, all support
-  if (modelId.startsWith('qwen3.5')) {
+  // qwen 3.5~3.9 series models, all support
+  if (/^qwen3\.[5-9]/.test(modelId)) {
     return true
   }
 
@@ -464,9 +464,9 @@ export function isSupportedThinkingTokenQwenModel(model?: Model): boolean {
   //    In the global deployment environment, qwen-max still points to the non-reasoning snapshot from 2025-09-23,
   //    whereas in mainland China, qwen-max has been updated to the latest 2026-01-23 snapshot, which supports reasoning control. - 2026-03-05
   const MAX_REGEX = /^(?:qwen3-max(?!-2025-09-23)|qwen-max-latest)(?:-|$)/i
-  const PLUS_REGEX = /^qwen(?:3\.5)?-plus(?:-|$)/i
-  const FLASH_REGEX = /^qwen(?:3\.5)?-flash(?:-|$)/i
-  const TURBO_REGEX = /^qwen(?:3\.5)?-turbo(?:-|$)/i
+  const PLUS_REGEX = /^qwen(?:3\.[5-9])?-plus(?:-|$)/i
+  const FLASH_REGEX = /^qwen(?:3\.[5-9])?-flash(?:-|$)/i
+  const TURBO_REGEX = /^qwen(?:3\.[5-9])?-turbo(?:-|$)/i
   // open-weight qwen3 models with numeric size (e.g. qwen3-8b, qwen3-72b)
   const QWEN3_OPEN_REGEX = /^qwen3-\d/i
 
@@ -791,8 +791,8 @@ const THINKING_TOKEN_MAP: Record<string, { min: number; max: number }> = {
   'qwen-flash.*$': { min: 0, max: 81_920 },
   // qwen3-max series (reasoning models, equivalent to qwen-plus for thinking budget)
   'qwen3-max(-.*)?$': { min: 0, max: 81_920 },
-  // Qwen3.5 series (max thinking budget: 81920)
-  '^qwen3\\.5': { min: 0, max: 81_920 },
+  // Qwen3.5+ series (max thinking budget: 81920)
+  '^qwen3\\.[5-9]': { min: 0, max: 81_920 },
   'qwen3-(?!max).*$': { min: 1024, max: 38_912 },
 
   // Claude models (supports AWS Bedrock 'anthropic.' prefix, GCP Vertex AI '@' separator, and '-v1:0' suffix)


### PR DESCRIPTION
### What this PR does

Before this PR:

Qwen model detection functions (`isQwen35Model`, `isSupportedThinkingTokenQwenModel`, thinking budget config, etc.) only matched `qwen3.5-*` models via hardcoded `startsWith('qwen3.5')` checks.

After this PR:

All Qwen 3.5–3.9 series models are recognized by using `/^qwen3\.[5-9]/` regex patterns. The function `isQwen35Model` is renamed to `isQwen35to39Model` for clarity.

Fixes #13967

### Why we need it and why it was done in this way

Qwen will release 3.6+ models that share the same API behavior (vision, reasoning, thinking tokens, function calling) as 3.5. Hardcoding `qwen3.5` would require a code change for every new minor version.

The following tradeoffs were made:

Using `[5-9]` range instead of `\d+` with numeric comparison — simpler regex, and Qwen 4.x would be a different series requiring its own handling anyway.

The following alternatives were considered:

- Keeping `isQwen35Model` name unchanged — rejected because the broader match makes the old name misleading.
- Matching all `qwen3.\d+` — rejected because versions below 3.5 (if they existed) may have different behavior.

### Breaking changes

None. This is an internal refactoring of model detection utilities.

### Special notes for your reviewer

- The PLUS/FLASH/TURBO regexes in `isSupportedThinkingTokenQwenModel` were also updated from `(?:3\.5)?` to `(?:3\.[5-9])?` for consistency.
- The thinking budget regex was updated from `'^qwen3\\.5'` to `'^qwen3\\.[5-9]'`.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
