### PR TITLE
feat(api): add knowledge items ingest endpoint

### DIFF
--- a/packages/shared/data/types/knowledge.ts
+++ b/packages/shared/data/types/knowledge.ts
@@ -21,6 +21,14 @@ export const KNOWLEDGE_SEARCH_MODES = ['default', 'bm25', 'hybrid'] as const
 export const KnowledgeSearchModeSchema = z.enum(KNOWLEDGE_SEARCH_MODES)
 export type KnowledgeSearchMode = z.infer<typeof KnowledgeSearchModeSchema>
 
+export const KnowledgeItemIngestionSchema = z
+  .object({
+    loaderId: z.string().trim().min(1),
+    loaderIds: z.array(z.string().trim().min(1)).min(1)
+  })
+  .strict()
+export type KnowledgeItemIngestion = z.infer<typeof KnowledgeItemIngestionSchema>
+
 /**
  * Temporary schema mirroring the current FileMetadata shape.
  * TODO: Move to `types/file.ts` once the dedicated file domain schema is ready.
@@ -43,7 +51,8 @@ export const FileMetadataSchema: z.ZodType<FileMetadata> = z.object({
  * File item data.
  */
 export const FileItemDataSchema = z.object({
-  file: FileMetadataSchema
+  file: FileMetadataSchema,
+  ingestion: KnowledgeItemIngestionSchema.optional()
 })
 export type FileItemData = z.infer<typeof FileItemDataSchema>
 
@@ -52,7 +61,8 @@ export type FileItemData = z.infer<typeof FileItemDataSchema>
  */
 export const UrlItemDataSchema = z.object({
   url: z.string().trim().min(1),
-  name: z.string().trim().min(1)
+  name: z.string().trim().min(1),
+  ingestion: KnowledgeItemIngestionSchema.optional()
 })
 export type UrlItemData = z.infer<typeof UrlItemDataSchema>
 
@@ -61,7 +71,8 @@ export type UrlItemData = z.infer<typeof UrlItemDataSchema>
  */
 export const NoteItemDataSchema = z.object({
   content: z.string(),
-  sourceUrl: z.string().optional()
+  sourceUrl: z.string().optional(),
+  ingestion: KnowledgeItemIngestionSchema.optional()
 })
 export type NoteItemData = z.infer<typeof NoteItemDataSchema>
 
@@ -70,7 +81,8 @@ export type NoteItemData = z.infer<typeof NoteItemDataSchema>
  */
 export const SitemapItemDataSchema = z.object({
   url: z.string().trim().min(1),
-  name: z.string().trim().min(1)
+  name: z.string().trim().min(1),
+  ingestion: KnowledgeItemIngestionSchema.optional()
 })
 export type SitemapItemData = z.infer<typeof SitemapItemDataSchema>
 
@@ -79,7 +91,8 @@ export type SitemapItemData = z.infer<typeof SitemapItemDataSchema>
  */
 export const DirectoryItemDataSchema = z.object({
   path: z.string().trim().min(1),
-  recursive: z.boolean()
+  recursive: z.boolean(),
+  ingestion: KnowledgeItemIngestionSchema.optional()
 })
 export type DirectoryItemData = z.infer<typeof DirectoryItemDataSchema>
 

--- a/src/main/apiServer/app.ts
+++ b/src/main/apiServer/app.ts
@@ -135,6 +135,7 @@ app.get('/', (_req, res) => {
       agent_sessions: 'GET /v1/agents/:agentId/sessions',
       session_messages: 'GET /v1/agents/:agentId/sessions/:sessionId/messages',
       knowledge_bases: 'GET /v1/knowledge-bases',
+      knowledge_items_create: 'POST /v1/knowledge-bases/:id/items',
       knowledge_search: 'POST /v1/knowledge-bases/search'
     }
   })

--- a/src/main/apiServer/generated/openapi-spec.json
+++ b/src/main/apiServer/generated/openapi-spec.json
@@ -829,6 +829,83 @@
             "description": "Warning messages for partial search failures"
           }
         }
+      },
+      "KnowledgeItemEntity": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "baseId": {
+            "type": "string"
+          },
+          "groupId": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "enum": ["file", "url", "note", "sitemap", "directory"]
+          },
+          "data": {
+            "type": "object",
+            "description": "Type-specific item payload. Successful ingests include `ingestion.loaderId` and `ingestion.loaderIds`."
+          },
+          "status": {
+            "type": "string",
+            "enum": ["idle", "pending", "ocr", "read", "embed", "completed", "failed"]
+          },
+          "error": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "CreateKnowledgeItemsRequest": {
+        "type": "object",
+        "required": ["items"],
+        "properties": {
+          "items": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["type", "data"],
+              "properties": {
+                "groupId": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "type": {
+                  "type": "string",
+                  "enum": ["file", "url", "note", "sitemap", "directory"]
+                },
+                "data": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      },
+      "CreateKnowledgeItemsResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/KnowledgeItemEntity"
+            }
+          }
+        }
       }
     }
   },
@@ -2348,16 +2425,6 @@
                 }
               }
             }
-          },
-          "503": {
-            "description": "Service unavailable (Redux store not accessible)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
           }
         }
       }
@@ -2407,9 +2474,86 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/v1/knowledge-bases/{id}/items": {
+      "post": {
+        "summary": "Create and ingest knowledge items",
+        "description": "Create knowledge items for a knowledge base and ingest them into the vector store.\n\nSupported item types:\n- `file`\n- `url`\n- `note`\n- `sitemap`\n- `directory`\n\nEach returned item includes the persisted processing status.\nSuccessful ingests persist loader metadata inside `data.ingestion`.\n",
+        "tags": ["Knowledge"],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Knowledge base ID"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateKnowledgeItemsRequest"
+              },
+              "example": {
+                "items": [
+                  {
+                    "type": "note",
+                    "data": {
+                      "content": "Cherry Studio knowledge ingestion"
+                    }
+                  },
+                  {
+                    "type": "url",
+                    "data": {
+                      "url": "https://docs.cherry-ai.com",
+                      "name": "Cherry Studio Docs"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Knowledge items created and ingested",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateKnowledgeItemsResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Knowledge base not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           },
           "503": {
-            "description": "Service unavailable (Redux store not accessible)",
+            "description": "Provider configuration is unavailable",
             "content": {
               "application/json": {
                 "schema": {
@@ -2495,7 +2639,7 @@
             }
           },
           "503": {
-            "description": "Service unavailable (Redux store not accessible)",
+            "description": "Provider configuration is unavailable",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/main/apiServer/routes/knowledge/__tests__/handlers.test.ts
+++ b/src/main/apiServer/routes/knowledge/__tests__/handlers.test.ts
@@ -1,19 +1,53 @@
-import type { KnowledgeBase } from '@types'
 import type { Response } from 'express'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ValidationRequest } from '../../agents/validators/zodValidator'
 
-// Mock dependencies BEFORE importing handlers - no top-level variables
+const {
+  listWithOffsetMock,
+  listAllMock,
+  getKnowledgeBaseByIdMock,
+  createKnowledgeItemsMock,
+  updateKnowledgeItemMock,
+  reduxSelectMock,
+  knowledgeAddMock,
+  knowledgeSearchMock
+} = vi.hoisted(() => ({
+  listWithOffsetMock: vi.fn(),
+  listAllMock: vi.fn(),
+  getKnowledgeBaseByIdMock: vi.fn(),
+  createKnowledgeItemsMock: vi.fn(),
+  updateKnowledgeItemMock: vi.fn(),
+  reduxSelectMock: vi.fn(),
+  knowledgeAddMock: vi.fn(),
+  knowledgeSearchMock: vi.fn()
+}))
+
+vi.mock('@data/services/KnowledgeBaseService', () => ({
+  knowledgeBaseService: {
+    listWithOffset: listWithOffsetMock,
+    listAll: listAllMock,
+    getById: getKnowledgeBaseByIdMock
+  }
+}))
+
+vi.mock('@data/services/KnowledgeItemService', () => ({
+  knowledgeItemService: {
+    createMany: createKnowledgeItemsMock,
+    update: updateKnowledgeItemMock
+  }
+}))
+
 vi.mock('@main/services/ReduxService', () => ({
   reduxService: {
-    select: vi.fn()
+    select: reduxSelectMock
   }
 }))
 
 vi.mock('@main/services/KnowledgeService', () => ({
-  default: {
-    search: vi.fn()
+  knowledgeService: {
+    add: knowledgeAddMock,
+    search: knowledgeSearchMock
   }
 }))
 
@@ -28,26 +62,62 @@ vi.mock('@logger', () => ({
   }
 }))
 
-// Import handlers AFTER mocks
-import { getKnowledgeBase, listKnowledgeBases, searchKnowledge } from '../handlers'
+import { createKnowledgeItems, getKnowledgeBase, listKnowledgeBases, searchKnowledge } from '../handlers'
 
-// Helper to create mock KnowledgeBase
-function createMockKnowledgeBase(overrides: Partial<KnowledgeBase> = {}): KnowledgeBase {
+function createMockKnowledgeBase(overrides: Record<string, unknown> = {}) {
   return {
-    id: 'kb-test-id',
+    id: 'kb-1',
     name: 'Test Knowledge Base',
-    description: 'Test description',
-    model: { id: 'text-embedding-3-small', provider: 'openai' },
+    description: 'Knowledge description',
     dimensions: 1536,
+    embeddingModelId: 'openai::text-embedding-3-small',
+    rerankModelId: 'jina::jina-reranker-v1',
+    fileProcessorId: 'mineru',
     chunkSize: 500,
     chunkOverlap: 50,
+    threshold: 0.5,
     documentCount: 10,
-    version: 1,
-    items: [],
-    created_at: Date.now(),
-    updated_at: Date.now(),
+    searchMode: 'default',
+    createdAt: '2026-04-03T00:00:00.000Z',
+    updatedAt: '2026-04-03T01:00:00.000Z',
     ...overrides
-  } as KnowledgeBase
+  }
+}
+
+function createMockKnowledgeItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'item-1',
+    baseId: 'kb-1',
+    groupId: null,
+    type: 'note',
+    data: { content: 'hello world' },
+    status: 'idle',
+    error: null,
+    createdAt: '2026-04-03T00:00:00.000Z',
+    updatedAt: '2026-04-03T01:00:00.000Z',
+    ...overrides
+  }
+}
+
+function createMockProviders() {
+  return [
+    {
+      id: 'openai',
+      type: 'openai',
+      name: 'OpenAI',
+      apiKey: 'sk-openai',
+      apiHost: 'https://api.openai.com/v1',
+      models: [{ id: 'text-embedding-3-small', provider: 'openai', name: 'text-embedding-3-small', group: 'embed' }]
+    },
+    {
+      id: 'jina',
+      type: 'openai',
+      name: 'Jina',
+      apiKey: 'sk-jina',
+      apiHost: 'https://api.jina.ai/v1',
+      models: [{ id: 'jina-reranker-v1', provider: 'jina', name: 'jina-reranker-v1', group: 'rerank' }]
+    }
+  ]
 }
 
 describe('Knowledge Handlers', () => {
@@ -70,92 +140,58 @@ describe('Knowledge Handlers', () => {
   })
 
   describe('listKnowledgeBases', () => {
-    it('should return paginated knowledge bases', async () => {
-      const mockBases = [
-        createMockKnowledgeBase({ id: 'kb-1', name: 'KB 1' }),
-        createMockKnowledgeBase({ id: 'kb-2', name: 'KB 2' }),
-        createMockKnowledgeBase({ id: 'kb-3', name: 'KB 3' })
-      ]
-
-      const { reduxService } = await import('@main/services/ReduxService')
-      ;(reduxService.select as ReturnType<typeof vi.fn>).mockResolvedValue(mockBases)
-
-      req.validatedQuery = { limit: 2, offset: 0 }
-
-      await listKnowledgeBases(req as ValidationRequest, res as Response)
-
-      expect(jsonMock).toHaveBeenCalledWith({
-        knowledge_bases: mockBases.slice(0, 2),
-        total: 3
+    it('should return v2 knowledge bases with public API shape', async () => {
+      listWithOffsetMock.mockResolvedValue({
+        items: [createMockKnowledgeBase()],
+        total: 1
       })
-    })
-
-    it('should return 503 when Redux is unavailable', async () => {
-      const { reduxService } = await import('@main/services/ReduxService')
-      ;(reduxService.select as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Main window is not available'))
 
       req.validatedQuery = { limit: 20, offset: 0 }
 
       await listKnowledgeBases(req as ValidationRequest, res as Response)
 
-      expect(statusMock).toHaveBeenCalledWith(503)
+      expect(listWithOffsetMock).toHaveBeenCalledWith({ limit: 20, offset: 0 })
       expect(jsonMock).toHaveBeenCalledWith({
-        error: {
-          message: 'Knowledge bases are only available when Cherry Studio window is open',
-          type: 'service_unavailable',
-          code: 'REDUX_UNAVAILABLE'
-        }
+        knowledge_bases: [
+          expect.objectContaining({
+            id: 'kb-1',
+            version: 2,
+            model: {
+              id: 'text-embedding-3-small',
+              provider: 'openai'
+            }
+          })
+        ],
+        total: 1
       })
     })
   })
 
   describe('getKnowledgeBase', () => {
-    it('should return a single knowledge base', async () => {
-      const mockBase = createMockKnowledgeBase({ id: 'kb-1' })
-      const { reduxService } = await import('@main/services/ReduxService')
-      ;(reduxService.select as ReturnType<typeof vi.fn>).mockResolvedValue([mockBase])
+    it('should return a single v2 knowledge base', async () => {
+      getKnowledgeBaseByIdMock.mockResolvedValue(createMockKnowledgeBase())
 
       req.validatedParams = { id: 'kb-1' }
 
       await getKnowledgeBase(req as ValidationRequest, res as Response)
 
-      expect(jsonMock).toHaveBeenCalledWith(mockBase)
-    })
-
-    it('should return 404 when knowledge base not found', async () => {
-      const { reduxService } = await import('@main/services/ReduxService')
-      ;(reduxService.select as ReturnType<typeof vi.fn>).mockResolvedValue([])
-
-      req.validatedParams = { id: 'non-existent' }
-
-      await getKnowledgeBase(req as ValidationRequest, res as Response)
-
-      expect(statusMock).toHaveBeenCalledWith(404)
-      expect(jsonMock).toHaveBeenCalledWith({
-        error: {
-          message: 'Knowledge base not found: non-existent',
-          type: 'invalid_request_error',
-          code: 'KB_NOT_FOUND'
-        }
-      })
-    })
-
-    it('should return 503 when Redux is unavailable', async () => {
-      const { reduxService } = await import('@main/services/ReduxService')
-      ;(reduxService.select as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Main window is not available'))
-
-      req.validatedParams = { id: 'kb-1' }
-
-      await getKnowledgeBase(req as ValidationRequest, res as Response)
-
-      expect(statusMock).toHaveBeenCalledWith(503)
+      expect(getKnowledgeBaseByIdMock).toHaveBeenCalledWith('kb-1')
+      expect(jsonMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'kb-1',
+          version: 2,
+          preprocessProvider: {
+            type: 'preprocess',
+            provider: 'mineru'
+          }
+        })
+      )
     })
   })
 
   describe('searchKnowledge', () => {
-    it('should return warnings when no knowledge bases configured', async () => {
-      const { reduxService } = await import('@main/services/ReduxService')
-      ;(reduxService.select as ReturnType<typeof vi.fn>).mockResolvedValue([])
+    it('should return warnings when no knowledge bases are configured in v2', async () => {
+      listAllMock.mockResolvedValue([])
 
       req.validatedBody = { query: 'test query', document_count: 5 }
 
@@ -170,13 +206,12 @@ describe('Knowledge Handlers', () => {
       })
     })
 
-    it('should return 404 when specified knowledge bases not found', async () => {
-      const { reduxService } = await import('@main/services/ReduxService')
-      ;(reduxService.select as ReturnType<typeof vi.fn>).mockResolvedValue([createMockKnowledgeBase({ id: 'kb-1' })])
+    it('should return 404 when specified knowledge bases are not found in v2', async () => {
+      listAllMock.mockResolvedValue([createMockKnowledgeBase({ id: 'kb-1' })])
 
       req.validatedBody = {
         query: 'test query',
-        knowledge_base_ids: ['non-existent'],
+        knowledge_base_ids: ['missing'],
         document_count: 5
       }
 
@@ -192,15 +227,169 @@ describe('Knowledge Handlers', () => {
       })
     })
 
-    it('should return 503 when Redux is unavailable', async () => {
-      const { reduxService } = await import('@main/services/ReduxService')
-      ;(reduxService.select as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Main window is not available'))
+    it('should search knowledge bases using v2 metadata and legacy vector service', async () => {
+      listAllMock.mockResolvedValue([createMockKnowledgeBase()])
+      reduxSelectMock.mockResolvedValue(createMockProviders())
+      knowledgeSearchMock.mockResolvedValue([
+        {
+          pageContent: 'knowledge chunk',
+          score: 0.91,
+          metadata: {
+            source: 'note'
+          }
+        }
+      ])
 
-      req.validatedBody = { query: 'test query', document_count: 5 }
+      req.validatedBody = { query: 'knowledge', document_count: 5 }
 
       await searchKnowledge(req as ValidationRequest, res as Response)
 
-      expect(statusMock).toHaveBeenCalledWith(503)
+      expect(knowledgeSearchMock).toHaveBeenCalledTimes(1)
+      expect(jsonMock).toHaveBeenCalledWith({
+        query: 'knowledge',
+        results: [
+          {
+            pageContent: 'knowledge chunk',
+            score: 0.91,
+            metadata: {
+              source: 'note'
+            },
+            knowledge_base_id: 'kb-1',
+            knowledge_base_name: 'Test Knowledge Base'
+          }
+        ],
+        total: 1,
+        searched_bases: [{ id: 'kb-1', name: 'Test Knowledge Base' }]
+      })
+    })
+  })
+
+  describe('createKnowledgeItems', () => {
+    it('should create items and persist ingestion metadata on success', async () => {
+      getKnowledgeBaseByIdMock.mockResolvedValue(createMockKnowledgeBase())
+      reduxSelectMock.mockResolvedValue(createMockProviders())
+      createKnowledgeItemsMock.mockResolvedValue({
+        items: [createMockKnowledgeItem()]
+      })
+      updateKnowledgeItemMock
+        .mockResolvedValueOnce(createMockKnowledgeItem({ status: 'pending' }))
+        .mockResolvedValueOnce(
+          createMockKnowledgeItem({
+            status: 'completed',
+            data: {
+              content: 'hello world',
+              ingestion: {
+                loaderId: 'loader-1',
+                loaderIds: ['loader-1']
+              }
+            }
+          })
+        )
+      knowledgeAddMock.mockResolvedValue({
+        entriesAdded: 1,
+        uniqueId: 'loader-1',
+        uniqueIds: ['loader-1'],
+        loaderType: 'NoteLoader'
+      })
+
+      req.validatedParams = { id: 'kb-1' }
+      req.validatedBody = {
+        items: [
+          {
+            type: 'note',
+            data: {
+              content: 'hello world'
+            }
+          }
+        ]
+      }
+
+      await createKnowledgeItems(req as ValidationRequest, res as Response)
+
+      expect(createKnowledgeItemsMock).toHaveBeenCalledWith('kb-1', {
+        items: [
+          {
+            type: 'note',
+            data: {
+              content: 'hello world'
+            }
+          }
+        ]
+      })
+      expect(updateKnowledgeItemMock).toHaveBeenNthCalledWith(1, 'item-1', {
+        status: 'pending',
+        error: null
+      })
+      expect(updateKnowledgeItemMock).toHaveBeenNthCalledWith(2, 'item-1', {
+        data: {
+          content: 'hello world',
+          ingestion: {
+            loaderId: 'loader-1',
+            loaderIds: ['loader-1']
+          }
+        },
+        status: 'completed',
+        error: null
+      })
+      expect(statusMock).toHaveBeenCalledWith(201)
+      expect(jsonMock).toHaveBeenCalledWith({
+        items: [
+          expect.objectContaining({
+            id: 'item-1',
+            status: 'completed'
+          })
+        ]
+      })
+    })
+
+    it('should mark items as failed when vector ingest does not return loader ids', async () => {
+      getKnowledgeBaseByIdMock.mockResolvedValue(createMockKnowledgeBase())
+      reduxSelectMock.mockResolvedValue(createMockProviders())
+      createKnowledgeItemsMock.mockResolvedValue({
+        items: [createMockKnowledgeItem()]
+      })
+      updateKnowledgeItemMock
+        .mockResolvedValueOnce(createMockKnowledgeItem({ status: 'pending' }))
+        .mockResolvedValueOnce(
+          createMockKnowledgeItem({
+            status: 'failed',
+            error: 'Knowledge item ingest failed'
+          })
+        )
+      knowledgeAddMock.mockResolvedValue({
+        entriesAdded: 0,
+        uniqueId: '',
+        uniqueIds: [''],
+        loaderType: 'NoteLoader'
+      })
+
+      req.validatedParams = { id: 'kb-1' }
+      req.validatedBody = {
+        items: [
+          {
+            type: 'note',
+            data: {
+              content: 'hello world'
+            }
+          }
+        ]
+      }
+
+      await createKnowledgeItems(req as ValidationRequest, res as Response)
+
+      expect(updateKnowledgeItemMock).toHaveBeenNthCalledWith(2, 'item-1', {
+        status: 'failed',
+        error: 'Knowledge item ingest failed'
+      })
+      expect(statusMock).toHaveBeenCalledWith(201)
+      expect(jsonMock).toHaveBeenCalledWith({
+        items: [
+          expect.objectContaining({
+            id: 'item-1',
+            status: 'failed'
+          })
+        ]
+      })
     })
   })
 })

--- a/src/main/apiServer/routes/knowledge/handlers.ts
+++ b/src/main/apiServer/routes/knowledge/handlers.ts
@@ -1,29 +1,299 @@
-// TODO(v2): All Redux store reads in this file (state.knowledge.bases, state.llm.providers)
-//           should migrate to the V2 SQLite/Drizzle data layer (src/main/services/agents/).
-//           Redux is blocked for new data-model features until v2.0.0.
-//           See: src/main/services/agents/database/schema/index.ts
-
+import { knowledgeBaseService } from '@data/services/KnowledgeBaseService'
+import { knowledgeItemService } from '@data/services/KnowledgeItemService'
 import { loggerService } from '@logger'
 import { knowledgeService } from '@main/services/KnowledgeService'
 import { reduxService } from '@main/services/ReduxService'
-import type { KnowledgeBase, KnowledgeBaseParams, Provider } from '@types'
+import type { LoaderReturn } from '@shared/config/types'
+import { isDataApiError } from '@shared/data/api'
+import type { CreateKnowledgeItemsDto } from '@shared/data/api/schemas/knowledges'
+import type {
+  KnowledgeBase as V2KnowledgeBase,
+  KnowledgeItem as V2KnowledgeItem,
+  KnowledgeItemIngestion
+} from '@shared/data/types/knowledge'
+import type {
+  KnowledgeBaseParams,
+  KnowledgeItem as LegacyKnowledgeItem,
+  KnowledgeNoteItem as LegacyKnowledgeNoteItem,
+  Provider
+} from '@types'
 import type { Response } from 'express'
 import type * as z from 'zod'
 
 import type { ValidationRequest } from '../agents/validators/zodValidator'
-import type { KnowledgeSearchSchema } from './validators/zodSchemas'
+import type { CreateKnowledgeItemsRequestSchema, KnowledgeSearchSchema } from './validators/zodSchemas'
 
 const logger = loggerService.withContext('KnowledgeHandlers')
 
-// Infer types from Zod schemas to avoid duplication
 type ValidatedSearchBody = z.infer<typeof KnowledgeSearchSchema>
+type ValidatedCreateKnowledgeItemsBody = z.infer<typeof CreateKnowledgeItemsRequestSchema>
 
-/**
- * Helper to detect Redux unavailability errors
- */
+type ApiKnowledgeBaseEntity = {
+  id: string
+  name: string
+  description?: string
+  model: {
+    id: string
+    provider: string
+  }
+  dimensions?: number
+  chunkSize?: number
+  chunkOverlap?: number
+  documentCount?: number
+  version: number
+  threshold?: number
+  rerankModel?: {
+    id: string
+    provider: string
+  }
+  preprocessProvider?: {
+    type: 'preprocess'
+    provider: string
+  }
+  items: []
+  created_at: number
+  updated_at: number
+}
+
 function isReduxUnavailableError(error: unknown): boolean {
   const message = (error as Error)?.message || ''
   return message.includes('Main window is not available') || message.includes('Timeout waiting for Redux store')
+}
+
+function sendReduxUnavailable(res: Response): Response {
+  return res.status(503).json({
+    error: {
+      message: 'Provider configuration is only available when Cherry Studio window is open',
+      type: 'service_unavailable',
+      code: 'REDUX_UNAVAILABLE'
+    }
+  })
+}
+
+function sendDataApiError(res: Response, error: unknown): Response {
+  if (!isDataApiError(error)) {
+    throw error
+  }
+
+  return res.status(error.status).json({
+    error: {
+      message: error.message,
+      type: 'data_api_error',
+      code: error.code,
+      ...(error.details ? { details: error.details } : {})
+    }
+  })
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  return String(error)
+}
+
+function parseModelReference(modelReference?: string | null): { provider: string; id: string } | null {
+  if (!modelReference) {
+    return null
+  }
+
+  const trimmed = modelReference.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  const delimiterIndex = trimmed.indexOf('::')
+  if (delimiterIndex === -1) {
+    return {
+      provider: 'unknown',
+      id: trimmed
+    }
+  }
+
+  return {
+    provider: trimmed.slice(0, delimiterIndex).trim(),
+    id: trimmed.slice(delimiterIndex + 2).trim()
+  }
+}
+
+function toApiKnowledgeBaseEntity(base: V2KnowledgeBase): ApiKnowledgeBaseEntity {
+  const embeddingModel = parseModelReference(base.embeddingModelId)
+  const rerankModel = parseModelReference(base.rerankModelId)
+
+  return {
+    id: base.id,
+    name: base.name,
+    description: base.description,
+    model: embeddingModel ?? {
+      id: base.embeddingModelId,
+      provider: 'unknown'
+    },
+    dimensions: base.dimensions,
+    chunkSize: base.chunkSize,
+    chunkOverlap: base.chunkOverlap,
+    documentCount: base.documentCount,
+    version: 2,
+    threshold: base.threshold,
+    ...(rerankModel
+      ? {
+          rerankModel
+        }
+      : {}),
+    ...(base.fileProcessorId
+      ? {
+          preprocessProvider: {
+            type: 'preprocess' as const,
+            provider: base.fileProcessorId
+          }
+        }
+      : {}),
+    items: [],
+    created_at: Date.parse(base.createdAt),
+    updated_at: Date.parse(base.updatedAt)
+  }
+}
+
+async function getProviderConfigs(): Promise<Provider[]> {
+  return await reduxService.select<Provider[]>('state.llm.providers')
+}
+
+function resolveProviderModel(
+  modelReference: string,
+  providers: Provider[]
+): { providerId: string; modelId: string; provider: Provider } {
+  const composite = parseModelReference(modelReference)
+  if (composite && composite.provider !== 'unknown') {
+    const provider = providers.find((item) => item.id === composite.provider)
+    if (!provider) {
+      throw new Error(`Provider "${composite.provider}" not found for model "${modelReference}"`)
+    }
+
+    return {
+      providerId: composite.provider,
+      modelId: composite.id,
+      provider
+    }
+  }
+
+  const provider = providers.find((item) => item.models.some((model) => model.id === modelReference.trim()))
+  if (!provider) {
+    throw new Error(`Unable to resolve provider for model "${modelReference}"`)
+  }
+
+  return {
+    providerId: provider.id,
+    modelId: modelReference.trim(),
+    provider
+  }
+}
+
+function normalizeProviderBaseURL(provider: Provider): string {
+  return (provider.apiHost || '').replace(/\/+$/, '').replace(/#$/, '')
+}
+
+async function getKnowledgeBaseParams(base: V2KnowledgeBase, providers?: Provider[]): Promise<KnowledgeBaseParams> {
+  const resolvedProviders = providers ?? (await getProviderConfigs())
+  const embedding = resolveProviderModel(base.embeddingModelId, resolvedProviders)
+
+  const params: KnowledgeBaseParams = {
+    id: base.id,
+    dimensions: base.dimensions,
+    chunkSize: base.chunkSize,
+    chunkOverlap: base.chunkOverlap,
+    documentCount: base.documentCount,
+    embedApiClient: {
+      model: embedding.modelId,
+      provider: embedding.providerId,
+      apiKey: embedding.provider.apiKey || '',
+      baseURL: normalizeProviderBaseURL(embedding.provider),
+      ...(embedding.provider.apiVersion ? { apiVersion: embedding.provider.apiVersion } : {})
+    }
+  }
+
+  if (base.rerankModelId) {
+    const rerank = resolveProviderModel(base.rerankModelId, resolvedProviders)
+    params.rerankApiClient = {
+      model: rerank.modelId,
+      provider: rerank.providerId,
+      apiKey: rerank.provider.apiKey || '',
+      baseURL: normalizeProviderBaseURL(rerank.provider),
+      ...(rerank.provider.apiVersion ? { apiVersion: rerank.provider.apiVersion } : {})
+    }
+  }
+
+  return params
+}
+
+function toLegacyKnowledgeItem(item: V2KnowledgeItem): LegacyKnowledgeItem | LegacyKnowledgeNoteItem {
+  const timestamps = {
+    created_at: Date.parse(item.createdAt),
+    updated_at: Date.parse(item.updatedAt)
+  }
+
+  switch (item.type) {
+    case 'file':
+      return {
+        id: item.id,
+        baseId: item.baseId,
+        type: 'file',
+        content: item.data.file,
+        ...timestamps
+      }
+    case 'url':
+      return {
+        id: item.id,
+        baseId: item.baseId,
+        type: 'url',
+        content: item.data.url,
+        remark: item.data.name,
+        ...timestamps
+      }
+    case 'note':
+      return {
+        id: item.id,
+        baseId: item.baseId,
+        type: 'note',
+        content: item.data.content,
+        sourceUrl: item.data.sourceUrl,
+        ...timestamps
+      }
+    case 'sitemap':
+      return {
+        id: item.id,
+        baseId: item.baseId,
+        type: 'sitemap',
+        content: item.data.url,
+        remark: item.data.name,
+        ...timestamps
+      }
+    case 'directory':
+      return {
+        id: item.id,
+        baseId: item.baseId,
+        type: 'directory',
+        content: item.data.path,
+        ...timestamps
+      }
+  }
+}
+
+function buildIngestionMetadata(result: LoaderReturn): KnowledgeItemIngestion | null {
+  if (result.entriesAdded <= 0) {
+    return null
+  }
+
+  const normalizedLoaderIds = result.uniqueIds.filter((loaderId) => loaderId.trim() !== '')
+  const normalizedLoaderId = result.uniqueId.trim() || normalizedLoaderIds[0]
+
+  if (!normalizedLoaderId) {
+    return null
+  }
+
+  return {
+    loaderId: normalizedLoaderId,
+    loaderIds: normalizedLoaderIds.length > 0 ? normalizedLoaderIds : [normalizedLoaderId]
+  }
 }
 
 /**
@@ -31,38 +301,21 @@ function isReduxUnavailableError(error: unknown): boolean {
  */
 export const listKnowledgeBases = async (req: ValidationRequest, res: Response): Promise<Response> => {
   try {
-    // Use Zod-validated values (defaults already applied by validator)
     const { limit = 20, offset = 0 } = req.validatedQuery ?? {}
 
     logger.debug('Listing knowledge bases', { limit, offset })
 
-    // Get knowledge bases from Redux store
-    // TODO(v2): Migrate to V2 knowledge base storage (SQLite/Drizzle).
-    //           Redux access requires Cherry Studio window to be open.
-    let bases: KnowledgeBase[]
-    try {
-      bases = await reduxService.select<KnowledgeBase[]>('state.knowledge.bases')
-    } catch (error) {
-      if (isReduxUnavailableError(error)) {
-        logger.warn('Redux store not available, returning 503')
-        return res.status(503).json({
-          error: {
-            message: 'Knowledge bases are only available when Cherry Studio window is open',
-            type: 'service_unavailable',
-            code: 'REDUX_UNAVAILABLE'
-          }
-        })
-      }
-      throw error // Re-throw non-Redux errors to outer catch
-    }
+    const result = await knowledgeBaseService.listWithOffset({ limit, offset })
 
-    const total = bases?.length || 0
-    const paginatedBases = (bases || []).slice(offset, offset + limit)
     return res.json({
-      knowledge_bases: paginatedBases,
-      total
+      knowledge_bases: result.items.map((base) => toApiKnowledgeBaseEntity(base)),
+      total: result.total
     })
   } catch (error) {
+    if (isDataApiError(error)) {
+      return sendDataApiError(res, error)
+    }
+
     logger.error('Failed to list knowledge bases', error as Error)
     return res.status(500).json({
       error: {
@@ -79,36 +332,17 @@ export const listKnowledgeBases = async (req: ValidationRequest, res: Response):
  */
 export const getKnowledgeBase = async (req: ValidationRequest, res: Response): Promise<Response> => {
   try {
-    // Zod already validated id exists and is non-empty
     const { id } = req.validatedParams ?? {}
 
     logger.debug(`Getting knowledge base: ${id}`)
 
-    // TODO(v2): Migrate to V2 knowledge base storage (SQLite/Drizzle).
-    const bases = await reduxService.select<KnowledgeBase[]>('state.knowledge.bases')
-    const base = bases?.find((b) => b.id === id)
-
-    if (!base) {
-      return res.status(404).json({
-        error: {
-          message: `Knowledge base not found: ${id}`,
-          type: 'invalid_request_error',
-          code: 'KB_NOT_FOUND'
-        }
-      })
-    }
-
-    return res.json(base)
+    const base = await knowledgeBaseService.getById(id)
+    return res.json(toApiKnowledgeBaseEntity(base))
   } catch (error) {
-    if (isReduxUnavailableError(error)) {
-      return res.status(503).json({
-        error: {
-          message: 'Knowledge bases are only available when Cherry Studio window is open',
-          type: 'service_unavailable',
-          code: 'REDUX_UNAVAILABLE'
-        }
-      })
+    if (isDataApiError(error)) {
+      return sendDataApiError(res, error)
     }
+
     logger.error('Failed to get knowledge base', error as Error)
     return res.status(500).json({
       error: {
@@ -121,81 +355,76 @@ export const getKnowledgeBase = async (req: ValidationRequest, res: Response): P
 }
 
 /**
- * Get provider configuration from Redux store by provider ID
- *
- * TODO(v2): Migrate to V2 provider config storage (SQLite/Drizzle) so the API server
- *           can resolve embedding/rerank provider credentials without a running renderer.
- *
- * NOTE: Redux errors are allowed to propagate - they will be caught by the handler's
- *       try/catch and converted to 503 responses via isReduxUnavailableError().
+ * Create and ingest knowledge items into the vector store
  */
-async function getProviderConfig(providerId: string): Promise<{ apiKey: string; baseURL: string } | null> {
-  const providers = await reduxService.select<Provider[]>('state.llm.providers')
-  const provider = providers?.find((p) => p.id === providerId)
-  if (!provider) {
-    logger.warn(`Provider not found: ${providerId}`)
-    return null
-  }
-
-  // Derive baseURL from apiHost, removing trailing slashes and # suffix
-  let baseURL = provider.apiHost || ''
-  baseURL = baseURL.replace(/\/+$/, '')
-  baseURL = baseURL.replace(/#$/, '')
-
-  return {
-    apiKey: provider.apiKey || '',
-    baseURL
-  }
-}
-
-/**
- * Convert KnowledgeBase to KnowledgeBaseParams for search
- */
-async function getKnowledgeBaseParams(base: KnowledgeBase): Promise<KnowledgeBaseParams> {
-  // Validate that embedding model provider is configured
-  const embedProviderId = base.model?.provider
-  if (!embedProviderId) {
-    throw new Error(`Knowledge base "${base.name}" is missing embedding model provider configuration`)
-  }
-
-  const embedConfig = await getProviderConfig(embedProviderId)
-  if (!embedConfig) {
-    throw new Error(`Provider "${embedProviderId}" not found for knowledge base "${base.name}"`)
-  }
-
-  const embedApiClient = {
-    model: base.model?.id || '',
-    provider: embedProviderId,
-    apiKey: embedConfig.apiKey,
-    baseURL: embedConfig.baseURL
-  }
-
-  // Build the params object
-  const params: KnowledgeBaseParams = {
-    id: base.id,
-    dimensions: base.dimensions,
-    embedApiClient,
-    chunkSize: base.chunkSize,
-    chunkOverlap: base.chunkOverlap,
-    documentCount: base.documentCount
-  }
-
-  // Add rerank if configured
-  if (base.rerankModel?.provider) {
-    const rerankConfig = await getProviderConfig(base.rerankModel.provider)
-    if (!rerankConfig) {
-      logger.warn(`Rerank provider not found for knowledge base "${base.name}": ${base.rerankModel.provider}`)
-    } else {
-      params.rerankApiClient = {
-        model: base.rerankModel.id || '',
-        provider: base.rerankModel.provider,
-        apiKey: rerankConfig.apiKey,
-        baseURL: rerankConfig.baseURL
-      }
+export const createKnowledgeItems = async (req: ValidationRequest, res: Response): Promise<Response> => {
+  try {
+    const { id } = req.validatedParams ?? {}
+    const body = (req.validatedBody ?? {}) as ValidatedCreateKnowledgeItemsBody
+    const dto: CreateKnowledgeItemsDto = {
+      items: body.items
     }
-  }
 
-  return params
+    const [base, providers] = await Promise.all([knowledgeBaseService.getById(id), getProviderConfigs()])
+    const baseParams = await getKnowledgeBaseParams(base, providers)
+    const created = await knowledgeItemService.createMany(id, dto)
+
+    const updatedItems = await Promise.all(
+      created.items.map(async (item) => {
+        await knowledgeItemService.update(item.id, {
+          status: 'pending',
+          error: null
+        })
+
+        try {
+          const result = await knowledgeService.add({} as Electron.IpcMainInvokeEvent, {
+            base: baseParams,
+            item: toLegacyKnowledgeItem(item)
+          })
+          const ingestion = buildIngestionMetadata(result)
+
+          if (!ingestion) {
+            throw new Error(result.message || 'Knowledge item ingest failed')
+          }
+
+          return await knowledgeItemService.update(item.id, {
+            data: {
+              ...item.data,
+              ingestion
+            },
+            status: 'completed',
+            error: null
+          })
+        } catch (error) {
+          return await knowledgeItemService.update(item.id, {
+            status: 'failed',
+            error: getErrorMessage(error)
+          })
+        }
+      })
+    )
+
+    return res.status(201).json({
+      items: updatedItems
+    })
+  } catch (error) {
+    if (isReduxUnavailableError(error)) {
+      return sendReduxUnavailable(res)
+    }
+
+    if (isDataApiError(error)) {
+      return sendDataApiError(res, error)
+    }
+
+    logger.error('Failed to create knowledge items', error as Error)
+    return res.status(500).json({
+      error: {
+        message: 'Failed to create knowledge items',
+        type: 'internal_error',
+        code: 'CREATE_KNOWLEDGE_ITEMS_ERROR'
+      }
+    })
+  }
 }
 
 /**
@@ -206,16 +435,13 @@ async function getKnowledgeBaseParams(base: KnowledgeBase): Promise<KnowledgeBas
  */
 export const searchKnowledge = async (req: ValidationRequest, res: Response): Promise<Response> => {
   try {
-    // Use Zod-validated body (defaults already applied by validator)
     const { query, knowledge_base_ids, document_count = 5 } = (req.validatedBody ?? {}) as ValidatedSearchBody
 
     logger.debug(`Searching knowledge bases: "${query}"`, { knowledge_base_ids, document_count })
 
-    // Get knowledge bases from Redux
-    // TODO(v2): Migrate to V2 knowledge base storage (SQLite/Drizzle).
-    const bases = await reduxService.select<KnowledgeBase[]>('state.knowledge.bases')
+    const bases = await knowledgeBaseService.listAll()
 
-    if (!bases || bases.length === 0) {
+    if (bases.length === 0) {
       return res.json({
         query,
         results: [],
@@ -225,8 +451,9 @@ export const searchKnowledge = async (req: ValidationRequest, res: Response): Pr
       })
     }
 
-    // Filter by specified knowledge base IDs if provided
-    const targetBases = knowledge_base_ids?.length ? bases.filter((b) => knowledge_base_ids.includes(b.id)) : bases
+    const targetBases = knowledge_base_ids?.length
+      ? bases.filter((base) => knowledge_base_ids.includes(base.id))
+      : bases
 
     if (knowledge_base_ids?.length && targetBases.length === 0) {
       return res.status(404).json({
@@ -238,82 +465,82 @@ export const searchKnowledge = async (req: ValidationRequest, res: Response): Pr
       })
     }
 
-    // Search each knowledge base
-    const searchPromises = targetBases.map(async (base) => {
-      try {
-        const params = await getKnowledgeBaseParams(base)
+    const providers = await getProviderConfigs()
+    const resultsPerBase = await Promise.all(
+      targetBases.map(async (base) => {
+        try {
+          const params = await getKnowledgeBaseParams(base, providers)
+          const searchResults = await knowledgeService.search({} as Electron.IpcMainInvokeEvent, {
+            search: query,
+            base: params
+          })
 
-        // WORKAROUND: knowledgeService.search() expects Electron.IpcMainInvokeEvent for IPC signature.
-        // The @TraceMethod decorator doesn't currently access event properties, so passing {} is safe.
-        // TODO(v2): Add searchInternal() method to knowledgeService for non-IPC calls.
-        const searchResults = await knowledgeService.search({} as Electron.IpcMainInvokeEvent, {
-          search: query,
-          base: params
-        })
-
-        return {
-          baseId: base.id,
-          baseName: base.name,
-          results: searchResults.map((result) => ({
-            ...result,
-            knowledge_base_id: base.id,
-            knowledge_base_name: base.name
-          })),
-          error: undefined
+          return {
+            baseId: base.id,
+            baseName: base.name,
+            results: searchResults.map((result) => ({
+              ...result,
+              knowledge_base_id: base.id,
+              knowledge_base_name: base.name
+            })),
+            error: undefined
+          }
+        } catch (error) {
+          logger.error(`Error searching knowledge base ${base.id}`, error as Error)
+          return {
+            baseId: base.id,
+            baseName: base.name,
+            results: [],
+            error: getErrorMessage(error)
+          }
         }
-      } catch (error) {
-        logger.error(`Error searching knowledge base ${base.id}`, error as Error)
-        return {
-          baseId: base.id,
-          baseName: base.name,
-          results: [],
-          error: (error as Error).message
-        }
-      }
-    })
+      })
+    )
 
-    const resultsPerBase = await Promise.all(searchPromises)
-
-    // Check if all searches failed
-    const allFailed = resultsPerBase.every((r) => r.results.length === 0 && r.error)
+    const allFailed = resultsPerBase.every((item) => item.results.length === 0 && item.error)
     if (allFailed && resultsPerBase.length > 0) {
       return res.status(502).json({
         error: {
           message: 'All knowledge base searches failed. Check embedding provider configuration.',
           type: 'upstream_error',
           code: 'SEARCH_ALL_FAILED',
-          failed_bases: resultsPerBase.map((r) => ({ id: r.baseId, name: r.baseName, error: r.error }))
+          failed_bases: resultsPerBase.map((item) => ({
+            id: item.baseId,
+            name: item.baseName,
+            error: item.error
+          }))
         }
       })
     }
 
-    // Collect partial failures
     const warnings = resultsPerBase
-      .filter((r) => r.error && r.results.length === 0)
-      .map((r) => `Knowledge base "${r.baseName}" search failed: ${r.error}`)
+      .filter((item) => item.error && item.results.length === 0)
+      .map((item) => `Knowledge base "${item.baseName}" search failed: ${item.error}`)
 
-    const allResults = resultsPerBase.flatMap((r) => r.results)
-    const sortedResults = allResults.sort((a, b) => b.score - a.score).slice(0, document_count)
-
-    logger.debug(`Found ${sortedResults.length} results for query: "${query}"`)
+    const sortedResults = resultsPerBase
+      .flatMap((item) => item.results)
+      .sort((left, right) => right.score - left.score)
+      .slice(0, document_count)
 
     return res.json({
       query,
       results: sortedResults,
       total: sortedResults.length,
-      searched_bases: resultsPerBase.map((r) => ({ id: r.baseId, name: r.baseName })),
-      ...(warnings.length > 0 && { warnings })
+      searched_bases: resultsPerBase.map((item) => ({
+        id: item.baseId,
+        name: item.baseName
+      })),
+      ...(warnings.length > 0 ? { warnings } : {})
     })
   } catch (error) {
     if (isReduxUnavailableError(error)) {
-      return res.status(503).json({
-        error: {
-          message: 'Knowledge bases are only available when Cherry Studio window is open',
-          type: 'service_unavailable',
-          code: 'REDUX_UNAVAILABLE'
-        }
-      })
+      return sendReduxUnavailable(res)
     }
+
+    if (isDataApiError(error)) {
+      return sendDataApiError(res, error)
+    }
+
     logger.error('Failed to search knowledge bases', error as Error)
     return res.status(500).json({
       error: {

--- a/src/main/apiServer/routes/knowledge/index.ts
+++ b/src/main/apiServer/routes/knowledge/index.ts
@@ -1,7 +1,12 @@
 import express from 'express'
 
-import { getKnowledgeBase, listKnowledgeBases, searchKnowledge } from './handlers'
-import { validateKnowledgeBaseId, validateKnowledgeSearch, validatePagination } from './validators'
+import { createKnowledgeItems, getKnowledgeBase, listKnowledgeBases, searchKnowledge } from './handlers'
+import {
+  validateCreateKnowledgeItems,
+  validateKnowledgeBaseId,
+  validateKnowledgeSearch,
+  validatePagination
+} from './validators'
 
 // Create main knowledge router
 const knowledgeRouter = express.Router()
@@ -156,6 +161,64 @@ const knowledgeRouter = express.Router()
  *           items:
  *             type: string
  *           description: Warning messages for partial search failures
+ *
+ *     KnowledgeItemEntity:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *         baseId:
+ *           type: string
+ *         groupId:
+ *           type: string
+ *           nullable: true
+ *         type:
+ *           type: string
+ *           enum: [file, url, note, sitemap, directory]
+ *         data:
+ *           type: object
+ *           description: Type-specific item payload. Successful ingests include `ingestion.loaderId` and `ingestion.loaderIds`.
+ *         status:
+ *           type: string
+ *           enum: [idle, pending, ocr, read, embed, completed, failed]
+ *         error:
+ *           type: string
+ *           nullable: true
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *         updatedAt:
+ *           type: string
+ *           format: date-time
+ *
+ *     CreateKnowledgeItemsRequest:
+ *       type: object
+ *       required:
+ *         - items
+ *       properties:
+ *         items:
+ *           type: array
+ *           minItems: 1
+ *           items:
+ *             type: object
+ *             required: [type, data]
+ *             properties:
+ *               groupId:
+ *                 type: string
+ *                 nullable: true
+ *               type:
+ *                 type: string
+ *                 enum: [file, url, note, sitemap, directory]
+ *               data:
+ *                 type: object
+ *
+ *     CreateKnowledgeItemsResponse:
+ *       type: object
+ *       properties:
+ *         items:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/KnowledgeItemEntity'
  */
 
 /**
@@ -200,12 +263,6 @@ const knowledgeRouter = express.Router()
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
- *       503:
- *         description: Service unavailable (Redux store not accessible)
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
  */
 knowledgeRouter.get('/', validatePagination, listKnowledgeBases)
 
@@ -241,14 +298,76 @@ knowledgeRouter.get('/', validatePagination, listKnowledgeBases)
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ */
+knowledgeRouter.get('/:id', validateKnowledgeBaseId, getKnowledgeBase)
+
+/**
+ * @swagger
+ * /v1/knowledge-bases/{id}/items:
+ *   post:
+ *     summary: Create and ingest knowledge items
+ *     description: |
+ *       Create knowledge items for a knowledge base and ingest them into the vector store.
+ *
+ *       Supported item types:
+ *       - `file`
+ *       - `url`
+ *       - `note`
+ *       - `sitemap`
+ *       - `directory`
+ *
+ *       Each returned item includes the persisted processing status.
+ *       Successful ingests persist loader metadata inside `data.ingestion`.
+ *     tags: [Knowledge]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Knowledge base ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CreateKnowledgeItemsRequest'
+ *           example:
+ *             items:
+ *               - type: note
+ *                 data:
+ *                   content: "Cherry Studio knowledge ingestion"
+ *               - type: url
+ *                 data:
+ *                   url: "https://docs.cherry-ai.com"
+ *                   name: "Cherry Studio Docs"
+ *     responses:
+ *       201:
+ *         description: Knowledge items created and ingested
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/CreateKnowledgeItemsResponse'
+ *       404:
+ *         description: Knowledge base not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       422:
+ *         description: Validation failed
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       503:
- *         description: Service unavailable (Redux store not accessible)
+ *         description: Provider configuration is unavailable
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  */
-knowledgeRouter.get('/:id', validateKnowledgeBaseId, getKnowledgeBase)
+knowledgeRouter.post('/:id/items', validateCreateKnowledgeItems, createKnowledgeItems)
 
 /**
  * @swagger
@@ -310,7 +429,7 @@ knowledgeRouter.get('/:id', validateKnowledgeBaseId, getKnowledgeBase)
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       503:
- *         description: Service unavailable (Redux store not accessible)
+ *         description: Provider configuration is unavailable
  *         content:
  *           application/json:
  *             schema:

--- a/src/main/apiServer/routes/knowledge/validators/index.ts
+++ b/src/main/apiServer/routes/knowledge/validators/index.ts
@@ -1,5 +1,10 @@
 import { createZodValidator } from '../../agents/validators/zodValidator'
-import { KnowledgeBaseIdParamSchema, KnowledgeSearchSchema, PaginationQuerySchema } from './zodSchemas'
+import {
+  CreateKnowledgeItemsRequestSchema,
+  KnowledgeBaseIdParamSchema,
+  KnowledgeSearchSchema,
+  PaginationQuerySchema
+} from './zodSchemas'
 
 /**
  * Validation middleware for knowledge base search
@@ -20,4 +25,12 @@ export const validateKnowledgeBaseId = createZodValidator({
  */
 export const validatePagination = createZodValidator({
   query: PaginationQuerySchema
+})
+
+/**
+ * Validation middleware for knowledge item create requests
+ */
+export const validateCreateKnowledgeItems = createZodValidator({
+  params: KnowledgeBaseIdParamSchema,
+  body: CreateKnowledgeItemsRequestSchema
 })

--- a/src/main/apiServer/routes/knowledge/validators/zodSchemas.ts
+++ b/src/main/apiServer/routes/knowledge/validators/zodSchemas.ts
@@ -1,3 +1,4 @@
+import { CreateKnowledgeItemsSchema } from '@shared/data/api/schemas/knowledges'
 import * as z from 'zod'
 
 /**
@@ -28,3 +29,8 @@ export const PaginationQuerySchema = z.object({
 export const KnowledgeBaseIdParamSchema = z.object({
   id: KnowledgeBaseIdSchema
 })
+
+/**
+ * Zod schema for creating knowledge items
+ */
+export const CreateKnowledgeItemsRequestSchema = CreateKnowledgeItemsSchema

--- a/src/main/data/services/KnowledgeBaseService.ts
+++ b/src/main/data/services/KnowledgeBaseService.ts
@@ -42,10 +42,9 @@ function rowToKnowledgeBase(row: typeof knowledgeBaseTable.$inferSelect): Knowle
 }
 
 export class KnowledgeBaseService {
-  async list(query: KnowledgeBaseListQuery): Promise<OffsetPaginationResponse<KnowledgeBase>> {
+  async listWithOffset(query: { limit: number; offset: number }): Promise<{ items: KnowledgeBase[]; total: number }> {
     const db = application.get('DbService').getDb()
-    const { page, limit } = query
-    const offset = (page - 1) * limit
+    const { limit, offset } = query
 
     const [rows, [{ count }]] = await Promise.all([
       db
@@ -59,7 +58,28 @@ export class KnowledgeBaseService {
 
     return {
       items: rows.map((row) => rowToKnowledgeBase(row)),
-      total: count,
+      total: count
+    }
+  }
+
+  async listAll(): Promise<KnowledgeBase[]> {
+    const db = application.get('DbService').getDb()
+    const rows = await db
+      .select()
+      .from(knowledgeBaseTable)
+      .orderBy(desc(knowledgeBaseTable.createdAt), desc(knowledgeBaseTable.id))
+
+    return rows.map((row) => rowToKnowledgeBase(row))
+  }
+
+  async list(query: KnowledgeBaseListQuery): Promise<OffsetPaginationResponse<KnowledgeBase>> {
+    const { page, limit } = query
+    const offset = (page - 1) * limit
+    const result = await this.listWithOffset({ limit, offset })
+
+    return {
+      items: result.items,
+      total: result.total,
       page
     }
   }

--- a/src/main/data/services/__tests__/KnowledgeBaseService.test.ts
+++ b/src/main/data/services/__tests__/KnowledgeBaseService.test.ts
@@ -86,6 +86,44 @@ describe('KnowledgeBaseService', () => {
       })
       expect(result.items[0].description).toBeUndefined()
     })
+
+    it('should support offset-based listing for external API consumers', async () => {
+      const rows = [createMockRow({ id: 'kb-3', name: 'Offset Base' })]
+      const offsetFn = vi.fn().mockResolvedValue(rows)
+      const limitFn = vi.fn().mockReturnValue({ offset: offsetFn })
+      const orderBy = vi.fn().mockReturnValue({ limit: limitFn })
+      const from = vi.fn().mockReturnValue({ orderBy })
+      const countFrom = vi.fn().mockResolvedValue([{ count: 5 }])
+
+      mockSelect.mockReturnValueOnce({
+        from
+      })
+      mockSelect.mockReturnValueOnce({
+        from: countFrom
+      })
+
+      const result = await service.listWithOffset({ limit: 2, offset: 3 })
+
+      expect(limitFn).toHaveBeenCalledWith(2)
+      expect(offsetFn).toHaveBeenCalledWith(3)
+      expect(result).toMatchObject({
+        total: 5,
+        items: [{ id: 'kb-3', name: 'Offset Base' }]
+      })
+    })
+
+    it('should list all knowledge bases in descending created order', async () => {
+      const rows = [createMockRow({ id: 'kb-4' }), createMockRow({ id: 'kb-5' })]
+      const orderBy = vi.fn().mockResolvedValue(rows)
+      const from = vi.fn().mockReturnValue({ orderBy })
+      mockSelect.mockReturnValueOnce({ from })
+
+      const result = await service.listAll()
+
+      expect(result).toHaveLength(2)
+      expect(result[0]).toMatchObject({ id: 'kb-4' })
+      expect(result[1]).toMatchObject({ id: 'kb-5' })
+    })
   })
 
   describe('getById', () => {


### PR DESCRIPTION
### What this PR does

Before this PR:
The public Knowledge Base REST API only exposed read operations (`GET /v1/knowledge-bases`, `GET /v1/knowledge-bases/:id`, `POST /v1/knowledge-bases/search`). There was no way to programmatically add documents to a knowledge base via the API.

After this PR:
A new `POST /v1/knowledge-bases/:id/items` endpoint is available that creates knowledge items and ingests them into the vector store. All item types are supported: `file`, `url`, `note`, `sitemap`, and `directory`. Each item goes through the existing KnowledgeService pipeline with status tracking (`pending` → `completed`/`failed`).

### Why we need it and why it was done in this way

External tools (browser extensions, scripts, MCP agents, scheduled pipelines) need a stable API to programmatically ingest content into knowledge bases. The internal IPC-based `KnowledgeService.add()` capability already exists but was not exposed as a public REST endpoint.

The following tradeoffs were made:
- **Synchronous processing**: Items are ingested inline before the response is returned. This keeps the MVP simple but may time out for large batches. Async task queues can be added in a follow-up.
- **Reuses legacy KnowledgeService**: The ingest pipeline bridges v2 DataApi items to the existing vector store via `toLegacyKnowledgeItem()`, avoiding a full rewrite of the embedding pipeline.

The following alternatives were considered:
- Async ingest with task status polling — deferred to keep the first version minimal.
- Separate endpoints per item type — rejected in favor of a single batch endpoint with discriminated `type` field.

### Breaking changes

None. This is a purely additive change to the public API.

### Special notes for your reviewer

- The existing `listKnowledgeBases`, `getKnowledgeBase`, and `searchKnowledge` handlers were migrated from the legacy Redux-backed store to v2 `KnowledgeBaseService` (DataApi/SQLite) in the same commit, since they share the same handler file.
- `KnowledgeBaseService.listWithOffset()` was added to support offset-based pagination for external API consumers (the existing `list()` uses page-based pagination).
- The 10 pre-existing test failures in the repo (`BootConfigService`, `filesystem MCP security`) are unrelated to this change.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Add `POST /v1/knowledge-bases/:id/items` API endpoint for programmatic knowledge base ingestion. Supports file, URL, note, sitemap, and directory item types with status tracking.
```