### PR TITLE
fix: suppress UNDICI-EHPA experimental warning in Claude Code child process

### DIFF
--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -459,7 +459,7 @@ class ClaudeCodeService implements AgentServiceInterface {
             proxyBootstrapPath: this.claudeProxyBootstrapPath
           })
 
-          execArgv = [...process.execArgv, '--require', this.claudeProxyBootstrapPath]
+          execArgv = [...process.execArgv, '--disable-warning=UNDICI-EHPA', '--require', this.claudeProxyBootstrapPath]
         }
 
         const child = fork(spawnOptions.args[0], spawnOptions.args.slice(1), {


### PR DESCRIPTION
### What this PR does

Before this PR:
When proxy is enabled, the Claude Code child process emits an `[UNDICI-EHPA] Warning: EnvHttpProxyAgent is experimental` warning to stderr. This warning gets captured and displayed to users as part of error messages, misleading them into thinking there is a proxy or SSL certificate issue.

After this PR:
The specific `UNDICI-EHPA` experimental warning is suppressed via `--disable-warning=UNDICI-EHPA` in the child process execArgv, so it no longer pollutes error output.

### Why we need it and why it was done in this way

The proxy bootstrap preload script (`bootstrap.ts`) instantiates `EnvHttpProxyAgent` from undici, which emits an experimental warning to stderr. The Claude Code service captures stderr into `errorChunks`, and when any SDK error occurs, the warning text gets prepended to the error message — confusing users.

The following tradeoffs were made:
Using Node.js built-in `--disable-warning` flag scoped to only the `UNDICI-EHPA` code, which is safe since the project requires Node ≥22.

The following alternatives were considered:
- Overriding `process.emitWarning` in bootstrap.ts — fragile, relies on internal API details
- Filtering stderr output in the Claude Code service — would also hide the warning from developer logs

### Breaking changes

None.

### Special notes for your reviewer

Minimal one-line change. Only suppresses the specific `UNDICI-EHPA` warning code — all other warnings remain visible.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
