### PR TITLE
hotfix: narrow overly broad keywords in error diagnosis and add CherryIN context

### DIFF
--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -242,6 +242,7 @@ class ClaudeCodeService implements AgentServiceInterface {
     }
 
     const errorChunks: string[] = []
+    const isNodeWarning = (chunk: string) => /^\(node:\d+\)\s*\[/.test(chunk.trim())
 
     const sessionAllowedTools = new Set<string>(session.allowed_tools ?? [])
     const autoAllowTools = new Set<string>([...DEFAULT_AUTO_ALLOW_TOOLS, ...sessionAllowedTools])
@@ -472,7 +473,9 @@ class ClaudeCodeService implements AgentServiceInterface {
         child.stderr?.on('data', (data: Buffer) => {
           const text = data.toString()
           logger.warn('claude stderr', { chunk: text })
-          errorChunks.push(text)
+          if (!isNodeWarning(text)) {
+            errorChunks.push(text)
+          }
         })
         return child as unknown as SpawnedProcess
       },

--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -242,7 +242,7 @@ class ClaudeCodeService implements AgentServiceInterface {
     }
 
     const errorChunks: string[] = []
-    const isNodeWarning = (chunk: string) => /^\(node:\d+\)\s*\[/.test(chunk.trim())
+    const isNodeWarning = (chunk: string) => /^\(node:\d+\).*Warning:/.test(chunk.trim())
 
     const sessionAllowedTools = new Set<string>(session.allowed_tools ?? [])
     const autoAllowTools = new Set<string>([...DEFAULT_AUTO_ALLOW_TOOLS, ...sessionAllowedTools])

--- a/src/renderer/src/services/ErrorDiagnosisService.ts
+++ b/src/renderer/src/services/ErrorDiagnosisService.ts
@@ -98,6 +98,7 @@ function buildContextHint(errorInfo: Record<string, unknown>, context?: Diagnosi
     msg.includes('fetch failed') ||
     msg.includes('proxy error') ||
     msg.includes('proxy connection') ||
+    msg.includes('proxy refused') ||
     msg.includes('certificate')
   ) {
     return `## Context\nNetwork or proxy error. Cherry Studio supports HTTP/SOCKS proxy configuration in general settings. The user may be behind a firewall or using a custom API endpoint.\n`

--- a/src/renderer/src/services/ErrorDiagnosisService.ts
+++ b/src/renderer/src/services/ErrorDiagnosisService.ts
@@ -53,10 +53,19 @@ async function buildModelsToTry(context?: DiagnosisContext): Promise<Model[]> {
   return models
 }
 
+function isCherryInProvider(errorInfo: Record<string, unknown>, context?: DiagnosisContext): boolean {
+  const provider = String(errorInfo.provider || context?.providerName || '').toLowerCase()
+  return provider === 'cherryin' || provider === 'cherry in' || provider === 'cherry_in'
+}
+
 function buildContextHint(errorInfo: Record<string, unknown>, context?: DiagnosisContext): string {
   const msg = String(errorInfo.message || '').toLowerCase()
   const status = Number(errorInfo.status) || 0
   const source = context?.errorSource || String(errorInfo.source || '')
+  const isCherryIn = isCherryInProvider(errorInfo, context)
+  const cherryInNote = isCherryIn
+    ? ' Note: CherryIN is an ecosystem partner of Cherry Studio, NOT an official relay service. Direct users to CherryIN support for account/billing issues.'
+    : ''
 
   // Auth / API key issues
   if (
@@ -67,19 +76,19 @@ function buildContextHint(errorInfo: Record<string, unknown>, context?: Diagnosi
     msg.includes('forbidden')
   ) {
     const provider = errorInfo.provider || context?.providerName || 'the provider'
-    return `## Context\nThe user is calling ${provider} API and got an authentication error. Cherry Studio lets users configure API keys per provider in provider settings.\n`
+    return `## Context\nThe user is calling ${provider} API and got an authentication error. Cherry Studio lets users configure API keys per provider in provider settings.${cherryInNote}\n`
   }
 
   // Quota / rate limit
   if (status === 429 || msg.includes('quota') || msg.includes('rate_limit') || msg.includes('insufficient')) {
     const provider = errorInfo.provider || context?.providerName || 'the provider'
-    return `## Context\nThe user hit a rate limit or quota issue with ${provider}. Users can check billing/quota on the provider's website or switch to a different model.\n`
+    return `## Context\nThe user hit a rate limit or quota issue with ${provider}. Users can check billing/quota on the provider's website or switch to a different model.${cherryInNote}\n`
   }
 
   // Model not found
   if (status === 404 || msg.includes('model_not_found') || msg.includes('model not found')) {
     const model = errorInfo.modelId || context?.modelId || 'unknown'
-    return `## Context\nModel "${model}" was not found. The model may be deprecated, the ID may be wrong, or the user's API plan may not include this model.\n`
+    return `## Context\nModel "${model}" was not found. The model may be deprecated, the ID may be wrong, or the user's API plan may not include this model.${cherryInNote}\n`
   }
 
   // Network / proxy
@@ -87,14 +96,15 @@ function buildContextHint(errorInfo: Record<string, unknown>, context?: Diagnosi
     msg.includes('econnrefused') ||
     msg.includes('timeout') ||
     msg.includes('fetch failed') ||
-    msg.includes('proxy') ||
+    msg.includes('proxy error') ||
+    msg.includes('proxy connection') ||
     msg.includes('certificate')
   ) {
     return `## Context\nNetwork or proxy error. Cherry Studio supports HTTP/SOCKS proxy configuration in general settings. The user may be behind a firewall or using a custom API endpoint.\n`
   }
 
   // MCP
-  if (msg.includes('mcp')) {
+  if (msg.includes('mcp server') || msg.includes('mcp connection') || msg.includes('mcp error')) {
     return `## Context\nMCP (Model Context Protocol) server error. Users manage MCP servers in MCP settings. Common issues: server not started, wrong configuration, connection timeout.\n`
   }
 

--- a/src/renderer/src/utils/__tests__/errorClassifier.test.ts
+++ b/src/renderer/src/utils/__tests__/errorClassifier.test.ts
@@ -155,6 +155,50 @@ describe('classifyError', () => {
     expect(result.category).not.toBe('mcp')
   })
 
+  // Proxy — narrowed keywords
+  it('classifies proxy error as proxy', () => {
+    const result = classifyError(makeError({ message: 'proxy error: connection refused' }))
+    expect(result.category).toBe('proxy')
+    expect(result.navTarget).toBe('/settings/general')
+  })
+
+  it('classifies proxy connection as proxy', () => {
+    const result = classifyError(makeError({ message: 'proxy connection failed' }))
+    expect(result.category).toBe('proxy')
+  })
+
+  it('does not match plain "proxy" without qualifier', () => {
+    const result = classifyError(makeError({ message: 'something proxy related' }))
+    expect(result.category).not.toBe('proxy')
+  })
+
+  // Stream — narrowed keywords
+  it('classifies stream error as stream', () => {
+    const result = classifyError(makeError({ message: 'stream error occurred' }))
+    expect(result.category).toBe('stream')
+  })
+
+  it('classifies stream interrupted as stream', () => {
+    const result = classifyError(makeError({ message: 'stream interrupted by server' }))
+    expect(result.category).toBe('stream')
+  })
+
+  it('does not match plain "stream" without qualifier', () => {
+    const result = classifyError(makeError({ message: 'something stream related' }))
+    expect(result.category).not.toBe('stream')
+  })
+
+  // Parse — narrowed keywords (no bare "json" match)
+  it('classifies unexpected token as parse', () => {
+    const result = classifyError(makeError({ message: 'unexpected token < in JSON' }))
+    expect(result.category).toBe('parse')
+  })
+
+  it('does not match bare "json" as parse', () => {
+    const result = classifyError(makeError({ message: 'json response received' }))
+    expect(result.category).not.toBe('parse')
+  })
+
   // Status as string
   it('handles status as string', () => {
     const result = classifyError(makeError({ status: '401' }))

--- a/src/renderer/src/utils/__tests__/errorClassifier.test.ts
+++ b/src/renderer/src/utils/__tests__/errorClassifier.test.ts
@@ -167,6 +167,11 @@ describe('classifyError', () => {
     expect(result.category).toBe('proxy')
   })
 
+  it('classifies proxy refused as proxy', () => {
+    const result = classifyError(makeError({ message: 'proxy refused connection' }))
+    expect(result.category).toBe('proxy')
+  })
+
   it('does not match plain "proxy" without qualifier', () => {
     const result = classifyError(makeError({ message: 'something proxy related' }))
     expect(result.category).not.toBe('proxy')
@@ -180,6 +185,11 @@ describe('classifyError', () => {
 
   it('classifies stream interrupted as stream', () => {
     const result = classifyError(makeError({ message: 'stream interrupted by server' }))
+    expect(result.category).toBe('stream')
+  })
+
+  it('classifies stream closed as stream', () => {
+    const result = classifyError(makeError({ message: 'stream closed unexpectedly' }))
     expect(result.category).toBe('stream')
   })
 

--- a/src/renderer/src/utils/errorClassifier.ts
+++ b/src/renderer/src/utils/errorClassifier.ts
@@ -94,7 +94,9 @@ export function classifyError(error?: SerializedError, providerId?: string): Err
 
   // Proxy / SSL certificate errors
   if (
-    msg.includes('proxy') ||
+    msg.includes('proxy error') ||
+    msg.includes('proxy connection') ||
+    msg.includes('proxy refused') ||
     msg.includes('socks') ||
     msg.includes('certificate') ||
     msg.includes('self-signed') ||
@@ -104,7 +106,13 @@ export function classifyError(error?: SerializedError, providerId?: string): Err
   }
 
   // Stream interrupted
-  if (msg.includes('econnreset') || msg.includes('stream') || msg.includes('connection reset')) {
+  if (
+    msg.includes('econnreset') ||
+    msg.includes('stream error') ||
+    msg.includes('stream interrupted') ||
+    msg.includes('stream closed') ||
+    msg.includes('connection reset')
+  ) {
     return { category: 'stream', i18nKey: 'error.diagnosis.stream', navTarget: null }
   }
 
@@ -146,12 +154,7 @@ export function classifyError(error?: SerializedError, providerId?: string): Err
   }
 
   // Response parse errors
-  if (
-    msg.includes('json') ||
-    msg.includes('unexpected token') ||
-    msg.includes('invalid response') ||
-    msg.includes('parse error')
-  ) {
+  if (msg.includes('unexpected token') || msg.includes('invalid response') || msg.includes('parse error')) {
     return { category: 'parse', i18nKey: 'error.diagnosis.parse', navTarget: null }
   }
 


### PR DESCRIPTION
### What this PR does

Before this PR:
- Error classifier uses overly broad keywords (`proxy`, `stream`, `json`) that cause false positive matches on unrelated error messages
- `buildContextHint` in ErrorDiagnosisService has the same broad keyword issue for `proxy` and `mcp`
- CherryIN provider is not identified as an ecosystem partner in diagnosis prompts
- Node.js experimental warnings (e.g., `(node:12345) [UNDICI-EHPA]`) from Claude Code stderr are included in error output

After this PR:
- Proxy keywords narrowed: `proxy` → `proxy error` / `proxy connection` / `proxy refused`
- Stream keywords narrowed: `stream` → `stream error` / `stream interrupted` / `stream closed`
- Parse keywords: removed bare `json` match (keeps `unexpected token`, `invalid response`, `parse error`)
- MCP keywords narrowed in `buildContextHint`: `mcp` → `mcp server` / `mcp connection` / `mcp error`
- Added `isCherryInProvider()` helper to add CherryIN ecosystem partner context to diagnosis prompts
- Node.js warnings filtered from Claude Code stderr via regex check
- Added tests for all narrowed keyword behaviors

### Why we need it and why it was done in this way

These are follow-up bug fixes from the self-review of #13894 (AI error diagnosis feature). The broad keywords caused false classifications — e.g., any error message mentioning "json" would be classified as a parse error, and any message mentioning "stream" would be classified as a stream interruption.

The following tradeoffs were made:
- Each keyword is narrowed to more specific phrases rather than using regex, keeping the classifier fast and readable

The following alternatives were considered:
- Using regex patterns — rejected in favor of simple string matching for maintainability

### Breaking changes

None

### Special notes for your reviewer

This is a follow-up fix PR for #13894. The original PR was merged to main but these fix commits were on the feature branch and not included in the squash merge.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it
- [ ] Upgrade: N/A
- [ ] Documentation: Not required (internal behavior improvement)
- [x] Self-review: I have reviewed my own code

### Release note

```release-note
NONE
```

### Related issues

- Refs #15025 (Improve AI Error Diagnosis with More Context and Hidden Raw Stack) — this PR narrows the overly broad error-diagnosis keyword set and adds CherryIN-specific context; the broader UX improvements in #15025 remain open.
