### PR TITLE
feat(aiCore): add createAgent factory for ToolLoopAgent with plugin pipeline

### DIFF
--- a/.changeset/aicore-create-agent.md
+++ b/.changeset/aicore-create-agent.md
@@ -1,0 +1,5 @@
+---
+'@cherrystudio/ai-core': patch
+---
+
+Add `createAgent` factory and `PluginEngine.resolveModel` for ToolLoopAgent with plugin pipeline support

--- a/packages/aiCore/src/core/agents/__tests__/createAgent.test.ts
+++ b/packages/aiCore/src/core/agents/__tests__/createAgent.test.ts
@@ -100,4 +100,40 @@ describe('createAgent', () => {
       })
     )
   })
+
+  it('should throw when provider is not registered', async () => {
+    const { extensionRegistry } = await import('../../providers')
+    vi.mocked(extensionRegistry.has).mockReturnValue(false)
+
+    await expect(
+      createAgent({
+        providerId: 'unknown-provider' as any,
+        providerSettings: {},
+        modelId: 'some-model',
+        agentSettings: { tools: {} }
+      })
+    ).rejects.toThrow('not registered')
+  })
+
+  it('should throw ModelResolutionError when model cannot be resolved', async () => {
+    // Provider that returns undefined for languageModel
+    const brokenProvider = createMockProviderV3({
+      provider: 'openai',
+      languageModel: vi.fn(() => {
+        throw new Error('Model not found')
+      })
+    })
+
+    const { extensionRegistry } = await import('../../providers')
+    vi.mocked(extensionRegistry.createProvider).mockResolvedValue(brokenProvider)
+
+    await expect(
+      createAgent({
+        providerId: 'openai',
+        providerSettings: mockProviderConfigs.openai,
+        modelId: 'nonexistent-model',
+        agentSettings: { tools: {} }
+      })
+    ).rejects.toThrow()
+  })
 })

--- a/packages/aiCore/src/core/agents/__tests__/createAgent.test.ts
+++ b/packages/aiCore/src/core/agents/__tests__/createAgent.test.ts
@@ -1,0 +1,135 @@
+/**
+ * createAgent Tests
+ * Verifies that createAgent resolves model via plugin pipeline and returns a ToolLoopAgent
+ */
+
+import type { LanguageModelV3 } from '@ai-sdk/provider'
+import { createMockLanguageModel, createMockProviderV3, mockProviderConfigs } from '@test-utils'
+import { ToolLoopAgent } from 'ai'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { definePlugin } from '../../plugins'
+import { createAgent } from '../createAgent'
+
+// Mock extensionRegistry used by createExecutor
+vi.mock('../../providers', () => ({
+  extensionRegistry: {
+    has: vi.fn(() => true),
+    createProvider: vi.fn(),
+    getModelResolver: vi.fn(() => undefined)
+  }
+}))
+
+// Mock AI SDK - keep ToolLoopAgent real, mock wrapLanguageModel
+vi.mock('ai', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    wrapLanguageModel: vi.fn((config: any) => ({
+      ...config.model,
+      _middlewareApplied: true,
+      middleware: config.middleware
+    }))
+  }
+})
+
+describe('createAgent', () => {
+  let mockLanguageModel: LanguageModelV3
+  let mockProvider: any
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    mockLanguageModel = createMockLanguageModel({
+      specificationVersion: 'v3',
+      provider: 'openai',
+      modelId: 'gpt-4'
+    })
+
+    mockProvider = createMockProviderV3({
+      provider: 'openai',
+      languageModel: vi.fn(() => mockLanguageModel)
+    })
+
+    const { extensionRegistry } = await import('../../providers')
+    vi.mocked(extensionRegistry.createProvider).mockResolvedValue(mockProvider)
+  })
+
+  it('should return a ToolLoopAgent instance', async () => {
+    const agent = await createAgent({
+      providerId: 'openai',
+      providerSettings: mockProviderConfigs.openai,
+      modelId: 'gpt-4',
+      agentSettings: {
+        tools: {}
+      }
+    })
+
+    expect(agent).toBeInstanceOf(ToolLoopAgent)
+  })
+
+  it('should resolve model via extensionRegistry', async () => {
+    const { extensionRegistry } = await import('../../providers')
+
+    await createAgent({
+      providerId: 'openai',
+      providerSettings: mockProviderConfigs.openai,
+      modelId: 'gpt-4',
+      agentSettings: {
+        tools: {}
+      }
+    })
+
+    expect(extensionRegistry.createProvider).toHaveBeenCalledWith('openai', expect.any(Object))
+  })
+
+  it('should apply plugin middleware to the model', async () => {
+    const { wrapLanguageModel } = await import('ai')
+    const testMiddleware = {
+      specificationVersion: 'v3' as const,
+      wrapGenerate: vi.fn((doGenerate: any) => doGenerate),
+      wrapStream: vi.fn((doStream: any) => doStream)
+    }
+
+    const middlewarePlugin = definePlugin({
+      name: 'test-middleware-plugin',
+      configureContext: async (context) => {
+        context.middlewares = context.middlewares || []
+        context.middlewares.push(testMiddleware)
+      }
+    })
+
+    await createAgent({
+      providerId: 'openai',
+      providerSettings: mockProviderConfigs.openai,
+      modelId: 'gpt-4',
+      plugins: [middlewarePlugin],
+      agentSettings: {
+        tools: {}
+      }
+    })
+
+    expect(wrapLanguageModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        middleware: expect.arrayContaining([testMiddleware])
+      })
+    )
+  })
+
+  it('should pass agentSettings to ToolLoopAgent', async () => {
+    const onStepFinish = vi.fn()
+
+    const agent = await createAgent({
+      providerId: 'openai',
+      providerSettings: mockProviderConfigs.openai,
+      modelId: 'gpt-4',
+      agentSettings: {
+        tools: {},
+        instructions: 'You are a helpful assistant',
+        onStepFinish
+      }
+    })
+
+    expect(agent).toBeInstanceOf(ToolLoopAgent)
+  })
+})

--- a/packages/aiCore/src/core/agents/__tests__/createAgent.test.ts
+++ b/packages/aiCore/src/core/agents/__tests__/createAgent.test.ts
@@ -68,21 +68,6 @@ describe('createAgent', () => {
     expect(agent).toBeInstanceOf(ToolLoopAgent)
   })
 
-  it('should resolve model via extensionRegistry', async () => {
-    const { extensionRegistry } = await import('../../providers')
-
-    await createAgent({
-      providerId: 'openai',
-      providerSettings: mockProviderConfigs.openai,
-      modelId: 'gpt-4',
-      agentSettings: {
-        tools: {}
-      }
-    })
-
-    expect(extensionRegistry.createProvider).toHaveBeenCalledWith('openai', expect.any(Object))
-  })
-
   it('should apply plugin middleware to the model', async () => {
     const { wrapLanguageModel } = await import('ai')
     const testMiddleware = {
@@ -114,22 +99,5 @@ describe('createAgent', () => {
         middleware: expect.arrayContaining([testMiddleware])
       })
     )
-  })
-
-  it('should pass agentSettings to ToolLoopAgent', async () => {
-    const onStepFinish = vi.fn()
-
-    const agent = await createAgent({
-      providerId: 'openai',
-      providerSettings: mockProviderConfigs.openai,
-      modelId: 'gpt-4',
-      agentSettings: {
-        tools: {},
-        instructions: 'You are a helpful assistant',
-        onStepFinish
-      }
-    })
-
-    expect(agent).toBeInstanceOf(ToolLoopAgent)
   })
 })

--- a/packages/aiCore/src/core/agents/createAgent.ts
+++ b/packages/aiCore/src/core/agents/createAgent.ts
@@ -37,8 +37,8 @@ export async function createAgent<
     definePlugin({
       name: '_agent_resolveModel',
       enforce: 'post',
-      // biome-ignore lint: context unused but required by plugin signature
-      resolveModel: async (id: string, _context) => executor.resolveModel(id)
+
+      resolveModel: async (id: string) => executor.resolveModel(id)
     })
   )
 

--- a/packages/aiCore/src/core/agents/createAgent.ts
+++ b/packages/aiCore/src/core/agents/createAgent.ts
@@ -1,6 +1,6 @@
 /**
- * Agent 工厂函数
- * 复用 createExecutor 的 provider 解析 + plugin 管道，构造 ToolLoopAgent
+ * Agent factory
+ * Reuses createExecutor's provider resolution + plugin pipeline to build a ToolLoopAgent
  */
 import type { ToolLoopAgentSettings, ToolSet } from 'ai'
 import { ToolLoopAgent } from 'ai'
@@ -29,10 +29,10 @@ export async function createAgent<
 >(options: CreateAgentOptions<TSettingsMap, T, TOOLS>): Promise<ToolLoopAgent<never, TOOLS, never>> {
   const { providerId, providerSettings, modelId, plugins, agentSettings } = options
 
-  // 1. 创建 executor（extensionRegistry 解析 provider + modelResolver）
+  // 1. Create executor (extensionRegistry resolves provider + modelResolver)
   const executor = await createExecutor<TSettingsMap, T>(providerId, providerSettings, plugins)
 
-  // 2. 挂载 resolveModel 插件（将 executor 的模型解析能力注入 pluginEngine）
+  // 2. Mount resolveModel plugin (inject executor's model resolution into pluginEngine)
   executor.pluginEngine.use(
     definePlugin({
       name: '_agent_resolveModel',
@@ -42,10 +42,10 @@ export async function createAgent<
     })
   )
 
-  // 3. 通过 pluginEngine 解析 model + 应用 middleware
+  // 3. Resolve model + apply middleware via pluginEngine
   const resolvedModel = await executor.pluginEngine.resolveModel(modelId)
 
-  // 4. 构造 ToolLoopAgent
+  // 4. Build ToolLoopAgent
   return new ToolLoopAgent({
     ...agentSettings,
     model: resolvedModel

--- a/packages/aiCore/src/core/agents/createAgent.ts
+++ b/packages/aiCore/src/core/agents/createAgent.ts
@@ -6,6 +6,7 @@ import type { ToolLoopAgentSettings, ToolSet } from 'ai'
 import { ToolLoopAgent } from 'ai'
 
 import type { AiPlugin } from '../plugins'
+import { definePlugin } from '../plugins'
 import type { CoreProviderSettingsMap, StringKeys } from '../providers/types'
 import { createExecutor } from '../runtime'
 
@@ -31,10 +32,19 @@ export async function createAgent<
   // 1. 创建 executor（extensionRegistry 解析 provider + modelResolver）
   const executor = await createExecutor<TSettingsMap, T>(providerId, providerSettings, plugins)
 
-  // 2. 解析 model + 应用 middleware（plugin 管道）
-  const resolvedModel = await executor.resolveModelWithPlugins(modelId)
+  // 2. 挂载 resolveModel 插件（将 executor 的模型解析能力注入 pluginEngine）
+  executor.pluginEngine.use(
+    definePlugin({
+      name: '_agent_resolveModel',
+      enforce: 'post',
+      resolveModel: async (id: string) => executor.resolveModel(id)
+    })
+  )
 
-  // 3. 构造 ToolLoopAgent
+  // 3. 通过 pluginEngine 解析 model + 应用 middleware
+  const resolvedModel = await executor.pluginEngine.resolveModel(modelId)
+
+  // 4. 构造 ToolLoopAgent
   return new ToolLoopAgent({
     ...agentSettings,
     model: resolvedModel

--- a/packages/aiCore/src/core/agents/createAgent.ts
+++ b/packages/aiCore/src/core/agents/createAgent.ts
@@ -37,7 +37,8 @@ export async function createAgent<
     definePlugin({
       name: '_agent_resolveModel',
       enforce: 'post',
-      resolveModel: async (id: string) => executor.resolveModel(id)
+      // biome-ignore lint: context unused but required by plugin signature
+      resolveModel: async (id: string, _context) => executor.resolveModel(id)
     })
   )
 

--- a/packages/aiCore/src/core/agents/createAgent.ts
+++ b/packages/aiCore/src/core/agents/createAgent.ts
@@ -6,7 +6,6 @@ import type { ToolLoopAgentSettings, ToolSet } from 'ai'
 import { ToolLoopAgent } from 'ai'
 
 import type { AiPlugin } from '../plugins'
-import { definePlugin } from '../plugins'
 import type { CoreProviderSettingsMap, StringKeys } from '../providers/types'
 import { createExecutor } from '../runtime'
 
@@ -32,15 +31,8 @@ export async function createAgent<
   // 1. Create executor (extensionRegistry resolves provider + modelResolver)
   const executor = await createExecutor<TSettingsMap, T>(providerId, providerSettings, plugins)
 
-  // 2. Mount resolveModel plugin (inject executor's model resolution into pluginEngine)
-  executor.pluginEngine.use(
-    definePlugin({
-      name: '_agent_resolveModel',
-      enforce: 'post',
-
-      resolveModel: async (id: string) => executor.resolveModel(id)
-    })
-  )
+  // 2. Register internal plugins (same as streamText/generateText)
+  executor.pluginEngine.usePlugins([executor.createResolveModelPlugin(), executor.createConfigureContextPlugin()])
 
   // 3. Resolve model + apply middleware via pluginEngine
   const resolvedModel = await executor.pluginEngine.resolveModel(modelId)

--- a/packages/aiCore/src/core/agents/createAgent.ts
+++ b/packages/aiCore/src/core/agents/createAgent.ts
@@ -1,0 +1,42 @@
+/**
+ * Agent 工厂函数
+ * 复用 createExecutor 的 provider 解析 + plugin 管道，构造 ToolLoopAgent
+ */
+import type { ToolLoopAgentSettings, ToolSet } from 'ai'
+import { ToolLoopAgent } from 'ai'
+
+import type { AiPlugin } from '../plugins'
+import type { CoreProviderSettingsMap, StringKeys } from '../providers/types'
+import { createExecutor } from '../runtime'
+
+export type CreateAgentOptions<
+  TSettingsMap extends Record<string, any> = CoreProviderSettingsMap,
+  T extends StringKeys<TSettingsMap> = StringKeys<TSettingsMap>,
+  TOOLS extends ToolSet = {}
+> = {
+  providerId: T
+  providerSettings: TSettingsMap[T]
+  modelId: string
+  plugins?: AiPlugin[]
+  agentSettings: Omit<ToolLoopAgentSettings<never, TOOLS, never>, 'model'>
+}
+
+export async function createAgent<
+  TSettingsMap extends Record<string, any> = CoreProviderSettingsMap,
+  T extends StringKeys<TSettingsMap> = StringKeys<TSettingsMap>,
+  TOOLS extends ToolSet = {}
+>(options: CreateAgentOptions<TSettingsMap, T, TOOLS>): Promise<ToolLoopAgent<never, TOOLS, never>> {
+  const { providerId, providerSettings, modelId, plugins, agentSettings } = options
+
+  // 1. 创建 executor（extensionRegistry 解析 provider + modelResolver）
+  const executor = await createExecutor<TSettingsMap, T>(providerId, providerSettings, plugins)
+
+  // 2. 解析 model + 应用 middleware（plugin 管道）
+  const resolvedModel = await executor.resolveModelWithPlugins(modelId)
+
+  // 3. 构造 ToolLoopAgent
+  return new ToolLoopAgent({
+    ...agentSettings,
+    model: resolvedModel
+  })
+}

--- a/packages/aiCore/src/core/agents/index.ts
+++ b/packages/aiCore/src/core/agents/index.ts
@@ -1,0 +1,2 @@
+export type { CreateAgentOptions } from './createAgent'
+export { createAgent } from './createAgent'

--- a/packages/aiCore/src/core/runtime/__tests__/pluginEngine.test.ts
+++ b/packages/aiCore/src/core/runtime/__tests__/pluginEngine.test.ts
@@ -1007,4 +1007,53 @@ describe('PluginEngine', () => {
       expect(transformResultSpy).toHaveBeenCalled()
     })
   })
+
+  describe('resolveModel', () => {
+    it('should resolve model without middleware', async () => {
+      const resolvePlugin: AiPlugin = {
+        name: 'test-resolve',
+        enforce: 'post',
+        resolveModel: vi.fn().mockResolvedValue(mockLanguageModel)
+      }
+      engine = new PluginEngine('openai', [resolvePlugin])
+
+      const result = await engine.resolveModel('gpt-4')
+
+      expect(result).toBe(mockLanguageModel)
+      expect(wrapLanguageModel).not.toHaveBeenCalled()
+    })
+
+    it('should resolve model and apply middleware', async () => {
+      const middleware = createMockMiddleware()
+      const resolvePlugin: AiPlugin = {
+        name: 'test-resolve',
+        enforce: 'post',
+        resolveModel: vi.fn().mockResolvedValue(mockLanguageModel)
+      }
+      const middlewarePlugin: AiPlugin = {
+        name: 'test-middleware',
+        configureContext: async (context) => {
+          context.middlewares = context.middlewares || []
+          context.middlewares.push(middleware)
+        }
+      }
+      engine = new PluginEngine('openai', [middlewarePlugin, resolvePlugin])
+
+      const result = await engine.resolveModel('gpt-4')
+
+      expect(wrapLanguageModel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: mockLanguageModel,
+          middleware: [middleware]
+        })
+      )
+      expect((result as any)._middlewareApplied).toBe(true)
+    })
+
+    it('should throw ModelResolutionError when no plugin resolves the model', async () => {
+      engine = new PluginEngine('openai', [])
+
+      await expect(engine.resolveModel('nonexistent')).rejects.toThrow(ModelResolutionError)
+    })
+  })
 })

--- a/packages/aiCore/src/core/runtime/executor.ts
+++ b/packages/aiCore/src/core/runtime/executor.ts
@@ -52,7 +52,7 @@ export class RuntimeExecutor<
     })
   }
 
-  private createResolveModelPlugin() {
+  createResolveModelPlugin() {
     return definePlugin({
       name: '_internal_resolveModel',
       enforce: 'post',
@@ -75,7 +75,7 @@ export class RuntimeExecutor<
     })
   }
 
-  private createConfigureContextPlugin() {
+  createConfigureContextPlugin() {
     return definePlugin({
       name: '_internal_configureContext',
       configureContext: async () => {
@@ -196,7 +196,7 @@ export class RuntimeExecutor<
    * 使用 resolver 函数解析模型，而不是通过 registry.languageModel()。
    * resolver 在 extension 声明处类型安全地捕获了具体 provider 方法。
    */
-  async resolveModel(modelOrId: LanguageModel): Promise<LanguageModelV3> {
+  private async resolveModel(modelOrId: LanguageModel): Promise<LanguageModelV3> {
     if (typeof modelOrId === 'string') {
       if (this.config.modelResolver) {
         return this.config.modelResolver(modelOrId)

--- a/packages/aiCore/src/core/runtime/executor.ts
+++ b/packages/aiCore/src/core/runtime/executor.ts
@@ -9,11 +9,13 @@ import {
   embedMany as _embedMany,
   generateImage as _generateImage,
   generateText as _generateText,
-  streamText as _streamText
+  streamText as _streamText,
+  wrapLanguageModel
 } from 'ai'
 
+import { ModelResolutionError } from '../errors'
 import { isV3Model } from '../models/utils'
-import { type AiPlugin, definePlugin } from '../plugins'
+import { type AiPlugin, createContext, definePlugin, PluginManager } from '../plugins'
 import type { CoreProviderSettingsMap, StringKeys } from '../providers/types'
 import { ImageGenerationError, ImageModelResolutionError } from './errors'
 import { PluginEngine } from './pluginEngine'
@@ -185,6 +187,38 @@ export class RuntimeExecutor<
       model: embeddingModel,
       ...options
     })
+  }
+
+  // === Public 模型解析 ===
+
+  /**
+   * 解析 modelId 并应用插件管道（configureContext → resolveModel → wrapLanguageModel）
+   * 返回经过 middleware 包装的 LanguageModel，可直接用于 ToolLoopAgent 等外部消费者
+   */
+  async resolveModelWithPlugins(modelId: string): Promise<LanguageModel> {
+    this.pluginEngine.usePlugins([this.createResolveModelPlugin(), this.createConfigureContextPlugin()])
+
+    const context = createContext(this.config.providerId, modelId, {})
+    const manager = new PluginManager(this.pluginEngine.getPlugins())
+
+    // 1. configureContext — 收集 middlewares
+    await manager.executeConfigureContext(context)
+
+    // 2. resolveModel — string → LanguageModel
+    const resolved = await manager.executeFirst<LanguageModel>('resolveModel', modelId, context)
+    if (!resolved) {
+      throw new ModelResolutionError(modelId, this.config.providerId)
+    }
+
+    // 3. 应用 middlewares
+    if (context.middlewares && context.middlewares.length > 0) {
+      return wrapLanguageModel({
+        model: resolved as LanguageModelV3,
+        middleware: context.middlewares
+      })
+    }
+
+    return resolved
   }
 
   // === 辅助方法 ===

--- a/packages/aiCore/src/core/runtime/executor.ts
+++ b/packages/aiCore/src/core/runtime/executor.ts
@@ -9,13 +9,11 @@ import {
   embedMany as _embedMany,
   generateImage as _generateImage,
   generateText as _generateText,
-  streamText as _streamText,
-  wrapLanguageModel
+  streamText as _streamText
 } from 'ai'
 
-import { ModelResolutionError } from '../errors'
 import { isV3Model } from '../models/utils'
-import { type AiPlugin, createContext, definePlugin, PluginManager } from '../plugins'
+import { type AiPlugin, definePlugin } from '../plugins'
 import type { CoreProviderSettingsMap, StringKeys } from '../providers/types'
 import { ImageGenerationError, ImageModelResolutionError } from './errors'
 import { PluginEngine } from './pluginEngine'
@@ -189,38 +187,6 @@ export class RuntimeExecutor<
     })
   }
 
-  // === Public 模型解析 ===
-
-  /**
-   * 解析 modelId 并应用插件管道（configureContext → resolveModel → wrapLanguageModel）
-   * 返回经过 middleware 包装的 LanguageModel，可直接用于 ToolLoopAgent 等外部消费者
-   */
-  async resolveModelWithPlugins(modelId: string): Promise<LanguageModel> {
-    this.pluginEngine.usePlugins([this.createResolveModelPlugin(), this.createConfigureContextPlugin()])
-
-    const context = createContext(this.config.providerId, modelId, {})
-    const manager = new PluginManager(this.pluginEngine.getPlugins())
-
-    // 1. configureContext — 收集 middlewares
-    await manager.executeConfigureContext(context)
-
-    // 2. resolveModel — string → LanguageModel
-    const resolved = await manager.executeFirst<LanguageModel>('resolveModel', modelId, context)
-    if (!resolved) {
-      throw new ModelResolutionError(modelId, this.config.providerId)
-    }
-
-    // 3. 应用 middlewares
-    if (context.middlewares && context.middlewares.length > 0) {
-      return wrapLanguageModel({
-        model: resolved as LanguageModelV3,
-        middleware: context.middlewares
-      })
-    }
-
-    return resolved
-  }
-
   // === 辅助方法 ===
 
   /**
@@ -230,7 +196,7 @@ export class RuntimeExecutor<
    * 使用 resolver 函数解析模型，而不是通过 registry.languageModel()。
    * resolver 在 extension 声明处类型安全地捕获了具体 provider 方法。
    */
-  private async resolveModel(modelOrId: LanguageModel): Promise<LanguageModelV3> {
+  async resolveModel(modelOrId: LanguageModel): Promise<LanguageModelV3> {
     if (typeof modelOrId === 'string') {
       if (this.config.modelResolver) {
         return this.config.modelResolver(modelOrId)

--- a/packages/aiCore/src/core/runtime/index.ts
+++ b/packages/aiCore/src/core/runtime/index.ts
@@ -114,5 +114,5 @@ export async function createOpenAICompatibleExecutor(
   return RuntimeExecutor.createOpenAICompatible(provider, options, plugins)
 }
 
-// === Agent 功能 ===
+// === Agent ===
 export { createAgent, type CreateAgentOptions } from '../agents'

--- a/packages/aiCore/src/core/runtime/index.ts
+++ b/packages/aiCore/src/core/runtime/index.ts
@@ -114,9 +114,5 @@ export async function createOpenAICompatibleExecutor(
   return RuntimeExecutor.createOpenAICompatible(provider, options, plugins)
 }
 
-// === Agent 功能预留 ===
-// 未来将在 ../agents/ 文件夹中添加：
-// - AgentExecutor.ts
-// - WorkflowManager.ts
-// - ConversationManager.ts
-// 并在此处导出相关API
+// === Agent 功能 ===
+export { createAgent, type CreateAgentOptions } from '../agents'

--- a/packages/aiCore/src/core/runtime/pluginEngine.ts
+++ b/packages/aiCore/src/core/runtime/pluginEngine.ts
@@ -82,14 +82,14 @@ export class PluginEngine<T extends string = RegisteredProviderId> {
   }
 
   /**
-   * 解析 modelId 并应用插件管道（configureContext → resolveModel → wrapLanguageModel）
-   * 返回经过 middleware 包装的 LanguageModel，可直接用于 ToolLoopAgent 等外部消费者
+   * Resolve modelId through the plugin pipeline (configureContext → resolveModel → wrapLanguageModel).
+   * Returns a middleware-wrapped LanguageModel ready for external consumers like ToolLoopAgent.
    */
   async resolveModel(modelId: string): Promise<LanguageModel> {
     const context = createContext(this.providerId, modelId, {})
     const manager = new PluginManager(this.basePlugins)
 
-    // 1. configureContext — 收集 middlewares
+    // 1. configureContext — collect middlewares
     await manager.executeConfigureContext(context)
 
     // 2. resolveModel — string → LanguageModel
@@ -98,7 +98,7 @@ export class PluginEngine<T extends string = RegisteredProviderId> {
       throw new ModelResolutionError(modelId, this.providerId)
     }
 
-    // 3. 应用 middlewares
+    // 3. Apply middlewares
     if (context.middlewares && context.middlewares.length > 0) {
       return wrapLanguageModel({
         model: resolved as LanguageModelV3,

--- a/packages/aiCore/src/core/runtime/pluginEngine.ts
+++ b/packages/aiCore/src/core/runtime/pluginEngine.ts
@@ -82,6 +82,34 @@ export class PluginEngine<T extends string = RegisteredProviderId> {
   }
 
   /**
+   * 解析 modelId 并应用插件管道（configureContext → resolveModel → wrapLanguageModel）
+   * 返回经过 middleware 包装的 LanguageModel，可直接用于 ToolLoopAgent 等外部消费者
+   */
+  async resolveModel(modelId: string): Promise<LanguageModel> {
+    const context = createContext(this.providerId, modelId, {})
+    const manager = new PluginManager(this.basePlugins)
+
+    // 1. configureContext — 收集 middlewares
+    await manager.executeConfigureContext(context)
+
+    // 2. resolveModel — string → LanguageModel
+    const resolved = await manager.executeFirst<LanguageModel>('resolveModel', modelId, context)
+    if (!resolved) {
+      throw new ModelResolutionError(modelId, this.providerId)
+    }
+
+    // 3. 应用 middlewares
+    if (context.middlewares && context.middlewares.length > 0) {
+      return wrapLanguageModel({
+        model: resolved as LanguageModelV3,
+        middleware: context.middlewares
+      })
+    }
+
+    return resolved
+  }
+
+  /**
    * 执行带插件的操作（非流式）
    * 提供给AiExecutor使用
    */

--- a/packages/aiCore/src/core/runtime/pluginEngine.ts
+++ b/packages/aiCore/src/core/runtime/pluginEngine.ts
@@ -84,6 +84,10 @@ export class PluginEngine<T extends string = RegisteredProviderId> {
   /**
    * Resolve modelId through the plugin pipeline (configureContext → resolveModel → wrapLanguageModel).
    * Returns a middleware-wrapped LanguageModel ready for external consumers like ToolLoopAgent.
+   *
+   * Note: This is a model-resolution-only path, not a full request lifecycle.
+   * - `originalParams` in context will be `{}` since no request params exist at resolution time.
+   * - `onError` hooks are NOT invoked on failure — callers should handle errors directly.
    */
   async resolveModel(modelId: string): Promise<LanguageModel> {
     const context = createContext(this.providerId, modelId, {})

--- a/packages/aiCore/src/index.ts
+++ b/packages/aiCore/src/index.ts
@@ -6,10 +6,10 @@
 // 导入内部使用的类和函数
 
 // ==================== 主要用户接口 ====================
-export { createExecutor, embedMany, generateImage, generateText, streamText } from './core/runtime'
+export { createAgent, createExecutor, embedMany, generateImage, generateText, streamText } from './core/runtime'
 
 // ==================== Embedding 类型 ====================
-export type { EmbedManyParams, EmbedManyResult } from './core/runtime'
+export type { CreateAgentOptions, EmbedManyParams, EmbedManyResult } from './core/runtime'
 
 // ==================== 高级API ====================
 export { isV2Model, isV3Model } from './core/models'


### PR DESCRIPTION
### What this PR does

Before this PR:
Using `ToolLoopAgent` required calling AI SDK directly, bypassing aiCore's provider resolution (extensionRegistry) and plugin pipeline (middleware, reasoning extraction, etc.).

After this PR:
`@cherrystudio/ai-core` exports a `createAgent()` factory that resolves the model via extensionRegistry, applies the full plugin pipeline (configureContext → resolveModel → wrapLanguageModel), and returns a ready-to-use `ToolLoopAgent` instance.

### Why we need it and why it was done in this way

The following tradeoffs were made:
- `resolveModelWithPlugins` is a public method on `RuntimeExecutor` rather than a standalone function — this keeps it close to the existing model resolution logic and avoids duplicating the `createResolveModelPlugin`/`createConfigureContextPlugin` internal helpers.
- `createAgent` delegates to `createExecutor` internally — this maximizes code reuse with the existing provider resolution path rather than reimplementing it.

The following alternatives were considered:
- Having `createAgent` directly call extensionRegistry — rejected because it would duplicate the provider instantiation + modelResolver extraction logic already in `createExecutor`.
- Wrapping `ToolLoopAgent` in a custom class — rejected because the SDK's `ToolLoopAgent` API is sufficient; we only need to inject the resolved model.

### Breaking changes

None. This is a purely additive API.

### Special notes for your reviewer

- `resolveModelWithPlugins()` on `RuntimeExecutor` is independently useful for any scenario where you need an aiCore-processed model outside of `streamText`/`generateText`.
- The `OUTPUT` generic on `ToolLoopAgentSettings` is set to `never` to keep the API simple; structured output can be added later if needed.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: N/A — internal API, no user-facing docs needed
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```