### PR TITLE
feat(selection): add screenshot-to-translate action with OCR

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -73,6 +73,7 @@ asarUnpack:
   - resources/**
   - "**/*.{metal,exp,lib}"
   - "node_modules/@img/sharp-libvips-*/**"
+  - "node_modules/node-screenshots-*/**"
 extraResources:
   - from: "migrations/sqlite-drizzle"
     to: "migrations/sqlite-drizzle"

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -139,6 +139,7 @@ export default defineConfig({
           selectionToolbar: resolve(__dirname, 'src/renderer/selectionToolbar.html'),
           selectionAction: resolve(__dirname, 'src/renderer/selectionAction.html'),
           traceWindow: resolve(__dirname, 'src/renderer/traceWindow.html'),
+          screenshotSelection: resolve(__dirname, 'src/renderer/screenshotSelection.html'),
           migrationV2: resolve(__dirname, 'src/renderer/migrationV2.html')
         },
         onwarn(warning, warn) {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "grammy": "^1.36.3",
     "gray-matter": "4.0.3",
     "jsdom": "26.1.0",
+    "node-screenshots": "0.2.1",
     "node-stream-zip": "1.15.0",
     "officeparser": "4.2.0",
     "os-proxy-config": "1.1.2",

--- a/packages/shared/IpcChannel.ts
+++ b/packages/shared/IpcChannel.ts
@@ -345,6 +345,7 @@ export enum IpcChannel {
   Selection_ProcessAction = 'selection:process-action',
   Selection_UpdateActionData = 'selection:update-action-data',
   Selection_GetLinuxEnvInfo = 'selection:get-linux-env-info',
+  Selection_CaptureScreenshot = 'selection:capture-screenshot',
 
   // Memory
   Memory_Add = 'memory:add',
@@ -476,5 +477,13 @@ export enum IpcChannel {
   OpenClaw_PerformUpdate = 'openclaw:perform-update',
 
   // Analytics
-  Analytics_TrackTokenUsage = 'analytics:track-token-usage'
+  Analytics_TrackTokenUsage = 'analytics:track-token-usage',
+
+  // Screenshot
+  Screenshot_CheckPermission = 'screenshot:check-permission',
+  Screenshot_Capture = 'screenshot:capture',
+  Screenshot_CaptureWithSelection = 'screenshot:capture-with-selection',
+  Screenshot_SelectionWindowReady = 'screenshot:selection-window-ready',
+  Screenshot_SelectionConfirm = 'screenshot:selection-confirm',
+  Screenshot_SelectionCancel = 'screenshot:selection-cancel'
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       jsdom:
         specifier: 26.1.0
         version: 26.1.0
+      node-screenshots:
+        specifier: 0.2.1
+        version: 0.2.1
       node-stream-zip:
         specifier: 1.15.0
         version: 1.15.0
@@ -1506,7 +1509,7 @@ importers:
         version: 0.0.5
       '@storybook/addon-docs':
         specifier: ^10.0.5
-        version: 10.3.4(@types/react@19.2.7)(esbuild@0.25.12)(rolldown-vite@7.3.0(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(rollup@4.55.1)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: 10.3.4(@types/react@19.2.7)(esbuild@0.25.12)(rollup@4.55.1)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.3(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       '@storybook/addon-themes':
         specifier: ^10.0.5
         version: 10.3.4(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
@@ -1515,7 +1518,7 @@ importers:
         version: 10.3.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
       '@storybook/react-vite':
         specifier: ^10.0.5
-        version: 10.3.4(esbuild@0.25.12)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown-vite@7.3.0(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(rollup@4.55.1)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
+        version: 10.3.4(esbuild@0.25.12)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.55.1)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)(vite@8.0.3(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       '@svgr/core':
         specifier: ^8.1.0
         version: 8.1.0(typescript@5.8.3)
@@ -4641,6 +4644,9 @@ packages:
   '@oxc-project/types@0.112.0':
     resolution: {integrity: sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ==}
 
+  '@oxc-project/types@0.122.0':
+    resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
+
   '@oxc-project/types@0.95.0':
     resolution: {integrity: sha512-vACy7vhpMPhjEJhULNxrdR0D943TkA/MigMpJCHmBHvMXxRStRi/dPtTlfQ3uDwWSzRpT8z+7ImjZVf8JWBocQ==}
 
@@ -5924,6 +5930,12 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-android-arm64@1.0.0-rc.3':
     resolution: {integrity: sha512-0T1k9FinuBZ/t7rZ8jN6OpUKPnUjNdYHoj/cESWrQ3ZraAJ4OMm6z7QjSfCxqj8mOp9kTKc1zHK3kGz5vMu+nQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5938,6 +5950,12 @@ packages:
 
   '@rolldown/binding-darwin-arm64@1.0.0-beta.53':
     resolution: {integrity: sha512-yIsKqMz0CtRnVa6x3Pa+mzTihr4Ty+Z6HfPbZ7RVbk1Uxnco4+CUn7Qbm/5SBol1JD/7nvY8rphAgyAi7Lj6Vg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -5960,6 +5978,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
+    resolution: {integrity: sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
   '@rolldown/binding-darwin-x64@1.0.0-rc.3':
     resolution: {integrity: sha512-MTakBxfx3tde5WSmbHxuqlDsIW0EzQym+PJYGF4P6lG2NmKzi128OGynoFUqoD5ryCySEY85dug4v+LWGBElIw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5974,6 +5998,12 @@ packages:
 
   '@rolldown/binding-freebsd-x64@1.0.0-beta.53':
     resolution: {integrity: sha512-9Tmp7bBvKqyDkMcL4e089pH3RsjD3SUungjmqWtyhNOxoQMh0fSmINTyYV8KXtE+JkxYMPWvnEt+/mfpVCkk8w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
+    resolution: {integrity: sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -5996,6 +6026,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
+    resolution: {integrity: sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.3':
     resolution: {integrity: sha512-A0n8P3hdLAaqzSFrQoA42p23ZKBYQOw+8EH5r15Sa9X1kD9/JXe0YT2gph2QTWvdr0CVK2BOXiK6ENfy6DXOag==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6010,6 +6046,12 @@ packages:
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.53':
     resolution: {integrity: sha512-bpIGX+ov9PhJYV+wHNXl9rzq4F0QvILiURn0y0oepbQx+7stmQsKA0DhPGwmhfvF856wq+gbM8L92SAa/CBcLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -6032,10 +6074,28 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+    resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.3':
     resolution: {integrity: sha512-Z03/wrqau9Bicfgb3Dbs6SYTHliELk2PM2LpG2nFd+cGupTMF5kanLEcj2vuuJLLhptNyS61rtk7SOZ+lPsTUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
     os: [linux]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.45':
@@ -6046,6 +6106,12 @@ packages:
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.53':
     resolution: {integrity: sha512-qL+63WKVQs1CMvFedlPt0U9PiEKJOAL/bsHMKUDS6Vp2Q+YAv/QLPu8rcvkfIMvQ0FPU2WL0aX4eWwF6e/GAnA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -6068,6 +6134,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+    resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.3':
     resolution: {integrity: sha512-qaj+MFudtdCv9xZo9znFvkgoajLdc+vwf0Kz5N44g+LU5XMe+IsACgn3UG7uTRlCCvhMAGXm1XlpEA5bZBrOcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6082,6 +6154,12 @@ packages:
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.53':
     resolution: {integrity: sha512-B4iIserJXuSnNzA5xBLFUIjTfhNy7d9sq4FUMQY3GhQWGVhS2RWWzzDnkSU6MUt7/aHUrep0CdQfXUJI9D3W7A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -6102,6 +6180,11 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
+    resolution: {integrity: sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.3':
     resolution: {integrity: sha512-gekrQ3Q2HiC1T5njGyuUJoGpK/l6B/TNXKed3fZXNf9YRTJn3L5MOZsFBn4bN2+UX+8+7hgdlTcEsexX988G4g==}
     engines: {node: '>=14.0.0'}
@@ -6115,6 +6198,12 @@ packages:
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.53':
     resolution: {integrity: sha512-s27uU7tpCWSjHBnxyVXHt3rMrQdJq5MHNv3BzsewCIroIw3DJFjMH1dzCPPMUFxnh1r52Nf9IJ/eWp6LDoyGcw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
+    resolution: {integrity: sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -6143,6 +6232,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+    resolution: {integrity: sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.3':
     resolution: {integrity: sha512-a4VUQZH7LxGbUJ3qJ/TzQG8HxdHvf+jOnqf7B7oFx1TEBm+j2KNL2zr5SQ7wHkNAcaPevF6gf9tQnVBnC4mD+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6157,6 +6252,9 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
+
+  '@rolldown/pluginutils@1.0.0-rc.12':
+    resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
 
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
@@ -11285,8 +11383,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.30.2:
     resolution: {integrity: sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -11297,8 +11407,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.30.2:
     resolution: {integrity: sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -11309,8 +11431,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.30.2:
     resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -11321,8 +11455,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -11333,8 +11479,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -11345,8 +11503,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.30.2:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
   lines-and-columns@1.2.4:
@@ -12151,6 +12319,57 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  node-screenshots-darwin-arm64@0.2.1:
+    resolution: {integrity: sha512-mcNcdn5zABYNVXIb1vq58mItFlpr03T8VJetD892qy+hqNAQdZd/vvplw+ZIlb4tuH7sR1gia67WRsBRO5nrQA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  node-screenshots-darwin-universal@0.2.1:
+    resolution: {integrity: sha512-cNqBasCyMU/P87Ej3hK/vedAk86DrVkpoxd2zz5qLA3h850Ew9qb/7g0MTYsRatbZFoLhw7MgFwAZkiNh4Mr9g==}
+    engines: {node: '>= 10'}
+    os: [darwin]
+
+  node-screenshots-darwin-x64@0.2.1:
+    resolution: {integrity: sha512-8TOou5WwytgGV+IuV1vnnYaGzwfYgIw6XkOoZtt4qhSmTEW0K8EGa46Uq42/W5qQPxKt3GLqjlY3wL69eZWIyA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  node-screenshots-linux-x64-gnu@0.2.1:
+    resolution: {integrity: sha512-P2h511my2JytMSAW8+uvO+lGj1BwapERWbC6i56u5WbLIy/zgT1SQwNvcZNbPE8sxb1q8pqF3MerLcftnW0f+w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  node-screenshots-linux-x64-musl@0.2.1:
+    resolution: {integrity: sha512-+B37/VYzH86ywWyF9XkYYicyf/BTan4TADsmxPlK+a/UHHZEnp1YjEM66sBIQTIVhVhv1DC6YUv9AppBpoV9AA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  node-screenshots-win32-arm64-msvc@0.2.1:
+    resolution: {integrity: sha512-+sj1FAF4qufcWO1KdmCOhPRMELfWu7hRv2qvr8e3jLPLM0/XGU8UTWWej9qAhf3UY83LaAsvxMhzai9JLIis1w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  node-screenshots-win32-ia32-msvc@0.2.1:
+    resolution: {integrity: sha512-8fzmFqbotHAzwIARG9fI8eD+Vw2g98Bl7aKlhu57nCjCXNrdl4Ck+b3uvMjdQD+v7rKC/sT+NZK973y4YgRoMA==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  node-screenshots-win32-x64-msvc@0.2.1:
+    resolution: {integrity: sha512-dfxAck3LR9eTYpc/hVtomQYxpP/80p4+vP9k1whDBCClTzRlHvgx1U9b6c5bYpe8JZFtCZsJL75S5p0kQJk7Dg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  node-screenshots@0.2.1:
+    resolution: {integrity: sha512-1UY7VY/34uE6Giq/Winl0J7022KKwWt9T9Gu5ZBCxhXkWrv9q5pTVQRgZCcUIsIHq3zu8UFu5s8rqgauK2CnLA==}
+    engines: {node: '>= 10'}
+
   node-stream-zip@1.15.0:
     resolution: {integrity: sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==}
     engines: {node: '>=0.12.0'}
@@ -12561,6 +12780,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
@@ -12636,6 +12859,10 @@ packages:
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postject@1.0.0-alpha.6:
@@ -13593,6 +13820,11 @@ packages:
 
   rolldown@1.0.0-beta.53:
     resolution: {integrity: sha512-Qd9c2p0XKZdgT5AYd+KgAMggJ8ZmCs3JnS9PTMWkyUfteKlfmKtxJbWTHkVakxwXs1Ub7jrRYVeFeF7N0sQxyw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rolldown@1.0.0-rc.12:
+    resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -14815,6 +15047,49 @@ packages:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
+
+  vite@8.0.3:
+    resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.25.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   vitest@3.2.4:
     resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
@@ -18642,11 +18917,11 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(rolldown-vite@7.3.0(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(typescript@5.8.3)':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.8.3)(vite@8.0.3(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@5.8.3)
-      vite: rolldown-vite@7.3.0(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.3(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
       typescript: 5.8.3
 
@@ -19404,6 +19679,8 @@ snapshots:
   '@oxc-project/types@0.101.0': {}
 
   '@oxc-project/types@0.112.0': {}
+
+  '@oxc-project/types@0.122.0': {}
 
   '@oxc-project/types@0.95.0': {}
 
@@ -20963,6 +21240,9 @@ snapshots:
   '@rolldown/binding-android-arm64@1.0.0-beta.53':
     optional: true
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+    optional: true
+
   '@rolldown/binding-android-arm64@1.0.0-rc.3':
     optional: true
 
@@ -20970,6 +21250,9 @@ snapshots:
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-beta.53':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-rc.3':
@@ -20981,6 +21264,9 @@ snapshots:
   '@rolldown/binding-darwin-x64@1.0.0-beta.53':
     optional: true
 
+  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
+    optional: true
+
   '@rolldown/binding-darwin-x64@1.0.0-rc.3':
     optional: true
 
@@ -20988,6 +21274,9 @@ snapshots:
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-beta.53':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-rc.3':
@@ -20999,6 +21288,9 @@ snapshots:
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.53':
     optional: true
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
+    optional: true
+
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.3':
     optional: true
 
@@ -21006,6 +21298,9 @@ snapshots:
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.53':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.3':
@@ -21017,13 +21312,25 @@ snapshots:
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.53':
     optional: true
 
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+    optional: true
+
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.45':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.53':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.3':
@@ -21035,6 +21342,9 @@ snapshots:
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.53':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+    optional: true
+
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.3':
     optional: true
 
@@ -21042,6 +21352,9 @@ snapshots:
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.53':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.3':
@@ -21057,6 +21370,11 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.1
     optional: true
 
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
+    optional: true
+
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.3':
     dependencies:
       '@napi-rs/wasm-runtime': 1.1.1
@@ -21066,6 +21384,9 @@ snapshots:
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.53':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.3':
@@ -21080,6 +21401,9 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-beta.53':
     optional: true
 
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+    optional: true
+
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.3':
     optional: true
 
@@ -21088,6 +21412,8 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-beta.45': {}
 
   '@rolldown/pluginutils@1.0.0-beta.53': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.12': {}
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
@@ -21590,10 +21916,10 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@storybook/addon-docs@10.3.4(@types/react@19.2.7)(esbuild@0.25.12)(rolldown-vite@7.3.0(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(rollup@4.55.1)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+  '@storybook/addon-docs@10.3.4(@types/react@19.2.7)(esbuild@0.25.12)(rollup@4.55.1)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.3(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.7)(react@19.2.3)
-      '@storybook/csf-plugin': 10.3.4(esbuild@0.25.12)(rolldown-vite@7.3.0(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(rollup@4.55.1)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@storybook/csf-plugin': 10.3.4(esbuild@0.25.12)(rollup@4.55.1)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.3(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       '@storybook/icons': 2.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@storybook/react-dom-shim': 10.3.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       react: 19.2.3
@@ -21612,25 +21938,25 @@ snapshots:
       storybook: 10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       ts-dedent: 2.2.0
 
-  '@storybook/builder-vite@10.3.4(esbuild@0.25.12)(rolldown-vite@7.3.0(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(rollup@4.55.1)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+  '@storybook/builder-vite@10.3.4(esbuild@0.25.12)(rollup@4.55.1)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.3(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@storybook/csf-plugin': 10.3.4(esbuild@0.25.12)(rolldown-vite@7.3.0(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(rollup@4.55.1)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@storybook/csf-plugin': 10.3.4(esbuild@0.25.12)(rollup@4.55.1)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.3(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       storybook: 10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       ts-dedent: 2.2.0
-      vite: rolldown-vite@7.3.0(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.3(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.3.4(esbuild@0.25.12)(rolldown-vite@7.3.0(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(rollup@4.55.1)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+  '@storybook/csf-plugin@10.3.4(esbuild@0.25.12)(rollup@4.55.1)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.3(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       storybook: 10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.25.12
       rollup: 4.55.1
-      vite: rolldown-vite@7.3.0(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.3(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@storybook/global@5.0.0': {}
 
@@ -21645,11 +21971,11 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       storybook: 10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  '@storybook/react-vite@10.3.4(esbuild@0.25.12)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown-vite@7.3.0(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(rollup@4.55.1)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)':
+  '@storybook/react-vite@10.3.4(esbuild@0.25.12)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.55.1)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)(vite@8.0.3(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(rolldown-vite@7.3.0(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(typescript@5.8.3)
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.8.3)(vite@8.0.3(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       '@rollup/pluginutils': 5.3.0(rollup@4.55.1)
-      '@storybook/builder-vite': 10.3.4(esbuild@0.25.12)(rolldown-vite@7.3.0(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(rollup@4.55.1)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@storybook/builder-vite': 10.3.4(esbuild@0.25.12)(rollup@4.55.1)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.3(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       '@storybook/react': 10.3.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -21659,7 +21985,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tsconfig-paths: 4.2.0
-      vite: rolldown-vite@7.3.0(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.3(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -27321,34 +27647,67 @@ snapshots:
   lightningcss-android-arm64@1.30.2:
     optional: true
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-x64@1.30.2:
     optional: true
 
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.30.2:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.30.2:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.30.2:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.30.2:
     optional: true
 
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.30.2:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.30.2:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
     optional: true
 
   lightningcss@1.30.2:
@@ -27366,6 +27725,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.30.2
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lines-and-columns@1.2.4: {}
 
@@ -28456,6 +28831,41 @@ snapshots:
 
   node-releases@2.0.27: {}
 
+  node-screenshots-darwin-arm64@0.2.1:
+    optional: true
+
+  node-screenshots-darwin-universal@0.2.1:
+    optional: true
+
+  node-screenshots-darwin-x64@0.2.1:
+    optional: true
+
+  node-screenshots-linux-x64-gnu@0.2.1:
+    optional: true
+
+  node-screenshots-linux-x64-musl@0.2.1:
+    optional: true
+
+  node-screenshots-win32-arm64-msvc@0.2.1:
+    optional: true
+
+  node-screenshots-win32-ia32-msvc@0.2.1:
+    optional: true
+
+  node-screenshots-win32-x64-msvc@0.2.1:
+    optional: true
+
+  node-screenshots@0.2.1:
+    optionalDependencies:
+      node-screenshots-darwin-arm64: 0.2.1
+      node-screenshots-darwin-universal: 0.2.1
+      node-screenshots-darwin-x64: 0.2.1
+      node-screenshots-linux-x64-gnu: 0.2.1
+      node-screenshots-linux-x64-musl: 0.2.1
+      node-screenshots-win32-arm64-msvc: 0.2.1
+      node-screenshots-win32-ia32-msvc: 0.2.1
+      node-screenshots-win32-x64-msvc: 0.2.1
+
   node-stream-zip@1.15.0: {}
 
   noop-logger@0.1.1: {}
@@ -28871,6 +29281,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.4: {}
+
   pify@2.3.0: {}
 
   pify@3.0.0: {}
@@ -28942,6 +29354,12 @@ snapshots:
       source-map-js: 1.2.1
 
   postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.8:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -30219,6 +30637,27 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.0-beta.53
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.53
       '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.53
+
+  rolldown@1.0.0-rc.12:
+    dependencies:
+      '@oxc-project/types': 0.122.0
+      '@rolldown/pluginutils': 1.0.0-rc.12
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
 
   rolldown@1.0.0-rc.3:
     dependencies:
@@ -31647,6 +32086,21 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vite@8.0.3(@types/node@24.10.4)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.8
+      rolldown: 1.0.0-rc.12
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 24.10.4
+      esbuild: 0.25.12
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      tsx: 4.21.0
+      yaml: 2.8.2
 
   vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.10.4)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(esbuild@0.25.12)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.12.7(@types/node@24.10.4)(typescript@5.8.3))(tsx@4.21.0)(yaml@2.8.2):
     dependencies:

--- a/src/main/services/ScreenshotService.ts
+++ b/src/main/services/ScreenshotService.ts
@@ -1,0 +1,362 @@
+import { loggerService } from '@logger'
+import { isDev, isMac, isWin } from '@main/constant'
+import { fileStorage } from '@main/services/FileStorage'
+import { IpcChannel } from '@shared/IpcChannel'
+import type { FileMetadata } from '@types'
+import { BrowserWindow, screen, systemPreferences } from 'electron'
+import fs from 'fs'
+import { join } from 'path'
+import path from 'path'
+import { v4 as uuidv4 } from 'uuid'
+
+let ScreenshotsModule: any = null
+try {
+  ScreenshotsModule = require('node-screenshots')
+} catch (error) {
+  loggerService.withContext('ScreenshotService').error('Failed to load node-screenshots:', error as Error)
+}
+
+const logger = loggerService.withContext('ScreenshotService')
+
+type PermissionStatus = 'granted' | 'denied'
+
+type CaptureResult =
+  | { success: true; file: FileMetadata }
+  | { success: false; status: PermissionStatus; needsRestart: boolean; message: string }
+
+type SelectionCaptureResult =
+  | { success: true; file: FileMetadata }
+  | { success: false; status: 'cancelled' | 'denied' | 'error'; needsRestart?: boolean; message: string }
+
+interface Rectangle {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+class ScreenshotService {
+  private selectionWindow: BrowserWindow | null = null
+  private screenshotBuffer: Buffer | null = null
+  private screenshotData: string | null = null
+  private screenshotTempPath: string | null = null
+  private currentFileName: string | null = null
+  private selectionPromise: {
+    resolve: (value: SelectionCaptureResult) => void
+    reject: (reason?: any) => void
+  } | null = null
+
+  public async capture(fileName: string): Promise<CaptureResult> {
+    try {
+      if (!ScreenshotsModule) {
+        try {
+          ScreenshotsModule = require('node-screenshots')
+        } catch (loadError) {
+          logger.error('Failed to load node-screenshots module', loadError as Error)
+          return {
+            success: false,
+            status: 'denied',
+            needsRestart: false,
+            message: 'Screenshot module not available'
+          }
+        }
+      }
+
+      const monitor = ScreenshotsModule.Monitor.fromPoint(0, 0) ?? ScreenshotsModule.Monitor.all()[0]
+
+      if (!monitor) {
+        logger.error('No monitor found for screenshot')
+        return {
+          success: false,
+          status: 'denied',
+          needsRestart: false,
+          message: 'No monitor found'
+        }
+      }
+
+      const image = await monitor.captureImage()
+      const buffer = await image.toPng()
+
+      const ext = '.png'
+      const tempFilePath = await fileStorage.createTempFile({} as any, fileName || `screenshot${ext}`)
+      await fs.promises.writeFile(tempFilePath, buffer)
+
+      const stats = await fs.promises.stat(tempFilePath)
+      const id = uuidv4()
+      const file: FileMetadata = {
+        id,
+        name: `${id}${ext}`,
+        origin_name: path.basename(fileName || 'screenshot.png'),
+        path: tempFilePath,
+        size: stats.size,
+        ext,
+        type: 'image',
+        created_at: new Date().toISOString(),
+        count: 1
+      }
+
+      return { success: true, file }
+    } catch (error) {
+      logger.error('Screenshot capture failed', error as Error)
+
+      if (process.platform === 'darwin') {
+        const status = systemPreferences.getMediaAccessStatus('screen')
+        logger.info('Permission status after error:', { status })
+
+        if (status !== 'granted') {
+          return {
+            success: false,
+            status: 'denied',
+            needsRestart: status === 'not-determined' ? false : true,
+            message: 'Screen recording permission required'
+          }
+        }
+      }
+
+      return {
+        success: false,
+        status: 'denied',
+        needsRestart: false,
+        message: error instanceof Error ? error.message : 'Screenshot capture failed'
+      }
+    }
+  }
+
+  private createSelectionWindow(): BrowserWindow {
+    const display = screen.getPrimaryDisplay()
+    const { width, height } = display.bounds
+
+    const window = new BrowserWindow({
+      width,
+      height,
+      x: display.bounds.x,
+      y: display.bounds.y,
+      show: false,
+      frame: false,
+      transparent: true,
+      alwaysOnTop: true,
+      skipTaskbar: true,
+      resizable: false,
+      minimizable: false,
+      maximizable: false,
+      fullscreenable: false,
+      movable: false,
+      hasShadow: false,
+      enableLargerThanScreen: true,
+      ...(isWin ? { type: 'toolbar', focusable: false } : { type: 'panel' }),
+      ...(isMac && { hiddenInMissionControl: true, acceptFirstMouse: true, visibleOnAllWorkspaces: true }),
+      webPreferences: {
+        preload: join(__dirname, '../preload/index.js'),
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: false,
+        devTools: isDev ? true : false
+      }
+    })
+
+    window.on('closed', async () => {
+      await this.cleanupSelection()
+    })
+
+    if (isDev) {
+      void window.loadURL(`http://localhost:5173/screenshotSelection.html`)
+    } else {
+      void window.loadFile(join(__dirname, '../renderer/screenshotSelection.html'))
+    }
+
+    return window
+  }
+
+  private async cleanupSelection() {
+    if (this.selectionWindow && !this.selectionWindow.isDestroyed()) {
+      this.selectionWindow.destroy()
+    }
+    this.selectionWindow = null
+    this.screenshotBuffer = null
+    this.screenshotData = null
+    this.currentFileName = null
+    this.selectionPromise = null
+
+    if (this.screenshotTempPath) {
+      try {
+        await fs.promises.unlink(this.screenshotTempPath)
+      } catch (error) {
+        logger.warn('Failed to delete temporary screenshot file', error as Error)
+      }
+      this.screenshotTempPath = null
+    }
+  }
+
+  public async confirmSelection(selection: Rectangle): Promise<void> {
+    if (!this.selectionPromise) {
+      logger.warn('No active selection to confirm')
+      return
+    }
+
+    if (selection.width < 10 || selection.height < 10) {
+      this.selectionPromise.resolve({
+        success: false,
+        status: 'error',
+        message: 'Selection too small (minimum 10×10 pixels)'
+      })
+      await this.cleanupSelection()
+      return
+    }
+
+    await this.processSelection(selection)
+  }
+
+  public async cancelSelection(): Promise<void> {
+    if (!this.selectionPromise) {
+      logger.warn('No active selection to cancel')
+      return
+    }
+
+    this.selectionPromise.resolve({
+      success: false,
+      status: 'cancelled',
+      message: 'User cancelled selection'
+    })
+    await this.cleanupSelection()
+  }
+
+  private async processSelection(selection: Rectangle): Promise<void> {
+    if (!this.screenshotBuffer || !this.selectionPromise) {
+      logger.error('Missing screenshot buffer or selection promise')
+      await this.cleanupSelection()
+      return
+    }
+
+    try {
+      const cursorPoint = screen.getCursorScreenPoint()
+      const display = screen.getDisplayNearestPoint(cursorPoint)
+      const scaleFactor = display.scaleFactor
+
+      const croppedBuffer = await this.cropScreenshot(this.screenshotBuffer, selection, scaleFactor)
+
+      const ext = '.png'
+      const fileName = this.currentFileName || `screenshot_${Date.now()}${ext}`
+      const tempFilePath = await fileStorage.createTempFile({} as any, fileName)
+      await fs.promises.writeFile(tempFilePath, croppedBuffer)
+
+      const stats = await fs.promises.stat(tempFilePath)
+      const id = uuidv4()
+      const file: FileMetadata = {
+        id,
+        name: `${id}${ext}`,
+        origin_name: fileName,
+        path: tempFilePath,
+        size: stats.size,
+        ext,
+        type: 'image',
+        created_at: new Date().toISOString(),
+        count: 1
+      }
+
+      this.selectionPromise.resolve({ success: true, file })
+    } catch (error) {
+      logger.error('Failed to process selection', error as Error)
+      this.selectionPromise.resolve({
+        success: false,
+        status: 'error',
+        message: error instanceof Error ? error.message : 'Failed to process selection'
+      })
+    } finally {
+      await this.cleanupSelection()
+    }
+  }
+
+  private async cropScreenshot(buffer: Buffer, selection: Rectangle, scaleFactor: number): Promise<Buffer> {
+    const sharp = (await import('sharp')).default
+
+    return sharp(buffer)
+      .extract({
+        left: Math.round(selection.x * scaleFactor),
+        top: Math.round(selection.y * scaleFactor),
+        width: Math.round(selection.width * scaleFactor),
+        height: Math.round(selection.height * scaleFactor)
+      })
+      .png()
+      .toBuffer()
+  }
+
+  public async captureWithSelection(fileName: string): Promise<SelectionCaptureResult> {
+    try {
+      if (!ScreenshotsModule) {
+        try {
+          ScreenshotsModule = require('node-screenshots')
+        } catch (loadError) {
+          logger.error('Failed to load node-screenshots module', loadError as Error)
+          return {
+            success: false,
+            status: 'error',
+            message: 'Screenshot module not available'
+          }
+        }
+      }
+      const monitor = ScreenshotsModule.Monitor.fromPoint(0, 0) ?? ScreenshotsModule.Monitor.all()[0]
+
+      if (!monitor) {
+        logger.error('No monitor found for screenshot')
+        return {
+          success: false,
+          status: 'error',
+          message: 'No monitor found'
+        }
+      }
+
+      const image = await monitor.captureImage()
+      const buffer = await image.toPng()
+
+      this.screenshotBuffer = buffer
+      this.currentFileName = fileName
+
+      const tempFilePath = await fileStorage.createTempFile({} as any, `screenshot-${uuidv4()}.png`)
+      await fs.promises.writeFile(tempFilePath, buffer)
+      this.screenshotTempPath = tempFilePath
+      this.screenshotData = `file://${tempFilePath}`
+
+      if (!this.selectionWindow || this.selectionWindow.isDestroyed()) {
+        this.selectionWindow = this.createSelectionWindow()
+      }
+
+      return new Promise((resolve, reject) => {
+        this.selectionPromise = { resolve, reject }
+
+        this.selectionWindow!.once('ready-to-show', () => {
+          this.selectionWindow!.show()
+          this.selectionWindow!.focus()
+
+          this.selectionWindow!.webContents.send(IpcChannel.Screenshot_SelectionWindowReady, {
+            screenshotData: this.screenshotData
+          })
+        })
+      })
+    } catch (error) {
+      logger.error('Screenshot capture with selection failed', error as Error)
+      await this.cleanupSelection()
+
+      if (process.platform === 'darwin') {
+        const status = systemPreferences.getMediaAccessStatus('screen')
+        logger.info('Permission status after error:', { status })
+
+        if (status !== 'granted') {
+          return {
+            success: false,
+            status: 'denied',
+            needsRestart: status === 'not-determined' ? false : true,
+            message: 'Screen recording permission required'
+          }
+        }
+      }
+
+      return {
+        success: false,
+        status: 'error',
+        message: error instanceof Error ? error.message : 'Screenshot capture failed'
+      }
+    }
+  }
+}
+
+export const screenshotService = new ScreenshotService()

--- a/src/main/services/SelectionService.ts
+++ b/src/main/services/SelectionService.ts
@@ -6,7 +6,8 @@ import { type Activatable, BaseService, Injectable, Phase, ServicePhase } from '
 import type { SelectionActionItem } from '@shared/data/preference/preferenceTypes'
 import { SelectionTriggerMode } from '@shared/data/preference/preferenceTypes'
 import { IpcChannel } from '@shared/IpcChannel'
-import { app, BrowserWindow, clipboard, screen, systemPreferences } from 'electron'
+import type { FileMetadata } from '@types'
+import { app, BrowserWindow, clipboard, ipcMain, screen, systemPreferences } from 'electron'
 import { join } from 'path'
 import type {
   KeyboardEventData,
@@ -15,6 +16,8 @@ import type {
   SelectionHookInstance,
   TextSelectionData
 } from 'selection-hook'
+
+import { screenshotService } from './ScreenshotService'
 
 const logger = loggerService.withContext('SelectionService')
 
@@ -1652,6 +1655,53 @@ export class SelectionService extends BaseService implements Activatable {
       this.ipcHandle(IpcChannel.Selection_GetLinuxEnvInfo, () => {
         return this.getLinuxEnvInfo()
       })
+    }
+
+    this.ipcHandle(IpcChannel.Selection_CaptureScreenshot, async () => {
+      return this.captureScreenshot()
+    })
+
+    ipcMain.handle(IpcChannel.Screenshot_CheckPermission, async () => {
+      if (!isMac) {
+        return { status: 'granted' as const }
+      }
+      const status = systemPreferences.getMediaAccessStatus('screen')
+      return {
+        status: status === 'granted' ? ('granted' as const) : ('denied' as const)
+      }
+    })
+
+    ipcMain.handle(IpcChannel.Screenshot_Capture, async (_event, fileName: string) => {
+      return await screenshotService.capture(fileName)
+    })
+
+    ipcMain.handle(IpcChannel.Screenshot_CaptureWithSelection, async (_event, fileName: string) => {
+      return await screenshotService.captureWithSelection(fileName)
+    })
+
+    ipcMain.handle(
+      IpcChannel.Screenshot_SelectionConfirm,
+      async (_event, selection: { x: number; y: number; width: number; height: number }) => {
+        await screenshotService.confirmSelection(selection)
+      }
+    )
+
+    ipcMain.handle(IpcChannel.Screenshot_SelectionCancel, async () => {
+      await screenshotService.cancelSelection()
+    })
+  }
+
+  public async captureScreenshot(): Promise<FileMetadata | null> {
+    try {
+      const result = await screenshotService.capture(`screenshot_${Date.now()}.png`)
+      if (result.success) {
+        return result.file
+      }
+      logger.error('Screenshot capture failed:', new Error(result.message))
+      return null
+    } catch (error) {
+      logger.error('Failed to capture screenshot:', error as Error)
+      throw error
     }
   }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -564,7 +564,18 @@ const api = {
     // [Windows only] Electron bug workaround - can be removed once https://github.com/electron/electron/issues/48554 is fixed
     resizeActionWindow: (deltaX: number, deltaY: number, direction: string) =>
       ipcRenderer.invoke(IpcChannel.Selection_ActionWindowResize, deltaX, deltaY, direction),
-    getLinuxEnvInfo: () => ipcRenderer.invoke(IpcChannel.Selection_GetLinuxEnvInfo)
+    getLinuxEnvInfo: () => ipcRenderer.invoke(IpcChannel.Selection_GetLinuxEnvInfo),
+    captureScreenshot: () => ipcRenderer.invoke(IpcChannel.Selection_CaptureScreenshot)
+  },
+  screenshot: {
+    checkPermission: (): Promise<{ status: 'granted' | 'denied' }> =>
+      ipcRenderer.invoke(IpcChannel.Screenshot_CheckPermission),
+    capture: (fileName: string) => ipcRenderer.invoke(IpcChannel.Screenshot_Capture, fileName),
+    captureWithSelection: (fileName: string) =>
+      ipcRenderer.invoke(IpcChannel.Screenshot_CaptureWithSelection, fileName),
+    confirmSelection: (selection: { x: number; y: number; width: number; height: number }) =>
+      ipcRenderer.invoke(IpcChannel.Screenshot_SelectionConfirm, selection),
+    cancelSelection: () => ipcRenderer.invoke(IpcChannel.Screenshot_SelectionCancel)
   },
   agentTools: {
     respondToPermission: (payload: {

--- a/src/renderer/screenshotSelection.html
+++ b/src/renderer/screenshotSelection.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="initial-scale=1, width=device-width" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; connect-src blob: *; script-src 'self' 'unsafe-eval' *; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' *; font-src 'self' data: *; img-src 'self' data: file: * blob:; frame-src * file:" />
+    <title>Cherry Studio Screenshot Selection</title>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/windows/screenshot/entryPoint.tsx"></script>
+    <style>
+      html {
+        margin: 0 !important;
+        padding: 0 !important;
+        overflow: hidden !important;
+        background-color: transparent !important;
+        background-image: none !important;
+      }
+
+      body {
+        margin: 0 !important;
+        padding: 0 !important;
+        overflow: hidden !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        background-color: transparent !important;
+        cursor: crosshair !important;
+
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+      }
+
+      #root {
+        margin: 0 !important;
+        padding: 0 !important;
+        width: 100% !important;
+        height: 100% !important;
+      }
+    </style>
+  </body>
+</html>

--- a/src/renderer/src/components/app/Sidebar.tsx
+++ b/src/renderer/src/components/app/Sidebar.tsx
@@ -15,6 +15,7 @@ import { isEmoji } from '@renderer/utils'
 import { getDefaultRouteTitle } from '@renderer/utils/routeTitle'
 import { ThemeMode } from '@shared/data/preference/preferenceTypes'
 import {
+  Camera,
   Code,
   FileSearch,
   Folder,
@@ -146,6 +147,7 @@ const MainMenus: FC = () => {
     store: <Sparkle size={18} className="icon" />,
     paintings: <Palette size={18} className="icon" />,
     translate: <Languages size={18} className="icon" />,
+    screenshot: <Camera size={18} className="icon" />,
     minapp: <LayoutGrid size={18} className="icon" />,
     knowledge: <FileSearch size={18} className="icon" />,
     files: <Folder size={18} className="icon" />,
@@ -160,6 +162,7 @@ const MainMenus: FC = () => {
     store: '/app/assistant',
     paintings: `/app/paintings/${defaultPaintingProvider}`,
     translate: '/app/translate',
+    screenshot: '/app/screenshot',
     minapp: '/app/minapp',
     knowledge: '/app/knowledge',
     files: '/app/files',

--- a/src/renderer/src/i18n/label.ts
+++ b/src/renderer/src/i18n/label.ts
@@ -190,6 +190,7 @@ const sidebarIconKeyMap = {
   store: 'assistants.presets.title',
   paintings: 'paintings.title',
   translate: 'translate.title',
+  screenshot: 'screenshot.title',
   minapp: 'minapp.title',
   knowledge: 'knowledge.title',
   files: 'files.title',

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -3690,6 +3690,20 @@
       "undo": "Undo"
     }
   },
+  "screenshot": {
+    "cancelled": "Screenshot capture cancelled",
+    "capture": "Capture Screenshot",
+    "empty_text": "No text was recognized in the screenshot",
+    "failed": "Screenshot capture failed",
+    "ocr_placeholder": "Captured text will appear here...",
+    "ocr_text": "Recognized Text",
+    "process": "Process",
+    "process_failed": "Failed to process screenshot",
+    "result_placeholder": "Processed result will appear here...",
+    "start_hint": "Select a screen area after Snipping Tool opens",
+    "title": "Screenshot",
+    "unsupported": "Screenshot capture is currently supported on Windows only"
+  },
   "selection": {
     "action": {
       "builtin": {
@@ -4630,6 +4644,9 @@
         },
         "painting": {
           "icon": "Show Painting icon"
+        },
+        "screenshot": {
+          "icon": "Show Screenshot icon"
         },
         "title": "Sidebar Settings",
         "translate": {
@@ -5860,6 +5877,7 @@
     "notes": "Notes",
     "openclaw": "OpenClaw",
     "paintings": "Paintings",
+    "screenshot": "Screenshot",
     "settings": "Settings",
     "store": "Assistant Library",
     "translate": "Translate"

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -3690,6 +3690,20 @@
       "undo": "撤销"
     }
   },
+  "screenshot": {
+    "cancelled": "已取消截图",
+    "capture": "截取屏幕",
+    "empty_text": "未识别到文字",
+    "failed": "截图失败",
+    "ocr_placeholder": "识别的文字将显示于此...",
+    "ocr_text": "识别文字",
+    "process": "处理",
+    "process_failed": "处理截图失败",
+    "result_placeholder": "处理结果将显示于此...",
+    "start_hint": "请在系统截图工具打开后框选要截取的区域",
+    "title": "截图",
+    "unsupported": "截图功能目前仅支持 Windows"
+  },
   "selection": {
     "action": {
       "builtin": {
@@ -4630,6 +4644,9 @@
         },
         "painting": {
           "icon": "显示绘画图标"
+        },
+        "screenshot": {
+          "icon": "显示截图图标"
         },
         "title": "侧边栏设置",
         "translate": {
@@ -5860,6 +5877,7 @@
     "notes": "笔记",
     "openclaw": "OpenClaw",
     "paintings": "绘画",
+    "screenshot": "截图",
     "settings": "设置",
     "store": "助手库",
     "translate": "翻译"

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -3690,6 +3690,20 @@
       "undo": "復原"
     }
   },
+  "screenshot": {
+    "cancelled": "已取消截圖",
+    "capture": "擷取螢幕",
+    "empty_text": "未辨識到文字",
+    "failed": "截圖失敗",
+    "ocr_placeholder": "擷取的文字將顯示於此...",
+    "ocr_text": "辨識文字",
+    "process": "處理",
+    "process_failed": "處理截圖失敗",
+    "result_placeholder": "處理結果將顯示於此...",
+    "start_hint": "請在系統截圖工具開啟後框選要擷取的區域",
+    "title": "截圖",
+    "unsupported": "截圖功能目前僅支援 Windows"
+  },
   "selection": {
     "action": {
       "builtin": {
@@ -4630,6 +4644,9 @@
         },
         "painting": {
           "icon": "顯示繪圖圖示"
+        },
+        "screenshot": {
+          "icon": "顯示截圖圖示"
         },
         "title": "側邊欄設定",
         "translate": {
@@ -5860,6 +5877,7 @@
     "notes": "筆記",
     "openclaw": "OpenClaw",
     "paintings": "繪畫",
+    "screenshot": "截圖",
     "settings": "設定",
     "store": "助手庫",
     "translate": "翻譯"

--- a/src/renderer/src/pages/screenshot/ScreenshotPage.tsx
+++ b/src/renderer/src/pages/screenshot/ScreenshotPage.tsx
@@ -1,0 +1,367 @@
+import { SendOutlined } from '@ant-design/icons'
+import { loggerService } from '@logger'
+import { Navbar, NavbarCenter } from '@renderer/components/app/Navbar'
+import { isWin } from '@renderer/config/constant'
+import { useDefaultModel } from '@renderer/hooks/useAssistant'
+import { useOcr } from '@renderer/hooks/useOcr'
+import { useSettings } from '@renderer/hooks/useSettings'
+import { estimateTextTokens } from '@renderer/services/TokenService'
+import { useAppDispatch } from '@renderer/store'
+import { setTranslateAbortKey } from '@renderer/store/runtime'
+import type { ImageFileMetadata, TranslateLanguage } from '@renderer/types'
+import { uuid } from '@renderer/utils'
+import { formatErrorMessageWithPrefix, isAbortError } from '@renderer/utils/error'
+import { Button, Flex, Select, Typography } from 'antd'
+import type { TextAreaRef } from 'antd/es/input/TextArea'
+import TextArea from 'antd/es/input/TextArea'
+import { Camera, Copy, Languages, MessageSquare, ScanText, Sparkles } from 'lucide-react'
+import type { FC } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+
+import { fetchChatCompletion } from '../../services/ApiService'
+import { getDefaultAssistant } from '../../services/AssistantService'
+import { translateText } from '../../services/TranslateService'
+import { ChunkType } from '../../types/chunk'
+
+const logger = loggerService.withContext('ScreenshotPage')
+
+type ScreenshotAction = 'translate' | 'summarize' | 'explain' | 'refine'
+
+const ScreenshotPage: FC = () => {
+  const { t } = useTranslation()
+  const { ocr } = useOcr()
+  const { translateModel } = useDefaultModel()
+  const { language } = useSettings()
+  const dispatch = useAppDispatch()
+
+  const [ocrText, setOcrText] = useState('')
+  const [resultText, setResultText] = useState('')
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [selectedAction, setSelectedAction] = useState<ScreenshotAction>('translate')
+  const [copied, setCopied] = useState(false)
+
+  const textAreaRef = useRef<TextAreaRef>(null)
+  const outputTextRef = useRef<HTMLDivElement>(null)
+
+  const captureScreenshot = useCallback(async () => {
+    if (!isWin) {
+      window.toast.warning(t('screenshot.unsupported'))
+      return
+    }
+
+    window.toast.info(t('screenshot.start_hint'))
+
+    try {
+      const file = await window.api.selection.captureScreenshot()
+      if (!file) {
+        window.toast.info(t('screenshot.cancelled'))
+        return
+      }
+
+      setIsProcessing(true)
+
+      const ocrResult = await ocr(file as ImageFileMetadata)
+      const text = ocrResult.text.trim()
+
+      if (!text) {
+        window.toast.warning(t('screenshot.empty_text'))
+        setIsProcessing(false)
+        return
+      }
+
+      setOcrText(text)
+      setIsProcessing(false)
+    } catch (error) {
+      logger.error('Failed to capture screenshot:', error as Error)
+      window.toast.error(t('screenshot.failed'))
+      setIsProcessing(false)
+    }
+  }, [ocr, t])
+
+  const processText = useCallback(async () => {
+    if (!ocrText.trim()) {
+      window.toast.warning(t('screenshot.empty_text'))
+      return
+    }
+    if (!translateModel) {
+      window.toast.error(t('translate.error.not_configured'))
+      return
+    }
+
+    setIsProcessing(true)
+    setResultText('')
+
+    try {
+      if (selectedAction === 'translate') {
+        await handleTranslate()
+      } else {
+        await handleLLMAction()
+      }
+    } catch (error) {
+      logger.error('Failed to process text:', error as Error)
+      window.toast.error(t('screenshot.process_failed'))
+      setIsProcessing(false)
+    }
+  }, [ocrText, selectedAction, translateModel, t])
+
+  const handleTranslate = useCallback(async () => {
+    const abortKey = uuid()
+    dispatch(setTranslateAbortKey(abortKey))
+
+    try {
+      const translated = await translateText(
+        ocrText,
+        language as unknown as TranslateLanguage,
+        (text) => setResultText(text),
+        abortKey
+      )
+      setResultText(translated)
+      window.toast.success(t('translate.complete'))
+    } catch (e) {
+      if (!isAbortError(e)) {
+        logger.error('Translation failed', e as Error)
+        window.toast.error(formatErrorMessageWithPrefix(e, t('translate.error.failed')))
+      }
+    } finally {
+      setIsProcessing(false)
+    }
+  }, [ocrText, language, dispatch, t])
+
+  const handleLLMAction = useCallback(async () => {
+    const prompts: Record<ScreenshotAction, string> = {
+      summarize: t('selection.action.prompt.summary', { language }),
+      explain: t('selection.action.prompt.explain'),
+      refine: t('selection.action.prompt.refine'),
+      translate: ''
+    }
+
+    const prompt = prompts[selectedAction]
+    if (!prompt) return
+
+    const abortKey = uuid()
+    dispatch(setTranslateAbortKey(abortKey))
+
+    const assistant = getDefaultAssistant()
+    assistant.model = translateModel
+    assistant.prompt = prompt
+
+    try {
+      await fetchChatCompletion({
+        prompt: prompt + '\n\n' + ocrText,
+        assistant,
+        onChunkReceived: (chunk) => {
+          if (chunk.type === ChunkType.TEXT_DELTA) {
+            if (chunk.text) {
+              setResultText(chunk.text)
+            }
+          } else if (chunk.type === ChunkType.TEXT_COMPLETE) {
+            window.toast.success(t('common.success'))
+            setIsProcessing(false)
+          } else if (chunk.type === ChunkType.ERROR) {
+            if (!isAbortError(chunk.error)) {
+              window.toast.error(formatErrorMessageWithPrefix(chunk.error, t('screenshot.process_failed')))
+            }
+            setIsProcessing(false)
+          }
+        }
+      })
+    } catch (e) {
+      if (!isAbortError(e)) {
+        logger.error('LLM request failed', e as Error)
+        window.toast.error(formatErrorMessageWithPrefix(e, t('screenshot.process_failed')))
+      }
+      setIsProcessing(false)
+    }
+  }, [ocrText, translateModel, selectedAction, language, dispatch, t])
+
+  const onCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(resultText)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch (error) {
+      logger.error('Failed to copy text:', error as Error)
+    }
+  }, [resultText])
+
+  const tokenCount = useMemo(() => estimateTextTokens(ocrText), [ocrText])
+
+  const actionOptions = [
+    { value: 'translate', label: t('selection.action.builtin.translate'), icon: <Languages size={16} /> },
+    { value: 'summarize', label: t('selection.action.builtin.summary'), icon: <ScanText size={16} /> },
+    { value: 'explain', label: t('selection.action.builtin.explain'), icon: <MessageSquare size={16} /> },
+    { value: 'refine', label: t('selection.action.builtin.refine'), icon: <Sparkles size={16} /> }
+  ]
+
+  return (
+    <Container>
+      <Navbar>
+        <NavbarCenter style={{ borderRight: 'none' }}>{t('screenshot.title')}</NavbarCenter>
+      </Navbar>
+      <ContentContainer>
+        <Toolbar>
+          <Flex gap={8} align="center">
+            <Button
+              type="primary"
+              icon={<Camera size={16} />}
+              onClick={captureScreenshot}
+              loading={isProcessing && !ocrText}>
+              {t('screenshot.capture')}
+            </Button>
+            <Select
+              value={selectedAction}
+              onChange={setSelectedAction}
+              options={actionOptions}
+              style={{ width: 180 }}
+              optionRender={(option) => (
+                <Flex gap={8} align="center">
+                  {option.data.icon}
+                  {option.data.label}
+                </Flex>
+              )}
+            />
+          </Flex>
+          <Button
+            type="primary"
+            icon={<SendOutlined />}
+            onClick={processText}
+            disabled={!ocrText.trim() || isProcessing}
+            loading={isProcessing && !!ocrText}>
+            {t('screenshot.process')}
+          </Button>
+        </Toolbar>
+
+        <AreaContainer>
+          <InputContainer>
+            <Typography.Text style={{ color: 'var(--color-text-3)', marginBottom: 8, display: 'block' }}>
+              {t('screenshot.ocr_text')}
+            </Typography.Text>
+            <Textarea
+              ref={textAreaRef}
+              variant="borderless"
+              value={ocrText}
+              onChange={(e) => setOcrText(e.target.value)}
+              placeholder={t('screenshot.ocr_placeholder')}
+              spellCheck={false}
+            />
+            <Footer>
+              <Typography.Text style={{ color: 'var(--color-text-3)' }}>{tokenCount} tokens</Typography.Text>
+            </Footer>
+          </InputContainer>
+
+          <OutputContainer>
+            <CopyButton
+              type="text"
+              size="small"
+              onClick={onCopy}
+              disabled={!resultText}
+              icon={<Copy size={16} color={copied ? 'var(--color-primary)' : undefined} />}
+            />
+            <OutputText ref={outputTextRef} className="selectable">
+              {!resultText ? (
+                <div style={{ color: 'var(--color-text-3)', userSelect: 'none' }}>
+                  {t('screenshot.result_placeholder')}
+                </div>
+              ) : (
+                <div className="plain">{resultText}</div>
+              )}
+            </OutputText>
+          </OutputContainer>
+        </AreaContainer>
+      </ContentContainer>
+    </Container>
+  )
+}
+
+const Container = styled.div`
+  flex: 1;
+`
+
+const ContentContainer = styled.div`
+  height: calc(100vh - var(--navbar-height));
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+  padding: 12px;
+`
+
+const Toolbar = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 0;
+`
+
+const AreaContainer = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  flex: 1;
+  gap: 8px;
+`
+
+const InputContainer = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding: 10px 5px;
+  border: 1px solid var(--color-border-soft);
+  border-radius: 10px;
+  overflow: hidden;
+`
+
+const Textarea = styled(TextArea)`
+  flex: 1;
+  .ant-input {
+    resize: none;
+    padding: 5px 16px;
+  }
+`
+
+const Footer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  padding: 4px 8px;
+`
+
+const OutputContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  position: relative;
+  background-color: var(--color-background-soft);
+  border-radius: 10px;
+  padding: 10px 5px;
+  overflow: hidden;
+
+  &:hover .copy-button {
+    opacity: 1;
+    visibility: visible;
+  }
+`
+
+const CopyButton = styled(Button)`
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 10;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s ease-in-out, visibility 0.2s ease-in-out;
+`
+
+const OutputText = styled.div`
+  flex: 1;
+  padding: 5px 16px;
+  overflow-y: auto;
+
+  .plain {
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+  }
+`
+
+export default ScreenshotPage

--- a/src/renderer/src/routes/app/screenshot.tsx
+++ b/src/renderer/src/routes/app/screenshot.tsx
@@ -1,0 +1,6 @@
+import ScreenshotPage from '@renderer/pages/screenshot/ScreenshotPage'
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/app/screenshot')({
+  component: ScreenshotPage
+})

--- a/src/renderer/src/windows/screenshot/ScreenshotSelection.tsx
+++ b/src/renderer/src/windows/screenshot/ScreenshotSelection.tsx
@@ -1,0 +1,192 @@
+import { loggerService } from '@logger'
+import { IpcChannel } from '@shared/IpcChannel'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const logger = loggerService.withContext('ScreenshotSelection')
+
+interface SelectionState {
+  startX: number
+  startY: number
+  endX: number
+  endY: number
+  isDragging: boolean
+}
+
+interface Rectangle {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+const ScreenshotSelection = () => {
+  const [screenshotData, setScreenshotData] = useState<string | null>(null)
+  const [selection, setSelection] = useState<SelectionState>({
+    startX: 0,
+    startY: 0,
+    endX: 0,
+    endY: 0,
+    isDragging: false
+  })
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handler = (_event: any, data: { screenshotData: string }) => {
+      logger.info('Received screenshot data')
+      setScreenshotData(data.screenshotData)
+    }
+
+    window.electron.ipcRenderer.on(IpcChannel.Screenshot_SelectionWindowReady, handler)
+
+    return () => {
+      window.electron.ipcRenderer.removeListener(IpcChannel.Screenshot_SelectionWindowReady, handler)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!screenshotData || !canvasRef.current) return
+
+    const canvas = canvasRef.current
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const img = new Image()
+    img.onload = () => {
+      canvas.width = window.innerWidth
+      canvas.height = window.innerHeight
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height)
+      logger.info('Screenshot drawn on canvas')
+    }
+    img.onerror = (e) => {
+      logger.error('Failed to load screenshot image', { error: e })
+      void window.api.screenshot.cancelSelection()
+    }
+    img.src = screenshotData
+  }, [screenshotData])
+
+  const getSelectionRectangle = useCallback((): Rectangle | null => {
+    if (!selection.isDragging && selection.endX === 0 && selection.endY === 0) {
+      return null
+    }
+
+    const x = Math.min(selection.startX, selection.endX)
+    const y = Math.min(selection.startY, selection.endY)
+    const width = Math.abs(selection.endX - selection.startX)
+    const height = Math.abs(selection.endY - selection.startY)
+
+    return { x, y, width, height }
+  }, [selection])
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        logger.info('User cancelled selection with ESC')
+        void window.api.screenshot.cancelSelection()
+      } else if (e.key === 'Enter') {
+        const rect = getSelectionRectangle()
+        if (rect && rect.width >= 10 && rect.height >= 10) {
+          logger.info('User confirmed selection with ENTER', rect)
+          void window.api.screenshot.confirmSelection(rect)
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [getSelectionRectangle])
+
+  const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    const rect = containerRef.current?.getBoundingClientRect()
+    if (!rect) return
+
+    const x = e.clientX - rect.left
+    const y = e.clientY - rect.top
+
+    setSelection({
+      startX: x,
+      startY: y,
+      endX: x,
+      endY: y,
+      isDragging: true
+    })
+  }
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!selection.isDragging) return
+
+    const rect = containerRef.current?.getBoundingClientRect()
+    if (!rect) return
+
+    const x = e.clientX - rect.left
+    const y = e.clientY - rect.top
+
+    setSelection((prev) => ({
+      ...prev,
+      endX: x,
+      endY: y
+    }))
+  }
+
+  const handleMouseUp = useCallback(() => {
+    if (!selection.isDragging) return
+
+    const rect = getSelectionRectangle()
+    if (rect && rect.width >= 10 && rect.height >= 10) {
+      logger.info('Selection completed', rect)
+      void window.api.screenshot.confirmSelection(rect)
+    } else {
+      setSelection((prev) => ({ ...prev, isDragging: false }))
+    }
+  }, [selection, getSelectionRectangle])
+
+  const rect = getSelectionRectangle()
+  const hasValidSelection = rect && rect.width > 0 && rect.height > 0
+
+  return (
+    <div
+      ref={containerRef}
+      className="fixed inset-0 h-full w-full overflow-hidden"
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      style={{ cursor: 'crosshair' }}>
+      <canvas ref={canvasRef} className="absolute inset-0 h-full w-full" />
+
+      <div className="pointer-events-none absolute inset-0 bg-black bg-opacity-40">
+        {hasValidSelection && rect && (
+          <div
+            className="pointer-events-none absolute"
+            style={{
+              left: `${rect.x}px`,
+              top: `${rect.y}px`,
+              width: `${rect.width}px`,
+              height: `${rect.height}px`,
+              backgroundColor: 'transparent',
+              boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.4)',
+              border: '2px solid #1890ff'
+            }}
+          />
+        )}
+      </div>
+
+      {hasValidSelection && rect && (
+        <div
+          className="pointer-events-none absolute rounded bg-black bg-opacity-75 px-2 py-1 text-sm text-white"
+          style={{
+            left: `${rect.x + rect.width / 2}px`,
+            top: `${rect.y - 30}px`,
+            transform: 'translateX(-50%)'
+          }}>
+          {Math.round(rect.width)} × {Math.round(rect.height)}
+        </div>
+      )}
+
+      <div className="-translate-x-1/2 pointer-events-none absolute bottom-4 left-1/2 transform rounded bg-black bg-opacity-75 px-4 py-2 text-white">
+        ESC to cancel | Drag to select | ENTER to confirm
+      </div>
+    </div>
+  )
+}
+
+export default ScreenshotSelection

--- a/src/renderer/src/windows/screenshot/entryPoint.tsx
+++ b/src/renderer/src/windows/screenshot/entryPoint.tsx
@@ -1,0 +1,31 @@
+import '@ant-design/v5-patch-for-react-19'
+
+import { loggerService } from '@logger'
+import { ThemeProvider } from '@renderer/context/ThemeProvider'
+import storeSyncService from '@renderer/services/StoreSyncService'
+import store, { persistor } from '@renderer/store'
+import type { FC } from 'react'
+import { createRoot } from 'react-dom/client'
+import { Provider } from 'react-redux'
+import { PersistGate } from 'redux-persist/integration/react'
+
+import ScreenshotSelection from './ScreenshotSelection'
+
+loggerService.initWindowSource('ScreenshotSelection')
+
+storeSyncService.subscribe()
+
+const App: FC = () => {
+  return (
+    <Provider store={store}>
+      <ThemeProvider>
+        <PersistGate loading={null} persistor={persistor}>
+          <ScreenshotSelection />
+        </PersistGate>
+      </ThemeProvider>
+    </Provider>
+  )
+}
+
+const root = createRoot(document.getElementById('root') as HTMLElement)
+root.render(<App />)

--- a/tsconfig.tsbuildinfo
+++ b/tsconfig.tsbuildinfo
@@ -1,0 +1,1 @@
+{"fileNames":[],"fileInfos":[],"root":[],"options":{"emitDecoratorMetadata":true,"experimentalDecorators":true,"useDefineForClassFields":true},"version":"5.8.3"}


### PR DESCRIPTION
### What this PR does

Before this PR:
Selection Assistant could only process already-selected text. There was no built-in screenshot capture entrypoint to OCR text from arbitrary screen regions.

After this PR:
Selection Assistant adds a built-in `Screenshot Translate` action on Windows. It uses `node-screenshots` for screen capture, OCRs the captured image with the configured OCR provider, and opens a translate workflow with recognized text. A new Screenshot page is also added to the sidebar for direct access.

Fixes #13896

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Reused existing OCR providers and Selection Assistant action flow instead of adding a separate screenshot module.
- Implemented capture via `node-screenshots` library for cross-platform support (focused on Windows).
- Added explicit non-Windows guard messaging in the UI to avoid ambiguous no-op behavior.
- Built upon PR #11917's ScreenshotService infrastructure (screenshot region selection).

The following alternatives were considered:
- Building a fully custom cross-platform snipping overlay window.
- Adding a separate screenshot page/module outside Selection Assistant.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/13896

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- This is a backport of PR #13911 to the v2 branch
- Locale keys added for en-us, zh-cn, zh-tw
- Based on PR #11917 (screenshot region selection) infrastructure
- Validation run locally:
  - `npm run typecheck`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Selection Assistant now includes a Windows screenshot translate action. You can capture a screen region, OCR text from the screenshot, and directly open translation in the selection action window. A new Screenshot page is also available in the sidebar for direct access.
```