### PR TITLE
feat: add PopoverConfirm component

### DIFF
--- a/src/renderer/src/components/PopoverConfirm.tsx
+++ b/src/renderer/src/components/PopoverConfirm.tsx
@@ -1,7 +1,7 @@
 import { Button, Popover, PopoverContent, PopoverTrigger } from '@cherrystudio/ui'
 import { cn } from '@cherrystudio/ui/lib/utils'
 import { TriangleAlertIcon } from 'lucide-react'
-import type { PropsWithChildren, ReactNode } from 'react'
+import type { ComponentProps, PropsWithChildren, ReactNode } from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -18,6 +18,10 @@ type PopoverConfirmProps = {
     confirm?: string
     cancel?: string
   }
+  buttonProps?: {
+    confirm?: Omit<ComponentProps<typeof Button>, 'className' | 'disabled' | 'onClick'>
+    cancel?: Omit<ComponentProps<typeof Button>, 'className' | 'onClick'>
+  }
 }
 
 const PopoverConfirm = ({
@@ -26,7 +30,8 @@ const PopoverConfirm = ({
   description,
   onConfirm,
   onCancel,
-  classNames = {}
+  classNames = {},
+  buttonProps = {}
 }: PropsWithChildren<PopoverConfirmProps>) => {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
@@ -50,7 +55,8 @@ const PopoverConfirm = ({
               setOpen(false)
               onCancel?.()
             }}
-            className={cn(classNames.cancel)}>
+            className={cn(classNames.cancel)}
+            {...buttonProps.cancel}>
             {t('common.cancel')}
           </Button>
           <Button
@@ -65,7 +71,8 @@ const PopoverConfirm = ({
               }
             }}
             disabled={isLoading}
-            className={cn(classNames.confirm)}>
+            className={cn(classNames.confirm)}
+            {...buttonProps.confirm}>
             {isLoading ? <LoadingIcon /> : t('common.confirm')}
           </Button>
         </div>

--- a/src/renderer/src/components/PopoverConfirm.tsx
+++ b/src/renderer/src/components/PopoverConfirm.tsx
@@ -1,0 +1,77 @@
+import { Button, Popover, PopoverContent, PopoverTrigger } from '@cherrystudio/ui'
+import { cn } from '@cherrystudio/ui/lib/utils'
+import { TriangleAlertIcon } from 'lucide-react'
+import type { PropsWithChildren, ReactNode } from 'react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { LoadingIcon } from './Icons'
+
+type PopoverConfirmProps = {
+  title: ReactNode
+  description?: ReactNode
+  onConfirm: (() => Promise<unknown>) | (() => unknown)
+  onCancel?: () => void
+  classNames?: {
+    title?: string
+    description?: string
+    confirm?: string
+    cancel?: string
+  }
+}
+
+const PopoverConfirm = ({
+  children,
+  title,
+  description,
+  onConfirm,
+  onCancel,
+  classNames = {}
+}: PropsWithChildren<PopoverConfirmProps>) => {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent className="p-4 pl-6">
+        <div className="mb-2">
+          <div className="flex items-center gap-2">
+            <TriangleAlertIcon size={16} className="text-sm text-warning-base" />
+            <h3 className={cn('font-bold text-lg', classNames.title)}>{title}</h3>
+          </div>
+          {description && <p className={cn(classNames.description)}>{description}</p>}
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button
+            variant="outline"
+            onClick={() => {
+              setOpen(false)
+              onCancel?.()
+            }}
+            className={cn(classNames.cancel)}>
+            {t('common.cancel')}
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={async () => {
+              setIsLoading(true)
+              try {
+                await onConfirm()
+                setOpen(false)
+              } finally {
+                setIsLoading(false)
+              }
+            }}
+            disabled={isLoading}
+            className={cn(classNames.confirm)}>
+            {isLoading ? <LoadingIcon /> : t('common.confirm')}
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+export default PopoverConfirm

--- a/src/renderer/src/components/PopoverConfirm.tsx
+++ b/src/renderer/src/components/PopoverConfirm.tsx
@@ -15,6 +15,7 @@ type PopoverConfirmProps = {
   classNames?: {
     title?: string
     description?: string
+    icon?: string
     confirm?: string
     cancel?: string
   }
@@ -43,7 +44,7 @@ const PopoverConfirm = ({
       <PopoverContent className="p-4 pl-6">
         <div className="mb-2">
           <div className="flex items-center gap-2">
-            <TriangleAlertIcon size={16} className="text-sm text-warning-base" />
+            <TriangleAlertIcon className={cn('size-6 text-warning-base', classNames.icon)} />
             <h3 className={cn('font-bold text-lg', classNames.title)}>{title}</h3>
           </div>
           {description && <p className={cn(classNames.description)}>{description}</p>}


### PR DESCRIPTION
### What this PR does

Before this PR:
No reusable Popover-based confirmation component using `@cherrystudio/ui`.

After this PR:
Adds a `PopoverConfirm` component built with Shadcn UI Popover, supporting async confirm handlers with loading state, customizable classNames, and i18n.

<img width="299" height="177" alt="image" src="https://github.com/user-attachments/assets/4c7744e1-7fef-4858-b0c1-152defd162c2" />

<img width="286" height="171" alt="image" src="https://github.com/user-attachments/assets/528eb1a7-2a2d-40f5-800f-eda9f016e06c" />


### Why we need it and why it was done in this way

Provides a lightweight confirmation UI alternative to modal dialogs, suitable for inline destructive actions. Built on `@cherrystudio/ui` Popover to align with v2 UI standards.

### Breaking changes

None

### Special notes for your reviewer

N/A

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: Not required — internal component, no user-facing behavior change
- [x] Self-review: I have reviewed my own code before requesting review from others

```release-note
NONE
```
