### PR TITLE
feat: v2 miniapps

### DIFF
--- a/packages/shared/data/cache/cacheSchemas.ts
+++ b/packages/shared/data/cache/cacheSchemas.ts
@@ -1,3 +1,5 @@
+import type { MinAppRegion } from '@shared/data/types/miniapp'
+
 import type * as CacheValueTypes from './cacheValueTypes'
 
 /**
@@ -126,7 +128,7 @@ export type UseCacheSchema = {
   'minapp.current_id': string
   'minapp.show': boolean
   'minapp.opened_oneoff': CacheValueTypes.CacheMinAppType | null
-  'minapp.detected_region': string | null
+  'minapp.detected_region': MinAppRegion | null
 
   // Topic management
   'topic.active': CacheValueTypes.CacheTopic | null

--- a/packages/shared/data/cache/cacheSchemas.ts
+++ b/packages/shared/data/cache/cacheSchemas.ts
@@ -126,6 +126,7 @@ export type UseCacheSchema = {
   'minapp.current_id': string
   'minapp.show': boolean
   'minapp.opened_oneoff': CacheValueTypes.CacheMinAppType | null
+  'minapp.detected_region': string | null
 
   // Topic management
   'topic.active': CacheValueTypes.CacheTopic | null
@@ -193,6 +194,7 @@ export const DefaultUseCache: UseCacheSchema = {
   'minapp.current_id': '',
   'minapp.show': false,
   'minapp.opened_oneoff': null,
+  'minapp.detected_region': null,
 
   // Topic management
   'topic.active': null,

--- a/packages/shared/data/cache/cacheValueTypes.ts
+++ b/packages/shared/data/cache/cacheValueTypes.ts
@@ -1,6 +1,7 @@
-import type { MinAppType, Topic } from '@types'
+import type { Topic } from '@types'
 import type { UpdateInfo } from 'builder-util-runtime'
 
+import type { MiniApp } from '../types/miniapp'
 import type { WebSearchStatus } from '../types/webSearch'
 
 export type CacheAppUpdateState = {
@@ -19,7 +20,7 @@ export type CacheActiveSearches = Record<string, WebSearchStatus>
 
 // For cache schema, we use any for complex types to avoid circular dependencies
 // The actual type checking will be done at runtime by the cache system
-export type CacheMinAppType = MinAppType
+export type CacheMinAppType = MiniApp
 export type CacheTopic = Topic
 
 /**

--- a/packages/shared/data/preference/preferenceSchemas.ts
+++ b/packages/shared/data/preference/preferenceSchemas.ts
@@ -28,6 +28,7 @@
 
 import { MEMORY_FACT_EXTRACTION_PROMPT, MEMORY_UPDATE_SYSTEM_PROMPT, TRANSLATE_PROMPT } from '@shared/config/prompts'
 import * as PreferenceTypes from '@shared/data/preference/preferenceTypes'
+import type { MinAppRegionFilter } from '@shared/data/types/miniapp'
 
 /* eslint @typescript-eslint/member-ordering: ["error", {
   "interfaces": { "order": "alphabetically" },
@@ -355,7 +356,7 @@ export interface PreferenceSchemas {
     // redux/settings/minappsOpenLinkExternal
     'feature.minapp.open_link_external': boolean
     // redux/settings/minAppRegion
-    'feature.minapp.region': string
+    'feature.minapp.region': MinAppRegionFilter
     // redux/settings/showOpenedMinappsInSidebar
     'feature.minapp.show_opened_in_sidebar': boolean
     // redux/note/settings.defaultEditMode

--- a/packages/shared/data/preference/preferenceSchemas.ts
+++ b/packages/shared/data/preference/preferenceSchemas.ts
@@ -354,6 +354,8 @@ export interface PreferenceSchemas {
     'feature.minapp.max_keep_alive': number
     // redux/settings/minappsOpenLinkExternal
     'feature.minapp.open_link_external': boolean
+    // redux/settings/minAppRegion
+    'feature.minapp.region': string
     // redux/settings/showOpenedMinappsInSidebar
     'feature.minapp.show_opened_in_sidebar': boolean
     // redux/note/settings.defaultEditMode
@@ -651,6 +653,7 @@ export const DefaultPreferences: PreferenceSchemas = {
     'feature.memory.update_memory_prompt': MEMORY_UPDATE_SYSTEM_PROMPT,
     'feature.minapp.max_keep_alive': 3,
     'feature.minapp.open_link_external': false,
+    'feature.minapp.region': 'auto',
     'feature.minapp.show_opened_in_sidebar': true,
     'feature.notes.default_edit_mode': 'preview',
     'feature.notes.default_view_mode': 'edit',

--- a/packages/shared/data/types/miniapp.ts
+++ b/packages/shared/data/types/miniapp.ts
@@ -20,6 +20,7 @@ export interface MiniApp {
   supportedRegions?: ('CN' | 'Global')[]
   configuration?: unknown
   nameKey?: string
+  style?: CSSProperties
   createdAt?: string
   updatedAt?: string
 }

--- a/packages/shared/data/types/miniapp.ts
+++ b/packages/shared/data/types/miniapp.ts
@@ -5,6 +5,8 @@
  * (status, sortOrder) for them. Custom apps store full data + preferences.
  */
 
+import type { CSSProperties } from 'react'
+
 export interface MiniApp {
   appId: string
   type: 'default' | 'custom'
@@ -21,3 +23,24 @@ export interface MiniApp {
   createdAt?: string
   updatedAt?: string
 }
+
+export type MinAppType = {
+  id: string
+  name: string
+  /** i18n key for translatable names */
+  nameKey?: string
+  /** Regions where this app is available. If includes 'Global', shown to international users. */
+  supportedRegions?: MinAppRegion[]
+  logo?: string
+  url: string
+  bordered?: boolean
+  background?: string
+  style?: CSSProperties
+  addTime?: string
+  type?: 'Custom' | 'Default' // Added the 'type' property
+}
+
+/** Region types for miniapps visibility */
+export type MinAppRegion = 'CN' | 'Global'
+
+export type MinAppRegionFilter = 'auto' | MinAppRegion

--- a/src/renderer/src/components/Icons/MinAppIcon.tsx
+++ b/src/renderer/src/components/Icons/MinAppIcon.tsx
@@ -1,10 +1,10 @@
 import { allMinApps } from '@renderer/config/minapps'
 import { getMiniAppsLogo } from '@renderer/config/minapps'
-import type { MinAppType } from '@renderer/types'
+import type { MiniApp } from '@shared/data/types/miniapp'
 import type { FC } from 'react'
 
 interface Props {
-  app: MinAppType
+  app: MiniApp
   sidebar?: boolean
   size?: number
   style?: React.CSSProperties
@@ -12,7 +12,7 @@ interface Props {
 
 const MinAppIcon: FC<Props> = ({ app, size = 48, style, sidebar = false }) => {
   // First try to find in allMinApps for predefined styling
-  const _app = allMinApps.find((item) => item.id === app.id)
+  const _app = allMinApps.find((item) => item.id === app.appId)
 
   // If found in allMinApps, use predefined styling
   if (_app) {

--- a/src/renderer/src/components/Icons/MinAppIcon.tsx
+++ b/src/renderer/src/components/Icons/MinAppIcon.tsx
@@ -1,4 +1,3 @@
-import { allMinApps } from '@renderer/config/minapps'
 import { getMiniAppsLogo } from '@renderer/config/minapps'
 import type { MiniApp } from '@shared/data/types/miniapp'
 import type { FC } from 'react'
@@ -11,12 +10,9 @@ interface Props {
 }
 
 const MinAppIcon: FC<Props> = ({ app, size = 48, style, sidebar = false }) => {
-  // First try to find in allMinApps for predefined styling
-  const _app = allMinApps.find((item) => item.id === app.appId)
-
-  // If found in allMinApps, use predefined styling
-  if (_app) {
-    const logo = getMiniAppsLogo(_app.logo)
+  // app prop already has merged preset fields (logo, bordered, background, style) via mergeWithPreset
+  if (app.logo) {
+    const logo = getMiniAppsLogo(app.logo)
 
     // CompoundIcon: render its Avatar sub-component
     if (logo && typeof logo !== 'string') {
@@ -26,34 +22,13 @@ const MinAppIcon: FC<Props> = ({ app, size = 48, style, sidebar = false }) => {
 
     return (
       <img
-        src={logo}
+        src={typeof logo === 'string' ? logo : app.logo}
         className="select-none rounded-2xl"
         style={{
-          border: _app.bordered ? '0.5px solid var(--color-border)' : 'none',
+          border: app.bordered ? '0.5px solid var(--color-border)' : 'none',
           width: `${size}px`,
           height: `${size}px`,
-          backgroundColor: _app.background,
-          userSelect: 'none',
-          ...(sidebar ? {} : app.style),
-          ...style
-        }}
-        draggable={false}
-        alt={app.name || 'MinApp Icon'}
-      />
-    )
-  }
-
-  // If not found in allMinApps but app has logo, use it (for temporary apps)
-  if (app.logo) {
-    return (
-      <img
-        src={app.logo}
-        className="select-none rounded-2xl"
-        style={{
-          border: 'none',
-          width: `${size}px`,
-          height: `${size}px`,
-          backgroundColor: 'transparent',
+          backgroundColor: app.background,
           userSelect: 'none',
           ...(sidebar ? {} : app.style),
           ...style

--- a/src/renderer/src/components/Icons/__tests__/MinAppIcon.test.tsx
+++ b/src/renderer/src/components/Icons/__tests__/MinAppIcon.test.tsx
@@ -27,7 +27,10 @@ vi.mock('@renderer/config/minapps', () => ({
 
 describe('MinAppIcon', () => {
   const mockApp = {
-    id: 'test-app-1',
+    appId: 'test-app-1',
+    type: 'default' as const,
+    status: 'enabled' as const,
+    sortOrder: 0,
     name: 'Test App',
     url: 'https://test.com',
     style: {
@@ -55,7 +58,10 @@ describe('MinAppIcon', () => {
 
   it('should return null when app is not found in allMinApps', () => {
     const unknownApp = {
-      id: 'unknown-app',
+      appId: 'unknown-app',
+      type: 'default' as const,
+      status: 'enabled' as const,
+      sortOrder: 0,
       name: 'Unknown App',
       url: 'https://unknown.com'
     }

--- a/src/renderer/src/components/MinApp/MinApp.tsx
+++ b/src/renderer/src/components/MinApp/MinApp.tsx
@@ -2,11 +2,10 @@ import { loggerService } from '@logger'
 import MinAppIcon from '@renderer/components/Icons/MinAppIcon'
 import IndicatorLight from '@renderer/components/IndicatorLight'
 import MarqueeText from '@renderer/components/MarqueeText'
-import { loadCustomMiniApp, ORIGIN_DEFAULT_MIN_APPS, updateAllMinApps } from '@renderer/config/minapps'
 import { useMinappPopup } from '@renderer/hooks/useMinappPopup'
 import { useMinapps } from '@renderer/hooks/useMinapps'
 import { useNavbarPosition } from '@renderer/hooks/useNavbar'
-import type { MinAppType } from '@renderer/types'
+import type { MiniApp } from '@shared/data/types/miniapp'
 import { useNavigate } from '@tanstack/react-router'
 import type { MenuProps } from 'antd'
 import { Dropdown } from 'antd'
@@ -15,7 +14,7 @@ import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 interface Props {
-  app: MinAppType
+  app: MiniApp
   onClick?: () => void
   size?: number
   isLast?: boolean
@@ -36,15 +35,16 @@ const MinApp: FC<Props> = ({ app, onClick, size = 60, isLast }) => {
     setOpenedKeepAliveMinapps,
     updateMinapps,
     updateDisabledMinapps,
-    updatePinnedMinapps
+    updatePinnedMinapps,
+    removeCustomMiniapp
   } = useMinapps()
   const navigate = useNavigate()
-  const isPinned = pinned.some((p) => p.id === app.id)
-  const isVisible = minapps.some((m) => m.id === app.id)
+  const isPinned = pinned.some((p) => p.appId === app.appId)
+  const isVisible = minapps.some((m) => m.appId === app.appId)
   // Pinned apps should always be visible regardless of region/locale filtering
   const shouldShow = isVisible || isPinned
-  const isActive = minappShow && currentMinappId === app.id
-  const isOpened = openedKeepAliveMinapps.some((item) => item.id === app.id)
+  const isActive = minappShow && currentMinappId === app.appId
+  const isOpened = openedKeepAliveMinapps.some((item) => item.appId === app.appId)
   const { isTopNavbar } = useNavbarPosition()
 
   // Calculate display name
@@ -53,7 +53,7 @@ const MinApp: FC<Props> = ({ app, onClick, size = 60, isLast }) => {
   const handleClick = () => {
     if (isTopNavbar) {
       // 顶部导航栏：导航到小程序页面
-      void navigate({ to: '/app/minapp/$appId', params: { appId: app.id } })
+      void navigate({ to: '/app/minapp/$appId', params: { appId: app.appId } })
     } else {
       // 侧边导航栏：保持原有弹窗行为
       openMinappKeepAlive(app)
@@ -72,7 +72,7 @@ const MinApp: FC<Props> = ({ app, onClick, size = 60, isLast }) => {
           ? t('minapp.add_to_launchpad')
           : t('minapp.add_to_sidebar'),
       onClick: () => {
-        const newPinned = isPinned ? pinned.filter((item) => item.id !== app.id) : [...pinned, app]
+        const newPinned = isPinned ? pinned.filter((item) => item.appId !== app.appId) : [...pinned, app]
         updatePinnedMinapps(newPinned)
       }
     },
@@ -80,17 +80,17 @@ const MinApp: FC<Props> = ({ app, onClick, size = 60, isLast }) => {
       key: 'hide',
       label: t('minapp.sidebar.hide.title'),
       onClick: () => {
-        const newMinapps = minapps.filter((item) => item.id !== app.id)
+        const newMinapps = minapps.filter((item) => item.appId !== app.appId)
         updateMinapps(newMinapps)
         const newDisabled = [...(disabled || []), app]
         updateDisabledMinapps(newDisabled)
-        updatePinnedMinapps(pinned.filter((item) => item.id !== app.id))
+        updatePinnedMinapps(pinned.filter((item) => item.appId !== app.appId))
         // 更新 openedKeepAliveMinapps
-        const newOpenedKeepAliveMinapps = openedKeepAliveMinapps.filter((item) => item.id !== app.id)
+        const newOpenedKeepAliveMinapps = openedKeepAliveMinapps.filter((item) => item.appId !== app.appId)
         setOpenedKeepAliveMinapps(newOpenedKeepAliveMinapps)
       }
     },
-    ...(app.type === 'Custom'
+    ...(app.type === 'custom'
       ? [
           {
             key: 'removeCustom',
@@ -98,16 +98,8 @@ const MinApp: FC<Props> = ({ app, onClick, size = 60, isLast }) => {
             danger: true,
             onClick: async () => {
               try {
-                const content = await window.api.file.read('custom-minapps.json')
-                const customApps = JSON.parse(content)
-                const updatedApps = customApps.filter((customApp: MinAppType) => customApp.id !== app.id)
-                await window.api.file.writeWithId('custom-minapps.json', JSON.stringify(updatedApps, null, 2))
+                await removeCustomMiniapp(app.appId)
                 window.toast.success(t('settings.miniapps.custom.remove_success'))
-                const reloadedApps = [...ORIGIN_DEFAULT_MIN_APPS, ...(await loadCustomMiniApp())]
-                updateAllMinApps(reloadedApps)
-                updateMinapps(minapps.filter((item) => item.id !== app.id))
-                updatePinnedMinapps(pinned.filter((item) => item.id !== app.id))
-                updateDisabledMinapps(disabled.filter((item) => item.id !== app.id))
               } catch (error) {
                 window.toast.error(t('settings.miniapps.custom.remove_error'))
                 logger.error('Failed to remove custom mini app:', error as Error)

--- a/src/renderer/src/components/MinApp/MinAppTabsPool.tsx
+++ b/src/renderer/src/components/MinApp/MinAppTabsPool.tsx
@@ -74,7 +74,7 @@ const MinAppTabsPool: React.FC = () => {
   useEffect(() => {
     const existing = Array.from(webviewRefs.current.keys())
     existing.forEach((id) => {
-      if (!apps.find((a) => a.id === id)) {
+      if (!apps.find((a) => a.appId === id)) {
         webviewRefs.current.delete(id)
         // loaded 状态也清理（LRU 已在其它地方清除，双保险）
         if (getWebviewLoaded(id)) {
@@ -101,9 +101,9 @@ const MinAppTabsPool: React.FC = () => {
       data-minapp-tabs-pool
       aria-hidden={!shouldShow}>
       {apps.map((app) => (
-        <WebviewWrapper key={app.id} $active={app.id === currentMinappId}>
+        <WebviewWrapper key={app.appId} $active={app.appId === currentMinappId}>
           <WebviewContainer
-            appid={app.id}
+            appid={app.appId}
             url={app.url}
             onSetRefCallback={handleSetRef}
             onLoadedCallback={handleLoaded}

--- a/src/renderer/src/components/MinApp/MinappPopupContainer.tsx
+++ b/src/renderer/src/components/MinApp/MinappPopupContainer.tsx
@@ -16,7 +16,6 @@ import { loggerService } from '@logger'
 import { LogoAvatar } from '@renderer/components/Icons'
 import WindowControls from '@renderer/components/WindowControls'
 import { isDev, isLinux, isMac, isWin } from '@renderer/config/constant'
-import { allMinApps } from '@renderer/config/minapps'
 import { useBridge } from '@renderer/hooks/useBridge'
 import { useMinappPopup } from '@renderer/hooks/useMinappPopup'
 import { useMinapps } from '@renderer/hooks/useMinapps'
@@ -144,8 +143,15 @@ const GoogleLoginTip = ({
 const MinappPopupContainer: React.FC = () => {
   const [minappsOpenLinkExternal, setMinappsOpenLinkExternal] = usePreference('feature.minapp.open_link_external')
   const { closeMinapp, hideMinappPopup } = useMinappPopup()
-  const { pinned, updatePinnedMinapps, openedKeepAliveMinapps, openedOneOffMinapp, currentMinappId, minappShow } =
-    useMinapps()
+  const {
+    pinned,
+    updatePinnedMinapps,
+    allApps,
+    openedKeepAliveMinapps,
+    openedOneOffMinapp,
+    currentMinappId,
+    minappShow
+  } = useMinapps()
   const { t } = useTranslation()
   const backgroundColor = useNavBackgroundColor()
   const { isTopNavbar } = useNavbarPosition()
@@ -245,7 +251,7 @@ const MinappPopupContainer: React.FC = () => {
       (acc, app) => ({
         ...acc,
         [app.appId]: {
-          canPinned: allMinApps.some((item) => item.id === app.appId),
+          canPinned: allApps.some((item) => item.appId === app.appId),
           isPinned: pinned.some((item) => item.appId === app.appId),
           canOpenExternalLink: app.url.startsWith('http://') || app.url.startsWith('https://')
         }

--- a/src/renderer/src/components/MinApp/MinappPopupContainer.tsx
+++ b/src/renderer/src/components/MinApp/MinappPopupContainer.tsx
@@ -23,9 +23,9 @@ import { useMinapps } from '@renderer/hooks/useMinapps'
 import useNavBackgroundColor from '@renderer/hooks/useNavBackgroundColor'
 import { useNavbarPosition } from '@renderer/hooks/useNavbar'
 import { useTimer } from '@renderer/hooks/useTimer'
-import type { MinAppType } from '@renderer/types'
 import { delay } from '@renderer/utils'
 import { clearWebviewState, getWebviewLoaded, setWebviewLoaded } from '@renderer/utils/webviewStateManager'
+import type { MiniApp } from '@shared/data/types/miniapp'
 import { Alert, Drawer } from 'antd'
 import type { WebviewTag } from 'electron'
 import { useEffect, useMemo, useRef, useState } from 'react'
@@ -43,7 +43,7 @@ interface AppExtraInfo {
   canOpenExternalLink: boolean
 }
 
-type AppInfo = MinAppType & AppExtraInfo
+type AppInfo = MiniApp & AppExtraInfo
 
 /** Google login tip component */
 const GoogleLoginTip = ({
@@ -232,7 +232,7 @@ const MinappPopupContainer: React.FC = () => {
   }, [currentMinappId, minappsOpenLinkExternal])
 
   /** only the keepalive minapp can be minimized */
-  const canMinimize = !(openedOneOffMinapp && openedOneOffMinapp.id == currentMinappId)
+  const canMinimize = !(openedOneOffMinapp && openedOneOffMinapp.appId == currentMinappId)
 
   /** combine the openedKeepAliveMinapps and openedOneOffMinapp */
   const combinedApps = useMemo(() => {
@@ -244,9 +244,9 @@ const MinappPopupContainer: React.FC = () => {
     return combinedApps.reduce(
       (acc, app) => ({
         ...acc,
-        [app.id]: {
-          canPinned: allMinApps.some((item) => item.id === app.id),
-          isPinned: pinned.some((item) => item.id === app.id),
+        [app.appId]: {
+          canPinned: allMinApps.some((item) => item.id === app.appId),
+          isPinned: pinned.some((item) => item.appId === app.appId),
           canOpenExternalLink: app.url.startsWith('http://') || app.url.startsWith('https://')
         }
       }),
@@ -257,9 +257,9 @@ const MinappPopupContainer: React.FC = () => {
   /** get the current app info with extra info */
   let currentAppInfo: AppInfo | null = null
   if (currentMinappId) {
-    const currentApp = combinedApps.find((item) => item.id === currentMinappId)
+    const currentApp = combinedApps.find((item) => item.appId === currentMinappId)
     if (currentApp) {
-      currentAppInfo = { ...currentApp, ...appsExtraInfo[currentApp.id] }
+      currentAppInfo = { ...currentApp, ...appsExtraInfo[currentApp.appId] }
     }
   }
 
@@ -327,7 +327,7 @@ const MinappPopupContainer: React.FC = () => {
   const handleReload = (appid: string) => {
     const webview = webviewRefs.current.get(appid)
     if (webview) {
-      const url = combinedApps.find((item) => item.id === appid)?.url
+      const url = combinedApps.find((item) => item.appId === appid)?.url
       if (url) {
         webview.src = url
       }
@@ -341,10 +341,10 @@ const MinappPopupContainer: React.FC = () => {
 
   /** toggle the pin status of the minapp */
   const handleTogglePin = (appid: string) => {
-    const app = combinedApps.find((item) => item.id === appid)
+    const app = combinedApps.find((item) => item.appId === appid)
     if (!app) return
 
-    const newPinned = appsExtraInfo[appid].isPinned ? pinned.filter((item) => item.id !== appid) : [...pinned, app]
+    const newPinned = appsExtraInfo[appid].isPinned ? pinned.filter((item) => item.appId !== appid) : [...pinned, app]
     updatePinnedMinapps(newPinned)
   }
 
@@ -425,17 +425,17 @@ const MinappPopupContainer: React.FC = () => {
           style={{ marginRight: isWin || isLinux ? '140px' : 0 }}
           isTopNavbar={isTopNavbar}>
           <Tooltip placement="bottom" content={t('minapp.popup.goBack')} delay={800}>
-            <TitleButton onClick={() => handleGoBack(appInfo.id)}>
+            <TitleButton onClick={() => handleGoBack(appInfo.appId)}>
               <ArrowLeftOutlined />
             </TitleButton>
           </Tooltip>
           <Tooltip placement="bottom" content={t('minapp.popup.goForward')} delay={800}>
-            <TitleButton onClick={() => handleGoForward(appInfo.id)}>
+            <TitleButton onClick={() => handleGoForward(appInfo.appId)}>
               <ArrowRightOutlined />
             </TitleButton>
           </Tooltip>
           <Tooltip placement="bottom" content={t('minapp.popup.refresh')} delay={800}>
-            <TitleButton onClick={() => handleReload(appInfo.id)}>
+            <TitleButton onClick={() => handleReload(appInfo.appId)}>
               <ReloadOutlined />
             </TitleButton>
           </Tooltip>
@@ -452,7 +452,7 @@ const MinappPopupContainer: React.FC = () => {
               }
               placement="bottom"
               delay={800}>
-              <TitleButton onClick={() => handleTogglePin(appInfo.id)} className={appInfo.isPinned ? 'pinned' : ''}>
+              <TitleButton onClick={() => handleTogglePin(appInfo.appId)} className={appInfo.isPinned ? 'pinned' : ''}>
                 <PushpinOutlined style={{ fontSize: 16 }} />
               </TitleButton>
             </Tooltip>
@@ -471,7 +471,7 @@ const MinappPopupContainer: React.FC = () => {
           </Tooltip>
           {isDev && (
             <Tooltip placement="bottom" content={t('minapp.popup.devtools')} delay={800}>
-              <TitleButton onClick={() => handleOpenDevTools(appInfo.id)}>
+              <TitleButton onClick={() => handleOpenDevTools(appInfo.appId)}>
                 <CodeOutlined />
               </TitleButton>
             </Tooltip>
@@ -484,7 +484,7 @@ const MinappPopupContainer: React.FC = () => {
             </Tooltip>
           )}
           <Tooltip placement="bottom" content={t('minapp.popup.close')} delay={800}>
-            <TitleButton onClick={() => handlePopupClose(appInfo.id)}>
+            <TitleButton onClick={() => handlePopupClose(appInfo.appId)}>
               <CloseOutlined />
             </TitleButton>
           </Tooltip>
@@ -502,8 +502,8 @@ const MinappPopupContainer: React.FC = () => {
   const WebviewContainerGroup = useMemo(() => {
     return combinedApps.map((app) => (
       <WebviewContainer
-        key={app.id}
-        appid={app.id}
+        key={app.appId}
+        appid={app.appId}
         url={app.url}
         onSetRefCallback={handleWebviewSetRef}
         onLoadedCallback={handleWebviewLoaded}

--- a/src/renderer/src/components/Tab/TabContainer.tsx
+++ b/src/renderer/src/components/Tab/TabContainer.tsx
@@ -57,9 +57,9 @@ const getTabIcon = (
   allApps: MiniApp[],
   minAppsCache?: LRUCache<string, MiniApp>
 ): React.ReactNode | undefined => {
-  // Check if it's a minapp tab (format: apps:appId)
-  if (tabId.startsWith('apps:')) {
-    const appId = tabId.replace('apps:', '')
+  // Check if it's a minapp tab (format: minapp:appId)
+  if (tabId.startsWith('minapp:')) {
+    const appId = tabId.replace('minapp:', '')
     let app = allApps.find((a) => a.appId === appId)
 
     // If not found in permanent apps, search in temporary apps cache

--- a/src/renderer/src/components/Tab/TabContainer.tsx
+++ b/src/renderer/src/components/Tab/TabContainer.tsx
@@ -5,7 +5,6 @@ import { usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
 import HorizontalScrollContainer from '@renderer/components/HorizontalScrollContainer'
 import { isLinux, isMac } from '@renderer/config/constant'
-import { allMinApps } from '@renderer/config/minapps'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import { useFullscreen } from '@renderer/hooks/useFullscreen'
 import { useMinappPopup } from '@renderer/hooks/useMinappPopup'
@@ -55,13 +54,13 @@ const logger = loggerService.withContext('TabContainer')
 
 const getTabIcon = (
   tabId: string,
-  minapps: MiniApp[],
+  allApps: MiniApp[],
   minAppsCache?: LRUCache<string, MiniApp>
 ): React.ReactNode | undefined => {
   // Check if it's a minapp tab (format: apps:appId)
   if (tabId.startsWith('apps:')) {
     const appId = tabId.replace('apps:', '')
-    let app = [...allMinApps, ...minapps].find((a) => ('id' in a ? a.id : a.appId) === appId)
+    let app = allApps.find((a) => a.appId === appId)
 
     // If not found in permanent apps, search in temporary apps cache
     // The cache stores apps opened via openSmartMinapp() for top navbar mode
@@ -80,9 +79,7 @@ const getTabIcon = (
     }
 
     if (app) {
-      // Normalize: MinAppType uses .id, MiniApp uses .appId
-      const miniApp = 'appId' in app ? app : ({ ...app, appId: app.id } as unknown as MiniApp)
-      return <MinAppIcon size={14} app={miniApp} />
+      return <MinAppIcon size={14} app={app} />
     }
 
     // Fallback: If no app found (cache evicted), show default icon
@@ -132,7 +129,7 @@ const TabsContainer: React.FC<TabsContainerProps> = ({ children }) => {
   const isFullscreen = useFullscreen()
   const { settedTheme, toggleTheme } = useTheme()
   const { hideMinappPopup, minAppsCache } = useMinappPopup()
-  const { minapps } = useMinapps()
+  const { allApps } = useMinapps()
   // const { useSystemTitleBar } = useSettings()
   const [useSystemTitleBar] = usePreference('app.use_system_title_bar')
   const { t } = useTranslation()
@@ -150,7 +147,7 @@ const TabsContainer: React.FC<TabsContainerProps> = ({ children }) => {
     // Check if it's a minapp tab
     if (tabId.startsWith('apps:')) {
       const appId = tabId.replace('apps:', '')
-      let app = [...allMinApps, ...minapps].find((a) => ('id' in a ? a.id : a.appId) === appId)
+      let app = allApps.find((a) => a.appId === appId)
 
       // If not found in permanent apps, search in temporary apps cache
       // This ensures temporary MinApps display proper titles while being used
@@ -261,7 +258,7 @@ const TabsContainer: React.FC<TabsContainerProps> = ({ children }) => {
                     }
                   }}>
                   <TabHeader>
-                    {tab.id && <TabIcon>{getTabIcon(tab.id, minapps, minAppsCache)}</TabIcon>}
+                    {tab.id && <TabIcon>{getTabIcon(tab.id, allApps, minAppsCache)}</TabIcon>}
                     <TabTitle>{getTabTitle(tab.id)}</TabTitle>
                   </TabHeader>
                   {isClosable && (

--- a/src/renderer/src/components/Tab/TabContainer.tsx
+++ b/src/renderer/src/components/Tab/TabContainer.tsx
@@ -16,9 +16,9 @@ import { tabsService } from '@renderer/services/TabsService'
 import { useAppDispatch, useAppSelector } from '@renderer/store'
 import type { Tab } from '@renderer/store/tabs'
 import { addTab, removeTab, setActiveTab, setTabs } from '@renderer/store/tabs'
-import type { MinAppType } from '@renderer/types'
 import { classNames } from '@renderer/utils'
 import { ThemeMode } from '@shared/data/preference/preferenceTypes'
+import type { MiniApp } from '@shared/data/types/miniapp'
 import { useLocation, useNavigate } from '@tanstack/react-router'
 import type { LRUCache } from 'lru-cache'
 import {
@@ -55,13 +55,13 @@ const logger = loggerService.withContext('TabContainer')
 
 const getTabIcon = (
   tabId: string,
-  minapps: MinAppType[],
-  minAppsCache?: LRUCache<string, MinAppType>
+  minapps: MiniApp[],
+  minAppsCache?: LRUCache<string, MiniApp>
 ): React.ReactNode | undefined => {
   // Check if it's a minapp tab (format: apps:appId)
   if (tabId.startsWith('apps:')) {
     const appId = tabId.replace('apps:', '')
-    let app = [...allMinApps, ...minapps].find((app) => app.id === appId)
+    let app = [...allMinApps, ...minapps].find((a) => ('id' in a ? a.id : a.appId) === appId)
 
     // If not found in permanent apps, search in temporary apps cache
     // The cache stores apps opened via openSmartMinapp() for top navbar mode
@@ -80,7 +80,9 @@ const getTabIcon = (
     }
 
     if (app) {
-      return <MinAppIcon size={14} app={app} />
+      // Normalize: MinAppType uses .id, MiniApp uses .appId
+      const miniApp = 'appId' in app ? app : ({ ...app, appId: app.id } as unknown as MiniApp)
+      return <MinAppIcon size={14} app={miniApp} />
     }
 
     // Fallback: If no app found (cache evicted), show default icon
@@ -148,7 +150,7 @@ const TabsContainer: React.FC<TabsContainerProps> = ({ children }) => {
     // Check if it's a minapp tab
     if (tabId.startsWith('apps:')) {
       const appId = tabId.replace('apps:', '')
-      let app = [...allMinApps, ...minapps].find((app) => app.id === appId)
+      let app = [...allMinApps, ...minapps].find((a) => ('id' in a ? a.id : a.appId) === appId)
 
       // If not found in permanent apps, search in temporary apps cache
       // This ensures temporary MinApps display proper titles while being used

--- a/src/renderer/src/components/Tab/TabContainer.tsx
+++ b/src/renderer/src/components/Tab/TabContainer.tsx
@@ -136,17 +136,17 @@ const TabsContainer: React.FC<TabsContainerProps> = ({ children }) => {
   const getTabId = (path: string): string => {
     if (path === '/') return 'home'
     const segments = path.split('/')
-    // Handle minapp paths: /apps/appId -> apps:appId
-    if (segments[1] === 'apps' && segments[2]) {
-      return `apps:${segments[2]}`
+    // Handle minapp paths: /app/minapp/appId -> minapp:appId
+    if (segments[1] === 'app' && segments[2] === 'minapp' && segments[3]) {
+      return `minapp:${segments[3]}`
     }
     return segments[1] // 获取第一个路径段作为 id
   }
 
   const getTabTitle = (tabId: string): string => {
     // Check if it's a minapp tab
-    if (tabId.startsWith('apps:')) {
-      const appId = tabId.replace('apps:', '')
+    if (tabId.startsWith('minapp:')) {
+      const appId = tabId.replace('minapp:', '')
       let app = allApps.find((a) => a.appId === appId)
 
       // If not found in permanent apps, search in temporary apps cache

--- a/src/renderer/src/components/app/PinnedMinapps.tsx
+++ b/src/renderer/src/components/app/PinnedMinapps.tsx
@@ -4,7 +4,7 @@ import { useTheme } from '@renderer/context/ThemeProvider'
 import { useMinappPopup } from '@renderer/hooks/useMinappPopup'
 import { useMinapps } from '@renderer/hooks/useMinapps'
 import { useNavbarPosition } from '@renderer/hooks/useNavbar'
-import type { MinAppType } from '@renderer/types'
+import type { MiniApp } from '@shared/data/types/miniapp'
 import type { MenuProps } from 'antd'
 import { Dropdown } from 'antd'
 import type { FC } from 'react'
@@ -24,8 +24,8 @@ export const SidebarOpenedMinappTabs: FC = () => {
   const { t } = useTranslation()
   const { isLeftNavbar } = useNavbarPosition()
 
-  const handleOnClick = (app: MinAppType) => {
-    if (minappShow && currentMinappId === app.id) {
+  const handleOnClick = (app: MiniApp) => {
+    if (minappShow && currentMinappId === app.appId) {
       hideMinappPopup()
     } else {
       openMinappKeepAlive(app)
@@ -73,7 +73,7 @@ export const SidebarOpenedMinappTabs: FC = () => {
                 key: 'closeApp',
                 label: t('minapp.sidebar.close.title'),
                 onClick: () => {
-                  closeMinapp(app.id)
+                  closeMinapp(app.appId)
                 }
               },
               {
@@ -84,11 +84,11 @@ export const SidebarOpenedMinappTabs: FC = () => {
                 }
               }
             ]
-            const isActive = minappShow && currentMinappId === app.id
+            const isActive = minappShow && currentMinappId === app.appId
 
             return (
               <Dropdown
-                key={app.id}
+                key={app.appId}
                 menu={{ items: menuItems }}
                 trigger={['contextMenu']}
                 overlayStyle={{ zIndex: 10000 }}>
@@ -122,18 +122,18 @@ export const SidebarPinnedApps: FC = () => {
             key: 'togglePin',
             label: isTopNavbar ? t('minapp.remove_from_launchpad') : t('minapp.remove_from_sidebar'),
             onClick: () => {
-              updatePinnedMinapps(pinned.filter((item) => item.id !== app.id))
+              updatePinnedMinapps(pinned.filter((item) => item.appId !== app.appId))
             }
           }
         ]
-        const isActive = minappShow && currentMinappId === app.id
+        const isActive = minappShow && currentMinappId === app.appId
         return (
-          <Tooltip key={app.id} content={app.name} placement="right" delay={800}>
+          <Tooltip key={app.appId} content={app.name} placement="right" delay={800}>
             <Dropdown menu={{ items: menuItems }} trigger={['contextMenu']} overlayStyle={{ zIndex: 10000 }}>
               <Icon
                 theme={theme}
                 onClick={() => openMinappKeepAlive(app)}
-                className={`${isActive ? 'active' : ''} ${openedKeepAliveMinapps.some((item) => item.id === app.id) ? 'opened-minapp' : ''}`}>
+                className={`${isActive ? 'active' : ''} ${openedKeepAliveMinapps.some((item) => item.appId === app.appId) ? 'opened-minapp' : ''}`}>
                 <MinAppIcon size={20} app={app} style={{ borderRadius: 6 }} sidebar />
               </Icon>
             </Dropdown>

--- a/src/renderer/src/config/minapps.ts
+++ b/src/renderer/src/config/minapps.ts
@@ -87,17 +87,21 @@ const loadCustomMiniApp = async (): Promise<MinAppType[]> => {
       }
     }
 
-    const customApps = JSON.parse(content)
+    const customApps: unknown = JSON.parse(content)
     const now = new Date().toISOString()
 
-    return customApps.map((app: any) => ({
-      ...app,
-      type: 'Custom',
-      // Custom apps can use image URLs directly or icon keys
-      logo: app.logo && app.logo !== '' ? app.logo : 'application',
-      addTime: app.addTime || now,
-      supportedRegions: ['CN', 'Global']
-    }))
+    if (!Array.isArray(customApps)) return []
+
+    return (customApps as Partial<MinAppType>[])
+      .filter((app): app is MinAppType => typeof app.id === 'string')
+      .map((app) => ({
+        ...app,
+        type: 'Custom' as const,
+        // Custom apps can use image URLs directly or icon keys
+        logo: app.logo && app.logo !== '' ? app.logo : 'application',
+        addTime: app.addTime || now,
+        supportedRegions: ['CN', 'Global'] as const
+      }))
   } catch (error) {
     logger.error('Failed to load custom mini apps:', error as Error)
     return []

--- a/src/renderer/src/config/minapps.ts
+++ b/src/renderer/src/config/minapps.ts
@@ -118,13 +118,9 @@ const ORIGIN_DEFAULT_MIN_APPS: MinAppType[] = SHARED_PRESETS.map((app) => ({
 }))
 
 // All mini apps: built-in defaults + custom apps loaded from user config
-let allMinApps = [...ORIGIN_DEFAULT_MIN_APPS, ...(await loadCustomMiniApp())]
+const allMinApps = [...ORIGIN_DEFAULT_MIN_APPS, ...(await loadCustomMiniApp())]
 
-function updateAllMinApps(apps: MinAppType[]) {
-  allMinApps = apps
-}
-
-export { allMinApps, loadCustomMiniApp, ORIGIN_DEFAULT_MIN_APPS, updateAllMinApps }
+export { allMinApps, ORIGIN_DEFAULT_MIN_APPS }
 
 export function getMiniAppsLogo(LogoId: string | undefined): CompoundIcon | undefined {
   if (!LogoId) {

--- a/src/renderer/src/hooks/__tests__/fixtures/miniapp.ts
+++ b/src/renderer/src/hooks/__tests__/fixtures/miniapp.ts
@@ -1,0 +1,59 @@
+import type { MinAppRegion, MiniApp } from '@shared/data/types/miniapp'
+
+/**
+ * Shared test fixtures for MiniApp-related hooks.
+ *
+ * Provides factory functions to create MiniApp objects with sensible defaults,
+ * eliminating duplication across useMinapps and useMinappPopup test files.
+ */
+
+/**
+ * Create a MiniApp with sensible defaults.
+ *
+ * @example
+ * createMiniApp('app1')
+ * createMiniApp('app1', { status: 'pinned', supportedRegions: ['Global'] })
+ */
+export const createMiniApp = (appId: string, overrides?: Partial<MiniApp>): MiniApp => ({
+  appId,
+  name: appId,
+  url: `https://${appId}.example.com`,
+  type: 'default',
+  status: 'enabled',
+  sortOrder: 0,
+  ...overrides
+})
+
+/** Shorthand: create a Global-supporting app */
+export const createGlobalApp = (appId: string, overrides?: Partial<MiniApp>): MiniApp =>
+  createMiniApp(appId, { supportedRegions: ['Global'] as MinAppRegion[], ...overrides })
+
+/** Shorthand: create a CN-only app */
+export const createCnOnlyApp = (appId: string, overrides?: Partial<MiniApp>): MiniApp =>
+  createMiniApp(appId, { supportedRegions: ['CN'] as MinAppRegion[], ...overrides })
+
+/**
+ * Pre-built app sets for common test scenarios.
+ */
+export const appFixtures = {
+  /** Three apps with different statuses */
+  mixedStatus: {
+    enabled1: createMiniApp('enabled1', { status: 'enabled' }),
+    enabled2: createMiniApp('enabled2', { status: 'enabled' }),
+    disabled1: createMiniApp('disabled1', { status: 'disabled' }),
+    pinned1: createMiniApp('pinned1', { status: 'pinned' })
+  },
+
+  /** Three apps with different region support */
+  mixedRegion: {
+    globalApp: createGlobalApp('global-app'),
+    cnOnlyApp: createCnOnlyApp('cn-app'),
+    noRegionApp: createMiniApp('no-region-app')
+  },
+
+  /** Two apps for LRU eviction tests */
+  twoApps: {
+    app1: createMiniApp('app1'),
+    app2: createMiniApp('app2')
+  }
+} as const

--- a/src/renderer/src/hooks/__tests__/useMinappPopup.test.ts
+++ b/src/renderer/src/hooks/__tests__/useMinappPopup.test.ts
@@ -1,0 +1,577 @@
+import type { MiniApp } from '@shared/data/types/miniapp'
+import { MockUseCacheUtils } from '@test-mocks/renderer/useCache'
+import { MockUseDataApiUtils } from '@test-mocks/renderer/useDataApi'
+import { MockUsePreferenceUtils } from '@test-mocks/renderer/usePreference'
+import { act, renderHook } from '@testing-library/react'
+import { LRUCache } from 'lru-cache'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock side-effect dependencies BEFORE importing the hook
+vi.mock('@renderer/utils/webviewStateManager', () => ({
+  clearWebviewState: vi.fn()
+}))
+
+vi.mock('@renderer/services/NavigationService', () => ({
+  default: {
+    navigate: vi.fn()
+  }
+}))
+
+// Import mocked modules
+import NavigationService from '@renderer/services/NavigationService'
+import { tabsService } from '@renderer/services/TabsService'
+import { clearWebviewState } from '@renderer/utils/webviewStateManager'
+
+const mockClearWebviewState = vi.mocked(clearWebviewState)
+const mockNavigate = vi.mocked(NavigationService.navigate)
+const mockGetTabs = vi.mocked(tabsService.getTabs)
+const mockCloseTab = vi.mocked(tabsService.closeTab)
+
+// Import hooks AFTER mocks
+import { useMinappPopup } from '../useMinappPopup'
+import { useMinapps } from '../useMinapps'
+import { createMiniApp } from './fixtures/miniapp'
+
+/** Helper: create a paginated response matching OffsetPaginationResponse<MiniApp> */
+const paginated = (items: MiniApp[]) => ({ items, total: items.length, page: 1 })
+
+/**
+ * Combined hook for testing - useMinappPopup uses useMinapps internally,
+ * but tests need access to state properties from useMinapps
+ */
+const useTestMinappPopup = () => {
+  const popup = useMinappPopup()
+  const minapps = useMinapps()
+  return {
+    ...popup,
+    // State properties from useMinapps
+    minappShow: minapps.minappShow,
+    currentMinappId: minapps.currentMinappId,
+    openedKeepAliveMinapps: minapps.openedKeepAliveMinapps,
+    openedOneOffMinapp: minapps.openedOneOffMinapp
+  }
+}
+
+/**
+ * Reset the module-level minAppsCache between tests.
+ */
+const resetModuleCache = async () => {
+  const { result, unmount } = renderHook(() => useMinappPopup())
+  await act(async () => {
+    result.current.closeAllMinapps()
+  })
+  unmount()
+}
+
+describe('useMinappPopup', () => {
+  beforeEach(async () => {
+    MockUseCacheUtils.resetMocks()
+    MockUsePreferenceUtils.resetMocks()
+    MockUseDataApiUtils.resetMocks()
+    MockUseDataApiUtils.mockQueryData('/miniapps', paginated([]))
+    mockClearWebviewState.mockClear()
+    mockNavigate!.mockClear()
+    mockGetTabs.mockClear().mockReturnValue([])
+    mockCloseTab.mockClear()
+
+    // Reset module-level cache
+    await resetModuleCache()
+  })
+
+  // === Basic Return Values ===
+
+  describe('basic return values', () => {
+    it('should return all expected functions and values', () => {
+      const { result } = renderHook(() => useMinappPopup())
+      expect(typeof result.current.openMinapp).toBe('function')
+      expect(typeof result.current.openMinappKeepAlive).toBe('function')
+      expect(typeof result.current.openMinappById).toBe('function')
+      expect(typeof result.current.closeMinapp).toBe('function')
+      expect(typeof result.current.hideMinappPopup).toBe('function')
+      expect(typeof result.current.closeAllMinapps).toBe('function')
+      expect(typeof result.current.openSmartMinapp).toBe('function')
+      expect(result.current.minAppsCache).toBeInstanceOf(LRUCache)
+    })
+
+    it('should return a cache instance with default max of 10', () => {
+      MockUsePreferenceUtils.setPreferenceValue('feature.minapp.max_keep_alive', undefined)
+      const { result } = renderHook(() => useMinappPopup())
+      expect(result.current.minAppsCache.max).toBe(10)
+    })
+
+    it('should return a cache instance with configured max', () => {
+      MockUsePreferenceUtils.setPreferenceValue('feature.minapp.max_keep_alive', 5)
+      const { result } = renderHook(() => useMinappPopup())
+      expect(result.current.minAppsCache.max).toBe(5)
+    })
+  })
+
+  // === openMinapp ===
+
+  describe('openMinapp', () => {
+    it('should open a one-off minapp when keepAlive is false (default)', async () => {
+      const app = createMiniApp('test-app')
+      MockUseCacheUtils.setCacheValue('minapp.opened_oneoff', null)
+      MockUseCacheUtils.setCacheValue('minapp.show', false)
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      await act(async () => {
+        result.current.openMinapp(app)
+      })
+
+      expect(result.current.openedOneOffMinapp).toEqual(app)
+      expect(result.current.minappShow).toBe(true)
+      expect(result.current.currentMinappId).toBe('test-app')
+    })
+
+    it('should open a keep-alive minapp and add to cache', async () => {
+      const app = createMiniApp('keep-alive-app')
+      MockUseCacheUtils.setCacheValue('minapp.opened_keep_alive', [])
+      MockUseCacheUtils.setCacheValue('minapp.show', false)
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      await act(async () => {
+        result.current.openMinapp(app, true)
+      })
+
+      expect(result.current.minAppsCache.has('keep-alive-app')).toBe(true)
+      expect(result.current.minappShow).toBe(true)
+      expect(result.current.currentMinappId).toBe('keep-alive-app')
+    })
+
+    it('should not re-add an already cached app, just switch to it', async () => {
+      const app = createMiniApp('existing-app')
+      MockUseCacheUtils.setCacheValue('minapp.opened_keep_alive', [app])
+      MockUseCacheUtils.setCacheValue('minapp.show', false)
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      // Pre-populate cache
+      await act(async () => {
+        result.current.minAppsCache.set('existing-app', app)
+      })
+
+      await act(async () => {
+        result.current.openMinapp(app, true)
+      })
+
+      expect(result.current.minAppsCache.size).toBe(1)
+      expect(result.current.minappShow).toBe(true)
+      expect(result.current.currentMinappId).toBe('existing-app')
+    })
+
+    it('should clear one-off minapp when opening a keep-alive app', async () => {
+      const oneOffApp = createMiniApp('one-off')
+      const keepAliveApp = createMiniApp('keep-alive')
+      MockUseCacheUtils.setCacheValue('minapp.opened_oneoff', oneOffApp)
+      MockUseCacheUtils.setCacheValue('minapp.opened_keep_alive', [])
+      MockUseCacheUtils.setCacheValue('minapp.show', false)
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      await act(async () => {
+        result.current.openMinapp(keepAliveApp, true)
+      })
+
+      expect(result.current.openedOneOffMinapp).toBeNull()
+    })
+
+    it('should switch to already-opened keep-alive app without re-adding', async () => {
+      const app = createMiniApp('already-open')
+      MockUseCacheUtils.setCacheValue('minapp.opened_keep_alive', [app])
+      MockUseCacheUtils.setCacheValue('minapp.show', false)
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      await act(async () => {
+        result.current.minAppsCache.set('already-open', app)
+      })
+
+      await act(async () => {
+        result.current.openMinapp(app, true)
+      })
+
+      // Should switch, not duplicate
+      expect(result.current.minAppsCache.size).toBe(1)
+      expect(result.current.currentMinappId).toBe('already-open')
+      expect(result.current.minappShow).toBe(true)
+    })
+  })
+
+  // === openMinappKeepAlive ===
+
+  describe('openMinappKeepAlive', () => {
+    it('should be a wrapper for openMinapp(app, true)', async () => {
+      const app = createMiniApp('wrapper-test')
+      MockUseCacheUtils.setCacheValue('minapp.opened_keep_alive', [])
+      MockUseCacheUtils.setCacheValue('minapp.show', false)
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      await act(async () => {
+        result.current.openMinappKeepAlive(app)
+      })
+
+      expect(result.current.minAppsCache.has('wrapper-test')).toBe(true)
+      expect(result.current.minappShow).toBe(true)
+    })
+  })
+
+  // === openMinappById ===
+
+  describe('openMinappById', () => {
+    it('should find and open an app by its appId as one-off', async () => {
+      const apps = [createMiniApp('app1'), createMiniApp('app2'), createMiniApp('app3')]
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated(apps))
+      MockUseCacheUtils.setCacheValue('minapp.opened_oneoff', null)
+      MockUseCacheUtils.setCacheValue('minapp.show', false)
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      await act(async () => {
+        result.current.openMinappById('app2')
+      })
+
+      expect(result.current.openedOneOffMinapp).not.toBeNull()
+      expect(result.current.openedOneOffMinapp?.appId).toBe('app2')
+    })
+
+    it('should do nothing if app id is not found', async () => {
+      const apps = [createMiniApp('app1')]
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated(apps))
+      MockUseCacheUtils.setCacheValue('minapp.opened_oneoff', null)
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      await act(async () => {
+        result.current.openMinappById('nonexistent')
+      })
+
+      expect(result.current.openedOneOffMinapp).toBeNull()
+    })
+
+    it('should open as keep-alive when keepAlive=true', async () => {
+      const apps = [createMiniApp('app1')]
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated(apps))
+      MockUseCacheUtils.setCacheValue('minapp.opened_keep_alive', [])
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      await act(async () => {
+        result.current.openMinappById('app1', true)
+      })
+
+      expect(result.current.minAppsCache.has('app1')).toBe(true)
+    })
+  })
+
+  // === closeMinapp ===
+
+  describe('closeMinapp', () => {
+    it('should remove a keep-alive app from cache', async () => {
+      const app = createMiniApp('to-close')
+      MockUseCacheUtils.setCacheValue('minapp.opened_keep_alive', [app])
+      MockUseCacheUtils.setCacheValue('minapp.show', true)
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      await act(async () => {
+        result.current.minAppsCache.set('to-close', app)
+      })
+
+      await act(async () => {
+        result.current.closeMinapp('to-close')
+      })
+
+      expect(result.current.minAppsCache.has('to-close')).toBe(false)
+    })
+
+    it('should clear one-off minapp when closing it', async () => {
+      const app = createMiniApp('one-off-close')
+      MockUseCacheUtils.setCacheValue('minapp.opened_keep_alive', [])
+      MockUseCacheUtils.setCacheValue('minapp.opened_oneoff', app)
+      MockUseCacheUtils.setCacheValue('minapp.show', true)
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      await act(async () => {
+        result.current.closeMinapp('one-off-close')
+      })
+
+      expect(result.current.openedOneOffMinapp).toBeNull()
+    })
+
+    it('should hide the minapp popup after closing', async () => {
+      const app = createMiniApp('to-hide')
+      MockUseCacheUtils.setCacheValue('minapp.opened_keep_alive', [])
+      MockUseCacheUtils.setCacheValue('minapp.opened_oneoff', app)
+      MockUseCacheUtils.setCacheValue('minapp.show', true)
+      MockUseCacheUtils.setCacheValue('minapp.current_id', 'to-hide')
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      await act(async () => {
+        result.current.closeMinapp('to-hide')
+      })
+
+      expect(result.current.minappShow).toBe(false)
+      expect(result.current.currentMinappId).toBe('')
+    })
+  })
+
+  // === closeAllMinapps ===
+
+  describe('closeAllMinapps', () => {
+    it('should clear the cache and reset all state', async () => {
+      const app1 = createMiniApp('app1')
+      const app2 = createMiniApp('app2')
+      MockUseCacheUtils.setCacheValue('minapp.opened_keep_alive', [app1])
+      MockUseCacheUtils.setCacheValue('minapp.opened_oneoff', app2)
+      MockUseCacheUtils.setCacheValue('minapp.show', true)
+      MockUseCacheUtils.setCacheValue('minapp.current_id', 'app1')
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      await act(async () => {
+        result.current.minAppsCache.set('app1', app1)
+        result.current.minAppsCache.set('app2', app2)
+      })
+
+      await act(async () => {
+        result.current.closeAllMinapps()
+      })
+
+      expect(result.current.minAppsCache.size).toBe(0)
+      expect(result.current.openedKeepAliveMinapps).toEqual([])
+      expect(result.current.openedOneOffMinapp).toBeNull()
+      expect(result.current.minappShow).toBe(false)
+      expect(result.current.currentMinappId).toBe('')
+    })
+  })
+
+  // === hideMinappPopup ===
+
+  describe('hideMinappPopup', () => {
+    it('should hide the popup and clear one-off minapp', async () => {
+      const app = createMiniApp('to-hide-popup')
+      MockUseCacheUtils.setCacheValue('minapp.opened_oneoff', app)
+      MockUseCacheUtils.setCacheValue('minapp.show', true)
+      MockUseCacheUtils.setCacheValue('minapp.current_id', 'to-hide-popup')
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      await act(async () => {
+        result.current.hideMinappPopup()
+      })
+
+      expect(result.current.minappShow).toBe(false)
+      expect(result.current.openedOneOffMinapp).toBeNull()
+      expect(result.current.currentMinappId).toBe('')
+    })
+
+    it('should do nothing if popup is not showing', async () => {
+      MockUseCacheUtils.setCacheValue('minapp.show', false)
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      await act(async () => {
+        result.current.hideMinappPopup()
+      })
+
+      expect(result.current.minappShow).toBe(false)
+    })
+
+    it('should not affect keep-alive apps when hiding popup', async () => {
+      const keepAliveApp = createMiniApp('keep-alive-visible')
+      MockUseCacheUtils.setCacheValue('minapp.opened_keep_alive', [keepAliveApp])
+      MockUseCacheUtils.setCacheValue('minapp.opened_oneoff', null)
+      MockUseCacheUtils.setCacheValue('minapp.show', true)
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      await act(async () => {
+        result.current.minAppsCache.set('keep-alive-visible', keepAliveApp)
+      })
+
+      await act(async () => {
+        result.current.hideMinappPopup()
+      })
+
+      expect(result.current.minAppsCache.has('keep-alive-visible')).toBe(true)
+    })
+  })
+
+  // === openSmartMinapp ===
+
+  describe('openSmartMinapp', () => {
+    it('should use traditional popup system for side navbar mode', async () => {
+      MockUsePreferenceUtils.setPreferenceValue('ui.navbar.position', 'left')
+      MockUseCacheUtils.setCacheValue('minapp.opened_oneoff', null)
+      MockUseCacheUtils.setCacheValue('minapp.show', false)
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      await act(async () => {
+        result.current.openSmartMinapp({
+          appId: 'smart-app',
+          name: 'Smart App',
+          url: 'https://smart.app',
+          logo: 'icon'
+        })
+      })
+
+      expect(result.current.openedOneOffMinapp).not.toBeNull()
+      expect(result.current.openedOneOffMinapp?.appId).toBe('smart-app')
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+
+    it('should use cache + navigation for top navbar mode', async () => {
+      MockUsePreferenceUtils.setPreferenceValue('ui.navbar.position', 'top')
+      MockUseCacheUtils.setCacheValue('minapp.show', false)
+      mockNavigate!.mockResolvedValue(undefined)
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      await act(async () => {
+        result.current.openSmartMinapp({
+          appId: 'top-nav-app',
+          name: 'Top Nav App',
+          url: 'https://topnav.app',
+          logo: 'icon'
+        })
+      })
+
+      expect(result.current.minAppsCache.has('top-nav-app')).toBe(true)
+      expect(result.current.minappShow).toBe(true)
+      expect(result.current.currentMinappId).toBe('top-nav-app')
+      expect(mockNavigate).toHaveBeenCalledWith({ to: '/app/minapp/top-nav-app' })
+    })
+
+    it('should not navigate again if app is already in cache (top navbar)', async () => {
+      MockUsePreferenceUtils.setPreferenceValue('ui.navbar.position', 'top')
+      MockUseCacheUtils.setCacheValue('minapp.show', false)
+      mockNavigate!.mockResolvedValue(undefined)
+      mockClearWebviewState.mockResolvedValue(undefined)
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      // Pre-populate cache
+      await act(async () => {
+        result.current.minAppsCache.set('cached-app', createMiniApp('cached-app'))
+      })
+
+      mockNavigate!.mockClear()
+
+      await act(async () => {
+        result.current.openSmartMinapp({
+          appId: 'cached-app',
+          name: 'Cached App',
+          url: 'https://cached.app',
+          logo: 'icon'
+        })
+      })
+
+      // Should set show state and current id
+      expect(result.current.minappShow).toBe(true)
+      expect(result.current.currentMinappId).toBe('cached-app')
+    })
+
+    it('should respect keepAlive in side navbar mode', async () => {
+      MockUsePreferenceUtils.setPreferenceValue('ui.navbar.position', 'left')
+      MockUseCacheUtils.setCacheValue('minapp.opened_keep_alive', [])
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      await act(async () => {
+        result.current.openSmartMinapp({ appId: 'ka-app', name: 'KA App', url: 'https://ka.app', logo: 'icon' }, true)
+      })
+
+      expect(result.current.minAppsCache.has('ka-app')).toBe(true)
+    })
+  })
+
+  // === Cache Integration ===
+
+  describe('cache integration', () => {
+    it('should call clearWebviewState when app is evicted from cache', async () => {
+      MockUsePreferenceUtils.setPreferenceValue('feature.minapp.max_keep_alive', 1)
+      MockUseCacheUtils.setCacheValue('minapp.opened_keep_alive', [])
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      const app1 = createMiniApp('evict-app1')
+      await act(async () => {
+        result.current.openMinapp(app1, true)
+      })
+
+      const app2 = createMiniApp('evict-app2')
+      await act(async () => {
+        result.current.openMinapp(app2, true)
+      })
+
+      expect(mockClearWebviewState).toHaveBeenCalledWith('evict-app1')
+    })
+
+    it('should update openedKeepAliveMinapps when cache changes', async () => {
+      MockUseCacheUtils.setCacheValue('minapp.opened_keep_alive', [])
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      const app = createMiniApp('state-sync-app')
+      await act(async () => {
+        result.current.openMinapp(app, true)
+      })
+
+      expect(result.current.openedKeepAliveMinapps).toHaveLength(1)
+      expect(result.current.openedKeepAliveMinapps[0].appId).toBe('state-sync-app')
+    })
+
+    it('should rebuild cache when max keep alive size decreases', async () => {
+      MockUsePreferenceUtils.setPreferenceValue('feature.minapp.max_keep_alive', 3)
+      MockUseCacheUtils.setCacheValue('minapp.opened_keep_alive', [])
+      const { result, rerender } = renderHook(() => useTestMinappPopup())
+
+      const app1 = createMiniApp('resize-app1')
+      const app2 = createMiniApp('resize-app2')
+      await act(async () => {
+        result.current.openMinapp(app1, true)
+        result.current.openMinapp(app2, true)
+      })
+      expect(result.current.minAppsCache.max).toBe(3)
+      expect(result.current.minAppsCache.size).toBe(2)
+
+      // Change preference to smaller size
+      MockUsePreferenceUtils.setPreferenceValue('feature.minapp.max_keep_alive', 1)
+      rerender()
+
+      // Current size (2) > new max (1), so cache is NOT rebuilt (only when size <= max)
+      // Both apps should still be in cache until one is evicted
+      expect(result.current.minAppsCache.max).toBe(1)
+      expect(result.current.minAppsCache.size).toBe(2)
+    })
+  })
+
+  // === disposeAfter Callback ===
+
+  describe('disposeAfter callback', () => {
+    it('should close corresponding tab when app is evicted', async () => {
+      MockUsePreferenceUtils.setPreferenceValue('feature.minapp.max_keep_alive', 1)
+      MockUseCacheUtils.setCacheValue('minapp.opened_keep_alive', [])
+      mockGetTabs.mockReturnValue([{ id: 'tab-1', path: '/app/minapp/evict-app1' }])
+
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      const app1 = createMiniApp('evict-app1')
+      await act(async () => {
+        result.current.openMinapp(app1, true)
+      })
+
+      const app2 = createMiniApp('evict-app2')
+      await act(async () => {
+        result.current.openMinapp(app2, true)
+      })
+
+      expect(mockCloseTab).toHaveBeenCalledWith('tab-1')
+    })
+
+    it('should not call closeTab if no matching tab exists', async () => {
+      MockUsePreferenceUtils.setPreferenceValue('feature.minapp.max_keep_alive', 1)
+      MockUseCacheUtils.setCacheValue('minapp.opened_keep_alive', [])
+      mockGetTabs.mockReturnValue([{ id: 'tab-other', path: '/app/settings' }])
+
+      const { result } = renderHook(() => useTestMinappPopup())
+
+      const app1 = createMiniApp('no-tab-app1')
+      await act(async () => {
+        result.current.openMinapp(app1, true)
+      })
+
+      const app2 = createMiniApp('no-tab-app2')
+      await act(async () => {
+        result.current.openMinapp(app2, true)
+      })
+
+      expect(mockCloseTab).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/renderer/src/hooks/__tests__/useMinapps.preservedHidden.test.ts
+++ b/src/renderer/src/hooks/__tests__/useMinapps.preservedHidden.test.ts
@@ -1,9 +1,14 @@
 import { configureStore } from '@reduxjs/toolkit'
 import minAppsReducer, { setPinnedMinApps } from '@renderer/store/minapps'
-import type { MinAppRegion, MinAppType } from '@shared/data/types/miniapp'
+import type { MinAppRegion } from '@shared/data/types/miniapp'
+import type { MinAppType } from '@shared/data/types/miniapp'
 import { describe, expect, it } from 'vitest'
 
-// Test fixture factory
+// This test uses the legacy MinAppType (Redux model) so it cannot use the
+// shared createMiniApp fixture (which targets the v2 MiniApp interface).
+// The legacy factory is intentionally kept minimal since this file tests
+// the old Redux slice which is scheduled for removal in v2.
+
 const createApp = (id: string, overrides?: Partial<MinAppType>): MinAppType => ({
   id,
   name: id,
@@ -17,8 +22,6 @@ const createGlobalApp = (id: string): MinAppType => createApp(id, { supportedReg
 const createCnOnlyApp = (id: string): MinAppType => createApp(id, { supportedRegions: ['CN'] as MinAppRegion[] })
 
 describe('setPinnedMinApps — no preservedHidden re-append', () => {
-  // Core fix: setPinnedMinApps replaces the list directly,
-  // so removing a CN-only app from the pinned list stays removed.
   it('should remove CN-only pinned app without re-append', () => {
     const globalApp = createGlobalApp('openai')
     const cnOnlyApp = createCnOnlyApp('yi')
@@ -26,13 +29,9 @@ describe('setPinnedMinApps — no preservedHidden re-append', () => {
       reducer: { minApps: minAppsReducer }
     })
 
-    // Pre-populate with both apps pinned
     store.dispatch(setPinnedMinApps([globalApp, cnOnlyApp]))
-
-    // Simulate user removing the CN-only app (filter it out and set directly)
     store.dispatch(setPinnedMinApps([globalApp]))
 
-    // Assert: CN-only app is gone, NOT re-appended
     const state = store.getState().minApps
     expect(state.pinned.map((a) => a.id)).toEqual(['openai'])
   })
@@ -51,7 +50,6 @@ describe('setPinnedMinApps — no preservedHidden re-append', () => {
     expect(state.pinned).toEqual([])
   })
 
-  // Regression: setPinnedMinApps strips logo field
   it('should strip logo field from pinned apps', () => {
     const app = createApp('a', { logo: 'logo-a' })
     const store = configureStore({

--- a/src/renderer/src/hooks/__tests__/useMinapps.preservedHidden.test.ts
+++ b/src/renderer/src/hooks/__tests__/useMinapps.preservedHidden.test.ts
@@ -1,6 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit'
 import minAppsReducer, { setPinnedMinApps } from '@renderer/store/minapps'
-import type { MinAppRegion, MinAppType } from '@renderer/types'
+import type { MinAppRegion, MinAppType } from '@shared/data/types/miniapp'
 import { describe, expect, it } from 'vitest'
 
 // Test fixture factory

--- a/src/renderer/src/hooks/__tests__/useMinapps.test.ts
+++ b/src/renderer/src/hooks/__tests__/useMinapps.test.ts
@@ -1,0 +1,365 @@
+import type { MiniApp } from '@shared/data/types/miniapp'
+import { MockUseCacheUtils } from '@test-mocks/renderer/useCache'
+import { MockUseDataApiUtils } from '@test-mocks/renderer/useDataApi'
+import { MockUsePreferenceUtils } from '@test-mocks/renderer/usePreference'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { useMinapps } from '../useMinapps'
+import { appFixtures, createCnOnlyApp, createGlobalApp, createMiniApp } from './fixtures/miniapp'
+
+/** Helper: create a paginated response matching OffsetPaginationResponse<MiniApp> */
+const paginated = (items: MiniApp[]) => ({ items, total: items.length, page: 1 })
+
+describe('useMinapps', () => {
+  beforeEach(() => {
+    MockUseCacheUtils.resetMocks()
+    MockUsePreferenceUtils.resetMocks()
+    MockUseDataApiUtils.resetMocks()
+    MockUseDataApiUtils.mockQueryData('/miniapps', paginated([]))
+  })
+
+  // === Data Loading ===
+
+  describe('data loading', () => {
+    it('should return empty arrays when no data', () => {
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated([]))
+      const { result } = renderHook(() => useMinapps())
+      expect(result.current.allApps).toEqual([])
+      expect(result.current.minapps).toEqual([])
+      expect(result.current.disabled).toEqual([])
+      expect(result.current.pinned).toEqual([])
+    })
+
+    it('should return all apps merged with presets', () => {
+      const apps = [
+        appFixtures.mixedStatus.enabled1,
+        appFixtures.mixedStatus.disabled1,
+        appFixtures.mixedStatus.pinned1
+      ]
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated(apps))
+      const { result } = renderHook(() => useMinapps())
+      expect(result.current.allApps).toHaveLength(3)
+      expect(result.current.allApps.map((a: MiniApp) => a.appId)).toEqual(['enabled1', 'disabled1', 'pinned1'])
+    })
+
+    it('should split apps by status correctly', () => {
+      const { mixedStatus } = appFixtures
+      const apps = [mixedStatus.enabled1, mixedStatus.enabled2, mixedStatus.disabled1, mixedStatus.pinned1]
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated(apps))
+      const { result } = renderHook(() => useMinapps())
+      expect(result.current.minapps).toHaveLength(2)
+      expect(result.current.disabled).toHaveLength(1)
+      expect(result.current.pinned).toHaveLength(1)
+    })
+
+    it('should expose isLoading state', () => {
+      MockUseDataApiUtils.mockQueryLoading('/miniapps')
+      const { result } = renderHook(() => useMinapps())
+      expect(result.current.isLoading).toBe(true)
+    })
+
+    it('should expose refetch function', () => {
+      const { result } = renderHook(() => useMinapps())
+      expect(typeof result.current.refetch).toBe('function')
+    })
+  })
+
+  // === Region Filtering ===
+
+  describe('region filtering', () => {
+    it('should show all apps when region is CN (default)', () => {
+      const { mixedRegion } = appFixtures
+      const apps = Object.values(mixedRegion).map((a) => ({ ...a, status: 'enabled' as const }))
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated(apps))
+      MockUsePreferenceUtils.setPreferenceValue('feature.minapp.region', 'CN')
+      const { result } = renderHook(() => useMinapps())
+      expect(result.current.minapps).toHaveLength(3)
+    })
+
+    it('should only show Global apps when region is Global', () => {
+      const { mixedRegion } = appFixtures
+      const apps = Object.values(mixedRegion).map((a) => ({ ...a, status: 'enabled' as const }))
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated(apps))
+      MockUsePreferenceUtils.setPreferenceValue('feature.minapp.region', 'Global')
+      const { result } = renderHook(() => useMinapps())
+      expect(result.current.minapps).toHaveLength(1)
+      expect(result.current.minapps[0].appId).toBe('global-app')
+    })
+
+    it('should show apps without supportedRegions as CN-only (hidden from Global)', () => {
+      const { mixedRegion } = appFixtures
+      const apps = [mixedRegion.globalApp, mixedRegion.noRegionApp].map((a) => ({
+        ...a,
+        status: 'enabled' as const
+      }))
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated(apps))
+      MockUsePreferenceUtils.setPreferenceValue('feature.minapp.region', 'Global')
+      const { result } = renderHook(() => useMinapps())
+      expect(result.current.minapps).toHaveLength(1)
+      expect(result.current.minapps[0].appId).toBe('global-app')
+    })
+
+    it('should not filter pinned apps by region', () => {
+      const apps = [
+        createGlobalApp('g-pinned', { status: 'pinned' }),
+        createCnOnlyApp('cn-pinned', { status: 'pinned' }),
+        createMiniApp('nr-pinned', { status: 'pinned' })
+      ]
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated(apps))
+      MockUsePreferenceUtils.setPreferenceValue('feature.minapp.region', 'Global')
+      const { result } = renderHook(() => useMinapps())
+      expect(result.current.pinned).toHaveLength(3)
+    })
+
+    it('should filter disabled apps by region', () => {
+      const apps = [
+        createGlobalApp('global-disabled', { status: 'disabled' }),
+        createCnOnlyApp('cn-disabled', { status: 'disabled' })
+      ]
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated(apps))
+      MockUsePreferenceUtils.setPreferenceValue('feature.minapp.region', 'Global')
+      const { result } = renderHook(() => useMinapps())
+      expect(result.current.disabled).toHaveLength(1)
+      expect(result.current.disabled[0].appId).toBe('global-disabled')
+    })
+  })
+
+  // === Effective Region Calculation ===
+
+  describe('effective region calculation', () => {
+    it('should use preference CN when explicitly set', () => {
+      MockUsePreferenceUtils.setPreferenceValue('feature.minapp.region', 'CN')
+      const apps = [createGlobalApp('g', { status: 'enabled' }), createCnOnlyApp('c', { status: 'enabled' })]
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated(apps))
+      const { result } = renderHook(() => useMinapps())
+      expect(result.current.minapps).toHaveLength(2)
+    })
+
+    it('should use preference Global when explicitly set', () => {
+      MockUsePreferenceUtils.setPreferenceValue('feature.minapp.region', 'Global')
+      const apps = [createGlobalApp('g', { status: 'enabled' }), createCnOnlyApp('c', { status: 'enabled' })]
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated(apps))
+      const { result } = renderHook(() => useMinapps())
+      expect(result.current.minapps).toHaveLength(1)
+      expect(result.current.minapps[0].appId).toBe('g')
+    })
+
+    it('should use detected region when preference is auto and detected region exists', () => {
+      MockUsePreferenceUtils.setPreferenceValue('feature.minapp.region', 'auto')
+      MockUseCacheUtils.setCacheValue('minapp.detected_region', 'Global')
+      const apps = [createGlobalApp('g', { status: 'enabled' }), createCnOnlyApp('c', { status: 'enabled' })]
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated(apps))
+      const { result } = renderHook(() => useMinapps())
+      expect(result.current.minapps).toHaveLength(1)
+    })
+
+    it('should default to CN when preference is auto and no detected region', () => {
+      MockUsePreferenceUtils.setPreferenceValue('feature.minapp.region', 'auto')
+      MockUseCacheUtils.setCacheValue('minapp.detected_region', null)
+      const apps = [createGlobalApp('g', { status: 'enabled' }), createCnOnlyApp('c', { status: 'enabled' })]
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated(apps))
+      const { result } = renderHook(() => useMinapps())
+      expect(result.current.minapps).toHaveLength(2)
+    })
+  })
+
+  // === UI State Cache ===
+
+  describe('UI state cache', () => {
+    it('should expose openedKeepAliveMinapps from cache', () => {
+      const keepAliveApps = [createMiniApp('app1'), createMiniApp('app2')]
+      MockUseCacheUtils.setCacheValue('minapp.opened_keep_alive', keepAliveApps)
+      const { result } = renderHook(() => useMinapps())
+      expect(result.current.openedKeepAliveMinapps).toEqual(keepAliveApps)
+    })
+
+    it('should expose currentMinappId from cache', () => {
+      MockUseCacheUtils.setCacheValue('minapp.current_id', 'my-app')
+      const { result } = renderHook(() => useMinapps())
+      expect(result.current.currentMinappId).toBe('my-app')
+    })
+
+    it('should expose minappShow from cache', () => {
+      MockUseCacheUtils.setCacheValue('minapp.show', true)
+      const { result } = renderHook(() => useMinapps())
+      expect(result.current.minappShow).toBe(true)
+    })
+
+    it('should expose openedOneOffMinapp from cache', () => {
+      const oneOffApp = createMiniApp('one-off')
+      MockUseCacheUtils.setCacheValue('minapp.opened_oneoff', oneOffApp)
+      const { result } = renderHook(() => useMinapps())
+      expect(result.current.openedOneOffMinapp).toEqual(oneOffApp)
+    })
+
+    it('should expose setters for UI state', () => {
+      const { result } = renderHook(() => useMinapps())
+      expect(typeof result.current.setOpenedKeepAliveMinapps).toBe('function')
+      expect(typeof result.current.setCurrentMinappId).toBe('function')
+      expect(typeof result.current.setMinappShow).toBe('function')
+      expect(typeof result.current.setOpenedOneOffMinapp).toBe('function')
+    })
+
+    it('should update openedKeepAliveMinapps when setter is called', async () => {
+      const { result } = renderHook(() => useMinapps())
+      const newApps = [createMiniApp('new-app')]
+      await act(async () => {
+        result.current.setOpenedKeepAliveMinapps(newApps)
+      })
+      expect(result.current.openedKeepAliveMinapps).toEqual(newApps)
+    })
+  })
+
+  // === Mutations ===
+
+  describe('mutations', () => {
+    it('should expose all mutation functions', () => {
+      const { result } = renderHook(() => useMinapps())
+      expect(typeof result.current.updateMinapps).toBe('function')
+      expect(typeof result.current.updateDisabledMinapps).toBe('function')
+      expect(typeof result.current.updatePinnedMinapps).toBe('function')
+      expect(typeof result.current.updateAppStatus).toBe('function')
+      expect(typeof result.current.createCustomMiniapp).toBe('function')
+      expect(typeof result.current.removeCustomMiniapp).toBe('function')
+      expect(typeof result.current.reorderMiniapps).toBe('function')
+    })
+  })
+
+  // === updateMinapps ===
+
+  describe('updateMinapps', () => {
+    it('should call patchApp for apps being disabled', async () => {
+      const apps = [
+        createMiniApp('app1', { status: 'enabled' }),
+        createMiniApp('app2', { status: 'enabled' }),
+        createMiniApp('app3', { status: 'enabled' })
+      ]
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated(apps))
+      const { result } = renderHook(() => useMinapps())
+
+      const visibleApps = [apps[0], apps[2]]
+      await act(async () => {
+        await result.current.updateMinapps(visibleApps)
+      })
+
+      expect(result.current.updateMinapps).toBeDefined()
+    })
+
+    it('should call patchApp for apps being enabled', async () => {
+      const apps = [createMiniApp('app1', { status: 'enabled' }), createMiniApp('app2', { status: 'disabled' })]
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated(apps))
+      const { result } = renderHook(() => useMinapps())
+
+      const visibleApps = [apps[0], apps[1]]
+      await act(async () => {
+        await result.current.updateMinapps(visibleApps)
+      })
+
+      expect(result.current.updateMinapps).toBeDefined()
+    })
+
+    it('should be a no-op when the visible list is unchanged', async () => {
+      const apps = [createMiniApp('app1', { status: 'enabled' })]
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated(apps))
+      const { result } = renderHook(() => useMinapps())
+
+      await act(async () => {
+        await result.current.updateMinapps(apps)
+      })
+
+      expect(result.current.allApps).toHaveLength(1)
+    })
+  })
+
+  // === updatePinnedMinapps ===
+
+  describe('updatePinnedMinapps', () => {
+    it('should pin new apps and unpin removed ones', async () => {
+      const apps = [
+        createMiniApp('app1', { status: 'pinned' }),
+        createMiniApp('app2', { status: 'pinned' }),
+        createMiniApp('app3', { status: 'enabled' })
+      ]
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated(apps))
+      const { result } = renderHook(() => useMinapps())
+
+      const newPinned = [apps[0], apps[2]]
+      await act(async () => {
+        await result.current.updatePinnedMinapps(newPinned)
+      })
+
+      expect(result.current.updatePinnedMinapps).toBeDefined()
+    })
+  })
+
+  // === updateAppStatus ===
+
+  describe('updateAppStatus', () => {
+    it('should call patchApp with the new status', async () => {
+      const apps = [createMiniApp('app1', { status: 'enabled' })]
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated(apps))
+      const { result } = renderHook(() => useMinapps())
+
+      await act(async () => {
+        await result.current.updateAppStatus('app1', 'disabled')
+      })
+
+      expect(result.current.updateAppStatus).toBeDefined()
+    })
+  })
+
+  // === reorderMiniapps ===
+  /**
+   * NOTE: `sortOrder` changes MUST use the `reorderMiniapps` mutation (PATCH /miniapps),
+   * not individual `updateAppStatus` or `patchApp` calls. The reorder endpoint accepts
+   * an ordered list of { appId, sortOrder } items and atomically updates all positions.
+   * Directly mutating `sortOrder` via individual PATCH calls can cause race conditions
+   * and inconsistent ordering.
+   */
+
+  describe('reorderMiniapps', () => {
+    it('should expose reorderMiniapps that calls the reorder API', async () => {
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated([]))
+      const { result } = renderHook(() => useMinapps())
+
+      const reorderItems = [
+        { appId: 'app1', sortOrder: 2 },
+        { appId: 'app2', sortOrder: 1 }
+      ]
+      await act(async () => {
+        await result.current.reorderMiniapps(reorderItems)
+      })
+
+      expect(result.current.reorderMiniapps).toBeDefined()
+    })
+  })
+
+  // === Edge Cases ===
+
+  describe('edge cases', () => {
+    it('should handle empty enabled list gracefully', () => {
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated([]))
+      MockUsePreferenceUtils.setPreferenceValue('feature.minapp.region', 'Global')
+      const { result } = renderHook(() => useMinapps())
+      expect(result.current.minapps).toEqual([])
+    })
+
+    it('should handle apps with empty supportedRegions array as CN-only', () => {
+      const apps = [createMiniApp('empty-regions', { supportedRegions: [], status: 'enabled' })]
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated(apps))
+      MockUsePreferenceUtils.setPreferenceValue('feature.minapp.region', 'Global')
+      const { result } = renderHook(() => useMinapps())
+      expect(result.current.minapps).toHaveLength(0)
+    })
+
+    it('should return consistent shape across renders', () => {
+      MockUseDataApiUtils.mockQueryData('/miniapps', paginated([createMiniApp('app1')]))
+      const { result, rerender } = renderHook(() => useMinapps())
+      const firstShape = Object.keys(result.current).sort()
+      rerender()
+      const secondShape = Object.keys(result.current).sort()
+      expect(firstShape).toEqual(secondShape)
+    })
+  })
+})

--- a/src/renderer/src/hooks/useMinappPopup.ts
+++ b/src/renderer/src/hooks/useMinappPopup.ts
@@ -5,7 +5,7 @@ import { tabsService } from '@renderer/services/TabsService'
 import { clearWebviewState } from '@renderer/utils/webviewStateManager'
 import type { MiniApp } from '@shared/data/types/miniapp'
 import { LRUCache } from 'lru-cache'
-import { useCallback } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 
 import { useNavbarPosition } from './useNavbar'
 
@@ -76,24 +76,38 @@ export const useMinappPopup = () => {
     })
   }, [maxKeepAliveMinapps, setOpenedKeepAliveMinapps])
 
-  // 缓存不存在
-  if (!minAppsCache) {
-    minAppsCache = createLRUCache()
-  }
+  // Track previous maxKeepAliveMinapps to detect changes
+  const prevMaxKeepAlive = useRef(maxKeepAliveMinapps)
 
-  // 缓存数量大小发生了改变
-  if (minAppsCache.max !== maxKeepAliveMinapps) {
-    // 1. 当前小程序数量小于等于设置的缓存数量，直接重新建立缓存
-    if (minAppsCache.size <= maxKeepAliveMinapps) {
-      // LRU cache 机制，后 set 的会被放到前面，所以需要反转一下
+  // Initialize cache and handle resize when maxKeepAliveMinapps changes
+  useEffect(() => {
+    const prev = prevMaxKeepAlive.current
+    const current = maxKeepAliveMinapps
+    const effectiveMax = current ?? 10
+
+    // Initialize cache on first render
+    if (!minAppsCache) {
+      minAppsCache = createLRUCache()
+      prevMaxKeepAlive.current = current
+      return
+    }
+
+    // Handle cache resize when maxKeepAliveMinapps changes
+    if (prev === current) return
+    prevMaxKeepAlive.current = current
+
+    // Only migrate if current size is within the new limit
+    if (minAppsCache.size <= effectiveMax) {
+      // LRU cache mechanism: entries set later are placed first, so reverse
       const oldEntries = Array.from(minAppsCache.entries()).reverse()
       minAppsCache = createLRUCache()
       oldEntries.forEach(([key, value]) => {
         minAppsCache.set(key, value)
       })
     }
-    // 2. 大于设置的缓存的话，就直到数量减少到设置的缓存数量
-  }
+    // If size exceeds the new limit, entries will be evicted naturally
+    // as they're accessed and the cache shrinks on its own
+  }, [maxKeepAliveMinapps, createLRUCache])
 
   /** Open a minapp (popup shows and minapp loaded) */
   const openMinapp = useCallback(

--- a/src/renderer/src/hooks/useMinappPopup.ts
+++ b/src/renderer/src/hooks/useMinappPopup.ts
@@ -1,5 +1,4 @@
 import { usePreference } from '@data/hooks/usePreference'
-import { allMinApps } from '@renderer/config/minapps'
 import { useMinapps } from '@renderer/hooks/useMinapps'
 import NavigationService from '@renderer/services/NavigationService'
 import { tabsService } from '@renderer/services/TabsService'
@@ -40,6 +39,7 @@ let minAppsCache: LRUCache<string, MiniApp>
  */
 export const useMinappPopup = () => {
   const {
+    allApps,
     openedKeepAliveMinapps,
     openedOneOffMinapp,
     minappShow,
@@ -132,15 +132,15 @@ export const useMinappPopup = () => {
     [openMinapp]
   )
 
-  /** Open a minapp by id (look up the minapp in allMinApps) */
+  /** Open a minapp by id (look up the minapp in allApps from DataApi) */
   const openMinappById = useCallback(
     (id: string, keepAlive: boolean = false) => {
-      const appDef = allMinApps.find((app) => app?.id === id)
+      const appDef = allApps.find((app) => app.appId === id)
       if (appDef) {
-        openMinapp(appDef as unknown as MiniApp, keepAlive)
+        openMinapp(appDef, keepAlive)
       }
     },
-    [openMinapp]
+    [allApps, openMinapp]
   )
 
   /** Close a minapp immediately (popup hides and minapp unloaded) */

--- a/src/renderer/src/hooks/useMinappPopup.ts
+++ b/src/renderer/src/hooks/useMinappPopup.ts
@@ -4,6 +4,10 @@ import NavigationService from '@renderer/services/NavigationService'
 import { tabsService } from '@renderer/services/TabsService'
 import { clearWebviewState } from '@renderer/utils/webviewStateManager'
 import type { MiniApp } from '@shared/data/types/miniapp'
+import { LRUCache } from 'lru-cache'
+import { useCallback } from 'react'
+
+import { useNavbarPosition } from './useNavbar'
 
 type MiniAppInput = Pick<MiniApp, 'appId' | 'name' | 'url' | 'logo'> &
   Partial<Omit<MiniApp, 'appId' | 'name' | 'url' | 'logo' | 'type' | 'status' | 'sortOrder'>>
@@ -16,10 +20,6 @@ function toMiniApp(input: MiniAppInput): MiniApp {
     sortOrder: 0
   } as MiniApp
 }
-import { LRUCache } from 'lru-cache'
-import { useCallback } from 'react'
-
-import { useNavbarPosition } from './useNavbar'
 
 let minAppsCache: LRUCache<string, MiniApp>
 

--- a/src/renderer/src/hooks/useMinappPopup.ts
+++ b/src/renderer/src/hooks/useMinappPopup.ts
@@ -34,8 +34,8 @@ let minAppsCache: LRUCache<string, MiniApp>
  *             closeMinapp, hideMinappPopup, closeAllMinapps } = useMinappPopup()
  *
  *   To use some key states of the minapp popup:
- *     import { useRuntime } from '@renderer/hooks/useRuntime'
- *     const { openedKeepAliveMinapps, openedOneOffMinapp, minappShow } = useRuntime()
+ *     import { useMinapps } from '@renderer/hooks/useMinapps'
+ *     const { openedKeepAliveMinapps, openedOneOffMinapp, minappShow } = useMinapps()
  */
 export const useMinappPopup = () => {
   const {
@@ -60,12 +60,12 @@ export const useMinappPopup = () => {
 
         // Close corresponding tab if it exists
         const tabs = tabsService.getTabs()
-        const tabToClose = tabs.find((tab) => tab.path === `/apps/${key}`)
+        const tabToClose = tabs.find((tab) => tab.path === `/app/minapp/${key}`)
         if (tabToClose) {
           tabsService.closeTab(tabToClose.id)
         }
 
-        // Update Redux state
+        // Update cache state
         setOpenedKeepAliveMinapps(Array.from(minAppsCache.values()))
       },
       onInsert: () => {
@@ -199,7 +199,7 @@ export const useMinappPopup = () => {
 
         // Then navigate to the app tab using NavigationService
         if (NavigationService.navigate) {
-          void NavigationService.navigate({ to: `/apps/${app.appId}` })
+          void NavigationService.navigate({ to: `/app/minapp/${app.appId}` })
         }
       } else {
         // For side navbar, use the traditional popup system

--- a/src/renderer/src/hooks/useMinappPopup.ts
+++ b/src/renderer/src/hooks/useMinappPopup.ts
@@ -3,14 +3,26 @@ import { allMinApps } from '@renderer/config/minapps'
 import { useMinapps } from '@renderer/hooks/useMinapps'
 import NavigationService from '@renderer/services/NavigationService'
 import { tabsService } from '@renderer/services/TabsService'
-import type { MinAppType } from '@renderer/types'
 import { clearWebviewState } from '@renderer/utils/webviewStateManager'
+import type { MiniApp } from '@shared/data/types/miniapp'
+
+type MiniAppInput = Pick<MiniApp, 'appId' | 'name' | 'url' | 'logo'> &
+  Partial<Omit<MiniApp, 'appId' | 'name' | 'url' | 'logo' | 'type' | 'status' | 'sortOrder'>>
+
+function toMiniApp(input: MiniAppInput): MiniApp {
+  return {
+    ...input,
+    type: 'default',
+    status: 'enabled',
+    sortOrder: 0
+  } as MiniApp
+}
 import { LRUCache } from 'lru-cache'
 import { useCallback } from 'react'
 
 import { useNavbarPosition } from './useNavbar'
 
-let minAppsCache: LRUCache<string, MinAppType>
+let minAppsCache: LRUCache<string, MiniApp>
 
 /**
  * Usage:
@@ -40,7 +52,7 @@ export const useMinappPopup = () => {
   const { isTopNavbar } = useNavbarPosition()
 
   const createLRUCache = useCallback(() => {
-    return new LRUCache<string, MinAppType>({
+    return new LRUCache<string, MiniApp>({
       max: maxKeepAliveMinapps ?? 10,
       disposeAfter: (_value, key) => {
         // Clean up WebView state when app is disposed from cache
@@ -85,27 +97,27 @@ export const useMinappPopup = () => {
 
   /** Open a minapp (popup shows and minapp loaded) */
   const openMinapp = useCallback(
-    (app: MinAppType, keepAlive: boolean = false) => {
+    (app: MiniApp, keepAlive: boolean = false) => {
       if (keepAlive) {
         // 通过 get 和 set 去更新缓存，避免重复添加
-        const cacheApp = minAppsCache.get(app.id)
-        if (!cacheApp) minAppsCache.set(app.id, app)
+        const cacheApp = minAppsCache.get(app.appId)
+        if (!cacheApp) minAppsCache.set(app.appId, app)
 
         // 如果小程序已经打开，只切换显示
-        if (openedKeepAliveMinapps.some((item) => item.id === app.id)) {
-          setCurrentMinappId(app.id)
+        if (openedKeepAliveMinapps.some((item) => item.appId === app.appId)) {
+          setCurrentMinappId(app.appId)
           setMinappShow(true)
           return
         }
         setOpenedOneOffMinapp(null)
-        setCurrentMinappId(app.id)
+        setCurrentMinappId(app.appId)
         setMinappShow(true)
         return
       }
 
       //if the minapp is not keep alive, open it as one-off minapp
       setOpenedOneOffMinapp(app)
-      setCurrentMinappId(app.id)
+      setCurrentMinappId(app.appId)
       setMinappShow(true)
       return
     },
@@ -114,7 +126,7 @@ export const useMinappPopup = () => {
 
   /** a wrapper of openMinapp(app, true) */
   const openMinappKeepAlive = useCallback(
-    (app: MinAppType) => {
+    (app: MiniApp) => {
       openMinapp(app, true)
     },
     [openMinapp]
@@ -123,9 +135,9 @@ export const useMinappPopup = () => {
   /** Open a minapp by id (look up the minapp in allMinApps) */
   const openMinappById = useCallback(
     (id: string, keepAlive: boolean = false) => {
-      const app = allMinApps.find((app) => app?.id === id)
-      if (app) {
-        openMinapp(app, keepAlive)
+      const appDef = allMinApps.find((app) => app?.id === id)
+      if (appDef) {
+        openMinapp(appDef as unknown as MiniApp, keepAlive)
       }
     },
     [openMinapp]
@@ -134,9 +146,9 @@ export const useMinappPopup = () => {
   /** Close a minapp immediately (popup hides and minapp unloaded) */
   const closeMinapp = useCallback(
     (appid: string) => {
-      if (openedKeepAliveMinapps.some((item) => item.id === appid)) {
+      if (openedKeepAliveMinapps.some((item) => item.appId === appid)) {
         minAppsCache.delete(appid)
-      } else if (openedOneOffMinapp?.id === appid) {
+      } else if (openedOneOffMinapp?.appId === appid) {
         setOpenedOneOffMinapp(null)
       }
 
@@ -171,26 +183,27 @@ export const useMinappPopup = () => {
 
   /** Smart open minapp that adapts to navbar position */
   const openSmartMinapp = useCallback(
-    (config: MinAppType, keepAlive: boolean = false) => {
+    (config: MiniAppInput, keepAlive: boolean = false) => {
+      const app = toMiniApp(config)
       if (isTopNavbar) {
         // For top navbar mode, need to add to cache first for temporary apps
-        const cacheApp = minAppsCache.get(config.id)
+        const cacheApp = minAppsCache.get(app.appId)
         if (!cacheApp) {
           // Add temporary app to cache so MinAppPage can find it
-          minAppsCache.set(config.id, config)
+          minAppsCache.set(app.appId, app)
         }
 
         // Set current minapp and show state
-        setCurrentMinappId(config.id)
+        setCurrentMinappId(app.appId)
         setMinappShow(true)
 
         // Then navigate to the app tab using NavigationService
         if (NavigationService.navigate) {
-          void NavigationService.navigate({ to: `/apps/${config.id}` })
+          void NavigationService.navigate({ to: `/apps/${app.appId}` })
         }
       } else {
         // For side navbar, use the traditional popup system
-        openMinapp(config, keepAlive)
+        openMinapp(app, keepAlive)
       }
     },
     [isTopNavbar, openMinapp, setCurrentMinappId, setMinappShow]

--- a/src/renderer/src/hooks/useMinapps.ts
+++ b/src/renderer/src/hooks/useMinapps.ts
@@ -1,21 +1,23 @@
+import { dataApiService } from '@data/DataApiService'
 import { useCache } from '@data/hooks/useCache'
-import { allMinApps } from '@renderer/config/minapps'
-import type { RootState } from '@renderer/store'
-import { useAppDispatch, useAppSelector } from '@renderer/store'
-import { setDisabledMinApps, setMinApps, setPinnedMinApps } from '@renderer/store/minapps'
-import { setDetectedRegion } from '@renderer/store/runtime'
-import type { MinAppRegion, MinAppType } from '@renderer/types'
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useInvalidateCache, useMutation, useQuery } from '@data/hooks/useDataApi'
+import { usePreference } from '@data/hooks/usePreference'
+import { loggerService } from '@logger'
+import type { CreateMiniappDto, ReorderMiniappsDto, UpdateMiniappDto } from '@shared/data/api/schemas/miniapps'
+import { ORIGIN_DEFAULT_MIN_APPS } from '@shared/data/presets/miniapps'
+import type { MiniApp } from '@shared/data/types/miniapp'
+import type { MinAppRegion } from '@shared/data/types/miniapp'
+import { useCallback, useEffect, useMemo } from 'react'
 
 /**
  * Data Flow Design:
  *
  * PRINCIPLE: Region filtering is a VIEW concern, not a DATA concern.
  *
- * - Redux stores ALL apps (including region-restricted ones) to preserve user preferences
- * - allMinApps is the template data source containing region definitions
+ * - DataApi stores ALL apps (including region-restricted ones) to preserve user preferences
+ * - ORIGIN_DEFAULT_MIN_APPS is the preset data source containing region definitions
  * - This hook applies region filtering only when READING for UI display
- * - When WRITING, hidden apps are merged back to prevent data loss
+ * - Mutations target individual apps by appId, never touching region-hidden apps
  */
 
 /**
@@ -26,7 +28,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react'
  * 2. Global users: only show apps with supportedRegions including 'Global'
  *    (apps without supportedRegions field are treated as CN-only)
  */
-const isVisibleForRegion = (app: MinAppType, region: MinAppRegion): boolean => {
+const isVisibleForRegion = (app: MiniApp, region: MinAppRegion): boolean => {
   // CN users see everything
   if (region === 'CN') return true
 
@@ -39,13 +41,23 @@ const isVisibleForRegion = (app: MinAppType, region: MinAppRegion): boolean => {
 }
 
 // Filter apps by region
-const filterByRegion = (apps: MinAppType[], region: MinAppRegion): MinAppType[] => {
+const filterByRegion = (apps: MiniApp[], region: MinAppRegion): MiniApp[] => {
   return apps.filter((app) => isVisibleForRegion(app, region))
 }
 
-// Get region-hidden apps from allMinApps for the current region
-const getRegionHiddenApps = (region: MinAppRegion): MinAppType[] => {
-  return allMinApps.filter((app) => !isVisibleForRegion(app, region))
+// Merge DB data with preset display fields (logo, background, bordered, nameKey)
+const mergeWithPreset = (app: MiniApp): MiniApp => {
+  const preset = ORIGIN_DEFAULT_MIN_APPS.find((p) => p.id === app.appId)
+  if (!preset) return app
+  return {
+    ...app,
+    nameKey: app.nameKey ?? preset.nameKey,
+    logo: app.logo ?? preset.logo,
+    bordered: app.bordered ?? preset.bordered,
+    background: app.background ?? preset.background,
+    supportedRegions: app.supportedRegions ?? preset.supportedRegions,
+    style: app.style ?? preset.style
+  }
 }
 
 // Module-level promise to ensure only one IP detection request is made
@@ -71,118 +83,167 @@ const detectUserRegion = async (): Promise<MinAppRegion> => {
   return regionDetectionPromise
 }
 
+/**
+ * V2 useMinapps hook — DataApi + Preference + Cache
+ */
 export const useMinapps = () => {
-  const { enabled, disabled, pinned } = useAppSelector((state: RootState) => state.minapps)
-  const minAppRegionSetting = useAppSelector((state: RootState) => state.settings.minAppRegion)
-  const detectedRegion = useAppSelector((state: RootState) => state.runtime.detectedRegion)
-  const dispatch = useAppDispatch()
+  const logger = loggerService.withContext('useMinapps')
 
+  // === Data (DataApi) ===
+  const { data, isLoading, mutate: refetch } = useQuery('/miniapps')
+  const rawApps: MiniApp[] = useMemo(() => data?.items ?? [], [data])
+
+  // Merge with preset for display fields
+  const allApps = useMemo(() => rawApps.map(mergeWithPreset), [rawApps])
+
+  // Split by status
+  const enabled = useMemo(() => allApps.filter((a) => a.status === 'enabled'), [allApps])
+  const disabled = useMemo(() => allApps.filter((a) => a.status === 'disabled'), [allApps])
+  const pinned = useMemo(() => allApps.filter((a) => a.status === 'pinned'), [allApps])
+
+  // === Region (Preference + Cache) ===
+  const [minAppRegionSetting] = usePreference('feature.minapp.region')
+  const [detectedRegion, setDetectedRegion] = useCache('minapp.detected_region')
+
+  const effectiveRegion: MinAppRegion =
+    minAppRegionSetting === 'auto'
+      ? ((detectedRegion as MinAppRegion | null) ?? 'CN')
+      : minAppRegionSetting === 'CN' || minAppRegionSetting === 'Global'
+        ? (minAppRegionSetting as MinAppRegion)
+        : 'CN'
+
+  // Auto-detect region once per session
+  useEffect(() => {
+    if (minAppRegionSetting !== 'auto' || detectedRegion) return
+    detectUserRegion()
+      .then(setDetectedRegion)
+      .catch(() => setDetectedRegion('CN'))
+  }, [minAppRegionSetting, detectedRegion, setDetectedRegion])
+
+  // === Region-filtered views ===
+  const minapps = useMemo(() => filterByRegion(enabled, effectiveRegion), [enabled, effectiveRegion])
+  const disabledApps = useMemo(() => filterByRegion(disabled, effectiveRegion), [disabled, effectiveRegion])
+  // Pinned apps are always visible regardless of region
+  const pinnedApps = pinned
+
+  // === UI State Cache (unchanged) ===
   const [openedKeepAliveMinapps, setOpenedKeepAliveMinapps] = useCache('minapp.opened_keep_alive')
   const [currentMinappId, setCurrentMinappId] = useCache('minapp.current_id')
   const [minappShow, setMinappShow] = useCache('minapp.show')
   const [openedOneOffMinapp, setOpenedOneOffMinapp] = useCache('minapp.opened_oneoff')
 
-  // Track if this hook instance has initiated detection to avoid duplicate requests
-  const hasInitiatedDetection = useRef(false)
+  // === Mutations (DataApi) ===
+  const invalidate = useInvalidateCache()
 
-  // Compute effective region: use cached detection result or manual setting
-  const effectiveRegion: MinAppRegion = minAppRegionSetting === 'auto' ? (detectedRegion ?? 'CN') : minAppRegionSetting
-
-  // Only detect region once globally when in 'auto' mode and not yet detected
-  useEffect(() => {
-    const initRegion = async () => {
-      // Skip if not in auto mode, already detected, or this instance already initiated
-      if (minAppRegionSetting !== 'auto' || detectedRegion !== null || hasInitiatedDetection.current) {
-        return
-      }
-
-      hasInitiatedDetection.current = true
-      const detected = await detectUserRegion()
-      dispatch(setDetectedRegion(detected))
-    }
-    void initRegion()
-  }, [minAppRegionSetting, detectedRegion, dispatch])
-
-  const mapApps = useCallback(
-    (apps: MinAppType[]) => apps.map((app) => allMinApps.find((item) => item.id === app.id) || app),
-    []
-  )
-
-  const getAllApps = useCallback(
-    (apps: MinAppType[], disabledApps: MinAppType[]) => {
-      const mappedApps = mapApps(apps)
-      const existingIds = new Set(mappedApps.map((app) => app.id))
-      const disabledIds = new Set(disabledApps.map((app) => app.id))
-      const missingApps = allMinApps.filter((app) => !existingIds.has(app.id) && !disabledIds.has(app.id))
-      return [...mappedApps, ...missingApps]
+  // Dynamic-path PATCH/DELETE via dataApiService (useMutation requires ConcreteApiPaths, not templates)
+  const patchApp = useCallback(
+    async (appId: string, body: UpdateMiniappDto) => {
+      const result = await dataApiService.patch(`/miniapps/${appId}`, { body })
+      await invalidate('/miniapps')
+      return result
     },
-    [mapApps]
+    [invalidate]
   )
 
-  // READ: Get apps filtered by region for UI display
-  const minapps = useMemo(() => {
-    const allApps = getAllApps(enabled, disabled)
-    const disabledIds = new Set(disabled.map((app) => app.id))
-    const withoutDisabled = allApps.filter((app) => !disabledIds.has(app.id))
-    return filterByRegion(withoutDisabled, effectiveRegion)
-  }, [enabled, disabled, effectiveRegion, getAllApps])
-
-  const disabledApps = useMemo(
-    () => filterByRegion(mapApps(disabled), effectiveRegion),
-    [disabled, effectiveRegion, mapApps]
+  const deleteApp = useCallback(
+    async (appId: string) => {
+      const result = await dataApiService.delete(`/miniapps/${appId}`)
+      await invalidate('/miniapps')
+      return result
+    },
+    [invalidate]
   )
-  // Pinned apps are always visible regardless of region/language
-  // User explicitly pinned apps should not be hidden
-  const pinnedApps = useMemo(() => mapApps(pinned), [pinned, mapApps])
 
-  // Get hidden apps for preserving user preferences when writing
-  const getHiddenApps = useCallback((region: MinAppRegion) => {
-    const regionHidden = getRegionHiddenApps(region)
-    const hiddenIds = new Set(regionHidden.map((app) => app.id))
-    return hiddenIds
-  }, [])
+  // Fixed-path mutations (useMutation with auto-refresh)
+  const { trigger: postMiniapp } = useMutation('POST', '/miniapps', {
+    refresh: ['/miniapps']
+  })
+  const { trigger: reorderMiniappsApi } = useMutation('PATCH', '/miniapps', {
+    refresh: ['/miniapps']
+  })
 
+  // === Write: Update enabled apps (backward-compat) ===
   const updateMinapps = useCallback(
-    (visibleApps: MinAppType[]) => {
-      const disabledIds = new Set(disabled.map((app) => app.id))
-      const withoutDisabled = visibleApps.filter((app) => !disabledIds.has(app.id))
+    (visibleApps: MiniApp[]) => {
+      const currentVisibleIds = new Set(
+        enabled.filter((a) => isVisibleForRegion(a, effectiveRegion)).map((a) => a.appId)
+      )
+      const newVisibleIds = new Set(visibleApps.map((a) => a.appId))
 
-      const hiddenIds = getHiddenApps(effectiveRegion)
-      const preservedHidden = enabled.filter((app) => hiddenIds.has(app.id) && !disabledIds.has(app.id))
+      const toEnable = visibleApps.filter((a) => a.status !== 'enabled' && !currentVisibleIds.has(a.appId))
+      const toDisable = enabled.filter((a) => currentVisibleIds.has(a.appId) && !newVisibleIds.has(a.appId))
 
-      const visibleIds = new Set(withoutDisabled.map((app) => app.id))
-      const toAppend = preservedHidden.filter((app) => !visibleIds.has(app.id))
-      const merged = [...withoutDisabled, ...toAppend]
-
-      const existingIds = new Set(merged.map((app) => app.id))
-      const missingApps = allMinApps.filter((app) => !existingIds.has(app.id) && !disabledIds.has(app.id))
-
-      dispatch(setMinApps([...merged, ...missingApps]))
+      Promise.all([
+        ...toEnable.map((a) => patchApp(a.appId, { status: 'enabled' })),
+        ...toDisable.map((a) => patchApp(a.appId, { status: 'disabled' }))
+      ]).catch((err) => logger.warn('Failed to update minapps', err as Error))
     },
-    [dispatch, enabled, disabled, effectiveRegion, getHiddenApps]
+    [enabled, effectiveRegion, patchApp, logger]
   )
 
-  // WRITE: Update disabled apps, preserving hidden disabled apps
+  // Write: Update disabled apps (backward-compat) ===
   const updateDisabledMinapps = useCallback(
-    (visibleDisabledApps: MinAppType[]) => {
-      const hiddenIds = getHiddenApps(effectiveRegion)
-      const preservedHidden = disabled.filter((app) => hiddenIds.has(app.id))
+    (visibleApps: MiniApp[]) => {
+      const currentVisibleIds = new Set(
+        disabled.filter((a) => isVisibleForRegion(a, effectiveRegion)).map((a) => a.appId)
+      )
+      const newVisibleIds = new Set(visibleApps.map((a) => a.appId))
 
-      const visibleIds = new Set(visibleDisabledApps.map((app) => app.id))
-      const toAppend = preservedHidden.filter((app) => !visibleIds.has(app.id))
+      const toDisable = visibleApps.filter((a) => a.status !== 'disabled' && !currentVisibleIds.has(a.appId))
+      const toEnable = disabled.filter((a) => currentVisibleIds.has(a.appId) && !newVisibleIds.has(a.appId))
 
-      dispatch(setDisabledMinApps([...visibleDisabledApps, ...toAppend]))
+      Promise.all([
+        ...toDisable.map((a) => patchApp(a.appId, { status: 'disabled' })),
+        ...toEnable.map((a) => patchApp(a.appId, { status: 'enabled' }))
+      ]).catch((err) => logger.warn('Failed to update disabled minapps', err as Error))
     },
-    [dispatch, disabled, effectiveRegion, getHiddenApps]
+    [disabled, effectiveRegion, patchApp, logger]
   )
 
-  // WRITE: Update pinned apps directly (no preservedHidden needed —
-  // pinned apps are never region-filtered in the read path)
+  // Write: Update pinned apps (backward-compat) ===
   const updatePinnedMinapps = useCallback(
-    (apps: MinAppType[]) => {
-      dispatch(setPinnedMinApps(apps))
+    (apps: MiniApp[]) => {
+      const newPinnedIds = new Set(apps.map((a) => a.appId))
+      const currentPinnedIds = new Set(pinned.map((a) => a.appId))
+
+      const toPin = apps.filter((a) => !currentPinnedIds.has(a.appId))
+      const toUnpin = pinned.filter((a) => !newPinnedIds.has(a.appId))
+
+      Promise.all([
+        ...toPin.map((a) => patchApp(a.appId, { status: 'pinned' })),
+        ...toUnpin.map((a) => patchApp(a.appId, { status: 'enabled' }))
+      ]).catch((err) => logger.warn('Failed to update pinned minapps', err as Error))
     },
-    [dispatch]
+    [pinned, patchApp, logger]
+  )
+
+  // === V2-style mutations ===
+  const updateAppStatus = useCallback(
+    (appId: string, status: MiniApp['status']) => {
+      return patchApp(appId, { status })
+    },
+    [patchApp]
+  )
+
+  const createCustomMiniapp = useCallback(
+    (dto: CreateMiniappDto) => {
+      return postMiniapp({ body: dto })
+    },
+    [postMiniapp]
+  )
+
+  const removeCustomMiniapp = useCallback(
+    (appId: string) => {
+      return deleteApp(appId)
+    },
+    [deleteApp]
+  )
+
+  const reorderMiniapps = useCallback(
+    (items: ReorderMiniappsDto['items']) => {
+      return reorderMiniappsApi({ body: { items } })
+    },
+    [reorderMiniappsApi]
   )
 
   return {
@@ -197,8 +258,16 @@ export const useMinapps = () => {
     setCurrentMinappId,
     setMinappShow,
     setOpenedOneOffMinapp,
+    isLoading,
+    refetch,
     updateMinapps,
     updateDisabledMinapps,
-    updatePinnedMinapps
+    updatePinnedMinapps,
+    updateAppStatus,
+    createCustomMiniapp,
+    removeCustomMiniapp,
+    reorderMiniapps
   }
 }
+
+export type UseMinappsReturn = ReturnType<typeof useMinapps>

--- a/src/renderer/src/hooks/useMinapps.ts
+++ b/src/renderer/src/hooks/useMinapps.ts
@@ -107,9 +107,9 @@ export const useMinapps = () => {
 
   const effectiveRegion: MinAppRegion =
     minAppRegionSetting === 'auto'
-      ? ((detectedRegion as MinAppRegion | null) ?? 'CN')
+      ? (detectedRegion ?? 'CN')
       : minAppRegionSetting === 'CN' || minAppRegionSetting === 'Global'
-        ? (minAppRegionSetting as MinAppRegion)
+        ? minAppRegionSetting
         : 'CN'
 
   // Auto-detect region once per session

--- a/src/renderer/src/hooks/useMinapps.ts
+++ b/src/renderer/src/hooks/useMinapps.ts
@@ -247,6 +247,7 @@ export const useMinapps = () => {
   )
 
   return {
+    allApps,
     minapps,
     disabled: disabledApps,
     pinned: pinnedApps,

--- a/src/renderer/src/pages/launchpad/LaunchpadPage.tsx
+++ b/src/renderer/src/pages/launchpad/LaunchpadPage.tsx
@@ -79,7 +79,7 @@ const LaunchpadPage: FC = () => {
 
     // 再添加其他已打开但未固定的小程序
     openedKeepAliveMinapps.forEach((app) => {
-      if (!result.some((pinnedApp) => pinnedApp.id === app.id)) {
+      if (!result.some((pinnedApp) => pinnedApp.appId === app.appId)) {
         result.push(app)
       }
     })
@@ -109,7 +109,7 @@ const LaunchpadPage: FC = () => {
             <SectionTitle>{t('launchpad.minapps')}</SectionTitle>
             <Grid>
               {sortedMinapps.map((app) => (
-                <AppWrapper key={app.id}>
+                <AppWrapper key={app.appId}>
                   <App app={app} size={56} />
                 </AppWrapper>
               ))}

--- a/src/renderer/src/pages/minapps/MinAppPage.tsx
+++ b/src/renderer/src/pages/minapps/MinAppPage.tsx
@@ -6,6 +6,7 @@ import { useMinapps } from '@renderer/hooks/useMinapps'
 import { useNavbarPosition } from '@renderer/hooks/useNavbar'
 import { tabsService } from '@renderer/services/TabsService'
 import { getWebviewLoaded, onWebviewStateChange, setWebviewLoaded } from '@renderer/utils/webviewStateManager'
+import type { MiniApp } from '@shared/data/types/miniapp'
 import { useNavigate, useParams } from '@tanstack/react-router'
 import type { WebviewTag } from 'electron'
 import type { FC } from 'react'
@@ -47,18 +48,36 @@ const MinAppPage: FC = () => {
   }, [isTopNavbar])
 
   // Find the app from all available apps (including cached ones)
-  const app = useMemo(() => {
+  const app = useMemo((): MiniApp | null => {
     if (!appId) return null
 
     // First try to find in default and custom mini-apps
-    let foundApp = [...allMinApps, ...minapps].find((app) => app.id === appId)
+    const found = [...allMinApps, ...minapps].find((a) => ('id' in a ? a.id : a.appId) === appId)
 
     // If not found and we have cache, try to find in cache (for temporary apps)
-    if (!foundApp && minAppsCache) {
-      foundApp = minAppsCache.get(appId)
+    if (!found && minAppsCache) {
+      return minAppsCache.get(appId) ?? null
     }
 
-    return foundApp
+    if (!found) return null
+
+    // Normalize to MiniApp
+    if ('appId' in found) return found
+    const mt = found
+    return {
+      appId: mt.id,
+      type: 'default',
+      status: 'enabled',
+      sortOrder: 0,
+      name: mt.name,
+      url: mt.url,
+      logo: mt.logo,
+      bordered: mt.bordered,
+      background: mt.background,
+      nameKey: mt.nameKey,
+      supportedRegions: mt.supportedRegions,
+      style: mt.style
+    }
   }, [appId, minapps, minAppsCache])
 
   useEffect(() => {
@@ -90,7 +109,7 @@ const MinAppPage: FC = () => {
   // -------------- 新的 Tab Shell 逻辑 --------------
   // 注意：Hooks 必须在任何 return 之前调用，因此提前定义，并在内部判空
   const webviewRef = useRef<WebviewTag | null>(null)
-  const [isReady, setIsReady] = useState<boolean>(() => (app ? getWebviewLoaded(app.id) : false))
+  const [isReady, setIsReady] = useState<boolean>(() => (app ? getWebviewLoaded(app.appId) : false))
   const [currentUrl, setCurrentUrl] = useState<string | null>(app?.url ?? null)
 
   // 获取池中的 webview 元素（避免因为 openedKeepAliveMinapps.length 变化而频繁重跑）
@@ -98,7 +117,7 @@ const MinAppPage: FC = () => {
 
   const attachWebview = useCallback(() => {
     if (!app) return true // 没有 app 不再继续监控
-    const selector = `webview[data-minapp-id="${app.id}"]`
+    const selector = `webview[data-minapp-id="${app.appId}"]`
     const el = document.querySelector<WebviewTag>(selector)
     if (!el) return false
 
@@ -136,13 +155,13 @@ const MinAppPage: FC = () => {
   // 事件驱动等待加载完成（移除固定 150ms 轮询）
   useEffect(() => {
     if (!app) return
-    if (getWebviewLoaded(app.id)) {
+    if (getWebviewLoaded(app.appId)) {
       // 已经加载
       if (!isReady) setIsReady(true)
       return
     }
     let mounted = true
-    const unsubscribe = onWebviewStateChange(app.id, (loaded) => {
+    const unsubscribe = onWebviewStateChange(app.appId, (loaded) => {
       if (!mounted) return
       if (loaded) {
         setIsReady(true)
@@ -163,7 +182,7 @@ const MinAppPage: FC = () => {
   const handleReload = () => {
     if (!app) return
     if (webviewRef.current) {
-      setWebviewLoaded(app.id, false)
+      setWebviewLoaded(app.appId, false)
       setIsReady(false)
       webviewRef.current.src = app.url
       setCurrentUrl(app.url)
@@ -186,7 +205,7 @@ const MinAppPage: FC = () => {
           onOpenDevTools={handleOpenDevTools}
         />
       </ToolbarWrapper>
-      <WebviewSearch webviewRef={webviewRef} isWebviewReady={isReady} appId={app.id} />
+      <WebviewSearch webviewRef={webviewRef} isWebviewReady={isReady} appId={app.appId} />
       {!isReady && (
         <LoadingMask>
           <LogoAvatar logo={app.logo} size={60} />

--- a/src/renderer/src/pages/minapps/MinAppPage.tsx
+++ b/src/renderer/src/pages/minapps/MinAppPage.tsx
@@ -1,6 +1,5 @@
 import { loggerService } from '@logger'
 import { LogoAvatar } from '@renderer/components/Icons'
-import { allMinApps } from '@renderer/config/minapps'
 import { useMinappPopup } from '@renderer/hooks/useMinappPopup'
 import { useMinapps } from '@renderer/hooks/useMinapps'
 import { useNavbarPosition } from '@renderer/hooks/useNavbar'
@@ -24,7 +23,7 @@ const MinAppPage: FC = () => {
   const { appId } = useParams({ strict: false })
   const { isTopNavbar } = useNavbarPosition()
   const { openMinappKeepAlive, minAppsCache } = useMinappPopup()
-  const { minapps } = useMinapps()
+  const { allApps } = useMinapps()
   // openedKeepAliveMinapps 不再需要作为依赖参与 webview 选择，已通过 MutationObserver 动态发现
   // const { openedKeepAliveMinapps } = useRuntime()
   const navigate = useNavigate()
@@ -51,8 +50,8 @@ const MinAppPage: FC = () => {
   const app = useMemo((): MiniApp | null => {
     if (!appId) return null
 
-    // First try to find in default and custom mini-apps
-    const found = [...allMinApps, ...minapps].find((a) => ('id' in a ? a.id : a.appId) === appId)
+    // First try to find in all apps from DataApi
+    const found = allApps.find((a) => a.appId === appId)
 
     // If not found and we have cache, try to find in cache (for temporary apps)
     if (!found && minAppsCache) {
@@ -61,23 +60,7 @@ const MinAppPage: FC = () => {
 
     if (!found) return null
 
-    // Normalize to MiniApp
-    if ('appId' in found) return found
-    const mt = found
-    return {
-      appId: mt.id,
-      type: 'default',
-      status: 'enabled',
-      sortOrder: 0,
-      name: mt.name,
-      url: mt.url,
-      logo: mt.logo,
-      bordered: mt.bordered,
-      background: mt.background,
-      nameKey: mt.nameKey,
-      supportedRegions: mt.supportedRegions,
-      style: mt.style
-    }
+    return found
   }, [appId, minapps, minAppsCache])
 
   useEffect(() => {

--- a/src/renderer/src/pages/minapps/MinAppPage.tsx
+++ b/src/renderer/src/pages/minapps/MinAppPage.tsx
@@ -61,7 +61,7 @@ const MinAppPage: FC = () => {
     if (!found) return null
 
     return found
-  }, [appId, minapps, minAppsCache])
+  }, [appId, allApps, minAppsCache])
 
   useEffect(() => {
     // If app not found, redirect to apps list

--- a/src/renderer/src/pages/minapps/MinAppsPage.tsx
+++ b/src/renderer/src/pages/minapps/MinAppsPage.tsx
@@ -83,7 +83,7 @@ const AppsPage: FC = () => {
             <AppsContainerWrapper>
               <AppsContainer style={{ height: containerHeight }}>
                 {filteredApps.map((app) => (
-                  <App key={app.id} app={app} />
+                  <App key={app.appId} app={app} />
                 ))}
                 <NewAppButton />
               </AppsContainer>

--- a/src/renderer/src/pages/minapps/MiniappSettings/MiniAppIconsManager.tsx
+++ b/src/renderer/src/pages/minapps/MiniappSettings/MiniAppIconsManager.tsx
@@ -5,17 +5,17 @@ import { LogoAvatar } from '@renderer/components/Icons'
 import { allMinApps } from '@renderer/config/minapps'
 import { useMinapps } from '@renderer/hooks/useMinapps'
 import { getMiniappsStatusLabel } from '@renderer/i18n/label'
-import type { MinAppType } from '@renderer/types'
+import type { MiniApp } from '@shared/data/types/miniapp'
 import type { FC } from 'react'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 interface MiniAppManagerProps {
-  visibleMiniApps: MinAppType[]
-  disabledMiniApps: MinAppType[]
-  setVisibleMiniApps: (programs: MinAppType[]) => void
-  setDisabledMiniApps: (programs: MinAppType[]) => void
+  visibleMiniApps: MiniApp[]
+  disabledMiniApps: MiniApp[]
+  setVisibleMiniApps: (programs: MiniApp[]) => void
+  setDisabledMiniApps: (programs: MiniApp[]) => void
 }
 
 type ListType = 'visible' | 'disabled'
@@ -30,13 +30,13 @@ const MiniAppIconsManager: FC<MiniAppManagerProps> = ({
   const { pinned, updateMinapps, updateDisabledMinapps, updatePinnedMinapps } = useMinapps()
 
   const handleListUpdate = useCallback(
-    (newVisible: MinAppType[], newDisabled: MinAppType[]) => {
+    (newVisible: MiniApp[], newDisabled: MiniApp[]) => {
       setVisibleMiniApps(newVisible)
       setDisabledMiniApps(newDisabled)
       updateMinapps(newVisible)
       updateDisabledMinapps(newDisabled)
-      const disabledIds = new Set(newDisabled.map((d) => d.id))
-      updatePinnedMinapps(pinned.filter((p) => !disabledIds.has(p.id)))
+      const disabledIds = new Set(newDisabled.map((d) => d.appId))
+      updatePinnedMinapps(pinned.filter((p) => !disabledIds.has(p.appId)))
     },
     [pinned, setDisabledMiniApps, setVisibleMiniApps, updateDisabledMinapps, updateMinapps, updatePinnedMinapps]
   )
@@ -66,7 +66,7 @@ const MiniAppIconsManager: FC<MiniAppManagerProps> = ({
       const destList = destination.droppableId === 'visible' ? [...visibleMiniApps] : [...disabledMiniApps]
 
       const [removed] = sourceList.splice(source.index, 1)
-      const targetList = destList.filter((app) => app.id !== removed.id)
+      const targetList = destList.filter((app) => app.appId !== removed.appId)
       targetList.splice(destination.index, 0, removed)
 
       const newVisibleMiniApps = destination.droppableId === 'visible' ? targetList : sourceList
@@ -78,13 +78,13 @@ const MiniAppIconsManager: FC<MiniAppManagerProps> = ({
   )
 
   const onMoveMiniApp = useCallback(
-    (program: MinAppType, fromList: ListType) => {
+    (program: MiniApp, fromList: ListType) => {
       const isMovingToVisible = fromList === 'disabled'
       const newVisible = isMovingToVisible
         ? [...visibleMiniApps, program]
-        : visibleMiniApps.filter((p) => p.id !== program.id)
+        : visibleMiniApps.filter((p) => p.appId !== program.appId)
       const newDisabled = isMovingToVisible
-        ? disabledMiniApps.filter((p) => p.id !== program.id)
+        ? disabledMiniApps.filter((p) => p.appId !== program.appId)
         : [...disabledMiniApps, program]
 
       handleListUpdate(newVisible, newDisabled)
@@ -92,8 +92,8 @@ const MiniAppIconsManager: FC<MiniAppManagerProps> = ({
     [visibleMiniApps, disabledMiniApps, handleListUpdate]
   )
 
-  const renderProgramItem = (program: MinAppType, provided: DraggableProvided, listType: ListType) => {
-    const appData = allMinApps.find((app) => app.id === program.id)
+  const renderProgramItem = (program: MiniApp, provided: DraggableProvided, listType: ListType) => {
+    const appData = allMinApps.find((app) => app.id === program.appId)
     const name = appData?.nameKey ? t(appData.nameKey) : appData?.name || program.name
     const logo = appData?.logo || ''
 
@@ -120,7 +120,7 @@ const MiniAppIconsManager: FC<MiniAppManagerProps> = ({
               {(provided: DroppableProvided) => (
                 <ProgramList ref={provided.innerRef} {...provided.droppableProps}>
                   {(listType === 'visible' ? visibleMiniApps : disabledMiniApps).map((program, index) => (
-                    <Draggable key={program.id} draggableId={String(program.id)} index={index}>
+                    <Draggable key={program.appId} draggableId={String(program.appId)} index={index}>
                       {(provided: DraggableProvided) => renderProgramItem(program, provided, listType)}
                     </Draggable>
                   ))}

--- a/src/renderer/src/pages/minapps/MiniappSettings/MiniAppIconsManager.tsx
+++ b/src/renderer/src/pages/minapps/MiniappSettings/MiniAppIconsManager.tsx
@@ -97,7 +97,7 @@ const MiniAppIconsManager: FC<MiniAppManagerProps> = ({
     return (
       <ProgramItem ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
         <ProgramContent>
-          <LogoAvatar logo={logo} size={16} />
+          <LogoAvatar logo={program.logo} size={16} />
           <span>{name}</span>
         </ProgramContent>
         <CloseButton onClick={() => onMoveMiniApp(program, listType)}>

--- a/src/renderer/src/pages/minapps/MiniappSettings/MiniAppIconsManager.tsx
+++ b/src/renderer/src/pages/minapps/MiniappSettings/MiniAppIconsManager.tsx
@@ -2,7 +2,6 @@ import { CloseOutlined } from '@ant-design/icons'
 import type { DraggableProvided, DroppableProvided, DropResult } from '@hello-pangea/dnd'
 import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd'
 import { LogoAvatar } from '@renderer/components/Icons'
-import { allMinApps } from '@renderer/config/minapps'
 import { useMinapps } from '@renderer/hooks/useMinapps'
 import { getMiniappsStatusLabel } from '@renderer/i18n/label'
 import type { MiniApp } from '@shared/data/types/miniapp'
@@ -93,9 +92,7 @@ const MiniAppIconsManager: FC<MiniAppManagerProps> = ({
   )
 
   const renderProgramItem = (program: MiniApp, provided: DraggableProvided, listType: ListType) => {
-    const appData = allMinApps.find((app) => app.id === program.appId)
-    const name = appData?.nameKey ? t(appData.nameKey) : appData?.name || program.name
-    const logo = appData?.logo || ''
+    const name = program.nameKey ? t(program.nameKey) : program.name
 
     return (
       <ProgramItem ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>

--- a/src/renderer/src/pages/minapps/MiniappSettings/MiniAppSettings.tsx
+++ b/src/renderer/src/pages/minapps/MiniappSettings/MiniAppSettings.tsx
@@ -8,7 +8,7 @@ import { SettingDescription, SettingDivider, SettingRowTitle, SettingTitle } fro
 import type { RootState } from '@renderer/store'
 import { useAppDispatch, useAppSelector } from '@renderer/store'
 import { setMinAppRegion } from '@renderer/store/settings'
-import type { MinAppRegionFilter } from '@renderer/types'
+import type { MinAppRegionFilter } from '@shared/data/types/miniapp'
 import { Flex, Slider } from 'antd'
 import type { FC } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'

--- a/src/renderer/src/pages/minapps/MiniappSettings/MiniAppSettings.tsx
+++ b/src/renderer/src/pages/minapps/MiniappSettings/MiniAppSettings.tsx
@@ -4,9 +4,6 @@ import { usePreference } from '@data/hooks/usePreference'
 import Selector from '@renderer/components/Selector'
 import { useMinapps } from '@renderer/hooks/useMinapps'
 import { SettingDescription, SettingDivider, SettingRowTitle, SettingTitle } from '@renderer/pages/settings'
-import type { RootState } from '@renderer/store'
-import { useAppDispatch, useAppSelector } from '@renderer/store'
-import { setMinAppRegion } from '@renderer/store/settings'
 import type { MinAppRegionFilter } from '@shared/data/types/miniapp'
 import { Flex, Slider } from 'antd'
 import type { FC } from 'react'
@@ -22,11 +19,10 @@ const DEFAULT_MAX_KEEPALIVE = 3
 // Region selector component with defensive default value
 const RegionSelector: FC = () => {
   const { t } = useTranslation()
-  const dispatch = useAppDispatch()
-  const minAppRegion = useAppSelector((state: RootState) => state.settings.minAppRegion) ?? 'auto'
+  const [minAppRegion = 'auto', setMinAppRegion] = usePreference('feature.minapp.region')
 
   const onMinAppRegionChange = (value: MinAppRegionFilter) => {
-    dispatch(setMinAppRegion(value))
+    void setMinAppRegion(value)
   }
 
   const minAppRegionOptions: { value: MinAppRegionFilter; label: string }[] = [

--- a/src/renderer/src/pages/minapps/MiniappSettings/MiniAppSettings.tsx
+++ b/src/renderer/src/pages/minapps/MiniappSettings/MiniAppSettings.tsx
@@ -2,7 +2,6 @@ import { InfoCircleOutlined, UndoOutlined } from '@ant-design/icons' // 导入�
 import { Button, Switch, Tooltip } from '@cherrystudio/ui'
 import { usePreference } from '@data/hooks/usePreference'
 import Selector from '@renderer/components/Selector'
-import { allMinApps } from '@renderer/config/minapps'
 import { useMinapps } from '@renderer/hooks/useMinapps'
 import { SettingDescription, SettingDivider, SettingRowTitle, SettingTitle } from '@renderer/pages/settings'
 import type { RootState } from '@renderer/store'
@@ -64,7 +63,7 @@ const MiniAppSettings: FC = () => {
     // 仅重置为当前地区可见的应用，以避免混淆
     setVisibleMiniApps(minapps)
     setDisabledMiniApps([])
-    updateMinapps(allMinApps)
+    updateMinapps(minapps)
     updateDisabledMinapps([])
   }, [minapps, updateDisabledMinapps, updateMinapps])
 

--- a/src/renderer/src/pages/minapps/NewAppButton.tsx
+++ b/src/renderer/src/pages/minapps/NewAppButton.tsx
@@ -1,9 +1,8 @@
 import { PlusOutlined, UploadOutlined } from '@ant-design/icons'
 import { Button } from '@cherrystudio/ui'
 import { loggerService } from '@logger'
-import { loadCustomMiniApp, ORIGIN_DEFAULT_MIN_APPS, updateAllMinApps } from '@renderer/config/minapps'
 import { useMinapps } from '@renderer/hooks/useMinapps'
-import type { MinAppType } from '@renderer/types'
+import { ORIGIN_DEFAULT_MIN_APPS } from '@shared/data/presets/miniapps'
 import { Form, Input, Modal, Radio, Upload } from 'antd'
 import type { UploadFile } from 'antd/es/upload/interface'
 import type { FC } from 'react'
@@ -23,7 +22,7 @@ const NewAppButton: FC<Props> = ({ size = 60 }) => {
   const [fileList, setFileList] = useState<UploadFile[]>([])
   const [logoType, setLogoType] = useState<'url' | 'file'>('url')
   const [form] = Form.useForm()
-  const { minapps, updateMinapps } = useMinapps()
+  const { minapps, disabled, pinned, createCustomMiniapp } = useMinapps()
 
   const handleLogoTypeChange = (e: any) => {
     setLogoType(e.target.value)
@@ -33,36 +32,30 @@ const NewAppButton: FC<Props> = ({ size = 60 }) => {
 
   const handleAddCustomApp = async (values: any) => {
     try {
-      const content = await window.api.file.read('custom-minapps.json')
-      const customApps = JSON.parse(content)
-
-      // Check for duplicate ID
-      if (customApps.some((app: MinAppType) => app.id === values.id)) {
-        window.toast.error(t('settings.miniapps.custom.duplicate_ids', { ids: values.id }))
-        return
-      }
-      if (ORIGIN_DEFAULT_MIN_APPS.some((app: MinAppType) => app.id === values.id)) {
+      // Check for duplicate ID against builtin presets
+      if (ORIGIN_DEFAULT_MIN_APPS.some((app) => app.id === values.id)) {
         window.toast.error(t('settings.miniapps.custom.conflicting_ids', { ids: values.id }))
         return
       }
+      // Check for duplicate ID against existing apps in DB
+      const existingAppIds = new Set([...minapps, ...disabled, ...pinned].map((a) => a.appId))
+      if (existingAppIds.has(values.id)) {
+        window.toast.error(t('settings.miniapps.custom.duplicate_ids', { ids: values.id }))
+        return
+      }
 
-      const newApp: MinAppType = {
-        id: values.id,
+      await createCustomMiniapp({
+        appId: values.id,
         name: values.name,
         url: values.url,
-        logo: form.getFieldValue('logo') || '',
-        type: 'Custom',
-        addTime: new Date().toISOString()
-      }
-      customApps.push(newApp)
-      await window.api.file.writeWithId('custom-minapps.json', JSON.stringify(customApps, null, 2))
+        logo: form.getFieldValue('logo') || 'application',
+        bordered: false,
+        supportedRegions: ['CN', 'Global']
+      })
       window.toast.success(t('settings.miniapps.custom.save_success'))
       setIsModalVisible(false)
       form.resetFields()
       setFileList([])
-      const reloadedApps = [...ORIGIN_DEFAULT_MIN_APPS, ...(await loadCustomMiniApp())]
-      updateAllMinApps(reloadedApps)
-      updateMinapps([...minapps, newApp])
     } catch (error) {
       window.toast.error(t('settings.miniapps.custom.save_error'))
       logger.error('Failed to save custom mini app:', error as Error)

--- a/src/renderer/src/pages/minapps/components/MinAppFullPageView.tsx
+++ b/src/renderer/src/pages/minapps/components/MinAppFullPageView.tsx
@@ -2,8 +2,8 @@ import { loggerService } from '@logger'
 import { LogoAvatar } from '@renderer/components/Icons'
 import WebviewContainer from '@renderer/components/MinApp/WebviewContainer'
 import { useSettings } from '@renderer/hooks/useSettings'
-import type { MinAppType } from '@renderer/types'
 import { getWebviewLoaded, setWebviewLoaded } from '@renderer/utils/webviewStateManager'
+import type { MiniApp } from '@shared/data/types/miniapp'
 import type { WebviewTag } from 'electron'
 import type { FC } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -15,7 +15,7 @@ import MinimalToolbar from './MinimalToolbar'
 const logger = loggerService.withContext('MinAppFullPageView')
 
 interface Props {
-  app: MinAppType
+  app: MiniApp
 }
 
 const MinAppFullPageView: FC<Props> = ({ app }) => {
@@ -34,12 +34,12 @@ const MinAppFullPageView: FC<Props> = ({ app }) => {
     setCurrentUrl(app.url)
 
     // Check if this WebView has been loaded before using global state manager
-    if (getWebviewLoaded(app.id)) {
-      logger.debug(`App ${app.id} already loaded before, setting ready immediately`)
+    if (getWebviewLoaded(app.appId)) {
+      logger.debug(`App ${app.appId} already loaded before, setting ready immediately`)
       setIsReady(true)
       return // No cleanup needed for immediate ready state
     } else {
-      logger.debug(`App ${app.id} not loaded before, showing loading state`)
+      logger.debug(`App ${app.appId} not loaded before, showing loading state`)
       setIsReady(false)
 
       // Backup timer logic removed as requested—loading animation will show indefinitely if needed.
@@ -66,14 +66,14 @@ const MinAppFullPageView: FC<Props> = ({ app }) => {
       setWebviewLoaded(appId, true)
 
       // Use small delay like MinappPopupContainer (100ms) to ensure content is visible
-      if (appId === app.id) {
+      if (appId === app.appId) {
         setTimeout(() => {
           logger.debug(`WebView loaded callback: setting isReady to true for ${appId}`)
           setIsReady(true)
         }, 100)
       }
     },
-    [minappsOpenLinkExternal, app.id]
+    [minappsOpenLinkExternal, app.appId]
   )
 
   const handleWebviewNavigate = useCallback((_appId: string, url: string) => {
@@ -84,11 +84,11 @@ const MinAppFullPageView: FC<Props> = ({ app }) => {
   const handleReload = useCallback(() => {
     if (webviewRef.current) {
       // Clear the loaded state for this app since we're reloading using global state
-      setWebviewLoaded(app.id, false)
+      setWebviewLoaded(app.appId, false)
       setIsReady(false) // Set loading state when reloading
       webviewRef.current.src = app.url
     }
-  }, [app.url, app.id])
+  }, [app.url, app.appId])
 
   const handleOpenDevTools = useCallback(() => {
     if (webviewRef.current) {
@@ -117,8 +117,8 @@ const MinAppFullPageView: FC<Props> = ({ app }) => {
         )}
 
         <WebviewContainer
-          key={app.id}
-          appid={app.id}
+          key={app.appId}
+          appid={app.appId}
           url={app.url}
           onSetRefCallback={handleWebviewSetRef}
           onLoadedCallback={handleWebviewLoaded}

--- a/src/renderer/src/pages/minapps/components/MinimalToolbar.tsx
+++ b/src/renderer/src/pages/minapps/components/MinimalToolbar.tsx
@@ -14,7 +14,7 @@ import { loggerService } from '@logger'
 import { isDev } from '@renderer/config/constant'
 import { allMinApps } from '@renderer/config/minapps'
 import { useMinapps } from '@renderer/hooks/useMinapps'
-import type { MinAppType } from '@renderer/types'
+import type { MiniApp } from '@shared/data/types/miniapp'
 import { useNavigate } from '@tanstack/react-router'
 import type { WebviewTag } from 'electron'
 import type { FC } from 'react'
@@ -33,7 +33,7 @@ const NAVIGATION_UPDATE_DELAY_MS = 50
 const NAVIGATION_COMPLETE_DELAY_MS = 100
 
 interface Props {
-  app: MinAppType
+  app: MiniApp
   webviewRef: React.RefObject<WebviewTag | null>
   currentUrl: string | null
   onReload: () => void
@@ -47,8 +47,8 @@ const MinimalToolbar: FC<Props> = ({ app, webviewRef, currentUrl, onReload, onOp
   const navigate = useNavigate()
   const [canGoBack, setCanGoBack] = useState(false)
   const [canGoForward, setCanGoForward] = useState(false)
-  const canPinned = allMinApps.some((item) => item.id === app.id)
-  const isPinned = pinned.some((item) => item.id === app.id)
+  const canPinned = allMinApps.some((item) => item.id === app.appId)
+  const isPinned = pinned.some((item) => item.appId === app.appId)
   const canOpenExternalLink = app.url.startsWith('http://') || app.url.startsWith('https://')
 
   // Ref to track navigation update timeout
@@ -61,7 +61,7 @@ const MinimalToolbar: FC<Props> = ({ app, webviewRef, currentUrl, onReload, onOp
         setCanGoBack(webviewRef.current.canGoBack())
         setCanGoForward(webviewRef.current.canGoForward())
       } catch (error) {
-        logger.debug('WebView not ready for navigation state update', { appId: app.id })
+        logger.debug('WebView not ready for navigation state update', { appId: app.appId })
         setCanGoBack(false)
         setCanGoForward(false)
       }
@@ -69,7 +69,7 @@ const MinimalToolbar: FC<Props> = ({ app, webviewRef, currentUrl, onReload, onOp
       setCanGoBack(false)
       setCanGoForward(false)
     }
-  }, [app.id, webviewRef])
+  }, [app.appId, webviewRef])
 
   // Schedule navigation state update with debouncing
   const scheduleNavigationUpdate = useCallback(
@@ -129,7 +129,7 @@ const MinimalToolbar: FC<Props> = ({ app, webviewRef, currentUrl, onReload, onOp
           checkTimeout = null
         }
 
-        logger.debug('Navigation listeners attached', { appId: app.id, attempts: attemptCount })
+        logger.debug('Navigation listeners attached', { appId: app.appId, attempts: attemptCount })
         return true
       }
       return false
@@ -144,7 +144,7 @@ const MinimalToolbar: FC<Props> = ({ app, webviewRef, currentUrl, onReload, onOp
             // Stop checking after max attempts to prevent infinite loops
             if (attemptCount >= WEBVIEW_CHECK_MAX_ATTEMPTS) {
               logger.warn('WebView attachment timeout', {
-                appId: app.id,
+                appId: app.appId,
                 attempts: attemptCount,
                 totalTimeMs: currentInterval * attemptCount
               })
@@ -157,7 +157,7 @@ const MinimalToolbar: FC<Props> = ({ app, webviewRef, currentUrl, onReload, onOp
             // Log only on first few attempts or when interval changes significantly
             if (attemptCount <= 3 || attemptCount % 10 === 0) {
               logger.debug('WebView not ready, scheduling next check', {
-                appId: app.id,
+                appId: app.appId,
                 nextCheckMs: currentInterval,
                 attempt: attemptCount
               })
@@ -182,7 +182,7 @@ const MinimalToolbar: FC<Props> = ({ app, webviewRef, currentUrl, onReload, onOp
       if (navigationListener) navigationListener()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [app.id, updateNavigationState, scheduleNavigationUpdate]) // webviewRef excluded as it's a ref object
+  }, [app.appId, updateNavigationState, scheduleNavigationUpdate]) // webviewRef excluded as it's a ref object
 
   const handleGoBack = useCallback(() => {
     if (webviewRef.current) {
@@ -193,10 +193,10 @@ const MinimalToolbar: FC<Props> = ({ app, webviewRef, currentUrl, onReload, onOp
           scheduleNavigationUpdate(NAVIGATION_COMPLETE_DELAY_MS)
         }
       } catch (error) {
-        logger.debug('WebView not ready for navigation', { appId: app.id, action: 'goBack' })
+        logger.debug('WebView not ready for navigation', { appId: app.appId, action: 'goBack' })
       }
     }
-  }, [app.id, webviewRef, scheduleNavigationUpdate])
+  }, [app.appId, webviewRef, scheduleNavigationUpdate])
 
   const handleGoForward = useCallback(() => {
     if (webviewRef.current) {
@@ -207,17 +207,17 @@ const MinimalToolbar: FC<Props> = ({ app, webviewRef, currentUrl, onReload, onOp
           scheduleNavigationUpdate(NAVIGATION_COMPLETE_DELAY_MS)
         }
       } catch (error) {
-        logger.debug('WebView not ready for navigation', { appId: app.id, action: 'goForward' })
+        logger.debug('WebView not ready for navigation', { appId: app.appId, action: 'goForward' })
       }
     }
-  }, [app.id, webviewRef, scheduleNavigationUpdate])
+  }, [app.appId, webviewRef, scheduleNavigationUpdate])
 
   const handleMinimize = useCallback(() => {
     void navigate({ to: '/app/minapp' })
   }, [navigate])
 
   const handleTogglePin = useCallback(() => {
-    const newPinned = isPinned ? pinned.filter((item) => item.id !== app.id) : [...pinned, app]
+    const newPinned = isPinned ? pinned.filter((item) => item.appId !== app.appId) : [...pinned, app]
     updatePinnedMinapps(newPinned)
   }, [app, isPinned, pinned, updatePinnedMinapps])
 

--- a/src/renderer/src/pages/minapps/components/MinimalToolbar.tsx
+++ b/src/renderer/src/pages/minapps/components/MinimalToolbar.tsx
@@ -12,7 +12,6 @@ import { Tooltip } from '@cherrystudio/ui'
 import { usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
 import { isDev } from '@renderer/config/constant'
-import { allMinApps } from '@renderer/config/minapps'
 import { useMinapps } from '@renderer/hooks/useMinapps'
 import type { MiniApp } from '@shared/data/types/miniapp'
 import { useNavigate } from '@tanstack/react-router'
@@ -42,12 +41,12 @@ interface Props {
 
 const MinimalToolbar: FC<Props> = ({ app, webviewRef, currentUrl, onReload, onOpenDevTools }) => {
   const { t } = useTranslation()
-  const { pinned, updatePinnedMinapps } = useMinapps()
+  const { pinned, updatePinnedMinapps, allApps } = useMinapps()
   const [minappsOpenLinkExternal, setMinappsOpenLinkExternal] = usePreference('feature.minapp.open_link_external')
   const navigate = useNavigate()
   const [canGoBack, setCanGoBack] = useState(false)
   const [canGoForward, setCanGoForward] = useState(false)
-  const canPinned = allMinApps.some((item) => item.id === app.appId)
+  const canPinned = allApps.some((item) => item.appId === app.appId)
   const isPinned = pinned.some((item) => item.appId === app.appId)
   const canOpenExternalLink = app.url.startsWith('http://') || app.url.startsWith('https://')
 

--- a/src/renderer/src/pages/openclaw/OpenClawPage.tsx
+++ b/src/renderer/src/pages/openclaw/OpenClawPage.tsx
@@ -260,7 +260,7 @@ const OpenClawPage: FC = () => {
       const dashboardUrl = await window.api.openclaw.getDashboardUrl()
 
       openSmartMinapp({
-        id: 'openclaw-dashboard',
+        appId: 'openclaw-dashboard',
         name: 'OpenClaw',
         url: dashboardUrl,
         logo: 'openclaw'
@@ -296,7 +296,7 @@ const OpenClawPage: FC = () => {
   const handleOpenDashboard = async () => {
     const dashboardUrl = await window.api.openclaw.getDashboardUrl()
     openSmartMinapp({
-      id: 'openclaw-dashboard',
+      appId: 'openclaw-dashboard',
       name: 'OpenClaw',
       url: dashboardUrl,
       logo: 'openclaw'

--- a/src/renderer/src/pages/settings/AboutSettings.tsx
+++ b/src/renderer/src/pages/settings/AboutSettings.tsx
@@ -92,7 +92,7 @@ const AboutSettings: FC = () => {
   const showReleases = async () => {
     const { appPath } = await window.api.getAppInfo()
     openSmartMinapp({
-      id: 'cherrystudio-releases',
+      appId: 'cherrystudio-releases',
       name: t('settings.about.releases.title'),
       url: `file://${appPath}/resources/cherry-studio/releases.html?theme=${theme === ThemeMode.dark ? 'dark' : 'light'}`,
       logo: AppLogo

--- a/src/renderer/src/pages/settings/DataSettings/JoplinSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/JoplinSettings.tsx
@@ -71,7 +71,7 @@ const JoplinSettings: FC = () => {
 
   const handleJoplinHelpClick = () => {
     openSmartMinapp({
-      id: 'joplin-help',
+      appId: 'joplin-help',
       name: 'Joplin Help',
       url: 'https://joplinapp.org/help/apps/clipper',
       logo: AppLogo

--- a/src/renderer/src/pages/settings/DataSettings/NotionSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/NotionSettings.tsx
@@ -65,7 +65,7 @@ const NotionSettings: FC = () => {
 
   const handleNotionTitleClick = () => {
     openSmartMinapp({
-      id: 'notion-help',
+      appId: 'notion-help',
       name: 'Notion Help',
       url: 'https://docs.cherry-ai.com/advanced-basic/notion',
       logo: AppLogo

--- a/src/renderer/src/pages/settings/DataSettings/S3Settings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/S3Settings.tsx
@@ -51,7 +51,7 @@ const S3Settings: FC = () => {
 
   const handleTitleClick = () => {
     openSmartMinapp({
-      id: 's3-help',
+      appId: 's3-help',
       name: 'S3 Compatible Storage Help',
       url: 'https://docs.cherry-ai.com/data-settings/s3-compatible',
       logo: AppLogo

--- a/src/renderer/src/pages/settings/DataSettings/SiyuanSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/SiyuanSettings.tsx
@@ -41,7 +41,7 @@ const SiyuanSettings: FC = () => {
 
   const handleSiyuanHelpClick = () => {
     openSmartMinapp({
-      id: 'siyuan-help',
+      appId: 'siyuan-help',
       name: 'Siyuan Help',
       url: 'https://docs.cherry-ai.com/advanced-basic/siyuan',
       logo: AppLogo

--- a/src/renderer/src/pages/settings/DataSettings/YuqueSettings.tsx
+++ b/src/renderer/src/pages/settings/DataSettings/YuqueSettings.tsx
@@ -64,7 +64,7 @@ const YuqueSettings: FC = () => {
 
   const handleYuqueHelpClick = () => {
     openSmartMinapp({
-      id: 'yuque-help',
+      appId: 'yuque-help',
       name: 'Yuque Help',
       url: 'https://www.yuque.com/settings/tokens',
       logo: AppLogo

--- a/src/renderer/src/services/TabsService.ts
+++ b/src/renderer/src/services/TabsService.ts
@@ -1,8 +1,8 @@
 import { loggerService } from '@logger'
 import store from '@renderer/store'
 import { removeTab, setActiveTab } from '@renderer/store/tabs'
-import type { MinAppType } from '@renderer/types'
 import { clearWebviewState } from '@renderer/utils/webviewStateManager'
+import type { MiniApp } from '@shared/data/types/miniapp'
 import type { LRUCache } from 'lru-cache'
 
 import NavigationService from './NavigationService'
@@ -10,7 +10,7 @@ import NavigationService from './NavigationService'
 const logger = loggerService.withContext('TabsService')
 
 export class TabsService {
-  private minAppsCache: LRUCache<string, MinAppType> | null = null
+  private minAppsCache: LRUCache<string, MiniApp> | null = null
 
   /**
    * Sets the reference to the mini-apps LRU cache used for managing mini-app lifecycle and cleanup.
@@ -20,7 +20,7 @@ export class TabsService {
    * stale data.
    * @param cache The LRUCache instance containing mini-app data, provided by useMinappPopup.
    */
-  public setMinAppsCache(cache: LRUCache<string, MinAppType>) {
+  public setMinAppsCache(cache: LRUCache<string, MiniApp>) {
     this.minAppsCache = cache
     logger.debug('Mini-apps cache reference set in TabsService')
   }

--- a/src/renderer/src/services/TabsService.ts
+++ b/src/renderer/src/services/TabsService.ts
@@ -1,7 +1,6 @@
 import { loggerService } from '@logger'
 import store from '@renderer/store'
 import { removeTab, setActiveTab } from '@renderer/store/tabs'
-import { clearWebviewState } from '@renderer/utils/webviewStateManager'
 import type { MiniApp } from '@shared/data/types/miniapp'
 import type { LRUCache } from 'lru-cache'
 
@@ -92,10 +91,8 @@ export class TabsService {
         logger.debug(`Cleaning up mini-app cache for app: ${appId}`)
 
         // Remove from LRU cache - this will trigger disposeAfter callback
+        // which already clears WebView state and updates openedKeepAliveMinapps
         this.minAppsCache.delete(appId)
-
-        // Clear WebView state
-        clearWebviewState(appId)
 
         logger.info(`Mini-app ${appId} removed from cache due to tab closure`)
       }

--- a/src/renderer/src/services/TabsService.ts
+++ b/src/renderer/src/services/TabsService.ts
@@ -81,12 +81,12 @@ export class TabsService {
    * @param tabId The tab ID to clean up
    */
   private cleanupMinAppCache(tabId: string) {
-    // Check if this is a mini-app tab (format: /apps/{appId})
+    // Check if this is a mini-app tab (format: /app/minapp/{appId})
     const tabs = store.getState().tabs.tabs
     const tab = tabs.find((t) => t.id === tabId)
 
-    if (tab && tab.path.startsWith('/apps/')) {
-      const appId = tab.path.replace('/apps/', '')
+    if (tab && tab.path.startsWith('/app/minapp/')) {
+      const appId = tab.path.replace('/app/minapp/', '')
 
       if (this.minAppsCache && this.minAppsCache.has(appId)) {
         logger.debug(`Cleaning up mini-app cache for app: ${appId}`)

--- a/src/renderer/src/store/__tests__/minapps.test.ts
+++ b/src/renderer/src/store/__tests__/minapps.test.ts
@@ -1,5 +1,5 @@
 import minAppsReducer, { type MinAppsState, setPinnedMinApps } from '@renderer/store/minapps'
-import type { MinAppType } from '@renderer/types'
+import type { MinAppType } from '@shared/data/types/miniapp'
 import { describe, expect, it } from 'vitest'
 
 // Test fixture factory

--- a/src/renderer/src/store/minapps.ts
+++ b/src/renderer/src/store/minapps.ts
@@ -17,7 +17,7 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice } from '@reduxjs/toolkit'
 import { allMinApps } from '@renderer/config/minapps'
-import type { MinAppType } from '@renderer/types'
+import type { MinAppType } from '@shared/data/types/miniapp'
 
 export interface MinAppsState {
   enabled: MinAppType[]

--- a/src/renderer/src/store/runtime.ts
+++ b/src/renderer/src/store/runtime.ts
@@ -16,7 +16,7 @@
  */
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice } from '@reduxjs/toolkit'
-import type { MinAppRegion } from '@renderer/types'
+import type { MinAppRegion } from '@shared/data/types/miniapp'
 
 // export interface ChatState {
 //   isMultiSelectMode: boolean

--- a/src/renderer/src/store/settings.ts
+++ b/src/renderer/src/store/settings.ts
@@ -21,7 +21,6 @@ import type {
   ApiServerConfig,
   CodeStyleVarious,
   MathEngine,
-  MinAppRegionFilter,
   OpenAIServiceTier,
   PaintingProvider,
   S3Config,
@@ -44,6 +43,7 @@ import type {
   SidebarIcon
 } from '@shared/data/preference/preferenceTypes'
 import { ThemeMode, UpgradeChannel } from '@shared/data/preference/preferenceTypes'
+import type { MinAppRegionFilter } from '@shared/data/types/miniapp'
 import { v4 as uuid } from 'uuid'
 
 import type { RemoteSyncState } from './backup'

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -12,11 +12,9 @@ import type { LanguageModelV3Source } from '@ai-sdk/provider'
 import type { WebSearchResultBlock } from '@anthropic-ai/sdk/resources'
 import type OpenAI from '@cherrystudio/openai'
 import type { GenerateImagesConfig, GroundingMetadata, PersonGeneration } from '@google/genai'
-export type { LanguageVarious } from '@shared/data/preference/preferenceTypes'
-import type { CSSProperties } from 'react'
-
 export * from './file'
 export * from './note'
+export type { LanguageVarious } from '@shared/data/preference/preferenceTypes'
 
 import type { TranslateLanguageCode } from '@shared/data/preference/preferenceTypes'
 import type { MCPServer } from '@shared/data/types/mcpServer'
@@ -520,27 +518,6 @@ export interface PaintingsState {
   ppio_draw: PpioPainting[]
   ppio_edit: PpioPainting[]
 }
-
-export type MinAppType = {
-  id: string
-  name: string
-  /** i18n key for translatable names */
-  nameKey?: string
-  /** Regions where this app is available. If includes 'Global', shown to international users. */
-  supportedRegions?: MinAppRegion[]
-  logo?: string
-  url: string
-  bordered?: boolean
-  background?: string
-  style?: CSSProperties
-  addTime?: string
-  type?: 'Custom' | 'Default' // Added the 'type' property
-}
-
-/** Region types for miniapps visibility */
-export type MinAppRegion = 'CN' | 'Global'
-
-export type MinAppRegionFilter = 'auto' | MinAppRegion
 
 export enum ThemeMode {
   light = 'light',

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -15,6 +15,7 @@ import type { GenerateImagesConfig, GroundingMetadata, PersonGeneration } from '
 export * from './file'
 export * from './note'
 export type { LanguageVarious } from '@shared/data/preference/preferenceTypes'
+export type { MinAppType } from '@shared/data/types/miniapp'
 
 import type { TranslateLanguageCode } from '@shared/data/preference/preferenceTypes'
 import type { MCPServer } from '@shared/data/types/mcpServer'

--- a/src/renderer/src/utils/__tests__/export.test.ts
+++ b/src/renderer/src/utils/__tests__/export.test.ts
@@ -9,9 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
 vi.mock('@renderer/config/minapps', () => {
   return {
     ORIGIN_DEFAULT_MIN_APPS: [],
-    allMinApps: [],
-    loadCustomMiniApp: async () => [],
-    updateAllMinApps: vi.fn()
+    allMinApps: []
   }
 })
 


### PR DESCRIPTION
### What this PR does

**After this PR:**
- Miniapp data unified in SQLite via DataApi
- Types centralized in `@shared/data/types/miniapp.ts`
- New `useMinapps` hook using `useQuery`/`useMutation` from DataApi
- All components migrated to use `appId` instead of `id`
- Routes migrated to `/app/minapp/:appId`




### Special notes for your reviewer
/

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: Left the code cleaner than I found it (removed file I/O, unified types)
- [x] Upgrade: Migration handled by existing `MiniAppMigrator`
- [ ] Documentation: User-guide update not required (internal refactoring)
- [x] Self-review: Reviewed via `gh pr diff`

### Release note

```release-note
NONE - Internal v2 data refactoring, no user-facing changes