### PR TITLE
fix: include cherryai provider in model validation

### DIFF
--- a/src/renderer/src/services/ModelService.ts
+++ b/src/renderer/src/services/ModelService.ts
@@ -10,7 +10,7 @@ export const getModelUniqId = (m?: Model) => {
 
 export const hasModel = (m?: Model) => {
   const allModels = getStoreProviders()
-    .filter((p) => p.enabled)
+    .filter((p) => p.enabled || p.id === 'cherryai')
     .map((p) => p.models)
     .flat()
 
@@ -31,7 +31,7 @@ export function getModelName(model?: Model) {
 
 export function getModelById(modelId: string) {
   const allModels = getStoreProviders()
-    .filter((p) => p.enabled)
+    .filter((p) => p.enabled || p.id === 'cherryai')
     .map((p) => p.models)
     .flat()
   return allModels.find((m) => m.id === modelId)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR:
The translation feature and text selection assistant were showing "Translation Is Not Available" / "Model does not exist" errors, even though they used the default cherryai provider with qwen model.

After this PR:
The cherryai system provider is now explicitly included in model validation, ensuring the default translation model and other features using cherryai provider work correctly.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #14069

### Why we need it and why it was done in this way

The translation feature relies on a default model stored in Redux state that uses the cherryai provider (id: 'cherryai', provider: 'cherryai'). The model validation functions `hasModel` and `getModelById` were filtering providers by `p.enabled`, which excluded the cherryai provider from valid model checks, causing translation to fail.

The following alternatives were considered:
- Modifying the initial state: Would not fix the issue for existing users who already have their state persisted
- Changing the enabled flag: Could have unintended side effects on other cherryai functionality

### Breaking changes

<!-- optional -->

None - this fix restores previously working functionality.

### Special notes for your reviewer

This fix affects two functions in ModelService.ts:
1. `hasModel` - used to validate if a model exists in enabled providers
2. `getModelById` - used to retrieve a model by its ID

Both now explicitly include cherryai provider in addition to enabled providers, matching the pattern used in other parts of the codebase (e.g., `getStoreProviders()` in useStore.ts).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed an issue where translation and text selection assistant features would show "Model does not exist" error despite using the default model.
```