### PR TITLE
test: fix model.test.ts mock to use importOriginal for partial mocking

### DIFF
--- a/src/renderer/src/utils/__tests__/model.test.ts
+++ b/src/renderer/src/utils/__tests__/model.test.ts
@@ -4,14 +4,18 @@ import { describe, expect, it, vi } from 'vitest'
 import { getDuplicateModelNames, getModelTags, isFreeModel } from '../model'
 
 // Mock the model checking functions from @renderer/config/models
-vi.mock('@renderer/config/models', () => ({
-  isVisionModel: vi.fn().mockImplementation((m: Model) => m.id === 'vision'),
-  isEmbeddingModel: vi.fn().mockImplementation((m: Model) => m.id === 'embedding'),
-  isReasoningModel: vi.fn().mockImplementation((m: Model) => m.id === 'reasoning'),
-  isFunctionCallingModel: vi.fn().mockImplementation((m: Model) => m.id === 'tool'),
-  isWebSearchModel: vi.fn().mockImplementation((m: Model) => m.id === 'search'),
-  isRerankModel: vi.fn().mockImplementation((m: Model) => m.id === 'rerank')
-}))
+vi.mock(import('@renderer/config/models'), async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    isVisionModel: vi.fn().mockImplementation((m: Model) => m.id === 'vision'),
+    isEmbeddingModel: vi.fn().mockImplementation((m: Model) => m.id === 'embedding'),
+    isReasoningModel: vi.fn().mockImplementation((m: Model) => m.id === 'reasoning'),
+    isFunctionCallingModel: vi.fn().mockImplementation((m: Model) => m.id === 'tool'),
+    isWebSearchModel: vi.fn().mockImplementation((m: Model) => m.id === 'search'),
+    isRerankModel: vi.fn().mockImplementation((m: Model) => m.id === 'rerank')
+  }
+})
 
 describe('model', () => {
   describe('isFreeModel', () => {


### PR DESCRIPTION
### What this PR does

Before this PR:
The test file `src/renderer/src/utils/__tests__/model.test.ts` was failing with:
```
Error: [vitest] No "SYSTEM_MODELS" export is defined on the "@renderer/config/models" mock.
```

This was caused by PR #<original-pr-number> which added an import from `@renderer/hooks/useStore` in `model.ts`. The import chain requires exports from `@renderer/config/models` that were missing in the test's manual mock.

After this PR:
The test mock now uses `importOriginal` for partial mocking, preserving all actual exports from `@renderer/config/models` while only overriding the specific functions needed for testing. All 221 test files now pass.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Using `importOriginal` creates a dependency on the actual module, but this is acceptable for tests
- The mock is now more maintainable as it doesn't need to manually replicate all exports

The following alternatives were considered:
- Manually adding all missing exports (qwenModel, SYSTEM_MODELS, etc.) to the mock, but this is fragile and would break again if new exports are added
- Mocking `@renderer/hooks/useStore` separately, but this would require deeper changes

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

None

### Special notes for your reviewer

This is a follow-up fix to the previously merged PR that added `apiModelAdapter` functionality. The original PR introduced a new import chain that the test mock didn't account for.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
