### PR TITLE
fix: clean up OAuth tokens when deleting MCP server

### DIFF
--- a/src/main/services/MCPService.ts
+++ b/src/main/services/MCPService.ts
@@ -1,4 +1,5 @@
 import crypto from 'node:crypto'
+import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
@@ -6,6 +7,7 @@ import { loggerService } from '@logger'
 import { getMCPServersFromRedux } from '@main/apiServer/utils/mcp'
 import { createInMemoryMCPServer } from '@main/mcpServers/factory'
 import { makeSureDirExists, removeEnvProxy } from '@main/utils'
+import { getConfigDir } from '@main/utils/file'
 import { findCommandInShellEnv, getBinaryName, getBinaryPath, isBinaryExists } from '@main/utils/process'
 import getLoginShellEnvironment from '@main/utils/shell-env'
 import { TraceMethod, withSpanFunc } from '@mcp-trace/trace-core'
@@ -781,6 +783,31 @@ class McpService {
     const existingClient = this.clients.get(serverKey)
     if (existingClient) {
       await this.closeClient(serverKey)
+    }
+
+    // Cleanup OAuth token file for this server, but only if no other server
+    // entry still points at the same baseUrl (shared OAuth storage key is
+    // md5(baseUrl), so unlinking prematurely would break the remaining entry).
+    if (server.baseUrl) {
+      try {
+        const remainingServers = await getMCPServersFromRedux()
+        const baseUrlStillInUse = remainingServers.some(
+          (s) => s.id !== server.id && s.baseUrl === server.baseUrl
+        )
+        if (!baseUrlStillInUse) {
+          const serverUrlHash = crypto.createHash('md5').update(server.baseUrl).digest('hex')
+          const oauthFilePath = path.join(getConfigDir(), 'mcp', 'oauth', `${serverUrlHash}_oauth.json`)
+          await fs.unlink(oauthFilePath)
+          getServerLogger(server).debug(`Cleaned up OAuth token file`)
+        } else {
+          getServerLogger(server).debug(`Skipped OAuth token cleanup; baseUrl still in use by another server`)
+        }
+      } catch (error) {
+        // Ignore ENOENT - file may not exist if server never used OAuth
+        if (error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          getServerLogger(server).error(`Failed to cleanup OAuth token file`, error as Error)
+        }
+      }
     }
 
     // If this is a DXT server, cleanup its directory

--- a/src/main/services/MCPService.ts
+++ b/src/main/services/MCPService.ts
@@ -791,9 +791,7 @@ class McpService {
     if (server.baseUrl) {
       try {
         const remainingServers = await getMCPServersFromRedux()
-        const baseUrlStillInUse = remainingServers.some(
-          (s) => s.id !== server.id && s.baseUrl === server.baseUrl
-        )
+        const baseUrlStillInUse = remainingServers.some((s) => s.id !== server.id && s.baseUrl === server.baseUrl)
         if (!baseUrlStillInUse) {
           const serverUrlHash = crypto.createHash('md5').update(server.baseUrl).digest('hex')
           const oauthFilePath = path.join(getConfigDir(), 'mcp', 'oauth', `${serverUrlHash}_oauth.json`)


### PR DESCRIPTION
## Summary

- When deleting a MCP server, the corresponding OAuth token file (`{serverUrlHash}_oauth.json`) in `~/.cherrystudio/config/mcp/oauth/` is now automatically cleaned up
- Prevents stale OAuth tokens from persisting after server removal, addressing the privacy/security risk
- Only affects servers with `baseUrl` set (i.e., SSE/HTTP servers that use OAuth); silently skips if no token file exists

Fixes #14047

## Test plan

- [ ] Create an MCP server that requires OAuth authentication
- [ ] Complete the OAuth flow to generate a token file
- [ ] Verify the token file exists in `~/.cherrystudio/config/mcp/oauth/`
- [ ] Delete the MCP server
- [ ] Verify the token file is removed from the oauth directory
- [ ] Re-add the server and confirm OAuth flow is required again

🤖 Generated with [Claude Code](https://claude.com/claude-code)