### PR TITLE
fix(providers): azure-anthropic web search uses correct Anthropic toolFactories

### DIFF
--- a/.changeset/fix-azure-anthropic-websearch.md
+++ b/.changeset/fix-azure-anthropic-websearch.md
@@ -1,0 +1,10 @@
+---
+'@cherrystudio/ai-core': patch
+---
+
+fix(providers): azure-anthropic variant uses correct Anthropic toolFactories for web search
+
+- Add `TOutput` generic to `ProviderVariant` so `transform` output type flows to `toolFactories` and `resolveModel`
+- Add Anthropic-specific `toolFactories` to `azure-anthropic` variant (fixes `provider.tools.webSearchPreview is not a function`)
+- Fix `urlContext` factory incorrectly mapping to `webSearch` tool key instead of `urlContext`
+- Fix `BedrockExtension` `satisfies` type to use `AmazonBedrockProvider` instead of `ProviderV3`

--- a/packages/aiCore/src/core/providers/__tests__/ExtensionRegistry.test.ts
+++ b/packages/aiCore/src/core/providers/__tests__/ExtensionRegistry.test.ts
@@ -922,4 +922,160 @@ describe('ExtensionRegistry', () => {
       expect(ext?.config.name).toBe('openai')
     })
   })
+
+  describe('getToolFactory', () => {
+    it('should return variant-level toolFactory for variant provider', () => {
+      const variantFactory = vi.fn()
+      const baseFactory = vi.fn()
+
+      registry.register(
+        new ProviderExtension({
+          name: 'azure',
+          create: createMockProviderV3,
+          toolFactories: {
+            webSearch: baseFactory
+          },
+          variants: [
+            {
+              suffix: 'anthropic',
+              name: 'Azure Anthropic',
+              transform: (_provider: ProviderV3) => createMockProviderV3(),
+              toolFactories: {
+                webSearch: variantFactory
+              }
+            }
+          ]
+        })
+      )
+
+      const factory = registry.getToolFactory('azure-anthropic', 'webSearch')
+      expect(factory).toBe(variantFactory)
+    })
+
+    it('should fall back to base toolFactory when variant has no override', () => {
+      const baseFactory = vi.fn()
+
+      registry.register(
+        new ProviderExtension({
+          name: 'azure',
+          create: createMockProviderV3,
+          toolFactories: {
+            webSearch: baseFactory
+          },
+          variants: [
+            {
+              suffix: 'responses',
+              name: 'Azure Responses',
+              transform: (_provider: ProviderV3) => createMockProviderV3()
+            }
+          ]
+        })
+      )
+
+      const factory = registry.getToolFactory('azure-responses', 'webSearch')
+      expect(factory).toBe(baseFactory)
+    })
+
+    it('should return undefined for unsupported capability', () => {
+      registry.register(
+        new ProviderExtension({
+          name: 'test',
+          create: createMockProviderV3,
+          toolFactories: {
+            webSearch: vi.fn()
+          }
+        })
+      )
+
+      expect(registry.getToolFactory('test', 'fileSearch')).toBeUndefined()
+    })
+  })
+
+  describe('getToolProvider (via resolveToolCapability)', () => {
+    it('should return variant-transformed provider for variant IDs', async () => {
+      const baseProvider = createMockProviderV3({ provider: 'azure-base' })
+      const variantProvider = createMockProviderV3({ provider: 'anthropic-variant' })
+      const transformSpy = vi.fn().mockReturnValue(variantProvider)
+      const factorySpy = vi.fn().mockReturnValue(() => ({ tools: {} }))
+
+      registry.register(
+        new ProviderExtension({
+          name: 'azure',
+          create: () => baseProvider,
+          variants: [
+            {
+              suffix: 'anthropic',
+              name: 'Azure Anthropic',
+              transform: transformSpy,
+              toolFactories: {
+                webSearch: factorySpy
+              }
+            }
+          ]
+        })
+      )
+
+      const result = await registry.resolveToolCapability('azure-anthropic', 'webSearch')
+      expect(result).toBeDefined()
+      // The factory should receive the variant-transformed provider
+      expect(result!.provider).toBe(variantProvider)
+      expect(transformSpy).toHaveBeenCalled()
+    })
+
+    it('should return base provider for non-variant IDs', async () => {
+      const baseProvider = createMockProviderV3({ provider: 'azure-base' })
+      const factorySpy = vi.fn().mockReturnValue(() => ({ tools: {} }))
+
+      registry.register(
+        new ProviderExtension({
+          name: 'azure',
+          create: () => baseProvider,
+          toolFactories: {
+            webSearch: factorySpy
+          }
+        })
+      )
+
+      const result = await registry.resolveToolCapability('azure', 'webSearch')
+      expect(result).toBeDefined()
+      expect(result!.provider).toBe(baseProvider)
+    })
+  })
+
+  describe('urlContext key mapping regression', () => {
+    it('should map urlContext factory to urlContext key (not webSearch)', () => {
+      // Regression: urlContext factory was previously mapped to { tools: { webSearch: ... } }
+      // instead of { tools: { urlContext: ... } }
+      const mockTool = { type: 'tool' }
+      const mockProvider = {
+        ...createMockProviderV3(),
+        tools: {
+          webFetch_20260209: vi.fn().mockReturnValue(mockTool)
+        }
+      }
+
+      const urlContextFactory =
+        (provider: any) => (config: any) => ({
+          tools: { urlContext: provider.tools.webFetch_20260209(config) }
+        })
+
+      registry.register(
+        new ProviderExtension({
+          name: 'anthropic',
+          create: () => mockProvider as any,
+          toolFactories: {
+            urlContext: urlContextFactory as any
+          }
+        })
+      )
+
+      const factory = registry.getToolFactory('anthropic', 'urlContext')
+      expect(factory).toBeDefined()
+
+      const innerFactory = factory!(mockProvider as any)
+      const result = innerFactory({})
+      expect(result.tools).toHaveProperty('urlContext')
+      expect(result.tools).not.toHaveProperty('webSearch')
+    })
+  })
 })

--- a/packages/aiCore/src/core/providers/__tests__/ExtensionRegistry.test.ts
+++ b/packages/aiCore/src/core/providers/__tests__/ExtensionRegistry.test.ts
@@ -939,7 +939,7 @@ describe('ExtensionRegistry', () => {
             {
               suffix: 'anthropic',
               name: 'Azure Anthropic',
-              transform: (_provider: ProviderV3) => createMockProviderV3(),
+              transform: () => createMockProviderV3(),
               toolFactories: {
                 webSearch: variantFactory
               }
@@ -966,7 +966,7 @@ describe('ExtensionRegistry', () => {
             {
               suffix: 'responses',
               name: 'Azure Responses',
-              transform: (_provider: ProviderV3) => createMockProviderV3()
+              transform: () => createMockProviderV3()
             }
           ]
         })

--- a/packages/aiCore/src/core/providers/__tests__/ExtensionRegistry.test.ts
+++ b/packages/aiCore/src/core/providers/__tests__/ExtensionRegistry.test.ts
@@ -1054,10 +1054,9 @@ describe('ExtensionRegistry', () => {
         }
       }
 
-      const urlContextFactory =
-        (provider: any) => (config: any) => ({
-          tools: { urlContext: provider.tools.webFetch_20260209(config) }
-        })
+      const urlContextFactory = (provider: any) => (config: any) => ({
+        tools: { urlContext: provider.tools.webFetch_20260209(config) }
+      })
 
       registry.register(
         new ProviderExtension({

--- a/packages/aiCore/src/core/providers/core/ExtensionRegistry.ts
+++ b/packages/aiCore/src/core/providers/core/ExtensionRegistry.ts
@@ -442,7 +442,7 @@ export class ExtensionRegistry {
     return undefined
   }
 
-  /** Get base provider for .tools extraction (cached or dummy instance) */
+  /** Get provider for .tools extraction (cached or dummy instance) */
   private async getToolProvider(providerId: string): Promise<ProviderV3 | undefined> {
     const parsed = this.parseProviderId(providerId)
     if (!parsed) return undefined
@@ -450,11 +450,14 @@ export class ExtensionRegistry {
     const extension = this.get(parsed.baseId)
     if (!extension) return undefined
 
-    const cached = extension.getCachedProvider()
-    if (cached) return cached
-
     try {
-      return await extension.createProvider({ apiKey: '_tool_descriptor' })
+      // For variants, create the variant-transformed provider so that
+      // toolFactories receive the correct provider type (e.g. AnthropicProvider
+      // for azure-anthropic instead of AzureOpenAIProvider).
+      return await extension.createProvider(
+        extension.getCachedProvider() ? undefined : { apiKey: '_tool_descriptor' },
+        parsed.isVariant ? parsed.mode : undefined
+      )
     } catch {
       return undefined
     }

--- a/packages/aiCore/src/core/providers/core/ProviderExtension.ts
+++ b/packages/aiCore/src/core/providers/core/ProviderExtension.ts
@@ -43,7 +43,7 @@ interface ProviderExtensionConfigBase<
    * Provider 变体配置
    * 用于注册同一 provider 的不同模式
    */
-  variants?: readonly ProviderVariant<TSettings, TProvider>[]
+  variants?: readonly ProviderVariant<TSettings, TProvider, any>[]
 
   /**
    * Tool factory 映射

--- a/packages/aiCore/src/core/providers/core/initialization.ts
+++ b/packages/aiCore/src/core/providers/core/initialization.ts
@@ -26,7 +26,12 @@ import { createOpenRouter } from '@openrouter/ai-sdk-provider'
 import { customProvider } from 'ai'
 
 import type { OpenRouterSearchConfig } from '../../plugins/built-in/webSearchPlugin'
-import type { ExtensionConfigToIdResolutionMap, ExtractExtensionIds, UnionToIntersection } from '../types'
+import type {
+  ExtensionConfigToIdResolutionMap,
+  ExtractExtensionIds,
+  ProviderVariant,
+  UnionToIntersection
+} from '../types'
 import { extensionRegistry } from './ExtensionRegistry'
 import type { ProviderExtensionConfig } from './ProviderExtension'
 import { ProviderExtension } from './ProviderExtension'
@@ -41,11 +46,11 @@ const AnthropicExtension = ProviderExtension.create({
   toolFactories: {
     webSearch:
       (provider) => (config: NonNullable<Parameters<AnthropicProvider['tools']['webSearch_20250305']>[0]>) => ({
-        tools: { webSearch: provider.tools.webSearch_20250305(config) }
+        tools: { webSearch: provider.tools.webSearch_20260209(config) }
       }),
     urlContext:
       (provider) => (config: NonNullable<Parameters<AnthropicProvider['tools']['webFetch_20260209']>[0]>) => ({
-        tools: { webSearch: provider.tools.webFetch_20260209(config) }
+        tools: { urlContext: provider.tools.webFetch_20260209(config) }
       })
   }
 } as const satisfies ProviderExtensionConfig<AnthropicProviderSettings, AnthropicProvider, 'anthropic'>)
@@ -78,13 +83,14 @@ const AzureExtension = ProviderExtension.create({
     {
       suffix: 'responses',
       name: 'Azure OpenAI Responses',
-      transform: (provider) =>
-        customProvider({
-          fallbackProvider: {
-            ...provider,
-            languageModel: (modelId: string) => provider.responses(modelId)
-          }
-        })
+      transform: (_provider, settings) => createAzure(settings),
+      toolFactories: {
+        webSearch:
+          (provider: AzureOpenAIProvider) =>
+          (config: NonNullable<Parameters<AzureOpenAIProvider['tools']['webSearchPreview']>[0]>) => ({
+            tools: { webSearch: provider.tools.webSearchPreview(config) }
+          })
+      }
     },
     // Azure 上的 Claude 模型走 Anthropic SDK
     // https://platform.claude.com/docs/en/build-with-claude/claude-in-microsoft-foundry
@@ -96,8 +102,18 @@ const AzureExtension = ProviderExtension.create({
           baseURL: (settings?.baseURL ?? '') + '/anthropic/v1',
           apiKey: settings?.apiKey ?? '',
           headers: settings?.headers
-        })
-    }
+        }),
+      toolFactories: {
+        webSearch:
+          (provider) => (config: NonNullable<Parameters<AnthropicProvider['tools']['webSearch_20250305']>[0]>) => ({
+            tools: { webSearch: provider.tools.webSearch_20260209(config) }
+          }),
+        urlContext:
+          (provider) => (config: NonNullable<Parameters<AnthropicProvider['tools']['webFetch_20260209']>[0]>) => ({
+            tools: { urlContext: provider.tools.webFetch_20260209(config) }
+          })
+      }
+    } satisfies ProviderVariant<AzureOpenAIProviderSettings, AzureOpenAIProvider, AnthropicProvider>
   ] as const
 } as const satisfies ProviderExtensionConfig<AzureOpenAIProviderSettings, AzureOpenAIProvider, 'azure'>)
 

--- a/packages/aiCore/src/core/providers/core/initialization.ts
+++ b/packages/aiCore/src/core/providers/core/initialization.ts
@@ -45,7 +45,7 @@ const AnthropicExtension = ProviderExtension.create({
   create: createAnthropic,
   toolFactories: {
     webSearch:
-      (provider) => (config: NonNullable<Parameters<AnthropicProvider['tools']['webSearch_20250305']>[0]>) => ({
+      (provider) => (config: NonNullable<Parameters<AnthropicProvider['tools']['webSearch_20260209']>[0]>) => ({
         tools: { webSearch: provider.tools.webSearch_20260209(config) }
       }),
     urlContext:
@@ -83,6 +83,8 @@ const AzureExtension = ProviderExtension.create({
     {
       suffix: 'responses',
       name: 'Azure OpenAI Responses',
+      // AI SDK defaults to responses API, so createAzure(settings) without
+      // the chat override (used in base `create`) gives us Responses API behavior.
       transform: (_provider, settings) => createAzure(settings),
       toolFactories: {
         webSearch:
@@ -105,7 +107,7 @@ const AzureExtension = ProviderExtension.create({
         }),
       toolFactories: {
         webSearch:
-          (provider) => (config: NonNullable<Parameters<AnthropicProvider['tools']['webSearch_20250305']>[0]>) => ({
+          (provider) => (config: NonNullable<Parameters<AnthropicProvider['tools']['webSearch_20260209']>[0]>) => ({
             tools: { webSearch: provider.tools.webSearch_20260209(config) }
           }),
         urlContext:

--- a/packages/aiCore/src/core/providers/types/index.ts
+++ b/packages/aiCore/src/core/providers/types/index.ts
@@ -73,18 +73,30 @@ export type AiSdkModelReturn<T extends AiSdkModelType> = AiSdkModelReturnMap[T]
 // Provider Extension 类型定义
 // ============================================================================
 
-/** Provider 变体配置 */
-export interface ProviderVariant<TSettings = any, TProvider extends ProviderV3 = ProviderV3> {
+/**
+ * Provider 变体配置
+ *
+ * @typeParam TSettings - Provider 配置类型
+ * @typeParam TProvider - 基础 provider 类型（transform 的输入）
+ * @typeParam TOutput - 变体输出的 provider 类型（transform 的输出），默认与 TProvider 相同
+ *                       当 transform 返回不同类型的 provider 时（如 azure-anthropic），
+ *                       toolFactories 和 resolveModel 将基于 TOutput 类型
+ */
+export interface ProviderVariant<
+  TSettings = any,
+  TProvider extends ProviderV3 = ProviderV3,
+  TOutput extends ProviderV3 = TProvider
+> {
   suffix: string
   name: string
 
   /** 类型安全的模型解析：provider.responses(modelId) / provider.chat(modelId) */
-  resolveModel?: (provider: TProvider, modelId: string) => LanguageModel
+  resolveModel?: (provider: TOutput, modelId: string) => LanguageModel
 
   /** 替换整个 provider（如 azure-anthropic），简单方法切换用 resolveModel */
-  transform?: (baseProvider: TProvider, settings?: TSettings) => ProviderV3
+  transform?: (baseProvider: TProvider, settings?: TSettings) => TOutput
 
-  toolFactories?: ToolFactoryMap<TProvider>
+  toolFactories?: ToolFactoryMap<TOutput>
 }
 
 // ============================================================================

--- a/src/renderer/src/aiCore/provider/extensions/index.ts
+++ b/src/renderer/src/aiCore/provider/extensions/index.ts
@@ -3,6 +3,7 @@
  * 用于支持运行时动态导入的 AI Providers
  */
 
+import type { AmazonBedrockProvider } from '@ai-sdk/amazon-bedrock'
 import { type AmazonBedrockProviderSettings, createAmazonBedrock } from '@ai-sdk/amazon-bedrock'
 import { type CerebrasProviderSettings, createCerebras } from '@ai-sdk/cerebras'
 import { createGateway, type GatewayProviderSettings } from '@ai-sdk/gateway'
@@ -93,8 +94,20 @@ export const BedrockExtension = ProviderExtension.create({
   name: 'bedrock',
   aliases: ['aws-bedrock'] as const,
   supportsImageGeneration: true,
-  create: createAmazonBedrock
-} as const satisfies ProviderExtensionConfig<AmazonBedrockProviderSettings, ProviderV3, 'bedrock'>)
+  create: createAmazonBedrock,
+  toolFactories: {
+    webSearch:
+      (provider: AmazonBedrockProvider) =>
+      (config: NonNullable<Parameters<AmazonBedrockProvider['tools']['webSearch_20260209']>[0]>) => ({
+        tools: { webSearch: provider.tools.webSearch_20260209(config) }
+      }),
+    urlContext:
+      (provider: AmazonBedrockProvider) =>
+      (config: NonNullable<Parameters<AmazonBedrockProvider['tools']['webFetch_20260209']>[0]>) => ({
+        tools: { urlContext: provider.tools.webFetch_20260209(config) }
+      })
+  }
+} as const satisfies ProviderExtensionConfig<AmazonBedrockProviderSettings, AmazonBedrockProvider, 'bedrock'>)
 
 /**
  * Perplexity Extension


### PR DESCRIPTION
### What this PR does

Before this PR:

Using web search with the `azure-anthropic` variant throws `provider.tools.webSearchPreview is not a function` because it falls back to the Azure base extension's `toolFactories`, which calls `webSearchPreview` — a method that doesn't exist on `AnthropicProvider`.

Additionally, the `urlContext` tool factory for Anthropic incorrectly maps `webFetch` to the `webSearch` tool key instead of `urlContext`.

After this PR:

- `azure-anthropic` variant has its own Anthropic-specific `toolFactories` (webSearch + urlContext)
- `ProviderVariant` gains a `TOutput` generic so `transform` output type correctly flows to `toolFactories` and `resolveModel`
- `urlContext` factory correctly maps to `urlContext` tool key (not `webSearch`)
- `BedrockExtension` uses `AmazonBedrockProvider` instead of `ProviderV3` in its `satisfies` type

### Why we need it and why it was done in this way

The root cause is that `ProviderVariant` typed `toolFactories` against `TProvider` (the base provider), but `transform` can return a completely different provider type. Adding `TOutput` generic (defaulting to `TProvider`) lets variants declare their output type, so `toolFactories` gets the correct type without casts.

The following tradeoffs were made:

- `variants` array type uses `ProviderVariant<TSettings, TProvider, any>` to allow heterogeneous output types per variant

The following alternatives were considered:

- Using `unknown` + `as` casts in each toolFactory — rejected for being less type-safe

### Breaking changes

None. The `TOutput` generic defaults to `TProvider`, so existing code is unaffected.

### Special notes for your reviewer

The `urlContext` → `webSearch` key bug exists in the original `AnthropicExtension` too (not just the variant), both are fixed in this PR.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
fix: Azure Anthropic web search no longer crashes with "webSearchPreview is not a function"
```