### PR TITLE
fix(tabs): resolve detach moving main window and restore opacity on drag end

### DIFF
--- a/src/main/services/DetachedWindowManager.ts
+++ b/src/main/services/DetachedWindowManager.ts
@@ -31,8 +31,8 @@ export class DetachedWindowManager {
       }
     })
 
-    ipcMain.on(IpcChannel.Tab_MoveWindow, (event, payload: { tabId: string; x: number; y: number }) => {
-      const win = BrowserWindow.fromWebContents(event.sender) ?? this.windows.get(payload.tabId)
+    ipcMain.on(IpcChannel.Tab_MoveWindow, (_, payload: { tabId: string; x: number; y: number }) => {
+      const win = this.windows.get(payload.tabId)
       if (win && !win.isDestroyed()) {
         win.setPosition(Math.round(payload.x), Math.round(payload.y))
         if (!win.isVisible()) {
@@ -80,8 +80,14 @@ export class DetachedWindowManager {
       }
     )
 
-    ipcMain.on(IpcChannel.Tab_DragEnd, () => {
-      logger.info('Tab drag end')
+    ipcMain.on(IpcChannel.Tab_DragEnd, (_, payload?: { tabId?: string }) => {
+      if (payload?.tabId) {
+        const win = this.windows.get(payload.tabId)
+        if (win && !win.isDestroyed()) {
+          win.setOpacity(1)
+        }
+      }
+      logger.info('Tab drag end', payload)
     })
   }
 

--- a/src/renderer/src/components/layout/AppShellTabBar.tsx
+++ b/src/renderer/src/components/layout/AppShellTabBar.tsx
@@ -525,7 +525,7 @@ export const AppShellTabBar = ({
         if (!dragRef.current.tabClosed && dragRef.current.tabType === 'normal') {
           closeTab(dragState.tabId)
         }
-        window.electron.ipcRenderer.send(IpcChannel.Tab_DragEnd)
+        window.electron.ipcRenderer.send(IpcChannel.Tab_DragEnd, { tabId: dragState.tabId })
       }
 
       if (rafId.current !== null) {


### PR DESCRIPTION
## Summary
- Fix `Tab_MoveWindow` IPC handler using `BrowserWindow.fromWebContents(event.sender)` which returned the **main window** instead of the detached window, causing the main window to be repositioned and set to 0.5 opacity during tab detach drag
- Fix by looking up the detached window via `this.windows.get(payload.tabId)`
- Pass `tabId` in `Tab_DragEnd` so the main process can restore the detached window opacity to 1 after drag completes

## Test plan
- [ ] Drag a tab out of the tab bar to detach — a new window should appear, main window should NOT move
- [ ] Release the mouse — the detached window opacity should restore to 1.0 (not stay semi-transparent)
- [ ] Verify normal tab reorder drag still works correctly