### PR TITLE
perf: move AgentBootstrapService to Phase.Background and parallelize init

### DIFF
--- a/src/main/services/AgentBootstrapService.ts
+++ b/src/main/services/AgentBootstrapService.ts
@@ -17,10 +17,12 @@ const logger = loggerService.withContext('AgentBootstrapService')
 @Injectable('AgentBootstrapService')
 @ServicePhase(Phase.Background)
 export class AgentBootstrapService extends BaseService {
-  protected async onReady(): Promise<void> {
+  protected onInit(): void {
     registerSessionStreamIpc()
     logger.info('Session stream IPC registered')
+  }
 
+  protected async onReady(): Promise<void> {
     await Promise.all([
       bootstrapBuiltinAgents().then(() => logger.info('Built-in agents bootstrapped')),
       schedulerService.restoreSchedulers().then(() => logger.info('Schedulers restored')),

--- a/src/main/services/AgentBootstrapService.ts
+++ b/src/main/services/AgentBootstrapService.ts
@@ -1,4 +1,4 @@
-import { BaseService, DependsOn, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
+import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
 
 import { bootstrapBuiltinAgents } from './agents/services/builtin/BuiltinAgentBootstrap'
 import { channelManager } from './agents/services/channels'
@@ -11,26 +11,21 @@ const logger = loggerService.withContext('AgentBootstrapService')
 /**
  * Lifecycle-managed service that orchestrates agent subsystem initialization.
  *
- * Wraps the non-lifecycle agent singletons (schedulerService, channelManager,
- * bootstrapBuiltinAgents) so their startup/shutdown is managed by the
- * application lifecycle instead of manual calls in index.ts.
+ * Uses Phase.Background — fire-and-forget, never blocks other phases.
+ * All operations are idempotent and non-critical for UI startup.
  */
 @Injectable('AgentBootstrapService')
-@ServicePhase(Phase.WhenReady)
-@DependsOn(['ApiServerService'])
+@ServicePhase(Phase.Background)
 export class AgentBootstrapService extends BaseService {
   protected async onReady(): Promise<void> {
-    await bootstrapBuiltinAgents()
-    logger.info('Built-in agents bootstrapped')
-
-    await schedulerService.restoreSchedulers()
-    logger.info('Schedulers restored')
-
     registerSessionStreamIpc()
     logger.info('Session stream IPC registered')
 
-    await channelManager.start()
-    logger.info('Channel manager started')
+    await Promise.all([
+      bootstrapBuiltinAgents().then(() => logger.info('Built-in agents bootstrapped')),
+      schedulerService.restoreSchedulers().then(() => logger.info('Schedulers restored')),
+      channelManager.start().then(() => logger.info('Channel manager started'))
+    ])
   }
 
   protected async onDestroy(): Promise<void> {

--- a/src/main/services/agents/services/channels/ChannelManager.ts
+++ b/src/main/services/agents/services/channels/ChannelManager.ts
@@ -41,9 +41,7 @@ class ChannelManager {
       const channels = await channelService.listChannels()
       const activeChannels = channels.filter((ch) => ch.isActive && ch.agentId)
 
-      for (const channel of activeChannels) {
-        await this.connectChannelFromRow(channel)
-      }
+      await Promise.all(activeChannels.map((channel) => this.connectChannelFromRow(channel)))
 
       logger.info('Channel manager started', { adapterCount: this.adapters.size })
     } catch (error) {


### PR DESCRIPTION
### What this PR does

Before this PR:
`AgentBootstrapService` ran in `Phase.WhenReady` with a sequential initialization chain (~4.4s), blocking other WhenReady services and delaying UI startup.

After this PR:
- Moved to `Phase.Background` (fire-and-forget, never blocks other phases)
- Removed unnecessary `@DependsOn(['ApiServerService'])` — none of the bootstrap operations use ApiServerService
- Parallelized `bootstrapBuiltinAgents`, `restoreSchedulers`, and `channelManager.start` via `Promise.all`
- Parallelized channel adapter connections in `ChannelManager.start()` (was sequential `for...await`)

<img width="347" height="663" alt="image" src="https://github.com/user-attachments/assets/bcac84a8-2acb-4856-8d84-89a171150e24" />


### Why we need it and why it was done in this way

The following tradeoffs were made:
- All three bootstrap operations are idempotent, self-contained, and non-critical for UI rendering, so `Phase.Background` is the correct lifecycle phase per the [Phase Selection Guide](docs/en/references/lifecycle/lifecycle-overview.md).

The following alternatives were considered:
- Keeping `Phase.WhenReady` with manual fire-and-forget (`this.initDone = Promise.all(...)` without `await`) — rejected because it reimplements what `Phase.Background` already provides natively.
- Parallelizing `initCherryClaw` and `initCherryAssistant` inside `bootstrapBuiltinAgents` — not done due to documented SQLITE_BUSY risk from concurrent writes.

### Breaking changes

None. All changes are internal to the main process startup sequence.

### Special notes for your reviewer

- `registerSessionStreamIpc()` is synchronous (just registers `ipcMain.handle` calls) — no `await` needed.
- `ipcMain` registration works in `Phase.Background` since it doesn't require Electron's app to be ready.
- Channel adapters already handle their own errors in `connectChannelFromRow`, so `Promise.all` won't short-circuit on a single adapter failure.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
