### PR TITLE
fix(ci): restore missing Linux build dependencies in nightly workflow

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Build Linux
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get install -y rpm
+          sudo apt-get install -y rpm libevdev-dev libxtst-dev libx11-dev libxfixes-dev libwayland-dev
           pnpm build:linux
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What this PR does

Before this PR:
The nightly build for `ubuntu-latest` fails because the Linux build step is missing required native dependencies (`libevdev-dev`, `libxtst-dev`, `libx11-dev`, `libxfixes-dev`, `libwayland-dev`). The `selection-hook` native module fails to compile with `fatal error: X11/XKBlib.h: No such file or directory`.

After this PR:
Restores the missing `apt-get install` packages so the Linux nightly build compiles successfully.

### Why we need it and why it was done in this way

The dependencies were accidentally removed from the nightly build workflow. This restores them to match the release workflow.

### Breaking changes

None.

### Special notes for your reviewer

CI-only change. No application code is modified.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
