### PR TITLE
hotfix(think): MiMo thinking toggle

### DIFF
--- a/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
+++ b/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
@@ -78,6 +78,7 @@ vi.mock('@renderer/config/models', async (importOriginal) => {
     isSupportedThinkingTokenGeminiModel: vi.fn(() => false),
     isSupportedThinkingTokenDoubaoModel: vi.fn(() => false),
     isSupportedThinkingTokenZhipuModel: vi.fn(() => false),
+    isSupportedThinkingTokenMiMoModel: vi.fn(() => false),
     isSupportedReasoningEffortModel: vi.fn(() => false),
     isDeepSeekHybridInferenceModel: vi.fn(() => false),
     isSupportedReasoningEffortGrokModel: vi.fn(() => false),
@@ -344,6 +345,62 @@ describe('reasoning utils', () => {
       const result = getReasoningEffort(assistant, model)
       expect(result).toEqual({
         reasoningEffort: 'none'
+      })
+    })
+
+    it('should disable thinking for MiMo models when reasoning effort is none', async () => {
+      const { isReasoningModel, isSupportedThinkingTokenMiMoModel } = await import('@renderer/config/models')
+
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+      vi.mocked(isSupportedThinkingTokenMiMoModel).mockReturnValue(true)
+
+      const model: Model = {
+        id: 'mimo-v2-pro',
+        name: 'MiMo V2 Pro',
+        provider: SystemProviderIds.mimo
+      } as Model
+
+      const assistant: Assistant = {
+        id: 'test',
+        name: 'Test',
+        settings: {
+          reasoning_effort: 'none'
+        }
+      } as Assistant
+
+      const result = getReasoningEffort(assistant, model)
+      expect(result).toEqual({
+        thinking: {
+          type: 'disabled'
+        }
+      })
+    })
+
+    it('should enable thinking for MiMo models when reasoning effort is auto', async () => {
+      const { isReasoningModel, isSupportedThinkingTokenMiMoModel } = await import('@renderer/config/models')
+
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+      vi.mocked(isSupportedThinkingTokenMiMoModel).mockReturnValue(true)
+
+      const model: Model = {
+        id: 'mimo-v2-pro',
+        name: 'MiMo V2 Pro',
+        provider: SystemProviderIds.mimo
+      } as Model
+
+      const assistant: Assistant = {
+        id: 'test',
+        name: 'Test',
+        settings: {
+          reasoning_effort: 'auto'
+        }
+      } as Assistant
+
+      const result = getReasoningEffort(assistant, model)
+      expect(result).toEqual({
+        thinking: {
+          type: 'enabled'
+        }
       })
     })
 

--- a/src/renderer/src/aiCore/utils/reasoning.ts
+++ b/src/renderer/src/aiCore/utils/reasoning.ts
@@ -174,6 +174,7 @@ export function getReasoningEffort(assistant: Assistant, model: Model): Reasonin
     if (
       isSupportedThinkingTokenDoubaoModel(model) ||
       isSupportedThinkingTokenZhipuModel(model) ||
+      isSupportedThinkingTokenMiMoModel(model) ||
       isSupportedThinkingTokenKimiModel(model)
     ) {
       if (provider.id === SystemProviderIds.cerebras) {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR:
- Xiaomi MiMo `mimo-v2-pro` did not reliably respect the thinking/non-thinking toggle in Cherry Studio.
- Disabling thinking could still leave the model sending thinking content.

After this PR:
- MiMo models now explicitly send `thinking: { type: 'disabled' }` when reasoning effort is set to `none`.
- The toggle behavior is aligned with Xiaomi MiMo OpenAI API docs and works as expected for `mimo-v2-pro`.

Fix #14028

### Why we need it and why it was done in this way

This is a user-visible bug fix for the Xiaomi MiMo provider. The smallest safe change was to extend the existing reasoning parameter mapping so MiMo participates in the same disable-thinking path as other thinking-token models.

The following tradeoffs were made:
- Keep the change minimal and localized to the reasoning parameter builder.
- Avoid refactoring provider architecture during the `main` branch code freeze.
- Prefer explicit API parameters over special-case UI behavior.

The following alternatives were considered:
- Adding a provider-specific workaround elsewhere in the request pipeline.
- Introducing a dedicated MiMo-only branch in provider options.  
  Rejected because the existing reasoning layer already handles the toggle semantics cleanly.

Links to places where the discussion took place:
- https://github.com/CherryHQ/cherry-studio/issues/14028
- Xiaomi MiMo OpenAI API docs: https://platform.xiaomimimo.com/#/docs/api/chat/openai-api

### Breaking changes

None.

### Special notes for your reviewer

This is a minimal hotfix for `main` branch freeze policy. The change only affects MiMo reasoning toggle behavior and includes a regression test.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix Xiaomi MiMo thinking/non-thinking toggle behavior for mimo-v2-pro by explicitly disabling thinking when reasoning effort is set to none.
