### PR TITLE
fix(gemini): strip data URI prefix from PDF base64 data

### DIFF
--- a/src/renderer/src/aiCore/prepareParams/fileProcessor.ts
+++ b/src/renderer/src/aiCore/prepareParams/fileProcessor.ts
@@ -232,9 +232,17 @@ export async function convertFileBlockToFilePart(fileBlock: FileMessageBlock, mo
 
       const base64Data = await window.api.file.base64File(file.id + file.ext)
 
+      let fileData = base64Data.data
+      if (fileData.startsWith('data:')) {
+        const base64Match = fileData.match(/^data:[^;]+;base64,(.+)$/)
+        if (base64Match) {
+          fileData = base64Match[1]
+        }
+      }
+
       return {
         type: 'file',
-        data: base64Data.data,
+        data: fileData,
         mediaType: base64Data.mime,
         filename: file.origin_name
       }


### PR DESCRIPTION
### What this PR does

Before this PR:
Uploading a PDF file and sending it to Gemini-3.1-pro-preview (or other Gemini models via certain proxies) failed with a "Base64 decoding failed" error because the payload incorrectly included the `data:application/pdf;base64,` prefix.

After this PR:
The application correctly strips the Data URI prefix from the base64 data for PDF files, ensuring only the raw base64 string is sent to the API.

Fixes #14097

### Why we need it and why it was done in this way

Certain API proxies or specific model versions are stricter about the `inline_data.data` format and do not handle the Data URI prefix. Stripping it ensures compatibility across different providers while remaining compliant with the expected standard of raw base64 for these fields.

The following tradeoffs were made:
- Added a simple regex check to strip the prefix if present. This adds a negligible overhead but significantly improves compatibility.

The following alternatives were considered:
- Modifying the backend to handle the prefix, but since this is a frontend-to-SDK interaction, fixing it at the source of parameter preparation is more direct and robust.

### Breaking changes

None.

### Special notes for your reviewer

I've verified that `base64File` returns raw base64 in `FileStorage.ts`, but added this defensive check in `fileProcessor.ts` to ensure that any data passed to the AI SDK is clean.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via `/gh-pr-review`, `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed an issue where PDF file uploads to Gemini models failed due to incorrect Base64 encoding format.
```
