### PR TITLE
hotfix(channels): toggle single channel no longer reconnects all channels

### DIFF
--- a/src/main/apiServer/routes/agents/handlers/agents.ts
+++ b/src/main/apiServer/routes/agents/handlers/agents.ts
@@ -18,7 +18,6 @@ function syncSchedulerIfNeeded(agentId: string, agent: { configuration?: unknown
   if (!config.heartbeat_enabled && !config.scheduler_enabled) return
 
   void schedulerService.syncScheduler()
-  void channelManager.syncAgent(agentId)
   schedulerService.ensureHeartbeatTask(agentId, config.heartbeat_interval ?? 30).catch((err) => {
     logger.warn('Failed to sync heartbeat task', {
       agentId,
@@ -598,8 +597,8 @@ export const deleteAgent = async (req: Request, res: Response): Promise<Response
       })
     }
 
-    // Sync channels after deletion so syncAgent finds no agent and disconnects adapters
-    void channelManager.syncAgent(agentId)
+    // Disconnect all channel adapters for the deleted agent
+    void channelManager.disconnectAgent(agentId)
 
     logger.info('Agent deleted', { agentId })
     return res.status(204).send()

--- a/src/main/apiServer/routes/channels/handlers.ts
+++ b/src/main/apiServer/routes/channels/handlers.ts
@@ -18,9 +18,7 @@ export const createChannel = async (req: Request, res: Response): Promise<Respon
       permissionMode: permission_mode
     })
 
-    if (channel.agentId) {
-      await channelManager.syncAgent(channel.agentId)
-    }
+    await channelManager.syncChannel(channel.id)
 
     logger.info('Channel created', { channelId: channel.id, type })
     return res.status(201).json(channel)
@@ -123,12 +121,9 @@ export const deleteChannel = async (req: Request, res: Response): Promise<Respon
       })
     }
 
-    const agentId = channel.agentId
     await channelService.deleteChannel(channelId)
 
-    if (agentId) {
-      await channelManager.syncAgent(agentId)
-    }
+    await channelManager.syncChannel(channelId)
 
     logger.info('Channel deleted', { channelId })
     return res.status(204).send()

--- a/src/main/apiServer/routes/channels/handlers.ts
+++ b/src/main/apiServer/routes/channels/handlers.ts
@@ -95,9 +95,7 @@ export const updateChannel = async (req: Request, res: Response): Promise<Respon
       })
     }
 
-    if (channel.agentId) {
-      await channelManager.syncAgent(channel.agentId)
-    }
+    await channelManager.syncChannel(channelId)
 
     logger.info('Channel updated', { channelId })
     return res.json(channel)

--- a/src/main/apiServer/routes/channels/handlers.ts
+++ b/src/main/apiServer/routes/channels/handlers.ts
@@ -123,7 +123,7 @@ export const deleteChannel = async (req: Request, res: Response): Promise<Respon
 
     await channelService.deleteChannel(channelId)
 
-    await channelManager.syncChannel(channelId)
+    await channelManager.disconnectChannel(channelId)
 
     logger.info('Channel deleted', { channelId })
     return res.status(204).send()

--- a/src/main/mcpServers/__tests__/claw.test.ts
+++ b/src/main/mcpServers/__tests__/claw.test.ts
@@ -13,6 +13,7 @@ const mockNetFetch = vi.fn()
 const mockGetAgent = vi.fn()
 const mockUpdateAgent = vi.fn()
 const mockSyncChannel = vi.fn()
+const mockDisconnectChannel = vi.fn()
 const mockWaitForQrUrl = vi.fn()
 const mockQRCodeToDataURL = vi.fn()
 const mockMkdir = vi.fn()
@@ -59,6 +60,7 @@ vi.mock('@main/services/agents/services/channels/ChannelManager', () => ({
     getAgentAdapters: mockGetNotifyAdapters,
     getAdapterStatuses: vi.fn().mockReturnValue([]),
     syncChannel: mockSyncChannel,
+    disconnectChannel: mockDisconnectChannel,
     waitForQrUrl: mockWaitForQrUrl
   }
 }))
@@ -638,6 +640,7 @@ describe('ClawServer', () => {
 
     beforeEach(() => {
       mockSyncChannel.mockResolvedValue(undefined)
+      mockDisconnectChannel.mockResolvedValue(undefined)
       mockListChannels.mockResolvedValue([])
       mockGetChannel.mockResolvedValue(null)
       mockDeleteChannel.mockResolvedValue(undefined)
@@ -782,8 +785,9 @@ describe('ClawServer', () => {
         expect(result.content[0].text).toContain('not saved')
         // Should have deleted the orphan channel
         expect(mockDeleteChannel).toHaveBeenCalledWith('ch_wc2')
-        // Should have synced twice: once for add (fire-and-forget), once for orphan cleanup
-        expect(mockSyncChannel).toHaveBeenCalledTimes(2)
+        // syncChannel for the initial add (fire-and-forget), disconnectChannel for orphan cleanup
+        expect(mockSyncChannel).toHaveBeenCalledTimes(1)
+        expect(mockDisconnectChannel).toHaveBeenCalledWith('ch_wc2')
       })
 
       it('should error when required config field is missing', async () => {
@@ -844,7 +848,7 @@ describe('ClawServer', () => {
         expect(result.content[0].text).toContain('removed')
         expect(result.content[0].text).toContain('My Telegram')
         expect(mockDeleteChannel).toHaveBeenCalledWith('ch_1')
-        expect(mockSyncChannel).toHaveBeenCalledWith('ch_1')
+        expect(mockDisconnectChannel).toHaveBeenCalledWith('ch_1')
       })
 
       it('should error when channel_id is missing', async () => {

--- a/src/main/mcpServers/__tests__/claw.test.ts
+++ b/src/main/mcpServers/__tests__/claw.test.ts
@@ -12,7 +12,7 @@ const mockSkillList = vi.fn()
 const mockNetFetch = vi.fn()
 const mockGetAgent = vi.fn()
 const mockUpdateAgent = vi.fn()
-const mockSyncAgent = vi.fn()
+const mockSyncChannel = vi.fn()
 const mockWaitForQrUrl = vi.fn()
 const mockQRCodeToDataURL = vi.fn()
 const mockMkdir = vi.fn()
@@ -58,7 +58,7 @@ vi.mock('@main/services/agents/services/channels/ChannelManager', () => ({
     getNotifyAdapters: mockGetNotifyAdapters,
     getAgentAdapters: mockGetNotifyAdapters,
     getAdapterStatuses: vi.fn().mockReturnValue([]),
-    syncAgent: mockSyncAgent,
+    syncChannel: mockSyncChannel,
     waitForQrUrl: mockWaitForQrUrl
   }
 }))
@@ -637,7 +637,7 @@ describe('ClawServer', () => {
     }
 
     beforeEach(() => {
-      mockSyncAgent.mockResolvedValue(undefined)
+      mockSyncChannel.mockResolvedValue(undefined)
       mockListChannels.mockResolvedValue([])
       mockGetChannel.mockResolvedValue(null)
       mockDeleteChannel.mockResolvedValue(undefined)
@@ -716,7 +716,7 @@ describe('ClawServer', () => {
             isActive: true
           })
         )
-        expect(mockSyncAgent).toHaveBeenCalledWith('agent_1')
+        expect(mockSyncChannel).toHaveBeenCalledWith('ch_new')
       })
 
       it('should error when type is missing', async () => {
@@ -761,7 +761,7 @@ describe('ClawServer', () => {
         expect(result.content[1].type).toBe('image')
         expect(result.content[1].data).toBe('iVBORw0KGgo=')
         expect(result.content[1].mimeType).toBe('image/png')
-        expect(mockSyncAgent).toHaveBeenCalledWith('agent_1')
+        expect(mockSyncChannel).toHaveBeenCalledWith('ch_wc1')
         expect(mockWaitForQrUrl).toHaveBeenCalledWith('agent_1', 'ch_wc1', 30_000)
       })
 
@@ -783,7 +783,7 @@ describe('ClawServer', () => {
         // Should have deleted the orphan channel
         expect(mockDeleteChannel).toHaveBeenCalledWith('ch_wc2')
         // Should have synced twice: once for add (fire-and-forget), once for orphan cleanup
-        expect(mockSyncAgent).toHaveBeenCalledTimes(2)
+        expect(mockSyncChannel).toHaveBeenCalledTimes(2)
       })
 
       it('should error when required config field is missing', async () => {
@@ -812,7 +812,7 @@ describe('ClawServer', () => {
 
         expect(result.content[0].text).toContain('updated and reloaded')
         expect(mockUpdateChannel).toHaveBeenCalledWith('ch_1', expect.objectContaining({ isActive: false }))
-        expect(mockSyncAgent).toHaveBeenCalledWith('agent_1')
+        expect(mockSyncChannel).toHaveBeenCalledWith('ch_1')
       })
 
       it('should error when channel_id is missing', async () => {
@@ -844,7 +844,7 @@ describe('ClawServer', () => {
         expect(result.content[0].text).toContain('removed')
         expect(result.content[0].text).toContain('My Telegram')
         expect(mockDeleteChannel).toHaveBeenCalledWith('ch_1')
-        expect(mockSyncAgent).toHaveBeenCalledWith('agent_1')
+        expect(mockSyncChannel).toHaveBeenCalledWith('ch_1')
       })
 
       it('should error when channel_id is missing', async () => {

--- a/src/main/mcpServers/claw.ts
+++ b/src/main/mcpServers/claw.ts
@@ -870,8 +870,8 @@ class ClawServer {
 
     if (needsQr) {
       const qrPromise = channelManager.waitForQrUrl(this.agentId, newChannel.id, 30_000)
-      // Fire-and-forget: syncAgent will complete once the user scans
-      channelManager.syncAgent(this.agentId).catch((err) => {
+      // Fire-and-forget: syncChannel will complete once the user scans
+      channelManager.syncChannel(newChannel.id).catch((err) => {
         logger.error(`${type} sync failed`, {
           agentId: this.agentId,
           channelId: newChannel.id,
@@ -909,7 +909,7 @@ class ClawServer {
           ]
         }
       } catch (err) {
-        // QR timed out — remove the orphan channel so it doesn't block future syncAgent calls
+        // QR timed out — remove the orphan channel so it doesn't block future connections
         await this.removeOrphanChannel(newChannel.id)
 
         logger.warn(`Failed to get ${channelLabel} QR code, orphan channel removed`, {
@@ -929,7 +929,7 @@ class ClawServer {
       }
     }
 
-    await channelManager.syncAgent(this.agentId)
+    await channelManager.syncChannel(newChannel.id)
 
     logger.info('Channel added via config tool', { agentId: this.agentId, channelId: newChannel.id, type })
     return {
@@ -957,7 +957,7 @@ class ClawServer {
     }
 
     await channelService.updateChannel(channelId, updates)
-    await channelManager.syncAgent(this.agentId)
+    await channelManager.syncChannel(channelId)
 
     logger.info('Channel updated via config tool', { agentId: this.agentId, channelId })
     return {
@@ -973,7 +973,7 @@ class ClawServer {
     if (!channel) throw new McpError(ErrorCode.InvalidParams, `Channel "${channelId}" not found`)
 
     await channelService.deleteChannel(channelId)
-    await channelManager.syncAgent(this.agentId)
+    await channelManager.syncChannel(channelId)
 
     logger.info('Channel removed via config tool', { agentId: this.agentId, channelId, type: channel.type })
     return {
@@ -992,8 +992,7 @@ class ClawServer {
       channel.type === 'wechat' || (channel.type === 'feishu' && !(channel.config as Record<string, unknown>).app_id)
 
     if (!needsQr) {
-      // For non-QR channels, just re-sync
-      await channelManager.syncAgent(this.agentId)
+      await channelManager.syncChannel(channelId)
       return {
         content: [{ type: 'text' as const, text: `Channel "${channelId}" reconnected.` }]
       }
@@ -1001,7 +1000,7 @@ class ClawServer {
 
     // QR-based reconnect: sync in background, wait for QR URL
     const qrPromise = channelManager.waitForQrUrl(this.agentId, channelId, 30_000)
-    channelManager.syncAgent(this.agentId).catch((err) => {
+    channelManager.syncChannel(channelId).catch((err) => {
       logger.error('Reconnect sync failed', {
         agentId: this.agentId,
         channelId,
@@ -1091,12 +1090,12 @@ class ClawServer {
 
   /**
    * Remove a channel from config that failed to connect (e.g. QR timeout).
-   * Prevents orphaned channels from blocking future syncAgent calls.
+   * Prevents orphaned channels from blocking future connections.
    */
   private async removeOrphanChannel(channelId: string): Promise<void> {
     try {
       await channelService.deleteChannel(channelId)
-      await channelManager.syncAgent(this.agentId)
+      await channelManager.syncChannel(channelId)
     } catch (err) {
       logger.error('Failed to remove orphan channel', {
         agentId: this.agentId,

--- a/src/main/mcpServers/claw.ts
+++ b/src/main/mcpServers/claw.ts
@@ -973,7 +973,7 @@ class ClawServer {
     if (!channel) throw new McpError(ErrorCode.InvalidParams, `Channel "${channelId}" not found`)
 
     await channelService.deleteChannel(channelId)
-    await channelManager.syncChannel(channelId)
+    await channelManager.disconnectChannel(channelId)
 
     logger.info('Channel removed via config tool', { agentId: this.agentId, channelId, type: channel.type })
     return {
@@ -1095,7 +1095,7 @@ class ClawServer {
   private async removeOrphanChannel(channelId: string): Promise<void> {
     try {
       await channelService.deleteChannel(channelId)
-      await channelManager.syncChannel(channelId)
+      await channelManager.disconnectChannel(channelId)
     } catch (err) {
       logger.error('Failed to remove orphan channel', {
         agentId: this.agentId,

--- a/src/main/services/agents/services/channels/ChannelManager.ts
+++ b/src/main/services/agents/services/channels/ChannelManager.ts
@@ -141,7 +141,7 @@ class ChannelManager {
 
   /**
    * Sync a single channel: disconnect its adapter (if any) and reconnect if active.
-   * Use this instead of syncAgent() when only one channel changed.
+   * Use this instead of disconnectAgent() when only one channel changed.
    */
   async syncChannel(channelId: string): Promise<void> {
     // Disconnect existing adapter for this channel
@@ -165,15 +165,18 @@ class ChannelManager {
     }
   }
 
-  async syncAgent(agentId: string): Promise<void> {
-    // Disconnect existing adapters for this agent in parallel
+  /**
+   * Disconnect all adapters for an agent without reconnecting.
+   * Use when the agent is deleted or its channels should all be torn down.
+   */
+  async disconnectAgent(agentId: string): Promise<void> {
     const toDisconnect = [...this.adapters.entries()].filter(([, a]) => a.agentId === agentId)
     await Promise.all(
       toDisconnect.map(([key, adapter]) =>
         adapter
           .disconnect()
           .catch((err) => {
-            logger.warn('Error disconnecting adapter during sync', {
+            logger.warn('Error disconnecting adapter', {
               key,
               error: err instanceof Error ? err.message : String(err)
             })
@@ -185,14 +188,6 @@ class ChannelManager {
     )
 
     channelMessageHandler.clearSessionTracker(agentId)
-
-    // Re-create from current DB rows
-    const channels = await channelService.listChannels({ agentId })
-    const activeChannels = channels.filter((ch) => ch.isActive)
-
-    for (const channel of activeChannels) {
-      await this.connectChannelFromRow(channel)
-    }
   }
 
   /**
@@ -213,7 +208,7 @@ class ChannelManager {
     })
 
     logger.info('Saved QR registration credentials, reconnecting', { agentId, channelId })
-    await this.syncAgent(agentId)
+    await this.syncChannel(channelId)
   }
 
   private async connectChannelFromRow(row: ChannelRow): Promise<void> {

--- a/src/main/services/agents/services/channels/ChannelManager.ts
+++ b/src/main/services/agents/services/channels/ChannelManager.ts
@@ -139,24 +139,27 @@ class ChannelManager {
     }
   }
 
-  /**
-   * Sync a single channel: disconnect its adapter (if any) and reconnect if active.
-   * Use this instead of disconnectAgent() when only one channel changed.
-   */
-  async syncChannel(channelId: string): Promise<void> {
-    // Disconnect existing adapter for this channel
+  /** Disconnect the adapter for a single channel without reconnecting. */
+  async disconnectChannel(channelId: string): Promise<void> {
     for (const [key, adapter] of this.adapters) {
       if (adapter.channelId === channelId) {
         await adapter.disconnect().catch((err) => {
-          logger.warn('Error disconnecting adapter during channel sync', {
+          logger.warn('Error disconnecting adapter', {
             key,
             error: err instanceof Error ? err.message : String(err)
           })
         })
         this.adapters.delete(key)
-        break
       }
     }
+  }
+
+  /**
+   * Sync a single channel: disconnect its adapter (if any) and reconnect if active.
+   * Use this instead of disconnectAgent() when only one channel changed.
+   */
+  async syncChannel(channelId: string): Promise<void> {
+    await this.disconnectChannel(channelId)
 
     // Re-read from DB and reconnect if active
     const channel = await channelService.getChannel(channelId)

--- a/src/main/services/agents/services/channels/ChannelManager.ts
+++ b/src/main/services/agents/services/channels/ChannelManager.ts
@@ -139,6 +139,32 @@ class ChannelManager {
     }
   }
 
+  /**
+   * Sync a single channel: disconnect its adapter (if any) and reconnect if active.
+   * Use this instead of syncAgent() when only one channel changed.
+   */
+  async syncChannel(channelId: string): Promise<void> {
+    // Disconnect existing adapter for this channel
+    for (const [key, adapter] of this.adapters) {
+      if (adapter.channelId === channelId) {
+        await adapter.disconnect().catch((err) => {
+          logger.warn('Error disconnecting adapter during channel sync', {
+            key,
+            error: err instanceof Error ? err.message : String(err)
+          })
+        })
+        this.adapters.delete(key)
+        break
+      }
+    }
+
+    // Re-read from DB and reconnect if active
+    const channel = await channelService.getChannel(channelId)
+    if (channel && channel.isActive && channel.agentId) {
+      await this.connectChannelFromRow(channel)
+    }
+  }
+
   async syncAgent(agentId: string): Promise<void> {
     // Disconnect existing adapters for this agent in parallel
     const toDisconnect = [...this.adapters.entries()].filter(([, a]) => a.agentId === agentId)

--- a/src/main/services/agents/services/channels/__tests__/ChannelManager.test.ts
+++ b/src/main/services/agents/services/channels/__tests__/ChannelManager.test.ts
@@ -148,6 +148,50 @@ describe('ChannelManager', () => {
     expect(createdAdapters).toHaveLength(1) // no new adapter
   })
 
+  it('syncChannel only disconnects the target channel, leaving others untouched', async () => {
+    vi.mocked(channelService.listChannels).mockResolvedValueOnce([
+      makeChannelRow({ id: 'ch-1', config: { bot_token: 'tok1' } }),
+      makeChannelRow({ id: 'ch-2', config: { bot_token: 'tok2' } })
+    ])
+
+    await channelManager.start()
+    expect(createdAdapters).toHaveLength(2)
+
+    // Toggle ch-1 inactive — syncChannel should only disconnect ch-1
+    vi.mocked(channelService.getChannel).mockResolvedValueOnce(makeChannelRow({ id: 'ch-1', isActive: false }))
+
+    await channelManager.syncChannel('ch-1')
+
+    // ch-1 disconnected, ch-2 untouched
+    expect(createdAdapters[0].disconnect).toHaveBeenCalledTimes(1)
+    expect(createdAdapters[1].disconnect).not.toHaveBeenCalled()
+    // No new adapter created since ch-1 is inactive
+    expect(createdAdapters).toHaveLength(2)
+  })
+
+  it('syncChannel reconnects the channel when toggled active', async () => {
+    vi.mocked(channelService.listChannels).mockResolvedValueOnce([
+      makeChannelRow({ id: 'ch-1', config: { bot_token: 'tok1' } }),
+      makeChannelRow({ id: 'ch-2', config: { bot_token: 'tok2' } })
+    ])
+
+    await channelManager.start()
+    expect(createdAdapters).toHaveLength(2)
+
+    // Toggle ch-1 with updated config — syncChannel reconnects only ch-1
+    vi.mocked(channelService.getChannel).mockResolvedValueOnce(
+      makeChannelRow({ id: 'ch-1', isActive: true, config: { bot_token: 'new-tok' } })
+    )
+
+    await channelManager.syncChannel('ch-1')
+
+    expect(createdAdapters[0].disconnect).toHaveBeenCalledTimes(1)
+    expect(createdAdapters[1].disconnect).not.toHaveBeenCalled()
+    // New adapter created for ch-1
+    expect(createdAdapters).toHaveLength(3)
+    expect(createdAdapters[2].connect).toHaveBeenCalledTimes(1)
+  })
+
   it('inactive channels are skipped', async () => {
     vi.mocked(channelService.listChannels).mockResolvedValueOnce([makeChannelRow({ isActive: false })])
 

--- a/src/main/services/agents/services/channels/__tests__/ChannelManager.test.ts
+++ b/src/main/services/agents/services/channels/__tests__/ChannelManager.test.ts
@@ -117,35 +117,32 @@ describe('ChannelManager', () => {
     createdAdapters.forEach((a) => expect(a.disconnect).toHaveBeenCalledTimes(1))
   })
 
-  it('syncAgent disconnects old and reconnects', async () => {
-    vi.mocked(channelService.listChannels).mockResolvedValueOnce([makeChannelRow()])
+  it('disconnectAgent disconnects all adapters for agent and clears session tracker', async () => {
+    vi.mocked(channelService.listChannels).mockResolvedValueOnce([
+      makeChannelRow({ id: 'ch-1', config: { bot_token: 'tok1' } }),
+      makeChannelRow({ id: 'ch-2', config: { bot_token: 'tok2' } })
+    ])
 
     await channelManager.start()
-    expect(createdAdapters).toHaveLength(1)
+    expect(createdAdapters).toHaveLength(2)
 
-    // Sync — channelService.listChannels with agentId filter returns updated channel
-    vi.mocked(channelService.listChannels).mockResolvedValueOnce([makeChannelRow({ config: { bot_token: 'new-tok' } })])
-
-    await channelManager.syncAgent('agent-1')
+    await channelManager.disconnectAgent('agent-1')
 
     expect(createdAdapters[0].disconnect).toHaveBeenCalledTimes(1)
-    expect(createdAdapters).toHaveLength(2) // new adapter created
-    expect(createdAdapters[1].connect).toHaveBeenCalledTimes(1)
+    expect(createdAdapters[1].disconnect).toHaveBeenCalledTimes(1)
+    expect(createdAdapters).toHaveLength(2) // no new adapters created
     expect(channelMessageHandler.clearSessionTracker).toHaveBeenCalledWith('agent-1')
   })
 
-  it('syncAgent for deleted agent disconnects without reconnecting', async () => {
+  it('disconnectAgent for unknown agent is a no-op', async () => {
     vi.mocked(channelService.listChannels).mockResolvedValueOnce([makeChannelRow()])
 
     await channelManager.start()
     expect(createdAdapters).toHaveLength(1)
 
-    // No channels for agent after deletion
-    vi.mocked(channelService.listChannels).mockResolvedValueOnce([])
-    await channelManager.syncAgent('agent-1')
+    await channelManager.disconnectAgent('unknown-agent')
 
-    expect(createdAdapters[0].disconnect).toHaveBeenCalledTimes(1)
-    expect(createdAdapters).toHaveLength(1) // no new adapter
+    expect(createdAdapters[0].disconnect).not.toHaveBeenCalled()
   })
 
   it('syncChannel only disconnects the target channel, leaving others untouched', async () => {

--- a/src/main/services/agents/services/channels/__tests__/ChannelManager.test.ts
+++ b/src/main/services/agents/services/channels/__tests__/ChannelManager.test.ts
@@ -145,6 +145,23 @@ describe('ChannelManager', () => {
     expect(createdAdapters[0].disconnect).not.toHaveBeenCalled()
   })
 
+  it('disconnectChannel only disconnects the target channel without reconnecting', async () => {
+    vi.mocked(channelService.listChannels).mockResolvedValueOnce([
+      makeChannelRow({ id: 'ch-1', config: { bot_token: 'tok1' } }),
+      makeChannelRow({ id: 'ch-2', config: { bot_token: 'tok2' } })
+    ])
+
+    await channelManager.start()
+    expect(createdAdapters).toHaveLength(2)
+
+    await channelManager.disconnectChannel('ch-1')
+
+    expect(createdAdapters[0].disconnect).toHaveBeenCalledTimes(1)
+    expect(createdAdapters[1].disconnect).not.toHaveBeenCalled()
+    // No new adapter created — disconnect only
+    expect(createdAdapters).toHaveLength(2)
+  })
+
   it('syncChannel only disconnects the target channel, leaving others untouched', async () => {
     vi.mocked(channelService.listChannels).mockResolvedValueOnce([
       makeChannelRow({ id: 'ch-1', config: { bot_token: 'tok1' } }),

--- a/src/main/services/agents/services/channels/adapters/feishu/FeishuAdapter.ts
+++ b/src/main/services/agents/services/channels/adapters/feishu/FeishuAdapter.ts
@@ -477,7 +477,7 @@ class FeishuAdapter extends ChannelAdapter {
       // Return without connecting. The base class background branch will call
       // markConnected via .then(), but we override that below: checkReady()
       // returned false, so we explicitly mark as NOT connected. The adapter
-      // will be recreated by syncAgent once credentials arrive.
+      // will be recreated by syncChannel once credentials arrive.
       this.startRegistrationInBackground()
       return
     }


### PR DESCRIPTION
### What this PR does

Before this PR:

Toggling a single channel's active state (on/off) in the frontend triggers `syncAgent()`, which disconnects **all** channels for that agent and reconnects only the active ones. This causes unnecessary reconnection churn for unrelated channels.

After this PR:

The `updateChannel` handler calls a new `syncChannel(channelId)` method that only disconnects and reconnects the specific channel being toggled. Other channels remain untouched.

### Why we need it and why it was done in this way

The following tradeoffs were made:

- `syncAgent()` is preserved for cases that genuinely need a full agent-level resync (e.g., agent deletion, credential rotation). Only the `updateChannel` handler was changed to use the more targeted `syncChannel()`.

The following alternatives were considered:

- Making `syncAgent()` diff-aware (only disconnect channels whose state actually changed). This was rejected as more complex and fragile compared to a simple single-channel sync path.

### Breaking changes

None.

### Special notes for your reviewer

- `syncAgent()` is still used by `createChannel`, `deleteChannel`, and `saveCredentialsAndReconnect` where a full resync is appropriate.
- Two new tests verify that `syncChannel` only affects the target channel.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
