### PR TITLE
hotfix(build): include resources directory files excluded by glob pattern

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -68,6 +68,7 @@ files:
   - "!node_modules/tesseract.js-core/{tesseract-core-lstm.js,tesseract-core-lstm.wasm,tesseract-core-lstm.wasm.js}" # we don't need source files
   - "!node_modules/tesseract.js-core/{tesseract-core-simd-lstm.js,tesseract-core-simd-lstm.wasm,tesseract-core-simd-lstm.wasm.js}" # we don't need source files
   - "!**/*.{h,iobj,ipdb,tlog,recipe,vcxproj,vcxproj.filters,Makefile,*.Makefile}" # filter .node build files
+  - "resources/**/*" # include all files in resources, and unpack them from asar for runtime access
 asarUnpack:
   - out/proxy/**
   - resources/**


### PR DESCRIPTION
### What this PR does

Before this PR:

Built-in skill `.md` files under `resources/skills/` were excluded from the packaged app because the glob pattern `!**/*.{...md...}` in `electron-builder.yml` matched them.

After this PR:

An explicit include rule `resources/**/*` is added so all resource files (including `.md` skill definitions) are correctly packaged into the app.

### Why we need it and why it was done in this way

The `files` section in `electron-builder.yml` uses broad exclusion globs to reduce bundle size (e.g., `!**/*.{...md...}`). This unintentionally excludes `.md` files inside `resources/skills/`, which are required at runtime for the built-in skills system.

Adding `resources/**/*` as an explicit include after the exclusion rules overrides the glob for that directory, ensuring all resource files are packaged. The `asarUnpack` section already lists `resources/**` so the files will be correctly unpacked for runtime access.

The following tradeoffs were made:

None — this is a minimal one-line fix.

The following alternatives were considered:

Narrowing the `!**/*.md` exclusion to `!node_modules/**/*.md` was considered but would be more fragile and could miss future resource files.

### Breaking changes

None.

### Special notes for your reviewer

The `asarUnpack` section already includes `resources/**`, so no additional unpack configuration is needed.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix built-in skill files (.md) missing from packaged app due to electron-builder glob exclusion
```
