### PR TITLE
feat: migrate legacy agents db through v2

### DIFF
--- a/migrations/sqlite-drizzle/0009_lazy_vin_gonzales.sql
+++ b/migrations/sqlite-drizzle/0009_lazy_vin_gonzales.sql
@@ -1,0 +1,145 @@
+CREATE TABLE `agents_agents` (
+	`id` text PRIMARY KEY NOT NULL,
+	`type` text NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`accessible_paths` text,
+	`instructions` text,
+	`model` text NOT NULL,
+	`plan_model` text,
+	`small_model` text,
+	`mcps` text,
+	`allowed_tools` text,
+	`configuration` text,
+	`sort_order` integer DEFAULT 0 NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `agents_agents_name_idx` ON `agents_agents` (`name`);--> statement-breakpoint
+CREATE INDEX `agents_agents_type_idx` ON `agents_agents` (`type`);--> statement-breakpoint
+CREATE INDEX `agents_agents_created_at_idx` ON `agents_agents` (`created_at`);--> statement-breakpoint
+CREATE INDEX `agents_agents_sort_order_idx` ON `agents_agents` (`sort_order`);--> statement-breakpoint
+CREATE TABLE `agents_channel_task_subscriptions` (
+	`channel_id` text NOT NULL,
+	`task_id` text NOT NULL,
+	PRIMARY KEY(`channel_id`, `task_id`),
+	FOREIGN KEY (`channel_id`) REFERENCES `agents_channels`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`task_id`) REFERENCES `agents_tasks`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `agents_channel_task_subscriptions_channel_id_idx` ON `agents_channel_task_subscriptions` (`channel_id`);--> statement-breakpoint
+CREATE INDEX `agents_channel_task_subscriptions_task_id_idx` ON `agents_channel_task_subscriptions` (`task_id`);--> statement-breakpoint
+CREATE TABLE `agents_channels` (
+	`id` text PRIMARY KEY NOT NULL,
+	`type` text NOT NULL,
+	`name` text NOT NULL,
+	`agent_id` text,
+	`session_id` text,
+	`config` text NOT NULL,
+	`is_active` integer DEFAULT true NOT NULL,
+	`active_chat_ids` text DEFAULT '[]',
+	`permission_mode` text,
+	`created_at` integer,
+	`updated_at` integer,
+	FOREIGN KEY (`agent_id`) REFERENCES `agents_agents`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`session_id`) REFERENCES `agents_sessions`(`id`) ON UPDATE no action ON DELETE set null,
+	CONSTRAINT "agents_channels_type_check" CHECK("agents_channels"."type" IN ('telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack')),
+	CONSTRAINT "agents_channels_permission_mode_check" CHECK("agents_channels"."permission_mode" IS NULL OR "agents_channels"."permission_mode" IN ('default', 'acceptEdits', 'bypassPermissions', 'plan'))
+);
+--> statement-breakpoint
+CREATE INDEX `agents_channels_agent_id_idx` ON `agents_channels` (`agent_id`);--> statement-breakpoint
+CREATE INDEX `agents_channels_type_idx` ON `agents_channels` (`type`);--> statement-breakpoint
+CREATE INDEX `agents_channels_session_id_idx` ON `agents_channels` (`session_id`);--> statement-breakpoint
+CREATE TABLE `agents_session_messages` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`session_id` text NOT NULL,
+	`role` text NOT NULL,
+	`content` text NOT NULL,
+	`agent_session_id` text DEFAULT '',
+	`metadata` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`session_id`) REFERENCES `agents_sessions`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `agents_session_messages_session_id_idx` ON `agents_session_messages` (`session_id`);--> statement-breakpoint
+CREATE INDEX `agents_session_messages_created_at_idx` ON `agents_session_messages` (`created_at`);--> statement-breakpoint
+CREATE INDEX `agents_session_messages_updated_at_idx` ON `agents_session_messages` (`updated_at`);--> statement-breakpoint
+CREATE TABLE `agents_sessions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`agent_type` text NOT NULL,
+	`agent_id` text NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`accessible_paths` text,
+	`instructions` text,
+	`model` text NOT NULL,
+	`plan_model` text,
+	`small_model` text,
+	`mcps` text,
+	`allowed_tools` text,
+	`slash_commands` text,
+	`configuration` text,
+	`sort_order` integer DEFAULT 0 NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`agent_id`) REFERENCES `agents_agents`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `agents_sessions_created_at_idx` ON `agents_sessions` (`created_at`);--> statement-breakpoint
+CREATE INDEX `agents_sessions_agent_id_idx` ON `agents_sessions` (`agent_id`);--> statement-breakpoint
+CREATE INDEX `agents_sessions_model_idx` ON `agents_sessions` (`model`);--> statement-breakpoint
+CREATE INDEX `agents_sessions_sort_order_idx` ON `agents_sessions` (`sort_order`);--> statement-breakpoint
+CREATE TABLE `agents_skills` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`folder_name` text NOT NULL,
+	`source` text NOT NULL,
+	`source_url` text,
+	`namespace` text,
+	`author` text,
+	`tags` text,
+	`content_hash` text NOT NULL,
+	`is_enabled` integer DEFAULT true NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `agents_skills_folder_name_unique` ON `agents_skills` (`folder_name`);--> statement-breakpoint
+CREATE INDEX `agents_skills_source_idx` ON `agents_skills` (`source`);--> statement-breakpoint
+CREATE INDEX `agents_skills_is_enabled_idx` ON `agents_skills` (`is_enabled`);--> statement-breakpoint
+CREATE TABLE `agents_task_run_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`task_id` text NOT NULL,
+	`session_id` text,
+	`run_at` text NOT NULL,
+	`duration_ms` integer NOT NULL,
+	`status` text NOT NULL,
+	`result` text,
+	`error` text,
+	FOREIGN KEY (`task_id`) REFERENCES `agents_tasks`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `agents_task_run_logs_task_id_idx` ON `agents_task_run_logs` (`task_id`);--> statement-breakpoint
+CREATE TABLE `agents_tasks` (
+	`id` text PRIMARY KEY NOT NULL,
+	`agent_id` text NOT NULL,
+	`name` text NOT NULL,
+	`prompt` text NOT NULL,
+	`schedule_type` text NOT NULL,
+	`schedule_value` text NOT NULL,
+	`timeout_minutes` integer DEFAULT 2 NOT NULL,
+	`next_run` text,
+	`last_run` text,
+	`last_result` text,
+	`status` text DEFAULT 'active' NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`agent_id`) REFERENCES `agents_agents`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `agents_tasks_agent_id_idx` ON `agents_tasks` (`agent_id`);--> statement-breakpoint
+CREATE INDEX `agents_tasks_next_run_idx` ON `agents_tasks` (`next_run`);--> statement-breakpoint
+CREATE INDEX `agents_tasks_status_idx` ON `agents_tasks` (`status`);

--- a/migrations/sqlite-drizzle/meta/0009_snapshot.json
+++ b/migrations/sqlite-drizzle/meta/0009_snapshot.json
@@ -1,0 +1,2302 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "066e332f-b6e9-4930-89c8-f279d718f303",
+  "prevId": "4105c4f2-d9df-4048-acab-0049e5a95941",
+  "tables": {
+    "agents_agents": {
+      "name": "agents_agents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessible_paths": {
+          "name": "accessible_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_model": {
+          "name": "plan_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "small_model": {
+          "name": "small_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcps": {
+          "name": "mcps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agents_agents_name_idx": {
+          "name": "agents_agents_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "agents_agents_type_idx": {
+          "name": "agents_agents_type_idx",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "agents_agents_created_at_idx": {
+          "name": "agents_agents_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "agents_agents_sort_order_idx": {
+          "name": "agents_agents_sort_order_idx",
+          "columns": ["sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agents_channel_task_subscriptions": {
+      "name": "agents_channel_task_subscriptions",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agents_channel_task_subscriptions_channel_id_idx": {
+          "name": "agents_channel_task_subscriptions_channel_id_idx",
+          "columns": ["channel_id"],
+          "isUnique": false
+        },
+        "agents_channel_task_subscriptions_task_id_idx": {
+          "name": "agents_channel_task_subscriptions_task_id_idx",
+          "columns": ["task_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agents_channel_task_subscriptions_channel_id_agents_channels_id_fk": {
+          "name": "agents_channel_task_subscriptions_channel_id_agents_channels_id_fk",
+          "tableFrom": "agents_channel_task_subscriptions",
+          "tableTo": "agents_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agents_channel_task_subscriptions_task_id_agents_tasks_id_fk": {
+          "name": "agents_channel_task_subscriptions_task_id_agents_tasks_id_fk",
+          "tableFrom": "agents_channel_task_subscriptions",
+          "tableTo": "agents_tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agents_channel_task_subscriptions_channel_id_task_id_pk": {
+          "columns": ["channel_id", "task_id"],
+          "name": "agents_channel_task_subscriptions_channel_id_task_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agents_channels": {
+      "name": "agents_channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "active_chat_ids": {
+          "name": "active_chat_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agents_channels_agent_id_idx": {
+          "name": "agents_channels_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agents_channels_type_idx": {
+          "name": "agents_channels_type_idx",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "agents_channels_session_id_idx": {
+          "name": "agents_channels_session_id_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agents_channels_agent_id_agents_agents_id_fk": {
+          "name": "agents_channels_agent_id_agents_agents_id_fk",
+          "tableFrom": "agents_channels",
+          "tableTo": "agents_agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agents_channels_session_id_agents_sessions_id_fk": {
+          "name": "agents_channels_session_id_agents_sessions_id_fk",
+          "tableFrom": "agents_channels",
+          "tableTo": "agents_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agents_channels_type_check": {
+          "name": "agents_channels_type_check",
+          "value": "\"agents_channels\".\"type\" IN ('telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack')"
+        },
+        "agents_channels_permission_mode_check": {
+          "name": "agents_channels_permission_mode_check",
+          "value": "\"agents_channels\".\"permission_mode\" IS NULL OR \"agents_channels\".\"permission_mode\" IN ('default', 'acceptEdits', 'bypassPermissions', 'plan')"
+        }
+      }
+    },
+    "agents_session_messages": {
+      "name": "agents_session_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agents_session_messages_session_id_idx": {
+          "name": "agents_session_messages_session_id_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        },
+        "agents_session_messages_created_at_idx": {
+          "name": "agents_session_messages_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "agents_session_messages_updated_at_idx": {
+          "name": "agents_session_messages_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agents_session_messages_session_id_fk": {
+          "name": "agents_session_messages_session_id_fk",
+          "tableFrom": "agents_session_messages",
+          "tableTo": "agents_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agents_sessions": {
+      "name": "agents_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_type": {
+          "name": "agent_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessible_paths": {
+          "name": "accessible_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_model": {
+          "name": "plan_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "small_model": {
+          "name": "small_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcps": {
+          "name": "mcps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slash_commands": {
+          "name": "slash_commands",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agents_sessions_created_at_idx": {
+          "name": "agents_sessions_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "agents_sessions_agent_id_idx": {
+          "name": "agents_sessions_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agents_sessions_model_idx": {
+          "name": "agents_sessions_model_idx",
+          "columns": ["model"],
+          "isUnique": false
+        },
+        "agents_sessions_sort_order_idx": {
+          "name": "agents_sessions_sort_order_idx",
+          "columns": ["sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agents_sessions_agent_id_fk": {
+          "name": "agents_sessions_agent_id_fk",
+          "tableFrom": "agents_sessions",
+          "tableTo": "agents_agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agents_skills": {
+      "name": "agents_skills",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folder_name": {
+          "name": "folder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agents_skills_folder_name_unique": {
+          "name": "agents_skills_folder_name_unique",
+          "columns": ["folder_name"],
+          "isUnique": true
+        },
+        "agents_skills_source_idx": {
+          "name": "agents_skills_source_idx",
+          "columns": ["source"],
+          "isUnique": false
+        },
+        "agents_skills_is_enabled_idx": {
+          "name": "agents_skills_is_enabled_idx",
+          "columns": ["is_enabled"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agents_task_run_logs": {
+      "name": "agents_task_run_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agents_task_run_logs_task_id_idx": {
+          "name": "agents_task_run_logs_task_id_idx",
+          "columns": ["task_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agents_task_run_logs_task_id_fk": {
+          "name": "agents_task_run_logs_task_id_fk",
+          "tableFrom": "agents_task_run_logs",
+          "tableTo": "agents_tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agents_tasks": {
+      "name": "agents_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_value": {
+          "name": "schedule_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeout_minutes": {
+          "name": "timeout_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "next_run": {
+          "name": "next_run",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_result": {
+          "name": "last_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agents_tasks_agent_id_idx": {
+          "name": "agents_tasks_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agents_tasks_next_run_idx": {
+          "name": "agents_tasks_next_run_idx",
+          "columns": ["next_run"],
+          "isUnique": false
+        },
+        "agents_tasks_status_idx": {
+          "name": "agents_tasks_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agents_tasks_agent_id_fk": {
+          "name": "agents_tasks_agent_id_fk",
+          "tableFrom": "agents_tasks",
+          "tableTo": "agents_agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_state": {
+      "name": "app_state",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group": {
+      "name": "group",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_entity_sort_idx": {
+          "name": "group_entity_sort_idx",
+          "columns": ["entity_type", "sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "knowledge_base": {
+      "name": "knowledge_base",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_model_id": {
+          "name": "embedding_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rerank_model_id": {
+          "name": "rerank_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_processor_id": {
+          "name": "file_processor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chunk_size": {
+          "name": "chunk_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chunk_overlap": {
+          "name": "chunk_overlap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_mode": {
+          "name": "search_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hybrid_alpha": {
+          "name": "hybrid_alpha",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "knowledge_base_search_mode_check": {
+          "name": "knowledge_base_search_mode_check",
+          "value": "\"knowledge_base\".\"search_mode\" IN ('default', 'bm25', 'hybrid') OR \"knowledge_base\".\"search_mode\" IS NULL"
+        }
+      }
+    },
+    "knowledge_item": {
+      "name": "knowledge_item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idle'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "knowledge_item_base_type_created_idx": {
+          "name": "knowledge_item_base_type_created_idx",
+          "columns": ["base_id", "type", "created_at"],
+          "isUnique": false
+        },
+        "knowledge_item_base_group_created_idx": {
+          "name": "knowledge_item_base_group_created_idx",
+          "columns": ["base_id", "group_id", "created_at"],
+          "isUnique": false
+        },
+        "knowledge_item_baseId_id_unique": {
+          "name": "knowledge_item_baseId_id_unique",
+          "columns": ["base_id", "id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "knowledge_item_base_id_knowledge_base_id_fk": {
+          "name": "knowledge_item_base_id_knowledge_base_id_fk",
+          "tableFrom": "knowledge_item",
+          "tableTo": "knowledge_base",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_item_base_id_group_id_knowledge_item_base_id_id_fk": {
+          "name": "knowledge_item_base_id_group_id_knowledge_item_base_id_id_fk",
+          "tableFrom": "knowledge_item",
+          "tableTo": "knowledge_item",
+          "columnsFrom": ["base_id", "group_id"],
+          "columnsTo": ["base_id", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "knowledge_item_type_check": {
+          "name": "knowledge_item_type_check",
+          "value": "\"knowledge_item\".\"type\" IN ('file', 'url', 'note', 'sitemap', 'directory')"
+        },
+        "knowledge_item_status_check": {
+          "name": "knowledge_item_status_check",
+          "value": "\"knowledge_item\".\"status\" IN ('idle', 'pending', 'ocr', 'read', 'embed', 'completed', 'failed')"
+        }
+      }
+    },
+    "mcp_server": {
+      "name": "mcp_server",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_url": {
+          "name": "provider_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "long_running": {
+          "name": "long_running",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dxt_version": {
+          "name": "dxt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dxt_path": {
+          "name": "dxt_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_key": {
+          "name": "search_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config_sample": {
+          "name": "config_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_tools": {
+          "name": "disabled_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_auto_approve_tools": {
+          "name": "disabled_auto_approve_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "should_config": {
+          "name": "should_config",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "install_source": {
+          "name": "install_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_trusted": {
+          "name": "is_trusted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trusted_at": {
+          "name": "trusted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_server_name_idx": {
+          "name": "mcp_server_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "mcp_server_is_active_idx": {
+          "name": "mcp_server_is_active_idx",
+          "columns": ["is_active"],
+          "isUnique": false
+        },
+        "mcp_server_sort_order_idx": {
+          "name": "mcp_server_sort_order_idx",
+          "columns": ["sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "mcp_server_type_check": {
+          "name": "mcp_server_type_check",
+          "value": "\"mcp_server\".\"type\" IS NULL OR \"mcp_server\".\"type\" IN ('stdio', 'sse', 'streamableHttp', 'inMemory')"
+        },
+        "mcp_server_install_source_check": {
+          "name": "mcp_server_install_source_check",
+          "value": "\"mcp_server\".\"install_source\" IS NULL OR \"mcp_server\".\"install_source\" IN ('builtin', 'manual', 'protocol', 'unknown')"
+        }
+      }
+    },
+    "message": {
+      "name": "message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "searchable_text": {
+          "name": "searchable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "siblings_group_id": {
+          "name": "siblings_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assistant_meta": {
+          "name": "assistant_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_meta": {
+          "name": "model_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "message_parent_id_idx": {
+          "name": "message_parent_id_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "message_topic_created_idx": {
+          "name": "message_topic_created_idx",
+          "columns": ["topic_id", "created_at"],
+          "isUnique": false
+        },
+        "message_trace_id_idx": {
+          "name": "message_trace_id_idx",
+          "columns": ["trace_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "message_topic_id_topic_id_fk": {
+          "name": "message_topic_id_topic_id_fk",
+          "tableFrom": "message",
+          "tableTo": "topic",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_parent_id_message_id_fk": {
+          "name": "message_parent_id_message_id_fk",
+          "tableFrom": "message",
+          "tableTo": "message",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "message_role_check": {
+          "name": "message_role_check",
+          "value": "\"message\".\"role\" IN ('user', 'assistant', 'system')"
+        },
+        "message_status_check": {
+          "name": "message_status_check",
+          "value": "\"message\".\"status\" IN ('pending', 'success', 'error', 'paused')"
+        }
+      }
+    },
+    "miniapp": {
+      "name": "miniapp",
+      "columns": {
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'custom'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'enabled'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bordered": {
+          "name": "bordered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "background": {
+          "name": "background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supported_regions": {
+          "name": "supported_regions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_key": {
+          "name": "name_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "miniapp_status_sort_idx": {
+          "name": "miniapp_status_sort_idx",
+          "columns": ["status", "sort_order"],
+          "isUnique": false
+        },
+        "miniapp_type_idx": {
+          "name": "miniapp_type_idx",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "miniapp_status_type_idx": {
+          "name": "miniapp_status_type_idx",
+          "columns": ["status", "type"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "miniapp_status_check": {
+          "name": "miniapp_status_check",
+          "value": "\"miniapp\".\"status\" IN ('enabled', 'disabled', 'pinned')"
+        },
+        "miniapp_type_check": {
+          "name": "miniapp_type_check",
+          "value": "\"miniapp\".\"type\" IN ('default', 'custom')"
+        }
+      }
+    },
+    "preference": {
+      "name": "preference",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "preference_scope_key_pk": {
+          "columns": ["scope", "key"],
+          "name": "preference_scope_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "entity_tag": {
+      "name": "entity_tag",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "entity_tag_tag_id_idx": {
+          "name": "entity_tag_tag_id_idx",
+          "columns": ["tag_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "entity_tag_tag_id_tag_id_fk": {
+          "name": "entity_tag_tag_id_tag_id_fk",
+          "tableFrom": "entity_tag",
+          "tableTo": "tag",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "entity_tag_entity_type_entity_id_tag_id_pk": {
+          "columns": ["entity_type", "entity_id", "tag_id"],
+          "name": "entity_tag_entity_type_entity_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag": {
+      "name": "tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tag_name_unique": {
+          "name": "tag_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "topic": {
+      "name": "topic",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_name_manually_edited": {
+          "name": "is_name_manually_edited",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assistant_meta": {
+          "name": "assistant_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_node_id": {
+          "name": "active_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "pinned_order": {
+          "name": "pinned_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "topic_group_updated_idx": {
+          "name": "topic_group_updated_idx",
+          "columns": ["group_id", "updated_at"],
+          "isUnique": false
+        },
+        "topic_group_sort_idx": {
+          "name": "topic_group_sort_idx",
+          "columns": ["group_id", "sort_order"],
+          "isUnique": false
+        },
+        "topic_updated_at_idx": {
+          "name": "topic_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "topic_is_pinned_idx": {
+          "name": "topic_is_pinned_idx",
+          "columns": ["is_pinned", "pinned_order"],
+          "isUnique": false
+        },
+        "topic_assistant_id_idx": {
+          "name": "topic_assistant_id_idx",
+          "columns": ["assistant_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "topic_group_id_group_id_fk": {
+          "name": "topic_group_id_group_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translate_history": {
+      "name": "translate_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_text": {
+          "name": "target_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_language": {
+          "name": "source_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "star": {
+          "name": "star",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "translate_history_created_at_idx": {
+          "name": "translate_history_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "translate_history_star_created_at_idx": {
+          "name": "translate_history_star_created_at_idx",
+          "columns": ["star", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "translate_history_source_language_translate_language_lang_code_fk": {
+          "name": "translate_history_source_language_translate_language_lang_code_fk",
+          "tableFrom": "translate_history",
+          "tableTo": "translate_language",
+          "columnsFrom": ["source_language"],
+          "columnsTo": ["lang_code"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translate_history_target_language_translate_language_lang_code_fk": {
+          "name": "translate_history_target_language_translate_language_lang_code_fk",
+          "tableFrom": "translate_history",
+          "tableTo": "translate_language",
+          "columnsFrom": ["target_language"],
+          "columnsTo": ["lang_code"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translate_language": {
+      "name": "translate_language",
+      "columns": {
+        "lang_code": {
+          "name": "lang_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/sqlite-drizzle/meta/_journal.json
+++ b/migrations/sqlite-drizzle/meta/_journal.json
@@ -63,6 +63,13 @@
       "when": 1775137534101,
       "tag": "0008_wild_ultron",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1775708573065,
+      "tag": "0009_lazy_vin_gonzales",
+      "breakpoints": true
     }
   ],
   "version": "7"

--- a/packages/shared/data/api/schemas/agents.ts
+++ b/packages/shared/data/api/schemas/agents.ts
@@ -1,0 +1,122 @@
+import type { OffsetPaginationResponse } from '../apiTypes'
+
+export interface AgentToolDto {
+  id: string
+  name: string
+  type: string
+  description?: string
+  requirePermissions?: boolean
+}
+
+export interface SlashCommandDto {
+  command: string
+  description?: string
+}
+
+export interface AgentPluginDto {
+  filename: string
+  type: 'agent' | 'command' | 'skill'
+  metadata: Record<string, unknown>
+}
+
+export interface AgentSummaryDto {
+  id: string
+  type: string
+  name: string
+  description?: string
+  accessible_paths?: string[]
+  instructions?: string
+  model: string
+  plan_model?: string
+  small_model?: string
+  mcps?: string[]
+  allowed_tools?: string[]
+  configuration?: Record<string, unknown>
+  sort_order?: number
+  created_at: string
+  updated_at: string
+}
+
+export interface AgentDetailDto extends AgentSummaryDto {
+  tools?: AgentToolDto[]
+}
+
+export interface AgentSessionSummaryDto {
+  id: string
+  agent_id: string
+  agent_type: string
+  name: string
+  description?: string
+  accessible_paths?: string[]
+  instructions?: string
+  model: string
+  plan_model?: string
+  small_model?: string
+  mcps?: string[]
+  allowed_tools?: string[]
+  slash_commands?: SlashCommandDto[]
+  configuration?: Record<string, unknown>
+  sort_order?: number
+  created_at: string
+  updated_at: string
+}
+
+export interface AgentSessionMessageDto {
+  id: number
+  session_id: string
+  role: string
+  content: unknown
+  agent_session_id: string
+  metadata?: Record<string, unknown>
+  created_at: string
+  updated_at: string
+}
+
+export interface AgentSessionDetailDto extends AgentSessionSummaryDto {
+  tools?: AgentToolDto[]
+  messages?: AgentSessionMessageDto[]
+  plugins?: AgentPluginDto[]
+}
+
+export interface AgentListQueryDto {
+  page?: number
+  limit?: number
+  sortBy?: 'created_at' | 'updated_at' | 'name' | 'sort_order'
+  orderBy?: 'asc' | 'desc'
+}
+
+export interface AgentSessionListQueryDto {
+  page?: number
+  limit?: number
+}
+
+export interface AgentSchemas {
+  '/agents': {
+    GET: {
+      query?: AgentListQueryDto
+      response: OffsetPaginationResponse<AgentDetailDto>
+    }
+  }
+
+  '/agents/:id': {
+    GET: {
+      params: { id: string }
+      response: AgentDetailDto
+    }
+  }
+
+  '/agents/:agentId/sessions': {
+    GET: {
+      params: { agentId: string }
+      query?: AgentSessionListQueryDto
+      response: OffsetPaginationResponse<AgentSessionSummaryDto>
+    }
+  }
+
+  '/agents/:agentId/sessions/:id': {
+    GET: {
+      params: { agentId: string; id: string }
+      response: AgentSessionDetailDto
+    }
+  }
+}

--- a/packages/shared/data/api/schemas/agents.ts
+++ b/packages/shared/data/api/schemas/agents.ts
@@ -19,19 +19,37 @@ export interface AgentPluginDto {
   metadata: Record<string, unknown>
 }
 
+export interface AgentConfigurationDto extends Record<string, unknown> {
+  avatar?: string
+  slash_commands?: string[]
+  permission_mode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan'
+  max_turns?: number
+  env_vars?: Record<string, string>
+  soul_enabled?: boolean
+  bootstrap_completed?: boolean
+  scheduler_enabled?: boolean
+  scheduler_type?: 'cron' | 'interval' | 'one-time'
+  scheduler_cron?: string
+  scheduler_interval?: number
+  scheduler_one_time_delay?: number
+  scheduler_last_run?: string
+  heartbeat_enabled?: boolean
+  heartbeat_interval?: number
+}
+
 export interface AgentSummaryDto {
   id: string
   type: string
-  name: string
+  name?: string
   description?: string
-  accessible_paths?: string[]
+  accessible_paths: string[]
   instructions?: string
   model: string
   plan_model?: string
   small_model?: string
   mcps?: string[]
   allowed_tools?: string[]
-  configuration?: Record<string, unknown>
+  configuration?: AgentConfigurationDto
   sort_order?: number
   created_at: string
   updated_at: string
@@ -41,13 +59,44 @@ export interface AgentDetailDto extends AgentSummaryDto {
   tools?: AgentToolDto[]
 }
 
+export interface CreateAgentDto {
+  type: string
+  name?: string
+  description?: string
+  accessible_paths: string[]
+  instructions?: string
+  model: string
+  plan_model?: string
+  small_model?: string
+  mcps?: string[]
+  allowed_tools?: string[]
+  configuration?: AgentConfigurationDto
+}
+
+export interface UpdateAgentDto {
+  name?: string
+  description?: string
+  accessible_paths?: string[]
+  instructions?: string
+  model?: string
+  plan_model?: string
+  small_model?: string
+  mcps?: string[]
+  allowed_tools?: string[]
+  configuration?: AgentConfigurationDto
+}
+
+export interface ReorderAgentsDto {
+  orderedIds: string[]
+}
+
 export interface AgentSessionSummaryDto {
   id: string
   agent_id: string
   agent_type: string
-  name: string
+  name?: string
   description?: string
-  accessible_paths?: string[]
+  accessible_paths: string[]
   instructions?: string
   model: string
   plan_model?: string
@@ -55,7 +104,7 @@ export interface AgentSessionSummaryDto {
   mcps?: string[]
   allowed_tools?: string[]
   slash_commands?: SlashCommandDto[]
-  configuration?: Record<string, unknown>
+  configuration?: AgentConfigurationDto
   sort_order?: number
   created_at: string
   updated_at: string
@@ -78,6 +127,38 @@ export interface AgentSessionDetailDto extends AgentSessionSummaryDto {
   plugins?: AgentPluginDto[]
 }
 
+export interface CreateAgentSessionDto {
+  name?: string
+  description?: string
+  accessible_paths: string[]
+  instructions?: string
+  model: string
+  plan_model?: string
+  small_model?: string
+  mcps?: string[]
+  allowed_tools?: string[]
+  slash_commands?: SlashCommandDto[]
+  configuration?: AgentConfigurationDto
+}
+
+export interface UpdateAgentSessionDto {
+  name?: string
+  description?: string
+  accessible_paths?: string[]
+  instructions?: string
+  model?: string
+  plan_model?: string
+  small_model?: string
+  mcps?: string[]
+  allowed_tools?: string[]
+  slash_commands?: SlashCommandDto[]
+  configuration?: AgentConfigurationDto
+}
+
+export interface ReorderAgentSessionsDto {
+  orderedIds: string[]
+}
+
 export interface AgentListQueryDto {
   page?: number
   limit?: number
@@ -96,12 +177,29 @@ export interface AgentSchemas {
       query?: AgentListQueryDto
       response: OffsetPaginationResponse<AgentDetailDto>
     }
+    POST: {
+      body: CreateAgentDto
+      response: AgentDetailDto
+    }
+    PATCH: {
+      body: ReorderAgentsDto
+      response: { success: true }
+    }
   }
 
   '/agents/:id': {
     GET: {
       params: { id: string }
       response: AgentDetailDto
+    }
+    PATCH: {
+      params: { id: string }
+      body: UpdateAgentDto
+      response: AgentDetailDto
+    }
+    DELETE: {
+      params: { id: string }
+      response: void
     }
   }
 
@@ -111,12 +209,31 @@ export interface AgentSchemas {
       query?: AgentSessionListQueryDto
       response: OffsetPaginationResponse<AgentSessionSummaryDto>
     }
+    POST: {
+      params: { agentId: string }
+      body: CreateAgentSessionDto
+      response: AgentSessionDetailDto
+    }
+    PATCH: {
+      params: { agentId: string }
+      body: ReorderAgentSessionsDto
+      response: { success: true }
+    }
   }
 
   '/agents/:agentId/sessions/:id': {
     GET: {
       params: { agentId: string; id: string }
       response: AgentSessionDetailDto
+    }
+    PATCH: {
+      params: { agentId: string; id: string }
+      body: UpdateAgentSessionDto
+      response: AgentSessionDetailDto
+    }
+    DELETE: {
+      params: { agentId: string; id: string }
+      response: void
     }
   }
 }

--- a/packages/shared/data/api/schemas/index.ts
+++ b/packages/shared/data/api/schemas/index.ts
@@ -20,6 +20,7 @@
  */
 
 import type { AssertValidSchemas } from '../apiTypes'
+import type { AgentSchemas } from './agents'
 import type { FileProcessingSchemas } from './fileProcessing'
 import type { KnowledgeSchemas } from './knowledges'
 import type { MCPServerSchemas } from './mcpServers'
@@ -48,5 +49,6 @@ export type ApiSchemas = AssertValidSchemas<
     FileProcessingSchemas &
     MCPServerSchemas &
     KnowledgeSchemas &
-    MiniappSchemas
+    MiniappSchemas &
+    AgentSchemas
 >

--- a/src/main/core/paths/pathRegistry.ts
+++ b/src/main/core/paths/pathRegistry.ts
@@ -105,6 +105,7 @@ export function buildPathRegistry() {
     'feature.agents.skills.builtin': path.join(appRootResources, 'skills'), // bundled skill templates (read-only)
     'feature.agents.skills': path.join(appUserDataData, 'Skills'), // installed skills storage
     'feature.agents.skills.install.temp': path.join(appTemp, 'skill-install'),
+    'feature.agents.db_file': path.join(appUserDataData, 'agents.db'), // legacy standalone agents SQLite used by v2 migration
     'feature.agents.claude.root': path.join(appUserData, '.claude'), // Claude Code config (relocated from ~/.claude for Windows compat)
     'feature.agents.claude.skills': path.join(appUserData, '.claude', 'skills'), // symlinks → feature.agents.skills
     'feature.agents.channels': path.join(appUserDataData, 'Channels'),

--- a/src/main/data/api/handlers/agents.ts
+++ b/src/main/data/api/handlers/agents.ts
@@ -12,24 +12,52 @@ export const agentHandlers: {
   '/agents': {
     GET: async ({ query }) => {
       return await agentsDataService.listAgents(query ?? {})
+    },
+    POST: async ({ body }) => {
+      return await agentsDataService.createAgent(body)
+    },
+    PATCH: async ({ body }) => {
+      await agentsDataService.reorderAgents(body.orderedIds)
+      return { success: true as const }
     }
   },
 
   '/agents/:id': {
     GET: async ({ params }) => {
       return await agentsDataService.getAgent(params.id)
+    },
+    PATCH: async ({ params, body }) => {
+      return await agentsDataService.updateAgent(params.id, body)
+    },
+    DELETE: async ({ params }) => {
+      await agentsDataService.deleteAgent(params.id)
+      return undefined
     }
   },
 
   '/agents/:agentId/sessions': {
     GET: async ({ params, query }) => {
       return await agentsDataService.listSessions(params.agentId, query ?? {})
+    },
+    POST: async ({ params, body }) => {
+      return await agentsDataService.createSession(params.agentId, body)
+    },
+    PATCH: async ({ params, body }) => {
+      await agentsDataService.reorderSessions(params.agentId, body.orderedIds)
+      return { success: true as const }
     }
   },
 
   '/agents/:agentId/sessions/:id': {
     GET: async ({ params }) => {
       return await agentsDataService.getSession(params.agentId, params.id)
+    },
+    PATCH: async ({ params, body }) => {
+      return await agentsDataService.updateSession(params.agentId, params.id, body)
+    },
+    DELETE: async ({ params }) => {
+      await agentsDataService.deleteSession(params.agentId, params.id)
+      return undefined
     }
   }
 }

--- a/src/main/data/api/handlers/agents.ts
+++ b/src/main/data/api/handlers/agents.ts
@@ -1,0 +1,35 @@
+import { agentsDataService } from '@data/services/AgentsDataService'
+import type { ApiHandler, ApiMethods } from '@shared/data/api/apiTypes'
+import type { AgentSchemas } from '@shared/data/api/schemas/agents'
+
+type AgentHandler<Path extends keyof AgentSchemas, Method extends ApiMethods<Path>> = ApiHandler<Path, Method>
+
+export const agentHandlers: {
+  [Path in keyof AgentSchemas]: {
+    [Method in keyof AgentSchemas[Path]]: AgentHandler<Path, Method & ApiMethods<Path>>
+  }
+} = {
+  '/agents': {
+    GET: async ({ query }) => {
+      return await agentsDataService.listAgents(query ?? {})
+    }
+  },
+
+  '/agents/:id': {
+    GET: async ({ params }) => {
+      return await agentsDataService.getAgent(params.id)
+    }
+  },
+
+  '/agents/:agentId/sessions': {
+    GET: async ({ params, query }) => {
+      return await agentsDataService.listSessions(params.agentId, query ?? {})
+    }
+  },
+
+  '/agents/:agentId/sessions/:id': {
+    GET: async ({ params }) => {
+      return await agentsDataService.getSession(params.agentId, params.id)
+    }
+  }
+}

--- a/src/main/data/api/handlers/index.ts
+++ b/src/main/data/api/handlers/index.ts
@@ -12,6 +12,7 @@
 
 import type { ApiImplementation } from '@shared/data/api/apiTypes'
 
+import { agentHandlers } from './agents'
 import { fileProcessingHandlers } from './fileProcessing'
 import { knowledgeHandlers } from './knowledges'
 import { mcpServerHandlers } from './mcpServers'
@@ -28,6 +29,7 @@ import { translateHandlers } from './translate'
  * TypeScript ensures exhaustive coverage - missing handlers cause compile errors.
  */
 export const apiHandlers: ApiImplementation = {
+  ...agentHandlers,
   ...fileProcessingHandlers,
   ...topicHandlers,
   ...messageHandlers,

--- a/src/main/data/db/schemas/agentsAgents.ts
+++ b/src/main/data/db/schemas/agentsAgents.ts
@@ -1,0 +1,31 @@
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+
+export const agentsAgentsTable = sqliteTable(
+  'agents_agents',
+  {
+    id: text().primaryKey(),
+    type: text().notNull(),
+    name: text().notNull(),
+    description: text(),
+    accessible_paths: text(),
+    instructions: text(),
+    model: text().notNull(),
+    plan_model: text(),
+    small_model: text(),
+    mcps: text(),
+    allowed_tools: text(),
+    configuration: text(),
+    sort_order: integer().notNull().default(0),
+    created_at: text().notNull(),
+    updated_at: text().notNull()
+  },
+  (t) => [
+    index('agents_agents_name_idx').on(t.name),
+    index('agents_agents_type_idx').on(t.type),
+    index('agents_agents_created_at_idx').on(t.created_at),
+    index('agents_agents_sort_order_idx').on(t.sort_order)
+  ]
+)
+
+export type AgentsAgentRow = typeof agentsAgentsTable.$inferSelect
+export type InsertAgentsAgentRow = typeof agentsAgentsTable.$inferInsert

--- a/src/main/data/db/schemas/agentsChannels.ts
+++ b/src/main/data/db/schemas/agentsChannels.ts
@@ -1,0 +1,55 @@
+import { sql } from 'drizzle-orm'
+import { check, index, integer, primaryKey, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+
+import { agentsAgentsTable } from './agentsAgents'
+import { agentsSessionsTable } from './agentsSessions'
+import { agentsTasksTable } from './agentsTasks'
+
+export const agentsChannelsTable = sqliteTable(
+  'agents_channels',
+  {
+    id: text().primaryKey(),
+    type: text().notNull(),
+    name: text().notNull(),
+    agent_id: text().references(() => agentsAgentsTable.id, { onDelete: 'set null' }),
+    session_id: text().references(() => agentsSessionsTable.id, { onDelete: 'set null' }),
+    config: text({ mode: 'json' }).$type<Record<string, unknown>>().notNull(),
+    is_active: integer({ mode: 'boolean' }).notNull().default(true),
+    active_chat_ids: text({ mode: 'json' }).$type<string[]>().default([]),
+    permission_mode: text(),
+    created_at: integer(),
+    updated_at: integer()
+  },
+  (t) => [
+    index('agents_channels_agent_id_idx').on(t.agent_id),
+    index('agents_channels_type_idx').on(t.type),
+    index('agents_channels_session_id_idx').on(t.session_id),
+    check('agents_channels_type_check', sql`${t.type} IN ('telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack')`),
+    check(
+      'agents_channels_permission_mode_check',
+      sql`${t.permission_mode} IS NULL OR ${t.permission_mode} IN ('default', 'acceptEdits', 'bypassPermissions', 'plan')`
+    )
+  ]
+)
+
+export const agentsChannelTaskSubscriptionsTable = sqliteTable(
+  'agents_channel_task_subscriptions',
+  {
+    channel_id: text()
+      .notNull()
+      .references(() => agentsChannelsTable.id, { onDelete: 'cascade' }),
+    task_id: text()
+      .notNull()
+      .references(() => agentsTasksTable.id, { onDelete: 'cascade' })
+  },
+  (t) => [
+    primaryKey({ columns: [t.channel_id, t.task_id] }),
+    index('agents_channel_task_subscriptions_channel_id_idx').on(t.channel_id),
+    index('agents_channel_task_subscriptions_task_id_idx').on(t.task_id)
+  ]
+)
+
+export type AgentsChannelRow = typeof agentsChannelsTable.$inferSelect
+export type InsertAgentsChannelRow = typeof agentsChannelsTable.$inferInsert
+export type AgentsChannelTaskSubscriptionRow = typeof agentsChannelTaskSubscriptionsTable.$inferSelect
+export type InsertAgentsChannelTaskSubscriptionRow = typeof agentsChannelTaskSubscriptionsTable.$inferInsert

--- a/src/main/data/db/schemas/agentsSessionMessages.ts
+++ b/src/main/data/db/schemas/agentsSessionMessages.ts
@@ -1,0 +1,30 @@
+import { foreignKey, index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+
+import { agentsSessionsTable } from './agentsSessions'
+
+export const agentsSessionMessagesTable = sqliteTable(
+  'agents_session_messages',
+  {
+    id: integer().primaryKey({ autoIncrement: true }),
+    session_id: text().notNull(),
+    role: text().notNull(),
+    content: text().notNull(),
+    agent_session_id: text().default(''),
+    metadata: text(),
+    created_at: text().notNull(),
+    updated_at: text().notNull()
+  },
+  (t) => [
+    foreignKey({
+      columns: [t.session_id],
+      foreignColumns: [agentsSessionsTable.id],
+      name: 'agents_session_messages_session_id_fk'
+    }).onDelete('cascade'),
+    index('agents_session_messages_session_id_idx').on(t.session_id),
+    index('agents_session_messages_created_at_idx').on(t.created_at),
+    index('agents_session_messages_updated_at_idx').on(t.updated_at)
+  ]
+)
+
+export type AgentsSessionMessageRow = typeof agentsSessionMessagesTable.$inferSelect
+export type InsertAgentsSessionMessageRow = typeof agentsSessionMessagesTable.$inferInsert

--- a/src/main/data/db/schemas/agentsSessions.ts
+++ b/src/main/data/db/schemas/agentsSessions.ts
@@ -1,0 +1,40 @@
+import { foreignKey, index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+
+import { agentsAgentsTable } from './agentsAgents'
+
+export const agentsSessionsTable = sqliteTable(
+  'agents_sessions',
+  {
+    id: text().primaryKey(),
+    agent_type: text().notNull(),
+    agent_id: text().notNull(),
+    name: text().notNull(),
+    description: text(),
+    accessible_paths: text(),
+    instructions: text(),
+    model: text().notNull(),
+    plan_model: text(),
+    small_model: text(),
+    mcps: text(),
+    allowed_tools: text(),
+    slash_commands: text(),
+    configuration: text(),
+    sort_order: integer().notNull().default(0),
+    created_at: text().notNull(),
+    updated_at: text().notNull()
+  },
+  (t) => [
+    foreignKey({
+      columns: [t.agent_id],
+      foreignColumns: [agentsAgentsTable.id],
+      name: 'agents_sessions_agent_id_fk'
+    }).onDelete('cascade'),
+    index('agents_sessions_created_at_idx').on(t.created_at),
+    index('agents_sessions_agent_id_idx').on(t.agent_id),
+    index('agents_sessions_model_idx').on(t.model),
+    index('agents_sessions_sort_order_idx').on(t.sort_order)
+  ]
+)
+
+export type AgentsSessionRow = typeof agentsSessionsTable.$inferSelect
+export type InsertAgentsSessionRow = typeof agentsSessionsTable.$inferInsert

--- a/src/main/data/db/schemas/agentsSkills.ts
+++ b/src/main/data/db/schemas/agentsSkills.ts
@@ -1,0 +1,28 @@
+import { index, integer, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core'
+
+export const agentsSkillsTable = sqliteTable(
+  'agents_skills',
+  {
+    id: text().primaryKey(),
+    name: text().notNull(),
+    description: text(),
+    folder_name: text().notNull(),
+    source: text().notNull(),
+    source_url: text(),
+    namespace: text(),
+    author: text(),
+    tags: text(),
+    content_hash: text().notNull(),
+    is_enabled: integer({ mode: 'boolean' }).notNull().default(true),
+    created_at: integer().notNull(),
+    updated_at: integer().notNull()
+  },
+  (t) => [
+    uniqueIndex('agents_skills_folder_name_unique').on(t.folder_name),
+    index('agents_skills_source_idx').on(t.source),
+    index('agents_skills_is_enabled_idx').on(t.is_enabled)
+  ]
+)
+
+export type AgentsSkillRow = typeof agentsSkillsTable.$inferSelect
+export type InsertAgentsSkillRow = typeof agentsSkillsTable.$inferInsert

--- a/src/main/data/db/schemas/agentsTasks.ts
+++ b/src/main/data/db/schemas/agentsTasks.ts
@@ -1,0 +1,59 @@
+import { foreignKey, index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+
+import { agentsAgentsTable } from './agentsAgents'
+
+export const agentsTasksTable = sqliteTable(
+  'agents_tasks',
+  {
+    id: text().primaryKey(),
+    agent_id: text().notNull(),
+    name: text().notNull(),
+    prompt: text().notNull(),
+    schedule_type: text().notNull(),
+    schedule_value: text().notNull(),
+    timeout_minutes: integer().notNull().default(2),
+    next_run: text(),
+    last_run: text(),
+    last_result: text(),
+    status: text().notNull().default('active'),
+    created_at: text().notNull(),
+    updated_at: text().notNull()
+  },
+  (t) => [
+    foreignKey({
+      columns: [t.agent_id],
+      foreignColumns: [agentsAgentsTable.id],
+      name: 'agents_tasks_agent_id_fk'
+    }).onDelete('cascade'),
+    index('agents_tasks_agent_id_idx').on(t.agent_id),
+    index('agents_tasks_next_run_idx').on(t.next_run),
+    index('agents_tasks_status_idx').on(t.status)
+  ]
+)
+
+export const agentsTaskRunLogsTable = sqliteTable(
+  'agents_task_run_logs',
+  {
+    id: integer().primaryKey({ autoIncrement: true }),
+    task_id: text().notNull(),
+    session_id: text(),
+    run_at: text().notNull(),
+    duration_ms: integer().notNull(),
+    status: text().notNull(),
+    result: text(),
+    error: text()
+  },
+  (t) => [
+    foreignKey({
+      columns: [t.task_id],
+      foreignColumns: [agentsTasksTable.id],
+      name: 'agents_task_run_logs_task_id_fk'
+    }).onDelete('cascade'),
+    index('agents_task_run_logs_task_id_idx').on(t.task_id)
+  ]
+)
+
+export type AgentsTaskRow = typeof agentsTasksTable.$inferSelect
+export type InsertAgentsTaskRow = typeof agentsTasksTable.$inferInsert
+export type AgentsTaskRunLogRow = typeof agentsTaskRunLogsTable.$inferSelect
+export type InsertAgentsTaskRunLogRow = typeof agentsTaskRunLogsTable.$inferInsert

--- a/src/main/data/migration/v2/core/MigrationEngine.ts
+++ b/src/main/data/migration/v2/core/MigrationEngine.ts
@@ -3,6 +3,12 @@
  * Coordinates migrators, manages progress, and handles failures
  */
 
+import { agentsAgentsTable } from '@data/db/schemas/agentsAgents'
+import { agentsChannelsTable, agentsChannelTaskSubscriptionsTable } from '@data/db/schemas/agentsChannels'
+import { agentsSessionMessagesTable } from '@data/db/schemas/agentsSessionMessages'
+import { agentsSessionsTable } from '@data/db/schemas/agentsSessions'
+import { agentsSkillsTable } from '@data/db/schemas/agentsSkills'
+import { agentsTaskRunLogsTable, agentsTasksTable } from '@data/db/schemas/agentsTasks'
 import { appStateTable } from '@data/db/schemas/appState'
 import { knowledgeBaseTable, knowledgeItemTable } from '@data/db/schemas/knowledge'
 import { mcpServerTable } from '@data/db/schemas/mcpServer'
@@ -29,6 +35,7 @@ import fs from 'fs/promises'
 import path from 'path'
 
 import type { BaseMigrator, ProgressMessage } from '../migrators/BaseMigrator'
+import { LegacyAgentsDbReader } from '../utils/LegacyAgentsDbReader'
 import { createMigrationContext } from './MigrationContext'
 import { MigrationDbService } from './MigrationDbService'
 
@@ -39,6 +46,7 @@ import { MigrationDbService } from './MigrationDbService'
 const logger = loggerService.withContext('MigrationEngine')
 
 const MIGRATION_V2_STATUS = 'migration_v2_status'
+const MIGRATION_V2_TARGET_VERSION = '2.1.0'
 
 export class MigrationEngine {
   private migrators: BaseMigrator[] = []
@@ -95,7 +103,26 @@ export class MigrationEngine {
 
     if (status?.value) {
       const statusValue = status.value as MigrationStatusValue
-      return statusValue.status !== 'completed'
+
+      if (statusValue.status !== 'completed') {
+        return true
+      }
+
+      if (statusValue.version === MIGRATION_V2_TARGET_VERSION) {
+        return false
+      }
+
+      if (!this.hasLegacyData()) {
+        logger.info('No remaining legacy data found for the current migration target, marking completed')
+        await this.markCompleted()
+        return false
+      }
+
+      logger.info('Legacy data still exists for a newer v2 migration target', {
+        currentVersion: statusValue.version,
+        targetVersion: MIGRATION_V2_TARGET_VERSION
+      })
+      return true
     }
 
     // No migration status record — check if this is a fresh install or an upgrade.
@@ -117,9 +144,11 @@ export class MigrationEngine {
    */
   private hasLegacyData(): boolean {
     const legacyStore = new Store()
-    const hasData = legacyStore.size > 0
+    const hasElectronStore = legacyStore.size > 0
+    const hasLegacyAgentsDb = new LegacyAgentsDbReader().resolvePath() !== null
+    const hasData = hasElectronStore || hasLegacyAgentsDb
 
-    logger.info('Legacy data detection', { hasElectronStore: hasData })
+    logger.info('Legacy data detection', { hasElectronStore, hasLegacyAgentsDb })
     return hasData
   }
 
@@ -266,6 +295,14 @@ export class MigrationEngine {
     // Tables to clear - add more as they are created
     // Order matters: child tables must be cleared before parent tables
     const tables = [
+      { table: agentsSessionMessagesTable, name: 'agents_session_messages' },
+      { table: agentsChannelTaskSubscriptionsTable, name: 'agents_channel_task_subscriptions' },
+      { table: agentsTaskRunLogsTable, name: 'agents_task_run_logs' },
+      { table: agentsChannelsTable, name: 'agents_channels' },
+      { table: agentsTasksTable, name: 'agents_tasks' },
+      { table: agentsSessionsTable, name: 'agents_sessions' },
+      { table: agentsSkillsTable, name: 'agents_skills' },
+      { table: agentsAgentsTable, name: 'agents_agents' },
       { table: messageTable, name: 'message' }, // Must clear before topic (FK reference)
       { table: topicTable, name: 'topic' },
       { table: mcpServerTable, name: 'mcp_server' },
@@ -290,6 +327,14 @@ export class MigrationEngine {
     }
 
     // Clear tables in dependency order (children before parents)
+    await db.delete(agentsSessionMessagesTable)
+    await db.delete(agentsChannelTaskSubscriptionsTable)
+    await db.delete(agentsTaskRunLogsTable)
+    await db.delete(agentsChannelsTable)
+    await db.delete(agentsTasksTable)
+    await db.delete(agentsSessionsTable)
+    await db.delete(agentsSkillsTable)
+    await db.delete(agentsAgentsTable)
     // Messages reference topics, so delete messages first
     await db.delete(messageTable)
     await db.delete(topicTable)
@@ -428,7 +473,7 @@ export class MigrationEngine {
     const statusValue: MigrationStatusValue = {
       status: 'completed',
       completedAt: Date.now(),
-      version: '2.0.0',
+      version: MIGRATION_V2_TARGET_VERSION,
       error: null
     }
 
@@ -455,7 +500,7 @@ export class MigrationEngine {
     const statusValue: MigrationStatusValue = {
       status: 'failed',
       failedAt: Date.now(),
-      version: '2.0.0',
+      version: MIGRATION_V2_TARGET_VERSION,
       error: error
     }
 

--- a/src/main/data/migration/v2/core/MigrationEngine.ts
+++ b/src/main/data/migration/v2/core/MigrationEngine.ts
@@ -46,7 +46,9 @@ import { MigrationDbService } from './MigrationDbService'
 const logger = loggerService.withContext('MigrationEngine')
 
 const MIGRATION_V2_STATUS = 'migration_v2_status'
-const MIGRATION_V2_TARGET_VERSION = '2.1.0'
+const MIGRATION_V2_AGENTS_STATUS = 'migration_v2_agents_status'
+const MIGRATION_V2_TARGET_VERSION = '2.0.0'
+const MIGRATION_V2_AGENTS_TARGET_VERSION = '2.1.0-agents'
 
 export class MigrationEngine {
   private migrators: BaseMigrator[] = []
@@ -98,37 +100,9 @@ export class MigrationEngine {
    */
   //TODO 不能仅仅判断数据库，如果是全新安装，而不是升级上来的用户，其实并不需要迁移，但是按现在的逻辑，还是会进行迁移，这不正确
   async needsMigration(): Promise<boolean> {
-    const db = this.getDb()
-    const status = await db.select().from(appStateTable).where(eq(appStateTable.key, MIGRATION_V2_STATUS)).get()
+    const plan = await this.getPendingMigrationPlan()
 
-    if (status?.value) {
-      const statusValue = status.value as MigrationStatusValue
-
-      if (statusValue.status !== 'completed') {
-        return true
-      }
-
-      if (statusValue.version === MIGRATION_V2_TARGET_VERSION) {
-        return false
-      }
-
-      if (!this.hasLegacyData()) {
-        logger.info('No remaining legacy data found for the current migration target, marking completed')
-        await this.markCompleted()
-        return false
-      }
-
-      logger.info('Legacy data still exists for a newer v2 migration target', {
-        currentVersion: statusValue.version,
-        targetVersion: MIGRATION_V2_TARGET_VERSION
-      })
-      return true
-    }
-
-    // No migration status record — check if this is a fresh install or an upgrade.
-    if (!this.hasLegacyData()) {
-      logger.info('Fresh install detected (no legacy data found), skipping migration')
-      await this.markCompleted()
+    if (!plan.fullMigrationNeeded && !plan.agentsMigrationNeeded) {
       return false
     }
 
@@ -136,35 +110,77 @@ export class MigrationEngine {
   }
 
   /**
-   * FIXME: 当前仅通过 electron-store 判断是否有旧数据，这是临时方案。
+   * FIXME: 当前仅通过 electron-store 判断 core v2 是否有旧数据，这是临时方案。
    * electron-store (config.json) 在 v2 中也可能被写入，导致误判。
    * localStorage 和 IndexedDB 的文件系统路径不可靠（UserData 路径问题待迁移后期统一处理），暂不检测。
    * 宁可误触发迁移（空数据迁移可安全完成），也不漏掉真正的升级用户。
    * 后续引入 version history 后可用精确的版本记录替代这些启发式检测。
    */
-  private hasLegacyData(): boolean {
+  private hasCoreLegacyData(): boolean {
     const legacyStore = new Store()
-    const hasElectronStore = legacyStore.size > 0
-    const hasLegacyAgentsDb = new LegacyAgentsDbReader().resolvePath() !== null
-    const hasData = hasElectronStore || hasLegacyAgentsDb
+    return legacyStore.size > 0
+  }
 
-    logger.info('Legacy data detection', { hasElectronStore, hasLegacyAgentsDb })
-    return hasData
+  private hasLegacyAgentsData(): boolean {
+    return new LegacyAgentsDbReader().resolvePath() !== null
+  }
+
+  private async getStatus(key: string): Promise<MigrationStatusValue | null> {
+    const db = this.getDb()
+    const record = await db.select().from(appStateTable).where(eq(appStateTable.key, key)).get()
+    return (record?.value as MigrationStatusValue | undefined) ?? null
+  }
+
+  private async getPendingMigrationPlan(): Promise<{
+    fullMigrationNeeded: boolean
+    agentsMigrationNeeded: boolean
+    migrators: BaseMigrator[]
+  }> {
+    const fullStatus = await this.getStatus(MIGRATION_V2_STATUS)
+    const agentsStatus = await this.getStatus(MIGRATION_V2_AGENTS_STATUS)
+    const hasCoreLegacyData = this.hasCoreLegacyData()
+    const hasLegacyAgentsData = this.hasLegacyAgentsData()
+
+    let fullMigrationNeeded = false
+    if (fullStatus) {
+      fullMigrationNeeded = fullStatus.status !== 'completed'
+    } else if (hasCoreLegacyData) {
+      fullMigrationNeeded = true
+    } else {
+      logger.info('Fresh install detected for core v2 migration, marking completed')
+      await this.markCompleted()
+    }
+
+    let agentsMigrationNeeded = false
+    if (hasLegacyAgentsData) {
+      agentsMigrationNeeded = agentsStatus?.status !== 'completed'
+    } else if (!agentsStatus || agentsStatus.status !== 'completed') {
+      await this.markAgentsCompleted()
+    }
+
+    const migrators = fullMigrationNeeded ? this.migrators : this.migrators.filter((m) => m.id === 'agents')
+
+    return {
+      fullMigrationNeeded,
+      agentsMigrationNeeded,
+      migrators: agentsMigrationNeeded || fullMigrationNeeded ? migrators : []
+    }
   }
 
   /**
    * Get last migration error (for UI display)
    */
   async getLastError(): Promise<string | null> {
-    const db = this.getDb()
-    const status = await db.select().from(appStateTable).where(eq(appStateTable.key, MIGRATION_V2_STATUS)).get()
-
-    if (status?.value) {
-      const statusValue = status.value as MigrationStatusValue
-      if (statusValue.status === 'failed') {
-        return statusValue.error || 'Unknown error'
-      }
+    const fullStatus = await this.getStatus(MIGRATION_V2_STATUS)
+    if (fullStatus?.status === 'failed') {
+      return fullStatus.error || 'Unknown error'
     }
+
+    const agentsStatus = await this.getStatus(MIGRATION_V2_AGENTS_STATUS)
+    if (agentsStatus?.status === 'failed') {
+      return agentsStatus.error || 'Unknown error'
+    }
+
     return null
   }
 
@@ -181,29 +197,47 @@ export class MigrationEngine {
     const startTime = Date.now()
     const results: MigratorResult[] = []
 
+    const plan = await this.getPendingMigrationPlan()
+    const activeMigrators = plan.migrators
+
     try {
-      for (const migrator of this.migrators) {
+      for (const migrator of activeMigrators) {
         migrator.reset()
       }
 
-      // Safety check: verify new tables status before clearing
-      await this.verifyAndClearNewTables()
+      if (plan.fullMigrationNeeded) {
+        await this.verifyAndClearNewTables()
+      } else if (plan.agentsMigrationNeeded) {
+        await this.verifyAndClearAgentsTables()
+      }
 
       // Create migration context
       const context = await createMigrationContext(this.getDb(), reduxData, dexieExportPath, localStorageExportPath)
 
-      for (let i = 0; i < this.migrators.length; i++) {
-        const migrator = this.migrators[i]
+      for (let i = 0; i < activeMigrators.length; i++) {
+        const migrator = activeMigrators[i]
         const migratorStartTime = Date.now()
 
         logger.info(`Starting migrator: ${migrator.name}`, { id: migrator.id })
 
         // Update progress: migrator starting
-        this.updateProgress('migration', this.calculateProgress(i, 0), migrator)
+        this.updateProgress(
+          'migration',
+          this.calculateProgress(i, 0, activeMigrators.length),
+          migrator,
+          undefined,
+          activeMigrators
+        )
 
         // Set up migrator progress callback
         migrator.setProgressCallback((progress, progressMessage) => {
-          this.updateProgress('migration', this.calculateProgress(i, progress), migrator, progressMessage)
+          this.updateProgress(
+            'migration',
+            this.calculateProgress(i, progress, activeMigrators.length),
+            migrator,
+            progressMessage,
+            activeMigrators
+          )
         })
 
         // Phase 1: Prepare (includes dry-run validation)
@@ -242,14 +276,30 @@ export class MigrationEngine {
         })
 
         // Update progress: migrator completed
-        this.updateProgress('migration', this.calculateProgress(i + 1, 0), migrator)
+        if (migrator.id === 'agents') {
+          await this.markAgentsCompleted()
+        }
+
+        this.updateProgress(
+          'migration',
+          this.calculateProgress(i + 1, 0, activeMigrators.length),
+          migrator,
+          undefined,
+          activeMigrators
+        )
       }
 
       // Verify FK integrity after all inserts (FK was off during bulk inserts)
       await this.verifyForeignKeys()
 
       // Mark migration completed
-      await this.markCompleted()
+      if (plan.fullMigrationNeeded) {
+        await this.markCompleted()
+      }
+
+      if (plan.agentsMigrationNeeded && !activeMigrators.some((m) => m.id === 'agents')) {
+        await this.markAgentsCompleted()
+      }
 
       // Cleanup temporary files
       await this.cleanupTempFiles(dexieExportPath)
@@ -274,7 +324,12 @@ export class MigrationEngine {
       logger.error('Migration failed', { error: errorMessage })
 
       // Mark migration as failed with error details
-      await this.markFailed(errorMessage)
+      if (plan.fullMigrationNeeded) {
+        await this.markFailed(errorMessage)
+      }
+      if (plan.agentsMigrationNeeded) {
+        await this.markAgentsFailed(errorMessage)
+      }
 
       return {
         success: false,
@@ -354,6 +409,44 @@ export class MigrationEngine {
   }
 
   /**
+   * Verify and clear only agents-import target tables.
+   * Used when the core v2 migration is already complete and only legacy agents.db
+   * still needs to be imported into the main database.
+   */
+  private async verifyAndClearAgentsTables(): Promise<void> {
+    const db = this.getDb()
+    const tables = [
+      { table: agentsSessionMessagesTable, name: 'agents_session_messages' },
+      { table: agentsChannelTaskSubscriptionsTable, name: 'agents_channel_task_subscriptions' },
+      { table: agentsTaskRunLogsTable, name: 'agents_task_run_logs' },
+      { table: agentsChannelsTable, name: 'agents_channels' },
+      { table: agentsTasksTable, name: 'agents_tasks' },
+      { table: agentsSessionsTable, name: 'agents_sessions' },
+      { table: agentsSkillsTable, name: 'agents_skills' },
+      { table: agentsAgentsTable, name: 'agents_agents' }
+    ]
+
+    for (const { table, name } of tables) {
+      const result = await db.select({ count: sql<number>`count(*)` }).from(table).get()
+      const count = result?.count ?? 0
+      if (count > 0) {
+        logger.warn(`Table '${name}' is not empty (${count} rows), clearing for agents-only migration`)
+      }
+    }
+
+    await db.delete(agentsSessionMessagesTable)
+    await db.delete(agentsChannelTaskSubscriptionsTable)
+    await db.delete(agentsTaskRunLogsTable)
+    await db.delete(agentsChannelsTable)
+    await db.delete(agentsTasksTable)
+    await db.delete(agentsSessionsTable)
+    await db.delete(agentsSkillsTable)
+    await db.delete(agentsAgentsTable)
+
+    logger.info('Agents import target tables cleared successfully')
+  }
+
+  /**
    * Verify foreign key integrity after all data has been inserted.
    * FK constraints were disabled during bulk inserts for performance;
    * this post-insert check ensures referential integrity is correct.
@@ -423,9 +516,13 @@ export class MigrationEngine {
   /**
    * Calculate overall progress based on completed migrators and current migrator progress
    */
-  private calculateProgress(completedMigrators: number, currentMigratorProgress: number): number {
-    if (this.migrators.length === 0) return 0
-    const migratorWeight = 100 / this.migrators.length
+  private calculateProgress(
+    completedMigrators: number,
+    currentMigratorProgress: number,
+    totalMigrators: number
+  ): number {
+    if (totalMigrators === 0) return 0
+    const migratorWeight = 100 / totalMigrators
     return Math.round(completedMigrators * migratorWeight + (currentMigratorProgress / 100) * migratorWeight)
   }
 
@@ -436,9 +533,10 @@ export class MigrationEngine {
     stage: MigrationStage,
     overallProgress: number,
     currentMigrator: BaseMigrator,
-    progressMessage?: ProgressMessage
+    progressMessage?: ProgressMessage,
+    migrators: BaseMigrator[] = this.migrators
   ): void {
-    const migratorsProgress = this.migrators.map((m) => ({
+    const migratorsProgress = migrators.map((m) => ({
       id: m.id,
       name: m.name,
       status: this.getMigratorStatus(m, currentMigrator)
@@ -508,6 +606,54 @@ export class MigrationEngine {
       .insert(appStateTable)
       .values({
         key: MIGRATION_V2_STATUS,
+        value: statusValue
+      })
+      .onConflictDoUpdate({
+        target: appStateTable.key,
+        set: {
+          value: statusValue,
+          updatedAt: Date.now()
+        }
+      })
+  }
+
+  private async markAgentsCompleted(): Promise<void> {
+    const db = this.getDb()
+    const statusValue: MigrationStatusValue = {
+      status: 'completed',
+      completedAt: Date.now(),
+      version: MIGRATION_V2_AGENTS_TARGET_VERSION,
+      error: null
+    }
+
+    await db
+      .insert(appStateTable)
+      .values({
+        key: MIGRATION_V2_AGENTS_STATUS,
+        value: statusValue
+      })
+      .onConflictDoUpdate({
+        target: appStateTable.key,
+        set: {
+          value: statusValue,
+          updatedAt: Date.now()
+        }
+      })
+  }
+
+  private async markAgentsFailed(error: string): Promise<void> {
+    const db = this.getDb()
+    const statusValue: MigrationStatusValue = {
+      status: 'failed',
+      failedAt: Date.now(),
+      version: MIGRATION_V2_AGENTS_TARGET_VERSION,
+      error
+    }
+
+    await db
+      .insert(appStateTable)
+      .values({
+        key: MIGRATION_V2_AGENTS_STATUS,
         value: statusValue
       })
       .onConflictDoUpdate({

--- a/src/main/data/migration/v2/core/__tests__/MigrationEngine.test.ts
+++ b/src/main/data/migration/v2/core/__tests__/MigrationEngine.test.ts
@@ -1,3 +1,4 @@
+import type { MigrationStatusValue } from '@shared/data/migration/v2/types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { MigrationEngine } from '../MigrationEngine'
@@ -53,6 +54,21 @@ describe('MigrationEngine', () => {
     vi.spyOn(engine as any, 'cleanupTempFiles').mockResolvedValue(undefined)
   })
 
+  function mockStatus(statusValue?: MigrationStatusValue) {
+    const get = vi.fn().mockResolvedValue(statusValue ? { value: statusValue } : undefined)
+    ;(engine as any).migrationDb = {
+      getDb: vi.fn(() => ({
+        select: vi.fn(() => ({
+          from: vi.fn(() => ({
+            where: vi.fn(() => ({ get }))
+          }))
+        }))
+      })),
+      close: vi.fn()
+    }
+    return { get }
+  }
+
   it('resets every migrator before each run starts', async () => {
     const events: string[] = []
     const boot = createTestMigrator('boot', 1, events)
@@ -83,5 +99,26 @@ describe('MigrationEngine', () => {
       'chat:execute',
       'chat:validate'
     ])
+  })
+
+  it('requires migration again when the stored completed version is outdated and legacy data exists', async () => {
+    mockStatus({ status: 'completed', version: '2.0.0', completedAt: Date.now(), error: null })
+    vi.spyOn(engine as any, 'hasLegacyData').mockReturnValue(true)
+
+    await expect(engine.needsMigration()).resolves.toBe(true)
+  })
+
+  it('marks the new target version as completed when no legacy data exists anymore', async () => {
+    mockStatus({ status: 'completed', version: '2.0.0', completedAt: Date.now(), error: null })
+    vi.spyOn(engine as any, 'hasLegacyData').mockReturnValue(false)
+
+    await expect(engine.needsMigration()).resolves.toBe(false)
+    expect((engine as any).markCompleted).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips migration when the stored completed version matches the current target', async () => {
+    mockStatus({ status: 'completed', version: '2.1.0', completedAt: Date.now(), error: null })
+
+    await expect(engine.needsMigration()).resolves.toBe(false)
   })
 })

--- a/src/main/data/migration/v2/core/__tests__/MigrationEngine.test.ts
+++ b/src/main/data/migration/v2/core/__tests__/MigrationEngine.test.ts
@@ -51,11 +51,16 @@ describe('MigrationEngine', () => {
     vi.spyOn(engine as any, 'verifyForeignKeys').mockResolvedValue(undefined)
     vi.spyOn(engine as any, 'markCompleted').mockResolvedValue(undefined)
     vi.spyOn(engine as any, 'markFailed').mockResolvedValue(undefined)
+    vi.spyOn(engine as any, 'markAgentsCompleted').mockResolvedValue(undefined)
+    vi.spyOn(engine as any, 'markAgentsFailed').mockResolvedValue(undefined)
     vi.spyOn(engine as any, 'cleanupTempFiles').mockResolvedValue(undefined)
   })
 
-  function mockStatus(statusValue?: MigrationStatusValue) {
-    const get = vi.fn().mockResolvedValue(statusValue ? { value: statusValue } : undefined)
+  function mockStatuses(fullStatus?: MigrationStatusValue, agentsStatus?: MigrationStatusValue) {
+    const get = vi.fn<() => Promise<{ value: MigrationStatusValue } | undefined>>().mockResolvedValue(undefined)
+    get.mockResolvedValueOnce(fullStatus ? { value: fullStatus } : undefined)
+    get.mockResolvedValueOnce(agentsStatus ? { value: agentsStatus } : undefined)
+
     ;(engine as any).migrationDb = {
       getDb: vi.fn(() => ({
         select: vi.fn(() => ({
@@ -75,6 +80,11 @@ describe('MigrationEngine', () => {
     const chat = createTestMigrator('chat', 2, events)
 
     engine.registerMigrators([chat as any, boot as any])
+    vi.spyOn(engine as any, 'getPendingMigrationPlan').mockResolvedValue({
+      fullMigrationNeeded: true,
+      agentsMigrationNeeded: false,
+      migrators: [boot, chat]
+    })
 
     await engine.run({}, '/tmp/dexie_export', '/tmp/localstorage_export/export.json')
     await engine.run({}, '/tmp/dexie_export', '/tmp/localstorage_export/export.json')
@@ -101,24 +111,52 @@ describe('MigrationEngine', () => {
     ])
   })
 
-  it('requires migration again when the stored completed version is outdated and legacy data exists', async () => {
-    mockStatus({ status: 'completed', version: '2.0.0', completedAt: Date.now(), error: null })
-    vi.spyOn(engine as any, 'hasLegacyData').mockReturnValue(true)
+  it('requires migration again when core v2 is complete but agents import is still pending', async () => {
+    mockStatuses({ status: 'completed', version: '2.0.0', completedAt: Date.now(), error: null }, undefined)
+    vi.spyOn(engine as any, 'hasCoreLegacyData').mockReturnValue(false)
+    vi.spyOn(engine as any, 'hasLegacyAgentsData').mockReturnValue(true)
 
     await expect(engine.needsMigration()).resolves.toBe(true)
   })
 
-  it('marks the new target version as completed when no legacy data exists anymore', async () => {
-    mockStatus({ status: 'completed', version: '2.0.0', completedAt: Date.now(), error: null })
-    vi.spyOn(engine as any, 'hasLegacyData').mockReturnValue(false)
+  it('marks agents import as completed when no legacy agents db exists anymore', async () => {
+    mockStatuses({ status: 'completed', version: '2.0.0', completedAt: Date.now(), error: null }, undefined)
+    vi.spyOn(engine as any, 'hasCoreLegacyData').mockReturnValue(false)
+    vi.spyOn(engine as any, 'hasLegacyAgentsData').mockReturnValue(false)
 
     await expect(engine.needsMigration()).resolves.toBe(false)
-    expect((engine as any).markCompleted).toHaveBeenCalledTimes(1)
+    expect((engine as any).markAgentsCompleted).toHaveBeenCalledTimes(1)
   })
 
-  it('skips migration when the stored completed version matches the current target', async () => {
-    mockStatus({ status: 'completed', version: '2.1.0', completedAt: Date.now(), error: null })
+  it('skips migration when both core v2 and agents import are already completed', async () => {
+    mockStatuses(
+      { status: 'completed', version: '2.0.0', completedAt: Date.now(), error: null },
+      { status: 'completed', version: '2.1.0-agents', completedAt: Date.now(), error: null }
+    )
+    vi.spyOn(engine as any, 'hasCoreLegacyData').mockReturnValue(false)
+    vi.spyOn(engine as any, 'hasLegacyAgentsData').mockReturnValue(false)
 
     await expect(engine.needsMigration()).resolves.toBe(false)
+  })
+
+  it('runs only the agents migrator and clears only agents tables for an agents-only migration', async () => {
+    const events: string[] = []
+    const boot = createTestMigrator('boot', 1, events)
+    const agents = createTestMigrator('agents', 2.5, events)
+
+    engine.registerMigrators([boot as any, agents as any])
+
+    vi.spyOn(engine as any, 'getPendingMigrationPlan').mockResolvedValue({
+      fullMigrationNeeded: false,
+      agentsMigrationNeeded: true,
+      migrators: [agents]
+    })
+    const clearAgentsTables = vi.spyOn(engine as any, 'verifyAndClearAgentsTables').mockResolvedValue(undefined)
+
+    await engine.run({}, '/tmp/dexie_export', '/tmp/localstorage_export/export.json')
+
+    expect(clearAgentsTables).toHaveBeenCalledTimes(1)
+    expect((engine as any).verifyAndClearNewTables).not.toHaveBeenCalled()
+    expect(events).toStrictEqual(['agents:reset', 'agents:prepare', 'agents:execute', 'agents:validate'])
   })
 })

--- a/src/main/data/migration/v2/migrators/AgentsMigrator.ts
+++ b/src/main/data/migration/v2/migrators/AgentsMigrator.ts
@@ -1,0 +1,137 @@
+import { loggerService } from '@logger'
+import type { ExecuteResult, PrepareResult, ValidateResult, ValidationError } from '@shared/data/migration/v2/types'
+import { sql } from 'drizzle-orm'
+
+import type { MigrationContext } from '../core/MigrationContext'
+import { LegacyAgentsDbReader } from '../utils/LegacyAgentsDbReader'
+import { BaseMigrator } from './BaseMigrator'
+import {
+  AGENTS_TABLE_MIGRATION_SPECS,
+  type AgentsTableRowCounts,
+  buildAgentsImportStatements,
+  getTotalAgentsRowCount
+} from './mappings/AgentsDbMappings'
+
+const logger = loggerService.withContext('AgentsMigrator')
+
+export class AgentsMigrator extends BaseMigrator {
+  readonly id = 'agents'
+  readonly name = 'Agents'
+  readonly description = 'Migrate legacy agents.db data into the main SQLite database'
+  readonly order = 2.5
+
+  private sourceCounts: AgentsTableRowCounts = this.createEmptyCounts()
+
+  override reset(): void {
+    this.sourceCounts = this.createEmptyCounts()
+  }
+
+  async prepare(): Promise<PrepareResult> {
+    const reader = new LegacyAgentsDbReader()
+    const dbPath = reader.resolvePath()
+
+    if (!dbPath) {
+      return {
+        success: true,
+        itemCount: 0,
+        warnings: ['agents.db not found - no agents data to migrate']
+      }
+    }
+
+    this.sourceCounts = await reader.countRows()
+
+    return {
+      success: true,
+      itemCount: getTotalAgentsRowCount(this.sourceCounts)
+    }
+  }
+
+  async execute(ctx: MigrationContext): Promise<ExecuteResult> {
+    const reader = new LegacyAgentsDbReader()
+    const dbPath = reader.resolvePath()
+
+    if (!dbPath) {
+      logger.info('No legacy agents.db found, skipping agents migration')
+      return { success: true, processedCount: 0 }
+    }
+
+    if (getTotalAgentsRowCount(this.sourceCounts) === 0) {
+      this.sourceCounts = await reader.countRows()
+    }
+
+    const statements = buildAgentsImportStatements(dbPath)
+
+    for (const statement of statements) {
+      await ctx.db.run(sql.raw(statement))
+    }
+
+    return {
+      success: true,
+      processedCount: getTotalAgentsRowCount(this.sourceCounts)
+    }
+  }
+
+  async validate(ctx: MigrationContext): Promise<ValidateResult> {
+    const reader = new LegacyAgentsDbReader()
+    const dbPath = reader.resolvePath()
+
+    if (!dbPath) {
+      return {
+        success: true,
+        errors: [],
+        stats: {
+          sourceCount: 0,
+          targetCount: 0,
+          skippedCount: 0
+        }
+      }
+    }
+
+    if (getTotalAgentsRowCount(this.sourceCounts) === 0) {
+      this.sourceCounts = await reader.countRows()
+    }
+
+    const errors: ValidationError[] = []
+    let targetCount = 0
+
+    for (const spec of AGENTS_TABLE_MIGRATION_SPECS) {
+      const result = await ctx.db.get<{ count: number }>(sql.raw(`SELECT COUNT(*) AS count FROM ${spec.targetTable}`))
+      const tableTargetCount = Number(result?.count ?? 0)
+      const tableSourceCount = this.sourceCounts[spec.sourceTable]
+      targetCount += tableTargetCount
+
+      if (tableTargetCount < tableSourceCount) {
+        errors.push({
+          key: `${spec.targetTable}_count_mismatch`,
+          expected: tableSourceCount,
+          actual: tableTargetCount,
+          message: `${spec.targetTable} count too low: expected ${tableSourceCount}, got ${tableTargetCount}`
+        })
+      }
+    }
+
+    return {
+      success: errors.length === 0,
+      errors,
+      stats: {
+        sourceCount: getTotalAgentsRowCount(this.sourceCounts),
+        targetCount,
+        skippedCount: 0,
+        mismatchReason: errors.length > 0 ? 'One or more agents_* tables were not fully imported' : undefined
+      }
+    }
+  }
+
+  private createEmptyCounts(): AgentsTableRowCounts {
+    return {
+      agents: 0,
+      sessions: 0,
+      skills: 0,
+      scheduled_tasks: 0,
+      task_run_logs: 0,
+      channels: 0,
+      channel_task_subscriptions: 0,
+      session_messages: 0
+    }
+  }
+}

--- a/src/main/data/migration/v2/migrators/README-AgentsMigrator.md
+++ b/src/main/data/migration/v2/migrators/README-AgentsMigrator.md
@@ -1,0 +1,55 @@
+# AgentsMigrator
+
+## Purpose
+
+Migrates the legacy standalone `agents.db` SQLite database into the main `cherrystudio.sqlite` database during the v2 migration flow.
+
+## Source
+
+Legacy source database locations checked in order:
+
+1. `application.getPath('feature.agents.db_file')` → `{userData}/Data/agents.db`
+2. `application.getPath('app.userdata', 'agents.db')` → legacy fallback `{userData}/agents.db`
+
+## Target tables
+
+- `agents_agents`
+- `agents_sessions`
+- `agents_skills`
+- `agents_tasks`
+- `agents_task_run_logs`
+- `agents_channels`
+- `agents_channel_task_subscriptions`
+- `agents_session_messages`
+
+## Import strategy
+
+The migrator uses SQLite-native copy statements:
+
+1. `ATTACH DATABASE ... AS agents_legacy`
+2. `INSERT INTO agents_* (...) SELECT ... FROM agents_legacy.*`
+3. `DETACH DATABASE agents_legacy`
+
+This keeps IDs, timestamps, and JSON/text payloads intact while avoiding per-row TypeScript transforms.
+
+## Table mapping
+
+| Legacy table | Main DB table |
+| --- | --- |
+| `agents` | `agents_agents` |
+| `sessions` | `agents_sessions` |
+| `skills` | `agents_skills` |
+| `scheduled_tasks` | `agents_tasks` |
+| `task_run_logs` | `agents_task_run_logs` |
+| `channels` | `agents_channels` |
+| `channel_task_subscriptions` | `agents_channel_task_subscriptions` |
+| `session_messages` | `agents_session_messages` |
+
+## Validation
+
+Validation compares source and target row counts for every migrated table. Any target table with fewer rows than its source table fails the migration.
+
+## Notes
+
+- The v2 migration target version was bumped so installs already marked as `2.0.0` will still rerun migration if legacy `agents.db` data remains.
+- The import is intentionally schema-preserving to reduce cutover risk for the later agents-service refactor.

--- a/src/main/data/migration/v2/migrators/__tests__/AgentsMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/AgentsMigrator.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: vi.fn(() => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn()
+    }))
+  }
+}))
+
+import { LegacyAgentsDbReader } from '../../utils/LegacyAgentsDbReader'
+import { AgentsMigrator } from '../AgentsMigrator'
+
+function createCounts() {
+  return {
+    agents: 1,
+    sessions: 2,
+    skills: 3,
+    scheduled_tasks: 4,
+    task_run_logs: 5,
+    channels: 6,
+    channel_task_subscriptions: 7,
+    session_messages: 8
+  }
+}
+
+describe('AgentsMigrator', () => {
+  let migrator: AgentsMigrator
+
+  beforeEach(() => {
+    migrator = new AgentsMigrator()
+    vi.restoreAllMocks()
+  })
+
+  it('prepare skips cleanly when no legacy agents db exists', async () => {
+    vi.spyOn(LegacyAgentsDbReader.prototype, 'resolvePath').mockReturnValue(null)
+
+    const result = await migrator.prepare()
+
+    expect(result.success).toBe(true)
+    expect(result.itemCount).toBe(0)
+    expect(result.warnings).toEqual(['agents.db not found - no agents data to migrate'])
+  })
+
+  it('prepare counts all legacy agents rows', async () => {
+    vi.spyOn(LegacyAgentsDbReader.prototype, 'resolvePath').mockReturnValue('/mock/feature.agents.db_file')
+    vi.spyOn(LegacyAgentsDbReader.prototype, 'countRows').mockResolvedValue(createCounts())
+
+    const result = await migrator.prepare()
+
+    expect(result.success).toBe(true)
+    expect(result.itemCount).toBe(36)
+  })
+
+  it('execute attaches the legacy db and imports every table', async () => {
+    const run = vi.fn().mockResolvedValue(undefined)
+    vi.spyOn(LegacyAgentsDbReader.prototype, 'resolvePath').mockReturnValue('/mock/feature.agents.db_file')
+    vi.spyOn(LegacyAgentsDbReader.prototype, 'countRows').mockResolvedValue(createCounts())
+
+    const result = await migrator.execute({ db: { run } } as never)
+
+    expect(result.success).toBe(true)
+    expect(result.processedCount).toBe(36)
+    expect(run).toHaveBeenCalledTimes(10)
+  })
+
+  it('validate fails when imported table counts are lower than the source counts', async () => {
+    vi.spyOn(LegacyAgentsDbReader.prototype, 'resolvePath').mockReturnValue('/mock/feature.agents.db_file')
+    vi.spyOn(LegacyAgentsDbReader.prototype, 'countRows').mockResolvedValue(createCounts())
+
+    const get = vi
+      .fn()
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValueOnce({ count: 3 })
+      .mockResolvedValueOnce({ count: 4 })
+      .mockResolvedValueOnce({ count: 5 })
+      .mockResolvedValueOnce({ count: 6 })
+      .mockResolvedValueOnce({ count: 7 })
+      .mockResolvedValueOnce({ count: 8 })
+
+    const result = await migrator.validate({ db: { get } } as never)
+
+    expect(result.success).toBe(false)
+    expect(result.errors[0]?.key).toBe('agents_sessions_count_mismatch')
+    expect(result.stats.sourceCount).toBe(36)
+    expect(result.stats.targetCount).toBe(35)
+  })
+})

--- a/src/main/data/migration/v2/migrators/index.ts
+++ b/src/main/data/migration/v2/migrators/index.ts
@@ -5,6 +5,7 @@
 export { BaseMigrator } from './BaseMigrator'
 
 // Import all migrators
+import { AgentsMigrator } from './AgentsMigrator'
 import { AssistantMigrator } from './AssistantMigrator'
 import { BootConfigMigrator } from './BootConfigMigrator'
 import { ChatMigrator } from './ChatMigrator'
@@ -16,6 +17,7 @@ import { TranslateMigrator } from './TranslateMigrator'
 
 // Export migrator classes
 export {
+  AgentsMigrator,
   AssistantMigrator,
   BootConfigMigrator,
   ChatMigrator,
@@ -36,6 +38,7 @@ export function getAllMigrators() {
     new MiniAppMigrator(),
     new McpServerMigrator(),
     new AssistantMigrator(),
+    new AgentsMigrator(),
     new KnowledgeMigrator(),
     new ChatMigrator(),
     new TranslateMigrator()

--- a/src/main/data/migration/v2/migrators/mappings/AgentsDbMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/AgentsDbMappings.ts
@@ -1,0 +1,168 @@
+export type AgentsSourceTableName =
+  | 'agents'
+  | 'sessions'
+  | 'skills'
+  | 'scheduled_tasks'
+  | 'task_run_logs'
+  | 'channels'
+  | 'channel_task_subscriptions'
+  | 'session_messages'
+
+export type AgentsTableRowCounts = Record<AgentsSourceTableName, number>
+
+export type AgentsTableMigrationSpec = {
+  sourceTable: AgentsSourceTableName
+  targetTable:
+    | 'agents_agents'
+    | 'agents_sessions'
+    | 'agents_skills'
+    | 'agents_tasks'
+    | 'agents_task_run_logs'
+    | 'agents_channels'
+    | 'agents_channel_task_subscriptions'
+    | 'agents_session_messages'
+  columns: readonly string[]
+}
+
+export const AGENTS_TABLE_MIGRATION_SPECS: readonly AgentsTableMigrationSpec[] = [
+  {
+    sourceTable: 'agents',
+    targetTable: 'agents_agents',
+    columns: [
+      'id',
+      'type',
+      'name',
+      'description',
+      'accessible_paths',
+      'instructions',
+      'model',
+      'plan_model',
+      'small_model',
+      'mcps',
+      'allowed_tools',
+      'configuration',
+      'sort_order',
+      'created_at',
+      'updated_at'
+    ]
+  },
+  {
+    sourceTable: 'sessions',
+    targetTable: 'agents_sessions',
+    columns: [
+      'id',
+      'agent_type',
+      'agent_id',
+      'name',
+      'description',
+      'accessible_paths',
+      'instructions',
+      'model',
+      'plan_model',
+      'small_model',
+      'mcps',
+      'allowed_tools',
+      'slash_commands',
+      'configuration',
+      'sort_order',
+      'created_at',
+      'updated_at'
+    ]
+  },
+  {
+    sourceTable: 'skills',
+    targetTable: 'agents_skills',
+    columns: [
+      'id',
+      'name',
+      'description',
+      'folder_name',
+      'source',
+      'source_url',
+      'namespace',
+      'author',
+      'tags',
+      'content_hash',
+      'is_enabled',
+      'created_at',
+      'updated_at'
+    ]
+  },
+  {
+    sourceTable: 'scheduled_tasks',
+    targetTable: 'agents_tasks',
+    columns: [
+      'id',
+      'agent_id',
+      'name',
+      'prompt',
+      'schedule_type',
+      'schedule_value',
+      'timeout_minutes',
+      'next_run',
+      'last_run',
+      'last_result',
+      'status',
+      'created_at',
+      'updated_at'
+    ]
+  },
+  {
+    sourceTable: 'task_run_logs',
+    targetTable: 'agents_task_run_logs',
+    columns: ['id', 'task_id', 'session_id', 'run_at', 'duration_ms', 'status', 'result', 'error']
+  },
+  {
+    sourceTable: 'channels',
+    targetTable: 'agents_channels',
+    columns: [
+      'id',
+      'type',
+      'name',
+      'agent_id',
+      'session_id',
+      'config',
+      'is_active',
+      'active_chat_ids',
+      'permission_mode',
+      'created_at',
+      'updated_at'
+    ]
+  },
+  {
+    sourceTable: 'channel_task_subscriptions',
+    targetTable: 'agents_channel_task_subscriptions',
+    columns: ['channel_id', 'task_id']
+  },
+  {
+    sourceTable: 'session_messages',
+    targetTable: 'agents_session_messages',
+    columns: ['id', 'session_id', 'role', 'content', 'agent_session_id', 'metadata', 'created_at', 'updated_at']
+  }
+] as const
+
+export function getAgentsSourceTableNames(): AgentsSourceTableName[] {
+  return AGENTS_TABLE_MIGRATION_SPECS.map((spec) => spec.sourceTable)
+}
+
+export function getTotalAgentsRowCount(counts: Partial<AgentsTableRowCounts>): number {
+  return getAgentsSourceTableNames().reduce((total, tableName) => total + (counts[tableName] ?? 0), 0)
+}
+
+export function quoteSqlitePath(path: string): string {
+  return `'${path.replaceAll("'", "''")}'`
+}
+
+export function buildAgentsImportStatements(dbPath: string): string[] {
+  const statements = [`ATTACH DATABASE ${quoteSqlitePath(dbPath)} AS agents_legacy`]
+
+  for (const spec of AGENTS_TABLE_MIGRATION_SPECS) {
+    const columns = spec.columns.join(', ')
+    statements.push(
+      `INSERT INTO ${spec.targetTable} (${columns}) SELECT ${columns} FROM agents_legacy.${spec.sourceTable}`
+    )
+  }
+
+  statements.push('DETACH DATABASE agents_legacy')
+  return statements
+}

--- a/src/main/data/migration/v2/migrators/mappings/__tests__/AgentsDbMappings.test.ts
+++ b/src/main/data/migration/v2/migrators/mappings/__tests__/AgentsDbMappings.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  AGENTS_TABLE_MIGRATION_SPECS,
+  buildAgentsImportStatements,
+  getAgentsSourceTableNames,
+  getTotalAgentsRowCount,
+  quoteSqlitePath
+} from '../AgentsDbMappings'
+
+describe('AgentsDbMappings', () => {
+  it('builds attach/import/detach statements for the legacy agents db', () => {
+    const statements = buildAgentsImportStatements("/tmp/agent's.db")
+
+    expect(statements[0]).toBe("ATTACH DATABASE '/tmp/agent''s.db' AS agents_legacy")
+    expect(statements).toContain(
+      'INSERT INTO agents_agents (id, type, name, description, accessible_paths, instructions, model, plan_model, small_model, mcps, allowed_tools, configuration, sort_order, created_at, updated_at) SELECT id, type, name, description, accessible_paths, instructions, model, plan_model, small_model, mcps, allowed_tools, configuration, sort_order, created_at, updated_at FROM agents_legacy.agents'
+    )
+    expect(statements.at(-1)).toBe('DETACH DATABASE agents_legacy')
+  })
+
+  it('exposes all source table names in dependency order', () => {
+    expect(getAgentsSourceTableNames()).toEqual([
+      'agents',
+      'sessions',
+      'skills',
+      'scheduled_tasks',
+      'task_run_logs',
+      'channels',
+      'channel_task_subscriptions',
+      'session_messages'
+    ])
+  })
+
+  it('sums row counts across all tables', () => {
+    expect(
+      getTotalAgentsRowCount({
+        agents: 2,
+        sessions: 3,
+        skills: 4,
+        scheduled_tasks: 5,
+        task_run_logs: 6,
+        channels: 7,
+        channel_task_subscriptions: 8,
+        session_messages: 9
+      })
+    ).toBe(44)
+  })
+
+  it('keeps the table spec list aligned with the source table names', () => {
+    expect(AGENTS_TABLE_MIGRATION_SPECS.map((spec) => spec.sourceTable)).toEqual(getAgentsSourceTableNames())
+  })
+
+  it('quotes sqlite file paths safely', () => {
+    expect(quoteSqlitePath("/tmp/a'b/c.db")).toBe("'/tmp/a''b/c.db'")
+  })
+})

--- a/src/main/data/migration/v2/utils/LegacyAgentsDbReader.ts
+++ b/src/main/data/migration/v2/utils/LegacyAgentsDbReader.ts
@@ -1,0 +1,83 @@
+import { existsSync } from 'node:fs'
+
+import { createClient } from '@libsql/client'
+import { application } from '@main/core/application'
+import { sql } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/libsql'
+import { pathToFileURL } from 'url'
+
+import { type AgentsTableRowCounts, getAgentsSourceTableNames } from '../migrators/mappings/AgentsDbMappings'
+
+export type ResolveLegacyAgentsDbPathArgs = {
+  canonicalPath: string
+  legacyPath: string
+  exists: (path: string) => boolean
+}
+
+export function resolveLegacyAgentsDbPath({
+  canonicalPath,
+  legacyPath,
+  exists
+}: ResolveLegacyAgentsDbPathArgs): string | null {
+  if (exists(canonicalPath)) {
+    return canonicalPath
+  }
+
+  if (exists(legacyPath)) {
+    return legacyPath
+  }
+
+  return null
+}
+
+export class LegacyAgentsDbReader {
+  constructor(private readonly exists = existsSync) {}
+
+  getCanonicalPath(): string {
+    return application.getPath('feature.agents.db_file')
+  }
+
+  getLegacyPath(): string {
+    return application.getPath('app.userdata', 'agents.db')
+  }
+
+  resolvePath(): string | null {
+    return resolveLegacyAgentsDbPath({
+      canonicalPath: this.getCanonicalPath(),
+      legacyPath: this.getLegacyPath(),
+      exists: this.exists
+    })
+  }
+
+  async countRows(): Promise<AgentsTableRowCounts> {
+    const dbPath = this.resolvePath()
+
+    if (!dbPath) {
+      return this.createEmptyCounts()
+    }
+
+    const client = createClient({
+      url: pathToFileURL(dbPath).href,
+      intMode: 'number'
+    })
+
+    const db = drizzle(client)
+
+    try {
+      const counts = this.createEmptyCounts()
+
+      for (const tableName of getAgentsSourceTableNames()) {
+        const result = await db.get<{ count: number }>(sql.raw(`SELECT COUNT(*) AS count FROM ${tableName}`))
+        counts[tableName] = Number(result?.count ?? 0)
+      }
+
+      return counts
+    } finally {
+      client.close()
+    }
+  }
+
+  private createEmptyCounts(): AgentsTableRowCounts {
+    return Object.fromEntries(getAgentsSourceTableNames().map((tableName) => [tableName, 0])) as AgentsTableRowCounts
+  }
+}

--- a/src/main/data/migration/v2/utils/__tests__/LegacyAgentsDbReader.test.ts
+++ b/src/main/data/migration/v2/utils/__tests__/LegacyAgentsDbReader.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { resolveLegacyAgentsDbPath } from '../LegacyAgentsDbReader'
+
+describe('LegacyAgentsDbReader', () => {
+  it('prefers the canonical agents db path when it exists', () => {
+    const exists = vi.fn((candidate: string) => candidate === '/data/agents.db')
+
+    expect(
+      resolveLegacyAgentsDbPath({
+        canonicalPath: '/data/agents.db',
+        legacyPath: '/user/agents.db',
+        exists
+      })
+    ).toBe('/data/agents.db')
+  })
+
+  it('falls back to the old userData root path', () => {
+    const exists = vi.fn((candidate: string) => candidate === '/user/agents.db')
+
+    expect(
+      resolveLegacyAgentsDbPath({
+        canonicalPath: '/data/agents.db',
+        legacyPath: '/user/agents.db',
+        exists
+      })
+    ).toBe('/user/agents.db')
+  })
+
+  it('returns null when no legacy agents db exists', () => {
+    expect(
+      resolveLegacyAgentsDbPath({
+        canonicalPath: '/data/agents.db',
+        legacyPath: '/user/agents.db',
+        exists: () => false
+      })
+    ).toBeNull()
+  })
+})

--- a/src/main/data/services/AgentsDataService.ts
+++ b/src/main/data/services/AgentsDataService.ts
@@ -7,7 +7,11 @@ import type {
   AgentListQueryDto,
   AgentSessionDetailDto,
   AgentSessionListQueryDto,
-  AgentSessionSummaryDto
+  AgentSessionSummaryDto,
+  CreateAgentDto,
+  CreateAgentSessionDto,
+  UpdateAgentDto,
+  UpdateAgentSessionDto
 } from '@shared/data/api/schemas/agents'
 
 const DEFAULT_PAGE = 1
@@ -35,12 +39,47 @@ export class AgentsDataService {
     }
   }
 
+  async createAgent(body: CreateAgentDto): Promise<AgentDetailDto> {
+    const agent = await agentService.createAgent(body as any)
+
+    try {
+      await sessionService.createSession(agent.id, {})
+    } catch (error) {
+      await agentService.deleteAgent(agent.id)
+      throw DataApiErrorFactory.database(error as Error, 'create default agent session')
+    }
+
+    return await this.getAgent(agent.id)
+  }
+
   async getAgent(id: string): Promise<AgentDetailDto> {
     const agent = await agentService.getAgent(id)
     if (!agent) {
       throw DataApiErrorFactory.notFound('Agent', id)
     }
     return agent as AgentDetailDto
+  }
+
+  async updateAgent(id: string, body: UpdateAgentDto): Promise<AgentDetailDto> {
+    const updated = await agentService.updateAgent(id, body as any)
+    if (!updated) {
+      throw DataApiErrorFactory.notFound('Agent', id)
+    }
+    return updated as AgentDetailDto
+  }
+
+  async deleteAgent(id: string): Promise<void> {
+    const deleted = await agentService.deleteAgent(id)
+    if (!deleted) {
+      throw DataApiErrorFactory.notFound('Agent', id)
+    }
+  }
+
+  async reorderAgents(orderedIds: string[]): Promise<void> {
+    if (orderedIds.length === 0) {
+      throw DataApiErrorFactory.validation({ orderedIds: ['orderedIds must not be empty'] })
+    }
+    await agentService.reorderAgents(orderedIds)
   }
 
   async listSessions(
@@ -63,12 +102,42 @@ export class AgentsDataService {
     }
   }
 
+  async createSession(agentId: string, body: CreateAgentSessionDto): Promise<AgentSessionDetailDto> {
+    const session = await sessionService.createSession(agentId, body as any)
+    if (!session) {
+      throw DataApiErrorFactory.notFound('Agent', agentId)
+    }
+    return session as AgentSessionDetailDto
+  }
+
   async getSession(agentId: string, sessionId: string): Promise<AgentSessionDetailDto> {
     const session = await sessionService.getSession(agentId, sessionId)
     if (!session) {
       throw DataApiErrorFactory.notFound('AgentSession', sessionId)
     }
     return session as AgentSessionDetailDto
+  }
+
+  async updateSession(agentId: string, sessionId: string, body: UpdateAgentSessionDto): Promise<AgentSessionDetailDto> {
+    const session = await sessionService.updateSession(agentId, sessionId, body as any)
+    if (!session) {
+      throw DataApiErrorFactory.notFound('AgentSession', sessionId)
+    }
+    return session as AgentSessionDetailDto
+  }
+
+  async deleteSession(agentId: string, sessionId: string): Promise<void> {
+    const deleted = await sessionService.deleteSession(agentId, sessionId)
+    if (!deleted) {
+      throw DataApiErrorFactory.notFound('AgentSession', sessionId)
+    }
+  }
+
+  async reorderSessions(agentId: string, orderedIds: string[]): Promise<void> {
+    if (orderedIds.length === 0) {
+      throw DataApiErrorFactory.validation({ orderedIds: ['orderedIds must not be empty'] })
+    }
+    await sessionService.reorderSessions(agentId, orderedIds)
   }
 }
 

--- a/src/main/data/services/AgentsDataService.ts
+++ b/src/main/data/services/AgentsDataService.ts
@@ -1,0 +1,75 @@
+import { agentService } from '@main/services/agents/services/AgentService'
+import { sessionService } from '@main/services/agents/services/SessionService'
+import { DataApiErrorFactory } from '@shared/data/api'
+import type { OffsetPaginationResponse } from '@shared/data/api/apiTypes'
+import type {
+  AgentDetailDto,
+  AgentListQueryDto,
+  AgentSessionDetailDto,
+  AgentSessionListQueryDto,
+  AgentSessionSummaryDto
+} from '@shared/data/api/schemas/agents'
+
+const DEFAULT_PAGE = 1
+const DEFAULT_LIMIT = 20
+
+export class AgentsDataService {
+  async listAgents(query: AgentListQueryDto = {}): Promise<OffsetPaginationResponse<AgentDetailDto>> {
+    const page = Math.max(query.page ?? DEFAULT_PAGE, 1)
+    const limit = Math.max(query.limit ?? DEFAULT_LIMIT, 1)
+    const offset = (page - 1) * limit
+    const sortBy = query.sortBy ?? 'sort_order'
+    const orderBy = query.orderBy ?? (sortBy === 'sort_order' ? 'asc' : 'desc')
+
+    const result = await agentService.listAgents({
+      limit,
+      offset,
+      sortBy,
+      orderBy
+    })
+
+    return {
+      items: result.agents as AgentDetailDto[],
+      total: result.total,
+      page
+    }
+  }
+
+  async getAgent(id: string): Promise<AgentDetailDto> {
+    const agent = await agentService.getAgent(id)
+    if (!agent) {
+      throw DataApiErrorFactory.notFound('Agent', id)
+    }
+    return agent as AgentDetailDto
+  }
+
+  async listSessions(
+    agentId: string,
+    query: AgentSessionListQueryDto = {}
+  ): Promise<OffsetPaginationResponse<AgentSessionSummaryDto>> {
+    const page = Math.max(query.page ?? DEFAULT_PAGE, 1)
+    const limit = Math.max(query.limit ?? DEFAULT_LIMIT, 1)
+    const offset = (page - 1) * limit
+
+    const result = await sessionService.listSessions(agentId, {
+      limit,
+      offset
+    })
+
+    return {
+      items: result.sessions as AgentSessionSummaryDto[],
+      total: result.total,
+      page
+    }
+  }
+
+  async getSession(agentId: string, sessionId: string): Promise<AgentSessionDetailDto> {
+    const session = await sessionService.getSession(agentId, sessionId)
+    if (!session) {
+      throw DataApiErrorFactory.notFound('AgentSession', sessionId)
+    }
+    return session as AgentSessionDetailDto
+  }
+}
+
+export const agentsDataService = new AgentsDataService()

--- a/src/main/services/agents/BaseService.ts
+++ b/src/main/services/agents/BaseService.ts
@@ -8,7 +8,6 @@ import { objectKeys } from '@types'
 import fs from 'fs'
 import path from 'path'
 
-import { databaseManager } from './database/DatabaseManager'
 import { type AgentModelField, AgentModelValidationError } from './errors'
 import { builtinSlashCommands } from './services/claudecode/commands'
 import { builtinTools } from './services/claudecode/tools'
@@ -144,12 +143,13 @@ export abstract class BaseService {
   }
 
   /**
-   * Get database instance
-   * Automatically waits for initialization to complete
+   * Get the consolidated v2 main database.
+   *
+   * Agents services now read/write the shared main SQLite database via
+   * `DbService` instead of the deprecated standalone `agents.db` manager.
    */
   public async getDatabase() {
-    await databaseManager.initialize()
-    return databaseManager.getDatabase()
+    return application.get('DbService').getDb()
   }
 
   protected serializeJsonFields(data: any): any {

--- a/src/main/services/agents/database/schema/agents.schema.ts
+++ b/src/main/services/agents/database/schema/agents.schema.ts
@@ -4,7 +4,7 @@
 
 import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
-export const agentsTable = sqliteTable('agents', {
+export const agentsTable = sqliteTable('agents_agents', {
   id: text('id').primaryKey(),
   type: text('type').notNull(),
   name: text('name').notNull(),

--- a/src/main/services/agents/database/schema/channels.schema.ts
+++ b/src/main/services/agents/database/schema/channels.schema.ts
@@ -36,7 +36,7 @@ export { ChannelConfigSchema }
 // ---- Channels table ----
 
 export const channelsTable = sqliteTable(
-  'channels',
+  'agents_channels',
   {
     id: text('id')
       .primaryKey()
@@ -69,7 +69,7 @@ export const channelsTable = sqliteTable(
 // ---- Channel ↔ Task subscriptions (many-to-many) ----
 
 export const channelTaskSubscriptionsTable = sqliteTable(
-  'channel_task_subscriptions',
+  'agents_channel_task_subscriptions',
   {
     channelId: text('channel_id')
       .notNull()

--- a/src/main/services/agents/database/schema/messages.schema.ts
+++ b/src/main/services/agents/database/schema/messages.schema.ts
@@ -3,7 +3,7 @@ import { foreignKey, index, integer, sqliteTable, text } from 'drizzle-orm/sqlit
 import { sessionsTable } from './sessions.schema'
 
 // session_messages table to log all messages, thoughts, actions, observations in a session
-export const sessionMessagesTable = sqliteTable('session_messages', {
+export const sessionMessagesTable = sqliteTable('agents_session_messages', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   session_id: text('session_id').notNull(),
   role: text('role').notNull(), // 'user', 'agent', 'system', 'tool'

--- a/src/main/services/agents/database/schema/sessions.schema.ts
+++ b/src/main/services/agents/database/schema/sessions.schema.ts
@@ -6,7 +6,7 @@ import { foreignKey, index, integer, sqliteTable, text } from 'drizzle-orm/sqlit
 
 import { agentsTable } from './agents.schema'
 
-export const sessionsTable = sqliteTable('sessions', {
+export const sessionsTable = sqliteTable('agents_sessions', {
   id: text('id').primaryKey(),
   agent_type: text('agent_type').notNull(),
   agent_id: text('agent_id').notNull(), // Primary agent ID for the session

--- a/src/main/services/agents/database/schema/skills.schema.ts
+++ b/src/main/services/agents/database/schema/skills.schema.ts
@@ -11,7 +11,7 @@ import { randomUUID } from 'node:crypto'
 import { index, integer, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core'
 
 export const skillsTable = sqliteTable(
-  'skills',
+  'agents_skills',
   {
     id: text('id')
       .primaryKey()

--- a/src/main/services/agents/database/schema/tasks.schema.ts
+++ b/src/main/services/agents/database/schema/tasks.schema.ts
@@ -6,7 +6,7 @@ import { foreignKey, index, integer, sqliteTable, text } from 'drizzle-orm/sqlit
 
 import { agentsTable } from './agents.schema'
 
-export const scheduledTasksTable = sqliteTable('scheduled_tasks', {
+export const scheduledTasksTable = sqliteTable('agents_tasks', {
   id: text('id').primaryKey(),
   agent_id: text('agent_id').notNull(),
   name: text('name').notNull(),
@@ -22,7 +22,7 @@ export const scheduledTasksTable = sqliteTable('scheduled_tasks', {
   updated_at: text('updated_at').notNull()
 })
 
-export const taskRunLogsTable = sqliteTable('task_run_logs', {
+export const taskRunLogsTable = sqliteTable('agents_task_run_logs', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   task_id: text('task_id').notNull(),
   session_id: text('session_id'),

--- a/src/renderer/src/hooks/agents/useAgent.ts
+++ b/src/renderer/src/hooks/agents/useAgent.ts
@@ -1,48 +1,20 @@
-import { useCallback } from 'react'
-import { useTranslation } from 'react-i18next'
-import useSWR from 'swr'
-
-import { useApiServer } from '../useApiServer'
-import { useAgentClient } from './useAgentClient'
+import { useQuery } from '@renderer/data/hooks/useDataApi'
+import type { GetAgentResponse } from '@renderer/types'
 
 export const useAgent = (id: string | null) => {
-  const { t } = useTranslation()
-  const client = useAgentClient()
-  const key = client && id ? client.agentPaths.withId(id) : null
-  const { apiServerConfig, apiServerRunning } = useApiServer()
-
-  // Disable SWR fetching until auth is ready
-  const swrKey = apiServerRunning && apiServerConfig.apiKey && id && key ? key : null
-
-  const fetcher = useCallback(async () => {
-    if (!id) {
-      throw new Error(t('agent.get.error.null_id'))
+  const path: `/agents/${string}` = `/agents/${id ?? '__pending__'}`
+  const { data, error, isLoading, refetch } = useQuery(path, {
+    enabled: !!id,
+    swrOptions: {
+      revalidateOnMount: true,
+      dedupingInterval: 2000
     }
-    if (!apiServerConfig.enabled) {
-      throw new Error(t('apiServer.messages.notEnabled'))
-    }
-    if (!client) {
-      throw new Error(t('apiServer.messages.notEnabled'))
-    }
-    const result = await client.getAgent(id)
-    return result
-  }, [apiServerConfig.enabled, client, id, t])
-  const {
-    data,
-    error,
-    isLoading,
-    mutate: revalidate
-  } = useSWR(swrKey, fetcher, {
-    // Agent config may be modified externally (e.g. claw MCP tool in main process),
-    // so always revalidate on mount and reduce dedup window to get fresh data.
-    revalidateOnMount: true,
-    dedupingInterval: 2000
   })
 
   return {
-    agent: data,
-    error,
+    agent: data as GetAgentResponse | undefined,
+    error: error ?? null,
     isLoading,
-    revalidate
+    revalidate: refetch
   }
 }

--- a/src/renderer/src/hooks/agents/useAgentSessionInitializer.ts
+++ b/src/renderer/src/hooks/agents/useAgentSessionInitializer.ts
@@ -1,9 +1,10 @@
 import { loggerService } from '@logger'
 import { cacheService } from '@renderer/data/CacheService'
+import { dataApiService } from '@renderer/data/DataApiService'
 import { useCache } from '@renderer/data/hooks/useCache'
+import type { AgentSessionEntity } from '@renderer/types'
+import type { OffsetPaginationResponse } from '@shared/data/api/apiTypes'
 import { useCallback, useEffect, useRef } from 'react'
-
-import { useAgentClient } from './useAgentClient'
 
 const logger = loggerService.withContext('useAgentSessionInitializer')
 
@@ -13,7 +14,6 @@ const logger = loggerService.withContext('useAgentSessionInitializer')
  * its most recent session is automatically selected.
  */
 export const useAgentSessionInitializer = () => {
-  const client = useAgentClient()
   const [activeAgentId] = useCache('agent.active_id')
   const [activeSessionIdMap] = useCache('agent.session.active_id_map')
 
@@ -25,39 +25,38 @@ export const useAgentSessionInitializer = () => {
    * Initialize session for the given agent by loading its sessions
    * and setting the latest one as active
    */
-  const initializeAgentSession = useCallback(
-    async (agentId: string) => {
-      if (!agentId || !client) return
+  const initializeAgentSession = useCallback(async (agentId: string) => {
+    if (!agentId) return
 
-      try {
-        // Check if this agent has already been initialized (key exists in map)
-        if (agentId in activeSessionIdMapRef.current) {
-          // Already initialized, nothing to do
-          return
-        }
-
-        // Load sessions for this agent
-        const response = await client.listSessions(agentId)
-        const sessions = response.data
-
-        if (sessions && sessions.length > 0) {
-          // Get the latest session (first in the list, assuming they're sorted by updatedAt)
-          const latestSession = sessions[0]
-
-          // Set the latest session as active
-          const currentMap = cacheService.get('agent.session.active_id_map') ?? {}
-          cacheService.set('agent.session.active_id_map', { ...currentMap, [agentId]: latestSession.id })
-        } else {
-          // Mark as initialized with no session (null vs undefined distinction)
-          const currentMap = cacheService.get('agent.session.active_id_map') ?? {}
-          cacheService.set('agent.session.active_id_map', { ...currentMap, [agentId]: null })
-        }
-      } catch (error) {
-        logger.error('Failed to initialize agent session:', error as Error)
+    try {
+      // Check if this agent has already been initialized (key exists in map)
+      if (agentId in activeSessionIdMapRef.current) {
+        // Already initialized, nothing to do
+        return
       }
-    },
-    [client]
-  )
+
+      // Load sessions for this agent
+      const response = (await dataApiService.get(`/agents/${agentId}/sessions`, {
+        query: { page: 1, limit: 20 }
+      })) as OffsetPaginationResponse<AgentSessionEntity>
+      const sessions = response.items
+
+      if (sessions && sessions.length > 0) {
+        // Get the latest session (first in the list, assuming they're sorted by updatedAt)
+        const latestSession = sessions[0]
+
+        // Set the latest session as active
+        const currentMap = cacheService.get('agent.session.active_id_map') ?? {}
+        cacheService.set('agent.session.active_id_map', { ...currentMap, [agentId]: latestSession.id })
+      } else {
+        // Mark as initialized with no session (null vs undefined distinction)
+        const currentMap = cacheService.get('agent.session.active_id_map') ?? {}
+        cacheService.set('agent.session.active_id_map', { ...currentMap, [agentId]: null })
+      }
+    } catch (error) {
+      logger.error('Failed to initialize agent session:', error as Error)
+    }
+  }, [])
 
   /**
    * Auto-initialize when activeAgentId changes

--- a/src/renderer/src/hooks/agents/useAgents.ts
+++ b/src/renderer/src/hooks/agents/useAgents.ts
@@ -1,4 +1,5 @@
 import { cacheService } from '@renderer/data/CacheService'
+import { dataApiService } from '@renderer/data/DataApiService'
 import { useCache } from '@renderer/data/hooks/useCache'
 import { useInvalidateCache, useQuery } from '@renderer/data/hooks/useDataApi'
 import type { AddAgentForm, CreateAgentResponse, GetAgentResponse } from '@renderer/types'
@@ -6,8 +7,6 @@ import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
 import type { OffsetPaginationResponse } from '@shared/data/api/apiTypes'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-
-import { useAgentClient } from './useAgentClient'
 
 type Result<T> =
   | {
@@ -21,7 +20,6 @@ type Result<T> =
 
 export const useAgents = () => {
   const { t } = useTranslation()
-  const client = useAgentClient()
   const invalidate = useInvalidateCache()
   const { data, error, isLoading, refetch } = useQuery('/agents', {
     query: {
@@ -37,11 +35,11 @@ export const useAgents = () => {
   const addAgent = useCallback(
     async (form: AddAgentForm): Promise<Result<CreateAgentResponse>> => {
       try {
-        if (!client) {
-          throw new Error(t('apiServer.messages.notEnabled'))
-        }
-        const result = await client.createAgent(form)
+        const result = (await dataApiService.post('/agents', {
+          body: form
+        })) as CreateAgentResponse
         await invalidate('/agents')
+        await invalidate(`/agents/${result.id}`)
         window.toast.success(t('common.add_success'))
         return { success: true, data: result }
       } catch (error) {
@@ -53,16 +51,13 @@ export const useAgents = () => {
         return { success: false, error: new Error(formatErrorMessageWithPrefix(error, t('agent.add.error.failed'))) }
       }
     },
-    [client, invalidate, t]
+    [invalidate, t]
   )
 
   const deleteAgent = useCallback(
     async (id: string) => {
       try {
-        if (!client) {
-          throw new Error(t('apiServer.messages.notEnabled'))
-        }
-        await client.deleteAgent(id)
+        await dataApiService.delete(`/agents/${id}`)
         const currentMap = cacheService.get('agent.session.active_id_map') ?? {}
         cacheService.set('agent.session.active_id_map', { ...currentMap, [id]: null })
         if (activeAgentId === id) {
@@ -75,35 +70,31 @@ export const useAgents = () => {
         window.toast.error(formatErrorMessageWithPrefix(error, t('agent.delete.error.failed')))
       }
     },
-    [activeAgentId, client, pagedData, invalidate, t]
+    [activeAgentId, pagedData, invalidate, t]
   )
 
   const getAgent = useCallback(
     async (id: string) => {
-      if (!client) {
-        return
-      }
       await invalidate(`/agents/${id}`)
       await invalidate('/agents')
     },
-    [client, invalidate]
+    [invalidate]
   )
 
   const reorderAgents = useCallback(
     async (reorderedList: GetAgentResponse[]) => {
       const orderedIds = reorderedList.map((a) => a.id)
       try {
-        if (!client) {
-          throw new Error(t('apiServer.messages.notEnabled'))
-        }
-        await client.reorderAgents(orderedIds)
+        await dataApiService.patch('/agents', {
+          body: { orderedIds }
+        })
         await invalidate('/agents')
       } catch (error) {
         await invalidate('/agents')
         window.toast.error(formatErrorMessageWithPrefix(error, t('agent.reorder.error.failed')))
       }
     },
-    [client, invalidate, t]
+    [invalidate, t]
   )
 
   return {

--- a/src/renderer/src/hooks/agents/useAgents.ts
+++ b/src/renderer/src/hooks/agents/useAgents.ts
@@ -1,12 +1,12 @@
 import { cacheService } from '@renderer/data/CacheService'
 import { useCache } from '@renderer/data/hooks/useCache'
+import { useInvalidateCache, useQuery } from '@renderer/data/hooks/useDataApi'
 import type { AddAgentForm, CreateAgentResponse, GetAgentResponse } from '@renderer/types'
 import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
+import type { OffsetPaginationResponse } from '@shared/data/api/apiTypes'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import useSWR from 'swr'
 
-import { useApiServer } from '../useApiServer'
 import { useAgentClient } from './useAgentClient'
 
 type Result<T> =
@@ -22,30 +22,17 @@ type Result<T> =
 export const useAgents = () => {
   const { t } = useTranslation()
   const client = useAgentClient()
-  const key = client?.agentPaths.base
-  const { apiServerConfig, apiServerRunning } = useApiServer()
-
-  // Disable SWR fetching when server auth is not ready
-  const swrKey = apiServerRunning && apiServerConfig.apiKey && key ? key : null
-
-  const fetcher = useCallback(async () => {
-    // API server will start on startup if enabled OR there are agents
-    if (!apiServerConfig.enabled && !apiServerRunning) {
-      throw new Error(t('apiServer.messages.notEnabled'))
+  const invalidate = useInvalidateCache()
+  const { data, error, isLoading, refetch } = useQuery('/agents', {
+    query: {
+      page: 1,
+      limit: 200,
+      sortBy: 'sort_order',
+      orderBy: 'asc'
     }
-    if (!apiServerRunning) {
-      throw new Error(t('agent.server.error.not_running'))
-    }
-    if (!client) {
-      throw new Error(t('apiServer.messages.notEnabled'))
-    }
-    const result = await client.listAgents({ sortBy: 'sort_order', orderBy: 'asc' })
-    // NOTE: We only use the array for now. useUpdateAgent depends on this behavior.
-    return result.data
-  }, [apiServerConfig.enabled, apiServerRunning, client, t])
-
-  const { data, error, isLoading, mutate } = useSWR(swrKey, fetcher)
+  })
   const [activeAgentId] = useCache('agent.active_id')
+  const pagedData = data as OffsetPaginationResponse<GetAgentResponse> | undefined
 
   const addAgent = useCallback(
     async (form: AddAgentForm): Promise<Result<CreateAgentResponse>> => {
@@ -54,7 +41,7 @@ export const useAgents = () => {
           throw new Error(t('apiServer.messages.notEnabled'))
         }
         const result = await client.createAgent(form)
-        void mutate((prev) => [result, ...(prev ?? [])])
+        await invalidate('/agents')
         window.toast.success(t('common.add_success'))
         return { success: true, data: result }
       } catch (error) {
@@ -62,12 +49,11 @@ export const useAgents = () => {
         window.toast.error(errorMessage)
         if (error instanceof Error) {
           return { success: false, error }
-        } else {
-          return { success: false, error: new Error(formatErrorMessageWithPrefix(error, t('agent.add.error.failed'))) }
         }
+        return { success: false, error: new Error(formatErrorMessageWithPrefix(error, t('agent.add.error.failed'))) }
       }
     },
-    [client, mutate, t]
+    [client, invalidate, t]
   )
 
   const deleteAgent = useCallback(
@@ -80,16 +66,16 @@ export const useAgents = () => {
         const currentMap = cacheService.get('agent.session.active_id_map') ?? {}
         cacheService.set('agent.session.active_id_map', { ...currentMap, [id]: null })
         if (activeAgentId === id) {
-          const newId = data?.filter((a) => a.id !== id).find(() => true)?.id
+          const newId = pagedData?.items.filter((a) => a.id !== id).find(() => true)?.id
           cacheService.set('agent.active_id', newId ?? null)
         }
-        void mutate((prev) => prev?.filter((a) => a.id !== id) ?? [])
+        await invalidate(['/agents', `/agents/${id}`])
         window.toast.success(t('common.delete_success'))
       } catch (error) {
         window.toast.error(formatErrorMessageWithPrefix(error, t('agent.delete.error.failed')))
       }
     },
-    [activeAgentId, client, data, mutate, t]
+    [activeAgentId, client, pagedData, invalidate, t]
   )
 
   const getAgent = useCallback(
@@ -97,37 +83,37 @@ export const useAgents = () => {
       if (!client) {
         return
       }
-      const result = await client.getAgent(id)
-      void mutate((prev) => prev?.map((a) => (a.id === result.id ? result : a)) ?? [])
+      await invalidate(`/agents/${id}`)
+      await invalidate('/agents')
     },
-    [client, mutate]
+    [client, invalidate]
   )
 
   const reorderAgents = useCallback(
     async (reorderedList: GetAgentResponse[]) => {
       const orderedIds = reorderedList.map((a) => a.id)
-      // Optimistic update
-      void mutate(reorderedList, false)
       try {
         if (!client) {
           throw new Error(t('apiServer.messages.notEnabled'))
         }
         await client.reorderAgents(orderedIds)
+        await invalidate('/agents')
       } catch (error) {
-        void mutate()
+        await invalidate('/agents')
         window.toast.error(formatErrorMessageWithPrefix(error, t('agent.reorder.error.failed')))
       }
     },
-    [client, mutate, t]
+    [client, invalidate, t]
   )
 
   return {
-    agents: data,
+    agents: pagedData?.items,
     error,
     isLoading,
     addAgent,
     deleteAgent,
     getAgent,
-    reorderAgents
+    reorderAgents,
+    refetch
   }
 }

--- a/src/renderer/src/hooks/agents/useSession.ts
+++ b/src/renderer/src/hooks/agents/useSession.ts
@@ -1,28 +1,20 @@
-import { useTranslation } from 'react-i18next'
-import useSWR from 'swr'
+import { useQuery } from '@renderer/data/hooks/useDataApi'
+import type { GetAgentSessionResponse } from '@renderer/types'
 
-import { requireAgentClient, useAgentClient } from './useAgentClient'
 import { useUpdateSession } from './useUpdateSession'
 
 export const useSession = (agentId: string | null, sessionId: string | null) => {
-  const { t } = useTranslation()
-  const client = useAgentClient()
-  const key = agentId && sessionId && client ? client.getSessionPaths(agentId).withId(sessionId) : null
   const { updateSession } = useUpdateSession(agentId)
-
-  const fetcher = async () => {
-    if (!agentId) throw new Error(t('agent.get.error.null_id'))
-    if (!sessionId) throw new Error(t('agent.session.get.error.null_id'))
-    const data = await requireAgentClient(client).getSession(agentId, sessionId)
-    return data
-  }
-  const { data, error, isLoading, mutate } = useSWR(key, fetcher)
+  const path: `/agents/${string}/sessions/${string}` = `/agents/${agentId ?? '__pending__'}/sessions/${sessionId ?? '__pending__'}`
+  const { data, error, isLoading, refetch } = useQuery(path, {
+    enabled: !!agentId && !!sessionId
+  })
 
   return {
-    session: data,
-    error,
+    session: data as GetAgentSessionResponse | undefined,
+    error: error ?? null,
     isLoading,
     updateSession,
-    mutate
+    mutate: refetch
   }
 }

--- a/src/renderer/src/hooks/agents/useSessions.ts
+++ b/src/renderer/src/hooks/agents/useSessions.ts
@@ -1,12 +1,14 @@
 import { DEFAULT_SESSION_PAGE_SIZE } from '@renderer/api/agent'
+import { dataApiService } from '@renderer/data/DataApiService'
+import { useInvalidateCache } from '@renderer/data/hooks/useDataApi'
 import type {
   AgentSessionEntity,
   CreateAgentSessionResponse,
   CreateSessionForm,
-  GetAgentSessionResponse,
-  ListAgentSessionsResponse
+  GetAgentSessionResponse
 } from '@renderer/types'
 import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
+import type { OffsetPaginationResponse } from '@shared/data/api/apiTypes'
 import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import useSWRInfinite from 'swr/infinite'
@@ -14,35 +16,41 @@ import useSWRInfinite from 'swr/infinite'
 import { useAgentClient } from './useAgentClient'
 import { useSessionChanged } from './useSessionChanged'
 
+type SessionsPage = OffsetPaginationResponse<AgentSessionEntity>
+
 export const useSessions = (agentId: string | null, pageSize = DEFAULT_SESSION_PAGE_SIZE) => {
   const { t } = useTranslation()
   const client = useAgentClient()
+  const invalidate = useInvalidateCache()
+  const listPath = agentId ? `/agents/${agentId}/sessions` : null
 
-  const getKey = (pageIndex: number, previousPageData: ListAgentSessionsResponse | null) => {
-    if (!agentId || !client) return null
-    if (previousPageData && previousPageData.data.length < pageSize) return null
-    return [client.getSessionPaths(agentId).base, pageIndex, pageSize]
+  const getKey = (pageIndex: number, previousPageData: SessionsPage | null) => {
+    if (!listPath) return null
+    if (previousPageData && previousPageData.items.length < pageSize) return null
+    return [listPath, pageIndex, pageSize] as const
   }
 
-  const fetcher = async ([, pageIndex, pageLimit]: [string, number, number]) => {
-    if (!agentId || !client) throw new Error('No active agent.')
-    return await client.listSessions(agentId, {
-      limit: pageLimit,
-      offset: pageIndex * pageLimit
-    })
+  const fetcher = async ([path, pageIndex, pageLimit]: readonly [`/agents/${string}/sessions`, number, number]) => {
+    return (await dataApiService.get(path, {
+      query: {
+        page: pageIndex + 1,
+        limit: pageLimit
+      }
+    })) as SessionsPage
   }
 
-  const { data, error, isLoading, isValidating, mutate, size, setSize } = useSWRInfinite(getKey, fetcher)
+  const { data, error, isLoading, isValidating, mutate, size, setSize } = useSWRInfinite<SessionsPage>(getKey, fetcher)
 
   const sessions = useMemo(() => {
     if (!data) return []
-    return data.flatMap((page) => page.data)
+    return data.flatMap((page) => page.items)
   }, [data])
 
   const total = useMemo(() => {
     if (!data || data.length === 0) return 0
     return data[data.length - 1].total
   }, [data])
+
   const hasMore = sessions.length < total
   const isLoadingMore = isLoading || (size > 0 && data && typeof data[size - 1] === 'undefined')
 
@@ -50,13 +58,12 @@ export const useSessions = (agentId: string | null, pageSize = DEFAULT_SESSION_P
     if (!isLoadingMore && hasMore) {
       void setSize((currentSize) => currentSize + 1)
     }
-  }, [isLoadingMore, hasMore, setSize])
+  }, [hasMore, isLoadingMore, setSize])
 
   const reload = useCallback(async () => {
     await mutate()
   }, [mutate])
 
-  // Auto-refresh when IM channel creates/updates sessions
   useSessionChanged(agentId ?? undefined, reload)
 
   const createSession = useCallback(
@@ -67,12 +74,13 @@ export const useSessions = (agentId: string | null, pageSize = DEFAULT_SESSION_P
         void mutate(
           (prev) => {
             if (!prev || prev.length === 0) {
-              return [{ data: [result], total: 1, limit: pageSize, offset: 0 }]
+              return [{ items: [result], total: 1, page: 1 }]
             }
+
             const newTotal = prev[0].total + 1
-            return prev.map((page, i) => ({
+            return prev.map((page, index) => ({
               ...page,
-              data: i === 0 ? [result, ...page.data] : page.data,
+              items: index === 0 ? [result, ...page.items] : page.items,
               total: newTotal
             }))
           },
@@ -84,19 +92,19 @@ export const useSessions = (agentId: string | null, pageSize = DEFAULT_SESSION_P
         return null
       }
     },
-    [agentId, client, mutate, pageSize, t]
+    [agentId, client, mutate, t]
   )
 
   const getSession = useCallback(
     async (id: string): Promise<GetAgentSessionResponse | null> => {
-      if (!agentId || !client) return null
+      if (!agentId) return null
       try {
-        const result = await client.getSession(agentId, id)
+        const result = (await dataApiService.get(`/agents/${agentId}/sessions/${id}`)) as GetAgentSessionResponse
         void mutate(
           (prev) =>
             prev?.map((page) => ({
               ...page,
-              data: page.data.map((session) => (session.id === result.id ? result : session))
+              items: page.items.map((session) => (session.id === result.id ? result : session))
             })),
           { revalidate: false }
         )
@@ -106,7 +114,7 @@ export const useSessions = (agentId: string | null, pageSize = DEFAULT_SESSION_P
         return null
       }
     },
-    [agentId, client, mutate, t]
+    [agentId, mutate, t]
   )
 
   const deleteSession = useCallback(
@@ -120,7 +128,7 @@ export const useSessions = (agentId: string | null, pageSize = DEFAULT_SESSION_P
             const newTotal = prev[0].total - 1
             return prev.map((page) => ({
               ...page,
-              data: page.data.filter((session) => session.id !== id),
+              items: page.items.filter((session) => session.id !== id),
               total: newTotal
             }))
           },
@@ -139,22 +147,25 @@ export const useSessions = (agentId: string | null, pageSize = DEFAULT_SESSION_P
     async (reorderedList: AgentSessionEntity[]) => {
       if (!agentId || !client) return
       const orderedIds = reorderedList.map((s) => s.id)
-      // Optimistic update: replace all pages with single page containing reordered list
       void mutate(
         (prev) => {
           const realTotal = prev && prev.length > 0 ? prev[prev.length - 1].total : reorderedList.length
-          return [{ data: reorderedList, total: realTotal, limit: pageSize, offset: 0 }]
+          return [{ items: reorderedList, total: realTotal, page: 1 }]
         },
         { revalidate: false }
       )
+
       try {
         await client.reorderSessions(agentId, orderedIds)
+        if (listPath) {
+          await invalidate(listPath)
+        }
       } catch (error) {
         void mutate()
         window.toast.error(formatErrorMessageWithPrefix(error, t('agent.session.reorder.error.failed')))
       }
     },
-    [agentId, client, mutate, pageSize, t]
+    [agentId, client, invalidate, listPath, mutate, t]
   )
 
   return {

--- a/src/renderer/src/hooks/agents/useSessions.ts
+++ b/src/renderer/src/hooks/agents/useSessions.ts
@@ -13,14 +13,12 @@ import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import useSWRInfinite from 'swr/infinite'
 
-import { useAgentClient } from './useAgentClient'
 import { useSessionChanged } from './useSessionChanged'
 
 type SessionsPage = OffsetPaginationResponse<AgentSessionEntity>
 
 export const useSessions = (agentId: string | null, pageSize = DEFAULT_SESSION_PAGE_SIZE) => {
   const { t } = useTranslation()
-  const client = useAgentClient()
   const invalidate = useInvalidateCache()
   const listPath = agentId ? `/agents/${agentId}/sessions` : null
 
@@ -68,9 +66,11 @@ export const useSessions = (agentId: string | null, pageSize = DEFAULT_SESSION_P
 
   const createSession = useCallback(
     async (form: CreateSessionForm): Promise<CreateAgentSessionResponse | null> => {
-      if (!agentId || !client) return null
+      if (!agentId) return null
       try {
-        const result = await client.createSession(agentId, form)
+        const result = (await dataApiService.post(`/agents/${agentId}/sessions`, {
+          body: form
+        })) as CreateAgentSessionResponse
         void mutate(
           (prev) => {
             if (!prev || prev.length === 0) {
@@ -86,13 +86,14 @@ export const useSessions = (agentId: string | null, pageSize = DEFAULT_SESSION_P
           },
           { revalidate: false }
         )
+        await invalidate(`/agents/${agentId}/sessions/${result.id}`)
         return result
       } catch (error) {
         window.toast.error(formatErrorMessageWithPrefix(error, t('agent.session.create.error.failed')))
         return null
       }
     },
-    [agentId, client, mutate, t]
+    [agentId, invalidate, mutate, t]
   )
 
   const getSession = useCallback(
@@ -119,9 +120,9 @@ export const useSessions = (agentId: string | null, pageSize = DEFAULT_SESSION_P
 
   const deleteSession = useCallback(
     async (id: string): Promise<boolean> => {
-      if (!agentId || !client) return false
+      if (!agentId) return false
       try {
-        await client.deleteSession(agentId, id)
+        await dataApiService.delete(`/agents/${agentId}/sessions/${id}`)
         void mutate(
           (prev) => {
             if (!prev || prev.length === 0) return prev
@@ -140,12 +141,12 @@ export const useSessions = (agentId: string | null, pageSize = DEFAULT_SESSION_P
         return false
       }
     },
-    [agentId, client, mutate, t]
+    [agentId, mutate, t]
   )
 
   const reorderSessions = useCallback(
     async (reorderedList: AgentSessionEntity[]) => {
-      if (!agentId || !client) return
+      if (!agentId || !listPath) return
       const orderedIds = reorderedList.map((s) => s.id)
       void mutate(
         (prev) => {
@@ -156,16 +157,16 @@ export const useSessions = (agentId: string | null, pageSize = DEFAULT_SESSION_P
       )
 
       try {
-        await client.reorderSessions(agentId, orderedIds)
-        if (listPath) {
-          await invalidate(listPath)
-        }
+        await dataApiService.patch(listPath as `/agents/${string}/sessions`, {
+          body: { orderedIds }
+        })
+        await invalidate(listPath as `/agents/${string}/sessions`)
       } catch (error) {
         void mutate()
         window.toast.error(formatErrorMessageWithPrefix(error, t('agent.session.reorder.error.failed')))
       }
     },
-    [agentId, client, invalidate, listPath, mutate, t]
+    [agentId, invalidate, listPath, mutate, t]
   )
 
   return {

--- a/src/renderer/src/hooks/agents/useUpdateAgent.ts
+++ b/src/renderer/src/hooks/agents/useUpdateAgent.ts
@@ -1,3 +1,4 @@
+import { dataApiService } from '@renderer/data/DataApiService'
 import { useInvalidateCache } from '@renderer/data/hooks/useDataApi'
 import type { AgentEntity, UpdateAgentForm } from '@renderer/types'
 import type { UpdateAgentBaseOptions, UpdateAgentFunction } from '@renderer/types/agent'
@@ -5,20 +6,16 @@ import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { useAgentClient } from './useAgentClient'
-
 export const useUpdateAgent = () => {
   const { t } = useTranslation()
-  const client = useAgentClient()
   const invalidate = useInvalidateCache()
 
   const updateAgent: UpdateAgentFunction = useCallback(
     async (form: UpdateAgentForm, options?: UpdateAgentBaseOptions): Promise<AgentEntity | undefined> => {
       try {
-        if (!client) {
-          throw new Error(t('apiServer.messages.notEnabled'))
-        }
-        const result = await client.updateAgent(form)
+        const result = (await dataApiService.patch(`/agents/${form.id}`, {
+          body: form
+        })) as AgentEntity
         await invalidate(['/agents', `/agents/${form.id}`])
         if (options?.showSuccessToast ?? true) {
           window.toast.success({ key: 'update-agent', title: t('common.update_success') })
@@ -29,7 +26,7 @@ export const useUpdateAgent = () => {
         return undefined
       }
     },
-    [client, invalidate, t]
+    [invalidate, t]
   )
 
   const updateModel = useCallback(

--- a/src/renderer/src/hooks/agents/useUpdateAgent.ts
+++ b/src/renderer/src/hooks/agents/useUpdateAgent.ts
@@ -1,31 +1,25 @@
-import type { AgentEntity, ListAgentsResponse, UpdateAgentForm } from '@renderer/types'
+import { useInvalidateCache } from '@renderer/data/hooks/useDataApi'
+import type { AgentEntity, UpdateAgentForm } from '@renderer/types'
 import type { UpdateAgentBaseOptions, UpdateAgentFunction } from '@renderer/types/agent'
 import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { mutate } from 'swr'
 
 import { useAgentClient } from './useAgentClient'
 
 export const useUpdateAgent = () => {
   const { t } = useTranslation()
   const client = useAgentClient()
-  const listKey = client?.agentPaths.base
+  const invalidate = useInvalidateCache()
 
   const updateAgent: UpdateAgentFunction = useCallback(
     async (form: UpdateAgentForm, options?: UpdateAgentBaseOptions): Promise<AgentEntity | undefined> => {
       try {
-        if (!client || !listKey) {
+        if (!client) {
           throw new Error(t('apiServer.messages.notEnabled'))
         }
-        const itemKey = client.agentPaths.withId(form.id)
-        // may change to optimistic update
         const result = await client.updateAgent(form)
-        void mutate<ListAgentsResponse['data']>(
-          listKey,
-          (prev) => prev?.map((a) => (a.id === result.id ? result : a)) ?? []
-        )
-        void mutate(itemKey, result)
+        await invalidate(['/agents', `/agents/${form.id}`])
         if (options?.showSuccessToast ?? true) {
           window.toast.success({ key: 'update-agent', title: t('common.update_success') })
         }
@@ -35,7 +29,7 @@ export const useUpdateAgent = () => {
         return undefined
       }
     },
-    [client, listKey, t]
+    [client, invalidate, t]
   )
 
   const updateModel = useCallback(

--- a/src/renderer/src/hooks/agents/useUpdateSession.ts
+++ b/src/renderer/src/hooks/agents/useUpdateSession.ts
@@ -1,3 +1,4 @@
+import { dataApiService } from '@renderer/data/DataApiService'
 import { useInvalidateCache } from '@renderer/data/hooks/useDataApi'
 import type { AgentSessionEntity, UpdateSessionForm } from '@renderer/types'
 import type { UpdateAgentBaseOptions, UpdateAgentSessionFunction } from '@renderer/types/agent'
@@ -5,19 +6,18 @@ import { getErrorMessage } from '@renderer/utils/error'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { useAgentClient } from './useAgentClient'
-
 export const useUpdateSession = (agentId: string | null) => {
   const { t } = useTranslation()
-  const client = useAgentClient()
   const invalidate = useInvalidateCache()
 
   const updateSession: UpdateAgentSessionFunction = useCallback(
     async (form: UpdateSessionForm, options?: UpdateAgentBaseOptions): Promise<AgentSessionEntity | undefined> => {
-      if (!agentId || !client) return
+      if (!agentId) return
 
       try {
-        const result = await client.updateSession(agentId, form)
+        const result = (await dataApiService.patch(`/agents/${agentId}/sessions/${form.id}`, {
+          body: form
+        })) as AgentSessionEntity
         await invalidate([`/agents/${agentId}/sessions`, `/agents/${agentId}/sessions/${form.id}`])
         if (options?.showSuccessToast ?? true) {
           window.toast.success(t('common.update_success'))
@@ -29,7 +29,7 @@ export const useUpdateSession = (agentId: string | null) => {
         return undefined
       }
     },
-    [agentId, client, invalidate, t]
+    [agentId, invalidate, t]
   )
 
   const updateModel = useCallback(

--- a/src/renderer/src/hooks/agents/useUpdateSession.ts
+++ b/src/renderer/src/hooks/agents/useUpdateSession.ts
@@ -1,69 +1,35 @@
-import { DEFAULT_SESSION_PAGE_SIZE } from '@renderer/api/agent'
-import type { AgentSessionEntity, ListAgentSessionsResponse, UpdateSessionForm } from '@renderer/types'
+import { useInvalidateCache } from '@renderer/data/hooks/useDataApi'
+import type { AgentSessionEntity, UpdateSessionForm } from '@renderer/types'
 import type { UpdateAgentBaseOptions, UpdateAgentSessionFunction } from '@renderer/types/agent'
 import { getErrorMessage } from '@renderer/utils/error'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { mutate } from 'swr'
-import { unstable_serialize } from 'swr/infinite'
 
 import { useAgentClient } from './useAgentClient'
-
-type InfiniteData = ListAgentSessionsResponse[]
-
-const mutateInfiniteList = (
-  infKey: string,
-  sessionId: string,
-  updater: (session: AgentSessionEntity) => AgentSessionEntity
-) => {
-  void mutate<InfiniteData>(
-    infKey,
-    (prev) => {
-      if (!prev) return prev
-      return prev.map((page) => ({
-        ...page,
-        data: page.data.map((session) => (session.id === sessionId ? updater(session) : session))
-      }))
-    },
-    { revalidate: false }
-  )
-}
 
 export const useUpdateSession = (agentId: string | null) => {
   const { t } = useTranslation()
   const client = useAgentClient()
+  const invalidate = useInvalidateCache()
 
   const updateSession: UpdateAgentSessionFunction = useCallback(
     async (form: UpdateSessionForm, options?: UpdateAgentBaseOptions): Promise<AgentSessionEntity | undefined> => {
       if (!agentId || !client) return
-      const paths = client.getSessionPaths(agentId)
-      const listKey = paths.base
-      const sessionId = form.id
-      const itemKey = paths.withId(sessionId)
-      const infKey = unstable_serialize(() => [listKey, 0, DEFAULT_SESSION_PAGE_SIZE])
-
-      // Optimistic update
-      mutateInfiniteList(infKey, sessionId, (session) => ({ ...session, ...form }))
-      void mutate<AgentSessionEntity>(itemKey, (prev) => (prev ? { ...prev, ...form } : prev), { revalidate: false })
 
       try {
         const result = await client.updateSession(agentId, form)
-        // Update with server response
-        mutateInfiniteList(infKey, sessionId, () => result)
-        void mutate(itemKey, result, { revalidate: false })
+        await invalidate([`/agents/${agentId}/sessions`, `/agents/${agentId}/sessions/${form.id}`])
         if (options?.showSuccessToast ?? true) {
           window.toast.success(t('common.update_success'))
         }
         return result
       } catch (error) {
-        // Rollback: revalidate to get fresh data
-        void mutate(infKey)
-        void mutate(itemKey)
+        await invalidate([`/agents/${agentId}/sessions`, `/agents/${agentId}/sessions/${form.id}`])
         window.toast.error({ title: t('agent.session.update.error.failed'), description: getErrorMessage(error) })
         return undefined
       }
     },
-    [agentId, client, t]
+    [agentId, client, invalidate, t]
   )
 
   const updateModel = useCallback(


### PR DESCRIPTION
### What this PR does

Before this PR:
- Agents data lived in a separate legacy SQLite database at `agents.db`.
- The main v2 database had no `agents_*` target tables.
- The v2 migration status did not account for legacy `agents.db` data remaining on installs already marked as migrated.

After this PR:
- The main database adds `agents_*` tables for legacy agents data.
- The v2 migration flow includes a new `AgentsMigrator` that imports `agents.db` into the main database using SQLite `ATTACH` + `INSERT ... SELECT`.
- The v2 migration target version is bumped so installs marked as `2.0.0` rerun migration when legacy `agents.db` data still exists.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #
N/A

### Why we need it and why it was done in this way

We need a single v2 migration flow that can move legacy agents data into the main database without requiring a separate upgrade path.

The import is implemented with SQLite-native `ATTACH DATABASE` and `INSERT ... SELECT` statements inside the v2 migrator so that legacy IDs, timestamps, and JSON/text payloads are preserved while keeping the migration logic simple and efficient.

The following tradeoffs were made:
- The new `agents_*` schema intentionally stays close to the legacy `agents.db` schema to reduce migration risk.
- This PR focuses on schema creation and data import; runtime service cutover to the main DB can follow in a separate change.

The following alternatives were considered:
- A standalone post-v2 startup migration for `agents.db`
- Row-by-row TypeScript transformation instead of SQLite-native import

Links to places where the discussion took place: None

### Breaking changes

N/A

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- This PR adds the v2 import path and main-db schema only.
- Agents runtime services are not fully switched to the new main-db tables in this change.
- Migration coverage includes unit tests for SQL import mapping, legacy DB path discovery, migrator phases, and version-aware rerun behavior.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
