### PR TITLE
chore: release v1.9.0

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -142,7 +142,7 @@ artifactBuildCompleted: scripts/artifact-build-completed.js
 releaseInfo:
   releaseNotes: |
     <!--LANG:en-->
-    Cherry Studio 1.9.0-rc.0 - CherryClaw Agent, Skills System & Security Hardening
+    Cherry Studio 1.9.0 - CherryClaw Agent & Skills System
 
     ⚠️ Breaking Changes
     - [Agents] "Plugins" system renamed to "Skills". Plugin marketplace has been replaced by a unified Skills management interface
@@ -162,17 +162,24 @@ releaseInfo:
     - [Security] Fix XSS vulnerability in MCP description and search results
 
     🐛 Bug Fixes
+    - [Models] Add Ollama gemma4 format support for Gemma 4 model capability detection
     - [Models] Fix new-api provider ignoring configured host for Anthropic format requests
     - [Models] Fix Poe provider unable to load models dynamically
     - [Models] Fix Google Gemini web search failing
     - [Models] Fix model detection for Qwen3.5–3.9 and GPT series
     - [Models] Fix NVIDIA provider reasoning parameters for Qwen/DeepSeek/Kimi/Zhipu models
+    - [Models] Fix Xiaomi MiMo thinking/non-thinking toggle behavior
     - [Agents] Fix Claude Code child processes ignoring app proxy settings (including SOCKS proxy)
+    - [Agents] Fix Cherry Assistant ignoring user's language and always responding in English
+    - [MCP] Fix Hub-mode MCP tool calls silently truncating list-style responses
     - [Knowledge] Fix epub file embedding failure
     - [Notes] Fix KaTeX formula corruption when toggling editor modes
+    - [Notes] Fix note editor search state and scrolling
     - [Thinking] Fix thinking time display showing incorrect values
     - [MiniApps] Fix removed pinned mini-apps silently reappearing
     - [Code Tools] Fix kimi-cli crash when uv is not installed
+    - [Build] Fix built-in skill files (.md) missing from packaged app
+    - [Chat] Fix data loss when selecting model via keyboard shortcut
     - [UI] Fix move-to submenu height overflow
     - [UI] Fix macOS traffic light alignment in custom title bar
 
@@ -181,7 +188,7 @@ releaseInfo:
     - [Agent] Improve session switch experience
 
     <!--LANG:zh-CN-->
-    Cherry Studio 1.9.0-rc.0 - CherryClaw 智能体、技能系统与安全加固
+    Cherry Studio 1.9.0 - CherryClaw 智能体与技能系统
 
     ⚠️ 破坏性变更
     - [智能体] "插件"系统更名为"技能（Skills）"，插件市场已替换为统一的技能管理界面
@@ -201,17 +208,24 @@ releaseInfo:
     - [安全] 修复 MCP 描述和搜索结果中的 XSS 漏洞
 
     🐛 问题修复
+    - [模型] 添加 Ollama gemma4 格式支持以正确识别 Gemma 4 模型能力
     - [模型] 修复 new-api 服务商在 Anthropic 格式请求时忽略已配置主机的问题
     - [模型] 修复 Poe 服务商无法动态加载模型的问题
     - [模型] 修复 Google Gemini 网络搜索失败的问题
     - [模型] 修复 Qwen3.5–3.9 和 GPT 系列模型的识别问题
     - [模型] 修复 NVIDIA 服务商的 Qwen/DeepSeek/Kimi/Zhipu 模型推理参数
+    - [模型] 修复小米 MiMo 思考模式开关行为异常
     - [智能体] 修复 Claude Code 子进程忽略应用代理设置的问题（包括 SOCKS 代理）
+    - [智能体] 修复 Cherry Assistant 忽略用户语言、始终以英语回复的问题
+    - [MCP] 修复 Hub 模式下 MCP 工具调用静默截断列表样式响应的问题
     - [知识库] 修复 epub 文件嵌入失败的问题
     - [笔记] 修复切换编辑器模式时 KaTeX 公式损坏的问题
+    - [笔记] 修复笔记编辑器搜索状态和滚动问题
     - [思考] 修复思考时间显示数值异常的问题
     - [小程序] 修复已移除的固定小程序意外重新出现的问题
     - [代码工具] 修复未安装 uv 时 kimi-cli 崩溃的问题
+    - [构建] 修复内置技能文件（.md）未包含在打包应用中的问题
+    - [聊天] 修复通过键盘快捷键选择模型导致数据丢失的问题
     - [UI] 修复"移动到"子菜单高度溢出
     - [UI] 修复 macOS 自定义标题栏中红绿灯控件对齐问题
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CherryStudio",
-  "version": "1.9.0-rc.0",
+  "version": "1.9.0",
   "private": true,
   "description": "A powerful AI assistant for producer.",
   "desktopName": "CherryStudio.desktop",


### PR DESCRIPTION
### What this PR does

This is a release PR for version 1.9.0. It updates the version number and release notes.

Before this PR:
- Version was set to 1.9.0-rc.0 (release candidate)
- Release notes contained RC-specific content

After this PR:
- Version is now 1.9.0 (stable release)
- Release notes updated with all bug fixes and improvements since RC

### Why we need it and why it was done in this way

This marks the official 1.9.0 stable release after the RC testing period. The release includes all bug fixes committed after 1.9.0-rc.0.

### Breaking changes

None. This is a version bump from RC to stable.

### Special notes for your reviewer

**Included commits (since v1.9.0-rc.0):**
- fix(models): add Ollama gemma4 format support for capability detection (#14036)
- hotfix(mcp): preserve multi-element hub tool results (#14116)
- fix: optimize agent bootstrap startup time (~1.6s → ~270ms) (#14098)
- hotfix(channels): toggle single channel no longer reconnects all channels (#14112)
- fix: prevent data loss when selecting model via keyboard shortcut (#14130)
- fix: restore rich editor search state and scrolling (#14117)
- fix(ci): restore missing Linux build dependencies in nightly workflow (#14105)
- hotfix(build): include resources directory files excluded by glob pattern (#14121)
- fix(agents): remove conflicting language instruction from Cherry Assistant (#14076)
- hotfix(think): MiMo thinking toggle (#14109)
- hotfix(renderer): rendering issue of the unescaped '|' in <sup> within Markdown tables. (#14092)

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
See release notes in electron-builder.yml for full details.

Key fixes since RC:
- [Models] Add Ollama gemma4 format support for Gemma 4 model capability detection
- [MCP] Fix Hub-mode MCP tool calls silently truncating list-style responses
- [Chat] Fix data loss when selecting model via keyboard shortcut
- [Notes] Fix note editor search state and scrolling
- [Build] Fix built-in skill files (.md) missing from packaged app
- [Agents] Fix Cherry Assistant ignoring user's language
- [Models] Fix Xiaomi MiMo thinking/non-thinking toggle behavior
```
