### PR TITLE
hotfix(analytics): track token usage with source distinction for chat and agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "@changesets/changelog-github": "^0.5.2",
     "@changesets/cli": "^2.29.8",
     "@cherrystudio/ai-core": "workspace:*",
-    "@cherrystudio/analytics-client": "^1.2.0",
+    "@cherrystudio/analytics-client": "^1.3.0",
     "@cherrystudio/embedjs": "0.1.31",
     "@cherrystudio/embedjs-interfaces": "0.1.31",
     "@cherrystudio/embedjs-libsql": "0.1.31",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,8 +253,8 @@ importers:
         specifier: workspace:*
         version: link:packages/aiCore
       '@cherrystudio/analytics-client':
-        specifier: ^1.2.0
-        version: 1.2.0(typescript@5.8.3)
+        specifier: ^1.3.0
+        version: 1.3.0(typescript@5.8.3)
       '@cherrystudio/embedjs':
         specifier: 0.1.31
         version: 0.1.31(@langchain/core@1.0.2(patch_hash=8dc787a82cebafe8b23c8826f25f29aca64fc8b43a0a1878e0010782e4da96ed)(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.20.0)(zod@4.3.4)))(@langchain/ollama@0.1.6(@langchain/core@1.0.2(patch_hash=8dc787a82cebafe8b23c8826f25f29aca64fc8b43a0a1878e0010782e4da96ed)(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.20.0)(zod@4.3.4))))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(axios@1.13.2)(cheerio@1.1.2)(handlebars@4.7.8)(openai@6.15.0(ws@8.20.0)(zod@4.3.4))(ws@8.20.0)
@@ -374,7 +374,7 @@ importers:
         version: 0.1.3
       '@langchain/community':
         specifier: ^1.0.0
-        version: 1.1.1(85a135bf2fd7c48b5323d86c6d655bd0)
+        version: 1.1.1(3bba964449060bd176fc73da062d305c)
       '@langchain/core':
         specifier: 1.0.2
         version: 1.0.2(patch_hash=8dc787a82cebafe8b23c8826f25f29aca64fc8b43a0a1878e0010782e4da96ed)(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.20.0)(zod@4.3.4))
@@ -1946,8 +1946,8 @@ packages:
   '@braintree/sanitize-url@7.1.1':
     resolution: {integrity: sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==}
 
-  '@browserbasehq/sdk@2.9.0':
-    resolution: {integrity: sha512-Xzm1+6suzQypXjley4Phqer++pjnYyST6S7CArUn3kWyGA8aruXjAV5wkmqE21lgXo9K3/OQJvCu48bKEZFNDQ==}
+  '@browserbasehq/sdk@2.10.0':
+    resolution: {integrity: sha512-pOL4yW8P8AI2+N5y6zEP6XXKqIXtYyKunr1JXppqQDOyKLxxvZEDqQCHJXWUzqgx3R1tGWpn7m9AjXN7MeYInA==}
 
   '@browserbasehq/stagehand@1.14.0':
     resolution: {integrity: sha512-Hi/EzgMFWz+FKyepxHTrqfTPjpsuBS4zRy3e9sbMpBgLPv+9c0R+YZEvS7Bw4mTS66QtvvURRT6zgDGFotthVQ==}
@@ -2028,8 +2028,8 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@cherrystudio/analytics-client@1.2.0':
-    resolution: {integrity: sha512-1HHhodo0+Y48kMSurd8UZBBLfNVSbJ4bFseFTa20wQHqMiVqR4rpByqnQ1OVGVhjcuIM2TQ6ApaTDj7wuHZJUQ==}
+  '@cherrystudio/analytics-client@1.3.0':
+    resolution: {integrity: sha512-/dzKNngoAsNOGd1BpTqH4AgqGWKMkUIL48bxo13MAfZjubAeRpomiCv3F9I5CcJlte/3pZggtThC4Zs3hSYZAg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       typescript: '>=4.7.0'
@@ -6195,8 +6195,8 @@ packages:
   axios@1.13.6:
     resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
 
-  axios@1.14.0:
-    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   b4a@1.7.3:
     resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
@@ -6243,6 +6243,7 @@ packages:
   basic-ftp@5.2.0:
     resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   bcp-47-match@2.0.3:
     resolution: {integrity: sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==}
@@ -13785,7 +13786,7 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.1': {}
 
-  '@browserbasehq/sdk@2.9.0(encoding@0.1.13)':
+  '@browserbasehq/sdk@2.10.0(encoding@0.1.13)':
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
@@ -13800,7 +13801,7 @@ snapshots:
   '@browserbasehq/stagehand@1.14.0(@playwright/test@1.57.0)(deepmerge@4.3.1)(dotenv@16.6.1)(encoding@0.1.13)(openai@6.15.0(ws@8.20.0)(zod@4.3.4))(zod@4.3.4)':
     dependencies:
       '@anthropic-ai/sdk': 0.27.3(encoding@0.1.13)
-      '@browserbasehq/sdk': 2.9.0(encoding@0.1.13)
+      '@browserbasehq/sdk': 2.10.0(encoding@0.1.13)
       '@playwright/test': 1.57.0
       deepmerge: 4.3.1
       dotenv: 16.6.1
@@ -13980,7 +13981,7 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@cherrystudio/analytics-client@1.2.0(typescript@5.8.3)':
+  '@cherrystudio/analytics-client@1.3.0(typescript@5.8.3)':
     optionalDependencies:
       typescript: 5.8.3
 
@@ -14648,7 +14649,7 @@ snapshots:
       node-gyp: 11.5.0
       ora: 5.4.1
       read-binary-file-arch: 1.0.6
-      semver: 7.7.1
+      semver: 7.7.2
       tar: 6.2.1
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -15238,7 +15239,7 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/community@1.1.1(85a135bf2fd7c48b5323d86c6d655bd0)':
+  '@langchain/community@1.1.1(3bba964449060bd176fc73da062d305c)':
     dependencies:
       '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.57.0)(deepmerge@4.3.1)(dotenv@16.6.1)(encoding@0.1.13)(openai@6.15.0(ws@8.20.0)(zod@4.3.4))(zod@4.3.4)
       '@ibm-cloud/watsonx-ai': 1.7.5
@@ -15257,7 +15258,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-sdk/client-s3': 3.998.0
       '@aws-sdk/credential-provider-node': 3.972.13
-      '@browserbasehq/sdk': 2.9.0(encoding@0.1.13)
+      '@browserbasehq/sdk': 2.10.0(encoding@0.1.13)
       '@libsql/client': 0.14.0
       '@mozilla/readability': 0.6.0
       '@notionhq/client': 2.3.0(encoding@0.1.13)
@@ -18839,7 +18840,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  axios@1.14.0(debug@4.4.3):
+  axios@1.15.0(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 4.0.5
@@ -21606,7 +21607,7 @@ snapshots:
       '@types/debug': 4.1.13
       '@types/node': 18.19.130
       '@types/tough-cookie': 4.0.5
-      axios: 1.14.0(debug@4.4.3)
+      axios: 1.15.0(debug@4.4.3)
       camelcase: 6.3.0
       debug: 4.4.3
       dotenv: 16.6.1
@@ -21616,7 +21617,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.14.0(debug@4.4.3))
+      retry-axios: 2.6.0(axios@1.15.0(debug@4.4.3))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -24838,9 +24839,9 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
-  retry-axios@2.6.0(axios@1.14.0(debug@4.4.3)):
+  retry-axios@2.6.0(axios@1.15.0(debug@4.4.3)):
     dependencies:
-      axios: 1.14.0(debug@4.4.3)
+      axios: 1.15.0(debug@4.4.3)
 
   retry@0.12.0: {}
 

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -284,6 +284,15 @@ export async function fetchChatCompletion({
     knowledgeRecognition: assistant.knowledgeRecognition
   }
 
+  // Wrap onChunkReceived to automatically track token usage on completion
+  const originalOnChunk = middlewareConfig.onChunk
+  middlewareConfig.onChunk = (chunk: Chunk) => {
+    if (chunk.type === ChunkType.BLOCK_COMPLETE) {
+      trackTokenUsage({ usage: chunk.response?.usage, model: assistant?.model, source: 'chat' })
+    }
+    originalOnChunk?.(chunk)
+  }
+
   // --- Call AI Completions ---
   await AI.completions(modelId, aiSdkParams, {
     ...middlewareConfig,

--- a/src/renderer/src/services/TranslateService.ts
+++ b/src/renderer/src/services/TranslateService.ts
@@ -13,7 +13,6 @@ import type { Chunk } from '@renderer/types/chunk'
 import { ChunkType } from '@renderer/types/chunk'
 import { uuid } from '@renderer/utils'
 import { readyToAbort } from '@renderer/utils/abortController'
-import { trackTokenUsage } from '@renderer/utils/analytics'
 import { isAbortError } from '@renderer/utils/error'
 import { NoOutputGeneratedError } from 'ai'
 import { t } from 'i18next'
@@ -53,15 +52,11 @@ export const translateText = async (
 
   let translatedText = ''
   let completed = false
-  const model = assistant.model
   const onChunk = (chunk: Chunk) => {
     if (chunk.type === ChunkType.TEXT_DELTA) {
       translatedText = chunk.text
     } else if (chunk.type === ChunkType.TEXT_COMPLETE) {
       completed = true
-    } else if (chunk.type === ChunkType.BLOCK_COMPLETE) {
-      const usage = chunk.response?.usage
-      trackTokenUsage({ usage, model })
     } else if (chunk.type === ChunkType.ERROR) {
       error = chunk.error
       if (isAbortError(chunk.error)) {

--- a/src/renderer/src/services/messageStreaming/callbacks/baseCallbacks.ts
+++ b/src/renderer/src/services/messageStreaming/callbacks/baseCallbacks.ts
@@ -19,6 +19,7 @@ import type {
 } from '@renderer/types/newMessage'
 import { AssistantMessageStatus, MessageBlockStatus, MessageBlockType } from '@renderer/types/newMessage'
 import { uuid } from '@renderer/utils'
+import { isAgentSessionTopicId } from '@renderer/utils/agentSession'
 import { trackTokenUsage } from '@renderer/utils/analytics'
 import { isAbortError, isTimeoutError, serializeError } from '@renderer/utils/error'
 import { createBaseMessageBlock, createErrorBlock } from '@renderer/utils/messageUtils/create'
@@ -367,9 +368,9 @@ export const createBaseCallbacks = (deps: BaseCallbacksDependencies) => {
       )
       await saveUpdatesToDB(assistantMsgId, topicId, messageUpdates, todoBlocksToSave)
 
-      // Track token usage analytics
-      if (status === 'success') {
-        trackTokenUsage({ usage: response?.usage, model: assistant?.model })
+      // Track token usage for agent sessions (chat sessions are tracked in fetchChatCompletion)
+      if (status === 'success' && isAgentSessionTopicId(topicId)) {
+        trackTokenUsage({ usage: response?.usage, model: assistant?.model, source: 'agent' })
       }
 
       void EventEmitter.emit(EVENT_NAMES.MESSAGE_COMPLETE, { id: assistantMsgId, topicId, status })

--- a/src/renderer/src/utils/__tests__/analytics.test.ts
+++ b/src/renderer/src/utils/__tests__/analytics.test.ts
@@ -49,7 +49,8 @@ describe('trackTokenUsage', () => {
       provider: 'openai',
       model: 'gpt-4',
       input_tokens: 100,
-      output_tokens: 50
+      output_tokens: 50,
+      source: 'chat'
     })
   })
 
@@ -69,7 +70,8 @@ describe('trackTokenUsage', () => {
       provider: 'anthropic',
       model: 'claude-3',
       input_tokens: 200,
-      output_tokens: 100
+      output_tokens: 100,
+      source: 'chat'
     })
   })
 

--- a/src/renderer/src/utils/analytics.ts
+++ b/src/renderer/src/utils/analytics.ts
@@ -8,6 +8,7 @@ type TokenUsage = Usage | LanguageModelUsage
 interface TokenUsageParams {
   usage: TokenUsage | undefined
   model: Model | undefined
+  source?: 'chat' | 'agent'
 }
 
 /**
@@ -51,7 +52,7 @@ function getProviderTrackId(id: string): string {
  * Track token usage for analytics
  * Handles both OpenAI format (prompt_tokens) and AI SDK format (inputTokens)
  */
-export function trackTokenUsage({ usage, model }: TokenUsageParams): void {
+export function trackTokenUsage({ usage, model, source = 'chat' }: TokenUsageParams): void {
   if (!usage || !model?.provider || !model?.id) return
 
   const [inputTokens, outputTokens] = isAiSdkUsage(usage)
@@ -63,7 +64,8 @@ export function trackTokenUsage({ usage, model }: TokenUsageParams): void {
       provider: getProviderTrackId(model.provider),
       model: model.id,
       input_tokens: inputTokens,
-      output_tokens: outputTokens
+      output_tokens: outputTokens,
+      source
     })
   }
 }


### PR DESCRIPTION
### What this PR does

Before this PR:
- Token usage tracking was missing for mini window, selection action window, and translate service (they call `fetchChatCompletion` but don't go through `baseCallbacks`)
- Agent session token usage was not distinguished from regular chat usage
- `baseCallbacks.ts` and `TranslateService.ts` had duplicate tracking that was redundant with `fetchChatCompletion`

After this PR:
- All `fetchChatCompletion` callers (chat, translate, mini window, selection action) are automatically tracked with `source: 'chat'`
- Agent sessions are tracked in `baseCallbacks` with `source: 'agent'`
- No duplicate tracking; each code path is tracked exactly once
- Upgraded `@cherrystudio/analytics-client` to 1.3.0 with native `source` field support

### Why we need it and why it was done in this way

Token usage analytics were incomplete — several code paths that consume tokens were not being tracked. Additionally, there was no way to distinguish whether token usage came from regular chat or agent sessions.

The following tradeoffs were made:
- Tracking is done via `onChunk` wrapper in `fetchChatCompletion` rather than requiring each caller to manually track, preventing future omissions
- Agent tracking stays in `baseCallbacks` because agent sessions use `createAgentMessageStream` directly and bypass `fetchChatCompletion`

The following alternatives were considered:
- Adding tracking to each individual caller — rejected because it's error-prone and led to the current missing coverage

### Breaking changes

None.

### Special notes for your reviewer

- `fetchChatCompletion` now wraps `onChunk` to intercept `BLOCK_COMPLETE` and track usage — this covers chat, translate, mini window, and selection action
- `baseCallbacks.ts` only tracks agent sessions (guarded by `isAgentSessionTopicId`) to avoid double-counting with `fetchChatCompletion`
- The `source` field is `optional` in `@cherrystudio/analytics-client@1.3.0`, defaulting to `'chat'`

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
