### PR TITLE
fix(openclaw): avoid appending /v1 to GitHub/Copilot provider hosts (fixes #14118)

### DIFF
--- a/src/main/services/OpenClawService.ts
+++ b/src/main/services/OpenClawService.ts
@@ -12,7 +12,7 @@ import { crossPlatformSpawn, findExecutableInEnv, getBinaryPath, runInstallScrip
 import getShellEnv, { refreshShellEnv } from '@main/utils/shell-env'
 import type { OperationResult } from '@shared/config/types'
 import { IpcChannel } from '@shared/IpcChannel'
-import { hasAPIVersion, withoutTrailingSlash } from '@shared/utils'
+import { formatApiHost, hasAPIVersion, withoutTrailingSlash } from '@shared/utils'
 import type { Model, Provider, ProviderType, VertexProvider } from '@types'
 
 import { parseCurrentVersion, parseUpdateStatus } from './utils/openClawParsers'
@@ -1045,6 +1045,14 @@ class OpenClawService {
    * - Others: {host}/v1
    */
   private formatOpenAIUrl(provider: Provider): string {
+    // Special-case built-in GitHub / Copilot providers: these hosts should
+    // not have a `/v1` suffix appended by default (renderer applies
+    // `formatApiHost(..., false)` for these). Mirror that behavior here
+    // to avoid constructing incorrect endpoints that return 404.
+    if (provider.id === 'copilot' || provider.id === 'github') {
+      return formatApiHost(provider.apiHost, false)
+    }
+
     const url = withoutTrailingSlash(provider.apiHost)
     const providerType = provider.type
 


### PR DESCRIPTION
### What this PR does

Before this PR:
- OpenClaw provider base URLs in main process could have `/v1` appended for some built-in providers (GitHub / Copilot), producing incorrect endpoints and 404s.

After this PR:
- Main process `OpenClawService` formats GitHub/Copilot provider hosts the same way the renderer does, avoiding appending `/v1` for these providers. This prevents 404 errors when OpenClaw forwards requests.

Fixes #14118

### Why we need it and why it was done in this way

- The renderer already special-cases `copilot`/`github` and calls `formatApiHost(..., false)` to avoid adding `/v1`. The main process built OpenClaw provider URLs differently, causing mismatched endpoints.
- Mirroring the renderer formatting in `OpenClawService` is minimal, low-risk, and preserves existing behavior for other providers.

The following tradeoffs were made:
- Kept change minimal and targeted to `OpenClawService` to avoid cross-cutting refactors.

### Breaking changes
- None.

### Special notes for your reviewer
- Updated file: src/main/services/OpenClawService.ts
- Behavior: only affects how provider `apiHost` is formatted when syncing OpenClaw config for `copilot`/`github` providers.

### Checklist
- [x] PR: The PR description is expressive enough.
- [x] Code: Minimal, targeted fix.
- [ ] Refactor: N/A
- [ ] Upgrade: N/A
- [ ] Documentation: N/A (bug fix visible to users)

### Release note

```release-note
Fix: avoid appending `/v1` to GitHub/Copilot provider hosts when syncing OpenClaw config, preventing 404 errors when sending messages with GitHub Copilot models (fixes #14118).
```
