### PR TITLE
fix(data): log non-NotFound errors in getEffectiveReasoningConfig

### DIFF
--- a/src/main/data/services/ProviderRegistryService.ts
+++ b/src/main/data/services/ProviderRegistryService.ts
@@ -16,6 +16,7 @@ import { buildRuntimeEndpointConfigs } from '@cherrystudio/provider-registry'
 import { RegistryLoader } from '@cherrystudio/provider-registry/node'
 import { loggerService } from '@logger'
 import { application } from '@main/core/application'
+import { ErrorCode, isDataApiError } from '@shared/data/api/apiErrors'
 import type { Model } from '@shared/data/types/model'
 import type { EndpointConfig, ReasoningFormatType } from '@shared/data/types/provider'
 import { createCustomModel, extractReasoningFormatTypes, mergePresetModel } from '@shared/data/utils/modelMerger'
@@ -101,8 +102,10 @@ class ProviderRegistryService {
         extractReasoningFormatTypes(provider.endpointConfigs) ?? registryConfig.reasoningFormatTypes
 
       return { defaultChatEndpoint, reasoningFormatTypes }
-    } catch {
-      // Provider not in DB yet (e.g. during initial model resolve) — use registry defaults
+    } catch (error) {
+      if (!(isDataApiError(error) && error.code === ErrorCode.NOT_FOUND)) {
+        logger.warn('Failed to fetch provider for reasoning config, using registry defaults', error as Error)
+      }
       return registryConfig
     }
   }


### PR DESCRIPTION
### What this PR does

Before this PR:

`getEffectiveReasoningConfig()` in `ProviderRegistryService` used a bare `catch {}` that silently swallowed **all** errors when fetching provider data from the DB — including DB connection failures, schema mismatches, and bugs in `rowToRuntimeProvider()`.

After this PR:

Only `NOT_FOUND` errors (provider not in DB yet) are silently handled. All other errors are logged via `logger.warn()` before falling back to registry defaults, making production debugging possible.

### Why we need it and why it was done in this way

The bare `catch {}` was introduced in PR #14115 when `getEffectiveReasoningConfig()` was refactored from a direct DB query to delegating through `providerService.getByProviderId()`. The original direct query only fell back when the provider didn't exist; the refactored version falls back on *any* error.

The following tradeoffs were made:

We keep the fallback-to-registry behavior for all errors (not just NotFound) to avoid breaking model resolution. The key improvement is that non-NotFound errors are now logged so they can be investigated.

The following alternatives were considered:

Adding a `findByProviderId()` method that returns `null` instead of throwing. This would match the original query semantics more closely but is a larger change. The current approach is minimal and sufficient.

### Breaking changes

None.

### Special notes for your reviewer

This method is called on every `resolveModels()` and `lookupModel()` invocation, so the silent degradation affected all model resolution paths.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
