### PR TITLE
refactor(copilot): separate business logic from IPC handler signatures

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -615,12 +615,14 @@ export async function registerIpc(mainWindow: BrowserWindow, app: Electron.App) 
   ipcMain.handle(IpcChannel.App_InstallOvmsBinary, () => runInstallScript('install-ovms.js'))
 
   //copilot
-  ipcMain.handle(IpcChannel.Copilot_GetAuthMessage, copilotService.getAuthMessage.bind(copilotService))
-  ipcMain.handle(IpcChannel.Copilot_GetCopilotToken, copilotService.getCopilotToken.bind(copilotService))
-  ipcMain.handle(IpcChannel.Copilot_SaveCopilotToken, copilotService.saveCopilotToken.bind(copilotService))
-  ipcMain.handle(IpcChannel.Copilot_GetToken, copilotService.getToken.bind(copilotService))
-  ipcMain.handle(IpcChannel.Copilot_Logout, copilotService.logout.bind(copilotService))
-  ipcMain.handle(IpcChannel.Copilot_GetUser, copilotService.getUser.bind(copilotService))
+  ipcMain.handle(IpcChannel.Copilot_GetAuthMessage, (_e, headers) => copilotService.getAuthMessage(headers))
+  ipcMain.handle(IpcChannel.Copilot_GetCopilotToken, (_e, code, headers) =>
+    copilotService.getCopilotToken(code, headers)
+  )
+  ipcMain.handle(IpcChannel.Copilot_SaveCopilotToken, (_e, token) => copilotService.saveCopilotToken(token))
+  ipcMain.handle(IpcChannel.Copilot_GetToken, (_e, headers) => copilotService.getToken(headers))
+  ipcMain.handle(IpcChannel.Copilot_Logout, () => copilotService.logout())
+  ipcMain.handle(IpcChannel.Copilot_GetUser, (_e, token) => copilotService.getUser(token))
 
   // CherryIN OAuth
   ipcMain.handle(IpcChannel.CherryIN_SaveToken, cherryINOAuthService.saveToken.bind(cherryINOAuthService))

--- a/src/main/services/CopilotService.ts
+++ b/src/main/services/CopilotService.ts
@@ -131,7 +131,7 @@ class CopilotService {
   /**
    * 获取GitHub登录信息
    */
-  public getUser = async (_: Electron.IpcMainInvokeEvent, token: string): Promise<UserResponse> => {
+  public getUser = async (token: string): Promise<UserResponse> => {
     try {
       const response = await net.fetch(CONFIG.API_URLS.GITHUB_USER, {
         method: 'GET',
@@ -164,10 +164,7 @@ class CopilotService {
   /**
    * 获取GitHub设备授权信息
    */
-  public getAuthMessage = async (
-    _: Electron.IpcMainInvokeEvent,
-    headers?: Record<string, string>
-  ): Promise<AuthResponse> => {
+  public getAuthMessage = async (headers?: Record<string, string>): Promise<AuthResponse> => {
     try {
       this.updateHeaders(headers)
 
@@ -197,11 +194,7 @@ class CopilotService {
   /**
    * 使用设备码获取访问令牌 - 优化轮询逻辑
    */
-  public getCopilotToken = async (
-    _: Electron.IpcMainInvokeEvent,
-    device_code: string,
-    headers?: Record<string, string>
-  ): Promise<TokenResponse> => {
+  public getCopilotToken = async (device_code: string, headers?: Record<string, string>): Promise<TokenResponse> => {
     this.updateHeaders(headers)
 
     let currentDelay = CONFIG.POLLING.INITIAL_DELAY_MS
@@ -250,7 +243,7 @@ class CopilotService {
   /**
    * 保存Copilot令牌到本地文件
    */
-  public saveCopilotToken = async (_: Electron.IpcMainInvokeEvent, token: string): Promise<void> => {
+  public saveCopilotToken = async (token: string): Promise<void> => {
     try {
       const encryptedToken = safeStorage.encryptString(token)
       // 确保目录存在
@@ -269,10 +262,7 @@ class CopilotService {
   /**
    * 从本地文件读取令牌并获取Copilot令牌
    */
-  public getToken = async (
-    _: Electron.IpcMainInvokeEvent,
-    headers?: Record<string, string>
-  ): Promise<CopilotTokenResponse> => {
+  public getToken = async (headers?: Record<string, string>): Promise<CopilotTokenResponse> => {
     try {
       this.updateHeaders(headers)
 


### PR DESCRIPTION
### What this PR does

Before this PR:
All `CopilotService` public methods included `_: Electron.IpcMainInvokeEvent` as their first parameter, coupling business logic to the IPC transport layer. Internal callers had to pass `null` as a dummy event.

After this PR:
Business methods have clean signatures (no event parameter). IPC wrappers in `ipc.ts` strip the event before forwarding arguments.

### Why we need it and why it was done in this way

CopilotService methods are used both as IPC handlers and called directly from other main-process code. Mixing the IPC event into the business signature forced callers to pass `null` and made the API misleading. The fix keeps IPC adaptation at the registration site where it belongs.

The following tradeoffs were made:
- None significant — this is a straightforward separation of concerns.

The following alternatives were considered:
- Migrating CopilotService into the lifecycle system (as noted in the TODO comment). That's a larger change tracked separately.

### Breaking changes

None. The IPC contract (channel names and argument order from renderer) is unchanged.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```