### PR TITLE
fix(agents): remove SOUL badge from agent list item

### DIFF
--- a/src/renderer/src/pages/agents/components/AgentItem.tsx
+++ b/src/renderer/src/pages/agents/components/AgentItem.tsx
@@ -2,7 +2,7 @@ import { DeleteIcon, EditIcon } from '@renderer/components/Icons'
 import MarqueeText from '@renderer/components/MarqueeText'
 import { useSettings } from '@renderer/hooks/useSettings'
 import AgentSettingsPopup from '@renderer/pages/settings/AgentSettings/AgentSettingsPopup'
-import { AgentLabel, isSoulModeEnabled } from '@renderer/pages/settings/AgentSettings/shared'
+import { AgentLabel } from '@renderer/pages/settings/AgentSettings/shared'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import type { AgentEntity } from '@renderer/types'
 import { cn } from '@renderer/utils'
@@ -81,7 +81,6 @@ const AgentItem = ({ agent, isActive, onDelete, onPress }: AgentItemProps) => {
           <MarqueeText className="flex min-w-0 flex-1">
             <AgentLabel agent={agent} hideIcon={assistantIconType === 'none'} />
           </MarqueeText>
-          {isSoulModeEnabled(agent.configuration) && <SoulTag>SOUL</SoulTag>}
           {(isActive || isHovered) && (
             <Dropdown
               menu={{ items: menuItems }}
@@ -142,16 +141,6 @@ export const BotIcon: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ ...pro
     </Tooltip>
   )
 }
-
-export const SoulTag: React.FC<React.HTMLAttributes<HTMLSpanElement>> = ({ className, ...props }) => (
-  <span
-    className={cn(
-      'shrink-0 rounded-md bg-purple-500/15 px-1.5 py-0.5 font-medium text-[10px] text-purple-600 leading-none dark:text-purple-400',
-      className
-    )}
-    {...props}
-  />
-)
 
 export const SessionCount: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ className, ...props }) => (
   <div


### PR DESCRIPTION
### What this PR does

Before this PR:
- A purple `SOUL` badge was rendered next to every agent name in the sidebar list whenever the agent had Soul Mode enabled.
- The badge used internal jargon ("SOUL") that did not match anything users see elsewhere in the UI, and there was no tooltip or explanation.
- On narrower sidebar widths the badge crowded out the agent name, sometimes truncating it.

After this PR:
- The `SOUL` badge is removed from the agent list item.
- The Soul Mode toggle is unchanged and still lives in the agent settings panel — users who care about the mode can still see and change it there.
- Removed the now-unused `SoulTag` styled component and the `isSoulModeEnabled` import in `AgentItem.tsx`. The `isSoulModeEnabled` helper itself stays in `shared.tsx` since other settings panels still use it.

Fixes #

### Why we need it and why it was done in this way

Reported by Kenny / 郑克 as a P0: the badge label was unexplained jargon and visually competed with the agent name. The fix is the smallest possible scope — delete the badge render plus the local styled component and import, leave the underlying Soul Mode feature and its settings UI alone.

The following tradeoffs were made:
- Just delete the badge instead of trying to make it discoverable (e.g. tooltip / icon-only / rename). The badge was not pulling its weight in the list item, and the settings panel is already the right place for users to learn about Soul Mode.

The following alternatives were considered:
- Keep the badge but rename / translate it. Rejected — the underlying problem is that "Soul Mode" itself is internal-facing terminology, so renaming the badge would not solve the comprehension issue, it would only move it.
- Move the badge into the dropdown / context menu. Rejected — adds complexity for a label users said they did not understand.

Links to places where the discussion took place: N/A

### Breaking changes

None. UI-only removal of a label. The Soul Mode feature, its settings, and all functionality (claw MCP server gating, etc.) are unchanged.

### Special notes for your reviewer

- Single file change: `src/renderer/src/pages/agents/components/AgentItem.tsx`.
- Verified locally that `isSoulModeEnabled` is no longer referenced from `AgentItem.tsx` and the helper itself remains exported from `shared.tsx` for the settings panels.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: Boy Scout Rule applied — also dropped the now-dead `SoulTag` component and unused import
- [x] Upgrade: No upgrade impact
- [x] Documentation: User-visible label removed; no docs reference this badge
- [x] Self-review: Reviewed via local diff before pushing

### Release note

```release-note
fix(agents): remove the unexplained SOUL badge from agent sidebar items so the agent name is no longer obscured. The Soul Mode toggle is unchanged and still available from agent settings.
```
