### PR TITLE
fix(agents): avoid resuming incompatible Claude Code sessions after provider switches

### DIFF
--- a/src/main/services/agents/services/SessionMessageService.ts
+++ b/src/main/services/agents/services/SessionMessageService.ts
@@ -9,7 +9,7 @@ import type {
   ListOptions
 } from '@types'
 import type { TextStreamPart } from 'ai'
-import { and, desc, eq, not } from 'drizzle-orm'
+import { and, desc, eq, not, sql } from 'drizzle-orm'
 
 import { BaseService } from '../BaseService'
 import { sessionMessagesTable } from '../database/schema'

--- a/src/main/services/agents/services/SessionMessageService.ts
+++ b/src/main/services/agents/services/SessionMessageService.ts
@@ -16,6 +16,7 @@ import { sessionMessagesTable } from '../database/schema'
 import { agentMessageRepository } from '../database/sessionMessageRepository'
 import type { AgentStreamEvent } from '../interfaces/AgentStreamInterface'
 import ClaudeCodeService from './claudecode'
+import { canResumeClaudeSession } from './claudecode/sessionCompatibility'
 
 const claudeCodeService = new ClaudeCodeService()
 
@@ -181,7 +182,7 @@ export class SessionMessageService extends BaseService {
     abortController: AbortController,
     options?: CreateMessageOptions
   ): Promise<SessionStreamResult> {
-    const agentSessionId = await this.getLastAgentSessionId(session.id)
+    const agentSessionId = await this.getLastAgentSessionId(session)
     logger.debug('Session Message stream message data:', { message: req, session_id: agentSessionId })
 
     const claudeStream = await claudeCodeService.invoke(
@@ -429,21 +430,66 @@ export class SessionMessageService extends BaseService {
     return result
   }
 
-  private async getLastAgentSessionId(sessionId: string): Promise<string> {
+  private async getLastAgentSessionId(session: GetAgentSessionResponse): Promise<string> {
     try {
       const database = await this.getDatabase()
       const result = await database
-        .select({ agent_session_id: sessionMessagesTable.agent_session_id })
+        .select({
+          agent_session_id: sessionMessagesTable.agent_session_id,
+          content: sessionMessagesTable.content
+        })
         .from(sessionMessagesTable)
-        .where(and(eq(sessionMessagesTable.session_id, sessionId), not(eq(sessionMessagesTable.agent_session_id, ''))))
+        .where(
+          and(
+            eq(sessionMessagesTable.session_id, session.id),
+            sql`${sessionMessagesTable.role} in ('assistant', 'agent')`,
+            not(eq(sessionMessagesTable.agent_session_id, ''))
+          )
+        )
         .orderBy(desc(sessionMessagesTable.created_at))
         .limit(1)
 
-      logger.silly('Last agent session ID result:', { agentSessionId: result[0]?.agent_session_id, sessionId })
-      return result[0]?.agent_session_id || ''
+      const latestMessage = result[0]
+      if (!latestMessage) {
+        return ''
+      }
+
+      let lastModelId: string | undefined
+      try {
+        const parsed = JSON.parse(latestMessage.content) as AgentPersistedMessage
+        lastModelId = parsed?.message?.modelId ?? parsed?.message?.model?.id
+      } catch (error) {
+        logger.warn('Failed to parse last agent session message content', {
+          sessionId: session.id,
+          error: error instanceof Error ? error.message : String(error)
+        })
+        return ''
+      }
+
+      if (!lastModelId) {
+        logger.debug('Skipping agent session resume because the last message is missing model metadata', {
+          sessionId: session.id
+        })
+        return ''
+      }
+
+      if (!canResumeClaudeSession(session.model, lastModelId)) {
+        logger.debug('Skipping agent session resume because the provider changed', {
+          sessionId: session.id,
+          currentModel: session.model,
+          lastModelId: lastModelId || ''
+        })
+        return ''
+      }
+
+      logger.silly('Last agent session ID result:', {
+        agentSessionId: latestMessage.agent_session_id,
+        sessionId: session.id
+      })
+      return latestMessage.agent_session_id || ''
     } catch (error) {
       logger.error('Failed to get last agent session ID', {
-        sessionId,
+        sessionId: session.id,
         error
       })
       return ''

--- a/src/main/services/agents/services/__tests__/sessionCompatibility.test.ts
+++ b/src/main/services/agents/services/__tests__/sessionCompatibility.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { canResumeClaudeSession } from '../claudecode/sessionCompatibility'
+
+describe('canResumeClaudeSession', () => {
+  it('allows resuming when the provider stays the same', () => {
+    expect(canResumeClaudeSession('openai:gpt-4o', 'openai:gpt-4.1')).toBe(true)
+  })
+
+  it('blocks resuming when the provider changes', () => {
+    expect(canResumeClaudeSession('openai:gpt-4o', 'minimax:abab6.5')).toBe(false)
+  })
+
+  it('blocks resuming when the previous model metadata is missing', () => {
+    expect(canResumeClaudeSession('openai:gpt-4o', undefined)).toBe(false)
+  })
+})

--- a/src/main/services/agents/services/claudecode/sessionCompatibility.ts
+++ b/src/main/services/agents/services/claudecode/sessionCompatibility.ts
@@ -1,0 +1,22 @@
+const getProviderIdFromModelId = (modelId?: string | null): string | undefined => {
+  if (!modelId || !modelId.includes(':')) {
+    return undefined
+  }
+
+  return modelId.split(':', 1)[0]
+}
+
+/**
+ * Claude Code sessions are provider-specific. When the provider changes, the
+ * previous SDK session can carry incompatible context and must not be reused.
+ */
+export const canResumeClaudeSession = (currentModelId: string, lastModelId?: string | null): boolean => {
+  const currentProviderId = getProviderIdFromModelId(currentModelId)
+  const lastProviderId = getProviderIdFromModelId(lastModelId)
+
+  if (!currentProviderId || !lastProviderId) {
+    return false
+  }
+
+  return currentProviderId === lastProviderId
+}


### PR DESCRIPTION
### What this PR does

Before this PR:
- Agent mode could resume a previous Claude Code session even after switching to a different provider/model.
- That reused incompatible context and triggered compatibility/parse errors.

After this PR:
- We only resume a Claude Code session when the last assistant turn came from the same provider.
- If the provider changed, or the stored model metadata is missing, we start a fresh session instead.
- Added unit coverage for same-provider resume, provider-switch reset, and missing metadata.

Fixes #14199

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Switching providers/models now resets the SDK session instead of trying to reuse a session that may not be compatible.

The following alternatives were considered:
- Keep reusing the previous session and try to normalize context across providers, but that risks replaying invalid state.

Links to places where the discussion took place: None

### Breaking changes

None

### Special notes for your reviewer

None

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix Agent mode session resume so switching to a different provider starts a fresh Claude Code session instead of replaying incompatible context.
```