### PR TITLE
fix(agents): sync agent settings changes to active session

### DIFF
--- a/src/main/services/agents/services/AgentService.ts
+++ b/src/main/services/agents/services/AgentService.ts
@@ -13,7 +13,7 @@ import { AgentBaseSchema } from '@types'
 import { asc, count, desc, eq, sql } from 'drizzle-orm'
 
 import { BaseService } from '../BaseService'
-import { type AgentRow, agentsTable, type InsertAgentRow } from '../database/schema'
+import { type AgentRow, agentsTable, type InsertAgentRow, sessionsTable } from '../database/schema'
 import type { AgentModelField } from '../errors'
 import { seedWorkspaceTemplates } from './cherryclaw/seedWorkspace'
 
@@ -383,7 +383,73 @@ export class AgentService extends BaseService {
 
     const database = await this.getDatabase()
     await database.update(agentsTable).set(updateData).where(eq(agentsTable.id, id))
+
+    // Sync changed fields to all sessions that still match the agent's old values.
+    // Sessions where the user has customized a field are left untouched.
+    await this.syncSettingsToSessions(database, id, existing, updates)
+
     return await this.getAgent(id)
+  }
+
+  /**
+   * Sync agent settings to all sessions that haven't been individually customized.
+   *
+   * For each changed field, we compare the session's current value against the agent's
+   * OLD value (before update). If they match, the session inherited the default and
+   * should receive the new value. If they differ, the user customized that field on
+   * the session, so we skip it.
+   */
+  private async syncSettingsToSessions(
+    database: Awaited<ReturnType<typeof this.getDatabase>>,
+    agentId: string,
+    oldAgent: AgentEntity,
+    updates: UpdateAgentRequest
+  ): Promise<void> {
+    const syncFields = ['model', 'plan_model', 'small_model', 'allowed_tools', 'configuration', 'mcps', 'instructions']
+
+    // Collect only the fields that were actually changed
+    const changedFields = syncFields.filter((field) => Object.prototype.hasOwnProperty.call(updates, field))
+    if (changedFields.length === 0) return
+
+    try {
+      const sessions = await database.select().from(sessionsTable).where(eq(sessionsTable.agent_id, agentId))
+
+      if (sessions.length === 0) return
+
+      const now = new Date().toISOString()
+      const serializedUpdates = this.serializeJsonFields(updates)
+      const serializedOldAgent = this.serializeJsonFields(oldAgent)
+
+      for (const session of sessions) {
+        const sessionUpdateData: Partial<Record<string, unknown>> = {}
+
+        for (const field of changedFields) {
+          const oldAgentValue = serializedOldAgent[field] ?? null
+          const sessionValue = (session as Record<string, unknown>)[field] ?? null
+
+          // Only sync if session still has the agent's old value (not user-customized)
+          if (oldAgentValue === sessionValue) {
+            sessionUpdateData[field] = serializedUpdates[field] ?? null
+          }
+        }
+
+        if (Object.keys(sessionUpdateData).length > 0) {
+          sessionUpdateData.updated_at = now
+          await database.update(sessionsTable).set(sessionUpdateData).where(eq(sessionsTable.id, session.id))
+        }
+      }
+
+      logger.info('Synced agent settings to sessions', {
+        agentId,
+        changedFields,
+        sessionCount: sessions.length
+      })
+    } catch (error) {
+      logger.warn('Failed to sync agent settings to sessions', {
+        agentId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
   }
 
   async reorderAgents(orderedIds: string[]): Promise<void> {

--- a/src/renderer/src/hooks/agents/useUpdateAgent.ts
+++ b/src/renderer/src/hooks/agents/useUpdateAgent.ts
@@ -1,5 +1,5 @@
 import store from '@renderer/store'
-import type { AgentEntity, ListAgentsResponse, UpdateAgentForm, UpdateSessionForm } from '@renderer/types'
+import type { AgentEntity, ListAgentsResponse, UpdateAgentForm } from '@renderer/types'
 import type { UpdateAgentBaseOptions, UpdateAgentFunction } from '@renderer/types/agent'
 import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
 import { useCallback } from 'react'
@@ -7,17 +7,6 @@ import { useTranslation } from 'react-i18next'
 import { mutate } from 'swr'
 
 import { useAgentClient } from './useAgentClient'
-
-/** Fields that should be synced from agent to its active session */
-const SYNC_FIELDS = [
-  'model',
-  'plan_model',
-  'small_model',
-  'allowed_tools',
-  'configuration',
-  'mcps',
-  'instructions'
-] as const
 
 export const useUpdateAgent = () => {
   const { t } = useTranslation()
@@ -39,27 +28,13 @@ export const useUpdateAgent = () => {
           window.toast.success({ key: 'update-agent', title: t('common.update_success') })
         }
 
-        // Sync changed fields to the active session for this agent
+        // Backend syncs agent settings to all sessions (skipping user-customized fields).
+        // Revalidate the active session's SWR cache so the UI picks up changes immediately.
         const { activeSessionIdMap } = store.getState().runtime.chat
         const activeSessionId = activeSessionIdMap[form.id]
         if (activeSessionId) {
-          const sessionUpdate: UpdateSessionForm = { id: activeSessionId }
-          let hasChanges = false
-          for (const field of SYNC_FIELDS) {
-            if (Object.prototype.hasOwnProperty.call(form, field)) {
-              sessionUpdate[field] = form[field]
-              hasChanges = true
-            }
-          }
-          if (hasChanges) {
-            try {
-              const updatedSession = await client.updateSession(form.id, sessionUpdate)
-              const sessionKey = client.getSessionPaths(form.id).withId(activeSessionId)
-              void mutate(sessionKey, updatedSession, { revalidate: false })
-            } catch {
-              // Session sync is best-effort; agent update already succeeded
-            }
-          }
+          const sessionKey = client.getSessionPaths(form.id).withId(activeSessionId)
+          void mutate(sessionKey)
         }
 
         return result

--- a/src/renderer/src/hooks/agents/useUpdateAgent.ts
+++ b/src/renderer/src/hooks/agents/useUpdateAgent.ts
@@ -1,4 +1,5 @@
-import type { AgentEntity, ListAgentsResponse, UpdateAgentForm } from '@renderer/types'
+import store from '@renderer/store'
+import type { AgentEntity, ListAgentsResponse, UpdateAgentForm, UpdateSessionForm } from '@renderer/types'
 import type { UpdateAgentBaseOptions, UpdateAgentFunction } from '@renderer/types/agent'
 import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
 import { useCallback } from 'react'
@@ -6,6 +7,17 @@ import { useTranslation } from 'react-i18next'
 import { mutate } from 'swr'
 
 import { useAgentClient } from './useAgentClient'
+
+/** Fields that should be synced from agent to its active session */
+const SYNC_FIELDS = [
+  'model',
+  'plan_model',
+  'small_model',
+  'allowed_tools',
+  'configuration',
+  'mcps',
+  'instructions'
+] as const
 
 export const useUpdateAgent = () => {
   const { t } = useTranslation()
@@ -26,6 +38,30 @@ export const useUpdateAgent = () => {
         if (options?.showSuccessToast ?? true) {
           window.toast.success({ key: 'update-agent', title: t('common.update_success') })
         }
+
+        // Sync changed fields to the active session for this agent
+        const { activeSessionIdMap } = store.getState().runtime.chat
+        const activeSessionId = activeSessionIdMap[form.id]
+        if (activeSessionId) {
+          const sessionUpdate: UpdateSessionForm = { id: activeSessionId }
+          let hasChanges = false
+          for (const field of SYNC_FIELDS) {
+            if (Object.prototype.hasOwnProperty.call(form, field)) {
+              sessionUpdate[field] = form[field]
+              hasChanges = true
+            }
+          }
+          if (hasChanges) {
+            try {
+              const updatedSession = await client.updateSession(form.id, sessionUpdate)
+              const sessionKey = client.getSessionPaths(form.id).withId(activeSessionId)
+              void mutate(sessionKey, updatedSession, { revalidate: false })
+            } catch {
+              // Session sync is best-effort; agent update already succeeded
+            }
+          }
+        }
+
         return result
       } catch (error) {
         window.toast.error(formatErrorMessageWithPrefix(error, t('agent.update.error.failed')))


### PR DESCRIPTION
### What this PR does

Before this PR:
When modifying agent-level settings (permission mode, model, allowed tools, MCPs, instructions) via the Agent Settings popup, changes only took effect in newly created sessions. The currently active session kept using stale configuration, requiring users to create a new session to see the update.

After this PR:
Agent settings changes are automatically synced to the currently active session, taking effect immediately without requiring a new session.

Fixes #14197

### Why we need it and why it was done in this way

The agent–session architecture uses a snapshot model: sessions inherit agent configuration at creation time and then diverge independently. This is correct for session-level overrides, but when users edit agent-level settings (the "template"), they expect changes to apply to their current conversation.

The fix adds sync logic in `useUpdateAgent`: after a successful agent update, it checks for an active session and propagates the changed fields (model, plan_model, small_model, allowed_tools, configuration, mcps, instructions) to it via `client.updateSession()`. The sync is best-effort — if the session update fails, the agent update still succeeds.

The following tradeoffs were made:
- Only syncs fields present in the update form (not a full replace), so session-specific overrides for unmodified fields are preserved.
- Sync is fire-and-forget for the session update; the agent update is never blocked by a session sync failure.

The following alternatives were considered:
- Backend-side sync (in `AgentService.updateAgent`): rejected because session selection state lives in the renderer Redux store, not the backend.
- SWR revalidation only (no DB write): rejected because the session DB record would remain stale and be used on next message send.

### Breaking changes

None.

### Special notes for your reviewer

The `SYNC_FIELDS` constant defines which agent fields propagate to the active session. `name`, `description`, and `accessible_paths` are intentionally excluded since those are identity/workspace fields that should remain session-specific.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Agent settings changes (permission mode, model, tools, etc.) now take effect immediately in the current session without requiring a new session.
```
