### PR TITLE
feat: Insert message

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -1198,6 +1198,10 @@
       }
     },
     "message": {
+      "insert": {
+        "label": "Insert Messages",
+        "success": "Messages inserted"
+      },
       "new": {
         "branch": {
           "created": "New Branch Created",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -1198,6 +1198,10 @@
       }
     },
     "message": {
+      "insert": {
+        "label": "插入消息",
+        "success": "消息已插入"
+      },
       "new": {
         "branch": {
           "created": "新分支已创建",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -1198,6 +1198,10 @@
       }
     },
     "message": {
+      "insert": {
+        "label": "插入訊息",
+        "success": "訊息已插入"
+      },
       "new": {
         "branch": {
           "created": "新分支已建立",

--- a/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
@@ -23,7 +23,7 @@ import { translateText } from '@renderer/services/TranslateService'
 import store, { useAppDispatch } from '@renderer/store'
 import { messageBlocksSelectors } from '@renderer/store/messageBlock'
 import { selectMessagesForTopic } from '@renderer/store/newMessage'
-import { removeBlocksThunk } from '@renderer/store/thunk/messageThunk'
+import { insertMessagesThunk, removeBlocksThunk } from '@renderer/store/thunk/messageThunk'
 import { TraceIcon } from '@renderer/trace/pages/Component'
 import type { Assistant, Model, Topic, TranslateLanguage } from '@renderer/types'
 import { type Message, MessageBlockStatus, MessageBlockType } from '@renderer/types/newMessage'
@@ -61,6 +61,7 @@ import {
   Languages,
   ListChecks,
   Menu,
+  MessageSquarePlus,
   NotebookPen,
   Save,
   Split,
@@ -233,6 +234,11 @@ const MessageMenubar: FC<Props> = (props) => {
     window.toast.success(t('chat.message.new.branch.created'))
   }, [index, t])
 
+  const onInsertMessages = useCallback(async () => {
+    await dispatch(insertMessagesThunk(topic.id, message.id, assistant.id))
+    window.toast.success(t('chat.message.insert.success'))
+  }, [dispatch, topic.id, message.id, assistant.id, t])
+
   const handleResendUserMessage = useCallback(
     async (messageUpdate?: Message) => {
       await resendMessage(messageUpdate ?? message, assistant)
@@ -338,6 +344,12 @@ const MessageMenubar: FC<Props> = (props) => {
         onClick: () => {
           toggleMultiSelectMode(true)
         }
+      },
+      {
+        label: t('chat.message.insert.label'),
+        key: 'insert-message',
+        icon: <MessageSquarePlus size={15} />,
+        onClick: onInsertMessages
       },
       {
         label: t('chat.save.label'),
@@ -494,6 +506,7 @@ const MessageMenubar: FC<Props> = (props) => {
     message,
     messageContainerRef,
     onEdit,
+    onInsertMessages,
     onNewBranch,
     t,
     toggleMultiSelectMode,

--- a/src/renderer/src/store/thunk/messageThunk.ts
+++ b/src/renderer/src/store/thunk/messageThunk.ts
@@ -1723,6 +1723,109 @@ export const appendAssistantResponseThunk =
   }
 
 /**
+ * Inserts a pair of user and assistant messages after a specified message.
+ * Creates messages with default content and persists to DB and Redux.
+ * @param topicId The ID of the topic
+ * @param afterMessageId The ID of the message after which to insert
+ * @param assistantId The ID of the assistant
+ */
+export const insertMessagesThunk =
+  (topicId: string, afterMessageId: string, assistantId: string) =>
+  async (dispatch: AppDispatch, getState: () => RootState): Promise<void> => {
+    try {
+      const state = getState()
+      const topicMessages = selectMessagesForTopic(state, topicId)
+
+      if (!topicMessages || topicMessages.length === 0) {
+        logger.error(`[insertMessagesThunk] Topic ${topicId} not found or is empty.`)
+        return
+      }
+
+      // Find the index of the message after which to insert
+      const afterMessageIndex = topicMessages.findIndex((msg) => msg.id === afterMessageId)
+      if (afterMessageIndex === -1) {
+        logger.error(`[insertMessagesThunk] Message ${afterMessageId} not found in topic ${topicId}.`)
+        return
+      }
+
+      const insertIndex = afterMessageIndex + 1
+      const now = new Date().toISOString()
+
+      // Create user message with block
+      const userMessageId = uuid()
+      const userBlockId = uuid()
+      const userBlock: MessageBlock = {
+        id: userBlockId,
+        messageId: userMessageId,
+        type: MessageBlockType.MAIN_TEXT,
+        content: '新用户消息',
+        status: MessageBlockStatus.SUCCESS,
+        createdAt: now
+      }
+      const userMessage: Message = {
+        id: userMessageId,
+        role: 'user',
+        assistantId,
+        topicId,
+        createdAt: now,
+        status: UserMessageStatus.SUCCESS,
+        blocks: [userBlockId]
+      }
+
+      // Create assistant message with block
+      const assistantMessageId = uuid()
+      const assistantBlockId = uuid()
+      const assistantBlock: MessageBlock = {
+        id: assistantBlockId,
+        messageId: assistantMessageId,
+        type: MessageBlockType.MAIN_TEXT,
+        content: '新助手消息',
+        status: MessageBlockStatus.SUCCESS,
+        createdAt: now
+      }
+      const assistantMessage: Message = {
+        id: assistantMessageId,
+        role: 'assistant',
+        assistantId,
+        topicId,
+        createdAt: now,
+        status: AssistantMessageStatus.SUCCESS,
+        blocks: [assistantBlockId],
+        askId: userMessageId
+      }
+
+      // Add blocks to Redux
+      dispatch(upsertOneBlock(userBlock))
+      dispatch(upsertOneBlock(assistantBlock))
+
+      // Insert messages to Redux at the correct position
+      dispatch(
+        newMessagesActions.insertMessageAtIndex({
+          topicId,
+          message: userMessage,
+          index: insertIndex
+        })
+      )
+      dispatch(
+        newMessagesActions.insertMessageAtIndex({
+          topicId,
+          message: assistantMessage,
+          index: insertIndex + 1
+        })
+      )
+
+      // Persist to database
+      await saveMessageAndBlocksToDB(topicId, userMessage, [userBlock], insertIndex)
+      await saveMessageAndBlocksToDB(topicId, assistantMessage, [assistantBlock], insertIndex + 1)
+
+      logger.info(`[insertMessagesThunk] Inserted messages after ${afterMessageId} at index ${insertIndex}`)
+    } catch (error) {
+      logger.error(`[insertMessagesThunk] Error inserting messages:`, error as Error)
+      throw error
+    }
+  }
+
+/**
  * Clones messages from a source topic up to a specified index into a *pre-existing* new topic.
  * Generates new unique IDs for all cloned messages and blocks.
  * Updates the DB and Redux message/block state for the new topic.


### PR DESCRIPTION
### What this PR does

在聊天气泡菜单中新增「插入消息」功能，支持在任意消息后插入一对新的用户消息和助手消息。

Before this PR:

用户无法在现有对话中插入新消息，只能在末尾追加。

After this PR:

用户点击任意消息的气泡菜单，选择「插入消息」，可在该消息之后插入一对新的用户消息和助手消息，插入后后续消息顺序保持不变。

### Why we need it and why it was done in this way

允许用户在对话中途插入新消息，填补了对话编辑能力的空白。用户可以灵活地重新对话，而不必删除或重新开始整个对话。

The following tradeoffs were made:

- 插入位置选择在消息之后而非之前，简化了 UX 和实现复杂度
- 初始内容为占位文本，用户可自行编辑

The following alternatives were considered:

- 在输入框上方添加「插入」按钮 → 需要额外处理光标位置和焦点问题

### Breaking changes

无。

### Special notes for your reviewer

- 功能入口：src/renderer/src/pages/home/Messages/MessageMenubar.tsx 气泡菜单
- 核心逻辑：src/renderer/src/store/thunk/messageThunk.ts 的 insertMessagesThunk
- i18n 支持：中/英/繁三语

### Checklist

- [x] PR: PR 描述遵循项目模板格式
- [x] Code: 代码简洁，符合项目风格
- [ ] Refactor: 新增功能，非重构
- [ ] Upgrade: 不影响升级流程
- [ ] Documentation: 用户界面变更，待用户指南更新
- [x] Self-review: 已自查代码

### Release note

```release-note
feat: 新增在对话中插入消息的功能，用户可在任意消息后插入一对新的用户/助手消息
```