### PR TITLE
refactor: move rtk extraction into agent bootstrap service

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -39,7 +39,6 @@ import { app } from 'electron'
 
 import { registerIpc } from './ipc'
 import { versionService } from './services/VersionService'
-import { extractRtkBinaries } from './utils/rtk'
 
 const logger = loggerService.withContext('MainEntry')
 
@@ -51,14 +50,6 @@ const startApp = async () => {
   // 'handled' = migration window took over OR fatal error already quit the app.
   const migrationResult = await runV2MigrationGate()
   if (migrationResult === 'handled') return
-
-  // Extract bundled rtk binary to ~/.cherrystudio/bin/ on first run
-  // TODO: v2 refactor to use lifecycle
-  extractRtkBinaries().catch((error) => {
-    logger.warn('Failed to extract rtk binaries (non-fatal)', {
-      error: error instanceof Error ? error.message : String(error)
-    })
-  })
 
   // Start lifecycle (BeforeReady runs parallel with app.whenReady)
   application.registerAll(serviceList)

--- a/src/main/services/AgentBootstrapService.ts
+++ b/src/main/services/AgentBootstrapService.ts
@@ -1,6 +1,7 @@
 import { loggerService } from '@logger'
 import { BaseService, DependsOn, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
 
+import { extractRtkBinaries } from '../utils/rtk'
 import { bootstrapBuiltinAgents } from './agents/services/builtin/BuiltinAgentBootstrap'
 import { channelManager } from './agents/services/channels'
 import { registerSessionStreamIpc } from './agents/services/channels/sessionStreamIpc'
@@ -20,6 +21,8 @@ const logger = loggerService.withContext('AgentBootstrapService')
 @DependsOn(['ApiServerService'])
 export class AgentBootstrapService extends BaseService {
   protected async onReady(): Promise<void> {
+    await this.extractRtkBinaries()
+
     await bootstrapBuiltinAgents()
     logger.info('Built-in agents bootstrapped')
 
@@ -39,5 +42,15 @@ export class AgentBootstrapService extends BaseService {
 
     await channelManager.stop()
     logger.info('Channel manager stopped')
+  }
+
+  private async extractRtkBinaries(): Promise<void> {
+    try {
+      await extractRtkBinaries()
+    } catch (error) {
+      logger.warn('Failed to extract rtk binaries (non-fatal)', {
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
   }
 }

--- a/src/main/utils/rtk.ts
+++ b/src/main/utils/rtk.ts
@@ -45,7 +45,7 @@ function getUserBinDir(): string {
 
 /**
  * Extract bundled rtk binary to ~/.cherrystudio/bin/ if not already present or outdated.
- * Called once at app startup.
+ * Invoked during agent subsystem bootstrap.
  */
 export async function extractRtkBinaries(): Promise<void> {
   if (!isPlatformSupported()) {


### PR DESCRIPTION
### What this PR does

Before this PR:
- `extractRtkBinaries()` was triggered directly from `src/main/index.ts` during app startup.
- Agent-specific rtk binary extraction lived in the global main startup sequence instead of the agent subsystem lifecycle.

After this PR:
- `extractRtkBinaries()` is triggered by `AgentBootstrapService` during agent subsystem bootstrap.
- `src/main/index.ts` no longer contains this agent-specific startup step.
- rtk extraction keeps the same non-fatal warning behavior if extraction fails.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

This change improves cohesion. rtk extraction exists to support the agent/claude-code command rewrite path, so it should be initialized from the agent subsystem instead of the global main bootstrap path.

The following tradeoffs were made:
- The change was kept minimal by moving the call into `AgentBootstrapService` instead of doing a broader refactor of the rtk utility structure.
- rtk extraction still happens eagerly during agent bootstrap rather than lazily on first claudecode use, which preserves current behavior and reduces risk.

The following alternatives were considered:
- Keeping the call in `main/index.ts`, which was rejected because it keeps agent-specific setup in the app entrypoint.
- Moving extraction deeper into the claudecode service, which was rejected for now because it would expand the scope beyond a minimal reviewable refactor.

Links to places where the discussion took place: None

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

This is an internal refactor only. Behavior should remain unchanged apart from moving the responsibility into the agent lifecycle.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
