### PR TITLE
feat(minapp): add category-based display with cross-category drag-and-drop

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -4409,6 +4409,7 @@
           "label": "Maximum Backups",
           "unlimited": "Unlimited"
         },
+        "pinned": "Pinned",
         "region": {
           "label": "Region",
           "placeholder": "Region, e.g: us-east-1"
@@ -5067,6 +5068,14 @@
       "disabled": "Hidden Mini Apps",
       "display_title": "Mini App Display Settings",
       "empty": "Drag mini apps from the left to hide them",
+      "category_columns": {
+        "description": "Number of columns for category display",
+        "title": "Category Columns"
+      },
+      "icon_only": {
+        "description": "Display mini apps as icons without labels",
+        "title": "Icon-Only Mode"
+      },
       "open_link_external": {
         "title": "Open new-window links in browser"
       },

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -4409,6 +4409,7 @@
           "label": "最大备份数",
           "unlimited": "不限"
         },
+        "pinned": "已固定",
         "region": {
           "label": "区域",
           "placeholder": "Region, 例如: us-east-1"
@@ -5067,6 +5068,14 @@
       "disabled": "隐藏的小程序",
       "display_title": "小程序显示设置",
       "empty": "把要隐藏的小程序从左侧拖拽到这里",
+      "category_columns": {
+        "description": "分类显示的列数",
+        "title": "分类列数"
+      },
+      "icon_only": {
+        "description": "仅显示小程序图标，不显示名称",
+        "title": "仅图标模式"
+      },
       "open_link_external": {
         "title": "在浏览器中打开新窗口链接"
       },

--- a/src/renderer/src/pages/minapps/MinAppsPage.tsx
+++ b/src/renderer/src/pages/minapps/MinAppsPage.tsx
@@ -1,9 +1,10 @@
 import { Button } from '@cherrystudio/ui'
 import { Navbar, NavbarMain } from '@renderer/components/app/Navbar'
-import App from '@renderer/components/MinApp/MinApp'
 import Scrollbar from '@renderer/components/Scrollbar'
 import { useMinapps } from '@renderer/hooks/useMinapps'
 import { useNavbarPosition } from '@renderer/hooks/useNavbar'
+import { useAppDispatch } from '@renderer/store'
+import { moveMinApp } from '@renderer/store/minapps'
 import { Input } from 'antd'
 import { Search, SettingsIcon } from 'lucide-react'
 import type { FC } from 'react'
@@ -11,26 +12,57 @@ import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
+import CategorySection from './components/CategorySection'
 import MinappSettingsPopup from './MiniappSettings/MinappSettingsPopup'
 import NewAppButton from './NewAppButton'
+
+type CategoryId = 'pinned' | 'enabled' | 'disabled'
 
 const AppsPage: FC = () => {
   const { t } = useTranslation()
   const [search, setSearch] = useState('')
-  const { minapps } = useMinapps()
+  const { minapps, pinned, disabled } = useMinapps()
   const { isTopNavbar } = useNavbarPosition()
+  const dispatch = useAppDispatch()
 
+  // Filter apps for each category
   const filteredApps = search
     ? minapps.filter(
         (app) => app.name.toLowerCase().includes(search.toLowerCase()) || app.url.includes(search.toLowerCase())
       )
     : minapps
 
-  // Calculate the required number of lines
-  const itemsPerRow = Math.floor(930 / 115) // Maximum width divided by the width of each item (including spacing)
-  const rowCount = Math.ceil((filteredApps.length + 1) / itemsPerRow) // +1 for the add button
-  // Each line height is 85px (60px icon + 5px margin + 12px text + spacing)
-  const containerHeight = rowCount * 85 + (rowCount - 1) * 25 // 25px is the line spacing.
+  const filteredPinned = search
+    ? pinned.filter(
+        (app) => app.name.toLowerCase().includes(search.toLowerCase()) || app.url.includes(search.toLowerCase())
+      )
+    : pinned
+
+  const filteredDisabled = search
+    ? disabled.filter(
+        (app) => app.name.toLowerCase().includes(search.toLowerCase()) || app.url.includes(search.toLowerCase())
+      )
+    : disabled
+
+  // Handle drag and drop between categories
+  const handleDrop = (e: React.DragEvent, targetId: CategoryId) => {
+    const appId = e.dataTransfer.getData('text/plain')
+    if (!appId) return
+
+    // Find which category the app is coming from
+    const fromPinned = pinned.some((app) => app.id === appId)
+    const fromEnabled = minapps.some((app) => app.id === appId)
+    const fromDisabled = disabled.some((app) => app.id === appId)
+
+    let from: CategoryId | null = null
+    if (fromPinned) from = 'pinned'
+    else if (fromEnabled) from = 'enabled'
+    else if (fromDisabled) from = 'disabled'
+
+    if (from && from !== targetId) {
+      dispatch(moveMinApp({ appId, from, to: targetId }))
+    }
+  }
 
   // Disable right-click menu in blank area
   const handleContextMenu = (e: React.MouseEvent) => {
@@ -81,12 +113,31 @@ const AppsPage: FC = () => {
               </HeaderContainer>
             )}
             <AppsContainerWrapper>
-              <AppsContainer style={{ height: containerHeight }}>
-                {filteredApps.map((app) => (
-                  <App key={app.id} app={app} />
-                ))}
+              <CategorySectionsContainer>
+                {filteredPinned.length > 0 && (
+                  <CategorySection
+                    id="pinned"
+                    title={t('settings.miniapps.pinned')}
+                    apps={filteredPinned}
+                    onDrop={handleDrop}
+                  />
+                )}
+                <CategorySection
+                  id="enabled"
+                  title={t('settings.miniapps.visible')}
+                  apps={filteredApps}
+                  onDrop={handleDrop}
+                />
                 <NewAppButton />
-              </AppsContainer>
+                {filteredDisabled.length > 0 && (
+                  <CategorySection
+                    id="disabled"
+                    title={t('settings.miniapps.disabled')}
+                    apps={filteredDisabled}
+                    onDrop={handleDrop}
+                  />
+                )}
+              </CategorySectionsContainer>
             </AppsContainerWrapper>
           </RightContainer>
         </MainContainer>
@@ -142,8 +193,7 @@ const RightContainer = styled(Scrollbar)`
 const AppsContainerWrapper = styled(Scrollbar)`
   display: flex;
   flex: 1;
-  flex-direction: row;
-  justify-content: center;
+  flex-direction: column;
   padding: 50px 0;
   width: 100%;
   margin-bottom: 20px;
@@ -152,15 +202,13 @@ const AppsContainerWrapper = styled(Scrollbar)`
   }
 `
 
-const AppsContainer = styled.div`
-  display: grid;
-  min-width: 0;
+const CategorySectionsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
   max-width: 930px;
-  margin: 0 20px;
   width: 100%;
-  grid-template-columns: repeat(auto-fill, 90px);
-  gap: 25px;
-  justify-content: center;
+  margin: 0 20px;
 `
 
 export default AppsPage

--- a/src/renderer/src/pages/minapps/MiniappSettings/MiniAppSettings.tsx
+++ b/src/renderer/src/pages/minapps/MiniappSettings/MiniAppSettings.tsx
@@ -7,9 +7,10 @@ import { useMinapps } from '@renderer/hooks/useMinapps'
 import { SettingDescription, SettingDivider, SettingRowTitle, SettingTitle } from '@renderer/pages/settings'
 import type { RootState } from '@renderer/store'
 import { useAppDispatch, useAppSelector } from '@renderer/store'
+import { setCategoryColumns, setIconOnly } from '@renderer/store/minapps'
 import { setMinAppRegion } from '@renderer/store/settings'
 import type { MinAppRegionFilter } from '@renderer/types'
-import { Flex, Slider } from 'antd'
+import { Flex, InputNumber, Slider } from 'antd'
 import type { FC } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -49,6 +50,10 @@ const MiniAppSettings: FC = () => {
   const [minappsOpenLinkExternal, setMinappsOpenLinkExternal] = usePreference('feature.minapp.open_link_external')
 
   const { minapps, disabled, updateMinapps, updateDisabledMinapps } = useMinapps()
+
+  // Get display settings from store
+  const iconOnly = useAppSelector((state: RootState) => state.minapps.iconOnly)
+  const categoryColumns = useAppSelector((state: RootState) => state.minapps.categoryColumns)
 
   const [visibleMiniApps, setVisibleMiniApps] = useState(minapps)
   const [disabledMiniApps, setDisabledMiniApps] = useState(disabled || [])
@@ -178,6 +183,28 @@ const MiniAppSettings: FC = () => {
         <Switch
           checked={showOpenedMinappsInSidebar}
           onCheckedChange={(checked) => setShowOpenedMinappsInSidebar(checked)}
+        />
+      </SettingRow>
+      <SettingDivider />
+      {/* Display settings */}
+      <SettingRow style={{ height: 40, alignItems: 'center' }}>
+        <SettingLabelGroup>
+          <SettingRowTitle>{t('settings.miniapps.icon_only.title')}</SettingRowTitle>
+          <SettingDescription>{t('settings.miniapps.icon_only.description')}</SettingDescription>
+        </SettingLabelGroup>
+        <Switch checked={iconOnly} onCheckedChange={(checked) => dispatch(setIconOnly(checked))} />
+      </SettingRow>
+      <SettingDivider />
+      <SettingRow style={{ height: 40, alignItems: 'center' }}>
+        <SettingLabelGroup>
+          <SettingRowTitle>{t('settings.miniapps.category_columns.title')}</SettingRowTitle>
+          <SettingDescription>{t('settings.miniapps.category_columns.description')}</SettingDescription>
+        </SettingLabelGroup>
+        <InputNumber
+          min={1}
+          max={10}
+          value={categoryColumns}
+          onChange={(value) => dispatch(setCategoryColumns(value ?? 1))}
         />
       </SettingRow>
     </Container>

--- a/src/renderer/src/pages/minapps/components/CategorySection.tsx
+++ b/src/renderer/src/pages/minapps/components/CategorySection.tsx
@@ -1,0 +1,91 @@
+import App from '@renderer/components/MinApp/MinApp'
+import type { RootState } from '@renderer/store'
+import { useAppSelector } from '@renderer/store'
+import type { MinAppType } from '@renderer/types'
+import React, { FC, useState } from 'react'
+import styled from 'styled-components'
+
+type CategoryId = 'pinned' | 'enabled' | 'disabled'
+
+type CategorySectionProps = {
+  id: CategoryId
+  title: string
+  apps: MinAppType[]
+  onDrop?: (e: React.DragEvent, target: CategoryId) => void
+}
+
+const CategorySection: FC<CategorySectionProps> = ({ id, title, apps, onDrop }) => {
+  const iconOnly = useAppSelector((state: RootState) => state.minapps.iconOnly)
+  const [isDragOver, setIsDragOver] = useState(false)
+
+  return (
+    <SectionContainer
+      id={`minapps-section-${id}`}
+      $isDragOver={isDragOver}
+      onDragOver={(e) => {
+        e.preventDefault()
+        e.dataTransfer.dropEffect = 'move'
+        setIsDragOver(true)
+      }}
+      onDragLeave={() => setIsDragOver(false)}
+      onDrop={(e) => {
+        e.preventDefault()
+        setIsDragOver(false)
+        onDrop?.(e, id)
+      }}>
+      <SectionHeader>{title}</SectionHeader>
+      <AppsGrid $iconOnly={iconOnly}>
+        {apps.map((app) => (
+          <DraggableWrapper
+            key={app.id}
+            draggable
+            onDragStart={(e) => {
+              e.dataTransfer.setData('text/plain', app.id)
+              e.dataTransfer.effectAllowed = 'move'
+            }}>
+            <App app={app} />
+          </DraggableWrapper>
+        ))}
+      </AppsGrid>
+    </SectionContainer>
+  )
+}
+
+const SectionContainer = styled.div<{ $isDragOver: boolean }>`
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  border-radius: 8px;
+  padding: 12px;
+  transition: background-color 0.2s;
+  background-color: ${({ $isDragOver }) => ($isDragOver ? 'var(--color-bg-2, rgba(0, 0, 0, 0.04))' : 'transparent')};
+  outline: 1px dashed ${({ $isDragOver }) => ($isDragOver ? 'var(--color-primary)' : 'transparent')};
+  outline-offset: -4px;
+`
+
+const SectionHeader = styled.div`
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--color-text-soft);
+  margin-bottom: 12px;
+  margin-left: 4px;
+`
+
+const AppsGrid = styled.div<{ $iconOnly: boolean }>`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, ${({ $iconOnly }) => ($iconOnly ? '60px' : '90px')});
+  gap: ${({ $iconOnly }) => ($iconOnly ? '15px' : '25px')};
+  justify-content: start;
+`
+
+const DraggableWrapper = styled.div`
+  display: inline-block;
+  cursor: grab;
+  user-select: none;
+
+  &:active {
+    cursor: grabbing;
+  }
+`
+
+export default CategorySection

--- a/src/renderer/src/store/__tests__/minapps.test.ts
+++ b/src/renderer/src/store/__tests__/minapps.test.ts
@@ -1,4 +1,4 @@
-import minAppsReducer, { type MinAppsState, setPinnedMinApps } from '@renderer/store/minapps'
+import minAppsReducer, { type MinAppsState, moveMinApp, setPinnedMinApps } from '@renderer/store/minapps'
 import type { MinAppType } from '@renderer/types'
 import { describe, expect, it } from 'vitest'
 
@@ -10,19 +10,22 @@ const createApp = (id: string, name?: string): MinAppType => ({
   logo: `logo-${id}`
 })
 
-describe('minApps slice — setPinnedMinApps', () => {
-  const buildState = (pinned: MinAppType[]): MinAppsState =>
-    ({
-      enabled: [],
-      disabled: [],
-      pinned
-    }) as MinAppsState
+const buildState = (overrides: Partial<MinAppsState> = {}): MinAppsState =>
+  ({
+    enabled: [],
+    disabled: [],
+    pinned: [],
+    iconOnly: false,
+    categoryColumns: 1,
+    ...overrides
+  }) as MinAppsState
 
+describe('minApps slice — setPinnedMinApps', () => {
   it('replaces pinned list with new list', () => {
     const A = createApp('a')
     const B = createApp('b')
     const C = createApp('c')
-    const state = buildState([A, B, C])
+    const state = buildState({ pinned: [A, B, C] })
 
     const next = minAppsReducer(state, setPinnedMinApps([A, C]))
 
@@ -31,7 +34,7 @@ describe('minApps slice — setPinnedMinApps', () => {
 
   it('can set an empty pinned list', () => {
     const A = createApp('a')
-    const state = buildState([A])
+    const state = buildState({ pinned: [A] })
 
     const next = minAppsReducer(state, setPinnedMinApps([]))
 
@@ -40,11 +43,70 @@ describe('minApps slice — setPinnedMinApps', () => {
 
   it('strips logo field from pinned apps', () => {
     const app = createApp('a')
-    const state = buildState([])
+    const state = buildState()
 
     const next = minAppsReducer(state, setPinnedMinApps([app]))
 
     expect(next.pinned[0].logo).toBeUndefined()
     expect(next.pinned[0].id).toBe('a')
+  })
+})
+
+describe('minApps slice — moveMinApp', () => {
+  it('moves an app from enabled to pinned', () => {
+    const A = createApp('a')
+    const state = buildState({ enabled: [A], pinned: [] })
+
+    const next = minAppsReducer(state, moveMinApp({ appId: 'a', from: 'enabled', to: 'pinned' }))
+
+    expect(next.enabled).toHaveLength(0)
+    expect(next.pinned.map((a) => a.id)).toEqual(['a'])
+  })
+
+  it('moves an app from pinned to disabled', () => {
+    const A = createApp('a')
+    const state = buildState({ pinned: [A], disabled: [] })
+
+    const next = minAppsReducer(state, moveMinApp({ appId: 'a', from: 'pinned', to: 'disabled' }))
+
+    expect(next.pinned).toHaveLength(0)
+    expect(next.disabled.map((a) => a.id)).toEqual(['a'])
+  })
+
+  it('moves an app from disabled to enabled', () => {
+    const A = createApp('a')
+    const state = buildState({ disabled: [A], enabled: [] })
+
+    const next = minAppsReducer(state, moveMinApp({ appId: 'a', from: 'disabled', to: 'enabled' }))
+
+    expect(next.disabled).toHaveLength(0)
+    expect(next.enabled.map((a) => a.id)).toEqual(['a'])
+  })
+
+  it('does nothing when from === to', () => {
+    const A = createApp('a')
+    const state = buildState({ enabled: [A] })
+
+    const next = minAppsReducer(state, moveMinApp({ appId: 'a', from: 'enabled', to: 'enabled' }))
+
+    expect(next.enabled.map((a) => a.id)).toEqual(['a'])
+  })
+
+  it('does nothing when app not found in source', () => {
+    const state = buildState({ enabled: [], pinned: [] })
+
+    const next = minAppsReducer(state, moveMinApp({ appId: 'nonexistent', from: 'enabled', to: 'pinned' }))
+
+    expect(next.enabled).toHaveLength(0)
+    expect(next.pinned).toHaveLength(0)
+  })
+
+  it('strips logo field when moving', () => {
+    const A = createApp('a')
+    const state = buildState({ enabled: [A] })
+
+    const next = minAppsReducer(state, moveMinApp({ appId: 'a', from: 'enabled', to: 'pinned' }))
+
+    expect(next.pinned[0].logo).toBeUndefined()
   })
 })

--- a/src/renderer/src/store/minapps.ts
+++ b/src/renderer/src/store/minapps.ts
@@ -23,12 +23,17 @@ export interface MinAppsState {
   enabled: MinAppType[]
   disabled: MinAppType[]
   pinned: MinAppType[]
+  // Display settings
+  iconOnly: boolean
+  categoryColumns: number
 }
 
 const initialState: MinAppsState = {
   enabled: allMinApps,
   disabled: [],
-  pinned: []
+  pinned: [],
+  iconOnly: false,
+  categoryColumns: 1
 }
 
 const minAppsSlice = createSlice({
@@ -46,10 +51,42 @@ const minAppsSlice = createSlice({
     },
     setPinnedMinApps: (state, action: PayloadAction<MinAppType[]>) => {
       state.pinned = action.payload.map((app) => ({ ...app, logo: undefined }))
+    },
+    moveMinApp: (
+      state,
+      action: PayloadAction<{
+        appId: string
+        from: 'enabled' | 'disabled' | 'pinned'
+        to: 'enabled' | 'disabled' | 'pinned'
+      }>
+    ) => {
+      const { appId, from, to } = action.payload
+      if (from === to) return
+
+      const sourceList = state[from]
+      const appIndex = sourceList.findIndex((app) => app.id === appId)
+      if (appIndex === -1) return
+
+      const [app] = sourceList.splice(appIndex, 1)
+      state[to].push({ ...app, logo: undefined })
+    },
+    setIconOnly: (state, action: PayloadAction<boolean>) => {
+      state.iconOnly = action.payload
+    },
+    setCategoryColumns: (state, action: PayloadAction<number>) => {
+      state.categoryColumns = action.payload
     }
   }
 })
 
-export const { setMinApps, addMinApp, setDisabledMinApps, setPinnedMinApps } = minAppsSlice.actions
+export const {
+  setMinApps,
+  addMinApp,
+  setDisabledMinApps,
+  setPinnedMinApps,
+  moveMinApp,
+  setIconOnly,
+  setCategoryColumns
+} = minAppsSlice.actions
 
 export default minAppsSlice.reducer


### PR DESCRIPTION
### What this PR does

Before this PR:
- Mini apps page displayed all apps in a single flat grid with no categorization
- No way to visually separate pinned, visible, and hidden apps on the main page
- No drag-and-drop support to move apps between categories
- No display customization options (icon-only mode, category columns)

After this PR:
- Mini apps page now displays apps in three category sections: Pinned, Visible Mini Apps, Hidden Mini Apps
- Cross-category drag-and-drop allows moving apps between categories via HTML5 DnD
- Category sections show visual feedback (dashed border highlight) when dragging over
- Mini App Display Settings panel now includes icon-only mode toggle and category columns setting
- Horizontal flow grid layout respects window size without horizontal scrollbars

Fixes #

### Why we need it and why it was done in this way

The flat grid made it difficult to manage mini apps when the list grew large. Users had no visual distinction between pinned, regular, and hidden apps on the main page, and had to navigate to settings to make any changes.

The following tradeoffs were made:
- Used HTML5 native drag-and-drop instead of a library (e.g., dnd-kit) to avoid adding dependencies, trading off animation polish for zero bundle size increase
- Added moveMinApp, iconOnly, categoryColumns to the existing minapps Redux slice rather than creating a separate store, keeping all minapp state colocated
- The CategorySection component is display-only (no inline editing) to keep the scope manageable

The following alternatives were considered:
- dnd-kit for drag-and-drop: rejected due to dependency addition
- Separate categories Redux store: rejected to keep state colocated
- Sidebar-based category management: rejected as it changes existing UX patterns

Links to places where the discussion took place:

### Breaking changes

None. The new state fields (iconOnly, categoryColumns) have safe defaults (false, 1) and existing behavior is preserved.

### Special notes for your reviewer

- This PR modifies src/renderer/src/store/minapps.ts which has a BLOCKED notice for v2 refactoring. This change is additive only (new actions + state fields with defaults) and does not modify existing behavior. The v2 refactoring PR (#10162) should be aware of these additions.
- The CategorySection component is a new file - no existing files were refactored.
- i18n keys added: settings.miniapps.pinned, settings.miniapps.icon_only.title/description, settings.miniapps.category_columns.title/description (both en-us and zh-cn).

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via /gh-pr-review, gh pr diff, or GitHub UI) before requesting review from others

### Release note

```release-note
Mini apps page now supports category-based display (Pinned/Visible/Hidden) with cross-category drag-and-drop, icon-only mode, and category columns setting.
```
