### PR TITLE
fix(aiCore): restore error handling in MCP recursive tool call

### DIFF
--- a/packages/aiCore/src/core/plugins/built-in/toolUsePlugin/StreamEventManager.ts
+++ b/packages/aiCore/src/core/plugins/built-in/toolUsePlugin/StreamEventManager.ts
@@ -111,20 +111,29 @@ export class StreamEventManager {
     recursiveParams: Partial<TParams>,
     context: AiRequestContext<TParams, StreamTextResult>
   ): Promise<void> {
-    // try {
-    // 重置工具执行状态，准备处理新的步骤
-    context.hasExecutedToolsInCurrentStep = false
+    try {
+      // 重置工具执行状态，准备处理新的步骤
+      context.hasExecutedToolsInCurrentStep = false
 
-    const recursiveResult = await context.recursiveCall(recursiveParams)
+      const recursiveResult = await context.recursiveCall(recursiveParams)
 
-    if (hasFullStream(recursiveResult)) {
-      await this.pipeRecursiveStream(controller, recursiveResult.fullStream)
-    } else {
-      console.warn('[MCP Prompt] No fullstream found in recursive result:', recursiveResult)
+      if (hasFullStream(recursiveResult)) {
+        await this.pipeRecursiveStream(controller, recursiveResult.fullStream)
+      } else {
+        console.warn('[MCP Prompt] No fullstream found in recursive result:', recursiveResult)
+      }
+    } catch (error) {
+      console.error('[MCP Prompt] Recursive call failed:', error)
+      // 发送 error 与 finish-step 事件，避免流因异常被吞掉而 UI 静默挂起
+      controller.enqueue({ type: 'error', error })
+      controller.enqueue({
+        type: 'finish-step',
+        finishReason: 'error',
+        response: undefined,
+        usage: undefined,
+        providerMetadata: undefined
+      })
     }
-    // } catch (error) {
-    //   this.handleRecursiveCallError(controller, error, stepId)
-    // }
   }
 
   /**


### PR DESCRIPTION
### What this PR does

Before this PR:

When an MCP tool call triggers a recursive LLM call via `StreamEventManager.handleRecursiveCall` (prompt-based tool use path, used by OpenAI-compatible providers), any exception thrown by `context.recursiveCall(...)` or by `pipeRecursiveStream` is swallowed by the outer TransformStream. The user sees the assistant stuck in a "generating" state forever with no error surfaced in the UI or logs.

After this PR:

The previously commented-out `try/catch` wrapping `handleRecursiveCall` is restored. On failure the method now:
- logs the error via `console.error` (matching the existing pattern in this file),
- enqueues an `{ type: 'error', error }` chunk so the UI layer can render the failure,
- enqueues a `finish-step` with `finishReason: 'error'` so the stream terminates cleanly instead of hanging.

The original commented handler referenced a non-existent `handleRecursiveCallError(controller, error, stepId)` method and a `stepId` variable that is not in scope in this function, so the handling is inlined rather than recreated as a separate method.

Fixes #13961

### Why we need it and why it was done in this way

The commented `try/catch` was a known placeholder — its referenced helper was never implemented and the comment contained a dangling `stepId` reference. Restoring it with minimal inline handling:
- stays within `main`'s hotfix scope (no refactor, no new abstractions),
- keeps existing happy-path and `no fullStream` behavior byte-for-byte identical (verified by the 23 existing `StreamEventManager.test.ts` cases),
- uses stream events (`error` + `finish-step`) that downstream AI SDK consumers already understand.

The following tradeoffs were made:

- Inlined rather than creating a named `handleRecursiveCallError` helper, since it is only called from one site and adding a new method in a file marked for v2 replacement would invite scope creep.
- The emitted `finish-step` passes `usage: undefined` / `providerMetadata: undefined` because no usage data is available on the error path. Downstream consumers already handle undefined usage (see `accumulateUsage` null guard at line 197).

The following alternatives were considered:

- Rethrowing the error instead of swallowing it. Rejected because the outer TransformStream pipeline swallows rejections at this layer and would still produce the silent-hang symptom in the renderer.
- Implementing a separate `handleRecursiveCallError` method as the comment originally intended. Rejected as unnecessary scope for a `main`-branch hotfix; the v2 refactor can formalize error paths.

Links to places where the discussion took place: N/A

### Breaking changes

None. The public surface of `StreamEventManager` is unchanged. Existing tests pass unmodified.

### Special notes for your reviewer

**How to reproduce (before fix)**:
1. Use any OpenAI-compatible provider (Poe, Copilot, new-api aggregator) with MCP tools enabled.
2. Configure the provider so the *follow-up* completion (the recursive call after the tool executes successfully) will fail — e.g. by using a short-lived token that expires between the first and second request, or by momentarily disabling network.
3. Ask the assistant to use a tool.
4. Observe: MCP tool executes and returns a result, but the UI stays in "generating" state indefinitely with no error shown, and no error in devtools console.

**How to verify (after fix)**:
- Reproduce the same setup — the UI now shows the error (via the `error` chunk) and the stream terminates cleanly.

**Test results**:
- `pnpm test:aicore` — 380 tests passed, including all 23 `StreamEventManager` tests.
- `pnpm test` (full suite) — 4111 passed / 72 skipped.
- `pnpm lint` / `pnpm format` — clean.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix: MCP tool chats on OpenAI-compatible providers no longer hang silently when the follow-up model call fails; the error is now surfaced and the stream terminates cleanly
```
