### PR TITLE
fix(agents): set Cherry Assistant default avatar to 🍒

### DIFF
--- a/resources/builtin-agents/cherry-assistant/agent.json
+++ b/resources/builtin-agents/cherry-assistant/agent.json
@@ -18,6 +18,7 @@
   "allowed_tools": [],
   "mcps": [],
   "configuration": {
+    "avatar": "🍒",
     "permission_mode": "default",
     "max_turns": 100,
     "env_vars": {}


### PR DESCRIPTION
### What this PR does

Before this PR:

Cherry Assistant's `resources/builtin-agents/cherry-assistant/agent.json` had no `configuration.avatar` field. The Agent rendering path falls back to a generic `⭐️` when no avatar is set (see `src/renderer/src/pages/settings/AgentSettings/components/NameSetting.tsx:27` and `shared.tsx:98`), so users saw an off-brand star icon for the built-in Cherry Assistant.

After this PR:

Sets `configuration.avatar` to `🍒` in `cherry-assistant/agent.json`, matching Cherry Studio's brand. The value is consumed by the existing `agent?.configuration?.avatar || '⭐️'` fallback, so no renderer changes are needed.

Partially addresses #14253.

### Why we need it and why it was done in this way

`#14253` reports that both built-in agents ship with the wrong icons:
1. **Cherry Assistant** — should be `🍒`, currently renders as `⭐️` (user called it 🌟 in the issue).
2. **Cherry Claw** — should be a custom lobster/claw SVG/PNG asset, currently renders as `🦞` (hard-coded in `AgentService.ts:327`).

This PR only addresses (1) because it is a pure data change (one JSON field). Fixing (2) requires shipping a design-delivered raster/vector asset and changing the avatar rendering path to support non-emoji avatars; that is out of scope for a `main`-branch hotfix and will be handled in a separate PR once the asset is provided.

The following tradeoffs were made:

- Chose the same emoji delivery mechanism (`configuration.avatar`) used by `Cherry Claw`, instead of introducing an image asset, to keep the change minimal and consistent with existing built-in agent conventions.

The following alternatives were considered:

- Bundling both Cherry Assistant and Cherry Claw fixes in one PR. Rejected because the Claw fix needs a new design asset and an avatar-rendering change.

Links to places where the discussion took place: N/A

### Breaking changes

None. JSON schema is unchanged; `avatar` is an existing optional field already consumed by the renderer.

### Special notes for your reviewer

- After merge, only new installations will pick up the avatar. Existing users who already have the seeded Cherry Assistant agent will need either a reset or a one-time migration to see the new avatar. This matches how `Cherry Claw`'s avatar is delivered (hard-coded at seed time, no migration), so no new upgrade-path code is introduced here.
- Cherry Claw's `🦞` → custom lobster asset is intentionally not fixed in this PR.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix: Cherry Assistant built-in agent now displays the 🍒 avatar instead of the generic ⭐️ fallback
```
