### PR TITLE
fix(agent): include globally installed skills for agents with custom workspace

### DIFF
--- a/src/main/services/agents/plugins/PluginService.ts
+++ b/src/main/services/agents/plugins/PluginService.ts
@@ -1,6 +1,7 @@
 import * as crypto from 'node:crypto'
 
 import { loggerService } from '@logger'
+import { getDataPath } from '@main/utils'
 import { directoryExists, fileExists, isPathInside, pathExists } from '@main/utils/file'
 import { deleteDirectoryRecursive } from '@main/utils/fileOperations'
 import {
@@ -691,6 +692,18 @@ export class PluginService {
 
     const plugins = await this.listInstalledFromCache(workdir)
 
+    // Also include globally installed plugins from the default workspace
+    const defaultWorkdir = this.getDefaultWorkdir(agent.id)
+    if (defaultWorkdir !== workdir && (await directoryExists(defaultWorkdir))) {
+      const globalPlugins = await this.listInstalledFromCache(defaultWorkdir)
+      const existingNames = new Set(plugins.map((p) => p.metadata.name))
+      for (const gp of globalPlugins) {
+        if (!existingNames.has(gp.metadata.name)) {
+          plugins.push(gp)
+        }
+      }
+    }
+
     logger.debug('Listed installed plugins from cache', {
       agentId,
       count: plugins.length
@@ -709,6 +722,7 @@ export class PluginService {
     const workdir = this.getWorkdirOrThrow(agent, agentId)
     await this.validateWorkdir(agent, workdir)
 
+    // Collect plugins from custom workdir
     const installedPlugins = await this.listInstalledFromCache(workdir)
     const packageNames = new Set<string>()
 
@@ -716,10 +730,6 @@ export class PluginService {
       if (plugin.metadata.packageName) {
         packageNames.add(this.sanitizeFolderName(plugin.metadata.packageName))
       }
-    }
-
-    if (packageNames.size === 0) {
-      return []
     }
 
     const pluginPaths: string[] = []
@@ -732,6 +742,25 @@ export class PluginService {
         pluginPaths.push(pluginPath)
       } else {
         logger.warn('Skipping plugin without manifest', { pluginPath, manifestPath })
+      }
+    }
+
+    // Also include plugin packages from the default workspace
+    const defaultWorkdir = this.getDefaultWorkdir(agent.id)
+    if (defaultWorkdir !== workdir && (await directoryExists(defaultWorkdir))) {
+      const globalPlugins = await this.listInstalledFromCache(defaultWorkdir)
+      for (const plugin of globalPlugins) {
+        if (plugin.metadata.packageName) {
+          const folderName = this.sanitizeFolderName(plugin.metadata.packageName)
+          if (!packageNames.has(folderName)) {
+            packageNames.add(folderName)
+            const pluginPath = path.join(defaultWorkdir, '.claude', 'plugins', folderName)
+            const manifestPath = path.join(pluginPath, '.claude-plugin', 'plugin.json')
+            if (await fileExists(manifestPath)) {
+              pluginPaths.push(pluginPath)
+            }
+          }
+        }
       }
     }
 
@@ -1583,6 +1612,15 @@ export class PluginService {
       } as PluginError
     }
     return workdir
+  }
+
+  /**
+   * Get the default workspace path for an agent (where globally installed plugins reside).
+   * Mirrors BaseService.resolveAccessiblePaths default logic.
+   */
+  private getDefaultWorkdir(agentId: string): string {
+    const shortId = agentId.substring(agentId.length - 9)
+    return path.join(getDataPath(), 'Agents', shortId)
   }
 
   /**


### PR DESCRIPTION
### What this PR does

Before this PR:

Agents with a custom workspace path (`accessible_paths`) could not see or use skills installed via the skill management UI. Only skills manually placed in the custom workspace directory were visible.

After this PR:

Agents with a custom workspace now also discover globally installed skills from their default workspace (`{userData}/Data/Agents/{shortId}/`). Results are merged with deduplication, giving custom workspace skills priority over global ones.

Fixes #14327

### Why we need it and why it was done in this way

When an agent has a custom workspace, `PluginService.listInstalled()` and `listInstalledPluginPackagePaths()` only searched `accessible_paths[0]`. Skills installed via the UI reside in the agent's default workspace directory, which is different from the custom path — so they became invisible.

The fix adds a `getDefaultWorkdir(agentId)` helper (mirroring `BaseService.resolveAccessiblePaths` logic) and searches both directories when they differ. This approach:

- Has zero impact on agents without custom workspaces (paths are equal, no extra lookup)
- Preserves custom workspace priority (deduplication favors custom over global)
- Requires no schema or data model changes

The following alternatives were considered:

- Copying global skills into the custom workspace on path change — rejected as it would duplicate data and cause sync issues
- Modifying `BaseService.resolveAccessiblePaths` to always include the default path — rejected as it would change the security model of `accessible_paths`

### Breaking changes

None.

### Special notes for your reviewer

- Only `src/main/services/agents/plugins/PluginService.ts` is modified
- The `getDefaultWorkdir()` logic mirrors `BaseService.resolveAccessiblePaths` (line 269-274) — if that logic changes, this should be updated too
- The early-return `if (packageNames.size === 0) return []` was removed from `listInstalledPluginPackagePaths()` because we need to continue to check the default workspace even when the custom workspace has no plugins

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix agents with custom workspace paths being unable to use globally installed skills (#14327)
```
