### PR TITLE
hotfix: Custom params not passed to `Gemini` API when using `NewAPI`/`AiHubMix`

### DIFF
--- a/src/renderer/src/aiCore/utils/__tests__/options.test.ts
+++ b/src/renderer/src/aiCore/utils/__tests__/options.test.ts
@@ -1123,6 +1123,54 @@ describe('options utils', () => {
         })
       })
 
+      it('should build Google options for Gemini models through newapi', () => {
+        const newapiProvider: Provider = {
+          id: 'newapi',
+          name: 'NewAPI',
+          type: 'openai',
+          models: [] as Model[]
+        } as Provider
+
+        const geminiModel: Model = {
+          id: 'gemini-3.1-flash-image-preview',
+          name: 'Gemini 3.1 Flash Image Preview',
+          provider: 'newapi'
+        } as Model
+
+        const result = buildProviderOptions(mockAssistant, geminiModel, newapiProvider, {
+          enableReasoning: false,
+          enableWebSearch: false,
+          enableGenerateImage: false
+        })
+
+        expect(result.providerOptions).toHaveProperty('google')
+        expect(result.providerOptions).not.toHaveProperty('newapi')
+      })
+
+      it('should build Google options for Gemini models through aihubmix', () => {
+        const aihubmixProvider: Provider = {
+          id: 'aihubmix',
+          name: 'AiHubMix',
+          type: 'openai',
+          models: [] as Model[]
+        } as Provider
+
+        const geminiModel: Model = {
+          id: 'gemini-3.1-flash-image-preview',
+          name: 'Gemini 3.1 Flash Image Preview',
+          provider: 'aihubmix'
+        } as Model
+
+        const result = buildProviderOptions(mockAssistant, geminiModel, aihubmixProvider, {
+          enableReasoning: false,
+          enableWebSearch: false,
+          enableGenerateImage: false
+        })
+
+        expect(result.providerOptions).toHaveProperty('google')
+        expect(result.providerOptions).not.toHaveProperty('aihubmix')
+      })
+
       // Note: For proxy providers like aihubmix/newapi, users should write AI SDK provider ID (google/anthropic)
       // instead of the Cherry Studio provider ID for custom parameters to work correctly
 

--- a/src/renderer/src/aiCore/utils/__tests__/options.test.ts
+++ b/src/renderer/src/aiCore/utils/__tests__/options.test.ts
@@ -1123,53 +1123,45 @@ describe('options utils', () => {
         })
       })
 
-      it('should build Google options for Gemini models through newapi', () => {
-        const newapiProvider: Provider = {
-          id: 'newapi',
-          name: 'NewAPI',
-          type: 'openai',
-          models: [] as Model[]
-        } as Provider
+      it.each([
+        { providerId: 'newapi', providerName: 'NewAPI' },
+        { providerId: 'aihubmix', providerName: 'AiHubMix' }
+      ])(
+        'should route Gemini models to google providerOptions through $providerName',
+        async ({ providerId, providerName }) => {
+          const { getCustomParameters } = await import('../reasoning')
+          vi.mocked(getCustomParameters).mockReturnValue({
+            generationConfig: { responseModalities: ['IMAGE', 'TEXT'] },
+            imageConfig: { aspectRatio: '3:4', imageSize: '4K' }
+          })
 
-        const geminiModel: Model = {
-          id: 'gemini-3.1-flash-image-preview',
-          name: 'Gemini 3.1 Flash Image Preview',
-          provider: 'newapi'
-        } as Model
+          const provider: Provider = {
+            id: providerId,
+            name: providerName,
+            type: 'openai',
+            models: [] as Model[]
+          } as Provider
 
-        const result = buildProviderOptions(mockAssistant, geminiModel, newapiProvider, {
-          enableReasoning: false,
-          enableWebSearch: false,
-          enableGenerateImage: false
-        })
+          const geminiModel: Model = {
+            id: 'gemini-3.1-flash-image-preview',
+            name: 'Gemini 3.1 Flash Image Preview',
+            provider: providerId
+          } as Model
 
-        expect(result.providerOptions).toHaveProperty('google')
-        expect(result.providerOptions).not.toHaveProperty('newapi')
-      })
+          const result = buildProviderOptions(mockAssistant, geminiModel, provider, {
+            enableReasoning: false,
+            enableWebSearch: false,
+            enableGenerateImage: true
+          })
 
-      it('should build Google options for Gemini models through aihubmix', () => {
-        const aihubmixProvider: Provider = {
-          id: 'aihubmix',
-          name: 'AiHubMix',
-          type: 'openai',
-          models: [] as Model[]
-        } as Provider
-
-        const geminiModel: Model = {
-          id: 'gemini-3.1-flash-image-preview',
-          name: 'Gemini 3.1 Flash Image Preview',
-          provider: 'aihubmix'
-        } as Model
-
-        const result = buildProviderOptions(mockAssistant, geminiModel, aihubmixProvider, {
-          enableReasoning: false,
-          enableWebSearch: false,
-          enableGenerateImage: false
-        })
-
-        expect(result.providerOptions).toHaveProperty('google')
-        expect(result.providerOptions).not.toHaveProperty('aihubmix')
-      })
+          expect(result.providerOptions).toHaveProperty('google')
+          expect(result.providerOptions).not.toHaveProperty(providerId)
+          expect(result.providerOptions.google).toMatchObject({
+            generationConfig: { responseModalities: ['IMAGE', 'TEXT'] },
+            imageConfig: { aspectRatio: '3:4', imageSize: '4K' }
+          })
+        }
+      )
 
       // Note: For proxy providers like aihubmix/newapi, users should write AI SDK provider ID (google/anthropic)
       // instead of the Cherry Studio provider ID for custom parameters to work correctly

--- a/src/renderer/src/aiCore/utils/options.ts
+++ b/src/renderer/src/aiCore/utils/options.ts
@@ -205,19 +205,10 @@ export function buildProviderOptions(
     case SystemProviderIds.ollama:
       providerSpecificOptions = buildOllamaProviderOptions(assistant, model, capabilities)
       break
-    case SystemProviderIds.gateway:
-      providerSpecificOptions = buildAIGatewayOptions(assistant, model, capabilities, serviceTier, textVerbosity)
-      break
     case 'newapi':
     case 'aihubmix':
-      providerSpecificOptions = buildProxyProviderOptions(
-        rawProviderId,
-        assistant,
-        model,
-        capabilities,
-        serviceTier,
-        textVerbosity
-      )
+    case SystemProviderIds.gateway:
+      providerSpecificOptions = buildAIGatewayOptions(assistant, model, capabilities, serviceTier, textVerbosity)
       break
     case 'deepseek':
     case 'openrouter':
@@ -494,33 +485,6 @@ function buildCherryInProviderOptions(
     default:
       return buildGenericProviderOptions('cherryin', assistant, model, capabilities)
   }
-}
-
-/**
- * Build providerOptions for proxy providers (newapi, aihubmix) that route to different backends.
- * These providers use model ID to determine the actual backend, not provider.type.
- */
-function buildProxyProviderOptions(
-  rawProviderId: string,
-  assistant: Assistant,
-  model: Model,
-  capabilities: Pick<ProviderCapabilities, 'enableReasoning' | 'enableWebSearch' | 'enableGenerateImage'>,
-  serviceTier: OpenAIServiceTier,
-  textVerbosity: OpenAIVerbosity
-): Record<string, OpenAIResponsesProviderOptions | AnthropicProviderOptions | GoogleGenerativeAIProviderOptions> {
-  if (isGeminiModel(model)) {
-    return buildGeminiProviderOptions(assistant, model, capabilities)
-  }
-  if (isAnthropicModel(model)) {
-    return buildAnthropicProviderOptions(assistant, model, capabilities)
-  }
-  if (isOpenAIModel(model)) {
-    return buildOpenAIProviderOptions(assistant, model, capabilities, serviceTier, textVerbosity)
-  }
-  if (isGrokModel(model)) {
-    return buildXAIProviderOptions(assistant, model, capabilities)
-  }
-  return buildGenericProviderOptions(rawProviderId, assistant, model, capabilities)
 }
 
 /**

--- a/src/renderer/src/aiCore/utils/options.ts
+++ b/src/renderer/src/aiCore/utils/options.ts
@@ -208,6 +208,17 @@ export function buildProviderOptions(
     case SystemProviderIds.gateway:
       providerSpecificOptions = buildAIGatewayOptions(assistant, model, capabilities, serviceTier, textVerbosity)
       break
+    case 'newapi':
+    case 'aihubmix':
+      providerSpecificOptions = buildProxyProviderOptions(
+        rawProviderId,
+        assistant,
+        model,
+        capabilities,
+        serviceTier,
+        textVerbosity
+      )
+      break
     case 'deepseek':
     case 'openrouter':
     case 'openai-compatible':
@@ -483,6 +494,33 @@ function buildCherryInProviderOptions(
     default:
       return buildGenericProviderOptions('cherryin', assistant, model, capabilities)
   }
+}
+
+/**
+ * Build providerOptions for proxy providers (newapi, aihubmix) that route to different backends.
+ * These providers use model ID to determine the actual backend, not provider.type.
+ */
+function buildProxyProviderOptions(
+  rawProviderId: string,
+  assistant: Assistant,
+  model: Model,
+  capabilities: Pick<ProviderCapabilities, 'enableReasoning' | 'enableWebSearch' | 'enableGenerateImage'>,
+  serviceTier: OpenAIServiceTier,
+  textVerbosity: OpenAIVerbosity
+): Record<string, OpenAIResponsesProviderOptions | AnthropicProviderOptions | GoogleGenerativeAIProviderOptions> {
+  if (isGeminiModel(model)) {
+    return buildGeminiProviderOptions(assistant, model, capabilities)
+  }
+  if (isAnthropicModel(model)) {
+    return buildAnthropicProviderOptions(assistant, model, capabilities)
+  }
+  if (isOpenAIModel(model)) {
+    return buildOpenAIProviderOptions(assistant, model, capabilities, serviceTier, textVerbosity)
+  }
+  if (isGrokModel(model)) {
+    return buildXAIProviderOptions(assistant, model, capabilities)
+  }
+  return buildGenericProviderOptions(rawProviderId, assistant, model, capabilities)
 }
 
 /**

--- a/src/renderer/src/config/models/vision.ts
+++ b/src/renderer/src/config/models/vision.ts
@@ -119,7 +119,7 @@ const IMAGE_ENHANCEMENT_MODELS = [
   'gpt-image-1',
   'gemini-2.5-flash-image(?:-[\\w-]+)?',
   'gemini-2.0-flash-preview-image-generation',
-  'gemini-3(?:\\.\\d+)?-pro-image(?:-[\\w-]+)?'
+  'gemini-3(?:\\.\\d+)?-(?:flash|pro)-image(?:-[\\w-]+)?'
 ]
 
 const IMAGE_ENHANCEMENT_MODELS_REGEX = new RegExp(IMAGE_ENHANCEMENT_MODELS.join('|'), 'i')
@@ -129,7 +129,7 @@ const DEDICATED_IMAGE_MODEL_REGEX = new RegExp(DEDICATED_IMAGE_MODELS.join('|'),
 // Models that should auto-enable image generation button when selected
 const AUTO_ENABLE_IMAGE_MODELS = [
   'gemini-2.5-flash-image(?:-[\\w-]+)?',
-  'gemini-3(?:\\.\\d+)?-pro-image(?:-[\\w-]+)?',
+  'gemini-3(?:\\.\\d+)?-(?:flash|pro)-image(?:-[\\w-]+)?',
   ...DEDICATED_IMAGE_MODELS
 ]
 
@@ -147,7 +147,7 @@ const OPENAI_TOOL_USE_IMAGE_GENERATION_MODELS = [
 
 const OPENAI_IMAGE_GENERATION_MODELS = [...OPENAI_TOOL_USE_IMAGE_GENERATION_MODELS, 'gpt-image-1']
 
-const MODERN_IMAGE_MODELS = ['gemini-3(?:\\.\\d+)?-pro-image(?:-[\\w-]+)?']
+const MODERN_IMAGE_MODELS = ['gemini-3(?:\\.\\d+)?-(?:flash|pro)-image(?:-[\\w-]+)?']
 
 const GENERATE_IMAGE_MODELS = [
   'gemini-2.0-flash-exp(?:-[\\w-]+)?',


### PR DESCRIPTION
### What this PR does

Before this PR: Custom `generationConfig` parameters set in model settings were silently ignored when using Gemini models via `NewAPI`/`AiHubMix`. The outgoing request always contained an empty `generationConfig: {}`

After this PR: Custom `generationConfig` fields are correctly applied to the API request

Fixes #14301 

### Why we need it and why it was done in this way

`NewAPI`/`AiHubMix` providers fell through to the generic `default` branch in `buildProviderOptions`, producing `{ newapi: {...} }` instead of `{ google: {...} }` for Gemini models. Fix: route these providers to `buildProxyProviderOptions` which dispatches by model type

The following tradeoffs were made: `buildCherryInProviderOptions` (which used `provider.type` to dispatch) was replaced by `buildProxyProviderOptions` (which uses model ID). This is more robust for proxy providers that don't set `type: 'gemini'`

### Release note

```release-note
fix: Custom parameters were not being passed to `Gemini` API when using `NewAPI` or `AiHubMix` providers
```