### PR TITLE
fix: Fix Ollama model list loading when metadata contains null families values

### DIFF
--- a/src/renderer/src/aiCore/services/__tests__/listModels.test.ts
+++ b/src/renderer/src/aiCore/services/__tests__/listModels.test.ts
@@ -30,6 +30,7 @@ vi.mock('@shared/utils', () => ({
 }))
 
 const { listModels } = await import('../listModels')
+const { OllamaTagsResponseSchema } = await import('../schemas')
 
 // === Real API response fixtures (captured 2026-03-19) ===
 
@@ -385,6 +386,62 @@ describe('listModels', () => {
       mockGetFromApi.mockResolvedValue({ value: duped })
       const models = await listModels(makeProvider({ id: 'aihubmix' }))
       expect(models).toHaveLength(2)
+    })
+  })
+
+  describe('Ollama', () => {
+    it('should accept null families in Ollama tags schema', () => {
+      const parsed = OllamaTagsResponseSchema.parse({
+        models: [
+          {
+            name: 'glm-5:cloud',
+            model: 'glm-5:cloud',
+            details: {
+              parent_model: '',
+              format: '',
+              family: '',
+              families: null,
+              parameter_size: '',
+              quantization_level: ''
+            }
+          }
+        ]
+      })
+
+      expect(parsed.models[0].details?.families).toBeUndefined()
+    })
+
+    it('should accept null families in real Ollama tag responses', async () => {
+      mockGetFromApi.mockResolvedValue({
+        value: {
+          models: [
+            {
+              name: 'glm-5:cloud',
+              model: 'glm-5:cloud',
+              details: {
+                parent_model: '',
+                format: '',
+                family: '',
+                families: null,
+                parameter_size: '',
+                quantization_level: ''
+              }
+            },
+            {
+              name: 'qwen3.5:9b',
+              model: 'qwen3.5:9b',
+              details: {
+                family: 'qwen35',
+                families: ['qwen35']
+              }
+            }
+          ]
+        }
+      })
+
+      const models = await listModels(makeProvider({ id: 'ollama', type: 'ollama', apiHost: 'http://localhost:11434' }))
+      assertValidModels(models)
+      expect(models.map((m) => m.id)).toEqual(['glm-5:cloud', 'qwen3.5:9b'])
     })
   })
 

--- a/src/renderer/src/aiCore/services/schemas.ts
+++ b/src/renderer/src/aiCore/services/schemas.ts
@@ -36,7 +36,11 @@ export const OllamaTagsResponseSchema = z.object({
           parent_model: z.string().optional(),
           format: z.string().optional(),
           family: z.string().optional(),
-          families: z.array(z.string()).optional(),
+          families: z
+            .array(z.string())
+            .nullable()
+            .optional()
+            .transform((v) => v ?? undefined),
           parameter_size: z.string().optional(),
           quantization_level: z.string().optional()
         })


### PR DESCRIPTION
### What this PR does

Before this PR:

Ollama model discovery could fail in the model management flow when the local tags response contained null in metadata fields such as families. This caused type validation errors and prevented the model list from loading.

After this PR:

The Ollama model list parser now accepts nullable metadata from real-world responses and safely normalizes it. This fixes model loading for affected Ollama setups and adds regression coverage for the case.

Fixes #N/A

### Why we need it and why it was done in this way

This change is needed because Ollama responses are not always strictly consistent across local and cloud-backed models. Some models return null for metadata fields that were previously assumed to always be arrays.

The following tradeoffs were made:

A minimal schema compatibility fix was used instead of broader parsing changes, so the scope stays small and focused on the bug.

The following alternatives were considered:

Skipping invalid models after parsing, or weakening validation across the full response. These options were not chosen because they either hide valid models or broaden the change more than necessary.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

No breaking changes are introduced.

### Special notes for your reviewer

This is a focused bug fix for Ollama model listing. It includes a targeted regression test covering responses where metadata.families is null.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required for this bug fix
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

Fixed an issue where Ollama model lists could fail to load when the API returned null metadata for some models.