### PR TITLE
fix: skip symlinks in backup copies

### DIFF
--- a/src/main/services/BackupManager.ts
+++ b/src/main/services/BackupManager.ts
@@ -821,6 +821,10 @@ class BackupManager {
 
     for (const item of items) {
       const fullPath = path.join(dirPath, item.name)
+      if (item.isSymbolicLink()) {
+        logger.debug('[getDirSize] Skipping symlink entry', { path: fullPath })
+        continue
+      }
       if (item.isDirectory()) {
         size += await this.getDirSize(fullPath)
       } else if (item.isFile()) {
@@ -940,6 +944,9 @@ class BackupManager {
       let count = 0
       const items = await fs.readdir(dir, { withFileTypes: true })
       for (const item of items) {
+        if (item.isSymbolicLink()) {
+          continue
+        }
         if (item.isDirectory()) {
           count += await countFiles(path.join(dir, item.name))
         } else if (item.isFile()) {
@@ -958,6 +965,11 @@ class BackupManager {
       for (const item of items) {
         const sourcePath = path.join(src, item.name)
         const destPath = path.join(dest, item.name)
+
+        if (item.isSymbolicLink()) {
+          logger.debug('[copyDirWithProgress] Skipping symlink entry', { path: sourcePath })
+          continue
+        }
 
         if (item.isDirectory()) {
           await fs.ensureDir(destPath)

--- a/src/main/services/BackupManager.ts
+++ b/src/main/services/BackupManager.ts
@@ -28,6 +28,7 @@ import type { CreateDirectoryOptions, FileStat } from 'webdav'
 
 import { getDataPath } from '../utils'
 import { resolveAndValidatePath } from '../utils/file'
+import { copyDirectoryRecursive } from '../utils/fileOperations'
 import S3Storage from './S3Storage'
 import WebDav from './WebDav'
 import { windowService } from './WindowService'
@@ -165,7 +166,7 @@ class BackupManager {
       const indexedDBSource = path.join(userDataPath, 'IndexedDB')
       const indexedDBDest = path.join(this.tempDir, 'IndexedDB')
       if (await fs.pathExists(indexedDBSource)) {
-        await fs.copy(indexedDBSource, indexedDBDest)
+        await copyDirectoryRecursive(indexedDBSource, indexedDBDest)
       } else {
         logger.debug('[backupDirect] IndexedDB directory not found, skipping')
       }
@@ -173,7 +174,7 @@ class BackupManager {
       const localStorageSource = path.join(userDataPath, 'Local Storage')
       const localStorageDest = path.join(this.tempDir, 'Local Storage')
       if (await fs.pathExists(localStorageSource)) {
-        await fs.copy(localStorageSource, localStorageDest)
+        await copyDirectoryRecursive(localStorageSource, localStorageDest)
       } else {
         logger.debug('[backupDirect] Local Storage directory not found, skipping')
       }
@@ -327,7 +328,7 @@ class BackupManager {
             const fullPath = path.join(dirPath, item.name)
             if (item.isDirectory()) {
               await calculateTotals(fullPath)
-            } else {
+            } else if (item.isFile()) {
               totalEntries++
               const stats = await fs.stat(fullPath)
               totalBytes += stats.size
@@ -588,12 +589,12 @@ class BackupManager {
       // Always remove target directory first to ensure clean overwrite
       if (await fs.pathExists(indexedDBSource)) {
         await fs.remove(indexedDBDest).catch(() => {})
-        await fs.copy(indexedDBSource, indexedDBDest)
+        await copyDirectoryRecursive(indexedDBSource, indexedDBDest)
       }
 
       if (await fs.pathExists(localStorageSource)) {
         await fs.remove(localStorageDest).catch(() => {})
-        await fs.copy(localStorageSource, localStorageDest)
+        await copyDirectoryRecursive(localStorageSource, localStorageDest)
       }
 
       onProgress({ stage: 'restoring_database', progress: 65, total: 100 })
@@ -822,7 +823,7 @@ class BackupManager {
       const fullPath = path.join(dirPath, item.name)
       if (item.isDirectory()) {
         size += await this.getDirSize(fullPath)
-      } else {
+      } else if (item.isFile()) {
         const stats = await fs.stat(fullPath)
         size += stats.size
       }
@@ -941,7 +942,7 @@ class BackupManager {
       for (const item of items) {
         if (item.isDirectory()) {
           count += await countFiles(path.join(dir, item.name))
-        } else {
+        } else if (item.isFile()) {
           count++
         }
       }
@@ -961,7 +962,7 @@ class BackupManager {
         if (item.isDirectory()) {
           await fs.ensureDir(destPath)
           await copyDir(sourcePath, destPath)
-        } else {
+        } else if (item.isFile()) {
           const stats = await fs.stat(sourcePath)
           await fs.copy(sourcePath, destPath)
           processedFiles++

--- a/src/main/services/__tests__/BackupManager.test.ts
+++ b/src/main/services/__tests__/BackupManager.test.ts
@@ -364,10 +364,10 @@ describe('BackupManager.deleteLanTransferBackup - Security Tests', () => {
   })
 
   describe('Directory Copy Helpers', () => {
-    it('should skip symlinks while copying directories with progress', async () => {
+    it('should skip broken symlinks while copying directories with progress', async () => {
       const entries = [
         {
-          name: 'linked-skill',
+          name: 'broken-link',
           isDirectory: () => false,
           isSymbolicLink: () => true,
           isFile: () => false
@@ -382,7 +382,12 @@ describe('BackupManager.deleteLanTransferBackup - Security Tests', () => {
 
       vi.mocked(fs.readdir).mockResolvedValue(entries as never)
       vi.mocked(fs.stat).mockImplementation((filePath) => {
-        const size = String(filePath).includes('settings.json') ? 32 : 999
+        const file = String(filePath)
+        if (file.includes('broken-link')) {
+          throw new Error('ENOENT: no such file or directory')
+        }
+
+        const size = file.includes('settings.json') ? 32 : 999
         return { size } as never
       })
       vi.mocked(fs.copy).mockResolvedValue(undefined as never)
@@ -394,14 +399,14 @@ describe('BackupManager.deleteLanTransferBackup - Security Tests', () => {
 
       expect(fs.copy).toHaveBeenCalledTimes(1)
       expect(fs.copy).toHaveBeenCalledWith('/source/settings.json', '/dest/settings.json')
-      expect(fs.copy).not.toHaveBeenCalledWith('/source/linked-skill', '/dest/linked-skill')
+      expect(fs.copy).not.toHaveBeenCalledWith('/source/broken-link', '/dest/broken-link')
       expect(progressUpdates).toEqual([32])
     })
 
     it('should ignore symlinks when calculating directory size', async () => {
       const entries = [
         {
-          name: 'linked-skill',
+          name: 'broken-link',
           isDirectory: () => false,
           isSymbolicLink: () => true,
           isFile: () => false
@@ -416,7 +421,12 @@ describe('BackupManager.deleteLanTransferBackup - Security Tests', () => {
 
       vi.mocked(fs.readdir).mockResolvedValue(entries as never)
       vi.mocked(fs.stat).mockImplementation((filePath) => {
-        if (String(filePath).includes('settings.json')) {
+        const file = String(filePath)
+        if (file.includes('broken-link')) {
+          throw new Error('ENOENT: no such file or directory')
+        }
+
+        if (file.includes('settings.json')) {
           return { size: 32 } as never
         }
 

--- a/src/main/services/__tests__/BackupManager.test.ts
+++ b/src/main/services/__tests__/BackupManager.test.ts
@@ -38,11 +38,22 @@ vi.mock('path', async () => {
 })
 
 // Use vi.hoisted to define mocks that are available during hoisting
-const { mockLogger } = vi.hoisted(() => ({
+const { mockLogger, mockApp } = vi.hoisted(() => ({
   mockLogger: {
     info: vi.fn(),
     warn: vi.fn(),
-    error: vi.fn()
+    error: vi.fn(),
+    debug: vi.fn()
+  },
+  mockApp: {
+    getPath: vi.fn((key: string) => {
+      if (key === 'temp') return '/tmp'
+      if (key === 'userData') return '/mock/userData'
+      return '/mock/unknown'
+    }),
+    getVersion: vi.fn(() => '1.9.1'),
+    relaunch: vi.fn(),
+    exit: vi.fn()
   }
 }))
 
@@ -53,13 +64,11 @@ vi.mock('@logger', () => ({
 }))
 
 vi.mock('electron', () => ({
-  app: {
-    getPath: vi.fn((key: string) => {
-      if (key === 'temp') return '/tmp'
-      if (key === 'userData') return '/mock/userData'
-      return '/mock/unknown'
-    })
-  }
+  app: mockApp
+}))
+
+vi.mock('../../utils/fileOperations', () => ({
+  copyDirectoryRecursive: vi.fn()
 }))
 
 vi.mock('fs-extra', () => ({
@@ -71,9 +80,14 @@ vi.mock('fs-extra', () => ({
     readdir: vi.fn(),
     stat: vi.fn(),
     readFile: vi.fn(),
+    readJson: vi.fn(),
+    writeJson: vi.fn(),
     writeFile: vi.fn(),
     createWriteStream: vi.fn(),
-    createReadStream: vi.fn()
+    createReadStream: vi.fn(),
+    promises: {
+      mkdir: vi.fn()
+    }
   },
   pathExists: vi.fn(),
   remove: vi.fn(),
@@ -82,8 +96,33 @@ vi.mock('fs-extra', () => ({
   readdir: vi.fn(),
   stat: vi.fn(),
   readFile: vi.fn(),
+  readJson: vi.fn(),
+  writeJson: vi.fn(),
   writeFile: vi.fn(),
-  createWriteStream: vi.fn(),
+  createWriteStream: vi.fn(() => {
+    const listeners: Record<string, Array<(...args: unknown[]) => void>> = {}
+
+    const stream = {
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        listeners[event] ??= []
+        listeners[event].push(handler)
+        return stream
+      }),
+      emit: vi.fn((event: string, ...args: unknown[]) => {
+        for (const handler of listeners[event] ?? []) {
+          handler(...args)
+        }
+        return true
+      }),
+      write: vi.fn(() => true),
+      end: vi.fn(() => {
+        stream.emit('finish')
+        stream.emit('close')
+      })
+    }
+
+    return stream
+  }),
   createReadStream: vi.fn()
 }))
 
@@ -106,7 +145,21 @@ vi.mock('../../utils', () => ({
 }))
 
 vi.mock('archiver', () => ({
-  default: vi.fn()
+  default: vi.fn(() => {
+    let pipedOutput: { emit?: (event: string, ...args: unknown[]) => void } | null = null
+
+    return {
+      on: vi.fn(),
+      pipe: vi.fn((output: { emit?: (event: string, ...args: unknown[]) => void }) => {
+        pipedOutput = output
+        return output
+      }),
+      directory: vi.fn(),
+      finalize: vi.fn(async () => {
+        pipedOutput?.emit?.('close')
+      })
+    }
+  })
 }))
 
 vi.mock('node-stream-zip', () => ({
@@ -116,6 +169,7 @@ vi.mock('node-stream-zip', () => ({
 // Import after mocks
 import * as fs from 'fs-extra'
 
+import { copyDirectoryRecursive } from '../../utils/fileOperations'
 import BackupManager from '../BackupManager'
 
 describe('BackupManager.deleteLanTransferBackup - Security Tests', () => {
@@ -306,6 +360,135 @@ describe('BackupManager.deleteLanTransferBackup - Security Tests', () => {
 
       // path.normalize handles double slashes
       expect(result).toBe(true)
+    })
+  })
+
+  describe('Directory Copy Helpers', () => {
+    it('should skip symlinks while copying directories with progress', async () => {
+      const entries = [
+        {
+          name: 'linked-skill',
+          isDirectory: () => false,
+          isSymbolicLink: () => true,
+          isFile: () => false
+        },
+        {
+          name: 'settings.json',
+          isDirectory: () => false,
+          isSymbolicLink: () => false,
+          isFile: () => true
+        }
+      ]
+
+      vi.mocked(fs.readdir).mockResolvedValue(entries as never)
+      vi.mocked(fs.stat).mockImplementation((filePath) => {
+        const size = String(filePath).includes('settings.json') ? 32 : 999
+        return { size } as never
+      })
+      vi.mocked(fs.copy).mockResolvedValue(undefined as never)
+
+      const progressUpdates: number[] = []
+      await (backupManager as any).copyDirWithProgress('/source', '/dest', (size: number) => {
+        progressUpdates.push(size)
+      })
+
+      expect(fs.copy).toHaveBeenCalledTimes(1)
+      expect(fs.copy).toHaveBeenCalledWith('/source/settings.json', '/dest/settings.json')
+      expect(fs.copy).not.toHaveBeenCalledWith('/source/linked-skill', '/dest/linked-skill')
+      expect(progressUpdates).toEqual([32])
+    })
+
+    it('should ignore symlinks when calculating directory size', async () => {
+      const entries = [
+        {
+          name: 'linked-skill',
+          isDirectory: () => false,
+          isSymbolicLink: () => true,
+          isFile: () => false
+        },
+        {
+          name: 'settings.json',
+          isDirectory: () => false,
+          isSymbolicLink: () => false,
+          isFile: () => true
+        }
+      ]
+
+      vi.mocked(fs.readdir).mockResolvedValue(entries as never)
+      vi.mocked(fs.stat).mockImplementation((filePath) => {
+        if (String(filePath).includes('settings.json')) {
+          return { size: 32 } as never
+        }
+
+        return { size: 999 } as never
+      })
+
+      const totalSize = await (backupManager as any).getDirSize('/source')
+
+      expect(totalSize).toBe(32)
+      expect(fs.stat).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('Direct Backup Flow', () => {
+    it('should use symlink-safe directory copies for local backup databases', async () => {
+      vi.mocked(fs.ensureDir).mockResolvedValue(undefined as never)
+      vi.mocked(fs.pathExists).mockImplementation(async (targetPath) => {
+        return String(targetPath).includes('IndexedDB') || String(targetPath).includes('Local Storage')
+      })
+      vi.mocked(fs.writeJson).mockResolvedValue(undefined as never)
+      vi.mocked(fs.remove).mockResolvedValue(undefined as never)
+      vi.mocked(copyDirectoryRecursive).mockResolvedValue(undefined as never)
+
+      const backupPath = await backupManager.backupToLocalDir({} as Electron.IpcMainInvokeEvent, 'backup.zip', {
+        localBackupDir: '/mock/backup'
+      })
+
+      expect(backupPath).toBe('/mock/backup/backup.zip')
+      expect(copyDirectoryRecursive).toHaveBeenCalledTimes(2)
+      expect(copyDirectoryRecursive).toHaveBeenCalledWith(
+        '/mock/userData/IndexedDB',
+        '/tmp/cherry-studio/backup/temp/IndexedDB'
+      )
+      expect(copyDirectoryRecursive).toHaveBeenCalledWith(
+        '/mock/userData/Local Storage',
+        '/tmp/cherry-studio/backup/temp/Local Storage'
+      )
+      expect(fs.copy).not.toHaveBeenCalled()
+    })
+
+    it('should use symlink-safe directory copies when restoring database directories', async () => {
+      const restoreSuffix = process.platform === 'win32' ? '.restore' : ''
+
+      vi.mocked(fs.readJson).mockResolvedValue({
+        version: 6,
+        timestamp: Date.now(),
+        appName: 'Cherry Studio',
+        appVersion: '1.9.1',
+        platform: process.platform,
+        arch: process.arch
+      } as never)
+      vi.mocked(fs.pathExists).mockImplementation(async (targetPath) => {
+        const target = String(targetPath)
+        return target.includes('IndexedDB') || target.includes('Local Storage')
+      })
+      vi.mocked(fs.remove).mockResolvedValue(undefined as never)
+      vi.mocked(copyDirectoryRecursive).mockResolvedValue(undefined as never)
+
+      await (backupManager as any).restoreDirect()
+
+      expect(copyDirectoryRecursive).toHaveBeenCalledTimes(2)
+      expect(copyDirectoryRecursive).toHaveBeenCalledWith(
+        '/tmp/cherry-studio/backup/temp/IndexedDB',
+        `/mock/userData/IndexedDB${restoreSuffix}`
+      )
+      expect(copyDirectoryRecursive).toHaveBeenCalledWith(
+        '/tmp/cherry-studio/backup/temp/Local Storage',
+        `/mock/userData/Local Storage${restoreSuffix}`
+      )
+      expect(mockApp.relaunch).toHaveBeenCalled()
+      expect(mockApp.exit).toHaveBeenCalledWith(0)
+      expect(fs.copy).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
### What this PR does

Before this PR:
Windows backups could fail with `EPERM` or `ENOENT` when backup contents contained symlink entries, including broken workspace skill links under `.claude/skills/`.

After this PR:
Backup and restore directory copies skip symlink entries before any recursive `stat()` or copy step. Standard Windows users can complete backups successfully even when the source tree contains broken workspace symlinks.

Fixes #14360

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Symlink entries are derived workspace state. The real skill content lives in `Data/Skills` and the enablement state lives in the database, so skipping the link objects avoids Windows `EPERM`/`ENOENT` failures without losing the underlying skill data.
- The shared symlink-safe directory copy helper is reused for direct database copy paths, and the recursive Data-directory walker ignores symlink entries before counting or copying them.

The following alternatives were considered:
- Catching and ignoring `EPERM` or `ENOENT` from `fs.copy` or `fs.stat` at the call site, which would still leave the code path attempting to traverse the broken link.
- Preserving symlinks on Windows, which would still require elevated privileges or Developer Mode.

Links to places where the discussion took place:
- https://github.com/CherryHQ/cherry-studio/issues/14360

### Breaking changes

None.

### Special notes for your reviewer

Verified with `pnpm exec vitest run src/main/services/__tests__/BackupManager.test.ts`, including broken-symlink coverage.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix Windows backups failing when backup contents include symlinks, including broken workspace links that previously triggered EPERM/ENOENT.
```