### PR TITLE
fix: preserve model group labels

### DIFF
--- a/src/renderer/src/i18n/label.ts
+++ b/src/renderer/src/i18n/label.ts
@@ -107,6 +107,10 @@ export const getProviderLabel = (id: string): string => {
   return getLabel(providerKeyMap, id)
 }
 
+export const hasProviderLabel = (id: string): boolean => {
+  return Object.prototype.hasOwnProperty.call(providerKeyMap, id)
+}
+
 const backupProgressKeyMap = {
   completed: 'backup.progress.completed',
   compressing: 'backup.progress.compressing',

--- a/src/renderer/src/pages/settings/ProviderSettings/ModelList/ManageModelsList.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ModelList/ManageModelsList.tsx
@@ -6,6 +6,7 @@ import { getModelLogoById } from '@renderer/config/models'
 import FileItem from '@renderer/pages/files/FileItem'
 import NewApiBatchAddModelPopup from '@renderer/pages/settings/ProviderSettings/ModelList/NewApiBatchAddModelPopup'
 import type { Model, Provider } from '@renderer/types'
+import { getModelGroupDisplayName } from '@renderer/utils/model'
 import { isNewApiProvider } from '@renderer/utils/provider'
 import { Button, Flex, Tooltip } from 'antd'
 import { Avatar } from 'antd'
@@ -162,7 +163,9 @@ const ManageModelsList: React.FC<ManageModelsListProps> = ({
                     strokeWidth={1.5}
                     style={{ transform: isCollapsed ? 'rotate(0deg)' : 'rotate(90deg)' }}
                   />
-                  <span style={{ fontWeight: 'bold', fontSize: '14px' }}>{row.groupName}</span>
+                  <span style={{ fontWeight: 'bold', fontSize: '14px' }}>
+                    {getModelGroupDisplayName(row.groupName)}
+                  </span>
                   <CustomTag color="#02B96B" size={10}>
                     {row.models.length}
                   </CustomTag>

--- a/src/renderer/src/pages/settings/ProviderSettings/ModelList/ModelListGroup.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ModelList/ModelListGroup.tsx
@@ -2,6 +2,7 @@ import CustomCollapse from '@renderer/components/CustomCollapse'
 import { DynamicVirtualList, type DynamicVirtualListRef } from '@renderer/components/VirtualList'
 import type { Model } from '@renderer/types'
 import type { ModelWithStatus } from '@renderer/types/healthCheck'
+import { getModelGroupDisplayName } from '@renderer/utils/model'
 import { Button, Flex, Tooltip } from 'antd'
 import { Minus } from 'lucide-react'
 import React, { memo, useCallback, useRef } from 'react'
@@ -54,7 +55,7 @@ const ModelListGroup: React.FC<ModelListGroupProps> = ({
         onChange={handleCollapseChange}
         label={
           <Flex align="center" gap={10}>
-            <span style={{ fontWeight: 'bold' }}>{groupName}</span>
+            <span style={{ fontWeight: 'bold' }}>{getModelGroupDisplayName(groupName)}</span>
           </Flex>
         }
         extra={

--- a/src/renderer/src/utils/__tests__/model.test.ts
+++ b/src/renderer/src/utils/__tests__/model.test.ts
@@ -1,7 +1,16 @@
 import type { Model, ModelTag } from '@renderer/types'
 import { describe, expect, it, vi } from 'vitest'
 
-import { getDuplicateModelNames, getModelTags, isFreeModel } from '../model'
+vi.mock('@renderer/i18n/label', () => ({
+  getProviderLabel: (id: string) => {
+    if (id === 'openai') return 'OpenAI'
+    if (id === 'minimax-global') return 'MiniMax Global'
+    return id
+  },
+  hasProviderLabel: (id: string) => id === 'openai' || id === 'minimax-global'
+}))
+
+import { getDuplicateModelNames, getModelGroupDisplayName, getModelTags, isFreeModel } from '../model'
 
 // Mock the model checking functions from @renderer/config/models
 vi.mock('@renderer/config/models', () => ({
@@ -117,6 +126,39 @@ describe('model', () => {
           { name: 'claude-3-7-sonnet' }
         ])
       ).toStrictEqual(new Set(['gpt-4o', 'claude-3-7-sonnet']))
+    })
+  })
+
+  describe('getModelGroupDisplayName', () => {
+    it('should use localized provider labels when available', () => {
+      expect(getModelGroupDisplayName('openai')).toBe('OpenAI')
+      expect(getModelGroupDisplayName('minimax-global')).toBe('MiniMax Global')
+    })
+
+    it('should humanize known provider-style aliases', () => {
+      expect(getModelGroupDisplayName('black-forest-labs')).toBe('Black Forest Labs')
+      expect(getModelGroupDisplayName('qwen')).toBe('Qwen')
+      expect(getModelGroupDisplayName('google')).toBe('Google')
+      expect(getModelGroupDisplayName('cartesia')).toBe('Cartesia')
+      expect(getModelGroupDisplayName('hexgrad')).toBe('Hexgrad')
+      expect(getModelGroupDisplayName('deepseek-ai')).toBe('DeepSeek')
+      expect(getModelGroupDisplayName('mistralai')).toBe('Mistral AI')
+      expect(getModelGroupDisplayName('MISTRALAI')).toBe('Mistral AI')
+      expect(getModelGroupDisplayName('x-ai')).toBe('xAI')
+      expect(getModelGroupDisplayName('X-AI')).toBe('xAI')
+    })
+
+    it('should preserve canonical family identifiers and other raw labels', () => {
+      expect(getModelGroupDisplayName('Pro')).toBe('Pro')
+      expect(getModelGroupDisplayName('gpt-5')).toBe('gpt-5')
+      expect(getModelGroupDisplayName('gpt-image')).toBe('gpt-image')
+      expect(getModelGroupDisplayName('gpt-4.1-mini')).toBe('gpt-4.1-mini')
+      expect(getModelGroupDisplayName('GPT4')).toBe('GPT4')
+      expect(getModelGroupDisplayName('APIKey')).toBe('APIKey')
+      expect(getModelGroupDisplayName('MyModel')).toBe('MyModel')
+      expect(getModelGroupDisplayName('moonshot-v1')).toBe('moonshot-v1')
+      expect(getModelGroupDisplayName('GLM-4.5')).toBe('GLM-4.5')
+      expect(getModelGroupDisplayName('DeepSeek-AI')).toBe('DeepSeek')
     })
   })
 })

--- a/src/renderer/src/utils/model.ts
+++ b/src/renderer/src/utils/model.ts
@@ -6,6 +6,7 @@ import {
   isVisionModel,
   isWebSearchModel
 } from '@renderer/config/models'
+import { getProviderLabel, hasProviderLabel } from '@renderer/i18n/label'
 import type { AdaptedApiModel, ApiModel, Model, ModelTag } from '@renderer/types'
 import { objectKeys } from '@renderer/types'
 
@@ -70,6 +71,37 @@ export function isFreeModel(model: Model) {
   }
 
   return (model.id + model.name).toLocaleLowerCase().includes('free')
+}
+
+const MODEL_GROUP_DISPLAY_ALIASES: Record<string, string> = {
+  'black-forest-labs': 'Black Forest Labs',
+  'deepseek-ai': 'DeepSeek',
+  cartesia: 'Cartesia',
+  google: 'Google',
+  hexgrad: 'Hexgrad',
+  mistralai: 'Mistral AI',
+  qwen: 'Qwen',
+  'x-ai': 'xAI',
+  xai: 'xAI'
+}
+
+export function getModelGroupDisplayName(group: string): string {
+  const trimmedGroup = group.trim()
+
+  if (!trimmedGroup) {
+    return ''
+  }
+
+  if (hasProviderLabel(trimmedGroup)) {
+    return getProviderLabel(trimmedGroup)
+  }
+
+  const alias = MODEL_GROUP_DISPLAY_ALIASES[trimmedGroup.toLowerCase()]
+  if (alias) {
+    return alias
+  }
+
+  return trimmedGroup
 }
 
 export const getDuplicateModelNames = <T extends Pick<Model, 'name'>>(models: T[]): Set<string> => {


### PR DESCRIPTION
### What this PR does

Before this PR:
Model list group headers could show raw provider-style slugs, and a generic formatter could also mangle canonical family ids like `gpt-5` and `gpt-image`.

After this PR:
Model list group labels are normalized conservatively: known provider slugs are rendered with friendly names, while canonical family ids remain unchanged.

Fixes #14362

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Only explicit provider-style aliases are humanized, so valid model family ids are preserved.
- The shared label helper is reused in both model list views to keep the display behavior consistent.

The following alternatives were considered:
- Title-casing every slug-like group, which would fix some raw provider names but break valid family labels like `gpt-5`.
- Leaving the raw group string everywhere, which would preserve correctness but keep the original garbled labels.

Links to places where the discussion took place:
- https://github.com/CherryHQ/cherry-studio/issues/14362

### Breaking changes

None.

### Special notes for your reviewer

Verified with `pnpm exec vitest run src/renderer/src/utils/__tests__/model.test.ts`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Normalize model group labels so known provider slugs render cleanly while preserving canonical model family ids like gpt-5 and gpt-image.
```