### PR TITLE
fix: restore focus after reopening main window

### DIFF
--- a/src/main/services/WindowService.ts
+++ b/src/main/services/WindowService.ts
@@ -370,6 +370,20 @@ export class WindowService {
     return this.mainWindow
   }
 
+  private hideMainWindowWithFocusRestore(mainWindow: BrowserWindow) {
+    if (isWin) {
+      mainWindow.minimize()
+      setImmediate(() => {
+        if (!mainWindow.isDestroyed()) {
+          mainWindow.hide()
+        }
+      })
+      return
+    }
+
+    mainWindow.hide()
+  }
+
   private setupWindowLifecycleEvents(mainWindow: BrowserWindow) {
     mainWindow.on('close', (event) => {
       // save data before when close window
@@ -407,7 +421,7 @@ export class WindowService {
         event.preventDefault()
       }
 
-      mainWindow.hide()
+      this.hideMainWindowWithFocusRestore(mainWindow)
 
       //for mac users, should hide dock icon if close to tray
       if (isMac && isTrayOnClose) {
@@ -440,6 +454,7 @@ export class WindowService {
     if (this.mainWindow && !this.mainWindow.isDestroyed()) {
       if (this.mainWindow.isMinimized()) {
         this.mainWindow.restore()
+        this.mainWindow.focus()
         return
       }
 
@@ -508,7 +523,7 @@ export class WindowService {
       if (this.mainWindow.isFocused()) {
         // if tray is enabled, hide the main window, else do nothing
         if (configManager.getTray()) {
-          this.mainWindow.hide()
+          this.hideMainWindowWithFocusRestore(this.mainWindow)
           app.dock?.hide()
         }
       } else {

--- a/src/main/services/__tests__/WindowService.test.ts
+++ b/src/main/services/__tests__/WindowService.test.ts
@@ -133,6 +133,17 @@ vi.mock('electron-window-state', () => ({
   default: vi.fn(() => ({ manage: vi.fn(), isMaximized: false }))
 }))
 
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: vi.fn(() => ({
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn()
+    }))
+  }
+}))
+
 import { configManager } from '../ConfigManager'
 
 type MockMainWindow = {
@@ -151,6 +162,7 @@ type MockMainWindow = {
   isFullScreen: ReturnType<typeof vi.fn>
   isVisible: ReturnType<typeof vi.fn>
   isFocused: ReturnType<typeof vi.fn>
+  getListener: (event: string) => ((...args: any[]) => void) | undefined
 }
 
 const flushImmediate = () => new Promise<void>((resolve) => setImmediate(resolve))
@@ -187,8 +199,7 @@ describe('WindowService Windows hide behavior', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    return import('../../../../tests/main.setup').then(async () => {
-      const electron = await import('electron')
+    return import('electron').then(async (electron) => {
       app = electron.app
       windowService = (await import('../WindowService')).windowService
 

--- a/src/main/services/__tests__/WindowService.test.ts
+++ b/src/main/services/__tests__/WindowService.test.ts
@@ -1,0 +1,256 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@main/constant', () => ({
+  isDev: false,
+  isLinux: false,
+  isMac: false,
+  isWin: true
+}))
+
+vi.mock('@main/utils/file', () => ({
+  getFilesDir: vi.fn(() => '/mock/files')
+}))
+
+vi.mock('@main/utils/windowUtil', () => ({
+  getWindowsBackgroundMaterial: vi.fn(() => undefined)
+}))
+
+vi.mock('@electron-toolkit/utils', () => ({
+  is: {
+    dev: false
+  }
+}))
+
+vi.mock('electron', () => {
+  const mock = {
+    app: {
+      dock: {
+        hide: vi.fn(),
+        show: vi.fn()
+      },
+      getPath: vi.fn((key: string) => {
+        switch (key) {
+          case 'userData':
+            return '/mock/userData'
+          case 'temp':
+            return '/mock/temp'
+          case 'logs':
+            return '/mock/logs'
+          default:
+            return '/mock/unknown'
+        }
+      }),
+      getVersion: vi.fn(() => '1.0.0'),
+      isQuitting: false,
+      quit: vi.fn(),
+      on: vi.fn(),
+      whenReady: vi.fn(() => Promise.resolve()),
+      requestSingleInstanceLock: vi.fn(() => true)
+    },
+    BrowserWindow: vi.fn(),
+    ipcMain: {
+      handle: vi.fn(),
+      on: vi.fn(),
+      once: vi.fn(),
+      removeHandler: vi.fn(),
+      removeAllListeners: vi.fn()
+    },
+    dialog: {
+      showErrorBox: vi.fn(),
+      showMessageBox: vi.fn(),
+      showOpenDialog: vi.fn(),
+      showSaveDialog: vi.fn()
+    },
+    nativeImage: {
+      createFromPath: vi.fn(() => ({}))
+    },
+    nativeTheme: {
+      shouldUseDarkColors: false,
+      themeSource: 'system',
+      on: vi.fn(),
+      removeListener: vi.fn()
+    },
+    net: {
+      fetch: vi.fn()
+    },
+    Notification: vi.fn(),
+    screen: {
+      getCursorScreenPoint: vi.fn(() => ({ x: 0, y: 0 })),
+      getDisplayNearestPoint: vi.fn(() => ({ id: 1, bounds: { x: 0, y: 0, width: 1920, height: 1080 } })),
+      getPrimaryDisplay: vi.fn(() => ({ workArea: { x: 0, y: 0, width: 1920, height: 1080 } })),
+      getAllDisplays: vi.fn(() => [])
+    },
+    session: {
+      defaultSession: {
+        clearCache: vi.fn(),
+        clearStorageData: vi.fn()
+      }
+    },
+    shell: {
+      openExternal: vi.fn(),
+      showItemInFolder: vi.fn()
+    },
+    systemPreferences: {
+      askForMediaAccess: vi.fn(),
+      getMediaAccessStatus: vi.fn()
+    },
+    webContents: {
+      getAllWebContents: vi.fn(() => [])
+    }
+  }
+
+  return { __esModule: true, ...mock, default: mock }
+})
+
+vi.mock('../ConfigManager', () => ({
+  configManager: {
+    getEnableQuickAssistant: vi.fn(() => false),
+    getTheme: vi.fn(() => 'system'),
+    getTray: vi.fn(() => true),
+    getTrayOnClose: vi.fn(() => true),
+    getUseSystemTitleBar: vi.fn(() => false),
+    getZoomFactor: vi.fn(() => 1),
+    setTheme: vi.fn()
+  }
+}))
+
+vi.mock('../ContextMenu', () => ({
+  contextMenu: {
+    contextMenu: vi.fn()
+  }
+}))
+
+vi.mock('../WebviewService', () => ({
+  initSessionUserAgent: vi.fn()
+}))
+
+vi.mock('../config', () => ({
+  titleBarOverlayDark: {},
+  titleBarOverlayLight: {}
+}))
+
+vi.mock('electron-window-state', () => ({
+  default: vi.fn(() => ({ manage: vi.fn(), isMaximized: false }))
+}))
+
+import { configManager } from '../ConfigManager'
+
+type MockMainWindow = {
+  webContents: {
+    send: ReturnType<typeof vi.fn>
+  }
+  on: ReturnType<typeof vi.fn>
+  once: ReturnType<typeof vi.fn>
+  hide: ReturnType<typeof vi.fn>
+  minimize: ReturnType<typeof vi.fn>
+  focus: ReturnType<typeof vi.fn>
+  restore: ReturnType<typeof vi.fn>
+  show: ReturnType<typeof vi.fn>
+  isDestroyed: ReturnType<typeof vi.fn>
+  isMinimized: ReturnType<typeof vi.fn>
+  isFullScreen: ReturnType<typeof vi.fn>
+  isVisible: ReturnType<typeof vi.fn>
+  isFocused: ReturnType<typeof vi.fn>
+}
+
+const flushImmediate = () => new Promise<void>((resolve) => setImmediate(resolve))
+
+let app: any
+let windowService: any
+
+function createMockMainWindow(): MockMainWindow {
+  const listeners = new Map<string, (...args: any[]) => void>()
+
+  return {
+    webContents: {
+      send: vi.fn()
+    },
+    on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+      listeners.set(event, handler)
+    }),
+    once: vi.fn(),
+    hide: vi.fn(),
+    minimize: vi.fn(),
+    focus: vi.fn(),
+    restore: vi.fn(),
+    show: vi.fn(),
+    isDestroyed: vi.fn(() => false),
+    isMinimized: vi.fn(() => false),
+    isFullScreen: vi.fn(() => false),
+    isVisible: vi.fn(() => true),
+    isFocused: vi.fn(() => true),
+    getListener: (event: string) => listeners.get(event)
+  } as MockMainWindow & { getListener: (event: string) => ((...args: any[]) => void) | undefined }
+}
+
+describe('WindowService Windows hide behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    return import('../../../../tests/main.setup').then(async () => {
+      const electron = await import('electron')
+      app = electron.app
+      windowService = (await import('../WindowService')).windowService
+
+      vi.spyOn(app, 'quit').mockImplementation(vi.fn())
+      app.isQuitting = false
+      windowService.mainWindow = null
+      windowService.miniWindow = null
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('minimizes before hiding the main window from the show/hide shortcut', async () => {
+    const mainWindow = createMockMainWindow()
+    ;(windowService as any).mainWindow = mainWindow
+
+    windowService.toggleMainWindow()
+
+    expect(mainWindow.minimize).toHaveBeenCalledTimes(1)
+    expect(mainWindow.hide).not.toHaveBeenCalled()
+
+    await flushImmediate()
+
+    expect(mainWindow.hide).toHaveBeenCalledTimes(1)
+  })
+
+  it('minimizes before hiding the main window when closing to tray', async () => {
+    const mainWindow = createMockMainWindow()
+    ;(windowService as any).setupWindowLifecycleEvents(mainWindow)
+
+    const closeHandler = mainWindow.getListener('close')
+    expect(closeHandler).toBeDefined()
+
+    const event = {
+      preventDefault: vi.fn()
+    }
+
+    closeHandler?.(event)
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1)
+    expect(mainWindow.minimize).toHaveBeenCalledTimes(1)
+    expect(mainWindow.hide).not.toHaveBeenCalled()
+
+    await flushImmediate()
+
+    expect(mainWindow.hide).toHaveBeenCalledTimes(1)
+    expect(app.quit).not.toHaveBeenCalled()
+    expect(vi.mocked(configManager.getTray)).toHaveBeenCalled()
+    expect(vi.mocked(configManager.getTrayOnClose)).toHaveBeenCalled()
+  })
+
+  it('restores and refocuses a minimized main window when reopening', () => {
+    const mainWindow = createMockMainWindow()
+    mainWindow.isMinimized = vi.fn(() => true)
+    ;(windowService as any).mainWindow = mainWindow
+
+    windowService.showMainWindow()
+
+    expect(mainWindow.restore).toHaveBeenCalledTimes(1)
+    expect(mainWindow.focus).toHaveBeenCalledTimes(1)
+    expect(mainWindow.show).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/services/__tests__/WindowService.test.ts
+++ b/src/main/services/__tests__/WindowService.test.ts
@@ -205,7 +205,7 @@ describe('WindowService Windows hide behavior', () => {
 
   it('minimizes before hiding the main window from the show/hide shortcut', async () => {
     const mainWindow = createMockMainWindow()
-    ;(windowService as any).mainWindow = mainWindow
+    windowService.mainWindow = mainWindow
 
     windowService.toggleMainWindow()
 
@@ -219,7 +219,7 @@ describe('WindowService Windows hide behavior', () => {
 
   it('minimizes before hiding the main window when closing to tray', async () => {
     const mainWindow = createMockMainWindow()
-    ;(windowService as any).setupWindowLifecycleEvents(mainWindow)
+    windowService.setupWindowLifecycleEvents(mainWindow)
 
     const closeHandler = mainWindow.getListener('close')
     expect(closeHandler).toBeDefined()
@@ -245,7 +245,7 @@ describe('WindowService Windows hide behavior', () => {
   it('restores and refocuses a minimized main window when reopening', () => {
     const mainWindow = createMockMainWindow()
     mainWindow.isMinimized = vi.fn(() => true)
-    ;(windowService as any).mainWindow = mainWindow
+    windowService.mainWindow = mainWindow
 
     windowService.showMainWindow()
 


### PR DESCRIPTION
### What this PR does

Before this PR:
- Hiding Cherry Studio on Windows could leave the previously active app unfocused.
- Reopening the main window from a minimized state restored the window but did not explicitly focus it.

After this PR:
- Windows now minimizes the main window before hiding it so focus returns to the previously active app.
- Reopening a minimized main window restores and explicitly focuses it.
- Added a regression test for the hide and reopen paths.

Fixes #14370

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Reused the existing Windows minimize-before-hide pattern already used for the mini window instead of introducing a new focus management mechanism.
- Kept the change scoped to `WindowService` so normal quit behavior and non-Windows behavior stay unchanged.

The following alternatives were considered:
- Leaving the hide path as a direct `hide()` call, which reproduces the focus loss on Windows.
- Introducing a broader focus-management abstraction, which would be larger than needed for this hotfix.

Links to places where the discussion took place: #14370, #10547

### Breaking changes

None.

### Special notes for your reviewer

Windows-only hotfix. The regression test covers the close-to-tray path, the show/hide shortcut path, and reopening a minimized main window.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Windows main window hiding now restores focus to the previously active app, and reopening a minimized main window explicitly refocuses it.
```
