### PR TITLE
fix: use bunx for claude-code on Windows to avoid bun global install …

### DIFF
--- a/src/main/services/CodeToolsService.ts
+++ b/src/main/services/CodeToolsService.ts
@@ -969,7 +969,7 @@ class CodeToolsService {
       } else {
         baseCommand = `export BUN_INSTALL="${bunInstallPath}" && export NPM_CONFIG_REGISTRY="${registryUrl}" && ${bunxCmd}`
       }
-      logger.debug('Using bunx command for claude-code:', baseCommand)
+      logger.debug(`Using bunx command for claude-code: ${baseCommand}`)
     }
 
     // Special handling for qwen-code: add --auth-type openai for version >= 0.12.3

--- a/src/main/services/CodeToolsService.ts
+++ b/src/main/services/CodeToolsService.ts
@@ -796,6 +796,17 @@ class CodeToolsService {
       }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error)
+
+      // Detect bun "failed to remap" error on Windows
+      if (isWin && errorMessage.includes('Bun failed to remap')) {
+        const retryMessage = `Failed to update ${cliTool} due to bun global install issue on Windows. Try running 'bun install --force' in the project root manually.`
+        logger.error(retryMessage, error as Error)
+        return {
+          success: false,
+          message: retryMessage
+        }
+      }
+
       const failureMessage = `Failed to update ${cliTool}: ${errorMessage}`
       logger.error(failureMessage, error as Error)
       return {
@@ -944,6 +955,15 @@ class CodeToolsService {
       baseCommand = `${uvPath} tool run ${packageName}`
     }
 
+    // Special handling for claude-code on Windows: use bunx to avoid bun global install issues
+    // This avoids the "Bun failed to remap" error on Windows
+    if (useBunxForClaudeCode) {
+      const registryUrl = await this.getNpmRegistryUrl()
+      const bunxCmd = `"${bunPath}" -y ${packageName} --prefix .`
+      baseCommand = `set "BUN_INSTALL=${bunInstallPath}" && set "NPM_CONFIG_REGISTRY=${registryUrl}" && ${bunxCmd}`
+      logger.debug('Using bunx command for claude-code:', baseCommand)
+    }
+
     // Special handling for qwen-code: add --auth-type openai for version >= 0.12.3
     if (cliTool === codeTools.qwenCode) {
       // Use semver for proper version comparison (handles v-prefix, prereleases, etc.)
@@ -1004,11 +1024,19 @@ class CodeToolsService {
 
     const bunInstallPath = path.join(os.homedir(), HOME_CHERRY_DIR)
 
+    // Special handling for claude-code: use bunx on Windows to avoid bun global install issues
+    // See: https://github.com/CherryHQ/cherry-studio/issues/14367
+    const useBunxForClaudeCode = cliTool === codeTools.claudeCode && platform === 'win32'
+
+    if (useBunxForClaudeCode) {
+      logger.info('Using bunx to run claude-code on Windows to avoid global install issues')
+    }
+
     // Special handling for kimi-cli: uvx handles installation automatically
     if (cliTool === codeTools.kimiCli) {
       // uvx will automatically download and run kimi-cli, no need to install
       // Just use the base command directly
-    } else if (isInstalled) {
+    } else if (useBunxForClaudeCode || isInstalled) {
       // If already installed, run executable directly (with optional update message)
       if (updateMessage) {
         // updateMessage already has escaped dynamic content, && connectors are intentional

--- a/src/main/services/CodeToolsService.ts
+++ b/src/main/services/CodeToolsService.ts
@@ -955,6 +955,9 @@ class CodeToolsService {
       baseCommand = `${uvPath} tool run ${packageName}`
     }
 
+    const bunInstallPath = path.join(os.homedir(), HOME_CHERRY_DIR)
+    const useBunxForClaudeCode = cliTool === codeTools.claudeCode && platform === 'win32'
+
     // Special handling for claude-code on Windows: use bunx to avoid bun global install issues
     // This avoids the "Bun failed to remap" error on Windows
     // Using "x" (bunx) which caches packages globally - avoids directory pollution
@@ -1021,16 +1024,6 @@ class CodeToolsService {
 
       // Add --model flag with dynamic provider prefix to avoid race conditions
       baseCommand = `${baseCommand} --model Cherry-${providerName}/${modelId}`
-    }
-
-    const bunInstallPath = path.join(os.homedir(), HOME_CHERRY_DIR)
-
-    // Special handling for claude-code: use bunx on Windows to avoid bun global install issues
-    // See: https://github.com/CherryHQ/cherry-studio/issues/14367
-    const useBunxForClaudeCode = cliTool === codeTools.claudeCode && platform === 'win32'
-
-    if (useBunxForClaudeCode) {
-      logger.info('Using bunx to run claude-code on Windows to avoid global install issues')
     }
 
     // Special handling for kimi-cli: uvx handles installation automatically

--- a/src/main/services/CodeToolsService.ts
+++ b/src/main/services/CodeToolsService.ts
@@ -797,9 +797,9 @@ class CodeToolsService {
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error)
 
-      // Detect bun "failed to remap" error on Windows
-      if (isWin && errorMessage.includes('Bun failed to remap')) {
-        const retryMessage = `Failed to update ${cliTool} due to bun global install issue on Windows. The application will try using bunx to run the package instead.`
+      // Detect bun global install issues (postinstall not executed or bin remap failure)
+      if (errorMessage.includes('Bun failed to remap') || errorMessage.includes('postinstall')) {
+        const retryMessage = `Failed to update ${cliTool} due to bun global install issue. The application will try using bunx to run the package instead.`
         logger.error(retryMessage, error as Error)
         return {
           success: false,
@@ -956,15 +956,19 @@ class CodeToolsService {
     }
 
     const bunInstallPath = path.join(os.homedir(), HOME_CHERRY_DIR)
-    const useBunxForClaudeCode = cliTool === codeTools.claudeCode && platform === 'win32'
+    const useBunxForClaudeCode = cliTool === codeTools.claudeCode
 
-    // Special handling for claude-code on Windows: use bunx to avoid bun global install issues
-    // This avoids the "Bun failed to remap" error on Windows
+    // Special handling for claude-code: use bunx to avoid bun global install issues
+    // This avoids the "Bun failed to remap" error on Windows and "postinstall not executed" on Linux/macOS
     // Using "x" (bunx) which caches packages globally - avoids directory pollution
     if (useBunxForClaudeCode) {
       const registryUrl = await this.getNpmRegistryUrl()
       const bunxCmd = `"${bunPath}" x ${packageName}`
-      baseCommand = `set "BUN_INSTALL=${bunInstallPath}" && set "NPM_CONFIG_REGISTRY=${registryUrl}" && ${bunxCmd}`
+      if (platform === 'win32') {
+        baseCommand = `set "BUN_INSTALL=${bunInstallPath}" && set "NPM_CONFIG_REGISTRY=${registryUrl}" && ${bunxCmd}`
+      } else {
+        baseCommand = `export BUN_INSTALL="${bunInstallPath}" && export NPM_CONFIG_REGISTRY="${registryUrl}" && ${bunxCmd}`
+      }
       logger.debug('Using bunx command for claude-code:', baseCommand)
     }
 

--- a/src/main/services/CodeToolsService.ts
+++ b/src/main/services/CodeToolsService.ts
@@ -799,7 +799,7 @@ class CodeToolsService {
 
       // Detect bun "failed to remap" error on Windows
       if (isWin && errorMessage.includes('Bun failed to remap')) {
-        const retryMessage = `Failed to update ${cliTool} due to bun global install issue on Windows. Try running 'bun install --force' in the project root manually.`
+        const retryMessage = `Failed to update ${cliTool} due to bun global install issue on Windows. The application will try using bunx to run the package instead.`
         logger.error(retryMessage, error as Error)
         return {
           success: false,
@@ -957,9 +957,10 @@ class CodeToolsService {
 
     // Special handling for claude-code on Windows: use bunx to avoid bun global install issues
     // This avoids the "Bun failed to remap" error on Windows
+    // Using "x" (bunx) which caches packages globally - avoids directory pollution
     if (useBunxForClaudeCode) {
       const registryUrl = await this.getNpmRegistryUrl()
-      const bunxCmd = `"${bunPath}" -y ${packageName} --prefix .`
+      const bunxCmd = `"${bunPath}" x ${packageName}`
       baseCommand = `set "BUN_INSTALL=${bunInstallPath}" && set "NPM_CONFIG_REGISTRY=${registryUrl}" && ${bunxCmd}`
       logger.debug('Using bunx command for claude-code:', baseCommand)
     }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR:
On Windows, running claudecode as a Code Tool would fail with "error: could not create process" and "Bun failed to remap this bin to its proper location" because `bun install -g @anthropic-ai/claude-code` creates a corrupted binary in `~/.cherrystudio/bin/`.

After this PR:
On Windows, claudecode uses `bun -y @anthropic-ai/claude-code --prefix .` (local install) instead of `bun install -g`, bypassing the Windows bin remapping issue.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #14367 

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Used `bun -y packageName --prefix .` (local install to current directory) instead of `bunx` command directly, to maintain consistency with how other CLI tools are launched and to ensure the package is cached locally.

The following alternatives were considered:
- Using `npx` instead of `bun`: Rejected because the app already uses bun as the package manager
- Reverting to use the Agent mode (claude-agent-sdk): Rejected because users specifically want to use claude-code as a CLI tool
- Adding retry logic with `bun install --force`: Less reliable, doesn't always fix the issue

Links to places where the discussion took place: #14367 <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

This PR does **NOT** introduce any breaking changes.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
fix: Use bunx for claude-code CLI tool on Windows to avoid "Bun failed to remap" error
```
