### PR TITLE
fix(analytics): respect data collection setting for all tracking events

### DIFF
--- a/src/main/services/AnalyticsService.ts
+++ b/src/main/services/AnalyticsService.ts
@@ -21,6 +21,11 @@ class AnalyticsService {
   }
 
   public init(): void {
+    if (!configManager.getEnableDataCollection()) {
+      logger.info('Analytics service disabled by user preference')
+      return
+    }
+
     this.client = new AnalyticsClient({
       clientId: configManager.getClientId(),
       channel: 'cherry-studio',
@@ -34,12 +39,10 @@ class AnalyticsService {
       }
     })
 
-    if (configManager.getEnableDataCollection()) {
-      this.client.trackAppLaunch({
-        version: app.getVersion(),
-        os: process.platform
-      })
-    }
+    this.client.trackAppLaunch({
+      version: app.getVersion(),
+      os: process.platform
+    })
 
     logger.info('Analytics service initialized')
   }

--- a/src/main/services/AnalyticsService.ts
+++ b/src/main/services/AnalyticsService.ts
@@ -34,10 +34,12 @@ class AnalyticsService {
       }
     })
 
-    this.client.trackAppLaunch({
-      version: app.getVersion(),
-      os: process.platform
-    })
+    if (configManager.getEnableDataCollection()) {
+      this.client.trackAppLaunch({
+        version: app.getVersion(),
+        os: process.platform
+      })
+    }
 
     logger.info('Analytics service initialized')
   }
@@ -53,7 +55,7 @@ class AnalyticsService {
   }
 
   public async trackAppUpdate(): Promise<void> {
-    if (!this.client) {
+    if (!this.client || !configManager.getEnableDataCollection()) {
       return
     }
 


### PR DESCRIPTION
## Summary

- `trackAppLaunch` (called unconditionally in `init()`) and `trackAppUpdate` currently **bypass** the `enableDataCollection` user setting, sending telemetry to `analytics.cherry-ai.com` even when users have explicitly disabled data collection.
- Only `trackTokenUsage` correctly checks `configManager.getEnableDataCollection()`.
- This regression was introduced in 6061d472 (2026-03-22), which removed the original opt-out guard from `init()` that existed since the initial implementation in 1734467f.

## Changes

- Add `enableDataCollection` check before `trackAppLaunch` in `init()`
- Add `enableDataCollection` check in `trackAppUpdate()`
- All three tracking methods now consistently respect the user's data collection preference

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (2 pre-existing symlink failures on Windows, unrelated)
- [ ] Verify with data collection **enabled**: all three events (`app_launch`, `token_usage`, `app_update`) are sent normally
- [ ] Verify with data collection **disabled**: no events are sent to `analytics.cherry-ai.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)