### PR TITLE
chore: release v1.9.2

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -142,94 +142,52 @@ artifactBuildCompleted: scripts/artifact-build-completed.js
 releaseInfo:
   releaseNotes: |
     <!--LANG:en-->
-    Cherry Studio 1.9.1 - CherryClaw Agent & Skills System
-
-    ⚠️ Breaking Changes
-    - [Agents] "Plugins" system renamed to "Skills". Plugin marketplace has been replaced by a unified Skills management interface
+    Cherry Studio 1.9.2 - Skills Creation & Vietnamese Support
 
     ✨ New Features
-    - [Agents] Add CherryClaw autonomous agent: personality system, scheduled tasks, multi-channel integration (Telegram, Discord, Feishu, Slack, WeChat, QQ), and filesystem sandbox
-    - [Agents] Add built-in Cherry Assistant — helps diagnose issues, navigate pages, collect FAQs, and submit bug reports
-    - [Agents] Improved tool output display with syntax highlighting, diff viewer, line numbers, and file type icons
-    - [ErrorHandling] Add AI-powered error diagnosis with instant classification and step-by-step fix suggestions
-    - [MCP] Add flomo as a built-in MCP server for capturing notes and ideas
-    - [MCP] Add MCPWorld (mcpworld.com) as a new MCP server marketplace
-    - [Topics] Support pinning topics to the top of the list
-    - [Models] Add endpoint option for aionly provider and update default models
-
-    🔒 Security Fixes
-    - [Security] Fix potential security issues with external URL handling and file operations
-    - [Security] Fix XSS vulnerability in MCP description and search results
+    - [Skills] Agents can now author and register new skills directly from chat using the skills tool
+    - [Skills] Add "Add More Skills" button to agent settings for quick navigation to Skills management
+    - [Skills] Skills and memory MCP tools now available to all agents (not just Soul Mode agents)
+    - [i18n] Add Vietnamese (Tiếng Việt) language support with complete UI translations
 
     🐛 Bug Fixes
-    - [Models] Add Ollama gemma4 format support for Gemma 4 model capability detection
-    - [Models] Fix new-api provider ignoring configured host for Anthropic format requests
-    - [Models] Fix Poe provider unable to load models dynamically
-    - [Models] Fix Google Gemini web search failing
-    - [Models] Fix model detection for Qwen3.5–3.9 and GPT series
-    - [Models] Fix NVIDIA provider reasoning parameters for Qwen/DeepSeek/Kimi/Zhipu models
-    - [Models] Fix Xiaomi MiMo thinking/non-thinking toggle behavior
-    - [Agents] Fix Claude Code child processes ignoring app proxy settings (including SOCKS proxy)
-    - [Agents] Fix Cherry Assistant ignoring user's language and always responding in English
-    - [MCP] Fix Hub-mode MCP tool calls silently truncating list-style responses
-    - [Knowledge] Fix epub file embedding failure
-    - [Notes] Fix KaTeX formula corruption when toggling editor modes
-    - [Notes] Fix note editor search state and scrolling
-    - [Thinking] Fix thinking time display showing incorrect values
-    - [MiniApps] Fix removed pinned mini-apps silently reappearing
-    - [Code Tools] Fix kimi-cli crash when uv is not installed
-    - [Build] Fix built-in skill files (.md) missing from packaged app
-    - [Chat] Fix data loss when selecting model via keyboard shortcut
-    - [UI] Fix move-to submenu height overflow
-    - [UI] Fix macOS traffic light alignment in custom title bar
+    - [Agents] Agent settings changes (model, permissions, tools, etc.) now sync immediately to all active sessions
+    - [Agents] Built-in agent prompt updates now properly sync to existing sessions
+    - [Agents] Cherry Assistant now displays the 🍒 avatar instead of generic ⭐️
+    - [Analytics] Fix telemetry being sent even when data collection is disabled
+    - [Search] Fix CJK (Chinese/Japanese/Korean) text search failing in whole-word mode
+    - [Search] Add phrase search support (e.g., "machine learning" with quotes)
+    - [Export] Fix Obsidian export silently failing due to blocked obsidian:// protocol
+    - [Knowledge] Fix knowledge base creation failing for Ollama embedding models
+    - [Models] Fix custom parameters not being passed to Gemini API when using NewAPI/AiHubMix providers
+    - [Knowledge] Fix Dify knowledge search compatibility with Dify 1.13.3
+    - [OpenClaw] Fix language selection not persisting in overview page
 
     ⚡ Performance
-    - [Backup] Faster backups with smaller file sizes
-    - [Agent] Improve session switch experience
+    - [Electron] Upgrade to Electron 41.2.1 with improved window resize handling on Windows
 
     <!--LANG:zh-CN-->
-    Cherry Studio 1.9.1 - CherryClaw 智能体与技能系统
-
-    ⚠️ 破坏性变更
-    - [智能体] "插件"系统更名为"技能（Skills）"，插件市场已替换为统一的技能管理界面
+    Cherry Studio 1.9.2 - 技能创作与越南语支持
 
     ✨ 新功能
-    - [智能体] 新增 CherryClaw 自主智能体：个性系统、定时任务、多渠道集成（Telegram、Discord、飞书、Slack、微信、QQ）和文件系统沙箱
-    - [智能体] 新增内置 Cherry Assistant — 可帮助诊断问题、导航页面、收集常见问题和提交 Bug 报告
-    - [智能体] 改进工具输出展示：语法高亮、差异对比视图、行号和文件类型图标
-    - [错误处理] 新增 AI 驱动的错误诊断，支持即时分类和分步修复建议
-    - [MCP] 新增 flomo 内置 MCP 服务器，支持通过 AI 捕捉笔记和灵感
-    - [MCP] 新增 MCPWorld (mcpworld.com) 作为新的 MCP 服务器市场
-    - [话题] 支持将话题置顶显示
-    - [模型] 为 aionly 服务商添加端点选项并更新默认模型
-
-    🔒 安全修复
-    - [安全] 修复外部链接打开和文件操作中的潜在安全问题
-    - [安全] 修复 MCP 描述和搜索结果中的 XSS 漏洞
+    - [技能] 智能体现在可以直接在对话中通过 skills 工具编写和注册新技能
+    - [技能] 在智能体设置的技能页面添加"添加更多技能"按钮，快速跳转到技能管理页面
+    - [技能] skills 和 memory MCP 工具现对所有智能体可用（不仅限于灵魂模式）
+    - [i18n] 新增越南语（Tiếng Việt）支持，包含完整的 UI 翻译
 
     🐛 问题修复
-    - [模型] 添加 Ollama gemma4 格式支持以正确识别 Gemma 4 模型能力
-    - [模型] 修复 new-api 服务商在 Anthropic 格式请求时忽略已配置主机的问题
-    - [模型] 修复 Poe 服务商无法动态加载模型的问题
-    - [模型] 修复 Google Gemini 网络搜索失败的问题
-    - [模型] 修复 Qwen3.5–3.9 和 GPT 系列模型的识别问题
-    - [模型] 修复 NVIDIA 服务商的 Qwen/DeepSeek/Kimi/Zhipu 模型推理参数
-    - [模型] 修复小米 MiMo 思考模式开关行为异常
-    - [智能体] 修复 Claude Code 子进程忽略应用代理设置的问题（包括 SOCKS 代理）
-    - [智能体] 修复 Cherry Assistant 忽略用户语言、始终以英语回复的问题
-    - [MCP] 修复 Hub 模式下 MCP 工具调用静默截断列表样式响应的问题
-    - [知识库] 修复 epub 文件嵌入失败的问题
-    - [笔记] 修复切换编辑器模式时 KaTeX 公式损坏的问题
-    - [笔记] 修复笔记编辑器搜索状态和滚动问题
-    - [思考] 修复思考时间显示数值异常的问题
-    - [小程序] 修复已移除的固定小程序意外重新出现的问题
-    - [代码工具] 修复未安装 uv 时 kimi-cli 崩溃的问题
-    - [构建] 修复内置技能文件（.md）未包含在打包应用中的问题
-    - [聊天] 修复通过键盘快捷键选择模型导致数据丢失的问题
-    - [UI] 修复"移动到"子菜单高度溢出
-    - [UI] 修复 macOS 自定义标题栏中红绿灯控件对齐问题
+    - [智能体] 智能体设置更改（模型、权限、工具等）现立即同步到所有活跃会话
+    - [智能体] 内置智能体提示词更新现正确同步到现有会话
+    - [智能体] Cherry Assistant 现显示 🍒 头像而非通用的 ⭐️
+    - [数据收集] 修复即使禁用数据收集仍发送遥测数据的问题
+    - [搜索] 修复中日韩（CJK）文本在全词模式下搜索失败的问题
+    - [搜索] 添加短语搜索支持（例如带引号的 "machine learning"）
+    - [导出] 修复因 obsidian:// 协议被阻止导致 Obsidian 导出静默失败的问题
+    - [知识库] 修复使用 Ollama 嵌入模型创建知识库失败的问题
+    - [模型] 修复使用 NewAPI/AiHubMix 服务商时自定义参数未传递给 Gemini API 的问题
+    - [知识库] 修复与 Dify 1.13.3 的知识搜索兼容性问题
+    - [OpenClaw] 修复概览页面语言选择无法持久化的问题
 
     ⚡ 性能优化
-    - [备份] 优化备份速度，减小备份文件大小
-    - [智能体] 改善会话切换时的体验
+    - [Electron] 升级至 Electron 41.2.1，改进 Windows 平台的窗口调整大小体验
     <!--LANG:END-->

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -151,10 +151,10 @@ releaseInfo:
     - [i18n] Add Vietnamese (Tiếng Việt) language support with complete UI translations
 
     🐛 Bug Fixes
+    - [Analytics] Fix telemetry being sent even when data collection is disabled
     - [Agents] Agent settings changes (model, permissions, tools, etc.) now sync immediately to all active sessions
     - [Agents] Built-in agent prompt updates now properly sync to existing sessions
     - [Agents] Cherry Assistant now displays the 🍒 avatar instead of generic ⭐️
-    - [Analytics] Fix telemetry being sent even when data collection is disabled
     - [Search] Fix CJK (Chinese/Japanese/Korean) text search failing in whole-word mode
     - [Search] Add phrase search support (e.g., "machine learning" with quotes)
     - [Export] Fix Obsidian export silently failing due to blocked obsidian:// protocol
@@ -176,10 +176,10 @@ releaseInfo:
     - [i18n] 新增越南语（Tiếng Việt）支持，包含完整的 UI 翻译
 
     🐛 问题修复
+    - [数据统计] 修复即使禁用数据统计仍发送统计数据的问题
     - [智能体] 智能体设置更改（模型、权限、工具等）现立即同步到所有活跃会话
     - [智能体] 内置智能体提示词更新现正确同步到现有会话
     - [智能体] Cherry Assistant 现显示 🍒 头像而非通用的 ⭐️
-    - [数据收集] 修复即使禁用数据收集仍发送遥测数据的问题
     - [搜索] 修复中日韩（CJK）文本在全词模式下搜索失败的问题
     - [搜索] 添加短语搜索支持（例如带引号的 "machine learning"）
     - [导出] 修复因 obsidian:// 协议被阻止导致 Obsidian 导出静默失败的问题

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CherryStudio",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "private": true,
   "description": "A powerful AI assistant for producer.",
   "desktopName": "CherryStudio.desktop",


### PR DESCRIPTION
### What this PR does

Before this PR:
- Version 1.9.1 was the latest release
- Several user-facing bugs and feature requests needed to be addressed

After this PR:
- Bumps version to 1.9.2
- Updates release notes with bilingual (English/Chinese) changelog

### Summary of Changes

This release includes 20 commits since v1.9.1, featuring:

**New Features:**
- Vietnamese language support (Tiếng Việt)
- Agents can now author and register new skills directly from chat
- Skills/memory tools now available to all agents

**Bug Fixes:**
- Agent settings now sync immediately to active sessions
- Fixed telemetry being sent despite data collection disabled
- Fixed CJK text search failures and added phrase search
- Fixed Obsidian export silently failing
- Fixed Ollama model loading and knowledge base issues
- Fixed custom parameters not passing to Gemini API via NewAPI/AiHubMix
- Various other fixes for Dify, Cherry Assistant, and OpenClaw

**Included Commits:**
- 2120fddf4 fix: update node-abi for Electron 41 packaging
- 7c2ada6d6 fix(analytics): respect data collection setting for all tracking events
- da2302237 fix: Fix Ollama model list loading when metadata contains null families values
- 76ec2f1c0 fix(export): add obsidian:// to allowed protocol whitelist
- d89ce0871 fix(search): support phrase search and fix CJK matching in history search
- fbda0d213 hotfix: Custom params not passed to Gemini API when using NewAPI/AiHubMix
- 7afabbdf2 fix(agents): set Cherry Assistant default avatar to 🍒
- b85c28d50 fix(knowledge): support Ollama knowledge embeddings
- 41554411d fix: sync builtin agent prompt updates to sessions
- 6b5cb0b76 feat(i18n): add Vietnamese (vi-VN) language support
- bf3235be8 fix(selection): upgrade electron to 41.2.1
- 0477bd0ad fix(skills): per-agent skill enablement with workspace symlinks
- 68d32c7f7 fix: limit topic naming retries and timeout
- ae8f0888b fix(agents): add more skills button to agent skills settings missing
- e2366b351 fix: update dify knowledge retrieval payload
- 0d7e13bd4 fix(skills): support agent-authored skills via skills tool init/register
- 51eed6e74 fix(agents): sync agent settings changes to active session
- e54cfe97e fix(agents): set NODE_PATH so spawned Claude Code process can resolve @img/sharp
- d75883d63 fix(openclaw): persist language selection in overview page

### Review Checklist

- [ ] Review generated release notes in `electron-builder.yml`
- [ ] Verify version bump in `package.json` (1.9.1 → 1.9.2)
- [ ] CI passes
- [ ] Merge to trigger release build

### Release note

See the bilingual release notes in `electron-builder.yml` for full details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)