### PR TITLE
hotfix: Support `case-insensitive` file extensions for drag-and-drop uploads when editing messages

### DIFF
--- a/src/renderer/src/pages/home/Messages/MessageEditor.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageEditor.tsx
@@ -185,7 +185,7 @@ const MessageBlockEditor: FC<Props> = ({ message, topicId, onSave, onResend, onC
     if (files) {
       let supportedFiles = 0
       files.forEach((file) => {
-        if (extensions.includes(file.ext)) {
+        if (extensions.includes(file.ext.toLowerCase())) {
           setFiles((prevFiles) => [...prevFiles, file])
           supportedFiles++
         }


### PR DESCRIPTION
### What this PR does

Before this PR: When editing a message, files uploaded via drag-and-drop were not recognized if their extensions were in uppercase (e.g., `.JPG`, which is the default format on iOS). The system only performed case-sensitive matching for allowed file types

After this PR: File extension validation is now case-insensitive. Dragging and dropping files with uppercase extensions like `.JPG` or `.PNG` during message editing now works as expected

Fixes #14414 

### Why we need it and why it was done in this way

On iOS and some other platforms, image extensions are frequently capitalized by default. Our previous implementation used strict string matching, causing valid image files to be ignored or rejected

The fix involves normalizing the file extension to lowercase during the validation check in the drag-and-drop handler. This ensures compatibility across different operating systems without affecting the original filename metadata

### Release note

```release-note
fix: Support `case-insensitive` file extensions for drag-and-drop uploads when editing messages
```