### PR TITLE
fix(agents): preserve session instructions in Soul Mode

### DIFF
--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -517,7 +517,7 @@ class ClaudeCodeService implements AgentServiceInterface {
       systemPrompt: assistantSystemPrompt
         ? assistantSystemPrompt
         : soulSystemPrompt
-          ? `${soulSystemPrompt}${channelSecurityBlock}\n\n${getLanguageInstruction()}`
+          ? `${soulSystemPrompt}${session.instructions ? `\n\n${session.instructions}` : ''}${channelSecurityBlock}\n\n${getLanguageInstruction()}`
           : {
               type: 'preset',
               preset: 'claude_code',


### PR DESCRIPTION
### What this PR does

Before this PR:
In Soul Mode, `ClaudeCodeService.invoke` replaced the system prompt
entirely with `soulSystemPrompt` and never appended
`session.instructions`. Any user-provided session instructions were
silently dropped; only the Assistant and default branches honored them.

After this PR:
The Soul branch now appends `session.instructions` between
`soulSystemPrompt` and the channel security / language suffix. Soul
persona, channel safety policy, and language directive are preserved;
user intent is no longer lost.

Fixes #

### Why we need it and why it was done in this way

Minimal one-line change inside the existing `systemPrompt` ternary —
keeps ordering stable (persona -> user intent -> safety -> language) and
avoids touching `PromptBuilder.buildSystemPrompt`, which is Soul-
specific and should not be aware of per-session overrides.

The following tradeoffs were made:
- Appending rather than prepending keeps Soul persona dominant while
  still letting the user steer behavior.
- Placed before `channelSecurityBlock` so external-channel safety rules
  still take final precedence over user-provided instructions.

The following alternatives were considered:
- Passing `session.instructions` into `buildSystemPrompt` and merging
  inside the builder — rejected as scope creep beyond a hotfix.
- Moving Soul to the preset `append` path — rejected; Soul intentionally
  replaces the preset.

Links to places where the discussion took place: N/A

### Breaking changes

None. Soul Mode sessions that previously set `instructions` will now
have those instructions actually applied; sessions without
`instructions` behave identically to before.

### Special notes for your reviewer

Diff is a single line at `src/main/services/agents/services/claudecode/index.ts:520`.
No refactor, no new files, no schema changes — complies with `main`
code freeze / hotfix requirements.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix Soul Mode silently dropping user-provided session instructions; they are now applied after the Soul persona and before channel safety / language directives.
```
