### PR TITLE
fix: prevent empty baseURL/region string in Bedrock provider config

### DIFF
--- a/src/renderer/src/aiCore/provider/providerConfig.ts
+++ b/src/renderer/src/aiCore/provider/providerConfig.ts
@@ -209,17 +209,20 @@ function buildOllamaConfig(ctx: BuilderContext): ProviderConfig<'ollama'> {
 
 function buildBedrockConfig(ctx: BuilderContext): ProviderConfig<'bedrock'> {
   const authType = getAwsBedrockAuthType()
-  const region = getAwsBedrockRegion()
+  const region = getAwsBedrockRegion() || undefined
 
   const base = { providerId: 'bedrock' as const, endpoint: ctx.endpoint }
 
+  const baseURL = ctx.baseConfig.baseURL || undefined
+
   if (authType === 'apiKey') {
-    return { ...base, providerSettings: { ...ctx.baseConfig, region, apiKey: getAwsBedrockApiKey() } }
+    return { ...base, providerSettings: { ...ctx.baseConfig, baseURL, region, apiKey: getAwsBedrockApiKey() } }
   }
   return {
     ...base,
     providerSettings: {
       ...ctx.baseConfig,
+      baseURL,
       region,
       accessKeyId: getAwsBedrockAccessKeyId(),
       secretAccessKey: getAwsBedrockSecretAccessKey()

--- a/src/renderer/src/aiCore/provider/providerConfig.ts
+++ b/src/renderer/src/aiCore/provider/providerConfig.ts
@@ -209,7 +209,7 @@ function buildOllamaConfig(ctx: BuilderContext): ProviderConfig<'ollama'> {
 
 function buildBedrockConfig(ctx: BuilderContext): ProviderConfig<'bedrock'> {
   const authType = getAwsBedrockAuthType()
-  const region = getAwsBedrockRegion() || undefined
+  const region = getAwsBedrockRegion().trim() || undefined
 
   const base = { providerId: 'bedrock' as const, endpoint: ctx.endpoint }
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR: When a user configures the built-in AWS Bedrock provider (leaving **API Host** blank, which is the default), every request fails immediately with `failed to fetch`. This happens regardless of whether API Key or IAM authentication is used, and regardless of whether the Region and credentials are correctly filled in.

After this PR: The SDK correctly constructs the endpoint URL from the configured Region automatically (e.g. `https://bedrock-runtime.us-east-1.amazonaws.com`), and requests should succeed normally.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #14423

### Why we need it and why it was done in this way

`buildBedrockConfig()` spreads `ctx.baseConfig` (which contains `baseURL: ""` when the user leaves API Host blank) directly into the `providerSettings` passed to `createAmazonBedrock()`.

Inside `@ai-sdk/amazon-bedrock`, the base URL selection logic uses a loose `!= null` check:

```/dev/null/sdk-snippet.js#L1-5
// Inside @ai-sdk/amazon-bedrock: bedrock-provider.ts
const getBedrockRuntimeBaseUrl = () => {
  return withoutTrailingSlash(
    options.baseURL != null        // "" != null → true (empty string passes this check!)
      ? options.baseURL            // → uses "" as the base URL
      : `https://bedrock-runtime.${region}.amazonaws.com`
  ) ?? `https://bedrock-runtime.us-east-1.amazonaws.com`;
  // The ?? fallback also never triggers: withoutTrailingSlash("") returns ""
};
```

Because `"" != null` is `true`, an empty string is treated as a valid, intentional base URL. Every request then goes to `""/model/{modelId}/converse` — an invalid URL — causing the `failed to fetch` failure.

The fix converts both `baseURL` and `region` from empty string to `undefined` before passing them to the SDK. `undefined != null` is `false`, so the SDK correctly falls back to constructing the proper endpoint from the region. The same guard on `region` prevents a secondary issue where an empty region would produce a malformed URL like `https://bedrock-runtime..amazonaws.com`.

The following tradeoffs were made:

- Using `|| undefined` (falsy check) rather than a strict `=== ""` check, so any other whitespace-only or otherwise empty value is also handled safely.
- The fix is applied only inside `buildBedrockConfig()` and does not affect any other provider.

The following alternatives were considered:

- Patching the `@ai-sdk/amazon-bedrock` package — rejected because the SDK's behavior is internally consistent.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

None.

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

The changed function is `buildBedrockConfig()` in `src/renderer/src/aiCore/provider/providerConfig.ts`. The diff is minimal: one variable extraction for `baseURL`, one `|| undefined` guard on `region`, and the propagation of `baseURL` into both return paths.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed AWS Bedrock requests failing with "failed to fetch" when API Host is left blank (the default). The SDK endpoint should now be correctly derived from the configured Region.
```
