### PR TITLE
fix(settings): show selection assistant status in shortcut settings

### DIFF
--- a/src/renderer/src/pages/settings/ShortcutSettings.tsx
+++ b/src/renderer/src/pages/settings/ShortcutSettings.tsx
@@ -5,23 +5,24 @@ import { useTheme } from '@renderer/context/ThemeProvider'
 import { useShortcuts } from '@renderer/hooks/useShortcuts'
 import { useTimer } from '@renderer/hooks/useTimer'
 import { getShortcutLabel } from '@renderer/i18n/label'
-import { useAppDispatch } from '@renderer/store'
+import { useAppDispatch, useAppSelector } from '@renderer/store'
 import { initialState, resetShortcuts, toggleShortcut, updateShortcut } from '@renderer/store/shortcuts'
 import type { Shortcut } from '@renderer/types'
 import type { InputRef } from 'antd'
-import { Button, Input, Switch, Table as AntTable, Tooltip } from 'antd'
+import { Button, Input, Switch, Table as AntTable, Tag, Tooltip } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import type { FC } from 'react'
 import React, { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
-import { SettingContainer, SettingDivider, SettingGroup, SettingTitle } from '.'
+import { SettingContainer, SettingDivider, SettingGroup, SettingRow, SettingRowTitle, SettingTitle } from '.'
 
 const ShortcutSettings: FC = () => {
   const { t } = useTranslation()
   const { theme } = useTheme()
   const dispatch = useAppDispatch()
+  const selectionAssistantEnabled = useAppSelector((state) => state.selectionStore.selectionEnabled)
   const { shortcuts: originalShortcuts } = useShortcuts()
   const inputRefs = useRef<Record<string, InputRef>>({})
   const [editingKey, setEditingKey] = useState<string | null>(null)
@@ -402,6 +403,12 @@ const ShortcutSettings: FC = () => {
       <SettingGroup theme={theme} style={{ paddingBottom: 0 }}>
         <SettingTitle>{t('settings.shortcuts.title')}</SettingTitle>
         <SettingDivider style={{ marginBottom: 0 }} />
+        <SettingRow style={{ marginBottom: 12 }}>
+          <SettingRowTitle>{t('selection.name')}</SettingRowTitle>
+          <Tag color={selectionAssistantEnabled ? 'success' : 'warning'} style={{ margin: 0, borderRadius: 999 }}>
+            {selectionAssistantEnabled ? t('common.enabled') : t('common.disabled')}
+          </Tag>
+        </SettingRow>
         <Table
           columns={columns as ColumnsType<unknown>}
           dataSource={shortcuts.map((s) => ({ ...s, name: getShortcutLabel(s.key) }))}


### PR DESCRIPTION
### What this PR does

Before this PR:
- The keyboard shortcuts settings page did not show whether the Selection Assistant was globally enabled.
- Users could not see that state without checking another settings page or the tray menu.

After this PR:
- A small status tag is shown above the shortcut table with the current Selection Assistant state.
- The tag reuses the existing synced selection state and the shared enabled/disabled labels.

Fixes #14453

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Reused the existing selection state from the renderer store instead of adding new IPC or config plumbing.
- Kept the change local to the shortcuts page so it only addresses the UX gap reported in the issue.

The following alternatives were considered:
- Adding a new warning block on the Selection Assistant page.
- Modifying the shortcut list itself to surface the state inline.

Links to places where the discussion took place:
- GitHub issue #14453

### Breaking changes

None.

### Special notes for your reviewer

UI/UX only. No behavior or shortcut logic changes.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Show the Selection Assistant enabled/disabled status in the keyboard shortcuts settings page so users can see why the shortcut may not be working.
```
