### PR TITLE
fix: preserve referenced models during v2 migration

### DIFF
--- a/src/main/data/migration/v2/migrators/ProviderModelMigrator.ts
+++ b/src/main/data/migration/v2/migrators/ProviderModelMigrator.ts
@@ -13,14 +13,18 @@ import { userModelTable } from '@data/db/schemas/userModel'
 import { userProviderTable } from '@data/db/schemas/userProvider'
 import { loggerService } from '@logger'
 import type { ExecuteResult, PrepareResult, ValidateResult } from '@shared/data/migration/v2/types'
-import { createUniqueModelId, isUniqueModelId, type UniqueModelId } from '@shared/data/types/model'
-import type { Provider as LegacyProvider } from '@types'
+import { createUniqueModelId, isUniqueModelId, parseUniqueModelId, type UniqueModelId } from '@shared/data/types/model'
+import type { Model as LegacyModel, Provider as LegacyProvider } from '@types'
 import { eq, sql } from 'drizzle-orm'
 
 import type { MigrationContext } from '../core/MigrationContext'
 import { assignOrderKeysInSequence } from '../utils/orderKey'
 import { BaseMigrator } from './BaseMigrator'
+import type { OldAssistant } from './mappings/AssistantMappings'
+import type { OldMessage, OldTopic } from './mappings/ChatMappings'
+import type { LegacyKnowledgeState } from './mappings/KnowledgeMappings'
 import { type OldLlmSettings, transformModel, transformProvider } from './mappings/ProviderModelMappings'
+import { legacyModelToUniqueId } from './transformers/ModelTransformers'
 
 const logger = loggerService.withContext('ProviderModelMigrator')
 
@@ -29,7 +33,34 @@ const BATCH_SIZE = 100
 interface LlmState {
   providers?: LegacyProvider[]
   settings?: OldLlmSettings
+  defaultModel?: Partial<LegacyModel>
+  topicNamingModel?: Partial<LegacyModel>
+  quickModel?: Partial<LegacyModel>
+  translateModel?: Partial<LegacyModel>
 }
+
+interface AssistantState {
+  assistants?: OldAssistant[]
+  presets?: OldAssistant[]
+}
+
+type CollectedModel = Partial<LegacyModel> & { id: string; provider: string }
+interface UnknownProviderSample {
+  source: string
+  providerId: string
+  modelId: string
+}
+
+interface MessageReferenceRegistrationResult {
+  skippedBareModelId: boolean
+  bareModelIdMismatch?: {
+    messageId: string
+    modelId: string
+    messageModelId: string
+  }
+}
+
+type BareModelIdMismatch = NonNullable<MessageReferenceRegistrationResult['bareModelIdMismatch']>
 
 function createModelId(providerId: string, modelId: string): UniqueModelId | null {
   try {
@@ -105,12 +136,20 @@ export class ProviderModelMigrator extends BaseMigrator {
   private settings: OldLlmSettings = {}
   private totalModelCount = 0
   private pinnedModelIds: UniqueModelId[] = []
+  private modelsByProvider = new Map<string, Map<string, CollectedModel>>()
+  private providerIds: ReadonlySet<string> = new Set()
+  private skippedUnknownProviderRefs = 0
+  private skippedUnknownProviderSamples: UnknownProviderSample[] = []
 
   override reset(): void {
     this.providers = []
     this.settings = {}
     this.totalModelCount = 0
     this.pinnedModelIds = []
+    this.modelsByProvider = new Map()
+    this.providerIds = new Set()
+    this.skippedUnknownProviderRefs = 0
+    this.skippedUnknownProviderSamples = []
   }
 
   async prepare(ctx: MigrationContext): Promise<PrepareResult> {
@@ -143,13 +182,25 @@ export class ProviderModelMigrator extends BaseMigrator {
 
       this.providers = dedupedProviders
       this.settings = llmState.settings ?? {}
-      this.totalModelCount = this.providers.reduce((count, provider) => {
-        const uniqueModelIds = new Set((provider.models ?? []).map((model) => model.id))
-        return count + uniqueModelIds.size
-      }, 0)
+      this.providerIds = new Set(this.providers.map((provider) => provider.id))
+
+      for (const provider of this.providers) {
+        for (const model of provider.models ?? []) {
+          this.registerModelReference({ ...model, provider: provider.id }, `provider:${provider.id}`)
+        }
+      }
+      this.collectLlmModelReferences(llmState)
+      this.collectAssistantModelReferences(ctx)
+      this.collectKnowledgeModelReferences(ctx)
+      await this.collectChatModelReferences(ctx)
+
+      this.totalModelCount = Array.from(this.modelsByProvider.values()).reduce(
+        (count, models) => count + models.size,
+        0
+      )
       const validModelIds = new Set(
         this.providers.flatMap((provider) =>
-          Array.from(new Set((provider.models ?? []).map((model) => model.id)))
+          Array.from(this.modelsByProvider.get(provider.id)?.keys() ?? [])
             .map((modelId) => createModelId(provider.id, modelId))
             .filter((modelId): modelId is UniqueModelId => Boolean(modelId))
         )
@@ -158,6 +209,13 @@ export class ProviderModelMigrator extends BaseMigrator {
 
       if (skippedProviders > 0) {
         warnings.push(`Skipped ${skippedProviders} duplicate provider(s)`)
+      }
+
+      if (this.skippedUnknownProviderRefs > 0) {
+        logger.warn('Skipped model references for unknown providers during migration', {
+          count: this.skippedUnknownProviderRefs,
+          samples: this.skippedUnknownProviderSamples
+        })
       }
 
       logger.info('Preparation completed', {
@@ -197,12 +255,12 @@ export class ProviderModelMigrator extends BaseMigrator {
           await tx.insert(userProviderTable).values(transformProvider(provider, this.settings, providerIndex))
           processedProviders++
 
-          const uniqueModels = Array.from(new Map((provider.models ?? []).map((model) => [model.id, model])).values())
+          const uniqueModels = Array.from(this.modelsByProvider.get(provider.id)?.values() ?? [])
 
           for (let modelIndex = 0; modelIndex < uniqueModels.length; modelIndex += BATCH_SIZE) {
             const batch = uniqueModels
               .slice(modelIndex, modelIndex + BATCH_SIZE)
-              .map((model, batchIndex) => transformModel(model, provider.id, modelIndex + batchIndex))
+              .map((model, batchIndex) => transformModel(model as LegacyModel, provider.id, modelIndex + batchIndex))
 
             if (batch.length > 0) {
               await tx.insert(userModelTable).values(batch)
@@ -315,5 +373,226 @@ export class ProviderModelMigrator extends BaseMigrator {
         }
       }
     }
+  }
+
+  private collectLlmModelReferences(llmState: LlmState): void {
+    this.registerModelReference(llmState.defaultModel, 'llm.defaultModel')
+    this.registerModelReference(llmState.topicNamingModel, 'llm.topicNamingModel')
+    this.registerModelReference(llmState.quickModel, 'llm.quickModel')
+    this.registerModelReference(llmState.translateModel, 'llm.translateModel')
+  }
+
+  private collectAssistantModelReferences(ctx: MigrationContext): void {
+    const assistantState = ctx.sources.reduxState.getCategory<AssistantState>('assistants')
+    const assistants: unknown[] = [
+      ...(Array.isArray(assistantState?.assistants) ? assistantState.assistants : []),
+      ...(Array.isArray(assistantState?.presets) ? assistantState.presets : [])
+    ]
+
+    for (const assistant of assistants) {
+      if (!assistant || typeof assistant !== 'object') {
+        continue
+      }
+      const assistantRecord = assistant as OldAssistant
+      const assistantId = assistantRecord.id ?? 'unknown'
+      this.registerModelReference(assistantRecord.model, `assistant:${assistantId}`)
+      this.registerModelReference(assistantRecord.defaultModel, `assistant:${assistantId}.defaultModel`)
+      this.registerModelReference(
+        assistantRecord.settings?.defaultModel,
+        `assistant:${assistantId}.settings.defaultModel`
+      )
+    }
+  }
+
+  private collectKnowledgeModelReferences(ctx: MigrationContext): void {
+    const knowledgeState = ctx.sources.reduxState.getCategory<LegacyKnowledgeState>('knowledge')
+    const bases: unknown[] = Array.isArray(knowledgeState?.bases) ? knowledgeState.bases : []
+
+    for (const [index, base] of bases.entries()) {
+      if (!base || typeof base !== 'object') {
+        continue
+      }
+
+      const baseRecord = base as NonNullable<LegacyKnowledgeState['bases']>[number]
+      const sourcePrefix = `knowledge[${index}]:${baseRecord.id ?? 'unknown'}`
+      this.registerModelReference(baseRecord.model, `${sourcePrefix}.model`)
+      this.registerModelReference(baseRecord.rerankModel, `${sourcePrefix}.rerankModel`)
+    }
+  }
+
+  private async collectChatModelReferences(ctx: MigrationContext): Promise<void> {
+    if (!(await ctx.sources.dexieExport.tableExists('topics'))) {
+      return
+    }
+
+    let skippedBareModelIds = 0
+    const skippedBareModelSamples: string[] = []
+    let mismatchedBareModelIds = 0
+    const mismatchedBareModelSamples: BareModelIdMismatch[] = []
+    const topicReader = ctx.sources.dexieExport.createStreamReader('topics')
+    await topicReader.readInBatches<OldTopic>(BATCH_SIZE, async (topics) => {
+      for (const topic of topics) {
+        if (!topic || !Array.isArray(topic.messages)) {
+          continue
+        }
+        for (const message of topic.messages) {
+          if (!message || typeof message !== 'object') {
+            continue
+          }
+
+          const result = this.registerMessageModelReference(message)
+          if (result.skippedBareModelId) {
+            skippedBareModelIds += 1
+            if (skippedBareModelSamples.length < 5) {
+              skippedBareModelSamples.push(`${message.id}:${message.modelId}`)
+            }
+          }
+
+          if (result.bareModelIdMismatch) {
+            mismatchedBareModelIds += 1
+            if (mismatchedBareModelSamples.length < 5) {
+              mismatchedBareModelSamples.push(result.bareModelIdMismatch)
+            }
+          }
+        }
+      }
+    })
+
+    if (skippedBareModelIds > 0) {
+      logger.warn('Skipped legacy bare modelId references during migration', {
+        count: skippedBareModelIds,
+        samples: skippedBareModelSamples
+      })
+    }
+
+    if (mismatchedBareModelIds > 0) {
+      logger.warn('Detected mismatched legacy bare modelId values during migration', {
+        count: mismatchedBareModelIds,
+        samples: mismatchedBareModelSamples
+      })
+    }
+  }
+
+  private registerMessageModelReference(message: OldMessage): MessageReferenceRegistrationResult {
+    this.registerModelReference(message.model, `message:${message.id}`)
+    let skippedBareModelId = false
+    let bareModelIdMismatch: MessageReferenceRegistrationResult['bareModelIdMismatch']
+
+    if (typeof message.modelId === 'string' && message.modelId) {
+      const rawModelId = message.modelId.trim()
+      const normalizedMessageModel = this.normalizeModelReference(message.model)
+
+      if (normalizedMessageModel && this.providerIds.has(normalizedMessageModel.providerId)) {
+        const messageModelId = isUniqueModelId(rawModelId)
+          ? legacyModelToUniqueId(normalizedMessageModel.model)
+          : normalizedMessageModel.model.id
+
+        if (messageModelId && messageModelId !== rawModelId) {
+          bareModelIdMismatch = {
+            messageId: message.id,
+            modelId: rawModelId,
+            messageModelId
+          }
+        }
+      } else if (isUniqueModelId(rawModelId)) {
+        this.registerModelReference({ id: rawModelId }, `message:${message.id}.modelId`)
+      } else {
+        skippedBareModelId = true
+      }
+    }
+
+    if (Array.isArray(message.mentions)) {
+      for (const [index, mention] of message.mentions.entries()) {
+        this.registerModelReference(mention, `message:${message.id}.mentions[${index}]`)
+      }
+    }
+
+    return { skippedBareModelId, bareModelIdMismatch }
+  }
+
+  private registerModelReference(model: Partial<LegacyModel> | null | undefined, source: string): void {
+    const normalized = this.normalizeModelReference(model)
+    if (!normalized) {
+      return
+    }
+
+    if (!this.providerIds.has(normalized.providerId)) {
+      this.skippedUnknownProviderRefs += 1
+      if (this.skippedUnknownProviderSamples.length < 5) {
+        this.skippedUnknownProviderSamples.push({
+          source,
+          providerId: normalized.providerId,
+          modelId: normalized.model.id
+        })
+      }
+      return
+    }
+
+    const models = this.getModelMap(normalized.providerId)
+    if (!models.has(normalized.model.id)) {
+      models.set(normalized.model.id, normalized.model)
+    }
+  }
+
+  private normalizeModelReference(
+    model: Partial<LegacyModel> | null | undefined
+  ): { providerId: string; model: CollectedModel } | null {
+    if (!model || typeof model !== 'object') {
+      return null
+    }
+
+    const rawModelId = model.id?.trim()
+    const explicitProviderId = model.provider?.trim()
+    if (!rawModelId) {
+      return null
+    }
+
+    if (
+      isUniqueModelId(rawModelId) &&
+      explicitProviderId &&
+      !explicitProviderId.includes('::') &&
+      this.providerIds.has(explicitProviderId)
+    ) {
+      const parsedUniqueModelId = parseUniqueModelId(rawModelId)
+
+      if (!this.providerIds.has(parsedUniqueModelId.providerId)) {
+        return {
+          providerId: explicitProviderId,
+          model: {
+            ...model,
+            id: parsedUniqueModelId.modelId,
+            provider: explicitProviderId,
+            name: model.name?.trim() || parsedUniqueModelId.modelId,
+            group: model.group?.trim() || undefined
+          }
+        }
+      }
+    }
+
+    const uniqueId = legacyModelToUniqueId({ id: model.id, provider: model.provider }, model.id)
+    if (!uniqueId) {
+      return null
+    }
+
+    const { providerId, modelId } = parseUniqueModelId(uniqueId)
+    return {
+      providerId,
+      model: {
+        ...model,
+        id: modelId,
+        provider: providerId,
+        name: model.name?.trim() || modelId,
+        group: model.group?.trim() || undefined
+      }
+    }
+  }
+
+  private getModelMap(providerId: string): Map<string, CollectedModel> {
+    let models = this.modelsByProvider.get(providerId)
+    if (!models) {
+      models = new Map()
+      this.modelsByProvider.set(providerId, models)
+    }
+    return models
   }
 }

--- a/src/main/data/migration/v2/migrators/__tests__/ProviderModelMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/ProviderModelMigrator.test.ts
@@ -1,4 +1,3 @@
-import { pinTable } from '@data/db/schemas/pin'
 import { userProviderTable } from '@data/db/schemas/userProvider'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -25,37 +24,23 @@ vi.mock('@application', async () => {
   return mockApplicationFactory()
 })
 
-interface MockContextOptions {
-  failOnPinInsert?: boolean
-}
-
 function createMockContext(
   reduxState: Record<string, unknown> = {},
-  sourceData: Record<string, unknown> = {},
-  options: MockContextOptions = {}
+  dexieTables: Record<string, unknown[]> = {}
 ): MigrationContext {
   const insertValues: unknown[][] = []
-  let stagedInsertValues: unknown[][] = []
   const flattenInsertedRows = () =>
     insertValues
       .flatMap((batch) => batch)
       .filter((row): row is Record<string, unknown> => !!row && typeof row === 'object')
-  const getInsertedProviders = () =>
-    flattenInsertedRows().filter((row) => Object.hasOwn(row, 'providerId') && !Object.hasOwn(row, 'modelId'))
+  const getInsertedProviders = () => flattenInsertedRows().filter((row) => !Object.hasOwn(row, 'modelId'))
   const getInsertedModels = () => flattenInsertedRows().filter((row) => Object.hasOwn(row, 'modelId'))
-  const getInsertedPins = () => flattenInsertedRows().filter((row) => row.entityType === 'model')
 
   const mockTx = {
-    insert: vi.fn((table: unknown) => ({
+    insert: vi.fn(() => ({
       values: vi.fn((vals: unknown) => {
-        const rows = Array.isArray(vals) ? vals : [vals]
-        if (options.failOnPinInsert && table === pinTable) {
-          throw new Error('pin insert failed')
-        }
-        stagedInsertValues.push(rows)
-        return {
-          onConflictDoNothing: vi.fn(() => Promise.resolve())
-        }
+        insertValues.push(Array.isArray(vals) ? vals : [vals])
+        return Promise.resolve()
       })
     }))
   }
@@ -65,17 +50,14 @@ function createMockContext(
       reduxState: {
         getCategory: vi.fn((cat: string) => reduxState[cat])
       },
-      dexieSettings: {
-        get: vi.fn((key: string) => sourceData[key])
-      },
       dexieExport: {
         tableExists: vi.fn((table: string) =>
-          Promise.resolve(Array.isArray(sourceData[table]))
+          Promise.resolve(Object.prototype.hasOwnProperty.call(dexieTables, table))
         ),
         createStreamReader: vi.fn((table: string) => ({
           readInBatches: vi.fn(
             async (batchSize: number, callback: (items: unknown[], index: number) => Promise<void>) => {
-              const rows = Array.isArray(sourceData[table]) ? sourceData[table] : []
+              const rows = dexieTables[table] ?? []
               const safeBatchSize = Math.max(batchSize, 1)
 
               for (let index = 0; index < rows.length; index += safeBatchSize) {
@@ -87,22 +69,12 @@ function createMockContext(
       }
     },
     db: {
-      transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
-        stagedInsertValues = []
-        const result = await fn(mockTx)
-        insertValues.push(...stagedInsertValues)
-        return result
-      }),
+      transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(mockTx)),
       select: vi.fn(() => ({
         from: vi.fn((table: unknown) => ({
           get: vi.fn(() =>
             Promise.resolve({
-              count:
-                table === userProviderTable
-                  ? getInsertedProviders().length
-                  : table === pinTable
-                    ? getInsertedPins().length
-                    : getInsertedModels().length
+              count: table === userProviderTable ? getInsertedProviders().length : getInsertedModels().length
             })
           ),
           limit: vi.fn(() => ({
@@ -279,6 +251,805 @@ describe('ProviderModelMigrator', () => {
       expect(result.success).toBe(false)
       expect(result.error).toContain('pin insert failed')
       expect((ctx as unknown as { _insertValues: unknown[][] })._insertValues).toEqual([])
+    })
+
+    it('adds llm default-model references that are missing from provider.models', async () => {
+      const ctx = createMockContext({
+        llm: {
+          providers: [makeProvider('openai', [{ id: 'gpt-4o' }])],
+          defaultModel: {
+            id: 'gpt-5.1',
+            provider: 'openai',
+            name: 'GPT 5.1',
+            group: 'OpenAI'
+          }
+        }
+      })
+      await migrator.prepare(ctx)
+
+      const result = await migrator.execute(ctx)
+
+      expect(result.success).toBe(true)
+      const inserted = (ctx as unknown as { _insertValues: unknown[][] })._insertValues
+      const modelInsert = inserted[1] as Array<Record<string, unknown>>
+      expect(modelInsert.map((row) => row.id)).toEqual(['openai::gpt-4o', 'openai::gpt-5.1'])
+    })
+
+    it('validates collected model counts after execute when references add missing models', async () => {
+      const ctx = createMockContext({
+        llm: {
+          providers: [makeProvider('openai', [{ id: 'gpt-4o' }])],
+          defaultModel: {
+            id: 'gpt-5.1',
+            provider: 'openai',
+            name: 'GPT 5.1',
+            group: 'OpenAI'
+          }
+        }
+      })
+
+      const prepareResult = await migrator.prepare(ctx)
+
+      expect(prepareResult.success).toBe(true)
+      expect(prepareResult.itemCount).toBe(1)
+
+      const executeResult = await migrator.execute(ctx)
+
+      expect(executeResult.success).toBe(true)
+
+      const validateResult = await migrator.validate(ctx)
+
+      expect(validateResult.success).toBe(true)
+      expect(validateResult.errors).toEqual([])
+      expect(validateResult.stats).toEqual({
+        sourceCount: 1,
+        targetCount: 1,
+        skippedCount: 0
+      })
+    })
+
+    it('adds assistant-referenced models that are missing from provider.models', async () => {
+      const providerId = 'a17b6846-e129-4508-b81a-b6e11a5efb85'
+      const ctx = createMockContext({
+        llm: {
+          providers: [makeProvider(providerId, [{ id: 'gpt-4o' }])]
+        },
+        assistants: {
+          assistants: [
+            {
+              id: 'assistant-1',
+              name: 'Assistant',
+              model: {
+                id: '[L]gemini-2.5-pro',
+                provider: providerId,
+                name: 'Gemini 2.5 Pro',
+                group: 'Gemini'
+              }
+            }
+          ],
+          presets: []
+        }
+      })
+      await migrator.prepare(ctx)
+
+      const result = await migrator.execute(ctx)
+
+      expect(result.success).toBe(true)
+      const inserted = (ctx as unknown as { _insertValues: unknown[][] })._insertValues
+      const modelInsert = inserted[1] as Array<Record<string, unknown>>
+      expect(modelInsert.map((row) => row.id)).toEqual([`${providerId}::gpt-4o`, `${providerId}::[L]gemini-2.5-pro`])
+    })
+
+    it('does not collect defaultAssistant models because defaultAssistant is not migrated', async () => {
+      const ctx = createMockContext({
+        llm: {
+          providers: [makeProvider('openai', [{ id: 'gpt-4o' }])]
+        },
+        assistants: {
+          assistants: [],
+          presets: [],
+          defaultAssistant: {
+            id: 'default-assistant',
+            name: 'Default Assistant',
+            model: {
+              id: 'gpt-5.1',
+              provider: 'openai',
+              name: 'GPT 5.1',
+              group: 'OpenAI'
+            }
+          }
+        }
+      })
+      await migrator.prepare(ctx)
+
+      const result = await migrator.execute(ctx)
+
+      expect(result.success).toBe(true)
+      const inserted = (ctx as unknown as { _insertValues: unknown[][] })._insertValues
+      const modelInsert = inserted[1] as Array<Record<string, unknown>>
+      expect(modelInsert.map((row) => row.id)).toEqual(['openai::gpt-4o'])
+    })
+
+    it('adds models referenced by presets, assistant.defaultModel, and assistant.settings.defaultModel', async () => {
+      const ctx = createMockContext({
+        llm: {
+          providers: [makeProvider('openai', [{ id: 'gpt-4o' }])]
+        },
+        assistants: {
+          assistants: [
+            {
+              id: 'assistant-1',
+              name: 'Assistant',
+              defaultModel: {
+                id: 'gpt-5.1-mini',
+                provider: 'openai',
+                name: 'GPT 5.1 Mini',
+                group: 'OpenAI'
+              },
+              settings: {
+                defaultModel: {
+                  id: 'gpt-5.1-nano',
+                  provider: 'openai',
+                  name: 'GPT 5.1 Nano',
+                  group: 'OpenAI'
+                }
+              }
+            }
+          ],
+          presets: [
+            {
+              id: 'preset-1',
+              name: 'Preset',
+              model: {
+                id: 'gpt-5.1',
+                provider: 'openai',
+                name: 'GPT 5.1',
+                group: 'OpenAI'
+              }
+            }
+          ]
+        }
+      })
+      await migrator.prepare(ctx)
+
+      const result = await migrator.execute(ctx)
+
+      expect(result.success).toBe(true)
+      const inserted = (ctx as unknown as { _insertValues: unknown[][] })._insertValues
+      const modelInsert = inserted[1] as Array<Record<string, unknown>>
+      expect(modelInsert.map((row) => row.id)).toEqual([
+        'openai::gpt-4o',
+        'openai::gpt-5.1-mini',
+        'openai::gpt-5.1-nano',
+        'openai::gpt-5.1'
+      ])
+    })
+
+    it('adds models referenced by topicNamingModel, quickModel, and translateModel', async () => {
+      const ctx = createMockContext({
+        llm: {
+          providers: [makeProvider('openai', [{ id: 'gpt-4o' }])],
+          topicNamingModel: {
+            id: 'gpt-5.1-topic',
+            provider: 'openai',
+            name: 'GPT 5.1 Topic',
+            group: 'OpenAI'
+          },
+          quickModel: {
+            id: 'gpt-5.1-quick',
+            provider: 'openai',
+            name: 'GPT 5.1 Quick',
+            group: 'OpenAI'
+          },
+          translateModel: {
+            id: 'gpt-5.1-translate',
+            provider: 'openai',
+            name: 'GPT 5.1 Translate',
+            group: 'OpenAI'
+          }
+        }
+      })
+      await migrator.prepare(ctx)
+
+      const result = await migrator.execute(ctx)
+
+      expect(result.success).toBe(true)
+      const inserted = (ctx as unknown as { _insertValues: unknown[][] })._insertValues
+      const modelInsert = inserted[1] as Array<Record<string, unknown>>
+      expect(modelInsert.map((row) => row.id)).toEqual([
+        'openai::gpt-4o',
+        'openai::gpt-5.1-topic',
+        'openai::gpt-5.1-quick',
+        'openai::gpt-5.1-translate'
+      ])
+    })
+
+    it('salvages composite model ids whose embedded provider is unknown when explicit provider is valid', async () => {
+      const ctx = createMockContext({
+        llm: {
+          providers: [makeProvider('openai', [{ id: 'gpt-4o' }])],
+          defaultModel: {
+            id: 'ghost-provider::gpt-5.1',
+            provider: 'openai',
+            name: 'GPT 5.1',
+            group: 'OpenAI'
+          }
+        }
+      })
+      await migrator.prepare(ctx)
+
+      const result = await migrator.execute(ctx)
+
+      expect(result.success).toBe(true)
+      const inserted = (ctx as unknown as { _insertValues: unknown[][] })._insertValues
+      const modelInsert = inserted[1] as Array<Record<string, unknown>>
+      expect(modelInsert.map((row) => row.id)).toEqual(['openai::gpt-4o', 'openai::gpt-5.1'])
+    })
+
+    it('aggregates unknown-provider references instead of logging each occurrence', async () => {
+      const ctx = createMockContext({
+        llm: {
+          providers: [makeProvider('openai', [{ id: 'gpt-4o' }])],
+          defaultModel: {
+            id: 'ghost-provider::gpt-5.1',
+            provider: 'still-ghost',
+            name: 'Ghost 5.1',
+            group: 'Ghost'
+          }
+        },
+        knowledge: {
+          bases: [
+            {
+              id: 'knowledge-1',
+              name: 'Knowledge',
+              model: {
+                id: 'ghost-provider::bge-m3',
+                provider: 'still-ghost',
+                name: 'Ghost Embed',
+                group: 'Ghost'
+              }
+            }
+          ]
+        }
+      })
+
+      const prepareResult = await migrator.prepare(ctx)
+
+      expect(prepareResult.success).toBe(true)
+      expect(loggerWarnMock).toHaveBeenCalledWith('Skipped model references for unknown providers during migration', {
+        count: 2,
+        samples: [
+          {
+            source: 'llm.defaultModel',
+            providerId: 'ghost-provider',
+            modelId: 'gpt-5.1'
+          },
+          {
+            source: 'knowledge[0]:knowledge-1.model',
+            providerId: 'ghost-provider',
+            modelId: 'bge-m3'
+          }
+        ]
+      })
+    })
+
+    it('adds chat message model references that are missing from provider.models', async () => {
+      const ctx = createMockContext(
+        {
+          llm: {
+            providers: [makeProvider('openai', [{ id: 'gpt-4o' }])]
+          }
+        },
+        {
+          topics: [
+            {
+              id: 'topic-1',
+              messages: [
+                {
+                  id: 'message-1',
+                  role: 'assistant',
+                  model: { id: 'gpt-5.1', provider: 'openai', name: 'GPT 5.1', group: 'OpenAI' }
+                }
+              ]
+            }
+          ]
+        }
+      )
+      await migrator.prepare(ctx)
+
+      const result = await migrator.execute(ctx)
+
+      expect(result.success).toBe(true)
+      const inserted = (ctx as unknown as { _insertValues: unknown[][] })._insertValues
+      const modelInsert = inserted[1] as Array<Record<string, unknown>>
+      expect(modelInsert.map((row) => row.id)).toEqual(['openai::gpt-4o', 'openai::gpt-5.1'])
+    })
+
+    it('adds chat message fallback modelId references that are already composite', async () => {
+      const ctx = createMockContext(
+        {
+          llm: {
+            providers: [makeProvider('openai', [{ id: 'gpt-4o' }])]
+          }
+        },
+        {
+          topics: [
+            {
+              id: 'topic-1',
+              messages: [
+                {
+                  id: 'message-1',
+                  role: 'assistant',
+                  modelId: 'openai::gpt-5.1'
+                }
+              ]
+            }
+          ]
+        }
+      )
+      await migrator.prepare(ctx)
+
+      const result = await migrator.execute(ctx)
+
+      expect(result.success).toBe(true)
+      const inserted = (ctx as unknown as { _insertValues: unknown[][] })._insertValues
+      const modelInsert = inserted[1] as Array<Record<string, unknown>>
+      expect(modelInsert.map((row) => row.id)).toEqual(['openai::gpt-4o', 'openai::gpt-5.1'])
+    })
+
+    it('uses composite message.modelId fallback when message.model points to an unknown provider', async () => {
+      const ctx = createMockContext(
+        {
+          llm: {
+            providers: [makeProvider('openai', [{ id: 'gpt-4o' }])]
+          }
+        },
+        {
+          topics: [
+            {
+              id: 'topic-1',
+              messages: [
+                {
+                  id: 'message-1',
+                  role: 'assistant',
+                  model: { id: 'gpt-5.1', provider: 'ghost-provider', name: 'GPT 5.1', group: 'Ghost' },
+                  modelId: 'openai::gpt-5.1'
+                }
+              ]
+            }
+          ]
+        }
+      )
+      await migrator.prepare(ctx)
+
+      const result = await migrator.execute(ctx)
+
+      expect(result.success).toBe(true)
+      const inserted = (ctx as unknown as { _insertValues: unknown[][] })._insertValues
+      const modelInsert = inserted[1] as Array<Record<string, unknown>>
+      expect(modelInsert.map((row) => row.id)).toEqual(['openai::gpt-4o', 'openai::gpt-5.1'])
+    })
+
+    it('ignores composite message.modelId when message.model already resolves to a different provider model', async () => {
+      const ctx = createMockContext(
+        {
+          llm: {
+            providers: [
+              makeProvider('openai', [{ id: 'gpt-4o' }]),
+              makeProvider('anthropic', [{ id: 'claude-3-5-sonnet' }])
+            ]
+          }
+        },
+        {
+          topics: [
+            {
+              id: 'topic-1',
+              messages: [
+                {
+                  id: 'message-1',
+                  role: 'assistant',
+                  model: { id: 'gpt-4o', provider: 'openai', name: 'GPT 4o', group: 'OpenAI' },
+                  modelId: 'anthropic::claude-3-5-sonnet'
+                }
+              ]
+            }
+          ]
+        }
+      )
+      await migrator.prepare(ctx)
+
+      const result = await migrator.execute(ctx)
+
+      expect(result.success).toBe(true)
+      const inserted = (ctx as unknown as { _insertValues: unknown[][] })._insertValues
+      const openaiModelInsert = inserted[1] as Array<Record<string, unknown>>
+      const anthropicModelInsert = inserted[3] as Array<Record<string, unknown>>
+
+      expect(openaiModelInsert.map((row) => row.id)).toEqual(['openai::gpt-4o'])
+      expect(anthropicModelInsert.map((row) => row.id)).toEqual(['anthropic::claude-3-5-sonnet'])
+    })
+
+    it('does not warn when composite message.modelId matches message.model', async () => {
+      const ctx = createMockContext(
+        {
+          llm: {
+            providers: [makeProvider('openai', [{ id: 'gpt-4o' }])]
+          }
+        },
+        {
+          topics: [
+            {
+              id: 'topic-1',
+              messages: [
+                {
+                  id: 'message-1',
+                  role: 'assistant',
+                  model: { id: 'gpt-4o', provider: 'openai', name: 'GPT 4o', group: 'OpenAI' },
+                  modelId: 'openai::gpt-4o'
+                }
+              ]
+            }
+          ]
+        }
+      )
+
+      const prepareResult = await migrator.prepare(ctx)
+
+      expect(prepareResult.success).toBe(true)
+      expect(loggerWarnMock).not.toHaveBeenCalledWith(
+        'Detected mismatched legacy bare modelId values during migration',
+        expect.anything()
+      )
+    })
+
+    it('skips bare chat message modelId values that have no provider info', async () => {
+      const ctx = createMockContext(
+        {
+          llm: {
+            providers: [makeProvider('openai', [{ id: 'gpt-4o' }])]
+          }
+        },
+        {
+          topics: [
+            {
+              id: 'topic-1',
+              messages: [
+                {
+                  id: 'message-1',
+                  role: 'assistant',
+                  modelId: 'gpt-5.1'
+                }
+              ]
+            }
+          ]
+        }
+      )
+      await migrator.prepare(ctx)
+
+      const result = await migrator.execute(ctx)
+
+      expect(result.success).toBe(true)
+      const inserted = (ctx as unknown as { _insertValues: unknown[][] })._insertValues
+      const modelInsert = inserted[1] as Array<Record<string, unknown>>
+      expect(modelInsert.map((row) => row.id)).toEqual(['openai::gpt-4o'])
+    })
+
+    it('aggregates skipped bare chat message modelId warnings', async () => {
+      const ctx = createMockContext(
+        {
+          llm: {
+            providers: [makeProvider('openai', [{ id: 'gpt-4o' }])]
+          }
+        },
+        {
+          topics: [
+            {
+              id: 'topic-1',
+              messages: [
+                { id: 'message-1', role: 'assistant', modelId: 'gpt-5.1' },
+                { id: 'message-2', role: 'assistant', modelId: 'claude-3.7-sonnet' }
+              ]
+            }
+          ]
+        }
+      )
+
+      const prepareResult = await migrator.prepare(ctx)
+
+      expect(prepareResult.success).toBe(true)
+      expect(loggerWarnMock).toHaveBeenCalledWith('Skipped legacy bare modelId references during migration', {
+        count: 2,
+        samples: ['message-1:gpt-5.1', 'message-2:claude-3.7-sonnet']
+      })
+    })
+
+    it('aggregates skipped bare chat message modelId warnings across dexie batches and caps samples at five', async () => {
+      const ctx = createMockContext(
+        {
+          llm: {
+            providers: [makeProvider('openai', [{ id: 'gpt-4o' }])]
+          }
+        },
+        {
+          topics: Array.from({ length: 101 }, (_, index) => ({
+            id: `topic-${index}`,
+            messages: [{ id: `message-${index}`, role: 'assistant', modelId: `bare-${index}` }]
+          }))
+        }
+      )
+
+      const prepareResult = await migrator.prepare(ctx)
+
+      expect(prepareResult.success).toBe(true)
+      expect(loggerWarnMock).toHaveBeenCalledWith('Skipped legacy bare modelId references during migration', {
+        count: 101,
+        samples: ['message-0:bare-0', 'message-1:bare-1', 'message-2:bare-2', 'message-3:bare-3', 'message-4:bare-4']
+      })
+    })
+
+    it('still registers mentions when a message has only a bare modelId', async () => {
+      const ctx = createMockContext(
+        {
+          llm: {
+            providers: [makeProvider('openai', [{ id: 'gpt-4o' }])]
+          }
+        },
+        {
+          topics: [
+            {
+              id: 'topic-1',
+              messages: [
+                {
+                  id: 'message-1',
+                  role: 'assistant',
+                  modelId: 'gpt-5.1',
+                  mentions: [{ id: 'gpt-5.1', provider: 'openai', name: 'GPT 5.1', group: 'OpenAI' }]
+                }
+              ]
+            }
+          ]
+        }
+      )
+      await migrator.prepare(ctx)
+
+      const result = await migrator.execute(ctx)
+
+      expect(result.success).toBe(true)
+      const inserted = (ctx as unknown as { _insertValues: unknown[][] })._insertValues
+      const modelInsert = inserted[1] as Array<Record<string, unknown>>
+      expect(modelInsert.map((row) => row.id)).toEqual(['openai::gpt-4o', 'openai::gpt-5.1'])
+      expect(loggerWarnMock).toHaveBeenCalledWith('Skipped legacy bare modelId references during migration', {
+        count: 1,
+        samples: ['message-1:gpt-5.1']
+      })
+    })
+
+    it('aggregates mismatched bare modelId warnings when model and modelId disagree', async () => {
+      const ctx = createMockContext(
+        {
+          llm: {
+            providers: [makeProvider('openai', [{ id: 'gpt-4o' }])]
+          }
+        },
+        {
+          topics: [
+            {
+              id: 'topic-1',
+              messages: [
+                {
+                  id: 'message-1',
+                  role: 'assistant',
+                  model: { id: 'gpt-4o', provider: 'openai', name: 'GPT 4o', group: 'OpenAI' },
+                  modelId: 'claude-3.5-sonnet'
+                }
+              ]
+            }
+          ]
+        }
+      )
+
+      const prepareResult = await migrator.prepare(ctx)
+
+      expect(prepareResult.success).toBe(true)
+      expect(loggerWarnMock).toHaveBeenCalledWith('Detected mismatched legacy bare modelId values during migration', {
+        count: 1,
+        samples: [
+          {
+            messageId: 'message-1',
+            modelId: 'claude-3.5-sonnet',
+            messageModelId: 'gpt-4o'
+          }
+        ]
+      })
+    })
+
+    it('registers composite modelId fallback when message.model is incomplete', async () => {
+      const ctx = createMockContext(
+        {
+          llm: {
+            providers: [makeProvider('openai', [{ id: 'gpt-4o' }])]
+          }
+        },
+        {
+          topics: [
+            {
+              id: 'topic-1',
+              messages: [
+                {
+                  id: 'message-1',
+                  role: 'assistant',
+                  model: { id: 'gpt-5.1' },
+                  modelId: 'openai::gpt-5.1'
+                }
+              ]
+            }
+          ]
+        }
+      )
+      await migrator.prepare(ctx)
+
+      const result = await migrator.execute(ctx)
+
+      expect(result.success).toBe(true)
+      const inserted = (ctx as unknown as { _insertValues: unknown[][] })._insertValues
+      const modelInsert = inserted[1] as Array<Record<string, unknown>>
+      expect(modelInsert.map((row) => row.id)).toEqual(['openai::gpt-4o', 'openai::gpt-5.1'])
+    })
+
+    it('tolerates null topics, corrupt messages, and topics with non-array messages field', async () => {
+      const ctx = createMockContext(
+        {
+          llm: {
+            providers: [makeProvider('openai', [{ id: 'gpt-4o' }])]
+          }
+        },
+        {
+          topics: [
+            null,
+            { id: 'topic-broken', messages: 'corrupted' },
+            { id: 'topic-broken-2', messages: [null] },
+            { id: 'topic-ok', messages: undefined }
+          ]
+        }
+      )
+
+      const prepareResult = await migrator.prepare(ctx)
+
+      expect(prepareResult.success).toBe(true)
+      const result = await migrator.execute(ctx)
+      expect(result.success).toBe(true)
+      const inserted = (ctx as unknown as { _insertValues: unknown[][] })._insertValues
+      const modelInsert = inserted[1] as Array<Record<string, unknown>>
+      expect(modelInsert.map((row) => row.id)).toEqual(['openai::gpt-4o'])
+    })
+
+    it('tolerates corrupt assistant and knowledge entries without aborting preparation', async () => {
+      const ctx = createMockContext({
+        llm: {
+          providers: [makeProvider('openai', [{ id: 'gpt-4o' }])],
+          defaultModel: {
+            id: 'gpt-5.1',
+            provider: 'openai',
+            name: 'GPT 5.1',
+            group: 'OpenAI'
+          }
+        },
+        assistants: {
+          assistants: [null, 'corrupted', { id: 'assistant-1', model: { id: 'gpt-5.1-mini', provider: 'openai' } }],
+          presets: [undefined]
+        },
+        knowledge: {
+          bases: [
+            null,
+            42,
+            { id: 'knowledge-1', name: 'Knowledge', model: { id: 'gpt-5.1-embed', provider: 'openai' } }
+          ]
+        }
+      })
+
+      const prepareResult = await migrator.prepare(ctx)
+
+      expect(prepareResult.success).toBe(true)
+      const result = await migrator.execute(ctx)
+      expect(result.success).toBe(true)
+      const inserted = (ctx as unknown as { _insertValues: unknown[][] })._insertValues
+      const modelInsert = inserted[1] as Array<Record<string, unknown>>
+      expect(modelInsert.map((row) => row.id)).toEqual([
+        'openai::gpt-4o',
+        'openai::gpt-5.1',
+        'openai::gpt-5.1-mini',
+        'openai::gpt-5.1-embed'
+      ])
+    })
+
+    it('adds knowledge base model references that are missing from provider.models', async () => {
+      const ctx = createMockContext({
+        llm: {
+          providers: [makeProvider('silicon', [{ id: 'qwen' }])]
+        },
+        knowledge: {
+          bases: [
+            {
+              id: 'knowledge-1',
+              name: 'Knowledge',
+              model: {
+                id: 'BAAI/bge-m3',
+                provider: 'silicon',
+                name: 'BGE M3',
+                group: 'Embedding'
+              },
+              rerankModel: {
+                id: 'BAAI/bge-reranker',
+                provider: 'silicon',
+                name: 'BGE Reranker',
+                group: 'Rerank'
+              }
+            }
+          ]
+        }
+      })
+      await migrator.prepare(ctx)
+
+      const result = await migrator.execute(ctx)
+
+      expect(result.success).toBe(true)
+      const inserted = (ctx as unknown as { _insertValues: unknown[][] })._insertValues
+      const modelInsert = inserted[1] as Array<Record<string, unknown>>
+      expect(modelInsert.map((row) => row.id)).toEqual([
+        'silicon::qwen',
+        'silicon::BAAI/bge-m3',
+        'silicon::BAAI/bge-reranker'
+      ])
+    })
+
+    it('keeps the first provider-owned model definition when later references reuse the same model id', async () => {
+      const ctx = createMockContext({
+        llm: {
+          providers: [
+            {
+              ...makeProvider('openai'),
+              models: [{ id: 'gpt-4o', name: 'Canonical' }]
+            }
+          ]
+        },
+        assistants: {
+          assistants: [
+            {
+              id: 'assistant-1',
+              model: { id: 'gpt-4o', provider: 'openai', name: 'Override' }
+            }
+          ],
+          presets: []
+        }
+      })
+      await migrator.prepare(ctx)
+
+      const result = await migrator.execute(ctx)
+
+      expect(result.success).toBe(true)
+      const inserted = (ctx as unknown as { _insertValues: unknown[][] })._insertValues
+      const modelInsert = inserted[1] as Array<Record<string, unknown>>
+      expect(modelInsert).toHaveLength(1)
+      expect(modelInsert[0]).toMatchObject({
+        id: 'openai::gpt-4o',
+        name: 'Canonical'
+      })
+    })
+
+    it('skips chat model collection when the topics table is absent', async () => {
+      const ctx = createMockContext({
+        llm: {
+          providers: [makeProvider('openai', [{ id: 'gpt-4o' }])]
+        }
+      })
+      await migrator.prepare(ctx)
+
+      const result = await migrator.execute(ctx)
+
+      expect(result.success).toBe(true)
+      const inserted = (ctx as unknown as { _insertValues: unknown[][] })._insertValues
+      const modelInsert = inserted[1] as Array<Record<string, unknown>>
+      expect(modelInsert.map((row) => row.id)).toEqual(['openai::gpt-4o'])
     })
   })
 

--- a/src/main/data/migration/v2/migrators/__tests__/ProviderModelMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/ProviderModelMigrator.test.ts
@@ -1,3 +1,4 @@
+import { pinTable } from '@data/db/schemas/pin'
 import { userProviderTable } from '@data/db/schemas/userProvider'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -24,23 +25,37 @@ vi.mock('@application', async () => {
   return mockApplicationFactory()
 })
 
+interface MockContextOptions {
+  failOnPinInsert?: boolean
+}
+
 function createMockContext(
   reduxState: Record<string, unknown> = {},
-  dexieTables: Record<string, unknown[]> = {}
+  sourceData: Record<string, unknown> = {},
+  options: MockContextOptions = {}
 ): MigrationContext {
   const insertValues: unknown[][] = []
+  let stagedInsertValues: unknown[][] = []
   const flattenInsertedRows = () =>
     insertValues
       .flatMap((batch) => batch)
       .filter((row): row is Record<string, unknown> => !!row && typeof row === 'object')
-  const getInsertedProviders = () => flattenInsertedRows().filter((row) => !Object.hasOwn(row, 'modelId'))
+  const getInsertedProviders = () =>
+    flattenInsertedRows().filter((row) => Object.hasOwn(row, 'providerId') && !Object.hasOwn(row, 'modelId'))
   const getInsertedModels = () => flattenInsertedRows().filter((row) => Object.hasOwn(row, 'modelId'))
+  const getInsertedPins = () => flattenInsertedRows().filter((row) => row.entityType === 'model')
 
   const mockTx = {
-    insert: vi.fn(() => ({
+    insert: vi.fn((table: unknown) => ({
       values: vi.fn((vals: unknown) => {
-        insertValues.push(Array.isArray(vals) ? vals : [vals])
-        return Promise.resolve()
+        const rows = Array.isArray(vals) ? vals : [vals]
+        if (options.failOnPinInsert && table === pinTable) {
+          throw new Error('pin insert failed')
+        }
+        stagedInsertValues.push(rows)
+        return {
+          onConflictDoNothing: vi.fn(() => Promise.resolve())
+        }
       })
     }))
   }
@@ -50,14 +65,15 @@ function createMockContext(
       reduxState: {
         getCategory: vi.fn((cat: string) => reduxState[cat])
       },
+      dexieSettings: {
+        get: vi.fn((key: string) => sourceData[key])
+      },
       dexieExport: {
-        tableExists: vi.fn((table: string) =>
-          Promise.resolve(Object.prototype.hasOwnProperty.call(dexieTables, table))
-        ),
+        tableExists: vi.fn((table: string) => Promise.resolve(Array.isArray(sourceData[table]))),
         createStreamReader: vi.fn((table: string) => ({
           readInBatches: vi.fn(
             async (batchSize: number, callback: (items: unknown[], index: number) => Promise<void>) => {
-              const rows = dexieTables[table] ?? []
+              const rows = Array.isArray(sourceData[table]) ? sourceData[table] : []
               const safeBatchSize = Math.max(batchSize, 1)
 
               for (let index = 0; index < rows.length; index += safeBatchSize) {
@@ -69,18 +85,33 @@ function createMockContext(
       }
     },
     db: {
-      transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(mockTx)),
+      transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+        stagedInsertValues = []
+        const result = await fn(mockTx)
+        insertValues.push(...stagedInsertValues)
+        return result
+      }),
       select: vi.fn(() => ({
-        from: vi.fn((table: unknown) => ({
-          get: vi.fn(() =>
+        from: vi.fn((table: unknown) => {
+          const getCount = vi.fn(() =>
             Promise.resolve({
-              count: table === userProviderTable ? getInsertedProviders().length : getInsertedModels().length
+              count:
+                table === userProviderTable
+                  ? getInsertedProviders().length
+                  : table === pinTable
+                    ? getInsertedPins().length
+                    : getInsertedModels().length
             })
-          ),
-          limit: vi.fn(() => ({
-            all: vi.fn(() => Promise.resolve(table === userProviderTable ? getInsertedProviders().slice(0, 5) : []))
-          }))
-        }))
+          )
+
+          return {
+            get: getCount,
+            where: vi.fn(() => ({ get: getCount })),
+            limit: vi.fn(() => ({
+              all: vi.fn(() => Promise.resolve(table === userProviderTable ? getInsertedProviders().slice(0, 5) : []))
+            }))
+          }
+        })
       }))
     },
     _insertValues: insertValues

--- a/src/main/data/migration/v2/migrators/__tests__/ProviderModelMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/ProviderModelMigrator.test.ts
@@ -1,8 +1,24 @@
 import { pinTable } from '@data/db/schemas/pin'
+import { userProviderTable } from '@data/db/schemas/userProvider'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { MigrationContext } from '../../core/MigrationContext'
 import { ProviderModelMigrator } from '../ProviderModelMigrator'
+
+const { loggerWarnMock } = vi.hoisted(() => ({
+  loggerWarnMock: vi.fn()
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: vi.fn(() => ({
+      info: vi.fn(),
+      warn: loggerWarnMock,
+      error: vi.fn(),
+      debug: vi.fn()
+    }))
+  }
+}))
 
 vi.mock('@application', async () => {
   const { mockApplicationFactory } = await import('@test-mocks/main/application')
@@ -15,11 +31,19 @@ interface MockContextOptions {
 
 function createMockContext(
   reduxState: Record<string, unknown> = {},
-  dexieSettings: Record<string, unknown> = {},
+  sourceData: Record<string, unknown> = {},
   options: MockContextOptions = {}
 ): MigrationContext {
   const insertValues: unknown[][] = []
   let stagedInsertValues: unknown[][] = []
+  const flattenInsertedRows = () =>
+    insertValues
+      .flatMap((batch) => batch)
+      .filter((row): row is Record<string, unknown> => !!row && typeof row === 'object')
+  const getInsertedProviders = () =>
+    flattenInsertedRows().filter((row) => Object.hasOwn(row, 'providerId') && !Object.hasOwn(row, 'modelId'))
+  const getInsertedModels = () => flattenInsertedRows().filter((row) => Object.hasOwn(row, 'modelId'))
+  const getInsertedPins = () => flattenInsertedRows().filter((row) => row.entityType === 'model')
 
   const mockTx = {
     insert: vi.fn((table: unknown) => ({
@@ -42,7 +66,24 @@ function createMockContext(
         getCategory: vi.fn((cat: string) => reduxState[cat])
       },
       dexieSettings: {
-        get: vi.fn((key: string) => dexieSettings[key])
+        get: vi.fn((key: string) => sourceData[key])
+      },
+      dexieExport: {
+        tableExists: vi.fn((table: string) =>
+          Promise.resolve(Array.isArray(sourceData[table]))
+        ),
+        createStreamReader: vi.fn((table: string) => ({
+          readInBatches: vi.fn(
+            async (batchSize: number, callback: (items: unknown[], index: number) => Promise<void>) => {
+              const rows = Array.isArray(sourceData[table]) ? sourceData[table] : []
+              const safeBatchSize = Math.max(batchSize, 1)
+
+              for (let index = 0; index < rows.length; index += safeBatchSize) {
+                await callback(rows.slice(index, index + safeBatchSize), index / safeBatchSize)
+              }
+            }
+          )
+        }))
       }
     },
     db: {
@@ -53,8 +94,20 @@ function createMockContext(
         return result
       }),
       select: vi.fn(() => ({
-        from: vi.fn(() => ({
-          get: vi.fn(() => Promise.resolve({ count: 0 }))
+        from: vi.fn((table: unknown) => ({
+          get: vi.fn(() =>
+            Promise.resolve({
+              count:
+                table === userProviderTable
+                  ? getInsertedProviders().length
+                  : table === pinTable
+                    ? getInsertedPins().length
+                    : getInsertedModels().length
+            })
+          ),
+          limit: vi.fn(() => ({
+            all: vi.fn(() => Promise.resolve(table === userProviderTable ? getInsertedProviders().slice(0, 5) : []))
+          }))
         }))
       }))
     },
@@ -77,6 +130,7 @@ describe('ProviderModelMigrator', () => {
 
   beforeEach(() => {
     migrator = new ProviderModelMigrator()
+    loggerWarnMock.mockClear()
   })
 
   describe('prepare', () => {

--- a/src/main/data/services/__tests__/MessageService.test.ts
+++ b/src/main/data/services/__tests__/MessageService.test.ts
@@ -107,6 +107,25 @@ describe('MessageService', () => {
     await dbh.db.insert(messageTable).values(messages)
   }
 
+  describe('create', () => {
+    it('preserves v2 model foreign keys', async () => {
+      await dbh.db.insert(topicTable).values({ id: 'topic-create' })
+      const modelId = createUniqueModelId('provider-a', 'model-A')
+
+      const message = await messageService.create('topic-create', {
+        role: 'assistant',
+        data: mainText('pending'),
+        status: 'pending',
+        modelId
+      })
+
+      expect(message.modelId).toBe(modelId)
+
+      const [row] = await dbh.db.select().from(messageTable)
+      expect(row.modelId).toBe(modelId)
+    })
+  })
+
   describe('getBranchMessages — regression for raw SQL casing bug', () => {
     it('returns camelCase fields (parentId, siblingsGroupId) for path messages', async () => {
       await seedMultiModelTree()

--- a/src/main/data/services/__tests__/MessageService.test.ts
+++ b/src/main/data/services/__tests__/MessageService.test.ts
@@ -2,7 +2,6 @@ import { messageTable } from '@data/db/schemas/message'
 import { topicTable } from '@data/db/schemas/topic'
 import { userModelTable } from '@data/db/schemas/userModel'
 import { userProviderTable } from '@data/db/schemas/userProvider'
-import { classifySqliteError } from '@data/db/sqliteErrors'
 import { messageService } from '@data/services/MessageService'
 import { BlockType, type MessageData } from '@shared/data/types/message'
 import { createUniqueModelId } from '@shared/data/types/model'
@@ -107,41 +106,6 @@ describe('MessageService', () => {
     ]
     await dbh.db.insert(messageTable).values(messages)
   }
-
-  describe('create', () => {
-    it('persists existing v2 model foreign keys under database constraints', async () => {
-      await dbh.db.insert(topicTable).values({ id: 'topic-create' })
-      const modelId = createUniqueModelId('provider-a', 'model-A')
-
-      const message = await messageService.create('topic-create', {
-        role: 'assistant',
-        data: mainText('pending'),
-        status: 'pending',
-        modelId
-      })
-
-      expect(message.modelId).toBe(modelId)
-
-      const [row] = await dbh.db.select({ modelId: messageTable.modelId }).from(messageTable)
-      expect(row.modelId).toBe(modelId)
-    })
-
-    it('rejects dangling v2 model foreign keys', async () => {
-      await dbh.db.insert(topicTable).values({ id: 'topic-create-missing-model' })
-
-      await expect(
-        messageService.create('topic-create-missing-model', {
-          role: 'assistant',
-          data: mainText('pending'),
-          status: 'pending',
-          modelId: createUniqueModelId('provider-a', 'model-missing')
-        })
-      ).rejects.toSatisfy((error: unknown) => {
-        expect(classifySqliteError(error)).toEqual({ kind: 'foreign_key' })
-        return true
-      })
-    })
-  })
 
   describe('getBranchMessages — regression for raw SQL casing bug', () => {
     it('returns camelCase fields (parentId, siblingsGroupId) for path messages', async () => {

--- a/src/main/data/services/__tests__/MessageService.test.ts
+++ b/src/main/data/services/__tests__/MessageService.test.ts
@@ -2,6 +2,7 @@ import { messageTable } from '@data/db/schemas/message'
 import { topicTable } from '@data/db/schemas/topic'
 import { userModelTable } from '@data/db/schemas/userModel'
 import { userProviderTable } from '@data/db/schemas/userProvider'
+import { classifySqliteError } from '@data/db/sqliteErrors'
 import { messageService } from '@data/services/MessageService'
 import { BlockType, type MessageData } from '@shared/data/types/message'
 import { createUniqueModelId } from '@shared/data/types/model'
@@ -108,7 +109,7 @@ describe('MessageService', () => {
   }
 
   describe('create', () => {
-    it('preserves v2 model foreign keys', async () => {
+    it('persists existing v2 model foreign keys under database constraints', async () => {
       await dbh.db.insert(topicTable).values({ id: 'topic-create' })
       const modelId = createUniqueModelId('provider-a', 'model-A')
 
@@ -121,8 +122,24 @@ describe('MessageService', () => {
 
       expect(message.modelId).toBe(modelId)
 
-      const [row] = await dbh.db.select().from(messageTable)
+      const [row] = await dbh.db.select({ modelId: messageTable.modelId }).from(messageTable)
       expect(row.modelId).toBe(modelId)
+    })
+
+    it('rejects dangling v2 model foreign keys', async () => {
+      await dbh.db.insert(topicTable).values({ id: 'topic-create-missing-model' })
+
+      await expect(
+        messageService.create('topic-create-missing-model', {
+          role: 'assistant',
+          data: mainText('pending'),
+          status: 'pending',
+          modelId: createUniqueModelId('provider-a', 'model-missing')
+        })
+      ).rejects.toSatisfy((error: unknown) => {
+        expect(classifySqliteError(error)).toEqual({ kind: 'foreign_key' })
+        return true
+      })
     })
   })
 


### PR DESCRIPTION
### What this PR does

Before this PR:

Provider/model migration only inserted models from `provider.models`. If assistants, knowledge bases, LLM defaults, or historical chat messages referenced a model missing from that provider list, downstream v2 migrators could treat the model reference as dangling and clear it. The chat model pre-scan also assumed `topic.messages` was always an array.

After this PR:

Provider/model migration now also collects models referenced by LLM default model settings, assistants, presets, knowledge bases, chat messages, valid composite message `modelId` fallbacks, and message mentions. It tolerates non-array `topic.messages` values and adds regression tests for the recovered model-reference paths.

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This keeps the fix inside `ProviderModelMigrator`, where `user_model` rows are created before assistant, knowledge, and chat migrators validate foreign keys. It avoids changing downstream migrators or weakening FK validation.

The following alternatives were considered:

Clearing dangling references downstream was already the existing fallback, but it loses recoverable model associations. Another option was to synthesize missing models in each downstream migrator, but that would duplicate ownership of `user_model` creation.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Focus on v2 migration ordering and model FK preservation. This PR intentionally registers models that are actually referenced by migrated user data even when they are absent from `provider.models`.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix v2 migration to preserve model references used by assistants, knowledge bases, default model settings, and historical chat messages when those models are missing from provider model lists.
- Added better-sqlite3, drizzle-orm, drizzle-kit, and their respective type definitions.
- Updated various esbuild-related packages to their latest versions.
- Enhanced package management for improved compatibility and performance.