### PR TITLE
fix: preserve scroll position when toggling skills

### DIFF
--- a/src/renderer/src/pages/settings/AgentSettings/components/SkillsSettings/SkillsSettings.tsx
+++ b/src/renderer/src/pages/settings/AgentSettings/components/SkillsSettings/SkillsSettings.tsx
@@ -4,7 +4,7 @@ import { useInstalledSkills } from '@renderer/hooks/useSkills'
 import type { InstalledSkill, LocalSkill } from '@types'
 import { Button, Card, type CardProps, Empty, Spin, Switch, Tag } from 'antd'
 import { Plus, Puzzle } from 'lucide-react'
-import { type FC, memo, useCallback, useEffect, useEffectEvent, useMemo, useState } from 'react'
+import { type FC, memo, useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { type AgentOrSessionSettingsProps, SettingsContainer, SettingsItem, SettingsTitle } from '../../shared'
@@ -105,6 +105,7 @@ export const InstalledSkillsSettings: FC<AgentOrSessionSettingsProps> = ({ agent
   const [filter, setFilter] = useState('')
   const [togglingId, setTogglingId] = useState<string | null>(null)
   const [localPlugins, setLocalSkills] = useState<LocalSkill[]>([])
+  const scrollPositionRef = useRef<number>(0)
 
   const workdir = agentBase?.accessible_paths?.[0]
 
@@ -136,11 +137,22 @@ export const InstalledSkillsSettings: FC<AgentOrSessionSettingsProps> = ({ agent
 
   const handleToggle = useCallback(
     async (skill: InstalledSkill, checked: boolean) => {
+      const popup = document.querySelector('.ant-modal-content')
+      const scrollContainer = popup?.querySelector('[data-skills-scroll="true"]')
+      if (scrollContainer) {
+        scrollPositionRef.current = (scrollContainer as HTMLDivElement).scrollTop
+      }
       setTogglingId(skill.id)
       try {
         await toggle(skill.id, checked)
       } finally {
         setTogglingId(null)
+        setTimeout(() => {
+          const sc = popup?.querySelector('[data-skills-scroll="true"]')
+          if (sc) {
+            ;(sc as HTMLDivElement).scrollTop = scrollPositionRef.current
+          }
+        }, 0)
       }
     },
     [toggle]
@@ -149,7 +161,7 @@ export const InstalledSkillsSettings: FC<AgentOrSessionSettingsProps> = ({ agent
   const hasNoResults = filteredSkills.length === 0 && filteredLocal.length === 0
 
   return (
-    <SettingsContainer>
+    <SettingsContainer data-skills-scroll="true">
       <SettingsItem divider={false}>
         <SettingsTitle
           contentAfter={


### PR DESCRIPTION
### What this PR does

Before this PR:
On the skills page in Agent Settings, when toggling a skill on/off, the page automatically scrolls to the top instead of staying at the current position.

After this PR:
The page now preserves the scroll position when toggling a skill, so users stay at their current location in the list.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged): -->

Fixes #

### Why we need it and why it was done in this way

When toggling a skill, the `toggle()` function calls `refresh()` to fetch the updated skills list from the API. This causes the skills state to update, triggering a re-render. The Scrollbar component would then reset its scroll position to 0.

The fix stores the scroll position before the toggle operation and restores it after the toggle completes, using a data attribute selector to find the scroll container.

The following tradeoffs were made:
- Used document.querySelector to find the scroll container for simplicity, as the Scrollbar component doesn't expose its ref easily to child components

The following alternatives were considered:
- Using a ref passed through context - more complex
- Modifying the Scrollbar component to preserve scroll position - more invasive

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

NONE

### Special notes for your reviewer

<!-- optional -->

The fix uses a small delay (setTimeout with 0ms) to ensure the DOM has updated before restoring scroll position, which is necessary because React's state updates are asynchronous.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix: On the skills page in Agent Settings, the page no longer scrolls to the top when toggling a skill on/off. The scroll position is now preserved.
```