### PR TITLE
feat(notify): support image and file attachments across channels

### DIFF
--- a/src/main/mcpServers/__tests__/claw.test.ts
+++ b/src/main/mcpServers/__tests__/claw.test.ts
@@ -303,12 +303,14 @@ describe('ClawServer', () => {
       expect(mockSendMessage).not.toHaveBeenCalled()
     })
 
-    it('should error when message is missing', async () => {
+    it('should error when no payload is provided', async () => {
       const server = createServer()
       const result = await callTool(server, {}, 'notify')
 
       expect(result.isError).toBe(true)
-      expect(result.content[0].text).toContain("'message' is required")
+      expect(result.content[0].text).toContain(
+        "At least one of 'message', 'image_path', 'image_base64', or 'file_path'"
+      )
     })
 
     it('should report partial failures', async () => {
@@ -320,6 +322,119 @@ describe('ClawServer', () => {
 
       expect(result.content[0].text).toContain('1 chat(s)')
       expect(result.content[0].text).toContain('rate limited')
+    })
+
+    it('should send image via sendMedia when image_base64 is provided', async () => {
+      const mockSendMedia = vi.fn().mockResolvedValue(undefined)
+      const adapter = {
+        channelId: 'wx1',
+        notifyChatIds: ['wxid_abc'],
+        sendMessage: mockSendMessage,
+        sendMedia: mockSendMedia
+      }
+      mockGetNotifyAdapters.mockReturnValue([adapter])
+
+      const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+      const server = createServer('agent_1')
+      const result = await callTool(server, { image_base64: pngBytes.toString('base64') }, 'notify')
+
+      expect(mockSendMedia).toHaveBeenCalledTimes(1)
+      expect(mockSendMedia).toHaveBeenCalledWith('wxid_abc', expect.any(Buffer), 'image')
+      const [, bufferArg] = mockSendMedia.mock.calls[0]
+      expect((bufferArg as Buffer).equals(pngBytes)).toBe(true)
+      expect(mockSendMessage).not.toHaveBeenCalled()
+      expect(result.content[0].text).toContain('Image sent to 1 chat(s)')
+    })
+
+    it('should reject when both image_path and image_base64 are supplied', async () => {
+      mockGetNotifyAdapters.mockReturnValue([])
+
+      const server = createServer('agent_1')
+      const result = await callTool(
+        server,
+        { image_path: '/tmp/img.png', image_base64: Buffer.from('x').toString('base64') },
+        'notify'
+      )
+
+      expect(result.isError).toBe(true)
+      expect(result.content[0].text).toContain("only one of 'image_path' or 'image_base64'")
+    })
+
+    it('should require absolute path for image_path', async () => {
+      mockGetNotifyAdapters.mockReturnValue([])
+
+      const server = createServer('agent_1')
+      const result = await callTool(server, { image_path: 'relative/img.png' }, 'notify')
+
+      expect(result.isError).toBe(true)
+      expect(result.content[0].text).toContain('absolute path')
+    })
+
+    it('should send both image and message when provided together', async () => {
+      const mockSendMedia = vi.fn().mockResolvedValue(undefined)
+      const adapter = {
+        channelId: 'wx1',
+        notifyChatIds: ['wxid_abc'],
+        sendMessage: mockSendMessage,
+        sendMedia: mockSendMedia
+      }
+      mockSendMessage.mockResolvedValue(undefined)
+      mockGetNotifyAdapters.mockReturnValue([adapter])
+
+      const server = createServer('agent_1')
+      const result = await callTool(
+        server,
+        { message: 'here is the pic', image_base64: Buffer.from('abc').toString('base64') },
+        'notify'
+      )
+
+      expect(mockSendMedia).toHaveBeenCalledTimes(1)
+      expect(mockSendMessage).toHaveBeenCalledWith('wxid_abc', 'here is the pic')
+      expect(result.content[0].text).toContain('Notification sent to 1 chat(s)')
+      expect(result.content[0].text).toContain('Image sent to 1 chat(s)')
+    })
+
+    it('should send file via sendMedia with basename when file_path is provided', async () => {
+      const fs = await import('node:fs/promises')
+      const nodePath = await import('node:path')
+
+      const tmpFile = `/tmp/cherry-notify-test-${Date.now()}.pdf`
+      const fileBytes = Buffer.from('%PDF-1.4\n%fake pdf\n')
+      await fs.writeFile(tmpFile, fileBytes)
+
+      try {
+        const mockSendMedia = vi.fn().mockResolvedValue(undefined)
+        const adapter = {
+          channelId: 'wx1',
+          notifyChatIds: ['wxid_abc'],
+          sendMessage: mockSendMessage,
+          sendMedia: mockSendMedia
+        }
+        mockGetNotifyAdapters.mockReturnValue([adapter])
+
+        const server = createServer('agent_1')
+        const result = await callTool(server, { file_path: tmpFile }, 'notify')
+
+        expect(mockSendMedia).toHaveBeenCalledTimes(1)
+        const [chatId, bufferArg, mediaType, fileName] = mockSendMedia.mock.calls[0]
+        expect(chatId).toBe('wxid_abc')
+        expect((bufferArg as Buffer).equals(fileBytes)).toBe(true)
+        expect(mediaType).toBe('file')
+        expect(fileName).toBe(nodePath.basename(tmpFile))
+        expect(result.content[0].text).toContain('File sent to 1 chat(s)')
+      } finally {
+        await fs.rm(tmpFile, { force: true })
+      }
+    })
+
+    it('should require absolute path for file_path', async () => {
+      mockGetNotifyAdapters.mockReturnValue([])
+
+      const server = createServer('agent_1')
+      const result = await callTool(server, { file_path: 'relative/doc.pdf' }, 'notify')
+
+      expect(result.isError).toBe(true)
+      expect(result.content[0].text).toContain('absolute path')
     })
   })
 

--- a/src/main/mcpServers/claw.ts
+++ b/src/main/mcpServers/claw.ts
@@ -1,6 +1,10 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
 import { loggerService } from '@logger'
 import { type ChannelConfig, ChannelConfigSchema } from '@main/services/agents/database/schema'
 import { agentService } from '@main/services/agents/services/AgentService'
+import type { ChannelAdapter } from '@main/services/agents/services/channels/ChannelAdapter'
 import { channelManager } from '@main/services/agents/services/channels/ChannelManager'
 import { channelService } from '@main/services/agents/services/ChannelService'
 import { taskService } from '@main/services/agents/services/TaskService'
@@ -83,20 +87,34 @@ const CRON_TOOL: Tool = {
 const NOTIFY_TOOL: Tool = {
   name: 'notify',
   description:
-    'Send a notification message to the user through connected channels (e.g. Telegram). Use this to proactively inform the user about task results, status updates, or any important information.',
+    "Send a notification to the user through connected channels (e.g. Telegram, WeChat). Use to proactively deliver task results, status updates, or files you've generated. Supports optional image attachment (image_path OR image_base64) and/or file attachment (file_path) so images and documents you produce in the agent workspace can be relayed straight to the user's IM client instead of sending URLs. Media delivery currently supported by WeChat.",
   inputSchema: {
     type: 'object',
     properties: {
       message: {
         type: 'string',
-        description: 'The notification message to send to the user'
+        description:
+          'The notification message to send. Optional when an image or file is attached — the attachment is then sent on its own.'
       },
       channel_id: {
         type: 'string',
         description: 'Optional: send to a specific channel only (omit to send to all notify-enabled channels)'
+      },
+      image_path: {
+        type: 'string',
+        description: 'Absolute local file path to an image (PNG/JPEG/GIF/WebP). Mutually exclusive with image_base64.'
+      },
+      image_base64: {
+        type: 'string',
+        description: 'Base64-encoded image bytes (raw or data URI). Mutually exclusive with image_path.'
+      },
+      file_path: {
+        type: 'string',
+        description:
+          'Absolute local file path to a document (PDF, DOCX, etc.) to send as a file attachment. The basename is used as the file name shown to the recipient.'
       }
     },
-    required: ['message']
+    required: []
   }
 }
 
@@ -200,6 +218,109 @@ const CONFIG_TOOL: Tool = {
     },
     required: ['action']
   }
+}
+
+// ── Notify tool helpers ────────────────────────────────────────────────
+// Kept as module-level functions so ClawServer.sendNotification stays short:
+// parse args → build payloads → deliver → format summary.
+
+type NotifyKind = 'text' | 'image' | 'file'
+
+type NotifyPayload = {
+  kind: NotifyKind
+  send: (adapter: ChannelAdapter, chatId: string) => Promise<void>
+}
+
+const NOTIFY_KIND_LABELS: Record<NotifyKind, string> = {
+  text: 'Notification',
+  image: 'Image',
+  file: 'File'
+}
+
+async function buildNotifyPayloads(args: Record<string, unknown>): Promise<NotifyPayload[]> {
+  const message = args.message as string | undefined
+  const imagePath = args.image_path as string | undefined
+  const imageBase64 = args.image_base64 as string | undefined
+  const filePath = args.file_path as string | undefined
+
+  if (imagePath && imageBase64) {
+    throw new McpError(ErrorCode.InvalidParams, "Provide only one of 'image_path' or 'image_base64'")
+  }
+
+  const payloads: NotifyPayload[] = []
+
+  const imageBuffer = await resolveImageBytes(imagePath, imageBase64)
+  if (imageBuffer) {
+    payloads.push({
+      kind: 'image',
+      send: (adapter, chatId) => adapter.sendMedia(chatId, imageBuffer, 'image')
+    })
+  }
+
+  if (filePath) {
+    const file = await resolveFileBytes(filePath)
+    payloads.push({
+      kind: 'file',
+      send: (adapter, chatId) => adapter.sendMedia(chatId, file.buffer, 'file', file.fileName)
+    })
+  }
+
+  if (message) {
+    payloads.push({
+      kind: 'text',
+      send: (adapter, chatId) => adapter.sendMessage(chatId, message)
+    })
+  }
+
+  if (payloads.length === 0) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      "At least one of 'message', 'image_path', 'image_base64', or 'file_path' is required"
+    )
+  }
+
+  return payloads
+}
+
+async function resolveImageBytes(imagePath?: string, imageBase64?: string): Promise<Buffer | undefined> {
+  if (imagePath) return readAbsoluteFile(imagePath, 'image_path')
+  if (!imageBase64) return undefined
+
+  const raw = imageBase64.startsWith('data:') ? (imageBase64.split(',', 2)[1] ?? '') : imageBase64
+  const buffer = Buffer.from(raw, 'base64')
+  if (buffer.length === 0) {
+    throw new McpError(ErrorCode.InvalidParams, "'image_base64' did not decode to any bytes")
+  }
+  return buffer
+}
+
+async function resolveFileBytes(filePath: string): Promise<{ buffer: Buffer; fileName: string }> {
+  const buffer = await readAbsoluteFile(filePath, 'file_path')
+  return { buffer, fileName: path.basename(filePath) }
+}
+
+async function readAbsoluteFile(absPath: string, argName: string): Promise<Buffer> {
+  if (!path.isAbsolute(absPath)) {
+    throw new McpError(ErrorCode.InvalidParams, `'${argName}' must be an absolute path`)
+  }
+  try {
+    return await readFile(absPath)
+  } catch (err) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      `Failed to read ${argName} "${absPath}": ${err instanceof Error ? err.message : String(err)}`
+    )
+  }
+}
+
+function formatNotifyResult(payloads: NotifyPayload[], stats: Record<NotifyKind, number>, errors: string[]): string {
+  const attempted = new Set(payloads.map((p) => p.kind))
+  const parts: string[] = []
+  for (const kind of ['text', 'image', 'file'] as const) {
+    if (attempted.has(kind)) parts.push(`${NOTIFY_KIND_LABELS[kind]} sent to ${stats[kind]} chat(s).`)
+  }
+  if (errors.length > 0) parts.push(`Errors: ${errors.join('; ')}`)
+  return parts.join(' ')
 }
 
 class ClawServer {
@@ -356,16 +477,9 @@ class ClawServer {
     }
   }
 
-  private async sendNotification(args: Record<string, string | undefined>) {
-    const message = args.message
-    if (!message) throw new McpError(ErrorCode.InvalidParams, "'message' is required for notify")
-
-    const targetChannelId = args.channel_id
-    let adapters = channelManager.getAgentAdapters(this.agentId)
-
-    if (targetChannelId) {
-      adapters = adapters.filter((a) => a.channelId === targetChannelId)
-    }
+  private async sendNotification(args: Record<string, unknown>) {
+    const payloads = await buildNotifyPayloads(args)
+    const adapters = this.resolveNotifyAdapters(args.channel_id as string | undefined)
 
     if (adapters.length === 0) {
       return {
@@ -378,36 +492,43 @@ class ClawServer {
       }
     }
 
-    let sent = 0
+    const stats: Record<NotifyKind, number> = { text: 0, image: 0, file: 0 }
     const errors: string[] = []
 
     for (const adapter of adapters) {
       for (const chatId of adapter.notifyChatIds) {
-        try {
-          await adapter.sendMessage(chatId, message)
-          sent++
-        } catch (err) {
-          const errMsg = err instanceof Error ? err.message : String(err)
-          errors.push(`${adapter.channelId}/${chatId}: ${errMsg}`)
-          logger.warn('Failed to send notification', {
-            agentId: this.agentId,
-            channelId: adapter.channelId,
-            chatId,
-            error: errMsg
-          })
+        for (const payload of payloads) {
+          try {
+            await payload.send(adapter, chatId)
+            stats[payload.kind]++
+          } catch (err) {
+            const errMsg = err instanceof Error ? err.message : String(err)
+            errors.push(`${adapter.channelId}/${chatId} (${payload.kind}): ${errMsg}`)
+            logger.warn('Failed to send notification payload', {
+              agentId: this.agentId,
+              channelId: adapter.channelId,
+              chatId,
+              kind: payload.kind,
+              error: errMsg
+            })
+          }
         }
       }
     }
 
-    const parts = [`Notification sent to ${sent} chat(s).`]
-    if (errors.length > 0) {
-      parts.push(`Errors: ${errors.join('; ')}`)
-    }
-
-    logger.info('Notification sent via notify tool', { agentId: this.agentId, sent, errors: errors.length })
+    logger.info('Notification sent via notify tool', {
+      agentId: this.agentId,
+      ...stats,
+      errors: errors.length
+    })
     return {
-      content: [{ type: 'text' as const, text: parts.join(' ') }]
+      content: [{ type: 'text' as const, text: formatNotifyResult(payloads, stats, errors) }]
     }
+  }
+
+  private resolveNotifyAdapters(targetChannelId: string | undefined): ChannelAdapter[] {
+    const adapters = channelManager.getAgentAdapters(this.agentId)
+    return targetChannelId ? adapters.filter((a) => a.channelId === targetChannelId) : adapters
   }
 
   // ── Config tool handlers ──────────────────────────────────────────

--- a/src/main/services/agents/services/channels/ChannelAdapter.ts
+++ b/src/main/services/agents/services/channels/ChannelAdapter.ts
@@ -274,6 +274,13 @@ export abstract class ChannelAdapter extends EventEmitter {
   abstract sendTypingIndicator(chatId: string): Promise<void>
 
   /**
+   * Send a binary media payload (image or file) to a chat. Adapters that
+   * don't support media delivery should keep the default throw-implementation
+   * so the caller (MCP notify tool) can surface a clear error. Subclasses that
+   * support it override this method.
+   */
+  abstract sendMedia(chatId: string, data: Buffer, mediaType: 'image' | 'file', fileName?: string): Promise<void>
+  /**
    * Called on every text update during streaming. The adapter decides
    * internally when/how to flush to the platform (throttle, mutex, etc.).
    * @param fullText - The full cumulative response text so far.

--- a/src/main/services/agents/services/channels/__tests__/ChannelManager.test.ts
+++ b/src/main/services/agents/services/channels/__tests__/ChannelManager.test.ts
@@ -38,6 +38,7 @@ class MockAdapter extends ChannelAdapter {
   disconnect = vi.fn().mockResolvedValue(undefined)
   sendMessage = vi.fn().mockResolvedValue(undefined)
   sendTypingIndicator = vi.fn().mockResolvedValue(undefined)
+  sendMedia = vi.fn().mockResolvedValue(undefined)
 
   protected async performConnect(): Promise<void> {}
   protected async performDisconnect(): Promise<void> {}

--- a/src/main/services/agents/services/channels/adapters/__tests__/FeishuAdapter.test.ts
+++ b/src/main/services/agents/services/channels/adapters/__tests__/FeishuAdapter.test.ts
@@ -29,12 +29,17 @@ const mockCardSettings = vi.fn().mockResolvedValue({ code: 0 })
 const mockCardUpdate = vi.fn().mockResolvedValue({ code: 0 })
 const mockElementContent = vi.fn().mockResolvedValue({ code: 0 })
 
+const mockImImageCreate = vi.fn()
+const mockImFileCreate = vi.fn()
+
 const mockClient = {
   im: {
     message: {
       create: mockImCreate,
       update: mockImUpdate
-    }
+    },
+    image: { create: mockImImageCreate },
+    file: { create: mockImFileCreate }
   },
   cardkit: {
     v1: {
@@ -76,6 +81,8 @@ describe('FeishuAdapter', () => {
   beforeEach(() => {
     mockImCreate.mockClear().mockResolvedValue({ code: 0, data: { message_id: 'msg-1' } })
     mockImUpdate.mockClear().mockResolvedValue({ code: 0 })
+    mockImImageCreate.mockClear().mockResolvedValue({ image_key: 'img_key_stub' })
+    mockImFileCreate.mockClear().mockResolvedValue({ file_key: 'file_key_stub' })
     mockCardCreate.mockClear().mockResolvedValue({ code: 0, data: { card_id: 'card-1' } })
     mockCardSettings.mockClear().mockResolvedValue({ code: 0 })
     mockCardUpdate.mockClear().mockResolvedValue({ code: 0 })
@@ -380,5 +387,57 @@ describe('FeishuAdapter', () => {
   it('sets notifyChatIds from allowed_chat_ids', () => {
     const adapter = createAdapter({ allowed_chat_ids: ['oc_a', 'oc_b'] })
     expect(adapter.notifyChatIds).toEqual(['oc_a', 'oc_b'])
+  })
+
+  it('sendMedia(image) uploads via im.image.create then posts an image message', async () => {
+    const adapter = createAdapter()
+    await adapter.connect()
+
+    const buf = Buffer.from([0x89, 0x50, 0x4e, 0x47])
+    await adapter.sendMedia('oc_123', buf, 'image')
+
+    expect(mockImImageCreate).toHaveBeenCalledWith({ data: { image_type: 'message', image: buf } })
+    const msgCall = mockImCreate.mock.calls.at(-1)!
+    expect(msgCall[0]).toMatchObject({
+      params: { receive_id_type: 'chat_id' },
+      data: { receive_id: 'oc_123', msg_type: 'image', content: JSON.stringify({ image_key: 'img_key_stub' }) }
+    })
+  })
+
+  it('sendMedia(file) uploads via im.file.create with derived file_type, then posts a file message', async () => {
+    const adapter = createAdapter()
+    await adapter.connect()
+
+    const buf = Buffer.from('pdf-body')
+    await adapter.sendMedia('oc_123', buf, 'file', 'report.pdf')
+
+    expect(mockImFileCreate).toHaveBeenCalledWith({
+      data: { file_type: 'pdf', file_name: 'report.pdf', file: buf }
+    })
+    const msgCall = mockImCreate.mock.calls.at(-1)!
+    expect(msgCall[0]).toMatchObject({
+      params: { receive_id_type: 'chat_id' },
+      data: { receive_id: 'oc_123', msg_type: 'file', content: JSON.stringify({ file_key: 'file_key_stub' }) }
+    })
+  })
+
+  it('sendMedia(file) falls back to file_type "stream" for unknown extensions', async () => {
+    const adapter = createAdapter()
+    await adapter.connect()
+
+    await adapter.sendMedia('oc_123', Buffer.from('x'), 'file', 'archive.zip')
+
+    expect(mockImFileCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ file_type: 'stream', file_name: 'archive.zip' })
+      })
+    )
+  })
+
+  it('sendMedia(file) throws when fileName is missing', async () => {
+    const adapter = createAdapter()
+    await adapter.connect()
+
+    await expect(adapter.sendMedia('oc_123', Buffer.from('x'), 'file')).rejects.toThrow(/fileName is required/)
   })
 })

--- a/src/main/services/agents/services/channels/adapters/__tests__/SlackAdapter.test.ts
+++ b/src/main/services/agents/services/channels/adapters/__tests__/SlackAdapter.test.ts
@@ -686,6 +686,62 @@ describe('SlackAdapter', () => {
 
   // ─── User Name Resolution ────────────────────────────────
 
+  it('sendMedia() runs files.uploadV2 three-step flow and completes into channel', async () => {
+    const adapter = await connectAdapter()
+
+    const calls: string[] = []
+    mockNetFetch.mockImplementation((url: string) => {
+      calls.push(url)
+      if (url.includes('auth.test')) {
+        return Promise.resolve(mockJsonResponse({ ok: true, user_id: BOT_USER_ID }))
+      }
+      if (url.includes('files.getUploadURLExternal')) {
+        return Promise.resolve(
+          mockJsonResponse({ ok: true, upload_url: 'https://files.slack/upload/abc', file_id: 'F123' })
+        )
+      }
+      if (url.includes('/upload/abc')) {
+        return Promise.resolve(mockJsonResponse({ ok: true }))
+      }
+      if (url.includes('files.completeUploadExternal')) {
+        return Promise.resolve(mockJsonResponse({ ok: true }))
+      }
+      return Promise.resolve(mockJsonResponse({ ok: true }))
+    })
+
+    await adapter.sendMedia('C0ALLOWED', Buffer.from('abcd'), 'file', 'report.pdf')
+
+    expect(calls.some((u) => u.includes('files.getUploadURLExternal'))).toBe(true)
+    expect(calls.some((u) => u.includes('/upload/abc'))).toBe(true)
+    expect(calls.some((u) => u.includes('files.completeUploadExternal'))).toBe(true)
+
+    const completeCall = mockNetFetch.mock.calls.find((c: unknown[]) =>
+      (c[0] as string).includes('files.completeUploadExternal')
+    )
+    const body = JSON.parse(completeCall![1].body) as {
+      files: { id: string; title: string }[]
+      channel_id: string
+    }
+    expect(body.files).toEqual([{ id: 'F123', title: 'report.pdf' }])
+    expect(body.channel_id).toBe('C0ALLOWED')
+  })
+
+  it('sendMedia() throws when Slack rejects the reservation', async () => {
+    const adapter = await connectAdapter()
+
+    mockNetFetch.mockImplementation((url: string) => {
+      if (url.includes('auth.test')) {
+        return Promise.resolve(mockJsonResponse({ ok: true, user_id: BOT_USER_ID }))
+      }
+      if (url.includes('files.getUploadURLExternal')) {
+        return Promise.resolve(mockJsonResponse({ ok: false, error: 'invalid_auth' }))
+      }
+      return Promise.resolve(mockJsonResponse({ ok: true }))
+    })
+
+    await expect(adapter.sendMedia('C0ALLOWED', Buffer.from('x'), 'image')).rejects.toThrow(/invalid_auth/)
+  })
+
   it('caches user names across messages', async () => {
     const adapter = await connectAdapter()
     const messageSpy = vi.fn()

--- a/src/main/services/agents/services/channels/adapters/__tests__/TelegramAdapter.test.ts
+++ b/src/main/services/agents/services/channels/adapters/__tests__/TelegramAdapter.test.ts
@@ -18,19 +18,32 @@ const mockBot = {
   api: {
     setMyCommands: vi.fn().mockResolvedValue(undefined),
     sendMessage: vi.fn().mockResolvedValue(undefined),
-    sendChatAction: vi.fn().mockResolvedValue(undefined)
+    sendChatAction: vi.fn().mockResolvedValue(undefined),
+    sendPhoto: vi.fn().mockResolvedValue(undefined),
+    sendDocument: vi.fn().mockResolvedValue(undefined)
   },
   catch: vi.fn(),
   start: vi.fn().mockResolvedValue(undefined),
   stop: vi.fn().mockResolvedValue(undefined)
 }
 
-vi.mock('grammy', () => ({
-  Bot: vi.fn().mockImplementation(() => mockBot)
-}))
+vi.mock('grammy', () => {
+  class FakeInputFile {
+    constructor(
+      public source: unknown,
+      public filename?: string
+    ) {}
+  }
+  return {
+    Bot: vi.fn().mockImplementation(() => mockBot),
+    InputFile: FakeInputFile
+  }
+})
 
 // Import the module to trigger self-registration side effect
 import '../telegram/TelegramAdapter'
+
+type FakeInputFile = { source: unknown; filename?: string }
 
 import { registerAdapterFactory } from '../../ChannelManager'
 
@@ -49,6 +62,8 @@ describe('TelegramAdapter', () => {
     mockBot.api.setMyCommands.mockClear().mockResolvedValue(undefined)
     mockBot.api.sendMessage.mockClear().mockResolvedValue(undefined)
     mockBot.api.sendChatAction.mockClear().mockResolvedValue(undefined)
+    mockBot.api.sendPhoto.mockClear().mockResolvedValue(undefined)
+    mockBot.api.sendDocument.mockClear().mockResolvedValue(undefined)
     mockBot.catch.mockClear()
     mockBot.start.mockClear().mockResolvedValue(undefined)
     mockBot.stop.mockClear().mockResolvedValue(undefined)
@@ -244,5 +259,39 @@ describe('TelegramAdapter', () => {
       userName: 'TestUser',
       text: 'Hello bot'
     })
+  })
+
+  it('sendMedia(image) calls bot.api.sendPhoto with an InputFile wrapping the buffer', async () => {
+    const adapter = createAdapter()
+    await adapter.connect()
+
+    const buf = Buffer.from([0x89, 0x50, 0x4e, 0x47]) // PNG magic
+    await adapter.sendMedia('123', buf, 'image')
+
+    expect(mockBot.api.sendPhoto).toHaveBeenCalledTimes(1)
+    const [chatId, inputFile] = mockBot.api.sendPhoto.mock.calls[0]
+    expect(chatId).toBe('123')
+    expect((inputFile as FakeInputFile).source).toBe(buf)
+    expect((inputFile as FakeInputFile).filename).toBe('image.png')
+    expect(mockBot.api.sendDocument).not.toHaveBeenCalled()
+  })
+
+  it('sendMedia(file) calls bot.api.sendDocument with the provided filename', async () => {
+    const adapter = createAdapter()
+    await adapter.connect()
+
+    const buf = Buffer.from('abc')
+    await adapter.sendMedia('123', buf, 'file', 'report.pdf')
+
+    expect(mockBot.api.sendDocument).toHaveBeenCalledTimes(1)
+    const [, inputFile] = mockBot.api.sendDocument.mock.calls[0]
+    expect((inputFile as FakeInputFile).filename).toBe('report.pdf')
+  })
+
+  it('sendMedia(file) throws when fileName is missing', async () => {
+    const adapter = createAdapter()
+    await adapter.connect()
+
+    await expect(adapter.sendMedia('123', Buffer.from('x'), 'file')).rejects.toThrow(/fileName is required/)
   })
 })

--- a/src/main/services/agents/services/channels/adapters/__tests__/WeChatAdapter.test.ts
+++ b/src/main/services/agents/services/channels/adapters/__tests__/WeChatAdapter.test.ts
@@ -36,7 +36,9 @@ const mockBot = {
   send: vi.fn().mockResolvedValue(undefined),
   reply: vi.fn().mockResolvedValue(undefined),
   sendTyping: vi.fn().mockResolvedValue(undefined),
-  stopTyping: vi.fn().mockResolvedValue(undefined)
+  stopTyping: vi.fn().mockResolvedValue(undefined),
+  sendImage: vi.fn().mockResolvedValue(undefined),
+  sendFile: vi.fn().mockResolvedValue(undefined)
 }
 
 vi.mock('../wechat/WeChatProtocol', () => ({
@@ -69,6 +71,8 @@ describe('WeChatAdapter', () => {
     mockBot.reply.mockClear().mockResolvedValue(undefined)
     mockBot.sendTyping.mockClear().mockResolvedValue(undefined)
     mockBot.stopTyping.mockClear().mockResolvedValue(undefined)
+    mockBot.sendImage.mockClear().mockResolvedValue(undefined)
+    mockBot.sendFile.mockClear().mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -212,6 +216,35 @@ describe('WeChatAdapter', () => {
     })
 
     expect(messageSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('sendMedia() routes image to bot.sendImage()', async () => {
+    const adapter = createAdapter()
+    await adapter.connect()
+
+    const buf = Buffer.from([0x89, 0x50, 0x4e, 0x47])
+    await adapter.sendMedia('user-123', buf, 'image')
+
+    expect(mockBot.sendImage).toHaveBeenCalledWith('user-123', buf)
+    expect(mockBot.sendFile).not.toHaveBeenCalled()
+  })
+
+  it('sendMedia() routes file to bot.sendFile() with fileName', async () => {
+    const adapter = createAdapter()
+    await adapter.connect()
+
+    const buf = Buffer.from('hello')
+    await adapter.sendMedia('user-123', buf, 'file', 'report.pdf')
+
+    expect(mockBot.sendFile).toHaveBeenCalledWith('user-123', buf, 'report.pdf')
+    expect(mockBot.sendImage).not.toHaveBeenCalled()
+  })
+
+  it('sendMedia() rejects file without fileName', async () => {
+    const adapter = createAdapter()
+    await adapter.connect()
+
+    await expect(adapter.sendMedia('user-123', Buffer.from('x'), 'file')).rejects.toThrow(/fileName is required/)
   })
 
   it('/whoami command replies with user info', async () => {

--- a/src/main/services/agents/services/channels/adapters/discord/DiscordAdapter.ts
+++ b/src/main/services/agents/services/channels/adapters/discord/DiscordAdapter.ts
@@ -14,7 +14,7 @@ import {
 import { registerAdapterFactory } from '../../ChannelManager'
 import { isSlashCommand, SLASH_COMMANDS } from '../../constants'
 import { FlushController } from '../../FlushController'
-import { splitMessage } from '../../utils'
+import { detectImageExtension, detectImageMime, mimeFromFileName, splitMessage } from '../../utils'
 
 const DISCORD_API_BASE = 'https://discord.com/api/v10'
 const DISCORD_MAX_LENGTH = 2000
@@ -703,6 +703,47 @@ class DiscordAdapter extends ChannelAdapter {
       })
     } catch {
       // Typing indicator is best-effort
+    }
+  }
+
+  override async sendMedia(
+    chatId: string,
+    data: Buffer,
+    mediaType: 'image' | 'file',
+    fileName?: string
+  ): Promise<void> {
+    const channelId = chatId.split(':')[1]
+    if (!channelId) {
+      throw new Error(`Invalid Discord chatId: ${chatId}`)
+    }
+
+    let uploadName: string
+    let mime: string
+    if (mediaType === 'image') {
+      uploadName = fileName ?? `image.${detectImageExtension(data)}`
+      mime = detectImageMime(data)
+    } else {
+      if (!fileName) throw new Error('fileName is required when sending a file to Discord')
+      uploadName = fileName
+      mime = mimeFromFileName(fileName)
+    }
+
+    const form = new FormData()
+    form.append('payload_json', JSON.stringify({ attachments: [{ id: 0, filename: uploadName }] }))
+    form.append('files[0]', new Blob([new Uint8Array(data)], { type: mime }), uploadName)
+
+    const response = await net.fetch(`${DISCORD_API_BASE}/channels/${channelId}/messages`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bot ${this.botToken}`,
+        'User-Agent': USER_AGENT
+      },
+      body: form
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => '')
+      throw new Error(`Discord media upload failed: HTTP ${response.status} - ${errorText}`)
     }
   }
 

--- a/src/main/services/agents/services/channels/adapters/feishu/FeishuAdapter.ts
+++ b/src/main/services/agents/services/channels/adapters/feishu/FeishuAdapter.ts
@@ -193,6 +193,31 @@ function buildPostPayload(text: string): string {
   })
 }
 
+/** Feishu's im.file.create only accepts a small enum — map by extension, default to 'stream'. */
+type FeishuFileType = 'opus' | 'mp4' | 'pdf' | 'doc' | 'xls' | 'ppt' | 'stream'
+function deriveFeishuFileType(fileName: string): FeishuFileType {
+  const ext = fileName.includes('.') ? fileName.split('.').pop()!.toLowerCase() : ''
+  switch (ext) {
+    case 'pdf':
+      return 'pdf'
+    case 'doc':
+    case 'docx':
+      return 'doc'
+    case 'xls':
+    case 'xlsx':
+      return 'xls'
+    case 'ppt':
+    case 'pptx':
+      return 'ppt'
+    case 'mp4':
+      return 'mp4'
+    case 'opus':
+      return 'opus'
+    default:
+      return 'stream'
+  }
+}
+
 const STREAMING_ELEMENT_ID = 'streaming_content'
 
 /** Throttle interval for CardKit streaming updates (ms). */
@@ -637,6 +662,76 @@ class FeishuAdapter extends ChannelAdapter {
     void _chatId
     // Feishu doesn't have a native typing indicator API.
     // The streaming card itself serves as a visual indicator.
+  }
+
+  /**
+   * Send an image or file to a Feishu chat via the Open Platform:
+   *   1. Upload the bytes with im.image.create / im.file.create → returns image_key / file_key
+   *   2. Post an image or file message carrying that key
+   *
+   * im.file.create requires a typed `file_type` enum; for arbitrary documents
+   * (docx/txt/zip/...) we fall back to 'stream', which the SDK accepts.
+   */
+  override async sendMedia(
+    chatId: string,
+    data: Buffer,
+    mediaType: 'image' | 'file',
+    fileName?: string
+  ): Promise<void> {
+    if (!this.client) {
+      throw new Error('Client is not connected')
+    }
+
+    if (mediaType === 'image') {
+      const uploadResp = await this.client.im.image.create({
+        data: { image_type: 'message', image: data }
+      })
+      const imageKey = uploadResp?.image_key
+      if (!imageKey) {
+        throw new Error('Feishu image upload returned no image_key')
+      }
+
+      ensureFeishuSuccess(
+        await this.client.im.message.create({
+          params: { receive_id_type: 'chat_id' },
+          data: {
+            receive_id: chatId,
+            msg_type: 'image',
+            content: JSON.stringify({ image_key: imageKey })
+          }
+        }),
+        'Send Feishu image'
+      )
+      return
+    }
+
+    if (!fileName) {
+      throw new Error('fileName is required when sending a file to Feishu')
+    }
+
+    const uploadResp = await this.client.im.file.create({
+      data: {
+        file_type: deriveFeishuFileType(fileName),
+        file_name: fileName,
+        file: data
+      }
+    })
+    const fileKey = uploadResp?.file_key
+    if (!fileKey) {
+      throw new Error('Feishu file upload returned no file_key')
+    }
+
+    ensureFeishuSuccess(
+      await this.client.im.message.create({
+        params: { receive_id_type: 'chat_id' },
+        data: {
+          receive_id: chatId,
+          msg_type: 'file',
+          content: JSON.stringify({ file_key: fileKey })
+        }
+      }),
+      'Send Feishu file'
+    )
   }
 
   override async onTextUpdate(chatId: string, fullText: string): Promise<void> {

--- a/src/main/services/agents/services/channels/adapters/qq/QQAdapter.ts
+++ b/src/main/services/agents/services/channels/adapters/qq/QQAdapter.ts
@@ -16,6 +16,11 @@ import { splitMessage } from '../../utils'
 const QQ_MAX_LENGTH = 2000
 const QQ_API_BASE = 'https://api.sgroup.qq.com'
 
+// Rich-media file_type enum for /v2/{users|groups}/{id}/files
+// (openclaw-qqbot MediaFileType: IMAGE=1, VIDEO=2, VOICE=3, FILE=4)
+const QQ_MEDIA_FILE_TYPE_IMAGE = 1
+const QQ_MEDIA_FILE_TYPE_FILE = 4
+
 // QQ Bot WebSocket opcodes
 const OP_DISPATCH = 0
 const OP_HEARTBEAT = 1
@@ -558,6 +563,60 @@ class QQAdapter extends ChannelAdapter {
     // QQ Bot API does not support typing indicators for most message types
     // For C2C, there's sendC2CInputNotify but it requires message_id context
     // This is a no-op
+  }
+
+  /**
+   * Upload rich media to the QQ open-platform CDN and push a media message.
+   * Protocol mirrors tencent-connect/openclaw-qqbot's simple-upload path:
+   *   1. POST /v2/{users|groups}/{id}/files  with { file_type, file_data (base64), file_name?, srv_send_msg: false }
+   *      → { file_info }
+   *   2. POST /v2/{users|groups}/{id}/messages  with { msg_type: 7, media: { file_info }, msg_seq }
+   *
+   * Supported chat types: c2c, group. `channel` and `dm` (guild API) don't share
+   * this endpoint — we'd need the older guild-side rich-media flow.
+   */
+  override async sendMedia(
+    chatId: string,
+    data: Buffer,
+    mediaType: 'image' | 'file',
+    fileName?: string
+  ): Promise<void> {
+    const [type, id] = chatId.split(':')
+    if ((type !== 'c2c' && type !== 'group') || !id) {
+      throw new Error(`QQ sendMedia only supports 'c2c:' and 'group:' chats, got "${chatId}"`)
+    }
+    if (mediaType === 'file' && !fileName) {
+      throw new Error('fileName is required when sending a file to QQ')
+    }
+
+    const fileType = mediaType === 'image' ? QQ_MEDIA_FILE_TYPE_IMAGE : QQ_MEDIA_FILE_TYPE_FILE
+    const body: Record<string, unknown> = {
+      file_type: fileType,
+      file_data: data.toString('base64'),
+      srv_send_msg: false
+    }
+    if (mediaType === 'file') {
+      body.file_name = fileName
+    }
+
+    const uploadEndpoint =
+      type === 'c2c' ? `${QQ_API_BASE}/v2/users/${id}/files` : `${QQ_API_BASE}/v2/groups/${id}/files`
+    const uploadResp = await this.apiRequest(uploadEndpoint, { method: 'POST', body })
+    const uploadData = (await uploadResp.json()) as { file_info?: string }
+    if (!uploadData.file_info) {
+      throw new Error('QQ media upload returned no file_info')
+    }
+
+    const messageEndpoint =
+      type === 'c2c' ? `${QQ_API_BASE}/v2/users/${id}/messages` : `${QQ_API_BASE}/v2/groups/${id}/messages`
+    await this.apiRequest(messageEndpoint, {
+      method: 'POST',
+      body: {
+        msg_type: 7,
+        media: { file_info: uploadData.file_info },
+        msg_seq: Math.floor(Math.random() * 1_000_000) + 1
+      }
+    })
   }
 
   private cleanup(): void {

--- a/src/main/services/agents/services/channels/adapters/slack/SlackAdapter.ts
+++ b/src/main/services/agents/services/channels/adapters/slack/SlackAdapter.ts
@@ -12,7 +12,7 @@ import {
 import { registerAdapterFactory } from '../../ChannelManager'
 import { isSlashCommand } from '../../constants'
 import { FlushController } from '../../FlushController'
-import { splitMessage } from '../../utils'
+import { detectImageExtension, detectImageMime, mimeFromFileName, splitMessage } from '../../utils'
 import { toSlackMarkdown } from './slackMarkdown'
 
 const SLACK_API_BASE = 'https://slack.com/api'
@@ -557,6 +557,62 @@ class SlackAdapter extends ChannelAdapter {
   async sendTypingIndicator(_chatId: string): Promise<void> {
     // Slack doesn't have a public "typing" API for bots.
     // Acknowledgment is handled via reactions in handleEvent() instead.
+  }
+
+  /**
+   * Upload a file via Slack's 3-step files.uploadV2 flow:
+   *   1. files.getUploadURLExternal — reserves an upload URL for (filename, length)
+   *   2. POST the bytes to that URL
+   *   3. files.completeUploadExternal — finalizes and shares into the target channel
+   */
+  override async sendMedia(
+    chatId: string,
+    data: Buffer,
+    mediaType: 'image' | 'file',
+    fileName?: string
+  ): Promise<void> {
+    let uploadName: string
+    let mime: string
+    if (mediaType === 'image') {
+      uploadName = fileName ?? `image.${detectImageExtension(data)}`
+      mime = detectImageMime(data)
+    } else {
+      if (!fileName) throw new Error('fileName is required when sending a file to Slack')
+      uploadName = fileName
+      mime = mimeFromFileName(fileName)
+    }
+
+    const getUrl = new URLSearchParams({ filename: uploadName, length: String(data.length) })
+    const getResp = await net.fetch(`${SLACK_API_BASE}/files.getUploadURLExternal?${getUrl}`, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${this.botToken}` }
+    })
+    if (!getResp.ok) {
+      throw new Error(`Slack files.getUploadURLExternal: HTTP ${getResp.status}`)
+    }
+    const { ok, error, upload_url, file_id } = (await getResp.json()) as {
+      ok: boolean
+      error?: string
+      upload_url?: string
+      file_id?: string
+    }
+    if (!ok || !upload_url || !file_id) {
+      throw new Error(`Slack files.getUploadURLExternal: ${error ?? 'missing upload_url/file_id'}`)
+    }
+
+    const uploadResp = await net.fetch(upload_url, {
+      method: 'POST',
+      headers: { 'Content-Type': mime },
+      body: new Uint8Array(data)
+    })
+    if (!uploadResp.ok) {
+      throw new Error(`Slack CDN upload failed: HTTP ${uploadResp.status}`)
+    }
+
+    await this.apiRequest('files.completeUploadExternal', {
+      files: [{ id: file_id, title: uploadName }],
+      channel_id: chatId
+    })
   }
 
   // ─── Streaming ─────────────────────────────────────────────

--- a/src/main/services/agents/services/channels/adapters/telegram/TelegramAdapter.ts
+++ b/src/main/services/agents/services/channels/adapters/telegram/TelegramAdapter.ts
@@ -1,4 +1,4 @@
-import { Bot } from 'grammy'
+import { Bot, InputFile } from 'grammy'
 import { convert as toMarkdownV2 } from 'telegram-markdown-v2'
 
 import {
@@ -12,10 +12,9 @@ import {
   type SendMessageOptions
 } from '../../ChannelAdapter'
 import { registerAdapterFactory } from '../../ChannelManager'
+import { detectImageExtension, splitMessage } from '../../utils'
 
 const TELEGRAM_MAX_LENGTH = 4096
-
-import { splitMessage } from '../../utils'
 
 class TelegramAdapter extends ChannelAdapter {
   private bot: Bot | null = null
@@ -273,6 +272,28 @@ class TelegramAdapter extends ChannelAdapter {
     }
 
     await this.bot.api.sendChatAction(chatId, 'typing')
+  }
+
+  override async sendMedia(
+    chatId: string,
+    data: Buffer,
+    mediaType: 'image' | 'file',
+    fileName?: string
+  ): Promise<void> {
+    if (!this.bot) {
+      throw new Error('Bot is not connected')
+    }
+
+    if (mediaType === 'image') {
+      const name = fileName ?? `image.${detectImageExtension(data)}`
+      await this.bot.api.sendPhoto(chatId, new InputFile(data, name))
+      return
+    }
+
+    if (!fileName) {
+      throw new Error('fileName is required when sending a file to Telegram')
+    }
+    await this.bot.api.sendDocument(chatId, new InputFile(data, fileName))
   }
 }
 

--- a/src/main/services/agents/services/channels/adapters/wechat/WeChatAdapter.ts
+++ b/src/main/services/agents/services/channels/adapters/wechat/WeChatAdapter.ts
@@ -116,6 +116,27 @@ class WeChatAdapter extends ChannelAdapter {
     }
   }
 
+  override async sendMedia(
+    chatId: string,
+    data: Buffer,
+    mediaType: 'image' | 'file',
+    fileName?: string
+  ): Promise<void> {
+    if (!this.bot) {
+      throw new Error('Bot is not connected')
+    }
+
+    if (mediaType === 'image') {
+      await this.bot.sendImage(chatId, data)
+      return
+    }
+
+    if (!fileName) {
+      throw new Error('fileName is required when sending a file to WeChat')
+    }
+    await this.bot.sendFile(chatId, data, fileName)
+  }
+
   private sendQrToRenderer(
     url: string,
     status: 'pending' | 'confirmed' | 'expired' | 'disconnected',

--- a/src/main/services/agents/services/channels/adapters/wechat/WeChatProtocol.ts
+++ b/src/main/services/agents/services/channels/adapters/wechat/WeChatProtocol.ts
@@ -4,7 +4,7 @@
  * Inlined from @pinixai/weixin-bot to avoid the external dependency
  * and its fragile postinstall build step.
  */
-import { createCipheriv, createDecipheriv, randomBytes, randomUUID } from 'node:crypto'
+import { createCipheriv, createDecipheriv, createHash, randomBytes, randomUUID } from 'node:crypto'
 import fs from 'node:fs'
 import { chmod, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import path from 'node:path'
@@ -64,9 +64,22 @@ interface MessageItem {
   text_item?: { text: string }
   image_item?: ImageItem
   voice_item?: { text?: string }
-  file_item?: { file_name?: string; file_size?: number; media?: CDNMedia; aeskey?: string }
+  /** Inbound carries file_size (number); outbound uses len (string, plaintext bytes). */
+  file_item?: { file_name?: string; file_size?: number; len?: string; media?: CDNMedia; aeskey?: string; md5?: string }
   video_item?: unknown
   ref_msg?: unknown
+}
+
+/**
+ * Upload `media_type` values for /ilink/bot/getuploadurl.
+ * Note: this enum is DIFFERENT from MessageItemType — FILE here is 3, but
+ * MessageItemType.FILE is 4. See @tencent-weixin/openclaw-weixin api/types.ts.
+ */
+const enum UploadMediaType {
+  IMAGE = 1,
+  VIDEO = 2,
+  FILE = 3,
+  VOICE = 4
 }
 
 interface WeixinMessage {
@@ -273,44 +286,62 @@ async function cdnDownloadFile(item: FileItem): Promise<Buffer | null> {
 // --------------- CDN upload ---------------
 
 const GetUploadUrlRespSchema = z.object({
-  upload_param: z.string()
+  upload_param: z.string().optional(),
+  upload_full_url: z.string().optional()
 })
 
-async function cdnUploadImage(
+type UploadResult = {
+  downloadEncryptedQueryParam: string
+  /** Raw 16-byte AES key (for any encoding the caller needs). */
+  aeskey: Buffer
+  /** Ciphertext size after AES-128-ECB PKCS7 padding. */
+  ciphertextSize: number
+}
+
+/** AES-128-ECB with PKCS7 padding always adds 1..16 bytes, rounded up to a 16-byte boundary. */
+function aesEcbPaddedSize(plaintextSize: number): number {
+  return Math.ceil((plaintextSize + 1) / 16) * 16
+}
+
+async function cdnUpload(
   baseUrl: string,
   token: string,
   uin: string,
   toUserId: string,
-  imageData: Buffer
-): Promise<{ downloadEncryptedQueryParam: string; aeskey: Buffer; ciphertextSize: number } | null> {
+  data: Buffer,
+  options: { mediaType: UploadMediaType }
+): Promise<UploadResult | null> {
   const aeskey = randomBytes(16)
   const filekey = randomBytes(16).toString('hex')
-  const md5Hash = await import('node:crypto').then((c) => c.createHash('md5').update(imageData).digest('hex'))
+  const md5Hash = createHash('md5').update(data).digest('hex')
+  const ciphertextSize = aesEcbPaddedSize(data.length)
 
-  // Step 1: get upload URL
-  const raw = await apiFetch(
-    baseUrl,
-    '/ilink/bot/getuploadurl',
-    {
-      filekey,
-      media_type: 1,
-      to_user_id: toUserId,
-      rawsize: imageData.length,
-      rawfilemd5: md5Hash,
-      filesize: imageData.length,
-      no_need_thumb: true,
-      aeskey: aeskey.toString('hex'),
-      base_info: buildBaseInfo()
-    },
-    token,
-    uin,
-    15_000
-  )
-  const { upload_param } = GetUploadUrlRespSchema.parse(raw)
+  const requestBody: Record<string, unknown> = {
+    filekey,
+    media_type: options.mediaType,
+    to_user_id: toUserId,
+    rawsize: data.length,
+    rawfilemd5: md5Hash,
+    filesize: ciphertextSize,
+    no_need_thumb: true,
+    aeskey: aeskey.toString('hex'),
+    base_info: buildBaseInfo()
+  }
 
-  // Step 2: encrypt and upload
-  const ciphertext = aesEcbEncrypt(imageData, aeskey)
-  const uploadUrl = `${CDN_BASE_URL}/upload?encrypted_query_param=${encodeURIComponent(upload_param)}&filekey=${encodeURIComponent(filekey)}`
+  const raw = await apiFetch(baseUrl, '/ilink/bot/getuploadurl', requestBody, token, uin, 15_000)
+  const { upload_param, upload_full_url } = GetUploadUrlRespSchema.parse(raw)
+
+  const ciphertext = aesEcbEncrypt(data, aeskey)
+  const uploadUrl = upload_full_url?.trim()
+    ? upload_full_url.trim()
+    : upload_param
+      ? `${CDN_BASE_URL}/upload?encrypted_query_param=${encodeURIComponent(upload_param)}&filekey=${encodeURIComponent(filekey)}`
+      : null
+  if (!uploadUrl) {
+    logger.error('getUploadUrl returned neither upload_full_url nor upload_param', { mediaType: options.mediaType })
+    return null
+  }
+
   const uploadResp = await net.fetch(uploadUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/octet-stream' },
@@ -318,17 +349,47 @@ async function cdnUploadImage(
   })
 
   if (!uploadResp.ok) {
-    logger.error('CDN upload failed', { status: uploadResp.status })
+    logger.error('CDN upload failed', { status: uploadResp.status, mediaType: options.mediaType })
     return null
   }
 
   const downloadEncryptedQueryParam = uploadResp.headers.get('x-encrypted-param')
   if (!downloadEncryptedQueryParam) {
-    logger.error('CDN upload response missing x-encrypted-param header')
+    logger.error('CDN upload response missing x-encrypted-param header', { mediaType: options.mediaType })
     return null
   }
 
-  return { downloadEncryptedQueryParam, aeskey, ciphertextSize: ciphertext.length }
+  return { downloadEncryptedQueryParam, aeskey, ciphertextSize }
+}
+
+function cdnUploadImage(
+  baseUrl: string,
+  token: string,
+  uin: string,
+  toUserId: string,
+  imageData: Buffer
+): Promise<UploadResult | null> {
+  return cdnUpload(baseUrl, token, uin, toUserId, imageData, { mediaType: UploadMediaType.IMAGE })
+}
+
+function cdnUploadFile(
+  baseUrl: string,
+  token: string,
+  uin: string,
+  toUserId: string,
+  fileData: Buffer
+): Promise<UploadResult | null> {
+  return cdnUpload(baseUrl, token, uin, toUserId, fileData, { mediaType: UploadMediaType.FILE })
+}
+
+/**
+ * Encode a 16-byte AES key the way the iLink server expects on the wire:
+ *   base64( ASCII bytes of lowercase hex string )  → 44-char base64 of 32 hex chars.
+ * This matches @tencent-weixin/openclaw-weixin send.ts and the "32-char hex ASCII"
+ * branch of parseAesKey() above.
+ */
+function encodeAesKeyForWire(aeskey: Buffer): string {
+  return Buffer.from(aeskey.toString('hex'), 'ascii').toString('base64')
 }
 
 // --------------- API helpers ---------------
@@ -777,6 +838,8 @@ export class WeixinBot {
 
   /**
    * Send an image to a user by uploading to WeChat CDN.
+   * Payload shape mirrors @tencent-weixin/openclaw-weixin: `filesize` is the
+   * AES-ECB padded ciphertext length and `aes_key` travels as base64(hex-ASCII).
    */
   async sendImage(userId: string, imageData: Buffer): Promise<void> {
     const contextToken = this.contextTokens.get(userId)
@@ -803,10 +866,57 @@ export class WeixinBot {
           image_item: {
             media: {
               encrypt_query_param: uploaded.downloadEncryptedQueryParam,
-              aes_key: Buffer.from(uploaded.aeskey).toString('base64'),
+              aes_key: encodeAesKeyForWire(uploaded.aeskey),
               encrypt_type: 1
             },
             mid_size: uploaded.ciphertextSize
+          }
+        }
+      ]
+    }
+
+    await apiSendMessage(this.baseUrl, credentials.token, this.uin, msg)
+  }
+
+  /**
+   * Send a generic file (PDF, DOCX, zip, etc.) to a user by uploading to WeChat CDN.
+   * Uses UploadMediaType.FILE (3) for upload; the outbound message item carries
+   * MessageItemType.FILE (4) with `file_name` and `len` (plaintext bytes as string).
+   */
+  async sendFile(userId: string, fileData: Buffer, fileName: string): Promise<void> {
+    if (!fileName) {
+      throw new Error('fileName is required for sendFile')
+    }
+
+    const contextToken = this.contextTokens.get(userId)
+    if (!contextToken) {
+      logger.warn('No cached context token for sendFile, sending without context', { userId })
+    }
+
+    const credentials = await this.ensureCredentials()
+    const uploaded = await cdnUploadFile(this.baseUrl, credentials.token, this.uin, userId, fileData)
+    if (!uploaded) {
+      throw new Error('Failed to upload file to WeChat CDN')
+    }
+
+    const msg = {
+      from_user_id: '',
+      to_user_id: userId,
+      client_id: randomUUID(),
+      message_type: MessageType.BOT,
+      message_state: MessageState.FINISH,
+      context_token: contextToken ?? '',
+      item_list: [
+        {
+          type: MessageItemType.FILE,
+          file_item: {
+            file_name: fileName,
+            len: String(fileData.length),
+            media: {
+              encrypt_query_param: uploaded.downloadEncryptedQueryParam,
+              aes_key: encodeAesKeyForWire(uploaded.aeskey),
+              encrypt_type: 1
+            }
           }
         }
       ]

--- a/src/main/services/agents/services/channels/utils.ts
+++ b/src/main/services/agents/services/channels/utils.ts
@@ -40,3 +40,31 @@ export const FILE_EXTENSION_MIME_MAP: Record<string, string> = {
   md: 'text/markdown',
   zip: 'application/zip'
 }
+
+/** Resolve a MIME type from a filename's extension; falls back to application/octet-stream. */
+export function mimeFromFileName(fileName: string | undefined): string {
+  if (!fileName) return 'application/octet-stream'
+  const ext = fileName.includes('.') ? fileName.split('.').pop()!.toLowerCase() : ''
+  return FILE_EXTENSION_MIME_MAP[ext] ?? 'application/octet-stream'
+}
+
+/**
+ * Detect an image MIME type from magic bytes. Handles PNG/JPEG/GIF/WebP/BMP.
+ * Defaults to image/png on unknown signatures — adequate for the upstream IMs
+ * that accept common image formats without strict validation.
+ */
+export function detectImageMime(data: Buffer): string {
+  if (data.length < 4) return 'image/png'
+  if (data[0] === 0xff && data[1] === 0xd8) return 'image/jpeg'
+  if (data[0] === 0x89 && data[1] === 0x50 && data[2] === 0x4e && data[3] === 0x47) return 'image/png'
+  if (data[0] === 0x47 && data[1] === 0x49 && data[2] === 0x46) return 'image/gif'
+  if (data[0] === 0x52 && data[1] === 0x49 && data[2] === 0x46 && data[3] === 0x46) return 'image/webp'
+  if (data[0] === 0x42 && data[1] === 0x4d) return 'image/bmp'
+  return 'image/png'
+}
+
+/** Pick an image extension (no dot) from magic bytes. Used to synthesize an upload filename. */
+export function detectImageExtension(data: Buffer): string {
+  const mime = detectImageMime(data)
+  return mime.split('/')[1] ?? 'png'
+}


### PR DESCRIPTION
### What this PR does

Before this PR:

- The `notify` MCP tool only accepted a text `message` — agents that produced images (e.g. Gemini image generation) or documents had no way to deliver them through a connected IM and were forced to upload to third-party hosts and paste URLs.
- `ChannelAdapter` had no outbound media contract. Every adapter only implemented `sendMessage`.
- `WeChatAdapter` shipped an internal `sendImage` path in `WeChatProtocol.ts` but it was never wired to the tool layer, and it carried wire-format bugs (`filesize` used plaintext length, not AES-ECB padded ciphertext length; `aes_key` used `base64(raw 16 bytes)` instead of the `base64(hex-ASCII)` form the iLink server expects). `sendFile` did not exist.

After this PR:

- `notify` accepts three new optional parameters: `image_path` (absolute local path), `image_base64` (raw or data-URI), and `file_path` (absolute local path; basename becomes the delivered file name). Text, image, and file can be combined in one call and are delivered per-chatId; per-attachment errors are reported without aborting the batch.
- New abstract `ChannelAdapter.sendMedia(chatId, data, mediaType, fileName?)` contract. Every adapter implements it against the correct per-platform API:
  - **WeChat** — realigned to `@tencent-weixin/openclaw-weixin`: uses `UploadMediaType.FILE = 3`, sends AES-ECB padded ciphertext size as `filesize`, encodes `aes_key` as `base64(hex-ASCII)`, and falls back to `upload_full_url` when the server returns it. Adds `WeixinBot.sendFile` with the `file_item.len` (string) + `file_name` shape, and fixes `sendImage` along the same lines.
  - **Telegram** — `bot.api.sendPhoto` / `sendDocument` with `new InputFile(buffer, filename)`.
  - **Discord** — `POST /channels/{id}/messages` as `multipart/form-data` (`payload_json` + `files[0]`).
  - **Slack** — `files.uploadV2` three-step flow: `files.getUploadURLExternal` → `POST upload_url` → `files.completeUploadExternal` with `channel_id`.
  - **QQ** — mirrors `tencent-connect/openclaw-qqbot`: `POST /v2/{users|groups}/{id}/files` with `file_data` (base64) + `file_type` + `srv_send_msg: false`, then `POST /.../messages` with `msg_type: 7, media: { file_info }`. Only `c2c:` / `group:` chat ids — `channel:` / `dm:` (guild API) throw.
  - **Feishu/Lark** — `client.im.image.create` / `client.im.file.create` (accepts `Buffer` directly), then `client.im.message.create(msg_type: 'image' | 'file')`. `file_type` is derived from the extension with fallback to `'stream'`.
- Shared MIME helpers extracted into `channels/utils.ts` (`detectImageMime`, `detectImageExtension`, `mimeFromFileName`).
- `sendNotification` was refactored from ~140 lines with three parallel try/catch blocks into a payload-object dispatch: `buildNotifyPayloads(args)` returns `NotifyPayload[]`, then one loop delivers each payload and aggregates stats + errors.

Fixes #14324

### Why we need it and why it was done in this way

The issue's use case — "the agent produced an image/document, deliver it to the user's IM client" — was blocked by the `notify` tool's text-only shape. The shortest safe path was:

1. Add a per-adapter `sendMedia` hook rather than overloading `sendMessage`, because each IM uses a different upload-then-reference protocol and the failure modes differ per platform.
2. Wire the MCP tool layer to that hook, keeping text delivery identical to before when no attachment is provided.
3. Follow each platform's reference implementation exactly — the existing WeChat `sendImage` path taught me that "close enough" isn't — so protocol choices (AES-ECB padded `filesize`, hex-ASCII `aes_key`, `UploadMediaType.FILE = 3` vs `MessageItemType.FILE = 4`, Lark `file_type` enum) are copied from the official openclaw references and SDK type definitions, not inferred.

The following tradeoffs were made:

- `sendMedia` is abstract rather than a throwing default. This forces every adapter author to make an explicit choice (implement vs. throw), at the cost of a small amount of boilerplate in test-only `MockAdapter`s. Without the abstract constraint, the Biome linter kept rewriting any default-body implementation to `abstract` anyway.
- QQ proactive media push inherits the existing platform-level limitation: without a passive `msg_id` it can only deliver when the bot has proactive-message quota. Matches the current `sendMessage` behavior; not changed here.
- File support was not added to non-WeChat adapters' `sendFile` helpers — we go straight through the adapter's own SDK. Keeps the surface area small.

The following alternatives were considered:

- A single overloaded `send(chatId, content: string | MediaPayload)` — rejected because it would churn every adapter and the type split keeps call sites obvious.
- Passing the text caption through `sendMedia` for platforms that support it (Telegram / Discord / Slack / QQ accept captions natively). Deferred; current shape sends caption as a separate `sendMessage` so ordering stays predictable across all adapters.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/14324

### Breaking changes

None for end users. For channel-adapter authors there is an internal API change: `ChannelAdapter.sendMedia` is now abstract and must be implemented by every subclass. All shipped adapters in this PR already implement it.

### Special notes for your reviewer

- I could not exercise any of the outbound-media paths against a real IM in this environment. The WeChat/QQ/Lark payload shapes are built directly from the official openclaw references and SDK type definitions; Telegram/Discord/Slack use the standard documented REST flows. A smoke-test on each channel before merge is worthwhile.
- The `aes_key` encoding change in WeChat's `sendImage` corrects a bug in the pre-existing helper. If anyone was relying on the old (likely-broken) path, their flow now goes through the corrected one.
- The `sendNotification` refactor preserves observable behavior (ordering, summary format) with one cosmetic change: the per-chat text-send error prefix is now `(text)` for symmetry with `(image)` / `(file)`.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
`notify` MCP tool now supports image and file attachments via new `image_path`, `image_base64`, and `file_path` parameters. Images and files produced by an agent can be delivered directly to the user through connected channels (WeChat, Telegram, Discord, Slack, QQ, Feishu/Lark) instead of needing third-party URL hosting.
```
