### PR TITLE
chore: release v1.9.3

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -142,52 +142,46 @@ artifactBuildCompleted: scripts/artifact-build-completed.js
 releaseInfo:
   releaseNotes: |
     <!--LANG:en-->
-    Cherry Studio 1.9.2 - Skills Creation & Vietnamese Support
-
-    ✨ New Features
-    - [Skills] Agents can now author and register new skills directly from chat using the skills tool
-    - [Skills] Add "Add More Skills" button to agent settings for quick navigation to Skills management
-    - [Skills] Skills and memory MCP tools now available to all agents (not just Soul Mode agents)
-    - [i18n] Add Vietnamese (Tiếng Việt) language support with complete UI translations
+    Cherry Studio 1.9.3 - Bug Fixes & Improvements
 
     🐛 Bug Fixes
-    - [Analytics] Fix telemetry being sent even when data collection is disabled
-    - [Agents] Agent settings changes (model, permissions, tools, etc.) now sync immediately to all active sessions
-    - [Agents] Built-in agent prompt updates now properly sync to existing sessions
-    - [Agents] Cherry Assistant now displays the 🍒 avatar instead of generic ⭐️
-    - [Search] Fix CJK (Chinese/Japanese/Korean) text search failing in whole-word mode
-    - [Search] Add phrase search support (e.g., "machine learning" with quotes)
-    - [Export] Fix Obsidian export silently failing due to blocked obsidian:// protocol
-    - [Knowledge] Fix knowledge base creation failing for Ollama embedding models
-    - [Models] Fix custom parameters not being passed to Gemini API when using NewAPI/AiHubMix providers
-    - [Knowledge] Fix Dify knowledge search compatibility with Dify 1.13.3
-    - [OpenClaw] Fix language selection not persisting in overview page
-
-    ⚡ Performance
-    - [Electron] Upgrade to Electron 41.2.1 with improved window resize handling on Windows
+    - [Web Search] Fix built-in web search repeatedly running and consuming excessive tokens
+    - [Backup] Fix Windows backup failures caused by symlinks in the Data directory
+    - [UI] Fix horizontal multi-model message scrolling issue on card edges
+    - [Models] Add support for OpenAI's gpt-image-2 model
+    - [MCP] Fix MCP SSE/streamableHttp servers timing out during initialization
+    - [AI Core] Fix native tool-call conversations stopping after first execution
+    - [Bedrock] Fix AWS Bedrock requests failing when API Host is blank
+    - [Agents] Fix agent skills page scroll position reset when toggling skills
+    - [Feishu] Restore image message support from Feishu/Lark bot users
+    - [Proxy Providers] Fix structured output error with Claude models through AiHubMix/NewAPI
+    - [API Server] Fix API server failing for providers with comma-separated API keys
+    - [Agents] Fix Soul Mode dropping user-provided session instructions
+    - [File Upload] Support case-insensitive file extensions for drag-and-drop uploads
+    - [Deep Links] Fix "Open in VS Code/Cursor/Zed" buttons being blocked
+    - [Proxy Providers] Fix custom parameters not being passed for CherryIN/NewAPI
+    - [Claude Code] Fix Claude Code failing to launch on all platforms
+    - [Quick Panel] Fix model deselection bug when pasting messages with "@"
 
     <!--LANG:zh-CN-->
-    Cherry Studio 1.9.2 - 技能创作与越南语支持
-
-    ✨ 新功能
-    - [技能] 智能体现在可以直接在对话中通过 skills 工具编写和注册新技能
-    - [技能] 在智能体设置的技能页面添加"添加更多技能"按钮，快速跳转到技能管理页面
-    - [技能] skills 和 memory MCP 工具现对所有智能体可用（不仅限于灵魂模式）
-    - [i18n] 新增越南语（Tiếng Việt）支持，包含完整的 UI 翻译
+    Cherry Studio 1.9.3 - 错误修复与改进
 
     🐛 问题修复
-    - [数据统计] 修复即使禁用数据统计仍发送统计数据的问题
-    - [智能体] 智能体设置更改（模型、权限、工具等）现立即同步到所有活跃会话
-    - [智能体] 内置智能体提示词更新现正确同步到现有会话
-    - [智能体] Cherry Assistant 现显示 🍒 头像而非通用的 ⭐️
-    - [搜索] 修复中日韩（CJK）文本在全词模式下搜索失败的问题
-    - [搜索] 添加短语搜索支持（例如带引号的 "machine learning"）
-    - [导出] 修复因 obsidian:// 协议被阻止导致 Obsidian 导出静默失败的问题
-    - [知识库] 修复使用 Ollama 嵌入模型创建知识库失败的问题
-    - [模型] 修复使用 NewAPI/AiHubMix 服务商时自定义参数未传递给 Gemini API 的问题
-    - [知识库] 修复与 Dify 1.13.3 的知识搜索兼容性问题
-    - [OpenClaw] 修复概览页面语言选择无法持久化的问题
-
-    ⚡ 性能优化
-    - [Electron] 升级至 Electron 41.2.1，改进 Windows 平台的窗口调整大小体验
+    - [网络搜索] 修复内置网络搜索重复运行并消耗过多 token 的问题
+    - [备份] 修复 Windows 平台因 Data 目录中的符号链接导致备份失败的问题
+    - [UI] 修复水平多模型消息卡片边缘滚动问题
+    - [模型] 添加对 OpenAI gpt-image-2 模型的支持
+    - [MCP] 修复 MCP SSE/streamableHttp 服务器初始化超时问题
+    - [AI 核心] 修复原生工具调用对话在首次执行后停止的问题
+    - [Bedrock] 修复 AWS Bedrock 在 API Host 为空时请求失败的问题
+    - [智能体] 修复切换技能时技能页面滚动位置重置的问题
+    - [飞书] 恢复飞书/Lark 机器人用户的图片消息接收功能
+    - [代理服务商] 修复通过 AiHubMix/NewAPI 调用 Claude 模型时的结构化输出错误
+    - [API 服务器] 修复使用逗号分隔 API 密钥的服务商在 API 服务器中失败的问题
+    - [智能体] 修复灵魂模式丢弃用户提供的会话指令的问题
+    - [文件上传] 支持拖放上传时不区分大小写的文件扩展名
+    - [深度链接] 修复"在 VS Code/Cursor/Zed 中打开"按钮被阻止的问题
+    - [代理服务商] 修复 CherryIN/NewAPI 自定义参数未传递的问题
+    - [Claude Code] 修复 Claude Code 在所有平台上无法启动的问题
+    - [快速面板] 修复粘贴包含"@"的消息时模型取消选择的 bug
     <!--LANG:END-->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CherryStudio",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "private": true,
   "description": "A powerful AI assistant for producer.",
   "desktopName": "CherryStudio.desktop",


### PR DESCRIPTION
### What this PR does

This PR prepares the release of Cherry Studio v1.9.3.

**Release Summary:**

Cherry Studio 1.9.3 is a bug fix release that addresses 17 issues across various components:

- [Web Search] Fix built-in web search repeatedly running and consuming excessive tokens
- [Backup] Fix Windows backup failures caused by symlinks in the Data directory
- [UI] Fix horizontal multi-model message scrolling issue on card edges
- [Models] Add support for OpenAI's gpt-image-2 model
- [MCP] Fix MCP SSE/streamableHttp servers timing out during initialization
- [AI Core] Fix native tool-call conversations stopping after first execution
- [Bedrock] Fix AWS Bedrock requests failing when API Host is blank
- [Agents] Fix agent skills page scroll position reset when toggling skills
- [Feishu] Restore image message support from Feishu/Lark bot users
- [Proxy Providers] Fix structured output error with Claude models through AiHubMix/NewAPI
- [API Server] Fix API server failing for providers with comma-separated API keys
- [Agents] Fix Soul Mode dropping user-provided session instructions
- [File Upload] Support case-insensitive file extensions for drag-and-drop uploads
- [Deep Links] Fix "Open in VS Code/Cursor/Zed" buttons being blocked
- [Proxy Providers] Fix custom parameters not being passed for CherryIN/NewAPI
- [Claude Code] Fix Claude Code failing to launch on all platforms
- [Quick Panel] Fix model deselection bug when pasting messages with "@"

**Changes in this release:**

1. Updated version to 1.9.3 in `package.json`
2. Updated release notes in `electron-builder.yml`

### Included Commits

- 0636b601f fix: limit builtin web search usage (#14466)
- 930fdf75b fix: handle symlinks during backup copy (#14471)
- 09da6a336 fix: prevent outer scrolling in horizontal multi-model messages (#13964)
- c0b3c880e hotfix(ai-sdk/openai): patch @ai-sdk/openai to support gpt-image-2 (#14488)
- 5cc1b9c41 fix(mcp): delegate connect timeout to SDK to restore slow SSE servers (#14348)
- 5d98273d8 fix(ai-core): keep native tool loops going (#14481)
- c4b3a93ab fix: prevent empty baseURL/region string in Bedrock provider config (#14425)
- 47fb14c65 fix(useInstalledSkills): keep agent skills list stable while toggling (#14472)
- fbf73962c fix(feishu): handle image messages from IM channel (#14421)
- 01caaf06f hotfix: disable native structured output for AiHubMix/NewAPI Anthropic models (#14376)
- 3f463e178 fix(api-server): rotate comma-separated provider API keys (#14346)
- ec4e787d1 fix(agents): preserve session instructions in Soul Mode (#14424)
- ccb047c3c hotfix: Support case-insensitive file extensions for drag-and-drop (#14416)
- 84240baa4 fix(security): allow vscode/cursor/zed deep-links in openExternal (#14437)
- c2b330258 hotfix: Custom params dropped by CherryIN/NewAPI — respect model.endpoint_type (#14409)
- 4c0ce8f79 fix: use cli-wrapper.cjs to launch claude-code instead of native binary (#14430)
- cd6d84c84 fix(quick-panel): reset stale state on panel close to prevent model deselection (#14378)

### Review Checklist

- [ ] Review generated release notes in `electron-builder.yml`
- [ ] Verify version bump in `package.json`
- [ ] CI passes
- [ ] Merge to trigger release build

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>