### PR TITLE
fix: align CherryIN seed apiHost with migration 183 (.cc)

### DIFF
--- a/src/renderer/src/config/providers.ts
+++ b/src/renderer/src/config/providers.ts
@@ -84,8 +84,8 @@ export const SYSTEM_PROVIDERS_CONFIG: Record<SystemProviderId, SystemProvider> =
     name: 'CherryIN',
     type: 'openai',
     apiKey: '',
-    apiHost: 'https://open.cherryin.net',
-    anthropicApiHost: 'https://open.cherryin.net',
+    apiHost: 'https://open.cherryin.cc',
+    anthropicApiHost: 'https://open.cherryin.cc',
     models: [],
     isSystem: true,
     enabled: true


### PR DESCRIPTION
### What this PR does

Before this PR:
- New installs seed `CherryIN` provider with `apiHost: https://open.cherryin.net` and matching `anthropicApiHost` (via `SYSTEM_PROVIDERS_CONFIG` in `src/renderer/src/config/providers.ts`).
- Existing installs are migrated to `https://open.cherryin.cc` by migration 183 (introduced in #11797), so new vs. upgraded users end up on different CherryIN domains.

After this PR:
- New installs are seeded with `https://open.cherryin.cc` (the accelerated/domestic domain), matching migration 183 and the CherryIN settings dropdown default.

Fixes #

### Why we need it and why it was done in this way

The mismatch was an oversight in #11797: the migration and the settings UI were updated to `.cc`, but the seed config was not. Aligning the seed is a two-line, minimal-scope change and does not touch the migration, the dropdown, or any OAuth logic.

The following tradeoffs were made:
- Chose `.cc` (matches migration 183 and dropdown fallback) over `.net` (previous seed). Users can still switch to `.net` / `.ai` via the existing dropdown in provider settings.

The following alternatives were considered:
- Reverting migration 183 instead — rejected because it would force already-migrated users back to `.net` and contradicts the original PR's stated intent.

Links to places where the discussion took place: None

### Breaking changes

None. The change only affects the default for brand-new installs; existing users are unaffected (they already run migration 183). The domain is switchable in settings.

### Special notes for your reviewer

Scope is limited to `src/renderer/src/config/providers.ts` (2 lines). No refactoring, no unrelated changes — per `hotfix/*` branch policy.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix CherryIN provider default API host for new installs to use the accelerated domain (open.cherryin.cc), matching the behavior applied to existing users by migration 183.
```
