### PR TITLE
refactor(agents): drop @cherry/browser MCP auto-injection

### DIFF
--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -23,7 +23,6 @@ import { config as apiConfigService } from '@main/apiServer/config'
 import { validateModelId } from '@main/apiServer/utils'
 import { isWin } from '@main/constant'
 import AssistantServer from '@main/mcpServers/assistant'
-import BrowserServer from '@main/mcpServers/browser/server'
 import ClawServer from '@main/mcpServers/claw'
 import SkillsServer from '@main/mcpServers/skills'
 import WorkspaceMemoryServer from '@main/mcpServers/workspaceMemory'
@@ -572,8 +571,6 @@ class ClaudeCodeService implements AgentServiceInterface {
 
     // Inject @cherry/browser MCP for all agents (replaces SDK built-in WebSearch/WebFetch)
     if (!options.mcpServers) options.mcpServers = {}
-    const browserServer = new BrowserServer()
-    options.mcpServers.browser = { type: 'sdk', name: '@cherry/browser', instance: browserServer.mcpServer }
 
     // Inject Exa MCP for structured web search (free tier, no API key required)
     options.mcpServers.exa = {

--- a/src/renderer/src/pages/settings/AgentSettings/components/ToolsSettings.tsx
+++ b/src/renderer/src/pages/settings/AgentSettings/components/ToolsSettings.tsx
@@ -82,8 +82,6 @@ export const ToolsSettings: FC<AgentOrSessionSettingsProps> = ({ agentBase, upda
   const selectedMcpIds = useMemo(() => agentBase?.mcps ?? [], [agentBase?.mcps])
   const isSoulEnabled = isSoulModeEnabled(agentBase?.configuration)
 
-  const availableServers = useMemo(() => (allServers ?? []).filter((s) => s.name !== '@cherry/browser'), [allServers])
-
   const filteredTools = useMemo(() => {
     const hiddenTools = [
       ...(GLOBALLY_DISALLOWED_TOOLS as readonly string[]),
@@ -246,13 +244,13 @@ export const ToolsSettings: FC<AgentOrSessionSettingsProps> = ({ agentBase, upda
               'Connect MCP servers to unlock additional tools you can approve above.'
             )}
           </span>
-          {availableServers.length === 0 ? (
+          {allServers.length === 0 ? (
             <div className="rounded-medium border border-default-200 border-dashed px-4 py-6 text-center text-foreground-500 text-sm">
               {t('agent.settings.tooling.mcp.empty', 'No MCP servers detected. Add one from the MCP settings page.')}
             </div>
           ) : (
             <div className="flex flex-col gap-2">
-              {availableServers.map((server) => {
+              {allServers.map((server) => {
                 const isSelected = selectedMcpIds.includes(server.id)
                 return (
                   <Card


### PR DESCRIPTION
### What this PR does

Before this PR:

- `ClaudeCodeService` unconditionally injected an in-process `@cherry/browser` MCP server into every agent session.
- `ToolsSettings` filtered `@cherry/browser` out of the selectable MCP server list to hide this injected server from users.

After this PR:

- The `@cherry/browser` MCP auto-injection (and its import) is removed from `ClaudeCodeService`.
- `ToolsSettings` no longer filters out `@cherry/browser`; it renders the full `allServers` list directly.

Fixes #

### Why we need it and why it was done in this way

Web browsing for Claude Code agents is now covered by the structured Exa MCP (also auto-injected in `ClaudeCodeService`) plus any MCP servers the user explicitly configures. Keeping the built-in `@cherry/browser` injection duplicates that capability and forced the settings UI to filter a server it had silently injected. Removing both the injection and the filter leaves a single, consistent source of truth for what MCP servers are active per agent.

The following tradeoffs were made:

- Agents that previously relied on the auto-injected `@cherry/browser` tools will need to enable a browsing MCP (Exa is already available by default) or add their own.

The following alternatives were considered:

- Keeping the injection and only hiding it in the UI — rejected, since it left hidden behavior that surprised users inspecting their MCP list.

Links to places where the discussion took place:

### Breaking changes

Agents configured with Claude Code no longer receive a built-in `@cherry/browser` MCP server. If a workflow depended on that server explicitly, users must opt in to another browsing MCP.

### Special notes for your reviewer

N/A

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Remove the auto-injected @cherry/browser MCP server from Claude Code agents; browsing is now provided via the Exa MCP or any user-configured MCP server. action required: re-enable a browsing MCP if you depended on @cherry/browser.
```
