### PR TITLE
feat(topics): Add folder grouping for pinned topics

### DIFF
--- a/packages/shared/data/preference/preferenceSchemas.ts
+++ b/packages/shared/data/preference/preferenceSchemas.ts
@@ -460,6 +460,10 @@ export interface PreferenceSchemas {
     'shortcut.topic.rename': PreferenceTypes.PreferenceShortcutType
     // redux/shortcuts/shortcuts.toggle_show_topics
     'shortcut.topic.toggle_show_topics': PreferenceTypes.PreferenceShortcutType
+    // redux/settings/topicFoldersOrder
+    'topic.folders.collapsed': Record<string, string[]>
+    // redux/settings/collapsedTopicFolders
+    'topic.folders.order': Record<string, string[]>
     // redux/settings/enableTopicNaming
     'topic.naming.enabled': boolean
     // target-key-definitions/complex/complex
@@ -737,6 +741,8 @@ export const DefaultPreferences: PreferenceSchemas = {
     'shortcut.topic.new': { binding: ['CommandOrControl', 'N'], enabled: true },
     'shortcut.topic.rename': { binding: ['CommandOrControl', 'T'], enabled: false },
     'shortcut.topic.toggle_show_topics': { binding: ['CommandOrControl', ']'], enabled: true },
+    'topic.folders.collapsed': {},
+    'topic.folders.order': {},
     'topic.naming.enabled': true,
     'topic.naming.model_id': null,
     'topic.naming_prompt': '',

--- a/src/renderer/src/hooks/useTopicFolders.ts
+++ b/src/renderer/src/hooks/useTopicFolders.ts
@@ -1,0 +1,136 @@
+import { useMultiplePreferences } from '@data/hooks/usePreference'
+import type { Topic } from '@renderer/types'
+import { groupBy, uniq } from 'lodash'
+import { useCallback, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface TopicFolderGroup {
+  folder: string
+  topics: Topic[]
+}
+
+export const useTopicFolders = (assistantId: string, pinnedTopics: Topic[]) => {
+  const { t } = useTranslation()
+  const [foldersState, setFoldersState] = useMultiplePreferences({
+    foldersOrder: 'topic.folders.order',
+    collapsedFolders: 'topic.folders.collapsed'
+  })
+
+  const topicFoldersOrder = foldersState.foldersOrder
+  const collapsedFolders = foldersState.collapsedFolders
+
+  const allFolders = useMemo(() => {
+    const folders = uniq(pinnedTopics.map((topic) => topic.folder).filter((f): f is string => !!f))
+    const savedOrder = topicFoldersOrder[assistantId] || []
+    if (savedOrder.length > 0) {
+      return [
+        ...savedOrder.filter((folder) => folders.includes(folder)),
+        ...folders.filter((folder) => !savedOrder.includes(folder))
+      ]
+    }
+    return folders
+  }, [pinnedTopics, assistantId, topicFoldersOrder])
+
+  const getGroupedPinnedTopics = useMemo((): TopicFolderGroup[] => {
+    const grouped = Object.entries(groupBy(pinnedTopics, 'folder')).map(([folder, topics]) => ({
+      folder: folder === 'undefined' || !folder ? t('chat.topics.folder.uncategorized') : folder,
+      topics
+    }))
+
+    const uncategorizedIndex = grouped.findIndex((g) => g.folder === t('chat.topics.folder.uncategorized'))
+    if (uncategorizedIndex > -1) {
+      const [uncategorized] = grouped.splice(uncategorizedIndex, 1)
+      grouped.unshift(uncategorized)
+    }
+
+    if (allFolders.length > 0) {
+      const uncategorized = grouped.find((g) => g.folder === t('chat.topics.folder.uncategorized'))
+      const sortedFolders = grouped.filter((g) => g.folder !== t('chat.topics.folder.uncategorized'))
+
+      sortedFolders.sort((a, b) => {
+        const indexA = allFolders.indexOf(a.folder)
+        const indexB = allFolders.indexOf(b.folder)
+        if (indexA === -1 && indexB === -1) return 0
+        if (indexA === -1) return 1
+        if (indexB === -1) return -1
+        return indexA - indexB
+      })
+
+      if (uncategorized) {
+        sortedFolders.unshift(uncategorized)
+      }
+      return sortedFolders
+    }
+
+    return grouped
+  }, [pinnedTopics, allFolders, t])
+
+  const isCollapsed = useCallback(
+    (folder: string) => {
+      return (collapsedFolders[assistantId] || []).includes(folder)
+    },
+    [assistantId, collapsedFolders]
+  )
+
+  const toggleFolderCollapse = useCallback(
+    async (folder: string) => {
+      const current = collapsedFolders[assistantId] || []
+      let newCollapsed: string[]
+      if (current.includes(folder)) {
+        newCollapsed = current.filter((f) => f !== folder)
+      } else {
+        newCollapsed = [...current, folder]
+      }
+      await setFoldersState({
+        foldersOrder: { ...topicFoldersOrder, [assistantId]: allFolders },
+        collapsedFolders: { ...collapsedFolders, [assistantId]: newCollapsed }
+      })
+    },
+    [assistantId, collapsedFolders, topicFoldersOrder, allFolders, setFoldersState]
+  )
+
+  const createFolder = useCallback(
+    async (name: string) => {
+      const currentOrder = topicFoldersOrder[assistantId] || []
+      await setFoldersState({
+        foldersOrder: { ...topicFoldersOrder, [assistantId]: [...currentOrder, name] }
+      })
+    },
+    [assistantId, topicFoldersOrder, setFoldersState]
+  )
+
+  const renameFolder = useCallback(
+    async (oldName: string, newName: string) => {
+      const currentOrder = topicFoldersOrder[assistantId] || []
+      const newOrder = currentOrder.map((f) => (f === oldName ? newName : f))
+      await setFoldersState({
+        foldersOrder: { ...topicFoldersOrder, [assistantId]: newOrder }
+      })
+    },
+    [assistantId, topicFoldersOrder, setFoldersState]
+  )
+
+  const deleteFolder = useCallback(
+    async (name: string) => {
+      const currentOrder = topicFoldersOrder[assistantId] || []
+      const newOrder = currentOrder.filter((f) => f !== name)
+      const currentCollapsed = collapsedFolders[assistantId] || []
+      const newCollapsed = currentCollapsed.filter((f) => f !== name)
+      await setFoldersState({
+        foldersOrder: { ...topicFoldersOrder, [assistantId]: newOrder },
+        collapsedFolders: { ...collapsedFolders, [assistantId]: newCollapsed }
+      })
+    },
+    [assistantId, topicFoldersOrder, collapsedFolders, setFoldersState]
+  )
+
+  return {
+    allFolders,
+    getGroupedPinnedTopics,
+    isCollapsed,
+    toggleFolderCollapse,
+    createFolder,
+    renameFolder,
+    deleteFolder
+  }
+}

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -1447,6 +1447,16 @@
         "word": "Export as Word",
         "yuque": "Export to Yuque"
       },
+      "folder": {
+        "create": "Create new folder",
+        "create_placeholder": "Enter folder name",
+        "delete": "Delete folder",
+        "move_to": "Move to folder",
+        "remove": "Remove from folder",
+        "rename": "Rename folder",
+        "rename_placeholder": "Enter new folder name",
+        "uncategorized": "Uncategorized"
+      },
       "list": "Topic List",
       "manage": {
         "clear_selection": "Clear Selection",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -1447,6 +1447,16 @@
         "word": "导出为 Word",
         "yuque": "导出到语雀"
       },
+      "folder": {
+        "create": "创建新文件夹",
+        "create_placeholder": "输入文件夹名称",
+        "delete": "删除文件夹",
+        "move_to": "移动到文件夹",
+        "remove": "从文件夹移除",
+        "rename": "重命名文件夹",
+        "rename_placeholder": "输入新文件夹名称",
+        "uncategorized": "未分类"
+      },
       "list": "话题列表",
       "manage": {
         "clear_selection": "取消选择",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -1447,6 +1447,16 @@
         "word": "匯出為 Word",
         "yuque": "匯出到語雀"
       },
+      "folder": {
+        "create": "建立新資料夾",
+        "create_placeholder": "輸入資料夾名稱",
+        "delete": "刪除資料夾",
+        "move_to": "移動到資料夾",
+        "remove": "從資料夾移除",
+        "rename": "重新命名資料夾",
+        "rename_placeholder": "輸入新資料夾名稱",
+        "uncategorized": "未分類"
+      },
       "list": "話題列表",
       "manage": {
         "clear_selection": "取消選擇",

--- a/src/renderer/src/i18n/translate/de-de.json
+++ b/src/renderer/src/i18n/translate/de-de.json
@@ -1447,6 +1447,16 @@
         "word": "Als Word exportieren",
         "yuque": "Nach Yuque exportieren"
       },
+      "folder": {
+        "create": "[to be translated]:Create new folder",
+        "create_placeholder": "[to be translated]:Enter folder name",
+        "delete": "[to be translated]:Delete folder",
+        "move_to": "[to be translated]:Move to folder",
+        "remove": "[to be translated]:Remove from folder",
+        "rename": "[to be translated]:Rename folder",
+        "rename_placeholder": "[to be translated]:Enter new folder name",
+        "uncategorized": "[to be translated]:Uncategorized"
+      },
       "list": "Themenliste",
       "manage": {
         "clear_selection": "Auswahl aufheben",

--- a/src/renderer/src/i18n/translate/el-gr.json
+++ b/src/renderer/src/i18n/translate/el-gr.json
@@ -1447,6 +1447,16 @@
         "word": "Εξαγωγή ως Word",
         "yuque": "Εξαγωγή στο Yuque"
       },
+      "folder": {
+        "create": "[to be translated]:Create new folder",
+        "create_placeholder": "[to be translated]:Enter folder name",
+        "delete": "[to be translated]:Delete folder",
+        "move_to": "[to be translated]:Move to folder",
+        "remove": "[to be translated]:Remove from folder",
+        "rename": "[to be translated]:Rename folder",
+        "rename_placeholder": "[to be translated]:Enter new folder name",
+        "uncategorized": "[to be translated]:Uncategorized"
+      },
       "list": "Λίστα θεμάτων",
       "manage": {
         "clear_selection": "Καθαρισμός Επιλογής",

--- a/src/renderer/src/i18n/translate/es-es.json
+++ b/src/renderer/src/i18n/translate/es-es.json
@@ -1447,6 +1447,16 @@
         "word": "Exportar como Word",
         "yuque": "Exportar a Yuque"
       },
+      "folder": {
+        "create": "[to be translated]:Create new folder",
+        "create_placeholder": "[to be translated]:Enter folder name",
+        "delete": "[to be translated]:Delete folder",
+        "move_to": "[to be translated]:Move to folder",
+        "remove": "[to be translated]:Remove from folder",
+        "rename": "[to be translated]:Rename folder",
+        "rename_placeholder": "[to be translated]:Enter new folder name",
+        "uncategorized": "[to be translated]:Uncategorized"
+      },
       "list": "Lista de temas",
       "manage": {
         "clear_selection": "Borrar selección",

--- a/src/renderer/src/i18n/translate/fr-fr.json
+++ b/src/renderer/src/i18n/translate/fr-fr.json
@@ -1447,6 +1447,16 @@
         "word": "Exporter sous forme de Word",
         "yuque": "Exporter vers Yuque"
       },
+      "folder": {
+        "create": "[to be translated]:Create new folder",
+        "create_placeholder": "[to be translated]:Enter folder name",
+        "delete": "[to be translated]:Delete folder",
+        "move_to": "[to be translated]:Move to folder",
+        "remove": "[to be translated]:Remove from folder",
+        "rename": "[to be translated]:Rename folder",
+        "rename_placeholder": "[to be translated]:Enter new folder name",
+        "uncategorized": "[to be translated]:Uncategorized"
+      },
       "list": "Liste des sujets",
       "manage": {
         "clear_selection": "Effacer la sélection",

--- a/src/renderer/src/i18n/translate/ja-jp.json
+++ b/src/renderer/src/i18n/translate/ja-jp.json
@@ -1447,6 +1447,16 @@
         "word": "Wordとしてエクスポート",
         "yuque": "語雀にエクスポート"
       },
+      "folder": {
+        "create": "[to be translated]:Create new folder",
+        "create_placeholder": "[to be translated]:Enter folder name",
+        "delete": "[to be translated]:Delete folder",
+        "move_to": "[to be translated]:Move to folder",
+        "remove": "[to be translated]:Remove from folder",
+        "rename": "[to be translated]:Rename folder",
+        "rename_placeholder": "[to be translated]:Enter new folder name",
+        "uncategorized": "[to be translated]:Uncategorized"
+      },
       "list": "トピックリスト",
       "manage": {
         "clear_selection": "選択をクリア",

--- a/src/renderer/src/i18n/translate/pt-pt.json
+++ b/src/renderer/src/i18n/translate/pt-pt.json
@@ -1447,6 +1447,16 @@
         "word": "Exportar como Word",
         "yuque": "Exportar para Yuque"
       },
+      "folder": {
+        "create": "[to be translated]:Create new folder",
+        "create_placeholder": "[to be translated]:Enter folder name",
+        "delete": "[to be translated]:Delete folder",
+        "move_to": "[to be translated]:Move to folder",
+        "remove": "[to be translated]:Remove from folder",
+        "rename": "[to be translated]:Rename folder",
+        "rename_placeholder": "[to be translated]:Enter new folder name",
+        "uncategorized": "[to be translated]:Uncategorized"
+      },
       "list": "Lista de tópicos",
       "manage": {
         "clear_selection": "Limpar Seleção",

--- a/src/renderer/src/i18n/translate/ro-ro.json
+++ b/src/renderer/src/i18n/translate/ro-ro.json
@@ -1447,6 +1447,16 @@
         "word": "Exportă ca Word",
         "yuque": "Exportă în Yuque"
       },
+      "folder": {
+        "create": "[to be translated]:Create new folder",
+        "create_placeholder": "[to be translated]:Enter folder name",
+        "delete": "[to be translated]:Delete folder",
+        "move_to": "[to be translated]:Move to folder",
+        "remove": "[to be translated]:Remove from folder",
+        "rename": "[to be translated]:Rename folder",
+        "rename_placeholder": "[to be translated]:Enter new folder name",
+        "uncategorized": "[to be translated]:Uncategorized"
+      },
       "list": "Listă subiecte",
       "manage": {
         "clear_selection": "Șterge selecția",

--- a/src/renderer/src/i18n/translate/ru-ru.json
+++ b/src/renderer/src/i18n/translate/ru-ru.json
@@ -1447,6 +1447,16 @@
         "word": "Экспорт как Word",
         "yuque": "Экспорт в Yuque"
       },
+      "folder": {
+        "create": "[to be translated]:Create new folder",
+        "create_placeholder": "[to be translated]:Enter folder name",
+        "delete": "[to be translated]:Delete folder",
+        "move_to": "[to be translated]:Move to folder",
+        "remove": "[to be translated]:Remove from folder",
+        "rename": "[to be translated]:Rename folder",
+        "rename_placeholder": "[to be translated]:Enter new folder name",
+        "uncategorized": "[to be translated]:Uncategorized"
+      },
       "list": "Список топиков",
       "manage": {
         "clear_selection": "Очистить выбор",

--- a/src/renderer/src/i18n/translate/vi-vn.json
+++ b/src/renderer/src/i18n/translate/vi-vn.json
@@ -1447,6 +1447,16 @@
         "word": "Xuất ra Word",
         "yuque": "Xuất sang Yuque"
       },
+      "folder": {
+        "create": "[to be translated]:Create new folder",
+        "create_placeholder": "[to be translated]:Enter folder name",
+        "delete": "[to be translated]:Delete folder",
+        "move_to": "[to be translated]:Move to folder",
+        "remove": "[to be translated]:Remove from folder",
+        "rename": "[to be translated]:Rename folder",
+        "rename_placeholder": "[to be translated]:Enter new folder name",
+        "uncategorized": "[to be translated]:Uncategorized"
+      },
       "list": "Daftar Topik",
       "manage": {
         "clear_selection": "Xóa lựa chọn",
@@ -1491,6 +1501,7 @@
       "unpin": "Bỏ ghim chủ đề"
     },
     "translate": "Dịch",
+    "user": "[to be translated]:User",
     "web_search": {
       "warning": {
         "openai": "Mô hình GPT-5 với nỗ lực suy luận tối thiểu không hỗ trợ tìm kiếm web."
@@ -1502,11 +1513,23 @@
     "bun_required_message": "Môi trường Bun là bắt buộc để chạy các công cụ CLI",
     "cli_tool": "Công cụ CLI",
     "cli_tool_placeholder": "Chọn công cụ CLI để sử dụng",
+    "count_one": "[to be translated]:{{count}} item",
+    "count_other": "[to be translated]:{{count}} items",
     "custom_path": "Đường dẫn tùy chỉnh",
     "custom_path_error": "Falha ao definir caminho personalizado do terminal",
     "custom_path_required": "Chemin personnalisé requis pour ce terminal",
     "custom_path_set": "Đường dẫn terminal tùy chỉnh đã được đặt thành công",
     "description": "Khởi chạy nhanh nhiều công cụ CLI mã để nâng cao hiệu suất phát triển",
+    "empty": {
+      "no_match": {
+        "description": "[to be translated]:Try adjusting your search terms",
+        "title": "[to be translated]:No matching tools found"
+      },
+      "no_tool": {
+        "description": "[to be translated]:Add a CLI tool or code assistant to get started",
+        "title": "[to be translated]:No code tools yet"
+      }
+    },
     "env_vars_help": "Nhập các biến môi trường tùy chỉnh (mỗi dòng một biến, định dạng: KEY=value)",
     "environment_variables": "Biến Môi trường",
     "folder_placeholder": "Chọn thư mục làm việc",
@@ -1516,21 +1539,28 @@
       "bun_required": "Vui lòng cài đặt môi trường Bun trước khi khởi chạy các công cụ CLI",
       "error": "Lancement échoué, veuillez réessayer",
       "label": "Lanzamiento",
+      "launched": "[to be translated]:Launched",
       "success": "Khởi chạy thành công",
       "validation_error": "Vui lòng hoàn thành tất cả các trường bắt buộc: công cụ CLI, mô hình và thư mục làm việc"
     },
     "launching": "Lanzando...",
     "model": "Modelo",
+    "model_hint": "[to be translated]:Choose which AI model the CLI tool should use",
     "model_placeholder": "Chọn mô hình cần sử dụng",
     "model_required": "Vui lòng chọn một mô hình",
+    "official_tag": "[to be translated]:Official",
+    "official_tools": "[to be translated]:Official",
+    "search_placeholder": "[to be translated]:Search CLI tools…",
     "select_folder": "Pilih Folder",
     "set_custom_path": "Đặt đường dẫn terminal tùy chỉnh",
     "supported_providers": "Nhà cung cấp được hỗ trợ",
     "terminal": "Thiết bị đầu cuối",
+    "terminal_hint": "[to be translated]:Choose which terminal application to run the CLI in",
     "terminal_placeholder": "Chọn ứng dụng thiết bị đầu cuối",
     "title": "Công cụ mã",
     "update_options": "Tùy chọn Cập nhật",
-    "working_directory": "Thư mục làm việc"
+    "working_directory": "Thư mục làm việc",
+    "working_directory_hint": "[to be translated]:The working directory that the CLI tool launches in"
   },
   "code_block": {
     "collapse": "Colapso",
@@ -2130,112 +2160,6 @@
     },
     "title": "LM Studio"
   },
-  "memory": {
-    "actions": "Hành động",
-    "add_failed": "Không thể thêm bộ nhớ",
-    "add_first_memory": "Adicione Sua Primeira Memória",
-    "add_memory": "Adicionar Memória",
-    "add_new_user": "Thêm Người Dùng Mới",
-    "add_success": "Memoria añadida con éxito",
-    "add_user": "Thêm Người dùng",
-    "add_user_failed": "Không thể thêm người dùng",
-    "all_users": "Tất cả người dùng",
-    "cannot_delete_default_user": "Không thể xóa người dùng mặc định",
-    "configure_memory_first": "Vui lòng định cấu hình cài đặt bộ nhớ trước",
-    "content": "Nội dung",
-    "current_user": "Người dùng hiện tại",
-    "custom": "Tùy chỉnh",
-    "default": "Mặc định",
-    "default_user": "Người dùng Mặc định",
-    "delete_confirm": "Bạn có chắc chắn muốn xóa ký ức này không?",
-    "delete_confirm_content": "Bạn có chắc chắn muốn xóa {{count}} ký ức?",
-    "delete_confirm_single": "Bạn có chắc chắn muốn xóa ký ức này không?",
-    "delete_confirm_title": "Xóa Ký Ức",
-    "delete_failed": "Gagal menghapus memori",
-    "delete_selected": "Xóa đã chọn",
-    "delete_success": "Bộ nhớ đã được xóa thành công",
-    "delete_user": "Xóa Người dùng",
-    "delete_user_confirm_content": "Bạn có chắc chắn muốn xóa người dùng {{user}} và toàn bộ ký ức của họ không?",
-    "delete_user_confirm_title": "Xóa người dùng",
-    "delete_user_failed": "Không xóa được người dùng",
-    "description": "Bộ nhớ cho phép bạn lưu trữ và quản lý thông tin về các tương tác của bạn với trợ lý. Bạn có thể thêm, chỉnh sửa và xóa ký ức, cũng như lọc và tìm kiếm trong số chúng.",
-    "edit_memory": "Chỉnh sửa Bộ nhớ",
-    "embedding_dimensions": "Kích thước nhúng",
-    "embedding_model": "Mô hình Nhúng",
-    "enable_global_memory_first": "Vui lòng bật bộ nhớ toàn cầu trước",
-    "end_date": "Ngày kết thúc",
-    "global_memory": "Bộ nhớ toàn cục",
-    "global_memory_description": "Để sử dụng các tính năng bộ nhớ, vui lòng kích hoạt bộ nhớ toàn cầu trong cài đặt trợ lý.",
-    "global_memory_disabled_desc": "Để sử dụng các tính năng bộ nhớ, vui lòng bật bộ nhớ toàn cục trong cài đặt trợ lý trước.",
-    "global_memory_disabled_title": "Bộ Nhớ Toàn Cầu Đã Bị Vô Hiệu Hóa",
-    "global_memory_enabled": "Bộ nhớ toàn cầu đã được kích hoạt",
-    "go_to_memory_page": "Đi tới Trang Bộ nhớ",
-    "initial_memory_content": "Chào mừng! Đây là ký ức đầu tiên của bạn.",
-    "llm_model": "Mô hình LLM",
-    "load_failed": "Không tải được ký ức",
-    "loading": "Đang tải ký ức...",
-    "loading_memories": "Đang tải ký ức...",
-    "memories_description": "Hiển thị {{count}} trong tổng số {{total}} ký ức",
-    "memories_reset_success": "Tất cả ký ức cho {{user}} đã được đặt lại thành công",
-    "memory": "bộ nhớ",
-    "memory_content": "Nội dung bộ nhớ",
-    "memory_placeholder": "Nhập nội dung bộ nhớ...",
-    "new_user_id": "ID Người Dùng Mới",
-    "new_user_id_placeholder": "Nhập ID người dùng duy nhất",
-    "no_matching_memories": "Không tìm thấy ký ức phù hợp nào",
-    "no_memories": "Chưa có kỷ niệm nào",
-    "no_memories_description": "Bắt đầu bằng cách thêm ký ức đầu tiên của bạn để bắt đầu",
-    "not_configured_desc": "Vui lòng cấu hình các mô hình embedding và LLM trong cài đặt bộ nhớ để kích hoạt chức năng bộ nhớ.",
-    "not_configured_title": "Bộ nhớ chưa được cấu hình",
-    "pagination_total": "{{start}}-{{end}} trong tổng số {{total}} mục",
-    "please_enter_memory": "Vui lòng nhập nội dung bộ nhớ",
-    "please_select_embedding_model": "Vui lòng chọn một mô hình nhúng",
-    "please_select_llm_model": "Vui lòng chọn một mô hình LLM",
-    "reset_filters": "Đặt lại Bộ lọc",
-    "reset_memories": "Đặt lại Ký ức",
-    "reset_memories_confirm_content": "Bạn có chắc chắn muốn xóa vĩnh viễn tất cả ký ức của {{user}} không? Hành động này không thể hoàn tác.",
-    "reset_memories_confirm_title": "Đặt lại Tất cả Ký ức",
-    "reset_memories_failed": "Không thể đặt lại ký ức",
-    "reset_user_memories": "Đặt lại Bộ nhớ Người dùng",
-    "reset_user_memories_confirm_content": "Bạn có chắc chắn muốn đặt lại toàn bộ ký ức cho {{user}} không?",
-    "reset_user_memories_confirm_title": "Đặt lại bộ nhớ người dùng",
-    "reset_user_memories_failed": "Không thể đặt lại bộ nhớ người dùng",
-    "score": "Điểm",
-    "search": "Tìm kiếm",
-    "search_placeholder": "Tìm kiếm ký ức...",
-    "select_embedding_model_placeholder": "Chọn Mô hình Nhúng",
-    "select_llm_model_placeholder": "Chọn mô hình LLM",
-    "select_user": "Chọn Người dùng",
-    "settings": "Cài đặt",
-    "settings_title": "Cài đặt bộ nhớ",
-    "start_date": "Ngày bắt đầu",
-    "statistics": "Thống kê",
-    "stored_memories": "Ký Ức Được Lưu Trữ",
-    "switch_user": "Chuyển người dùng",
-    "switch_user_confirm": "Chuyển ngữ cảnh người dùng sang {{user}}?",
-    "time": "Thời gian",
-    "title": "Kỷ niệm",
-    "total_memories": "tổng số ký ức",
-    "try_different_filters": "Thử điều chỉnh tiêu chí tìm kiếm của bạn",
-    "update_failed": "Không thể cập nhật bộ nhớ",
-    "update_success": "Bộ nhớ đã được cập nhật thành công",
-    "user": "Người dùng",
-    "user_created": "Người dùng {{user}} đã được tạo và chuyển đổi thành công",
-    "user_deleted": "Người dùng {{user}} đã được xóa thành công",
-    "user_id": "ID người dùng",
-    "user_id_exists": "ID người dùng này đã tồn tại",
-    "user_id_invalid_chars": "ID người dùng chỉ có thể chứa chữ cái, chữ số, dấu gạch ngang và dấu gạch dưới",
-    "user_id_placeholder": "Nhập ID người dùng (tùy chọn)",
-    "user_id_required": "ID người dùng là bắt buộc",
-    "user_id_reserved": "'default-user' được giữ lại, vui lòng sử dụng một ID khác",
-    "user_id_rules": "ID người dùng phải là duy nhất và chỉ chứa chữ cái, chữ số, dấu gạch ngang (-) và dấu gạch dưới (_)",
-    "user_id_too_long": "ID người dùng không được vượt quá 50 ký tự",
-    "user_management": "Quản lý người dùng",
-    "user_memories_reset": "Tất cả ký ức cho {{user}} đã được đặt lại",
-    "user_switch_failed": "Không thể chuyển đổi người dùng",
-    "user_switched": "Ngữ cảnh người dùng đã chuyển sang {{user}}",
-    "users": "người dùng"
-  },
   "message": {
     "agents": {
       "import": {
@@ -2638,37 +2562,6 @@
     "wps-copilot": "WPS Copilot",
     "xiaoyi": "Tiểu Nghi",
     "zhihu": "Zhihu"
-  },
-  "miniwindow": {
-    "alert": {
-      "google_login": "Mẹo: Nếu bạn thấy thông báo 'trình duyệt không được tin cậy' khi đăng nhập vào Google, vui lòng trước tiên đăng nhập qua mini app Google trong danh sách mini app, sau đó mới dùng đăng nhập Google ở các mini app khác"
-    },
-    "clipboard": {
-      "empty": "Bộ nhớ tạm trống"
-    },
-    "feature": {
-      "chat": "Trả lời câu hỏi này",
-      "explanation": "Giải thích",
-      "summary": "Tóm tắt nội dung",
-      "translate": "Dịch văn bản"
-    },
-    "footer": {
-      "backspace_clear": "Nhấn Backspace để xóa",
-      "copy_last_message": "Nhấn C để sao chép",
-      "esc": "ESC để {{action}}",
-      "esc_back": "trả về",
-      "esc_close": "đóng",
-      "esc_pause": "tạm dừng"
-    },
-    "input": {
-      "placeholder": {
-        "empty": "Hỏi {{model}} để được giúp đỡ...",
-        "title": "Bạn muốn làm gì với văn bản này?"
-      }
-    },
-    "tooltip": {
-      "pin": "Giữ cửa sổ ở trên cùng"
-    }
   },
   "models": {
     "add_parameter": "Thêm tham số",
@@ -3455,6 +3348,37 @@
     "zai": "Z.ai",
     "zhinao": "360AI",
     "zhipu": "Mô hình Lớn"
+  },
+  "quickAssistant": {
+    "alert": {
+      "google_login": "[to be translated]:Tip: If you see a 'browser not trusted' message when logging into Google, please first login through the Google mini app in the mini app list, then use Google login in other mini apps"
+    },
+    "clipboard": {
+      "empty": "[to be translated]:Clipboard is empty"
+    },
+    "feature": {
+      "chat": "[to be translated]:Answer this question",
+      "explanation": "[to be translated]:Explanation",
+      "summary": "[to be translated]:Content summary",
+      "translate": "[to be translated]:Text translation"
+    },
+    "footer": {
+      "backspace_clear": "[to be translated]:Backspace to clear",
+      "copy_last_message": "[to be translated]:Press C to copy",
+      "esc": "[to be translated]:ESC to {{action}}",
+      "esc_back": "[to be translated]:return",
+      "esc_close": "[to be translated]:close",
+      "esc_pause": "[to be translated]:pause"
+    },
+    "input": {
+      "placeholder": {
+        "empty": "[to be translated]:Ask {{model}} for help...",
+        "title": "[to be translated]:What do you want to do with this text?"
+      }
+    },
+    "tooltip": {
+      "pin": "[to be translated]:Keep Window on Top"
+    }
   },
   "restore": {
     "confirm": {
@@ -5554,22 +5478,29 @@
     "shortcuts": {
       "action": "Hành động",
       "actions": "hoạt động",
+      "bind_first_to_enable": "[to be translated]:Bind a shortcut first to change its enabled state",
       "clear_shortcut": "Phím tắt rõ ràng",
       "clear_topic": "Tin nhắn rõ ràng",
+      "conflict_with": "[to be translated]:Already used by \"{{name}}\"",
       "copy_last_message": "Sao tin nhắn cuối cùng",
       "edit_last_user_message": "Chỉnh sửa tin nhắn cuối cùng của người dùng",
       "enabled": "Kích hoạt",
       "exit_fullscreen": "Thoát toàn màn hình",
       "label": "Khóa",
-      "mini_window": "Trợ lý Nhanh",
       "new_topic": "Chủ đề mới",
+      "occupied_by_other_application": "[to be translated]:This shortcut is already used by the system or another application",
       "press_shortcut": "Nhấn Phím tắt",
+      "quick_assistant": "[to be translated]:Quick Assistant",
       "rename_topic": "Đổi tên chủ đề",
       "reset_defaults": "Đặt lại mặc định",
       "reset_defaults_confirm": "Bạn có chắc chắn muốn đặt lại tất cả phím tắt không?",
+      "reset_defaults_failed": "[to be translated]:Failed to reset shortcuts to defaults",
       "reset_to_default": "Đặt lại về mặc định",
+      "save_failed": "[to be translated]:Failed to save shortcut",
+      "save_failed_with_name": "[to be translated]:Failed to save shortcut: {{name}}",
       "search_message": "Tin nhắn tìm kiếm",
       "search_message_in_chat": "Tìm Tin nhắn trong Cuộc trò chuyện Hiện tại",
+      "search_placeholder": "[to be translated]:Search shortcuts...",
       "select_model": "Chọn Mô hình",
       "selection_assistant_select_text": "Trợ lý Lựa chọn: Chọn Văn bản",
       "selection_assistant_toggle": "Bật Trợ lý Chọn",
@@ -5577,8 +5508,8 @@
       "show_settings": "Mở Cài đặt",
       "title": "Phím tắt",
       "toggle_new_context": "Ngữ cảnh rõ ràng",
-      "toggle_show_assistants": "Bật Trợ lý",
       "toggle_show_topics": "Chuyển đổi chủ đề",
+      "toggle_sidebar": "[to be translated]:Toggle Sidebar",
       "zoom_in": "Phóng to",
       "zoom_out": "Thu nhỏ",
       "zoom_reset": "Đặt lại thu phóng"
@@ -5846,6 +5777,13 @@
       "title": "Zoom de página"
     }
   },
+  "tab": {
+    "close": "[to be translated]:Close Tab",
+    "moveToFirst": "[to be translated]:Move to First",
+    "new": "[to be translated]:New Tab",
+    "pin": "[to be translated]:Pin Tab",
+    "unpin": "[to be translated]:Unpin Tab"
+  },
   "title": {
     "apps": "Ứng dụng",
     "code": "Mã",
@@ -5854,7 +5792,6 @@
     "knowledge": "Cơ sở tri thức",
     "launchpad": "Bảng khởi chạy",
     "mcp-servers": "MCP Servers",
-    "memories": "Kỷ niệm",
     "notes": "Ghi chú",
     "openclaw": "OpenClaw",
     "paintings": "Tranh vẽ",
@@ -6012,7 +5949,7 @@
   },
   "tray": {
     "quit": "Thôi",
-    "show_mini_window": "Trợ lý Nhanh",
+    "show_quick_assistant": "[to be translated]:Quick Assistant",
     "show_window": "Hiển thị cửa sổ"
   },
   "update": {

--- a/src/renderer/src/pages/home/Tabs/components/TopicFolderGroup.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/TopicFolderGroup.tsx
@@ -1,0 +1,69 @@
+import { DownOutlined, RightOutlined } from '@ant-design/icons'
+import { cn } from '@renderer/utils'
+import { Tooltip } from 'antd'
+import type { FC, ReactNode } from 'react'
+
+interface TopicFolderGroupProps {
+  folder: string
+  isCollapsed: boolean
+  onToggle: (folder: string) => void
+  showTitle?: boolean
+  children: ReactNode
+}
+
+export const TopicFolderGroup: FC<TopicFolderGroupProps> = ({
+  folder,
+  isCollapsed,
+  onToggle,
+  showTitle = true,
+  children
+}) => {
+  return (
+    <FolderContainer>
+      {showTitle && (
+        <FolderHeader onClick={() => onToggle(folder)}>
+          <Tooltip title={folder}>
+            <FolderHeaderName>
+              {isCollapsed ? (
+                <RightOutlined style={{ fontSize: '10px', marginRight: '5px' }} />
+              ) : (
+                <DownOutlined style={{ fontSize: '10px', marginRight: '5px' }} />
+              )}
+              {folder}
+            </FolderHeaderName>
+          </Tooltip>
+          <FolderHeaderDivider />
+        </FolderHeader>
+      )}
+      {!isCollapsed && <div>{children}</div>}
+    </FolderContainer>
+  )
+}
+
+const FolderContainer: FC<React.HTMLAttributes<HTMLDivElement>> = ({ children, ...props }) => (
+  <div className={cn('flex flex-col gap-2')} {...props}>
+    {children}
+  </div>
+)
+
+const FolderHeader: FC<React.HTMLAttributes<HTMLDivElement>> = ({ children, ...props }) => (
+  <div
+    className={cn(
+      'my-1 flex h-6 cursor-pointer flex-row items-center justify-between font-medium text-[var(--color-text-2)] text-xs'
+    )}
+    {...props}>
+    {children}
+  </div>
+)
+
+const FolderHeaderName: FC<React.HTMLAttributes<HTMLDivElement>> = ({ children, ...props }) => (
+  <div
+    className={cn('mr-1 box-border flex max-w-[50%] truncate px-1 text-[13px] text-[var(--color-text)] leading-6')}
+    {...props}>
+    {children}
+  </div>
+)
+
+const FolderHeaderDivider: FC<React.HTMLAttributes<HTMLDivElement>> = (props) => (
+  <div className={cn('flex-1 border-[var(--color-border)] border-t')} {...props} />
+)

--- a/src/renderer/src/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/Topics.tsx
@@ -15,6 +15,7 @@ import { useInPlaceEdit } from '@renderer/hooks/useInPlaceEdit'
 import { modelGenerating } from '@renderer/hooks/useModel'
 import { useNotesSettings } from '@renderer/hooks/useNotesSettings'
 import { finishTopicRenaming, startTopicRenaming, TopicManager } from '@renderer/hooks/useTopic'
+import { useTopicFolders } from '@renderer/hooks/useTopicFolders'
 import { fetchMessagesSummary } from '@renderer/services/ApiService'
 import { getDefaultTopic } from '@renderer/services/AssistantService'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
@@ -40,6 +41,7 @@ import { findIndex } from 'lodash'
 import {
   BrushCleaning,
   CheckSquare,
+  FolderIcon,
   FolderOpen,
   HelpCircle,
   ListChecks,
@@ -95,6 +97,9 @@ export const Topics: React.FC<Props> = ({ assistant: _assistant, activeTopic, se
   // 管理模式状态
   const manageState = useTopicManageMode()
   const { isManageMode, selectedIds, searchText, enterManageMode, exitManageMode, toggleSelectTopic } = manageState
+
+  const pinnedTopics = useMemo(() => assistant.topics.filter((t) => t.pinned), [assistant.topics])
+  const { allFolders, createFolder } = useTopicFolders(assistant.id, pinnedTopics)
 
   const { startEdit, isEditing, inputProps } = useInPlaceEdit({
     onSave: (name: string) => {
@@ -344,6 +349,57 @@ export const Topics: React.FC<Props> = ({ assistant: _assistant, activeTopic, se
         }
       },
       {
+        label: t('chat.topics.folder.move_to'),
+        key: 'folder',
+        icon: <FolderIcon size={14} />,
+        children: [
+          ...(topic.folder
+            ? [
+                {
+                  label: t('chat.topics.folder.remove'),
+                  key: 'remove-from-folder',
+                  onClick: () => {
+                    const updatedTopic = { ...topic, folder: undefined }
+                    updateTopic(updatedTopic)
+                    topic.id === activeTopic.id && setActiveTopic(updatedTopic)
+                  }
+                }
+              ]
+            : []),
+          ...allFolders.map((folderName) => ({
+            label: folderName,
+            key: `folder-${folderName}`,
+            onClick: () => {
+              const updatedTopic = { ...topic, folder: folderName }
+              updateTopic(updatedTopic)
+              topic.id === activeTopic.id && setActiveTopic(updatedTopic)
+            }
+          })),
+          { type: 'divider' as const },
+          {
+            label: t('chat.topics.folder.create'),
+            key: 'create-folder',
+            onClick: async () => {
+              const folderName = await PromptPopup.show({
+                title: t('chat.topics.folder.create'),
+                message: '',
+                defaultValue: '',
+                inputProps: {
+                  placeholder: t('chat.topics.folder.create_placeholder'),
+                  allowClear: true
+                }
+              })
+              if (folderName) {
+                void createFolder(folderName)
+                const updatedTopic = { ...topic, folder: folderName }
+                updateTopic(updatedTopic)
+                topic.id === activeTopic.id && setActiveTopic(updatedTopic)
+              }
+            }
+          }
+        ]
+      },
+      {
         label: t('notes.save'),
         key: 'notes',
         icon: <NotebookPen size={14} />,
@@ -539,7 +595,9 @@ export const Topics: React.FC<Props> = ({ assistant: _assistant, activeTopic, se
     onClearMessages,
     setTopicPosition,
     onMoveTopic,
-    onDeleteTopic
+    onDeleteTopic,
+    allFolders,
+    createFolder
   ])
 
   // Sort topics based on pinned status if pinTopicsToTop is enabled

--- a/src/renderer/src/store/settings.ts
+++ b/src/renderer/src/store/settings.ts
@@ -90,6 +90,8 @@ export interface SettingsState {
   topicPosition: 'left' | 'right'
   showTopicTime: boolean
   pinTopicsToTop: boolean
+  topicFoldersOrder: Record<string, string[]>
+  collapsedTopicFolders: Record<string, string[]>
   assistantIconType: AssistantIconType
   pasteLongTextAsFile: boolean
   pasteLongTextThreshold: number
@@ -288,6 +290,8 @@ export const initialState: SettingsState = {
   topicPosition: 'left',
   showTopicTime: false,
   pinTopicsToTop: false,
+  topicFoldersOrder: {},
+  collapsedTopicFolders: {},
   assistantIconType: 'emoji',
   pasteLongTextAsFile: false,
   pasteLongTextThreshold: 1500,

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -277,6 +277,7 @@ export type Topic = {
   updatedAt: string
   messages: Message[]
   pinned?: boolean
+  folder?: string
   prompt?: string
   isNameManuallyEdited?: boolean
 }


### PR DESCRIPTION
### What this PR does

Implements a **Pinned Topic Folders** feature that allows users to organize their pinned topics into collapsible folders, addressing issue #14445.

Before this PR:
- Pinned topics were displayed in a flat list
- Users had to scroll through many pinned topics in the sidebar
- No way to categorize or group pinned items

After this PR:
- Users can create folders (e.g., "Work", "Investment Research", "Code Assistant")
- Folders are collapsible to save sidebar space
- Right-click on pinned topics to "Move to folder..." or create new folders
- Folder order and collapse state are persisted per assistant

Resolves #14445 

### Why we need it and why it was done in this way

As users accumulate many pinned topics over time, the sidebar becomes cluttered and retrieval efficiency decreases. This feature provides:
- **Space efficiency**: Collapsible folders reduce vertical space usage
- **Visual clarity**: Topics organized by category are easier to find
- **Persistence**: Folder structure is saved across sessions

Implementation follows the existing `useTags` pattern for assistants to minimize code divergence.

The following tradeoffs were made:
- Used preference keys `topic.folders.order` and `topic.folders.collapsed` (per-assistant) rather than global folder system
- Context menu integration was chosen over drag-and-drop for initial implementation

The following alternatives were considered:
- Drag-and-drop grouping (deferred for future enhancement)
- Per-assistant vs global folders (per-assistant chosen for better isolation)

### Breaking changes

None - this is a purely additive feature that does not affect existing functionality.

### Special notes for your reviewer

- Files created: `useTopicFolders.ts` hook, `TopicFolderGroup.tsx` component
- Modified: `Topics.tsx` for context menu, `Topic` type for `folder` property
- i18n: synced across 9 language files via `pnpm i18n:sync`

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Follows existing `useTags` pattern, reusable `TopicFolderGroup` component
- [x] Refactor: Clean component separation, no duplication of existing patterns
- [x] Upgrade: No impact on upgrade flows
- [ ] Documentation: User-guide update not required (feature is self-explanatory via UI)
- [x] Self-review: Code reviewed via lint, typecheck, and format checks

### Release note

```release-note
feat(topics): Add folder grouping functionality for pinned topics. Users can now organize pinned topics into collapsible folders via right-click context menu ("Move to folder...").
```