### PR TITLE
fix: normalize image edit inputs for uploads and prior generated images

### DIFF
--- a/src/main/services/FileStorage.ts
+++ b/src/main/services/FileStorage.ts
@@ -696,7 +696,7 @@ class FileStorage {
         path: destPath,
         created_at: new Date().toISOString(),
         size: buffer.length,
-        ext: ext.slice(1),
+        ext,
         type: getFileTypeByExt(ext),
         count: 1
       }
@@ -746,7 +746,7 @@ class FileStorage {
         path: destPath,
         created_at: new Date().toISOString(),
         size: stats.size,
-        ext: ext.slice(1),
+        ext,
         type: getFileTypeByExt(ext),
         count: 1
       }

--- a/src/main/services/FileStorage.ts
+++ b/src/main/services/FileStorage.ts
@@ -33,6 +33,48 @@ import WordExtractor from 'word-extractor'
 
 const logger = loggerService.withContext('FileStorage')
 
+const IMAGE_MIME_BY_EXT: Record<string, string> = {
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  bmp: 'image/bmp'
+}
+
+function detectImageMimeFromBuffer(data: Buffer): string | null {
+  if (data.length >= 8 && data.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) {
+    return 'image/png'
+  }
+
+  if (data.length >= 3 && data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff) {
+    return 'image/jpeg'
+  }
+
+  if (data.length >= 6 && ['GIF87a', 'GIF89a'].includes(data.subarray(0, 6).toString('ascii'))) {
+    return 'image/gif'
+  }
+
+  if (
+    data.length >= 12 &&
+    data.subarray(0, 4).toString('ascii') === 'RIFF' &&
+    data.subarray(8, 12).toString('ascii') === 'WEBP'
+  ) {
+    return 'image/webp'
+  }
+
+  if (data.length >= 2 && data.subarray(0, 2).toString('ascii') === 'BM') {
+    return 'image/bmp'
+  }
+
+  return null
+}
+
+function getImageMimeFromPath(filePath: string, data: Buffer): string {
+  const ext = path.extname(filePath).slice(1).toLowerCase()
+  return IMAGE_MIME_BY_EXT[ext] || detectImageMimeFromBuffer(data) || 'image/png'
+}
+
 // Get ripgrep binary path
 const getRipgrepBinaryPath = (): string | null => {
   try {
@@ -653,8 +695,7 @@ class FileStorage {
     const filePath = path.join(this.storageDir, id)
     const data = await fs.promises.readFile(filePath)
     const base64 = data.toString('base64')
-    const ext = path.extname(filePath).slice(1) == 'jpg' ? 'jpeg' : path.extname(filePath).slice(1)
-    const mime = `image/${ext}`
+    const mime = getImageMimeFromPath(filePath, data)
     return {
       mime,
       base64,

--- a/src/main/utils/file.ts
+++ b/src/main/utils/file.ts
@@ -15,6 +15,48 @@ import { v4 as uuidv4 } from 'uuid'
 
 const logger = loggerService.withContext('Utils:File')
 
+const IMAGE_MIME_BY_EXT: Record<string, string> = {
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  bmp: 'image/bmp'
+}
+
+function detectImageMimeFromBuffer(data: Buffer): string | null {
+  if (data.length >= 8 && data.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) {
+    return 'image/png'
+  }
+
+  if (data.length >= 3 && data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff) {
+    return 'image/jpeg'
+  }
+
+  if (data.length >= 6 && ['GIF87a', 'GIF89a'].includes(data.subarray(0, 6).toString('ascii'))) {
+    return 'image/gif'
+  }
+
+  if (
+    data.length >= 12 &&
+    data.subarray(0, 4).toString('ascii') === 'RIFF' &&
+    data.subarray(8, 12).toString('ascii') === 'WEBP'
+  ) {
+    return 'image/webp'
+  }
+
+  if (data.length >= 2 && data.subarray(0, 2).toString('ascii') === 'BM') {
+    return 'image/bmp'
+  }
+
+  return null
+}
+
+function getImageMimeFromPath(filePath: string, data: Buffer): string {
+  const ext = path.extname(filePath).slice(1).toLowerCase()
+  return IMAGE_MIME_BY_EXT[ext] || detectImageMimeFromBuffer(data) || 'image/png'
+}
+
 // 创建文件类型映射表，提高查找效率
 const fileTypeMap = new Map<string, FileType>()
 
@@ -294,8 +336,7 @@ export async function base64Image(file: FileMetadata): Promise<{ mime: string; b
   const filePath = path.join(getFilesDir(), `${file.id}${file.ext}`)
   const data = await fs.promises.readFile(filePath)
   const base64 = data.toString('base64')
-  const ext = path.extname(filePath).slice(1) == 'jpg' ? 'jpeg' : path.extname(filePath).slice(1)
-  const mime = `image/${ext}`
+  const mime = getImageMimeFromPath(filePath, data)
   return {
     mime,
     base64,

--- a/src/renderer/src/pages/settings/ProviderSettings/ModelList/ManageModelsPopup.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ModelList/ManageModelsPopup.tsx
@@ -174,7 +174,7 @@ const PopupContainer: React.FC<Props> = ({ providerId, resolve }) => {
         }
       }
     })
-  }, [list, models, onAddModel, provider, t])
+  }, [list, onAddModel, provider, t])
 
   const loadModels = useCallback(async (provider: Provider) => {
     setLoadingModels(true)

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -38,7 +38,7 @@ import {
   getQuickModel
 } from './AssistantService'
 import { ConversationService } from './ConversationService'
-import FileManager from './FileManager'
+import { getEditableImageInput } from './imageEditInput'
 import { injectUserMessageWithKnowledgeSearchPrompt } from './KnowledgeService'
 import type { BlockManager } from './messageStreaming'
 import type { StreamProcessorCallbacks } from './StreamProcessingService'
@@ -310,25 +310,26 @@ export async function fetchChatCompletion({
  */
 async function collectImagesFromMessages(userMessage: Message, assistantMessage?: Message): Promise<string[]> {
   const images: string[] = []
+  const loadImageDataUrl = async (message: Message): Promise<string[]> => {
+    const imageBlocks = findImageBlocks(message)
+    const imageUrls: string[] = []
+
+    for (const block of imageBlocks) {
+      const imageInput = await getEditableImageInput(block)
+      if (imageInput) {
+        imageUrls.push(imageInput)
+      }
+    }
+
+    return imageUrls
+  }
 
   // 收集用户消息中的图像
-  const userImageBlocks = findImageBlocks(userMessage)
-  for (const block of userImageBlocks) {
-    if (block.file) {
-      const base64 = await FileManager.readBase64File(block.file)
-      const mimeType = block.file.type || 'image/png'
-      images.push(`data:${mimeType};base64,${base64}`)
-    }
-  }
+  images.push(...(await loadImageDataUrl(userMessage)))
 
   // 收集助手消息中的图像（用于继续编辑生成的图像）
   if (assistantMessage) {
-    const assistantImageBlocks = findImageBlocks(assistantMessage)
-    for (const block of assistantImageBlocks) {
-      if (block.url) {
-        images.push(block.url)
-      }
-    }
+    images.push(...(await loadImageDataUrl(assistantMessage)))
   }
 
   return images

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -160,21 +160,22 @@ export async function transformMessagesAndFetch(
   const { messages, assistant } = request
 
   try {
-    const { modelMessages, uiMessages } = await ConversationService.prepareMessagesForModel(messages, assistant)
+    // 专用图像生成模型直接走 fetchImageGeneration
+    const model = assistant.model || getDefaultModel()
 
     // replace prompt variables
     assistant.prompt = await replacePromptVariables(assistant.prompt, assistant.model?.name)
 
-    // 专用图像生成模型直接走 fetchImageGeneration
-    const model = assistant.model || getDefaultModel()
     if (isDedicatedImageGenerationModel(model)) {
       await fetchImageGeneration({
-        messages: uiMessages,
+        messages: ConversationService.prepareMessagesForImageGeneration(messages),
         assistant,
         onChunkReceived
       })
       return
     }
+
+    const { modelMessages, uiMessages } = await ConversationService.prepareMessagesForModel(messages, assistant)
 
     // inject knowledge search prompt into model messages
     await injectUserMessageWithKnowledgeSearchPrompt({
@@ -308,7 +309,7 @@ export async function fetchChatCompletion({
  * 从消息中收集图像（用于图像编辑）
  * 收集用户消息中上传的图像和助手消息中生成的图像
  */
-async function collectImagesFromMessages(userMessage: Message, assistantMessage?: Message): Promise<string[]> {
+async function collectImagesFromMessages(messages: Message[], userMessage: Message): Promise<string[]> {
   const images: string[] = []
   const loadImageDataUrl = async (message: Message): Promise<string[]> => {
     const imageBlocks = findImageBlocks(message)
@@ -327,9 +328,20 @@ async function collectImagesFromMessages(userMessage: Message, assistantMessage?
   // 收集用户消息中的图像
   images.push(...(await loadImageDataUrl(userMessage)))
 
-  // 收集助手消息中的图像（用于继续编辑生成的图像）
-  if (assistantMessage) {
-    images.push(...(await loadImageDataUrl(assistantMessage)))
+  // 收集当前用户消息之前最近一条助手图片消息（用于继续编辑生成的图像）
+  const userMessageIndex = messages.findLastIndex((message) => message.id === userMessage.id)
+  const previousMessages = userMessageIndex === -1 ? messages : messages.slice(0, userMessageIndex)
+  for (let index = previousMessages.length - 1; index >= 0; index--) {
+    const message = previousMessages[index]
+    if (message.role !== 'assistant') {
+      continue
+    }
+
+    const assistantImages = await loadImageDataUrl(message)
+    if (assistantImages.length > 0) {
+      images.push(...assistantImages)
+      break
+    }
   }
 
   return images
@@ -364,14 +376,13 @@ export async function fetchImageGeneration({
   try {
     // 提取 prompt 和图像
     const lastUserMessage = messages.findLast((m) => m.role === 'user')
-    const lastAssistantMessage = messages.findLast((m) => m.role === 'assistant')
 
     if (!lastUserMessage) {
       throw new Error('No user message found for image generation.')
     }
 
     const prompt = getMainTextContent(lastUserMessage)
-    const inputImages = await collectImagesFromMessages(lastUserMessage, lastAssistantMessage)
+    const inputImages = await collectImagesFromMessages(messages, lastUserMessage)
 
     // 调用 generateImage 或 editImage
     // 使用默认图像生成配置

--- a/src/renderer/src/services/ConversationService.ts
+++ b/src/renderer/src/services/ConversationService.ts
@@ -35,6 +35,21 @@ export class ConversationService {
     return userRoleStartMessages
   }
 
+  /**
+   * Dedicated image generation/editing needs the previous generated image even
+   * when chat context is disabled. Keep the normal cleanup rules, but do not
+   * trim by contextCount.
+   */
+  static prepareMessagesForImageGeneration(messages: Message[]): Message[] {
+    const messagesAfterContextClear = filterAfterContextClearMessages(messages)
+    const usefulMessages = filterUsefulMessages(messagesAfterContextClear)
+    const withoutErrorOnlyPairs = filterErrorOnlyMessagesWithRelated(usefulMessages)
+    const withoutTrailingAssistant = filterLastAssistantMessage(withoutErrorOnlyPairs)
+    const withoutAdjacentUsers = filterAdjacentUserMessaegs(withoutTrailingAssistant)
+    const nonEmptyMessages = filterEmptyMessages(withoutAdjacentUsers)
+    return filterUserRoleStartMessages(nonEmptyMessages)
+  }
+
   static async prepareMessagesForModel(
     messages: Message[],
     assistant: Assistant

--- a/src/renderer/src/services/__tests__/ConversationService.test.ts
+++ b/src/renderer/src/services/__tests__/ConversationService.test.ts
@@ -1,7 +1,7 @@
 import { combineReducers, configureStore } from '@reduxjs/toolkit'
 import { messageBlocksSlice } from '@renderer/store/messageBlock'
 import { MessageBlockStatus } from '@renderer/types/newMessage'
-import { createErrorBlock, createMainTextBlock, createMessage } from '@renderer/utils/messageUtils/create'
+import { createErrorBlock, createImageBlock, createMainTextBlock, createMessage } from '@renderer/utils/messageUtils/create'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ConversationService } from '../ConversationService'
@@ -162,5 +162,38 @@ describe('ConversationService.filterMessagesPipeline', () => {
     expect(filtered.find((m) => m.id === 'user-2')).toBeUndefined()
     expect(filtered[0].role).toBe('user')
     expect(filtered[filtered.length - 1].role).toBe('user')
+  })
+
+  it('keeps the previous assistant image for dedicated image generation even when chat context is disabled', () => {
+    const topicId = 'topic-1'
+    const assistantId = 'assistant-1'
+
+    const user1Block = createMainTextBlock('user-1', 'Draw an image', { status: MessageBlockStatus.SUCCESS })
+    const user1 = createMessage('user', topicId, assistantId, { id: 'user-1', blocks: [user1Block.id] })
+
+    const assistantImageBlock = createImageBlock('assistant-1', {
+      url: 'data:image/png;base64,previous-image',
+      status: MessageBlockStatus.SUCCESS
+    })
+    const assistant1 = createMessage('assistant', topicId, assistantId, {
+      id: 'assistant-1',
+      askId: 'user-1',
+      blocks: [assistantImageBlock.id]
+    })
+
+    const user2Block = createMainTextBlock('user-2', 'Make it more concise', {
+      status: MessageBlockStatus.SUCCESS
+    })
+    const user2 = createMessage('user', topicId, assistantId, { id: 'user-2', blocks: [user2Block.id] })
+
+    mockStore.dispatch(messageBlocksSlice.actions.upsertOneBlock(user1Block))
+    mockStore.dispatch(messageBlocksSlice.actions.upsertOneBlock(assistantImageBlock))
+    mockStore.dispatch(messageBlocksSlice.actions.upsertOneBlock(user2Block))
+
+    const chatFiltered = ConversationService.filterMessagesPipeline([user1, assistant1, user2], 0)
+    expect(chatFiltered.map((m) => m.id)).toEqual(['user-2'])
+
+    const imageMessages = ConversationService.prepareMessagesForImageGeneration([user1, assistant1, user2])
+    expect(imageMessages.map((m) => m.id)).toEqual(['user-1', 'assistant-1', 'user-2'])
   })
 })

--- a/src/renderer/src/services/__tests__/imageEditInput.test.ts
+++ b/src/renderer/src/services/__tests__/imageEditInput.test.ts
@@ -96,4 +96,30 @@ describe('getEditableImageInput', () => {
     expect(mocks.base64Image).not.toHaveBeenCalled()
     expect(result).toBe('https://example.com/image.png')
   })
+
+  it('normalizes incomplete image data URL MIME types from the file API', async () => {
+    mocks.base64Image.mockResolvedValue({
+      mime: 'image',
+      base64: 'aGVsbG8=',
+      data: 'data:image;base64,aGVsbG8='
+    })
+
+    const result = await getEditableImageInput(
+      createImageBlock({
+        file: {
+          id: 'file-3',
+          name: 'file-3.png',
+          origin_name: 'file-3.png',
+          path: '/tmp/file-3.png',
+          size: 5,
+          ext: '.png',
+          type: 'image',
+          created_at: new Date().toISOString(),
+          count: 1
+        }
+      })
+    )
+
+    expect(result).toBe('data:image/png;base64,aGVsbG8=')
+  })
 })

--- a/src/renderer/src/services/__tests__/imageEditInput.test.ts
+++ b/src/renderer/src/services/__tests__/imageEditInput.test.ts
@@ -1,7 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-
 import type { ImageMessageBlock } from '@renderer/types/newMessage'
 import { MessageBlockStatus, MessageBlockType } from '@renderer/types/newMessage'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getEditableImageInput } from '../imageEditInput'
 

--- a/src/renderer/src/services/__tests__/imageEditInput.test.ts
+++ b/src/renderer/src/services/__tests__/imageEditInput.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ImageMessageBlock } from '@renderer/types/newMessage'
+import { MessageBlockStatus, MessageBlockType } from '@renderer/types/newMessage'
+
+import { getEditableImageInput } from '../imageEditInput'
+
+const mocks = vi.hoisted(() => ({
+  base64Image: vi.fn()
+}))
+
+describe('getEditableImageInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('window', {
+      api: {
+        file: {
+          base64Image: mocks.base64Image
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  const createImageBlock = (overrides: Partial<ImageMessageBlock> = {}): ImageMessageBlock => ({
+    id: 'block-1',
+    messageId: 'msg-1',
+    type: MessageBlockType.IMAGE,
+    createdAt: new Date().toISOString(),
+    status: MessageBlockStatus.SUCCESS,
+    ...overrides
+  })
+
+  it('loads a generated local file back as a real data URL', async () => {
+    mocks.base64Image.mockResolvedValue({
+      mime: 'image/png',
+      base64: 'aGVsbG8=',
+      data: 'data:image/png;base64,aGVsbG8='
+    })
+
+    const result = await getEditableImageInput(
+      createImageBlock({
+        file: {
+          id: 'file-1',
+          name: 'file-1.png',
+          origin_name: 'file-1.png',
+          path: '/tmp/file-1.png',
+          size: 5,
+          ext: '.png',
+          type: 'image',
+          created_at: new Date().toISOString(),
+          count: 1
+        }
+      })
+    )
+
+    expect(mocks.base64Image).toHaveBeenCalledWith('file-1.png')
+    expect(result).toBe('data:image/png;base64,aGVsbG8=')
+  })
+
+  it('normalizes legacy ext values without a leading dot', async () => {
+    mocks.base64Image.mockResolvedValue({
+      mime: 'image/png',
+      base64: 'aGVsbG8=',
+      data: 'data:image/png;base64,aGVsbG8='
+    })
+
+    await getEditableImageInput(
+      createImageBlock({
+        file: {
+          id: 'file-2',
+          name: 'file-2.png',
+          origin_name: 'file-2.png',
+          path: '/tmp/file-2.png',
+          size: 5,
+          ext: 'png',
+          type: 'image',
+          created_at: new Date().toISOString(),
+          count: 1
+        }
+      })
+    )
+
+    expect(mocks.base64Image).toHaveBeenCalledWith('file-2.png')
+  })
+
+  it('passes through remote or data URLs unchanged', async () => {
+    const result = await getEditableImageInput(
+      createImageBlock({
+        url: 'https://example.com/image.png'
+      })
+    )
+
+    expect(mocks.base64Image).not.toHaveBeenCalled()
+    expect(result).toBe('https://example.com/image.png')
+  })
+})

--- a/src/renderer/src/services/imageEditInput.ts
+++ b/src/renderer/src/services/imageEditInput.ts
@@ -1,10 +1,46 @@
 import type { ImageMessageBlock } from '@renderer/types/newMessage'
 
+const VALID_IMAGE_SUBTYPES = new Set(['png', 'jpeg', 'webp', 'gif', 'bmp'])
+
+function getImageMimeFromExtension(ext?: string): string {
+  const subtype = ext?.replace(/^\./, '').toLowerCase()
+  if (!subtype) {
+    return 'image/png'
+  }
+
+  if (subtype === 'jpg') {
+    return 'image/jpeg'
+  }
+
+  return VALID_IMAGE_SUBTYPES.has(subtype) ? `image/${subtype}` : 'image/png'
+}
+
+function normalizeEditableImageDataUrl(data: string, mime?: string, fallbackExt?: string): string {
+  const match = data.match(/^data:([^;,]*);base64,(.*)$/s)
+  if (!match) {
+    return data
+  }
+
+  const mediaType = match[1].toLowerCase()
+  const subtype = mediaType.startsWith('image/') ? mediaType.slice('image/'.length) : ''
+  if (mediaType.startsWith('image/') && VALID_IMAGE_SUBTYPES.has(subtype)) {
+    return data
+  }
+
+  const mimeType = mime?.toLowerCase()
+  const normalizedMime =
+    mimeType?.startsWith('image/') && VALID_IMAGE_SUBTYPES.has(mimeType.slice('image/'.length))
+      ? mimeType
+      : getImageMimeFromExtension(fallbackExt)
+
+  return `data:${normalizedMime};base64,${match[2]}`
+}
+
 export async function getEditableImageInput(block: ImageMessageBlock): Promise<string | undefined> {
   if (block.file) {
     const ext = block.file.ext.startsWith('.') ? block.file.ext : `.${block.file.ext}`
     const image = await window.api.file.base64Image(block.file.id + ext)
-    return image.data
+    return normalizeEditableImageDataUrl(image.data, image.mime, ext)
   }
 
   return block.url

--- a/src/renderer/src/services/imageEditInput.ts
+++ b/src/renderer/src/services/imageEditInput.ts
@@ -1,0 +1,11 @@
+import type { ImageMessageBlock } from '@renderer/types/newMessage'
+
+export async function getEditableImageInput(block: ImageMessageBlock): Promise<string | undefined> {
+  if (block.file) {
+    const ext = block.file.ext.startsWith('.') ? block.file.ext : `.${block.file.ext}`
+    const image = await window.api.file.base64Image(block.file.id + ext)
+    return image.data
+  }
+
+  return block.url
+}


### PR DESCRIPTION
## Summary
- normalize image edit inputs to real data URLs for both uploaded images and previously generated images
- reload saved generated images from local files instead of passing `file://` URLs into the image edit flow
- keep the leading dot in image file metadata extensions when saving generated or pasted images

## Why
Cherry Studio currently builds uploaded image edit inputs from `block.file.type`, which is only the category `image`, so requests become `data:image;base64,...` instead of `data:image/png;base64,...`.

For follow-up edits in the same topic, generated images are persisted to disk and then stored as `file://...` URLs. The next image edit request reuses that `file://` URL directly, which is not a valid OpenAI image edit input.

`saveBase64Image()` and `savePastedImage()` also drop the leading dot from `ext`, which can produce malformed follow-up file access in other code paths.

## Testing
- `./node_modules/.bin/vitest run --project renderer src/renderer/src/services/__tests__/imageEditInput.test.ts`
- `./node_modules/.bin/tsgo --noEmit -p tsconfig.node.json --composite false`
- `./node_modules/.bin/tsgo --noEmit -p tsconfig.web.json --composite false`
