### PR TITLE
fix(skills): surface workspace-local skills with symlink targets

### DIFF
--- a/src/main/services/agents/skills/SkillService.ts
+++ b/src/main/services/agents/skills/SkillService.ts
@@ -6,7 +6,12 @@ import { loggerService } from '@logger'
 import { getDataPath } from '@main/utils'
 import { directoryExists } from '@main/utils/file'
 import { deleteDirectoryRecursive } from '@main/utils/fileOperations'
-import { findAllSkillDirectories, findSkillMdPath, parseSkillMetadata } from '@main/utils/markdownParser'
+import {
+  findAllSkillDirectories,
+  findSkillMdPath,
+  isDirectoryOrSymlinkToDirectory,
+  parseSkillMetadata
+} from '@main/utils/markdownParser'
 import { executeCommand, findExecutableInEnv } from '@main/utils/process'
 import type {
   InstalledSkill,
@@ -370,13 +375,18 @@ export class SkillService {
   async listLocal(workdir: string): Promise<Array<{ name: string; description?: string; filename: string }>> {
     const results: Array<{ name: string; description?: string; filename: string }> = []
     const skillsDir = path.join(workdir, '.claude', 'skills')
+    const globalSkillsRoot = path.resolve(getDataPath('Skills'))
 
     try {
       const entries = await fs.promises.readdir(skillsDir, { withFileTypes: true })
       for (const entry of entries) {
-        if (!entry.isDirectory()) continue
+        if (!(await isDirectoryOrSymlinkToDirectory(entry, skillsDir))) continue
+
+        const skillPath = path.join(skillsDir, entry.name)
+
+        if (await this.isLinkIntoGlobalStorage(skillPath, globalSkillsRoot)) continue
+
         try {
-          const skillPath = path.join(skillsDir, entry.name)
           const metadata = await parseSkillMetadata(skillPath, entry.name, 'skills')
           results.push({ name: metadata.name, description: metadata.description, filename: entry.name })
         } catch {
@@ -388,6 +398,15 @@ export class SkillService {
     }
 
     return results
+  }
+
+  private async isLinkIntoGlobalStorage(entryPath: string, globalSkillsRoot: string): Promise<boolean> {
+    try {
+      const real = await fs.promises.realpath(entryPath)
+      return real === globalSkillsRoot || real.startsWith(globalSkillsRoot + path.sep)
+    } catch {
+      return false
+    }
   }
 
   // ===========================================================================

--- a/src/main/utils/markdownParser.ts
+++ b/src/main/utils/markdownParser.ts
@@ -36,7 +36,7 @@ export async function findSkillMdPath(dirPath: string): Promise<string | null> {
  * Check if a directory entry is a directory or a symlink pointing to a directory
  * Follows symlinks to determine if they point to valid directories
  */
-async function isDirectoryOrSymlinkToDirectory(entry: fs.Dirent, parentDir: string): Promise<boolean> {
+export async function isDirectoryOrSymlinkToDirectory(entry: fs.Dirent, parentDir: string): Promise<boolean> {
   if (entry.isDirectory()) {
     return true
   }

--- a/src/renderer/src/pages/settings/AgentSettings/components/SkillsSettings/SkillsSettings.tsx
+++ b/src/renderer/src/pages/settings/AgentSettings/components/SkillsSettings/SkillsSettings.tsx
@@ -129,10 +129,12 @@ export const InstalledSkillsSettings: FC<AgentOrSessionSettingsProps> = ({ agent
   }, [skills, filter])
 
   const filteredLocal = useMemo(() => {
-    if (!filter.trim()) return localPlugins
+    const dbFolderNames = new Set(skills.map((s) => s.folderName))
+    const deduped = localPlugins.filter((p) => !dbFolderNames.has(p.filename))
+    if (!filter.trim()) return deduped
     const q = filter.toLowerCase()
-    return localPlugins.filter((p) => p.name.toLowerCase().includes(q) || p.description?.toLowerCase().includes(q))
-  }, [localPlugins, filter])
+    return deduped.filter((p) => p.name.toLowerCase().includes(q) || p.description?.toLowerCase().includes(q))
+  }, [localPlugins, skills, filter])
 
   const handleToggle = useCallback(
     async (skill: InstalledSkill, checked: boolean) => {


### PR DESCRIPTION
### What this PR does

Before this PR:

The Skills settings panel (Agent settings) only listed Cherry-managed skills (DB-backed marketplace / built-in entries). Workspace-local skills were partially handled via `SkillService.listLocal()`, but the implementation called `entry.isDirectory()` against `Dirent` objects returned by `readdir({ withFileTypes: true })`, which does **not** follow symbolic links. As a result, repo-checked-in project skills such as `.claude/skills/foo -> ../../.agents/skills/foo` were silently filtered out and never appeared in the UI, even though Claude Code itself could resolve and use them at runtime.

After this PR:

`listLocal()` now treats both real directories and symlinks pointing to directories as candidate skills, while explicitly skipping Cherry-managed symlinks that resolve into the global Skills storage (`{userData}/Data/Skills/`) so the same entry is not shown twice. The renderer additionally dedupes local entries against DB folder names to handle the edge case where a real local directory blocks Cherry's symlink while the same name is also installed via marketplace.

Fixes #

### Why we need it and why it was done in this way

The previous behavior assumed every legitimate workspace-local skill is a real directory. In practice, repos commonly check in skill folders under `.agents/skills/` and expose them through `.claude/skills/<name>` symlinks — Claude Code follows symlinks transparently, so these skills work at runtime, but Cherry's UI was blind to them.

The fix mirrors the existing `findAllSkillDirectories` helper which already uses `isDirectoryOrSymlinkToDirectory` for the same reason. Exposing that helper avoided duplicating the symlink-resolution logic.

The following tradeoffs were made:

- `realpath` is invoked per workspace entry to detect Cherry-managed symlinks. The cost is negligible relative to the existing per-entry `parseSkillMetadata` read.
- Renderer-side dedup (rather than backend) keeps the IPC signature of `listLocal(workdir)` stable and lets the UI keep the DB list authoritative on name collisions.

The following alternatives were considered:

- Always trusting `entry.isDirectory()` — rejected, this is exactly the source of the bug.
- Replacing the renderer's two-list rendering with a unified merged list in the backend — rejected as out of scope for a hotfix; would change the IPC shape consumed by other callers.

Links to places where the discussion took place: [#14337 review thread](https://github.com/CherryHQ/cherry-studio/pull/14337) — bug surfaced while reviewing that PR; the original PR target file `PluginService.ts` was already removed from `main` by the CherryClaw refactor (#13359), so its scenario is now structurally addressed by `SkillService`'s reconcile-on-session-start logic. The remaining gap (this PR) is independent.

### Breaking changes

None.

### Special notes for your reviewer

- The exported helper `isDirectoryOrSymlinkToDirectory` was already used internally by `findAllSkillDirectories` in the same module; only its visibility changed.
- `isLinkIntoGlobalStorage()` deliberately uses `realpath` rather than `readlink`, so chained / relative symlinks are normalized to an absolute path before comparison.
- Edge case (real local dir + same-name marketplace install): Cherry's `linkSkill()` already refuses to overwrite real directories. With this change, both the marketplace card (DB) and the local card (workspace) would otherwise appear; the renderer dedupe hides the local card and lets the DB-managed entry win.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix Skills settings panel not listing workspace-local skills installed as symlinks (e.g. repo-checked-in `.claude/skills/<name>` pointing to `.agents/skills/<name>`).
```
