### PR TITLE
fix(images/edits): default to image/png when file has no extension

### DIFF
--- a/src/main/services/FileStorage.ts
+++ b/src/main/services/FileStorage.ts
@@ -653,8 +653,9 @@ class FileStorage {
     const filePath = path.join(this.storageDir, id)
     const data = await fs.promises.readFile(filePath)
     const base64 = data.toString('base64')
-    const ext = path.extname(filePath).slice(1) == 'jpg' ? 'jpeg' : path.extname(filePath).slice(1)
-    const mime = `image/${ext}`
+    const rawExt = path.extname(filePath).slice(1)
+    const ext = rawExt === 'jpg' ? 'jpeg' : rawExt
+    const mime = ext ? `image/${ext}` : 'image/png'
     return {
       mime,
       base64,

--- a/src/main/utils/file.ts
+++ b/src/main/utils/file.ts
@@ -294,8 +294,9 @@ export async function base64Image(file: FileMetadata): Promise<{ mime: string; b
   const filePath = path.join(getFilesDir(), `${file.id}${file.ext}`)
   const data = await fs.promises.readFile(filePath)
   const base64 = data.toString('base64')
-  const ext = path.extname(filePath).slice(1) == 'jpg' ? 'jpeg' : path.extname(filePath).slice(1)
-  const mime = `image/${ext}`
+  const rawExt = path.extname(filePath).slice(1)
+  const ext = rawExt === 'jpg' ? 'jpeg' : rawExt
+  const mime = ext ? `image/${ext}` : 'image/png'
   return {
     mime,
     base64,


### PR DESCRIPTION
### What this PR does

Fixes the `/v1/images/edits` API call failing with "unsupported MIME type 'image'" when the image file has no extension (e.g., blob files).

Before this PR:
- Image files without extensions (blobs) would produce invalid MIME type `image/`
- Server rejected requests with "Invalid 'input[0].content[1].image_url'. Expected a base64-encoded data URL with an image MIME type..."

After this PR:
- `base64Image()` in `src/main/utils/file.ts:293-304` and `src/main/services/FileStorage.ts:649-663` now defaults to `image/png` when the file extension is missing or empty
- API requests now include valid MIME types like `data:image/png;base64,...`

Fixes #14608

### Why we need it and why it was done in this way

The issue occurred when users uploaded images that had no file extension. The code would construct MIME type as `image/${ext}` where `ext` was empty, resulting in `image/` - an invalid MIME type.

The fix adds a guard: `const mime = ext ? \`image/${ext}\` : 'image/png'`

### Tradeoffs

- None: This is a minimal safety fallback that only affects files without extensions

### Special notes for your reviewer

- 2 files modified with identical fix
- No behavior change for files with valid extensions

### Release note

```release-note
Fixed image edit API failing when uploaded images have no file extension by defaulting to image/png MIME type
```