### PR TITLE
fix(shell): source Git Bash profile on Windows to fix fnm/nvm/mise PATH

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -16,6 +16,7 @@ import {
   runInstallScript,
   validateGitBashPath
 } from '@main/utils/process'
+import { refreshShellEnv } from '@main/utils/shell-env'
 import { handleZoomFactor } from '@main/utils/zoom'
 import type { SpanEntity, TokenUsage } from '@mcp-trace/trace-core'
 import type { UpgradeChannel } from '@shared/config/constant'
@@ -556,6 +557,7 @@ export async function registerIpc(mainWindow: BrowserWindow, app: Electron.App) 
       configManager.set(ConfigKeys.GitBashPathSource, null)
       // Re-run auto-discovery to restore auto-discovered path if available
       autoDiscoverGitBash()
+      refreshShellEnv().catch(() => {})
       return true
     }
 
@@ -567,6 +569,7 @@ export async function registerIpc(mainWindow: BrowserWindow, app: Electron.App) 
     // Set path with 'manual' source
     configManager.set(ConfigKeys.GitBashPath, validated)
     configManager.set(ConfigKeys.GitBashPathSource, 'manual')
+    refreshShellEnv().catch(() => {})
     return true
   })
 

--- a/src/main/utils/__tests__/shell-env.test.ts
+++ b/src/main/utils/__tests__/shell-env.test.ts
@@ -17,7 +17,21 @@ vi.mock('@main/utils/git-bash', () => ({
   findGitBash: vi.fn().mockReturnValue(null)
 }))
 
+// Mock ConfigManager
+vi.mock('@main/services/ConfigManager', () => ({
+  ConfigKeys: {
+    GitBashPath: 'gitBashPath',
+    GitBashPathSource: 'gitBashPathSource'
+  },
+  configManager: {
+    get: vi.fn().mockReturnValue(undefined),
+    set: vi.fn()
+  }
+}))
+
 // Import AFTER mocks are registered so the module binds to mocked values.
+import { ConfigKeys, configManager } from '@main/services/ConfigManager'
+
 import { refreshShellEnv } from '../shell-env'
 
 // ---------------------------------------------------------------------------
@@ -202,6 +216,8 @@ describe('shell-env – Windows Git Bash spawn', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // Reset configManager mock
+    vi.mocked(configManager.get).mockReturnValue(undefined)
     process.env = {
       SystemRoot: 'C:\\Windows',
       USERPROFILE: 'C:\\Users\\TestUser',
@@ -235,12 +251,13 @@ describe('shell-env – Windows Git Bash spawn', () => {
     return mockChild
   }
 
-  // T006: Git Bash found → spawn with -ilc env
-  it('should spawn bash with -ilc env when Git Bash is found', async () => {
+  // T006: Git Bash found → spawn with -ilc env (MSYS PATH format)
+  it('should spawn bash with -ilc env and convert MSYS PATH to Windows', async () => {
     const { findGitBash } = await import('@main/utils/git-bash')
     vi.mocked(findGitBash).mockReturnValue('C:\\Program Files\\Git\\bin\\bash.exe')
 
-    const bashEnvOutput = 'PATH=C:\\fnm\\node\\v22.0.0;C:\\Users\\TestUser\\.local\\bin\nHOME=C:\\Users\\TestUser\n'
+    // Real Git Bash output: POSIX-style PATH with MSYS paths
+    const bashEnvOutput = 'PATH=/c/Users/TestUser/.local/bin:/c/fnm/node/v22.0.0:/usr/bin\nHOME=/c/Users/TestUser\n'
     mockSpawnSuccess(bashEnvOutput)
 
     // Registry returns system paths
@@ -257,7 +274,12 @@ describe('shell-env – Windows Git Bash spawn', () => {
       ['-ilc', 'env'],
       expect.objectContaining({ shell: false })
     )
-    expect(env.PATH || env.Path).toContain('C:\\fnm\\node\\v22.0.0')
+    // MSYS paths should be converted to Windows format
+    const pathValue = env.PATH || env.Path || ''
+    expect(pathValue).toContain('C:\\Users\\TestUser\\.local\\bin')
+    expect(pathValue).toContain('C:\\fnm\\node\\v22.0.0')
+    // Registry paths should be merged
+    expect(pathValue).toContain('C:\\Windows\\system32')
   })
 
   // T007: Git Bash not found → fallback to registry
@@ -340,13 +362,13 @@ describe('shell-env – Windows Git Bash spawn', () => {
     vi.useRealTimers()
   })
 
-  // T010: mergeWithRegistryPath preserves registry segments
+  // T010: mergeWithRegistryPath preserves registry segments (MSYS PATH format)
   it('should merge registry PATH segments not present in bash env', async () => {
     const { findGitBash } = await import('@main/utils/git-bash')
     vi.mocked(findGitBash).mockReturnValue('C:\\Program Files\\Git\\bin\\bash.exe')
 
-    // Bash env has user paths but not system paths
-    const bashEnvOutput = 'PATH=C:\\fnm\\node\\v22.0.0;C:\\Users\\TestUser\\.local\\bin\nHOME=C:\\Users\\TestUser\n'
+    // Real Git Bash output: POSIX-style PATH
+    const bashEnvOutput = 'PATH=/c/fnm/node/v22.0.0:/c/Users/TestUser/.local/bin\nHOME=/c/Users/TestUser\n'
     mockSpawnSuccess(bashEnvOutput)
 
     // Registry has system paths
@@ -359,20 +381,20 @@ describe('shell-env – Windows Git Bash spawn', () => {
     const env = await refreshShellEnv()
 
     const pathValue = env.PATH || env.Path || ''
-    // Both bash and registry paths should be present
+    // Both bash (converted) and registry paths should be present
     expect(pathValue).toContain('C:\\fnm\\node\\v22.0.0')
     expect(pathValue).toContain('C:\\Windows\\system32')
     // Bash paths should come before registry paths
     expect(pathValue.indexOf('C:\\fnm\\node\\v22.0.0')).toBeLessThan(pathValue.indexOf('C:\\Windows\\system32'))
   })
 
-  // T011: verify dedup — registry segment already in bash env is not duplicated
+  // T011: verify dedup — registry segment already in bash env is not duplicated (MSYS PATH format)
   it('should not duplicate PATH segments already present from bash env', async () => {
     const { findGitBash } = await import('@main/utils/git-bash')
     vi.mocked(findGitBash).mockReturnValue('C:\\Program Files\\Git\\bin\\bash.exe')
 
-    // Bash env already includes a system path
-    const bashEnvOutput = 'PATH=C:\\Windows\\system32;C:\\fnm\\node\\v22.0.0\nHOME=C:\\Users\\TestUser\n'
+    // Real Git Bash output: includes system32 as MSYS path
+    const bashEnvOutput = 'PATH=/c/Windows/system32:/c/fnm/node/v22.0.0\nHOME=/c/Users/TestUser\n'
     mockSpawnSuccess(bashEnvOutput)
 
     // Registry also includes the same system path
@@ -388,5 +410,113 @@ describe('shell-env – Windows Git Bash spawn', () => {
     const segments = pathValue.split(';')
     const system32Count = segments.filter((s: string) => s.toLowerCase().includes('system32')).length
     expect(system32Count).toBe(1)
+  })
+
+  // ---------------------------------------------------------------------------
+  // P2: Configured Git Bash path tests
+  // ---------------------------------------------------------------------------
+
+  // T-P2-01: Configured Git Bash path from settings is used
+  it('should use configured Git Bash path from settings', async () => {
+    const { findGitBash } = await import('@main/utils/git-bash')
+
+    // Mock configManager to return configured path
+    vi.mocked(configManager.get).mockImplementation((key: string) => {
+      if (key === ConfigKeys.GitBashPath) return 'D:\\CustomGit\\bin\\bash.exe'
+      return undefined
+    })
+
+    // findGitBash returns the configured path (after validation)
+    vi.mocked(findGitBash).mockReturnValue('D:\\CustomGit\\bin\\bash.exe')
+
+    const bashEnvOutput = 'PATH=/c/Users/TestUser/.local/bin\nHOME=/c/Users/TestUser\n'
+    mockSpawnSuccess(bashEnvOutput)
+
+    vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+      const keyPath = (args as string[])[1]
+      if (keyPath === HKLM_KEY) return regOutput(keyPath, 'C:\\Windows\\system32')
+      throw new Error('not found')
+    })
+
+    await refreshShellEnv()
+
+    // findGitBash should be called WITH the configured path
+    expect(findGitBash).toHaveBeenCalledWith('D:\\CustomGit\\bin\\bash.exe')
+  })
+
+  // T-P2-02: Configured path invalid falls back to auto-discovery
+  it('should pass configured path to findGitBash even if invalid', async () => {
+    const { findGitBash } = await import('@main/utils/git-bash')
+
+    // Mock configManager to return invalid path
+    vi.mocked(configManager.get).mockImplementation((key: string) => {
+      if (key === ConfigKeys.GitBashPath) return 'D:\\NonExistent\\bash.exe'
+      return undefined
+    })
+
+    // findGitBash returns null (invalid path), then auto-discovered path
+    vi.mocked(findGitBash).mockReturnValue('C:\\Program Files\\Git\\bin\\bash.exe')
+
+    const bashEnvOutput = 'PATH=/c/Users/TestUser/.local/bin\nHOME=/c/Users/TestUser\n'
+    mockSpawnSuccess(bashEnvOutput)
+
+    vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+      const keyPath = (args as string[])[1]
+      if (keyPath === HKLM_KEY) return regOutput(keyPath, 'C:\\Windows\\system32')
+      throw new Error('not found')
+    })
+
+    await refreshShellEnv()
+
+    // findGitBash was called with configured path (it handles validation internally)
+    expect(findGitBash).toHaveBeenCalledWith('D:\\NonExistent\\bash.exe')
+  })
+
+  // ---------------------------------------------------------------------------
+  // MSYS PATH conversion edge case tests
+  // ---------------------------------------------------------------------------
+
+  // T-MSYS-01: Mixed MSYS and Windows paths
+  it('should handle mixed MSYS and Windows paths in PATH', async () => {
+    const { findGitBash } = await import('@main/utils/git-bash')
+    vi.mocked(findGitBash).mockReturnValue('C:\\Program Files\\Git\\bin\\bash.exe')
+
+    // Mixed format: some MSYS, some already Windows (colon-separated)
+    const bashEnvOutput = 'PATH=/c/Users/TestUser/.local/bin:C:/Python39:/usr/bin\nHOME=/c/Users/TestUser\n'
+    mockSpawnSuccess(bashEnvOutput)
+
+    vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+      const keyPath = (args as string[])[1]
+      if (keyPath === HKLM_KEY) return regOutput(keyPath, 'C:\\Windows\\system32')
+      throw new Error('not found')
+    })
+
+    const env = await refreshShellEnv()
+
+    const pathValue = env.PATH || env.Path || ''
+    expect(pathValue).toContain('C:\\Users\\TestUser\\.local\\bin')
+    expect(pathValue).toContain('C:\\Python39')
+  })
+
+  // T-MSYS-02: Already Windows PATH (semicolon-separated) - skip conversion
+  it('should skip MSYS conversion when PATH is already Windows-style', async () => {
+    const { findGitBash } = await import('@main/utils/git-bash')
+    vi.mocked(findGitBash).mockReturnValue('C:\\Program Files\\Git\\bin\\bash.exe')
+
+    // Already Windows format (has ; separator)
+    const bashEnvOutput = 'PATH=C:\\fnm\\node\\v22.0.0;C:\\Users\\TestUser\\.local\\bin\nHOME=C:\\Users\\TestUser\n'
+    mockSpawnSuccess(bashEnvOutput)
+
+    vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+      const keyPath = (args as string[])[1]
+      if (keyPath === HKLM_KEY) return regOutput(keyPath, 'C:\\Windows\\system32')
+      throw new Error('not found')
+    })
+
+    const env = await refreshShellEnv()
+
+    const pathValue = env.PATH || env.Path || ''
+    expect(pathValue).toContain('C:\\fnm\\node\\v22.0.0')
+    expect(pathValue).toContain('C:\\Users\\TestUser\\.local\\bin')
   })
 })

--- a/src/main/utils/__tests__/shell-env.test.ts
+++ b/src/main/utils/__tests__/shell-env.test.ts
@@ -12,6 +12,11 @@ vi.mock('@main/constant', () => ({
 
 vi.mock('child_process')
 
+// Mock findGitBash — returns null by default (no Git Bash installed)
+vi.mock('@main/utils/git-bash', () => ({
+  findGitBash: vi.fn().mockReturnValue(null)
+}))
+
 // Import AFTER mocks are registered so the module binds to mocked values.
 import { refreshShellEnv } from '../shell-env'
 
@@ -175,7 +180,7 @@ describe('shell-env – Windows registry PATH', () => {
 
   // -- does not spawn cmd.exe -----------------------------------------------
 
-  it('should not spawn cmd.exe or any shell process', async () => {
+  it('should not spawn any shell process when Git Bash is not found', async () => {
     vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
       const keyPath = (args as string[])[1]
       if (keyPath === HKLM_KEY) return regOutput(keyPath, 'C:\\Windows')
@@ -185,5 +190,203 @@ describe('shell-env – Windows registry PATH', () => {
     await refreshShellEnv()
 
     expect(spawn).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Git Bash spawn tests
+// ---------------------------------------------------------------------------
+
+describe('shell-env – Windows Git Bash spawn', () => {
+  const savedEnv = process.env
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env = {
+      SystemRoot: 'C:\\Windows',
+      USERPROFILE: 'C:\\Users\\TestUser',
+      Path: 'C:\\StaleOldPath'
+    }
+  })
+
+  afterEach(() => {
+    process.env = savedEnv
+  })
+
+  // Helper: create a mock ChildProcess that emits 'close' with stdout
+  function mockSpawnSuccess(stdout: string) {
+    type ListenerFn = (...args: unknown[]) => void
+    const listeners: Record<string, ListenerFn[]> = {}
+    const mockChild = {
+      kill: vi.fn(),
+      stdout: { on: (_event: string, fn: ListenerFn) => { listeners['stdout'] = listeners['stdout'] || []; listeners['stdout'].push(fn) } },
+      stderr: { on: (_event: string, fn: ListenerFn) => { listeners['stderr'] = listeners['stderr'] || []; listeners['stderr'].push(fn) } },
+      on: (event: string, fn: ListenerFn) => { listeners[event] = listeners[event] || []; listeners[event].push(fn) }
+    }
+    vi.mocked(spawn).mockImplementation(() => {
+      // Simulate async data and close events
+      setTimeout(() => {
+        listeners['stdout']?.forEach((fn) => fn(stdout))
+        listeners['stderr']?.forEach((fn) => fn(''))
+        listeners['close']?.forEach((fn) => fn(0))
+      }, 0)
+      return mockChild as any
+    })
+    return mockChild
+  }
+
+  // T006: Git Bash found → spawn with -ilc env
+  it('should spawn bash with -ilc env when Git Bash is found', async () => {
+    const { findGitBash } = await import('@main/utils/git-bash')
+    vi.mocked(findGitBash).mockReturnValue('C:\\Program Files\\Git\\bin\\bash.exe')
+
+    const bashEnvOutput = 'PATH=C:\\fnm\\node\\v22.0.0;C:\\Users\\TestUser\\.local\\bin\nHOME=C:\\Users\\TestUser\n'
+    mockSpawnSuccess(bashEnvOutput)
+
+    // Registry returns system paths
+    vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+      const keyPath = (args as string[])[1]
+      if (keyPath === HKLM_KEY) return regOutput(keyPath, 'C:\\Windows\\system32')
+      throw new Error('not found')
+    })
+
+    const env = await refreshShellEnv()
+
+    expect(spawn).toHaveBeenCalledWith(
+      'C:\\Program Files\\Git\\bin\\bash.exe',
+      ['-ilc', 'env'],
+      expect.objectContaining({ shell: false })
+    )
+    expect(env.PATH || env.Path).toContain('C:\\fnm\\node\\v22.0.0')
+  })
+
+  // T007: Git Bash not found → fallback to registry
+  it('should fall back to registry PATH when Git Bash is not found', async () => {
+    const { findGitBash } = await import('@main/utils/git-bash')
+    vi.mocked(findGitBash).mockReturnValue(null)
+
+    vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+      const keyPath = (args as string[])[1]
+      if (keyPath === HKLM_KEY) return regOutput(keyPath, 'C:\\Windows\\system32')
+      throw new Error('not found')
+    })
+
+    const env = await refreshShellEnv()
+
+    expect(spawn).not.toHaveBeenCalled()
+    expect(env.Path).toContain('C:\\Windows\\system32')
+  })
+
+  // T008: spawn failure → fallback to registry
+  it('should fall back to registry PATH when bash spawn fails', async () => {
+    const { findGitBash } = await import('@main/utils/git-bash')
+    vi.mocked(findGitBash).mockReturnValue('C:\\Program Files\\Git\\bin\\bash.exe')
+
+    // spawn emits 'error' event
+    type ListenerFn = (...args: unknown[]) => void
+    const listeners: Record<string, ListenerFn[]> = {}
+    vi.mocked(spawn).mockImplementation(() => {
+      setTimeout(() => {
+        listeners['error']?.forEach((fn) => fn(new Error('ENOENT')))
+      }, 0)
+      return {
+        kill: vi.fn(),
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+        on: (event: string, fn: ListenerFn) => { listeners[event] = listeners[event] || []; listeners[event].push(fn) }
+      } as any
+    })
+
+    vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+      const keyPath = (args as string[])[1]
+      if (keyPath === HKLM_KEY) return regOutput(keyPath, 'C:\\FallbackPath')
+      throw new Error('not found')
+    })
+
+    const env = await refreshShellEnv()
+
+    expect(env.Path).toContain('C:\\FallbackPath')
+  })
+
+  // T009: spawn timeout → fallback to registry
+  it('should fall back to registry PATH when bash spawn times out', async () => {
+    vi.useFakeTimers()
+    const { findGitBash } = await import('@main/utils/git-bash')
+    vi.mocked(findGitBash).mockReturnValue('C:\\Program Files\\Git\\bin\\bash.exe')
+
+    // spawn never resolves (hangs)
+    vi.mocked(spawn).mockImplementation(() => ({
+      kill: vi.fn(),
+      stdout: { on: vi.fn() },
+      stderr: { on: vi.fn() },
+      on: vi.fn()
+    }) as any)
+
+    vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+      const keyPath = (args as string[])[1]
+      if (keyPath === HKLM_KEY) return regOutput(keyPath, 'C:\\TimeoutFallback')
+      throw new Error('not found')
+    })
+
+    const promise = refreshShellEnv()
+
+    // Advance past the 15s timeout
+    vi.advanceTimersByTime(16_000)
+
+    const env = await promise
+
+    expect(env.Path).toContain('C:\\TimeoutFallback')
+
+    vi.useRealTimers()
+  })
+
+  // T010: mergeWithRegistryPath preserves registry segments
+  it('should merge registry PATH segments not present in bash env', async () => {
+    const { findGitBash } = await import('@main/utils/git-bash')
+    vi.mocked(findGitBash).mockReturnValue('C:\\Program Files\\Git\\bin\\bash.exe')
+
+    // Bash env has user paths but not system paths
+    const bashEnvOutput = 'PATH=C:\\fnm\\node\\v22.0.0;C:\\Users\\TestUser\\.local\\bin\nHOME=C:\\Users\\TestUser\n'
+    mockSpawnSuccess(bashEnvOutput)
+
+    // Registry has system paths
+    vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+      const keyPath = (args as string[])[1]
+      if (keyPath === HKLM_KEY) return regOutput(keyPath, 'C:\\Windows\\system32;C:\\Windows')
+      throw new Error('not found')
+    })
+
+    const env = await refreshShellEnv()
+
+    const pathValue = env.PATH || env.Path || ''
+    // Both bash and registry paths should be present
+    expect(pathValue).toContain('C:\\fnm\\node\\v22.0.0')
+    expect(pathValue).toContain('C:\\Windows\\system32')
+    // Bash paths should come before registry paths
+    expect(pathValue.indexOf('C:\\fnm\\node\\v22.0.0')).toBeLessThan(pathValue.indexOf('C:\\Windows\\system32'))
+  })
+
+  // T011: verify dedup — registry segment already in bash env is not duplicated
+  it('should not duplicate PATH segments already present from bash env', async () => {
+    const { findGitBash } = await import('@main/utils/git-bash')
+    vi.mocked(findGitBash).mockReturnValue('C:\\Program Files\\Git\\bin\\bash.exe')
+
+    // Bash env already includes a system path
+    const bashEnvOutput = 'PATH=C:\\Windows\\system32;C:\\fnm\\node\\v22.0.0\nHOME=C:\\Users\\TestUser\n'
+    mockSpawnSuccess(bashEnvOutput)
+
+    // Registry also includes the same system path
+    vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+      const keyPath = (args as string[])[1]
+      if (keyPath === HKLM_KEY) return regOutput(keyPath, 'C:\\Windows\\system32;C:\\Windows')
+      throw new Error('not found')
+    })
+
+    const env = await refreshShellEnv()
+
+    const pathValue = env.PATH || env.Path || ''
+    const segments = pathValue.split(';')
+    const system32Count = segments.filter((s: string) => s.toLowerCase().includes('system32')).length
+    expect(system32Count).toBe(1)
   })
 })

--- a/src/main/utils/__tests__/shell-env.test.ts
+++ b/src/main/utils/__tests__/shell-env.test.ts
@@ -519,4 +519,62 @@ describe('shell-env – Windows Git Bash spawn', () => {
     expect(pathValue).toContain('C:\\fnm\\node\\v22.0.0')
     expect(pathValue).toContain('C:\\Users\\TestUser\\.local\\bin')
   })
+
+  // T-MSYS-03: MSYS-internal paths are filtered out
+  it('should filter out MSYS-internal paths from PATH', async () => {
+    const { findGitBash } = await import('@main/utils/git-bash')
+    vi.mocked(findGitBash).mockReturnValue('C:\\Program Files\\Git\\bin\\bash.exe')
+
+    // PATH includes MSYS-internal entries alongside valid MSYS drive paths
+    const bashEnvOutput =
+      'PATH=/c/Users/TestUser/.local/bin:/usr/bin:/usr/local/bin:/mingw64/bin:/bin:/cmd:/c/fnm/node/v22.0.0\nHOME=/c/Users/TestUser\n'
+    mockSpawnSuccess(bashEnvOutput)
+
+    vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+      const keyPath = (args as string[])[1]
+      if (keyPath === HKLM_KEY) return regOutput(keyPath, 'C:\\Windows\\system32')
+      throw new Error('not found')
+    })
+
+    const env = await refreshShellEnv()
+    const pathValue = env.PATH || env.Path || ''
+
+    // Valid MSYS drive paths should be present
+    expect(pathValue.toLowerCase()).toContain('c:\\users\\testuser\\.local\\bin')
+    expect(pathValue.toLowerCase()).toContain('c:\\fnm\\node\\v22.0.0')
+
+    // MSYS-internal paths should be filtered out — check as standalone segments
+    const segments = pathValue.split(';').map((s: string) => s.toLowerCase().trim())
+    expect(segments).not.toContain('/usr/bin')
+    expect(segments).not.toContain('/usr/local/bin')
+    expect(segments).not.toContain('/mingw64/bin')
+    expect(segments).not.toContain('/bin')
+    expect(segments).not.toContain('/cmd')
+  })
+
+  // T-P2-03: spawn receives fresh registry PATH as env
+  it('should pass fresh registry PATH to bash spawn env', async () => {
+    const { findGitBash } = await import('@main/utils/git-bash')
+    vi.mocked(findGitBash).mockReturnValue('C:\\Program Files\\Git\\bin\\bash.exe')
+
+    // Registry returns a path with a newly installed tool
+    vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+      const keyPath = (args as string[])[1]
+      if (keyPath === HKLM_KEY)
+        return regOutput(keyPath, 'C:\\Windows\\system32;C:\\NewTool\\bin')
+      throw new Error('not found')
+    })
+
+    const bashEnvOutput = 'PATH=/c/Users/TestUser/.local/bin\nHOME=/c/Users/TestUser\n'
+    mockSpawnSuccess(bashEnvOutput)
+
+    await refreshShellEnv()
+
+    // spawn should have been called with an env option containing the fresh registry PATH
+    const spawnOptions = vi.mocked(spawn).mock.calls[0][2]
+    expect(spawnOptions?.env).toBeDefined()
+    const spawnEnv = spawnOptions!.env as Record<string, string>
+    const spawnPath = spawnEnv.Path || spawnEnv.PATH || ''
+    expect(spawnPath).toContain('C:\\NewTool\\bin')
+  })
 })

--- a/src/main/utils/git-bash.ts
+++ b/src/main/utils/git-bash.ts
@@ -42,7 +42,7 @@ export function validateGitBashPath(customPath?: string | null): string | null {
 
 /**
  * Find git.exe on Windows via where.exe (no dependency on process.ts).
- * Returns the first match or null.
+ * Returns the first PATH-based match (skips current-directory hits) or null.
  */
 function findGitExeViaWhere(): string | null {
   try {
@@ -51,8 +51,17 @@ function findGitExeViaWhere(): string | null {
       timeout: 5000,
       windowsHide: true
     })
-    const firstLine = output.trim().split(/\r?\n/)[0]
-    return firstLine && fs.existsSync(firstLine) ? firstLine : null
+    const lines = output.trim().split(/\r?\n/)
+    // where.exe lists current-directory matches before PATH hits;
+    // skip entries that are relative or sit inside CWD
+    const cwdLower = process.cwd().toLowerCase() + path.sep
+    for (const line of lines) {
+      const resolved = path.resolve(line)
+      if (!fs.existsSync(resolved)) continue
+      if (resolved.toLowerCase().startsWith(cwdLower)) continue
+      return resolved
+    }
+    return null
   } catch {
     return null
   }

--- a/src/main/utils/git-bash.ts
+++ b/src/main/utils/git-bash.ts
@@ -1,0 +1,201 @@
+import { loggerService } from '@logger'
+import type { GitBashPathInfo, GitBashPathSource } from '@shared/config/constant'
+import { execFileSync } from 'child_process'
+import fs from 'fs'
+import path from 'path'
+
+import { isWin } from '../constant'
+import { ConfigKeys, configManager } from '../services/ConfigManager'
+
+const logger = loggerService.withContext('Process')
+
+// Re-export for process.ts which also uses this for findExecutable('git')
+export function getCommonGitRoots(): string[] {
+  return [
+    path.join(process.env.ProgramFiles || 'C:\\Program Files', 'Git'),
+    path.join(process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)', 'Git'),
+    ...(process.env.LOCALAPPDATA ? [path.join(process.env.LOCALAPPDATA, 'Programs', 'Git')] : [])
+  ]
+}
+
+export function validateGitBashPath(customPath?: string | null): string | null {
+  if (!customPath) {
+    return null
+  }
+
+  const resolved = path.resolve(customPath)
+
+  if (!fs.existsSync(resolved)) {
+    logger.warn('Custom Git Bash path does not exist', { path: resolved })
+    return null
+  }
+
+  const isExe = resolved.toLowerCase().endsWith('bash.exe')
+  if (!isExe) {
+    logger.warn('Custom Git Bash path is not bash.exe', { path: resolved })
+    return null
+  }
+
+  logger.debug('Validated custom Git Bash path', { path: resolved })
+  return resolved
+}
+
+/**
+ * Find git.exe on Windows via where.exe (no dependency on process.ts).
+ * Returns the first match or null.
+ */
+function findGitExeViaWhere(): string | null {
+  try {
+    const output = execFileSync('where', ['git'], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      windowsHide: true
+    })
+    const firstLine = output.trim().split(/\r?\n/)[0]
+    return firstLine && fs.existsSync(firstLine) ? firstLine : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Find Git Bash (bash.exe) on Windows
+ * @param customPath - Optional custom path from config
+ * @returns Full path to bash.exe or null if not found
+ */
+export function findGitBash(customPath?: string | null): string | null {
+  // Git Bash is Windows-only
+  if (!isWin) {
+    return null
+  }
+
+  // 1. Check custom path from config first
+  if (customPath) {
+    const validated = validateGitBashPath(customPath)
+    if (validated) {
+      logger.debug('Using custom Git Bash path from config', { path: validated })
+      return validated
+    }
+    logger.warn('Custom Git Bash path provided but invalid', { path: customPath })
+  }
+
+  // 2. Check environment variable override
+  const envOverride = process.env.CLAUDE_CODE_GIT_BASH_PATH
+  if (envOverride) {
+    const validated = validateGitBashPath(envOverride)
+    if (validated) {
+      logger.debug('Using CLAUDE_CODE_GIT_BASH_PATH override for bash.exe', { path: validated })
+      return validated
+    }
+    logger.warn('CLAUDE_CODE_GIT_BASH_PATH provided but path is invalid', { path: envOverride })
+  }
+
+  // 3. Find git.exe via where.exe, derive bash.exe path
+  const gitPath = findGitExeViaWhere()
+  if (gitPath) {
+    const possibleBashPaths = [
+      path.join(gitPath, '..', '..', 'bin', 'bash.exe'),
+      path.join(gitPath, '..', 'bash.exe'),
+      path.join(gitPath, '..', '..', 'usr', 'bin', 'bash.exe')
+    ]
+
+    for (const bashPath of possibleBashPaths) {
+      const resolvedBashPath = path.resolve(bashPath)
+      if (fs.existsSync(resolvedBashPath)) {
+        logger.debug('Found bash.exe via git.exe path derivation', { path: resolvedBashPath })
+        return resolvedBashPath
+      }
+    }
+
+    logger.debug('bash.exe not found at expected locations relative to git.exe', {
+      gitPath,
+      checkedPaths: possibleBashPaths.map((p) => path.resolve(p))
+    })
+  }
+
+  // 4. Fallback: check common Git installation paths directly
+  for (const root of getCommonGitRoots()) {
+    const fullPath = path.join(root, 'bin', 'bash.exe')
+    if (fs.existsSync(fullPath)) {
+      logger.debug('Found bash.exe at common path', { path: fullPath })
+      return fullPath
+    }
+  }
+
+  logger.debug('bash.exe not found - checked git derivation and common paths')
+  return null
+}
+
+/**
+ * Auto-discover and persist Git Bash path if not already configured
+ * Only called when Git Bash is actually needed
+ *
+ * Precedence order:
+ * 1. CLAUDE_CODE_GIT_BASH_PATH environment variable (highest - runtime override)
+ * 2. Configured path from settings (manual or auto)
+ * 3. Auto-discovery via findGitBash (only if no valid config exists)
+ */
+export function autoDiscoverGitBash(): string | null {
+  if (!isWin) {
+    return null
+  }
+
+  // 1. Check environment variable override first (highest priority)
+  const envOverride = process.env.CLAUDE_CODE_GIT_BASH_PATH
+  if (envOverride) {
+    const validated = validateGitBashPath(envOverride)
+    if (validated) {
+      logger.debug('Using CLAUDE_CODE_GIT_BASH_PATH override', { path: validated })
+      return validated
+    }
+    logger.warn('CLAUDE_CODE_GIT_BASH_PATH provided but path is invalid', { path: envOverride })
+  }
+
+  // 2. Check if a path is already configured
+  const existingPath = configManager.get<string | undefined>(ConfigKeys.GitBashPath)
+  const existingSource = configManager.get<GitBashPathSource | undefined>(ConfigKeys.GitBashPathSource)
+
+  if (existingPath) {
+    const validated = validateGitBashPath(existingPath)
+    if (validated) {
+      return validated
+    }
+    // Existing path is invalid, try to auto-discover
+    logger.warn('Existing Git Bash path is invalid, attempting auto-discovery', {
+      path: existingPath,
+      source: existingSource
+    })
+  }
+
+  // 3. Try to find Git Bash via auto-discovery
+  const discoveredPath = findGitBash()
+  if (discoveredPath) {
+    // Persist the discovered path with 'auto' source
+    configManager.set(ConfigKeys.GitBashPath, discoveredPath)
+    configManager.set(ConfigKeys.GitBashPathSource, 'auto')
+    logger.info('Auto-discovered Git Bash path', { path: discoveredPath })
+  }
+
+  return discoveredPath
+}
+
+/**
+ * Get Git Bash path info including source
+ * If no path is configured, triggers auto-discovery first
+ */
+export function getGitBashPathInfo(): GitBashPathInfo {
+  if (!isWin) {
+    return { path: null, source: null }
+  }
+
+  let path = configManager.get<string | null>(ConfigKeys.GitBashPath) ?? null
+  let source = configManager.get<GitBashPathSource | null>(ConfigKeys.GitBashPathSource) ?? null
+
+  // If no path configured, trigger auto-discovery (handles upgrade from old versions)
+  if (!path) {
+    path = autoDiscoverGitBash()
+    source = path ? 'auto' : null
+  }
+
+  return { path, source }
+}

--- a/src/main/utils/process.ts
+++ b/src/main/utils/process.ts
@@ -1,5 +1,4 @@
 import { loggerService } from '@logger'
-import type { GitBashPathInfo, GitBashPathSource } from '@shared/config/constant'
 import { HOME_CHERRY_DIR } from '@shared/config/constant'
 import chardet from 'chardet'
 import { type ChildProcess, execFileSync, spawn, type SpawnOptions } from 'child_process'
@@ -9,9 +8,12 @@ import os from 'os'
 import path from 'path'
 
 import { isWin } from '../constant'
-import { ConfigKeys, configManager } from '../services/ConfigManager'
 import { getResourcePath } from '.'
+import { getCommonGitRoots } from './git-bash'
 import getShellEnv, { refreshShellEnv } from './shell-env'
+
+// Re-export for consumers that import from process.ts
+export { autoDiscoverGitBash, findGitBash, getGitBashPathInfo, validateGitBashPath } from './git-bash'
 
 const logger = loggerService.withContext('Utils:Process')
 
@@ -511,18 +513,6 @@ export async function executeCommand(
 }
 
 /**
- * Common Git installation root directories on Windows
- * Used by findExecutable() (git special case) and findGitBash() to check fallback paths
- */
-function getCommonGitRoots(): string[] {
-  return [
-    path.join(process.env.ProgramFiles || 'C:\\Program Files', 'Git'),
-    path.join(process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)', 'Git'),
-    ...(process.env.LOCALAPPDATA ? [path.join(process.env.LOCALAPPDATA, 'Programs', 'Git')] : [])
-  ]
-}
-
-/**
  * Check if git is available in the user's environment
  * Refreshes shell env cache to detect newly installed Git
  * @returns Object with availability status and path to git executable
@@ -534,168 +524,3 @@ export async function checkGitAvailable(): Promise<{ available: boolean; path: s
   return { available: gitPath !== null, path: gitPath }
 }
 
-/**
- * Find Git Bash (bash.exe) on Windows
- * @param customPath - Optional custom path from config
- * @returns Full path to bash.exe or null if not found
- */
-export function findGitBash(customPath?: string | null): string | null {
-  // Git Bash is Windows-only
-  if (!isWin) {
-    return null
-  }
-
-  // 1. Check custom path from config first
-  if (customPath) {
-    const validated = validateGitBashPath(customPath)
-    if (validated) {
-      logger.debug('Using custom Git Bash path from config', { path: validated })
-      return validated
-    }
-    logger.warn('Custom Git Bash path provided but invalid', { path: customPath })
-  }
-
-  // 2. Check environment variable override
-  const envOverride = process.env.CLAUDE_CODE_GIT_BASH_PATH
-  if (envOverride) {
-    const validated = validateGitBashPath(envOverride)
-    if (validated) {
-      logger.debug('Using CLAUDE_CODE_GIT_BASH_PATH override for bash.exe', { path: validated })
-      return validated
-    }
-    logger.warn('CLAUDE_CODE_GIT_BASH_PATH provided but path is invalid', { path: envOverride })
-  }
-
-  // 3. Find git.exe via findExecutable (checks PATH + common Git install paths)
-  const gitPath = findExecutable('git')
-  if (gitPath) {
-    // Derive bash.exe from git.exe location
-    // Different Git installations have different directory structures
-    const possibleBashPaths = [
-      path.join(gitPath, '..', '..', 'bin', 'bash.exe'), // Standard Git: git.exe at Git/cmd/ -> navigate up 2 levels -> then bin/bash.exe
-      path.join(gitPath, '..', 'bash.exe'), // Portable Git: git.exe at Git/bin/ -> bash.exe in same directory
-      path.join(gitPath, '..', '..', 'usr', 'bin', 'bash.exe') // MSYS2 Git: git.exe at msys64/usr/bin/ -> navigate up 2 levels -> then usr/bin/bash.exe
-    ]
-
-    for (const bashPath of possibleBashPaths) {
-      const resolvedBashPath = path.resolve(bashPath)
-      if (fs.existsSync(resolvedBashPath)) {
-        logger.debug('Found bash.exe via git.exe path derivation', { path: resolvedBashPath })
-        return resolvedBashPath
-      }
-    }
-
-    logger.debug('bash.exe not found at expected locations relative to git.exe', {
-      gitPath,
-      checkedPaths: possibleBashPaths.map((p) => path.resolve(p))
-    })
-  }
-
-  // 4. Fallback: check common Git installation paths directly
-  for (const root of getCommonGitRoots()) {
-    const fullPath = path.join(root, 'bin', 'bash.exe')
-    if (fs.existsSync(fullPath)) {
-      logger.debug('Found bash.exe at common path', { path: fullPath })
-      return fullPath
-    }
-  }
-
-  logger.debug('bash.exe not found - checked git derivation and common paths')
-  return null
-}
-
-export function validateGitBashPath(customPath?: string | null): string | null {
-  if (!customPath) {
-    return null
-  }
-
-  const resolved = path.resolve(customPath)
-
-  if (!fs.existsSync(resolved)) {
-    logger.warn('Custom Git Bash path does not exist', { path: resolved })
-    return null
-  }
-
-  const isExe = resolved.toLowerCase().endsWith('bash.exe')
-  if (!isExe) {
-    logger.warn('Custom Git Bash path is not bash.exe', { path: resolved })
-    return null
-  }
-
-  logger.debug('Validated custom Git Bash path', { path: resolved })
-  return resolved
-}
-
-/**
- * Auto-discover and persist Git Bash path if not already configured
- * Only called when Git Bash is actually needed
- *
- * Precedence order:
- * 1. CLAUDE_CODE_GIT_BASH_PATH environment variable (highest - runtime override)
- * 2. Configured path from settings (manual or auto)
- * 3. Auto-discovery via findGitBash (only if no valid config exists)
- */
-export function autoDiscoverGitBash(): string | null {
-  if (!isWin) {
-    return null
-  }
-
-  // 1. Check environment variable override first (highest priority)
-  const envOverride = process.env.CLAUDE_CODE_GIT_BASH_PATH
-  if (envOverride) {
-    const validated = validateGitBashPath(envOverride)
-    if (validated) {
-      logger.debug('Using CLAUDE_CODE_GIT_BASH_PATH override', { path: validated })
-      return validated
-    }
-    logger.warn('CLAUDE_CODE_GIT_BASH_PATH provided but path is invalid', { path: envOverride })
-  }
-
-  // 2. Check if a path is already configured
-  const existingPath = configManager.get<string | undefined>(ConfigKeys.GitBashPath)
-  const existingSource = configManager.get<GitBashPathSource | undefined>(ConfigKeys.GitBashPathSource)
-
-  if (existingPath) {
-    const validated = validateGitBashPath(existingPath)
-    if (validated) {
-      return validated
-    }
-    // Existing path is invalid, try to auto-discover
-    logger.warn('Existing Git Bash path is invalid, attempting auto-discovery', {
-      path: existingPath,
-      source: existingSource
-    })
-  }
-
-  // 3. Try to find Git Bash via auto-discovery
-  const discoveredPath = findGitBash()
-  if (discoveredPath) {
-    // Persist the discovered path with 'auto' source
-    configManager.set(ConfigKeys.GitBashPath, discoveredPath)
-    configManager.set(ConfigKeys.GitBashPathSource, 'auto')
-    logger.info('Auto-discovered Git Bash path', { path: discoveredPath })
-  }
-
-  return discoveredPath
-}
-
-/**
- * Get Git Bash path info including source
- * If no path is configured, triggers auto-discovery first
- */
-export function getGitBashPathInfo(): GitBashPathInfo {
-  if (!isWin) {
-    return { path: null, source: null }
-  }
-
-  let path = configManager.get<string | null>(ConfigKeys.GitBashPath) ?? null
-  let source = configManager.get<GitBashPathSource | null>(ConfigKeys.GitBashPathSource) ?? null
-
-  // If no path configured, trigger auto-discovery (handles upgrade from old versions)
-  if (!path) {
-    path = autoDiscoverGitBash()
-    source = path ? 'auto' : null
-  }
-
-  return { path, source }
-}

--- a/src/main/utils/shell-env.ts
+++ b/src/main/utils/shell-env.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 import { loggerService } from '@logger'
 import { isMac, isWin } from '@main/constant'
+import { findGitBash } from '@main/utils/git-bash'
 import { execFileSync, spawn } from 'child_process'
 
 const logger = loggerService.withContext('ShellEnv')
@@ -139,45 +140,50 @@ function getWindowsEnvironment(): Record<string, string> {
 }
 
 /**
- * Spawns a login shell in the user's home directory to capture its environment variables.
- *
- * We explicitly run a login + interactive shell so it sources the same init files that a user
- * would typically rely on inside their terminal. Many CLIs export PATH or other variables from
- * these scripts; capturing them keeps spawned processes aligned with the user’s expectations.
- *
- * Timeout handling is important because profile scripts might block forever (e.g. misconfigured
- * `read` or prompts). We proactively kill the shell and surface an error in that case so that
- * the app does not hang.
- * @returns {Promise<Object>} A promise that resolves with an object containing
- * the environment variables, or rejects with an error.
+ * Merge registry PATH segments into a bash-captured environment.
+ * Ensures Windows system-level paths (e.g. System32) are not lost
+ * when the environment was captured from Git Bash.
  */
-function getLoginShellEnvironment(): Promise<Record<string, string>> {
-  // On Windows, skip the shell spawn entirely — `cmd.exe /c set` just inherits
-  // the (potentially stale) parent process env. Instead, read the current PATH
-  // straight from the Windows registry.
-  if (isWin) {
-    return Promise.resolve(getWindowsEnvironment())
+function mergeWithRegistryPath(env: Record<string, string>): Record<string, string> {
+  const registryPath = readWindowsRegistryPath(env)
+  if (!registryPath) {
+    return { ...env }
   }
 
+  // Find the PATH key in env (case-insensitive on Windows)
+  const pathKey = Object.keys(env).find((k) => k.toLowerCase() === 'path')
+  const canonicalKey = pathKey || 'Path'
+  const existingPath = env[canonicalKey] || ''
+
+  const normaliseSegment = (segment: string) => path.normalize(segment).toLowerCase()
+  const seenSegments = new Set(existingPath.split(';').map(normaliseSegment))
+
+  const registrySegments = registryPath.split(';').filter((segment) => {
+    const trimmed = segment.trim()
+    if (!trimmed) return false
+    const normalised = normaliseSegment(trimmed)
+    if (seenSegments.has(normalised)) return false
+    seenSegments.add(normalised)
+    return true
+  })
+
+  if (registrySegments.length > 0) {
+    return { ...env, [canonicalKey]: existingPath + ';' + registrySegments.join(';') }
+  }
+
+  return env
+}
+
+/**
+ * Spawn a login shell and capture its environment variables.
+ * Works with any POSIX-compatible shell (bash, zsh, etc.) on any platform.
+ */
+function spawnShellEnv(shellPath: string): Promise<Record<string, string>> {
   return new Promise((resolve, reject) => {
     const homeDirectory =
       process.env.HOME || process.env.Home || process.env.USERPROFILE || process.env.UserProfile || os.homedir()
     if (!homeDirectory) {
       return reject(new Error("Could not determine user's home directory."))
-    }
-
-    let shellPath = process.env.SHELL
-
-    if (!shellPath) {
-      if (isMac) {
-        logger.warn(
-          "process.env.SHELL is not set. Defaulting to /bin/zsh for macOS. This might not be the user's login shell."
-        )
-        shellPath = '/bin/zsh'
-      } else {
-        logger.warn("process.env.SHELL is not set. Defaulting to /bin/bash. This might not be the user's login shell.")
-        shellPath = '/bin/bash'
-      }
     }
 
     const commandArgs = ['-ilc', 'env']
@@ -213,16 +219,15 @@ function getLoginShellEnvironment(): Promise<Record<string, string>> {
     }
 
     const child = spawn(shellPath, commandArgs, {
-      cwd: homeDirectory, // Run the command in the user's home directory
-      detached: false, // Stay attached so we can clean up reliably
-      stdio: ['ignore', 'pipe', 'pipe'], // stdin, stdout, stderr
-      shell: false // We are specifying the shell command directly
+      cwd: homeDirectory,
+      detached: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: false
     })
 
     let output = ''
     let errorOutput = ''
 
-    // Protects against shells that wait for user input or hang during profile sourcing.
     timeoutId = setTimeout(() => {
       const errorMessage = `Timed out after ${SHELL_ENV_TIMEOUT_MS}ms while retrieving shell environment. Shell: ${shellPath}. Args: ${commandArgs.join(
         ' '
@@ -257,12 +262,9 @@ function getLoginShellEnvironment(): Promise<Record<string, string>> {
       }
 
       if (errorOutput.trim()) {
-        // Some shells might output warnings or non-fatal errors to stderr
-        // during profile loading. Log it, but proceed if exit code is 0.
         logger.warn(`Shell process stderr output (even with exit code 0):\n${errorOutput.trim()}`)
       }
 
-      // Convert each VAR=VALUE line into our env map.
       const env: Record<string, string> = {}
       const lines = output.split(/\r?\n/)
 
@@ -271,7 +273,6 @@ function getLoginShellEnvironment(): Promise<Record<string, string>> {
         if (trimmedLine) {
           const separatorIndex = trimmedLine.indexOf('=')
           if (separatorIndex > 0) {
-            // Ensure '=' is present and it's not the first character
             const key = trimmedLine.substring(0, separatorIndex)
             const value = trimmedLine.substring(separatorIndex + 1)
             env[key] = value
@@ -280,8 +281,6 @@ function getLoginShellEnvironment(): Promise<Record<string, string>> {
       })
 
       if (Object.keys(env).length === 0 && output.length < 100) {
-        // Arbitrary small length check
-        // This might indicate an issue if no env vars were parsed or output was minimal
         logger.warn(
           'Parsed environment is empty or output was very short. This might indicate an issue with shell execution or environment variable retrieval.'
         )
@@ -293,6 +292,55 @@ function getLoginShellEnvironment(): Promise<Record<string, string>> {
       resolveOnce(env)
     })
   })
+}
+
+/**
+ * Detect the user's default shell on macOS/Linux.
+ */
+function detectUnixShell(): string {
+  let shellPath = process.env.SHELL
+
+  if (!shellPath) {
+    if (isMac) {
+      logger.warn(
+        "process.env.SHELL is not set. Defaulting to /bin/zsh for macOS. This might not be the user's login shell."
+      )
+      shellPath = '/bin/zsh'
+    } else {
+      logger.warn("process.env.SHELL is not set. Defaulting to /bin/bash. This might not be the user's login shell.")
+      shellPath = '/bin/bash'
+    }
+  }
+
+  return shellPath
+}
+
+/**
+ * Spawns a login shell in the user's home directory to capture its environment variables.
+ *
+ * On Windows with Git Bash installed, spawns bash.exe to source profile files.
+ * On macOS/Linux, spawns the user's default login shell.
+ * Falls back to registry-based PATH on Windows when Git Bash is unavailable or spawn fails.
+ */
+function getLoginShellEnvironment(): Promise<Record<string, string>> {
+  // On Windows, try Git Bash first to source profile files
+  if (isWin) {
+    const gitBashPath = findGitBash()
+    if (gitBashPath) {
+      return spawnShellEnv(gitBashPath)
+        .then((bashEnv) => mergeWithRegistryPath(bashEnv))
+        .catch((error) => {
+          logger.warn('Git Bash spawn failed, falling back to registry PATH', { error: error.message })
+          return getWindowsEnvironment()
+        })
+    }
+    // No Git Bash found — fallback to registry-based PATH
+    return Promise.resolve(getWindowsEnvironment())
+  }
+
+  // macOS/Linux: spawn the user's default login shell
+  const shellPath = detectUnixShell()
+  return spawnShellEnv(shellPath)
 }
 
 let cachedEnv: Record<string, string> | null = null

--- a/src/main/utils/shell-env.ts
+++ b/src/main/utils/shell-env.ts
@@ -253,9 +253,14 @@ function normaliseBashEnvToWindows(env: Record<string, string>): Record<string, 
     } else if (/^[A-Za-z]:[\\/]/.test(trimmed)) {
       // Already Windows-style (e.g., C:/Python39), normalize slashes to backslashes
       windowsSegments.push(trimmed.replace(/\//g, '\\'))
+    } else if (/^\//.test(trimmed)) {
+      // MSYS-internal path (e.g., /usr/bin, /mingw64/bin, /bin, /cmd)
+      // These are virtual filesystem paths with no Windows equivalent.
+      // Git for Windows adds its cmd/ directory to the real Windows PATH
+      // during installation, so git.cmd remains accessible via registry merge.
+      logger.debug(`Filtering out MSYS-internal PATH segment: ${trimmed}`)
     } else {
-      // Other paths (e.g., /usr/bin) - pass through unchanged
-      // These are MSYS-internal paths that don't translate to Windows
+      // Relative paths or unusual entries — preserve as-is
       windowsSegments.push(trimmed)
     }
   }
@@ -311,11 +316,29 @@ function spawnShellEnv(shellPath: string): Promise<Record<string, string>> {
       reject(error)
     }
 
+    // Build spawn environment — on Windows, merge fresh registry PATH so that
+    // profile scripts can find tools installed after app launch.
+    let spawnEnv: Record<string, string> | undefined
+    if (isWin) {
+      spawnEnv = { ...(process.env as Record<string, string>) }
+      const freshRegistryPath = readWindowsRegistryPath(spawnEnv)
+      if (freshRegistryPath) {
+        const pathKeys = Object.keys(spawnEnv).filter((k) => k.toLowerCase() === 'path')
+        for (const key of pathKeys) {
+          spawnEnv[key] = freshRegistryPath
+        }
+        if (pathKeys.length === 0) {
+          spawnEnv.Path = freshRegistryPath
+        }
+      }
+    }
+
     const child = spawn(shellPath, commandArgs, {
       cwd: homeDirectory,
       detached: false,
       stdio: ['ignore', 'pipe', 'pipe'],
-      shell: false
+      shell: false,
+      ...(spawnEnv ? { env: spawnEnv } : {})
     })
 
     let output = ''

--- a/src/main/utils/shell-env.ts
+++ b/src/main/utils/shell-env.ts
@@ -271,8 +271,10 @@ function normaliseBashEnvToWindows(env: Record<string, string>): Record<string, 
  */
 function spawnShellEnv(shellPath: string): Promise<Record<string, string>> {
   return new Promise((resolve, reject) => {
-    const homeDirectory =
-      process.env.HOME || process.env.Home || process.env.USERPROFILE || process.env.UserProfile || os.homedir()
+    // On Windows, prefer USERPROFILE (native path) over HOME (may be MSYS format /c/...)
+    const homeDirectory = isWin
+      ? process.env.USERPROFILE || process.env.UserProfile || process.env.HOME || process.env.Home || os.homedir()
+      : process.env.HOME || process.env.Home || process.env.USERPROFILE || process.env.UserProfile || os.homedir()
     if (!homeDirectory) {
       return reject(new Error("Could not determine user's home directory."))
     }

--- a/src/main/utils/shell-env.ts
+++ b/src/main/utils/shell-env.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 import { loggerService } from '@logger'
 import { isMac, isWin } from '@main/constant'
+import { ConfigKeys, configManager } from '@main/services/ConfigManager'
 import { findGitBash } from '@main/utils/git-bash'
 import { execFileSync, spawn } from 'child_process'
 
@@ -175,6 +176,96 @@ function mergeWithRegistryPath(env: Record<string, string>): Record<string, stri
 }
 
 /**
+ * Convert MSYS/POSIX-style PATH and HOME to Windows-style.
+ * Git Bash outputs paths like /c/Users/... which need conversion.
+ */
+function normaliseBashEnvToWindows(env: Record<string, string>): Record<string, string> {
+  // Start with a copy to avoid mutation
+  const windowsEnv: Record<string, string> = { ...env }
+
+  // Convert HOME if present (MSYS format /c/Users/... → C:\Users\...)
+  const homeKey = Object.keys(windowsEnv).find((k) => k.toLowerCase() === 'home')
+  if (homeKey && windowsEnv[homeKey]) {
+    const homeValue = windowsEnv[homeKey]
+    const msysHomeMatch = /^\/([a-z])(\/.*)$/i.exec(homeValue)
+    if (msysHomeMatch) {
+      const driveLetter = msysHomeMatch[1].toUpperCase()
+      const rest = msysHomeMatch[2].replace(/\//g, '\\')
+      windowsEnv[homeKey] = `${driveLetter}:${rest}`
+    }
+  }
+
+  // Find PATH key (case-insensitive)
+  const pathKey = Object.keys(windowsEnv).find((k) => k.toLowerCase() === 'path')
+  if (!pathKey) {
+    return windowsEnv
+  }
+
+  const pathValue = windowsEnv[pathKey]
+  if (!pathValue) {
+    return windowsEnv
+  }
+
+  // Already Windows format (has ';' separator) - no conversion needed
+  if (pathValue.includes(';')) {
+    return windowsEnv
+  }
+
+  // POSIX format - split on ':' and convert each segment
+  // Handle edge case: Windows paths like C:/path contain ':' which shouldn't split
+  // Strategy: split on ':', then recombine drive letter fragments
+  const rawSegments = pathValue.split(':')
+  const segments: string[] = []
+
+  for (let i = 0; i < rawSegments.length; i++) {
+    const current = rawSegments[i].trim()
+    if (!current) continue
+
+    // Check if this looks like a drive letter (single letter)
+    // and next segment starts with / or \ (Windows-style path in POSIX PATH)
+    if (/^[A-Za-z]$/.test(current) && i + 1 < rawSegments.length) {
+      const next = rawSegments[i + 1].trim()
+      if (next.startsWith('/') || next.startsWith('\\')) {
+        // Combine: C + /Python39 → C:/Python39
+        segments.push(`${current}:${next}`)
+        i++ // Skip next segment since we combined it
+        continue
+      }
+    }
+
+    segments.push(current)
+  }
+
+  const windowsSegments: string[] = []
+
+  for (const segment of segments) {
+    const trimmed = segment.trim()
+    if (!trimmed) {
+      continue
+    }
+
+    // MSYS path: /c/Users/... → C:\Users\...
+    const msysMatch = /^\/([a-z])(\/.*)$/i.exec(trimmed)
+    if (msysMatch) {
+      const driveLetter = msysMatch[1].toUpperCase()
+      const rest = msysMatch[2].replace(/\//g, '\\')
+      windowsSegments.push(`${driveLetter}:${rest}`)
+    } else if (/^[A-Za-z]:[\\/]/.test(trimmed)) {
+      // Already Windows-style (e.g., C:/Python39), normalize slashes to backslashes
+      windowsSegments.push(trimmed.replace(/\//g, '\\'))
+    } else {
+      // Other paths (e.g., /usr/bin) - pass through unchanged
+      // These are MSYS-internal paths that don't translate to Windows
+      windowsSegments.push(trimmed)
+    }
+  }
+
+  const windowsPath = windowsSegments.join(';')
+  windowsEnv[pathKey] = windowsPath
+  return windowsEnv
+}
+
+/**
  * Spawn a login shell and capture its environment variables.
  * Works with any POSIX-compatible shell (bash, zsh, etc.) on any platform.
  */
@@ -287,8 +378,8 @@ function spawnShellEnv(shellPath: string): Promise<Record<string, string>> {
         logger.warn(`Raw output from shell:\n${output}`)
       }
 
-      appendCherryBinToPath(env)
-
+      // Note: appendCherryBinToPath is called after normaliseBashEnvToWindows
+      // to ensure PATH is in Windows format first
       resolveOnce(env)
     })
   })
@@ -325,10 +416,17 @@ function detectUnixShell(): string {
 function getLoginShellEnvironment(): Promise<Record<string, string>> {
   // On Windows, try Git Bash first to source profile files
   if (isWin) {
-    const gitBashPath = findGitBash()
+    // Read configured Git Bash path from settings (P2 fix)
+    const configuredPath = configManager.get<string | undefined>(ConfigKeys.GitBashPath)
+    const gitBashPath = findGitBash(configuredPath)
     if (gitBashPath) {
       return spawnShellEnv(gitBashPath)
+        .then((bashEnv) => normaliseBashEnvToWindows(bashEnv))
         .then((bashEnv) => mergeWithRegistryPath(bashEnv))
+        .then((env) => {
+          appendCherryBinToPath(env)
+          return env
+        })
         .catch((error) => {
           logger.warn('Git Bash spawn failed, falling back to registry PATH', { error: error.message })
           return getWindowsEnvironment()
@@ -340,7 +438,10 @@ function getLoginShellEnvironment(): Promise<Record<string, string>> {
 
   // macOS/Linux: spawn the user's default login shell
   const shellPath = detectUnixShell()
-  return spawnShellEnv(shellPath)
+  return spawnShellEnv(shellPath).then((env) => {
+    appendCherryBinToPath(env)
+    return env
+  })
 }
 
 let cachedEnv: Record<string, string> | null = null

--- a/src/main/utils/shell-env.ts
+++ b/src/main/utils/shell-env.ts
@@ -171,7 +171,7 @@ function mergeWithRegistryPath(env: Record<string, string>): Record<string, stri
     return { ...env, [canonicalKey]: existingPath + ';' + registrySegments.join(';') }
   }
 
-  return env
+  return { ...env }
 }
 
 /**

--- a/src/main/utils/shell-env.ts
+++ b/src/main/utils/shell-env.ts
@@ -429,8 +429,9 @@ function getLoginShellEnvironment(): Promise<Record<string, string>> {
           appendCherryBinToPath(env)
           return env
         })
-        .catch((error) => {
-          logger.warn('Git Bash spawn failed, falling back to registry PATH', { error: error.message })
+        .catch((error: unknown) => {
+          const msg = error instanceof Error ? error.message : String(error)
+          logger.warn('Git Bash spawn failed, falling back to registry PATH', { error: msg })
           return getWindowsEnvironment()
         })
     }


### PR DESCRIPTION
### What this PR does

Before this PR:
On Windows, `getLoginShellEnvironment()` bypassed shell spawning entirely — it only read PATH from the Windows registry. Git Bash profile files (`~/.bash_profile`, `~/.bashrc`, `~/.profile`) were never sourced. This meant tools installed and managed by fnm, nvm, or mise (e.g., Node.js, npm) were invisible to Cherry Studio's CLI integrations and agent shell environment.

After this PR:
On Windows with Git Bash installed, the app spawns `bash.exe -ilc env` as a login shell to capture the full environment (including profile-sourced PATH entries). The captured env is then merged with registry PATH to preserve system-level paths. Falls back gracefully to registry-only PATH when Git Bash is unavailable or spawn fails.

Fixes #14597

### Why we need it and why it was done in this way

Windows users who manage Node.js via fnm/nvm/mise could not use CLI integrations because the shell environment never loaded their profile files — the tool-managed PATH entries were missing.

The following tradeoffs were made:
- **Extracted `git-bash.ts`** from `process.ts` to break a circular dependency (`shell-env.ts` ↔ `process.ts`). This keeps the Git Bash discovery logic self-contained without depending on `process.ts`.
- **`findGitExeViaWhere()`** replaces the previous `findExecutable` injection — uses `execFileSync('where', ['git'])` directly since it's Windows-only and has no shell injection risk.
- **Immutable `mergeWithRegistryPath()`** — always returns a new object to avoid subtle mutation bugs.
- **Fallback chain**: Git Bash spawn → registry PATH → `process.env`, ensuring no regression even when Git Bash is missing.

The following alternatives were considered:
- Using `cmd.exe /c set` — doesn't source profile files, same problem
- Using PowerShell — heavier, slower startup, not universally available
- Modifying `process.ts` in-place — would have introduced circular dependency

Links to places where the discussion took place: #14597

### Breaking changes

None. macOS/Linux behavior is unchanged (`isWin` gate). Windows users without Git Bash fall back to the existing registry-based PATH behavior.

### Special notes for your reviewer

- The core change is in `src/main/utils/shell-env.ts` — the Windows branch of `getLoginShellEnvironment()`.
- `src/main/utils/git-bash.ts` is a new file extracted from `process.ts` to avoid circular imports.
- `src/main/utils/process.ts` now only re-exports from `git-bash.ts`.
- 6 new tests cover: Git Bash found → spawn, not found → fallback, spawn failure → fallback, timeout → fallback, registry merge, PATH dedup.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix Windows Git Bash profile loading: fnm/nvm/mise-managed tools are now available in CLI integrations
```