### PR TITLE
hotfix(vision): support versioned GPT image models in generation checks

### DIFF
--- a/src/renderer/src/config/models/__tests__/vision.test.ts
+++ b/src/renderer/src/config/models/__tests__/vision.test.ts
@@ -104,6 +104,11 @@ describe('vision helpers', () => {
     it('returns false when openai-response model is not on allow list', () => {
       expect(isGenerateImageModel(createModel({ id: 'gpt-4.2-experimental' }))).toBe(false)
     })
+
+    it('recognizes versioned GPT image models routed through OpenRouter', () => {
+      expect(isGenerateImageModel(createModel({ id: 'gpt-5.4-image-2', provider: 'openrouter' }))).toBe(true)
+      expect(isPureGenerateImageModel(createModel({ id: 'gpt-5.4-image-2', provider: 'openrouter' }))).toBe(true)
+    })
   })
 
   describe('isPureGenerateImageModel', () => {
@@ -122,12 +127,17 @@ describe('vision helpers', () => {
 
     it('detects models with restricted image size support and enhancement', () => {
       expect(isImageEnhancementModel(createModel({ id: 'qwen-image-edit' }))).toBe(true)
+      expect(isImageEnhancementModel(createModel({ id: 'gpt-5.4-image-2', provider: 'openrouter' }))).toBe(true)
       expect(isImageEnhancementModel(createModel({ id: 'gpt-4o' }))).toBe(false)
     })
 
     it('identifies dedicated and auto-enabled image generation models', () => {
       expect(isDedicatedImageGenerationModel(createModel({ id: 'grok-2-image-1212' }))).toBe(true)
       expect(isAutoEnableImageGenerationModel(createModel({ id: 'gemini-2.5-flash-image-ultra' }))).toBe(true)
+      expect(isDedicatedImageGenerationModel(createModel({ id: 'gpt-5.4-image-2', provider: 'openrouter' }))).toBe(true)
+      expect(isAutoEnableImageGenerationModel(createModel({ id: 'gpt-5.4-image-2', provider: 'openrouter' }))).toBe(
+        true
+      )
     })
 
     it('returns false when models are not in dedicated or auto-enable sets', () => {

--- a/src/renderer/src/config/models/vision.ts
+++ b/src/renderer/src/config/models/vision.ts
@@ -89,6 +89,7 @@ const DEDICATED_IMAGE_MODELS = [
   // OpenAI series
   'dall-e(?:-[\\w-]+)?',
   'gpt-image(?:-[\\w-]+)?',
+  'gpt-\\d+(?:\\.\\d+)?-image(?:-[\\w-]+)?',
   // xAI
   'grok-2-image(?:-[\\w-]+)?',
   // Google
@@ -119,6 +120,7 @@ const IMAGE_ENHANCEMENT_MODELS = [
   'qwen-image-edit',
   'gpt-image-1',
   'gpt-image-2',
+  'gpt-\\d+(?:\\.\\d+)?-image(?:-[\\w-]+)?',
   'gemini-2.5-flash-image(?:-[\\w-]+)?',
   'gemini-2.0-flash-preview-image-generation',
   'gemini-3(?:\\.\\d+)?-(?:flash|pro)-image(?:-[\\w-]+)?'


### PR DESCRIPTION
### What this PR does

Before this PR:
OpenRouter image models with versioned IDs such as `gpt-5.4-image-2` were not recognized as dedicated image-generation models, so the chat input did not enable the image-generation state correctly and the image-generation indicator was missing.

After this PR:
Versioned GPT image model IDs are matched by the image-generation capability checks, so OpenRouter `gpt-5.4-image-2` is handled like the existing GPT image family and shows the image-generation indicator correctly.

Fixes #14630

### Why we need it and why it was done in this way

The following tradeoffs were made:
Expanded the existing regex-based model-family detection so the fix stays localized to the capability checks that already drive the UI and request path.

The following alternatives were considered:
Hard-code `gpt-5.4-image-2` as a one-off special case, or normalize provider-specific aliases earlier in the model pipeline.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/14630

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- Focused validation passed: `pnpm vitest run src/renderer/src/config/models/__tests__/vision.test.ts`
- Full `pnpm test` in this Windows workspace still has unrelated pre-existing path/symlink failures outside this change.
- This branch is based on a fork `main` that is ahead of `upstream/main`, so the GitHub compare view against `upstream/main` will include unrelated fork-only commits in addition to this hotfix.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix the missing image-generation indicator for OpenRouter GPT image models with versioned IDs such as `gpt-5.4-image-2`.
```