### PR TITLE
fix(markdown): respect partial text selection when copying KaTeX formulas

### DIFF
--- a/src/renderer/src/pages/home/Markdown/Markdown.tsx
+++ b/src/renderer/src/pages/home/Markdown/Markdown.tsx
@@ -1,5 +1,5 @@
 import 'katex/dist/katex.min.css'
-import 'katex/dist/contrib/copy-tex'
+import '@renderer/utils/katex-copy-handler'
 import 'katex/dist/contrib/mhchem'
 import 'remark-github-blockquote-alert/alert.css'
 

--- a/src/renderer/src/utils/katex-copy-handler.ts
+++ b/src/renderer/src/utils/katex-copy-handler.ts
@@ -1,0 +1,75 @@
+/**
+ * Custom KaTeX copy handler that respects partial text selections.
+ *
+ * When the user selects part of a KaTeX formula and copies, this handler
+ * lets the browser perform normal text copy (so the selected text is copied).
+ * Only when the selection fully encompasses one or more KaTeX elements does
+ * it replace them with their LaTeX source.
+ *
+ * Replaces the default `katex/dist/contrib/copy-tex` behavior.
+ */
+
+function isKatexElement(el: Element | null): boolean {
+  return el != null && (el.classList.contains('katex') || el.classList.contains('katex-display'))
+}
+
+function getClosestKatex(el: Node | null): Element | null {
+  let current: Node | null = el
+  while (current != null) {
+    if (current.nodeType === Node.ELEMENT_NODE && isKatexElement(current as Element)) {
+      return current as Element
+    }
+    current = current.parentNode
+  }
+  return null
+}
+
+function extractLatex(katexEl: Element): string {
+  // Try data-latex attribute first (set by some renderers)
+  const dataLatex = katexEl.getAttribute('data-latex')
+  if (dataLatex) return dataLatex
+
+  // Try to find the annotation with the tex source (rendered by KaTeX)
+  const annotation = katexEl.querySelector('annotation[encoding="application/x-tex"]')
+  if (annotation) return annotation.textContent || ''
+
+  return ''
+}
+
+function handleKatexCopy(event: ClipboardEvent): void {
+  const selection = window.getSelection()
+  if (!selection || selection.isCollapsed) return
+
+  const range = selection.getRangeAt(0)
+  const container = range.commonAncestorContainer
+
+  // Find the closest KaTeX element to the selection
+  const katexEl = getClosestKatex(container.nodeType === Node.TEXT_NODE ? container.parentNode : container)
+
+  if (!katexEl) return
+
+  // Check if the selection covers the ENTIRE KaTeX element
+  // If the selection only partially covers the formula, let normal copy proceed
+  const katexRange = document.createRange()
+  katexRange.selectNodeContents(katexEl)
+
+  // Selection fully covers katex element -> replace with LaTeX
+  if (
+    range.compareBoundaryPoints(Range.START_TO_START, katexRange) <= 0 &&
+    range.compareBoundaryPoints(Range.END_TO_END, katexRange) >= 0
+  ) {
+    const latex = extractLatex(katexEl)
+    if (latex) {
+      event.preventDefault()
+      event.clipboardData?.setData('text/plain', latex)
+    }
+    return
+  }
+
+  // Partial selection - do nothing, let the browser copy the selected text
+}
+
+// Register the handler once when this module is imported
+if (typeof document !== 'undefined') {
+  document.addEventListener('copy', handleKatexCopy)
+}


### PR DESCRIPTION
## Problem

When selecting part of a KaTeX formula in the chat view and pressing
Ctrl+C, the entire formula's LaTeX source was copied to the clipboard
instead of just the selected text.

## Root Cause

`Markdown.tsx` imported `katex/dist/contrib/copy-tex`, which unconditionally
replaces clipboard content with the LaTeX source of any KaTeX element
within the selection, regardless of whether the user selected the full
formula or just a portion of it.

## Solution

Replaced the `copy-tex` import with a custom copy handler that:

- **Partial selection**: If the user selects only part of a formula, the
  browser performs normal text copy — the selected characters are copied
  as visible text.
- **Full selection**: If the user selects an entire KaTeX element, the
  LaTeX source is placed on the clipboard (preserving the original
  `copy-tex` convenience).

## Changes

- **New file**: `src/renderer/src/utils/katex-copy-handler.ts` — custom
  copy event handler with partial-selection awareness.
- **Modified**: `src/renderer/src/pages/home/Markdown/Markdown.tsx` —
  replaced `katex/dist/contrib/copy-tex` import with the new handler.