### PR TITLE
hotfix(api): fix OpenAI-compatible image endpoint routing and validation

### DIFF
--- a/.changeset/openai-compatible-image-endpoints.md
+++ b/.changeset/openai-compatible-image-endpoints.md
@@ -1,0 +1,9 @@
+---
+'@cherrystudio/ai-core': patch
+---
+
+Fix OpenAI-compatible image generation when providers use explicit image endpoints or versioned API hosts.
+
+- Honor explicit `images/generations` and `images/edits` endpoints for image models without rerouting chat traffic.
+- Validate dedicated image-generation models through `generateImage()` so broken image-only configs fail the API check correctly.
+- Retry OpenAI-compatible image requests once against a de-versioned base URL after a 404 from a versioned host.

--- a/packages/aiCore/src/core/providers/__tests__/openaiCompatibleEndpoint.test.ts
+++ b/packages/aiCore/src/core/providers/__tests__/openaiCompatibleEndpoint.test.ts
@@ -1,0 +1,90 @@
+import { generateText } from 'ai'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { extensionRegistry } from '../index'
+
+describe('openai-compatible custom endpoint', () => {
+  afterEach(() => {
+    extensionRegistry.get('openai-compatible')?.clearCache()
+  })
+
+  it('uses the configured endpoint for image generation requests', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ b64_json: 'ZmFrZQ==' }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    )
+
+    const provider = await extensionRegistry.createProvider('openai-compatible', {
+      apiKey: 'sk-test',
+      baseURL: 'https://api.example.com',
+      name: 'custom-openai-compatible',
+      customEndpoint: 'images/generations',
+      fetch: fetchSpy
+    } as any)
+
+    const imageModel = provider.imageModel('gpt-image-2')
+
+    await imageModel.doGenerate({
+      prompt: 'cat',
+      n: 1,
+      size: '1024x1024',
+      aspectRatio: undefined,
+      seed: undefined,
+      providerOptions: {},
+      headers: {},
+      files: undefined,
+      mask: undefined
+    })
+
+    const [url] = fetchSpy.mock.calls[0] as [string, RequestInit | undefined]
+
+    expect(url).toBe('https://api.example.com/images/generations')
+  })
+
+  it('keeps chat requests on the default chat endpoint when a custom image endpoint is configured', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 'chatcmpl-test',
+          created: 0,
+          model: 'gpt-4o-mini',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: 'ok' },
+              finish_reason: 'stop'
+            }
+          ],
+          usage: {
+            prompt_tokens: 1,
+            completion_tokens: 1,
+            total_tokens: 2
+          }
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        }
+      )
+    )
+
+    const provider = await extensionRegistry.createProvider('openai-compatible', {
+      apiKey: 'sk-test',
+      baseURL: 'https://api.example.com',
+      name: 'custom-openai-compatible',
+      customEndpoint: 'images/generations',
+      fetch: fetchSpy
+    } as any)
+
+    await generateText({
+      model: provider.languageModel('gpt-4o-mini') as any,
+      prompt: 'hello'
+    })
+
+    const [url] = fetchSpy.mock.calls[0] as [string, RequestInit | undefined]
+
+    expect(url).toBe('https://api.example.com/chat/completions')
+  })
+})

--- a/packages/aiCore/src/core/providers/core/initialization.ts
+++ b/packages/aiCore/src/core/providers/core/initialization.ts
@@ -15,8 +15,13 @@ import { createGoogleGenerativeAI } from '@ai-sdk/google'
 import type { OpenAIProvider, OpenAIProviderSettings } from '@ai-sdk/openai'
 import { createOpenAI } from '@ai-sdk/openai'
 import type { OpenAICompatibleProviderSettings } from '@ai-sdk/openai-compatible'
-import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
+import {
+  createOpenAICompatible,
+  OpenAICompatibleImageModel,
+  VERSION as OPENAI_COMPATIBLE_VERSION
+} from '@ai-sdk/openai-compatible'
 import type { ProviderV3 } from '@ai-sdk/provider'
+import { withoutTrailingSlash, withUserAgentSuffix } from '@ai-sdk/provider-utils'
 import type { XaiProvider, XaiProviderSettings } from '@ai-sdk/xai'
 import { createXai } from '@ai-sdk/xai'
 import type { CherryInProvider, CherryInProviderSettings } from '@cherrystudio/ai-sdk-provider'
@@ -35,6 +40,60 @@ import type {
 import { extensionRegistry } from './ExtensionRegistry'
 import type { ProviderExtensionConfig } from './ProviderExtension'
 import { ProviderExtension } from './ProviderExtension'
+
+type OpenAICompatibleProviderSettingsWithEndpoint = OpenAICompatibleProviderSettings & {
+  customEndpoint?: string
+}
+
+const OPENAI_COMPATIBLE_IMAGE_ENDPOINTS = new Set(['images/generations', 'images/edits', 'predict'])
+
+function createOpenAICompatibleWithEndpoint(settings: OpenAICompatibleProviderSettingsWithEndpoint): ProviderV3 {
+  const { customEndpoint, ...baseSettings } = settings
+
+  if (!customEndpoint || !OPENAI_COMPATIBLE_IMAGE_ENDPOINTS.has(customEndpoint)) {
+    return createOpenAICompatible(baseSettings)
+  }
+
+  const defaultProvider = createOpenAICompatible(baseSettings)
+
+  const baseURL = withoutTrailingSlash(baseSettings.baseURL)
+  const providerName = baseSettings.name
+  const normalizedEndpoint = customEndpoint.startsWith('/') ? customEndpoint : `/${customEndpoint}`
+  const headers = {
+    ...(baseSettings.apiKey && { Authorization: `Bearer ${baseSettings.apiKey}` }),
+    ...baseSettings.headers
+  }
+
+  const getHeaders = () => withUserAgentSuffix(headers, `ai-sdk/openai-compatible/${OPENAI_COMPATIBLE_VERSION}`)
+
+  const url = ({ path }: { path: string }) => {
+    const resolvedPath = path.startsWith('/images/edits') ? path : normalizedEndpoint
+    const requestUrl = new URL(`${baseURL}${resolvedPath}`)
+
+    if (baseSettings.queryParams) {
+      requestUrl.search = new URLSearchParams(baseSettings.queryParams).toString()
+    }
+
+    return requestUrl.toString()
+  }
+
+  const getImageModelConfig = () => ({
+    provider: `${providerName}.image`,
+    url,
+    headers: getHeaders,
+    fetch: baseSettings.fetch
+  })
+
+  const createImageModel = (modelId: string) =>
+    new OpenAICompatibleImageModel(modelId, {
+      ...getImageModelConfig()
+    })
+
+  return Object.assign((modelId: string) => defaultProvider.languageModel(modelId), {
+    ...defaultProvider,
+    imageModel: createImageModel
+  }) as unknown as ReturnType<typeof createOpenAICompatible>
+}
 
 // ==================== Core Extensions ====================
 
@@ -171,7 +230,7 @@ const OpenAICompatibleExtension = ProviderExtension.create({
     if (!settings) {
       throw new Error('OpenAI Compatible provider requires settings')
     }
-    return createOpenAICompatible(settings)
+    return createOpenAICompatibleWithEndpoint(settings as OpenAICompatibleProviderSettingsWithEndpoint)
   }
 } as const satisfies ProviderExtensionConfig<OpenAICompatibleProviderSettings, ProviderV3, 'openai-compatible'>)
 

--- a/src/renderer/src/aiCore/AiProvider.ts
+++ b/src/renderer/src/aiCore/AiProvider.ts
@@ -16,6 +16,7 @@ import {
 import type { StreamTextParams } from '@renderer/types/aiCoreTypes'
 import { getLowerBaseModelName } from '@renderer/utils'
 import { buildClaudeCodeSystemModelMessage } from '@shared/anthropic'
+import { withoutTrailingApiVersion } from '@shared/utils'
 import { createGateway } from 'ai'
 
 import AiSdkToChunkAdapter from './chunk/AiSdkToChunkAdapter'
@@ -26,6 +27,12 @@ import type { AppProviderSettingsMap, CompletionsResult, ProviderConfig } from '
 import type { AiSdkMiddlewareConfig } from './types/middlewareConfig'
 
 const logger = loggerService.withContext('AiProvider')
+
+type OpenAICompatibleProviderSettingsWithEndpoint = ProviderConfig<'openai-compatible'>['providerSettings'] & {
+  customEndpoint?: string
+}
+
+const OPENAI_COMPATIBLE_IMAGE_ENDPOINTS = new Set(['images/generations', 'images/edits', 'predict'])
 
 export type AiProviderConfig = AiSdkMiddlewareConfig & {
   assistant: Assistant
@@ -416,17 +423,22 @@ export default class AiProvider {
       ...(signal && { abortSignal: signal })
     }
 
-    const executor = await createExecutor<AppProviderSettingsMap>(
-      providerConfig.providerId,
-      providerConfig.providerSettings,
-      []
-    )
-    const result = await executor.generateImage({
-      model: model, // 直接使用 model ID 字符串，由 executor 内部解析
-      ...aiSdkParams
-    })
+    try {
+      return await this.executeImageRequest(providerConfig, {
+        model: model,
+        ...aiSdkParams
+      })
+    } catch (error) {
+      const fallbackConfig = this.buildOpenAICompatibleImageFallbackConfig(providerConfig, 'images/generations')
+      if (!fallbackConfig || !this.isNotFoundApiError(error)) {
+        throw error
+      }
 
-    return this.convertImageResult(result)
+      return await this.executeImageRequest(fallbackConfig, {
+        model: model,
+        ...aiSdkParams
+      })
+    }
   }
 
   /**
@@ -436,25 +448,80 @@ export default class AiProvider {
   private async modernEditImage(params: EditImageParams, providerConfig: ProviderConfig): Promise<string[]> {
     const { model, prompt, inputImages, mask, imageSize, signal } = params
 
+    const request = {
+      model: model,
+      prompt: {
+        text: prompt,
+        images: inputImages,
+        ...(mask && { mask })
+      },
+      size: (imageSize || '1024x1024') as `${number}x${number}`,
+      ...(signal && { abortSignal: signal })
+    }
+
+    try {
+      return await this.executeImageRequest(providerConfig, request)
+    } catch (error) {
+      const fallbackConfig = this.buildOpenAICompatibleImageFallbackConfig(providerConfig, 'images/edits')
+      if (!fallbackConfig || !this.isNotFoundApiError(error)) {
+        throw error
+      }
+
+      return await this.executeImageRequest(fallbackConfig, request)
+    }
+  }
+
+  private async executeImageRequest(
+    providerConfig: ProviderConfig,
+    params: Record<string, unknown>
+  ): Promise<string[]> {
     const executor = await createExecutor<AppProviderSettingsMap>(
       providerConfig.providerId,
       providerConfig.providerSettings,
       []
     )
 
-    // 使用 AI SDK 的 generateImage，通过 prompt.images 实现编辑
-    const result = await executor.generateImage({
-      model: model,
-      prompt: {
-        text: prompt,
-        images: inputImages, // 输入图像（必需）
-        ...(mask && { mask }) // 可选的 mask（用于 inpainting）
-      },
-      size: (imageSize || '1024x1024') as `${number}x${number}`,
-      ...(signal && { abortSignal: signal })
-    })
-
+    const result = await executor.generateImage(params as Parameters<typeof executor.generateImage>[0])
     return this.convertImageResult(result)
+  }
+
+  private buildOpenAICompatibleImageFallbackConfig(
+    providerConfig: ProviderConfig,
+    customEndpoint: 'images/generations' | 'images/edits'
+  ): ProviderConfig | undefined {
+    if (providerConfig.providerId !== 'openai-compatible') {
+      return undefined
+    }
+
+    const settings = providerConfig.providerSettings as OpenAICompatibleProviderSettingsWithEndpoint
+    if (settings.customEndpoint && !OPENAI_COMPATIBLE_IMAGE_ENDPOINTS.has(settings.customEndpoint)) {
+      return undefined
+    }
+
+    const fallbackBaseURL = withoutTrailingApiVersion(settings.baseURL)
+    if (!fallbackBaseURL || fallbackBaseURL === settings.baseURL) {
+      return undefined
+    }
+
+    const fallbackEndpoint = settings.customEndpoint || customEndpoint
+
+    return {
+      ...providerConfig,
+      providerSettings: {
+        ...settings,
+        baseURL: fallbackBaseURL,
+        customEndpoint: fallbackEndpoint
+      } as OpenAICompatibleProviderSettingsWithEndpoint
+    }
+  }
+
+  private isNotFoundApiError(error: unknown): error is { statusCode: number } {
+    return (
+      typeof error === 'object' &&
+      error !== null &&
+      'statusCode' in error &&
+      (error as { statusCode?: number }).statusCode === 404
+    )
   }
 
   /**

--- a/src/renderer/src/aiCore/provider/__tests__/providerConfig.test.ts
+++ b/src/renderer/src/aiCore/provider/__tests__/providerConfig.test.ts
@@ -1002,6 +1002,25 @@ describe('providerToAiSdkConfig', () => {
       expect(config.endpoint).toBe('chat/completions')
     })
 
+    it('passes custom endpoint through provider settings for openai-compatible providers', async () => {
+      const provider = makeProvider({
+        id: 'some-openai-compat',
+        type: 'openai',
+        apiHost: 'https://api.custom.com/images/generations#'
+      })
+
+      const config = (await providerToAiSdkConfig(
+        provider,
+        makeModel('gpt-image-2', provider.id)
+      )) as ProviderConfig<'openai-compatible'>
+
+      const settings = config.providerSettings as OpenAICompatibleProviderSettings & { customEndpoint?: string }
+
+      expect(config.endpoint).toBe('images/generations')
+      expect(settings.baseURL).toBe('https://api.custom.com')
+      expect(settings.customEndpoint).toBe('images/generations')
+    })
+
     it('returns empty endpoint for normal URLs', async () => {
       const provider = makeProvider({
         id: 'some-openai-compat',

--- a/src/renderer/src/aiCore/provider/providerConfig.ts
+++ b/src/renderer/src/aiCore/provider/providerConfig.ts
@@ -357,10 +357,18 @@ function buildOpenAICompatibleConfig(ctx: BuilderContext): ProviderConfig<'opena
     ? store.getState().settings.openAI?.streamOptions?.includeUsage
     : undefined
 
+  const providerSettings = {
+    ...ctx.baseConfig,
+    ...commonOptions,
+    name: ctx.actualProvider.id,
+    includeUsage,
+    ...(ctx.endpoint ? { customEndpoint: ctx.endpoint } : {})
+  } as ProviderConfig<'openai-compatible'>['providerSettings'] & { customEndpoint?: string }
+
   return {
     providerId: 'openai-compatible',
     endpoint: ctx.endpoint,
-    providerSettings: { ...ctx.baseConfig, ...commonOptions, name: ctx.actualProvider.id, includeUsage }
+    providerSettings
   }
 }
 

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -838,6 +838,18 @@ export async function checkApi(provider: Provider, model: Model, timeout = 15000
     logger.info('checkApi: embedding model detected, calling getEmbeddingDimensions', { modelId: model.id })
     const timerPromise = new Promise<never>((_, reject) => setTimeout(() => reject(new Error('Timeout')), timeout))
     await Promise.race([ai.getEmbeddingDimensions(model), timerPromise])
+  } else if (isDedicatedImageGenerationModel(model)) {
+    logger.info('checkApi: dedicated image model detected, calling generateImage', { modelId: model.id })
+    const timerPromise = new Promise<never>((_, reject) => setTimeout(() => reject(new Error('Timeout')), timeout))
+    await Promise.race([
+      ai.generateImage({
+        model: model.id,
+        prompt: 'test',
+        imageSize: '1024x1024',
+        batchSize: 1
+      }),
+      timerPromise
+    ])
   } else {
     const abortId = uuid()
     const signal = readyToAbort(abortId)

--- a/src/renderer/src/services/__tests__/ApiService.checkApi.test.ts
+++ b/src/renderer/src/services/__tests__/ApiService.checkApi.test.ts
@@ -1,0 +1,124 @@
+import type * as ModelsModule from '@renderer/config/models'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const generateImageMock = vi.hoisted(() => vi.fn())
+const completionsMock = vi.hoisted(() => vi.fn())
+const getEmbeddingDimensionsMock = vi.hoisted(() => vi.fn())
+const isDedicatedImageGenerationModelMock = vi.hoisted(() => vi.fn())
+const isEmbeddingModelMock = vi.hoisted(() => vi.fn())
+const getDefaultAssistantMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    })
+  }
+}))
+
+vi.mock('@renderer/config/models', async (importOriginal) => {
+  const actual = await importOriginal<typeof ModelsModule>()
+
+  return {
+    ...actual,
+    isDedicatedImageGenerationModel: (...args: any[]) => isDedicatedImageGenerationModelMock(...args),
+    isEmbeddingModel: (...args: any[]) => isEmbeddingModelMock(...args),
+    isFunctionCallingModel: vi.fn(() => false)
+  }
+})
+
+vi.mock('@renderer/i18n', () => ({
+  default: {
+    t: (key: string) => key
+  }
+}))
+
+vi.mock('@renderer/store', () => ({
+  default: {
+    getState: vi.fn(() => ({ mcp: { servers: [] } }))
+  }
+}))
+
+vi.mock('@renderer/store/mcp', () => ({
+  hubMCPServer: { id: 'hub', name: 'hub', isActive: true }
+}))
+
+vi.mock('@renderer/hooks/useSettings', () => ({
+  getStoreSetting: vi.fn()
+}))
+
+vi.mock('../../aiCore', () => ({
+  AiProvider: vi.fn().mockImplementation(() => ({
+    generateImage: generateImageMock,
+    completions: completionsMock,
+    getEmbeddingDimensions: getEmbeddingDimensionsMock
+  }))
+}))
+
+vi.mock('../AssistantService', () => ({
+  getDefaultAssistant: (...args: any[]) => getDefaultAssistantMock(...args),
+  getDefaultModel: vi.fn(() => ({ id: 'default-model' })),
+  getProviderByModel: vi.fn(),
+  getQuickModel: vi.fn()
+}))
+
+vi.mock('../ConversationService', () => ({
+  ConversationService: {
+    prepareMessagesForModel: vi.fn()
+  }
+}))
+
+vi.mock('../KnowledgeService', () => ({
+  injectUserMessageWithKnowledgeSearchPrompt: vi.fn()
+}))
+
+import { checkApi } from '../ApiService'
+
+describe('checkApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    generateImageMock.mockResolvedValue(['data:image/png;base64,ZmFrZQ=='])
+    completionsMock.mockResolvedValue(undefined)
+    getEmbeddingDimensionsMock.mockResolvedValue(1536)
+    isEmbeddingModelMock.mockReturnValue(false)
+    isDedicatedImageGenerationModelMock.mockReturnValue(true)
+    getDefaultAssistantMock.mockReturnValue({
+      id: 'default',
+      name: 'Default Assistant',
+      prompt: '',
+      settings: {}
+    })
+    ;(globalThis as any).window = {
+      toast: {
+        error: vi.fn()
+      }
+    }
+  })
+
+  it('validates dedicated image models with generateImage instead of chat completions', async () => {
+    const provider = {
+      id: 'custom-openai',
+      type: 'openai',
+      apiKey: 'sk-test',
+      apiHost: 'https://api.example.com',
+      models: [{ id: 'gpt-image-2' }]
+    } as any
+
+    const model = {
+      id: 'gpt-image-2'
+    } as any
+
+    await checkApi(provider, model, 1000)
+
+    expect(generateImageMock).toHaveBeenCalledWith({
+      model: 'gpt-image-2',
+      prompt: 'test',
+      imageSize: '1024x1024',
+      batchSize: 1
+    })
+    expect(completionsMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
### What this PR does

Before this PR:
- OpenAI-compatible providers could parse endpoint-style API hosts, but custom image endpoints were not honored consistently at runtime.
- Dedicated image model validation used chat completions, so some broken image configurations passed the API check.
- OpenAI-compatible image requests against versioned hosts such as `/v1` could fail with 404 and had no retry path.

After this PR:
- OpenAI-compatible image models honor explicit custom image endpoints without rerouting chat traffic.
- Dedicated image models are validated through `generateImage()`.
- OpenAI-compatible image generation and edit requests retry once with a de-versioned base URL after a 404.

Fixes #14640

### Why we need it and why it was done in this way

This issue was user-visible: some OpenAI-compatible image providers passed configuration checks but failed when users actually generated images. The fix was split across provider configuration, runtime request handling, and validation so the configured endpoint path, the test flow, and the production execution path all align.

The following tradeoffs were made:
- Kept the custom endpoint override scoped to image models only, so mixed-model OpenAI-compatible providers keep using default chat endpoints.
- Limited the retry behavior to a single OpenAI-compatible image retry after a 404 to avoid broad request mutation.
- Added focused regression tests for provider config propagation, runtime endpoint usage, and image-model validation instead of widening scope into unrelated failing suites.

The following alternatives were considered:
- Applying the custom endpoint override provider-wide, but that misroutes chat and embedding traffic for mixed-model providers.
- Keeping validation on chat completions, but that does not exercise the failing image API path.
- Retrying all 404s generically, but that risks masking unrelated endpoint problems.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/14640

### Breaking changes

None.

### Special notes for your reviewer

- The focused image-endpoint regression suites passed:
  - `pnpm exec vitest run src/renderer/src/services/__tests__/ApiService.checkApi.test.ts src/renderer/src/aiCore/provider/__tests__/providerConfig.test.ts packages/aiCore/src/core/providers/__tests__/openaiCompatibleEndpoint.test.ts`
- `pnpm build:check` still fails in this environment because of unrelated repository-wide test failures, including Windows path assertions in `src/main/mcpServers/__tests__/workspaceMemory.test.ts`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed OpenAI-compatible image generation so explicit image endpoints are honored correctly, dedicated image models are validated through the image API, and image requests can retry once against a de-versioned base URL after a 404.
```