### PR TITLE
feat: add enable/disable toggle for custom parameters

### DIFF
--- a/src/renderer/src/aiCore/utils/reasoning.ts
+++ b/src/renderer/src/aiCore/utils/reasoning.ts
@@ -952,6 +952,9 @@ export function getOllamaReasoningParams(assistant: Assistant, model: Model): Pi
  * 从 assistant 设置中提取自定义参数
  */
 export function getCustomParameters(assistant: Assistant): Record<string, any> {
+  if (assistant?.settings?.enableCustomParameters === false) {
+    return {}
+  }
   return (
     assistant?.settings?.customParameters?.reduce((acc, param) => {
       if (!param.name?.trim()) {

--- a/src/renderer/src/pages/settings/AssistantSettings/AssistantModelSettings.tsx
+++ b/src/renderer/src/pages/settings/AssistantSettings/AssistantModelSettings.tsx
@@ -65,6 +65,10 @@ const AssistantModelSettings: FC<Props> = ({ assistant, updateAssistant, updateA
   const [customParameters, setCustomParameters] = useState<AssistantSettingCustomParameters[]>(
     assistant?.settings?.customParameters ?? []
   )
+  const enableCustomParameters = useMemo(
+    () => assistant?.settings?.enableCustomParameters ?? DEFAULT_ASSISTANT_SETTINGS.enableCustomParameters,
+    [assistant?.settings?.enableCustomParameters]
+  )
   const enableTemperature = useMemo(
     () => assistant?.settings?.enableTemperature ?? DEFAULT_ASSISTANT_SETTINGS.enableTemperature,
     [assistant?.settings?.enableTemperature]
@@ -530,42 +534,54 @@ const AssistantModelSettings: FC<Props> = ({ assistant, updateAssistant, updateA
       <Divider style={{ margin: '10px 0' }} />
       <SettingRow style={{ minHeight: 30 }}>
         <Label>{t('models.custom_parameters')}</Label>
-        <Button onClick={onAddCustomParameter}>
+        <Switch
+          checked={enableCustomParameters}
+          onCheckedChange={(enabled) => {
+            updateAssistantSettings({ enableCustomParameters: enabled })
+          }}
+        />
+      </SettingRow>
+      {enableCustomParameters && customParameters.length > 0 && (
+        <div style={{ marginTop: 10 }}>
+          {customParameters.map((param, index) => (
+            <div key={index} style={{ marginTop: 10 }}>
+              <Row align="stretch" gutter={10}>
+                <Col span={6}>
+                  <Input
+                    placeholder={t('models.parameter_name')}
+                    value={param.name}
+                    onChange={(e) => onUpdateCustomParameter(index, 'name', e.target.value)}
+                  />
+                </Col>
+                <Col span={6}>
+                  <Select
+                    value={param.type}
+                    onChange={(value) => onUpdateCustomParameter(index, 'type', value)}
+                    style={{ width: '100%' }}>
+                    <Select.Option value="string">{t('models.parameter_type.string')}</Select.Option>
+                    <Select.Option value="number">{t('models.parameter_type.number')}</Select.Option>
+                    <Select.Option value="boolean">{t('models.parameter_type.boolean')}</Select.Option>
+                    <Select.Option value="json">{t('models.parameter_type.json')}</Select.Option>
+                  </Select>
+                </Col>
+                {param.type !== 'json' && <Col span={10}>{renderParameterValueInput(param, index)}</Col>}
+                <Col span={param.type === 'json' ? 12 : 2} style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                  <Button variant="destructive" size="icon-sm" onClick={() => onDeleteCustomParameter(index)}>
+                    <DeleteIcon size={14} className="lucide-custom" />
+                  </Button>
+                </Col>
+              </Row>
+              {param.type === 'json' && <div style={{ marginTop: 6 }}>{renderParameterValueInput(param, index)}</div>}
+            </div>
+          ))}
+        </div>
+      )}
+      {enableCustomParameters && (
+        <Button onClick={onAddCustomParameter} style={{ marginTop: 10 }}>
           <PlusIcon size={18} />
           {t('models.add_parameter')}
         </Button>
-      </SettingRow>
-      {customParameters.map((param, index) => (
-        <div key={index} style={{ marginTop: 10 }}>
-          <Row align="stretch" gutter={10}>
-            <Col span={6}>
-              <Input
-                placeholder={t('models.parameter_name')}
-                value={param.name}
-                onChange={(e) => onUpdateCustomParameter(index, 'name', e.target.value)}
-              />
-            </Col>
-            <Col span={6}>
-              <Select
-                value={param.type}
-                onChange={(value) => onUpdateCustomParameter(index, 'type', value)}
-                style={{ width: '100%' }}>
-                <Select.Option value="string">{t('models.parameter_type.string')}</Select.Option>
-                <Select.Option value="number">{t('models.parameter_type.number')}</Select.Option>
-                <Select.Option value="boolean">{t('models.parameter_type.boolean')}</Select.Option>
-                <Select.Option value="json">{t('models.parameter_type.json')}</Select.Option>
-              </Select>
-            </Col>
-            {param.type !== 'json' && <Col span={10}>{renderParameterValueInput(param, index)}</Col>}
-            <Col span={param.type === 'json' ? 12 : 2} style={{ display: 'flex', justifyContent: 'flex-end' }}>
-              <Button variant="destructive" size="icon-sm" onClick={() => onDeleteCustomParameter(index)}>
-                <DeleteIcon size={14} className="lucide-custom" />
-              </Button>
-            </Col>
-          </Row>
-          {param.type === 'json' && <div style={{ marginTop: 6 }}>{renderParameterValueInput(param, index)}</div>}
-        </div>
-      ))}
+      )}
       <Divider style={{ margin: '15px 0' }} />
       <RowFlex className="justify-end">
         <Button onClick={onReset} variant="destructive">

--- a/src/renderer/src/services/AssistantService.ts
+++ b/src/renderer/src/services/AssistantService.ts
@@ -53,6 +53,7 @@ export const DEFAULT_ASSISTANT_SETTINGS = {
   streamOutput: true,
   defaultModel: undefined,
   customParameters: [],
+  enableCustomParameters: true,
   reasoning_effort: 'default',
   qwenThinkMode: undefined,
   // It would gracefully fallback to prompt if not supported by model.

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -192,6 +192,7 @@ export type AssistantSettings = {
   streamOutput: boolean
   defaultModel?: Model
   customParameters?: AssistantSettingCustomParameters[]
+  enableCustomParameters?: boolean
   reasoning_effort: ReasoningEffortOption
   qwenThinkMode?: boolean
   toolUseMode: 'function' | 'prompt'


### PR DESCRIPTION
### What this PR does

Adds a toggle switch to enable/disable custom parameters in assistant settings, allowing users to temporarily hide custom parameters without losing their values.

Before this PR:

- Custom parameters could only be removed by deleting them
- Users had to re-enter all custom parameters when they needed them again
- No way to quickly disable parameters that conflict with each other

After this PR:

- A toggle switch allows users to enable/disable custom parameters with one click
- When disabled, parameters are hidden but preserved - re-enabling restores them without re-entry
- Follows the same pattern as existing `enableTemperature`, `enableTopP`, and `enableMaxTokens` toggles

Fix #14639 

### Why we need it and why it was done in this way

Solves issue #14639 where users requested the ability to disable custom parameters without deleting them, eliminating the need to re-enter values when parameters are needed again.

The implementation follows the established pattern for enable/disable toggles in the codebase (`enableTemperature`, `enableTopP`, `enableMaxTokens`) for consistency.

### Tradeoffs

- When toggled off, the custom parameters array is preserved in settings (not cleared). This is intentional so users don't lose their work. Users can manually clear parameters if desired.

### Breaking changes

None.

### Release note

```release-note
Added enable/disable toggle for custom parameters in assistant settings. Users can now temporarily disable custom parameters without losing their values.
```