### PR TITLE
fix(browser): replace CDP Page.captureScreenshot with native capturePage to prevent hanging

### DIFF
--- a/src/main/mcpServers/browser/controller.ts
+++ b/src/main/mcpServers/browser/controller.ts
@@ -857,8 +857,18 @@ export class CdpBrowserController {
   }
 
   /**
-   * Takes a screenshot of the current page using CDP Page.captureScreenshot.
-   * @param options - Screenshot options
+   * Takes a screenshot of the current page using Electron's native capturePage API.
+   *
+   * NOTE: Uses `webContents.capturePage()` instead of CDP `Page.captureScreenshot`
+   * to avoid hanging issues on certain platforms (e.g., MSYS2/MinGW where the CDP
+   * screenshot command can hang indefinitely). `capturePage()` also sidesteps
+   * GPU/rendering-layer incompatibilities that affect the CDP path.
+   *
+   * Known limitation: `capturePage()` only captures the visible viewport; the
+   * `fullPage` option is not yet supported via this path. A follow-up can implement
+   * full-page capture by resizing the view or stitching multiple captures.
+   *
+   * @param options - Screenshot options (fullPage is currently ignored)
    * @param privateMode - If true, targets private window (default: false)
    * @param tabId - Optional specific tab ID to target
    * @returns Base64-encoded image data
@@ -869,23 +879,17 @@ export class CdpBrowserController {
     tabId?: string
   ): Promise<string> {
     const { tabId: actualTabId, tab } = await this.getTab(privateMode, tabId)
-    const windowKey = this.getWindowKey(privateMode)
-    this.touchTab(windowKey, actualTabId)
-    const dbg = tab.view.webContents.debugger
-
-    await this.ensureDebuggerAttached(dbg, windowKey)
+    this.touchTab(this.getWindowKey(privateMode), actualTabId)
+    const { webContents } = tab.view
 
     const format = options.format ?? 'png'
-    const params: Record<string, unknown> = {
-      format,
-      captureBeyondViewport: options.fullPage ?? false
-    }
-    if (format === 'jpeg' && options.quality !== undefined) {
-      params.quality = options.quality
-    }
 
-    const result = (await dbg.sendCommand('Page.captureScreenshot', params)) as { data: string }
-    return result.data
+    const image = await webContents.capturePage()
+
+    const buffer =
+      format === 'jpeg' ? image.toJPEG(options.quality ?? 80) : image.toPNG()
+
+    return buffer.toString('base64')
   }
 
   /**


### PR DESCRIPTION
## Summary

Replace the CDP-based `debugger.sendCommand('Page.captureScreenshot')` approach with Electron's native `webContents.capturePage()` API in the browser screenshot functionality.

## Problem

On certain platforms (e.g., MSYS2/MinGW on Windows), the Chrome DevTools Protocol `Page.captureScreenshot` command can hang indefinitely. The underlying cause is a GPU/rendering-layer incompatibility between the Electron-hosted Chromium and the MSYS2 terminal environment — the CDP capture request never completes.

This is particularly impactful for users running Cherry Studio through Git Bash / MSYS2 terminals (common on Windows when users configure git-bash as their shell).

## Solution

Switch to `webContents.capturePage()`, which uses Electron's own rendering pipeline instead of going through the CDP protocol. This sidesteps the rendering-layer incompatibility entirely.

## Trade-off

- `capturePage()` only captures the visible viewport — the `fullPage` option is accepted but currently ignored.
- Full-page capture support can be added in a follow-up (by resizing the viewport or stitching multiple captures).

## Checklist

- [x] Change is minimal in scope (single method replacement)
- [x] No refactoring of surrounding code
- [x] Conventional commit message format