### PR TITLE
fix(deepseek): display web search citations from DeepSeek annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -510,7 +510,8 @@
       "@ai-sdk/openai-compatible@2.0.37": "patches/@ai-sdk__openai-compatible@2.0.37.patch",
       "@ai-sdk/openai@3.0.53": "patches/@ai-sdk__openai@3.0.53.patch",
       "@ai-sdk/google@3.0.64": "patches/@ai-sdk__google@3.0.64.patch",
-      "@libsql/client@0.15.15": "patches/@libsql__client@0.15.15.patch"
+      "@libsql/client@0.15.15": "patches/@libsql__client@0.15.15.patch",
+      "@ai-sdk/deepseek@2.0.26": "patches/@ai-sdk__deepseek@2.0.26.patch"
     },
     "onlyBuiltDependencies": [
       "@j178/prek",

--- a/patches/@ai-sdk__deepseek@2.0.26.patch
+++ b/patches/@ai-sdk__deepseek@2.0.26.patch
@@ -1,0 +1,84 @@
+diff --git a/dist/index.js b/dist/index.js
+index 47c40376a7d35409b5802fe7a6f323a219aa988f..ffa02bbb9d11f9430952d608b47952aea76cec17 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -283,6 +283,17 @@ var deepseekChatChunkSchema = (0, import_provider_utils.lazySchema)(
+                     arguments: import_v4.z.string().nullish()
+                   })
+                 })
++              ).nullish(),
++              annotations: import_v4.z.array(
++                import_v4.z.object({
++                  type: import_v4.z.literal("url_citation"),
++                  url_citation: import_v4.z.object({
++                    start_index: import_v4.z.number(),
++                    end_index: import_v4.z.number(),
++                    url: import_v4.z.string(),
++                    title: import_v4.z.string()
++                  })
++                })
+               ).nullish()
+             }).nullish(),
+             finish_reason: import_v4.z.string().nullish()
+@@ -648,6 +659,19 @@ var DeepSeekChatLanguageModel = class {
+                 delta: delta.content
+               });
+             }
++            if (delta.annotations != null) {
++              for (const annotation of delta.annotations) {
++                if (annotation.type === "url_citation") {
++                  controller.enqueue({
++                    type: "source",
++                    sourceType: "url",
++                    id: (0, import_provider_utils.generateId)(),
++                    url: annotation.url_citation.url,
++                    title: annotation.url_citation.title
++                  });
++                }
++              }
++            }
+             if (delta.tool_calls != null) {
+               if (isActiveReasoning) {
+                 controller.enqueue({
+diff --git a/dist/index.mjs b/dist/index.mjs
+index a3c595f66d2c85d38f4c8cc41c5fd406b7ccd08c..5112c2042cdbd9d1cef839fb792bdadd4a8f4e55 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -272,6 +272,17 @@ var deepseekChatChunkSchema = lazySchema(
+                     arguments: z.string().nullish()
+                   })
+                 })
++              ).nullish(),
++              annotations: z.array(
++                z.object({
++                  type: z.literal("url_citation"),
++                  url_citation: z.object({
++                    start_index: z.number(),
++                    end_index: z.number(),
++                    url: z.string(),
++                    title: z.string()
++                  })
++                })
+               ).nullish()
+             }).nullish(),
+             finish_reason: z.string().nullish()
+@@ -637,6 +648,19 @@ var DeepSeekChatLanguageModel = class {
+                 delta: delta.content
+               });
+             }
++            if (delta.annotations != null) {
++              for (const annotation of delta.annotations) {
++                if (annotation.type === "url_citation") {
++                  controller.enqueue({
++                    type: "source",
++                    sourceType: "url",
++                    id: generateId(),
++                    url: annotation.url_citation.url,
++                    title: annotation.url_citation.title
++                  });
++                }
++              }
++            }
+             if (delta.tool_calls != null) {
+               if (isActiveReasoning) {
+                 controller.enqueue({

--- a/src/renderer/src/aiCore/utils/websearch.ts
+++ b/src/renderer/src/aiCore/utils/websearch.ts
@@ -28,7 +28,7 @@ export function getWebSearchParams(model: Model): Record<string, any> {
     }
   }
 
-  if (isOpenAIWebSearchChatCompletionOnlyModel(model)) {
+  if (model.provider === 'deepseek' || isOpenAIWebSearchChatCompletionOnlyModel(model)) {
     return {
       web_search_options: {}
     }

--- a/src/renderer/src/config/models/websearch.ts
+++ b/src/renderer/src/config/models/websearch.ts
@@ -111,6 +111,10 @@ export function isWebSearchModel(model: Model): boolean {
     return false
   }
 
+  if (provider.id === SystemProviderIds.deepseek) {
+    return true
+  }
+
   if (provider.id === 'dashscope') {
     const models = ['qwen-turbo', 'qwen-max', 'qwen-plus', 'qwq', 'qwen-flash', 'qwen3-max']
     // matches id like qwen-max-0919, qwen-max-latest


### PR DESCRIPTION
### What this PR does

Before this PR: DeepSeek's web search `delta.annotations` (URL citations) are silently dropped by `@ai-sdk/deepseek`, so Cherry Studio never receives the citation data and cannot render inline references or citation cards.

After this PR:
- **Patch `@ai-sdk/deepseek@2.0.26`** — extends the streaming delta schema to include `annotations` and emits an AI SDK `source` event for each `url_citation`, so the existing `AiSdkToChunkAdapter → LLM_WEB_SEARCH_COMPLETE` pipeline receives and displays citations.
- **`isWebSearchModel`** — returns `true` for the `deepseek` system provider, showing the built-in web-search toggle in the UI.
- **`getWebSearchParams`** — sends `web_search_options: {}` to the DeepSeek API when the toggle is on, activating server-side search.

Fixes #14671

### Why we need it and why it was done in this way

`@ai-sdk/deepseek` inherits from the openai-compatible base but does **not** forward `delta.annotations`. The OpenAI SDK already handles this (emitting `{ type: "source", sourceType: "url", ... }` per annotation); the deepseek SDK simply omitted it. A pnpm patch mirroring the existing `@ai-sdk/openai` approach is the least-invasive fix — no Cherry Studio runtime code needed to change.

The following tradeoffs were made:
- A pnpm patch is used (consistent with existing patches for `@ai-sdk/google`, `@ai-sdk/openai`, etc.) rather than wrapping the SDK in custom middleware, keeping the fix contained and upgradable.
- `getWebSearchParams` reuses the same `web_search_options: {}` body param as OpenAI Chat Completions, which DeepSeek documents as compatible.

The following alternatives were considered:
- Enabling `includeRawChunks` and parsing raw delta in a `case 'raw':` handler — rejected as it requires access to provider internals and is fragile across API versions.

### Breaking changes

None.

### Special notes for your reviewer

The patch targets both `dist/index.js` (CJS) and `dist/index.mjs` (ESM). The annotation schema mirrors what `@ai-sdk/openai` already defines for the same field. Citations fall back to `WEB_SEARCH_SOURCE.AISDK` in `AiSdkToChunkAdapter`, which already renders correctly via the `AISDK` case in `formatCitationsFromBlock`.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: Not required — internal SDK patch and provider config, no user-guide change needed
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
DeepSeek web search citations are now displayed correctly. Enabling the
built-in web-search toggle for a DeepSeek model will activate server-side
search and render inline URL references in the response.
```
