### PR TITLE
fix(assistant-api): align patch defaults with entity schema

### DIFF
--- a/migrations/sqlite-drizzle/0015_groovy_tiger_shark.sql
+++ b/migrations/sqlite-drizzle/0015_groovy_tiger_shark.sql
@@ -1,0 +1,24 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_assistant` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`prompt` text DEFAULT '' NOT NULL,
+	`emoji` text NOT NULL,
+	`description` text DEFAULT '' NOT NULL,
+	`model_id` text,
+	`settings` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	`deleted_at` integer,
+	FOREIGN KEY (`model_id`) REFERENCES `user_model`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+-- Coalesce legacy NULL values to spec defaults so the rebuild never trips the new NOT NULL constraints.
+-- prompt / description: type-level empty ('') matches the new DB DEFAULT.
+-- emoji: product-chosen '🌟' matches the AssistantService.create() service-side default.
+-- settings: DEFAULT_ASSISTANT_SETTINGS frozen at this migration's time of writing; new rows go through the service.
+INSERT INTO `__new_assistant`("id", "name", "prompt", "emoji", "description", "model_id", "settings", "created_at", "updated_at", "deleted_at") SELECT "id", "name", COALESCE("prompt", ''), COALESCE("emoji", '🌟'), COALESCE("description", ''), "model_id", COALESCE("settings", '{"temperature":1,"enableTemperature":false,"topP":1,"enableTopP":false,"maxTokens":4096,"enableMaxTokens":false,"contextCount":5,"streamOutput":true,"reasoning_effort":"default","qwenThinkMode":false,"mcpMode":"auto","toolUseMode":"function","maxToolCalls":20,"enableMaxToolCalls":true,"enableWebSearch":false,"customParameters":[]}'), "created_at", "updated_at", "deleted_at" FROM `assistant`;--> statement-breakpoint
+DROP TABLE `assistant`;--> statement-breakpoint
+ALTER TABLE `__new_assistant` RENAME TO `assistant`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `assistant_created_at_idx` ON `assistant` (`created_at`);

--- a/migrations/sqlite-drizzle/meta/0015_snapshot.json
+++ b/migrations/sqlite-drizzle/meta/0015_snapshot.json
@@ -1,0 +1,3032 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c2b044ef-19ea-45cc-9cb6-523e117a7cd8",
+  "prevId": "5ed1efb9-bd34-437e-8762-2adfdc9b6816",
+  "tables": {
+    "agent": {
+      "name": "agent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessible_paths": {
+          "name": "accessible_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_model": {
+          "name": "plan_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "small_model": {
+          "name": "small_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcps": {
+          "name": "mcps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_name_idx": {
+          "name": "agent_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "agent_type_idx": {
+          "name": "agent_type_idx",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "agent_sort_order_idx": {
+          "name": "agent_sort_order_idx",
+          "columns": ["sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_channel": {
+      "name": "agent_channel",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "active_chat_ids": {
+          "name": "active_chat_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_channel_agent_id_idx": {
+          "name": "agent_channel_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agent_channel_type_idx": {
+          "name": "agent_channel_type_idx",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "agent_channel_session_id_idx": {
+          "name": "agent_channel_session_id_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_channel_agent_id_agent_id_fk": {
+          "name": "agent_channel_agent_id_agent_id_fk",
+          "tableFrom": "agent_channel",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_channel_session_id_agent_session_id_fk": {
+          "name": "agent_channel_session_id_agent_session_id_fk",
+          "tableFrom": "agent_channel",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agent_channel_type_check": {
+          "name": "agent_channel_type_check",
+          "value": "\"agent_channel\".\"type\" IN ('telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack')"
+        },
+        "agent_channel_permission_mode_check": {
+          "name": "agent_channel_permission_mode_check",
+          "value": "\"agent_channel\".\"permission_mode\" IS NULL OR \"agent_channel\".\"permission_mode\" IN ('default', 'acceptEdits', 'bypassPermissions', 'plan')"
+        }
+      }
+    },
+    "agent_channel_task": {
+      "name": "agent_channel_task",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_channel_task_channel_id_idx": {
+          "name": "agent_channel_task_channel_id_idx",
+          "columns": ["channel_id"],
+          "isUnique": false
+        },
+        "agent_channel_task_task_id_idx": {
+          "name": "agent_channel_task_task_id_idx",
+          "columns": ["task_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_channel_task_channel_id_agent_channel_id_fk": {
+          "name": "agent_channel_task_channel_id_agent_channel_id_fk",
+          "tableFrom": "agent_channel_task",
+          "tableTo": "agent_channel",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_channel_task_task_id_agent_task_id_fk": {
+          "name": "agent_channel_task_task_id_agent_task_id_fk",
+          "tableFrom": "agent_channel_task",
+          "tableTo": "agent_task",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_channel_task_channel_id_task_id_pk": {
+          "columns": ["channel_id", "task_id"],
+          "name": "agent_channel_task_channel_id_task_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_global_skill": {
+      "name": "agent_global_skill",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folder_name": {
+          "name": "folder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_global_skill_folder_name_unique": {
+          "name": "agent_global_skill_folder_name_unique",
+          "columns": ["folder_name"],
+          "isUnique": true
+        },
+        "agent_global_skill_source_idx": {
+          "name": "agent_global_skill_source_idx",
+          "columns": ["source"],
+          "isUnique": false
+        },
+        "agent_global_skill_is_enabled_idx": {
+          "name": "agent_global_skill_is_enabled_idx",
+          "columns": ["is_enabled"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_session": {
+      "name": "agent_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_type": {
+          "name": "agent_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessible_paths": {
+          "name": "accessible_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_model": {
+          "name": "plan_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "small_model": {
+          "name": "small_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcps": {
+          "name": "mcps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slash_commands": {
+          "name": "slash_commands",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_session_agent_id_idx": {
+          "name": "agent_session_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agent_session_model_idx": {
+          "name": "agent_session_model_idx",
+          "columns": ["model"],
+          "isUnique": false
+        },
+        "agent_session_sort_order_idx": {
+          "name": "agent_session_sort_order_idx",
+          "columns": ["sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_session_agent_id_agent_id_fk": {
+          "name": "agent_session_agent_id_agent_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_session_message": {
+      "name": "agent_session_message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_session_message_session_id_idx": {
+          "name": "agent_session_message_session_id_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_session_message_session_id_agent_session_id_fk": {
+          "name": "agent_session_message_session_id_agent_session_id_fk",
+          "tableFrom": "agent_session_message",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_skill": {
+      "name": "agent_skill",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_skill_agent_id_idx": {
+          "name": "agent_skill_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agent_skill_skill_id_idx": {
+          "name": "agent_skill_skill_id_idx",
+          "columns": ["skill_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_agent_id_agent_id_fk": {
+          "name": "agent_skill_agent_id_agent_id_fk",
+          "tableFrom": "agent_skill",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_skill_skill_id_agent_global_skill_id_fk": {
+          "name": "agent_skill_skill_id_agent_global_skill_id_fk",
+          "tableFrom": "agent_skill",
+          "tableTo": "agent_global_skill",
+          "columnsFrom": ["skill_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_skill_agent_id_skill_id_pk": {
+          "columns": ["agent_id", "skill_id"],
+          "name": "agent_skill_agent_id_skill_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_task_run_log": {
+      "name": "agent_task_run_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_task_run_log_task_id_idx": {
+          "name": "agent_task_run_log_task_id_idx",
+          "columns": ["task_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_task_run_log_task_id_agent_task_id_fk": {
+          "name": "agent_task_run_log_task_id_agent_task_id_fk",
+          "tableFrom": "agent_task_run_log",
+          "tableTo": "agent_task",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agent_task_run_log_status_check": {
+          "name": "agent_task_run_log_status_check",
+          "value": "\"agent_task_run_log\".\"status\" IN ('running', 'success', 'error')"
+        }
+      }
+    },
+    "agent_task": {
+      "name": "agent_task",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_value": {
+          "name": "schedule_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeout_minutes": {
+          "name": "timeout_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "next_run": {
+          "name": "next_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_result": {
+          "name": "last_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_task_agent_id_idx": {
+          "name": "agent_task_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agent_task_next_run_idx": {
+          "name": "agent_task_next_run_idx",
+          "columns": ["next_run"],
+          "isUnique": false
+        },
+        "agent_task_status_idx": {
+          "name": "agent_task_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_task_agent_id_agent_id_fk": {
+          "name": "agent_task_agent_id_agent_id_fk",
+          "tableFrom": "agent_task",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agent_task_schedule_type_check": {
+          "name": "agent_task_schedule_type_check",
+          "value": "\"agent_task\".\"schedule_type\" IN ('cron', 'interval', 'once')"
+        },
+        "agent_task_status_check": {
+          "name": "agent_task_status_check",
+          "value": "\"agent_task\".\"status\" IN ('active', 'paused', 'completed')"
+        }
+      }
+    },
+    "app_state": {
+      "name": "app_state",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assistant": {
+      "name": "assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "assistant_created_at_idx": {
+          "name": "assistant_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "assistant_model_id_user_model_id_fk": {
+          "name": "assistant_model_id_user_model_id_fk",
+          "tableFrom": "assistant",
+          "tableTo": "user_model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assistant_knowledge_base": {
+      "name": "assistant_knowledge_base",
+      "columns": {
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "knowledge_base_id": {
+          "name": "knowledge_base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "assistant_knowledge_base_assistant_id_assistant_id_fk": {
+          "name": "assistant_knowledge_base_assistant_id_assistant_id_fk",
+          "tableFrom": "assistant_knowledge_base",
+          "tableTo": "assistant",
+          "columnsFrom": ["assistant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assistant_knowledge_base_knowledge_base_id_knowledge_base_id_fk": {
+          "name": "assistant_knowledge_base_knowledge_base_id_knowledge_base_id_fk",
+          "tableFrom": "assistant_knowledge_base",
+          "tableTo": "knowledge_base",
+          "columnsFrom": ["knowledge_base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "assistant_knowledge_base_assistant_id_knowledge_base_id_pk": {
+          "columns": ["assistant_id", "knowledge_base_id"],
+          "name": "assistant_knowledge_base_assistant_id_knowledge_base_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assistant_mcp_server": {
+      "name": "assistant_mcp_server",
+      "columns": {
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "assistant_mcp_server_assistant_id_assistant_id_fk": {
+          "name": "assistant_mcp_server_assistant_id_assistant_id_fk",
+          "tableFrom": "assistant_mcp_server",
+          "tableTo": "assistant",
+          "columnsFrom": ["assistant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assistant_mcp_server_mcp_server_id_mcp_server_id_fk": {
+          "name": "assistant_mcp_server_mcp_server_id_mcp_server_id_fk",
+          "tableFrom": "assistant_mcp_server",
+          "tableTo": "mcp_server",
+          "columnsFrom": ["mcp_server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "assistant_mcp_server_assistant_id_mcp_server_id_pk": {
+          "columns": ["assistant_id", "mcp_server_id"],
+          "name": "assistant_mcp_server_assistant_id_mcp_server_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group": {
+      "name": "group",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_entity_type_order_key_idx": {
+          "name": "group_entity_type_order_key_idx",
+          "columns": ["entity_type", "order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "knowledge_base": {
+      "name": "knowledge_base",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_model_id": {
+          "name": "embedding_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rerank_model_id": {
+          "name": "rerank_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_processor_id": {
+          "name": "file_processor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chunk_size": {
+          "name": "chunk_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chunk_overlap": {
+          "name": "chunk_overlap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_mode": {
+          "name": "search_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hybrid_alpha": {
+          "name": "hybrid_alpha",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "knowledge_base_embedding_model_id_user_model_id_fk": {
+          "name": "knowledge_base_embedding_model_id_user_model_id_fk",
+          "tableFrom": "knowledge_base",
+          "tableTo": "user_model",
+          "columnsFrom": ["embedding_model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "knowledge_base_rerank_model_id_user_model_id_fk": {
+          "name": "knowledge_base_rerank_model_id_user_model_id_fk",
+          "tableFrom": "knowledge_base",
+          "tableTo": "user_model",
+          "columnsFrom": ["rerank_model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "knowledge_base_search_mode_check": {
+          "name": "knowledge_base_search_mode_check",
+          "value": "\"knowledge_base\".\"search_mode\" IN ('default', 'bm25', 'hybrid') OR \"knowledge_base\".\"search_mode\" IS NULL"
+        }
+      }
+    },
+    "knowledge_item": {
+      "name": "knowledge_item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idle'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "knowledge_item_base_type_created_idx": {
+          "name": "knowledge_item_base_type_created_idx",
+          "columns": ["base_id", "type", "created_at"],
+          "isUnique": false
+        },
+        "knowledge_item_base_group_created_idx": {
+          "name": "knowledge_item_base_group_created_idx",
+          "columns": ["base_id", "group_id", "created_at"],
+          "isUnique": false
+        },
+        "knowledge_item_baseId_id_unique": {
+          "name": "knowledge_item_baseId_id_unique",
+          "columns": ["base_id", "id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "knowledge_item_base_id_knowledge_base_id_fk": {
+          "name": "knowledge_item_base_id_knowledge_base_id_fk",
+          "tableFrom": "knowledge_item",
+          "tableTo": "knowledge_base",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_item_base_id_group_id_knowledge_item_base_id_id_fk": {
+          "name": "knowledge_item_base_id_group_id_knowledge_item_base_id_id_fk",
+          "tableFrom": "knowledge_item",
+          "tableTo": "knowledge_item",
+          "columnsFrom": ["base_id", "group_id"],
+          "columnsTo": ["base_id", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "knowledge_item_type_check": {
+          "name": "knowledge_item_type_check",
+          "value": "\"knowledge_item\".\"type\" IN ('file', 'url', 'note', 'sitemap', 'directory')"
+        },
+        "knowledge_item_status_check": {
+          "name": "knowledge_item_status_check",
+          "value": "\"knowledge_item\".\"status\" IN ('idle', 'pending', 'file_processing', 'read', 'embed', 'completed', 'failed')"
+        }
+      }
+    },
+    "mcp_server": {
+      "name": "mcp_server",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_url": {
+          "name": "provider_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "long_running": {
+          "name": "long_running",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dxt_version": {
+          "name": "dxt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dxt_path": {
+          "name": "dxt_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_key": {
+          "name": "search_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config_sample": {
+          "name": "config_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_tools": {
+          "name": "disabled_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_auto_approve_tools": {
+          "name": "disabled_auto_approve_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "should_config": {
+          "name": "should_config",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "install_source": {
+          "name": "install_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_trusted": {
+          "name": "is_trusted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trusted_at": {
+          "name": "trusted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_server_name_idx": {
+          "name": "mcp_server_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "mcp_server_is_active_idx": {
+          "name": "mcp_server_is_active_idx",
+          "columns": ["is_active"],
+          "isUnique": false
+        },
+        "mcp_server_sort_order_idx": {
+          "name": "mcp_server_sort_order_idx",
+          "columns": ["sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "mcp_server_type_check": {
+          "name": "mcp_server_type_check",
+          "value": "\"mcp_server\".\"type\" IS NULL OR \"mcp_server\".\"type\" IN ('stdio', 'sse', 'streamableHttp', 'inMemory')"
+        },
+        "mcp_server_install_source_check": {
+          "name": "mcp_server_install_source_check",
+          "value": "\"mcp_server\".\"install_source\" IS NULL OR \"mcp_server\".\"install_source\" IN ('builtin', 'manual', 'protocol', 'unknown')"
+        }
+      }
+    },
+    "message": {
+      "name": "message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "searchable_text": {
+          "name": "searchable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "siblings_group_id": {
+          "name": "siblings_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_snapshot": {
+          "name": "model_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "message_parent_id_idx": {
+          "name": "message_parent_id_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "message_topic_created_idx": {
+          "name": "message_topic_created_idx",
+          "columns": ["topic_id", "created_at"],
+          "isUnique": false
+        },
+        "message_trace_id_idx": {
+          "name": "message_trace_id_idx",
+          "columns": ["trace_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "message_topic_id_topic_id_fk": {
+          "name": "message_topic_id_topic_id_fk",
+          "tableFrom": "message",
+          "tableTo": "topic",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_model_id_user_model_id_fk": {
+          "name": "message_model_id_user_model_id_fk",
+          "tableFrom": "message",
+          "tableTo": "user_model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "message_parent_id_message_id_fk": {
+          "name": "message_parent_id_message_id_fk",
+          "tableFrom": "message",
+          "tableTo": "message",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "message_role_check": {
+          "name": "message_role_check",
+          "value": "\"message\".\"role\" IN ('user', 'assistant', 'system')"
+        },
+        "message_status_check": {
+          "name": "message_status_check",
+          "value": "\"message\".\"status\" IN ('pending', 'success', 'error', 'paused')"
+        }
+      }
+    },
+    "miniapp": {
+      "name": "miniapp",
+      "columns": {
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'custom'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'enabled'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bordered": {
+          "name": "bordered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "background": {
+          "name": "background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supported_regions": {
+          "name": "supported_regions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_key": {
+          "name": "name_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "miniapp_status_sort_idx": {
+          "name": "miniapp_status_sort_idx",
+          "columns": ["status", "sort_order"],
+          "isUnique": false
+        },
+        "miniapp_type_idx": {
+          "name": "miniapp_type_idx",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "miniapp_status_type_idx": {
+          "name": "miniapp_status_type_idx",
+          "columns": ["status", "type"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "miniapp_status_check": {
+          "name": "miniapp_status_check",
+          "value": "\"miniapp\".\"status\" IN ('enabled', 'disabled', 'pinned')"
+        },
+        "miniapp_type_check": {
+          "name": "miniapp_type_check",
+          "value": "\"miniapp\".\"type\" IN ('default', 'custom')"
+        }
+      }
+    },
+    "pin": {
+      "name": "pin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pin_entity_type_entity_id_unique_idx": {
+          "name": "pin_entity_type_entity_id_unique_idx",
+          "columns": ["entity_type", "entity_id"],
+          "isUnique": true
+        },
+        "pin_entity_type_order_key_idx": {
+          "name": "pin_entity_type_order_key_idx",
+          "columns": ["entity_type", "order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "preference": {
+      "name": "preference",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "preference_scope_key_pk": {
+          "columns": ["scope", "key"],
+          "name": "preference_scope_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "entity_tag": {
+      "name": "entity_tag",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "entity_tag_tag_id_idx": {
+          "name": "entity_tag_tag_id_idx",
+          "columns": ["tag_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "entity_tag_tag_id_tag_id_fk": {
+          "name": "entity_tag_tag_id_tag_id_fk",
+          "tableFrom": "entity_tag",
+          "tableTo": "tag",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "entity_tag_entity_type_entity_id_tag_id_pk": {
+          "columns": ["entity_type", "entity_id", "tag_id"],
+          "name": "entity_tag_entity_type_entity_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag": {
+      "name": "tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tag_name_unique": {
+          "name": "tag_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "topic": {
+      "name": "topic",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_name_manually_edited": {
+          "name": "is_name_manually_edited",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_node_id": {
+          "name": "active_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "pinned_order": {
+          "name": "pinned_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "topic_group_updated_idx": {
+          "name": "topic_group_updated_idx",
+          "columns": ["group_id", "updated_at"],
+          "isUnique": false
+        },
+        "topic_group_sort_idx": {
+          "name": "topic_group_sort_idx",
+          "columns": ["group_id", "sort_order"],
+          "isUnique": false
+        },
+        "topic_updated_at_idx": {
+          "name": "topic_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "topic_is_pinned_idx": {
+          "name": "topic_is_pinned_idx",
+          "columns": ["is_pinned", "pinned_order"],
+          "isUnique": false
+        },
+        "topic_assistant_id_idx": {
+          "name": "topic_assistant_id_idx",
+          "columns": ["assistant_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "topic_assistant_id_assistant_id_fk": {
+          "name": "topic_assistant_id_assistant_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "assistant",
+          "columnsFrom": ["assistant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "topic_group_id_group_id_fk": {
+          "name": "topic_group_id_group_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translate_history": {
+      "name": "translate_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_text": {
+          "name": "target_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_language": {
+          "name": "source_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "star": {
+          "name": "star",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "translate_history_created_at_idx": {
+          "name": "translate_history_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "translate_history_star_created_at_idx": {
+          "name": "translate_history_star_created_at_idx",
+          "columns": ["star", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "translate_history_source_language_translate_language_lang_code_fk": {
+          "name": "translate_history_source_language_translate_language_lang_code_fk",
+          "tableFrom": "translate_history",
+          "tableTo": "translate_language",
+          "columnsFrom": ["source_language"],
+          "columnsTo": ["lang_code"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translate_history_target_language_translate_language_lang_code_fk": {
+          "name": "translate_history_target_language_translate_language_lang_code_fk",
+          "tableFrom": "translate_history",
+          "tableTo": "translate_language",
+          "columnsFrom": ["target_language"],
+          "columnsTo": ["lang_code"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translate_language": {
+      "name": "translate_language",
+      "columns": {
+        "lang_code": {
+          "name": "lang_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_model": {
+      "name": "user_model",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_model_id": {
+          "name": "preset_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_modalities": {
+          "name": "output_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endpoint_types": {
+          "name": "endpoint_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_endpoint_url": {
+          "name": "custom_endpoint_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supports_streaming": {
+          "name": "supports_streaming",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_deprecated": {
+          "name": "is_deprecated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_overrides": {
+          "name": "user_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_model_preset_idx": {
+          "name": "user_model_preset_idx",
+          "columns": ["preset_model_id"],
+          "isUnique": false
+        },
+        "user_model_provider_enabled_idx": {
+          "name": "user_model_provider_enabled_idx",
+          "columns": ["provider_id", "is_enabled"],
+          "isUnique": false
+        },
+        "user_model_provider_sort_idx": {
+          "name": "user_model_provider_sort_idx",
+          "columns": ["provider_id", "sort_order"],
+          "isUnique": false
+        },
+        "user_model_provider_model_unique": {
+          "name": "user_model_provider_model_unique",
+          "columns": ["provider_id", "model_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_model_provider_id_user_provider_provider_id_fk": {
+          "name": "user_model_provider_id_user_provider_provider_id_fk",
+          "tableFrom": "user_model",
+          "tableTo": "user_provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["provider_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_provider": {
+      "name": "user_provider",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_provider_id": {
+          "name": "preset_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint_configs": {
+          "name": "endpoint_configs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_chat_endpoint": {
+          "name": "default_chat_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_keys": {
+          "name": "api_keys",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_features": {
+          "name": "api_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_settings": {
+          "name": "provider_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_provider_preset_idx": {
+          "name": "user_provider_preset_idx",
+          "columns": ["preset_provider_id"],
+          "isUnique": false
+        },
+        "user_provider_enabled_sort_idx": {
+          "name": "user_provider_enabled_sort_idx",
+          "columns": ["is_enabled", "sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/sqlite-drizzle/meta/_journal.json
+++ b/migrations/sqlite-drizzle/meta/_journal.json
@@ -105,6 +105,13 @@
       "when": 1776838196467,
       "tag": "0014_hot_ultron",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1777461460041,
+      "tag": "0015_groovy_tiger_shark",
+      "breakpoints": true
     }
   ],
   "version": "7"

--- a/packages/shared/data/api/schemas/assistants.ts
+++ b/packages/shared/data/api/schemas/assistants.ts
@@ -7,7 +7,12 @@
 
 import * as z from 'zod'
 
-import { type Assistant, AssistantSchema } from '../../types/assistant'
+import {
+  type Assistant,
+  AssistantSchema,
+  AssistantSettingsSchema,
+  DEFAULT_ASSISTANT_SETTINGS
+} from '../../types/assistant'
 import type { OffsetPaginationResponse } from '../apiTypes'
 
 // ============================================================================
@@ -35,14 +40,24 @@ const ASSISTANT_MUTABLE_FIELDS = {
  * - `name` is required (non-empty)
  * - `mcpServerIds` / `knowledgeBaseIds` are synced to junction tables
  */
-export const CreateAssistantSchema = AssistantSchema.pick(ASSISTANT_MUTABLE_FIELDS).partial().required({ name: true })
-export type CreateAssistantDto = z.infer<typeof CreateAssistantSchema>
+export const CreateAssistantSchema = AssistantSchema.pick(ASSISTANT_MUTABLE_FIELDS)
+  .partial()
+  .required({ name: true })
+  .extend({
+    prompt: z.string().default(''),
+    emoji: z.emoji().default('🌟'),
+    description: z.string().default(''),
+    settings: AssistantSettingsSchema.default(DEFAULT_ASSISTANT_SETTINGS)
+  })
+export type CreateAssistantBody = z.input<typeof CreateAssistantSchema>
+export type CreateAssistantDto = z.output<typeof CreateAssistantSchema>
 
 /**
- * DTO for updating an existing assistant. All fields optional, chain-derived from Create.
+ * DTO for updating an existing assistant. All fields optional.
  * Relation arrays (mcpServerIds, knowledgeBaseIds), if provided, replace existing junction table rows.
+ * Update picks directly from the entity, not Create, so Create defaults do not bleed into partial updates.
  */
-export const UpdateAssistantSchema = CreateAssistantSchema.partial()
+export const UpdateAssistantSchema = AssistantSchema.pick(ASSISTANT_MUTABLE_FIELDS).partial()
 export type UpdateAssistantDto = z.infer<typeof UpdateAssistantSchema>
 
 /**
@@ -79,7 +94,7 @@ export type AssistantSchemas = {
     }
     /** Create a new assistant */
     POST: {
-      body: CreateAssistantDto
+      body: CreateAssistantBody
       response: Assistant
     }
   }

--- a/packages/shared/data/api/schemas/assistants.ts
+++ b/packages/shared/data/api/schemas/assistants.ts
@@ -7,12 +7,7 @@
 
 import * as z from 'zod'
 
-import {
-  type Assistant,
-  AssistantSchema,
-  AssistantSettingsSchema,
-  DEFAULT_ASSISTANT_SETTINGS
-} from '../../types/assistant'
+import { type Assistant, AssistantSchema } from '../../types/assistant'
 import type { OffsetPaginationResponse } from '../apiTypes'
 
 // ============================================================================
@@ -40,17 +35,8 @@ const ASSISTANT_MUTABLE_FIELDS = {
  * - `name` is required (non-empty)
  * - `mcpServerIds` / `knowledgeBaseIds` are synced to junction tables
  */
-export const CreateAssistantSchema = AssistantSchema.pick(ASSISTANT_MUTABLE_FIELDS)
-  .partial()
-  .required({ name: true })
-  .extend({
-    prompt: z.string().default(''),
-    emoji: z.emoji().default('🌟'),
-    description: z.string().default(''),
-    settings: AssistantSettingsSchema.default(DEFAULT_ASSISTANT_SETTINGS)
-  })
-export type CreateAssistantBody = z.input<typeof CreateAssistantSchema>
-export type CreateAssistantDto = z.output<typeof CreateAssistantSchema>
+export const CreateAssistantSchema = AssistantSchema.pick(ASSISTANT_MUTABLE_FIELDS).partial().required({ name: true })
+export type CreateAssistantDto = z.infer<typeof CreateAssistantSchema>
 
 /**
  * DTO for updating an existing assistant. All fields optional.
@@ -94,7 +80,7 @@ export type AssistantSchemas = {
     }
     /** Create a new assistant */
     POST: {
-      body: CreateAssistantBody
+      body: CreateAssistantDto
       response: Assistant
     }
   }

--- a/packages/shared/data/types/assistant.ts
+++ b/packages/shared/data/types/assistant.ts
@@ -21,8 +21,7 @@ export type McpMode = z.infer<typeof McpModeSchema>
  * Assistant settings — inference parameters + context source toggles.
  * Stored as a single JSON column in the database.
  *
- * Default values are aligned with `DEFAULT_ASSISTANT_SETTINGS` in
- * `src/renderer/src/services/AssistantService.ts` (v1 source of truth).
+ * Default values are centralized in `DEFAULT_ASSISTANT_SETTINGS`.
  *
  * `enable*` flags control whether the corresponding parameter is sent to the model.
  * When `enable* = false`, the value is still stored but not used — the model's own
@@ -30,62 +29,50 @@ export type McpMode = z.infer<typeof McpModeSchema>
  */
 export const AssistantSettingsSchema = z.object({
   // -- Inference parameters --
-  // Defaults: AssistantService.ts L45–62, constants from config/constant.ts
-  /** @default 1.0 — from DEFAULT_TEMPERATURE */
-  temperature: z.number().min(0).max(2).default(1.0),
-  /** @default false — disabled = use model's own default */
-  enableTemperature: z.boolean().default(false),
-  /** @default 1 */
-  topP: z.number().min(0).max(1).default(1),
-  /** @default false */
-  enableTopP: z.boolean().default(false),
-  // TODO: use constant instead
-  /** @default 4096 — from DEFAULT_MAX_TOKENS */
-  maxTokens: z.number().int().positive().default(4096),
-  /** @default false — disabled = use model's own default */
-  enableMaxTokens: z.boolean().default(false),
-  // TODO: use constant instead
-  /** @default 5 — from DEFAULT_CONTEXTCOUNT */
-  contextCount: z.number().int().positive().default(5),
-  /** @default true — streaming provides better UX */
-  streamOutput: z.boolean().default(true),
-  /** @default 'default' — let model decide.
+  /** from DEFAULT_TEMPERATURE */
+  temperature: z.number().min(0).max(2),
+  /** disabled = use model's own default */
+  enableTemperature: z.boolean(),
+  topP: z.number().min(0).max(1),
+  enableTopP: z.boolean(),
+  /** from DEFAULT_MAX_TOKENS */
+  maxTokens: z.number().int().positive(),
+  /** disabled = use model's own default */
+  enableMaxTokens: z.boolean(),
+  /** from DEFAULT_CONTEXTCOUNT */
+  contextCount: z.number().int().positive(),
+  /** streaming provides better UX */
+  streamOutput: z.boolean(),
+  /** let model decide.
    *  String (not enum) because providers define custom values (e.g. 'xlow', 'high-reasoning'). */
-  reasoning_effort: z.string().default('default'),
-  /** @default false — Qwen-specific thinking mode */
-  qwenThinkMode: z.boolean().default(false),
+  reasoning_effort: z.string(),
+  /** Qwen-specific thinking mode */
+  qwenThinkMode: z.boolean(),
 
   // -- Tool use --
-  /** @default 'auto' */
-  mcpMode: McpModeSchema.default('auto'),
-  /** @default 'function' — gracefully falls back to prompt if not supported */
-  toolUseMode: z.enum(['function', 'prompt']).default('function'),
-  /** @default 20 */
-  maxToolCalls: z.number().int().positive().default(20),
-  /** @default true */
-  enableMaxToolCalls: z.boolean().default(true),
+  mcpMode: McpModeSchema,
+  /** gracefully falls back to prompt if not supported */
+  toolUseMode: z.enum(['function', 'prompt']),
+  maxToolCalls: z.number().int().positive(),
+  enableMaxToolCalls: z.boolean(),
 
   // -- Context sources --
-  /** @default false */
-  enableWebSearch: z.boolean().default(false),
+  enableWebSearch: z.boolean(),
 
   /** User-defined model parameters (e.g. {"top_k": 40, "repetition_penalty": 1.1}).
    *  Discriminated union on `type` ensures `value` is type-safe:
    *  - `string` → string value, rendered as text input
    *  - `number` → number value, rendered as number spinner
    *  - `boolean` → boolean value, rendered as toggle
-   *  - `json` → arbitrary JSON value, rendered as JSON editor
-   *  @default [] */
-  customParameters: z
-    .array(
-      z.discriminatedUnion('type', [
-        z.object({ name: z.string(), type: z.literal('string'), value: z.string() }),
-        z.object({ name: z.string(), type: z.literal('number'), value: z.number() }),
-        z.object({ name: z.string(), type: z.literal('boolean'), value: z.boolean() }),
-        z.object({ name: z.string(), type: z.literal('json'), value: z.unknown() })
-      ])
-    )
-    .default([])
+   *  - `json` → arbitrary JSON value, rendered as JSON editor */
+  customParameters: z.array(
+    z.discriminatedUnion('type', [
+      z.object({ name: z.string(), type: z.literal('string'), value: z.string() }),
+      z.object({ name: z.string(), type: z.literal('number'), value: z.number() }),
+      z.object({ name: z.string(), type: z.literal('boolean'), value: z.boolean() }),
+      z.object({ name: z.string(), type: z.literal('json'), value: z.unknown() })
+    ])
+  )
 })
 export type AssistantSettings = z.infer<typeof AssistantSettingsSchema>
 
@@ -118,7 +105,7 @@ export const AssistantIdSchema = z.uuidv4()
 /**
  * Complete Assistant entity as returned by the API.
  *
- * DB-nullable fields have defaults so the runtime type is always non-null.
+ * Row mappers normalize DB-nullable fields before returning this entity.
  * `modelId` is explicitly `.nullable()` because an assistant may have no model set.
  */
 export const AssistantSchema = z.strictObject({
@@ -127,11 +114,11 @@ export const AssistantSchema = z.strictObject({
   /** Display name */
   name: z.string().min(1),
   /** System prompt text or prompt template ID reference */
-  prompt: z.string().default(''),
+  prompt: z.string(),
   /** Emoji icon for UI display */
-  emoji: z.emoji().default('🌟'),
+  emoji: z.emoji(),
   /** Long-form description */
-  description: z.string().default(''),
+  description: z.string(),
   /** Inference settings — model params + context toggles */
   settings: AssistantSettingsSchema,
   /** Default/primary model ID in UniqueModelId format ("providerId::modelId") */

--- a/src/main/data/api/handlers/__tests__/assistants.test.ts
+++ b/src/main/data/api/handlers/__tests__/assistants.test.ts
@@ -1,0 +1,105 @@
+import { DEFAULT_ASSISTANT_SETTINGS } from '@shared/data/types/assistant'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { listMock, createMock, getByIdMock, updateMock, deleteMock } = vi.hoisted(() => ({
+  listMock: vi.fn(),
+  createMock: vi.fn(),
+  getByIdMock: vi.fn(),
+  updateMock: vi.fn(),
+  deleteMock: vi.fn()
+}))
+
+vi.mock('@data/services/AssistantService', () => ({
+  assistantDataService: {
+    list: listMock,
+    create: createMock,
+    getById: getByIdMock,
+    update: updateMock,
+    delete: deleteMock
+  }
+}))
+
+import { assistantHandlers } from '../assistants'
+
+const ASSISTANT_ID = '11111111-1111-4111-8111-111111111111'
+
+describe('assistantHandlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('/assistants', () => {
+    it('should apply create defaults at the API boundary', async () => {
+      createMock.mockResolvedValueOnce({ id: ASSISTANT_ID, name: 'New Assistant' })
+
+      await expect(
+        assistantHandlers['/assistants'].POST({
+          body: { name: 'New Assistant' }
+        } as never)
+      ).resolves.toMatchObject({ id: ASSISTANT_ID })
+
+      expect(createMock).toHaveBeenCalledWith({
+        name: 'New Assistant',
+        prompt: '',
+        emoji: '🌟',
+        description: '',
+        settings: DEFAULT_ASSISTANT_SETTINGS
+      })
+    })
+
+    it('should reject partial settings instead of filling nested defaults', async () => {
+      await expect(
+        assistantHandlers['/assistants'].POST({
+          body: {
+            name: 'New Assistant',
+            settings: { maxTokens: 8192 }
+          }
+        } as never)
+      ).rejects.toHaveProperty('name', 'ZodError')
+
+      expect(createMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('/assistants/:id', () => {
+    it('should forward relation-only PATCH bodies without defaulted column fields', async () => {
+      updateMock.mockResolvedValueOnce({ id: ASSISTANT_ID, name: 'Existing Assistant' })
+
+      await expect(
+        assistantHandlers['/assistants/:id'].PATCH({
+          params: { id: ASSISTANT_ID },
+          body: { mcpServerIds: ['srv-1'], knowledgeBaseIds: ['kb-1'] }
+        } as never)
+      ).resolves.toMatchObject({ id: ASSISTANT_ID })
+
+      expect(updateMock).toHaveBeenCalledWith(ASSISTANT_ID, {
+        mcpServerIds: ['srv-1'],
+        knowledgeBaseIds: ['kb-1']
+      })
+    })
+
+    it('should forward empty PATCH bodies without injecting create defaults', async () => {
+      updateMock.mockResolvedValueOnce({ id: ASSISTANT_ID, name: 'Existing Assistant' })
+
+      await expect(
+        assistantHandlers['/assistants/:id'].PATCH({
+          params: { id: ASSISTANT_ID },
+          body: {}
+        } as never)
+      ).resolves.toMatchObject({ id: ASSISTANT_ID })
+
+      expect(updateMock).toHaveBeenCalledWith(ASSISTANT_ID, {})
+    })
+
+    it('should reject partial settings updates before calling the service', async () => {
+      await expect(
+        assistantHandlers['/assistants/:id'].PATCH({
+          params: { id: ASSISTANT_ID },
+          body: { settings: { maxTokens: 8192 } }
+        } as never)
+      ).rejects.toHaveProperty('name', 'ZodError')
+
+      expect(updateMock).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/main/data/api/handlers/__tests__/assistants.test.ts
+++ b/src/main/data/api/handlers/__tests__/assistants.test.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_ASSISTANT_SETTINGS } from '@shared/data/types/assistant'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { listMock, createMock, getByIdMock, updateMock, deleteMock } = vi.hoisted(() => ({
@@ -29,7 +28,7 @@ describe('assistantHandlers', () => {
   })
 
   describe('/assistants', () => {
-    it('should apply create defaults at the API boundary', async () => {
+    it('should forward create bodies without injecting defaults', async () => {
       createMock.mockResolvedValueOnce({ id: ASSISTANT_ID, name: 'New Assistant' })
 
       await expect(
@@ -39,11 +38,7 @@ describe('assistantHandlers', () => {
       ).resolves.toMatchObject({ id: ASSISTANT_ID })
 
       expect(createMock).toHaveBeenCalledWith({
-        name: 'New Assistant',
-        prompt: '',
-        emoji: '🌟',
-        description: '',
-        settings: DEFAULT_ASSISTANT_SETTINGS
+        name: 'New Assistant'
       })
     })
 

--- a/src/main/data/db/schemas/assistant.ts
+++ b/src/main/data/db/schemas/assistant.ts
@@ -15,13 +15,18 @@ export const assistantTable = sqliteTable(
   {
     id: uuidPrimaryKey(),
     name: text().notNull(),
-    prompt: text().default(''),
-    emoji: text(),
-    description: text().default(''),
+    // Type-level empty: DB DEFAULT is the single source of truth
+    prompt: text().notNull().default(''),
+    // Product-chosen value: AssistantService.create() supplies '🌟' (see spec § DB defaults are near-permanent)
+    emoji: text().notNull(),
+    // Type-level empty: DB DEFAULT is the single source of truth
+    description: text().notNull().default(''),
     // Default/primary model: FK to user_model(id) — UniqueModelId "providerId::modelId"
+    // Legitimately nullable (R1): NULL = "no model selected yet"
     modelId: text().references(() => userModelTable.id, { onDelete: 'set null' }),
-    /** JSON blob: inference params + context source toggles */
-    settings: text({ mode: 'json' }).$type<AssistantSettings>(),
+    // JSON blob: inference params + context source toggles
+    // Tunable product value: AssistantService.create() supplies DEFAULT_ASSISTANT_SETTINGS
+    settings: text({ mode: 'json' }).$type<AssistantSettings>().notNull(),
     ...createUpdateDeleteTimestamps
   },
   (t) => [index('assistant_created_at_idx').on(t.createdAt)]

--- a/src/main/data/migration/v2/migrators/mappings/AssistantMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/AssistantMappings.ts
@@ -21,6 +21,7 @@
 
 import type { AssistantInsert } from '@data/db/schemas/assistant'
 import type { assistantKnowledgeBaseTable, assistantMcpServerTable } from '@data/db/schemas/assistantRelations'
+import { DEFAULT_ASSISTANT_SETTINGS } from '@shared/data/types/assistant'
 
 import { legacyModelToUniqueId } from '../transformers/ModelTransformers'
 
@@ -170,15 +171,24 @@ export function transformAssistant(source: OldAssistant): AssistantTransformResu
   if (source.mcpMode != null) legacySettings.mcpMode = source.mcpMode
   if (source.enableWebSearch != null) legacySettings.enableWebSearch = source.enableWebSearch
 
+  // Migrator bypasses AssistantService.create(), so it mirrors the same defaults that the
+  // service would supply: '🌟' for emoji, DEFAULT_ASSISTANT_SETTINGS for settings, and the
+  // DB-default '' for prompt / description. Keeps the migrator's output consistent with
+  // every other write path even though we're not going through the service layer.
+  const settings: AssistantInsert['settings'] =
+    Object.keys(legacySettings).length > 0
+      ? { ...DEFAULT_ASSISTANT_SETTINGS, ...(legacySettings as Partial<AssistantInsert['settings']>) }
+      : DEFAULT_ASSISTANT_SETTINGS
+
   return {
     assistant: {
       id: assistantId,
       name: source.name || 'Unnamed Assistant',
-      prompt: source.prompt ?? null,
-      emoji: source.emoji ?? null,
-      description: source.description ?? null,
+      prompt: source.prompt ?? '',
+      emoji: source.emoji ?? '🌟',
+      description: source.description ?? '',
       modelId: primaryModelId ?? null,
-      settings: Object.keys(legacySettings).length > 0 ? (legacySettings as AssistantInsert['settings']) : null
+      settings
     },
     mcpServers: mcpServerIds.map((mcpServerId) => ({ assistantId, mcpServerId })),
     knowledgeBases: knowledgeBaseIds.map((knowledgeBaseId) => ({ assistantId, knowledgeBaseId })),

--- a/src/main/data/migration/v2/migrators/mappings/__tests__/AssistantMappings.test.ts
+++ b/src/main/data/migration/v2/migrators/mappings/__tests__/AssistantMappings.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_ASSISTANT_SETTINGS } from '@shared/data/types/assistant'
 import { describe, expect, it } from 'vitest'
 
 import { transformAssistant } from '../AssistantMappings'
@@ -29,7 +30,9 @@ describe('AssistantMappings', () => {
         emoji: '🤖',
         description: 'A test assistant',
         modelId: 'openai::gpt-4',
-        settings: { temperature: 0.7, mcpMode: 'prompt', enableWebSearch: true }
+        // Migrator merges legacy fields onto DEFAULT_ASSISTANT_SETTINGS so the new
+        // NOT NULL settings column always sees a complete object.
+        settings: { ...DEFAULT_ASSISTANT_SETTINGS, temperature: 0.7, mcpMode: 'prompt', enableWebSearch: true }
       })
       expect(result.mcpServers).toStrictEqual([
         { assistantId: 'ast-1', mcpServerId: 'srv-1' },
@@ -41,14 +44,16 @@ describe('AssistantMappings', () => {
     it('should handle minimal assistant (only required fields)', () => {
       const result = transformAssistant({ id: 'ast-2', name: 'Minimal' })
 
+      // Migrator supplies the same defaults that AssistantService.create() would: empty strings
+      // for prompt/description (mirroring DB DEFAULT) and the product-chosen emoji + settings.
       expect(result.assistant).toStrictEqual({
         id: 'ast-2',
         name: 'Minimal',
-        prompt: null,
-        emoji: null,
-        description: null,
+        prompt: '',
+        emoji: '🌟',
+        description: '',
         modelId: null,
-        settings: null
+        settings: DEFAULT_ASSISTANT_SETTINGS
       })
       expect(result.mcpServers).toStrictEqual([])
       expect(result.knowledgeBases).toStrictEqual([])
@@ -130,11 +135,11 @@ describe('AssistantMappings', () => {
         enableWebSearch: undefined
       })
 
-      expect(result.assistant.prompt).toBeNull()
-      expect(result.assistant.emoji).toBeNull()
-      expect(result.assistant.description).toBeNull()
-      // mcpMode/enableWebSearch are merged into settings
-      expect(result.assistant.settings).toBeNull()
+      expect(result.assistant.prompt).toBe('')
+      expect(result.assistant.emoji).toBe('🌟')
+      expect(result.assistant.description).toBe('')
+      // mcpMode/enableWebSearch were null/undefined upstream, so settings stays at the default.
+      expect(result.assistant.settings).toStrictEqual(DEFAULT_ASSISTANT_SETTINGS)
       expect(result.tags).toStrictEqual([])
     })
 
@@ -162,7 +167,11 @@ describe('AssistantMappings', () => {
         mcpMode: 'auto',
         enableWebSearch: true
       })
-      expect(result.assistant.settings).toStrictEqual({ mcpMode: 'auto', enableWebSearch: true })
+      expect(result.assistant.settings).toStrictEqual({
+        ...DEFAULT_ASSISTANT_SETTINGS,
+        mcpMode: 'auto',
+        enableWebSearch: true
+      })
     })
   })
 })

--- a/src/main/data/services/AssistantService.ts
+++ b/src/main/data/services/AssistantService.ts
@@ -37,6 +37,9 @@ function normalizeSettings(settings: AssistantRow['settings']): Assistant['setti
   return { ...DEFAULT_ASSISTANT_SETTINGS, ...settings }
 }
 
+// TODO(R3 transitional): remove these `??` fallbacks once the follow-up migration
+// tightens prompt/emoji/description to NOT NULL with DB DEFAULTs and settings to NOT NULL.
+// See docs/references/data/best-practice-default-values-and-nullability.md § R3 + Case Study A.
 function rowToAssistant(row: AssistantRow, relations: AssistantRelationIds = createEmptyRelations()): Assistant {
   return {
     id: row.id,
@@ -172,17 +175,25 @@ export class AssistantDataService {
     this.validateName(dto.name)
 
     const row = await this.db.transaction(async (tx) => {
-      const [inserted] = await tx
-        .insert(assistantTable)
-        .values({
-          name: dto.name,
-          prompt: dto.prompt,
-          emoji: dto.emoji,
-          description: dto.description,
-          modelId: dto.modelId ?? null,
-          settings: dto.settings
-        })
-        .returning()
+      const insertValues: typeof assistantTable.$inferInsert = {
+        name: dto.name,
+        settings: dto.settings ?? DEFAULT_ASSISTANT_SETTINGS
+      }
+
+      if (dto.prompt !== undefined) {
+        insertValues.prompt = dto.prompt
+      }
+      if (dto.emoji !== undefined) {
+        insertValues.emoji = dto.emoji
+      }
+      if (dto.description !== undefined) {
+        insertValues.description = dto.description
+      }
+      if (dto.modelId !== undefined) {
+        insertValues.modelId = dto.modelId
+      }
+
+      const [inserted] = await tx.insert(assistantTable).values(insertValues).returning()
 
       // Insert junction table rows
       await this.syncRelations(tx, inserted.id, dto)

--- a/src/main/data/services/AssistantService.ts
+++ b/src/main/data/services/AssistantService.ts
@@ -18,7 +18,7 @@ import type { UniqueModelId } from '@shared/data/types/model'
 import { and, asc, eq, inArray, isNull, type SQL, sql } from 'drizzle-orm'
 
 import { tagService } from './TagService'
-import { timestampToISO } from './utils/rowMappers'
+import { nullsToUndefined, timestampToISO } from './utils/rowMappers'
 
 const logger = loggerService.withContext('DataApi:AssistantService')
 
@@ -33,22 +33,13 @@ function createEmptyRelations(): AssistantRelationIds {
   }
 }
 
-function normalizeSettings(settings: AssistantRow['settings']): Assistant['settings'] {
-  return { ...DEFAULT_ASSISTANT_SETTINGS, ...settings }
-}
-
-// TODO(R3 transitional): remove these `??` fallbacks once the follow-up migration
-// tightens prompt/emoji/description to NOT NULL with DB DEFAULTs and settings to NOT NULL.
-// See docs/references/data/best-practice-default-values-and-nullability.md § R3 + Case Study A.
 function rowToAssistant(row: AssistantRow, relations: AssistantRelationIds = createEmptyRelations()): Assistant {
+  // deletedAt is internal-only and not part of the Assistant entity contract.
+  const { deletedAt: _deletedAt, ...rest } = nullsToUndefined(row)
   return {
-    id: row.id,
-    name: row.name,
-    prompt: row.prompt ?? '',
-    emoji: row.emoji ?? '🌟',
-    description: row.description ?? '',
-    settings: normalizeSettings(row.settings),
-    modelId: (row.modelId ?? null) as UniqueModelId | null,
+    ...rest,
+    // Preserve the T | null contract: `modelId` is legitimately nullable (R3 exception).
+    modelId: row.modelId as UniqueModelId | null,
     mcpServerIds: relations.mcpServerIds,
     knowledgeBaseIds: relations.knowledgeBaseIds,
     createdAt: timestampToISO(row.createdAt),
@@ -175,22 +166,15 @@ export class AssistantDataService {
     this.validateName(dto.name)
 
     const row = await this.db.transaction(async (tx) => {
+      // Strip relation arrays (synced via junction tables, not assistant columns).
+      // `prompt` / `description` are omitted when undefined so the DB DEFAULT '' takes over.
+      // `emoji` and `settings` are filled here — Service is the single source of truth for
+      // their product-chosen / tunable defaults (spec § Decision Matrix 2).
+      const { mcpServerIds: _mcps, knowledgeBaseIds: _kbs, ...columnDto } = dto
       const insertValues: typeof assistantTable.$inferInsert = {
-        name: dto.name,
+        ...columnDto,
+        emoji: dto.emoji ?? '🌟',
         settings: dto.settings ?? DEFAULT_ASSISTANT_SETTINGS
-      }
-
-      if (dto.prompt !== undefined) {
-        insertValues.prompt = dto.prompt
-      }
-      if (dto.emoji !== undefined) {
-        insertValues.emoji = dto.emoji
-      }
-      if (dto.description !== undefined) {
-        insertValues.description = dto.description
-      }
-      if (dto.modelId !== undefined) {
-        insertValues.modelId = dto.modelId
       }
 
       const [inserted] = await tx.insert(assistantTable).values(insertValues).returning()

--- a/src/main/data/services/AssistantService.ts
+++ b/src/main/data/services/AssistantService.ts
@@ -33,6 +33,10 @@ function createEmptyRelations(): AssistantRelationIds {
   }
 }
 
+function normalizeSettings(settings: AssistantRow['settings']): Assistant['settings'] {
+  return { ...DEFAULT_ASSISTANT_SETTINGS, ...settings }
+}
+
 function rowToAssistant(row: AssistantRow, relations: AssistantRelationIds = createEmptyRelations()): Assistant {
   return {
     id: row.id,
@@ -40,7 +44,7 @@ function rowToAssistant(row: AssistantRow, relations: AssistantRelationIds = cre
     prompt: row.prompt ?? '',
     emoji: row.emoji ?? '🌟',
     description: row.description ?? '',
-    settings: row.settings ?? DEFAULT_ASSISTANT_SETTINGS,
+    settings: normalizeSettings(row.settings),
     modelId: (row.modelId ?? null) as UniqueModelId | null,
     mcpServerIds: relations.mcpServerIds,
     knowledgeBaseIds: relations.knowledgeBaseIds,

--- a/src/main/data/services/AssistantService.ts
+++ b/src/main/data/services/AssistantService.ts
@@ -34,10 +34,9 @@ function createEmptyRelations(): AssistantRelationIds {
 }
 
 function rowToAssistant(row: AssistantRow, relations: AssistantRelationIds = createEmptyRelations()): Assistant {
-  // deletedAt is internal-only and not part of the Assistant entity contract.
-  const { deletedAt: _deletedAt, ...rest } = nullsToUndefined(row)
+  const clean = nullsToUndefined(row)
   return {
-    ...rest,
+    ...clean,
     // Preserve the T | null contract: `modelId` is legitimately nullable (R3 exception).
     modelId: row.modelId as UniqueModelId | null,
     mcpServerIds: relations.mcpServerIds,
@@ -166,11 +165,11 @@ export class AssistantDataService {
     this.validateName(dto.name)
 
     const row = await this.db.transaction(async (tx) => {
-      // Strip relation arrays (synced via junction tables, not assistant columns).
-      // `prompt` / `description` are omitted when undefined so the DB DEFAULT '' takes over.
+      // Split column fields from relation arrays — relations are synced via junction tables.
+      // `prompt` / `description` stay omitted when undefined so the DB DEFAULT '' takes over.
       // `emoji` and `settings` are filled here — Service is the single source of truth for
       // their product-chosen / tunable defaults (spec § Decision Matrix 2).
-      const { mcpServerIds: _mcps, knowledgeBaseIds: _kbs, ...columnDto } = dto
+      const { mcpServerIds, knowledgeBaseIds, ...columnDto } = dto
       const insertValues: typeof assistantTable.$inferInsert = {
         ...columnDto,
         emoji: dto.emoji ?? '🌟',
@@ -180,7 +179,7 @@ export class AssistantDataService {
       const [inserted] = await tx.insert(assistantTable).values(insertValues).returning()
 
       // Insert junction table rows
-      await this.syncRelations(tx, inserted.id, dto)
+      await this.syncRelations(tx, inserted.id, { mcpServerIds, knowledgeBaseIds })
 
       return inserted
     })

--- a/src/main/data/services/__tests__/AssistantService.test.ts
+++ b/src/main/data/services/__tests__/AssistantService.test.ts
@@ -122,6 +122,20 @@ describe('AssistantDataService', () => {
       expect(result.knowledgeBaseIds).toEqual([])
     })
 
+    it('should merge default settings with partial legacy settings', async () => {
+      await dbh.db.insert(assistantTable).values({
+        id: 'ast-1',
+        name: 'test',
+        settings: { temperature: 0.7 } as typeof DEFAULT_ASSISTANT_SETTINGS
+      })
+
+      const result = await assistantDataService.getById('ast-1')
+      expect(result.settings).toEqual({
+        ...DEFAULT_ASSISTANT_SETTINGS,
+        temperature: 0.7
+      })
+    })
+
     it('should return soft-deleted assistant when includeDeleted is true', async () => {
       await dbh.db.insert(assistantTable).values({ id: 'ast-1', name: 'test' })
       await dbh.db.update(assistantTable).set({ deletedAt: Date.now() })

--- a/src/main/data/services/__tests__/AssistantService.test.ts
+++ b/src/main/data/services/__tests__/AssistantService.test.ts
@@ -7,11 +7,6 @@ import { userModelTable } from '@data/db/schemas/userModel'
 import { userProviderTable } from '@data/db/schemas/userProvider'
 import { AssistantDataService, assistantDataService } from '@data/services/AssistantService'
 import { ErrorCode } from '@shared/data/api'
-import {
-  type CreateAssistantBody,
-  type CreateAssistantDto,
-  CreateAssistantSchema
-} from '@shared/data/api/schemas/assistants'
 import { DEFAULT_ASSISTANT_SETTINGS } from '@shared/data/types/assistant'
 import { createUniqueModelId } from '@shared/data/types/model'
 import { setupTestDatabase } from '@test-helpers/db'
@@ -75,10 +70,6 @@ describe('AssistantDataService', () => {
       dimensions: 1024,
       embeddingModelId: createUniqueModelId('openai', 'text-embedding-3-large')
     })
-  }
-
-  function createAssistantDto(body: CreateAssistantBody): CreateAssistantDto {
-    return CreateAssistantSchema.parse(body)
   }
 
   it('should export a module-level singleton', () => {
@@ -231,7 +222,7 @@ describe('AssistantDataService', () => {
 
   describe('create', () => {
     it('should create and return assistant with generated id', async () => {
-      const result = await assistantDataService.create(createAssistantDto({ name: 'test-assistant' }))
+      const result = await assistantDataService.create({ name: 'test-assistant' })
 
       expect(result.id).toBeTruthy()
       expect(result.name).toBe('test-assistant')
@@ -240,25 +231,32 @@ describe('AssistantDataService', () => {
     })
 
     it('should persist assistant to database', async () => {
-      const created = await assistantDataService.create(createAssistantDto({ name: 'test-assistant' }))
+      const created = await assistantDataService.create({ name: 'test-assistant' })
 
       const [row] = await dbh.db.select().from(assistantTable)
       expect(row.id).toBe(created.id)
       expect(row.name).toBe('test-assistant')
     })
 
+    it('should apply default settings when settings are omitted', async () => {
+      const created = await assistantDataService.create({ name: 'test-assistant' })
+
+      expect(created.settings).toEqual(DEFAULT_ASSISTANT_SETTINGS)
+
+      const [row] = await dbh.db.select().from(assistantTable)
+      expect(row.settings).toEqual(DEFAULT_ASSISTANT_SETTINGS)
+    })
+
     it('should sync junction rows when relation ids are provided', async () => {
       await seedMcpServer()
       await seedKnowledgeBase()
 
-      const result = await assistantDataService.create(
-        createAssistantDto({
-          name: 'test-assistant',
-          modelId: 'openai::gpt-4',
-          mcpServerIds: ['srv-1'],
-          knowledgeBaseIds: ['kb-1']
-        })
-      )
+      const result = await assistantDataService.create({
+        name: 'test-assistant',
+        modelId: 'openai::gpt-4',
+        mcpServerIds: ['srv-1'],
+        knowledgeBaseIds: ['kb-1']
+      })
 
       expect(result.mcpServerIds).toEqual(['srv-1'])
       expect(result.knowledgeBaseIds).toEqual(['kb-1'])
@@ -271,15 +269,13 @@ describe('AssistantDataService', () => {
     })
 
     it('should throw validation error when name is empty', async () => {
-      await expect(
-        assistantDataService.create({ ...createAssistantDto({ name: 'valid' }), name: '' })
-      ).rejects.toMatchObject({
+      await expect(assistantDataService.create({ name: '' })).rejects.toMatchObject({
         code: ErrorCode.VALIDATION_ERROR
       })
     })
 
     it('should throw validation error when name is whitespace only', async () => {
-      await expect(assistantDataService.create(createAssistantDto({ name: '   ' }))).rejects.toMatchObject({
+      await expect(assistantDataService.create({ name: '   ' })).rejects.toMatchObject({
         code: ErrorCode.VALIDATION_ERROR
       })
     })

--- a/src/main/data/services/__tests__/AssistantService.test.ts
+++ b/src/main/data/services/__tests__/AssistantService.test.ts
@@ -7,6 +7,12 @@ import { userModelTable } from '@data/db/schemas/userModel'
 import { userProviderTable } from '@data/db/schemas/userProvider'
 import { AssistantDataService, assistantDataService } from '@data/services/AssistantService'
 import { ErrorCode } from '@shared/data/api'
+import {
+  type CreateAssistantBody,
+  type CreateAssistantDto,
+  CreateAssistantSchema
+} from '@shared/data/api/schemas/assistants'
+import { DEFAULT_ASSISTANT_SETTINGS } from '@shared/data/types/assistant'
 import { createUniqueModelId } from '@shared/data/types/model'
 import { setupTestDatabase } from '@test-helpers/db'
 import { beforeEach, describe, expect, it } from 'vitest'
@@ -71,6 +77,10 @@ describe('AssistantDataService', () => {
     })
   }
 
+  function createAssistantDto(body: CreateAssistantBody): CreateAssistantDto {
+    return CreateAssistantSchema.parse(body)
+  }
+
   it('should export a module-level singleton', () => {
     expect(assistantDataService).toBeInstanceOf(AssistantDataService)
   })
@@ -107,6 +117,7 @@ describe('AssistantDataService', () => {
       expect(result.prompt).toBe('')
       expect(result.emoji).toBe('🌟')
       expect(result.description).toBe('')
+      expect(result.settings).toEqual(DEFAULT_ASSISTANT_SETTINGS)
       expect(result.mcpServerIds).toEqual([])
       expect(result.knowledgeBaseIds).toEqual([])
     })
@@ -206,7 +217,7 @@ describe('AssistantDataService', () => {
 
   describe('create', () => {
     it('should create and return assistant with generated id', async () => {
-      const result = await assistantDataService.create({ name: 'test-assistant' })
+      const result = await assistantDataService.create(createAssistantDto({ name: 'test-assistant' }))
 
       expect(result.id).toBeTruthy()
       expect(result.name).toBe('test-assistant')
@@ -215,7 +226,7 @@ describe('AssistantDataService', () => {
     })
 
     it('should persist assistant to database', async () => {
-      const created = await assistantDataService.create({ name: 'test-assistant' })
+      const created = await assistantDataService.create(createAssistantDto({ name: 'test-assistant' }))
 
       const [row] = await dbh.db.select().from(assistantTable)
       expect(row.id).toBe(created.id)
@@ -226,12 +237,14 @@ describe('AssistantDataService', () => {
       await seedMcpServer()
       await seedKnowledgeBase()
 
-      const result = await assistantDataService.create({
-        name: 'test-assistant',
-        modelId: 'openai::gpt-4',
-        mcpServerIds: ['srv-1'],
-        knowledgeBaseIds: ['kb-1']
-      })
+      const result = await assistantDataService.create(
+        createAssistantDto({
+          name: 'test-assistant',
+          modelId: 'openai::gpt-4',
+          mcpServerIds: ['srv-1'],
+          knowledgeBaseIds: ['kb-1']
+        })
+      )
 
       expect(result.mcpServerIds).toEqual(['srv-1'])
       expect(result.knowledgeBaseIds).toEqual(['kb-1'])
@@ -244,13 +257,15 @@ describe('AssistantDataService', () => {
     })
 
     it('should throw validation error when name is empty', async () => {
-      await expect(assistantDataService.create({ name: '' })).rejects.toMatchObject({
+      await expect(
+        assistantDataService.create({ ...createAssistantDto({ name: 'valid' }), name: '' })
+      ).rejects.toMatchObject({
         code: ErrorCode.VALIDATION_ERROR
       })
     })
 
     it('should throw validation error when name is whitespace only', async () => {
-      await expect(assistantDataService.create({ name: '   ' })).rejects.toMatchObject({
+      await expect(assistantDataService.create(createAssistantDto({ name: '   ' }))).rejects.toMatchObject({
         code: ErrorCode.VALIDATION_ERROR
       })
     })

--- a/src/main/data/services/__tests__/AssistantService.test.ts
+++ b/src/main/data/services/__tests__/AssistantService.test.ts
@@ -72,13 +72,29 @@ describe('AssistantDataService', () => {
     })
   }
 
+  // Raw-insert helper that fills the NOT-NULL columns the DB has no DEFAULT for (emoji / settings).
+  // Tests that exercise read-path semantics on hand-crafted rows go through this helper so they
+  // don't need to repeat boilerplate every call site.
+  type SeedAssistantValues = Partial<typeof assistantTable.$inferInsert>
+  async function seedAssistantRow(values: SeedAssistantValues | SeedAssistantValues[]) {
+    const rows = Array.isArray(values) ? values : [values]
+    await dbh.db.insert(assistantTable).values(
+      rows.map((v) => ({
+        emoji: '🌟',
+        settings: DEFAULT_ASSISTANT_SETTINGS,
+        name: 'test',
+        ...v
+      }))
+    )
+  }
+
   it('should export a module-level singleton', () => {
     expect(assistantDataService).toBeInstanceOf(AssistantDataService)
   })
 
   describe('getById', () => {
     it('should return an assistant with relation ids when found', async () => {
-      await dbh.db.insert(assistantTable).values({ id: 'ast-1', name: 'test', modelId: 'openai::gpt-4' })
+      await seedAssistantRow({ id: 'ast-1', name: 'test', modelId: 'openai::gpt-4' })
       await seedMcpServer()
       await seedKnowledgeBase()
       await dbh.db.insert(assistantMcpServerTable).values({ assistantId: 'ast-1', mcpServerId: 'srv-1' })
@@ -95,40 +111,26 @@ describe('AssistantDataService', () => {
     })
 
     it('should return null modelId when not set', async () => {
-      await dbh.db.insert(assistantTable).values({ id: 'ast-1', name: 'test' })
+      await seedAssistantRow({ id: 'ast-1', name: 'test' })
 
       const result = await assistantDataService.getById('ast-1')
       expect(result.modelId).toBeNull()
     })
 
-    it('should apply default values for nullable fields', async () => {
-      await dbh.db.insert(assistantTable).values({ id: 'ast-1', name: 'test' })
+    it('should surface DB DEFAULT empty strings for prompt and description', async () => {
+      // emoji and settings are NOT NULL with no DB DEFAULT, so the helper supplies them.
+      // prompt and description carry DB DEFAULT '' — confirm SQLite fills them when omitted.
+      await seedAssistantRow({ id: 'ast-1', name: 'test' })
 
       const result = await assistantDataService.getById('ast-1')
       expect(result.prompt).toBe('')
-      expect(result.emoji).toBe('🌟')
       expect(result.description).toBe('')
-      expect(result.settings).toEqual(DEFAULT_ASSISTANT_SETTINGS)
       expect(result.mcpServerIds).toEqual([])
       expect(result.knowledgeBaseIds).toEqual([])
     })
 
-    it('should merge default settings with partial legacy settings', async () => {
-      await dbh.db.insert(assistantTable).values({
-        id: 'ast-1',
-        name: 'test',
-        settings: { temperature: 0.7 } as typeof DEFAULT_ASSISTANT_SETTINGS
-      })
-
-      const result = await assistantDataService.getById('ast-1')
-      expect(result.settings).toEqual({
-        ...DEFAULT_ASSISTANT_SETTINGS,
-        temperature: 0.7
-      })
-    })
-
     it('should return soft-deleted assistant when includeDeleted is true', async () => {
-      await dbh.db.insert(assistantTable).values({ id: 'ast-1', name: 'test' })
+      await seedAssistantRow({ id: 'ast-1', name: 'test' })
       await dbh.db.update(assistantTable).set({ deletedAt: Date.now() })
 
       const result = await assistantDataService.getById('ast-1', { includeDeleted: true })
@@ -136,7 +138,7 @@ describe('AssistantDataService', () => {
     })
 
     it('should NOT return soft-deleted assistant by default', async () => {
-      await dbh.db.insert(assistantTable).values({ id: 'ast-1', name: 'test' })
+      await seedAssistantRow({ id: 'ast-1', name: 'test' })
       await dbh.db.update(assistantTable).set({ deletedAt: Date.now() })
 
       await expect(assistantDataService.getById('ast-1')).rejects.toMatchObject({
@@ -153,7 +155,7 @@ describe('AssistantDataService', () => {
 
   describe('list', () => {
     it('should return all assistants with relation ids', async () => {
-      await dbh.db.insert(assistantTable).values([
+      await seedAssistantRow([
         { id: 'ast-1', name: 'first', modelId: 'openai::gpt-4', createdAt: 100 },
         { id: 'ast-2', name: 'second', modelId: 'anthropic::claude-3', createdAt: 200 }
       ])
@@ -170,7 +172,7 @@ describe('AssistantDataService', () => {
     })
 
     it('should exclude soft-deleted assistants', async () => {
-      await dbh.db.insert(assistantTable).values([
+      await seedAssistantRow([
         { id: 'ast-1', name: 'active' },
         { id: 'ast-2', name: 'deleted', deletedAt: Date.now() }
       ])
@@ -182,7 +184,7 @@ describe('AssistantDataService', () => {
     })
 
     it('should filter by id', async () => {
-      await dbh.db.insert(assistantTable).values([
+      await seedAssistantRow([
         { id: 'ast-1', name: 'first' },
         { id: 'ast-2', name: 'second' }
       ])
@@ -193,12 +195,13 @@ describe('AssistantDataService', () => {
     })
 
     it('should respect page and limit parameters', async () => {
-      const values = Array.from({ length: 5 }, (_, i) => ({
-        id: `ast-${i}`,
-        name: `assistant-${i}`,
-        createdAt: i * 100
-      }))
-      await dbh.db.insert(assistantTable).values(values)
+      await seedAssistantRow(
+        Array.from({ length: 5 }, (_, i) => ({
+          id: `ast-${i}`,
+          name: `assistant-${i}`,
+          createdAt: i * 100
+        }))
+      )
 
       const result = await assistantDataService.list({ page: 2, limit: 2 })
       expect(result.page).toBe(2)
@@ -209,7 +212,7 @@ describe('AssistantDataService', () => {
     })
 
     it('should order by createdAt ascending', async () => {
-      await dbh.db.insert(assistantTable).values([
+      await seedAssistantRow([
         { id: 'ast-new', name: 'new', createdAt: 300 },
         { id: 'ast-old', name: 'old', createdAt: 100 },
         { id: 'ast-mid', name: 'mid', createdAt: 200 }
@@ -245,6 +248,35 @@ describe('AssistantDataService', () => {
 
       const [row] = await dbh.db.select().from(assistantTable)
       expect(row.settings).toEqual(DEFAULT_ASSISTANT_SETTINGS)
+    })
+
+    it("should apply '🌟' as the default emoji when omitted", async () => {
+      const created = await assistantDataService.create({ name: 'test-assistant' })
+
+      expect(created.emoji).toBe('🌟')
+
+      const [row] = await dbh.db.select().from(assistantTable)
+      expect(row.emoji).toBe('🌟')
+    })
+
+    it('should apply DB DEFAULT empty strings to prompt and description when omitted', async () => {
+      const created = await assistantDataService.create({ name: 'test-assistant' })
+
+      expect(created.prompt).toBe('')
+      expect(created.description).toBe('')
+
+      const [row] = await dbh.db.select().from(assistantTable)
+      expect(row.prompt).toBe('')
+      expect(row.description).toBe('')
+    })
+
+    it('should preserve client-supplied emoji over the service default', async () => {
+      const created = await assistantDataService.create({ name: 'test-assistant', emoji: '🤖' })
+
+      expect(created.emoji).toBe('🤖')
+
+      const [row] = await dbh.db.select().from(assistantTable)
+      expect(row.emoji).toBe('🤖')
     })
 
     it('should sync junction rows when relation ids are provided', async () => {
@@ -283,14 +315,14 @@ describe('AssistantDataService', () => {
 
   describe('update', () => {
     it('should update and return assistant', async () => {
-      await dbh.db.insert(assistantTable).values({ id: 'ast-1', name: 'original' })
+      await seedAssistantRow({ id: 'ast-1', name: 'original' })
 
       const result = await assistantDataService.update('ast-1', { name: 'updated-name' })
       expect(result.name).toBe('updated-name')
     })
 
     it('should persist update to database', async () => {
-      await dbh.db.insert(assistantTable).values({ id: 'ast-1', name: 'original' })
+      await seedAssistantRow({ id: 'ast-1', name: 'original' })
 
       await assistantDataService.update('ast-1', { name: 'updated-name' })
 
@@ -299,7 +331,7 @@ describe('AssistantDataService', () => {
     })
 
     it('should not pass relation fields to the column update', async () => {
-      await dbh.db.insert(assistantTable).values({ id: 'ast-1', name: 'original' })
+      await seedAssistantRow({ id: 'ast-1', name: 'original' })
       await seedMcpServer()
 
       const result = await assistantDataService.update('ast-1', {
@@ -315,7 +347,7 @@ describe('AssistantDataService', () => {
     })
 
     it('should handle relation-only updates without modifying assistant columns', async () => {
-      await dbh.db.insert(assistantTable).values({ id: 'ast-1', name: 'original', modelId: 'openai::gpt-4' })
+      await seedAssistantRow({ id: 'ast-1', name: 'original', modelId: 'openai::gpt-4' })
       await seedMcpServer()
       await seedKnowledgeBase()
 
@@ -333,7 +365,7 @@ describe('AssistantDataService', () => {
     })
 
     it('should replace existing junction rows on relation update', async () => {
-      await dbh.db.insert(assistantTable).values({ id: 'ast-1', name: 'test' })
+      await seedAssistantRow({ id: 'ast-1', name: 'test' })
       await seedMcpServer('srv-1', 'MCP1')
       await seedMcpServer('srv-2', 'MCP2')
       await dbh.db.insert(assistantMcpServerTable).values({ assistantId: 'ast-1', mcpServerId: 'srv-1' })
@@ -346,7 +378,7 @@ describe('AssistantDataService', () => {
     })
 
     it('should preserve junction createdAt for unchanged relations on PATCH', async () => {
-      await dbh.db.insert(assistantTable).values({ id: 'ast-1', name: 'test' })
+      await seedAssistantRow({ id: 'ast-1', name: 'test' })
       await seedMcpServer('srv-1', 'MCP1')
       await seedMcpServer('srv-2', 'MCP2')
       await dbh.db
@@ -368,7 +400,7 @@ describe('AssistantDataService', () => {
     })
 
     it('should throw validation error when name is set to empty', async () => {
-      await dbh.db.insert(assistantTable).values({ id: 'ast-1', name: 'original' })
+      await seedAssistantRow({ id: 'ast-1', name: 'original' })
 
       await expect(assistantDataService.update('ast-1', { name: '' })).rejects.toMatchObject({
         code: ErrorCode.VALIDATION_ERROR
@@ -378,7 +410,7 @@ describe('AssistantDataService', () => {
 
   describe('delete', () => {
     it('should soft-delete by setting deletedAt timestamp', async () => {
-      await dbh.db.insert(assistantTable).values({ id: 'ast-1', name: 'test' })
+      await seedAssistantRow({ id: 'ast-1', name: 'test' })
 
       await assistantDataService.delete('ast-1')
 
@@ -388,7 +420,7 @@ describe('AssistantDataService', () => {
     })
 
     it('should not physically remove the row', async () => {
-      await dbh.db.insert(assistantTable).values({ id: 'ast-1', name: 'test' })
+      await seedAssistantRow({ id: 'ast-1', name: 'test' })
 
       await assistantDataService.delete('ast-1')
 
@@ -397,7 +429,7 @@ describe('AssistantDataService', () => {
     })
 
     it('should remove entity_tag rows for the deleted assistant', async () => {
-      await dbh.db.insert(assistantTable).values({ id: 'ast-1', name: 'test' })
+      await seedAssistantRow({ id: 'ast-1', name: 'test' })
       await dbh.db.insert(tagTable).values({ id: 'tag-1', name: 'work' })
       await dbh.db.insert(entityTagTable).values({ entityType: 'assistant', entityId: 'ast-1', tagId: 'tag-1' })
 
@@ -414,7 +446,7 @@ describe('AssistantDataService', () => {
     })
 
     it('should throw NOT_FOUND when deleting already-deleted assistant', async () => {
-      await dbh.db.insert(assistantTable).values({ id: 'ast-1', name: 'test', deletedAt: Date.now() })
+      await seedAssistantRow({ id: 'ast-1', name: 'test', deletedAt: Date.now() })
 
       await expect(assistantDataService.delete('ast-1')).rejects.toMatchObject({
         code: ErrorCode.NOT_FOUND
@@ -424,7 +456,7 @@ describe('AssistantDataService', () => {
 
   describe('db constraints', () => {
     it('should cascade-delete junction rows when assistant is physically deleted', async () => {
-      await dbh.db.insert(assistantTable).values({ id: 'ast-1', name: 'test' })
+      await seedAssistantRow({ id: 'ast-1', name: 'test' })
       await seedMcpServer()
       await dbh.db.insert(assistantMcpServerTable).values({ assistantId: 'ast-1', mcpServerId: 'srv-1' })
 
@@ -435,7 +467,7 @@ describe('AssistantDataService', () => {
     })
 
     it('should cascade-delete junction rows when mcp_server is deleted', async () => {
-      await dbh.db.insert(assistantTable).values({ id: 'ast-1', name: 'test' })
+      await seedAssistantRow({ id: 'ast-1', name: 'test' })
       await seedMcpServer()
       await dbh.db.insert(assistantMcpServerTable).values({ assistantId: 'ast-1', mcpServerId: 'srv-1' })
 
@@ -446,7 +478,7 @@ describe('AssistantDataService', () => {
     })
 
     it('should reject duplicate junction rows', async () => {
-      await dbh.db.insert(assistantTable).values({ id: 'ast-1', name: 'test' })
+      await seedAssistantRow({ id: 'ast-1', name: 'test' })
       await seedMcpServer()
       await dbh.db.insert(assistantMcpServerTable).values({ assistantId: 'ast-1', mcpServerId: 'srv-1' })
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR:

Assistant create/update DTOs inherited defaults from the assistant entity schema. As a result, partial PATCH requests could materialize omitted fields such as `prompt`, `emoji`, or `description` before reaching the service layer.

After this PR:

Assistant defaults are applied only at the create DTO boundary. The update DTO now derives directly from the assistant entity field pick, preserving omission semantics for partial updates and matching the agent DataApi pattern.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This keeps the fix at the shared DataApi schema boundary instead of adding renderer-side filtering or service-side cleanup. It also separates create input typing from parsed service DTO typing because Zod defaults make the input and output shapes different.

The following alternatives were considered:

- Filtering defaulted fields in the assistant handler or service was rejected because it would only mask the schema contract problem downstream.
- Keeping defaults on the entity schema was rejected because update schemas derived from create/entity shapes can accidentally mutate omitted fields.

Links to places where the discussion took place: N/A

### Breaking changes

N/A

### Special notes for your reviewer

- This follows the existing agent pattern where create-time defaults live on the create DTO and update schemas are derived from entity fields directly.
- `AssistantService.rowToAssistant` continues to normalize nullable DB rows into complete API entities, including `DEFAULT_ASSISTANT_SETTINGS` for null settings.
- Added handler regression tests for create defaults, relation-only PATCH bodies, empty PATCH bodies, and partial settings rejection.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix assistant partial updates so omitted fields no longer reset prompt, emoji, description, or settings defaults.
```
