### PR TITLE
fix(CodeBlock): do not recognize Unix-style paths as clickable links on Windows

### DIFF
--- a/src/renderer/src/pages/home/Markdown/CodeBlock.tsx
+++ b/src/renderer/src/pages/home/Markdown/CodeBlock.tsx
@@ -1,4 +1,5 @@
 import { CodeBlockView, HtmlArtifactsCard } from '@renderer/components/CodeBlockView'
+import { isWin } from '@renderer/config/constant'
 import { useSettings } from '@renderer/hooks/useSettings'
 import { ClickableFilePath } from '@renderer/pages/home/Messages/Tools/MessageAgentTools/ClickableFilePath'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
@@ -67,7 +68,8 @@ const CodeBlock: React.FC<Props> = ({ children, className, node, blockId }) => {
   }
 
   // Detect inline code that looks like an absolute file path (e.g. /Users/foo/bar.tsx)
-  if (typeof children === 'string' && /^\/[\w.-]+(?:\/[\w.-]+)+$/.test(children)) {
+  // On Windows, Unix-style paths are not valid local paths, so skip detection there.
+  if (!isWin && typeof children === 'string' && /^\/[\w.-]+(?:\/[\w.-]+)+$/.test(children)) {
     return (
       <code className={className} style={{ textWrap: 'wrap', fontSize: '95%', padding: '2px 4px' }}>
         <ClickableFilePath path={children} />

--- a/src/renderer/src/pages/home/Markdown/__tests__/CodeBlock.test.tsx
+++ b/src/renderer/src/pages/home/Markdown/__tests__/CodeBlock.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   isOpenFenceBlock: vi.fn(),
   selectById: vi.fn(),
   useSettings: vi.fn().mockReturnValue({ codeFancyBlock: true }),
+  isWin: false,
   CodeBlockView: vi.fn(({ onSave, children }) => (
     <div>
       <code>{children}</code>
@@ -63,6 +64,12 @@ vi.mock('@renderer/components/CodeBlockView', () => ({
   HtmlArtifactsCard: mocks.HtmlArtifactsCard
 }))
 
+vi.mock('@renderer/config/constant', () => ({
+  get isWin() {
+    return mocks.isWin
+  }
+}))
+
 // Mock ClickableFilePath
 vi.mock('@renderer/pages/home/Messages/Tools/MessageAgentTools/ClickableFilePath', () => ({
   ClickableFilePath: ({ path }: { path: string }) => <span data-testid="clickable-file-path">{path}</span>
@@ -84,6 +91,7 @@ describe('CodeBlock', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.isWin = false
     // Default mock return values
     mocks.getCodeBlockId.mockReturnValue('test-code-block-id')
     mocks.isOpenFenceBlock.mockReturnValue(false)
@@ -136,6 +144,15 @@ describe('CodeBlock', () => {
       'should NOT detect %s as a file path',
       (text) => {
         render(<CodeBlock {...defaultProps} className={undefined} children={text} />)
+        expect(screen.queryByTestId('clickable-file-path')).not.toBeInTheDocument()
+      }
+    )
+
+    it.each(['/home/user/project/src/index.ts', '/tmp/test.log', '/var/log/app.log', '/etc/nginx/nginx.conf'])(
+      'should NOT detect %s as a file path on Windows',
+      (path) => {
+        mocks.isWin = true
+        render(<CodeBlock {...defaultProps} className={undefined} children={path} />)
         expect(screen.queryByTestId('clickable-file-path')).not.toBeInTheDocument()
       }
     )


### PR DESCRIPTION
### What this PR does

Before this PR:
On Windows, inline code strings starting with `/` (e.g., `/home/runner/work`) were incorrectly rendered as blue clickable file-path links, even though they are not valid Windows paths.

After this PR:
On Windows, Unix-style absolute paths in inline code are no longer auto-detected as local file paths and are rendered as plain inline code instead. Existing behavior on macOS and Linux remains unchanged.

Fixes #14706

### Why we need it and why it was done in this way

The regex `^\/[\w.-]+(?:\/[\w.-]+)+$` in `CodeBlock.tsx` matched Unix-style paths unconditionally, without considering the host platform. Clicking these links on Windows would invoke `window.api.file.openPath(path)`, which fails for Unix-style paths.

The simplest and safest fix is to skip the Unix-style path detection entirely when `isWin` is true. This avoids both the visual bug and the non-functional click handler on Windows.

The following tradeoffs were made:
- We intentionally did **not** add Windows-style path detection (`C:\...`) in the same change, to keep the hotfix minimal and focused solely on the reported bug.

The following alternatives were considered:
- Updating `ClickableFilePath` to validate paths before opening them. Rejected because it would still leave misleading blue links in the UI.
- Changing the regex to exclude paths starting with `/` globally. Rejected because it would break the legitimate feature for macOS/Linux users.

Links to places where the discussion took place: <!-- N/A -->

### Breaking changes

None.

### Special notes for your reviewer

None.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed an issue on Windows where Unix-style paths (e.g., `/home/runner/work`) in inline code were incorrectly rendered as clickable file links.
```