### PR TITLE
feat(provider): support Responses API endpoint for Volcengine provider

### DIFF
--- a/src/renderer/src/aiCore/prepareParams/parameterBuilder.ts
+++ b/src/renderer/src/aiCore/prepareParams/parameterBuilder.ts
@@ -36,7 +36,7 @@ import { DEFAULT_TIMEOUT } from '@shared/config/constant'
 import type { ModelMessage } from 'ai'
 import { stepCountIs } from 'ai'
 
-import { getAiSdkProviderId } from '../provider/factory'
+import { getAiSdkProviderIdForModel } from '../provider/factory'
 import type { ProviderCapabilities } from '../types'
 import { setupToolsConfig } from '../utils/mcp'
 import { buildProviderOptions } from '../utils/options'
@@ -126,7 +126,7 @@ export async function buildStreamTextParams(
   const finalSignal = AbortSignal.any(signals)
 
   const model = assistant.model || getDefaultModel()
-  const aiSdkProviderId = getAiSdkProviderId(provider)
+  const aiSdkProviderId = getAiSdkProviderIdForModel(provider, model)
 
   // 这三个变量透传出来，交给下面启用插件/中间件
   // 也可以在外部构建好再传入buildStreamTextParams

--- a/src/renderer/src/aiCore/provider/__tests__/providerConfig.test.ts
+++ b/src/renderer/src/aiCore/provider/__tests__/providerConfig.test.ts
@@ -623,6 +623,149 @@ describe('providerToAiSdkConfig', () => {
     })
   })
 
+  describe('Volcengine Responses builder', () => {
+    it('uses OpenAI Responses with a request body sanitizer for Doubao response endpoint models', async () => {
+      const provider = makeProvider({
+        id: 'doubao',
+        type: 'openai',
+        apiHost: 'https://ark.cn-beijing.volces.com/api/v3',
+        apiKey: 'volcengine-key'
+      })
+
+      const config = await providerToAiSdkConfig(
+        provider,
+        makeModel('doubao-seed-2-0-pro-260215', provider.id, { endpoint_type: 'openai-response' })
+      )
+
+      expect(config.providerId).toBe('openai')
+      const settings = config.providerSettings as any
+      expect(typeof settings.fetch).toBe('function')
+
+      const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      await settings.fetch('https://ark.cn-beijing.volces.com/api/v3/responses', {
+        method: 'POST',
+        body: JSON.stringify({
+          model: 'doubao-seed-2-0-pro-260215',
+          input: [
+            { role: 'user', content: [{ type: 'input_text', text: 'hi' }] },
+            { role: 'assistant', content: [{ type: 'output_text', text: 'hello' }] },
+            { role: 'assistant', status: 'in_progress', content: [{ type: 'output_text', text: 'thinking' }] }
+          ],
+          include: ['web_search_call.action.sources', 'reasoning.encrypted_content'],
+          previous_response_id: 'resp_123',
+          store: false,
+          service_tier: 'auto',
+          tools: [
+            {
+              type: 'web_search',
+              search_context_size: 'medium',
+              user_location: { type: 'approximate', city: 'Beijing' }
+            },
+            {
+              type: 'function',
+              name: 'get_weather',
+              parameters: { type: 'object', properties: {} }
+            }
+          ]
+        })
+      })
+
+      const sanitizedBody = JSON.parse(fetchMock.mock.calls[0][1].body)
+      expect(sanitizedBody.include).toBeUndefined()
+      expect(sanitizedBody.previous_response_id).toBe('resp_123')
+      expect(sanitizedBody.store).toBe(false)
+      expect(sanitizedBody.service_tier).toBeUndefined()
+      expect(sanitizedBody.tools[0]).toEqual({ type: 'web_search' })
+      expect(sanitizedBody.tools[1]).toMatchObject({ type: 'function', name: 'get_weather' })
+      expect(sanitizedBody.input[0].type).toBe('message')
+      expect(sanitizedBody.input[0].status).toBeUndefined()
+      expect(sanitizedBody.input[1].type).toBe('message')
+      expect(sanitizedBody.input[1].status).toBe('completed')
+      expect(sanitizedBody.input[2].type).toBe('message')
+      expect(sanitizedBody.input[2].status).toBe('in_progress')
+    })
+
+    it('normalizes Volcengine Responses SSE url citations for AI SDK parsing', async () => {
+      const provider = makeProvider({
+        id: 'doubao',
+        type: 'openai',
+        apiHost: 'https://ark.cn-beijing.volces.com/api/v3',
+        apiKey: 'volcengine-key'
+      })
+
+      const config = await providerToAiSdkConfig(
+        provider,
+        makeModel('doubao-seed-2-0-pro-260215', provider.id, { endpoint_type: 'openai-response' })
+      )
+
+      const settings = config.providerSettings as any
+      const sse = [
+        'event: response.output_text.annotation.added',
+        'data: {"type":"response.output_text.annotation.added","annotation":{"type":"url_citation","title":"News","url":"https://example.com/news","logo_url":"https://example.com/logo.png"}}',
+        '',
+        'event: response.output_text.delta',
+        'data: {"type":"response.output_text.delta","delta":"hello"}',
+        '',
+        'event: response.content_part.done',
+        'data: {"type":"response.content_part.done","part":{"type":"output_text","text":"hello","annotations":[{"type":"url_citation","title":"Nested","url":"https://example.com/nested","site_name":"Example"},{"type":"file_citation","file_id":"file_123","filename":"doc.txt","index":0}]}}',
+        '',
+        'data: [DONE]',
+        ''
+      ].join('\n')
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(
+          new Response(sse, {
+            headers: { 'content-type': 'text/event-stream; charset=utf-8' },
+            status: 200
+          })
+        )
+      )
+
+      const response = (await settings.fetch('https://ark.cn-beijing.volces.com/api/v3/responses', {
+        method: 'POST',
+        body: JSON.stringify({ model: 'doubao-seed-2-0-pro-260215', stream: true })
+      })) as Response
+      const normalizedSse = await response.text()
+      const payloads = normalizedSse
+        .split('\n')
+        .filter((line) => line.startsWith('data: '))
+        .map((line) => line.slice('data: '.length))
+
+      const annotationEvent = JSON.parse(payloads[0])
+      expect(annotationEvent.annotation).toMatchObject({
+        type: 'url_citation',
+        title: 'News',
+        url: 'https://example.com/news',
+        logo_url: 'https://example.com/logo.png',
+        start_index: 0,
+        end_index: 0
+      })
+
+      expect(JSON.parse(payloads[1])).toEqual({ type: 'response.output_text.delta', delta: 'hello' })
+
+      const contentPartDone = JSON.parse(payloads[2])
+      expect(contentPartDone.part.annotations[0]).toMatchObject({
+        type: 'url_citation',
+        title: 'Nested',
+        url: 'https://example.com/nested',
+        site_name: 'Example',
+        start_index: 0,
+        end_index: 0
+      })
+      expect(contentPartDone.part.annotations[1]).toEqual({
+        type: 'file_citation',
+        file_id: 'file_123',
+        filename: 'doc.txt',
+        index: 0
+      })
+      expect(payloads[3]).toBe('[DONE]')
+    })
+  })
+
   describe('Anthropic OAuth builder', () => {
     it('uses OAuth token with bearer auth', async () => {
       const provider = makeProvider({

--- a/src/renderer/src/aiCore/provider/factory.ts
+++ b/src/renderer/src/aiCore/provider/factory.ts
@@ -1,7 +1,11 @@
 import { extensionRegistry } from '@cherrystudio/ai-core/provider'
 import { loggerService } from '@logger'
-import { type Provider, SystemProviderIds } from '@renderer/types'
-import { isAzureOpenAIProvider, isAzureResponsesEndpoint } from '@renderer/utils/provider'
+import { type Model, type Provider, SystemProviderIds } from '@renderer/types'
+import {
+  isAzureOpenAIProvider,
+  isAzureResponsesEndpoint,
+  isVolcengineResponsesEndpointModel
+} from '@renderer/utils/provider'
 
 import { type AppProviderId, appProviderIds } from '../types'
 import { extensions } from './extensions'
@@ -51,4 +55,12 @@ export function getAiSdkProviderId(provider: Provider): AppProviderId {
     registeredIds: Object.keys(appProviderIds)
   })
   return provider.id
+}
+
+export function getAiSdkProviderIdForModel(provider: Provider, model: Model): AppProviderId {
+  if (isVolcengineResponsesEndpointModel(provider, model)) {
+    return appProviderIds.openai
+  }
+
+  return getAiSdkProviderId(provider)
 }

--- a/src/renderer/src/aiCore/provider/providerConfig.ts
+++ b/src/renderer/src/aiCore/provider/providerConfig.ts
@@ -27,7 +27,8 @@ import {
   isOllamaProvider,
   isPerplexityProvider,
   isSupportStreamOptionsProvider,
-  isVertexProvider
+  isVertexProvider,
+  isVolcengineResponsesEndpointModel
 } from '@renderer/utils/provider'
 import { defaultAppHeaders } from '@shared/utils'
 import { cloneDeep, isEmpty } from 'lodash'
@@ -123,6 +124,10 @@ export function providerToAiSdkConfig(
   const builders: ConfigBuilderEntry[] = [
     { match: (p) => p.id === SystemProviderIds.copilot, build: buildCopilotConfig },
     { match: (p) => p.id === 'cherryai', build: buildCherryAIConfig },
+    {
+      match: (p) => isVolcengineResponsesEndpointModel(p, model),
+      build: buildVolcengineResponsesConfig
+    },
     { match: (p) => p.id === 'anthropic' && p.authType === 'oauth', build: buildAnthropicConfig },
     { match: (p) => isOllamaProvider(p), build: buildOllamaConfig },
     { match: (p) => isAzureOpenAIProvider(p), build: buildAzureConfig },
@@ -172,6 +177,245 @@ function buildCommonOptions(ctx: BuilderContext) {
     options.headers['X-Api-Key'] = ctx.baseConfig.apiKey
   }
   return options
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+const VOLCENGINE_RESPONSES_UNSUPPORTED_FIELDS = [
+  'conversation',
+  'include',
+  'metadata',
+  'parallel_tool_calls',
+  'prompt_cache_key',
+  'prompt_cache_retention',
+  'safety_identifier',
+  'service_tier',
+  'top_logprobs',
+  'truncation'
+] as const
+
+type VolcengineResponsesSanitizeResult = {
+  body: unknown
+  changed: boolean
+}
+
+function sanitizeVolcengineResponsesTool(tool: unknown): VolcengineResponsesSanitizeResult {
+  if (!isRecord(tool) || tool.type !== 'web_search') {
+    return { body: tool, changed: false }
+  }
+
+  if (Object.keys(tool).length === 1) {
+    return { body: tool, changed: false }
+  }
+
+  return { body: { type: 'web_search' }, changed: true }
+}
+
+function sanitizeVolcengineResponsesInputItem(inputItem: unknown): VolcengineResponsesSanitizeResult {
+  if (!isRecord(inputItem) || !inputItem.role) {
+    return { body: inputItem, changed: false }
+  }
+
+  const needsType = inputItem.type == null
+  const needsStatus = inputItem.role === 'assistant' && !inputItem.status
+
+  if (!needsType && !needsStatus) {
+    return { body: inputItem, changed: false }
+  }
+
+  const sanitized: Record<string, any> = {
+    ...inputItem
+  }
+
+  if (needsType) {
+    sanitized.type = 'message'
+  }
+
+  if (needsStatus) {
+    sanitized.status = 'completed'
+  }
+
+  return { body: sanitized, changed: true }
+}
+
+function sanitizeVolcengineResponsesBody(body: unknown): VolcengineResponsesSanitizeResult {
+  if (!isRecord(body)) {
+    return { body, changed: false }
+  }
+
+  let sanitized: Record<string, any> | undefined
+
+  const getSanitized = () => {
+    sanitized ??= { ...body }
+    return sanitized
+  }
+
+  for (const field of VOLCENGINE_RESPONSES_UNSUPPORTED_FIELDS) {
+    if (Object.hasOwn(body, field)) {
+      delete getSanitized()[field]
+    }
+  }
+
+  if (Array.isArray(body.tools)) {
+    let toolsChanged = false
+    const tools = body.tools.map((tool) => {
+      const result = sanitizeVolcengineResponsesTool(tool)
+      toolsChanged ||= result.changed
+      return result.body
+    })
+
+    if (toolsChanged) {
+      getSanitized().tools = tools
+    }
+  }
+
+  if (Array.isArray(body.input)) {
+    let inputChanged = false
+    const input = body.input.map((inputItem) => {
+      const result = sanitizeVolcengineResponsesInputItem(inputItem)
+      inputChanged ||= result.changed
+      return result.body
+    })
+
+    if (inputChanged) {
+      getSanitized().input = input
+    }
+  }
+
+  return {
+    body: sanitized ?? body,
+    changed: sanitized !== undefined
+  }
+}
+
+function sanitizeVolcengineResponsesRequestInit(init?: RequestInit): RequestInit | undefined {
+  if (typeof init?.body !== 'string') {
+    return init
+  }
+
+  try {
+    const result = sanitizeVolcengineResponsesBody(JSON.parse(init.body))
+    if (!result.changed) {
+      return init
+    }
+
+    return {
+      ...init,
+      body: JSON.stringify(result.body)
+    }
+  } catch {
+    return init
+  }
+}
+
+function normalizeVolcengineResponsesCitationAnnotations(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(normalizeVolcengineResponsesCitationAnnotations)
+  }
+
+  if (!isRecord(value)) {
+    return value
+  }
+
+  const normalized = { ...value }
+
+  if (
+    normalized.type === 'url_citation' &&
+    typeof normalized.url === 'string' &&
+    typeof normalized.title === 'string'
+  ) {
+    if (typeof normalized.start_index !== 'number') {
+      normalized.start_index = 0
+    }
+    if (typeof normalized.end_index !== 'number') {
+      normalized.end_index = 0
+    }
+  }
+
+  for (const key of Object.keys(normalized)) {
+    normalized[key] = normalizeVolcengineResponsesCitationAnnotations(normalized[key])
+  }
+
+  return normalized
+}
+
+function normalizeVolcengineResponsesSseDataLine(line: string): string {
+  if (!line.startsWith('data:')) {
+    return line
+  }
+
+  const data = line.slice('data:'.length)
+  const leadingSpace = data.startsWith(' ') ? ' ' : ''
+  const payload = leadingSpace ? data.slice(1) : data
+
+  if (payload.trim() === '[DONE]' || payload.trim() === '') {
+    return line
+  }
+
+  try {
+    const normalized = normalizeVolcengineResponsesCitationAnnotations(JSON.parse(payload))
+    return `data:${leadingSpace}${JSON.stringify(normalized)}`
+  } catch {
+    return line
+  }
+}
+
+function normalizeVolcengineResponsesSseFrame(frame: string): string {
+  return frame.split(/\r?\n/).map(normalizeVolcengineResponsesSseDataLine).join('\n')
+}
+
+function normalizeVolcengineResponsesSseStream(stream: ReadableStream<Uint8Array>): ReadableStream<Uint8Array> {
+  const decoder = new TextDecoder()
+  const encoder = new TextEncoder()
+  let buffer = ''
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      const reader = stream.getReader()
+
+      const read = (): void => {
+        reader
+          .read()
+          .then(({ done, value }) => {
+            if (done) {
+              buffer += decoder.decode()
+              if (buffer) {
+                controller.enqueue(encoder.encode(normalizeVolcengineResponsesSseFrame(buffer)))
+              }
+              controller.close()
+              return
+            }
+
+            buffer += decoder.decode(value, { stream: true })
+            const frames = buffer.split(/\r?\n\r?\n/)
+            buffer = frames.pop() ?? ''
+
+            for (const frame of frames) {
+              controller.enqueue(encoder.encode(`${normalizeVolcengineResponsesSseFrame(frame)}\n\n`))
+            }
+
+            read()
+          })
+          .catch((error) => controller.error(error))
+      }
+
+      read()
+    }
+  })
+}
+
+function normalizeVolcengineResponsesResponse(response: Response): Response {
+  if (!response.body || !response.headers.get('content-type')?.includes('text/event-stream')) {
+    return response
+  }
+
+  return new Response(normalizeVolcengineResponsesSseStream(response.body), {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers
+  })
 }
 
 async function buildCopilotConfig(ctx: BuilderContext): Promise<ProviderConfig<'github-copilot-openai-compatible'>> {
@@ -283,6 +527,21 @@ async function buildCherryAIConfig(ctx: BuilderContext): Promise<ProviderConfig<
         })
         return fetch(input, { ...init, headers: { ...init?.headers, ...signature } })
       }
+    }
+  }
+}
+
+function buildVolcengineResponsesConfig(ctx: BuilderContext): ProviderConfig<'openai'> {
+  const commonOptions = buildCommonOptions(ctx)
+
+  return {
+    providerId: 'openai',
+    endpoint: ctx.endpoint,
+    providerSettings: {
+      ...ctx.baseConfig,
+      ...commonOptions,
+      fetch: async (input: RequestInfo | URL, init?: RequestInit) =>
+        normalizeVolcengineResponsesResponse(await fetch(input, sanitizeVolcengineResponsesRequestInit(init)))
     }
   }
 }

--- a/src/renderer/src/aiCore/utils/__tests__/websearch.test.ts
+++ b/src/renderer/src/aiCore/utils/__tests__/websearch.test.ts
@@ -19,6 +19,10 @@ vi.mock('@renderer/utils/blacklistMatchPattern', () => ({
   mapRegexToPatterns: vi.fn((patterns) => patterns || [])
 }))
 
+vi.mock('@renderer/services/ProviderService', () => ({
+  getProviderById: vi.fn((id) => ({ id }))
+}))
+
 describe('websearch utils', () => {
   describe('getWebSearchParams', () => {
     it('should return enhancement params for hunyuan provider', () => {
@@ -184,6 +188,21 @@ describe('websearch utils', () => {
           openai: {
             searchContextSize: 'medium'
           }
+        })
+      })
+
+      it('should omit OpenAI-only web search options for Doubao Responses models', () => {
+        const model: Model = {
+          id: 'doubao-seed-2-0-pro-260215',
+          name: 'Doubao Seed 2.0 Pro',
+          provider: 'doubao',
+          endpoint_type: 'openai-response'
+        } as Model
+
+        const result = buildProviderBuiltinWebSearchConfig('openai', defaultWebSearchConfig, model)
+
+        expect(result).toEqual({
+          openai: {}
         })
       })
     })

--- a/src/renderer/src/aiCore/utils/options.ts
+++ b/src/renderer/src/aiCore/utils/options.ts
@@ -43,7 +43,7 @@ import { merge } from 'lodash'
 import type { OllamaProviderOptions } from 'ollama-ai-provider-v2'
 
 import { addAnthropicHeaders } from '../prepareParams/header'
-import { getAiSdkProviderId } from '../provider/factory'
+import { getAiSdkProviderIdForModel } from '../provider/factory'
 import type { ProviderCapabilities } from '../types'
 import { buildGeminiGenerateImageParams } from './image'
 import {
@@ -160,7 +160,7 @@ export function buildProviderOptions(
   providerOptions: Record<string, Record<string, JSONValue>>
   standardParams: Partial<Record<AiSdkParam, any>>
 } {
-  const rawProviderId = getAiSdkProviderId(actualProvider)
+  const rawProviderId = getAiSdkProviderIdForModel(actualProvider, model)
   logger.debug('buildProviderOptions', { assistant, model, actualProvider, capabilities, rawProviderId })
   // 构建 provider 特定的选项
   let providerSpecificOptions: Record<string, any> = {}

--- a/src/renderer/src/aiCore/utils/websearch.ts
+++ b/src/renderer/src/aiCore/utils/websearch.ts
@@ -1,9 +1,11 @@
 import type { WebSearchPluginConfig } from '@cherrystudio/ai-core/core/plugins/built-in/webSearchPlugin'
 import type { AppProviderId } from '@renderer/aiCore/types'
 import { isOpenAIDeepResearchModel, isOpenAIWebSearchChatCompletionOnlyModel } from '@renderer/config/models'
+import { getProviderById } from '@renderer/services/ProviderService'
 import type { CherryWebSearchConfig } from '@renderer/store/websearch'
 import type { Model } from '@renderer/types'
 import { mapRegexToPatterns } from '@renderer/utils/blacklistMatchPattern'
+import { isVolcengineResponsesEndpointModel } from '@renderer/utils/provider'
 
 export function getWebSearchParams(model: Model): Record<string, any> {
   if (model.provider === 'hunyuan') {
@@ -56,6 +58,11 @@ export function buildProviderBuiltinWebSearchConfig(
   switch (providerId) {
     case 'azure-responses':
     case 'openai': {
+      const provider = model ? getProviderById(model.provider) : undefined
+      if (model && provider && isVolcengineResponsesEndpointModel(provider, model)) {
+        return { openai: {} }
+      }
+
       const searchContextSize = isOpenAIDeepResearchModel(model)
         ? 'medium'
         : mapMaxResultToOpenAIContextSize(webSearchConfig.maxResults)

--- a/src/renderer/src/config/endpointTypes.ts
+++ b/src/renderer/src/config/endpointTypes.ts
@@ -1,4 +1,6 @@
 import type { EndpointType } from '@renderer/types'
+import type { Provider } from '@renderer/types'
+import { isVolcengineProvider } from '@renderer/utils/provider'
 
 export const endpointTypeOptions: { label: string; value: EndpointType }[] = [
   { value: 'openai', label: 'endpoint_type.openai' },
@@ -8,3 +10,11 @@ export const endpointTypeOptions: { label: string; value: EndpointType }[] = [
   { value: 'image-generation', label: 'endpoint_type.image-generation' },
   { value: 'jina-rerank', label: 'endpoint_type.jina-rerank' }
 ]
+
+export function getEndpointTypeOptions(provider: Provider): { label: string; value: EndpointType }[] {
+  if (isVolcengineProvider(provider)) {
+    return endpointTypeOptions.filter((option) => option.value === 'openai' || option.value === 'openai-response')
+  }
+
+  return endpointTypeOptions
+}

--- a/src/renderer/src/config/models/__tests__/websearch.test.ts
+++ b/src/renderer/src/config/models/__tests__/websearch.test.ts
@@ -37,7 +37,10 @@ const providerMocks = vi.hoisted(() => ({
   isOpenAIProvider: vi.fn(),
   isVertexProvider: vi.fn(),
   isAwsBedrockProvider: vi.fn(),
-  isAzureOpenAIProvider: vi.fn()
+  isAzureOpenAIProvider: vi.fn(),
+  isVolcengineResponsesEndpointModel: vi.fn(
+    (provider, model) => provider?.id === 'doubao' && model?.endpoint_type === 'openai-response'
+  )
 }))
 
 vi.mock('@renderer/utils/provider', () => providerMocks)
@@ -185,6 +188,16 @@ describe('websearch helpers', () => {
 
       const nonSearch = createModel({ id: 'gpt-4o-image' })
       expect(isWebSearchModel(nonSearch)).toBe(false)
+    })
+
+    it('supports Doubao models on the Doubao Responses endpoint', () => {
+      providerMock.mockReturnValueOnce(createProvider({ id: SystemProviderIds.doubao }))
+      expect(
+        isWebSearchModel(createModel({ id: 'doubao-seed-2-0-pro-260215', endpoint_type: 'openai-response' }))
+      ).toBe(true)
+
+      providerMock.mockReturnValueOnce(createProvider({ id: SystemProviderIds.doubao }))
+      expect(isWebSearchModel(createModel({ id: 'custom-model', endpoint_type: 'openai-response' }))).toBe(false)
     })
 
     it('supports Perplexity sonar families including mandatory variants', () => {

--- a/src/renderer/src/config/models/websearch.ts
+++ b/src/renderer/src/config/models/websearch.ts
@@ -8,7 +8,8 @@ import {
   isNewApiProvider,
   isOpenAICompatibleProvider,
   isOpenAIProvider,
-  isVertexProvider
+  isVertexProvider,
+  isVolcengineResponsesEndpointModel
 } from '@renderer/utils/provider'
 
 export { GEMINI_FLASH_MODEL_REGEX } from './utils'
@@ -36,6 +37,10 @@ export const PERPLEXITY_SEARCH_MODELS = [
   'sonar-deep-research'
 ]
 
+export function isVolcengineResponsesWebSearchModel(modelId: string): boolean {
+  return modelId === 'doubao' || modelId.startsWith('doubao-')
+}
+
 export function isWebSearchModel(model: Model): boolean {
   if (!model || isEmbeddingModel(model) || isRerankModel(model) || isTextToImageModel(model)) {
     return false
@@ -59,6 +64,10 @@ export function isWebSearchModel(model: Model): boolean {
       return isClaude4SeriesModel(model)
     }
     return CLAUDE_SUPPORTED_WEBSEARCH_REGEX.test(modelId)
+  }
+
+  if (isVolcengineResponsesEndpointModel(provider, model)) {
+    return isVolcengineResponsesWebSearchModel(modelId)
   }
 
   // TODO: 当其他供应商采用Response端点时，这个地方逻辑需要改进

--- a/src/renderer/src/pages/settings/ProviderSettings/EditModelPopup/ModelEditContent.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/EditModelPopup/ModelEditContent.tsx
@@ -8,7 +8,7 @@ import {
   VisionTag,
   WebSearchTag
 } from '@renderer/components/Tags/Model'
-import { endpointTypeOptions } from '@renderer/config/endpointTypes'
+import { getEndpointTypeOptions } from '@renderer/config/endpointTypes'
 import {
   isEmbeddingModel,
   isFunctionCallingModel,
@@ -20,7 +20,7 @@ import {
 import { useDynamicLabelWidth } from '@renderer/hooks/useDynamicLabelWidth'
 import type { Model, ModelCapability, ModelType, Provider } from '@renderer/types'
 import { getDefaultGroupName, getDifference, getUnion, uniqueObjectArray } from '@renderer/utils'
-import { isNewApiProvider } from '@renderer/utils/provider'
+import { isEndpointTypeProvider } from '@renderer/utils/provider'
 import type { ModalProps } from 'antd'
 import { Divider, Form, Input, InputNumber, Modal, Select } from 'antd'
 import { cloneDeep } from 'lodash'
@@ -47,6 +47,7 @@ const ModelEditContent: FC<ModelEditContentProps & ModalProps> = ({ provider, mo
   const originalModelCapabilities = cloneDeep(model.capabilities || [])
   const [supportedTextDelta, setSupportedTextDelta] = useState(model.supported_text_delta)
   const [hasUserModified, setHasUserModified] = useState(false)
+  const endpointTypeOptions = getEndpointTypeOptions(provider)
 
   const labelWidth = useDynamicLabelWidth([t('settings.models.add.endpoint_type.label')])
 
@@ -68,7 +69,7 @@ const ModelEditContent: FC<ModelEditContentProps & ModalProps> = ({ provider, mo
       id: formValues.id || model.id,
       name: formValues.name || model.name,
       group: formValues.group || model.group,
-      endpoint_type: isNewApiProvider(provider) ? formValues.endpointType : model.endpoint_type,
+      endpoint_type: isEndpointTypeProvider(provider) ? formValues.endpointType : model.endpoint_type,
       capabilities: overrides?.capabilities ?? modelCapabilities,
       supported_text_delta: overrides?.supported_text_delta ?? supportedTextDelta,
       pricing: {
@@ -87,7 +88,7 @@ const ModelEditContent: FC<ModelEditContentProps & ModalProps> = ({ provider, mo
       id: values.id || model.id,
       name: values.name || model.name,
       group: values.group || model.group,
-      endpoint_type: isNewApiProvider(provider) ? values.endpointType : model.endpoint_type,
+      endpoint_type: isEndpointTypeProvider(provider) ? values.endpointType : model.endpoint_type,
       capabilities: modelCapabilities,
       supported_text_delta: supportedTextDelta,
       pricing: {
@@ -239,7 +240,7 @@ const ModelEditContent: FC<ModelEditContentProps & ModalProps> = ({ provider, mo
     <Modal title={t('models.edit')} footer={null} transitionName="animation-move-down" centered {...props}>
       <Form
         form={form}
-        labelCol={{ flex: isNewApiProvider(provider) ? labelWidth : '110px' }}
+        labelCol={{ flex: isEndpointTypeProvider(provider) ? labelWidth : '110px' }}
         labelAlign="left"
         colon={false}
         style={{ marginTop: 15 }}
@@ -247,7 +248,7 @@ const ModelEditContent: FC<ModelEditContentProps & ModalProps> = ({ provider, mo
           id: model.id,
           name: model.name,
           group: model.group,
-          endpointType: model.endpoint_type,
+          endpointType: model.endpoint_type ?? 'openai',
           input_per_million_tokens: model.pricing?.input_per_million_tokens ?? 0,
           output_per_million_tokens: model.pricing?.output_per_million_tokens ?? 0,
           currencySymbol: symbols.includes(model.pricing?.currencySymbol || '$')
@@ -301,7 +302,7 @@ const ModelEditContent: FC<ModelEditContentProps & ModalProps> = ({ provider, mo
           tooltip={t('settings.models.add.group_name.tooltip')}>
           <Input placeholder={t('settings.models.add.group_name.placeholder')} spellCheck={false} />
         </Form.Item>
-        {isNewApiProvider(provider) && (
+        {isEndpointTypeProvider(provider) && (
           <Form.Item
             name="endpointType"
             label={t('settings.models.add.endpoint_type.label')}

--- a/src/renderer/src/pages/settings/ProviderSettings/ModelList/ManageModelsList.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ModelList/ManageModelsList.tsx
@@ -7,7 +7,7 @@ import { getModelLogo } from '@renderer/config/models'
 import FileItem from '@renderer/pages/files/FileItem'
 import NewApiBatchAddModelPopup from '@renderer/pages/settings/ProviderSettings/ModelList/NewApiBatchAddModelPopup'
 import type { Model, Provider } from '@renderer/types'
-import { isNewApiProvider } from '@renderer/utils/provider'
+import { isEndpointTypeProvider } from '@renderer/utils/provider'
 import { ChevronRight, Minus, Plus } from 'lucide-react'
 import React, { memo, useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -98,7 +98,7 @@ const ManageModelsList: React.FC<ManageModelsListProps> = ({
           // 添加整组
           const wouldAddModels = models.filter((model) => !isModelInProvider(provider, model.id))
 
-          if (isNewApiProvider(provider)) {
+          if (isEndpointTypeProvider(provider)) {
             if (wouldAddModels.every(isValidNewApiModel)) {
               wouldAddModels.forEach(onAddModel)
             } else {

--- a/src/renderer/src/pages/settings/ProviderSettings/ModelList/ManageModelsPopup.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ModelList/ManageModelsPopup.tsx
@@ -19,7 +19,7 @@ import { fetchModels } from '@renderer/services/ApiService'
 import type { Model, Provider } from '@renderer/types'
 import { filterModelsByKeywords, getFancyProviderName } from '@renderer/utils'
 import { getDuplicateModelNames, isFreeModel } from '@renderer/utils/model'
-import { isNewApiProvider } from '@renderer/utils/provider'
+import { isEndpointTypeProvider } from '@renderer/utils/provider'
 import { Empty, Modal, Spin, Tabs } from 'antd'
 import Input from 'antd/es/input/Input'
 import { groupBy, isEmpty, uniqBy } from 'lodash'
@@ -134,8 +134,8 @@ const PopupContainer: React.FC<Props> = ({ providerId, resolve }) => {
       if (!isEmpty(model.name)) {
         const hasSupportedEndpointTypes = model.supported_endpoint_types?.length
 
-        // NewAPI provider without supported_endpoint_types needs manual configuration
-        if (isNewApiProvider(provider) && !hasSupportedEndpointTypes) {
+        // Endpoint-selectable providers without supported_endpoint_types need manual configuration
+        if (isEndpointTypeProvider(provider) && !hasSupportedEndpointTypes) {
           void NewApiAddModelPopup.show({ title: t('settings.models.add.add_model'), provider, model })
           return
         }
@@ -159,7 +159,7 @@ const PopupContainer: React.FC<Props> = ({ providerId, resolve }) => {
       content: t('settings.models.manage.add_listed.confirm'),
       centered: true,
       onOk: () => {
-        if (isNewApiProvider(provider)) {
+        if (isEndpointTypeProvider(provider)) {
           if (wouldAddModel.every(isValidNewApiModel)) {
             wouldAddModel.forEach(onAddModel)
           } else {

--- a/src/renderer/src/pages/settings/ProviderSettings/ModelList/ModelList.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ModelList/ModelList.tsx
@@ -14,7 +14,7 @@ import NewApiAddModelPopup from '@renderer/pages/settings/ProviderSettings/Model
 import type { Model } from '@renderer/types'
 import { filterModelsByKeywords } from '@renderer/utils'
 import { getDuplicateModelNames } from '@renderer/utils/model'
-import { isNewApiProvider } from '@renderer/utils/provider'
+import { isEndpointTypeProvider } from '@renderer/utils/provider'
 import { Spin } from 'antd'
 import { groupBy, isEmpty, sortBy, toPairs } from 'lodash'
 import { Plus, RefreshCw } from 'lucide-react'
@@ -98,7 +98,7 @@ const ModelList: React.FC<ModelListProps> = ({ providerId }) => {
   }, [provider.id])
 
   const onAddModel = useCallback(() => {
-    if (isNewApiProvider(provider)) {
+    if (isEndpointTypeProvider(provider)) {
       void NewApiAddModelPopup.show({ title: t('settings.models.add.add_model'), provider })
     } else {
       void AddModelPopup.show({ title: t('settings.models.add.add_model'), provider })

--- a/src/renderer/src/pages/settings/ProviderSettings/ModelList/NewApiAddModelPopup.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ModelList/NewApiAddModelPopup.tsx
@@ -1,13 +1,13 @@
 import { Flex } from '@cherrystudio/ui'
 import { Button } from '@cherrystudio/ui'
 import { TopView } from '@renderer/components/TopView'
-import { endpointTypeOptions } from '@renderer/config/endpointTypes'
+import { getEndpointTypeOptions } from '@renderer/config/endpointTypes'
 import { isNotSupportTextDeltaModel } from '@renderer/config/models'
 import { useDynamicLabelWidth } from '@renderer/hooks/useDynamicLabelWidth'
 import { useProvider } from '@renderer/hooks/useProvider'
 import type { EndpointType, Model, Provider } from '@renderer/types'
 import { getDefaultGroupName } from '@renderer/utils'
-import { isNewApiProvider } from '@renderer/utils/provider'
+import { isEndpointTypeProvider } from '@renderer/utils/provider'
 import type { FormProps } from 'antd'
 import { Form, Input, Modal, Select } from 'antd'
 import { find } from 'lodash'
@@ -38,6 +38,7 @@ const PopupContainer: React.FC<Props> = ({ title, provider, resolve, model, endp
   const [form] = Form.useForm()
   const { addModel, models } = useProvider(provider.id)
   const { t } = useTranslation()
+  const endpointTypeOptions = getEndpointTypeOptions(provider)
 
   const onOk = () => {
     setOpen(false)
@@ -64,7 +65,7 @@ const PopupContainer: React.FC<Props> = ({ title, provider, resolve, model, endp
       provider: provider.id,
       name: values.name ? values.name : id.toUpperCase(),
       group: values.group ?? getDefaultGroupName(id),
-      endpoint_type: isNewApiProvider(provider) ? values.endpointType : undefined
+      endpoint_type: isEndpointTypeProvider(provider) ? values.endpointType : undefined
     }
 
     addModel({ ...model, supported_text_delta: !isNotSupportTextDeltaModel(model) })

--- a/src/renderer/src/pages/settings/ProviderSettings/ModelList/NewApiBatchAddModelPopup.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ModelList/NewApiBatchAddModelPopup.tsx
@@ -1,7 +1,7 @@
 import { Flex } from '@cherrystudio/ui'
 import { Button } from '@cherrystudio/ui'
 import { TopView } from '@renderer/components/TopView'
-import { endpointTypeOptions } from '@renderer/config/endpointTypes'
+import { getEndpointTypeOptions } from '@renderer/config/endpointTypes'
 import { isNotSupportTextDeltaModel } from '@renderer/config/models'
 import { useDynamicLabelWidth } from '@renderer/hooks/useDynamicLabelWidth'
 import { useProvider } from '@renderer/hooks/useProvider'
@@ -32,6 +32,7 @@ const PopupContainer: React.FC<Props> = ({ title, provider, resolve, batchModels
   const [form] = Form.useForm()
   const { addModel } = useProvider(provider.id)
   const { t } = useTranslation()
+  const endpointTypeOptions = getEndpointTypeOptions(provider)
 
   const onOk = () => {
     setOpen(false)

--- a/src/renderer/src/utils/__tests__/provider.test.ts
+++ b/src/renderer/src/utils/__tests__/provider.test.ts
@@ -1,4 +1,4 @@
-import { type AzureOpenAIProvider, type Provider, SystemProviderIds } from '@renderer/types'
+import { type AzureOpenAIProvider, type Model, type Provider, SystemProviderIds } from '@renderer/types'
 import { describe, expect, it, vi } from 'vitest'
 
 import {
@@ -9,6 +9,7 @@ import {
   isAnthropicSupportedProvider,
   isAzureOpenAIProvider,
   isCherryAIProvider,
+  isEndpointTypeProvider,
   isGeminiProvider,
   isGeminiWebSearchProvider,
   isNewApiProvider,
@@ -22,7 +23,9 @@ import {
   isSupportServiceTierProvider,
   isSupportStreamOptionsProvider,
   isSupportUrlContextProvider,
-  isSupportVerbosityProvider
+  isSupportVerbosityProvider,
+  isVolcengineProvider,
+  isVolcengineResponsesEndpointModel
 } from '../provider'
 
 vi.mock('@renderer/store/settings', () => ({
@@ -56,6 +59,14 @@ const createSystemProvider = (overrides: Partial<Provider> = {}): Provider =>
     isSystem: true,
     ...overrides
   })
+
+const createModel = (overrides: Partial<Model> = {}): Model =>
+  ({
+    id: 'gpt-4o',
+    name: 'gpt-4o',
+    provider: 'openai',
+    ...overrides
+  }) as Model
 
 describe('provider utils', () => {
   it('filters Claude supported providers', () => {
@@ -179,6 +190,32 @@ describe('provider utils', () => {
     expect(isNewApiProvider(createProvider({ id: SystemProviderIds.cherryin }))).toBe(true)
     expect(isNewApiProvider(createProvider({ type: 'new-api' }))).toBe(true)
     expect(isNewApiProvider(createProvider())).toBe(false)
+  })
+
+  it('detects endpoint type capable providers', () => {
+    expect(isEndpointTypeProvider(createProvider({ id: SystemProviderIds['new-api'] }))).toBe(true)
+    expect(isEndpointTypeProvider(createProvider({ id: SystemProviderIds.doubao }))).toBe(true)
+    expect(isEndpointTypeProvider(createProvider())).toBe(false)
+  })
+
+  it('detects Volcengine providers and Responses endpoint models', () => {
+    const doubaoProvider = createProvider({ id: SystemProviderIds.doubao })
+    const openaiProvider = createProvider({ id: SystemProviderIds.openai })
+
+    expect(isVolcengineProvider(doubaoProvider)).toBe(true)
+    expect(isVolcengineProvider(openaiProvider)).toBe(false)
+    expect(
+      isVolcengineResponsesEndpointModel(
+        doubaoProvider,
+        createModel({ provider: SystemProviderIds.doubao, endpoint_type: 'openai-response' })
+      )
+    ).toBe(true)
+    expect(
+      isVolcengineResponsesEndpointModel(doubaoProvider, createModel({ provider: SystemProviderIds.doubao }))
+    ).toBe(false)
+    expect(isVolcengineResponsesEndpointModel(openaiProvider, createModel({ endpoint_type: 'openai-response' }))).toBe(
+      false
+    )
   })
 
   it('detects specific provider ids', () => {

--- a/src/renderer/src/utils/provider.ts
+++ b/src/renderer/src/utils/provider.ts
@@ -1,4 +1,4 @@
-import type { AzureOpenAIProvider, ProviderType } from '@renderer/types'
+import type { AzureOpenAIProvider, Model, ProviderType } from '@renderer/types'
 import { isSystemProvider, type Provider, type SystemProviderId, SystemProviderIds } from '@renderer/types'
 import { isAzureOpenAIProvider } from '@shared/aiCore/provider/utils'
 import { CLAUDE_SUPPORTED_PROVIDERS } from '@shared/config/providers'
@@ -138,6 +138,18 @@ export const isGeminiWebSearchProvider = (provider: Provider) => {
 
 export const isNewApiProvider = (provider: Provider) => {
   return ['new-api', 'cherryin', 'aionly'].includes(provider.id) || provider.type === 'new-api'
+}
+
+export const isVolcengineProvider = (provider: Provider) => {
+  return provider.id === SystemProviderIds.doubao
+}
+
+export const isEndpointTypeProvider = (provider: Provider) => {
+  return isNewApiProvider(provider) || isVolcengineProvider(provider)
+}
+
+export const isVolcengineResponsesEndpointModel = (provider: Provider, model: Model) => {
+  return isVolcengineProvider(provider) && model.endpoint_type === 'openai-response'
 }
 
 /**


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR:

Volcengine models only used the existing OpenAI-compatible chat endpoint path. Doubao models could not reliably use the Responses API endpoint because Volcengine rejects some OpenAI-specific request fields and web search options.

After this PR:

Volcengine models can select the `OpenAI-Response` endpoint type. For Doubao Responses requests, Cherry Studio now removes unsupported request fields, normalizes the built-in `web_search` tool payload, and adapts streamed web search citations so sources can be displayed in the existing citation UI.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

Volcengine's Responses API is only partially compatible with OpenAI Responses. This PR keeps the compatibility handling scoped to the Volcengine provider's `OpenAI-Response` endpoint path and leaves the existing chat endpoint behavior unchanged.

The following alternatives were considered:

N/A

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR should target the `v2` branch.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Add Responses API endpoint support for Volcengine models.
```