### PR TITLE
fix(image-generation): preserve aspect ratios for gpt-image-2

### DIFF
--- a/src/renderer/src/aiCore/AiProvider.ts
+++ b/src/renderer/src/aiCore/AiProvider.ts
@@ -16,6 +16,7 @@ import {
 } from '@renderer/types'
 import type { StreamTextParams } from '@renderer/types/aiCoreTypes'
 import { getLowerBaseModelName } from '@renderer/utils'
+import { normalizeImageDimension } from '@renderer/utils/imageGeneration'
 import { buildClaudeCodeSystemModelMessage } from '@shared/anthropic'
 import { gateway } from 'ai'
 
@@ -412,7 +413,7 @@ export default class AiProvider {
     // 转换参数格式
     const aiSdkParams = {
       prompt,
-      size: (imageSize || '1024x1024') as `${number}x${number}`,
+      ...normalizeImageDimension(imageSize),
       n: batchSize || 1,
       ...(signal && { abortSignal: signal })
     }
@@ -451,7 +452,7 @@ export default class AiProvider {
         images: inputImages, // 输入图像（必需）
         ...(mask && { mask }) // 可选的 mask（用于 inpainting）
       },
-      size: (imageSize || '1024x1024') as `${number}x${number}`,
+      ...normalizeImageDimension(imageSize),
       ...(signal && { abortSignal: signal })
     })
 

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -22,6 +22,7 @@ import { trackTokenUsage } from '@renderer/utils/analytics'
 import { isToolUseModeFunction } from '@renderer/utils/assistant'
 import { isPromptToolUse, isSupportedToolUse } from '@renderer/utils/assistant'
 import { getErrorMessage, isAbortError } from '@renderer/utils/error'
+import { extractAspectRatioFromPrompt } from '@renderer/utils/imageGeneration'
 import { purifyMarkdownImages } from '@renderer/utils/markdown'
 import { findFileBlocks, findImageBlocks, getMainTextContent } from '@renderer/utils/messageUtils/find'
 import { containsSupportedVariables, replacePromptVariables } from '@renderer/utils/prompt'
@@ -381,7 +382,7 @@ export async function fetchImageGeneration({
 
     // 调用 generateImage 或 editImage
     // 使用默认图像生成配置
-    const imageSize = '1024x1024'
+    const imageSize = extractAspectRatioFromPrompt(prompt) || '1024x1024'
     const batchSize = 1
 
     let images: string[]

--- a/src/renderer/src/utils/__tests__/imageGeneration.test.ts
+++ b/src/renderer/src/utils/__tests__/imageGeneration.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { extractAspectRatioFromPrompt, normalizeImageDimension } from '../imageGeneration'
+
+describe('imageGeneration helpers', () => {
+  it('extracts a supported aspect ratio from prompt text', () => {
+    expect(extractAspectRatioFromPrompt('Generate a 16:9 cosmic planet image')).toBe('16:9')
+  })
+
+  it('ignores ratios in non-image prompts', () => {
+    expect(extractAspectRatioFromPrompt('The ratio is 7:5 for the cost breakdown')).toBeUndefined()
+  })
+
+  it('normalizes ratio-like image sizes to aspectRatio', () => {
+    expect(normalizeImageDimension('16:9')).toEqual({ aspectRatio: '16:9' })
+  })
+
+  it('preserves any normalized ratio string', () => {
+    expect(normalizeImageDimension('21:9')).toEqual({ aspectRatio: '21:9' })
+  })
+
+  it('keeps pixel sizes as size values', () => {
+    expect(normalizeImageDimension('1024x1024')).toEqual({ size: '1024x1024' })
+  })
+})

--- a/src/renderer/src/utils/imageGeneration.ts
+++ b/src/renderer/src/utils/imageGeneration.ts
@@ -1,0 +1,39 @@
+const ASPECT_RATIO_PATTERN = /\b(\d{1,2})\s*[:x×/]\s*(\d{1,2})\b/i
+const IMAGE_CONTEXT_PATTERN =
+  /\b(image|images|photo|photos|picture|pictures|illustration|illustrations|render|renders|painting|paintings|art|wallpaper|wallpapers|poster|posters|scene|scenes|graphic|graphics|banner|banners|thumbnail|thumbnails)\b/i
+
+const normalizeAspectRatio = (value: string): string | undefined => {
+  const normalized = value.trim().replace(/[x×/]/g, ':')
+
+  if (!/^\d{1,2}:\d{1,2}$/.test(normalized)) {
+    return undefined
+  }
+
+  return normalized
+}
+
+export const extractAspectRatioFromPrompt = (prompt: string): string | undefined => {
+  if (!/\baspect\s*ratio\b/i.test(prompt) && !IMAGE_CONTEXT_PATTERN.test(prompt)) {
+    return undefined
+  }
+
+  const match = prompt.match(ASPECT_RATIO_PATTERN)
+
+  if (!match) {
+    return undefined
+  }
+
+  return normalizeAspectRatio(`${match[1]}:${match[2]}`)
+}
+
+export const normalizeImageDimension = (
+  imageSize?: string
+): { size: `${number}x${number}`; aspectRatio?: never } | { size?: never; aspectRatio: string } => {
+  const aspectRatio = imageSize ? normalizeAspectRatio(imageSize) : undefined
+
+  if (aspectRatio) {
+    return { aspectRatio }
+  }
+
+  return { size: (imageSize || '1024x1024') as `${number}x${number}` }
+}

--- a/src/renderer/src/utils/imageGeneration.ts
+++ b/src/renderer/src/utils/imageGeneration.ts
@@ -2,17 +2,17 @@ const ASPECT_RATIO_PATTERN = /\b(\d{1,2})\s*[:x×/]\s*(\d{1,2})\b/i
 const IMAGE_CONTEXT_PATTERN =
   /\b(image|images|photo|photos|picture|pictures|illustration|illustrations|render|renders|painting|paintings|art|wallpaper|wallpapers|poster|posters|scene|scenes|graphic|graphics|banner|banners|thumbnail|thumbnails)\b/i
 
-const normalizeAspectRatio = (value: string): string | undefined => {
+const normalizeAspectRatio = (value: string): `${number}:${number}` | undefined => {
   const normalized = value.trim().replace(/[x×/]/g, ':')
 
   if (!/^\d{1,2}:\d{1,2}$/.test(normalized)) {
     return undefined
   }
 
-  return normalized
+  return normalized as `${number}:${number}`
 }
 
-export const extractAspectRatioFromPrompt = (prompt: string): string | undefined => {
+export const extractAspectRatioFromPrompt = (prompt: string): `${number}:${number}` | undefined => {
   if (!/\baspect\s*ratio\b/i.test(prompt) && !IMAGE_CONTEXT_PATTERN.test(prompt)) {
     return undefined
   }
@@ -28,7 +28,7 @@ export const extractAspectRatioFromPrompt = (prompt: string): string | undefined
 
 export const normalizeImageDimension = (
   imageSize?: string
-): { size: `${number}x${number}`; aspectRatio?: never } | { size?: never; aspectRatio: string } => {
+): { size: `${number}x${number}`; aspectRatio?: never } | { size?: never; aspectRatio: `${number}:${number}` } => {
   const aspectRatio = imageSize ? normalizeAspectRatio(imageSize) : undefined
 
   if (aspectRatio) {


### PR DESCRIPTION
### What this PR does

Before this PR:
- Dedicated image generation paths always forced `1024x1024` in the request pipeline.
- `gpt-image-2` could not receive a non-square aspect ratio from the prompt flow.

After this PR:
- Image generation can preserve supported aspect ratios instead of collapsing to square output.
- The chat image path extracts explicit image ratios from image-oriented prompts and forwards them through the AI SDK image request.
- Added tests for ratio extraction and normalization.

Fixes #14727

### Why we need it and why it was done in this way

This fixes the user-visible bug where `gpt-image-2` only produced 1:1 images even when a 16:9 ratio was requested.

The following tradeoffs were made:
- Kept the change localized to the image-generation pipeline instead of adding a new UI control.
- Used a small shared helper to normalize image dimensions and avoid duplicating request-shaping logic.
- Restricted prompt-based ratio extraction to image-oriented prompts to reduce accidental matches in normal text.

The following alternatives were considered:
- Adding a dedicated aspect-ratio setting in the image UI.
- Leaving the request shape unchanged and relying on model defaults.

Links to places where the discussion took place: None

### Breaking changes

None

### Special notes for your reviewer

The current implementation is intentionally narrow: it preserves explicit image ratios without introducing a new UI surface.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix image generation so supported non-square ratios can reach `gpt-image-2` instead of being forced to 1:1.
```