### PR TITLE
feat(message-service): add getPathThrough for branch-aware path queries

### DIFF
--- a/packages/shared/data/api/schemas/messages.ts
+++ b/packages/shared/data/api/schemas/messages.ts
@@ -148,6 +148,15 @@ export const DeleteMessageQuerySchema = z.strictObject({
 })
 export type DeleteMessageQuery = z.infer<typeof DeleteMessageQuerySchema>
 
+/**
+ * Query parameters for GET /topics/:topicId/path
+ */
+export const PathThroughQuerySchema = z.strictObject({
+  /** Node the returned path must pass through. */
+  nodeId: z.string().min(1)
+})
+export type PathThroughQueryParams = z.infer<typeof PathThroughQuerySchema>
+
 // ============================================================================
 // API Schema Definitions
 // ============================================================================
@@ -191,6 +200,24 @@ export type MessageSchemas = {
       params: { topicId: string }
       body: CreateMessageDto
       response: Message
+    }
+  }
+
+  /**
+   * Read-only path query passing through a given node.
+   *
+   * Returns root → leaf where leaf is the most recently created live
+   * descendant of `nodeId` (or `nodeId` itself if it has no live children).
+   * Does not modify topic state — use PUT /topics/:id/active-node to
+   * persist a chosen path.
+   *
+   * @example GET /topics/abc123/path?nodeId=msg42
+   */
+  '/topics/:topicId/path': {
+    GET: {
+      params: { topicId: string }
+      query: PathThroughQueryParams
+      response: Message[]
     }
   }
 

--- a/src/main/data/api/handlers/messages.ts
+++ b/src/main/data/api/handlers/messages.ts
@@ -14,6 +14,7 @@ import {
   CreateMessageSchema,
   DeleteMessageQuerySchema,
   type MessageSchemas,
+  PathThroughQuerySchema,
   TreeQuerySchema,
   UpdateMessageSchema
 } from '@shared/data/api/schemas/messages'
@@ -44,6 +45,13 @@ export const messageHandlers: HandlersFor<MessageSchemas> = {
     POST: async ({ params, body }) => {
       const parsed = CreateMessageSchema.parse(body)
       return await messageService.create(params.topicId, parsed)
+    }
+  },
+
+  '/topics/:topicId/path': {
+    GET: async ({ params, query }) => {
+      const q = PathThroughQuerySchema.parse(query ?? {})
+      return await messageService.getPathThrough(params.topicId, q.nodeId)
     }
   },
 

--- a/src/main/data/services/MessageService.ts
+++ b/src/main/data/services/MessageService.ts
@@ -866,6 +866,50 @@ export class MessageService {
 
     return ordered.reverse().map(rowToMessage)
   }
+
+  /**
+   * Read-only path query for branch-aware UI.
+   *
+   * Returns the conversation path that passes through `nodeId` and
+   * descends into its subtree to the leaf with the greatest `created_at`
+   * (skipping deleted nodes). If `nodeId` has no live children, the leaf
+   * is `nodeId` itself.
+   *
+   * Pure read — does not touch `topic.activeNodeId`. Callers that want to
+   * persist a navigation result should follow up with `setActiveNode`.
+   */
+  async getPathThrough(topicId: string, nodeId: string): Promise<Message[]> {
+    const db = application.get('DbService').getDb()
+
+    const [node] = await db
+      .select()
+      .from(messageTable)
+      .where(and(eq(messageTable.id, nodeId), eq(messageTable.topicId, topicId), isNull(messageTable.deletedAt)))
+      .limit(1)
+    if (!node) {
+      throw DataApiErrorFactory.notFound('Message', nodeId)
+    }
+
+    const [leaf] = await db.all<{ id: string }>(sql`
+      WITH RECURSIVE subtree AS (
+        SELECT id, created_at FROM message
+          WHERE id = ${nodeId} AND topic_id = ${topicId} AND deleted_at IS NULL
+        UNION ALL
+        SELECT m.id, m.created_at FROM message m
+          INNER JOIN subtree s ON m.parent_id = s.id
+          WHERE m.deleted_at IS NULL
+      )
+      SELECT s.id FROM subtree s
+      WHERE NOT EXISTS (
+        SELECT 1 FROM message c
+        WHERE c.parent_id = s.id AND c.deleted_at IS NULL
+      )
+      ORDER BY s.created_at DESC
+      LIMIT 1
+    `)
+
+    return await this.getPathToNode(leaf?.id ?? nodeId)
+  }
 }
 
 export const messageService = new MessageService()

--- a/src/main/data/services/__tests__/MessageService.test.ts
+++ b/src/main/data/services/__tests__/MessageService.test.ts
@@ -3,6 +3,7 @@ import { topicTable } from '@data/db/schemas/topic'
 import { userModelTable } from '@data/db/schemas/userModel'
 import { userProviderTable } from '@data/db/schemas/userProvider'
 import { messageService } from '@data/services/MessageService'
+import { DataApiError } from '@shared/data/api'
 import { BlockType, type MessageData } from '@shared/data/types/message'
 import { createUniqueModelId } from '@shared/data/types/model'
 import { setupTestDatabase } from '@test-helpers/db'
@@ -176,6 +177,166 @@ describe('MessageService', () => {
       expect(path[1].siblingsGroupId).toBe(1)
       expect(path[1].modelId).toBe(createUniqueModelId('provider-b', 'model-B'))
       expect(path[2].parentId).toBe('m-a2')
+    })
+  })
+
+  describe('getPathThrough', () => {
+    /**
+     * Tree shared by these tests:
+     *
+     *   m-root (t=100)
+     *   ├── m-a1 (t=200)
+     *   │     └── m-q1 (t=300)
+     *   │           ├── m-b1 (t=400)               ← leaf, older
+     *   │           └── m-b2 (t=500)
+     *   │                 └── m-deep (t=600)        ← leaf, newest in tree
+     *   └── m-a2 (t=210)
+     *         ├── m-q2 (t=310)                      ← live leaf
+     *         └── m-del (t=350, deletedAt set)      ← skipped
+     */
+    async function seedPathTree() {
+      await dbh.db.insert(topicTable).values({ id: 'topic-1', activeNodeId: 'm-deep' })
+      await dbh.db.insert(topicTable).values({ id: 'topic-2', activeNodeId: null })
+
+      const rows: (typeof messageTable.$inferInsert)[] = [
+        {
+          id: 'm-root',
+          parentId: null,
+          topicId: 'topic-1',
+          role: 'user',
+          data: mainText('root'),
+          status: 'success',
+          siblingsGroupId: 0,
+          createdAt: 100,
+          updatedAt: 100
+        },
+        {
+          id: 'm-a1',
+          parentId: 'm-root',
+          topicId: 'topic-1',
+          role: 'assistant',
+          data: mainText('a1'),
+          status: 'success',
+          siblingsGroupId: 1,
+          createdAt: 200,
+          updatedAt: 200
+        },
+        {
+          id: 'm-a2',
+          parentId: 'm-root',
+          topicId: 'topic-1',
+          role: 'assistant',
+          data: mainText('a2'),
+          status: 'success',
+          siblingsGroupId: 1,
+          createdAt: 210,
+          updatedAt: 210
+        },
+        {
+          id: 'm-q1',
+          parentId: 'm-a1',
+          topicId: 'topic-1',
+          role: 'user',
+          data: mainText('q1'),
+          status: 'success',
+          siblingsGroupId: 0,
+          createdAt: 300,
+          updatedAt: 300
+        },
+        {
+          id: 'm-b1',
+          parentId: 'm-q1',
+          topicId: 'topic-1',
+          role: 'assistant',
+          data: mainText('b1'),
+          status: 'success',
+          siblingsGroupId: 2,
+          createdAt: 400,
+          updatedAt: 400
+        },
+        {
+          id: 'm-b2',
+          parentId: 'm-q1',
+          topicId: 'topic-1',
+          role: 'assistant',
+          data: mainText('b2'),
+          status: 'success',
+          siblingsGroupId: 2,
+          createdAt: 500,
+          updatedAt: 500
+        },
+        {
+          id: 'm-deep',
+          parentId: 'm-b2',
+          topicId: 'topic-1',
+          role: 'user',
+          data: mainText('deep'),
+          status: 'success',
+          siblingsGroupId: 0,
+          createdAt: 600,
+          updatedAt: 600
+        },
+        {
+          id: 'm-q2',
+          parentId: 'm-a2',
+          topicId: 'topic-1',
+          role: 'user',
+          data: mainText('q2'),
+          status: 'success',
+          siblingsGroupId: 0,
+          createdAt: 310,
+          updatedAt: 310
+        },
+        {
+          id: 'm-del',
+          parentId: 'm-a2',
+          topicId: 'topic-1',
+          role: 'user',
+          data: mainText('deleted'),
+          status: 'success',
+          siblingsGroupId: 0,
+          createdAt: 350,
+          updatedAt: 350,
+          deletedAt: 360
+        }
+      ]
+      await dbh.db.insert(messageTable).values(rows)
+    }
+
+    it('descends to the most recent leaf in the subtree', async () => {
+      await seedPathTree()
+      // a1's subtree leaves: m-b1 (t=400), m-deep (t=600). Should pick m-deep.
+      const path = await messageService.getPathThrough('topic-1', 'm-a1')
+      expect(path.map((m) => m.id)).toEqual(['m-root', 'm-a1', 'm-q1', 'm-b2', 'm-deep'])
+    })
+
+    it('skips deleted children when descending', async () => {
+      await seedPathTree()
+      // a2's subtree: m-q2 (live, t=310), m-del (deleted). Should land on m-q2.
+      const path = await messageService.getPathThrough('topic-1', 'm-a2')
+      expect(path.map((m) => m.id)).toEqual(['m-root', 'm-a2', 'm-q2'])
+    })
+
+    it('returns root → nodeId when nodeId is itself a leaf', async () => {
+      await seedPathTree()
+      const path = await messageService.getPathThrough('topic-1', 'm-deep')
+      expect(path.map((m) => m.id)).toEqual(['m-root', 'm-a1', 'm-q1', 'm-b2', 'm-deep'])
+    })
+
+    it('descends from root to the globally newest leaf', async () => {
+      await seedPathTree()
+      const path = await messageService.getPathThrough('topic-1', 'm-root')
+      expect(path[path.length - 1].id).toBe('m-deep')
+    })
+
+    it('throws NOT_FOUND for unknown nodeId', async () => {
+      await seedPathTree()
+      await expect(messageService.getPathThrough('topic-1', 'm-nope')).rejects.toThrow(DataApiError)
+    })
+
+    it('throws NOT_FOUND when nodeId belongs to a different topic', async () => {
+      await seedPathTree()
+      await expect(messageService.getPathThrough('topic-2', 'm-a1')).rejects.toThrow(DataApiError)
     })
   })
 })


### PR DESCRIPTION
### What this PR does

Before this PR:

Branch-aware navigation in the chat tree had no read-only way to compute "the path through this sibling". The previous workaround was a `descend` mode on `setActiveNode`, which both resolved the path AND persisted it to `topic.activeNodeId` — unsuitable for hover/preview UI.

After this PR:

`MessageService.getPathThrough(topicId, nodeId)` returns the conversation path passing through `nodeId`, descending into its subtree to the leaf with the greatest `created_at` (skipping deleted nodes). If `nodeId` has no live children, the leaf is `nodeId` itself. Pure read — does not touch `topic.activeNodeId`. Callers that want to persist the result follow up with `setActiveNode` on the returned leaf.

Exposed as `GET /topics/:topicId/path?nodeId=X` via DataApi.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Implemented as a recursive CTE rather than iterative TS traversal — keeps subtree walk + leaf selection in one round-trip, avoids N+1 fetches for deep trees.
- Returns NOT_FOUND (rather than empty path) when `nodeId` is unknown or belongs to a different topic — surfaces caller bugs early instead of silently returning `[]`.

The following alternatives were considered:

- Re-purposing `setActiveNode` with a non-persisting flag — rejected; mixing read and write semantics on the same method was the original confusion.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This commit was cherry-picked out of `DeJeune/ai-service` so the `getPathThrough` API can land on `v2` independently of the larger AI service work. The receiving callers (`SiblingNavigator` / `MessageGroup` wiring) remain on `DeJeune/ai-service` and will rebase once this lands.

The conflict during cherry-pick was a co-located `reserveAssistantTurn` test from a different commit on the source branch — dropped from this PR. Also adapted the test seed to `origin/v2`'s topic schema (no `orderKey` column on v2).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via `/gh-pr-review`, `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
