### PR TITLE
fix(agents-migrator): coalesce legacy NULLs to schema defaults

### DIFF
--- a/src/main/data/migration/v2/migrators/mappings/AgentsDbMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/AgentsDbMappings.ts
@@ -31,10 +31,14 @@ export type AgentsColumnExpr =
  * Helper for legacy columns that map 1:1 to a target column declared `NOT NULL`
  * with a SQL default. Legacy `agents.db` allowed NULL on these columns, but a
  * plain `SELECT col` writes NULL into the target — column defaults only fill
- * in *omitted* columns, not explicit NULLs — and trips the NOT NULL check.
+ * in *omitted* columns, not explicit NULLs — and the insert fails with
+ * `SQLITE_CONSTRAINT_NOTNULL`.
  *
- * `defaultExpr` must be a SQL literal matching the target's `.default(...)`
- * (e.g. `"'[]'"` for json arrays, `'0'`/`'1'` for booleans, `'2'` for ints).
+ * `defaultExpr` is a SQL literal that should mirror the legacy schema's own
+ * `DEFAULT` to preserve user intent (not necessarily the v2 schema default —
+ * see `agent_global_skill.is_enabled`, where legacy `DEFAULT true` and v2
+ * `default(false)` disagree). Use `"'[]'"` / `"'{}'"` / `"''"` for json/text,
+ * `'0'`/`'1'` for booleans.
  */
 function notNullCol(name: string, defaultExpr: string): AgentsColumnExpr {
   return {
@@ -162,7 +166,7 @@ export const AGENTS_TABLE_MIGRATION_SPECS: readonly AgentsTableMigrationSpec[] =
       'author',
       notNullCol('tags', "'[]'"),
       'content_hash',
-      notNullCol('is_enabled', '0'),
+      notNullCol('is_enabled', '1'),
       'created_at',
       'updated_at'
     ]
@@ -251,8 +255,12 @@ export const AGENTS_TABLE_MIGRATION_SPECS: readonly AgentsTableMigrationSpec[] =
   {
     sourceTable: 'channels',
     targetTable: 'agent_channel',
-    // Legacy `channels.created_at` / `updated_at` are INTEGER epoch-ms
-    // (see resources/database/drizzle/0004_busy_giant_girl.sql) — no strftime wrap.
+    // Legacy `channels.created_at` / `updated_at` are NULLABLE INTEGER epoch-ms
+    // (resources/database/drizzle/0004_busy_giant_girl.sql:21-22). v2
+    // `agent_channel` uses `createUpdateTimestamps` (`notNull().$defaultFn(...)`) —
+    // a JS-side default that raw INSERT...SELECT bypasses, so a legacy NULL
+    // would trip SQLITE_CONSTRAINT_NOTNULL. COALESCE to "now" mirrors the
+    // pattern used for task_run_logs above.
     columns: [
       'id',
       'type',
@@ -263,8 +271,18 @@ export const AGENTS_TABLE_MIGRATION_SPECS: readonly AgentsTableMigrationSpec[] =
       notNullCol('is_active', '1'),
       'active_chat_ids',
       'permission_mode',
-      'created_at',
-      'updated_at'
+      {
+        name: 'created_at',
+        expr: "COALESCE(created_at, CAST(strftime('%s', 'now') AS INTEGER) * 1000)",
+        sourceColumn: 'created_at',
+        fallbackExpr: "CAST(strftime('%s', 'now') AS INTEGER) * 1000"
+      },
+      {
+        name: 'updated_at',
+        expr: "COALESCE(updated_at, CAST(strftime('%s', 'now') AS INTEGER) * 1000)",
+        sourceColumn: 'updated_at',
+        fallbackExpr: "CAST(strftime('%s', 'now') AS INTEGER) * 1000"
+      }
     ],
     // Channels reference agent and agent_session via FK; skip any channel whose
     // agent was deleted or whose session was filtered out.

--- a/src/main/data/migration/v2/migrators/mappings/AgentsDbMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/AgentsDbMappings.ts
@@ -27,6 +27,24 @@ export type AgentsColumnExpr =
       fallbackExpr?: string
     }
 
+/**
+ * Helper for legacy columns that map 1:1 to a target column declared `NOT NULL`
+ * with a SQL default. Legacy `agents.db` allowed NULL on these columns, but a
+ * plain `SELECT col` writes NULL into the target — column defaults only fill
+ * in *omitted* columns, not explicit NULLs — and trips the NOT NULL check.
+ *
+ * `defaultExpr` must be a SQL literal matching the target's `.default(...)`
+ * (e.g. `"'[]'"` for json arrays, `'0'`/`'1'` for booleans, `'2'` for ints).
+ */
+function notNullCol(name: string, defaultExpr: string): AgentsColumnExpr {
+  return {
+    name,
+    expr: `COALESCE(${name}, ${defaultExpr})`,
+    sourceColumn: name,
+    fallbackExpr: defaultExpr
+  }
+}
+
 export type AgentsTableMigrationSpec = {
   sourceTable: AgentsSourceTableName
   targetTable:
@@ -65,16 +83,16 @@ export const AGENTS_TABLE_MIGRATION_SPECS: readonly AgentsTableMigrationSpec[] =
       'id',
       'type',
       'name',
-      'description',
-      'accessible_paths',
+      notNullCol('description', "''"),
+      notNullCol('accessible_paths', "'[]'"),
       'instructions',
       'model',
       'plan_model',
       'small_model',
-      'mcps',
-      'allowed_tools',
-      'configuration',
-      { name: 'sort_order', expr: 'sort_order', fallbackExpr: '0' },
+      notNullCol('mcps', "'[]'"),
+      notNullCol('allowed_tools', "'[]'"),
+      notNullCol('configuration', "'{}'"),
+      notNullCol('sort_order', '0'),
       {
         name: 'deleted_at',
         expr: "CASE WHEN deleted_at IS NULL THEN NULL ELSE CAST(strftime('%s', deleted_at) AS INTEGER) * 1000 END",
@@ -100,17 +118,17 @@ export const AGENTS_TABLE_MIGRATION_SPECS: readonly AgentsTableMigrationSpec[] =
       'agent_type',
       'agent_id',
       'name',
-      'description',
-      'accessible_paths',
+      notNullCol('description', "''"),
+      notNullCol('accessible_paths', "'[]'"),
       'instructions',
       'model',
       'plan_model',
       'small_model',
-      'mcps',
-      'allowed_tools',
-      { name: 'slash_commands', expr: 'slash_commands' },
-      'configuration',
-      { name: 'sort_order', expr: 'sort_order', fallbackExpr: '0' },
+      notNullCol('mcps', "'[]'"),
+      notNullCol('allowed_tools', "'[]'"),
+      notNullCol('slash_commands', "'[]'"),
+      notNullCol('configuration', "'{}'"),
+      notNullCol('sort_order', '0'),
       {
         name: 'created_at',
         expr: "CAST(strftime('%s', created_at) AS INTEGER) * 1000",
@@ -142,9 +160,9 @@ export const AGENTS_TABLE_MIGRATION_SPECS: readonly AgentsTableMigrationSpec[] =
       'source_url',
       'namespace',
       'author',
-      'tags',
+      notNullCol('tags', "'[]'"),
       'content_hash',
-      'is_enabled',
+      notNullCol('is_enabled', '0'),
       'created_at',
       'updated_at'
     ]
@@ -154,13 +172,7 @@ export const AGENTS_TABLE_MIGRATION_SPECS: readonly AgentsTableMigrationSpec[] =
     targetTable: 'agent_skill',
     // Legacy `agent_skills.created_at` / `updated_at` are already INTEGER epoch-ms
     // (see resources/database/drizzle/0006_famous_fallen_one.sql) — no wrapping.
-    columns: [
-      { name: 'agent_id', expr: 'agent_id' },
-      { name: 'skill_id', expr: 'skill_id' },
-      { name: 'is_enabled', expr: 'is_enabled' },
-      'created_at',
-      'updated_at'
-    ],
+    columns: ['agent_id', 'skill_id', notNullCol('is_enabled', '0'), 'created_at', 'updated_at'],
     // Only import agent_skill rows whose agent and skill were both successfully
     // migrated; orphaned rows would fail the FK checks.
     whereClause: 'agent_id IN (SELECT id FROM agent) AND skill_id IN (SELECT id FROM agent_global_skill)'
@@ -175,7 +187,7 @@ export const AGENTS_TABLE_MIGRATION_SPECS: readonly AgentsTableMigrationSpec[] =
       'prompt',
       'schedule_type',
       'schedule_value',
-      'timeout_minutes',
+      notNullCol('timeout_minutes', '2'),
       {
         name: 'next_run',
         expr: "CASE WHEN next_run IS NULL THEN NULL ELSE CAST(strftime('%s', next_run) AS INTEGER) * 1000 END",
@@ -248,7 +260,7 @@ export const AGENTS_TABLE_MIGRATION_SPECS: readonly AgentsTableMigrationSpec[] =
       'agent_id',
       'session_id',
       'config',
-      'is_active',
+      notNullCol('is_active', '1'),
       'active_chat_ids',
       'permission_mode',
       'created_at',

--- a/src/main/data/migration/v2/migrators/mappings/__tests__/AgentsDbMappings.test.ts
+++ b/src/main/data/migration/v2/migrators/mappings/__tests__/AgentsDbMappings.test.ts
@@ -36,7 +36,7 @@ describe('AgentsDbMappings', () => {
 
     expect(statements[0]).toBe("ATTACH DATABASE '/tmp/agent''s.db' AS agents_legacy")
     expect(statements).toContain(
-      "INSERT INTO agent (id, type, name, description, accessible_paths, instructions, model, plan_model, small_model, mcps, allowed_tools, configuration, sort_order, deleted_at, created_at, updated_at) SELECT id, type, name, description, accessible_paths, instructions, model, plan_model, small_model, mcps, allowed_tools, configuration, sort_order, CASE WHEN deleted_at IS NULL THEN NULL ELSE CAST(strftime('%s', deleted_at) AS INTEGER) * 1000 END AS deleted_at, CAST(strftime('%s', created_at) AS INTEGER) * 1000 AS created_at, CAST(strftime('%s', updated_at) AS INTEGER) * 1000 AS updated_at FROM agents_legacy.agents"
+      "INSERT INTO agent (id, type, name, description, accessible_paths, instructions, model, plan_model, small_model, mcps, allowed_tools, configuration, sort_order, deleted_at, created_at, updated_at) SELECT id, type, name, COALESCE(description, '') AS description, COALESCE(accessible_paths, '[]') AS accessible_paths, instructions, model, plan_model, small_model, COALESCE(mcps, '[]') AS mcps, COALESCE(allowed_tools, '[]') AS allowed_tools, COALESCE(configuration, '{}') AS configuration, COALESCE(sort_order, 0) AS sort_order, CASE WHEN deleted_at IS NULL THEN NULL ELSE CAST(strftime('%s', deleted_at) AS INTEGER) * 1000 END AS deleted_at, CAST(strftime('%s', created_at) AS INTEGER) * 1000 AS created_at, CAST(strftime('%s', updated_at) AS INTEGER) * 1000 AS updated_at FROM agents_legacy.agents"
     )
     expect(statements.at(-1)).toBe('DETACH DATABASE agents_legacy')
   })
@@ -66,7 +66,7 @@ describe('AgentsDbMappings', () => {
 
     // deleted_at absent from source → skipped in INSERT (resolveColumnSelection returns null)
     expect(statements).toContain(
-      "INSERT INTO agent (id, type, name, description, accessible_paths, instructions, model, plan_model, small_model, mcps, allowed_tools, configuration, sort_order, created_at, updated_at) SELECT id, type, name, description, accessible_paths, instructions, model, plan_model, small_model, mcps, allowed_tools, configuration, 0 AS sort_order, CAST(strftime('%s', created_at) AS INTEGER) * 1000 AS created_at, CAST(strftime('%s', updated_at) AS INTEGER) * 1000 AS updated_at FROM agents_legacy.agents"
+      "INSERT INTO agent (id, type, name, description, accessible_paths, instructions, model, plan_model, small_model, mcps, allowed_tools, configuration, sort_order, created_at, updated_at) SELECT id, type, name, COALESCE(description, '') AS description, COALESCE(accessible_paths, '[]') AS accessible_paths, instructions, model, plan_model, small_model, COALESCE(mcps, '[]') AS mcps, COALESCE(allowed_tools, '[]') AS allowed_tools, COALESCE(configuration, '{}') AS configuration, 0 AS sort_order, CAST(strftime('%s', created_at) AS INTEGER) * 1000 AS created_at, CAST(strftime('%s', updated_at) AS INTEGER) * 1000 AS updated_at FROM agents_legacy.agents"
     )
     expect(statements.some((statement) => statement.includes('agents_legacy.skills'))).toBe(false)
   })
@@ -263,5 +263,120 @@ describe('AgentsDbMappings', () => {
 
   it('quotes sqlite file paths safely', () => {
     expect(quoteSqlitePath("/tmp/a'b/c.db")).toBe("'/tmp/a''b/c.db'")
+  })
+
+  // Regression: legacy agents.db allowed NULL on columns that the new schema
+  // declares NOT NULL with a SQL default (e.g. agent.mcps DEFAULT '[]').
+  // INSERT...SELECT bypasses column defaults when the column is named in the
+  // INSERT list, so a SELECT of NULL trips SQLITE_CONSTRAINT_NOTNULL. The
+  // mapping must wrap such columns in COALESCE(<col>, <default>).
+  it('wraps NOT NULL target columns in COALESCE so legacy NULLs fall back to schema defaults', () => {
+    const schemaInfo = createEmptyAgentsSchemaInfo()
+    schemaInfo.agents.exists = true
+    schemaInfo.agents.columns = new Set([
+      'id',
+      'type',
+      'name',
+      'description',
+      'accessible_paths',
+      'instructions',
+      'model',
+      'mcps',
+      'allowed_tools',
+      'configuration',
+      'sort_order',
+      'created_at',
+      'updated_at'
+    ])
+    schemaInfo.sessions.exists = true
+    schemaInfo.sessions.columns = new Set([
+      'id',
+      'agent_type',
+      'agent_id',
+      'name',
+      'description',
+      'accessible_paths',
+      'instructions',
+      'model',
+      'mcps',
+      'allowed_tools',
+      'slash_commands',
+      'configuration',
+      'sort_order',
+      'created_at',
+      'updated_at'
+    ])
+    schemaInfo.skills.exists = true
+    schemaInfo.skills.columns = new Set([
+      'id',
+      'name',
+      'folder_name',
+      'source',
+      'tags',
+      'content_hash',
+      'is_enabled',
+      'created_at',
+      'updated_at'
+    ])
+    schemaInfo.agent_skills.exists = true
+    schemaInfo.agent_skills.columns = new Set(['agent_id', 'skill_id', 'is_enabled', 'created_at', 'updated_at'])
+    schemaInfo.scheduled_tasks.exists = true
+    schemaInfo.scheduled_tasks.columns = new Set([
+      'id',
+      'agent_id',
+      'name',
+      'prompt',
+      'schedule_type',
+      'schedule_value',
+      'timeout_minutes',
+      'status',
+      'created_at',
+      'updated_at'
+    ])
+    schemaInfo.channels.exists = true
+    schemaInfo.channels.columns = new Set([
+      'id',
+      'type',
+      'name',
+      'agent_id',
+      'session_id',
+      'config',
+      'is_active',
+      'created_at',
+      'updated_at'
+    ])
+
+    const statements = buildAgentsImportStatements('/tmp/agents.db', schemaInfo)
+    const find = (target: string) => statements.find((s) => s.startsWith(`INSERT INTO ${target} `)) ?? ''
+
+    const agentInsert = find('agent')
+    expect(agentInsert).toContain("COALESCE(description, '') AS description")
+    expect(agentInsert).toContain("COALESCE(accessible_paths, '[]') AS accessible_paths")
+    expect(agentInsert).toContain("COALESCE(mcps, '[]') AS mcps")
+    expect(agentInsert).toContain("COALESCE(allowed_tools, '[]') AS allowed_tools")
+    expect(agentInsert).toContain("COALESCE(configuration, '{}') AS configuration")
+    expect(agentInsert).toContain('COALESCE(sort_order, 0) AS sort_order')
+
+    const sessionInsert = find('agent_session')
+    expect(sessionInsert).toContain("COALESCE(description, '') AS description")
+    expect(sessionInsert).toContain("COALESCE(accessible_paths, '[]') AS accessible_paths")
+    expect(sessionInsert).toContain("COALESCE(mcps, '[]') AS mcps")
+    expect(sessionInsert).toContain("COALESCE(allowed_tools, '[]') AS allowed_tools")
+    expect(sessionInsert).toContain("COALESCE(slash_commands, '[]') AS slash_commands")
+    expect(sessionInsert).toContain("COALESCE(configuration, '{}') AS configuration")
+    expect(sessionInsert).toContain('COALESCE(sort_order, 0) AS sort_order')
+
+    const skillInsert = find('agent_global_skill')
+    expect(skillInsert).toContain("COALESCE(tags, '[]') AS tags")
+    expect(skillInsert).toContain('COALESCE(is_enabled, 0) AS is_enabled')
+
+    const agentSkillInsert = find('agent_skill')
+    expect(agentSkillInsert).toContain('COALESCE(is_enabled, 0) AS is_enabled')
+
+    const taskInsert = find('agent_task')
+    expect(taskInsert).toContain('COALESCE(timeout_minutes, 2) AS timeout_minutes')
+
+    const channelInsert = find('agent_channel')
+    expect(channelInsert).toContain('COALESCE(is_active, 1) AS is_active')
   })
 })

--- a/src/main/data/migration/v2/migrators/mappings/__tests__/AgentsDbMappings.test.ts
+++ b/src/main/data/migration/v2/migrators/mappings/__tests__/AgentsDbMappings.test.ts
@@ -368,7 +368,9 @@ describe('AgentsDbMappings', () => {
 
     const skillInsert = find('agent_global_skill')
     expect(skillInsert).toContain("COALESCE(tags, '[]') AS tags")
-    expect(skillInsert).toContain('COALESCE(is_enabled, 0) AS is_enabled')
+    // Legacy `skills.is_enabled DEFAULT true`: coalesce to 1, not 0, so a
+    // migrated skill that was implicitly enabled does not flip to disabled.
+    expect(skillInsert).toContain('COALESCE(is_enabled, 1) AS is_enabled')
 
     const agentSkillInsert = find('agent_skill')
     expect(agentSkillInsert).toContain('COALESCE(is_enabled, 0) AS is_enabled')
@@ -378,5 +380,74 @@ describe('AgentsDbMappings', () => {
 
     const channelInsert = find('agent_channel')
     expect(channelInsert).toContain('COALESCE(is_active, 1) AS is_active')
+    expect(channelInsert).toContain("COALESCE(created_at, CAST(strftime('%s', 'now') AS INTEGER) * 1000) AS created_at")
+    expect(channelInsert).toContain("COALESCE(updated_at, CAST(strftime('%s', 'now') AS INTEGER) * 1000) AS updated_at")
+  })
+
+  it('matches each notNullCol defaultExpr against the canonical legacy/v2 schema defaults', () => {
+    type ColumnDefault = { defaultExpr: string }
+    const EXPECTED_DEFAULTS: Record<string, Record<string, ColumnDefault>> = {
+      agent: {
+        description: { defaultExpr: "''" },
+        accessible_paths: { defaultExpr: "'[]'" },
+        mcps: { defaultExpr: "'[]'" },
+        allowed_tools: { defaultExpr: "'[]'" },
+        configuration: { defaultExpr: "'{}'" },
+        sort_order: { defaultExpr: '0' }
+      },
+      agent_session: {
+        description: { defaultExpr: "''" },
+        accessible_paths: { defaultExpr: "'[]'" },
+        mcps: { defaultExpr: "'[]'" },
+        allowed_tools: { defaultExpr: "'[]'" },
+        slash_commands: { defaultExpr: "'[]'" },
+        configuration: { defaultExpr: "'{}'" },
+        sort_order: { defaultExpr: '0' }
+      },
+      agent_global_skill: {
+        tags: { defaultExpr: "'[]'" },
+        // Legacy `DEFAULT true` (0005_normal_doomsday.sql:12) overrides v2's
+        // `default(false)`; preserves user intent on coalesce.
+        is_enabled: { defaultExpr: '1' }
+      },
+      agent_skill: {
+        is_enabled: { defaultExpr: '0' }
+      },
+      agent_task: {
+        timeout_minutes: { defaultExpr: '2' }
+      },
+      agent_channel: {
+        is_active: { defaultExpr: '1' }
+      }
+    }
+
+    const seen = new Set<string>()
+    const NOT_NULL_COL_SHAPE = /^COALESCE\((\w+),\s+('[^']*'|\d+)\)$/
+
+    for (const spec of AGENTS_TABLE_MIGRATION_SPECS) {
+      for (const column of spec.columns) {
+        if (typeof column === 'string') continue
+        const match = column.expr.match(NOT_NULL_COL_SHAPE)
+        if (!match) continue
+        const [, sourceName, defaultExpr] = match
+        if (sourceName !== column.name) continue // safety: source col must equal target name
+
+        const key = `${spec.targetTable}.${column.name}`
+        seen.add(key)
+
+        const expected = EXPECTED_DEFAULTS[spec.targetTable]?.[column.name]
+        expect(expected, `unexpected notNullCol entry: ${key}`).toBeDefined()
+        expect(defaultExpr, `defaultExpr drift on ${key}`).toBe(expected.defaultExpr)
+        expect(column.fallbackExpr, `fallbackExpr drift on ${key}`).toBe(expected.defaultExpr)
+      }
+    }
+
+    // Every entry in EXPECTED_DEFAULTS must be present in the spec — catches the
+    // reverse direction (someone deletes a notNullCol without updating expectations).
+    for (const [table, cols] of Object.entries(EXPECTED_DEFAULTS)) {
+      for (const col of Object.keys(cols)) {
+        expect(seen, `missing notNullCol(${col}) on ${table}`).toContain(`${table}.${col}`)
+      }
+    }
   })
 })


### PR DESCRIPTION
### What this PR does

Before this PR:

The legacy `agents.db` migrator (`AgentsMigrator`) crashed on real user
data with `SQLITE_CONSTRAINT_NOTNULL: agent.mcps`, aborting the whole
v2 migration. The legacy schema allowed `NULL` on columns that the v2
schema declares `NOT NULL` with a SQL default (e.g. `agent.mcps DEFAULT
'[]'`). Because the migrator builds `INSERT...SELECT` statements that
name those columns explicitly, SQLite writes the source `NULL`
straight through — column defaults only fill in *omitted* columns, not
explicit `NULL`s.

After this PR:

Each affected column is wrapped in `COALESCE(<col>, <default>)` via a
new `notNullCol(name, defaultExpr)` helper. Coverage extends beyond the
crashing column to every `NOT NULL`-with-default target column whose
source allows `NULL`:

- `agent`: `description`, `accessible_paths`, `mcps`, `allowed_tools`,
  `configuration`, `sort_order`
- `agent_session`: `description`, `accessible_paths`, `mcps`,
  `allowed_tools`, `slash_commands`, `configuration`, `sort_order`
- `agent_global_skill`: `tags`, `is_enabled`
- `agent_skill`: `is_enabled`
- `agent_task`: `timeout_minutes`
- `agent_channel`: `is_active`

`fallbackExpr` is set to the same default, so the missing-column path
also stays consistent with the schema.

Fixes #

### Why we need it and why it was done in this way

The original mapping mixed bare-string column names with sparse expression objects, and only a handful of columns had explicit defaults. Auditing the schemas surfaced eight more vulnerable columns. A single `notNullCol(name, defaultExpr)` helper keeps the spec readable and ensures the SQL `COALESCE` value matches the schema `.default(...)` exactly.

The following tradeoffs were made:

- Hard-coding the SQL default literal (`"'[]'"`, `'0'`, etc.) in the migrator rather than reading it from the Drizzle schema. Drizzle does not expose `.default(...)` values in a portable form for raw SQL emission, and the schema is small enough that drift is easily caught by a unit test.

The following alternatives were considered:

- Pre-`UPDATE` legacy rows to backfill `NULL`s before the `INSERT...SELECT`. Rejected: requires a writable attached database and doubles the IO cost.
- Switching to row-by-row `INSERT` from JS so column defaults apply on omission. Rejected: 9 tables × N rows would blow the migration budget for users with large legacy DBs.

Links to places where the discussion took place: N/A

### Breaking changes

None. The fix only changes *how* legacy `NULL`s are written into the v2 tables; it does not change any user-visible API or data semantics. Rows that previously aborted the migration now land with the schema-default value.

### Special notes for your reviewer

- The crash was reported with `agent.mcps`. The fix audits all sibling columns with the same shape rather than patching only the reported one.
- `notNullCol()` sets both `expr` (`COALESCE(...)`) and `fallbackExpr` (the literal default) so missing-column and `NULL`-value paths agree.
- The `MigrationContext` is unchanged; only the SQL string builder in `AgentsDbMappings.ts` is touched.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix v2 data migration crashing with `NOT NULL constraint failed: agent.mcps` (and similar) when the legacy agents database contained `NULL` values in columns that the v2 schema declares NOT NULL with a default.
```
