### PR TITLE
feat(trace): make call chain window adapt to text length and size

### DIFF
--- a/src/main/services/NodeTraceService.ts
+++ b/src/main/services/NodeTraceService.ts
@@ -163,8 +163,8 @@ export class NodeTraceService extends BaseService implements Activatable {
     }
 
     this.traceWin = new BrowserWindow({
-      width: 600,
-      minWidth: 500,
+      width: 900,
+      minWidth: 700,
       minHeight: 600,
       height: 800,
       autoHideMenuBar: true,

--- a/src/renderer/src/trace/pages/Trace.css
+++ b/src/renderer/src/trace/pages/Trace.css
@@ -153,7 +153,7 @@
 
 .scroll-container {
   overflow-y: auto;
-  overflow-x: hidden;
+  overflow-x: auto;
   height: calc(100vh - 40px);
 }
 
@@ -231,4 +231,12 @@
 .footer-link:hover {
   color: #062afb;
   text-decoration: underline;
+}
+
+.text-ellipsis {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+  max-width: 100%;
 }

--- a/src/renderer/src/trace/pages/Trace.css
+++ b/src/renderer/src/trace/pages/Trace.css
@@ -91,9 +91,8 @@
 }
 
 .floating {
-  position: fixed;
-  top: 40px;
-  left: 0px;
+  position: sticky;
+  top: 0;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
   transition: all 0.3s ease;
   opacity: 0.9;

--- a/src/renderer/src/trace/pages/Trace.css
+++ b/src/renderer/src/trace/pages/Trace.css
@@ -239,4 +239,5 @@
   text-overflow: ellipsis;
   display: block;
   max-width: 100%;
+  min-width: 0;
 }

--- a/src/renderer/src/trace/pages/TraceTree.tsx
+++ b/src/renderer/src/trace/pages/TraceTree.tsx
@@ -58,8 +58,8 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, handleClick, treeData, paddin
           e.preventDefault()
           handleClick(node.id)
         }}>
-        <GridItem colSpan={8} style={{ paddingLeft: `${paddingLeft}px`, textAlign: 'left' }}>
-          <HStack gap={2}>
+        <GridItem colSpan={8} style={{ paddingLeft: `${paddingLeft}px`, textAlign: 'left', minWidth: 0 }}>
+          <HStack gap={2} style={{ minWidth: 0, overflow: 'hidden' }}>
             <IconButton
               aria-label="Toggle"
               aria-expanded={isOpen ? true : false}

--- a/src/renderer/src/trace/pages/TraceTree.tsx
+++ b/src/renderer/src/trace/pages/TraceTree.tsx
@@ -75,7 +75,11 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, handleClick, treeData, paddin
                 visibility: hasChildren ? 'visible' : 'hidden'
               }}
             />
-            <Text role="button" tabIndex={0} className={node.status === 'ERROR' ? 'error-text' : 'default-text'}>
+            <Text
+              role="button"
+              tabIndex={0}
+              title={node.name}
+              className={`${node.status === 'ERROR' ? 'error-text' : 'default-text'} text-ellipsis`}>
               {node.name}
             </Text>
           </HStack>

--- a/src/renderer/src/trace/pages/__tests__/TraceTree.test.tsx
+++ b/src/renderer/src/trace/pages/__tests__/TraceTree.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import TraceTree from '../TraceTree'
@@ -69,5 +69,8 @@ describe('TraceTree', () => {
 
     const row = screen.getByText('clickable-node').closest('.traceItem')
     expect(row).toBeInTheDocument()
+    fireEvent.click(row!)
+    expect(handleClick).toHaveBeenCalledTimes(1)
+    expect(handleClick).toHaveBeenCalledWith('test-id')
   })
 })

--- a/src/renderer/src/trace/pages/__tests__/TraceTree.test.tsx
+++ b/src/renderer/src/trace/pages/__tests__/TraceTree.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import TraceTree from '../TraceTree'
+
+// mock antd Divider
+vi.mock('antd/lib', () => ({
+  Divider: ({ style }: any) => <hr style={style} />
+}))
+
+describe('TraceTree', () => {
+  const createNode = (name: string, overrides?: Partial<any>): any => ({
+    id: 'test-id',
+    name,
+    status: 'OK',
+    startTime: Date.now(),
+    endTime: Date.now() + 100,
+    percent: 10,
+    start: 0,
+    children: [],
+    ...overrides
+  })
+
+  it('should render node name with text-ellipsis class and title tooltip', () => {
+    const longName = 'This is a very long span name that should be truncated with ellipsis'
+    const node = createNode(longName)
+
+    render(<TraceTree node={node} handleClick={vi.fn()} />)
+
+    const nameElement = screen.getByText(longName)
+    expect(nameElement).toBeInTheDocument()
+    expect(nameElement).toHaveAttribute('title', longName)
+    expect(nameElement).toHaveClass('text-ellipsis')
+  })
+
+  it('should apply error-text class for ERROR status', () => {
+    const node = createNode('error-node', { status: 'ERROR' })
+
+    render(<TraceTree node={node} handleClick={vi.fn()} />)
+
+    const nameElement = screen.getByText('error-node')
+    expect(nameElement).toHaveClass('error-text')
+  })
+
+  it('should apply default-text class for OK status', () => {
+    const node = createNode('ok-node', { status: 'OK' })
+
+    render(<TraceTree node={node} handleClick={vi.fn()} />)
+
+    const nameElement = screen.getByText('ok-node')
+    expect(nameElement).toHaveClass('default-text')
+  })
+
+  it('should render children when expanded', () => {
+    const childNode = createNode('child-node', { id: 'child-id' })
+    const parentNode = createNode('parent-node', { children: [childNode] })
+
+    render(<TraceTree node={parentNode} handleClick={vi.fn()} />)
+
+    expect(screen.getByText('parent-node')).toBeInTheDocument()
+    expect(screen.getByText('child-node')).toBeInTheDocument()
+  })
+
+  it('should handle click on node', () => {
+    const handleClick = vi.fn()
+    const node = createNode('clickable-node')
+
+    render(<TraceTree node={node} handleClick={handleClick} />)
+
+    const row = screen.getByText('clickable-node').closest('.traceItem')
+    expect(row).toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/trace/pages/index.tsx
+++ b/src/renderer/src/trace/pages/index.tsx
@@ -163,7 +163,9 @@ export const TracePage: React.FC<TracePageProp> = ({ topicId, traceId, modelName
                   <>
                     <SimpleGrid columns={20} style={{ width: '100%' }} className="floating">
                       <GridItem colSpan={8} padding={0} className={'table-header'}>
-                        <Text tabIndex={0}>{t('trace.name')}</Text>
+                        <Text tabIndex={0} className="text-ellipsis">
+                          {t('trace.name')}
+                        </Text>
                       </GridItem>
                       <GridItem colSpan={5} padding={0} className={'table-header'}>
                         <Text>{t('trace.tokenUsage')}</Text>&nbsp;

--- a/src/renderer/src/trace/pages/index.tsx
+++ b/src/renderer/src/trace/pages/index.tsx
@@ -181,7 +181,7 @@ export const TracePage: React.FC<TracePageProp> = ({ topicId, traceId, modelName
                       orientation="end"
                       style={{
                         width: '100%',
-                        marginTop: '36px',
+                        marginTop: '0px',
                         marginBottom: '0px'
                       }}
                     />


### PR DESCRIPTION
### What this PR does

**Before this PR:**
- The Call Chain (trace) window opened at a fixed width of 600px, which was too narrow for the multi-column layout (name, tokens, time, progress bar).
- Long span names were truncated without any visual indication or way to see the full text.
- The scroll container had `overflow-x: hidden`, so any content wider than the window was simply clipped.

**After this PR:**
- The trace window now opens at 900px wide with a minimum width of 700px, providing more space for the trace tree.
- Long span names are truncated with an ellipsis (`...`) and show the full name on hover via a native `title` tooltip.
- Horizontal scrolling is enabled when content exceeds the window width.
- A shared `.text-ellipsis` CSS class is used for consistent truncation styling across the tree nodes and header row.

Fixes #14722

### Why we need it and why it was done in this way

**The following tradeoffs were made:**
- We increased the default window size rather than implementing dynamic auto-resizing based on content. Auto-resizing would require cross-process DOM measurement and is more complex and fragile. The fixed larger size plus horizontal scroll is simpler and robust.
- We used a shared CSS class for ellipsis styling rather than inline styles, making future style changes easier.

**The following alternatives were considered:**
- Refactoring the grid to use `minmax()` CSS grid columns for a fully fluid layout. This was rejected because it would require deeper changes to the custom `SimpleGrid`/`GridItem` components and risk misalignment between the header row and data rows.

### Breaking changes

None.

### Special notes for your reviewer

- The new unit tests (`TraceTree.test.tsx`) mock `antd/lib/Divider` since the trace module does not use `@cherrystudio/ui` components yet.
- The `overflow-x: auto` change on `.scroll-container` is safe because the `.text-ellipsis` rules constrain the text content itself; horizontal scrolling will only appear if non-ellipsis content overflows.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
The Call Chain (trace) window now opens at a larger default size (900x800) and adapts to long text by truncating span names with an ellipsis and showing the full name on hover. Horizontal scrolling is also enabled when content exceeds the window width.
```
