### PR TITLE
fix: parse DeepSeek DSML tool-call markup into AI SDK tool calls

### DIFF
--- a/src/renderer/src/aiCore/plugins/PluginBuilder.ts
+++ b/src/renderer/src/aiCore/plugins/PluginBuilder.ts
@@ -1,7 +1,12 @@
 import type { AiPlugin } from '@cherrystudio/ai-core'
 import { createPromptToolUsePlugin, providerToolPlugin } from '@cherrystudio/ai-core/built-in/plugins'
 import { loggerService } from '@logger'
-import { isGemini3Model, isQwen35to39Model, isSupportedThinkingTokenQwenModel } from '@renderer/config/models'
+import {
+  isDeepSeekModel,
+  isGemini3Model,
+  isQwen35to39Model,
+  isSupportedThinkingTokenQwenModel
+} from '@renderer/config/models'
 import { getEnableDeveloperMode } from '@renderer/hooks/useSettings'
 import type { Assistant, Model, Provider } from '@renderer/types'
 import { SystemProviderIds } from '@renderer/types'
@@ -10,6 +15,7 @@ import { isOllamaProvider, isSupportEnableThinkingProvider } from '@renderer/uti
 import type { AiSdkMiddlewareConfig } from '../types/middlewareConfig'
 import { getReasoningTagName } from '../utils/reasoning'
 import { createAnthropicCachePlugin } from './anthropicCachePlugin'
+import { createDeepseekDsmlParserPlugin } from './deepseekDsmlParserPlugin'
 import { createNoThinkPlugin } from './noThinkPlugin'
 import { createOpenrouterReasoningPlugin } from './openrouterReasoningPlugin'
 import { createPdfCompatibilityPlugin } from './pdfCompatibilityPlugin'
@@ -82,6 +88,11 @@ export function buildPlugins({ provider, model, config }: BuildPluginsContext): 
   // 0.3 OpenRouter reasoning redaction
   if (provider.id === SystemProviderIds.openrouter) {
     plugins.push(createOpenrouterReasoningPlugin())
+  }
+
+  // 0.3.1 DeepSeek DSML tool-call parser — converts leaked DSML tags into proper tool calls
+  if (isDeepSeekModel(model)) {
+    plugins.push(createDeepseekDsmlParserPlugin())
   }
 
   // 0.4 OVMS no-think for MCP tools

--- a/src/renderer/src/aiCore/plugins/__tests__/deepseekDsmlParserPlugin.test.ts
+++ b/src/renderer/src/aiCore/plugins/__tests__/deepseekDsmlParserPlugin.test.ts
@@ -1,0 +1,358 @@
+import type { LanguageModelV3StreamPart } from '@ai-sdk/provider'
+import type { LanguageModelMiddleware } from 'ai'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({
+      debug: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn()
+    })
+  }
+}))
+
+import { createDeepseekDsmlParserPlugin } from '../deepseekDsmlParserPlugin'
+
+function getMiddleware(): LanguageModelMiddleware {
+  const plugin = createDeepseekDsmlParserPlugin()
+  const ctx = { middlewares: [] as LanguageModelMiddleware[] }
+  // configureContext mutates ctx.middlewares by pushing the parser middleware
+
+  plugin.configureContext?.(ctx as any)
+  expect(ctx.middlewares).toHaveLength(1)
+  return ctx.middlewares[0]
+}
+
+function buildSourceStream(deltas: string[], finishReasonUnified: 'stop' | 'tool-calls' = 'stop') {
+  const parts: LanguageModelV3StreamPart[] = [
+    { type: 'stream-start', warnings: [] },
+    { type: 'text-start', id: 'text-1' },
+    ...deltas.map<LanguageModelV3StreamPart>((delta) => ({
+      type: 'text-delta',
+      id: 'text-1',
+      delta
+    })),
+    { type: 'text-end', id: 'text-1' },
+    {
+      type: 'finish',
+      finishReason: { unified: finishReasonUnified, raw: finishReasonUnified },
+
+      usage: {} as any
+    }
+  ]
+
+  return new ReadableStream<LanguageModelV3StreamPart>({
+    start(controller) {
+      for (const part of parts) controller.enqueue(part)
+      controller.close()
+    }
+  })
+}
+
+async function runStream(deltas: string[], finishReasonUnified: 'stop' | 'tool-calls' = 'stop') {
+  const middleware = getMiddleware()
+  expect(middleware.wrapStream).toBeDefined()
+
+  const source = buildSourceStream(deltas, finishReasonUnified)
+  const wrapped = await middleware.wrapStream!({
+    doStream: async () => ({ stream: source, request: { body: {} }, response: { headers: {} } }),
+
+    doGenerate: (async () => ({})) as any,
+
+    params: {} as any,
+
+    model: {} as any
+  } as any)
+
+  const events: LanguageModelV3StreamPart[] = []
+  const reader = wrapped.stream.getReader()
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    events.push(value)
+  }
+  return events
+}
+
+// The actual chunk sequence captured from the user's DeepSeek SSE leak.
+// Concatenated this is two parallel builtin_web_search invokes inside one tool_calls block.
+const SSE_DELTAS: string[] = [
+  // <｜｜DSML｜｜tool_calls>
+  '<',
+  '｜｜DSML｜｜',
+  'tool',
+  '_c',
+  'alls',
+  '>\n',
+  // <｜｜DSML｜｜invoke name="builtin_web_search">
+  '<',
+  '｜｜DSML｜｜',
+  'inv',
+  'oke',
+  ' name',
+  '="',
+  'built',
+  'in',
+  '_',
+  'web',
+  '_search',
+  '">\n',
+  // <｜｜DSML｜｜parameter name="additionalContext" string="true">
+  '<',
+  '｜｜DSML｜｜',
+  'parameter',
+  ' name',
+  '="',
+  'additional',
+  'Context',
+  '"',
+  ' string',
+  '="',
+  'true',
+  '">',
+  // value (Chinese keywords)
+  '企',
+  '查',
+  '查',
+  ' ',
+  '融资',
+  '轮',
+  '次',
+  ' ',
+  '天使',
+  '轮',
+  ' A',
+  '轮',
+  ' B',
+  '轮',
+  ' ',
+  '投资',
+  ' ',
+  '金额',
+  ' ',
+  '时间',
+  // </｜｜DSML｜｜parameter>
+  '</',
+  '｜｜DSML｜｜',
+  'parameter',
+  '>\n',
+  // </｜｜DSML｜｜invoke>
+  '</',
+  '｜｜DSML｜｜',
+  'inv',
+  'oke',
+  '>\n',
+  // <｜｜DSML｜｜invoke name="builtin_web_search">
+  '<',
+  '｜｜DSML｜｜',
+  'inv',
+  'oke',
+  ' name',
+  '="',
+  'built',
+  'in',
+  '_',
+  'web',
+  '_search',
+  '">\n',
+  // <｜｜DSML｜｜parameter name="additionalContext" string="true">
+  '<',
+  '｜｜DSML｜｜',
+  'parameter',
+  ' name',
+  '="',
+  'additional',
+  'Context',
+  '"',
+  ' string',
+  '="',
+  'true',
+  '">',
+  // value (English keywords)
+  '企',
+  '查',
+  '查',
+  ' Q',
+  'ich',
+  'acha',
+  ' funding',
+  ' rounds',
+  ' series',
+  ' A',
+  ' B',
+  ' C',
+  ' investors',
+  ' amount',
+  // </｜｜DSML｜｜parameter>
+  '</',
+  '｜｜DSML｜｜',
+  'parameter',
+  '>\n',
+  // </｜｜DSML｜｜invoke>
+  '</',
+  '｜｜DSML｜｜',
+  'inv',
+  'oke',
+  '>\n',
+  // </｜｜DSML｜｜tool_calls>
+  '</',
+  '｜｜DSML｜｜',
+  'tool',
+  '_c',
+  'alls',
+  '>'
+]
+
+describe('deepseekDsmlParserPlugin', () => {
+  it('converts the captured SSE sample into two AI SDK tool-call events', async () => {
+    const events = await runStream(SSE_DELTAS, 'stop')
+
+    const toolCalls = events.filter((e) => e.type === 'tool-call')
+    expect(toolCalls).toHaveLength(2)
+
+    expect(toolCalls[0]).toMatchObject({
+      type: 'tool-call',
+      toolName: 'builtin_web_search'
+    })
+    expect(toolCalls[1]).toMatchObject({
+      type: 'tool-call',
+      toolName: 'builtin_web_search'
+    })
+
+    const args0 = JSON.parse(toolCalls[0].input)
+    const args1 = JSON.parse(toolCalls[1].input)
+    expect(args0).toEqual({
+      additionalContext: '企查查 融资轮次 天使轮 A轮 B轮 投资 金额 时间'
+    })
+    expect(args1).toEqual({
+      additionalContext: '企查查 Qichacha funding rounds series A B C investors amount'
+    })
+  })
+
+  it('emits the streaming tool-input lifecycle around each tool-call', async () => {
+    const events = await runStream(SSE_DELTAS, 'stop')
+
+    const lifecycle = events.filter((e) =>
+      ['tool-input-start', 'tool-input-delta', 'tool-input-end', 'tool-call'].includes(e.type)
+    )
+    // 4 events per tool-call * 2 invokes = 8 lifecycle events
+    expect(lifecycle).toHaveLength(8)
+    expect(lifecycle.map((e) => e.type)).toEqual([
+      'tool-input-start',
+      'tool-input-delta',
+      'tool-input-end',
+      'tool-call',
+      'tool-input-start',
+      'tool-input-delta',
+      'tool-input-end',
+      'tool-call'
+    ])
+
+    // tool-input-start id matches the corresponding tool-call's toolCallId
+    const start0 = lifecycle[0] as Extract<LanguageModelV3StreamPart, { type: 'tool-input-start' }>
+    const call0 = lifecycle[3] as Extract<LanguageModelV3StreamPart, { type: 'tool-call' }>
+    expect(start0.id).toBe(call0.toolCallId)
+  })
+
+  it('rewrites finishReason from stop to tool-calls when DSML produced tool calls', async () => {
+    const events = await runStream(SSE_DELTAS, 'stop')
+    const finish = events.find((e) => e.type === 'finish') as Extract<LanguageModelV3StreamPart, { type: 'finish' }>
+    expect(finish.finishReason.unified).toBe('tool-calls')
+  })
+
+  it('does not emit any text-delta with the DSML opening tag leaked', async () => {
+    const events = await runStream(SSE_DELTAS, 'stop')
+    const textDeltas = events.filter((e) => e.type === 'text-delta')
+    const concatenated = textDeltas.map((e) => e.delta).join('')
+    expect(concatenated).not.toContain('｜｜DSML｜｜')
+    expect(concatenated).not.toContain('<｜')
+    // No spurious text content in this fully-DSML fragment
+    expect(concatenated).toBe('')
+  })
+
+  it('preserves plain text before and after the DSML block', async () => {
+    const deltas = ['让我先搜索一下。', ...SSE_DELTAS, '\n搜索完成。']
+    const events = await runStream(deltas, 'stop')
+
+    const textDeltas = events
+      .filter((e) => e.type === 'text-delta')
+      .map((e) => e.delta)
+      .join('')
+    expect(textDeltas).toBe('让我先搜索一下。\n搜索完成。')
+
+    const toolCalls = events.filter((e) => e.type === 'tool-call')
+    expect(toolCalls).toHaveLength(2)
+  })
+
+  it('passes plain text streams through unchanged when no DSML appears', async () => {
+    const events = await runStream(['Hello, ', 'world!'], 'stop')
+    const textDeltas = events
+      .filter((e) => e.type === 'text-delta')
+      .map((e) => e.delta)
+      .join('')
+    expect(textDeltas).toBe('Hello, world!')
+    expect(events.filter((e) => e.type === 'tool-call')).toHaveLength(0)
+
+    const finish = events.find((e) => e.type === 'finish') as Extract<LanguageModelV3StreamPart, { type: 'finish' }>
+    expect(finish.finishReason.unified).toBe('stop')
+  })
+
+  it('flushes unclosed DSML block as plain text on text-end (fallback)', async () => {
+    const deltas = [
+      '<',
+      '｜｜DSML｜｜',
+      'tool',
+      '_calls',
+      '>\n',
+      '<',
+      '｜｜DSML｜｜',
+      'invoke name="x">'
+      // no close tag
+    ]
+    const events = await runStream(deltas, 'stop')
+
+    expect(events.filter((e) => e.type === 'tool-call')).toHaveLength(0)
+    const textDeltas = events
+      .filter((e) => e.type === 'text-delta')
+      .map((e) => e.delta)
+      .join('')
+    expect(textDeltas).toContain('<｜｜DSML｜｜tool_calls>')
+  })
+
+  it('handles a partial DSML opening tag that arrives across chunk boundaries with surrounding text', async () => {
+    // First emit some plain text, then split the open tag character-by-character
+    const deltas = [
+      'prefix ',
+      '<',
+      '｜',
+      '｜',
+      'D',
+      'S',
+      'M',
+      'L',
+      '｜',
+      '｜',
+      'tool_calls',
+      '>',
+      '<｜｜DSML｜｜invoke name="t">',
+      '<｜｜DSML｜｜parameter name="p" string="true">v</｜｜DSML｜｜parameter>',
+      '</｜｜DSML｜｜invoke>',
+      '</｜｜DSML｜｜tool_calls>',
+      ' suffix'
+    ]
+    const events = await runStream(deltas, 'stop')
+
+    const toolCalls = events.filter((e) => e.type === 'tool-call')
+    expect(toolCalls).toHaveLength(1)
+    expect(toolCalls[0].toolName).toBe('t')
+    expect(JSON.parse(toolCalls[0].input)).toEqual({ p: 'v' })
+
+    const text = events
+      .filter((e) => e.type === 'text-delta')
+      .map((e) => e.delta)
+      .join('')
+    expect(text).toBe('prefix  suffix')
+  })
+})

--- a/src/renderer/src/aiCore/plugins/__tests__/deepseekDsmlParserPlugin.test.ts
+++ b/src/renderer/src/aiCore/plugins/__tests__/deepseekDsmlParserPlugin.test.ts
@@ -320,6 +320,30 @@ describe('deepseekDsmlParserPlugin', () => {
     expect(textDeltas).toContain('<｜｜DSML｜｜tool_calls>')
   })
 
+  it('emits the original DSML markup as text when a closed block has no parseable invoke', async () => {
+    // Closed tool_calls block, but the inner content does not match an invoke pattern
+    // (e.g. malformed or unexpected payload). The parser should not silently swallow it.
+    const deltas = [
+      'before ',
+      '<｜｜DSML｜｜tool_calls>',
+      'oops not a valid invoke',
+      '</｜｜DSML｜｜tool_calls>',
+      ' after'
+    ]
+    const events = await runStream(deltas, 'stop')
+
+    expect(events.filter((e) => e.type === 'tool-call')).toHaveLength(0)
+
+    const text = events
+      .filter((e) => e.type === 'text-delta')
+      .map((e) => e.delta)
+      .join('')
+    expect(text).toBe('before <｜｜DSML｜｜tool_calls>oops not a valid invoke</｜｜DSML｜｜tool_calls> after')
+
+    const finish = events.find((e) => e.type === 'finish') as Extract<LanguageModelV3StreamPart, { type: 'finish' }>
+    expect(finish.finishReason.unified).toBe('stop')
+  })
+
   it('handles a partial DSML opening tag that arrives across chunk boundaries with surrounding text', async () => {
     // First emit some plain text, then split the open tag character-by-character
     const deltas = [
@@ -353,5 +377,86 @@ describe('deepseekDsmlParserPlugin', () => {
       .map((e) => e.delta)
       .join('')
     expect(text).toBe('prefix  suffix')
+  })
+
+  describe('wrapGenerate (non-streaming)', () => {
+    async function runGenerate(text: string, finishReasonUnified: 'stop' | 'tool-calls' = 'stop') {
+      const middleware = await getMiddleware()
+      expect(middleware.wrapGenerate).toBeDefined()
+
+      const result = await middleware.wrapGenerate!({
+        doGenerate: async () =>
+          ({
+            content: [{ type: 'text', text }],
+            finishReason: { unified: finishReasonUnified, raw: finishReasonUnified },
+            usage: {} as any,
+            warnings: [],
+            request: { body: {} },
+            response: { headers: {} }
+          }) as any,
+
+        doStream: (async () => ({})) as any,
+
+        params: {} as any,
+
+        model: {} as any
+      } as any)
+
+      return result as any
+    }
+
+    it('extracts multiple DSML blocks within a single text part', async () => {
+      const text =
+        'lead-in ' +
+        '<｜｜DSML｜｜tool_calls>' +
+        '<｜｜DSML｜｜invoke name="search_a">' +
+        '<｜｜DSML｜｜parameter name="q" string="true">first</｜｜DSML｜｜parameter>' +
+        '</｜｜DSML｜｜invoke>' +
+        '</｜｜DSML｜｜tool_calls>' +
+        ' middle ' +
+        '<｜｜DSML｜｜tool_calls>' +
+        '<｜｜DSML｜｜invoke name="search_b">' +
+        '<｜｜DSML｜｜parameter name="q" string="true">second</｜｜DSML｜｜parameter>' +
+        '</｜｜DSML｜｜invoke>' +
+        '</｜｜DSML｜｜tool_calls>' +
+        ' tail'
+
+      const result = await runGenerate(text, 'stop')
+
+      const toolCalls = result.content.filter((p: any) => p.type === 'tool-call')
+      expect(toolCalls).toHaveLength(2)
+      expect(toolCalls[0].toolName).toBe('search_a')
+      expect(JSON.parse(toolCalls[0].input)).toEqual({ q: 'first' })
+      expect(toolCalls[1].toolName).toBe('search_b')
+      expect(JSON.parse(toolCalls[1].input)).toEqual({ q: 'second' })
+
+      const reconstructed = result.content
+        .filter((p: any) => p.type === 'text')
+        .map((p: any) => p.text)
+        .join('')
+      expect(reconstructed).toBe('lead-in  middle  tail')
+      expect(reconstructed).not.toContain('｜｜DSML｜｜')
+
+      expect(result.finishReason.unified).toBe('tool-calls')
+    })
+
+    it('preserves a closed DSML block that contains no parseable invoke as text', async () => {
+      const text = 'before <｜｜DSML｜｜tool_calls>garbage</｜｜DSML｜｜tool_calls> after'
+      const result = await runGenerate(text, 'stop')
+
+      expect(result.content.filter((p: any) => p.type === 'tool-call')).toHaveLength(0)
+      // Single text part returned unchanged
+      expect(result.content).toHaveLength(1)
+      expect(result.content[0]).toMatchObject({ type: 'text', text })
+      expect(result.finishReason.unified).toBe('stop')
+    })
+
+    it('returns input unchanged when no DSML markup is present', async () => {
+      const text = 'plain response'
+      const result = await runGenerate(text, 'stop')
+      expect(result.content).toHaveLength(1)
+      expect(result.content[0]).toMatchObject({ type: 'text', text })
+      expect(result.finishReason.unified).toBe('stop')
+    })
   })
 })

--- a/src/renderer/src/aiCore/plugins/__tests__/deepseekDsmlParserPlugin.test.ts
+++ b/src/renderer/src/aiCore/plugins/__tests__/deepseekDsmlParserPlugin.test.ts
@@ -15,12 +15,11 @@ vi.mock('@logger', () => ({
 
 import { createDeepseekDsmlParserPlugin } from '../deepseekDsmlParserPlugin'
 
-function getMiddleware(): LanguageModelMiddleware {
+async function getMiddleware(): Promise<LanguageModelMiddleware> {
   const plugin = createDeepseekDsmlParserPlugin()
   const ctx = { middlewares: [] as LanguageModelMiddleware[] }
   // configureContext mutates ctx.middlewares by pushing the parser middleware
-
-  plugin.configureContext?.(ctx as any)
+  await plugin.configureContext?.(ctx as any)
   expect(ctx.middlewares).toHaveLength(1)
   return ctx.middlewares[0]
 }
@@ -52,7 +51,7 @@ function buildSourceStream(deltas: string[], finishReasonUnified: 'stop' | 'tool
 }
 
 async function runStream(deltas: string[], finishReasonUnified: 'stop' | 'tool-calls' = 'stop') {
-  const middleware = getMiddleware()
+  const middleware = await getMiddleware()
   expect(middleware.wrapStream).toBeDefined()
 
   const source = buildSourceStream(deltas, finishReasonUnified)

--- a/src/renderer/src/aiCore/plugins/deepseekDsmlParserPlugin.ts
+++ b/src/renderer/src/aiCore/plugins/deepseekDsmlParserPlugin.ts
@@ -1,0 +1,307 @@
+import type { LanguageModelV3StreamPart } from '@ai-sdk/provider'
+import { definePlugin } from '@cherrystudio/ai-core'
+import { loggerService } from '@logger'
+import type { LanguageModelMiddleware } from 'ai'
+
+const logger = loggerService.withContext('deepseekDsmlParser')
+
+const TOOL_CALLS_OPEN = '<｜｜DSML｜｜tool_calls>'
+const TOOL_CALLS_CLOSE = '</｜｜DSML｜｜tool_calls>'
+const SWALLOW_BUFFER_LIMIT = 64 * 1024
+
+const INVOKE_RE = /<｜｜DSML｜｜invoke\s+name="([^"]+)">([\s\S]*?)<\/｜｜DSML｜｜invoke>/g
+const PARAM_RE =
+  /<｜｜DSML｜｜parameter\s+name="([^"]+)"(?:\s+string="(true|false)")?>([\s\S]*?)<\/｜｜DSML｜｜parameter>/g
+
+interface ParsedDsmlCall {
+  toolName: string
+  args: Record<string, unknown>
+}
+
+function parseInvokeBlocks(dsmlContent: string): ParsedDsmlCall[] {
+  const calls: ParsedDsmlCall[] = []
+  INVOKE_RE.lastIndex = 0
+  let invokeMatch: RegExpExecArray | null
+  while ((invokeMatch = INVOKE_RE.exec(dsmlContent)) !== null) {
+    const toolName = invokeMatch[1]
+    const inner = invokeMatch[2]
+    const args: Record<string, unknown> = {}
+
+    PARAM_RE.lastIndex = 0
+    let paramMatch: RegExpExecArray | null
+    while ((paramMatch = PARAM_RE.exec(inner)) !== null) {
+      const paramName = paramMatch[1]
+      const isString = paramMatch[2] !== 'false'
+      const rawValue = paramMatch[3]
+      if (isString) {
+        args[paramName] = rawValue
+      } else {
+        try {
+          args[paramName] = JSON.parse(rawValue)
+        } catch {
+          args[paramName] = rawValue
+        }
+      }
+    }
+    calls.push({ toolName, args })
+  }
+  return calls
+}
+
+// Find longest suffix of `buffer` that is a non-empty prefix of `target`.
+// Used to keep partial DSML opening tag in buffer across chunk boundaries.
+function findPartialPrefix(buffer: string, target: string): number {
+  const maxLen = Math.min(buffer.length, target.length - 1)
+  for (let len = maxLen; len > 0; len--) {
+    if (target.startsWith(buffer.slice(buffer.length - len))) {
+      return buffer.length - len
+    }
+  }
+  return -1
+}
+
+function generateToolCallId(): string {
+  return `dsml_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`
+}
+
+function createDeepseekDsmlParserMiddleware(): LanguageModelMiddleware {
+  return {
+    specificationVersion: 'v3',
+
+    wrapStream: async ({ doStream }) => {
+      const { stream, ...rest } = await doStream()
+
+      let textBuffer = ''
+      let dsmlBuffer = ''
+      let inDsml = false
+      let activeTextId: string | null = null
+      let extractedToolCalls = false
+
+      // eslint-disable-next-line prefer-const
+      let drainDsmlBuffer: (
+        controller: TransformStreamDefaultController<LanguageModelV3StreamPart>,
+        textId: string
+      ) => void
+
+      const enqueueRemainderText = (
+        controller: TransformStreamDefaultController<LanguageModelV3StreamPart>,
+        textId: string
+      ) => {
+        const startIdx = textBuffer.indexOf(TOOL_CALLS_OPEN)
+        if (startIdx === -1) {
+          const partialIdx = findPartialPrefix(textBuffer, TOOL_CALLS_OPEN)
+          if (partialIdx >= 0) {
+            const safe = textBuffer.slice(0, partialIdx)
+            if (safe) controller.enqueue({ type: 'text-delta', id: textId, delta: safe })
+            textBuffer = textBuffer.slice(partialIdx)
+          } else {
+            if (textBuffer) controller.enqueue({ type: 'text-delta', id: textId, delta: textBuffer })
+            textBuffer = ''
+          }
+          return
+        }
+        if (startIdx > 0) {
+          controller.enqueue({ type: 'text-delta', id: textId, delta: textBuffer.slice(0, startIdx) })
+        }
+        dsmlBuffer = textBuffer.slice(startIdx + TOOL_CALLS_OPEN.length)
+        textBuffer = ''
+        inDsml = true
+        drainDsmlBuffer(controller, textId)
+      }
+
+      drainDsmlBuffer = (controller: TransformStreamDefaultController<LanguageModelV3StreamPart>, textId: string) => {
+        const closeIdx = dsmlBuffer.indexOf(TOOL_CALLS_CLOSE)
+        if (closeIdx === -1) {
+          if (dsmlBuffer.length > SWALLOW_BUFFER_LIMIT) {
+            logger.warn('DSML buffer exceeded limit without close tag, falling back to text')
+            controller.enqueue({
+              type: 'text-delta',
+              id: textId,
+              delta: TOOL_CALLS_OPEN + dsmlBuffer
+            })
+            dsmlBuffer = ''
+            inDsml = false
+          }
+          return
+        }
+
+        const blockContent = dsmlBuffer.slice(0, closeIdx)
+        const remainder = dsmlBuffer.slice(closeIdx + TOOL_CALLS_CLOSE.length)
+        const calls = parseInvokeBlocks(blockContent)
+
+        for (const call of calls) {
+          const id = generateToolCallId()
+          const inputJson = JSON.stringify(call.args)
+          controller.enqueue({ type: 'tool-input-start', id, toolName: call.toolName })
+          controller.enqueue({ type: 'tool-input-delta', id, delta: inputJson })
+          controller.enqueue({ type: 'tool-input-end', id })
+          controller.enqueue({
+            type: 'tool-call',
+            toolCallId: id,
+            toolName: call.toolName,
+            input: inputJson
+          })
+        }
+
+        if (calls.length > 0) {
+          extractedToolCalls = true
+          logger.info(`Parsed ${calls.length} DSML tool call(s)`, {
+            tools: calls.map((c) => c.toolName)
+          })
+        } else {
+          logger.warn('DSML block closed but no invoke blocks parsed')
+        }
+
+        dsmlBuffer = ''
+        inDsml = false
+        textBuffer = remainder
+        if (textBuffer) enqueueRemainderText(controller, textId)
+      }
+
+      return {
+        stream: stream.pipeThrough(
+          new TransformStream<LanguageModelV3StreamPart, LanguageModelV3StreamPart>({
+            transform(
+              chunk: LanguageModelV3StreamPart,
+              controller: TransformStreamDefaultController<LanguageModelV3StreamPart>
+            ) {
+              if (chunk.type === 'text-start') {
+                activeTextId = chunk.id
+                controller.enqueue(chunk)
+                return
+              }
+
+              if (chunk.type === 'text-end') {
+                const textId = chunk.id
+                if (inDsml) {
+                  logger.warn('text-end with unclosed DSML block, flushing as text')
+                  controller.enqueue({
+                    type: 'text-delta',
+                    id: textId,
+                    delta: TOOL_CALLS_OPEN + dsmlBuffer
+                  })
+                  dsmlBuffer = ''
+                  inDsml = false
+                } else if (textBuffer) {
+                  controller.enqueue({ type: 'text-delta', id: textId, delta: textBuffer })
+                  textBuffer = ''
+                }
+                controller.enqueue(chunk)
+                activeTextId = null
+                return
+              }
+
+              if (chunk.type === 'finish') {
+                if (extractedToolCalls && chunk.finishReason.unified === 'stop') {
+                  controller.enqueue({
+                    ...chunk,
+                    finishReason: { ...chunk.finishReason, unified: 'tool-calls' }
+                  })
+                } else {
+                  controller.enqueue(chunk)
+                }
+                return
+              }
+
+              if (chunk.type !== 'text-delta') {
+                controller.enqueue(chunk)
+                return
+              }
+
+              const textId = chunk.id
+              if (!activeTextId) activeTextId = textId
+
+              if (inDsml) {
+                dsmlBuffer += chunk.delta
+                drainDsmlBuffer(controller, textId)
+                return
+              }
+
+              textBuffer += chunk.delta
+              enqueueRemainderText(controller, textId)
+            },
+            flush(controller: TransformStreamDefaultController<LanguageModelV3StreamPart>) {
+              const textId = activeTextId ?? 'dsml-fallback'
+              if (inDsml) {
+                logger.warn('Stream flushed with unclosed DSML block')
+                controller.enqueue({
+                  type: 'text-delta',
+                  id: textId,
+                  delta: TOOL_CALLS_OPEN + dsmlBuffer
+                })
+              } else if (textBuffer) {
+                controller.enqueue({ type: 'text-delta', id: textId, delta: textBuffer })
+              }
+              textBuffer = ''
+              dsmlBuffer = ''
+              inDsml = false
+            }
+          })
+        ),
+        ...rest
+      }
+    },
+
+    wrapGenerate: async ({ doGenerate }) => {
+      const result = await doGenerate()
+      const newContent: typeof result.content = []
+      let extracted = false
+
+      for (const part of result.content) {
+        if (part.type !== 'text') {
+          newContent.push(part)
+          continue
+        }
+        const text = part.text
+        const startIdx = text.indexOf(TOOL_CALLS_OPEN)
+        if (startIdx === -1) {
+          newContent.push(part)
+          continue
+        }
+        const closeIdx = text.indexOf(TOOL_CALLS_CLOSE, startIdx)
+        if (closeIdx === -1) {
+          newContent.push(part)
+          continue
+        }
+        const before = text.slice(0, startIdx)
+        const blockContent = text.slice(startIdx + TOOL_CALLS_OPEN.length, closeIdx)
+        const after = text.slice(closeIdx + TOOL_CALLS_CLOSE.length)
+        const calls = parseInvokeBlocks(blockContent)
+
+        if (before) newContent.push({ ...part, text: before })
+        for (const call of calls) {
+          newContent.push({
+            type: 'tool-call',
+            toolCallId: generateToolCallId(),
+            toolName: call.toolName,
+            input: JSON.stringify(call.args)
+          })
+        }
+        if (after) newContent.push({ ...part, text: after })
+        if (calls.length > 0) extracted = true
+      }
+
+      if (!extracted) return result
+
+      logger.info('Parsed DSML tool calls in non-streaming response')
+      return {
+        ...result,
+        content: newContent,
+        finishReason:
+          result.finishReason.unified === 'stop'
+            ? { ...result.finishReason, unified: 'tool-calls' }
+            : result.finishReason
+      }
+    }
+  }
+}
+
+export const createDeepseekDsmlParserPlugin = () =>
+  definePlugin({
+    name: 'deepseekDsmlParser',
+    enforce: 'pre',
+    configureContext: (context) => {
+      context.middlewares = context.middlewares || []
+      context.middlewares.push(createDeepseekDsmlParserMiddleware())
+    }
+  })

--- a/src/renderer/src/aiCore/plugins/deepseekDsmlParserPlugin.ts
+++ b/src/renderer/src/aiCore/plugins/deepseekDsmlParserPlugin.ts
@@ -129,27 +129,31 @@ function createDeepseekDsmlParserMiddleware(): LanguageModelMiddleware {
         const remainder = dsmlBuffer.slice(closeIdx + TOOL_CALLS_CLOSE.length)
         const calls = parseInvokeBlocks(blockContent)
 
-        for (const call of calls) {
-          const id = generateToolCallId()
-          const inputJson = JSON.stringify(call.args)
-          controller.enqueue({ type: 'tool-input-start', id, toolName: call.toolName })
-          controller.enqueue({ type: 'tool-input-delta', id, delta: inputJson })
-          controller.enqueue({ type: 'tool-input-end', id })
+        if (calls.length === 0) {
+          logger.warn('DSML block closed but no invoke blocks parsed, emitting as text')
           controller.enqueue({
-            type: 'tool-call',
-            toolCallId: id,
-            toolName: call.toolName,
-            input: inputJson
+            type: 'text-delta',
+            id: textId,
+            delta: TOOL_CALLS_OPEN + blockContent + TOOL_CALLS_CLOSE
           })
-        }
-
-        if (calls.length > 0) {
+        } else {
+          for (const call of calls) {
+            const id = generateToolCallId()
+            const inputJson = JSON.stringify(call.args)
+            controller.enqueue({ type: 'tool-input-start', id, toolName: call.toolName })
+            controller.enqueue({ type: 'tool-input-delta', id, delta: inputJson })
+            controller.enqueue({ type: 'tool-input-end', id })
+            controller.enqueue({
+              type: 'tool-call',
+              toolCallId: id,
+              toolName: call.toolName,
+              input: inputJson
+            })
+          }
           extractedToolCalls = true
           logger.info(`Parsed ${calls.length} DSML tool call(s)`, {
             tools: calls.map((c) => c.toolName)
           })
-        } else {
-          logger.warn('DSML block closed but no invoke blocks parsed')
         }
 
         dsmlBuffer = ''
@@ -253,32 +257,59 @@ function createDeepseekDsmlParserMiddleware(): LanguageModelMiddleware {
           continue
         }
         const text = part.text
-        const startIdx = text.indexOf(TOOL_CALLS_OPEN)
-        if (startIdx === -1) {
-          newContent.push(part)
-          continue
-        }
-        const closeIdx = text.indexOf(TOOL_CALLS_CLOSE, startIdx)
-        if (closeIdx === -1) {
-          newContent.push(part)
-          continue
-        }
-        const before = text.slice(0, startIdx)
-        const blockContent = text.slice(startIdx + TOOL_CALLS_OPEN.length, closeIdx)
-        const after = text.slice(closeIdx + TOOL_CALLS_CLOSE.length)
-        const calls = parseInvokeBlocks(blockContent)
+        const partsForText: typeof newContent = []
+        let textAccum = ''
+        let cursor = 0
+        let foundCallInPart = false
 
-        if (before) newContent.push({ ...part, text: before })
-        for (const call of calls) {
-          newContent.push({
-            type: 'tool-call',
-            toolCallId: generateToolCallId(),
-            toolName: call.toolName,
-            input: JSON.stringify(call.args)
-          })
+        while (cursor < text.length) {
+          const startIdx = text.indexOf(TOOL_CALLS_OPEN, cursor)
+          if (startIdx === -1) {
+            textAccum += text.slice(cursor)
+            break
+          }
+          const closeIdx = text.indexOf(TOOL_CALLS_CLOSE, startIdx + TOOL_CALLS_OPEN.length)
+          if (closeIdx === -1) {
+            textAccum += text.slice(cursor)
+            break
+          }
+
+          const blockEnd = closeIdx + TOOL_CALLS_CLOSE.length
+          const blockContent = text.slice(startIdx + TOOL_CALLS_OPEN.length, closeIdx)
+          const calls = parseInvokeBlocks(blockContent)
+
+          if (calls.length === 0) {
+            // Unparseable block — preserve original markup as text instead of dropping it.
+            textAccum += text.slice(cursor, blockEnd)
+            cursor = blockEnd
+            continue
+          }
+
+          textAccum += text.slice(cursor, startIdx)
+          if (textAccum) {
+            partsForText.push({ ...part, text: textAccum })
+            textAccum = ''
+          }
+          for (const call of calls) {
+            partsForText.push({
+              type: 'tool-call',
+              toolCallId: generateToolCallId(),
+              toolName: call.toolName,
+              input: JSON.stringify(call.args)
+            })
+          }
+          foundCallInPart = true
+          cursor = blockEnd
         }
-        if (after) newContent.push({ ...part, text: after })
-        if (calls.length > 0) extracted = true
+
+        if (!foundCallInPart) {
+          newContent.push(part)
+          continue
+        }
+
+        newContent.push(...partsForText)
+        if (textAccum) newContent.push({ ...part, text: textAccum })
+        extracted = true
       }
 
       if (!extracted) return result

--- a/src/renderer/src/aiCore/plugins/searchOrchestrationPlugin.ts
+++ b/src/renderer/src/aiCore/plugins/searchOrchestrationPlugin.ts
@@ -15,20 +15,19 @@ import {
 } from '@cherrystudio/ai-core'
 import { loggerService } from '@logger'
 // import { generateObject } from '@cherrystudio/ai-core'
-import { isDeepSeekModel } from '@renderer/config/models'
 import {
   SEARCH_SUMMARY_PROMPT,
   SEARCH_SUMMARY_PROMPT_KNOWLEDGE_ONLY,
   SEARCH_SUMMARY_PROMPT_WEB_ONLY
 } from '@renderer/config/prompts'
+import { fetchGenerate } from '@renderer/services/ApiService'
 import { getDefaultModel, getProviderByModel } from '@renderer/services/AssistantService'
 import store from '@renderer/store'
 import { selectCurrentUserId, selectGlobalMemoryEnabled, selectMemoryConfig } from '@renderer/store/memory'
 import type { Assistant } from '@renderer/types'
 import type { ExtractResults } from '@renderer/utils/extract'
 import { extractInfoFromXML } from '@renderer/utils/extract'
-import type { LanguageModel, ModelMessage } from 'ai'
-import { generateText } from 'ai'
+import type { ModelMessage } from 'ai'
 import { isEmpty } from 'lodash'
 
 import { MemoryProcessor } from '../../services/MemoryProcessor'
@@ -138,9 +137,10 @@ async function analyzeSearchIntent(
       hasKnowledgeSearch: needKnowledgeExtract
     })
 
-    const { text: result } = await generateText({
-      model: context.model as LanguageModel,
-      prompt: formattedPrompt
+    const result = await fetchGenerate({
+      model,
+      prompt: formattedPrompt,
+      content: ''
     }).finally(() => {
       logger.info('Intent analysis generateText call completed', {
         modelId: model.id,
@@ -332,8 +332,7 @@ export const searchOrchestrationPlugin = (
             params.tools[BUILTIN_WEB_SEARCH_TOOL_NAME] = webSearchToolWithPreExtractedKeywords(
               assistant.webSearchProviderId,
               analysisResult.websearch,
-              context.requestId,
-              isDeepSeekModel(assistant.model)
+              context.requestId
             )
 
             const prepareStep = params.prepareStep

--- a/src/renderer/src/aiCore/plugins/searchOrchestrationPlugin.ts
+++ b/src/renderer/src/aiCore/plugins/searchOrchestrationPlugin.ts
@@ -148,6 +148,14 @@ async function analyzeSearchIntent(
         requestId: context.requestId
       })
     })
+
+    // fetchGenerate swallows errors and returns '' — treat that as a failure so
+    // search still runs against the original user question via the fallback.
+    if (!result.trim()) {
+      logger.warn('Intent analysis returned empty result, using fallback')
+      return getFallbackResult()
+    }
+
     const parsedResult = extractInfoFromXML(result)
     logger.debug('Intent analysis result', { parsedResult })
 

--- a/src/renderer/src/aiCore/tools/WebSearchTool.ts
+++ b/src/renderer/src/aiCore/tools/WebSearchTool.ts
@@ -10,8 +10,6 @@ export const BUILTIN_WEB_SEARCH_TOOL_NAME = 'builtin_web_search'
 
 const MAX_BUILTIN_WEB_SEARCH_QUERIES = 3
 
-const DEEPSEEK_DSML_SUPPRESSION = '\n- Do not output DSML tags'
-
 function normalizeWebSearchQueries(questions: string[]): string[] {
   if (questions[0] === 'not_needed') {
     return ['not_needed']
@@ -43,8 +41,7 @@ export const webSearchToolWithPreExtractedKeywords = (
     question: string[]
     links?: string[]
   },
-  requestId: string,
-  isDeepSeekModel = false
+  requestId: string
 ) => {
   const webSearchProvider = WebSearchService.getWebSearchProvider(webSearchProviderId)
   let cachedSearchResultsPromise: Promise<WebSearchProviderResponse> | undefined
@@ -122,7 +119,7 @@ You can use this tool as-is to search with the prepared queries, or provide addi
         '{question}',
         "Based on the search results, please answer the user's question with proper citations."
       ).replace('{references}', referenceContent)
-      const instructions = isDeepSeekModel ? `${fullInstructions}${DEEPSEEK_DSML_SUPPRESSION}` : fullInstructions
+      const instructions = fullInstructions
       return {
         type: 'content',
         value: [


### PR DESCRIPTION
### What this PR does

Before this PR:
DeepSeek models could leak DSML tool-call markup (e.g. `<｜｜DSML｜｜tool_calls>`, `<｜｜DSML｜｜invoke name="...">`) as plain text into the assistant response when the upstream inference engine failed to parse it into structured tool calls. The agent loop saw `finishReason: stop` and terminated without dispatching the intended tools, leaving raw markup visible to users. Prompt-level mitigations (suppression instruction in system prompt or tool result) were unreliable because DSML emission is driven by tokenizer-level patterns rather than instruction following.

After this PR:
A new middleware plugin `deepseekDsmlParserPlugin` intercepts streaming and non-streaming responses for DeepSeek models, runs a state-machine parser over text deltas, and converts complete `<｜｜DSML｜｜tool_calls>...</｜｜DSML｜｜tool_calls>` blocks into proper AI SDK `tool-input-start` / `tool-input-delta` / `tool-input-end` / `tool-call` events. `finishReason` is rewritten from `stop` to `tool-calls` so the agent loop continues and dispatches the recovered tool calls. Plain text and unclosed/partial blocks are handled with chunk-boundary buffering and a fallback that re-emits buffered content as text.

Fixes #14714

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Parsing in middleware (rather than client-side post-processing) preserves the agent loop. Just stripping DSML would leave intended tool calls undispatched and break multi-step search flows.
- A state-machine over `text-delta` chunks (rather than a one-shot regex on the full string) keeps streaming UX and handles tags split across SSE chunk boundaries (e.g. `<` / `｜｜DSML｜｜` / `tool` / `_calls` / `>` arriving in separate chunks, as observed in real responses).
- A 64KB swallow buffer cap with text fallback prevents the parser from indefinitely withholding content if a DSML block is truncated.

The following alternatives were considered:
- Appending a "Do not output DSML tags" suppression to the system prompt — verified ineffective because DSML emission is a tokenizer-level entrenched pattern, not instruction-driven.
- Stripping DSML residues with a post-processor — would break agent mode by discarding the intended tool calls.
- Forcing `tools: undefined` on the synthesis step — only fixes one of several leakage scenarios and still loses the parallel-call intent.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/14714 (and the prior partial fix in #14721 covering only the web-search tool-result side)

### Breaking changes

None.

### Special notes for your reviewer

- This PR targets `main` as a hotfix from `hotfix/deepseek-dsml-parser`, following the pattern of #14721. Scope is limited to fixing user-visible DeepSeek tool-call leakage; no refactoring is included.
- Real DSML token format uses **double** full-width vertical bars: `<｜｜DSML｜｜...>` (each `｜` is U+FF5C). Confirmed against captured live SSE samples; do not "correct" to single-bar form.
- The plugin is gated by `isDeepSeekModel(model)` in `PluginBuilder.ts`, so non-DeepSeek paths are not affected.
- 8 unit tests in `deepseekDsmlParserPlugin.test.ts` cover the captured SSE sample, lifecycle ordering, finishReason rewrite, no-DSML-leak invariant, mixed text+DSML, plain-text passthrough, unclosed-block fallback, and tag-split-across-chunks recovery.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix DeepSeek responses leaking DSML tool-call markup as plain text. The renderer now parses DSML blocks into proper AI SDK tool calls so multi-step web search and other agent flows resume correctly when the upstream parser fails.
```
