### PR TITLE
fix(models): route gpt-image-2 through chat completion instead of dedicated image API

### DIFF
--- a/src/renderer/src/config/models/__tests__/vision.test.ts
+++ b/src/renderer/src/config/models/__tests__/vision.test.ts
@@ -96,6 +96,7 @@ describe('vision helpers', () => {
 
     it('detects OpenAI and third-party generative image models', () => {
       expect(isGenerateImageModel(createModel({ id: 'gpt-4o-mini' }))).toBe(true)
+      expect(isGenerateImageModel(createModel({ id: 'gpt-image-2' }))).toBe(true)
 
       providerMock.mockReturnValue({ type: 'custom' } as any)
       expect(isGenerateImageModel(createModel({ id: 'gemini-2.5-flash-image' }))).toBe(true)
@@ -110,6 +111,7 @@ describe('vision helpers', () => {
     it('requires both generate and text-to-image support', () => {
       expect(isPureGenerateImageModel(createModel({ id: 'gpt-image-1' }))).toBe(true)
       expect(isPureGenerateImageModel(createModel({ id: 'gpt-4o' }))).toBe(false)
+      expect(isPureGenerateImageModel(createModel({ id: 'gpt-image-2' }))).toBe(false)
       expect(isPureGenerateImageModel(createModel({ id: 'gemini-2.5-flash-image-preview' }))).toBe(true)
     })
   })
@@ -127,11 +129,14 @@ describe('vision helpers', () => {
 
     it('identifies dedicated and auto-enabled image generation models', () => {
       expect(isDedicatedImageGenerationModel(createModel({ id: 'grok-2-image-1212' }))).toBe(true)
+      expect(isDedicatedImageGenerationModel(createModel({ id: 'gpt-image-1' }))).toBe(true)
       expect(isAutoEnableImageGenerationModel(createModel({ id: 'gemini-2.5-flash-image-ultra' }))).toBe(true)
+      expect(isAutoEnableImageGenerationModel(createModel({ id: 'gpt-image-2' }))).toBe(true)
     })
 
     it('returns false when models are not in dedicated or auto-enable sets', () => {
       expect(isDedicatedImageGenerationModel(createModel({ id: 'gpt-4o' }))).toBe(false)
+      expect(isDedicatedImageGenerationModel(createModel({ id: 'gpt-image-2' }))).toBe(false)
       expect(isAutoEnableImageGenerationModel(createModel({ id: 'gpt-4o' }))).toBe(false)
     })
   })

--- a/src/renderer/src/config/models/vision.ts
+++ b/src/renderer/src/config/models/vision.ts
@@ -180,7 +180,7 @@ export function isDedicatedImageModel(model: Model): boolean {
   const modelId = getLowerBaseModelName(model.id)
   // gpt-image-2 is a chat-capable image model (can return text + images),
   // so it should use the chat completion path, not the dedicated image generation API
-  if (/^gpt-image-2/.test(modelId)) return false
+  if (modelId.startsWith('gpt-image-2')) return false
   return DEDICATED_IMAGE_MODEL_REGEX.test(modelId)
 }
 

--- a/src/renderer/src/config/models/vision.ts
+++ b/src/renderer/src/config/models/vision.ts
@@ -132,6 +132,7 @@ const DEDICATED_IMAGE_MODEL_REGEX = new RegExp(DEDICATED_IMAGE_MODELS.join('|'),
 const AUTO_ENABLE_IMAGE_MODELS = [
   'gemini-2.5-flash-image(?:-[\\w-]+)?',
   'gemini-3(?:\\.\\d+)?-(?:flash|pro)-image(?:-[\\w-]+)?',
+  'gpt-image-2(?:-[\\w-]+)?',
   ...DEDICATED_IMAGE_MODELS
 ]
 
@@ -144,12 +145,13 @@ const OPENAI_TOOL_USE_IMAGE_GENERATION_MODELS = [
   'gpt-4.1',
   'gpt-4.1-mini',
   'gpt-4.1-nano',
-  'gpt-5'
+  'gpt-5',
+  'gpt-image-2'
 ]
 
 const OPENAI_IMAGE_GENERATION_MODELS = [...OPENAI_TOOL_USE_IMAGE_GENERATION_MODELS, 'gpt-image-1']
 
-const MODERN_IMAGE_MODELS = ['gemini-3(?:\\.\\d+)?-(?:flash|pro)-image(?:-[\\w-]+)?']
+const MODERN_IMAGE_MODELS = ['gemini-3(?:\\.\\d+)?-(?:flash|pro)-image(?:-[\\w-]+)?', 'gpt-image-2(?:-[\\w-]+)?']
 
 const GENERATE_IMAGE_MODELS = [
   'gemini-2.0-flash-exp(?:-[\\w-]+)?',
@@ -176,6 +178,9 @@ const MODERN_GENERATE_IMAGE_MODELS_REGEX = new RegExp(MODERN_IMAGE_MODELS.join('
 export function isDedicatedImageModel(model: Model): boolean {
   if (!model) return false
   const modelId = getLowerBaseModelName(model.id)
+  // gpt-image-2 is a chat-capable image model (can return text + images),
+  // so it should use the chat completion path, not the dedicated image generation API
+  if (/^gpt-image-2/.test(modelId)) return false
   return DEDICATED_IMAGE_MODEL_REGEX.test(modelId)
 }
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--
🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.
-->

### What this PR does

Before this PR:

- `gpt-image-2` was incorrectly classified as a dedicated image-only model (matching the `gpt-image(?:-[\w-]+)?` regex in `DEDICATED_IMAGE_MODELS`).
- This forced it through `fetchImageGeneration`, which only handles image responses and silently discards any text from the model.
- When `gpt-image-2` returned text suggestions, clarifications, or refusal messages, the user experienced a disruptive modal/popup interruption. The text could not be copied.

After this PR:

- `gpt-image-2` is reclassified as a **chat-capable image generation model** (like `gpt-4o`).
- It routes through the normal chat completion path (`fetchChatCompletion`) where both text and images are handled inline as part of the message stream.
- Text responses appear as normal, copyable chat messages. Image responses are still rendered correctly via the existing `file` chunk handling.
- No modal interruption occurs.

Fixes #14733

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The fix is intentionally minimal: only model classification regexes and one guard in `isDedicatedImageModel` were changed. No changes to the streaming or image rendering pipeline were needed because the chat path already supports multimodal output.
- `gpt-image-2` is added to `OPENAI_TOOL_USE_IMAGE_GENERATION_MODELS` so that `isPureGenerateImageModel` returns `false`, ensuring it does not get excluded from tool-use or reasoning flows.

The following alternatives were considered:

- Modifying `fetchImageGeneration` to handle text responses: rejected because it would require significant changes to the dedicated image generation callback pipeline (`IMAGE_COMPLETE` only emits images).
- Adding a new chunk type for image-generation text: rejected as over-engineering when the chat path already handles this natively.

Links to places where the discussion took place: #14733

### Breaking changes

None.

### Special notes for your reviewer

Scope is intentionally minimal for the main branch freeze: no refactoring, no new abstractions. Surface changes:
- One guard in `isDedicatedImageModel` (`vision.ts`)
- Three regex arrays updated in `vision.ts`
- Test assertions added in `vision.test.ts`

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix gpt-image-2 image generation flow: model text responses are now displayed as normal chat messages instead of causing a disruptive modal interruption. Text is natively copyable.