### PR TITLE
fix(deps): omit max_tokens for non-Anthropic models in @ai-sdk/anthropic

### DIFF
--- a/patches/@ai-sdk__anthropic.patch
+++ b/patches/@ai-sdk__anthropic.patch
@@ -1,7 +1,22 @@
 diff --git a/dist/internal/index.js b/dist/internal/index.js
-index 468e7518923b5bfaffa3a5a601e233b5271889ae..88d6a8c15902c65a4eed312eba974fb1f3026a72 100644
+index 468e7518923b5bfaffa3a5a601e233b5271889ae..8a20d03b8186bb35c2ddce6a50997a44ed80735a 100644
 --- a/dist/internal/index.js
 +++ b/dist/internal/index.js
+@@ -3044,12 +3044,12 @@ var AnthropicMessagesLanguageModel = class {
+     const isThinking = thinkingType === "enabled" || thinkingType === "adaptive";
+     let thinkingBudget = thinkingType === "enabled" ? (_f = anthropicOptions == null ? void 0 : anthropicOptions.thinking) == null ? void 0 : _f.budgetTokens : void 0;
+     const thinkingDisplay = thinkingType === "adaptive" ? (_g = anthropicOptions == null ? void 0 : anthropicOptions.thinking) == null ? void 0 : _g.display : void 0;
+-    const maxTokens = maxOutputTokens != null ? maxOutputTokens : maxOutputTokensForModel;
++    const maxTokens = maxOutputTokens != null ? maxOutputTokens : (isKnownModel || this.modelId.startsWith("claude-") ? maxOutputTokensForModel : void 0);
+     const baseArgs = {
+       // model id:
+       model: this.modelId,
+       // standardized settings:
+-      max_tokens: maxTokens,
++      ...(maxTokens != null && { max_tokens: maxTokens }),
+       temperature,
+       top_k: topK,
+       top_p: topP,
 @@ -3062,6 +3062,9 @@ var AnthropicMessagesLanguageModel = class {
            ...thinkingDisplay != null && { display: thinkingDisplay }
          }
@@ -12,10 +27,36 @@ index 468e7518923b5bfaffa3a5a601e233b5271889ae..88d6a8c15902c65a4eed312eba974fb1
        ...((anthropicOptions == null ? void 0 : anthropicOptions.effort) || (anthropicOptions == null ? void 0 : anthropicOptions.taskBudget) || useStructuredOutput && (responseFormat == null ? void 0 : responseFormat.type) === "json" && responseFormat.schema != null) && {
          output_config: {
            ...(anthropicOptions == null ? void 0 : anthropicOptions.effort) && {
+@@ -3217,7 +3220,9 @@ var AnthropicMessagesLanguageModel = class {
+           details: "topP is not supported when thinking is enabled"
+         });
+       }
+-      baseArgs.max_tokens = maxTokens + (thinkingBudget != null ? thinkingBudget : 0);
++      if (maxTokens != null) {
++        baseArgs.max_tokens = maxTokens + (thinkingBudget != null ? thinkingBudget : 0);
++      }
+     } else {
+       if (isAnthropicModel && topP != null && temperature != null) {
+         warnings.push({
 diff --git a/dist/internal/index.mjs b/dist/internal/index.mjs
-index 6e9ff51dd8ccc4785ecd423ec34a84eba8a7d42d..0bde5ccd9dc588b5aec4668b06d7590cfb18c768 100644
+index 6e9ff51dd8ccc4785ecd423ec34a84eba8a7d42d..a601f20a3d15672f55b35ee78980de3afca34784 100644
 --- a/dist/internal/index.mjs
 +++ b/dist/internal/index.mjs
+@@ -3073,12 +3073,12 @@ var AnthropicMessagesLanguageModel = class {
+     const isThinking = thinkingType === "enabled" || thinkingType === "adaptive";
+     let thinkingBudget = thinkingType === "enabled" ? (_f = anthropicOptions == null ? void 0 : anthropicOptions.thinking) == null ? void 0 : _f.budgetTokens : void 0;
+     const thinkingDisplay = thinkingType === "adaptive" ? (_g = anthropicOptions == null ? void 0 : anthropicOptions.thinking) == null ? void 0 : _g.display : void 0;
+-    const maxTokens = maxOutputTokens != null ? maxOutputTokens : maxOutputTokensForModel;
++    const maxTokens = maxOutputTokens != null ? maxOutputTokens : (isKnownModel || this.modelId.startsWith("claude-") ? maxOutputTokensForModel : void 0);
+     const baseArgs = {
+       // model id:
+       model: this.modelId,
+       // standardized settings:
+-      max_tokens: maxTokens,
++      ...(maxTokens != null && { max_tokens: maxTokens }),
+       temperature,
+       top_k: topK,
+       top_p: topP,
 @@ -3091,6 +3091,9 @@ var AnthropicMessagesLanguageModel = class {
            ...thinkingDisplay != null && { display: thinkingDisplay }
          }
@@ -26,3 +67,14 @@ index 6e9ff51dd8ccc4785ecd423ec34a84eba8a7d42d..0bde5ccd9dc588b5aec4668b06d7590c
        ...((anthropicOptions == null ? void 0 : anthropicOptions.effort) || (anthropicOptions == null ? void 0 : anthropicOptions.taskBudget) || useStructuredOutput && (responseFormat == null ? void 0 : responseFormat.type) === "json" && responseFormat.schema != null) && {
          output_config: {
            ...(anthropicOptions == null ? void 0 : anthropicOptions.effort) && {
+@@ -3246,7 +3249,9 @@ var AnthropicMessagesLanguageModel = class {
+           details: "topP is not supported when thinking is enabled"
+         });
+       }
+-      baseArgs.max_tokens = maxTokens + (thinkingBudget != null ? thinkingBudget : 0);
++      if (maxTokens != null) {
++        baseArgs.max_tokens = maxTokens + (thinkingBudget != null ? thinkingBudget : 0);
++      }
+     } else {
+       if (isAnthropicModel && topP != null && temperature != null) {
+         warnings.push({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ overrides:
 
 patchedDependencies:
   '@ai-sdk/anthropic':
-    hash: 306ee28d1836838d4f6bb8b2f3541756846d36f7b3d85c594d62d0301b91ad58
+    hash: 9e459da7b108668e23131b383077b3c254fe1cc93a51768da3615f4489299af9
     path: patches/@ai-sdk__anthropic.patch
   '@ai-sdk/deepseek@2.0.30':
     hash: db4c4c1e60c18e61952ec4432de7a401adf44420bdbfe4bb6f726a8958642790
@@ -183,7 +183,7 @@ importers:
         version: 4.0.96(zod@4.3.4)
       '@ai-sdk/anthropic':
         specifier: ^3.0.71
-        version: 3.0.71(patch_hash=306ee28d1836838d4f6bb8b2f3541756846d36f7b3d85c594d62d0301b91ad58)(zod@4.3.4)
+        version: 3.0.71(patch_hash=9e459da7b108668e23131b383077b3c254fe1cc93a51768da3615f4489299af9)(zod@4.3.4)
       '@ai-sdk/azure':
         specifier: ^3.0.54
         version: 3.0.54(zod@4.3.4)
@@ -1297,7 +1297,7 @@ importers:
     dependencies:
       '@ai-sdk/anthropic':
         specifier: ^3.0.71
-        version: 3.0.71(patch_hash=306ee28d1836838d4f6bb8b2f3541756846d36f7b3d85c594d62d0301b91ad58)(zod@4.3.6)
+        version: 3.0.71(patch_hash=9e459da7b108668e23131b383077b3c254fe1cc93a51768da3615f4489299af9)(zod@4.3.6)
       '@ai-sdk/google':
         specifier: ^3.0.64
         version: 3.0.64(patch_hash=3dbdd2fbbe5a44bc23a04b1195329dd8d78043447e925342ad5ed53c8c3b96ec)(zod@4.3.6)
@@ -1328,7 +1328,7 @@ importers:
     dependencies:
       '@ai-sdk/anthropic':
         specifier: ^3.0.71
-        version: 3.0.71(patch_hash=306ee28d1836838d4f6bb8b2f3541756846d36f7b3d85c594d62d0301b91ad58)(zod@4.3.4)
+        version: 3.0.71(patch_hash=9e459da7b108668e23131b383077b3c254fe1cc93a51768da3615f4489299af9)(zod@4.3.4)
       '@ai-sdk/azure':
         specifier: ^3.0.54
         version: 3.0.54(zod@4.3.4)
@@ -12937,7 +12937,7 @@ snapshots:
 
   '@ai-sdk/amazon-bedrock@4.0.96(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/anthropic': 3.0.71(patch_hash=306ee28d1836838d4f6bb8b2f3541756846d36f7b3d85c594d62d0301b91ad58)(zod@4.3.4)
+      '@ai-sdk/anthropic': 3.0.71(patch_hash=9e459da7b108668e23131b383077b3c254fe1cc93a51768da3615f4489299af9)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.4)
       '@smithy/eventstream-codec': 4.2.14
@@ -12945,13 +12945,13 @@ snapshots:
       aws4fetch: 1.0.20
       zod: 4.3.4
 
-  '@ai-sdk/anthropic@3.0.71(patch_hash=306ee28d1836838d4f6bb8b2f3541756846d36f7b3d85c594d62d0301b91ad58)(zod@4.3.4)':
+  '@ai-sdk/anthropic@3.0.71(patch_hash=9e459da7b108668e23131b383077b3c254fe1cc93a51768da3615f4489299af9)(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/anthropic@3.0.71(patch_hash=306ee28d1836838d4f6bb8b2f3541756846d36f7b3d85c594d62d0301b91ad58)(zod@4.3.6)':
+  '@ai-sdk/anthropic@3.0.71(patch_hash=9e459da7b108668e23131b383077b3c254fe1cc93a51768da3615f4489299af9)(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
@@ -12999,7 +12999,7 @@ snapshots:
 
   '@ai-sdk/google-vertex@4.0.112(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/anthropic': 3.0.71(patch_hash=306ee28d1836838d4f6bb8b2f3541756846d36f7b3d85c594d62d0301b91ad58)(zod@4.3.4)
+      '@ai-sdk/anthropic': 3.0.71(patch_hash=9e459da7b108668e23131b383077b3c254fe1cc93a51768da3615f4489299af9)(zod@4.3.4)
       '@ai-sdk/google': 3.0.64(patch_hash=3dbdd2fbbe5a44bc23a04b1195329dd8d78043447e925342ad5ed53c8c3b96ec)(zod@4.3.4)
       '@ai-sdk/openai-compatible': 2.0.41(zod@4.3.4)
       '@ai-sdk/provider': 3.0.8


### PR DESCRIPTION
### What this PR does

Before this PR:

When `@ai-sdk/anthropic`'s `AnthropicMessagesLanguageModel` was used as transport for non-Anthropic models (e.g. NewAPI configured with `endpointType: 'anthropic'` routing non-Claude models, or any gateway proxying non-Claude models through an Anthropic-compatible API), the SDK silently injected a default `max_tokens` value (4096 for unknown models, model-specific for Claude). This overrode the user's intent when they had disabled `enableMaxTokens` in assistant settings — Cherry Studio's `getMaxTokens` deliberately returns `undefined` in that case.

After this PR:

`max_tokens` is only emitted when either (a) the user has explicitly set it, or (b) the model is actually a Claude model (`isKnownModel || modelId.startsWith("claude-")`). For non-Anthropic models routed through the Anthropic SDK, the field is omitted, respecting the user's choice.

The fix lives in `patches/@ai-sdk__anthropic.patch`:
1. Make the fallback to `maxOutputTokensForModel` Claude-only.
2. Use a conditional spread for `max_tokens` in `baseArgs` so it's omitted when undefined.
3. Guard the thinking-budget addition (`maxTokens + thinkingBudget`) so it doesn't compute `NaN`.

Fixes #

### Why we need it and why it was done in this way

The Anthropic API itself requires `max_tokens`, so the SDK's default fallback is correct for actual Claude requests. But the same SDK class is reused as a transport for non-Anthropic backends in NewAPI / aggregator providers, and there the silent default leaks through and caps generation.

The following tradeoffs were made:

- Patched the upstream package via the existing `pnpm patch` workflow rather than wrapping/intercepting the SDK at the call site, because the field is constructed deep inside `getArgs()` and forking that path would duplicate a lot of logic.

The following alternatives were considered:

- Setting `maxOutputTokens` explicitly per-provider in `getMaxTokens`. Rejected because we want `undefined` to mean "let the server decide" for non-Anthropic backends, and there is no generic safe default.
- Pre-stripping `max_tokens` after the SDK builds the body. Rejected: the SDK posts directly via `postJsonToApi`; there is no public hook between body construction and request dispatch.

Links to places where the discussion took place: N/A

### Breaking changes

None. Behavior for real Anthropic Claude requests is unchanged (the default is still applied). The change only affects requests where the SDK is used against a non-Claude model and the user has not set `maxOutputTokens` — previously they got a silent 4096 cap, now they get whatever the upstream server defaults to.

### Special notes for your reviewer

- The patch is regenerated via `pnpm patch @ai-sdk/anthropic@3.0.71` + `pnpm patch-commit`, so the hash in `pnpm-lock.yaml` updates accordingly.
- Existing 28 tests in `src/renderer/src/aiCore/prepareParams/__tests__/model-parameters.test.ts` still pass.
- Hotfix branch per the post-2026-04-03 main-branch policy. No refactoring included.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix(deps): prevent @ai-sdk/anthropic from injecting a default max_tokens when used as transport for non-Anthropic models (e.g. NewAPI with anthropic endpoint type for non-Claude models). User's choice to disable max tokens is now respected on those backends.
```
