### PR TITLE
fix: refresh openrouter provider patch

### DIFF
--- a/patches/@openrouter__ai-sdk-provider.patch
+++ b/patches/@openrouter__ai-sdk-provider.patch
@@ -1,18 +1,42 @@
+diff --git a/dist/index.d.mts b/dist/index.d.mts
+index ce83b1b71..f71d85637 100644
+--- a/dist/index.d.mts
++++ b/dist/index.d.mts
+@@ -355,6 +355,7 @@ type OpenRouterProviderOptions = {
+      * help OpenRouter to monitor and detect abuse.
+      */
+     user?: string;
++    strictJsonSchema?: boolean;
+ };
+ type OpenRouterSharedSettings = OpenRouterProviderOptions & {
+     /**
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index ce83b1b71..f71d85637 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -355,6 +355,7 @@ type OpenRouterProviderOptions = {
+      * help OpenRouter to monitor and detect abuse.
+      */
+     user?: string;
++    strictJsonSchema?: boolean;
+ };
+ type OpenRouterSharedSettings = OpenRouterProviderOptions & {
+     /**
 diff --git a/dist/index.js b/dist/index.js
-index f33510a50d11a2cb92a90ea70cc0ac84c89f29b9..db0af7e2cc05c47baeb29c0a3974a155316fbd05 100644
+index 22a7359ac..860eabb80 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -1050,7 +1050,8 @@ var OpenRouterProviderMetadataSchema = import_v43.z.object({
- var OpenRouterProviderOptionsSchema = import_v43.z.object({
-   openrouter: import_v43.z.object({
-     reasoning_details: import_v43.z.array(ReasoningDetailUnionSchema).optional(),
+@@ -2380,7 +2380,8 @@ var OpenRouterProviderOptionsSchema = import_v43.z.object({
+     // (e.g., a future format not yet in the enum) is individually dropped
+     // rather than causing the entire array to fail parsing.
+     reasoning_details: ReasoningDetailArraySchema.optional(),
 -    annotations: import_v43.z.array(FileAnnotationSchema).optional()
 +    annotations: import_v43.z.array(FileAnnotationSchema).optional(),
 +    strictJsonSchema: import_v43.z.boolean().optional()
    }).optional()
  }).optional();
  
-@@ -1658,7 +1659,8 @@ var OpenRouterChatLanguageModel = class {
+@@ -3273,7 +3274,8 @@ var OpenRouterChatLanguageModel = class {
      responseFormat,
      topK,
      tools,
@@ -20,9 +44,9 @@ index f33510a50d11a2cb92a90ea70cc0ac84c89f29b9..db0af7e2cc05c47baeb29c0a3974a155
 +    toolChoice,
 +    providerOptions
    }) {
-     var _a15;
+     var _a16;
      const baseArgs = __spreadValues(__spreadValues({
-@@ -1712,7 +1714,8 @@ var OpenRouterChatLanguageModel = class {
+@@ -3329,7 +3331,8 @@ var OpenRouterChatLanguageModel = class {
          function: {
            name: tool.name,
            description: tool.description,
@@ -32,34 +56,34 @@ index f33510a50d11a2cb92a90ea70cc0ac84c89f29b9..db0af7e2cc05c47baeb29c0a3974a155
          }
        }));
        return __spreadProps(__spreadValues({}, baseArgs), {
-@@ -1725,7 +1728,7 @@ var OpenRouterChatLanguageModel = class {
-   async doGenerate(options) {
-     var _a15, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t, _u, _v, _w;
+@@ -3343,7 +3346,7 @@ var OpenRouterChatLanguageModel = class {
+     var _b16, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t, _u, _v, _w;
      const providerOptions = options.providerOptions || {};
--    const openrouterOptions = providerOptions.openrouter || {};
-+    const { strictJsonSchema: _strictJsonSchema, ...openrouterOptions } = providerOptions.openrouter || {};
-     const args = __spreadValues(__spreadValues({}, this.getArgs(options)), openrouterOptions);
+     const openrouterOptions = providerOptions.openrouter || {};
+-    const _a16 = openrouterOptions, { cacheControl } = _a16, restOpenrouterOptions = __objRest(_a16, ["cacheControl"]);
++    const _a16 = openrouterOptions, { cacheControl, strictJsonSchema: _strictJsonSchema } = _a16, restOpenrouterOptions = __objRest(_a16, ["cacheControl", "strictJsonSchema"]);
+     const args = __spreadValues(__spreadValues(__spreadValues({}, this.getArgs(options)), restOpenrouterOptions), cacheControl != null && !("cache_control" in restOpenrouterOptions) ? { cache_control: cacheControl } : {});
      const { value: responseValue, responseHeaders } = await postJsonToApi({
        url: this.config.url({
-@@ -1931,7 +1934,7 @@ var OpenRouterChatLanguageModel = class {
-   async doStream(options) {
-     var _a15;
+@@ -3541,7 +3544,7 @@ var OpenRouterChatLanguageModel = class {
+     var _b16;
      const providerOptions = options.providerOptions || {};
--    const openrouterOptions = providerOptions.openrouter || {};
-+    const { strictJsonSchema: _strictJsonSchema, ...openrouterOptions } = providerOptions.openrouter || {};
-     const args = __spreadValues(__spreadValues({}, this.getArgs(options)), openrouterOptions);
+     const openrouterOptions = providerOptions.openrouter || {};
+-    const _a16 = openrouterOptions, { cacheControl } = _a16, restOpenrouterOptions = __objRest(_a16, ["cacheControl"]);
++    const _a16 = openrouterOptions, { cacheControl, strictJsonSchema: _strictJsonSchema } = _a16, restOpenrouterOptions = __objRest(_a16, ["cacheControl", "strictJsonSchema"]);
+     const args = __spreadValues(__spreadValues(__spreadValues({}, this.getArgs(options)), restOpenrouterOptions), cacheControl != null && !("cache_control" in restOpenrouterOptions) ? { cache_control: cacheControl } : {});
      const { value: response, responseHeaders } = await postJsonToApi({
        url: this.config.url({
-@@ -2564,7 +2567,7 @@ var OpenRouterCompletionLanguageModel = class {
+@@ -4209,7 +4212,7 @@ var OpenRouterCompletionLanguageModel = class {
    async doGenerate(options) {
-     var _a15, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o;
+     var _a16, _b16, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q;
      const providerOptions = options.providerOptions || {};
 -    const openrouterOptions = providerOptions.openrouter || {};
 +    const { strictJsonSchema: _strictJsonSchema, ...openrouterOptions } = providerOptions.openrouter || {};
      const args = __spreadValues(__spreadValues({}, this.getArgs(options)), openrouterOptions);
      const { value: response, responseHeaders } = await postJsonToApi({
        url: this.config.url({
-@@ -2623,7 +2626,7 @@ var OpenRouterCompletionLanguageModel = class {
+@@ -4284,7 +4287,7 @@ var OpenRouterCompletionLanguageModel = class {
    }
    async doStream(options) {
      const providerOptions = options.providerOptions || {};
@@ -69,20 +93,20 @@ index f33510a50d11a2cb92a90ea70cc0ac84c89f29b9..db0af7e2cc05c47baeb29c0a3974a155
      const { value: response, responseHeaders } = await postJsonToApi({
        url: this.config.url({
 diff --git a/dist/index.mjs b/dist/index.mjs
-index 8a688331b88b4af738ee4ca8062b5f24124d3d81..a2aa299a44352addc26f8891d839ea31a2150ee2 100644
+index 3b4c63d74..96b592196 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
-@@ -1015,7 +1015,8 @@ var OpenRouterProviderMetadataSchema = z3.object({
- var OpenRouterProviderOptionsSchema = z3.object({
-   openrouter: z3.object({
-     reasoning_details: z3.array(ReasoningDetailUnionSchema).optional(),
+@@ -2347,7 +2347,8 @@ var OpenRouterProviderOptionsSchema = z3.object({
+     // (e.g., a future format not yet in the enum) is individually dropped
+     // rather than causing the entire array to fail parsing.
+     reasoning_details: ReasoningDetailArraySchema.optional(),
 -    annotations: z3.array(FileAnnotationSchema).optional()
 +    annotations: z3.array(FileAnnotationSchema).optional(),
 +    strictJsonSchema: z3.boolean().optional()
    }).optional()
  }).optional();
  
-@@ -1623,7 +1624,8 @@ var OpenRouterChatLanguageModel = class {
+@@ -3240,7 +3241,8 @@ var OpenRouterChatLanguageModel = class {
      responseFormat,
      topK,
      tools,
@@ -90,9 +114,9 @@ index 8a688331b88b4af738ee4ca8062b5f24124d3d81..a2aa299a44352addc26f8891d839ea31
 +    toolChoice,
 +    providerOptions
    }) {
-     var _a15;
+     var _a16;
      const baseArgs = __spreadValues(__spreadValues({
-@@ -1677,7 +1679,8 @@ var OpenRouterChatLanguageModel = class {
+@@ -3296,7 +3298,8 @@ var OpenRouterChatLanguageModel = class {
          function: {
            name: tool.name,
            description: tool.description,
@@ -102,34 +126,34 @@ index 8a688331b88b4af738ee4ca8062b5f24124d3d81..a2aa299a44352addc26f8891d839ea31
          }
        }));
        return __spreadProps(__spreadValues({}, baseArgs), {
-@@ -1690,7 +1693,7 @@ var OpenRouterChatLanguageModel = class {
-   async doGenerate(options) {
-     var _a15, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t, _u, _v, _w;
+@@ -3310,7 +3313,7 @@ var OpenRouterChatLanguageModel = class {
+     var _b16, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t, _u, _v, _w;
      const providerOptions = options.providerOptions || {};
--    const openrouterOptions = providerOptions.openrouter || {};
-+    const { strictJsonSchema: _strictJsonSchema, ...openrouterOptions } = providerOptions.openrouter || {};
-     const args = __spreadValues(__spreadValues({}, this.getArgs(options)), openrouterOptions);
+     const openrouterOptions = providerOptions.openrouter || {};
+-    const _a16 = openrouterOptions, { cacheControl } = _a16, restOpenrouterOptions = __objRest(_a16, ["cacheControl"]);
++    const _a16 = openrouterOptions, { cacheControl, strictJsonSchema: _strictJsonSchema } = _a16, restOpenrouterOptions = __objRest(_a16, ["cacheControl", "strictJsonSchema"]);
+     const args = __spreadValues(__spreadValues(__spreadValues({}, this.getArgs(options)), restOpenrouterOptions), cacheControl != null && !("cache_control" in restOpenrouterOptions) ? { cache_control: cacheControl } : {});
      const { value: responseValue, responseHeaders } = await postJsonToApi({
        url: this.config.url({
-@@ -1896,7 +1899,7 @@ var OpenRouterChatLanguageModel = class {
-   async doStream(options) {
-     var _a15;
+@@ -3508,7 +3511,7 @@ var OpenRouterChatLanguageModel = class {
+     var _b16;
      const providerOptions = options.providerOptions || {};
--    const openrouterOptions = providerOptions.openrouter || {};
-+    const { strictJsonSchema: _strictJsonSchema, ...openrouterOptions } = providerOptions.openrouter || {};
-     const args = __spreadValues(__spreadValues({}, this.getArgs(options)), openrouterOptions);
+     const openrouterOptions = providerOptions.openrouter || {};
+-    const _a16 = openrouterOptions, { cacheControl } = _a16, restOpenrouterOptions = __objRest(_a16, ["cacheControl"]);
++    const _a16 = openrouterOptions, { cacheControl, strictJsonSchema: _strictJsonSchema } = _a16, restOpenrouterOptions = __objRest(_a16, ["cacheControl", "strictJsonSchema"]);
+     const args = __spreadValues(__spreadValues(__spreadValues({}, this.getArgs(options)), restOpenrouterOptions), cacheControl != null && !("cache_control" in restOpenrouterOptions) ? { cache_control: cacheControl } : {});
      const { value: response, responseHeaders } = await postJsonToApi({
        url: this.config.url({
-@@ -2529,7 +2532,7 @@ var OpenRouterCompletionLanguageModel = class {
+@@ -4176,7 +4179,7 @@ var OpenRouterCompletionLanguageModel = class {
    async doGenerate(options) {
-     var _a15, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o;
+     var _a16, _b16, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q;
      const providerOptions = options.providerOptions || {};
 -    const openrouterOptions = providerOptions.openrouter || {};
 +    const { strictJsonSchema: _strictJsonSchema, ...openrouterOptions } = providerOptions.openrouter || {};
      const args = __spreadValues(__spreadValues({}, this.getArgs(options)), openrouterOptions);
      const { value: response, responseHeaders } = await postJsonToApi({
        url: this.config.url({
-@@ -2588,7 +2591,7 @@ var OpenRouterCompletionLanguageModel = class {
+@@ -4251,7 +4254,7 @@ var OpenRouterCompletionLanguageModel = class {
    }
    async doStream(options) {
      const providerOptions = options.providerOptions || {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,7 +59,7 @@ patchedDependencies:
     hash: aa1a73e445ee644774745b620589bb99d85bee6c95cc2a91fe9137e580da5bde
     path: patches/@napi-rs-system-ocr-npm-1.0.2-59e7a78e8b.patch
   '@openrouter/ai-sdk-provider':
-    hash: 508e8e662b8547de93410cb7c3b1336077f34c6bf79c520ef5273962ea777c52
+    hash: 6f905d5d4efe8dacf34b76a13807f84b19418cf68adc7febeaf1a96fa5886df8
     path: patches/@openrouter__ai-sdk-provider.patch
   '@opeoginni/github-copilot-openai-compatible@1.0.0':
     hash: 4bea0e526136ed32d0be4849ec5cbb41bd5de7b7418dd6920598357438cfef25
@@ -408,7 +408,7 @@ importers:
         version: 2.3.0(encoding@0.1.13)
       '@openrouter/ai-sdk-provider':
         specifier: ^2.3.3
-        version: 2.3.3(patch_hash=508e8e662b8547de93410cb7c3b1336077f34c6bf79c520ef5273962ea777c52)(ai@6.0.143(zod@4.3.4))(zod@4.3.4)
+        version: 2.3.3(patch_hash=6f905d5d4efe8dacf34b76a13807f84b19418cf68adc7febeaf1a96fa5886df8)(ai@6.0.143(zod@4.3.4))(zod@4.3.4)
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
@@ -1358,7 +1358,7 @@ importers:
         version: link:../ai-sdk-provider
       '@openrouter/ai-sdk-provider':
         specifier: ^2.3.3
-        version: 2.3.3(patch_hash=508e8e662b8547de93410cb7c3b1336077f34c6bf79c520ef5273962ea777c52)(ai@6.0.143(zod@4.3.4))(zod@4.3.4)
+        version: 2.3.3(patch_hash=6f905d5d4efe8dacf34b76a13807f84b19418cf68adc7febeaf1a96fa5886df8)(ai@6.0.143(zod@4.3.4))(zod@4.3.4)
       ai:
         specifier: ^6.0.116
         version: 6.0.143(zod@4.3.4)
@@ -15874,7 +15874,7 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@openrouter/ai-sdk-provider@2.3.3(patch_hash=508e8e662b8547de93410cb7c3b1336077f34c6bf79c520ef5273962ea777c52)(ai@6.0.143(zod@4.3.4))(zod@4.3.4)':
+  '@openrouter/ai-sdk-provider@2.3.3(patch_hash=6f905d5d4efe8dacf34b76a13807f84b19418cf68adc7febeaf1a96fa5886df8)(ai@6.0.143(zod@4.3.4))(zod@4.3.4)':
     dependencies:
       ai: 6.0.143(zod@4.3.4)
       zod: 4.3.4


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR:

The `@openrouter/ai-sdk-provider` pnpm patch no longer applied cleanly to the current `2.3.3` package contents, causing install-time patch warnings.

After this PR:

The patch has been refreshed for the current package layout, keeps `strictJsonSchema` support for OpenRouter tool schemas, strips that internal option from API request bodies, and updates the pnpm patch hash.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

This keeps the dependency version unchanged and only refreshes the existing patch, minimizing scope for the `main` branch.

The following alternatives were considered:

Upgrading `@openrouter/ai-sdk-provider` was avoided because this PR only needs to restore the existing patch behavior.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Validated with `pnpm install --ignore-scripts`, `pnpm lint`, `pnpm test`, `pnpm format`, and `git diff --check`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
