### PR TITLE
fix(search): prevent empty activeTools when web search is the only tool

### DIFF
--- a/src/renderer/src/aiCore/plugins/searchOrchestrationPlugin.ts
+++ b/src/renderer/src/aiCore/plugins/searchOrchestrationPlugin.ts
@@ -358,7 +358,7 @@ export const searchOrchestrationPlugin = (
               // rejects empty tools arrays. The tool's internal cache (cachedSearchResultsPromise)
               // already prevents actual re-searching.
               if (filteredTools.length === 0) return stepConfig
-              return { ...stepConfig, activeTools: filteredTools }
+              return { ...(stepConfig ?? {}), activeTools: filteredTools }
             }
           }
         }

--- a/src/renderer/src/aiCore/plugins/searchOrchestrationPlugin.ts
+++ b/src/renderer/src/aiCore/plugins/searchOrchestrationPlugin.ts
@@ -358,7 +358,7 @@ export const searchOrchestrationPlugin = (
               // rejects empty tools arrays. The tool's internal cache (cachedSearchResultsPromise)
               // already prevents actual re-searching.
               if (filteredTools.length === 0) return stepConfig
-              return { ...(stepConfig ?? {}), activeTools: filteredTools }
+              return { ...stepConfig, activeTools: filteredTools }
             }
           }
         }

--- a/src/renderer/src/aiCore/plugins/searchOrchestrationPlugin.ts
+++ b/src/renderer/src/aiCore/plugins/searchOrchestrationPlugin.ts
@@ -350,14 +350,15 @@ export const searchOrchestrationPlugin = (
                 step.toolCalls.some((toolCall) => toolCall.toolName === BUILTIN_WEB_SEARCH_TOOL_NAME)
               )
 
-              return hasWebSearchCall
-                ? {
-                    ...stepConfig,
-                    activeTools: (stepConfig?.activeTools ?? Object.keys(params.tools!)).filter(
-                      (toolName) => toolName !== BUILTIN_WEB_SEARCH_TOOL_NAME
-                    )
-                  }
-                : stepConfig
+              if (!hasWebSearchCall) return stepConfig
+              const filteredTools = (stepConfig?.activeTools ?? Object.keys(params.tools!)).filter(
+                (toolName) => toolName !== BUILTIN_WEB_SEARCH_TOOL_NAME
+              )
+              // When web search is the only tool, don't set activeTools to [] — Anthropic
+              // rejects empty tools arrays. The tool's internal cache (cachedSearchResultsPromise)
+              // already prevents actual re-searching.
+              if (filteredTools.length === 0) return stepConfig
+              return { ...stepConfig, activeTools: filteredTools }
             }
           }
         }


### PR DESCRIPTION
### What this PR does

Before this PR:

When `prepareStep` filtered the built-in web search tool out of `activeTools` after it had been called once, it could produce `activeTools: []` — an empty array. The AI SDK forwarded this as `tools: []` to the Anthropic API, which rejects it with a 400 error: *"tools: array must contain at least 1 element if present"*. This truncated the assistant's response mid-stream after the first web search completed.

After this PR:

When filtering the built-in web search tool would leave `activeTools` empty, `prepareStep` returns without setting `activeTools` instead. The AI SDK then passes all available tools to the model. The tool's internal `cachedSearchResultsPromise` already prevents actual re-searching, so the behaviour goal of `0636b601f` is preserved.

Fixes #14465 (regression introduced by the fix in `0636b601f`)

### Why we need it and why it was done in this way

The following tradeoffs were made:

The upstream fix in `0636b601f` correctly prevents repeated web searches but introduced a regression when web search is the *only* tool: the empty `activeTools` array reaches Anthropic and triggers a 400. The fix here is minimal — one guard before returning `{ activeTools: filteredTools }`.

The following alternatives were considered:

- Removing the `prepareStep` hook entirely: rejected because it would re-introduce runaway repeated searches.
- Returning `{ activeTools: undefined }` explicitly: equivalent to returning `undefined`/`stepConfig`; chose the latter for clarity.

### Breaking changes

None.

### Special notes for your reviewer

The `cachedSearchResultsPromise` closure in `WebSearchTool` is the mechanism that prevents re-searching when web search remains visible in subsequent steps. This was introduced in `0636b601f` and is relied upon here.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: Not required — internal bug fix, no user-facing behaviour change beyond fixing the truncation.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed built-in web search truncating the assistant response when web search was the only active tool.
```
