### PR TITLE
fix: restore full streaming model output display

### DIFF
--- a/src/renderer/src/aiCore/chunk/__tests__/AiSdkToChunkAdapter.test.ts
+++ b/src/renderer/src/aiCore/chunk/__tests__/AiSdkToChunkAdapter.test.ts
@@ -1,0 +1,49 @@
+import { ChunkType } from '@renderer/types/chunk'
+import { describe, expect, it, vi } from 'vitest'
+
+import { AiSdkToChunkAdapter } from '../AiSdkToChunkAdapter'
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({
+      silly: vi.fn(),
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    })
+  }
+}))
+
+describe('AiSdkToChunkAdapter', () => {
+  it('accumulates text deltas when requested', async () => {
+    const emittedTexts: string[] = []
+    const adapter = new AiSdkToChunkAdapter(
+      (chunk) => {
+        if (chunk.type === ChunkType.TEXT_DELTA) {
+          emittedTexts.push(chunk.text)
+        }
+      },
+      [],
+      true
+    )
+
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({ type: 'text-start', id: 'text-1' })
+        controller.enqueue({ type: 'text-delta', id: 'text-1', text: 'Hello ' })
+        controller.enqueue({ type: 'text-delta', id: 'text-1', text: 'world!' })
+        controller.enqueue({ type: 'text-end', id: 'text-1' })
+        controller.enqueue({ type: 'finish', finishReason: { unified: 'stop' }, totalUsage: {} })
+        controller.close()
+      }
+    })
+
+    await adapter.processStream({
+      fullStream: stream,
+      text: Promise.resolve('Hello world!')
+    })
+
+    expect(emittedTexts).toEqual(['Hello ', 'Hello world!'])
+  })
+})

--- a/src/renderer/src/store/thunk/messageThunk.ts
+++ b/src/renderer/src/store/thunk/messageThunk.ts
@@ -746,7 +746,7 @@ const fetchAndProcessAgentResponseImpl = async (
     const adapter = new AiSdkToChunkAdapter(
       streamProcessorCallbacks,
       [],
-      false,
+      true,
       false,
       (sessionId) => {
         void persistAgentSessionId(sessionId)
@@ -2227,7 +2227,7 @@ export const setupChannelStream = (
   const streamProcessorCallbacks = createStreamProcessor(callbacks)
   streamProcessorCallbacks({ type: ChunkType.LLM_RESPONSE_CREATED })
 
-  const adapter = new AiSdkToChunkAdapter(streamProcessorCallbacks, [], false, false)
+  const adapter = new AiSdkToChunkAdapter(streamProcessorCallbacks, [], true, false)
   adapter
     .processStream({
       fullStream: stream,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR:
- Streaming assistant responses were updated with raw deltas, so live output could appear as only the latest chunk instead of the full paragraph.

After this PR:
- Streaming assistant responses accumulate text before dispatching block updates, so the UI renders the full response while streaming.
- Added a regression test covering cumulative `AiSdkToChunkAdapter` text deltas.

Fixes #14701

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Switched the assistant streaming adapter call sites to cumulative mode instead of changing the markdown renderer, which keeps the fix localized to the streaming pipeline.

The following alternatives were considered:
- Patching markdown or layout CSS, but the issue was caused by the streaming update path rather than the renderer.

Links to places where the discussion took place: None

### Breaking changes

None

### Special notes for your reviewer

None

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix streaming assistant responses so the full answer is visible while output is still streaming.
```
