### PR TITLE
fix(models): group custom provider models by model ID

### DIFF
--- a/src/renderer/src/aiCore/services/listModels.ts
+++ b/src/renderer/src/aiCore/services/listModels.ts
@@ -13,8 +13,9 @@ import { loggerService } from '@logger'
 import { COPILOT_DEFAULT_HEADERS } from '@renderer/aiCore/provider/constants'
 import store from '@renderer/store'
 import type { EndpointType, Model, Provider } from '@renderer/types'
-import { SystemProviderIds } from '@renderer/types'
+import { isSystemProviderId, SystemProviderIds } from '@renderer/types'
 import { formatApiHost, withoutTrailingSlash } from '@renderer/utils'
+import { getDefaultGroupName } from '@renderer/utils/naming'
 import { isAIGatewayProvider, isGeminiProvider, isOllamaProvider, isVertexProvider } from '@renderer/utils/provider'
 import { defaultAppHeaders } from '@shared/utils'
 import * as z from 'zod'
@@ -121,7 +122,14 @@ function defaultHeaders(provider: Provider): Record<string, string> {
 
 function defaultGroup(modelId: string, providerId: string): string {
   const parts = modelId.split('/')
-  return parts.length > 1 ? parts[0] : providerId
+  if (parts.length > 1) return parts[0]
+  // For user-defined ("custom") providers, the provider.id is a UUID and makes
+  // a poor group name. Fall back to a model-ID-derived group so e.g.
+  // "gpt-4.1-mini" lands under "gpt-4.1" instead of the raw UUID.
+  if (!isSystemProviderId(providerId)) {
+    return getDefaultGroupName(modelId, providerId)
+  }
+  return providerId
 }
 
 function toModel(id: string, provider: Provider, extra?: Partial<Model>): Model {


### PR DESCRIPTION
### What this PR does

Before this PR:

For user-created ("custom") providers, every model whose ID doesn't contain `/` was grouped under the raw provider UUID in the model list UI. `listModels.ts`'s `defaultGroup()` fell back to `providerId` when there was no slash. For a custom provider with `provider.id` like `12deee2a-d3cc-4b17-bfba-edd4de5c8d58`, models such as `gpt-4.1-mini`, `claude-3.5-sonnet`, `deepseek-r1` all ended up under a group named after the UUID.

After this PR:

`defaultGroup()` keeps the existing behavior for system providers (providerId is a stable label like `gemini` or `silicon`), but for custom providers — whose `provider.id` is a UUID and makes a poor group name — it derives the group from the model ID via `getDefaultGroupName()` from `utils/naming.ts`, which already handles `-`, `_`, `:`, ` ` splits and has full unit-test coverage. So `gpt-4.1-mini` lands under `gpt-4.1` instead of the raw UUID.

Concretely:

| Scenario | Provider type | Model ID | Before | After |
|---|---|---|---|---|
| Slash in model ID | any | `BAAI/bge-large-zh-v1.5` | `BAAI` | `BAAI` (unchanged) |
| No slash | system (e.g. gemini) | `gemini-2.5-flash` | `gemini` | `gemini` (unchanged) |
| No delimiters | system aihubmix | `qwen3.6` | `aihubmix` | `aihubmix` (unchanged) |
| No slash | **custom (UUID)** | `gpt-4.1-mini` | `12deee2a-...` ❌ | `gpt-4.1` ✓ |

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The first version of this PR replaced `defaultGroup` entirely with `getDefaultGroupName`, which changed grouping for system providers too (e.g. `gemini-2.5-flash` → `gemini-2.5`, `BAAI` → `baai`). Snapshot tests caught this. Narrowed to only take effect for non-system providers, leaving system provider grouping untouched.
- Reuses the existing, already-tested `getDefaultGroupName` for the fallback rather than inventing new logic in this file.

The following alternatives were considered:

- Regex-matching UUIDs to detect custom providers: rejected — brittle and `isSystemProviderId()` is already available and authoritative.
- Updating the snapshot tests to match the broader new behavior: rejected — it's a user-visible behavior change for system providers without clear upside.

Links to places where the discussion took place: [#14774 (comment)](https://github.com/CherryHQ/cherry-studio/issues/14774#issuecomment-4359414029) briefly mentions the UUID warning that led to this finding.

### Breaking changes

None. For custom providers, groups that previously displayed a UUID will now display a model-ID-derived name. For system providers, grouping is unchanged.

### Special notes for your reviewer

- Local `pnpm lint` / `pnpm test` / `pnpm format` couldn't be run on the author's machine (no pnpm install available) — relying on CI. The initial push surfaced 3 snapshot/assertion regressions; the current revision is scoped to only affect custom providers and should leave existing snapshots intact.
- `main` is under code freeze, so this is submitted from a `hotfix/*` branch per the contributing guidelines.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix custom provider model groups showing the raw provider UUID instead of a model-derived group name.
```
