### PR TITLE
fix(reasoning): use enable_thinking param for SiliconFlow DeepSeek/Zhipu models when reasoning_effort is none

### DIFF
--- a/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
+++ b/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
@@ -431,6 +431,54 @@ describe('reasoning utils', () => {
       })
     })
 
+    it('should use enable_thinking:false for SiliconFlow + DeepSeek-V4-Flash when reasoning_effort is none', async () => {
+      const { isReasoningModel, isDeepSeekHybridInferenceModel } = await import('@renderer/config/models')
+
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+      vi.mocked(isDeepSeekHybridInferenceModel).mockReturnValue(true)
+
+      const model: Model = {
+        id: 'deepseek-ai/DeepSeek-V4-Flash',
+        name: 'DeepSeek V4 Flash',
+        provider: SystemProviderIds.silicon
+      } as Model
+
+      const assistant: Assistant = {
+        id: 'test',
+        name: 'Test',
+        settings: {
+          reasoning_effort: 'none'
+        }
+      } as Assistant
+
+      const result = getReasoningEffort(assistant, model)
+      expect(result).toEqual({ enable_thinking: false })
+    })
+
+    it('should use enable_thinking:false for SiliconFlow + Zhipu model when reasoning_effort is none', async () => {
+      const { isReasoningModel, isSupportedThinkingTokenZhipuModel } = await import('@renderer/config/models')
+
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+      vi.mocked(isSupportedThinkingTokenZhipuModel).mockReturnValue(true)
+
+      const model: Model = {
+        id: 'THUDM/glm-4.5-thinking',
+        name: 'GLM-4.5 Thinking',
+        provider: SystemProviderIds.silicon
+      } as Model
+
+      const assistant: Assistant = {
+        id: 'test',
+        name: 'Test',
+        settings: {
+          reasoning_effort: 'none'
+        }
+      } as Assistant
+
+      const result = getReasoningEffort(assistant, model)
+      expect(result).toEqual({ enable_thinking: false })
+    })
+
     it('should return medium effort for deep research models', async () => {
       const { isReasoningModel, isOpenAIDeepResearchModel } = await import('@renderer/config/models')
 

--- a/src/renderer/src/aiCore/utils/reasoning.ts
+++ b/src/renderer/src/aiCore/utils/reasoning.ts
@@ -143,7 +143,10 @@ export function getReasoningEffort(assistant: Assistant, model: Model): Reasonin
       (provider.id === SystemProviderIds.dashscope &&
         (isDeepSeekHybridInferenceModel(model) ||
           isSupportedThinkingTokenZhipuModel(model) ||
-          isSupportedThinkingTokenKimiModel(model)))
+          isSupportedThinkingTokenKimiModel(model))) ||
+      // SiliconFlow uses enable_thinking for DeepSeek and Zhipu models, same as positive path
+      (provider.id === SystemProviderIds.silicon &&
+        (isDeepSeekHybridInferenceModel(model) || isSupportedThinkingTokenZhipuModel(model)))
     ) {
       return { enable_thinking: false }
     }


### PR DESCRIPTION
### What this PR does

Before this PR: On SiliconFlow, using DeepSeek-V4-Flash (or other DeepSeek V3/V4+ variants) and Zhipu GLM thinking models caused topic title generation to fail with an "Invalid JSON response" error.

After this PR: Topic title generation works correctly for these models on SiliconFlow. The correct `enable_thinking: false` parameter is now sent instead of the Anthropic-style `thinking: { type: 'disabled' }`.

Fixes #14775

### Why we need it and why it was done in this way

SiliconFlow uses `enable_thinking: false` to disable thinking for DeepSeek and Zhipu models — the same format as the positive path (`enable_thinking: true`). The `reasoning_effort === 'none'` branch in `getReasoningEffort` lacked a SiliconFlow-specific case for `isDeepSeekHybridInferenceModel` and `isSupportedThinkingTokenZhipuModel`, so these models fell through to the generic `{ thinking: { type: 'disabled' } }` return (Anthropic format), which SiliconFlow doesn't accept.

The fix adds a silicon condition mirroring the existing `dashscope` pattern in the same block — minimal and consistent with the surrounding code.

The following tradeoffs were made: None. The fix is additive and does not affect any other provider.

The following alternatives were considered: Treating SiliconFlow like `openai-compatible` (returning `{}` for none). Rejected — `enable_thinking: false` is required to explicitly suppress thinking token budget on SiliconFlow's DeepSeek and Zhipu models.

### Breaking changes

None.

### Special notes for your reviewer

`isDeepSeekHybridInferenceModel` covers all DeepSeek V3.x and V4+ model variants. `isSupportedThinkingTokenZhipuModel` covers GLM-4.5/4.6/4.7 and GLM-5 series. Qwen models on SiliconFlow were already handled correctly by the existing `isSupportEnableThinkingProvider` condition.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed "Invalid JSON response" error when generating topic titles with DeepSeek-V4-Flash and Zhipu GLM thinking models on SiliconFlow.
```
