### PR TITLE
feat: add Duplicate Topic feature

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -1400,6 +1400,9 @@
       "delete": {
         "shortcut": "Hold {{key}} to delete directly"
       },
+      "duplicate": "Duplicate Topic",
+      "duplicate_error": "Failed to duplicate topic",
+      "duplicate_success": "Topic duplicated",
       "edit": {
         "placeholder": "Enter new name",
         "title": "Edit Name",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -1400,6 +1400,9 @@
       "delete": {
         "shortcut": "按住 {{key}} 可直接删除"
       },
+      "duplicate": "复制话题",
+      "duplicate_error": "话题复制失败",
+      "duplicate_success": "话题复制成功",
       "edit": {
         "placeholder": "输入新名称",
         "title": "编辑话题名",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -1400,6 +1400,9 @@
       "delete": {
         "shortcut": "按住 {{key}} 可直接刪除"
       },
+      "duplicate": "複製話題",
+      "duplicate_error": "話題複製失敗",
+      "duplicate_success": "話題複製成功",
       "edit": {
         "placeholder": "輸入新名稱",
         "title": "編輯名稱",

--- a/src/renderer/src/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/Topics.tsx
@@ -1,3 +1,4 @@
+import { dataApiService } from '@data/DataApiService'
 import { useCache } from '@data/hooks/useCache'
 import { useMultiplePreferences, usePreference } from '@data/hooks/usePreference'
 import AddButton from '@renderer/components/AddButton'
@@ -16,10 +17,12 @@ import { modelGenerating } from '@renderer/hooks/useModel'
 import { useNotesSettings } from '@renderer/hooks/useNotesSettings'
 import { finishTopicRenaming, startTopicRenaming, TopicManager } from '@renderer/hooks/useTopic'
 import { fetchMessagesSummary } from '@renderer/services/ApiService'
-import { getDefaultTopic } from '@renderer/services/AssistantService'
+import { getDefaultTopic, mapLegacyTopicToDto } from '@renderer/services/AssistantService'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import type { RootState } from '@renderer/store'
+import { useAppDispatch } from '@renderer/store'
 import { newMessagesActions } from '@renderer/store/newMessage'
+import { cloneMessagesToNewTopicThunk } from '@renderer/store/thunk/messageThunk'
 import type { Assistant, Topic } from '@renderer/types'
 import { classNames, removeSpecialCharactersForFileName } from '@renderer/utils'
 import { copyTopicAsMarkdown, copyTopicAsPlainText } from '@renderer/utils/copy'
@@ -40,6 +43,7 @@ import { findIndex } from 'lodash'
 import {
   BrushCleaning,
   CheckSquare,
+  CopyPlus,
   FolderOpen,
   HelpCircle,
   ListChecks,
@@ -56,7 +60,7 @@ import {
 } from 'lucide-react'
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useDispatch, useSelector } from 'react-redux'
+import { useSelector } from 'react-redux'
 import styled from 'styled-components'
 
 import { TopicManagePanel, useTopicManageMode } from './TopicManageMode'
@@ -113,7 +117,7 @@ export const Topics: React.FC<Props> = ({ assistant: _assistant, activeTopic, se
 
   const isPending = useCallback((topicId: string) => topicLoadingQuery[topicId], [topicLoadingQuery])
   const isFulfilled = useCallback((topicId: string) => topicFulfilledQuery[topicId], [topicFulfilledQuery])
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     dispatch(newMessagesActions.setTopicFulfilled({ topicId: activeTopic.id, fulfilled: false }))
@@ -233,6 +237,46 @@ export const Topics: React.FC<Props> = ({ assistant: _assistant, activeTopic, se
       moveTopic(topic, toAssistant)
     },
     [assistant.topics, moveTopic, setActiveTopic]
+  )
+
+  const onDuplicateTopic = useCallback(
+    async (topic: Topic) => {
+      await modelGenerating()
+
+      let topicWithPrompt: Topic | null = null
+      try {
+        const newTopic = getDefaultTopic(assistant.id)
+        newTopic.name = `${topic.name} (Copy)`
+
+        const createdTopic = await dataApiService.post('/topics', {
+          body: mapLegacyTopicToDto(newTopic)
+        })
+
+        topicWithPrompt = { ...createdTopic, prompt: topic.prompt, messages: [], assistantId: assistant.id }
+
+        await db.topics.add({ id: topicWithPrompt.id, messages: [] })
+        addTopic(topicWithPrompt)
+
+        const messages = await TopicManager.getTopicMessages(topic.id)
+        if (messages.length > 0) {
+          const success = await dispatch(cloneMessagesToNewTopicThunk(topic.id, messages.length, topicWithPrompt))
+          if (!success) {
+            window.toast.error(t('chat.topics.duplicate_error'))
+            removeTopic(topicWithPrompt)
+            return
+          }
+        }
+
+        setActiveTopic(topicWithPrompt)
+        window.toast.success(t('chat.topics.duplicate_success'))
+      } catch {
+        window.toast.error(t('chat.topics.duplicate_error'))
+        if (topicWithPrompt) {
+          removeTopic(topicWithPrompt)
+        }
+      }
+    },
+    [assistant.id, addTopic, removeTopic, dispatch, setActiveTopic, t]
   )
 
   const onSwitchTopic = useCallback(
@@ -484,6 +528,12 @@ export const Topics: React.FC<Props> = ({ assistant: _assistant, activeTopic, se
             }
           }
         ].filter(Boolean) as ItemType<MenuItemType>[]
+      },
+      {
+        label: t('chat.topics.duplicate'),
+        key: 'duplicate',
+        icon: <CopyPlus size={14} />,
+        onClick: () => onDuplicateTopic(topic)
       }
     ]
 
@@ -539,6 +589,7 @@ export const Topics: React.FC<Props> = ({ assistant: _assistant, activeTopic, se
     onClearMessages,
     setTopicPosition,
     onMoveTopic,
+    onDuplicateTopic,
     onDeleteTopic
   ])
 


### PR DESCRIPTION
### What this PR does

Before this PR:
Users could only copy topic content to clipboard (as image, markdown, or plain text) or export it to external formats. There was no way to create a full copy of a topic including all its conversation history within the app.

After this PR:
Right-clicking any topic in the topic list now shows a **"Duplicate Topic"** option. Selecting it creates a complete clone of the topic — including all messages, blocks, files, and the topic prompt — with the name suffixed by `" (Copy)"`. The duplicated topic is immediately activated so the user can continue the conversation.

Fixes #14773

### Why we need it and why it was done in this way

This feature was requested by AI novel creators who frequently need to branch stories within the same world view / background / premise. Without duplication, they had to manually save content or copy-paste, which is cumbersome for long conversations.

The implementation reuses the existing `cloneMessagesToNewTopicThunk` (already used for topic branching) to deep-clone all messages and blocks with remapped IDs. This avoids duplicating logic and ensures file references are handled correctly.

**Tradeoffs:**
- Messages are cloned into Dexie/Redux only, not bulk-posted to the backend SQLite API. This is consistent with the existing topic-branching behavior.
- The server-side topic created via `dataApiService.post` is not rolled back on local clone failure. This matches the existing `removeTopic` pattern in the codebase.

**Alternatives considered:**
- Prompting the user to rename the duplicated topic immediately. Rejected in favor of the simpler "name + (Copy)" approach.
- Keeping the exact same name. Rejected because it makes the list indistinguishable.

### Breaking changes

None.

### Special notes for your reviewer

- Switched `useDispatch` → `useAppDispatch` in `Topics.tsx` for better type safety.
- Added i18n keys for `en-us`, `zh-cn`, and `zh-tw`.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Added "Duplicate Topic" feature to the topic right-click context menu, allowing users to create a full copy of a topic including all conversation history.