### PR TITLE
fix(channels): split streaming output across multiple messages

### DIFF
--- a/src/main/services/agents/services/channels/StreamingMessageController.ts
+++ b/src/main/services/agents/services/channels/StreamingMessageController.ts
@@ -1,0 +1,193 @@
+import { FlushController } from './FlushController'
+import { splitMessage } from './utils'
+
+/**
+ * Per-platform bindings for posting and editing messages.
+ *
+ * The controller is API-agnostic — adapters supply how to talk to their
+ * platform (Discord REST, Slack web API, etc.) and what content transform
+ * to apply (e.g., Slack mrkdwn conversion) before splitting.
+ */
+export interface StreamingTransport<MessageId = string> {
+  /** Post a new message with the given content. Return its id, or null if the post failed. */
+  post(content: string): Promise<MessageId | null>
+  /** Edit an existing message in place. */
+  edit(messageId: MessageId, content: string): Promise<void>
+  /** Optional content transform applied before chunking (e.g., markdown dialect conversion). */
+  transformContent?(text: string): string
+}
+
+export interface StreamingMessageControllerOptions {
+  /** Per-message character limit (e.g., Discord 2000, Slack 4000). */
+  maxLength: number
+  /** Minimum interval between flushes in ms — must respect platform rate limits. */
+  throttleMs: number
+}
+
+/**
+ * Minimal logger shape this controller needs. The adapter-level
+ * `Record<ChannelLogLevel, ...>` log object satisfies this structurally.
+ */
+export interface StreamingControllerLogger {
+  warn: (message: string, meta?: Record<string, unknown>) => void
+}
+
+const FALLBACK_PLACEHOLDER = '...'
+
+/**
+ * Manages a streaming response that may span multiple platform messages.
+ *
+ * Behavior:
+ * - The first message is created lazily on first text update.
+ * - On every flush, `splitMessage` recomputes the chunks. Earlier chunks
+ *   are stable once a later chunk exists (they're sealed at safe boundaries),
+ *   so only the latest growing chunk receives throttled edits.
+ * - When a new chunk arrives, the previously-latest message is edited one
+ *   last time with its now-sealed content, then the new chunk is posted as
+ *   a follow-up message.
+ */
+export class StreamingMessageController<MessageId = string> {
+  private readonly messageIds: MessageId[] = []
+  private currentText = ''
+  private readonly flush: FlushController
+  private messageCreationPromise: Promise<void> | null = null
+  private _completed = false
+
+  constructor(
+    private readonly transport: StreamingTransport<MessageId>,
+    private readonly options: StreamingMessageControllerOptions,
+    private readonly log: StreamingControllerLogger
+  ) {
+    this.flush = new FlushController(() => this.performFlush())
+  }
+
+  get completed(): boolean {
+    return this._completed
+  }
+
+  async onText(text: string): Promise<void> {
+    if (this._completed) return
+    this.currentText = text
+    await this.ensureMessageCreated()
+    if (this.messageIds.length > 0) {
+      await this.flush.throttledUpdate(this.options.throttleMs)
+    }
+  }
+
+  async complete(finalText: string): Promise<boolean> {
+    if (this._completed) return false
+    this._completed = true
+    this.flush.complete()
+
+    if (this.messageCreationPromise) await this.messageCreationPromise
+    if (this.messageIds.length === 0) return false
+
+    await this.flush.waitForFlush()
+
+    try {
+      this.currentText = finalText
+      await this.flushAllChunks()
+      return true
+    } catch (error) {
+      this.log.warn('Failed to finalize streaming message', {
+        error: error instanceof Error ? error.message : String(error)
+      })
+      return false
+    }
+  }
+
+  async error(errorMessage: string): Promise<void> {
+    if (this._completed) return
+    this._completed = true
+    this.flush.complete()
+
+    if (this.messageCreationPromise) await this.messageCreationPromise
+    if (this.messageIds.length === 0) return
+
+    await this.flush.waitForFlush()
+
+    try {
+      const appendix = `\n\n---\n**Error**: ${errorMessage}`
+      this.currentText = this.currentText ? `${this.currentText}${appendix}` : `**Error**: ${errorMessage}`
+      await this.flushAllChunks()
+    } catch {
+      // Best-effort error update
+    }
+  }
+
+  dispose(): void {
+    this._completed = true
+    this.flush.cancelPendingFlush()
+    this.flush.complete()
+  }
+
+  // ---- Internal ----
+
+  private async ensureMessageCreated(): Promise<void> {
+    if (this.messageIds.length > 0) return
+    if (this.messageCreationPromise) {
+      await this.messageCreationPromise
+      return
+    }
+    this.messageCreationPromise = this.createInitialMessage()
+    await this.messageCreationPromise
+  }
+
+  private async createInitialMessage(): Promise<void> {
+    try {
+      const transformed = this.applyTransform(this.currentText)
+      const initial =
+        transformed.length > 0
+          ? splitMessage(transformed, this.options.maxLength)[0] || FALLBACK_PLACEHOLDER
+          : FALLBACK_PLACEHOLDER
+      const id = await this.transport.post(initial)
+      if (id !== null && id !== undefined) this.messageIds.push(id)
+    } catch (error) {
+      this.log.warn('Failed to create initial streaming message', {
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+  }
+
+  private async performFlush(): Promise<void> {
+    if (this.messageIds.length === 0) return
+    try {
+      await this.flushAllChunks()
+    } catch {
+      // Swallow flush errors — FlushController will reflush if needed
+    }
+  }
+
+  /**
+   * Re-split the current text and reconcile against previously-posted messages.
+   *
+   * - Sealed earlier chunks (i < messageIds.length - 1, i < chunks.length - 1) are skipped.
+   * - The previously-latest chunk gets one final edit when a new chunk arrives,
+   *   capturing its now-sealed content.
+   * - The currently-latest chunk gets edited every flush (it's still growing).
+   * - Any chunk index ≥ messageIds.length is posted as a new follow-up message.
+   */
+  private async flushAllChunks(): Promise<void> {
+    const transformed = this.applyTransform(this.currentText)
+    const chunks = splitMessage(transformed, this.options.maxLength)
+
+    for (let i = 0; i < chunks.length; i++) {
+      const content = chunks[i] || FALLBACK_PLACEHOLDER
+      if (i < this.messageIds.length) {
+        const isCurrentLatestChunk = i === chunks.length - 1
+        const isPreviousLatestMessage = i === this.messageIds.length - 1
+        if (isCurrentLatestChunk || isPreviousLatestMessage) {
+          await this.transport.edit(this.messageIds[i], content)
+        }
+      } else {
+        const id = await this.transport.post(content)
+        if (id === null || id === undefined) return
+        this.messageIds.push(id)
+      }
+    }
+  }
+
+  private applyTransform(text: string): string {
+    return this.transport.transformContent ? this.transport.transformContent(text) : text
+  }
+}

--- a/src/main/services/agents/services/channels/__tests__/StreamingMessageController.test.ts
+++ b/src/main/services/agents/services/channels/__tests__/StreamingMessageController.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  type StreamingControllerLogger,
+  StreamingMessageController,
+  type StreamingTransport
+} from '../StreamingMessageController'
+
+const log: StreamingControllerLogger = { warn: vi.fn() }
+
+interface RecordedTransport extends StreamingTransport<string> {
+  posts: string[]
+  edits: Array<{ id: string; content: string }>
+}
+
+function makeTransport(
+  opts: { failPostAfter?: number; transformContent?: (text: string) => string } = {}
+): RecordedTransport {
+  const posts: string[] = []
+  const edits: Array<{ id: string; content: string }> = []
+  let postCount = 0
+  return {
+    posts,
+    edits,
+    async post(content) {
+      postCount += 1
+      if (opts.failPostAfter !== undefined && postCount > opts.failPostAfter) return null
+      posts.push(content)
+      return `msg-${postCount}`
+    },
+    async edit(id, content) {
+      edits.push({ id, content })
+    },
+    transformContent: opts.transformContent
+  }
+}
+
+describe('StreamingMessageController', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('lazily creates the first message on onText', async () => {
+    const transport = makeTransport()
+    const controller = new StreamingMessageController(transport, { maxLength: 100, throttleMs: 50 }, log)
+
+    await controller.onText('hi')
+
+    expect(transport.posts).toHaveLength(1)
+    expect(transport.posts[0]).toBe('hi')
+  })
+
+  it('edits the existing message on subsequent updates within max length', async () => {
+    const transport = makeTransport()
+    const controller = new StreamingMessageController(transport, { maxLength: 100, throttleMs: 50 }, log)
+
+    await controller.onText('hello')
+    await vi.advanceTimersByTimeAsync(60)
+    await controller.onText('hello world')
+    await vi.advanceTimersByTimeAsync(2000)
+
+    expect(transport.posts).toHaveLength(1)
+    expect(transport.edits.length).toBeGreaterThanOrEqual(1)
+    expect(transport.edits[transport.edits.length - 1].content).toBe('hello world')
+  })
+
+  it('rolls over to a new message when content exceeds maxLength', async () => {
+    const transport = makeTransport()
+    const controller = new StreamingMessageController(transport, { maxLength: 50, throttleMs: 10 }, log)
+
+    const para = 'A'.repeat(45)
+    const longText = `${para}\n\n${para}\n\n${para}` // 3 paragraphs, each just under 50 chars
+    expect(longText.length).toBeGreaterThan(100)
+
+    await controller.onText(longText)
+    const result = await controller.complete(longText)
+
+    expect(result).toBe(true)
+    // Should have created at least 2 messages (3 chunks → multiple posts).
+    expect(transport.posts.length).toBeGreaterThanOrEqual(2)
+    for (const content of transport.posts) expect(content.length).toBeLessThanOrEqual(50)
+    for (const { content } of transport.edits) expect(content.length).toBeLessThanOrEqual(50)
+  })
+
+  it('seals the previously-latest message when a new chunk arrives', async () => {
+    const transport = makeTransport()
+    const controller = new StreamingMessageController(transport, { maxLength: 30, throttleMs: 10 }, log)
+
+    // First flush — under limit.
+    await controller.onText('first short message')
+    expect(transport.posts.length).toBe(1)
+
+    // Now overflow into a second chunk on complete.
+    const overflow = 'first short message\n\nsecond paragraph that pushes past the limit'
+    await controller.complete(overflow)
+
+    expect(transport.posts.length).toBeGreaterThanOrEqual(2)
+    // The original message must have been edited (sealed) before the rollover post.
+    expect(transport.edits.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('applies transformContent before splitting', async () => {
+    const transport = makeTransport({ transformContent: (text) => text.toUpperCase() })
+    const controller = new StreamingMessageController(transport, { maxLength: 100, throttleMs: 50 }, log)
+
+    await controller.onText('hello')
+
+    expect(transport.posts[0]).toBe('HELLO')
+  })
+
+  it('appends an error appendix and may roll into a new message', async () => {
+    const transport = makeTransport()
+    const controller = new StreamingMessageController(transport, { maxLength: 50, throttleMs: 10 }, log)
+
+    await controller.onText('partial output')
+    await controller.error('boom')
+
+    const allWritten = [...transport.posts, ...transport.edits.map((e) => e.content)].join('\n')
+    expect(allWritten).toContain('Error')
+    expect(allWritten).toContain('boom')
+  })
+
+  it('complete() returns false when no message has been created yet', async () => {
+    const transport = makeTransport()
+    const controller = new StreamingMessageController(transport, { maxLength: 100, throttleMs: 50 }, log)
+
+    const result = await controller.complete('final')
+    expect(result).toBe(false)
+  })
+
+  it('bails out of rollover loop when post fails', async () => {
+    const transport = makeTransport({ failPostAfter: 1 })
+    const controller = new StreamingMessageController(transport, { maxLength: 30, throttleMs: 10 }, log)
+
+    const longText = `${'A'.repeat(28)}\n\n${'B'.repeat(28)}\n\n${'C'.repeat(28)}`
+    await controller.onText(longText)
+    await controller.complete(longText)
+
+    // Only one POST succeeded; should not infinite-loop.
+    expect(transport.posts.length).toBe(1)
+  })
+})

--- a/src/main/services/agents/services/channels/adapters/__tests__/DiscordAdapter.test.ts
+++ b/src/main/services/agents/services/channels/adapters/__tests__/DiscordAdapter.test.ts
@@ -1,0 +1,167 @@
+import { EventEmitter } from 'events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), silly: vi.fn() })
+  }
+}))
+
+vi.mock('../../ChannelManager', () => ({
+  registerAdapterFactory: vi.fn()
+}))
+
+const mockNetFetch = vi.fn()
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/mock/userData' },
+  nativeTheme: { themeSource: '', shouldUseDarkColors: false },
+  net: { fetch: (...args: unknown[]) => mockNetFetch(...args) }
+}))
+
+class MockWebSocket extends EventEmitter {
+  static OPEN = 1
+  static CONNECTING = 0
+  readyState = 1
+  send = vi.fn()
+  close = vi.fn()
+  ping = vi.fn()
+}
+
+vi.mock('ws', () => {
+  const Ctor = vi.fn().mockImplementation(() => new MockWebSocket())
+  Object.assign(Ctor, { OPEN: 1, CONNECTING: 0, CLOSED: 3, CLOSING: 2 })
+  return { default: Ctor, WebSocket: Ctor }
+})
+
+import '../discord/DiscordAdapter'
+
+import { registerAdapterFactory } from '../../ChannelManager'
+
+function getFactory() {
+  const calls = vi.mocked(registerAdapterFactory).mock.calls
+  const discordCall = calls.find((c) => c[0] === 'discord')
+  if (!discordCall) throw new Error('registerAdapterFactory was not called for discord')
+  return discordCall[1] as (channel: any, agentId: string) => any
+}
+
+function mockJsonResponse(data: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data))
+  } as unknown as Response
+}
+
+describe('DiscordAdapter streaming', () => {
+  let postedMessageIds: number
+  let postBodies: string[]
+  let patchBodies: Array<{ messageId: string; content: string }>
+
+  beforeEach(() => {
+    mockNetFetch.mockReset()
+    postedMessageIds = 0
+    postBodies = []
+    patchBodies = []
+
+    mockNetFetch.mockImplementation((url: string, init?: { method?: string; body?: string }) => {
+      const method = init?.method ?? 'GET'
+      // POST /channels/:id/messages — create a message
+      if (method === 'POST' && /\/channels\/[^/]+\/messages$/.test(url)) {
+        const body = init?.body ? JSON.parse(init.body) : {}
+        postBodies.push(body.content ?? '')
+        postedMessageIds += 1
+        return Promise.resolve(mockJsonResponse({ id: `msg-${postedMessageIds}` }))
+      }
+      // PATCH /channels/:id/messages/:messageId — edit a message
+      const editMatch = /\/channels\/[^/]+\/messages\/([^/]+)$/.exec(url)
+      if (method === 'PATCH' && editMatch) {
+        const body = init?.body ? JSON.parse(init.body) : {}
+        patchBodies.push({ messageId: editMatch[1], content: body.content ?? '' })
+        return Promise.resolve(mockJsonResponse({}))
+      }
+      return Promise.resolve(mockJsonResponse({}))
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function createAdapter() {
+    const factory = getFactory()
+    return factory(
+      {
+        id: 'ch-discord-1',
+        type: 'discord',
+        enabled: true,
+        config: {
+          bot_token: 'bot-test-token',
+          allowed_channel_ids: ['channel:1234567890']
+        }
+      },
+      'agent-1'
+    )
+  }
+
+  it('registers itself as a discord adapter factory', () => {
+    expect(getFactory()).toBeTypeOf('function')
+  })
+
+  it('onStreamComplete with content under 2000 chars edits a single message', async () => {
+    const adapter = createAdapter()
+    const chatId = 'channel:1234567890'
+
+    await adapter.onTextUpdate(chatId, 'short reply')
+    const result = await adapter.onStreamComplete(chatId, 'short reply final')
+
+    expect(result).toBe(true)
+    // One message created, one final edit
+    expect(postBodies.length).toBe(1)
+    expect(patchBodies[patchBodies.length - 1].content).toBe('short reply final')
+  })
+
+  it('onStreamComplete splits a long final message across multiple Discord messages', async () => {
+    const adapter = createAdapter()
+    const chatId = 'channel:1234567890'
+
+    // Build ~5500-char text with paragraph breaks so split has clean boundaries.
+    const paragraph = 'A'.repeat(900)
+    const longText = Array.from({ length: 6 }, () => paragraph).join('\n\n')
+    expect(longText.length).toBeGreaterThan(2000 * 2)
+
+    await adapter.onTextUpdate(chatId, 'starting...')
+    const result = await adapter.onStreamComplete(chatId, longText)
+
+    expect(result).toBe(true)
+    // Should have created at least 3 messages to fit ~5500 chars at 2000/msg.
+    expect(postBodies.length).toBeGreaterThanOrEqual(3)
+    // Each posted/edited content must respect the 2000 char limit.
+    for (const content of postBodies) expect(content.length).toBeLessThanOrEqual(2000)
+    for (const { content } of patchBodies) expect(content.length).toBeLessThanOrEqual(2000)
+  })
+
+  it('onStreamError appends error text and may roll over to a new message', async () => {
+    const adapter = createAdapter()
+    const chatId = 'channel:1234567890'
+
+    // Fill close to the limit so the appended error pushes us into a second message.
+    const nearLimit = 'B'.repeat(1990)
+    await adapter.onTextUpdate(chatId, nearLimit)
+    await adapter.onStreamError(chatId, 'Boom')
+
+    // At least the original message; possibly a follow-up holding the error tail.
+    expect(postBodies.length).toBeGreaterThanOrEqual(1)
+    const allWritten = [...postBodies, ...patchBodies.map((p) => p.content)].join('\n')
+    expect(allWritten).toContain('Error')
+    expect(allWritten).toContain('Boom')
+  })
+
+  it('onStreamComplete returns false when there is no streaming session', async () => {
+    const adapter = createAdapter()
+    const result = await adapter.onStreamComplete('channel:9999', 'final')
+    expect(result).toBe(false)
+  })
+})

--- a/src/main/services/agents/services/channels/adapters/__tests__/SlackAdapter.test.ts
+++ b/src/main/services/agents/services/channels/adapters/__tests__/SlackAdapter.test.ts
@@ -586,6 +586,34 @@ describe('SlackAdapter', () => {
     expect(result).toBe(false)
   })
 
+  it('onStreamComplete() splits long final text across multiple Slack messages', async () => {
+    const adapter = await connectAdapter()
+    vi.useFakeTimers()
+
+    // Build text well past Slack's 4000-char limit, with paragraph breaks for clean split points.
+    const paragraph = 'A'.repeat(1900)
+    const longText = Array.from({ length: 5 }, () => paragraph).join('\n\n')
+    expect(longText.length).toBeGreaterThan(4000 * 2)
+
+    await adapter.onTextUpdate('C0ALLOWED', 'starting...')
+    await vi.advanceTimersByTimeAsync(2000)
+    const result = await adapter.onStreamComplete('C0ALLOWED', longText)
+    expect(result).toBe(true)
+
+    const postCalls = mockNetFetch.mock.calls.filter((c: unknown[]) => (c[0] as string).includes('chat.postMessage'))
+    // Initial post + at least one rollover post.
+    expect(postCalls.length).toBeGreaterThanOrEqual(3)
+    for (const call of postCalls) {
+      const body = JSON.parse((call as unknown as [unknown, { body: string }])[1].body)
+      expect(body.text.length).toBeLessThanOrEqual(4000)
+    }
+    const updateCalls = mockNetFetch.mock.calls.filter((c: unknown[]) => (c[0] as string).includes('chat.update'))
+    for (const call of updateCalls) {
+      const body = JSON.parse((call as unknown as [unknown, { body: string }])[1].body)
+      expect(body.text.length).toBeLessThanOrEqual(4000)
+    }
+  })
+
   it('onStreamError() updates the message with error text', async () => {
     const adapter = await connectAdapter()
     vi.useFakeTimers()

--- a/src/main/services/agents/services/channels/adapters/discord/DiscordAdapter.ts
+++ b/src/main/services/agents/services/channels/adapters/discord/DiscordAdapter.ts
@@ -13,7 +13,7 @@ import {
 } from '../../ChannelAdapter'
 import { registerAdapterFactory } from '../../ChannelManager'
 import { isSlashCommand, SLASH_COMMANDS } from '../../constants'
-import { FlushController } from '../../FlushController'
+import { type StreamingControllerLogger, StreamingMessageController } from '../../StreamingMessageController'
 import { splitMessage } from '../../utils'
 
 const DISCORD_API_BASE = 'https://discord.com/api/v10'
@@ -67,131 +67,31 @@ type DiscordMessage = {
  */
 const DISCORD_STREAM_THROTTLE_MS = 1200
 
-/**
- * Manages a single streaming response by creating a message, then
- * editing it in-place with throttled updates via FlushController.
- */
-class DiscordStreamingController {
-  private messageId: string | null = null
-  private currentText = ''
-  private readonly flush: FlushController
-  private messageCreationPromise: Promise<void> | null = null
-  private _completed = false
-
-  constructor(
-    private readonly discordChannelId: string,
-    private readonly apiRequest: DiscordAdapter['apiRequest'],
-    private readonly log: Record<string, (msg: string, meta?: Record<string, unknown>) => void>
-  ) {
-    this.flush = new FlushController(() => this.performFlush())
-  }
-
-  get completed(): boolean {
-    return this._completed
-  }
-
-  async onText(text: string): Promise<void> {
-    if (this._completed) return
-    this.currentText = text
-    await this.ensureMessageCreated()
-    if (this.messageId) {
-      await this.flush.throttledUpdate(DISCORD_STREAM_THROTTLE_MS)
-    }
-  }
-
-  async complete(finalText: string): Promise<boolean> {
-    if (this._completed) return false
-    this._completed = true
-    this.flush.complete()
-
-    if (this.messageCreationPromise) await this.messageCreationPromise
-    if (!this.messageId) return false
-
-    await this.flush.waitForFlush()
-
-    try {
-      this.currentText = finalText
-      await this.editMessage(finalText)
-      return true
-    } catch (error) {
-      this.log.warn('Failed to finalize Discord stream', {
-        error: error instanceof Error ? error.message : String(error)
-      })
-      return false
-    }
-  }
-
-  async error(errorMessage: string): Promise<void> {
-    if (this._completed) return
-    this._completed = true
-    this.flush.complete()
-
-    if (this.messageCreationPromise) await this.messageCreationPromise
-    if (!this.messageId) return
-
-    await this.flush.waitForFlush()
-
-    try {
-      const displayText = this.currentText
-        ? `${this.currentText}\n\n---\n**Error**: ${errorMessage}`
-        : `**Error**: ${errorMessage}`
-      await this.editMessage(displayText)
-    } catch {
-      // Best-effort error update
-    }
-  }
-
-  dispose(): void {
-    this._completed = true
-    this.flush.cancelPendingFlush()
-    this.flush.complete()
-  }
-
-  // ---- Internal ----
-
-  private async ensureMessageCreated(): Promise<void> {
-    if (this.messageId) return
-    if (this.messageCreationPromise) {
-      await this.messageCreationPromise
-      return
-    }
-    this.messageCreationPromise = this.createMessage()
-    await this.messageCreationPromise
-  }
-
-  private async createMessage(): Promise<void> {
-    try {
-      const response = await this.apiRequest(`${DISCORD_API_BASE}/channels/${this.discordChannelId}/messages`, {
-        method: 'POST',
-        body: { content: this.currentText || '...' }
-      })
-      const data = (await response.json()) as { id?: string }
-      this.messageId = data.id ?? null
-    } catch (error) {
-      this.log.warn('Failed to create Discord streaming message', {
-        error: error instanceof Error ? error.message : String(error)
-      })
-    }
-  }
-
-  private async editMessage(text: string): Promise<void> {
-    if (!this.messageId) return
-    // Discord messages max 2000 chars — truncate with indicator if needed
-    const content = text.length > DISCORD_MAX_LENGTH ? text.slice(0, DISCORD_MAX_LENGTH - 3) + '...' : text
-    await this.apiRequest(`${DISCORD_API_BASE}/channels/${this.discordChannelId}/messages/${this.messageId}`, {
-      method: 'PATCH',
-      body: { content }
-    })
-  }
-
-  private async performFlush(): Promise<void> {
-    if (!this.messageId || !this.currentText) return
-    try {
-      await this.editMessage(this.currentText)
-    } catch {
-      // Swallow flush errors — FlushController will reflush if needed
-    }
-  }
+function createDiscordStreamingController(
+  discordChannelId: string,
+  apiRequest: DiscordAdapter['apiRequest'],
+  log: StreamingControllerLogger
+): StreamingMessageController<string> {
+  return new StreamingMessageController<string>(
+    {
+      async post(content) {
+        const response = await apiRequest(`${DISCORD_API_BASE}/channels/${discordChannelId}/messages`, {
+          method: 'POST',
+          body: { content }
+        })
+        const data = (await response.json()) as { id?: string }
+        return data.id ?? null
+      },
+      async edit(messageId, content) {
+        await apiRequest(`${DISCORD_API_BASE}/channels/${discordChannelId}/messages/${messageId}`, {
+          method: 'PATCH',
+          body: { content }
+        })
+      }
+    },
+    { maxLength: DISCORD_MAX_LENGTH, throttleMs: DISCORD_STREAM_THROTTLE_MS },
+    log
+  )
 }
 
 // Discord Interaction types
@@ -232,7 +132,7 @@ class DiscordAdapter extends ChannelAdapter {
   private readonly reconnectDelays = [1000, 2000, 5000, 10000, 30000, 60000]
   private readonly maxReconnectAttempts = 50
   /** Per-chat streaming controller. One stream at a time per chat. */
-  private readonly streamingControllers = new Map<string, DiscordStreamingController>()
+  private readonly streamingControllers = new Map<string, StreamingMessageController<string>>()
 
   constructor(config: ChannelAdapterConfig) {
     super(config)
@@ -712,7 +612,7 @@ class DiscordAdapter extends ChannelAdapter {
     const discordChannelId = chatId.split(':')[1]
     let controller = this.streamingControllers.get(chatId)
     if (!controller || controller.completed) {
-      controller = new DiscordStreamingController(discordChannelId, this.apiRequest.bind(this), this.log)
+      controller = createDiscordStreamingController(discordChannelId, this.apiRequest.bind(this), this.log)
       this.streamingControllers.set(chatId, controller)
     }
     await controller.onText(fullText)

--- a/src/main/services/agents/services/channels/adapters/slack/SlackAdapter.ts
+++ b/src/main/services/agents/services/channels/adapters/slack/SlackAdapter.ts
@@ -11,7 +11,7 @@ import {
 } from '../../ChannelAdapter'
 import { registerAdapterFactory } from '../../ChannelManager'
 import { isSlashCommand } from '../../constants'
-import { FlushController } from '../../FlushController'
+import { type StreamingControllerLogger, StreamingMessageController } from '../../StreamingMessageController'
 import { splitMessage } from '../../utils'
 import { toSlackMarkdown } from './slackMarkdown'
 
@@ -62,131 +62,27 @@ type SlackSocketEnvelope = {
 
 // ─── Streaming Controller ─────────────────────────────────────
 
-/**
- * Manages a single streaming response by creating a message, then
- * editing it in-place with throttled updates via FlushController.
- */
-class SlackStreamingController {
-  private messageTs: string | null = null
-  private currentText = ''
-  private readonly flush: FlushController
-  private messageCreationPromise: Promise<void> | null = null
-  private _completed = false
-
-  constructor(
-    private readonly channelId: string,
-    private readonly apiRequest: SlackAdapter['apiRequest'],
-    private readonly log: Record<string, (msg: string, meta?: Record<string, unknown>) => void>
-  ) {
-    this.flush = new FlushController(() => this.performFlush())
-  }
-
-  get completed(): boolean {
-    return this._completed
-  }
-
-  async onText(text: string): Promise<void> {
-    if (this._completed) return
-    this.currentText = text
-    await this.ensureMessageCreated()
-    if (this.messageTs) {
-      await this.flush.throttledUpdate(SLACK_STREAM_THROTTLE_MS)
-    }
-  }
-
-  async complete(finalText: string): Promise<boolean> {
-    if (this._completed) return false
-    this._completed = true
-    this.flush.complete()
-
-    if (this.messageCreationPromise) await this.messageCreationPromise
-    if (!this.messageTs) return false
-
-    await this.flush.waitForFlush()
-
-    try {
-      this.currentText = finalText
-      await this.editMessage(finalText)
-      return true
-    } catch (error) {
-      this.log.warn('Failed to finalize Slack stream', {
-        error: error instanceof Error ? error.message : String(error)
-      })
-      return false
-    }
-  }
-
-  async error(errorMessage: string): Promise<void> {
-    if (this._completed) return
-    this._completed = true
-    this.flush.complete()
-
-    if (this.messageCreationPromise) await this.messageCreationPromise
-    if (!this.messageTs) return
-
-    await this.flush.waitForFlush()
-
-    try {
-      const displayText = this.currentText
-        ? `${this.currentText}\n\n---\n**Error**: ${errorMessage}`
-        : `**Error**: ${errorMessage}`
-      await this.editMessage(displayText)
-    } catch {
-      // Best-effort error update
-    }
-  }
-
-  dispose(): void {
-    this._completed = true
-    this.flush.cancelPendingFlush()
-    this.flush.complete()
-  }
-
-  // ---- Internal ----
-
-  private async ensureMessageCreated(): Promise<void> {
-    if (this.messageTs) return
-    if (this.messageCreationPromise) {
-      await this.messageCreationPromise
-      return
-    }
-    this.messageCreationPromise = this.createMessage()
-    await this.messageCreationPromise
-  }
-
-  private async createMessage(): Promise<void> {
-    try {
-      const data = await this.apiRequest('chat.postMessage', {
-        channel: this.channelId,
-        text: toSlackMarkdown(this.currentText) || '...'
-      })
-      this.messageTs = (data as { ts?: string }).ts ?? null
-    } catch (error) {
-      this.log.warn('Failed to create Slack streaming message', {
-        error: error instanceof Error ? error.message : String(error)
-      })
-    }
-  }
-
-  private async editMessage(text: string): Promise<void> {
-    if (!this.messageTs) return
-    const converted = toSlackMarkdown(text)
-    const content = converted.length > SLACK_MAX_LENGTH ? converted.slice(0, SLACK_MAX_LENGTH - 3) + '...' : converted
-    await this.apiRequest('chat.update', {
-      channel: this.channelId,
-      ts: this.messageTs,
-      text: content
-    })
-  }
-
-  private async performFlush(): Promise<void> {
-    if (!this.messageTs || !this.currentText) return
-    try {
-      await this.editMessage(this.currentText)
-    } catch {
-      // Swallow flush errors — FlushController will reflush if needed
-    }
-  }
+function createSlackStreamingController(
+  channelId: string,
+  apiRequest: SlackAdapter['apiRequest'],
+  log: StreamingControllerLogger
+): StreamingMessageController<string> {
+  return new StreamingMessageController<string>(
+    {
+      async post(content) {
+        const data = (await apiRequest('chat.postMessage', { channel: channelId, text: content })) as { ts?: string }
+        return data.ts ?? null
+      },
+      async edit(ts, content) {
+        await apiRequest('chat.update', { channel: channelId, ts, text: content })
+      },
+      transformContent(text) {
+        return toSlackMarkdown(text)
+      }
+    },
+    { maxLength: SLACK_MAX_LENGTH, throttleMs: SLACK_STREAM_THROTTLE_MS },
+    log
+  )
 }
 
 // ─── Slack Adapter ────────────────────────────────────────────
@@ -207,7 +103,7 @@ class SlackAdapter extends ChannelAdapter {
 
   private readonly reconnectDelays = [1000, 2000, 5000, 10000, 30000, 60000]
   private readonly maxReconnectAttempts = 50
-  private readonly streamingControllers = new Map<string, SlackStreamingController>()
+  private readonly streamingControllers = new Map<string, StreamingMessageController<string>>()
   /** Track the latest incoming message ts per chatId for reaction acknowledgment */
   private readonly pendingReactions = new Map<string, string>()
 
@@ -564,7 +460,7 @@ class SlackAdapter extends ChannelAdapter {
   override async onTextUpdate(chatId: string, fullText: string): Promise<void> {
     let controller = this.streamingControllers.get(chatId)
     if (!controller || controller.completed) {
-      controller = new SlackStreamingController(chatId, this.apiRequest.bind(this), this.log)
+      controller = createSlackStreamingController(chatId, this.apiRequest.bind(this), this.log)
       this.streamingControllers.set(chatId, controller)
     }
     await controller.onText(fullText)


### PR DESCRIPTION
### What this PR does

Before this PR:

Long agent replies streamed to Discord/Slack channels were silently truncated at the per-message character limit. The streaming controller posted exactly one message per reply and clipped any overflow to `…` (Discord 2000 chars, Slack 4000 chars), so any output longer than that vanished from the channel even though the rest of the response had already been generated successfully.

After this PR:

Streaming output that exceeds a single message's limit now rolls over into follow-up messages. Earlier messages are sealed at safe paragraph/line/word boundaries (via the existing `splitMessage` utility) and only the latest message receives throttled in-place edits. The shared logic now lives in `StreamingMessageController`; Discord and Slack adapters provide thin per-platform `StreamingTransport` bindings (POST/PATCH for Discord, `chat.postMessage`/`chat.update` + Slack mrkdwn transform for Slack).

Fixes #14792

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Reused the project-wide `splitMessage` helper instead of introducing a third-party splitter; no new runtime dependency.
- Extracted the streaming controller into one shared module rather than fixing each adapter in isolation. Net code is ~176 lines smaller and future adapters get the multi-message behavior for free.
- Stuck with character-count splitting on paragraph/line/word boundaries (the existing house style). A markdown-AST splitter would be heavier and not measurably better for this content.

The following alternatives were considered:

- A pure index-based "committedLength" walk (no splitMessage reuse) — rejected because it duplicated the boundary heuristic already in `utils.ts`.
- Using `discord.js` / Slack Bolt built-in splitters — rejected because pulling in a full client SDK just for splitting is disproportionate; the project uses raw WebSocket + REST.
- Fixing only Discord — rejected after auditing the other adapters: Slack has the same bug at 4000 chars; Feishu (CardKit) and Telegram (grammy `sendMessageDraft`) are unaffected; QQ/WeChat have no streaming overrides.

Links to places where the discussion took place: N/A

### Breaking changes

None. Public adapter behavior is unchanged for replies under the per-message limit; longer replies that previously got truncated now appear in full across multiple messages.

### Special notes for your reviewer

- Branch is `hotfix/discord-streaming-multimsg` per the April 3, 2026 main-branch policy.
- Diff is intentionally focused: 6 files, +586 / -256, no refactoring outside the streaming code path.
- Test coverage:
  - New `StreamingMessageController.test.ts` (8 cases) covers lazy create, in-place edit, multi-chunk rollover, previously-latest sealing, content transform, error appendix, no-session, and POST-failure bail-out.
  - New `DiscordAdapter.test.ts` (5 cases) exercises the adapter through the `onTextUpdate` / `onStreamComplete` API, including a 5500-char reply asserting ≥3 messages, all ≤2000 chars.
  - Existing `SlackAdapter.test.ts` still passes; added a long-content test asserting the same multi-message behavior at 4000 chars.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix Discord and Slack channel streaming output being silently truncated for replies longer than the per-message limit (Discord 2000 chars, Slack 4000 chars). Long replies are now split across multiple messages at safe paragraph/line/word boundaries.
```
