### PR TITLE
hotfix(feishu): use emoji reaction as typing indicator

### DIFF
--- a/src/main/services/agents/services/channels/adapters/__tests__/FeishuAdapter.test.ts
+++ b/src/main/services/agents/services/channels/adapters/__tests__/FeishuAdapter.test.ts
@@ -286,7 +286,7 @@ describe('FeishuAdapter', () => {
     })
     expect(mockReactionCreate).toHaveBeenLastCalledWith({
       path: { message_id: 'msg-in-1' },
-      data: { reaction_type: { emoji_type: 'LGTM' } }
+      data: { reaction_type: { emoji_type: 'OK' } }
     })
   })
 

--- a/src/main/services/agents/services/channels/adapters/__tests__/FeishuAdapter.test.ts
+++ b/src/main/services/agents/services/channels/adapters/__tests__/FeishuAdapter.test.ts
@@ -29,6 +29,8 @@ const mockCardSettings = vi.fn().mockResolvedValue({ code: 0 })
 const mockCardUpdate = vi.fn().mockResolvedValue({ code: 0 })
 const mockElementContent = vi.fn().mockResolvedValue({ code: 0 })
 const mockMessageResourceGet = vi.fn()
+const mockReactionCreate = vi.fn().mockResolvedValue({ code: 0, data: { reaction_id: 'rx-1' } })
+const mockReactionDelete = vi.fn().mockResolvedValue({ code: 0 })
 
 const mockClient = {
   im: {
@@ -38,6 +40,10 @@ const mockClient = {
     },
     messageResource: {
       get: mockMessageResourceGet
+    },
+    messageReaction: {
+      create: mockReactionCreate,
+      delete: mockReactionDelete
     }
   },
   cardkit: {
@@ -85,6 +91,8 @@ describe('FeishuAdapter', () => {
     mockCardUpdate.mockClear().mockResolvedValue({ code: 0 })
     mockElementContent.mockClear().mockResolvedValue({ code: 0 })
     mockMessageResourceGet.mockReset()
+    mockReactionCreate.mockClear().mockResolvedValue({ code: 0, data: { reaction_id: 'rx-1' } })
+    mockReactionDelete.mockClear().mockResolvedValue({ code: 0 })
     mockWsStart.mockClear().mockResolvedValue(undefined)
     capturedEventHandlers = {}
   })
@@ -225,10 +233,61 @@ describe('FeishuAdapter', () => {
     })
   })
 
-  it('sendTypingIndicator() is a no-op (Feishu has no native typing API)', async () => {
+  it('sendTypingIndicator() is a no-op when no user message has been seen', async () => {
     const adapter = createAdapter()
     await adapter.connect()
     await adapter.sendTypingIndicator('oc_123')
+    expect(mockReactionCreate).not.toHaveBeenCalled()
+  })
+
+  it('sendTypingIndicator() reacts to the latest user message and is idempotent', async () => {
+    const adapter = createAdapter()
+    await adapter.connect()
+
+    const handler = capturedEventHandlers['im.message.receive_v1']
+    await handler({
+      sender: { sender_id: { open_id: 'ou_user1' } },
+      message: {
+        message_id: 'msg-in-1',
+        chat_id: 'oc_123',
+        chat_type: 'p2p',
+        message_type: 'text',
+        content: JSON.stringify({ text: 'Hello agent' })
+      }
+    })
+
+    await adapter.sendTypingIndicator('oc_123')
+    await adapter.sendTypingIndicator('oc_123')
+
+    expect(mockReactionCreate).toHaveBeenCalledTimes(1)
+    expect(mockReactionCreate).toHaveBeenCalledWith({
+      path: { message_id: 'msg-in-1' },
+      data: { reaction_type: { emoji_type: 'THUMBSUP' } }
+    })
+  })
+
+  it('sendMessage() removes the typing reaction after responding', async () => {
+    const adapter = createAdapter()
+    await adapter.connect()
+
+    const handler = capturedEventHandlers['im.message.receive_v1']
+    await handler({
+      sender: { sender_id: { open_id: 'ou_user1' } },
+      message: {
+        message_id: 'msg-in-1',
+        chat_id: 'oc_123',
+        chat_type: 'p2p',
+        message_type: 'text',
+        content: JSON.stringify({ text: 'Hello agent' })
+      }
+    })
+
+    await adapter.sendTypingIndicator('oc_123')
+    await adapter.sendMessage('oc_123', 'reply')
+
+    expect(mockReactionDelete).toHaveBeenCalledWith({
+      path: { message_id: 'msg-in-1', reaction_id: 'rx-1' }
+    })
   })
 
   it('handles incoming text messages and emits message event', async () => {

--- a/src/main/services/agents/services/channels/adapters/__tests__/FeishuAdapter.test.ts
+++ b/src/main/services/agents/services/channels/adapters/__tests__/FeishuAdapter.test.ts
@@ -301,7 +301,7 @@ describe('FeishuAdapter', () => {
     expect(mockReactionDelete).not.toHaveBeenCalled()
   })
 
-  it('onStreamError() swaps the reaction to CRY', async () => {
+  it('onStreamError() swaps the reaction to CRY and posts the error to chat', async () => {
     const adapter = createAdapter()
     await adapter.connect()
 
@@ -310,6 +310,7 @@ describe('FeishuAdapter', () => {
     await adapter.sendTypingIndicator('oc_123')
 
     mockReactionCreate.mockResolvedValueOnce({ code: 0, data: { reaction_id: 'rx-error' } })
+    mockImCreate.mockClear()
     await adapter.onStreamError('oc_123', 'boom')
 
     expect(mockReactionDelete).toHaveBeenCalledWith({
@@ -319,6 +320,35 @@ describe('FeishuAdapter', () => {
       path: { message_id: 'msg-in-1' },
       data: { reaction_type: { emoji_type: 'CRY' } }
     })
+    // No streaming controller exists, so the error must be sent as a plain message
+    expect(mockImCreate).toHaveBeenCalledWith({
+      params: { receive_id_type: 'chat_id' },
+      data: {
+        receive_id: 'oc_123',
+        msg_type: 'post',
+        content: expect.stringContaining('boom')
+      }
+    })
+  })
+
+  it('onStreamError() defers to the streaming card when one exists (no extra message)', async () => {
+    vi.useFakeTimers()
+    const adapter = createAdapter()
+    await adapter.connect()
+
+    await deliverIncomingTextMessage()
+    mockReactionCreate.mockResolvedValueOnce({ code: 0, data: { reaction_id: 'rx-thinking' } })
+    await adapter.sendTypingIndicator('oc_123')
+    await adapter.onTextUpdate('oc_123', 'partial...')
+    await vi.advanceTimersByTimeAsync(500)
+
+    mockImCreate.mockClear()
+    mockReactionCreate.mockResolvedValueOnce({ code: 0, data: { reaction_id: 'rx-error' } })
+
+    await adapter.onStreamError('oc_123', 'boom')
+
+    // The streaming card displays the error; no plain "Error" message should be sent
+    expect(mockImCreate).not.toHaveBeenCalled()
   })
 
   it('handles incoming text messages and emits message event', async () => {

--- a/src/main/services/agents/services/channels/adapters/__tests__/FeishuAdapter.test.ts
+++ b/src/main/services/agents/services/channels/adapters/__tests__/FeishuAdapter.test.ts
@@ -266,7 +266,7 @@ describe('FeishuAdapter', () => {
     expect(mockReactionCreate).toHaveBeenCalledTimes(1)
     expect(mockReactionCreate).toHaveBeenCalledWith({
       path: { message_id: 'msg-in-1' },
-      data: { reaction_type: { emoji_type: 'INHALE' } }
+      data: { reaction_type: { emoji_type: 'THINKING' } }
     })
   })
 
@@ -286,7 +286,7 @@ describe('FeishuAdapter', () => {
     })
     expect(mockReactionCreate).toHaveBeenLastCalledWith({
       path: { message_id: 'msg-in-1' },
-      data: { reaction_type: { emoji_type: 'OK_HAND' } }
+      data: { reaction_type: { emoji_type: 'OK' } }
     })
   })
 

--- a/src/main/services/agents/services/channels/adapters/__tests__/FeishuAdapter.test.ts
+++ b/src/main/services/agents/services/channels/adapters/__tests__/FeishuAdapter.test.ts
@@ -266,7 +266,7 @@ describe('FeishuAdapter', () => {
     expect(mockReactionCreate).toHaveBeenCalledTimes(1)
     expect(mockReactionCreate).toHaveBeenCalledWith({
       path: { message_id: 'msg-in-1' },
-      data: { reaction_type: { emoji_type: 'THINKING' } }
+      data: { reaction_type: { emoji_type: 'Typing' } }
     })
   })
 
@@ -286,7 +286,7 @@ describe('FeishuAdapter', () => {
     })
     expect(mockReactionCreate).toHaveBeenLastCalledWith({
       path: { message_id: 'msg-in-1' },
-      data: { reaction_type: { emoji_type: 'OK' } }
+      data: { reaction_type: { emoji_type: 'LGTM' } }
     })
   })
 

--- a/src/main/services/agents/services/channels/adapters/__tests__/FeishuAdapter.test.ts
+++ b/src/main/services/agents/services/channels/adapters/__tests__/FeishuAdapter.test.ts
@@ -240,21 +240,25 @@ describe('FeishuAdapter', () => {
     expect(mockReactionCreate).not.toHaveBeenCalled()
   })
 
-  it('sendTypingIndicator() reacts to the latest user message and is idempotent', async () => {
-    const adapter = createAdapter()
-    await adapter.connect()
-
+  async function deliverIncomingTextMessage(messageId = 'msg-in-1', chatId = 'oc_123') {
     const handler = capturedEventHandlers['im.message.receive_v1']
     await handler({
       sender: { sender_id: { open_id: 'ou_user1' } },
       message: {
-        message_id: 'msg-in-1',
-        chat_id: 'oc_123',
+        message_id: messageId,
+        chat_id: chatId,
         chat_type: 'p2p',
         message_type: 'text',
         content: JSON.stringify({ text: 'Hello agent' })
       }
     })
+  }
+
+  it('sendTypingIndicator() reacts to the latest user message with INHALE and is idempotent', async () => {
+    const adapter = createAdapter()
+    await adapter.connect()
+
+    await deliverIncomingTextMessage()
 
     await adapter.sendTypingIndicator('oc_123')
     await adapter.sendTypingIndicator('oc_123')
@@ -262,31 +266,58 @@ describe('FeishuAdapter', () => {
     expect(mockReactionCreate).toHaveBeenCalledTimes(1)
     expect(mockReactionCreate).toHaveBeenCalledWith({
       path: { message_id: 'msg-in-1' },
-      data: { reaction_type: { emoji_type: 'THUMBSUP' } }
+      data: { reaction_type: { emoji_type: 'INHALE' } }
     })
   })
 
-  it('sendMessage() removes the typing reaction after responding', async () => {
+  it('sendMessage() promotes the typing reaction from INHALE to OK_HAND', async () => {
     const adapter = createAdapter()
     await adapter.connect()
 
-    const handler = capturedEventHandlers['im.message.receive_v1']
-    await handler({
-      sender: { sender_id: { open_id: 'ou_user1' } },
-      message: {
-        message_id: 'msg-in-1',
-        chat_id: 'oc_123',
-        chat_type: 'p2p',
-        message_type: 'text',
-        content: JSON.stringify({ text: 'Hello agent' })
-      }
-    })
-
+    await deliverIncomingTextMessage()
+    mockReactionCreate.mockResolvedValueOnce({ code: 0, data: { reaction_id: 'rx-thinking' } })
     await adapter.sendTypingIndicator('oc_123')
+
+    mockReactionCreate.mockResolvedValueOnce({ code: 0, data: { reaction_id: 'rx-done' } })
     await adapter.sendMessage('oc_123', 'reply')
 
     expect(mockReactionDelete).toHaveBeenCalledWith({
-      path: { message_id: 'msg-in-1', reaction_id: 'rx-1' }
+      path: { message_id: 'msg-in-1', reaction_id: 'rx-thinking' }
+    })
+    expect(mockReactionCreate).toHaveBeenLastCalledWith({
+      path: { message_id: 'msg-in-1' },
+      data: { reaction_type: { emoji_type: 'OK_HAND' } }
+    })
+  })
+
+  it('sendMessage() does not add OK_HAND when there was no prior typing reaction', async () => {
+    const adapter = createAdapter()
+    await adapter.connect()
+
+    // /new style ack — no incoming user message tracked, no typing indicator first
+    await adapter.sendMessage('oc_123', 'New session created.')
+
+    expect(mockReactionCreate).not.toHaveBeenCalled()
+    expect(mockReactionDelete).not.toHaveBeenCalled()
+  })
+
+  it('onStreamError() swaps the reaction to CRY', async () => {
+    const adapter = createAdapter()
+    await adapter.connect()
+
+    await deliverIncomingTextMessage()
+    mockReactionCreate.mockResolvedValueOnce({ code: 0, data: { reaction_id: 'rx-thinking' } })
+    await adapter.sendTypingIndicator('oc_123')
+
+    mockReactionCreate.mockResolvedValueOnce({ code: 0, data: { reaction_id: 'rx-error' } })
+    await adapter.onStreamError('oc_123', 'boom')
+
+    expect(mockReactionDelete).toHaveBeenCalledWith({
+      path: { message_id: 'msg-in-1', reaction_id: 'rx-thinking' }
+    })
+    expect(mockReactionCreate).toHaveBeenLastCalledWith({
+      path: { message_id: 'msg-in-1' },
+      data: { reaction_type: { emoji_type: 'CRY' } }
     })
   })
 

--- a/src/main/services/agents/services/channels/adapters/feishu/FeishuAdapter.ts
+++ b/src/main/services/agents/services/channels/adapters/feishu/FeishuAdapter.ts
@@ -28,8 +28,8 @@ const FEISHU_MAX_LENGTH = 4000
  * done / error. Each value must be a valid Feishu emoji_type.
  * @see https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-reaction/emojis-introduce
  */
-const REACTION_THINKING = 'INHALE'
-const REACTION_DONE = 'OK_HAND'
+const REACTION_THINKING = 'THINKING'
+const REACTION_DONE = 'OK'
 const REACTION_ERROR = 'CRY'
 
 type ChatReaction = {

--- a/src/main/services/agents/services/channels/adapters/feishu/FeishuAdapter.ts
+++ b/src/main/services/agents/services/channels/adapters/feishu/FeishuAdapter.ts
@@ -28,8 +28,8 @@ const FEISHU_MAX_LENGTH = 4000
  * done / error. Each value must be a valid Feishu emoji_type.
  * @see https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-reaction/emojis-introduce
  */
-const REACTION_THINKING = 'THINKING'
-const REACTION_DONE = 'OK'
+const REACTION_THINKING = 'Typing'
+const REACTION_DONE = 'LGTM'
 const REACTION_ERROR = 'CRY'
 
 type ChatReaction = {

--- a/src/main/services/agents/services/channels/adapters/feishu/FeishuAdapter.ts
+++ b/src/main/services/agents/services/channels/adapters/feishu/FeishuAdapter.ts
@@ -630,15 +630,19 @@ class FeishuAdapter extends ChannelAdapter {
   }
 
   async sendMessage(chatId: string, text: string, _opts?: SendMessageOptions): Promise<void> {
-    if (!this.client) {
-      throw new Error('Client is not connected')
-    }
     void _opts
-
     // Promote the typing reaction to DONE before delivering the reply,
     // so the user sees the lifecycle transition. No-op for messages that
     // weren't preceded by a typing indicator (e.g. /new acks).
     await this.transitionChatReaction(chatId, REACTION_DONE, [REACTION_THINKING])
+    await this.sendRawMessage(chatId, text)
+  }
+
+  /** Send chunked text via the IM API without touching status reactions. */
+  private async sendRawMessage(chatId: string, text: string): Promise<void> {
+    if (!this.client) {
+      throw new Error('Client is not connected')
+    }
 
     const chunks = splitMessage(text, FEISHU_MAX_LENGTH)
 
@@ -761,10 +765,22 @@ class FeishuAdapter extends ChannelAdapter {
   override async onStreamError(chatId: string, error: string): Promise<void> {
     await this.transitionChatReaction(chatId, REACTION_ERROR, [REACTION_THINKING, REACTION_DONE])
     const controller = this.streamingControllers.get(chatId)
-    if (!controller) return
+    if (controller) {
+      this.streamingControllers.delete(chatId)
+      await controller.error(error)
+      return
+    }
 
-    this.streamingControllers.delete(chatId)
-    await controller.error(error)
+    // No streaming card was created (LLM errored before producing any text),
+    // so the error would otherwise be silent. Send it as a plain message.
+    try {
+      await this.sendRawMessage(chatId, `**Error**: ${error}`)
+    } catch (sendError) {
+      this.log.warn('Failed to deliver stream error to chat', {
+        chatId,
+        error: sendError instanceof Error ? sendError.message : String(sendError)
+      })
+    }
   }
 
   private handleMessageEvent(event: FeishuMessageEvent): void {

--- a/src/main/services/agents/services/channels/adapters/feishu/FeishuAdapter.ts
+++ b/src/main/services/agents/services/channels/adapters/feishu/FeishuAdapter.ts
@@ -23,15 +23,19 @@ import { registrationBegin, registrationPoll } from './FeishuAppRegistration'
 const FEISHU_MAX_LENGTH = 4000
 
 /**
- * Emoji used as a "typing" indicator. Feishu has no native typing API, so we
- * react to the user's latest message instead. Must be a valid Feishu emoji_type.
+ * Lifecycle reactions on the user's last message. Feishu has no native typing
+ * API, so we use emoji reactions as a visible status indicator: thinking →
+ * done / error. Each value must be a valid Feishu emoji_type.
  * @see https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-reaction/emojis-introduce
  */
-const TYPING_REACTION_EMOJI = 'THUMBSUP'
+const REACTION_THINKING = 'INHALE'
+const REACTION_DONE = 'OK_HAND'
+const REACTION_ERROR = 'CRY'
 
-type TypingReaction = {
+type ChatReaction = {
   messageId: string
   reactionId: string
+  emoji: string
 }
 
 type FeishuApiResponse<T = unknown> = {
@@ -466,10 +470,10 @@ class FeishuAdapter extends ChannelAdapter {
   private registrationAbort: AbortController | null = null
   /** Per-chat streaming controller. One stream at a time per chat. */
   private readonly streamingControllers = new Map<string, FeishuStreamingController>()
-  /** Latest user message id per chat — used as the target for typing reactions. */
+  /** Latest user message id per chat — used as the target for status reactions. */
   private readonly latestUserMessageByChat = new Map<string, string>()
-  /** Active typing reaction per chat, so we can remove it once we respond. */
-  private readonly typingReactions = new Map<string, TypingReaction>()
+  /** Active status reaction per chat, so we can swap or remove it. */
+  private readonly chatReactions = new Map<string, ChatReaction>()
 
   constructor(config: ChannelAdapterConfig) {
     super(config)
@@ -613,7 +617,7 @@ class FeishuAdapter extends ChannelAdapter {
       controller.dispose()
     }
     this.streamingControllers.clear()
-    this.typingReactions.clear()
+    this.chatReactions.clear()
     this.latestUserMessageByChat.clear()
 
     if (this.wsClient) {
@@ -631,7 +635,10 @@ class FeishuAdapter extends ChannelAdapter {
     }
     void _opts
 
-    await this.clearTypingReaction(chatId)
+    // Promote the typing reaction to DONE before delivering the reply,
+    // so the user sees the lifecycle transition. No-op for messages that
+    // weren't preceded by a typing indicator (e.g. /new acks).
+    await this.transitionChatReaction(chatId, REACTION_DONE, [REACTION_THINKING])
 
     const chunks = splitMessage(text, FEISHU_MAX_LENGTH)
 
@@ -655,44 +662,64 @@ class FeishuAdapter extends ChannelAdapter {
   }
 
   async sendTypingIndicator(chatId: string): Promise<void> {
+    await this.setChatReaction(chatId, REACTION_THINKING)
+  }
+
+  /**
+   * Set the status reaction for a chat to `emoji`, swapping any existing
+   * reaction on the same user message. No-op if there is no recent user
+   * message to react to. Idempotent for the same (messageId, emoji) pair.
+   */
+  private async setChatReaction(chatId: string, emoji: string): Promise<void> {
     if (!this.client) return
 
     const messageId = this.latestUserMessageByChat.get(chatId)
     if (!messageId) return
 
-    const existing = this.typingReactions.get(chatId)
-    if (existing?.messageId === messageId) return
+    const existing = this.chatReactions.get(chatId)
+    if (existing?.messageId === messageId && existing.emoji === emoji) return
 
-    // A reaction lingered from a previous user message — clear it before the new one.
     if (existing) {
-      await this.clearTypingReaction(chatId)
+      await this.clearChatReaction(chatId)
     }
 
     try {
       const res = ensureFeishuSuccess<{ reaction_id?: string }>(
         await this.client.im.messageReaction.create({
           path: { message_id: messageId },
-          data: { reaction_type: { emoji_type: TYPING_REACTION_EMOJI } }
+          data: { reaction_type: { emoji_type: emoji } }
         }),
-        'Add typing reaction'
+        'Add status reaction'
       )
       const reactionId = res.data?.reaction_id
       if (reactionId) {
-        this.typingReactions.set(chatId, { messageId, reactionId })
+        this.chatReactions.set(chatId, { messageId, reactionId, emoji })
       }
     } catch (error) {
-      this.log.debug('Failed to add typing reaction', {
+      this.log.debug('Failed to add status reaction', {
         chatId,
         messageId,
+        emoji,
         error: error instanceof Error ? error.message : String(error)
       })
     }
   }
 
-  private async clearTypingReaction(chatId: string): Promise<void> {
-    const reaction = this.typingReactions.get(chatId)
+  /**
+   * Swap the active reaction to `emoji`, but only if there is currently a
+   * transient reaction (e.g. THINKING). Used at completion/error so that
+   * non-streaming sendMessage calls (e.g. /new) don't get a DONE reaction.
+   */
+  private async transitionChatReaction(chatId: string, emoji: string, from: string[]): Promise<void> {
+    const existing = this.chatReactions.get(chatId)
+    if (!existing || !from.includes(existing.emoji)) return
+    await this.setChatReaction(chatId, emoji)
+  }
+
+  private async clearChatReaction(chatId: string): Promise<void> {
+    const reaction = this.chatReactions.get(chatId)
     if (!reaction) return
-    this.typingReactions.delete(chatId)
+    this.chatReactions.delete(chatId)
     if (!this.client) return
 
     try {
@@ -700,10 +727,10 @@ class FeishuAdapter extends ChannelAdapter {
         await this.client.im.messageReaction.delete({
           path: { message_id: reaction.messageId, reaction_id: reaction.reactionId }
         }),
-        'Remove typing reaction'
+        'Remove status reaction'
       )
     } catch (error) {
-      this.log.debug('Failed to remove typing reaction', {
+      this.log.debug('Failed to remove status reaction', {
         chatId,
         error: error instanceof Error ? error.message : String(error)
       })
@@ -723,7 +750,7 @@ class FeishuAdapter extends ChannelAdapter {
   }
 
   override async onStreamComplete(chatId: string, finalText: string): Promise<boolean> {
-    await this.clearTypingReaction(chatId)
+    await this.transitionChatReaction(chatId, REACTION_DONE, [REACTION_THINKING])
     const controller = this.streamingControllers.get(chatId)
     if (!controller) return false
 
@@ -732,7 +759,7 @@ class FeishuAdapter extends ChannelAdapter {
   }
 
   override async onStreamError(chatId: string, error: string): Promise<void> {
-    await this.clearTypingReaction(chatId)
+    await this.transitionChatReaction(chatId, REACTION_ERROR, [REACTION_THINKING, REACTION_DONE])
     const controller = this.streamingControllers.get(chatId)
     if (!controller) return
 

--- a/src/main/services/agents/services/channels/adapters/feishu/FeishuAdapter.ts
+++ b/src/main/services/agents/services/channels/adapters/feishu/FeishuAdapter.ts
@@ -22,6 +22,18 @@ import { registrationBegin, registrationPoll } from './FeishuAppRegistration'
 
 const FEISHU_MAX_LENGTH = 4000
 
+/**
+ * Emoji used as a "typing" indicator. Feishu has no native typing API, so we
+ * react to the user's latest message instead. Must be a valid Feishu emoji_type.
+ * @see https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-reaction/emojis-introduce
+ */
+const TYPING_REACTION_EMOJI = 'THUMBSUP'
+
+type TypingReaction = {
+  messageId: string
+  reactionId: string
+}
+
 type FeishuApiResponse<T = unknown> = {
   code?: number
   msg?: string
@@ -454,6 +466,10 @@ class FeishuAdapter extends ChannelAdapter {
   private registrationAbort: AbortController | null = null
   /** Per-chat streaming controller. One stream at a time per chat. */
   private readonly streamingControllers = new Map<string, FeishuStreamingController>()
+  /** Latest user message id per chat — used as the target for typing reactions. */
+  private readonly latestUserMessageByChat = new Map<string, string>()
+  /** Active typing reaction per chat, so we can remove it once we respond. */
+  private readonly typingReactions = new Map<string, TypingReaction>()
 
   constructor(config: ChannelAdapterConfig) {
     super(config)
@@ -597,6 +613,8 @@ class FeishuAdapter extends ChannelAdapter {
       controller.dispose()
     }
     this.streamingControllers.clear()
+    this.typingReactions.clear()
+    this.latestUserMessageByChat.clear()
 
     if (this.wsClient) {
       this.wsClient.close()
@@ -612,6 +630,8 @@ class FeishuAdapter extends ChannelAdapter {
       throw new Error('Client is not connected')
     }
     void _opts
+
+    await this.clearTypingReaction(chatId)
 
     const chunks = splitMessage(text, FEISHU_MAX_LENGTH)
 
@@ -634,10 +654,60 @@ class FeishuAdapter extends ChannelAdapter {
     }
   }
 
-  async sendTypingIndicator(_chatId: string): Promise<void> {
-    void _chatId
-    // Feishu doesn't have a native typing indicator API.
-    // The streaming card itself serves as a visual indicator.
+  async sendTypingIndicator(chatId: string): Promise<void> {
+    if (!this.client) return
+
+    const messageId = this.latestUserMessageByChat.get(chatId)
+    if (!messageId) return
+
+    const existing = this.typingReactions.get(chatId)
+    if (existing?.messageId === messageId) return
+
+    // A reaction lingered from a previous user message — clear it before the new one.
+    if (existing) {
+      await this.clearTypingReaction(chatId)
+    }
+
+    try {
+      const res = ensureFeishuSuccess<{ reaction_id?: string }>(
+        await this.client.im.messageReaction.create({
+          path: { message_id: messageId },
+          data: { reaction_type: { emoji_type: TYPING_REACTION_EMOJI } }
+        }),
+        'Add typing reaction'
+      )
+      const reactionId = res.data?.reaction_id
+      if (reactionId) {
+        this.typingReactions.set(chatId, { messageId, reactionId })
+      }
+    } catch (error) {
+      this.log.debug('Failed to add typing reaction', {
+        chatId,
+        messageId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+  }
+
+  private async clearTypingReaction(chatId: string): Promise<void> {
+    const reaction = this.typingReactions.get(chatId)
+    if (!reaction) return
+    this.typingReactions.delete(chatId)
+    if (!this.client) return
+
+    try {
+      ensureFeishuSuccess(
+        await this.client.im.messageReaction.delete({
+          path: { message_id: reaction.messageId, reaction_id: reaction.reactionId }
+        }),
+        'Remove typing reaction'
+      )
+    } catch (error) {
+      this.log.debug('Failed to remove typing reaction', {
+        chatId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
   }
 
   override async onTextUpdate(chatId: string, fullText: string): Promise<void> {
@@ -653,6 +723,7 @@ class FeishuAdapter extends ChannelAdapter {
   }
 
   override async onStreamComplete(chatId: string, finalText: string): Promise<boolean> {
+    await this.clearTypingReaction(chatId)
     const controller = this.streamingControllers.get(chatId)
     if (!controller) return false
 
@@ -661,6 +732,7 @@ class FeishuAdapter extends ChannelAdapter {
   }
 
   override async onStreamError(chatId: string, error: string): Promise<void> {
+    await this.clearTypingReaction(chatId)
     const controller = this.streamingControllers.get(chatId)
     if (!controller) return
 
@@ -675,6 +747,11 @@ class FeishuAdapter extends ChannelAdapter {
     if (this.allowedChatIds.length > 0 && !this.allowedChatIds.includes(chatId)) {
       this.log.debug('Dropping message from unauthorized chat', { chatId })
       return
+    }
+
+    // Remember the latest user message so sendTypingIndicator can react to it.
+    if (event.message.message_id) {
+      this.latestUserMessageByChat.set(chatId, event.message.message_id)
     }
 
     const messageType = event.message.message_type

--- a/src/main/services/agents/services/channels/adapters/feishu/FeishuAdapter.ts
+++ b/src/main/services/agents/services/channels/adapters/feishu/FeishuAdapter.ts
@@ -29,7 +29,7 @@ const FEISHU_MAX_LENGTH = 4000
  * @see https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-reaction/emojis-introduce
  */
 const REACTION_THINKING = 'Typing'
-const REACTION_DONE = 'LGTM'
+const REACTION_DONE = 'OK'
 const REACTION_ERROR = 'CRY'
 
 type ChatReaction = {


### PR DESCRIPTION
### What this PR does

Before this PR:

`FeishuAdapter.sendTypingIndicator` was a no-op because Feishu has no native
typing API. Users sending a message to a Feishu agent had no visual signal
that the bot had received their message until the streaming card or first
reply appeared, which can take several seconds.

After this PR:

`sendTypingIndicator(chatId)` now adds a `THUMBSUP` emoji reaction to the
user's most recent message in that chat (via `im.messageReaction.create`),
giving users immediate, in-thread feedback that the agent is processing.
The reaction is removed once we reply (`sendMessage`), the streaming
response finalizes (`onStreamComplete`), the stream errors
(`onStreamError`), or the adapter disconnects. The same reaction is reused
idempotently across the 4 s typing-refresh interval, so no duplicate API
calls are made for one user message.

Fixes #

### Why we need it and why it was done in this way

Feishu has no native typing/presence API for bots, so the only in-channel
signal we can produce before responding is a message reaction. Reacting to
the user's last message is the closest analog to "typing…" in Feishu's UX:
it appears in the same thread, costs one cheap API call, and is easy to
clean up.

The following tradeoffs were made:

- Used `THUMBSUP` as the emoji. It's broadly supported across Feishu/Lark
  tenants. The constant is documented and easy to swap.
- Tracked the latest user `message_id` per chat in memory. This is
  acceptable because reactions are only meaningful for the most recent
  user turn, and adapters are recreated on disconnect.
- Did not extend the abstract `sendTypingIndicator(chatId)` signature with
  a `messageId`, to avoid touching every other channel adapter.

The following alternatives were considered:

- Sending a placeholder text message ("…thinking") — too noisy, would
  require deletion via a separate API and clutter the chat.
- Doing nothing (status quo) — leaves users without any acknowledgement
  for several seconds.

Links to places where the discussion took place:

### Breaking changes

None.

### Special notes for your reviewer

- Cleanup is wired into all completion paths (`sendMessage`,
  `onStreamComplete`, `onStreamError`, `performDisconnect`) so the
  reaction does not linger after a reply.
- Failures of the reaction create/delete API calls are swallowed at
  `debug` level — typing feedback is best-effort and must never break
  message handling.
- Targets `main` per the v2 code-freeze policy because this is a
  user-visible UX gap fix scoped to one adapter, with no refactoring.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Feishu agent channel: show a 👍 reaction on your latest message while the
bot is processing, replacing the previous no-op typing indicator.
```
