### PR TITLE
feat(notification): notify on every assistant completion + sound toggle

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -2869,7 +2869,7 @@
       "error": "{{error}}",
       "success": "Successfully added {{type}} to the knowledge base"
     },
-    "tip": "If the response is successful, then only messages exceeding 30 seconds will trigger a reminder"
+    "tip": "Sends a system notification when a response finishes and the Cherry Studio window is not focused or you have navigated away from the chat."
   },
   "ocr": {
     "builtin": {
@@ -5203,6 +5203,7 @@
       "assistant": "Assistant Message",
       "backup": "Backup Message",
       "knowledge_embed": "KnowledgeBase Message",
+      "sound": "Play Sound",
       "title": "Notification Settings"
     },
     "openai": {

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -2869,7 +2869,7 @@
       "error": "{{error}}",
       "success": "成功添加 {{type}} 到知识库"
     },
-    "tip": "如果响应成功，则只针对超过30秒的消息进行提醒"
+    "tip": "回答完成时若 Cherry Studio 不在前台或不在聊天页，将发送系统通知提醒"
   },
   "ocr": {
     "builtin": {
@@ -5203,6 +5203,7 @@
       "assistant": "助手消息",
       "backup": "备份",
       "knowledge_embed": "知识库",
+      "sound": "播放提示音",
       "title": "通知设置"
     },
     "openai": {

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -2869,7 +2869,7 @@
       "error": "無法將 {{type}} 加入知識庫：{{error}}",
       "success": "成功將 {{type}} 新增至知識庫"
     },
-    "tip": "如果回應成功，則只針對超過 30 秒的訊息發出提醒"
+    "tip": "回答完成時若 Cherry Studio 不在前景或已離開聊天頁，將發送系統通知提醒"
   },
   "ocr": {
     "builtin": {
@@ -5203,6 +5203,7 @@
       "assistant": "助手訊息",
       "backup": "備份訊息",
       "knowledge_embed": "知識庫訊息",
+      "sound": "播放提示音",
       "title": "通知設定"
     },
     "openai": {

--- a/src/renderer/src/pages/settings/GeneralSettings.tsx
+++ b/src/renderer/src/pages/settings/GeneralSettings.tsx
@@ -160,6 +160,10 @@ const GeneralSettings: FC = () => {
     dispatch(setNotificationSettings({ ...notificationSettings, [type]: value }))
   }
 
+  const handleNotificationSoundChange = (value: boolean) => {
+    dispatch(setNotificationSettings({ ...notificationSettings, sound: value }))
+  }
+
   const handleSpellCheckLanguagesChange = (selectedLanguages: string[]) => {
     dispatch(setSpellCheckLanguages(selectedLanguages))
     void window.api.setSpellCheckLanguages(selectedLanguages)
@@ -313,6 +317,11 @@ const GeneralSettings: FC = () => {
         <SettingRow>
           <SettingRowTitle>{t('settings.notification.knowledge_embed')}</SettingRowTitle>
           <Switch checked={notificationSettings.knowledge} onChange={(v) => handleNotificationChange('knowledge', v)} />
+        </SettingRow>
+        <SettingDivider />
+        <SettingRow>
+          <SettingRowTitle>{t('settings.notification.sound')}</SettingRowTitle>
+          <Switch checked={notificationSettings.sound} onChange={handleNotificationSoundChange} />
         </SettingRow>
       </SettingGroup>
       <SettingGroup theme={theme}>

--- a/src/renderer/src/queue/KnowledgeQueue.ts
+++ b/src/renderer/src/queue/KnowledgeQueue.ts
@@ -126,7 +126,6 @@ class KnowledgeQueue {
       type,
       title: t('common.knowledge_base'),
       message,
-      silent: false,
       timestamp: Date.now(),
       source: 'knowledge'
     })

--- a/src/renderer/src/services/BackupService.ts
+++ b/src/renderer/src/services/BackupService.ts
@@ -109,7 +109,6 @@ export async function restore() {
             type: 'success',
             title: i18n.t('common.success'),
             message: i18n.t('message.restore.success'),
-            silent: false,
             timestamp: Date.now(),
             source: 'backup',
             channel: 'system'
@@ -128,7 +127,6 @@ export async function restore() {
         type: 'success',
         title: i18n.t('common.success'),
         message: i18n.t('message.restore.success'),
-        silent: false,
         timestamp: Date.now(),
         source: 'backup',
         channel: 'system'
@@ -242,7 +240,6 @@ export async function backupToWebdav({
         type: 'success',
         title: i18n.t('common.success'),
         message: i18n.t('message.backup.success'),
-        silent: false,
         timestamp: Date.now(),
         source: 'backup',
         channel: 'system'
@@ -312,7 +309,6 @@ export async function backupToWebdav({
       type: 'error',
       title: i18n.t('message.backup.failed'),
       message: error.message,
-      silent: false,
       timestamp: Date.now(),
       source: 'backup',
       channel: 'system'
@@ -421,7 +417,6 @@ export async function backupToS3({
         type: 'success',
         title: i18n.t('common.success'),
         message: i18n.t('message.backup.success'),
-        silent: false,
         timestamp: Date.now(),
         source: 'backup',
         channel: 'system'
@@ -475,7 +470,6 @@ export async function backupToS3({
       type: 'error',
       title: i18n.t('message.backup.failed'),
       message: error.message,
-      silent: false,
       timestamp: Date.now(),
       source: 'backup',
       channel: 'system'
@@ -1037,7 +1031,6 @@ export async function backupToLocal({
           type: 'success',
           title: i18n.t('common.success'),
           message: i18n.t('message.backup.success'),
-          silent: false,
           timestamp: Date.now(),
           source: 'backup',
           channel: 'system'

--- a/src/renderer/src/services/NotificationService.ts
+++ b/src/renderer/src/services/NotificationService.ts
@@ -28,7 +28,10 @@ export class NotificationService {
     const notificationSettings = store.getState().settings.notification || defaultSettings.notification
 
     if (notificationSettings[notification.source]) {
-      void this.queue.add(notification)
+      // Apply user's global sound preference unless the caller forced silent.
+      const enriched: Notification =
+        notification.silent === undefined ? { ...notification, silent: !notificationSettings.sound } : notification
+      void this.queue.add(enriched)
     }
   }
 

--- a/src/renderer/src/services/__tests__/NotificationService.test.ts
+++ b/src/renderer/src/services/__tests__/NotificationService.test.ts
@@ -1,0 +1,98 @@
+import type { Notification } from '@renderer/types/notification'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const queueAdd = vi.fn()
+
+vi.mock('../../queue/NotificationQueue', () => ({
+  NotificationQueue: {
+    getInstance: () => ({
+      add: queueAdd,
+      clear: vi.fn(),
+      pending: 0,
+      size: 0
+    })
+  }
+}))
+
+vi.mock('@renderer/store', () => ({
+  default: {
+    getState: vi.fn()
+  }
+}))
+
+vi.mock('@renderer/store/settings', () => ({
+  initialState: {
+    notification: { assistant: false, backup: false, knowledge: false, sound: false }
+  }
+}))
+
+const mockIpcOn = vi.fn()
+;(global as any).window = {
+  ...(global as any).window,
+  electron: { ipcRenderer: { on: mockIpcOn } }
+}
+
+import store from '@renderer/store'
+
+import { NotificationService } from '../NotificationService'
+
+const mockGetState = vi.mocked(store.getState)
+
+function makeNotification(overrides: Partial<Notification> = {}): Notification {
+  return {
+    id: 'n1',
+    type: 'success',
+    title: 'done',
+    message: 'hello',
+    timestamp: 1,
+    source: 'assistant',
+    ...overrides
+  }
+}
+
+function setNotificationSettings(settings: Partial<{ assistant: boolean; sound: boolean }>) {
+  mockGetState.mockReturnValue({
+    settings: {
+      notification: { assistant: false, backup: false, knowledge: false, sound: false, ...settings }
+    }
+  } as any)
+}
+
+describe('NotificationService.send', () => {
+  beforeEach(() => {
+    queueAdd.mockClear()
+    mockGetState.mockReset()
+  })
+
+  it('drops the notification when its source toggle is off', async () => {
+    setNotificationSettings({ assistant: false })
+    await NotificationService.getInstance().send(makeNotification())
+    expect(queueAdd).not.toHaveBeenCalled()
+  })
+
+  it('queues silently when source is enabled and sound is off', async () => {
+    setNotificationSettings({ assistant: true, sound: false })
+    await NotificationService.getInstance().send(makeNotification())
+    expect(queueAdd).toHaveBeenCalledTimes(1)
+    expect(queueAdd.mock.calls[0][0]).toMatchObject({ source: 'assistant', silent: true })
+  })
+
+  it('queues with sound when both source and sound toggles are on', async () => {
+    setNotificationSettings({ assistant: true, sound: true })
+    await NotificationService.getInstance().send(makeNotification())
+    expect(queueAdd).toHaveBeenCalledTimes(1)
+    expect(queueAdd.mock.calls[0][0]).toMatchObject({ silent: false })
+  })
+
+  it('preserves an explicit silent flag from the caller', async () => {
+    setNotificationSettings({ assistant: true, sound: true })
+    await NotificationService.getInstance().send(makeNotification({ silent: true }))
+    expect(queueAdd.mock.calls[0][0].silent).toBe(true)
+  })
+
+  it('falls back to default settings when the slice is missing', async () => {
+    mockGetState.mockReturnValue({ settings: {} } as any)
+    await NotificationService.getInstance().send(makeNotification())
+    expect(queueAdd).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/services/messageStreaming/callbacks/baseCallbacks.ts
+++ b/src/renderer/src/services/messageStreaming/callbacks/baseCallbacks.ts
@@ -24,7 +24,7 @@ import { trackTokenUsage } from '@renderer/utils/analytics'
 import { isAbortError, isTimeoutError, serializeError } from '@renderer/utils/error'
 import { createBaseMessageBlock, createErrorBlock } from '@renderer/utils/messageUtils/create'
 import { findAllBlocks, getMainTextContent } from '@renderer/utils/messageUtils/find'
-import { isFocused, isOnHomePage } from '@renderer/utils/window'
+import { isFocused } from '@renderer/utils/window'
 import type { AISDKError } from 'ai'
 import { NoOutputGeneratedError } from 'ai'
 
@@ -54,7 +54,6 @@ export const createBaseCallbacks = (deps: BaseCallbacksDependencies) => {
     getCurrentThinkingInfo
   } = deps
 
-  const startTime = Date.now()
   const notificationService = NotificationService.getInstance()
 
   // 通用的 block 查找函数
@@ -145,21 +144,17 @@ export const createBaseCallbacks = (deps: BaseCallbacksDependencies) => {
         serializableError.i18nKey = ERROR_I18N_KEY_REQUEST_TIMEOUT
       }
 
-      const duration = Date.now() - startTime
-      // 发送错误通知（除了中止错误）
-      if (!isErrorTypeAbort) {
-        const timeOut = duration > 30 * 1000
-        if ((!isOnHomePage() && timeOut) || (!isFocused() && timeOut)) {
-          await notificationService.send({
-            id: uuid(),
-            type: 'error',
-            title: i18n.t('notification.assistant'),
-            message: serializableError.message ?? '',
-            silent: false,
-            timestamp: Date.now(),
-            source: 'assistant'
-          })
-        }
+      // 发送错误通知（除了中止错误）。
+      // 不再根据响应耗时门控：只要用户开启了 assistant 通知且窗口不在前台，就提醒。
+      if (!isErrorTypeAbort && !isFocused()) {
+        await notificationService.send({
+          id: uuid(),
+          type: 'error',
+          title: i18n.t('notification.assistant'),
+          message: serializableError.message ?? '',
+          timestamp: Date.now(),
+          source: 'assistant'
+        })
       }
 
       const possibleBlockId = findBlockIdForCompletion()
@@ -304,18 +299,16 @@ export const createBaseCallbacks = (deps: BaseCallbacksDependencies) => {
           blockManager.smartBlockUpdate(possibleBlockId, changes, blockManager.lastBlockType!, true)
         }
 
-        const duration = Date.now() - startTime
         const content = getMainTextContent(finalAssistantMsg)
 
-        const timeOut = duration > 30 * 1000
-        // 发送长时间运行消息的成功通知
-        if ((!isOnHomePage() && timeOut) || (!isFocused() && timeOut)) {
+        // 发送回答完成通知。窗口不在前台时提醒，
+        // 由 settings.notification.assistant 控制是否发送、settings.notification.sound 控制是否出声。
+        if (!isFocused()) {
           await notificationService.send({
             id: uuid(),
             type: 'success',
             title: i18n.t('notification.assistant'),
             message: content.length > 50 ? content.slice(0, 47) + '...' : content,
-            silent: false,
             timestamp: Date.now(),
             source: 'assistant',
             channel: 'system'

--- a/src/renderer/src/store/__tests__/notification-migration.test.ts
+++ b/src/renderer/src/store/__tests__/notification-migration.test.ts
@@ -1,0 +1,43 @@
+import { createMigrate } from 'redux-persist'
+import { describe, expect, it } from 'vitest'
+
+// Isolated copy of migrate.ts version 207 — backfill notification.sound for existing users.
+const migrate207 = (state: any) => {
+  if (state.settings?.notification && typeof state.settings.notification.sound !== 'boolean') {
+    state.settings.notification.sound = false
+  }
+  return state
+}
+
+const migrate = createMigrate({ '207': migrate207 as any })
+
+describe('migration 207: notification.sound backfill', () => {
+  it('adds sound=false when missing from an existing notification slice', async () => {
+    const state = {
+      settings: {
+        notification: { assistant: true, backup: false, knowledge: false }
+      },
+      _persist: { version: 206, rehydrated: false }
+    }
+    const migrated: any = await migrate(state, 207)
+    expect(migrated.settings.notification.sound).toBe(false)
+    expect(migrated.settings.notification.assistant).toBe(true)
+  })
+
+  it('preserves an existing sound=true preference', async () => {
+    const state = {
+      settings: {
+        notification: { assistant: true, backup: false, knowledge: false, sound: true }
+      },
+      _persist: { version: 206, rehydrated: false }
+    }
+    const migrated: any = await migrate(state, 207)
+    expect(migrated.settings.notification.sound).toBe(true)
+  })
+
+  it('is a no-op when notification slice is missing entirely', async () => {
+    const state = { settings: {}, _persist: { version: 206, rehydrated: false } }
+    const migrated: any = await migrate(state, 207)
+    expect(migrated.settings).toEqual({})
+  })
+})

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -86,7 +86,7 @@ const persistedReducer = persistReducer(
   {
     key: 'cherry-studio',
     storage,
-    version: 206,
+    version: 207,
     blacklist: ['runtime', 'messages', 'messageBlocks', 'tabs', 'toolPermissions'],
     migrate
   },

--- a/src/renderer/src/store/migrate.ts
+++ b/src/renderer/src/store/migrate.ts
@@ -3412,6 +3412,18 @@ const migrateConfig = {
       logger.error('migrate 206 error', error as Error)
       return state
     }
+  },
+  '207': (state: RootState) => {
+    try {
+      if (state.settings.notification && typeof state.settings.notification.sound !== 'boolean') {
+        state.settings.notification.sound = false
+      }
+      logger.info('migrate 207 success')
+      return state
+    } catch (error) {
+      logger.error('migrate 207 error', error as Error)
+      return state
+    }
   }
 }
 

--- a/src/renderer/src/store/settings.ts
+++ b/src/renderer/src/store/settings.ts
@@ -232,6 +232,8 @@ export interface SettingsState {
     assistant: boolean
     backup: boolean
     knowledge: boolean
+    /** Play sound on system notifications. Independent of source toggles. */
+    sound: boolean
   }
   // Local backup settings
   localBackupDir: string
@@ -416,7 +418,8 @@ export const initialState: SettingsState = {
   notification: {
     assistant: false,
     backup: false,
-    knowledge: false
+    knowledge: false,
+    sound: false
   },
   // Local backup settings
   localBackupDir: '',


### PR DESCRIPTION
Closes #13918.

## Summary

Adds a system notification + sound when an LLM response finishes generating, controlled by Settings. Replaces the previous \"only notify if response took >30s\" behavior, which the issue reporter explicitly called out as inadequate for long-running tasks where they switch away to other work.

### Behavior

- **Assistant notification**: when `settings.notification.assistant` is enabled and the Cherry Studio window is **not focused**, fire a system notification for every completion (success or error). No more 30-second gate.
- **Sound toggle**: new `settings.notification.sound` setting (default **off**). Controls Electron's `silent` flag for **all** sources (assistant, backup, knowledge) — the toggle lives in the same Notification Settings group, so the global scope is consistent with where it's surfaced.
- **Trigger condition**: `!isFocused()` only. The previous `(!isOnHomePage() || !isFocused())` branch fired on every non-root route, which meant any chat would always trip the notification — masked by the >30s gate before, but exposed once we removed it.

### Compatibility

- Redux-persist migration **207** backfills `notification.sound = false` for existing users (`store/migrate.ts`, `store/index.ts` version bump 206 → 207).
- Defaults preserved (sound off): no behavior change for users who don't opt in to the assistant toggle.
- Stripped hardcoded `silent: false` from `BackupService` (7 sites) and `KnowledgeQueue` (1 site) so the global Sound toggle reaches them. These sites no longer override the user's preference.

### i18n

Updated all three locales (en-us, zh-cn, zh-tw): added `settings.notification.sound` label and rewrote `notification.tip` to describe the new behavior (the old text mentioned the 30-second gate).

## Test plan

- [x] `pnpm test:renderer` — new `NotificationService.test.ts` (5 cases: source-off skip, sound-off → silent, sound-on → audible, caller-forced silent preserved, missing slice fallback) and `notification-migration.test.ts` (3 cases: backfill missing field, preserve existing preference, no-op on missing slice). All 8 pass.
- [x] `pnpm lint` — 0 errors. The single pre-existing warning in `ManageModelsPopup.tsx` is unrelated.
- [x] `pnpm format` — no diff after biome write.
- [x] `pnpm build:check` (lint + test) green.
- [ ] Manual smoke (recommend reviewer): toggle Notification Settings → Assistant on, send a short prompt with the window blurred → notification appears; toggle Sound on → audible.