### PR TITLE
fix(reasoning): use adaptive thinking for Claude 4.7+ models

### DIFF
--- a/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
+++ b/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
@@ -1163,6 +1163,33 @@ describe('reasoning utils', () => {
       expect(result).not.toHaveProperty('effort')
     })
 
+    it('should return adaptive thinking for Claude 4.7 model', async () => {
+      const { isReasoningModel, isSupportedThinkingTokenClaudeModel } = await import('@renderer/config/models')
+
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+      vi.mocked(isSupportedThinkingTokenClaudeModel).mockReturnValue(true)
+
+      const model: Model = {
+        id: 'claude-opus-4-7',
+        name: 'Claude Opus 4.7',
+        provider: SystemProviderIds.anthropic
+      } as Model
+
+      const assistant: Assistant = {
+        id: 'test',
+        name: 'Test',
+        settings: {
+          reasoning_effort: 'high'
+        }
+      } as Assistant
+
+      const result = getAnthropicReasoningParams(assistant, model)
+      expect(result).toEqual({
+        thinking: { type: 'adaptive' },
+        effort: 'high'
+      })
+    })
+
     it('should not add effort for non-DeepSeek models on the Claude endpoint', async () => {
       const { isReasoningModel, isSupportedThinkingTokenClaudeModel, isDeepSeekV4PlusModel, findTokenLimit } =
         await import('@renderer/config/models')
@@ -1781,6 +1808,35 @@ describe('reasoning utils', () => {
         reasoningConfig: {
           type: 'enabled',
           budgetTokens: 4096
+        }
+      })
+    })
+
+    it('should return adaptive reasoning config for Claude 4.7 on Bedrock', async () => {
+      const { isReasoningModel, isSupportedThinkingTokenClaudeModel } = await import('@renderer/config/models')
+
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+      vi.mocked(isSupportedThinkingTokenClaudeModel).mockReturnValue(true)
+
+      const model: Model = {
+        id: 'anthropic.claude-opus-4-7-20260501-v1:0',
+        name: 'Claude Opus 4.7',
+        provider: 'bedrock'
+      } as Model
+
+      const assistant: Assistant = {
+        id: 'test',
+        name: 'Test',
+        settings: {
+          reasoning_effort: 'high'
+        }
+      } as Assistant
+
+      const result = getBedrockReasoningParams(assistant, model)
+      expect(result).toEqual({
+        reasoningConfig: {
+          type: 'adaptive',
+          maxReasoningEffort: 'high'
         }
       })
     })

--- a/src/renderer/src/config/models/__tests__/reasoning.test.ts
+++ b/src/renderer/src/config/models/__tests__/reasoning.test.ts
@@ -2616,6 +2616,14 @@ describe('Claude Models', () => {
       expect(getThinkModelType(createModel({ id: 'anthropic.claude-opus-4-6-v1' }))).toBe('claude46')
     })
 
+    it('should return claude46 for Claude 4.7+ models', () => {
+      expect(getThinkModelType(createModel({ id: 'claude-opus-4-7' }))).toBe('claude46')
+      expect(getThinkModelType(createModel({ id: 'claude-opus-4.7' }))).toBe('claude46')
+      expect(getThinkModelType(createModel({ id: 'claude-sonnet-4-7' }))).toBe('claude46')
+      expect(getThinkModelType(createModel({ id: 'anthropic.claude-opus-4-7-20260501-v1:0' }))).toBe('claude46')
+      expect(getThinkModelType(createModel({ id: 'claude-opus-4-7@20260501' }))).toBe('claude46')
+    })
+
     it('should return default for non-reasoning Claude models', () => {
       expect(getThinkModelType(createModel({ id: 'claude-3-opus' }))).toBe('default')
       expect(getThinkModelType(createModel({ id: 'claude-3-haiku' }))).toBe('default')

--- a/src/renderer/src/config/models/__tests__/utils.test.ts
+++ b/src/renderer/src/config/models/__tests__/utils.test.ts
@@ -721,6 +721,14 @@ describe('model utils', () => {
         expect(isClaude46SeriesModel(createModel({ id: 'Anthropic.Claude-Opus-4-6-V1' }))).toBe(true)
       })
 
+      it('detects Claude 4.7+ models', () => {
+        expect(isClaude46SeriesModel(createModel({ id: 'claude-opus-4-7' }))).toBe(true)
+        expect(isClaude46SeriesModel(createModel({ id: 'claude-opus-4.7' }))).toBe(true)
+        expect(isClaude46SeriesModel(createModel({ id: 'claude-sonnet-4-7' }))).toBe(true)
+        expect(isClaude46SeriesModel(createModel({ id: 'anthropic.claude-opus-4-7-20260501-v1:0' }))).toBe(true)
+        expect(isClaude46SeriesModel(createModel({ id: 'claude-opus-4-7@20260501' }))).toBe(true)
+      })
+
       it('returns false for other Claude models', () => {
         expect(isClaude46SeriesModel(createModel({ id: 'claude-opus-4-5' }))).toBe(false)
         expect(isClaude46SeriesModel(createModel({ id: 'claude-opus-4.5' }))).toBe(false)
@@ -729,6 +737,11 @@ describe('model utils', () => {
         expect(isClaude46SeriesModel(createModel({ id: 'claude-opus-4-1' }))).toBe(false)
         expect(isClaude46SeriesModel(createModel({ id: 'claude-3-opus' }))).toBe(false)
         expect(isClaude46SeriesModel(createModel({ id: 'claude-3.5-sonnet' }))).toBe(false)
+      })
+
+      it('returns false for Bedrock Claude 4.0 with date stamp', () => {
+        expect(isClaude46SeriesModel(createModel({ id: 'anthropic.claude-sonnet-4-20250514-v1:0' }))).toBe(false)
+        expect(isClaude46SeriesModel(createModel({ id: 'anthropic.claude-opus-4-20250514-v1:0' }))).toBe(false)
       })
 
       it('detects Sonnet 4.6 in direct API format', () => {

--- a/src/renderer/src/config/models/utils.ts
+++ b/src/renderer/src/config/models/utils.ts
@@ -416,6 +416,6 @@ export function isClaude46SeriesModel(model: Model | undefined | null): boolean 
     return false
   }
   const modelId = getLowerBaseModelName(model.id, '/')
-  const regex = /(?:anthropic\.)?claude-(?:opus|sonnet)-4[.-](?:[6-9]|\d{2,})(?:[@\-:][\w\-:]+)?$/i
+  const regex = /(?:anthropic\.)?claude-(?:opus|sonnet)-4[.-](?:[6-9]|\d{2})(?:[@\-:][\w\-:]+)?$/i
   return regex.test(modelId)
 }

--- a/src/renderer/src/config/models/utils.ts
+++ b/src/renderer/src/config/models/utils.ts
@@ -405,23 +405,17 @@ export const isGemini31ProModel = (model: Model | undefined | null): boolean => 
 }
 
 /**
- * Check if the model is Claude Opus 4.6
- * Supports various formats including:
- * - Direct API: claude-opus-4-6
- * - AWS Bedrock: anthropic.claude-opus-4-6-v1
- * - GCP Vertex AI: claude-opus-4-6
+ * Check if the model is Claude 4.6+ (uses adaptive thinking + effort)
+ * Claude 4.6 supports both extended thinking and adaptive thinking.
+ * Claude 4.7+ only supports adaptive thinking (enabled returns 400).
  * @param model - The model to check
- * @returns true if the model is Claude 4.6 series model
+ * @returns true if the model is Claude 4.6+ series model
  */
 export function isClaude46SeriesModel(model: Model | undefined | null): boolean {
   if (!model) {
     return false
   }
   const modelId = getLowerBaseModelName(model.id, '/')
-  // Supports various formats:
-  // - Direct API: claude-opus-4-6, claude-opus-4.6
-  // - AWS Bedrock: anthropic.claude-opus-4-6-v1
-  // - GCP Vertex AI: claude-opus-4-6
-  const regex = /(?:anthropic\.)?claude-(?:opus|sonnet)-4[.-]6(?:[@\-:][\w\-:]+)?$/i
+  const regex = /(?:anthropic\.)?claude-(?:opus|sonnet)-4[.-](?:[6-9]|\d{2,})(?:[@\-:][\w\-:]+)?$/i
   return regex.test(modelId)
 }


### PR DESCRIPTION
### What this PR does

Before this PR:

Claude Opus 4.7 (`claude-opus-4-7`) fails with HTTP 400 when reasoning effort is set to any non-default value (low, medium, high). The error message: `"thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.`

After this PR:

Claude Opus 4.7 correctly uses `thinking: { type: "adaptive" }` with the `effort` parameter, matching the Anthropic API requirements.

Fixes #14805 
Fixes #14821

### Why we need it and why it was done in this way

The root cause is that `isClaude46SeriesModel()` in `utils.ts` used a regex that only matched `4-6`/`4.6`. Claude Opus 4.7 failed this check and fell through to the old `enabled` + `budgetTokens` code path, which Opus 4.7 does not support (returns HTTP 400).

The fix expands the regex from `4[.-]6` to `4[.-](?:[6-9]|\d{2,})` to match Claude 4.6+ models. This is the minimal change that fixes the issue and is forward-compatible with future 4.8, 4.9 releases, which are expected to continue using adaptive thinking (Anthropic is deprecating the `enabled` + `budgetTokens` approach).

The following tradeoffs were made:

- Chose to match all 4.6+ versions rather than adding a separate `isClaude47SeriesModel()` function, since the adaptive thinking API is the same for both 4.6 and 4.7+.

The following alternatives were considered:

- Adding a separate `isClaude47SeriesModel()` check — rejected as unnecessary duplication since both 4.6 and 4.7 use the same adaptive thinking API.

> **Note:** Some proxy APIs may automatically convert `enabled` + `budget_tokens` to `adaptive` parameters, masking this issue. Users connecting directly to the Anthropic API or AWS Bedrock are affected.

### Breaking changes

None.

### Special notes for your reviewer

All 4 call sites of `isClaude46SeriesModel()` benefit from this change:
1. `reasoning.ts:732` — Uses `adaptive` + `effort` instead of `enabled` + `budgetTokens`
2. `reasoning.ts:956` — Bedrock adaptive thinking (same logic)
3. `modelParameters.ts:146` — Skips budget subtraction from maxTokens
4. `reasoning.ts:136` — UI displays `claude46` effort options (includes `xhigh`)

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix Claude Opus 4.7 returning HTTP 400 when reasoning effort is set to non-default values. The model now correctly uses adaptive thinking parameters instead of the unsupported extended thinking format.
```
