### PR TITLE
fix(messages): normalize tool-call card shells under custom themes

### DIFF
--- a/src/renderer/src/pages/home/Messages/Blocks/ToolBlockGroup.tsx
+++ b/src/renderer/src/pages/home/Messages/Blocks/ToolBlockGroup.tsx
@@ -23,20 +23,26 @@ import BlockErrorFallback from './BlockErrorFallback'
 const Container = styled.div`
   width: fit-content;
   max-width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+  background: var(--color-background);
+  overflow: hidden;
 
   /* Only style the direct group collapse, not nested tool collapses */
-  > .ant-collapse {
-    background: transparent;
+  && > .ant-collapse {
+    background: transparent !important;
     border: none;
+    border-radius: 0;
 
     > .ant-collapse-item {
       border: none !important;
+      background: transparent;
 
       > .ant-collapse-header {
         padding: 8px 12px !important;
-        background: var(--color-background);
-        border: 1px solid var(--color-border);
-        border-radius: 0.75rem !important;
+        background: transparent !important;
+        border: none;
+        border-radius: 0 !important;
         display: flex;
         align-items: center;
 
@@ -48,8 +54,9 @@ const Container = styled.div`
       }
 
       > .ant-collapse-content {
-        border: none;
-        background: transparent;
+        border-top: 1px solid var(--color-border) !important;
+        border-radius: 0 !important;
+        background: transparent !important;
 
         > .ant-collapse-content-box {
           padding: 4px 0 0 0 !important;

--- a/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/index.tsx
+++ b/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/index.tsx
@@ -5,6 +5,7 @@ import type { CollapseProps } from 'antd'
 import { Collapse } from 'antd'
 import { parse as parsePartialJson } from 'partial-json'
 import { useMemo } from 'react'
+import styled from 'styled-components'
 
 // 导出所有类型
 export * from './types'
@@ -119,13 +120,14 @@ function ToolContent({
 
   return (
     <StreamingContext value={isStreaming}>
-      <Collapse
-        className="w-max max-w-full has-[.ant-collapse-item-active]:w-full"
-        expandIconPosition="end"
-        size="small"
-        defaultActiveKey={toolName === AgentToolsType.TodoWrite ? [AgentToolsType.TodoWrite] : []}
-        items={[toolContentItem]}
-      />
+      <ToolCardShell>
+        <Collapse
+          expandIconPosition="end"
+          size="small"
+          defaultActiveKey={toolName === AgentToolsType.TodoWrite ? [AgentToolsType.TodoWrite] : []}
+          items={[toolContentItem]}
+        />
+      </ToolCardShell>
     </StreamingContext>
   )
 }
@@ -185,3 +187,39 @@ export function MessageAgentTools({ toolResponse }: { toolResponse: NormalToolRe
     />
   )
 }
+
+const ToolCardShell = styled.div`
+  width: max-content;
+  max-width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background-color: var(--color-background);
+  overflow: hidden;
+
+  &:has(.ant-collapse-item-active) {
+    width: 100%;
+  }
+
+  && .ant-collapse {
+    border: none;
+    border-radius: 0;
+    background: transparent !important;
+  }
+
+  && .ant-collapse-item {
+    border: none !important;
+    background: transparent;
+  }
+
+  && .ant-collapse-header {
+    background-color: transparent !important;
+    background: transparent !important;
+    border-radius: 0 !important;
+  }
+
+  && .ant-collapse-content {
+    border-top: 1px solid var(--color-border) !important;
+    border-radius: 0 !important;
+    background: transparent !important;
+  }
+`

--- a/src/renderer/src/pages/home/Messages/Tools/MessageMcpTool.tsx
+++ b/src/renderer/src/pages/home/Messages/Tools/MessageMcpTool.tsx
@@ -336,9 +336,10 @@ const ToolResponseContent: FC<{
     return Object.entries(parsedArgs)
   }
   const entries = getEntries()
+  const hasArgsSection = entries.length > 0 || isStreaming
 
   const renderArgsTable = (): React.ReactNode => {
-    if (entries.length === 0) return null
+    if (!hasArgsSection) return null
     return (
       <ArgsSection>
         <ArgsSectionTitle>Arguments</ArgsSectionTitle>
@@ -366,52 +367,59 @@ const ToolResponseContent: FC<{
     )
   }
 
+  const responseSection = response !== undefined &&
+    response !== null &&
+    (highlightedResponse || responseImages.length > 0) && (
+      <McpResponseSection $isFirstSection={!hasArgsSection}>
+        <ArgsSectionTitle>Response</ArgsSectionTitle>
+        {highlightedResponse && (
+          <MarkdownContainer className="markdown" dangerouslySetInnerHTML={{ __html: highlightedResponse }} />
+        )}
+        {isTruncated && <TruncatedIndicator originalLength={originalLength} />}
+        {responseImages.map((img, idx) => (
+          <img
+            key={idx}
+            src={`data:${img.mimeType};base64,${img.data}`}
+            alt="Tool output"
+            style={{ maxWidth: 300, borderRadius: 4, marginTop: 8 }}
+          />
+        ))}
+      </McpResponseSection>
+    )
+
   return (
     <div>
-      {/* Arguments Table */}
-      {renderArgsTable()}
-
-      {/* Response */}
-      {response !== undefined && response !== null && (highlightedResponse || responseImages.length > 0) && (
-        <ResponseSection>
-          <ArgsSectionTitle>Response</ArgsSectionTitle>
-          {highlightedResponse && (
-            <MarkdownContainer className="markdown" dangerouslySetInnerHTML={{ __html: highlightedResponse }} />
-          )}
-          {isTruncated && <TruncatedIndicator originalLength={originalLength} />}
-          {responseImages.map((img, idx) => (
-            <img
-              key={idx}
-              src={`data:${img.mimeType};base64,${img.data}`}
-              alt="Tool output"
-              style={{ maxWidth: 300, borderRadius: 4, marginTop: 8 }}
-            />
-          ))}
-        </ResponseSection>
-      )}
+      {hasArgsSection && <FirstBodySection>{renderArgsTable()}</FirstBodySection>}
+      {responseSection && (!hasArgsSection ? <FirstBodySection>{responseSection}</FirstBodySection> : responseSection)}
     </div>
   )
 }
 
 const ToolContentWrapper = styled.div`
-  padding: 1px;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
+  background-color: var(--color-background);
   overflow: hidden;
 
-  .ant-collapse {
-    border: 1px solid var(--color-border);
+  && .ant-collapse {
+    border: none;
+    border-radius: 0;
+    background: transparent !important;
+  }
+
+  && .ant-collapse-item {
+    border: none !important;
+    background: transparent;
   }
 
   &.pending {
     background-color: var(--color-background-soft);
-    .ant-collapse {
-      border: none;
-    }
   }
 `
 
 const ActionsBar = styled.div`
   padding: 8px;
+  border-top: 1px solid var(--color-border);
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -437,17 +445,24 @@ const CollapseContainer = styled(Collapse)`
   --status-color-invoking: var(--color-primary);
   --status-color-error: var(--color-status-error, #ff4d4f);
   --status-color-success: var(--color-primary, green);
-  border-radius: 7px;
   border: none;
-  background-color: var(--color-background);
-  overflow: hidden;
+  border-radius: 0;
+  background: transparent !important;
 
-  .ant-collapse-header {
+  && .ant-collapse-header {
     padding: 8px 10px !important;
     align-items: center !important;
+    background-color: transparent !important;
+    background: transparent !important;
   }
 
-  .ant-collapse-content-box {
+  && .ant-collapse-content {
+    border-radius: 0 !important;
+    background-color: transparent !important;
+    background: transparent !important;
+  }
+
+  && .ant-collapse-content-box {
     padding: 0 !important;
   }
 `
@@ -545,11 +560,19 @@ const ActionButton = styled.button`
 `
 
 const ToolResponseContainer = styled.div`
-  border-radius: 0 0 4px 4px;
+  border-radius: 0;
   overflow: auto;
   max-height: 300px;
   border-top: none;
   position: relative;
+`
+
+const FirstBodySection = styled.div`
+  border-top: 1px solid var(--color-border);
+`
+
+const McpResponseSection = styled(ResponseSection)<{ $isFirstSection?: boolean }>`
+  border-top: ${({ $isFirstSection }) => ($isFirstSection ? 'none' : '1px solid var(--color-border)')};
 `
 
 export default memo(MessageMcpTool)

--- a/src/renderer/src/pages/home/Messages/Tools/ToolPermissionRequestCard.tsx
+++ b/src/renderer/src/pages/home/Messages/Tools/ToolPermissionRequestCard.tsx
@@ -96,18 +96,26 @@ const Container = styled.div`
   background-color: var(--color-background-soft);
   overflow: hidden;
 
-  .ant-collapse {
+  && .ant-collapse {
     border: none;
-    border-radius: 0;
+    border-radius: 0 !important;
+    background: transparent !important;
+  }
+
+  && .ant-collapse-item {
+    border: none !important;
     background: transparent;
   }
 
-  .ant-collapse-item {
-    border: none;
+  && .ant-collapse-header {
+    padding: 8px 12px !important;
+    background: transparent !important;
   }
 
-  .ant-collapse-header {
-    padding: 8px 12px !important;
+  && .ant-collapse-content {
+    border-top: 1px solid var(--color-border) !important;
+    border-radius: 0 !important;
+    background: transparent !important;
   }
 `
 

--- a/src/renderer/src/pages/home/Messages/Tools/__tests__/ToolCallThemeRadius.test.tsx
+++ b/src/renderer/src/pages/home/Messages/Tools/__tests__/ToolCallThemeRadius.test.tsx
@@ -1,0 +1,467 @@
+import type { NormalToolResponse } from '@renderer/types'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { type ReactNode, useState } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ToolBlockGroup from '../../Blocks/ToolBlockGroup'
+import { MessageAgentTools } from '../MessageAgentTools'
+import MessageMcpTool from '../MessageMcpTool'
+import ToolPermissionRequestCard from '../ToolPermissionRequestCard'
+
+const mockUseAppSelector = vi.fn()
+const mockUseToolApproval = vi.fn()
+const mockUseAgentToolApproval = vi.fn()
+
+let currentPendingPermission: Record<string, unknown> | null = null
+
+vi.mock('@renderer/store', () => ({
+  useAppSelector: (selector: (state: { toolPermissions: { requests: Record<string, unknown> } }) => unknown) =>
+    mockUseAppSelector(selector),
+  useAppDispatch: () => vi.fn()
+}))
+
+vi.mock('@renderer/store/toolPermissions', () => ({
+  selectPendingPermission: vi.fn(() => currentPendingPermission),
+  toolPermissionsActions: {
+    submissionSent: vi.fn(),
+    submissionFailed: vi.fn()
+  }
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown> | string) => {
+      if (key === 'message.tools.groupHeader' && typeof options === 'object') {
+        return `${options.count as number} tool calls`
+      }
+      if (typeof options === 'string') {
+        return options
+      }
+      return key
+    }
+  }),
+  initReactI18next: {
+    type: '3rdParty',
+    init: vi.fn()
+  }
+}))
+
+vi.mock('antd', () => {
+  const normalizeKeys = (keys?: string | string[]) => {
+    if (Array.isArray(keys)) {
+      return keys.map(String)
+    }
+    return keys ? [String(keys)] : []
+  }
+
+  const Collapse = ({
+    items = [],
+    className = '',
+    activeKey,
+    defaultActiveKey,
+    ghost,
+    expandIcon,
+    onChange
+  }: {
+    items?: Array<Record<string, any>>
+    className?: string
+    activeKey?: string | string[]
+    defaultActiveKey?: string | string[]
+    ghost?: boolean
+    expandIcon?: (props: { isActive: boolean }) => ReactNode
+    onChange?: (keys: string[]) => void
+  }) => {
+    const [innerKeys, setInnerKeys] = useState<string[]>(normalizeKeys(defaultActiveKey))
+    const isControlled = activeKey !== undefined
+    const resolvedKeys = isControlled ? normalizeKeys(activeKey) : innerKeys
+
+    return (
+      <div className={['ant-collapse', ghost ? 'ant-collapse-ghost' : '', className].filter(Boolean).join(' ')}>
+        {items.map((item) => {
+          const itemKey = String(item.key)
+          const isActive = resolvedKeys.includes(itemKey)
+
+          const toggleItem = () => {
+            const nextKeys = isActive ? resolvedKeys.filter((key) => key !== itemKey) : [...resolvedKeys, itemKey]
+            if (!isControlled) {
+              setInnerKeys(nextKeys)
+            }
+            onChange?.(nextKeys)
+          }
+
+          return (
+            <div
+              key={itemKey}
+              className={['ant-collapse-item', isActive ? 'ant-collapse-item-active' : ''].filter(Boolean).join(' ')}>
+              <div
+                className={['ant-collapse-header', item.classNames?.header].filter(Boolean).join(' ')}
+                onClick={toggleItem}>
+                <div className="ant-collapse-header-text">{item.label}</div>
+                <div className="ant-collapse-expand-icon">{expandIcon?.({ isActive })}</div>
+              </div>
+              <div className="ant-collapse-content">
+                <div className={['ant-collapse-content-box', item.classNames?.body].filter(Boolean).join(' ')}>
+                  {item.children}
+                </div>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    )
+  }
+
+  return {
+    Collapse,
+    ConfigProvider: ({ children }: { children: ReactNode }) => children,
+    Flex: ({ children, className }: { children: ReactNode; className?: string }) => (
+      <div className={className}>{children}</div>
+    ),
+    Progress: ({ percent }: { percent: number }) => <div data-testid="progress">{percent}</div>,
+    Tooltip: ({ children }: { children: ReactNode }) => children
+  }
+})
+
+vi.mock('@renderer/context/CodeStyleProvider', () => ({
+  useCodeStyle: () => ({
+    highlightCode: vi.fn(async (content: string) => content)
+  })
+}))
+
+vi.mock('@renderer/hooks/useSettings', () => ({
+  useSettings: () => ({
+    messageFont: 'sans',
+    fontSize: 14
+  })
+}))
+
+vi.mock('@renderer/hooks/useTimer', () => ({
+  useTimer: () => ({
+    setTimeoutTimer: vi.fn()
+  })
+}))
+
+vi.mock('@renderer/utils/mcp-tools', () => ({
+  isToolAutoApproved: vi.fn(() => false)
+}))
+
+vi.mock('@shared/IpcChannel', () => ({
+  IpcChannel: {
+    Mcp_Progress: 'Mcp_Progress'
+  }
+}))
+
+vi.mock('../hooks/useToolApproval', () => ({
+  useToolApproval: (...args: unknown[]) => mockUseToolApproval(...args)
+}))
+
+vi.mock('../hooks/useAgentToolApproval', () => ({
+  useAgentToolApproval: (...args: unknown[]) => mockUseAgentToolApproval(...args)
+}))
+
+vi.mock('../ToolApprovalActions', () => ({
+  default: () => <div data-testid="approval-actions">approval-actions</div>
+}))
+
+vi.mock('../MessageTools', () => ({
+  default: ({ block }: { block: { id: string } }) => <div data-testid={`tool-item-${block.id}`}>tool-item</div>
+}))
+
+vi.mock('@renderer/components/Icons', () => ({
+  CopyIcon: () => <span data-testid="copy-icon">copy</span>,
+  LoadingIcon: () => <span data-testid="loading-icon">loading</span>
+}))
+
+const applyTheme = () => {
+  document.body.setAttribute('theme-mode', 'light')
+  const style = document.createElement('style')
+  style.setAttribute('data-testid', 'theme-style')
+  style.textContent = `
+    :root {
+      --list-item-border-radius: 10px;
+      --color-border: rgba(31, 41, 55, 0.15);
+      --color-background: rgb(243, 244, 246);
+      --color-background-soft: rgb(229, 231, 235);
+      --color-text: rgb(31, 41, 55);
+      --color-text-1: rgb(31, 41, 55);
+      --color-text-2: rgba(31, 41, 55, 0.6);
+      --color-text-3: rgba(31, 41, 55, 0.38);
+      --color-primary: rgb(75, 85, 99);
+      --status-color-success: rgb(75, 85, 99);
+      --font-family: system-ui;
+      --font-family-serif: serif;
+    }
+
+    body[theme-mode='light'] .ant-collapse {
+      background-color: rgb(185, 190, 199);
+    }
+
+    body[theme-mode='light'] .ant-collapse-content {
+      background-color: rgb(205, 209, 217);
+    }
+  `
+  document.head.appendChild(style)
+  return style
+}
+
+const applyStrongTheme = () => {
+  document.body.setAttribute('theme-mode', 'light')
+  const style = document.createElement('style')
+  style.setAttribute('data-testid', 'theme-style-strong')
+  style.textContent = `
+    body[theme-mode='light'] .ant-collapse {
+      background-color: rgb(185, 190, 199) !important;
+    }
+
+    body[theme-mode='light'] .ant-collapse-header {
+      background-color: rgb(190, 194, 202) !important;
+    }
+
+    body[theme-mode='light'] .ant-collapse-content {
+      background-color: rgb(205, 209, 217) !important;
+      border-radius: 18px !important;
+    }
+  `
+  document.head.appendChild(style)
+  return style
+}
+
+const getStyleRuleText = (selectorFragment: string) => {
+  for (const styleSheet of Array.from(document.styleSheets)) {
+    const rules = Array.from(styleSheet.cssRules ?? [])
+    for (const rule of rules) {
+      if (rule.cssText.includes(selectorFragment)) {
+        return rule.cssText
+      }
+    }
+  }
+  return ''
+}
+
+const createAgentToolResponse = (overrides: Partial<NormalToolResponse> = {}): NormalToolResponse => ({
+  id: 'agent-tool-1',
+  toolCallId: 'call-1',
+  tool: {
+    id: 'Search',
+    name: 'Search',
+    description: 'Search tool',
+    type: 'provider'
+  },
+  arguments: 'radius test',
+  response: 'one\ntwo',
+  status: 'done',
+  ...overrides
+})
+
+const createToolBlock = (id: string, overrides: Record<string, unknown> = {}) =>
+  ({
+    id,
+    messageId: 'message-1',
+    metadata: {
+      rawMcpToolResponse: createAgentToolResponse(overrides)
+    }
+  }) as any
+
+const createMcpBlock = (overrides: Record<string, unknown> = {}) =>
+  ({
+    id: 'mcp-block-1',
+    messageId: 'message-1',
+    metadata: {
+      rawMcpToolResponse: {
+        id: 'mcp-call-1',
+        toolCallId: 'mcp-call-1',
+        tool: {
+          id: 'fetch',
+          name: 'fetch',
+          serverId: 'server-1',
+          serverName: 'server-a',
+          type: 'mcp'
+        },
+        arguments: { url: 'https://example.com' },
+        response: { isError: false, content: [] },
+        partialArguments: undefined,
+        status: 'done',
+        ...overrides
+      }
+    }
+  }) as any
+
+describe('tool-call theme radius hotfix regression', () => {
+  beforeEach(() => {
+    currentPendingPermission = null
+    mockUseAppSelector.mockImplementation((selector) => selector({ toolPermissions: { requests: {} } }))
+    mockUseToolApproval.mockReturnValue({
+      isWaiting: false,
+      isExecuting: false,
+      isSubmitting: false,
+      confirm: vi.fn(),
+      cancel: vi.fn(),
+      autoApprove: undefined
+    })
+    mockUseAgentToolApproval.mockReturnValue({
+      isWaiting: true,
+      isExecuting: false,
+      isSubmitting: false,
+      input: 'radius test',
+      confirm: vi.fn(),
+      cancel: vi.fn(),
+      autoApprove: undefined
+    })
+    window.electron.ipcRenderer.on = vi.fn(() => () => {})
+  })
+
+  afterEach(() => {
+    cleanup()
+    document.body.removeAttribute('theme-mode')
+    document.querySelector('[data-testid="theme-style"]')?.remove()
+    document.querySelector('[data-testid="theme-style-strong"]')?.remove()
+    vi.clearAllMocks()
+  })
+
+  it('uses a dedicated outer shell for generic agent tool cards under themed collapse styles', () => {
+    applyTheme()
+
+    const { container } = render(<MessageAgentTools toolResponse={createAgentToolResponse()} />)
+    const collapse = container.querySelector('.ant-collapse') as HTMLElement
+    const shell = collapse.parentElement as HTMLElement
+    const content = container.querySelector('.ant-collapse-content') as HTMLElement
+
+    expect(getComputedStyle(shell).borderRadius).toBe('8px')
+    expect(getComputedStyle(shell).overflow).toBe('hidden')
+    expect(getComputedStyle(collapse).backgroundColor).toBe('rgba(0, 0, 0, 0)')
+    expect(getComputedStyle(content).backgroundColor).toBe('rgba(0, 0, 0, 0)')
+  })
+
+  it('emits explicit neutralization rules for generic agent tool headers under strong custom theme rules', () => {
+    const { container } = render(<MessageAgentTools toolResponse={createAgentToolResponse()} />)
+
+    applyStrongTheme()
+
+    const collapse = container.querySelector('.ant-collapse') as HTMLElement
+    const shellClassName = Array.from((collapse.parentElement as HTMLElement).classList).find(
+      (className) => !className.startsWith('sc-')
+    ) as string
+    const headerRuleText = getStyleRuleText(`.${shellClassName}.${shellClassName} .ant-collapse-header`)
+
+    expect(headerRuleText).toContain('background-color: transparent !important')
+    expect(headerRuleText).toContain('background: transparent !important')
+  })
+
+  it('keeps grouped tool-call cards on a single rounded shell under themed collapse styles', () => {
+    applyTheme()
+
+    const blocks = [
+      createToolBlock('tool-block-1', { status: 'done' }),
+      createToolBlock('tool-block-2', { status: 'done' })
+    ]
+
+    const { container } = render(<ToolBlockGroup blocks={blocks} />)
+    const collapse = container.querySelector('.ant-collapse') as HTMLElement
+    const shell = collapse.parentElement as HTMLElement
+    const content = container.querySelector('.ant-collapse-content') as HTMLElement
+
+    expect(getComputedStyle(shell).borderRadius).toBe('0.75rem')
+    expect(getComputedStyle(shell).overflow).toBe('hidden')
+    expect(getComputedStyle(collapse).backgroundColor).toBe('rgba(0, 0, 0, 0)')
+    expect(getComputedStyle(content).backgroundColor).toBe('rgba(0, 0, 0, 0)')
+  })
+
+  it('keeps MCP tool cards on a single rounded shell while preserving the bottom actions area', () => {
+    applyTheme()
+
+    mockUseToolApproval.mockReturnValue({
+      isWaiting: true,
+      isExecuting: false,
+      isSubmitting: false,
+      confirm: vi.fn(),
+      cancel: vi.fn(),
+      autoApprove: undefined
+    })
+
+    const { container } = render(<MessageMcpTool block={createMcpBlock()} />)
+    const collapse = container.querySelector('.message-tools-container') as HTMLElement
+    const shell = collapse.parentElement as HTMLElement
+    const content = container.querySelector('.ant-collapse-content') as HTMLElement
+
+    expect(screen.getByTestId('approval-actions')).toBeInTheDocument()
+    expect(shell.contains(screen.getByTestId('approval-actions'))).toBe(true)
+    expect(getComputedStyle(shell).borderRadius).toBe('8px')
+    expect(getComputedStyle(shell).overflow).toBe('hidden')
+    expect(getComputedStyle(collapse).backgroundColor).toBe('rgba(0, 0, 0, 0)')
+    expect(getComputedStyle(content).backgroundColor).toBe('rgba(0, 0, 0, 0)')
+  })
+
+  it('emits explicit high-specificity neutralization rules for MCP collapse internals', () => {
+    const { container } = render(<MessageMcpTool block={createMcpBlock()} />)
+
+    applyStrongTheme()
+
+    const collapse = container.querySelector('.message-tools-container') as HTMLElement
+    const collapseClassName = Array.from(collapse.classList).find(
+      (className) =>
+        className !== 'message-tools-container' && !className.startsWith('ant-') && !className.startsWith('sc-')
+    ) as string
+    const headerRuleText = getStyleRuleText(`.${collapseClassName}.${collapseClassName} .ant-collapse-header`)
+    const contentRuleText = getStyleRuleText(`.${collapseClassName}.${collapseClassName} .ant-collapse-content`)
+
+    expect(headerRuleText).toContain('background-color: transparent !important')
+    expect(headerRuleText).toContain('background: transparent !important')
+    expect(contentRuleText).toContain('background-color: transparent !important')
+    expect(contentRuleText).toContain('background: transparent !important')
+    expect(contentRuleText).toContain('border-radius: 0 !important')
+  })
+
+  it('uses a single header-to-body divider for MCP response-only content', async () => {
+    applyTheme()
+
+    const { container } = render(
+      <MessageMcpTool
+        block={createMcpBlock({
+          arguments: undefined,
+          response: {
+            isError: false,
+            content: [{ type: 'text', text: '{"ok":true}' }]
+          }
+        })}
+      />
+    )
+
+    const header = container.querySelector('.ant-collapse-header') as HTMLElement
+    fireEvent.click(header)
+
+    const responseTitle = await screen.findByText('Response')
+    const collapseContent = container.querySelector('.ant-collapse-content') as HTMLElement
+    const responseSection = responseTitle.parentElement as HTMLElement
+    const collapseClassName = Array.from(collapseContent.parentElement?.parentElement?.classList ?? []).find(
+      (className) =>
+        className !== 'message-tools-container' && !className.startsWith('ant-') && !className.startsWith('sc-')
+    ) as string
+    const responseClassName = Array.from(responseSection.classList).find((className) => !className.startsWith('sc-'))
+    const collapseRuleText = getStyleRuleText(`.${collapseClassName} .ant-collapse-content`)
+    const responseRuleText = getStyleRuleText(`.${responseClassName}`)
+
+    expect(collapseRuleText).not.toContain('border-top')
+    expect(responseRuleText).toContain('border-top: 1px solid var(--color-border)')
+  })
+
+  it('neutralizes themed inner collapse backgrounds inside permission request cards', () => {
+    applyTheme()
+    currentPendingPermission = {
+      requestId: 'request-1',
+      toolCallId: 'call-1',
+      toolName: 'Search',
+      status: 'pending',
+      input: 'radius test'
+    }
+
+    const { container } = render(<ToolPermissionRequestCard toolResponse={createAgentToolResponse()} />)
+    const collapse = container.querySelector('.ant-collapse') as HTMLElement
+    const shell = collapse.parentElement as HTMLElement
+    const content = container.querySelector('.ant-collapse-content') as HTMLElement
+
+    expect(getComputedStyle(shell).borderRadius).toBe('0.75rem')
+    expect(getComputedStyle(shell).overflow).toBe('hidden')
+    expect(getComputedStyle(collapse).backgroundColor).toBe('rgba(0, 0, 0, 0)')
+    expect(getComputedStyle(content).backgroundColor).toBe('rgba(0, 0, 0, 0)')
+  })
+})


### PR DESCRIPTION
### What this PR does

Before this PR:
Under some custom themes from Cherry CSS, tool-call UI could show two visible rounded layers with inconsistent corner radii.
This was most obvious on tool-call cards that use `Collapse` internally, such as grouped tool calls, generic agent tool cards, MCP tool cards, and permission request cards.
In the MCP response-only path, the expanded body could also show an extra divider line.

After this PR:
Affected tool-call cards render as a single visible outer shell under custom themes.
Inner `Collapse` layers no longer render their own independent rounded/background shell.
The MCP response-only expanded view now keeps a single divider between the header and body.
The visible corner radius of these tool-call cards is also kept aligned with the previous UI instead of becoming overly rounded.

Fixes #

### Why we need it and why it was done in this way

Some custom themes style `.ant-collapse` and `.ant-collapse-content`, which exposed that these tool-call components were rendering multiple visible card layers with separate backgrounds and corner radii.

This fix keeps the change local to the affected tool-call components and makes the outer tool card the only visible shell.
That keeps the hotfix small and avoids changing the global theme system, custom CSS injection behavior, or unrelated `Collapse` usage.

The following tradeoffs were made:
A local renderer-only fix was chosen instead of adding a global Ant Design override.
Component-local radii were kept for these tool-call cards so the UI stays closer to the previous appearance and does not become pill-shaped in layouts where list-item radius tokens are larger.

The following alternatives were considered:
A global override in `ant.css` was considered, but rejected because it would broaden the change surface and could affect unrelated collapsible components.
Changing the custom theme contract was also considered, but rejected because tool-call cards should render correctly even when themes style Ant Design collapse internals.

Links to places where the discussion took place:
N/A

### Breaking changes

None.

### Special notes for your reviewer

A renderer regression test was added for:
- generic agent tool cards
- grouped tool-call cards
- MCP tool cards
- tool permission request cards
- MCP response-only divider behavior under themed collapse styles

Focused local verification was performed with:
- `pnpm exec eslint src/renderer/src/pages/home/Messages/Blocks/ToolBlockGroup.tsx src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/index.tsx src/renderer/src/pages/home/Messages/Tools/MessageMcpTool.tsx src/renderer/src/pages/home/Messages/Tools/ToolPermissionRequestCard.tsx src/renderer/src/pages/home/Messages/Tools/__tests__/ToolCallThemeRadius.test.tsx`
- `pnpm typecheck:web`
- `pnpm test:renderer -- src/renderer/src/pages/home/Messages/Tools/__tests__/ToolCallThemeRadius.test.tsx`
- `pnpm test:renderer -- src/renderer/src/pages/home/Messages/Tools/__tests__/MessageAgentTools.test.tsx`
- `pnpm test:renderer -- src/renderer/src/pages/home/Messages/Blocks/__tests__/ThinkingBlock.test.tsx`
- `pnpm test:renderer -- src/renderer/src/pages/home/Messages/Tools/hooks/__tests__/useMcpToolApproval.test.ts`
- `pnpm test:renderer -- src/renderer/src/pages/home/Messages/Tools/__tests__/ClickableFilePath.test.tsx`

Manual verification was also performed with the default theme and a Cherry CSS custom theme, including:
- collapsed and expanded generic tool cards
- grouped tool-call cards
- MCP tool cards
- permission request cards

The attached images use the `雁灰 (Yan-hui)` custom theme from Cherry CSS as a reproducible example of the issue.

Before:
<img width="198" height="78" alt="ScreenShot_2026-05-03_085130_599" src="https://github.com/user-attachments/assets/13d2511f-0087-47b2-9989-e3272dae9a1c" />
<img width="699" height="345" alt="ScreenShot_2026-05-03_085157_161" src="https://github.com/user-attachments/assets/58b5aac2-9dbd-40e9-8211-e2c30c9faa38" />

After:
<img width="213" height="78" alt="ScreenShot_2026-05-04_153311_337" src="https://github.com/user-attachments/assets/e4d9e6aa-4d8b-49e1-b2cd-c00e69d23fb8" />
<img width="579" height="234" alt="ScreenShot_2026-05-04_153345_036" src="https://github.com/user-attachments/assets/b26df096-db8b-4878-848c-74d26d5c24bc" />

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and keep it simple
- [x] Refactor: I have left the code cleaner than I found it
- [x] Upgrade: Impact of this change on upgrade flows was considered and not required
- [x] Documentation: A user-guide update was considered and is not required
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed a UI bug where some custom themes could render tool-call cards with mismatched inner and outer rounded corners, and fixed an extra divider line in the MCP response-only expanded view.