### PR TITLE
fix: respect trailing # in API host preview

### DIFF
--- a/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
@@ -332,6 +332,10 @@ const ProviderSetting: FC<Props> = ({ providerId, isOnboarding = false }) => {
   const hostPreview = () => {
     const formattedApiHost = adaptProvider({ provider: { ...provider, apiHost } }).apiHost
 
+    if (apiHost.trim().endsWith('#')) {
+      return formattedApiHost
+    }
+
     if (isOllamaProvider(provider)) {
       return formattedApiHost + '/chat'
     }


### PR DESCRIPTION
### What this PR does

When the API host URL ends with `#`, the preview text below the input no longer incorrectly appends endpoint paths like `/chat/completions`.

This is a **display-only** fix — only the `hostPreview()` UI function is affected. Actual API calls already correctly handle the trailing `#` via `isWithTrailingSharp`.

Fixes #14852

> Note: This same fix was previously submitted as #14555 targeting the `v2` branch. Resubmitting here as a hotfix to `main` since it's a minimal bug fix (4 lines, UI-only).

### Breaking changes

None.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)

### Release note

```release-note
Fix API host preview incorrectly appending endpoint paths when URL ends with `#`
```