### PR TITLE
Feat/pin chat session name

### DIFF
--- a/packages/shared/anthropic/__tests__/index.test.ts
+++ b/packages/shared/anthropic/__tests__/index.test.ts
@@ -1,0 +1,82 @@
+import type { Provider } from '@types'
+import { describe, expect, it, vi } from 'vitest'
+
+const mockAnthropicInstance = { _baseURL: '' }
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    constructor(opts: any) {
+      mockAnthropicInstance._baseURL = opts.baseURL
+    }
+  }
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    })
+  }
+}))
+
+const { getSdkClient } = await import('../index')
+
+function makeProvider(overrides: Partial<Provider> = {}): Provider {
+  return {
+    id: 'test-provider',
+    type: 'anthropic',
+    name: 'Test',
+    apiKey: 'sk-test',
+    apiHost: 'https://api.example.com/v1',
+    models: [],
+    enabled: true,
+    ...overrides
+  } as Provider
+}
+
+describe('getSdkClient', () => {
+  describe('baseURL should strip trailing API version', () => {
+    it('strips /v1 from apiHost for anthropic provider type', () => {
+      const provider = makeProvider({ type: 'anthropic', apiHost: 'https://api.example.com/v1' })
+      getSdkClient(provider)
+      expect(mockAnthropicInstance._baseURL).toBe('https://api.example.com')
+    })
+
+    it('strips /v1 from apiHost for non-anthropic provider type using apiHost fallback', () => {
+      const provider = makeProvider({ type: 'openai' as any, apiHost: 'https://gateway.example.com/v1' })
+      getSdkClient(provider)
+      expect(mockAnthropicInstance._baseURL).toBe('https://gateway.example.com')
+    })
+
+    it('strips /v1 from anthropicApiHost for non-anthropic provider type', () => {
+      const provider = makeProvider({
+        type: 'openai' as any,
+        apiHost: 'https://openai.example.com/v1',
+        anthropicApiHost: 'https://anthropic.example.com/v1'
+      })
+      getSdkClient(provider)
+      expect(mockAnthropicInstance._baseURL).toBe('https://anthropic.example.com')
+    })
+
+    it('handles apiHost without trailing version', () => {
+      const provider = makeProvider({ type: 'anthropic', apiHost: 'https://api.anthropic.com' })
+      getSdkClient(provider)
+      expect(mockAnthropicInstance._baseURL).toBe('https://api.anthropic.com')
+    })
+
+    it('strips /v2beta from apiHost', () => {
+      const provider = makeProvider({ type: 'anthropic', apiHost: 'https://api.example.com/v2beta' })
+      getSdkClient(provider)
+      expect(mockAnthropicInstance._baseURL).toBe('https://api.example.com')
+    })
+
+    it('preserves path segments before trailing version', () => {
+      const provider = makeProvider({ type: 'anthropic', apiHost: 'https://gateway.example.com/api/anthropic/v1' })
+      getSdkClient(provider)
+      expect(mockAnthropicInstance._baseURL).toBe('https://gateway.example.com/api/anthropic')
+    })
+  })
+})

--- a/packages/shared/anthropic/index.ts
+++ b/packages/shared/anthropic/index.ts
@@ -11,6 +11,7 @@
 import Anthropic from '@anthropic-ai/sdk'
 import type { TextBlockParam } from '@anthropic-ai/sdk/resources'
 import { loggerService } from '@logger'
+import { withoutTrailingApiVersion } from '@shared/utils/api'
 import type { Provider } from '@types'
 import type { ModelMessage } from 'ai'
 
@@ -88,10 +89,11 @@ export function getSdkClient(
       }
     })
   }
-  const baseURL =
+  const rawBaseURL =
     provider.type === 'anthropic'
       ? provider.apiHost
       : (provider.anthropicApiHost && provider.anthropicApiHost.trim()) || provider.apiHost
+  const baseURL = withoutTrailingApiVersion(rawBaseURL)
 
   logger.debug('Anthropic API baseURL', { baseURL, providerId: provider.id })
 

--- a/src/renderer/src/hooks/useTopic.ts
+++ b/src/renderer/src/hooks/useTopic.ts
@@ -154,6 +154,10 @@ export const autoRenameTopic = async (assistant: Assistant, topicId: string) => 
     }
 
     if (!enableTopicNaming) {
+      // Guard legacy manually-renamed topics that predate isNameManuallyEdited
+      if (topic.isNameManuallyEdited === undefined && topic.name !== i18n.t('chat.default.topic.name')) {
+        return
+      }
       const topicName = getFirstMessageName()
       if (topicName) {
         try {

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -1476,6 +1476,11 @@
       "move_to": "Move to",
       "new": "New Topic",
       "pin": "Pin Topic",
+      "pin_name": "Pin Name",
+      "unpin_name": "Unpin Name",
+      "pin_name_success": "Topic name pinned",
+      "unpin_name_success": "Topic name unpinned",
+      "name_pinned": "This topic name is pinned and will not be automatically updated",
       "prompt": {
         "edit": {
           "title": "Edit Topic Prompts"

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -1476,6 +1476,11 @@
       "move_to": "移动到",
       "new": "开始新对话",
       "pin": "固定话题",
+      "pin_name": "固定名称",
+      "unpin_name": "取消固定名称",
+      "pin_name_success": "话题名称已固定",
+      "unpin_name_success": "话题名称已取消固定",
+      "name_pinned": "该话题名称已固定，不会被自动更新",
       "prompt": {
         "edit": {
           "title": "编辑话题提示词"

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -1476,6 +1476,11 @@
       "move_to": "移動到",
       "new": "開始新對話",
       "pin": "固定話題",
+      "pin_name": "固定名稱",
+      "unpin_name": "取消固定名稱",
+      "pin_name_success": "話題名稱已固定",
+      "unpin_name_success": "話題名稱已取消固定",
+      "name_pinned": "該話題名稱已固定，不會被自動更新",
       "prompt": {
         "edit": {
           "title": "編輯話題提示詞"

--- a/src/renderer/src/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/Topics.tsx
@@ -44,6 +44,7 @@ import {
   FolderOpen,
   HelpCircle,
   ListChecks,
+  Lock,
   MenuIcon,
   NotebookPen,
   PackagePlus,
@@ -249,7 +250,7 @@ export const Topics: React.FC<Props> = ({ assistant: _assistant, activeTopic, se
         label: t('chat.topics.auto_rename'),
         key: 'auto-rename',
         icon: <Sparkles size={14} />,
-        disabled: isRenaming(topic.id),
+        disabled: isRenaming(topic.id) || topic.isNameManuallyEdited,
         async onClick() {
           const messages = await TopicManager.getTopicMessages(topic.id)
           if (messages.length >= 2) {
@@ -286,6 +287,18 @@ export const Topics: React.FC<Props> = ({ assistant: _assistant, activeTopic, se
             const updatedTopic = { ...topic, name, isNameManuallyEdited: true }
             updateTopic(updatedTopic)
           }
+        }
+      },
+      {
+        label: topic.isNameManuallyEdited ? t('chat.topics.unpin_name') : t('chat.topics.pin_name'),
+        key: 'toggle-pin-name',
+        icon: <Lock size={14} />,
+        onClick() {
+          const updatedTopic = { ...topic, isNameManuallyEdited: !topic.isNameManuallyEdited }
+          updateTopic(updatedTopic)
+          window.toast.success(
+            topic.isNameManuallyEdited ? t('chat.topics.unpin_name_success') : t('chat.topics.pin_name_success')
+          )
         }
       },
       {
@@ -655,6 +668,13 @@ export const Topics: React.FC<Props> = ({ assistant: _assistant, activeTopic, se
                       }>
                       {topicName}
                     </TopicName>
+                  )}
+                  {topic.isNameManuallyEdited && (
+                    <Tooltip title={t('chat.topics.name_pinned')} mouseEnterDelay={0.7}>
+                      <MenuButton className="pin">
+                        <Lock size={12} color="var(--color-text-3)" />
+                      </MenuButton>
+                    </Tooltip>
                   )}
                   {!topic.pinned && (
                     <Tooltip


### PR DESCRIPTION
### What this PR does

Adds an explicit "Pin Name" / "Unpin Name" control to the topic context menu so users can protect a chat session name from being auto-overwritten without needing to rename it. Also adds a visual lock icon indicator for pinned names.

Before this PR:
- Topic names were only protected if the user had previously renamed the topic (which implicitly set `isNameManuallyEdited: true`).
- There was no visual indicator showing whether a topic name was protected.
- Legacy topics (created before `isNameManuallyEdited` existed) with non-default names could still be overwritten when `enableTopicNaming` was false.
- The "Auto Rename" context menu item was available even for pinned names.

After this PR:
- Users can pin or unpin any topic name via context menu without renaming.
- A lock icon appears next to pinned topic names with a tooltip explaining the behavior.
- Legacy topics with non-default names are protected at runtime (no migration needed).
- The "Auto Rename" menu item is disabled when a topic name is pinned.

Fixes #14824 

### Why we need it and why it was done in this way

Issue #14824 reported that manually renamed topic names were being automatically overwritten after continuing a conversation. The codebase already had an `isNameManuallyEdited` flag, but it was only set through implicit rename actions and had no UI affordance. Users had no discoverable way to protect a name.

The fix avoids touching `migrate.ts` or `store/index.ts` because both are under v2 contribution block. Legacy protection is handled at runtime in `autoRenameTopic` by checking if `isNameManuallyEdited === undefined` and the name is non-default.

The following tradeoffs were made:
- **No Redux migration**: Runtime guard only protects legacy topics at the point of auto-rename, not retroactively. This is sufficient because the guard fires on every auto-rename trigger.
- **Context menu toggle over separate "protect" button**: Adding a new menu item is more consistent with existing UX patterns (rename, pin topic, etc.) and avoids extra UI surface area.

### Breaking changes

None.

### Special notes for your reviewer

- `src/renderer/src/hooks/useTopic.ts` — The legacy guard only applies to the `!enableTopicNaming` path. The `enableTopicNaming === true` path (AI summary) is already safe because it only targets topics with the default name.
- `src/renderer/src/store/migrate.ts` and `src/renderer/src/store/index.ts` were intentionally not modified to avoid conflicts with ongoing v2 migration work.
- Translations added for `en-us`, `zh-cn`, and `zh-tw` locales.

### Checklist

- [x] PR: Description is expressive and links to the issue
- [x] Code: Follows existing patterns in Topics.tsx and useTopic.ts
- [x] Refactor: No refactoring introduced
- [x] Upgrade: No upgrade impact
- [x] Documentation: Not required (existing behavior made visible, no feature change)
- [x] Self-review: Reviewed own changes

### Release note

```release-note
feat(topics): add explicit Pin Name / Unpin Name control with visual lock indicator for chat session names. Pinned names are protected from automatic renaming and the manual "Auto Rename" option is disabled for pinned topics.
```