### PR TITLE
feat: pin chat session name to prevent auto-renames

### DIFF
--- a/migrations/sqlite-drizzle/0020_pin_session_name.sql
+++ b/migrations/sqlite-drizzle/0020_pin_session_name.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `agent_session` ADD `is_name_manually_edited` integer DEFAULT false NOT NULL;

--- a/migrations/sqlite-drizzle/meta/_journal.json
+++ b/migrations/sqlite-drizzle/meta/_journal.json
@@ -140,6 +140,13 @@
       "when": 1777636561235,
       "tag": "0019_parallel_annihilus",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "6",
+      "when": 1778064000000,
+      "tag": "0020_pin_session_name",
+      "breakpoints": true
     }
   ],
   "version": "7"

--- a/packages/shared/data/api/schemas/agents.ts
+++ b/packages/shared/data/api/schemas/agents.ts
@@ -131,7 +131,8 @@ export const AGENT_MUTABLE_FIELDS = {
 /** Pick-set for session mutable fields — superset of AGENT_MUTABLE_FIELDS. */
 export const SESSION_MUTABLE_FIELDS = {
   ...AGENT_MUTABLE_FIELDS,
-  slashCommands: true
+  slashCommands: true,
+  isNameManuallyEdited: true
 } as const
 
 export const AgentEntitySchema = AgentBaseSchema.extend({
@@ -152,6 +153,7 @@ export const AgentSessionEntitySchema = AgentBaseSchema.extend({
   agentId: z.string(),
   agentType: z.enum(['claude-code']),
   slashCommands: z.array(SlashCommandSchema).optional(),
+  isNameManuallyEdited: z.boolean().optional(),
   createdAt: z.string(),
   updatedAt: z.string()
 })

--- a/src/main/data/db/schemas/agentSession.ts
+++ b/src/main/data/db/schemas/agentSession.ts
@@ -24,6 +24,7 @@ export const agentSessionTable = sqliteTable(
     allowedTools: text({ mode: 'json' }).$type<string[]>().notNull().default(sql`'[]'`),
     slashCommands: text({ mode: 'json' }).$type<SlashCommand[]>().notNull().default(sql`'[]'`),
     configuration: text({ mode: 'json' }).$type<AgentConfiguration>().notNull().default(sql`'{}'`),
+    isNameManuallyEdited: integer({ mode: 'boolean' }).notNull().default(false),
     sortOrder: integer().notNull().default(0),
     ...createUpdateTimestamps
   },

--- a/src/main/data/services/AgentSessionService.ts
+++ b/src/main/data/services/AgentSessionService.ts
@@ -62,6 +62,7 @@ function rowToSession(row: SessionRow): AgentSessionEntity {
     agentType: (row.agentType === 'cherry-claw' ? 'claude-code' : row.agentType) as AgentType,
     accessiblePaths: row.accessiblePaths,
     configuration: parseConfiguration(row.configuration),
+    isNameManuallyEdited: row.isNameManuallyEdited,
     createdAt: timestampToISO(row.createdAt),
     updatedAt: timestampToISO(row.updatedAt)
   }

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -1483,6 +1483,7 @@
       "move_to": "Move to",
       "new": "New Topic",
       "pin": "Pin Topic",
+      "pin_name": "Pin Name",
       "prompt": {
         "edit": {
           "title": "Edit Topic Prompts"
@@ -1495,7 +1496,8 @@
         "title": "Search"
       },
       "title": "Topics",
-      "unpin": "Unpin Topic"
+      "unpin": "Unpin Topic",
+      "unpin_name": "Unpin Name"
     },
     "translate": "Translate",
     "user": "User",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -1483,6 +1483,7 @@
       "move_to": "移动到",
       "new": "开始新对话",
       "pin": "固定话题",
+      "pin_name": "固定名称",
       "prompt": {
         "edit": {
           "title": "编辑话题提示词"
@@ -1495,7 +1496,8 @@
         "title": "搜索"
       },
       "title": "话题",
-      "unpin": "取消固定"
+      "unpin": "取消固定",
+      "unpin_name": "取消固定名称"
     },
     "translate": "翻译",
     "user": "用户",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -1483,6 +1483,7 @@
       "move_to": "移動到",
       "new": "開始新對話",
       "pin": "固定話題",
+      "pin_name": "固定名稱",
       "prompt": {
         "edit": {
           "title": "編輯話題提示詞"
@@ -1495,7 +1496,8 @@
         "title": "搜尋"
       },
       "title": "話題",
-      "unpin": "取消固定"
+      "unpin": "取消固定",
+      "unpin_name": "取消固定名稱"
     },
     "translate": "翻譯",
     "user": "使用者",

--- a/src/renderer/src/pages/agents/components/SessionItem.tsx
+++ b/src/renderer/src/pages/agents/components/SessionItem.tsx
@@ -19,7 +19,7 @@ import { getChannelTypeIcon } from '@renderer/utils/agentSession'
 import { buildAgentSessionTopicId } from '@renderer/utils/agentSession'
 import type { MenuProps } from 'antd'
 import { Dropdown } from 'antd'
-import { MenuIcon, Sparkles, XIcon } from 'lucide-react'
+import { MenuIcon, PinIcon, PinOffIcon, Sparkles, XIcon } from 'lucide-react'
 import React, { memo, startTransition, useDeferredValue, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -49,7 +49,7 @@ const SessionItem = ({ session, agentId, channelType, onDelete, onPress }: Sessi
   const { isEditing, isSaving, startEdit, inputProps } = useInPlaceEdit({
     onSave: async (value) => {
       if (value !== session.name) {
-        await updateSession({ id: session.id, name: value })
+        await updateSession({ id: session.id, name: value, isNameManuallyEdited: true })
       }
     }
   })
@@ -152,6 +152,14 @@ const SessionItem = ({ session, agentId, channelType, onDelete, onPress }: Sessi
         }
       },
       {
+        label: session.isNameManuallyEdited ? t('chat.topics.unpin_name') : t('chat.topics.pin_name'),
+        key: 'pin-name',
+        icon: session.isNameManuallyEdited ? <PinOffIcon size={14} /> : <PinIcon size={14} />,
+        onClick: async () => {
+          await updateSession({ id: session.id, isNameManuallyEdited: !session.isNameManuallyEdited })
+        }
+      },
+      {
         label: t('settings.topic.position.label'),
         key: 'topic-position',
         icon: <MenuIcon size={14} />,
@@ -178,7 +186,17 @@ const SessionItem = ({ session, agentId, channelType, onDelete, onPress }: Sessi
         }
       }
     ],
-    [agentId, dispatch, onDelete, session.id, sessionTopicId, setTopicPosition, t, targetSession.id]
+    [
+      agentId,
+      dispatch,
+      onDelete,
+      session.id,
+      session.isNameManuallyEdited,
+      sessionTopicId,
+      setTopicPosition,
+      t,
+      targetSession.id
+    ]
   )
 
   return (
@@ -203,6 +221,9 @@ const SessionItem = ({ session, agentId, channelType, onDelete, onPress }: Sessi
             <SessionEditInput {...inputProps} style={{ opacity: isSaving ? 0.5 : 1 }} />
           ) : (
             <>
+              {session.isNameManuallyEdited && (
+                <PinIcon size={10} color="var(--color-text-3)" style={{ minWidth: 10, flexShrink: 0 }} />
+              )}
               <SessionName>
                 {channelIcon && <ChannelIconImg src={channelIcon} />}
                 <MarqueeText className="flex min-w-0 flex-1">

--- a/src/renderer/src/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/Topics.tsx
@@ -308,6 +308,16 @@ export const Topics: React.FC<Props> = ({ assistant: _assistant, activeTopic, se
         }
       },
       {
+        label: topic.isNameManuallyEdited ? t('chat.topics.unpin_name') : t('chat.topics.pin_name'),
+        key: 'pin-name',
+        icon: topic.isNameManuallyEdited ? <PinOffIcon size={14} /> : <PinIcon size={14} />,
+        disabled: isRenaming(topic.id),
+        onClick() {
+          const updatedTopic = { ...topic, isNameManuallyEdited: !topic.isNameManuallyEdited }
+          updateTopic(updatedTopic)
+        }
+      },
+      {
         label: t('chat.topics.prompt.label'),
         key: 'topic-prompt',
         icon: <PackagePlus size={14} />,
@@ -661,19 +671,24 @@ export const Topics: React.FC<Props> = ({ assistant: _assistant, activeTopic, se
                   {editingTopicId === topic.id && isEditing ? (
                     <TopicEditInput {...inputProps} onClick={(e) => e.stopPropagation()} />
                   ) : (
-                    <TopicName
-                      className={getTopicNameClassName()}
-                      title={topicName}
-                      onDoubleClick={
-                        isManageMode
-                          ? undefined
-                          : () => {
-                              setEditingTopicId(topic.id)
-                              startEdit(topic.name)
-                            }
-                      }>
-                      {topicName}
-                    </TopicName>
+                    <>
+                      {topic.isNameManuallyEdited && (
+                        <PinIcon size={10} color="var(--color-text-3)" style={{ minWidth: 10, flexShrink: 0 }} />
+                      )}
+                      <TopicName
+                        className={getTopicNameClassName()}
+                        title={topic.isNameManuallyEdited ? `${topicName} (${t('chat.topics.pin_name')})` : topicName}
+                        onDoubleClick={
+                          isManageMode
+                            ? undefined
+                            : () => {
+                                setEditingTopicId(topic.id)
+                                startEdit(topic.name)
+                              }
+                        }>
+                        {topicName}
+                      </TopicName>
+                    </>
                   )}
                   {!topic.pinned && (
                     <Tooltip

--- a/src/renderer/src/store/thunk/messageThunk.ts
+++ b/src/renderer/src/store/thunk/messageThunk.ts
@@ -178,19 +178,13 @@ export const renameAgentSessionIfNeeded = async (agentSession: AgentSessionConte
     return
   }
 
+  agentSessionRenameLocks.add(lockId)
+
   try {
     const { messages } = await dbFacade.fetchMessages(topicId, true)
     if (!messages.length) {
       return
     }
-
-    const { text: summary } = await fetchMessagesSummary({ messages })
-    const summaryText = summary?.trim()
-    if (!summaryText) {
-      return
-    }
-
-    agentSessionRenameLocks.add(lockId)
 
     let session: AgentSessionEntity
     try {
@@ -199,6 +193,16 @@ export const renameAgentSessionIfNeeded = async (agentSession: AgentSessionConte
       )) as AgentSessionEntity
     } catch (error) {
       logger.warn('Failed to fetch agent session for rename', error as Error)
+      return
+    }
+
+    if (session.isNameManuallyEdited) {
+      return
+    }
+
+    const { text: summary } = await fetchMessagesSummary({ messages })
+    const summaryText = summary?.trim()
+    if (!summaryText) {
       return
     }
 

--- a/src/renderer/src/types/agent.ts
+++ b/src/renderer/src/types/agent.ts
@@ -170,6 +170,7 @@ export const AgentSessionEntitySchema = AgentBaseSchema.extend({
   agentId: z.string(),
   agentType: AgentTypeSchema,
   slashCommands: z.array(SlashCommandSchema).optional(),
+  isNameManuallyEdited: z.boolean().optional(),
   createdAt: z.iso.datetime(),
   updatedAt: z.iso.datetime()
 })
@@ -256,7 +257,7 @@ export type BaseSessionForm = AgentBase
 
 export type CreateSessionForm = BaseSessionForm & { id?: never }
 
-export type UpdateSessionForm = Partial<BaseSessionForm> & { id: string }
+export type UpdateSessionForm = Partial<BaseSessionForm> & { id: string; isNameManuallyEdited?: boolean }
 
 export type SessionForm = CreateSessionForm | UpdateSessionForm
 


### PR DESCRIPTION
### What this PR does

Before this PR:
- Assistant topics supported `isNameManuallyEdited` internally, but there was no explicit UI to pin/unpin a name without renaming.
- Agent sessions had no `isNameManuallyEdited` field at all, so they were always auto-renamed after each conversation turn.

After this PR:
- Adds `isNameManuallyEdited` support to **agent sessions** (DB schema, migration, shared schema, service mapper, renderer types, and auto-rename guard).
- Adds an explicit **"Pin Name" / "Unpin Name"** context-menu action to both assistant topics and agent sessions.
- Shows a small inline **pin icon** next to pinned topic/session names for immediate visual feedback.
- Renaming a topic or session via double-click or the Rename menu now automatically pins the name.
- Prevents agent session auto-renaming from wasting an LLM API call when the name is pinned.

Fixes #14824

### Why we need it and why it was done in this way

The user requested the ability to "pin" a chat session name so it won't be overwritten by automatic title generation. The existing `isNameManuallyEdited` field on `Topic` already provided the backend guard, but it was implicit (only set on manual rename) and agent sessions completely lacked it.

The following tradeoffs were made:
- **Unified behavior:** Both topics and sessions now share the same pin/unpin UX and backend logic.
- **Auto-pin on rename:** When a user manually renames, the name is automatically pinned. This matches user expectation that a manual rename should "stick."
- **No Redux migration:** Existing topics without `isNameManuallyEdited` continue to work because the field is optional/falsy by default.

The following alternatives were considered:
- Adding a separate "Pin" column or table — rejected because `isNameManuallyEdited` already exists for topics and is the simplest solution.
- Only implicit pinning (rename = pinned) — rejected because the issue specifically asks to "pin," and users may want to pin an auto-generated name without renaming it.

### Breaking changes

None. The new DB column has a `DEFAULT false`, so existing agent sessions are unaffected.

### Special notes for your reviewer

- Migration `0020_pin_session_name.sql` adds `is_name_manually_edited` to `agent_session`. The `_journal.json` entry was also added manually.
- The `agentSessionRenameLocks` in `messageThunk.ts` was moved before async I/O to prevent a race condition where concurrent messages could trigger duplicate LLM summaries.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Added the ability to pin chat session names so they are no longer overwritten by automatic title generation. A "Pin Name" / "Unpin Name" option is now available in the context menu for both assistant topics and agent sessions. Manually renaming a session or topic will also automatically pin the name.