### PR TITLE
hotfix(models): update DeepSeek default models to V4

### DIFF
--- a/src/renderer/src/config/models/default.ts
+++ b/src/renderer/src/config/models/default.ts
@@ -406,16 +406,16 @@ export const SYSTEM_MODELS: Record<SystemProviderId | 'defaultModel', Model[]> =
   ],
   deepseek: [
     {
-      id: 'deepseek-chat',
+      id: 'deepseek-v4-flash',
       provider: 'deepseek',
-      name: 'DeepSeek Chat',
-      group: 'DeepSeek Chat'
+      name: 'deepseek-v4-flash',
+      group: 'DeepSeek'
     },
     {
-      id: 'deepseek-reasoner',
+      id: 'deepseek-v4-pro',
       provider: 'deepseek',
-      name: 'DeepSeek Reasoner',
-      group: 'DeepSeek Reasoner'
+      name: 'deepseek-v4-pro',
+      group: 'DeepSeek'
     }
   ],
   together: [


### PR DESCRIPTION
### What this PR does

Before this PR:
- The built-in DeepSeek provider defaults still used the deprecated `deepseek-chat` and `deepseek-reasoner` model IDs.

After this PR:
- The built-in DeepSeek provider defaults use `deepseek-v4-flash` and `deepseek-v4-pro`.

Fixes #14872

### Why we need it and why it was done in this way

The following tradeoffs were made:
- This hotfix only updates the static default model configuration for the official DeepSeek provider.
- It intentionally does not change runtime model fetching or add compatibility logic, so the fix stays minimal for the code-frozen `main` branch.

The following alternatives were considered:
- Mapping deprecated DeepSeek model IDs to V4 models during runtime fetching.
- Adjusting other DeepSeek-related behavior outside the default model configuration.
- These alternatives were rejected because the issue only requires refreshing the built-in defaults.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/14872

### Breaking changes

N/A

### Special notes for your reviewer

- This PR is intentionally limited to a one-file configuration change.
- No new tests were added because the fix only updates built-in default model IDs.
- Validation run: `pnpm exec vitest run --project renderer src/renderer/src/services/__tests__/ModelMessageService.test.ts src/renderer/src/config/models/__tests__/models.test.ts --silent=true`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Updated the built-in DeepSeek provider defaults to use `deepseek-v4-flash` and `deepseek-v4-pro` instead of deprecated model IDs.
```
