### PR TITLE
hotfix(models): recognize DeepSeek V4 routed slugs with duplicated provider suffixes

### DIFF
--- a/src/renderer/src/config/models/__tests__/reasoning.test.ts
+++ b/src/renderer/src/config/models/__tests__/reasoning.test.ts
@@ -425,6 +425,8 @@ describe('DeepSeek V4+ Models', () => {
       expect(isDeepSeekV4PlusModel(createModel({ id: 'prefix-deepseek-v4-flash' }))).toBe(true)
       expect(isDeepSeekV4PlusModel(createModel({ id: 'agent/deepseek-v4-pro' }))).toBe(true)
       expect(isDeepSeekV4PlusModel(createModel({ id: 'accounts/fireworks/models/deepseek-v4-pro' }))).toBe(true)
+      expect(isDeepSeekV4PlusModel(createModel({ id: 'deepseek/deepseek-v4-flash:deepseek' }))).toBe(true)
+      expect(isDeepSeekV4PlusModel(createModel({ id: 'deepseek/deepseek-v4-pro:deepseek' }))).toBe(true)
     })
 
     it('is case insensitive', () => {
@@ -471,6 +473,8 @@ describe('DeepSeek V4+ Models', () => {
       expect(getThinkModelType(createModel({ id: 'deepseek-v4' }))).toBe('deepseek_v4')
       expect(getThinkModelType(createModel({ id: 'deepseek-v4-flash' }))).toBe('deepseek_v4')
       expect(getThinkModelType(createModel({ id: 'deepseek-v4-pro' }))).toBe('deepseek_v4')
+      expect(getThinkModelType(createModel({ id: 'deepseek/deepseek-v4-flash:deepseek' }))).toBe('deepseek_v4')
+      expect(getThinkModelType(createModel({ id: 'deepseek/deepseek-v4-pro:deepseek' }))).toBe('deepseek_v4')
       expect(getThinkModelType(createModel({ id: 'deepseek-v5' }))).toBe('deepseek_v4')
       expect(getThinkModelType(createModel({ id: 'deepseek-v10-ultra' }))).toBe('deepseek_v4')
     })
@@ -505,6 +509,16 @@ describe('DeepSeek V4+ Models', () => {
       ).toEqual(['default', 'none', 'high', 'xhigh'])
       expect(
         getModelSupportedReasoningEffortOptions(createModel({ id: 'deepseek-v4-pro', provider: 'openrouter' }))
+      ).toEqual(['default', 'none', 'high', 'xhigh'])
+      expect(
+        getModelSupportedReasoningEffortOptions(
+          createModel({ id: 'deepseek/deepseek-v4-flash:deepseek', provider: 'deepseek' })
+        )
+      ).toEqual(['default', 'none', 'high', 'xhigh'])
+      expect(
+        getModelSupportedReasoningEffortOptions(
+          createModel({ id: 'deepseek/deepseek-v4-pro:deepseek', provider: 'deepseek' })
+        )
       ).toEqual(['default', 'none', 'high', 'xhigh'])
       expect(getModelSupportedReasoningEffortOptions(createModel({ id: 'deepseek-v5', provider: 'deepseek' }))).toEqual(
         ['default', 'none', 'high', 'xhigh']

--- a/src/renderer/src/utils/__tests__/naming.test.ts
+++ b/src/renderer/src/utils/__tests__/naming.test.ts
@@ -231,6 +231,18 @@ describe('naming', () => {
       expect(getLowerBaseModelName('local/kimi-k2.5:cloud')).toBe('kimi-k2.5')
     })
 
+    it('should remove duplicated routed provider suffixes', () => {
+      expect(getLowerBaseModelName('deepseek/deepseek-v4-pro:deepseek')).toBe('deepseek-v4-pro')
+      expect(getLowerBaseModelName('openrouter/deepseek/deepseek-v4-flash:deepseek')).toBe('deepseek-v4-flash')
+    })
+
+    it('should preserve non-routed colon suffixes', () => {
+      expect(getLowerBaseModelName('qwen3:32b')).toBe('qwen3:32b')
+      expect(getLowerBaseModelName('anthropic.claude-sonnet-4-5-20250929-v1:0')).toBe(
+        'anthropic.claude-sonnet-4-5-20250929-v1:0'
+      )
+    })
+
     it('should normalize Fireworks model IDs by replacing digit-p-digit with digit-.-digit', () => {
       expect(getLowerBaseModelName('accounts/fireworks/models/deepseek-v3p2')).toBe('deepseek-v3.2')
       expect(getLowerBaseModelName('accounts/fireworks/models/kimi-k2p5')).toBe('kimi-k2.5')

--- a/src/renderer/src/utils/naming.ts
+++ b/src/renderer/src/utils/naming.ts
@@ -69,6 +69,7 @@ export const getBaseModelName = (id: string, delimiter: string = '/'): string =>
  * 例如：
  * - 'deepseek/DeepSeek-R1' => 'deepseek-r1'
  * - 'deepseek-ai/deepseek/DeepSeek-R1' => 'deepseek-r1'
+ * - 'deepseek/deepseek-v4-pro:deepseek' => 'deepseek-v4-pro'
  * @param {string} id 模型 ID
  * @param {string} [delimiter='/'] 分隔符，默认为 '/'
  * @returns {string} 小写的基础名称
@@ -80,8 +81,22 @@ export const getLowerBaseModelName = (id: string, delimiter: string = '/'): stri
   const normalizedId = id.toLowerCase().startsWith('accounts/fireworks/models/')
     ? id.replace(/(\d)p(?=\d)/g, '$1.')
     : id
+  const lowerNormalizedId = normalizedId.toLowerCase()
 
   let baseModelName = getBaseModelName(normalizedId, delimiter).toLowerCase()
+  // Some routed model IDs repeat the provider both in the path and as the final suffix,
+  // e.g. deepseek/deepseek-v4-pro:deepseek. Strip only that duplicated route suffix and
+  // keep semantic colon suffixes such as qwen3:32b or anthropic ... :0 untouched.
+  const duplicatedRouteSuffix = baseModelName.match(/:([^:()]+)$/)?.[1]
+
+  if (duplicatedRouteSuffix) {
+    const routeSegments = lowerNormalizedId.split(delimiter).slice(0, -1).filter(Boolean)
+
+    if (routeSegments.includes(duplicatedRouteSuffix)) {
+      baseModelName = baseModelName.slice(0, -(duplicatedRouteSuffix.length + 1))
+    }
+  }
+
   // Remove suffix
   // for openrouter
   if (baseModelName.endsWith(':free')) {


### PR DESCRIPTION
### What this PR does

Before this PR:
DeepSeek V4 routed model slugs such as `deepseek/deepseek-v4-flash:deepseek` and `deepseek/deepseek-v4-pro:deepseek` were not normalized consistently, so the DeepSeek V4 reasoning path did not recognize them.

After this PR:
Cherry Studio normalizes duplicated routed provider suffixes at the shared naming layer, so DeepSeek V4 routed slugs are recognized correctly without stripping semantic colon suffixes such as `qwen3:32b`.

Fixes #14867

### Why we need it and why it was done in this way

The following tradeoffs were made:
- The normalization rule was added in `getLowerBaseModelName` instead of keeping a DeepSeek-only special case in the reasoning detector.
- The new rule is intentionally narrow: it only strips a trailing `:suffix` when the same provider segment already appears earlier in the routed path.

The following alternatives were considered:
- Keeping a DeepSeek-specific `:deepseek` workaround inside the reasoning detection path.
- Stripping all trailing colon suffixes, which would break semantic model IDs such as `qwen3:32b`.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/14867

### Breaking changes

None.

### Special notes for your reviewer

- This PR stays within the `main` branch code-freeze policy by using a minimal `hotfix/*` bug-fix branch.
- Added regression coverage in both naming and reasoning tests.
- Validation run on this branch:
  - `pnpm lint`
  - `pnpm exec vitest run src/renderer/src/utils/__tests__/naming.test.ts src/renderer/src/config/models/__tests__/reasoning.test.ts`
- `pnpm test` still has existing unrelated Windows failures in current `main` test suites such as `seedWorkspace.test.ts`, `builtinSkills.test.ts`, and `prompt.test.ts`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via `/gh-pr-review`, `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed DeepSeek V4 routed model slugs such as `deepseek/deepseek-v4-flash:deepseek` and `deepseek/deepseek-v4-pro:deepseek` so Cherry Studio now correctly enables DeepSeek V4 reasoning intensity options for those models.
```