### PR TITLE
fix(mcp-service): sanitize MCP call arguments to avoid 'unhashable type: dict' from MCP servers

### DIFF
--- a/src/main/services/mcp/McpService.ts
+++ b/src/main/services/mcp/McpService.ts
@@ -104,6 +104,32 @@ function redactSensitive(input: any): any {
   return redact(input)
 }
 
+function sanitizeForMcp(val: any): any {
+  // Convert Maps/Sets and non-plain JS values into JSON-friendly plain objects/arrays.
+  if (val == null) return val
+  const t = typeof val
+  if (t === 'string' || t === 'number' || t === 'boolean') return val
+  if (t === 'bigint') return val.toString()
+  if (Array.isArray(val)) return val.map(sanitizeForMcp)
+  if (val instanceof Map) {
+    const out: Record<string, any> = {}
+    for (const [k, v] of val) {
+      out[String(k)] = sanitizeForMcp(v)
+    }
+    return out
+  }
+  if (val instanceof Set) return Array.from(val).map(sanitizeForMcp)
+  if (t === 'object') {
+    const out: Record<string, any> = {}
+    for (const [k, v] of Object.entries(val)) {
+      if (typeof v === 'function') continue
+      out[k] = sanitizeForMcp(v)
+    }
+    return out
+  }
+  return val
+}
+
 // Create a context-aware logger for a server
 function getServerLogger(server: MCPServer, extra?: Record<string, any>) {
   const base = {
@@ -948,6 +974,15 @@ export class McpService extends BaseService {
           if (args === '') {
             args = {}
           }
+        }
+        // Sanitize arguments to ensure they are plain JSON-friendly objects (Map/Set -> plain objects/arrays)
+        try {
+          args = sanitizeForMcp(args)
+        } catch (e) {
+          getServerLogger(server, { tool: name, callId: toolCallId }).warn(
+            'Failed to sanitize args, sending raw',
+            e as Error
+          )
         }
         const client = await this.initClient(server)
         const result = await client.callTool({ name, arguments: args }, undefined, {


### PR DESCRIPTION
### What this PR does

Before this PR:

- MCP tool call arguments could contain non-JSON-friendly JavaScript types (Map, Set, BigInt, nested non-plain objects). Some Python-based MCP servers (e.g., Nvidia Kimi K2.6) would receive these values and raise errors such as "unhashable type: 'dict'" when attempting to use them as hashable keys.

After this PR:

- Arguments are sanitized via sanitizeForMcp(...) in McpService before being forwarded to MCP clients. Maps and Sets are converted to plain objects/arrays, BigInt to string, and non-plain values are serialized to JSON-friendly structures.

Fixes #14868

### Why we need it and why it was done in this way

- Python MCP implementations expect plain JSON-compatible input. Converting complex JS runtime types to plain structures is the minimal, surgical change that prevents server-side exceptions without changing MCP protocol semantics.

The following tradeoffs were made:

- Pros: Minimal change, low risk, resolves reported server crash.
- Cons: Small runtime cost for deep sanitization of arguments.

The following alternatives were considered:

- Enforcing callers to only pass plain JSON (would require broader refactors).
- Serializing using a custom transport wrapper (more invasive).

Links to discussion: CherryHQ/cherry-studio#14868

### Breaking changes

None.

### Special notes for your reviewer

- This change is intentionally small and scoped to McpService.callTool argument sanitization.
- Unit tests can be added to cover sanitizeForMcp behavior if desired.

### Checklist

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: Code is simple and readable
- [ ] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
fix(mcp-service): sanitize MCP call arguments to prevent 'unhashable type: dict' errors with Python MCP servers (e.g., Nvidia Kimi K2.6)
```
