### PR TITLE
hotfix(models):detect routed DeepSeek V4 model slugs for reasoning effort

### DIFF
--- a/src/renderer/src/config/models/__tests__/reasoning.test.ts
+++ b/src/renderer/src/config/models/__tests__/reasoning.test.ts
@@ -425,6 +425,9 @@ describe('DeepSeek V4+ Models', () => {
       expect(isDeepSeekV4PlusModel(createModel({ id: 'prefix-deepseek-v4-flash' }))).toBe(true)
       expect(isDeepSeekV4PlusModel(createModel({ id: 'agent/deepseek-v4-pro' }))).toBe(true)
       expect(isDeepSeekV4PlusModel(createModel({ id: 'accounts/fireworks/models/deepseek-v4-pro' }))).toBe(true)
+      expect(isDeepSeekV4PlusModel(createModel({ id: 'deepseek/deepseek-v4-flash:deepseek' }))).toBe(true)
+      expect(isDeepSeekV4PlusModel(createModel({ id: 'deepseek/deepseek-v4-pro:fireworks' }))).toBe(true)
+      expect(isDeepSeekV4PlusModel(createModel({ id: 'deepseek/deepseek-v4-pro:deepseek:together' }))).toBe(true)
     })
 
     it('is case insensitive', () => {
@@ -471,6 +474,9 @@ describe('DeepSeek V4+ Models', () => {
       expect(getThinkModelType(createModel({ id: 'deepseek-v4' }))).toBe('deepseek_v4')
       expect(getThinkModelType(createModel({ id: 'deepseek-v4-flash' }))).toBe('deepseek_v4')
       expect(getThinkModelType(createModel({ id: 'deepseek-v4-pro' }))).toBe('deepseek_v4')
+      expect(getThinkModelType(createModel({ id: 'deepseek/deepseek-v4-flash:deepseek' }))).toBe('deepseek_v4')
+      expect(getThinkModelType(createModel({ id: 'deepseek/deepseek-v4-pro:fireworks' }))).toBe('deepseek_v4')
+      expect(getThinkModelType(createModel({ id: 'deepseek/deepseek-v4-pro:deepseek:together' }))).toBe('deepseek_v4')
       expect(getThinkModelType(createModel({ id: 'deepseek-v5' }))).toBe('deepseek_v4')
       expect(getThinkModelType(createModel({ id: 'deepseek-v10-ultra' }))).toBe('deepseek_v4')
     })
@@ -505,6 +511,21 @@ describe('DeepSeek V4+ Models', () => {
       ).toEqual(['default', 'none', 'high', 'xhigh'])
       expect(
         getModelSupportedReasoningEffortOptions(createModel({ id: 'deepseek-v4-pro', provider: 'openrouter' }))
+      ).toEqual(['default', 'none', 'high', 'xhigh'])
+      expect(
+        getModelSupportedReasoningEffortOptions(
+          createModel({ id: 'deepseek/deepseek-v4-flash:deepseek', provider: 'deepseek' })
+        )
+      ).toEqual(['default', 'none', 'high', 'xhigh'])
+      expect(
+        getModelSupportedReasoningEffortOptions(
+          createModel({ id: 'deepseek/deepseek-v4-pro:fireworks', provider: 'deepseek' })
+        )
+      ).toEqual(['default', 'none', 'high', 'xhigh'])
+      expect(
+        getModelSupportedReasoningEffortOptions(
+          createModel({ id: 'deepseek/deepseek-v4-pro:deepseek:together', provider: 'deepseek' })
+        )
       ).toEqual(['default', 'none', 'high', 'xhigh'])
       expect(getModelSupportedReasoningEffortOptions(createModel({ id: 'deepseek-v5', provider: 'deepseek' }))).toEqual(
         ['default', 'none', 'high', 'xhigh']

--- a/src/renderer/src/config/models/reasoning.ts
+++ b/src/renderer/src/config/models/reasoning.ts
@@ -653,7 +653,8 @@ export const isSupportedThinkingTokenKimiModel = (model: Model): boolean => {
  */
 export const isDeepSeekV4PlusModel = (model: Model) => {
   const { idResult, nameResult } = withModelIdAndNameAsId(model, (model) => {
-    const modelId = getLowerBaseModelName(model.id)
+    // Ignore routed provider suffix chains like :deepseek or :deepseek:together.
+    const modelId = getLowerBaseModelName(model.id).split(':', 1)[0]
     // Match deepseek-v{N} where N >= 4, with any optional suffix
     return /(\w+-)?deepseek-v([4-9]|\d{2,})([.-]\w+)*$/.test(modelId)
   })


### PR DESCRIPTION
### What this PR does

Before this PR:

DeepSeek V4 model IDs with routed provider suffixes such as deepseek/deepseek-v4-flash:deepseek and deepseek/deepseek-v4-pro:fireworks were not recognized as DeepSeek V4+ models, so Cherry Studio did not expose the expected reasoning effort options for them.

After this PR:

DeepSeek V4+ detection strips routed provider suffix chains before matching the model version, so routed DeepSeek V4 model slugs are recognized consistently and the correct reasoning effort options are available.

Fixes #14867

### Why we need it and why it was done in this way

The following tradeoffs were made:

The fix is scoped to DeepSeek V4+ detection instead of broadening global model-name normalization, which keeps the hotfix minimal and avoids changing matching behavior for unrelated model families.

The following alternatives were considered:

Normalizing duplicated or routed suffixes in shared naming utilities was considered, but that approach would not cover all routed suffix patterns and would increase the blast radius for a main-branch hotfix.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/14867

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Added regression coverage for routed suffix variants including :deepseek, :fireworks, and chained suffixes such as :deepseek:together.
Validated with: pnpm exec vitest run src/renderer/src/config/models/__tests__/reasoning.test.ts

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [ ] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via /gh-pr-review, gh pr diff, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed DeepSeek V4 routed model slugs with provider suffixes, such as deepseek/deepseek-v4-flash:deepseek and deepseek/deepseek-v4-pro:fireworks, so Cherry Studio now recognizes them as DeepSeek V4+ models and shows the correct reasoning effort options.
```