### PR TITLE
fix(db): normalize in-progress message/block statuses when loading from persisted storage

### DIFF
--- a/src/renderer/src/services/db/__tests__/normalizeLoadedData.test.ts
+++ b/src/renderer/src/services/db/__tests__/normalizeLoadedData.test.ts
@@ -1,0 +1,220 @@
+import type { Message, MessageBlock } from '@renderer/types/newMessage'
+import { AssistantMessageStatus, MessageBlockStatus, MessageBlockType } from '@renderer/types/newMessage'
+import { describe, expect, it } from 'vitest'
+
+import { normalizeLoadedBlocks, normalizeLoadedMessages } from '../normalizeLoadedData'
+
+describe('normalizeLoadedBlocks', () => {
+  it('should normalize STREAMING block statuses to SUCCESS', () => {
+    const blocks = [
+      {
+        id: 'block-1',
+        messageId: 'msg-1',
+        type: MessageBlockType.THINKING,
+        status: MessageBlockStatus.STREAMING,
+        content: 'Thinking...',
+        createdAt: new Date().toISOString()
+      },
+      {
+        id: 'block-2',
+        messageId: 'msg-1',
+        type: MessageBlockType.MAIN_TEXT,
+        status: MessageBlockStatus.SUCCESS,
+        content: 'Hello',
+        createdAt: new Date().toISOString()
+      }
+    ] as MessageBlock[]
+
+    const result = normalizeLoadedBlocks(blocks)
+
+    expect(result[0].status).toBe(MessageBlockStatus.SUCCESS)
+    expect(result[1].status).toBe(MessageBlockStatus.SUCCESS)
+  })
+
+  it('should normalize PROCESSING block statuses to SUCCESS', () => {
+    const blocks = [
+      {
+        id: 'block-1',
+        messageId: 'msg-1',
+        type: MessageBlockType.MAIN_TEXT,
+        status: MessageBlockStatus.PROCESSING,
+        content: 'Processing...',
+        createdAt: new Date().toISOString()
+      }
+    ] as MessageBlock[]
+
+    const result = normalizeLoadedBlocks(blocks)
+
+    expect(result[0].status).toBe(MessageBlockStatus.SUCCESS)
+  })
+
+  it('should normalize PENDING block statuses to SUCCESS', () => {
+    const blocks = [
+      {
+        id: 'block-1',
+        messageId: 'msg-1',
+        type: MessageBlockType.TOOL,
+        status: MessageBlockStatus.PENDING,
+        content: 'Pending tool call...',
+        createdAt: new Date().toISOString()
+      }
+    ] as MessageBlock[]
+
+    const result = normalizeLoadedBlocks(blocks)
+
+    expect(result[0].status).toBe(MessageBlockStatus.SUCCESS)
+  })
+
+  it('should preserve ERROR and PAUSED block statuses', () => {
+    const blocks = [
+      {
+        id: 'block-error',
+        messageId: 'msg-1',
+        type: MessageBlockType.ERROR,
+        status: MessageBlockStatus.ERROR,
+        content: 'Error',
+        createdAt: new Date().toISOString()
+      },
+      {
+        id: 'block-paused',
+        messageId: 'msg-1',
+        type: MessageBlockType.MAIN_TEXT,
+        status: MessageBlockStatus.PAUSED,
+        content: 'Paused',
+        createdAt: new Date().toISOString()
+      }
+    ] as MessageBlock[]
+
+    const result = normalizeLoadedBlocks(blocks)
+
+    expect(result[0].status).toBe(MessageBlockStatus.ERROR)
+    expect(result[1].status).toBe(MessageBlockStatus.PAUSED)
+  })
+
+  it('should not mutate original block objects', () => {
+    const originalBlock = {
+      id: 'block-1',
+      messageId: 'msg-1',
+      type: MessageBlockType.THINKING,
+      status: MessageBlockStatus.STREAMING,
+      content: 'Thinking...',
+      createdAt: new Date().toISOString()
+    } as MessageBlock
+
+    const result = normalizeLoadedBlocks([originalBlock])
+
+    expect(originalBlock.status).toBe(MessageBlockStatus.STREAMING)
+    expect(result[0].status).toBe(MessageBlockStatus.SUCCESS)
+  })
+})
+
+describe('normalizeLoadedMessages', () => {
+  it('should normalize PROCESSING assistant message statuses to SUCCESS', () => {
+    const messages: Message[] = [
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        assistantId: 'assistant-1',
+        topicId: 'topic-1',
+        status: AssistantMessageStatus.PROCESSING,
+        createdAt: new Date().toISOString(),
+        blocks: []
+      }
+    ]
+
+    const result = normalizeLoadedMessages(messages)
+
+    expect(result[0].status).toBe(AssistantMessageStatus.SUCCESS)
+  })
+
+  it('should normalize PENDING assistant message statuses to SUCCESS', () => {
+    const messages: Message[] = [
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        assistantId: 'assistant-1',
+        topicId: 'topic-1',
+        status: AssistantMessageStatus.PENDING,
+        createdAt: new Date().toISOString(),
+        blocks: []
+      }
+    ]
+
+    const result = normalizeLoadedMessages(messages)
+
+    expect(result[0].status).toBe(AssistantMessageStatus.SUCCESS)
+  })
+
+  it('should normalize SEARCHING assistant message statuses to SUCCESS', () => {
+    const messages: Message[] = [
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        assistantId: 'assistant-1',
+        topicId: 'topic-1',
+        status: AssistantMessageStatus.SEARCHING,
+        createdAt: new Date().toISOString(),
+        blocks: []
+      }
+    ]
+
+    const result = normalizeLoadedMessages(messages)
+
+    expect(result[0].status).toBe(AssistantMessageStatus.SUCCESS)
+  })
+
+  it('should preserve SUCCESS, PAUSED, and ERROR message statuses', () => {
+    const messages: Message[] = [
+      {
+        id: 'msg-success',
+        role: 'assistant',
+        assistantId: 'assistant-1',
+        topicId: 'topic-1',
+        status: AssistantMessageStatus.SUCCESS,
+        createdAt: new Date().toISOString(),
+        blocks: []
+      },
+      {
+        id: 'msg-paused',
+        role: 'assistant',
+        assistantId: 'assistant-1',
+        topicId: 'topic-1',
+        status: AssistantMessageStatus.PAUSED,
+        createdAt: new Date().toISOString(),
+        blocks: []
+      },
+      {
+        id: 'msg-error',
+        role: 'assistant',
+        assistantId: 'assistant-1',
+        topicId: 'topic-1',
+        status: AssistantMessageStatus.ERROR,
+        createdAt: new Date().toISOString(),
+        blocks: []
+      }
+    ]
+
+    const result = normalizeLoadedMessages(messages)
+
+    expect(result[0].status).toBe(AssistantMessageStatus.SUCCESS)
+    expect(result[1].status).toBe(AssistantMessageStatus.PAUSED)
+    expect(result[2].status).toBe(AssistantMessageStatus.ERROR)
+  })
+
+  it('should not mutate original message objects', () => {
+    const originalMessage: Message = {
+      id: 'msg-1',
+      role: 'assistant',
+      assistantId: 'assistant-1',
+      topicId: 'topic-1',
+      status: AssistantMessageStatus.PROCESSING,
+      createdAt: new Date().toISOString(),
+      blocks: []
+    }
+
+    const result = normalizeLoadedMessages([originalMessage])
+
+    expect(originalMessage.status).toBe(AssistantMessageStatus.PROCESSING)
+    expect(result[0].status).toBe(AssistantMessageStatus.SUCCESS)
+  })
+})

--- a/src/renderer/src/services/db/normalizeLoadedData.ts
+++ b/src/renderer/src/services/db/normalizeLoadedData.ts
@@ -1,0 +1,38 @@
+import type { Message, MessageBlock } from '@renderer/types/newMessage'
+import { AssistantMessageStatus, MessageBlockStatus } from '@renderer/types/newMessage'
+
+/**
+ * Normalize in-progress message statuses that may have been persisted mid-stream.
+ * Persisted storage should always represent a final state; active streams
+ * create new in-memory messages and never resume from history.
+ */
+export function normalizeLoadedMessages<T extends Message>(messages: T[]): T[] {
+  return messages.map((message) => {
+    if (
+      message.status === AssistantMessageStatus.PROCESSING ||
+      message.status === AssistantMessageStatus.PENDING ||
+      message.status === AssistantMessageStatus.SEARCHING
+    ) {
+      return { ...message, status: AssistantMessageStatus.SUCCESS }
+    }
+    return message
+  })
+}
+
+/**
+ * Normalize in-progress block statuses that may have been persisted mid-stream.
+ * Persisted storage should always represent a final state; active streams
+ * create new in-memory blocks and never resume from history.
+ */
+export function normalizeLoadedBlocks<T extends MessageBlock>(blocks: T[]): T[] {
+  return blocks.map((block) => {
+    if (
+      block.status === MessageBlockStatus.STREAMING ||
+      block.status === MessageBlockStatus.PROCESSING ||
+      block.status === MessageBlockStatus.PENDING
+    ) {
+      return { ...block, status: MessageBlockStatus.SUCCESS }
+    }
+    return block
+  })
+}


### PR DESCRIPTION
### What this PR does

Before this PR:
When browsing Agent session history, deep thinking timers in some historical sessions continued incrementing indefinitely. This occurred because thinking blocks (and their parent messages) were sometimes persisted with in-progress statuses (`STREAMING`, `PROCESSING`, `PENDING`, `SEARCHING`) — for example, when a stream was interrupted mid-persist. Upon reloading, `ThinkingBlock` saw `status: STREAMING` and started a live `setInterval` timer that never stopped.

After this PR:
`DbService.fetchMessages` now normalizes any in-progress statuses to final states before returning loaded data to the UI. Blocks with `STREAMING`, `PROCESSING`, or `PENDING` become `SUCCESS`. Assistant messages with `PROCESSING`, `PENDING`, or `SEARCHING` become `SUCCESS`. This ensures persisted storage always represents a final state, since active streams create new in-memory blocks/messages and never resume from history.

Fixes #14825

### Why we need it and why it was done in this way

The fix is placed at the `DbService` facade layer (`fetchMessages`) because:
- It is the single entry point for all loaded persisted data (both Dexie for regular chat and AgentMessageDataSource for agent sessions)
- It fixes the bug for both regular chat and agent sessions without duplicating logic in each data source
- It is architecturally correct: loading from disk = final state; streaming creates new in-memory objects

The following tradeoffs were made:
- `PENDING` blocks are normalized to `SUCCESS` rather than preserved. While `PENDING` can be a legitimate final state in some contexts, it is also used as an initial/intermediate state during streaming (e.g., tool calls awaiting execution). Normalizing it prevents stuck states at the cost of losing the "pending" semantic on reload. This is acceptable because a reloaded session cannot resume pending operations anyway.

The following alternatives were considered:
- Fixing only `AgentMessageDataSource.fetchMessages` (targeted but misses regular chat)
- Fixing only `ThinkingBlock` component (would not address the root cause and would leave other components with the same bug)
- Fixing both data sources individually (duplicates logic and misses future data sources)

### Breaking changes

NONE

### Special notes for your reviewer

- `DbService.ts` carries a v2 contribution hold notice. This change is a critical bug fix for persisted mid-stream state corruption and aligns with the "critical bug fixes only" policy.
- `getRawTopic()` intentionally bypasses normalization to preserve its "raw" contract. It is currently unused in UI state population.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed an issue where deep thinking timers in Agent session history would continue incrementing indefinitely after reloading.