### PR TITLE
feat: add client-side WebDAV/S3 sync primitives

### DIFF
--- a/packages/shared/IpcChannel.ts
+++ b/packages/shared/IpcChannel.ts
@@ -270,6 +270,10 @@ export enum IpcChannel {
   Backup_CheckS3Connection = 'backup:checkS3Connection',
   Backup_CreateLanTransferBackup = 'backup:createLanTransferBackup',
   Backup_DeleteLanTransferBackup = 'backup:deleteLanTransferBackup',
+  Backup_WriteWebdavText = 'backup:writeWebdavText',
+  Backup_ReadWebdavText = 'backup:readWebdavText',
+  Backup_WriteS3Text = 'backup:writeS3Text',
+  Backup_ReadS3Text = 'backup:readS3Text',
 
   // zip
   Zip_Compress = 'zip:compress',

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -595,6 +595,10 @@ export async function registerIpc(mainWindow: BrowserWindow, app: Electron.App) 
   ipcMain.handle(IpcChannel.Backup_CheckS3Connection, backupManager.checkS3Connection.bind(backupManager))
   ipcMain.handle(IpcChannel.Backup_CreateLanTransferBackup, backupManager.createLanTransferBackup.bind(backupManager))
   ipcMain.handle(IpcChannel.Backup_DeleteLanTransferBackup, backupManager.deleteLanTransferBackup.bind(backupManager))
+  ipcMain.handle(IpcChannel.Backup_WriteWebdavText, backupManager.writeWebdavText.bind(backupManager))
+  ipcMain.handle(IpcChannel.Backup_ReadWebdavText, backupManager.readWebdavText.bind(backupManager))
+  ipcMain.handle(IpcChannel.Backup_WriteS3Text, backupManager.writeS3Text.bind(backupManager))
+  ipcMain.handle(IpcChannel.Backup_ReadS3Text, backupManager.readS3Text.bind(backupManager))
 
   // file
   ipcMain.handle(IpcChannel.File_Open, fileManager.open.bind(fileManager))

--- a/src/main/services/BackupManager.ts
+++ b/src/main/services/BackupManager.ts
@@ -1255,6 +1255,50 @@ class BackupManager {
       throw new Error(error.message || 'Failed to delete backup file')
     }
   }
+
+  async writeWebdavText(_: Electron.IpcMainInvokeEvent, fileName: string, content: string, webdavConfig: WebDavConfig) {
+    try {
+      const webdavClient = this.getWebDavInstance(webdavConfig)
+      await webdavClient.putFileContents(fileName, content, { overwrite: true })
+      return true
+    } catch (error: any) {
+      logger.error('Failed to write WebDAV text file:', error)
+      throw new Error(error.message || 'Failed to write WebDAV file')
+    }
+  }
+
+  async readWebdavText(_: Electron.IpcMainInvokeEvent, fileName: string, webdavConfig: WebDavConfig): Promise<string> {
+    try {
+      const webdavClient = this.getWebDavInstance(webdavConfig)
+      const content = await webdavClient.getFileContents(fileName, { format: 'text' })
+      return String(content)
+    } catch (error: any) {
+      logger.error('Failed to read WebDAV text file:', error)
+      throw new Error(error.message || 'Failed to read WebDAV file')
+    }
+  }
+
+  async writeS3Text(_: Electron.IpcMainInvokeEvent, fileName: string, content: string, s3Config: S3Config) {
+    try {
+      const s3Client = this.getS3Storage(s3Config)
+      await s3Client.putFileContents(fileName, content)
+      return true
+    } catch (error: any) {
+      logger.error('Failed to write S3 text file:', error)
+      throw new Error(error.message || 'Failed to write S3 file')
+    }
+  }
+
+  async readS3Text(_: Electron.IpcMainInvokeEvent, fileName: string, s3Config: S3Config): Promise<string> {
+    try {
+      const s3Client = this.getS3Storage(s3Config)
+      const content = await s3Client.getFileContents(fileName)
+      return content.toString('utf-8')
+    } catch (error: any) {
+      logger.error('Failed to read S3 text file:', error)
+      throw new Error(error.message || 'Failed to read S3 file')
+    }
+  }
 }
 
 export { BackupManager }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -200,6 +200,14 @@ const api = {
     deleteS3File: (fileName: string, s3Config: S3Config) =>
       ipcRenderer.invoke(IpcChannel.Backup_DeleteS3File, fileName, s3Config),
     checkS3Connection: (s3Config: S3Config) => ipcRenderer.invoke(IpcChannel.Backup_CheckS3Connection, s3Config),
+    writeWebdavText: (fileName: string, content: string, webdavConfig: WebDavConfig) =>
+      ipcRenderer.invoke(IpcChannel.Backup_WriteWebdavText, fileName, content, webdavConfig),
+    readWebdavText: (fileName: string, webdavConfig: WebDavConfig): Promise<string> =>
+      ipcRenderer.invoke(IpcChannel.Backup_ReadWebdavText, fileName, webdavConfig),
+    writeS3Text: (fileName: string, content: string, s3Config: S3Config) =>
+      ipcRenderer.invoke(IpcChannel.Backup_WriteS3Text, fileName, content, s3Config),
+    readS3Text: (fileName: string, s3Config: S3Config): Promise<string> =>
+      ipcRenderer.invoke(IpcChannel.Backup_ReadS3Text, fileName, s3Config),
     createLanTransferBackup: (data: string, destinationPath?: string): Promise<string> =>
       ipcRenderer.invoke(IpcChannel.Backup_CreateLanTransferBackup, data, destinationPath),
     deleteLanTransferBackup: (filePath: string): Promise<boolean> =>

--- a/src/renderer/src/services/BackupService.ts
+++ b/src/renderer/src/services/BackupService.ts
@@ -8,6 +8,7 @@ import type { S3Config, WebDavConfig } from '@renderer/types'
 import { uuid } from '@renderer/utils'
 import dayjs from 'dayjs'
 
+import { syncWithS3, syncWithWebdav } from './DataSyncService'
 import { NotificationService } from './NotificationService'
 
 const logger = loggerService.withContext('BackupService')
@@ -85,6 +86,80 @@ export async function backupToLanTransfer() {
   await window.api.backup.createLanTransferBackup(backupData, savePath)
 
   window.toast.success(i18n.t('settings.data.export_to_phone.file.export_success'))
+}
+
+export async function syncDataToWebdav() {
+  const { webdavHost, webdavUser, webdavPass, webdavPath } = store.getState().settings
+
+  store.dispatch(setWebDAVSyncState({ syncing: true, lastSyncError: null }))
+
+  try {
+    const result = await syncWithWebdav({
+      webdavHost,
+      webdavUser,
+      webdavPass,
+      webdavPath
+    })
+
+    store.dispatch(
+      setWebDAVSyncState({
+        syncing: false,
+        lastSyncError: null,
+        lastSyncTime: Date.now()
+      })
+    )
+
+    return result
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    store.dispatch(
+      setWebDAVSyncState({
+        syncing: false,
+        lastSyncError: message
+      })
+    )
+    throw error
+  }
+}
+
+export async function syncDataToS3() {
+  const settings = store.getState().settings
+
+  store.dispatch(setS3SyncState({ syncing: true, lastSyncError: null }))
+
+  try {
+    const result = await syncWithS3({
+      endpoint: settings.s3.endpoint,
+      region: settings.s3.region,
+      bucket: settings.s3.bucket,
+      accessKeyId: settings.s3.accessKeyId,
+      secretAccessKey: settings.s3.secretAccessKey,
+      root: settings.s3.root,
+      skipBackupFile: settings.s3.skipBackupFile,
+      autoSync: settings.s3.autoSync,
+      syncInterval: settings.s3.syncInterval,
+      maxBackups: settings.s3.maxBackups
+    })
+
+    store.dispatch(
+      setS3SyncState({
+        syncing: false,
+        lastSyncError: null,
+        lastSyncTime: Date.now()
+      })
+    )
+
+    return result
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    store.dispatch(
+      setS3SyncState({
+        syncing: false,
+        lastSyncError: message
+      })
+    )
+    throw error
+  }
 }
 
 export async function restore() {

--- a/src/renderer/src/services/DataSyncService.ts
+++ b/src/renderer/src/services/DataSyncService.ts
@@ -1,0 +1,426 @@
+import { loggerService } from '@logger'
+import db from '@renderer/databases'
+import type { S3Config, WebDavConfig } from '@renderer/types'
+
+const logger = loggerService.withContext('DataSyncService')
+
+const SYNC_VERSION = 1
+const SNAPSHOT_FILE = 'sync/cherry-sync-snapshot.json'
+const MANIFEST_FILE = 'sync/cherry-sync-manifest.json'
+const LOCAL_STORAGE_KEYS = ['persist:cherry-studio', 'memory_currentUserId'] as const
+const DEVICE_ID_KEY = 'cherry-sync-device-id'
+
+type SyncProviderName = 'webdav' | 's3'
+
+type SyncManifest = {
+  version: number
+  snapshotFile: string
+  snapshotHash: string
+  updatedAt: number
+  deviceId: string
+}
+
+type SyncSnapshot = {
+  version: number
+  generatedAt: number
+  deviceId: string
+  localStorage: Record<string, string>
+  indexedDB: Record<string, Record<string, any>[]>
+}
+
+type LocalSyncMetadata = {
+  deviceId: string
+  lastSyncedHash: string | null
+  lastSyncedAt: number | null
+}
+
+type SyncProvider = {
+  name: SyncProviderName
+  readText: (fileName: string) => Promise<string>
+  writeText: (fileName: string, content: string) => Promise<void>
+}
+
+export type SyncResult = {
+  action: 'uploaded' | 'downloaded' | 'merged' | 'noop'
+  localHash: string
+  remoteHash: string
+  relaunchRequired: boolean
+}
+
+export async function syncWithWebdav(config: WebDavConfig): Promise<SyncResult> {
+  return performSync({
+    name: 'webdav',
+    readText: (fileName) => window.api.backup.readWebdavText(fileName, config),
+    writeText: async (fileName, content) => {
+      await window.api.backup.writeWebdavText(fileName, content, config)
+    }
+  })
+}
+
+export async function syncWithS3(config: S3Config): Promise<SyncResult> {
+  return performSync({
+    name: 's3',
+    readText: (fileName) => window.api.backup.readS3Text(fileName, config),
+    writeText: async (fileName, content) => {
+      await window.api.backup.writeS3Text(fileName, content, config)
+    }
+  })
+}
+
+async function performSync(provider: SyncProvider): Promise<SyncResult> {
+  const metadata = getLocalMetadata(provider.name)
+  const localSnapshot = await createSnapshot(metadata.deviceId)
+  const localHash = hashSnapshot(localSnapshot)
+  const remoteManifest = await readRemoteManifest(provider)
+
+  if (!remoteManifest) {
+    await uploadSnapshot(provider, localSnapshot, localHash)
+    saveLocalMetadata(provider.name, {
+      deviceId: metadata.deviceId,
+      lastSyncedHash: localHash,
+      lastSyncedAt: Date.now()
+    })
+    return { action: 'uploaded', localHash, remoteHash: localHash, relaunchRequired: false }
+  }
+
+  if (remoteManifest.snapshotHash === localHash) {
+    saveLocalMetadata(provider.name, {
+      deviceId: metadata.deviceId,
+      lastSyncedHash: localHash,
+      lastSyncedAt: remoteManifest.updatedAt
+    })
+    return { action: 'noop', localHash, remoteHash: localHash, relaunchRequired: false }
+  }
+
+  const remoteSnapshot = await readRemoteSnapshot(provider, remoteManifest)
+  const remoteHash = remoteManifest.snapshotHash
+
+  if (metadata.lastSyncedHash === remoteHash) {
+    await uploadSnapshot(provider, localSnapshot, localHash)
+    saveLocalMetadata(provider.name, {
+      deviceId: metadata.deviceId,
+      lastSyncedHash: localHash,
+      lastSyncedAt: Date.now()
+    })
+    return { action: 'uploaded', localHash, remoteHash: localHash, relaunchRequired: false }
+  }
+
+  if (metadata.lastSyncedHash === localHash) {
+    await applySnapshot(remoteSnapshot)
+    saveLocalMetadata(provider.name, {
+      deviceId: metadata.deviceId,
+      lastSyncedHash: remoteHash,
+      lastSyncedAt: remoteManifest.updatedAt
+    })
+    return { action: 'downloaded', localHash, remoteHash, relaunchRequired: true }
+  }
+
+  const mergedSnapshot = mergeSnapshots(localSnapshot, remoteSnapshot)
+  const mergedHash = hashSnapshot(mergedSnapshot)
+
+  await applySnapshot(mergedSnapshot)
+  await uploadSnapshot(provider, mergedSnapshot, mergedHash)
+  saveLocalMetadata(provider.name, {
+    deviceId: metadata.deviceId,
+    lastSyncedHash: mergedHash,
+    lastSyncedAt: Date.now()
+  })
+
+  return { action: 'merged', localHash: mergedHash, remoteHash: mergedHash, relaunchRequired: true }
+}
+
+async function createSnapshot(deviceId: string): Promise<SyncSnapshot> {
+  const indexedDB: SyncSnapshot['indexedDB'] = {}
+
+  for (const table of db.tables) {
+    indexedDB[table.name] = sortRowsByKey(await table.toArray())
+  }
+
+  return {
+    version: SYNC_VERSION,
+    generatedAt: Date.now(),
+    deviceId,
+    localStorage: readManagedLocalStorage(),
+    indexedDB
+  }
+}
+
+async function applySnapshot(snapshot: SyncSnapshot): Promise<void> {
+  writeManagedLocalStorage(snapshot.localStorage)
+
+  await db.transaction('rw', db.tables, async () => {
+    for (const table of db.tables) {
+      const rows = snapshot.indexedDB[table.name] || []
+      await table.clear()
+      if (rows.length > 0) {
+        await table.bulkAdd(rows)
+      }
+    }
+  })
+}
+
+async function uploadSnapshot(provider: SyncProvider, snapshot: SyncSnapshot, snapshotHash: string): Promise<void> {
+  const serializedSnapshot = stableStringify(snapshot)
+  const manifest: SyncManifest = {
+    version: SYNC_VERSION,
+    snapshotFile: SNAPSHOT_FILE,
+    snapshotHash,
+    updatedAt: Date.now(),
+    deviceId: snapshot.deviceId
+  }
+
+  await provider.writeText(SNAPSHOT_FILE, serializedSnapshot)
+  await provider.writeText(MANIFEST_FILE, stableStringify(manifest))
+}
+
+async function readRemoteManifest(provider: SyncProvider): Promise<SyncManifest | null> {
+  try {
+    return JSON.parse(await provider.readText(MANIFEST_FILE)) as SyncManifest
+  } catch (error) {
+    if (isMissingRemoteFile(error)) {
+      return null
+    }
+    logger.error(`Failed to read ${provider.name} sync manifest:`, error as Error)
+    throw error
+  }
+}
+
+async function readRemoteSnapshot(provider: SyncProvider, manifest: SyncManifest): Promise<SyncSnapshot> {
+  try {
+    return JSON.parse(await provider.readText(manifest.snapshotFile)) as SyncSnapshot
+  } catch (error) {
+    logger.error(`Failed to read ${provider.name} sync snapshot:`, error as Error)
+    throw error
+  }
+}
+
+function readManagedLocalStorage(): Record<string, string> {
+  return LOCAL_STORAGE_KEYS.reduce<Record<string, string>>((acc, key) => {
+    const value = localStorage.getItem(key)
+    if (value !== null) {
+      acc[key] = value
+    }
+    return acc
+  }, {})
+}
+
+function writeManagedLocalStorage(values: Record<string, string>): void {
+  for (const key of LOCAL_STORAGE_KEYS) {
+    const value = values[key]
+    if (value === undefined) {
+      localStorage.removeItem(key)
+    } else {
+      localStorage.setItem(key, value)
+    }
+  }
+}
+
+function getLocalMetadata(provider: SyncProviderName): LocalSyncMetadata {
+  const key = getMetadataKey(provider)
+  const raw = localStorage.getItem(key)
+  const deviceId = getOrCreateDeviceId()
+
+  if (!raw) {
+    return {
+      deviceId,
+      lastSyncedHash: null,
+      lastSyncedAt: null
+    }
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<LocalSyncMetadata>
+    return {
+      deviceId: parsed.deviceId || deviceId,
+      lastSyncedHash: parsed.lastSyncedHash || null,
+      lastSyncedAt: parsed.lastSyncedAt || null
+    }
+  } catch {
+    return {
+      deviceId,
+      lastSyncedHash: null,
+      lastSyncedAt: null
+    }
+  }
+}
+
+function saveLocalMetadata(provider: SyncProviderName, metadata: LocalSyncMetadata): void {
+  localStorage.setItem(getMetadataKey(provider), JSON.stringify(metadata))
+}
+
+function getMetadataKey(provider: SyncProviderName): string {
+  return `cherry-sync-metadata:${provider}`
+}
+
+function getOrCreateDeviceId(): string {
+  const existing = localStorage.getItem(DEVICE_ID_KEY)
+  if (existing) {
+    return existing
+  }
+
+  const deviceId = typeof crypto.randomUUID === 'function' ? crypto.randomUUID() : `device-${Date.now()}`
+  localStorage.setItem(DEVICE_ID_KEY, deviceId)
+  return deviceId
+}
+
+function isMissingRemoteFile(error: unknown): boolean {
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase()
+  return (
+    message.includes('not found') ||
+    message.includes('404') ||
+    message.includes('no such key') ||
+    message.includes('does not exist')
+  )
+}
+
+export function mergeSnapshots(local: SyncSnapshot, remote: SyncSnapshot): SyncSnapshot {
+  const mergedIndexedDb: SyncSnapshot['indexedDB'] = {}
+  const tableNames = new Set([...Object.keys(local.indexedDB), ...Object.keys(remote.indexedDB)])
+
+  for (const tableName of tableNames) {
+    mergedIndexedDb[tableName] = mergeTableRecords(local.indexedDB[tableName] || [], remote.indexedDB[tableName] || [])
+  }
+
+  return {
+    version: Math.max(local.version, remote.version),
+    generatedAt: Math.max(local.generatedAt, remote.generatedAt),
+    deviceId: local.deviceId,
+    localStorage: mergeStringMaps(local.localStorage, remote.localStorage),
+    indexedDB: mergedIndexedDb
+  }
+}
+
+function mergeStringMaps(local: Record<string, string>, remote: Record<string, string>): Record<string, string> {
+  const merged: Record<string, string> = {}
+  const keys = new Set([...Object.keys(local), ...Object.keys(remote)])
+
+  for (const key of keys) {
+    const localValue = local[key]
+    const remoteValue = remote[key]
+
+    if (localValue === undefined) {
+      merged[key] = remoteValue
+      continue
+    }
+
+    if (remoteValue === undefined || localValue === remoteValue) {
+      merged[key] = localValue
+      continue
+    }
+
+    merged[key] = remoteValue
+  }
+
+  return merged
+}
+
+function mergeTableRecords(localRows: Record<string, any>[], remoteRows: Record<string, any>[]): Record<string, any>[] {
+  const merged = new Map<string, Record<string, any>>()
+
+  for (const row of localRows) {
+    merged.set(getRecordKey(row), row)
+  }
+
+  for (const remoteRow of remoteRows) {
+    const key = getRecordKey(remoteRow)
+    const localRow = merged.get(key)
+
+    if (!localRow) {
+      merged.set(key, remoteRow)
+      continue
+    }
+
+    if (stableStringify(localRow) === stableStringify(remoteRow)) {
+      continue
+    }
+
+    merged.set(key, pickNewerRecord(localRow, remoteRow))
+  }
+
+  return sortRowsByKey(Array.from(merged.values()))
+}
+
+function getRecordKey(row: Record<string, any>): string {
+  if (row.id !== undefined && row.id !== null) {
+    return String(row.id)
+  }
+  return stableStringify(row)
+}
+
+function sortRowsByKey(rows: Record<string, any>[]): Record<string, any>[] {
+  return [...rows].sort((left, right) => getRecordKey(left).localeCompare(getRecordKey(right)))
+}
+
+function pickNewerRecord(localRow: Record<string, any>, remoteRow: Record<string, any>): Record<string, any> {
+  const localTimestamp = extractRecordTimestamp(localRow)
+  const remoteTimestamp = extractRecordTimestamp(remoteRow)
+
+  if (localTimestamp !== null && remoteTimestamp !== null) {
+    return localTimestamp >= remoteTimestamp ? localRow : remoteRow
+  }
+
+  if (localTimestamp !== null) {
+    return localRow
+  }
+
+  if (remoteTimestamp !== null) {
+    return remoteRow
+  }
+
+  return remoteRow
+}
+
+function extractRecordTimestamp(row: Record<string, any>): number | null {
+  const candidates = [row.updated_at, row.updatedAt, row.created_at, row.createdAt]
+
+  for (const candidate of candidates) {
+    if (candidate === undefined || candidate === null) {
+      continue
+    }
+
+    if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+      return candidate
+    }
+
+    const parsed = Date.parse(String(candidate))
+    if (!Number.isNaN(parsed)) {
+      return parsed
+    }
+  }
+
+  return null
+}
+
+export function hashSnapshot(snapshot: SyncSnapshot): string {
+  return hashString(
+    stableStringify({
+      version: snapshot.version,
+      localStorage: snapshot.localStorage,
+      indexedDB: snapshot.indexedDB
+    })
+  )
+}
+
+function hashString(value: string): string {
+  let hash = 2166136261
+
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+
+  return (hash >>> 0).toString(16)
+}
+
+export function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value)
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>).sort(([left], [right]) => left.localeCompare(right))
+  return `{${entries.map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`).join(',')}}`
+}

--- a/src/renderer/src/services/__tests__/DataSyncService.test.ts
+++ b/src/renderer/src/services/__tests__/DataSyncService.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn()
+    })
+  }
+}))
+
+vi.mock('@renderer/databases', () => ({
+  default: {
+    tables: []
+  }
+}))
+
+import { hashSnapshot, mergeSnapshots, stableStringify } from '../DataSyncService'
+
+describe('DataSyncService', () => {
+  it('stableStringify should sort object keys deterministically', () => {
+    expect(stableStringify({ b: 2, a: 1 })).toBe('{"a":1,"b":2}')
+  })
+
+  it('hashSnapshot should be stable for the same semantic snapshot', () => {
+    const snapshotA = {
+      version: 1,
+      generatedAt: 1,
+      deviceId: 'device-a',
+      localStorage: {
+        'persist:cherry-studio': '{"settings":"{}"}'
+      },
+      indexedDB: {
+        topics: [{ id: 'topic-1', updated_at: '2026-01-01T00:00:00.000Z', value: 'A' }]
+      }
+    }
+
+    const snapshotB = {
+      generatedAt: 1,
+      version: 1,
+      deviceId: 'device-a',
+      indexedDB: {
+        topics: [{ value: 'A', updated_at: '2026-01-01T00:00:00.000Z', id: 'topic-1' }]
+      },
+      localStorage: {
+        'persist:cherry-studio': '{"settings":"{}"}'
+      }
+    }
+
+    expect(hashSnapshot(snapshotA as any)).toBe(hashSnapshot(snapshotB as any))
+  })
+
+  it('mergeSnapshots should prefer the newer record per row when timestamps exist', () => {
+    const local = {
+      version: 1,
+      generatedAt: 10,
+      deviceId: 'device-a',
+      localStorage: {
+        'persist:cherry-studio': '{"settings":"local"}'
+      },
+      indexedDB: {
+        topics: [
+          { id: 'topic-1', updated_at: '2026-01-01T00:00:00.000Z', value: 'local' },
+          { id: 'topic-2', updated_at: '2026-01-01T00:00:00.000Z', value: 'only-local' }
+        ]
+      }
+    }
+
+    const remote = {
+      version: 1,
+      generatedAt: 20,
+      deviceId: 'device-b',
+      localStorage: {
+        'persist:cherry-studio': '{"settings":"remote"}'
+      },
+      indexedDB: {
+        topics: [
+          { id: 'topic-1', updated_at: '2026-01-02T00:00:00.000Z', value: 'remote' },
+          { id: 'topic-3', updated_at: '2026-01-02T00:00:00.000Z', value: 'only-remote' }
+        ]
+      }
+    }
+
+    const merged = mergeSnapshots(local as any, remote as any)
+    const topicMap = Object.fromEntries(merged.indexedDB.topics.map((topic) => [topic.id, topic.value]))
+
+    expect(merged.localStorage['persist:cherry-studio']).toBe('{"settings":"remote"}')
+    expect(topicMap['topic-1']).toBe('remote')
+    expect(topicMap['topic-2']).toBe('only-local')
+    expect(topicMap['topic-3']).toBe('only-remote')
+  })
+})


### PR DESCRIPTION
## Summary
- add client-side remote sync primitives on top of existing WebDAV/S3 backup transports
- add main/preload IPC for reading and writing remote text objects
- add snapshot/manifest based sync flow with conservative merge logic and tests

## Notes
- this is a client-only MVP for remote sync and does not introduce a dedicated sync server
- conflicts are resolved conservatively by preferring newer per-record timestamps when available

## Testing
- not run in this environment (no local pnpm/node_modules available for renderer tests/typecheck)