### PR TITLE
fix(code-tools): disable opencode built-in auto-update check

### DIFF
--- a/src/renderer/src/pages/code/index.ts
+++ b/src/renderer/src/pages/code/index.ts
@@ -235,6 +235,10 @@ export const generateToolEnvironment = ({
         env.OPENCODE_PROVIDER_NAME = providerName
         const envVarKey = `OPENCODE_API_KEY_${providerName.toUpperCase().replace(/[-.]/g, '_')}`
         env[envVarKey] = apiKey
+        // opencode's auto-update check can't detect Cherry Studio's bun install,
+        // causing a confusing "Update Available" dialog that always fails.
+        // Cherry Studio manages opencode updates via its own autoUpdateToLatest.
+        env.OPENCODE_DISABLE_AUTOUPDATE = 'true'
       }
       break
   }


### PR DESCRIPTION
### What this PR does

Before this PR:
opencode's built-in `checkUpgrade()` cannot detect Cherry Studio's `bun install -g` path (`~/.cherrystudio/`) and falls back to `"unknown"` install method. For minor/major updates, opencode shows an "Update Available" dialog that always fails because the `"unknown"` method cannot auto-upgrade.

After this PR:
Sets `OPENCODE_DISABLE_AUTOUPDATE=true` in the environment passed to opencode, disabling its built-in update check. Cherry Studio already manages opencode updates via its own `autoUpdateToLatest` mechanism.

Fixes #14924

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Disabling opencode's built-in update entirely rather than fixing the install detection. The detection relies on running `bun pm ls -g` which cannot find packages in Cherry Studio's custom bun install directory. Fixing the detection would require setting `BUN_INSTALL` in the opencode process environment, but this env var is not used by opencode's detection logic at all — it runs `bun pm ls -g` as a shell command.

The following alternatives were considered:
- Setting `BUN_INSTALL=~/.cherrystudio` to help opencode detect the install method — rejected because opencode's detection does not use this env var.
- Adding `"autoupdate": false` to `opencode.json` config — rejected because this config field may not be supported by opencode's Go binary.

### Breaking changes

None.

### Special notes for your reviewer

The env var is set in `generateToolEnvironment()` (renderer side) alongside all other opencode env vars. This keeps all tool-specific configuration in one place. The env var is passed through Electron IPC to `CodeToolsService.run()`, where `buildEnvPrefix()` converts it to an `export` command in the terminal's `bash -c` string.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [ ] Refactor: N/A
- [ ] Upgrade: N/A
- [ ] Documentation: Not required — internal behavior change, no user-facing UI
- [x] Self-review: I have reviewed my own code

### Release note

```release-note
Fix opencode showing a failing "Update Available" dialog when launched from Cherry Studio's Code Tools
```
