### PR TITLE
feat(agents): add mock todo list panel preview

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -4024,6 +4024,9 @@
         "triggerPlaceholder": "Select an agent",
         "valueProp": "Current value"
       },
+      "agentTodoList": {
+        "title": "Agent Todo List"
+      },
       "assistantSelector": {
         "clearSelection": "Clear",
         "configDescription": "Toggle props to preview component behavior",

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -578,6 +578,98 @@
     },
     "sidebar_title": "Agents",
     "todo": {
+      "mock": {
+        "actions": {
+          "complete": "Complete",
+          "dismiss": "Dismiss"
+        },
+        "details": {
+          "addRouter": {
+            "summary": "Configuring client routing with react-router-dom v6...",
+            "title": "Add React Router"
+          },
+          "configureProject": {
+            "resources": {
+              "createdMeta": "created",
+              "postcssConfig": "postcss.config.js",
+              "tailwindConfig": "tailwind.config.js",
+              "updatedMeta": "updated",
+              "viteConfig": "vite.config.ts - port 3001"
+            },
+            "title": "Configure project"
+          },
+          "installDependencies": {
+            "resources": {
+              "dependenciesMeta": "dependencies",
+              "devDependenciesMeta": "devDependencies",
+              "reactDeps": "react@18.3.1, react-dom@18.3.1",
+              "tailwindDeps": "tailwindcss@3.4.4, postcss@8.4.38",
+              "typescriptDeps": "typescript@5.4.5, vite@5.3.0"
+            },
+            "summary": "Installed react, react-dom, tailwindcss, postcss, autoprefixer, and TypeScript.",
+            "title": "Install dependencies"
+          },
+          "reviewReferences": {
+            "collectionTitle": "Reviewed references",
+            "resources": {
+              "npmCreateVite": "npm create vite - Official Scaffolding",
+              "npmMeta": "npmjs.com",
+              "reactDocs": "React Documentation - Quick Start",
+              "reactMeta": "react.dev",
+              "tailwindDocs": "Tailwind CSS - Installation Guide",
+              "tailwindMeta": "tailwindcss.com",
+              "viteDocs": "Vite - Next Generation Frontend Tooling",
+              "viteMeta": "vitejs.dev"
+            },
+            "title": "Review references"
+          },
+          "searchWeb": {
+            "resources": {
+              "reactViteQuery": "React Vite TypeScript starter 2025 best practices"
+            },
+            "summary": "Collected current references for React + Vite scaffolding and best practices.",
+            "title": "Search web references"
+          },
+          "title": "Execution details",
+          "writeComponents": {
+            "collectionTitle": "Created files",
+            "resources": {
+              "app": "src/App.tsx",
+              "button": "src/components/Button.tsx",
+              "card": "src/components/Card.tsx",
+              "footer": "src/components/Footer.tsx",
+              "header": "src/components/Header.tsx",
+              "layout": "src/components/Layout.tsx",
+              "modifiedMeta": "modified",
+              "newMeta": "new",
+              "updatedMeta": "updated"
+            },
+            "title": "Write components"
+          },
+          "writePages": {
+            "resources": {
+              "about": "src/pages/About.tsx",
+              "home": "src/pages/Home.tsx",
+              "newMeta": "new"
+            },
+            "title": "Write pages"
+          }
+        },
+        "progress": "{{completed}}/{{total}} tasks completed",
+        "tasks": {
+          "addLinting": "Add ESLint + Prettier",
+          "addRouter": "Add React Router",
+          "buildDeploy": "Build and deploy",
+          "configureProject": "Configure project",
+          "finish": "Finish",
+          "installDependencies": "Install dependencies",
+          "reviewReferences": "Review references",
+          "searchWeb": "Search web references",
+          "writeComponents": "Write components",
+          "writePages": "Write pages"
+        },
+        "title": "Tasks"
+      },
       "panel": {
         "title": "{{completed}}/{{total}} tasks completed"
       },

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -578,6 +578,98 @@
     },
     "sidebar_title": "智能体",
     "todo": {
+      "mock": {
+        "actions": {
+          "complete": "完成",
+          "dismiss": "关闭"
+        },
+        "details": {
+          "addRouter": {
+            "summary": "正在使用 react-router-dom v6 配置客户端路由...",
+            "title": "添加 React Router"
+          },
+          "configureProject": {
+            "resources": {
+              "createdMeta": "created",
+              "postcssConfig": "postcss.config.js",
+              "tailwindConfig": "tailwind.config.js",
+              "updatedMeta": "updated",
+              "viteConfig": "vite.config.ts - port 3001"
+            },
+            "title": "配置项目"
+          },
+          "installDependencies": {
+            "resources": {
+              "dependenciesMeta": "dependencies",
+              "devDependenciesMeta": "devDependencies",
+              "reactDeps": "react@18.3.1, react-dom@18.3.1",
+              "tailwindDeps": "tailwindcss@3.4.4, postcss@8.4.38",
+              "typescriptDeps": "typescript@5.4.5, vite@5.3.0"
+            },
+            "summary": "安装了 react, react-dom, tailwindcss, postcss, autoprefixer 和 TypeScript。",
+            "title": "安装依赖"
+          },
+          "reviewReferences": {
+            "collectionTitle": "审阅参考资料",
+            "resources": {
+              "npmCreateVite": "npm create vite - Official Scaffolding",
+              "npmMeta": "npmjs.com",
+              "reactDocs": "React Documentation - Quick Start",
+              "reactMeta": "react.dev",
+              "tailwindDocs": "Tailwind CSS - Installation Guide",
+              "tailwindMeta": "tailwindcss.com",
+              "viteDocs": "Vite - Next Generation Frontend Tooling",
+              "viteMeta": "vitejs.dev"
+            },
+            "title": "审阅参考资料"
+          },
+          "searchWeb": {
+            "resources": {
+              "reactViteQuery": "React Vite TypeScript starter 2025 best practices"
+            },
+            "summary": "收集了 React + Vite 项目脚手架和最佳实践的最新资料。",
+            "title": "搜索网络资料"
+          },
+          "title": "执行过程详情",
+          "writeComponents": {
+            "collectionTitle": "创建的文件",
+            "resources": {
+              "app": "src/App.tsx",
+              "button": "src/components/Button.tsx",
+              "card": "src/components/Card.tsx",
+              "footer": "src/components/Footer.tsx",
+              "header": "src/components/Header.tsx",
+              "layout": "src/components/Layout.tsx",
+              "modifiedMeta": "modified",
+              "newMeta": "new",
+              "updatedMeta": "updated"
+            },
+            "title": "编写组件"
+          },
+          "writePages": {
+            "resources": {
+              "about": "src/pages/About.tsx",
+              "home": "src/pages/Home.tsx",
+              "newMeta": "new"
+            },
+            "title": "编写页面"
+          }
+        },
+        "progress": "{{completed}}/{{total}} 任务已完成",
+        "tasks": {
+          "addLinting": "添加 ESLint + Prettier",
+          "addRouter": "添加 React Router",
+          "buildDeploy": "构建与部署",
+          "configureProject": "配置项目",
+          "finish": "完成",
+          "installDependencies": "安装依赖",
+          "reviewReferences": "审阅参考资料",
+          "searchWeb": "搜索网络资料",
+          "writeComponents": "编写组件",
+          "writePages": "编写页面"
+        },
+        "title": "任务"
+      },
       "panel": {
         "title": "已完成 {{completed}}/{{total}} 个任务"
       },

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -4024,6 +4024,9 @@
         "triggerPlaceholder": "选择智能体",
         "valueProp": "当前 value"
       },
+      "agentTodoList": {
+        "title": "Agent 任务列表"
+      },
       "assistantSelector": {
         "clearSelection": "清空",
         "configDescription": "调整 props 预览组件行为",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -4024,6 +4024,9 @@
         "triggerPlaceholder": "選擇智能體",
         "valueProp": "目前 value"
       },
+      "agentTodoList": {
+        "title": "Agent 任務列表"
+      },
       "assistantSelector": {
         "clearSelection": "清空",
         "configDescription": "切換 props 預覽元件行為",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -578,6 +578,98 @@
     },
     "sidebar_title": "Agents",
     "todo": {
+      "mock": {
+        "actions": {
+          "complete": "完成",
+          "dismiss": "關閉"
+        },
+        "details": {
+          "addRouter": {
+            "summary": "正在使用 react-router-dom v6 設定客戶端路由...",
+            "title": "新增 React Router"
+          },
+          "configureProject": {
+            "resources": {
+              "createdMeta": "created",
+              "postcssConfig": "postcss.config.js",
+              "tailwindConfig": "tailwind.config.js",
+              "updatedMeta": "updated",
+              "viteConfig": "vite.config.ts - port 3001"
+            },
+            "title": "設定專案"
+          },
+          "installDependencies": {
+            "resources": {
+              "dependenciesMeta": "dependencies",
+              "devDependenciesMeta": "devDependencies",
+              "reactDeps": "react@18.3.1, react-dom@18.3.1",
+              "tailwindDeps": "tailwindcss@3.4.4, postcss@8.4.38",
+              "typescriptDeps": "typescript@5.4.5, vite@5.3.0"
+            },
+            "summary": "安裝了 react, react-dom, tailwindcss, postcss, autoprefixer 和 TypeScript。",
+            "title": "安裝依賴"
+          },
+          "reviewReferences": {
+            "collectionTitle": "審閱參考資料",
+            "resources": {
+              "npmCreateVite": "npm create vite - Official Scaffolding",
+              "npmMeta": "npmjs.com",
+              "reactDocs": "React Documentation - Quick Start",
+              "reactMeta": "react.dev",
+              "tailwindDocs": "Tailwind CSS - Installation Guide",
+              "tailwindMeta": "tailwindcss.com",
+              "viteDocs": "Vite - Next Generation Frontend Tooling",
+              "viteMeta": "vitejs.dev"
+            },
+            "title": "審閱參考資料"
+          },
+          "searchWeb": {
+            "resources": {
+              "reactViteQuery": "React Vite TypeScript starter 2025 best practices"
+            },
+            "summary": "收集了 React + Vite 專案腳手架和最佳實務的最新資料。",
+            "title": "搜尋網路資料"
+          },
+          "title": "執行過程詳情",
+          "writeComponents": {
+            "collectionTitle": "建立的檔案",
+            "resources": {
+              "app": "src/App.tsx",
+              "button": "src/components/Button.tsx",
+              "card": "src/components/Card.tsx",
+              "footer": "src/components/Footer.tsx",
+              "header": "src/components/Header.tsx",
+              "layout": "src/components/Layout.tsx",
+              "modifiedMeta": "modified",
+              "newMeta": "new",
+              "updatedMeta": "updated"
+            },
+            "title": "編寫元件"
+          },
+          "writePages": {
+            "resources": {
+              "about": "src/pages/About.tsx",
+              "home": "src/pages/Home.tsx",
+              "newMeta": "new"
+            },
+            "title": "編寫頁面"
+          }
+        },
+        "progress": "{{completed}}/{{total}} 任務已完成",
+        "tasks": {
+          "addLinting": "新增 ESLint + Prettier",
+          "addRouter": "新增 React Router",
+          "buildDeploy": "建置與部署",
+          "configureProject": "設定專案",
+          "finish": "完成",
+          "installDependencies": "安裝依賴",
+          "reviewReferences": "審閱參考資料",
+          "searchWeb": "搜尋網路資料",
+          "writeComponents": "編寫元件",
+          "writePages": "編寫頁面"
+        },
+        "title": "任務"
+      },
       "panel": {
         "title": "已完成 {{completed}}/{{total}} 個任務"
       },

--- a/src/renderer/src/pages/agents/components/AgentTodoListPanel.tsx
+++ b/src/renderer/src/pages/agents/components/AgentTodoListPanel.tsx
@@ -1,3 +1,28 @@
+/**
+ * Mock-only Agent todo list panel.
+ *
+ * This file currently renders static fixture data through AgentTodoListPanel.MockProvider.
+ * It is intentionally not connected to any production API, agent session stream, or scheduled
+ * task endpoint. The mock data exists only to preview the UI shape and composition API while
+ * the real agent execution todo/progress contract is still undecided.
+ *
+ * When wiring real data later, keep this component presentational and add a connected wrapper
+ * or real provider beside it. That wrapper should:
+ * - accept the scope needed to query data, such as agentId plus sessionId/runId if the todo list
+ *   represents one agent execution rather than scheduled tasks.
+ * - fetch/subscribe to the real source of truth, then map the response into AgentTodoItem[] and
+ *   AgentTodoDetailGroup[] before passing it into the provider.
+ * - provide stable task ids, display labels or i18n keys, status values
+ *   ('completed' | 'in_progress' | 'pending'), detail group ids/icons/titles, optional summaries,
+ *   and optional resource rows with ids/icons/labels/meta.
+ * - expose action handlers only from the provider layer when they become real, such as complete,
+ *   dismiss, retry, refresh, or open-resource actions. The visual subcomponents should continue
+ *   reading from context instead of calling APIs directly.
+ *
+ * Do not treat /agents/:agentId/tasks as the default backing API unless the product meaning is
+ * actually "scheduled tasks". This panel currently models execution progress/todos, which may
+ * need a session/run-scoped API instead.
+ */
 import { Button, Tooltip } from '@cherrystudio/ui'
 import { cn } from '@renderer/utils/style'
 import {
@@ -335,7 +360,7 @@ const AgentTodoListMockProvider = ({
 const AgentTodoListRoot = ({ children, className }: AgentTodoListRootProps) => (
   <section
     className={cn(
-      'mx-3 mt-3 mb-1 flex-shrink-0 overflow-hidden rounded-xl border border-border/60 bg-card shadow-sm',
+      'mx-3 mt-3 mb-1 shrink-0 overflow-hidden rounded-xl border border-border/60 bg-background shadow-sm',
       className
     )}>
     {children}
@@ -358,10 +383,10 @@ const AgentTodoListHeader = () => {
       onClick={toggleTasks}>
       <ChevronDown
         size={10}
-        className={cn('flex-shrink-0 text-muted-foreground transition-transform', !isTasksExpanded && '-rotate-90')}
+        className={cn('shrink-0 text-muted-foreground transition-transform', !isTasksExpanded && '-rotate-90')}
       />
       <span className="min-w-0 flex-1 truncate text-[10.5px] text-foreground/85">{t('agent.todo.mock.title')}</span>
-      <span className="flex-shrink-0 text-[9px] text-muted-foreground tabular-nums">
+      <span className="shrink-0 text-[9px] text-muted-foreground tabular-nums">
         {completedCount}/{totalCount}
       </span>
     </button>
@@ -390,7 +415,7 @@ const AgentTodoListTaskRow = ({ task }: { task: AgentTodoItem }) => {
   const { t } = useTranslation()
 
   return (
-    <div className="flex min-h-6 items-center gap-2 px-1 py-[5px]">
+    <div className="flex min-h-6 items-center gap-2 px-1 py-1.25">
       <AgentTodoListStatusIcon status={task.status} />
       <span
         className={cn(
@@ -408,7 +433,7 @@ const AgentTodoListTaskRow = ({ task }: { task: AgentTodoItem }) => {
 const AgentTodoListStatusIcon = ({ status }: { status: AgentTodoStatus }) => {
   if (status === 'completed') {
     return (
-      <span className="flex size-4 flex-shrink-0 items-center justify-center rounded bg-primary/10 text-primary">
+      <span className="flex size-4 shrink-0 items-center justify-center rounded bg-primary/10 text-primary">
         <Check size={10} />
       </span>
     )
@@ -416,14 +441,14 @@ const AgentTodoListStatusIcon = ({ status }: { status: AgentTodoStatus }) => {
 
   if (status === 'in_progress') {
     return (
-      <span className="flex size-4 flex-shrink-0 items-center justify-center text-primary">
+      <span className="flex size-4 shrink-0 items-center justify-center text-primary">
         <LoaderCircle size={11} className="animate-spin" />
       </span>
     )
   }
 
   return (
-    <span className="flex size-4 flex-shrink-0 items-center justify-center text-muted-foreground/30">
+    <span className="flex size-4 shrink-0 items-center justify-center text-muted-foreground/30">
       <Circle size={10} />
     </span>
   )
@@ -445,10 +470,7 @@ const AgentTodoListDetails = () => {
         onClick={toggleDetails}>
         <ChevronDown
           size={9}
-          className={cn(
-            'flex-shrink-0 text-muted-foreground/60 transition-transform',
-            !isDetailsExpanded && '-rotate-90'
-          )}
+          className={cn('shrink-0 text-muted-foreground/60 transition-transform', !isDetailsExpanded && '-rotate-90')}
         />
         <span className="min-w-0 flex-1 truncate text-[10px] text-muted-foreground">
           {t('agent.todo.mock.details.title')}
@@ -490,7 +512,7 @@ const AgentTodoListDetailGroup = ({ detail }: { detail: AgentTodoDetailGroup }) 
                   <span className="truncate text-[10px] text-muted-foreground">{t(detail.collectionTitleKey)}</span>
                   <span className="text-[9px] text-muted-foreground/60">{resourceCount}</span>
                 </div>
-                <Share2 size={9} className="flex-shrink-0 text-muted-foreground/50" />
+                <Share2 size={9} className="shrink-0 text-muted-foreground/50" />
               </div>
             )}
             <div className="py-0.5">
@@ -510,14 +532,12 @@ const AgentTodoListDetailResource = ({ resource }: { resource: AgentTodoDetailRe
   const Icon = RESOURCE_ICONS[resource.icon]
 
   return (
-    <div className="flex items-center gap-2 px-3 py-[4px] transition-colors hover:bg-muted/80">
-      <span className="flex size-4 flex-shrink-0 items-center justify-center rounded bg-muted text-[10px]">
+    <div className="flex items-center gap-2 px-3 py-1 transition-colors hover:bg-muted/80">
+      <span className="flex size-4 shrink-0 items-center justify-center rounded bg-muted text-[10px]">
         <Icon size={10} className="text-muted-foreground/70" />
       </span>
       <span className="min-w-0 flex-1 truncate text-[10.5px] text-foreground/70">{t(resource.labelKey)}</span>
-      {resource.metaKey && (
-        <span className="flex-shrink-0 text-[9px] text-muted-foreground/60">{t(resource.metaKey)}</span>
-      )}
+      {resource.metaKey && <span className="shrink-0 text-[9px] text-muted-foreground/60">{t(resource.metaKey)}</span>}
     </div>
   )
 }
@@ -530,7 +550,7 @@ const AgentTodoListFooter = () => {
 
   return (
     <div className="flex items-center gap-2 border-border/40 border-t px-3.5 py-2">
-      <ListFilter size={11} className="flex-shrink-0 text-muted-foreground/60" />
+      <ListFilter size={11} className="shrink-0 text-muted-foreground/60" />
       <span className="min-w-0 flex-1 truncate text-[10px] text-muted-foreground">
         {t('agent.todo.mock.progress', { completed: completedCount, total: totalCount })}
       </span>

--- a/src/renderer/src/pages/agents/components/AgentTodoListPanel.tsx
+++ b/src/renderer/src/pages/agents/components/AgentTodoListPanel.tsx
@@ -1,0 +1,588 @@
+import { Button, Tooltip } from '@cherrystudio/ui'
+import { cn } from '@renderer/utils/style'
+import {
+  Atom,
+  BookOpen,
+  Check,
+  ChevronDown,
+  Circle,
+  CodeXml,
+  FileText,
+  Globe,
+  ListFilter,
+  LoaderCircle,
+  Package,
+  Paintbrush,
+  Palette,
+  Rocket,
+  Search,
+  Settings,
+  Share2,
+  X
+} from 'lucide-react'
+import type { ComponentType, PropsWithChildren } from 'react'
+import { createContext, use, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+type AgentTodoStatus = 'completed' | 'in_progress' | 'pending'
+type AgentTodoDetailIcon = 'code' | 'globe' | 'package' | 'paintbrush' | 'rocket' | 'search' | 'settings'
+type AgentTodoResourceIcon = 'atom' | 'book' | 'file' | 'package' | 'palette' | 'search' | 'settings'
+
+interface AgentTodoItem {
+  id: string
+  labelKey: string
+  status: AgentTodoStatus
+}
+
+interface AgentTodoDetailResource {
+  id: string
+  icon: AgentTodoResourceIcon
+  labelKey: string
+  metaKey?: string
+}
+
+interface AgentTodoDetailGroup {
+  id: string
+  icon: AgentTodoDetailIcon
+  titleKey: string
+  summaryKey?: string
+  collectionTitleKey?: string
+  resources?: AgentTodoDetailResource[]
+}
+
+interface AgentTodoListState {
+  tasks: AgentTodoItem[]
+  details: AgentTodoDetailGroup[]
+  isTasksExpanded: boolean
+  isDetailsExpanded: boolean
+}
+
+interface AgentTodoListActions {
+  toggleTasks: () => void
+  toggleDetails: () => void
+}
+
+interface AgentTodoListMeta {
+  completedCount: number
+  totalCount: number
+}
+
+interface AgentTodoListContextValue {
+  state: AgentTodoListState
+  actions: AgentTodoListActions
+  meta: AgentTodoListMeta
+}
+
+interface AgentTodoListProviderProps extends PropsWithChildren {
+  tasks?: AgentTodoItem[]
+  details?: AgentTodoDetailGroup[]
+  defaultTasksExpanded?: boolean
+  defaultDetailsExpanded?: boolean
+}
+
+interface AgentTodoListRootProps extends PropsWithChildren {
+  className?: string
+}
+
+const MOCK_TASKS: AgentTodoItem[] = [
+  { id: 'search-web', labelKey: 'agent.todo.mock.tasks.searchWeb', status: 'completed' },
+  { id: 'review-references', labelKey: 'agent.todo.mock.tasks.reviewReferences', status: 'completed' },
+  { id: 'install-dependencies', labelKey: 'agent.todo.mock.tasks.installDependencies', status: 'completed' },
+  { id: 'configure-project', labelKey: 'agent.todo.mock.tasks.configureProject', status: 'completed' },
+  { id: 'write-components', labelKey: 'agent.todo.mock.tasks.writeComponents', status: 'completed' },
+  { id: 'write-pages', labelKey: 'agent.todo.mock.tasks.writePages', status: 'completed' },
+  { id: 'add-router', labelKey: 'agent.todo.mock.tasks.addRouter', status: 'in_progress' },
+  { id: 'add-linting', labelKey: 'agent.todo.mock.tasks.addLinting', status: 'pending' },
+  { id: 'build-deploy', labelKey: 'agent.todo.mock.tasks.buildDeploy', status: 'pending' },
+  { id: 'finish', labelKey: 'agent.todo.mock.tasks.finish', status: 'pending' }
+]
+
+const MOCK_DETAILS: AgentTodoDetailGroup[] = [
+  {
+    id: 'search-web',
+    icon: 'search',
+    titleKey: 'agent.todo.mock.details.searchWeb.title',
+    summaryKey: 'agent.todo.mock.details.searchWeb.summary',
+    resources: [
+      {
+        id: 'react-vite-query',
+        icon: 'search',
+        labelKey: 'agent.todo.mock.details.searchWeb.resources.reactViteQuery'
+      }
+    ]
+  },
+  {
+    id: 'review-references',
+    icon: 'globe',
+    titleKey: 'agent.todo.mock.details.reviewReferences.title',
+    collectionTitleKey: 'agent.todo.mock.details.reviewReferences.collectionTitle',
+    resources: [
+      {
+        id: 'vite-docs',
+        icon: 'book',
+        labelKey: 'agent.todo.mock.details.reviewReferences.resources.viteDocs',
+        metaKey: 'agent.todo.mock.details.reviewReferences.resources.viteMeta'
+      },
+      {
+        id: 'react-docs',
+        icon: 'atom',
+        labelKey: 'agent.todo.mock.details.reviewReferences.resources.reactDocs',
+        metaKey: 'agent.todo.mock.details.reviewReferences.resources.reactMeta'
+      },
+      {
+        id: 'tailwind-docs',
+        icon: 'palette',
+        labelKey: 'agent.todo.mock.details.reviewReferences.resources.tailwindDocs',
+        metaKey: 'agent.todo.mock.details.reviewReferences.resources.tailwindMeta'
+      },
+      {
+        id: 'npm-create-vite',
+        icon: 'package',
+        labelKey: 'agent.todo.mock.details.reviewReferences.resources.npmCreateVite',
+        metaKey: 'agent.todo.mock.details.reviewReferences.resources.npmMeta'
+      }
+    ]
+  },
+  {
+    id: 'install-dependencies',
+    icon: 'package',
+    titleKey: 'agent.todo.mock.details.installDependencies.title',
+    summaryKey: 'agent.todo.mock.details.installDependencies.summary',
+    resources: [
+      {
+        id: 'react-deps',
+        icon: 'package',
+        labelKey: 'agent.todo.mock.details.installDependencies.resources.reactDeps',
+        metaKey: 'agent.todo.mock.details.installDependencies.resources.dependenciesMeta'
+      },
+      {
+        id: 'tailwind-deps',
+        icon: 'package',
+        labelKey: 'agent.todo.mock.details.installDependencies.resources.tailwindDeps',
+        metaKey: 'agent.todo.mock.details.installDependencies.resources.devDependenciesMeta'
+      },
+      {
+        id: 'typescript-deps',
+        icon: 'package',
+        labelKey: 'agent.todo.mock.details.installDependencies.resources.typescriptDeps',
+        metaKey: 'agent.todo.mock.details.installDependencies.resources.devDependenciesMeta'
+      }
+    ]
+  },
+  {
+    id: 'configure-project',
+    icon: 'settings',
+    titleKey: 'agent.todo.mock.details.configureProject.title',
+    resources: [
+      {
+        id: 'tailwind-config',
+        icon: 'settings',
+        labelKey: 'agent.todo.mock.details.configureProject.resources.tailwindConfig',
+        metaKey: 'agent.todo.mock.details.configureProject.resources.createdMeta'
+      },
+      {
+        id: 'postcss-config',
+        icon: 'settings',
+        labelKey: 'agent.todo.mock.details.configureProject.resources.postcssConfig',
+        metaKey: 'agent.todo.mock.details.configureProject.resources.createdMeta'
+      },
+      {
+        id: 'vite-config',
+        icon: 'settings',
+        labelKey: 'agent.todo.mock.details.configureProject.resources.viteConfig',
+        metaKey: 'agent.todo.mock.details.configureProject.resources.updatedMeta'
+      }
+    ]
+  },
+  {
+    id: 'write-components',
+    icon: 'code',
+    titleKey: 'agent.todo.mock.details.writeComponents.title',
+    collectionTitleKey: 'agent.todo.mock.details.writeComponents.collectionTitle',
+    resources: [
+      {
+        id: 'header',
+        icon: 'file',
+        labelKey: 'agent.todo.mock.details.writeComponents.resources.header',
+        metaKey: 'agent.todo.mock.details.writeComponents.resources.newMeta'
+      },
+      {
+        id: 'footer',
+        icon: 'file',
+        labelKey: 'agent.todo.mock.details.writeComponents.resources.footer',
+        metaKey: 'agent.todo.mock.details.writeComponents.resources.newMeta'
+      },
+      {
+        id: 'card',
+        icon: 'file',
+        labelKey: 'agent.todo.mock.details.writeComponents.resources.card',
+        metaKey: 'agent.todo.mock.details.writeComponents.resources.newMeta'
+      },
+      {
+        id: 'button',
+        icon: 'file',
+        labelKey: 'agent.todo.mock.details.writeComponents.resources.button',
+        metaKey: 'agent.todo.mock.details.writeComponents.resources.modifiedMeta'
+      },
+      {
+        id: 'layout',
+        icon: 'file',
+        labelKey: 'agent.todo.mock.details.writeComponents.resources.layout',
+        metaKey: 'agent.todo.mock.details.writeComponents.resources.newMeta'
+      },
+      {
+        id: 'app',
+        icon: 'file',
+        labelKey: 'agent.todo.mock.details.writeComponents.resources.app',
+        metaKey: 'agent.todo.mock.details.writeComponents.resources.updatedMeta'
+      }
+    ]
+  },
+  {
+    id: 'write-pages',
+    icon: 'paintbrush',
+    titleKey: 'agent.todo.mock.details.writePages.title',
+    resources: [
+      {
+        id: 'home-page',
+        icon: 'file',
+        labelKey: 'agent.todo.mock.details.writePages.resources.home',
+        metaKey: 'agent.todo.mock.details.writePages.resources.newMeta'
+      },
+      {
+        id: 'about-page',
+        icon: 'file',
+        labelKey: 'agent.todo.mock.details.writePages.resources.about',
+        metaKey: 'agent.todo.mock.details.writePages.resources.newMeta'
+      }
+    ]
+  },
+  {
+    id: 'add-router',
+    icon: 'rocket',
+    titleKey: 'agent.todo.mock.details.addRouter.title',
+    summaryKey: 'agent.todo.mock.details.addRouter.summary'
+  }
+]
+
+const DETAIL_ICONS: Record<AgentTodoDetailIcon, ComponentType<{ className?: string; size?: number }>> = {
+  code: CodeXml,
+  globe: Globe,
+  package: Package,
+  paintbrush: Paintbrush,
+  rocket: Rocket,
+  search: Search,
+  settings: Settings
+}
+
+const RESOURCE_ICONS: Record<AgentTodoResourceIcon, ComponentType<{ className?: string; size?: number }>> = {
+  atom: Atom,
+  book: BookOpen,
+  file: FileText,
+  package: Package,
+  palette: Palette,
+  search: Search,
+  settings: Settings
+}
+
+const AgentTodoListContext = createContext<AgentTodoListContextValue | null>(null)
+
+const useAgentTodoList = () => {
+  const context = use(AgentTodoListContext)
+
+  if (!context) {
+    throw new Error('AgentTodoListPanel compound components must be used within AgentTodoListPanel.MockProvider')
+  }
+
+  return context
+}
+
+const AgentTodoListMockProvider = ({
+  children,
+  tasks = MOCK_TASKS,
+  details = MOCK_DETAILS,
+  defaultTasksExpanded = true,
+  defaultDetailsExpanded = true
+}: AgentTodoListProviderProps) => {
+  const [isTasksExpanded, setIsTasksExpanded] = useState(defaultTasksExpanded)
+  const [isDetailsExpanded, setIsDetailsExpanded] = useState(defaultDetailsExpanded)
+
+  const completedCount = useMemo(() => tasks.filter((task) => task.status === 'completed').length, [tasks])
+
+  const value = useMemo<AgentTodoListContextValue>(
+    () => ({
+      state: {
+        tasks,
+        details,
+        isTasksExpanded,
+        isDetailsExpanded
+      },
+      actions: {
+        toggleTasks: () => setIsTasksExpanded((expanded) => !expanded),
+        toggleDetails: () => setIsDetailsExpanded((expanded) => !expanded)
+      },
+      meta: {
+        completedCount,
+        totalCount: tasks.length
+      }
+    }),
+    [completedCount, details, isDetailsExpanded, isTasksExpanded, tasks]
+  )
+
+  return <AgentTodoListContext value={value}>{children}</AgentTodoListContext>
+}
+
+const AgentTodoListRoot = ({ children, className }: AgentTodoListRootProps) => (
+  <section
+    className={cn(
+      'mx-3 mt-3 mb-1 flex-shrink-0 overflow-hidden rounded-xl border border-border/60 bg-card shadow-sm',
+      className
+    )}>
+    {children}
+  </section>
+)
+
+const AgentTodoListHeader = () => {
+  const { t } = useTranslation()
+  const {
+    state: { isTasksExpanded },
+    actions: { toggleTasks },
+    meta: { completedCount, totalCount }
+  } = useAgentTodoList()
+
+  return (
+    <button
+      type="button"
+      className="flex w-full items-center gap-2 px-3.5 py-2.5 text-left transition-colors hover:bg-muted/50"
+      aria-expanded={isTasksExpanded}
+      onClick={toggleTasks}>
+      <ChevronDown
+        size={10}
+        className={cn('flex-shrink-0 text-muted-foreground transition-transform', !isTasksExpanded && '-rotate-90')}
+      />
+      <span className="min-w-0 flex-1 truncate text-[10.5px] text-foreground/85">{t('agent.todo.mock.title')}</span>
+      <span className="flex-shrink-0 text-[9px] text-muted-foreground tabular-nums">
+        {completedCount}/{totalCount}
+      </span>
+    </button>
+  )
+}
+
+const AgentTodoListTasks = () => {
+  const {
+    state: { isTasksExpanded, tasks }
+  } = useAgentTodoList()
+
+  if (!isTasksExpanded) {
+    return null
+  }
+
+  return (
+    <div className="px-3 pb-1">
+      {tasks.map((task) => (
+        <AgentTodoListTaskRow key={task.id} task={task} />
+      ))}
+    </div>
+  )
+}
+
+const AgentTodoListTaskRow = ({ task }: { task: AgentTodoItem }) => {
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex min-h-6 items-center gap-2 px-1 py-[5px]">
+      <AgentTodoListStatusIcon status={task.status} />
+      <span
+        className={cn(
+          'min-w-0 flex-1 truncate text-[11px]',
+          task.status === 'completed' && 'text-foreground/80',
+          task.status === 'in_progress' && 'text-foreground',
+          task.status === 'pending' && 'text-muted-foreground/50'
+        )}>
+        {t(task.labelKey)}
+      </span>
+    </div>
+  )
+}
+
+const AgentTodoListStatusIcon = ({ status }: { status: AgentTodoStatus }) => {
+  if (status === 'completed') {
+    return (
+      <span className="flex size-4 flex-shrink-0 items-center justify-center rounded bg-primary/10 text-primary">
+        <Check size={10} />
+      </span>
+    )
+  }
+
+  if (status === 'in_progress') {
+    return (
+      <span className="flex size-4 flex-shrink-0 items-center justify-center text-primary">
+        <LoaderCircle size={11} className="animate-spin" />
+      </span>
+    )
+  }
+
+  return (
+    <span className="flex size-4 flex-shrink-0 items-center justify-center text-muted-foreground/30">
+      <Circle size={10} />
+    </span>
+  )
+}
+
+const AgentTodoListDetails = () => {
+  const { t } = useTranslation()
+  const {
+    state: { details, isDetailsExpanded },
+    actions: { toggleDetails }
+  } = useAgentTodoList()
+
+  return (
+    <div>
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 border-border/40 border-t px-4 py-2 text-left transition-colors hover:bg-muted/50"
+        aria-expanded={isDetailsExpanded}
+        onClick={toggleDetails}>
+        <ChevronDown
+          size={9}
+          className={cn(
+            'flex-shrink-0 text-muted-foreground/60 transition-transform',
+            !isDetailsExpanded && '-rotate-90'
+          )}
+        />
+        <span className="min-w-0 flex-1 truncate text-[10px] text-muted-foreground">
+          {t('agent.todo.mock.details.title')}
+        </span>
+      </button>
+      {isDetailsExpanded && (
+        <div className="px-3 pb-2">
+          {details.map((detail) => (
+            <AgentTodoListDetailGroup key={detail.id} detail={detail} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+const AgentTodoListDetailGroup = ({ detail }: { detail: AgentTodoDetailGroup }) => {
+  const { t } = useTranslation()
+  const Icon = DETAIL_ICONS[detail.icon]
+  const resourceCount = detail.resources?.length ?? 0
+
+  return (
+    <div className="mb-1.5">
+      <div className="mb-1 flex items-center gap-1.5 px-1">
+        <Icon size={10} className="text-primary" />
+        <span className="min-w-0 flex-1 truncate text-[10px] text-muted-foreground">{t(detail.titleKey)}</span>
+      </div>
+      <div className="mb-1 ml-6">
+        {detail.summaryKey && (
+          <div className="mb-1 rounded-md bg-muted/60 px-3 py-2">
+            <p className="m-0 text-[10px] text-foreground/60 leading-[1.6]">{t(detail.summaryKey)}</p>
+          </div>
+        )}
+        {!!resourceCount && (
+          <div className="overflow-hidden rounded-md bg-muted/60">
+            {detail.collectionTitleKey && (
+              <div className="flex items-center justify-between border-border/40 border-b px-3 py-1.5">
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <span className="truncate text-[10px] text-muted-foreground">{t(detail.collectionTitleKey)}</span>
+                  <span className="text-[9px] text-muted-foreground/60">{resourceCount}</span>
+                </div>
+                <Share2 size={9} className="flex-shrink-0 text-muted-foreground/50" />
+              </div>
+            )}
+            <div className="py-0.5">
+              {detail.resources?.map((resource) => (
+                <AgentTodoListDetailResource key={resource.id} resource={resource} />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const AgentTodoListDetailResource = ({ resource }: { resource: AgentTodoDetailResource }) => {
+  const { t } = useTranslation()
+  const Icon = RESOURCE_ICONS[resource.icon]
+
+  return (
+    <div className="flex items-center gap-2 px-3 py-[4px] transition-colors hover:bg-muted/80">
+      <span className="flex size-4 flex-shrink-0 items-center justify-center rounded bg-muted text-[10px]">
+        <Icon size={10} className="text-muted-foreground/70" />
+      </span>
+      <span className="min-w-0 flex-1 truncate text-[10.5px] text-foreground/70">{t(resource.labelKey)}</span>
+      {resource.metaKey && (
+        <span className="flex-shrink-0 text-[9px] text-muted-foreground/60">{t(resource.metaKey)}</span>
+      )}
+    </div>
+  )
+}
+
+const AgentTodoListFooter = () => {
+  const { t } = useTranslation()
+  const {
+    meta: { completedCount, totalCount }
+  } = useAgentTodoList()
+
+  return (
+    <div className="flex items-center gap-2 border-border/40 border-t px-3.5 py-2">
+      <ListFilter size={11} className="flex-shrink-0 text-muted-foreground/60" />
+      <span className="min-w-0 flex-1 truncate text-[10px] text-muted-foreground">
+        {t('agent.todo.mock.progress', { completed: completedCount, total: totalCount })}
+      </span>
+      <Tooltip content={t('agent.todo.mock.actions.dismiss')}>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="size-5 text-primary"
+          aria-label={t('agent.todo.mock.actions.dismiss')}
+          disabled>
+          <X size={10} />
+        </Button>
+      </Tooltip>
+      <Tooltip content={t('agent.todo.mock.actions.complete')}>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="size-5 text-primary"
+          aria-label={t('agent.todo.mock.actions.complete')}
+          disabled>
+          <Check size={11} />
+        </Button>
+      </Tooltip>
+    </div>
+  )
+}
+
+const AgentTodoListPanelView = ({ className }: { className?: string }) => (
+  <AgentTodoListPanel.Root className={className}>
+    <AgentTodoListPanel.Header />
+    <AgentTodoListPanel.Tasks />
+    <AgentTodoListPanel.Details />
+    <AgentTodoListPanel.Footer />
+  </AgentTodoListPanel.Root>
+)
+
+const AgentTodoListPanelDefault = ({ className }: { className?: string }) => (
+  <AgentTodoListPanel.MockProvider>
+    <AgentTodoListPanelView className={className} />
+  </AgentTodoListPanel.MockProvider>
+)
+
+export const AgentTodoListPanel = {
+  MockProvider: AgentTodoListMockProvider,
+  Root: AgentTodoListRoot,
+  Header: AgentTodoListHeader,
+  Tasks: AgentTodoListTasks,
+  Details: AgentTodoListDetails,
+  Footer: AgentTodoListFooter
+}
+
+export type { AgentTodoDetailGroup, AgentTodoItem, AgentTodoStatus }
+export default AgentTodoListPanelDefault

--- a/src/renderer/src/pages/agents/components/AgentTodoListPanel.tsx
+++ b/src/renderer/src/pages/agents/components/AgentTodoListPanel.tsx
@@ -1,27 +1,7 @@
 /**
- * Mock-only Agent todo list panel.
- *
- * This file currently renders static fixture data through AgentTodoListPanel.MockProvider.
- * It is intentionally not connected to any production API, agent session stream, or scheduled
- * task endpoint. The mock data exists only to preview the UI shape and composition API while
- * the real agent execution todo/progress contract is still undecided.
- *
- * When wiring real data later, keep this component presentational and add a connected wrapper
- * or real provider beside it. That wrapper should:
- * - accept the scope needed to query data, such as agentId plus sessionId/runId if the todo list
- *   represents one agent execution rather than scheduled tasks.
- * - fetch/subscribe to the real source of truth, then map the response into AgentTodoItem[] and
- *   AgentTodoDetailGroup[] before passing it into the provider.
- * - provide stable task ids, display labels or i18n keys, status values
- *   ('completed' | 'in_progress' | 'pending'), detail group ids/icons/titles, optional summaries,
- *   and optional resource rows with ids/icons/labels/meta.
- * - expose action handlers only from the provider layer when they become real, such as complete,
- *   dismiss, retry, refresh, or open-resource actions. The visual subcomponents should continue
- *   reading from context instead of calling APIs directly.
- *
- * Do not treat /agents/:agentId/tasks as the default backing API unless the product meaning is
- * actually "scheduled tasks". This panel currently models execution progress/todos, which may
- * need a session/run-scoped API instead.
+ * Mock-only preview: tasks and details come from in-file fixtures, not a real data source.
+ * Lives in ComponentLabSettings so the visual contract can be reviewed before the agent
+ * execution todo/progress API is decided.
  */
 import { Button, Tooltip } from '@cherrystudio/ui'
 import { cn } from '@renderer/utils/style'
@@ -316,7 +296,7 @@ const useAgentTodoList = () => {
   const context = use(AgentTodoListContext)
 
   if (!context) {
-    throw new Error('AgentTodoListPanel compound components must be used within AgentTodoListPanel.MockProvider')
+    throw new Error('AgentTodoListPanel compound components must be used within an AgentTodoListPanel provider')
   }
 
   return context
@@ -581,18 +561,18 @@ const AgentTodoListFooter = () => {
 }
 
 const AgentTodoListPanelView = ({ className }: { className?: string }) => (
-  <AgentTodoListPanel.Root className={className}>
-    <AgentTodoListPanel.Header />
-    <AgentTodoListPanel.Tasks />
-    <AgentTodoListPanel.Details />
-    <AgentTodoListPanel.Footer />
-  </AgentTodoListPanel.Root>
+  <AgentTodoListRoot className={className}>
+    <AgentTodoListHeader />
+    <AgentTodoListTasks />
+    <AgentTodoListDetails />
+    <AgentTodoListFooter />
+  </AgentTodoListRoot>
 )
 
 const AgentTodoListPanelDefault = ({ className }: { className?: string }) => (
-  <AgentTodoListPanel.MockProvider>
+  <AgentTodoListMockProvider>
     <AgentTodoListPanelView className={className} />
-  </AgentTodoListPanel.MockProvider>
+  </AgentTodoListMockProvider>
 )
 
 export const AgentTodoListPanel = {
@@ -604,5 +584,12 @@ export const AgentTodoListPanel = {
   Footer: AgentTodoListFooter
 }
 
-export type { AgentTodoDetailGroup, AgentTodoItem, AgentTodoStatus }
+export type {
+  AgentTodoDetailGroup,
+  AgentTodoDetailIcon,
+  AgentTodoDetailResource,
+  AgentTodoItem,
+  AgentTodoResourceIcon,
+  AgentTodoStatus
+}
 export default AgentTodoListPanelDefault

--- a/src/renderer/src/pages/agents/components/__tests__/AgentTodoListPanel.test.tsx
+++ b/src/renderer/src/pages/agents/components/__tests__/AgentTodoListPanel.test.tsx
@@ -2,7 +2,8 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import type { PropsWithChildren } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 
-import AgentTodoListPanel from '../AgentTodoListPanel'
+import type { AgentTodoItem } from '../AgentTodoListPanel'
+import AgentTodoListPanel, { AgentTodoListPanel as AgentTodoListPanelCompound } from '../AgentTodoListPanel'
 
 const translations: Record<string, string> = {
   'agent.todo.mock.actions.complete': 'Complete',
@@ -81,6 +82,33 @@ vi.mock('@cherrystudio/ui', () => ({
   Tooltip: ({ children }: PropsWithChildren<{ content?: React.ReactNode }>) => <>{children}</>
 }))
 
+vi.mock('lucide-react', () => {
+  const icon =
+    (testId: string) =>
+    ({ className }: { className?: string; size?: number }) => <svg data-testid={testId} className={className} />
+
+  return {
+    Atom: icon('atom-icon'),
+    BookOpen: icon('book-icon'),
+    Check: icon('check-icon'),
+    ChevronDown: icon('chevron-down-icon'),
+    Circle: icon('circle-icon'),
+    CodeXml: icon('code-icon'),
+    FileText: icon('file-icon'),
+    Globe: icon('globe-icon'),
+    ListFilter: icon('list-filter-icon'),
+    LoaderCircle: icon('loader-circle-icon'),
+    Package: icon('package-icon'),
+    Paintbrush: icon('paintbrush-icon'),
+    Palette: icon('palette-icon'),
+    Rocket: icon('rocket-icon'),
+    Search: icon('search-icon'),
+    Settings: icon('settings-icon'),
+    Share2: icon('share-icon'),
+    X: icon('x-icon')
+  }
+})
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string, values?: Record<string, number>) => {
@@ -96,6 +124,26 @@ vi.mock('react-i18next', () => ({
     }
   })
 }))
+
+const renderTasksOnly = (tasks: AgentTodoItem[]) =>
+  render(
+    <AgentTodoListPanelCompound.MockProvider tasks={tasks} details={[]}>
+      <AgentTodoListPanelCompound.Root>
+        <AgentTodoListPanelCompound.Tasks />
+      </AgentTodoListPanelCompound.Root>
+    </AgentTodoListPanelCompound.MockProvider>
+  )
+
+const renderPanelWithTasks = (tasks: AgentTodoItem[]) =>
+  render(
+    <AgentTodoListPanelCompound.MockProvider tasks={tasks} details={[]}>
+      <AgentTodoListPanelCompound.Root>
+        <AgentTodoListPanelCompound.Header />
+        <AgentTodoListPanelCompound.Tasks />
+        <AgentTodoListPanelCompound.Footer />
+      </AgentTodoListPanelCompound.Root>
+    </AgentTodoListPanelCompound.MockProvider>
+  )
 
 describe('AgentTodoListPanel', () => {
   it('renders the default mock task panel', () => {
@@ -133,5 +181,42 @@ describe('AgentTodoListPanel', () => {
 
     fireEvent.click(detailsToggle)
     expect(screen.getByText('React Vite TypeScript starter 2025 best practices')).toBeInTheDocument()
+  })
+
+  it('renders the completed status icon for completed tasks', () => {
+    renderTasksOnly([{ id: 'completed-task', labelKey: 'agent.todo.mock.tasks.searchWeb', status: 'completed' }])
+
+    expect(screen.getByTestId('check-icon')).toBeInTheDocument()
+  })
+
+  it('renders the spinning loader status icon for in_progress tasks', () => {
+    renderTasksOnly([{ id: 'active-task', labelKey: 'agent.todo.mock.tasks.addRouter', status: 'in_progress' }])
+
+    const loaderIcon = screen.getByTestId('loader-circle-icon')
+    expect(loaderIcon).toBeInTheDocument()
+    expect(loaderIcon).toHaveClass('animate-spin')
+  })
+
+  it('renders the pending status icon for pending tasks', () => {
+    renderTasksOnly([{ id: 'pending-task', labelKey: 'agent.todo.mock.tasks.addLinting', status: 'pending' }])
+
+    expect(screen.getByTestId('circle-icon')).toBeInTheDocument()
+  })
+
+  it('uses provided tasks instead of default mock tasks', () => {
+    renderPanelWithTasks([{ id: 'custom-task', labelKey: 'agent.todo.custom.task', status: 'pending' }])
+
+    expect(screen.getByText('agent.todo.custom.task')).toBeInTheDocument()
+    expect(screen.queryByText('Search web references')).not.toBeInTheDocument()
+  })
+
+  it('derives completed progress from provided tasks', () => {
+    renderPanelWithTasks([
+      { id: 'completed-task', labelKey: 'agent.todo.mock.tasks.searchWeb', status: 'completed' },
+      { id: 'active-task', labelKey: 'agent.todo.mock.tasks.addRouter', status: 'in_progress' },
+      { id: 'pending-task', labelKey: 'agent.todo.mock.tasks.addLinting', status: 'pending' }
+    ])
+
+    expect(screen.getByText('1/3 tasks completed')).toBeInTheDocument()
   })
 })

--- a/src/renderer/src/pages/agents/components/__tests__/AgentTodoListPanel.test.tsx
+++ b/src/renderer/src/pages/agents/components/__tests__/AgentTodoListPanel.test.tsx
@@ -1,0 +1,137 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { PropsWithChildren } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import AgentTodoListPanel from '../AgentTodoListPanel'
+
+const translations: Record<string, string> = {
+  'agent.todo.mock.actions.complete': 'Complete',
+  'agent.todo.mock.actions.dismiss': 'Dismiss',
+  'agent.todo.mock.details.addRouter.summary': 'Configuring client routing with react-router-dom v6...',
+  'agent.todo.mock.details.addRouter.title': 'Add React Router',
+  'agent.todo.mock.details.configureProject.resources.createdMeta': 'created',
+  'agent.todo.mock.details.configureProject.resources.postcssConfig': 'postcss.config.js',
+  'agent.todo.mock.details.configureProject.resources.tailwindConfig': 'tailwind.config.js',
+  'agent.todo.mock.details.configureProject.resources.updatedMeta': 'updated',
+  'agent.todo.mock.details.configureProject.resources.viteConfig': 'vite.config.ts - port 3001',
+  'agent.todo.mock.details.configureProject.title': 'Configure project',
+  'agent.todo.mock.details.installDependencies.resources.dependenciesMeta': 'dependencies',
+  'agent.todo.mock.details.installDependencies.resources.devDependenciesMeta': 'devDependencies',
+  'agent.todo.mock.details.installDependencies.resources.reactDeps': 'react@18.3.1, react-dom@18.3.1',
+  'agent.todo.mock.details.installDependencies.resources.tailwindDeps': 'tailwindcss@3.4.4, postcss@8.4.38',
+  'agent.todo.mock.details.installDependencies.resources.typescriptDeps': 'typescript@5.4.5, vite@5.3.0',
+  'agent.todo.mock.details.installDependencies.summary':
+    'Installed react, react-dom, tailwindcss, postcss, autoprefixer, and TypeScript.',
+  'agent.todo.mock.details.installDependencies.title': 'Install dependencies',
+  'agent.todo.mock.details.reviewReferences.collectionTitle': 'Reviewed references',
+  'agent.todo.mock.details.reviewReferences.resources.npmCreateVite': 'npm create vite - Official Scaffolding',
+  'agent.todo.mock.details.reviewReferences.resources.npmMeta': 'npmjs.com',
+  'agent.todo.mock.details.reviewReferences.resources.reactDocs': 'React Documentation - Quick Start',
+  'agent.todo.mock.details.reviewReferences.resources.reactMeta': 'react.dev',
+  'agent.todo.mock.details.reviewReferences.resources.tailwindDocs': 'Tailwind CSS - Installation Guide',
+  'agent.todo.mock.details.reviewReferences.resources.tailwindMeta': 'tailwindcss.com',
+  'agent.todo.mock.details.reviewReferences.resources.viteDocs': 'Vite - Next Generation Frontend Tooling',
+  'agent.todo.mock.details.reviewReferences.resources.viteMeta': 'vitejs.dev',
+  'agent.todo.mock.details.reviewReferences.title': 'Review references',
+  'agent.todo.mock.details.searchWeb.resources.reactViteQuery': 'React Vite TypeScript starter 2025 best practices',
+  'agent.todo.mock.details.searchWeb.summary':
+    'Collected current references for React + Vite scaffolding and best practices.',
+  'agent.todo.mock.details.searchWeb.title': 'Search web references',
+  'agent.todo.mock.details.title': 'Execution details',
+  'agent.todo.mock.details.writeComponents.collectionTitle': 'Created files',
+  'agent.todo.mock.details.writeComponents.resources.app': 'src/App.tsx',
+  'agent.todo.mock.details.writeComponents.resources.button': 'src/components/Button.tsx',
+  'agent.todo.mock.details.writeComponents.resources.card': 'src/components/Card.tsx',
+  'agent.todo.mock.details.writeComponents.resources.footer': 'src/components/Footer.tsx',
+  'agent.todo.mock.details.writeComponents.resources.header': 'src/components/Header.tsx',
+  'agent.todo.mock.details.writeComponents.resources.layout': 'src/components/Layout.tsx',
+  'agent.todo.mock.details.writeComponents.resources.modifiedMeta': 'modified',
+  'agent.todo.mock.details.writeComponents.resources.newMeta': 'new',
+  'agent.todo.mock.details.writeComponents.resources.updatedMeta': 'updated',
+  'agent.todo.mock.details.writeComponents.title': 'Write components',
+  'agent.todo.mock.details.writePages.resources.about': 'src/pages/About.tsx',
+  'agent.todo.mock.details.writePages.resources.home': 'src/pages/Home.tsx',
+  'agent.todo.mock.details.writePages.resources.newMeta': 'new',
+  'agent.todo.mock.details.writePages.title': 'Write pages',
+  'agent.todo.mock.progress': '{{completed}}/{{total}} tasks completed',
+  'agent.todo.mock.tasks.addLinting': 'Add ESLint + Prettier',
+  'agent.todo.mock.tasks.addRouter': 'Add React Router',
+  'agent.todo.mock.tasks.buildDeploy': 'Build and deploy',
+  'agent.todo.mock.tasks.configureProject': 'Configure project',
+  'agent.todo.mock.tasks.finish': 'Finish',
+  'agent.todo.mock.tasks.installDependencies': 'Install dependencies',
+  'agent.todo.mock.tasks.reviewReferences': 'Review references',
+  'agent.todo.mock.tasks.searchWeb': 'Search web references',
+  'agent.todo.mock.tasks.writeComponents': 'Write components',
+  'agent.todo.mock.tasks.writePages': 'Write pages',
+  'agent.todo.mock.title': 'Tasks'
+}
+
+vi.mock('@cherrystudio/ui', () => ({
+  Button: ({
+    children,
+    disabled,
+    onClick,
+    ...props
+  }: PropsWithChildren<{ disabled?: boolean; onClick?: React.MouseEventHandler<HTMLButtonElement> }>) => (
+    <button type="button" disabled={disabled} onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
+  Tooltip: ({ children }: PropsWithChildren<{ content?: React.ReactNode }>) => <>{children}</>
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: Record<string, number>) => {
+      let text = translations[key] ?? key
+
+      if (values) {
+        for (const [name, value] of Object.entries(values)) {
+          text = text.replace(`{{${name}}}`, String(value))
+        }
+      }
+
+      return text
+    }
+  })
+}))
+
+describe('AgentTodoListPanel', () => {
+  it('renders the default mock task panel', () => {
+    render(<AgentTodoListPanel />)
+
+    expect(screen.getByRole('button', { name: /tasks 6\/10/i })).toBeInTheDocument()
+    expect(screen.getAllByText('Search web references')).toHaveLength(2)
+    expect(screen.getAllByText('Add React Router')).toHaveLength(2)
+    expect(screen.getByText('Add ESLint + Prettier')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /execution details/i })).toBeInTheDocument()
+    expect(screen.getByText('6/10 tasks completed')).toBeInTheDocument()
+  })
+
+  it('collapses and expands the task list', () => {
+    render(<AgentTodoListPanel />)
+
+    const taskToggle = screen.getByRole('button', { name: /tasks 6\/10/i })
+    expect(screen.getByText('Add ESLint + Prettier')).toBeInTheDocument()
+
+    fireEvent.click(taskToggle)
+    expect(screen.queryByText('Add ESLint + Prettier')).not.toBeInTheDocument()
+
+    fireEvent.click(taskToggle)
+    expect(screen.getByText('Add ESLint + Prettier')).toBeInTheDocument()
+  })
+
+  it('collapses and expands the execution details', () => {
+    render(<AgentTodoListPanel />)
+
+    const detailsToggle = screen.getByRole('button', { name: /execution details/i })
+    expect(screen.getByText('React Vite TypeScript starter 2025 best practices')).toBeInTheDocument()
+
+    fireEvent.click(detailsToggle)
+    expect(screen.queryByText('React Vite TypeScript starter 2025 best practices')).not.toBeInTheDocument()
+
+    fireEvent.click(detailsToggle)
+    expect(screen.getByText('React Vite TypeScript starter 2025 best practices')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/pages/settings/ComponentLabSettings.tsx
+++ b/src/renderer/src/pages/settings/ComponentLabSettings.tsx
@@ -1,5 +1,6 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@cherrystudio/ui'
 import { useTheme } from '@renderer/context/ThemeProvider'
+import AgentTodoListPanel from '@renderer/pages/agents/components/AgentTodoListPanel'
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -21,6 +22,7 @@ const ComponentLabSettings: FC = () => {
             <TabsTrigger value="assistant-selector">{t('settings.componentLab.assistantSelector.title')}</TabsTrigger>
             <TabsTrigger value="agent-selector">{t('settings.componentLab.agentSelector.title')}</TabsTrigger>
             <TabsTrigger value="model-selector">{t('settings.componentLab.modelSelector.title')}</TabsTrigger>
+            <TabsTrigger value="agent-todo-list">{t('settings.componentLab.agentTodoList.title')}</TabsTrigger>
           </TabsList>
 
           <TabsContent value="assistant-selector" className="mt-0">
@@ -31,6 +33,9 @@ const ComponentLabSettings: FC = () => {
           </TabsContent>
           <TabsContent value="model-selector" className="mt-0">
             <ComponentLabModelSelectorSettings />
+          </TabsContent>
+          <TabsContent value="agent-todo-list" className="mt-0 max-w-3xl">
+            <AgentTodoListPanel />
           </TabsContent>
         </Tabs>
       </SettingGroup>


### PR DESCRIPTION
### What this PR does

Before this PR:

There was no React component preview for the agent todo list HTML mockup inside the app.

After this PR:

Adds a mock-only `AgentTodoListPanel` component using compound component composition, static fixture data, and localized display strings. The component is temporarily exposed in the development-only Settings Component Lab so reviewers can inspect the UI without wiring production data.

<img width="763" height="594" alt="image" src="https://github.com/user-attachments/assets/f472e76b-4e8c-42db-9117-e501e199882f" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The panel is intentionally mock-only for now. A file-level note documents the future data contract and warns not to assume `/agents/:agentId/tasks` is the backing API unless the product meaning is scheduled tasks. The preview is mounted in Component Lab instead of Agent Chat to avoid changing the real chat workflow.

The following alternatives were considered:

Mounting the panel directly in Agent Chat was considered for quick visual inspection, but it would pollute the production workflow surface. Building real API integration now was also deferred because the execution todo/progress contract is not finalized.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR adds a visual mock and preview surface only. It does not connect to real agent execution state, scheduled tasks, or session streams.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
