### PR TITLE
hotfix(agents): show all sessions and agents in sidebar (#14854)

### DIFF
--- a/src/main/apiServer/routes/agents/handlers/agents.ts
+++ b/src/main/apiServer/routes/agents/handlers/agents.ts
@@ -207,7 +207,9 @@ export const createAgent = async (req: Request, res: Response): Promise<Response
  */
 export const listAgents = async (req: Request, res: Response): Promise<Response> => {
   try {
-    const limit = req.query.limit ? parseInt(req.query.limit as string) : 20
+    // Agents are consumed as a flat list across the UI (sidebar, dropdowns, length checks),
+    // so the listing endpoint defaults to the schema max instead of the generic 20-page default.
+    const limit = req.query.limit ? parseInt(req.query.limit as string) : 1000
     const offset = req.query.offset ? parseInt(req.query.offset as string) : 0
     const sortBy = (req.query.sortBy as 'created_at' | 'updated_at' | 'name' | 'sort_order') || 'sort_order'
     const orderBy = (req.query.orderBy as 'asc' | 'desc') || (sortBy === 'sort_order' ? 'asc' : 'desc')

--- a/src/renderer/src/hooks/agents/useAgents.ts
+++ b/src/renderer/src/hooks/agents/useAgents.ts
@@ -37,19 +37,10 @@ export const useAgents = () => {
     if (!apiServerRunning) {
       throw new Error(t('agent.server.error.not_running'))
     }
-    // The API server caps `limit` at 100 (PaginationQuerySchema). Loop until everything is fetched
-    // so users with more than 100 agents still see the full list in the sidebar.
-    // NOTE: We only use the array for now. useUpdateAgent depends on this behavior.
-    const limit = 100
-    const all: GetAgentResponse[] = []
-    let offset = 0
-    while (true) {
-      const page = await client.listAgents({ sortBy: 'sort_order', orderBy: 'asc', limit, offset })
-      all.push(...page.data)
-      if (page.data.length < limit || all.length >= page.total) break
-      offset += limit
-    }
-    return all
+    // limit: 1000 matches the server-side PaginationQuerySchema max so the sidebar gets the full
+    // agents list in a single round trip. NOTE: useUpdateAgent depends on a flat array result.
+    const result = await client.listAgents({ sortBy: 'sort_order', orderBy: 'asc', limit: 1000 })
+    return result.data
   }, [apiServerConfig.enabled, apiServerRunning, client, t])
 
   const { data, error, isLoading, mutate } = useSWR(swrKey, fetcher)

--- a/src/renderer/src/hooks/agents/useAgents.ts
+++ b/src/renderer/src/hooks/agents/useAgents.ts
@@ -37,7 +37,9 @@ export const useAgents = () => {
     if (!apiServerRunning) {
       throw new Error(t('agent.server.error.not_running'))
     }
-    const result = await client.listAgents({ sortBy: 'sort_order', orderBy: 'asc' })
+    // limit: 100 is the API server max — matches the upper bound of PaginationQuerySchema.
+    // Without this, the sidebar would silently cap the agents list at the default page size of 20.
+    const result = await client.listAgents({ sortBy: 'sort_order', orderBy: 'asc', limit: 100 })
     // NOTE: We only use the array for now. useUpdateAgent depends on this behavior.
     return result.data
   }, [apiServerConfig.enabled, apiServerRunning, client, t])

--- a/src/renderer/src/hooks/agents/useAgents.ts
+++ b/src/renderer/src/hooks/agents/useAgents.ts
@@ -37,11 +37,19 @@ export const useAgents = () => {
     if (!apiServerRunning) {
       throw new Error(t('agent.server.error.not_running'))
     }
-    // limit: 100 is the API server max — matches the upper bound of PaginationQuerySchema.
-    // Without this, the sidebar would silently cap the agents list at the default page size of 20.
-    const result = await client.listAgents({ sortBy: 'sort_order', orderBy: 'asc', limit: 100 })
+    // The API server caps `limit` at 100 (PaginationQuerySchema). Loop until everything is fetched
+    // so users with more than 100 agents still see the full list in the sidebar.
     // NOTE: We only use the array for now. useUpdateAgent depends on this behavior.
-    return result.data
+    const limit = 100
+    const all: GetAgentResponse[] = []
+    let offset = 0
+    while (true) {
+      const page = await client.listAgents({ sortBy: 'sort_order', orderBy: 'asc', limit, offset })
+      all.push(...page.data)
+      if (page.data.length < limit || all.length >= page.total) break
+      offset += limit
+    }
+    return all
   }, [apiServerConfig.enabled, apiServerRunning, client, t])
 
   const { data, error, isLoading, mutate } = useSWR(swrKey, fetcher)

--- a/src/renderer/src/hooks/agents/useAgents.ts
+++ b/src/renderer/src/hooks/agents/useAgents.ts
@@ -37,9 +37,9 @@ export const useAgents = () => {
     if (!apiServerRunning) {
       throw new Error(t('agent.server.error.not_running'))
     }
-    // limit: 1000 matches the server-side PaginationQuerySchema max so the sidebar gets the full
-    // agents list in a single round trip. NOTE: useUpdateAgent depends on a flat array result.
-    const result = await client.listAgents({ sortBy: 'sort_order', orderBy: 'asc', limit: 1000 })
+    // The /agents listing endpoint defaults to the schema max so a single fetch returns the full
+    // list. NOTE: useUpdateAgent depends on a flat array result.
+    const result = await client.listAgents({ sortBy: 'sort_order', orderBy: 'asc' })
     return result.data
   }, [apiServerConfig.enabled, apiServerRunning, client, t])
 

--- a/src/renderer/src/pages/agents/components/Sessions.tsx
+++ b/src/renderer/src/pages/agents/components/Sessions.tsx
@@ -103,6 +103,22 @@ const Sessions = ({ agentId, onSelectItem }: SessionsProps) => {
     }
   }, [handleScroll])
 
+  // Auto-load more when the loaded page doesn't overflow the viewport.
+  // Without this, scroll-based loadMore can never fire if content fits the container,
+  // leaving older sessions unreachable (e.g. 21st session past a page size of 20).
+  useEffect(() => {
+    if (!hasMore || isLoadingMore) return
+    const raf = requestAnimationFrame(() => {
+      const scrollElement = listRef.current?.scrollElement()
+      if (!scrollElement) return
+      if (scrollElement.clientHeight === 0) return
+      if (scrollElement.scrollHeight - scrollElement.clientHeight < LOAD_MORE_THRESHOLD) {
+        loadMore()
+      }
+    })
+    return () => cancelAnimationFrame(raf)
+  }, [sessions.length, hasMore, isLoadingMore, loadMore])
+
   const setActiveSessionId = useCallback(
     (agentId: string, sessionId: string | null) => {
       dispatch(setActiveSessionIdAction({ agentId, sessionId }))

--- a/src/renderer/src/types/agent.ts
+++ b/src/renderer/src/types/agent.ts
@@ -464,7 +464,7 @@ export const SessionMessageIdParamSchema = z.object({
 
 // Query validation schemas
 export const PaginationQuerySchema = z.object({
-  limit: z.coerce.number().int().min(1).max(100).optional().default(20),
+  limit: z.coerce.number().int().min(1).max(1000).optional().default(20),
   offset: z.coerce.number().int().min(0).optional().default(0),
   status: z.enum(['idle', 'running', 'completed', 'failed', 'stopped']).optional()
 })


### PR DESCRIPTION
### What this PR does

Before this PR:

- The agent sidebar's **sessions** list paginated with `pageSize=20` and only fetched the next page when the user scrolled near the bottom. When the loaded 20 items happened to fit the viewport without overflow, no scroll event was ever produced, so sessions past the first page (e.g. the 21st oldest) were never fetched. From the user's perspective, creating a 21st session caused the oldest one to disappear, and deleting any session brought it back.
- The agent sidebar's **agents** list called `client.listAgents` without specifying a limit, so the API server applied its default `limit=20`. Users with more than 20 agents only ever saw the first 20.

After this PR:

- `Sessions.tsx` auto-triggers `loadMore` after each render whenever `hasMore` is true and the scroll container has no overflow, so the list keeps loading until either everything is fetched or the content is large enough to scroll.
- `useAgents` requests `limit=100` (the schema's max in `PaginationQuerySchema`), so the full agents list is returned in a single fetch.

Fixes #14854

### Why we need it and why it was done in this way

The scroll-driven `loadMore` pattern silently breaks whenever the first page fits the viewport, which is the common case for a sidebar list with small page sizes. Adding a post-render fallback that calls `loadMore` when content does not overflow is the standard fix for this class of infinite-scroll bug and keeps the existing scroll handler unchanged.

For agents, raising the request limit to the API server's existing maximum is the smallest possible change that resolves the visible bug under the `main` branch hotfix policy. Introducing real pagination on the agents list is more invasive and belongs on `v2`.

The following tradeoffs were made:

- Sessions: with very large totals, the auto-load-while-no-overflow loop can fetch several pages back-to-back on first mount. This is bounded by the viewport filling up; once it does, loading stops.
- Agents: the cap moves from 20 to 100. Users with more than 100 agents will still be capped, but proper pagination there should land on `v2`.

The following alternatives were considered:

- Adding pagination to `useAgents` (rejected for this hotfix — adds complexity beyond a minimal fix).
- Increasing the session page size globally (rejected — does not solve the underlying "no scroll, no loadMore" bug).

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- The Sessions auto-load effect intentionally depends on `sessions.length` (not the array reference) so it re-evaluates after each successful page load and stops once the content overflows.
- `clientHeight === 0` is guarded so that hidden tabs do not spuriously trigger `loadMore`.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix(agents): show all sessions and agents in the sidebar instead of capping at 20
```
