### PR TITLE
fix(ui): use SVG flag images to fix emoji border artifact on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@paymoapp/electron-shutdown-handler": "1.1.2",
     "cron-parser": "^5.0.8",
     "express": "5.1.0",
+    "flag-icons": "^7.5.0",
     "font-list": "2.0.0",
     "graceful-fs": "4.2.11",
     "grammy": "^1.36.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       express:
         specifier: 5.1.0
         version: 5.1.0
+      flag-icons:
+        specifier: ^7.5.0
+        version: 7.5.0
       font-list:
         specifier: 2.0.0
         version: 2.0.0
@@ -1957,24 +1960,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.2.4':
     resolution: {integrity: sha512-M/Iz48p4NAzMXOuH+tsn5BvG/Jb07KOMTdSVwJpicmhN309BeEyRyQX+n1XDF0JVSlu28+hiTQ2L4rZPvu7nMw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.2.4':
     resolution: {integrity: sha512-m41nFDS0ksXK2gwXL6W6yZTYPMH0LughqbsxInSKetoH6morVj43szqKx79Iudkp8WRT5SxSh7qVb8KCUiewGg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.2.4':
     resolution: {integrity: sha512-orr3nnf2Dpb2ssl6aihQtvcKtLySLta4E2UcXdp7+RTa7mfJjBgIsbS0B9GC8gVu0hjOu021aU8b3/I1tn+pVQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.2.4':
     resolution: {integrity: sha512-NXnfTeKHDFUWfxAefa57DiGmu9VyKi0cDqFpdI+1hJWQjGJhJutHPX0b5m+eXvTKOaf+brU+P0JrQAZMb5yYaQ==}
@@ -2757,89 +2764,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -3596,30 +3619,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.97':
     resolution: {integrity: sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.97':
     resolution: {integrity: sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.97':
     resolution: {integrity: sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.97':
     resolution: {integrity: sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.97':
     resolution: {integrity: sha512-u883Yr6A6fO7Vpsy9YE4FVCIxzzo5sO+7pIUjjoDLjS3vQaNMkVzx5bdIpEL+ob+gU88WDK4VcxYMZ6nmnoX9A==}
@@ -3907,48 +3935,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.56.0':
     resolution: {integrity: sha512-rkTZkBfJ4TYLjansjSzL6mgZOdN5IvUnSq3oNJSLwBcNvy3dlgQtpHPrRxrCEbbcp7oQ6If0tkNaqfOsphYZ9g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.56.0':
     resolution: {integrity: sha512-uqL1kMH3u69/e1CH2EJhP3CP28jw2ExLsku4o8RVAZ7fySo9zOyI2fy9pVlTAp4voBLVgzndXi3SgtdyCTa2aA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.56.0':
     resolution: {integrity: sha512-j0CcMBOgV6KsRaBdsebIeiy7hCjEvq2KdEsiULf2LZqAq0v1M1lWjelhCV57LxsqaIGChXFuFJ0RiFrSRHPhSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.56.0':
     resolution: {integrity: sha512-7VDOiL8cDG3DQ/CY3yKjbV1c4YPvc4vH8qW09Vv+5ukq3l/Kcyr6XGCd5NvxUmxqDb2vjMpM+eW/4JrEEsUetA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.56.0':
     resolution: {integrity: sha512-JGRpX0M+ikD3WpwJ7vKcHKV6Kg0dT52BW2Eu2BupXotYeqGXBrbY+QPkAyKO6MNgKozyTNaRh3r7g+VWgyAQYQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.56.0':
     resolution: {integrity: sha512-dNaICPvtmuxFP/VbqdofrLqdS3bM/AKJN3LMJD52si44ea7Be1cBk6NpfIahaysG9Uo+L98QKddU9CD5L8UHnQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.56.0':
     resolution: {integrity: sha512-pF1vOtM+GuXmbklM1hV8WMsn6tCNPvkUzklj/Ej98JhlanbmA2RB1BILgOpwSuCTRTIYx2MXssmEyQQ90QF5aA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.56.0':
     resolution: {integrity: sha512-bp8NQ4RE6fDIFLa4bdBiOA+TAvkNkg+rslR+AvvjlLTYXLy9/uKAYLQudaQouWihLD/hgkrXIKKzXi5IXOewwg==}
@@ -4473,48 +4509,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.3':
     resolution: {integrity: sha512-kWXkoxxarYISBJ4bLNf5vFkEbb4JvccOwxWDxuK9yee8lg5XA7OpvlTptfRuwEvYcOZf+7VS69Uenpmpyo5Bjw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.53':
     resolution: {integrity: sha512-bGe5EBB8FVjHBR1mOLOPEFg1Lp3//7geqWkU5NIhxe+yH0W8FVrQ6WRYOap4SUTKdklD/dC4qPLREkMMQ855FA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.3':
     resolution: {integrity: sha512-Z03/wrqau9Bicfgb3Dbs6SYTHliELk2PM2LpG2nFd+cGupTMF5kanLEcj2vuuJLLhptNyS61rtk7SOZ+lPsTUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.53':
     resolution: {integrity: sha512-qL+63WKVQs1CMvFedlPt0U9PiEKJOAL/bsHMKUDS6Vp2Q+YAv/QLPu8rcvkfIMvQ0FPU2WL0aX4eWwF6e/GAnA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.3':
     resolution: {integrity: sha512-iSXXZsQp08CSilff/DCTFZHSVEpEwdicV3W8idHyrByrcsRDVh9sGC3sev6d8BygSGj3vt8GvUKBPCoyMA4tgQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.53':
     resolution: {integrity: sha512-VGl9JIGjoJh3H8Mb+7xnVqODajBmrdOOb9lxWXdcmxyI+zjB2sux69br0hZJDTyLJfvBoYm439zPACYbCjGRmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.3':
     resolution: {integrity: sha512-qaj+MFudtdCv9xZo9znFvkgoajLdc+vwf0Kz5N44g+LU5XMe+IsACgn3UG7uTRlCCvhMAGXm1XlpEA5bZBrOcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.53':
     resolution: {integrity: sha512-B4iIserJXuSnNzA5xBLFUIjTfhNy7d9sq4FUMQY3GhQWGVhS2RWWzzDnkSU6MUt7/aHUrep0CdQfXUJI9D3W7A==}
@@ -4575,6 +4619,7 @@ packages:
     resolution: {integrity: sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
@@ -4901,24 +4946,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.8':
     resolution: {integrity: sha512-koiCqL09EwOP1S2RShCI7NbsQuG6r2brTqUYE7pV7kZm9O17wZ0LSz22m6gVibpwEnw8jI3IE1yYsQTVpluALw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.8':
     resolution: {integrity: sha512-4p6lOMU3bC+Vd5ARtKJ/FxpIC5G8v3XLoPEZ5s7mLR8h7411HWC/LmTXDHcrSXRC55zvAVia1eldy6zDLz8iFQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.8':
     resolution: {integrity: sha512-z3XBnbrZAL+6xDGAhJoN4lOueIxC/8rGrJ9tg+fEaeqLEuAtHSW2QHDHxDwkxZMjuF/pZ6MUTjHjbp8wLbuRLA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.8':
     resolution: {integrity: sha512-djQPJ9Rh9vP8GTS/Df3hcc6XP6xnG5c8qsngWId/BLA9oX6C7UzCPAn74BG/wGb9a6j4w3RINuoaieJB3t+7iQ==}
@@ -5002,24 +5051,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -8070,6 +8123,9 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
+  flag-icons@7.5.0:
+    resolution: {integrity: sha512-kd+MNXviFIg5hijH766tt+3x76ele1AXlo4zDdCxIvqWZhKt4T83bOtxUOOMlTx/EcFdUMH5yvQgYlFh1EqqFg==}
+
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
@@ -8318,11 +8374,11 @@ packages:
 
   glob@7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   global-agent@3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
@@ -9219,24 +9275,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -21010,6 +21070,8 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  flag-icons@7.5.0: {}
 
   flat-cache@4.0.1:
     dependencies:

--- a/src/renderer/src/components/FlagEmoji.tsx
+++ b/src/renderer/src/components/FlagEmoji.tsx
@@ -54,7 +54,7 @@ const FLAG_SVG_MAP: Record<string, string> = {
   vn: vnSvg
 }
 
-function emojiToCountryCode(emoji: string): string {
+export function emojiToCountryCode(emoji: string): string {
   return [...emoji]
     .map((c) => c.codePointAt(0)!)
     .filter((cp) => cp >= 0x1f1e6 && cp <= 0x1f1ff)
@@ -69,23 +69,21 @@ interface FlagEmojiProps {
 }
 
 const FlagEmoji = memo(({ emoji, size = 16, style }: FlagEmojiProps) => {
+  const fallback = (
+    <span className="country-flag-font" style={style}>
+      {emoji}
+    </span>
+  )
+
   if (!isWin) {
-    return (
-      <span className="country-flag-font" style={style}>
-        {emoji}
-      </span>
-    )
+    return fallback
   }
 
   const code = emojiToCountryCode(emoji)
   const svgUrl = FLAG_SVG_MAP[code]
 
   if (!svgUrl) {
-    return (
-      <span className="country-flag-font" style={style}>
-        {emoji}
-      </span>
-    )
+    return fallback
   }
 
   return (

--- a/src/renderer/src/components/FlagEmoji.tsx
+++ b/src/renderer/src/components/FlagEmoji.tsx
@@ -1,0 +1,107 @@
+import { isWin } from '@renderer/config/constant'
+import cnSvg from 'flag-icons/flags/4x3/cn.svg?url'
+import deSvg from 'flag-icons/flags/4x3/de.svg?url'
+import esSvg from 'flag-icons/flags/4x3/es.svg?url'
+import frSvg from 'flag-icons/flags/4x3/fr.svg?url'
+import gbSvg from 'flag-icons/flags/4x3/gb.svg?url'
+import grSvg from 'flag-icons/flags/4x3/gr.svg?url'
+import hkSvg from 'flag-icons/flags/4x3/hk.svg?url'
+import idSvg from 'flag-icons/flags/4x3/id.svg?url'
+import itSvg from 'flag-icons/flags/4x3/it.svg?url'
+import jpSvg from 'flag-icons/flags/4x3/jp.svg?url'
+import krSvg from 'flag-icons/flags/4x3/kr.svg?url'
+import mySvg from 'flag-icons/flags/4x3/my.svg?url'
+import nlSvg from 'flag-icons/flags/4x3/nl.svg?url'
+import pkSvg from 'flag-icons/flags/4x3/pk.svg?url'
+import plSvg from 'flag-icons/flags/4x3/pl.svg?url'
+import ptSvg from 'flag-icons/flags/4x3/pt.svg?url'
+import roSvg from 'flag-icons/flags/4x3/ro.svg?url'
+import ruSvg from 'flag-icons/flags/4x3/ru.svg?url'
+import saSvg from 'flag-icons/flags/4x3/sa.svg?url'
+import skSvg from 'flag-icons/flags/4x3/sk.svg?url'
+import thSvg from 'flag-icons/flags/4x3/th.svg?url'
+import trSvg from 'flag-icons/flags/4x3/tr.svg?url'
+import uaSvg from 'flag-icons/flags/4x3/ua.svg?url'
+import usSvg from 'flag-icons/flags/4x3/us.svg?url'
+import vnSvg from 'flag-icons/flags/4x3/vn.svg?url'
+import { type CSSProperties, memo } from 'react'
+
+const FLAG_SVG_MAP: Record<string, string> = {
+  cn: cnSvg,
+  de: deSvg,
+  es: esSvg,
+  fr: frSvg,
+  gb: gbSvg,
+  gr: grSvg,
+  hk: hkSvg,
+  id: idSvg,
+  it: itSvg,
+  jp: jpSvg,
+  kr: krSvg,
+  my: mySvg,
+  nl: nlSvg,
+  pk: pkSvg,
+  pl: plSvg,
+  pt: ptSvg,
+  ro: roSvg,
+  ru: ruSvg,
+  sa: saSvg,
+  sk: skSvg,
+  th: thSvg,
+  tr: trSvg,
+  ua: uaSvg,
+  us: usSvg,
+  vn: vnSvg
+}
+
+function emojiToCountryCode(emoji: string): string {
+  return [...emoji]
+    .map((c) => c.codePointAt(0)!)
+    .filter((cp) => cp >= 0x1f1e6 && cp <= 0x1f1ff)
+    .map((cp) => String.fromCharCode(cp - 0x1f1e6 + 97))
+    .join('')
+}
+
+interface FlagEmojiProps {
+  emoji: string
+  size?: number
+  style?: CSSProperties
+}
+
+const FlagEmoji = memo(({ emoji, size = 16, style }: FlagEmojiProps) => {
+  if (!isWin) {
+    return (
+      <span className="country-flag-font" style={style}>
+        {emoji}
+      </span>
+    )
+  }
+
+  const code = emojiToCountryCode(emoji)
+  const svgUrl = FLAG_SVG_MAP[code]
+
+  if (!svgUrl) {
+    return (
+      <span className="country-flag-font" style={style}>
+        {emoji}
+      </span>
+    )
+  }
+
+  return (
+    <img
+      src={svgUrl}
+      alt={emoji}
+      style={{
+        width: size,
+        height: size * 0.75,
+        verticalAlign: 'middle',
+        ...style
+      }}
+    />
+  )
+})
+
+FlagEmoji.displayName = 'FlagEmoji'
+
+export default FlagEmoji

--- a/src/renderer/src/components/LanguageSelect.tsx
+++ b/src/renderer/src/components/LanguageSelect.tsx
@@ -1,3 +1,4 @@
+import FlagEmoji from '@renderer/components/FlagEmoji'
 import { UNKNOWN } from '@renderer/config/translate'
 import useTranslate from '@renderer/hooks/useTranslate'
 import type { TranslateLanguage, TranslateLanguageCode } from '@renderer/types'
@@ -24,9 +25,7 @@ const LanguageSelect = (props: Props) => {
   const defaultLanguageRenderer = useCallback((lang: TranslateLanguage) => {
     return (
       <Space.Compact direction="horizontal" block>
-        <span role="img" aria-label={lang.emoji} style={{ marginRight: 8 }}>
-          {lang.emoji}
-        </span>
+        <FlagEmoji emoji={lang.emoji} style={{ marginRight: 8 }} />
         {lang.label()}
       </Space.Compact>
     )

--- a/src/renderer/src/components/__tests__/FlagEmoji.test.tsx
+++ b/src/renderer/src/components/__tests__/FlagEmoji.test.tsx
@@ -1,0 +1,91 @@
+import { render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { emojiToCountryCode } from '../FlagEmoji'
+
+describe('emojiToCountryCode', () => {
+  it('converts standard Regional Indicator emoji to country code', () => {
+    expect(emojiToCountryCode('🇨🇳')).toBe('cn')
+    expect(emojiToCountryCode('🇺🇸')).toBe('us')
+    expect(emojiToCountryCode('🇬🇧')).toBe('gb')
+    expect(emojiToCountryCode('🇯🇵')).toBe('jp')
+    expect(emojiToCountryCode('🇩🇪')).toBe('de')
+    expect(emojiToCountryCode('🇫🇷')).toBe('fr')
+  })
+
+  it('returns empty string for non-Regional Indicator emoji', () => {
+    expect(emojiToCountryCode('🌐')).toBe('')
+    expect(emojiToCountryCode('🏳️')).toBe('')
+    expect(emojiToCountryCode('😀')).toBe('')
+    expect(emojiToCountryCode('🚀')).toBe('')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(emojiToCountryCode('')).toBe('')
+  })
+})
+
+describe('FlagEmoji component', () => {
+  it('renders emoji in a span on non-Windows platforms', async () => {
+    const FlagEmoji = (await import('../FlagEmoji')).default
+    const { container } = render(<FlagEmoji emoji="🇨🇳" />)
+    const span = container.querySelector('span.country-flag-font')
+    expect(span).toBeTruthy()
+    expect(span!.textContent).toBe('🇨🇳')
+  })
+
+  it('applies custom style to the span', async () => {
+    const FlagEmoji = (await import('../FlagEmoji')).default
+    const { container } = render(<FlagEmoji emoji="🇺🇸" style={{ marginRight: 8 }} />)
+    const span = container.querySelector('span.country-flag-font') as HTMLElement
+    expect(span.style.marginRight).toBe('8px')
+  })
+
+  it('renders fallback span for non-Regional Indicator emoji on non-Windows', async () => {
+    const FlagEmoji = (await import('../FlagEmoji')).default
+    const { container } = render(<FlagEmoji emoji="🏳️" />)
+    const span = container.querySelector('span.country-flag-font')
+    expect(span).toBeTruthy()
+    expect(span!.textContent).toBe('🏳️')
+  })
+})
+
+describe('FlagEmoji on Windows', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders SVG img for known flag emoji', async () => {
+    vi.resetModules()
+    vi.doMock('@renderer/config/constant', () => ({ isWin: true }))
+    const { default: FlagEmoji } = await import('../FlagEmoji')
+    const { container } = render(<FlagEmoji emoji="🇨🇳" size={24} />)
+    const img = container.querySelector('img')
+    expect(img).toBeTruthy()
+    expect(img!.alt).toBe('🇨🇳')
+    expect(img!.style.width).toBe('24px')
+    expect(img!.style.height).toBe('18px')
+  })
+
+  it('renders fallback span for unknown flag emoji on Windows', async () => {
+    vi.resetModules()
+    vi.doMock('@renderer/config/constant', () => ({ isWin: true }))
+    const { default: FlagEmoji } = await import('../FlagEmoji')
+    const { container } = render(<FlagEmoji emoji="🏳️" />)
+    const span = container.querySelector('span.country-flag-font')
+    expect(span).toBeTruthy()
+    expect(span!.textContent).toBe('🏳️')
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  it('renders fallback span for non-Regional Indicator emoji on Windows', async () => {
+    vi.resetModules()
+    vi.doMock('@renderer/config/constant', () => ({ isWin: true }))
+    const { default: FlagEmoji } = await import('../FlagEmoji')
+    const { container } = render(<FlagEmoji emoji="🌐" />)
+    const span = container.querySelector('span.country-flag-font')
+    expect(span).toBeTruthy()
+    expect(span!.textContent).toBe('🌐')
+    expect(container.querySelector('img')).toBeNull()
+  })
+})

--- a/src/renderer/src/pages/agents/AgentSettingsTab.tsx
+++ b/src/renderer/src/pages/agents/AgentSettingsTab.tsx
@@ -1,4 +1,5 @@
 import EditableNumber from '@renderer/components/EditableNumber'
+import FlagEmoji from '@renderer/components/FlagEmoji'
 import Scrollbar from '@renderer/components/Scrollbar'
 import Selector from '@renderer/components/Selector'
 import { HelpTooltip } from '@renderer/components/TooltipIcons'
@@ -449,7 +450,14 @@ const AgentSettingsTab = () => {
               onChange={(value) => setTargetLanguage(value)}
               placeholder={UNKNOWN.emoji + ' ' + UNKNOWN.label()}
               options={translateLanguages.map((item) => {
-                return { value: item.langCode, label: item.emoji + ' ' + item.label() }
+                return {
+                  value: item.langCode,
+                  label: (
+                    <>
+                      <FlagEmoji emoji={item.emoji} /> {item.label()}
+                    </>
+                  )
+                }
               })}
             />
           </SettingRow>

--- a/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
@@ -1,5 +1,6 @@
 // import { InfoCircleOutlined } from '@ant-design/icons'
 import { loggerService } from '@logger'
+import FlagEmoji from '@renderer/components/FlagEmoji'
 import { CopyIcon, DeleteIcon, EditIcon, RefreshIcon } from '@renderer/components/Icons'
 import InspectMessagePopup from '@renderer/components/Popups/InspectMessagePopup'
 import ObsidianExportPopup from '@renderer/components/Popups/ObsidianExportPopup'
@@ -830,7 +831,11 @@ const buttonRenderers: Record<MessageMenubarButtonId, MessageMenubarButtonRender
 
     const items: MenuProps['items'] = [
       ...translateLanguages.map((item) => ({
-        label: item.emoji + ' ' + item.label(),
+        label: (
+          <>
+            <FlagEmoji emoji={item.emoji} /> {item.label()}
+          </>
+        ),
         key: item.langCode,
         onClick: () => handleTranslate(item)
       })),

--- a/src/renderer/src/pages/home/components/ChatNavBar/Tools/SettingsTab/AssistantSettingsTab.tsx
+++ b/src/renderer/src/pages/home/components/ChatNavBar/Tools/SettingsTab/AssistantSettingsTab.tsx
@@ -1,4 +1,5 @@
 import EditableNumber from '@renderer/components/EditableNumber'
+import FlagEmoji from '@renderer/components/FlagEmoji'
 import Scrollbar from '@renderer/components/Scrollbar'
 import Selector from '@renderer/components/Selector'
 import { HelpTooltip } from '@renderer/components/TooltipIcons'
@@ -533,7 +534,14 @@ const AssistantSettingsTab = (props: Props) => {
               onChange={(value) => setTargetLanguage(value)}
               placeholder={UNKNOWN.emoji + ' ' + UNKNOWN.label()}
               options={translateLanguages.map((item) => {
-                return { value: item.langCode, label: item.emoji + ' ' + item.label() }
+                return {
+                  value: item.langCode,
+                  label: (
+                    <>
+                      <FlagEmoji emoji={item.emoji} /> {item.label()}
+                    </>
+                  )
+                }
               })}
             />
           </SettingRow>

--- a/src/renderer/src/pages/settings/DocProcessSettings/OcrOVSettings.tsx
+++ b/src/renderer/src/pages/settings/DocProcessSettings/OcrOVSettings.tsx
@@ -1,3 +1,4 @@
+import FlagEmoji from '@renderer/components/FlagEmoji'
 import { useOcrProvider } from '@renderer/hooks/useOcrProvider'
 import { BuiltinOcrProviderIds, isOcrOVProvider } from '@renderer/types'
 import { Flex, Tag } from 'antd'
@@ -22,9 +23,15 @@ export const OcrOVSettings = () => {
           </Flex>
         </SettingRowTitle>
         <div style={{ display: 'flex', gap: '8px' }}>
-          <Tag>🇬🇧 {t('languages.english')}</Tag>
-          <Tag>🇨🇳 {t('languages.chinese')}</Tag>
-          <Tag>🇭🇰 {t('languages.chinese-traditional')}</Tag>
+          <Tag>
+            <FlagEmoji emoji="🇬🇧" /> {t('languages.english')}
+          </Tag>
+          <Tag>
+            <FlagEmoji emoji="🇨🇳" /> {t('languages.chinese')}
+          </Tag>
+          <Tag>
+            <FlagEmoji emoji="🇭🇰" /> {t('languages.chinese-traditional')}
+          </Tag>
         </div>
       </SettingRow>
     </>

--- a/src/renderer/src/pages/settings/DocProcessSettings/OcrSystemSettings.tsx
+++ b/src/renderer/src/pages/settings/DocProcessSettings/OcrSystemSettings.tsx
@@ -1,4 +1,5 @@
 // import { loggerService } from '@logger'
+import FlagEmoji from '@renderer/components/FlagEmoji'
 import { SuccessTag } from '@renderer/components/Tags/SuccessTag'
 import { InfoTooltip } from '@renderer/components/TooltipIcons'
 import { isMac, isWin } from '@renderer/config/constant'
@@ -35,7 +36,11 @@ export const OcrSystemSettings = () => {
     () =>
       translateLanguages.map((lang) => ({
         value: lang.langCode,
-        label: lang.emoji + ' ' + lang.label()
+        label: (
+          <>
+            <FlagEmoji emoji={lang.emoji} /> {lang.label()}
+          </>
+        )
       })),
     [translateLanguages]
   )

--- a/src/renderer/src/pages/settings/DocProcessSettings/OcrTesseractSettings.tsx
+++ b/src/renderer/src/pages/settings/DocProcessSettings/OcrTesseractSettings.tsx
@@ -1,4 +1,5 @@
 // import { loggerService } from '@logger'
+import FlagEmoji from '@renderer/components/FlagEmoji'
 import CustomTag from '@renderer/components/Tags/CustomTag'
 import { InfoTooltip } from '@renderer/components/TooltipIcons'
 import { TESSERACT_LANG_MAP } from '@renderer/config/ocr'
@@ -30,7 +31,11 @@ export const OcrTesseractSettings = () => {
       translateLanguages
         .map((lang) => ({
           value: TESSERACT_LANG_MAP[lang.langCode],
-          label: lang.emoji + ' ' + lang.label()
+          label: (
+            <>
+              <FlagEmoji emoji={lang.emoji} /> {lang.label()}
+            </>
+          )
         }))
         .filter((option) => option.value),
     [translateLanguages]

--- a/src/renderer/src/pages/settings/GeneralSettings.tsx
+++ b/src/renderer/src/pages/settings/GeneralSettings.tsx
@@ -1,4 +1,5 @@
 import { InfoCircleOutlined } from '@ant-design/icons'
+import FlagEmoji from '@renderer/components/FlagEmoji'
 import { HStack } from '@renderer/components/Layout'
 import Selector from '@renderer/components/Selector'
 import { InfoTooltip } from '@renderer/components/TooltipIcons'
@@ -221,9 +222,7 @@ const GeneralSettings: FC = () => {
             options={languagesOptions.map((lang) => ({
               label: (
                 <Flex align="center" gap={8}>
-                  <span role="img" aria-label={lang.flag}>
-                    {lang.flag}
-                  </span>
+                  <FlagEmoji emoji={lang.flag} />
                   {lang.label}
                 </Flex>
               ),
@@ -289,9 +288,7 @@ const GeneralSettings: FC = () => {
                   value: lang.value,
                   label: (
                     <Flex align="center" gap={8}>
-                      <span role="img" aria-label={lang.flag}>
-                        {lang.flag}
-                      </span>
+                      <FlagEmoji emoji={lang.flag} />
                       {lang.label}
                     </Flex>
                   )

--- a/src/renderer/src/windows/selection/action/components/ActionTranslate.tsx
+++ b/src/renderer/src/windows/selection/action/components/ActionTranslate.tsx
@@ -1,6 +1,7 @@
 import { LoadingOutlined } from '@ant-design/icons'
 import { loggerService } from '@logger'
 import CopyButton from '@renderer/components/CopyButton'
+import FlagEmoji from '@renderer/components/FlagEmoji'
 import LanguageSelect from '@renderer/components/LanguageSelect'
 import { LanguagesEnum, UNKNOWN } from '@renderer/config/translate'
 import db from '@renderer/databases'
@@ -334,7 +335,7 @@ const ActionTranslate: FC<Props> = ({ action, scrollToBottom }) => {
                 <span>{t('translate.detecting')}</span>
               ) : (
                 <>
-                  <span style={{ marginRight: 4 }}>{detectedLanguage?.emoji || '🌐'}</span>
+                  <FlagEmoji emoji={detectedLanguage?.emoji || '🌐'} style={{ marginRight: 4 }} />
                   <span>{detectedLanguage?.label() || t('translate.detected_source')}</span>
                 </>
               )}


### PR DESCRIPTION
## Summary

- Replace emoji-based flag rendering with SVG images from `flag-icons` on Windows to eliminate black/white border artifacts
- Create a reusable `FlagEmoji` component that uses SVG `<img>` on Windows and native emoji on other platforms
- Apply the fix across all UI locations showing country flag emojis (language selectors, translate menus, OCR settings, etc.)

## Linked Issue

Closes #14958

## Changes

- **New**: `src/renderer/src/components/FlagEmoji.tsx` — platform-aware flag rendering component
- **New dep**: `flag-icons@^7.5.0` — SVG flag image source (only 25 SVGs are bundled via static imports)
- **Modified**: 9 files updated to use `FlagEmoji` component instead of raw emoji text

## Why not font-based fix?

CSS `font-family` with Twemoji Country Flags cannot override Windows system-level color emoji rendering (Segoe UI Emoji). The SVG approach completely bypasses the emoji rendering pipeline.

## Test plan

- [ ] Verify flag emojis render without borders on Windows 10/11
- [ ] Verify native emoji still renders on macOS/Linux (no SVG used)
- [ ] Check all affected locations: General Settings language selector, translate dropdowns, message menubar translate menu, OCR settings, selection action translate window
- [ ] Confirm bundle size increase is minimal (~15-20KB for 25 SVGs)
