### PR TITLE
fix(backup): clean up selection hook before restore relaunch

### DIFF
--- a/src/main/services/BackupManager.ts
+++ b/src/main/services/BackupManager.ts
@@ -30,6 +30,7 @@ import type { CreateDirectoryOptions, FileStat } from 'webdav'
 import { getDataPath } from '../utils'
 import { isPathInside, resolveAndValidatePath } from '../utils/file'
 import S3Storage from './S3Storage'
+import selectionService from './SelectionService'
 import WebDav from './WebDav'
 import { windowService } from './WindowService'
 
@@ -641,6 +642,7 @@ class BackupManager {
 
       logger.info('[restoreDirect] Restore staged successfully, relaunching app to apply...')
 
+      selectionService?.quit()
       app.relaunch()
       app.exit(0)
     } catch (error) {


### PR DESCRIPTION
### What this PR does

Before this PR:

Direct backup restore staged restored data and immediately relaunched the app. If the selection helper was active, the app could hang during shutdown because the selection hook native resources were left to process teardown.

After this PR:

Direct backup restore explicitly quits `SelectionService` before relaunching the app, so the selection hook is cleaned up before process exit.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The fix is intentionally limited to the restore relaunch path that reproduced the hang. It does not change backup formats, renderer restore flow, Redux state, database schema, startup restore application, or the generic app relaunch IPC behavior.

The following alternatives were considered:

Changing the restore relaunch flow to be renderer-driven or changing the generic relaunch IPC was considered but rejected to keep this hotfix focused on the selection hook cleanup issue.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This targets a restore hang reproduced when the selection helper is enabled. Local validation passed with `pnpm lint`, `pnpm test`, and `pnpm format`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixes an issue where restoring a backup could hang before the app relaunched when the selection helper was enabled.
```
