### PR TITLE
hotfix(agents): report 1M context for DeepSeek V4+ pro on official host

### DIFF
--- a/src/main/services/agents/services/claudecode/__tests__/utils.test.ts
+++ b/src/main/services/agents/services/claudecode/__tests__/utils.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+
+import { isDeepSeekOfficialHost, withDeepSeek1mSuffix } from '../utils'
+
+describe('isDeepSeekOfficialHost', () => {
+  it('matches the canonical DeepSeek Anthropic endpoint', () => {
+    expect(isDeepSeekOfficialHost('https://api.deepseek.com/anthropic')).toBe(true)
+    expect(isDeepSeekOfficialHost('https://api.deepseek.com')).toBe(true)
+    expect(isDeepSeekOfficialHost('  https://api.deepseek.com/anthropic  ')).toBe(true)
+  })
+
+  it('matches future deepseek subdomains via hostname suffix', () => {
+    expect(isDeepSeekOfficialHost('https://api-1m.api.deepseek.com/anthropic')).toBe(true)
+  })
+
+  it('rejects third-party hosts that route to deepseek models', () => {
+    expect(isDeepSeekOfficialHost('https://openrouter.ai/api/v1')).toBe(false)
+    expect(isDeepSeekOfficialHost('https://api.fireworks.ai/inference')).toBe(false)
+    expect(isDeepSeekOfficialHost('https://deepseek.alayanew.com')).toBe(false)
+  })
+
+  it('handles missing or malformed hosts gracefully', () => {
+    expect(isDeepSeekOfficialHost(undefined)).toBe(false)
+    expect(isDeepSeekOfficialHost('')).toBe(false)
+    expect(isDeepSeekOfficialHost('   ')).toBe(false)
+    expect(isDeepSeekOfficialHost('not a url')).toBe(false)
+  })
+})
+
+describe('withDeepSeek1mSuffix', () => {
+  const officialHost = 'https://api.deepseek.com/anthropic'
+  const thirdPartyHost = 'https://openrouter.ai/api/v1'
+
+  it('appends [1m] to V4+ pro models on the official host', () => {
+    expect(withDeepSeek1mSuffix('deepseek-v4-pro', officialHost)).toBe('deepseek-v4-pro[1m]')
+    expect(withDeepSeek1mSuffix('deepseek-v4', officialHost)).toBe('deepseek-v4[1m]')
+    expect(withDeepSeek1mSuffix('deepseek-v5-pro', officialHost)).toBe('deepseek-v5-pro[1m]')
+  })
+
+  it('leaves the id alone when an existing [1m] suffix is present', () => {
+    expect(withDeepSeek1mSuffix('deepseek-v4-pro[1m]', officialHost)).toBe('deepseek-v4-pro[1m]')
+    expect(withDeepSeek1mSuffix('deepseek-v4-pro[1M]', officialHost)).toBe('deepseek-v4-pro[1M]')
+  })
+
+  it('does not append [1m] for flash variants (64K context, not 1M)', () => {
+    expect(withDeepSeek1mSuffix('deepseek-v4-flash', officialHost)).toBe('deepseek-v4-flash')
+    expect(withDeepSeek1mSuffix('deepseek-v5-flash', officialHost)).toBe('deepseek-v5-flash')
+  })
+
+  it('does not append [1m] when host is not DeepSeek-official', () => {
+    expect(withDeepSeek1mSuffix('deepseek-v4-pro', thirdPartyHost)).toBe('deepseek-v4-pro')
+    expect(withDeepSeek1mSuffix('deepseek-v4-pro', undefined)).toBe('deepseek-v4-pro')
+  })
+
+  it('leaves non-DeepSeek-V4+ models untouched', () => {
+    expect(withDeepSeek1mSuffix('deepseek-v3.2', officialHost)).toBe('deepseek-v3.2')
+    expect(withDeepSeek1mSuffix('deepseek-chat', officialHost)).toBe('deepseek-chat')
+    expect(withDeepSeek1mSuffix('claude-opus-4-7', officialHost)).toBe('claude-opus-4-7')
+    expect(withDeepSeek1mSuffix('gpt-4', officialHost)).toBe('gpt-4')
+  })
+
+  it('returns empty string when modelId is missing', () => {
+    expect(withDeepSeek1mSuffix(undefined, officialHost)).toBe('')
+    expect(withDeepSeek1mSuffix('', officialHost)).toBe('')
+  })
+})

--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -61,6 +61,7 @@ import { sessionService } from '../SessionService'
 import { buildNamespacedToolCallId } from './claude-stream-state'
 import { promptForToolApproval } from './tool-permissions'
 import { ClaudeStreamState, transformSDKMessageToStreamParts } from './transform'
+import { withDeepSeek1mSuffix } from './utils'
 
 const require_ = createRequire(import.meta.url)
 const logger = loggerService.withContext('ClaudeCodeService')
@@ -194,6 +195,7 @@ class ClaudeCodeService implements AgentServiceInterface {
       return withoutTrailingApiVersion(provider.anthropicApiHost?.trim() || provider.apiHost)
     }
     const anthropicBaseUrl = resolveAnthropicBaseUrl()
+    const sdkModelId = withDeepSeek1mSuffix(modelInfo.modelId, provider.anthropicApiHost)
 
     const env = {
       ...loginShellEnv,
@@ -207,11 +209,11 @@ class ClaudeCodeService implements AgentServiceInterface {
       ANTHROPIC_API_KEY: provider.apiKey,
       ANTHROPIC_AUTH_TOKEN: provider.apiKey,
       ANTHROPIC_BASE_URL: anthropicBaseUrl,
-      ANTHROPIC_MODEL: modelInfo.modelId,
-      ANTHROPIC_DEFAULT_OPUS_MODEL: modelInfo.modelId,
-      ANTHROPIC_DEFAULT_SONNET_MODEL: modelInfo.modelId,
+      ANTHROPIC_MODEL: sdkModelId,
+      ANTHROPIC_DEFAULT_OPUS_MODEL: sdkModelId,
+      ANTHROPIC_DEFAULT_SONNET_MODEL: sdkModelId,
       // TODO: support set small model in UI
-      ANTHROPIC_DEFAULT_HAIKU_MODEL: modelInfo.modelId,
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: sdkModelId,
       ELECTRON_RUN_AS_NODE: '1',
       ELECTRON_NO_ATTACH_CONSOLE: '1',
       // Set CLAUDE_CONFIG_DIR to app's userData directory to avoid path encoding issues

--- a/src/main/services/agents/services/claudecode/utils.ts
+++ b/src/main/services/agents/services/claudecode/utils.ts
@@ -109,3 +109,32 @@ export function convertClaudeCodeUsage(usage: ClaudeCodeUsage): LanguageModelUsa
     raw: usage as JSONObject
   }
 }
+
+// DeepSeek V4+ "pro" models on api.deepseek.com support a 1M context window,
+// but Claude Code CLI only knows about it via the `[1m]` model-id suffix
+// (parsed locally to switch /context budgeting to 1e6 tokens, then stripped
+// before the API call). DeepSeek's official Claude Code integration docs
+// recommend appending it; gating on the official host keeps third-party
+// DeepSeek deployments (OpenRouter / Fireworks / etc.) from claiming a
+// capacity their backend may not actually serve.
+// https://api-docs.deepseek.com/zh-cn/quick_start/agent_integrations/claude_code
+const DEEPSEEK_V4_PLUS_PRO_REGEX = /(\w+-)?deepseek-v([4-9]|\d{2,})([.-]\w+)*$/i
+
+export function isDeepSeekOfficialHost(host: string | undefined): boolean {
+  const trimmed = host?.trim()
+  if (!trimmed) return false
+  try {
+    return new URL(trimmed).hostname.endsWith('api.deepseek.com')
+  } catch {
+    return false
+  }
+}
+
+export function withDeepSeek1mSuffix(modelId: string | undefined, anthropicHost: string | undefined): string {
+  if (!modelId) return ''
+  if (!isDeepSeekOfficialHost(anthropicHost)) return modelId
+  if (/\[1m\]$/i.test(modelId)) return modelId
+  if (/flash/i.test(modelId)) return modelId
+  if (!DEEPSEEK_V4_PLUS_PRO_REGEX.test(modelId)) return modelId
+  return `${modelId}[1m]`
+}


### PR DESCRIPTION
### What this PR does

Before this PR:

When a user pointed Cherry Studio's agent backend at the DeepSeek official API (`api.deepseek.com`) and selected a DeepSeek V4+ pro model (e.g. `deepseek-v4-pro`), Claude Code's `/context` command displayed the context window as **200K** instead of the **1M** that DeepSeek actually serves. The Claude Code CLI bundled in `@anthropic-ai/claude-agent-sdk` falls back to 200K for any model id it doesn't recognize.

After this PR:

For the same setup, `/context` now correctly reports **1M (1,000,000) tokens**. We discovered the CLI uses a `[1m]` model-id suffix as a local flag — internally it strips the suffix before sending the upstream API call (`model.replace(/\[1m\]$/i, "")`) and switches its `/context` budget to `1e6`. DeepSeek's official integration docs explicitly recommend appending `[1m]` to the model id ([source](https://api-docs.deepseek.com/zh-cn/quick_start/agent_integrations/claude_code)).

<img width="1156" height="518" alt="image" src="https://github.com/user-attachments/assets/fac9d7ab-9295-481a-9f27-c574ee6638a3" />


`src/main/services/agents/services/claudecode/index.ts` now appends `[1m]` to the four `ANTHROPIC_*_MODEL` env vars before spawning the SDK, but only when **all** of the following hold:

- model id matches DeepSeek V4+ regex (`deepseek-v[4-9]…` or `deepseek-v\d{2,}…`)
- model id does **not** contain `flash` (flash variants cap at 64K)
- model id is not already suffixed with `[1m]`
- provider's `anthropicApiHost` resolves to a hostname ending in `api.deepseek.com`

Fixes #14789

### Why we need it and why it was done in this way

The following tradeoffs were made:

- **Gated to the official host only.** Third-party DeepSeek deployments (OpenRouter, Fireworks, SiliconCloud, etc.) might not actually serve a 1M context. If we appended `[1m]` for them too, the CLI would think it has 1M to play with but the upstream would reject oversized requests, which is a worse failure mode than the current 200K under-report.
- **No model rewriting beyond `[1m]`.** DeepSeek's docs also recommend `ANTHROPIC_DEFAULT_HAIKU_MODEL=deepseek-v4-flash` and `CLAUDE_CODE_SUBAGENT_MODEL=deepseek-v4-flash` for cheaper subagent calls. We deliberately do not auto-substitute, because that would assume `deepseek-v4-flash` is configured in the user's provider (not always true) and goes beyond the bug being fixed.
- **Inline regex instead of importing from `@renderer/config/models/reasoning`.** The renderer's `isDeepSeekV4PlusModel` lives in renderer code and pulls in renderer-only deps; duplicating the small regex into `services/claudecode/utils.ts` keeps the main process self-contained.

The following alternatives were considered:

- Translating the `[1m]` suffix in `getLowerBaseModelName` so the existing `isDeepSeekV4PlusModel` regex would also accept `deepseek-v4-pro[1m]` (a workaround some users currently type). Rejected because it doesn't solve the actual `/context` display bug — the SDK never sees the user-chosen variant; it sees whatever we put in `ANTHROPIC_MODEL`.
- Adding a `context_length` field to `Model` and propagating it through. Rejected as too large for the v2 main-branch freeze.

Links to places where the discussion took place: issue #14789 thread.

### Breaking changes

None. The transformation only fires for DeepSeek-official-host + DeepSeek V4+ pro model id; every other case returns the original id unchanged.

### Special notes for your reviewer

- All the `[1m]`-related logic the SDK relies on lives inside the bundled `cli.js` and is generic to model name (`if (DP(q)) return 1e6`), not Anthropic-specific — so this works without us shipping any model-table changes.
- DeepSeek's API never sees `[1m]` because the CLI strips it before the request: `_.messages.create({model:K.replace(/\[1m\]$/i,""), …})`. Verified against `node_modules/@anthropic-ai/claude-agent-sdk/cli.js`.
- 10 new unit tests in `src/main/services/agents/services/claudecode/__tests__/utils.test.ts` cover positive cases, the third-party-host gate, the flash exclusion, the existing-suffix idempotence, and the missing-id edge case.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix(agents): show the correct 1M context window for DeepSeek V4+ pro models when the agent backend is api.deepseek.com (previously reported 200K via `/context`).
```
