### PR TITLE
feat(agents): add optional PowerShell tool for Windows agent sessions

### DIFF
--- a/packages/shared/IpcChannel.ts
+++ b/packages/shared/IpcChannel.ts
@@ -312,6 +312,7 @@ export enum IpcChannel {
   System_GetGitBashPath = 'system:getGitBashPath',
   System_GetGitBashPathInfo = 'system:getGitBashPathInfo',
   System_SetGitBashPath = 'system:setGitBashPath',
+  System_CheckPwshAvailable = 'system:checkPwshAvailable',
 
   // DevTools
   System_ToggleDevTools = 'system:toggleDevTools',

--- a/packages/shared/data/api/schemas/agents.ts
+++ b/packages/shared/data/api/schemas/agents.ts
@@ -52,7 +52,9 @@ export const AgentConfigurationSchema = z
     scheduler_one_time_delay: z.number().optional(),
     scheduler_last_run: z.string().optional(),
     heartbeat_enabled: z.boolean().optional(),
-    heartbeat_interval: z.number().optional()
+    heartbeat_interval: z.number().optional(),
+    enable_powershell: z.boolean().optional(),
+    powershell_version: z.enum(['ps5', 'ps7']).optional()
   })
   // .loose() (passthrough) is intentional: the configuration object is stored as a JSON blob
   // and may contain keys written by older or newer versions of the app. Unknown fields must

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -11,6 +11,7 @@ import { anthropicService } from '@main/services/AnthropicService'
 import { getIpCountry } from '@main/utils/ipService'
 import {
   autoDiscoverGitBash,
+  findPwsh,
   getBinaryPath,
   getGitBashPathInfo,
   isBinaryExists,
@@ -360,6 +361,11 @@ export async function registerIpc() {
   // Returns { path, source } where source is 'manual' | 'auto' | null
   ipcMain.handle(IpcChannel.System_GetGitBashPathInfo, () => {
     return getGitBashPathInfo()
+  })
+
+  ipcMain.handle(IpcChannel.System_CheckPwshAvailable, () => {
+    if (!isWin) return false
+    return findPwsh() !== null
   })
 
   ipcMain.handle(IpcChannel.System_SetGitBashPath, (_, newPath: string | null) => {

--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -38,9 +38,9 @@ import {
 } from '@main/services/proxy/nodeProxy'
 import { toAsarUnpackedPath } from '@main/utils'
 import { getAppLanguage } from '@main/utils/language'
-import { autoDiscoverGitBash, getBinaryPath } from '@main/utils/process'
+import { autoDiscoverGitBash, findPowerShell, findPwsh, getBinaryPath } from '@main/utils/process'
 import { rtkRewrite } from '@main/utils/rtk'
-import getLoginShellEnvironment from '@main/utils/shell-env'
+import getLoginShellEnvironment, { getPowerShellProfileEnvironment } from '@main/utils/shell-env'
 import {
   CHANNEL_SECURITY_PROMPT,
   GLOBALLY_DISALLOWED_TOOLS,
@@ -183,6 +183,18 @@ class ClaudeCodeService implements AgentServiceInterface {
 
     // Auto-discover Git Bash path on Windows (already logs internally)
     const customGitBashPath = isWin ? autoDiscoverGitBash() : null
+
+    // PowerShell tool: load PS profile environment when enabled
+    const enablePwsh = isWin && (session.configuration?.enable_powershell ?? false)
+    const psVersion = session.configuration?.powershell_version ?? 'ps7'
+    let psProfileEnv: Record<string, string> = {}
+    if (enablePwsh) {
+      const psExePath = psVersion === 'ps7' ? findPwsh() : findPowerShell()
+      if (psExePath) {
+        psProfileEnv = await getPowerShellProfileEnvironment(psExePath, loginShellEnv)
+      }
+    }
+
     const bunPath = await getBinaryPath('bun')
 
     // Claude Agent SDK builds the final endpoint as `${ANTHROPIC_BASE_URL}/v1/messages`.
@@ -200,6 +212,7 @@ class ClaudeCodeService implements AgentServiceInterface {
 
     const env = {
       ...loginShellEnv,
+      ...psProfileEnv,
       ...getProxyEnvironment(process.env),
       // prevent claude agent sdk using bedrock api
       CLAUDE_CODE_USE_BEDROCK: '0',
@@ -225,7 +238,8 @@ class ClaudeCodeService implements AgentServiceInterface {
       CLAUDE_CONFIG_DIR: application.getPath('feature.agents.claude.root'),
       ENABLE_TOOL_SEARCH: 'auto',
       CHERRY_STUDIO_BUN_PATH: bunPath,
-      ...(customGitBashPath ? { CLAUDE_CODE_GIT_BASH_PATH: customGitBashPath } : {})
+      ...(customGitBashPath ? { CLAUDE_CODE_GIT_BASH_PATH: customGitBashPath } : {}),
+      ...(enablePwsh ? { CLAUDE_CODE_USE_POWERSHELL_TOOL: '1' } : {})
     }
 
     // Merge user-defined environment variables from session configuration
@@ -244,6 +258,7 @@ class ClaudeCodeService implements AgentServiceInterface {
         'CLAUDE_CONFIG_DIR',
         'CLAUDE_CODE_USE_BEDROCK',
         'CLAUDE_CODE_GIT_BASH_PATH',
+        'CLAUDE_CODE_USE_POWERSHELL_TOOL',
         'CHERRY_STUDIO_NODE_PROXY_RULES',
         'CHERRY_STUDIO_NODE_PROXY_BYPASS_RULES',
         'NODE_OPTIONS',

--- a/src/main/utils/process.ts
+++ b/src/main/utils/process.ts
@@ -699,3 +699,82 @@ export function getGitBashPathInfo(): GitBashPathInfo {
 
   return { path, source }
 }
+
+/**
+ * Validate that a path points to an actual pwsh.exe file (not a directory or
+ * differently-named executable). Returns true only for absolute paths whose
+ * basename is `pwsh.exe` and which point to a regular file.
+ */
+function isValidPwshPath(candidate: string): boolean {
+  try {
+    if (!path.isAbsolute(candidate)) return false
+    if (path.basename(candidate).toLowerCase() !== 'pwsh.exe') return false
+    if (!fs.existsSync(candidate)) return false
+    const stat = fs.statSync(candidate)
+    return stat.isFile()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Find PowerShell 7 (pwsh.exe) on Windows via pure discovery (no persistence).
+ * Checks env override, PATH, and known install paths.
+ */
+export function findPwsh(): string | null {
+  if (!isWin) {
+    return null
+  }
+
+  // 1. Check environment variable override
+  const envOverride = process.env.CLAUDE_CODE_PWSH_PATH
+  if (envOverride && isValidPwshPath(envOverride)) {
+    return envOverride
+  }
+
+  // 2. Check PATH for pwsh.exe
+  const pathResult = findExecutable('pwsh', { extensions: ['.exe'] })
+  if (pathResult) {
+    return pathResult
+  }
+
+  // 3. Check known PowerShell 7 install paths
+  const knownPaths = [
+    path.join(process.env.ProgramFiles ?? '', 'PowerShell', '7', 'pwsh.exe'),
+    path.join(process.env['ProgramFiles(x86)'] ?? '', 'PowerShell', '7', 'pwsh.exe'),
+    path.join(process.env.LOCALAPPDATA ?? '', 'Microsoft', 'WindowsApps', 'pwsh.exe')
+  ]
+
+  for (const candidate of knownPaths) {
+    if (candidate && isValidPwshPath(candidate)) {
+      return candidate
+    }
+  }
+
+  return null
+}
+
+/**
+ * Find Windows PowerShell 5.1 (powershell.exe) on Windows via pure discovery.
+ * System32 path always exists on Windows, so this should never return null.
+ */
+export function findPowerShell(): string | null {
+  if (!isWin) {
+    return null
+  }
+
+  // System32 PowerShell is always present on Windows
+  const systemPath = path.join(
+    process.env.SystemRoot ?? 'C:\\Windows',
+    'System32',
+    'WindowsPowerShell',
+    'v1.0',
+    'powershell.exe'
+  )
+  if (fs.existsSync(systemPath)) {
+    return systemPath
+  }
+
+  // Fallback: check PATH
+  return findExecutable('powershell', { extensions: ['.exe'] })
+}

--- a/src/main/utils/shell-env.ts
+++ b/src/main/utils/shell-env.ts
@@ -295,6 +295,110 @@ function getLoginShellEnvironment(): Promise<Record<string, string>> {
   })
 }
 
+/**
+ * Capture environment variables from a PowerShell profile session.
+ *
+ * Spawns PowerShell WITHOUT `-NoProfile` so the user's `$PROFILE` is loaded,
+ * then reads the resulting environment. This is a separate function from
+ * `getLoginShellEnvironment()` to avoid contaminating the module-level cache
+ * that is shared by MCP and other consumers.
+ *
+ * On timeout or error, returns `{}` (empty overlay — callers merge on top of
+ * the base env, so empty means no additions).
+ */
+export async function getPowerShellProfileEnvironment(
+  psExePath: string,
+  baseEnv?: Record<string, string>
+): Promise<Record<string, string>> {
+  return new Promise((resolve) => {
+    const spawnEnv =
+      baseEnv ??
+      (() => {
+        const env: Record<string, string> = {}
+        for (const key in process.env) {
+          env[key] = process.env[key] || ''
+        }
+        return env
+      })()
+
+    let settled = false
+    let timeoutId: NodeJS.Timeout | undefined
+
+    const cleanup = () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId)
+        timeoutId = undefined
+      }
+    }
+
+    const resolveOnce = (value: Record<string, string>) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resolve(value)
+    }
+
+    // ForEach-Object produces NAME=VALUE lines, same format as Unix `env`
+    const command = 'Get-ChildItem Env: | ForEach-Object { "$($_.Name)=$($_.Value)" }'
+
+    const child = spawn(psExePath, ['-NoLogo', '-Command', command], {
+      cwd: os.homedir(),
+      detached: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: false,
+      env: spawnEnv
+    })
+
+    let output = ''
+    let errorOutput = ''
+
+    timeoutId = setTimeout(() => {
+      logger.warn(`PowerShell profile capture timed out after ${SHELL_ENV_TIMEOUT_MS}ms`)
+      child.kill()
+      resolveOnce({})
+    }, SHELL_ENV_TIMEOUT_MS)
+
+    child.stdout.on('data', (data) => {
+      output += data.toString()
+    })
+
+    child.stderr.on('data', (data) => {
+      errorOutput += data.toString()
+    })
+
+    child.on('error', (error) => {
+      logger.error('Failed to spawn PowerShell for profile capture', error)
+      resolveOnce({})
+    })
+
+    child.on('close', (code) => {
+      if (settled) return
+
+      if (code !== 0) {
+        logger.warn('PowerShell profile capture exited non-zero', {
+          code,
+          stderr: errorOutput.trim()
+        })
+        return resolveOnce({})
+      }
+
+      const env: Record<string, string> = {}
+      const lines = output.split(/\r?\n/)
+      for (const line of lines) {
+        const trimmed = line.trim()
+        if (!trimmed) continue
+        const sep = trimmed.indexOf('=')
+        if (sep > 0) {
+          env[trimmed.substring(0, sep)] = trimmed.substring(sep + 1)
+        }
+      }
+
+      appendCherryBinToPath(env)
+      resolveOnce(env)
+    })
+  })
+}
+
 let cachedEnv: Record<string, string> | null = null
 
 async function fetchShellEnv(): Promise<Record<string, string>> {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -180,7 +180,8 @@ const api = {
     getGitBashPath: (): Promise<string | null> => ipcRenderer.invoke(IpcChannel.System_GetGitBashPath),
     getGitBashPathInfo: (): Promise<GitBashPathInfo> => ipcRenderer.invoke(IpcChannel.System_GetGitBashPathInfo),
     setGitBashPath: (newPath: string | null): Promise<boolean> =>
-      ipcRenderer.invoke(IpcChannel.System_SetGitBashPath, newPath)
+      ipcRenderer.invoke(IpcChannel.System_SetGitBashPath, newPath),
+    checkPwshAvailable: (): Promise<boolean> => ipcRenderer.invoke(IpcChannel.System_CheckPwshAvailable)
   },
   devTools: {
     toggle: () => ipcRenderer.invoke(IpcChannel.System_ToggleDevTools)

--- a/src/renderer/src/components/Popups/agent/AgentModal.tsx
+++ b/src/renderer/src/components/Popups/agent/AgentModal.tsx
@@ -67,6 +67,7 @@ const PopupContainer: React.FC<Props> = ({ agent, afterSubmit, resolve }) => {
 
   const [form, setForm] = useState<BaseAgentForm>(() => buildAgentForm(agent))
   const [gitBashPathInfo, setGitBashPathInfo] = useState<GitBashPathInfo>({ path: null, source: null })
+  const [pwshDetected, setPwshDetected] = useState(false)
 
   useEffect(() => {
     if (open) {
@@ -87,6 +88,14 @@ const PopupContainer: React.FC<Props> = ({ agent, afterSubmit, resolve }) => {
   useEffect(() => {
     void checkGitBash()
   }, [checkGitBash])
+
+  useEffect(() => {
+    if (!isWin) return
+    window.api.system
+      .checkPwshAvailable()
+      .then(setPwshDetected)
+      .catch(() => setPwshDetected(false))
+  }, [])
 
   const selectedPermissionMode = form.configuration?.permission_mode ?? 'default'
 
@@ -172,6 +181,30 @@ const PopupContainer: React.FC<Props> = ({ agent, afterSubmit, resolve }) => {
         configuration: nextConfig
       }
     })
+  }, [])
+
+  const enablePowershell = form.configuration?.enable_powershell ?? false
+  const powershellVersion = form.configuration?.powershell_version ?? 'ps7'
+
+  const onEnablePowershellChange = useCallback((checked: boolean) => {
+    setForm((prev) => ({
+      ...prev,
+      configuration: {
+        ...AgentConfigurationSchema.parse(prev.configuration ?? {}),
+        enable_powershell: checked,
+        powershell_version: checked ? (prev.configuration?.powershell_version ?? 'ps7') : undefined
+      }
+    }))
+  }, [])
+
+  const onPowershellVersionChange = useCallback((value: 'ps5' | 'ps7') => {
+    setForm((prev) => ({
+      ...prev,
+      configuration: {
+        ...AgentConfigurationSchema.parse(prev.configuration ?? {}),
+        powershell_version: value
+      }
+    }))
   }, [])
 
   const onNameChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
@@ -302,6 +335,14 @@ const PopupContainer: React.FC<Props> = ({ agent, afterSubmit, resolve }) => {
         return
       }
 
+      if (isWin && enablePowershell && powershellVersion === 'ps7' && !pwshDetected) {
+        window.toast.error(
+          t('agent.shell.ps7NotDetected', 'PowerShell 7 not detected. Install it or select Windows PowerShell.')
+        )
+        loadingRef.current = false
+        return
+      }
+
       if (isEditing(agent)) {
         if (!agent) {
           loadingRef.current = false
@@ -362,7 +403,10 @@ const PopupContainer: React.FC<Props> = ({ agent, afterSubmit, resolve }) => {
       updateAgent,
       afterSubmit,
       addAgent,
-      gitBashPathInfo.path
+      gitBashPathInfo.path,
+      enablePowershell,
+      powershellVersion,
+      pwshDetected
     ]
   )
 
@@ -451,6 +495,47 @@ const PopupContainer: React.FC<Props> = ({ agent, afterSubmit, resolve }) => {
                 </GitBashInputWrapper>
                 {gitBashPathInfo.path && gitBashPathInfo.source === 'auto' && (
                   <SourceHint>{t('agent.gitBash.autoDiscoveredHint', 'Auto-discovered')}</SourceHint>
+                )}
+              </FormItem>
+            )}
+
+            {isWin && (
+              <FormItem>
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <Label>{t('agent.shell.enablePowerShell', 'Enable PowerShell tool')}</Label>
+                    <HelpTooltip
+                      title={t(
+                        'agent.shell.enablePowerShellTooltip',
+                        'Adds PowerShell as an additional shell tool alongside Bash. The agent can use both.'
+                      )}
+                    />
+                  </div>
+                  <Switch checked={enablePowershell} size="sm" onCheckedChange={onEnablePowershellChange} />
+                </div>
+                {enablePowershell && (
+                  <div className="mt-2">
+                    <Select
+                      value={powershellVersion}
+                      onChange={onPowershellVersionChange}
+                      style={{ width: '100%' }}
+                      options={[
+                        {
+                          value: 'ps7',
+                          label: t('agent.shell.ps7', 'PowerShell 7') + (pwshDetected ? ' ✓' : '')
+                        },
+                        { value: 'ps5', label: t('agent.shell.ps5', 'Windows PowerShell (Built-in)') }
+                      ]}
+                    />
+                    {powershellVersion === 'ps7' && !pwshDetected && (
+                      <SourceHint style={{ color: '#ff4d4f' }}>
+                        {t(
+                          'agent.shell.ps7NotDetected',
+                          'PowerShell 7 not detected. Install from github.com/PowerShell/PowerShell or select Windows PowerShell.'
+                        )}
+                      </SourceHint>
+                    )}
+                  </div>
                 )}
               </FormItem>
             )}
@@ -549,7 +634,10 @@ const PopupContainer: React.FC<Props> = ({ agent, afterSubmit, resolve }) => {
               type="primary"
               htmlType="submit"
               loading={loadingRef.current}
-              disabled={isWin && !gitBashPathInfo.path}>
+              disabled={
+                (isWin && !gitBashPathInfo.path) ||
+                (isWin && enablePowershell && powershellVersion === 'ps7' && !pwshDetected)
+              }>
               {isEditing(agent) ? t('common.confirm') : t('common.add')}
             </Button>
           </FormFooter>

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -576,6 +576,13 @@
         }
       }
     },
+    "shell": {
+      "enablePowerShell": "Enable PowerShell tool",
+      "enablePowerShellTooltip": "Adds PowerShell as an additional shell tool alongside Bash. The agent can use both.",
+      "ps5": "Windows PowerShell (Built-in)",
+      "ps7": "PowerShell 7",
+      "ps7NotDetected": "PowerShell 7 not detected. Install from github.com/PowerShell/PowerShell or select Windows PowerShell."
+    },
     "sidebar_title": "Agents",
     "todo": {
       "mock": {

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -576,6 +576,13 @@
         }
       }
     },
+    "shell": {
+      "enablePowerShell": "启用 PowerShell 工具",
+      "enablePowerShellTooltip": "在 Bash 之外添加 PowerShell 作为额外的 Shell 工具。智能体可以同时使用两者。",
+      "ps5": "Windows PowerShell（内置）",
+      "ps7": "PowerShell 7",
+      "ps7NotDetected": "未检测到 PowerShell 7。请从 github.com/PowerShell/PowerShell 安装，或选择 Windows PowerShell。"
+    },
     "sidebar_title": "智能体",
     "todo": {
       "mock": {

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -576,6 +576,13 @@
         }
       }
     },
+    "shell": {
+      "enablePowerShell": "啟用 PowerShell 工具",
+      "enablePowerShellTooltip": "在 Bash 之外新增 PowerShell 作為額外的 Shell 工具。智慧體可以同時使用兩者。",
+      "ps5": "Windows PowerShell（內建）",
+      "ps7": "PowerShell 7",
+      "ps7NotDetected": "未偵測到 PowerShell 7。請從 github.com/PowerShell/PowerShell 安裝，或選擇 Windows PowerShell。"
+    },
     "sidebar_title": "Agents",
     "todo": {
       "mock": {

--- a/src/renderer/src/i18n/translate/de-de.json
+++ b/src/renderer/src/i18n/translate/de-de.json
@@ -576,8 +576,107 @@
         }
       }
     },
+    "shell": {
+      "enablePowerShell": "[to be translated]:Enable PowerShell tool",
+      "enablePowerShellTooltip": "[to be translated]:Adds PowerShell as an additional shell tool alongside Bash. The agent can use both.",
+      "ps5": "[to be translated]:Windows PowerShell (Built-in)",
+      "ps7": "[to be translated]:PowerShell 7",
+      "ps7NotDetected": "[to be translated]:PowerShell 7 not detected. Install from github.com/PowerShell/PowerShell or select Windows PowerShell."
+    },
     "sidebar_title": "Agenten",
     "todo": {
+      "mock": {
+        "actions": {
+          "complete": "[to be translated]:Complete",
+          "dismiss": "[to be translated]:Dismiss"
+        },
+        "details": {
+          "addRouter": {
+            "summary": "[to be translated]:Configuring client routing with react-router-dom v6...",
+            "title": "[to be translated]:Add React Router"
+          },
+          "configureProject": {
+            "resources": {
+              "createdMeta": "[to be translated]:created",
+              "postcssConfig": "[to be translated]:postcss.config.js",
+              "tailwindConfig": "[to be translated]:tailwind.config.js",
+              "updatedMeta": "[to be translated]:updated",
+              "viteConfig": "[to be translated]:vite.config.ts - port 3001"
+            },
+            "title": "[to be translated]:Configure project"
+          },
+          "installDependencies": {
+            "resources": {
+              "dependenciesMeta": "[to be translated]:dependencies",
+              "devDependenciesMeta": "[to be translated]:devDependencies",
+              "reactDeps": "[to be translated]:react@18.3.1, react-dom@18.3.1",
+              "tailwindDeps": "[to be translated]:tailwindcss@3.4.4, postcss@8.4.38",
+              "typescriptDeps": "[to be translated]:typescript@5.4.5, vite@5.3.0"
+            },
+            "summary": "[to be translated]:Installed react, react-dom, tailwindcss, postcss, autoprefixer, and TypeScript.",
+            "title": "[to be translated]:Install dependencies"
+          },
+          "reviewReferences": {
+            "collectionTitle": "[to be translated]:Reviewed references",
+            "resources": {
+              "npmCreateVite": "[to be translated]:npm create vite - Official Scaffolding",
+              "npmMeta": "[to be translated]:npmjs.com",
+              "reactDocs": "[to be translated]:React Documentation - Quick Start",
+              "reactMeta": "[to be translated]:react.dev",
+              "tailwindDocs": "[to be translated]:Tailwind CSS - Installation Guide",
+              "tailwindMeta": "[to be translated]:tailwindcss.com",
+              "viteDocs": "[to be translated]:Vite - Next Generation Frontend Tooling",
+              "viteMeta": "[to be translated]:vitejs.dev"
+            },
+            "title": "[to be translated]:Review references"
+          },
+          "searchWeb": {
+            "resources": {
+              "reactViteQuery": "[to be translated]:React Vite TypeScript starter 2025 best practices"
+            },
+            "summary": "[to be translated]:Collected current references for React + Vite scaffolding and best practices.",
+            "title": "[to be translated]:Search web references"
+          },
+          "title": "[to be translated]:Execution details",
+          "writeComponents": {
+            "collectionTitle": "[to be translated]:Created files",
+            "resources": {
+              "app": "[to be translated]:src/App.tsx",
+              "button": "[to be translated]:src/components/Button.tsx",
+              "card": "[to be translated]:src/components/Card.tsx",
+              "footer": "[to be translated]:src/components/Footer.tsx",
+              "header": "[to be translated]:src/components/Header.tsx",
+              "layout": "[to be translated]:src/components/Layout.tsx",
+              "modifiedMeta": "[to be translated]:modified",
+              "newMeta": "[to be translated]:new",
+              "updatedMeta": "[to be translated]:updated"
+            },
+            "title": "[to be translated]:Write components"
+          },
+          "writePages": {
+            "resources": {
+              "about": "[to be translated]:src/pages/About.tsx",
+              "home": "[to be translated]:src/pages/Home.tsx",
+              "newMeta": "[to be translated]:new"
+            },
+            "title": "[to be translated]:Write pages"
+          }
+        },
+        "progress": "[to be translated]:{{completed}}/{{total}} tasks completed",
+        "tasks": {
+          "addLinting": "[to be translated]:Add ESLint + Prettier",
+          "addRouter": "[to be translated]:Add React Router",
+          "buildDeploy": "[to be translated]:Build and deploy",
+          "configureProject": "[to be translated]:Configure project",
+          "finish": "[to be translated]:Finish",
+          "installDependencies": "[to be translated]:Install dependencies",
+          "reviewReferences": "[to be translated]:Review references",
+          "searchWeb": "[to be translated]:Search web references",
+          "writeComponents": "[to be translated]:Write components",
+          "writePages": "[to be translated]:Write pages"
+        },
+        "title": "[to be translated]:Tasks"
+      },
       "panel": {
         "title": "{{completed}}/{{total}} Aufgaben abgeschlossen"
       },
@@ -3931,6 +4030,9 @@
         "title": "Agenten-Auswahl",
         "triggerPlaceholder": "Wählen Sie einen Agenten",
         "valueProp": "Aktueller Wert"
+      },
+      "agentTodoList": {
+        "title": "[to be translated]:Agent Todo List"
       },
       "assistantSelector": {
         "clearSelection": "Klar",

--- a/src/renderer/src/i18n/translate/el-gr.json
+++ b/src/renderer/src/i18n/translate/el-gr.json
@@ -576,8 +576,107 @@
         }
       }
     },
+    "shell": {
+      "enablePowerShell": "[to be translated]:Enable PowerShell tool",
+      "enablePowerShellTooltip": "[to be translated]:Adds PowerShell as an additional shell tool alongside Bash. The agent can use both.",
+      "ps5": "[to be translated]:Windows PowerShell (Built-in)",
+      "ps7": "[to be translated]:PowerShell 7",
+      "ps7NotDetected": "[to be translated]:PowerShell 7 not detected. Install from github.com/PowerShell/PowerShell or select Windows PowerShell."
+    },
     "sidebar_title": "Πράκτορες",
     "todo": {
+      "mock": {
+        "actions": {
+          "complete": "[to be translated]:Complete",
+          "dismiss": "[to be translated]:Dismiss"
+        },
+        "details": {
+          "addRouter": {
+            "summary": "[to be translated]:Configuring client routing with react-router-dom v6...",
+            "title": "[to be translated]:Add React Router"
+          },
+          "configureProject": {
+            "resources": {
+              "createdMeta": "[to be translated]:created",
+              "postcssConfig": "[to be translated]:postcss.config.js",
+              "tailwindConfig": "[to be translated]:tailwind.config.js",
+              "updatedMeta": "[to be translated]:updated",
+              "viteConfig": "[to be translated]:vite.config.ts - port 3001"
+            },
+            "title": "[to be translated]:Configure project"
+          },
+          "installDependencies": {
+            "resources": {
+              "dependenciesMeta": "[to be translated]:dependencies",
+              "devDependenciesMeta": "[to be translated]:devDependencies",
+              "reactDeps": "[to be translated]:react@18.3.1, react-dom@18.3.1",
+              "tailwindDeps": "[to be translated]:tailwindcss@3.4.4, postcss@8.4.38",
+              "typescriptDeps": "[to be translated]:typescript@5.4.5, vite@5.3.0"
+            },
+            "summary": "[to be translated]:Installed react, react-dom, tailwindcss, postcss, autoprefixer, and TypeScript.",
+            "title": "[to be translated]:Install dependencies"
+          },
+          "reviewReferences": {
+            "collectionTitle": "[to be translated]:Reviewed references",
+            "resources": {
+              "npmCreateVite": "[to be translated]:npm create vite - Official Scaffolding",
+              "npmMeta": "[to be translated]:npmjs.com",
+              "reactDocs": "[to be translated]:React Documentation - Quick Start",
+              "reactMeta": "[to be translated]:react.dev",
+              "tailwindDocs": "[to be translated]:Tailwind CSS - Installation Guide",
+              "tailwindMeta": "[to be translated]:tailwindcss.com",
+              "viteDocs": "[to be translated]:Vite - Next Generation Frontend Tooling",
+              "viteMeta": "[to be translated]:vitejs.dev"
+            },
+            "title": "[to be translated]:Review references"
+          },
+          "searchWeb": {
+            "resources": {
+              "reactViteQuery": "[to be translated]:React Vite TypeScript starter 2025 best practices"
+            },
+            "summary": "[to be translated]:Collected current references for React + Vite scaffolding and best practices.",
+            "title": "[to be translated]:Search web references"
+          },
+          "title": "[to be translated]:Execution details",
+          "writeComponents": {
+            "collectionTitle": "[to be translated]:Created files",
+            "resources": {
+              "app": "[to be translated]:src/App.tsx",
+              "button": "[to be translated]:src/components/Button.tsx",
+              "card": "[to be translated]:src/components/Card.tsx",
+              "footer": "[to be translated]:src/components/Footer.tsx",
+              "header": "[to be translated]:src/components/Header.tsx",
+              "layout": "[to be translated]:src/components/Layout.tsx",
+              "modifiedMeta": "[to be translated]:modified",
+              "newMeta": "[to be translated]:new",
+              "updatedMeta": "[to be translated]:updated"
+            },
+            "title": "[to be translated]:Write components"
+          },
+          "writePages": {
+            "resources": {
+              "about": "[to be translated]:src/pages/About.tsx",
+              "home": "[to be translated]:src/pages/Home.tsx",
+              "newMeta": "[to be translated]:new"
+            },
+            "title": "[to be translated]:Write pages"
+          }
+        },
+        "progress": "[to be translated]:{{completed}}/{{total}} tasks completed",
+        "tasks": {
+          "addLinting": "[to be translated]:Add ESLint + Prettier",
+          "addRouter": "[to be translated]:Add React Router",
+          "buildDeploy": "[to be translated]:Build and deploy",
+          "configureProject": "[to be translated]:Configure project",
+          "finish": "[to be translated]:Finish",
+          "installDependencies": "[to be translated]:Install dependencies",
+          "reviewReferences": "[to be translated]:Review references",
+          "searchWeb": "[to be translated]:Search web references",
+          "writeComponents": "[to be translated]:Write components",
+          "writePages": "[to be translated]:Write pages"
+        },
+        "title": "[to be translated]:Tasks"
+      },
       "panel": {
         "title": "{{completed}}/{{total}} εργασίες ολοκληρώθηκαν"
       },
@@ -3931,6 +4030,9 @@
         "title": "Επιλογέας Πράκτορα",
         "triggerPlaceholder": "Επιλέξτε έναν πράκτορα",
         "valueProp": "Τρέχουσα τιμή"
+      },
+      "agentTodoList": {
+        "title": "[to be translated]:Agent Todo List"
       },
       "assistantSelector": {
         "clearSelection": "Καθαρό",

--- a/src/renderer/src/i18n/translate/es-es.json
+++ b/src/renderer/src/i18n/translate/es-es.json
@@ -576,8 +576,107 @@
         }
       }
     },
+    "shell": {
+      "enablePowerShell": "[to be translated]:Enable PowerShell tool",
+      "enablePowerShellTooltip": "[to be translated]:Adds PowerShell as an additional shell tool alongside Bash. The agent can use both.",
+      "ps5": "[to be translated]:Windows PowerShell (Built-in)",
+      "ps7": "[to be translated]:PowerShell 7",
+      "ps7NotDetected": "[to be translated]:PowerShell 7 not detected. Install from github.com/PowerShell/PowerShell or select Windows PowerShell."
+    },
     "sidebar_title": "Agentes",
     "todo": {
+      "mock": {
+        "actions": {
+          "complete": "[to be translated]:Complete",
+          "dismiss": "[to be translated]:Dismiss"
+        },
+        "details": {
+          "addRouter": {
+            "summary": "[to be translated]:Configuring client routing with react-router-dom v6...",
+            "title": "[to be translated]:Add React Router"
+          },
+          "configureProject": {
+            "resources": {
+              "createdMeta": "[to be translated]:created",
+              "postcssConfig": "[to be translated]:postcss.config.js",
+              "tailwindConfig": "[to be translated]:tailwind.config.js",
+              "updatedMeta": "[to be translated]:updated",
+              "viteConfig": "[to be translated]:vite.config.ts - port 3001"
+            },
+            "title": "[to be translated]:Configure project"
+          },
+          "installDependencies": {
+            "resources": {
+              "dependenciesMeta": "[to be translated]:dependencies",
+              "devDependenciesMeta": "[to be translated]:devDependencies",
+              "reactDeps": "[to be translated]:react@18.3.1, react-dom@18.3.1",
+              "tailwindDeps": "[to be translated]:tailwindcss@3.4.4, postcss@8.4.38",
+              "typescriptDeps": "[to be translated]:typescript@5.4.5, vite@5.3.0"
+            },
+            "summary": "[to be translated]:Installed react, react-dom, tailwindcss, postcss, autoprefixer, and TypeScript.",
+            "title": "[to be translated]:Install dependencies"
+          },
+          "reviewReferences": {
+            "collectionTitle": "[to be translated]:Reviewed references",
+            "resources": {
+              "npmCreateVite": "[to be translated]:npm create vite - Official Scaffolding",
+              "npmMeta": "[to be translated]:npmjs.com",
+              "reactDocs": "[to be translated]:React Documentation - Quick Start",
+              "reactMeta": "[to be translated]:react.dev",
+              "tailwindDocs": "[to be translated]:Tailwind CSS - Installation Guide",
+              "tailwindMeta": "[to be translated]:tailwindcss.com",
+              "viteDocs": "[to be translated]:Vite - Next Generation Frontend Tooling",
+              "viteMeta": "[to be translated]:vitejs.dev"
+            },
+            "title": "[to be translated]:Review references"
+          },
+          "searchWeb": {
+            "resources": {
+              "reactViteQuery": "[to be translated]:React Vite TypeScript starter 2025 best practices"
+            },
+            "summary": "[to be translated]:Collected current references for React + Vite scaffolding and best practices.",
+            "title": "[to be translated]:Search web references"
+          },
+          "title": "[to be translated]:Execution details",
+          "writeComponents": {
+            "collectionTitle": "[to be translated]:Created files",
+            "resources": {
+              "app": "[to be translated]:src/App.tsx",
+              "button": "[to be translated]:src/components/Button.tsx",
+              "card": "[to be translated]:src/components/Card.tsx",
+              "footer": "[to be translated]:src/components/Footer.tsx",
+              "header": "[to be translated]:src/components/Header.tsx",
+              "layout": "[to be translated]:src/components/Layout.tsx",
+              "modifiedMeta": "[to be translated]:modified",
+              "newMeta": "[to be translated]:new",
+              "updatedMeta": "[to be translated]:updated"
+            },
+            "title": "[to be translated]:Write components"
+          },
+          "writePages": {
+            "resources": {
+              "about": "[to be translated]:src/pages/About.tsx",
+              "home": "[to be translated]:src/pages/Home.tsx",
+              "newMeta": "[to be translated]:new"
+            },
+            "title": "[to be translated]:Write pages"
+          }
+        },
+        "progress": "[to be translated]:{{completed}}/{{total}} tasks completed",
+        "tasks": {
+          "addLinting": "[to be translated]:Add ESLint + Prettier",
+          "addRouter": "[to be translated]:Add React Router",
+          "buildDeploy": "[to be translated]:Build and deploy",
+          "configureProject": "[to be translated]:Configure project",
+          "finish": "[to be translated]:Finish",
+          "installDependencies": "[to be translated]:Install dependencies",
+          "reviewReferences": "[to be translated]:Review references",
+          "searchWeb": "[to be translated]:Search web references",
+          "writeComponents": "[to be translated]:Write components",
+          "writePages": "[to be translated]:Write pages"
+        },
+        "title": "[to be translated]:Tasks"
+      },
       "panel": {
         "title": "{{completed}}/{{total}} tareas completadas"
       },
@@ -3931,6 +4030,9 @@
         "title": "Selector de agente",
         "triggerPlaceholder": "Selecciona un agente",
         "valueProp": "Valor actual"
+      },
+      "agentTodoList": {
+        "title": "[to be translated]:Agent Todo List"
       },
       "assistantSelector": {
         "clearSelection": "Claro",

--- a/src/renderer/src/i18n/translate/fr-fr.json
+++ b/src/renderer/src/i18n/translate/fr-fr.json
@@ -576,8 +576,107 @@
         }
       }
     },
+    "shell": {
+      "enablePowerShell": "[to be translated]:Enable PowerShell tool",
+      "enablePowerShellTooltip": "[to be translated]:Adds PowerShell as an additional shell tool alongside Bash. The agent can use both.",
+      "ps5": "[to be translated]:Windows PowerShell (Built-in)",
+      "ps7": "[to be translated]:PowerShell 7",
+      "ps7NotDetected": "[to be translated]:PowerShell 7 not detected. Install from github.com/PowerShell/PowerShell or select Windows PowerShell."
+    },
     "sidebar_title": "Agents",
     "todo": {
+      "mock": {
+        "actions": {
+          "complete": "[to be translated]:Complete",
+          "dismiss": "[to be translated]:Dismiss"
+        },
+        "details": {
+          "addRouter": {
+            "summary": "[to be translated]:Configuring client routing with react-router-dom v6...",
+            "title": "[to be translated]:Add React Router"
+          },
+          "configureProject": {
+            "resources": {
+              "createdMeta": "[to be translated]:created",
+              "postcssConfig": "[to be translated]:postcss.config.js",
+              "tailwindConfig": "[to be translated]:tailwind.config.js",
+              "updatedMeta": "[to be translated]:updated",
+              "viteConfig": "[to be translated]:vite.config.ts - port 3001"
+            },
+            "title": "[to be translated]:Configure project"
+          },
+          "installDependencies": {
+            "resources": {
+              "dependenciesMeta": "[to be translated]:dependencies",
+              "devDependenciesMeta": "[to be translated]:devDependencies",
+              "reactDeps": "[to be translated]:react@18.3.1, react-dom@18.3.1",
+              "tailwindDeps": "[to be translated]:tailwindcss@3.4.4, postcss@8.4.38",
+              "typescriptDeps": "[to be translated]:typescript@5.4.5, vite@5.3.0"
+            },
+            "summary": "[to be translated]:Installed react, react-dom, tailwindcss, postcss, autoprefixer, and TypeScript.",
+            "title": "[to be translated]:Install dependencies"
+          },
+          "reviewReferences": {
+            "collectionTitle": "[to be translated]:Reviewed references",
+            "resources": {
+              "npmCreateVite": "[to be translated]:npm create vite - Official Scaffolding",
+              "npmMeta": "[to be translated]:npmjs.com",
+              "reactDocs": "[to be translated]:React Documentation - Quick Start",
+              "reactMeta": "[to be translated]:react.dev",
+              "tailwindDocs": "[to be translated]:Tailwind CSS - Installation Guide",
+              "tailwindMeta": "[to be translated]:tailwindcss.com",
+              "viteDocs": "[to be translated]:Vite - Next Generation Frontend Tooling",
+              "viteMeta": "[to be translated]:vitejs.dev"
+            },
+            "title": "[to be translated]:Review references"
+          },
+          "searchWeb": {
+            "resources": {
+              "reactViteQuery": "[to be translated]:React Vite TypeScript starter 2025 best practices"
+            },
+            "summary": "[to be translated]:Collected current references for React + Vite scaffolding and best practices.",
+            "title": "[to be translated]:Search web references"
+          },
+          "title": "[to be translated]:Execution details",
+          "writeComponents": {
+            "collectionTitle": "[to be translated]:Created files",
+            "resources": {
+              "app": "[to be translated]:src/App.tsx",
+              "button": "[to be translated]:src/components/Button.tsx",
+              "card": "[to be translated]:src/components/Card.tsx",
+              "footer": "[to be translated]:src/components/Footer.tsx",
+              "header": "[to be translated]:src/components/Header.tsx",
+              "layout": "[to be translated]:src/components/Layout.tsx",
+              "modifiedMeta": "[to be translated]:modified",
+              "newMeta": "[to be translated]:new",
+              "updatedMeta": "[to be translated]:updated"
+            },
+            "title": "[to be translated]:Write components"
+          },
+          "writePages": {
+            "resources": {
+              "about": "[to be translated]:src/pages/About.tsx",
+              "home": "[to be translated]:src/pages/Home.tsx",
+              "newMeta": "[to be translated]:new"
+            },
+            "title": "[to be translated]:Write pages"
+          }
+        },
+        "progress": "[to be translated]:{{completed}}/{{total}} tasks completed",
+        "tasks": {
+          "addLinting": "[to be translated]:Add ESLint + Prettier",
+          "addRouter": "[to be translated]:Add React Router",
+          "buildDeploy": "[to be translated]:Build and deploy",
+          "configureProject": "[to be translated]:Configure project",
+          "finish": "[to be translated]:Finish",
+          "installDependencies": "[to be translated]:Install dependencies",
+          "reviewReferences": "[to be translated]:Review references",
+          "searchWeb": "[to be translated]:Search web references",
+          "writeComponents": "[to be translated]:Write components",
+          "writePages": "[to be translated]:Write pages"
+        },
+        "title": "[to be translated]:Tasks"
+      },
       "panel": {
         "title": "{{completed}}/{{total}} tâches terminées"
       },
@@ -3931,6 +4030,9 @@
         "title": "Sélecteur d'agent",
         "triggerPlaceholder": "Sélectionnez un agent",
         "valueProp": "Valeur actuelle"
+      },
+      "agentTodoList": {
+        "title": "[to be translated]:Agent Todo List"
       },
       "assistantSelector": {
         "clearSelection": "Clair",

--- a/src/renderer/src/i18n/translate/ja-jp.json
+++ b/src/renderer/src/i18n/translate/ja-jp.json
@@ -576,8 +576,107 @@
         }
       }
     },
+    "shell": {
+      "enablePowerShell": "[to be translated]:Enable PowerShell tool",
+      "enablePowerShellTooltip": "[to be translated]:Adds PowerShell as an additional shell tool alongside Bash. The agent can use both.",
+      "ps5": "[to be translated]:Windows PowerShell (Built-in)",
+      "ps7": "[to be translated]:PowerShell 7",
+      "ps7NotDetected": "[to be translated]:PowerShell 7 not detected. Install from github.com/PowerShell/PowerShell or select Windows PowerShell."
+    },
     "sidebar_title": "エージェント",
     "todo": {
+      "mock": {
+        "actions": {
+          "complete": "[to be translated]:Complete",
+          "dismiss": "[to be translated]:Dismiss"
+        },
+        "details": {
+          "addRouter": {
+            "summary": "[to be translated]:Configuring client routing with react-router-dom v6...",
+            "title": "[to be translated]:Add React Router"
+          },
+          "configureProject": {
+            "resources": {
+              "createdMeta": "[to be translated]:created",
+              "postcssConfig": "[to be translated]:postcss.config.js",
+              "tailwindConfig": "[to be translated]:tailwind.config.js",
+              "updatedMeta": "[to be translated]:updated",
+              "viteConfig": "[to be translated]:vite.config.ts - port 3001"
+            },
+            "title": "[to be translated]:Configure project"
+          },
+          "installDependencies": {
+            "resources": {
+              "dependenciesMeta": "[to be translated]:dependencies",
+              "devDependenciesMeta": "[to be translated]:devDependencies",
+              "reactDeps": "[to be translated]:react@18.3.1, react-dom@18.3.1",
+              "tailwindDeps": "[to be translated]:tailwindcss@3.4.4, postcss@8.4.38",
+              "typescriptDeps": "[to be translated]:typescript@5.4.5, vite@5.3.0"
+            },
+            "summary": "[to be translated]:Installed react, react-dom, tailwindcss, postcss, autoprefixer, and TypeScript.",
+            "title": "[to be translated]:Install dependencies"
+          },
+          "reviewReferences": {
+            "collectionTitle": "[to be translated]:Reviewed references",
+            "resources": {
+              "npmCreateVite": "[to be translated]:npm create vite - Official Scaffolding",
+              "npmMeta": "[to be translated]:npmjs.com",
+              "reactDocs": "[to be translated]:React Documentation - Quick Start",
+              "reactMeta": "[to be translated]:react.dev",
+              "tailwindDocs": "[to be translated]:Tailwind CSS - Installation Guide",
+              "tailwindMeta": "[to be translated]:tailwindcss.com",
+              "viteDocs": "[to be translated]:Vite - Next Generation Frontend Tooling",
+              "viteMeta": "[to be translated]:vitejs.dev"
+            },
+            "title": "[to be translated]:Review references"
+          },
+          "searchWeb": {
+            "resources": {
+              "reactViteQuery": "[to be translated]:React Vite TypeScript starter 2025 best practices"
+            },
+            "summary": "[to be translated]:Collected current references for React + Vite scaffolding and best practices.",
+            "title": "[to be translated]:Search web references"
+          },
+          "title": "[to be translated]:Execution details",
+          "writeComponents": {
+            "collectionTitle": "[to be translated]:Created files",
+            "resources": {
+              "app": "[to be translated]:src/App.tsx",
+              "button": "[to be translated]:src/components/Button.tsx",
+              "card": "[to be translated]:src/components/Card.tsx",
+              "footer": "[to be translated]:src/components/Footer.tsx",
+              "header": "[to be translated]:src/components/Header.tsx",
+              "layout": "[to be translated]:src/components/Layout.tsx",
+              "modifiedMeta": "[to be translated]:modified",
+              "newMeta": "[to be translated]:new",
+              "updatedMeta": "[to be translated]:updated"
+            },
+            "title": "[to be translated]:Write components"
+          },
+          "writePages": {
+            "resources": {
+              "about": "[to be translated]:src/pages/About.tsx",
+              "home": "[to be translated]:src/pages/Home.tsx",
+              "newMeta": "[to be translated]:new"
+            },
+            "title": "[to be translated]:Write pages"
+          }
+        },
+        "progress": "[to be translated]:{{completed}}/{{total}} tasks completed",
+        "tasks": {
+          "addLinting": "[to be translated]:Add ESLint + Prettier",
+          "addRouter": "[to be translated]:Add React Router",
+          "buildDeploy": "[to be translated]:Build and deploy",
+          "configureProject": "[to be translated]:Configure project",
+          "finish": "[to be translated]:Finish",
+          "installDependencies": "[to be translated]:Install dependencies",
+          "reviewReferences": "[to be translated]:Review references",
+          "searchWeb": "[to be translated]:Search web references",
+          "writeComponents": "[to be translated]:Write components",
+          "writePages": "[to be translated]:Write pages"
+        },
+        "title": "[to be translated]:Tasks"
+      },
       "panel": {
         "title": "{{completed}}/{{total}} タスク完了"
       },
@@ -3931,6 +4030,9 @@
         "title": "エージェントセレクター",
         "triggerPlaceholder": "エージェントを選択してください",
         "valueProp": "現在値"
+      },
+      "agentTodoList": {
+        "title": "[to be translated]:Agent Todo List"
       },
       "assistantSelector": {
         "clearSelection": "クリア",

--- a/src/renderer/src/i18n/translate/pt-pt.json
+++ b/src/renderer/src/i18n/translate/pt-pt.json
@@ -576,8 +576,107 @@
         }
       }
     },
+    "shell": {
+      "enablePowerShell": "[to be translated]:Enable PowerShell tool",
+      "enablePowerShellTooltip": "[to be translated]:Adds PowerShell as an additional shell tool alongside Bash. The agent can use both.",
+      "ps5": "[to be translated]:Windows PowerShell (Built-in)",
+      "ps7": "[to be translated]:PowerShell 7",
+      "ps7NotDetected": "[to be translated]:PowerShell 7 not detected. Install from github.com/PowerShell/PowerShell or select Windows PowerShell."
+    },
     "sidebar_title": "Agentes",
     "todo": {
+      "mock": {
+        "actions": {
+          "complete": "[to be translated]:Complete",
+          "dismiss": "[to be translated]:Dismiss"
+        },
+        "details": {
+          "addRouter": {
+            "summary": "[to be translated]:Configuring client routing with react-router-dom v6...",
+            "title": "[to be translated]:Add React Router"
+          },
+          "configureProject": {
+            "resources": {
+              "createdMeta": "[to be translated]:created",
+              "postcssConfig": "[to be translated]:postcss.config.js",
+              "tailwindConfig": "[to be translated]:tailwind.config.js",
+              "updatedMeta": "[to be translated]:updated",
+              "viteConfig": "[to be translated]:vite.config.ts - port 3001"
+            },
+            "title": "[to be translated]:Configure project"
+          },
+          "installDependencies": {
+            "resources": {
+              "dependenciesMeta": "[to be translated]:dependencies",
+              "devDependenciesMeta": "[to be translated]:devDependencies",
+              "reactDeps": "[to be translated]:react@18.3.1, react-dom@18.3.1",
+              "tailwindDeps": "[to be translated]:tailwindcss@3.4.4, postcss@8.4.38",
+              "typescriptDeps": "[to be translated]:typescript@5.4.5, vite@5.3.0"
+            },
+            "summary": "[to be translated]:Installed react, react-dom, tailwindcss, postcss, autoprefixer, and TypeScript.",
+            "title": "[to be translated]:Install dependencies"
+          },
+          "reviewReferences": {
+            "collectionTitle": "[to be translated]:Reviewed references",
+            "resources": {
+              "npmCreateVite": "[to be translated]:npm create vite - Official Scaffolding",
+              "npmMeta": "[to be translated]:npmjs.com",
+              "reactDocs": "[to be translated]:React Documentation - Quick Start",
+              "reactMeta": "[to be translated]:react.dev",
+              "tailwindDocs": "[to be translated]:Tailwind CSS - Installation Guide",
+              "tailwindMeta": "[to be translated]:tailwindcss.com",
+              "viteDocs": "[to be translated]:Vite - Next Generation Frontend Tooling",
+              "viteMeta": "[to be translated]:vitejs.dev"
+            },
+            "title": "[to be translated]:Review references"
+          },
+          "searchWeb": {
+            "resources": {
+              "reactViteQuery": "[to be translated]:React Vite TypeScript starter 2025 best practices"
+            },
+            "summary": "[to be translated]:Collected current references for React + Vite scaffolding and best practices.",
+            "title": "[to be translated]:Search web references"
+          },
+          "title": "[to be translated]:Execution details",
+          "writeComponents": {
+            "collectionTitle": "[to be translated]:Created files",
+            "resources": {
+              "app": "[to be translated]:src/App.tsx",
+              "button": "[to be translated]:src/components/Button.tsx",
+              "card": "[to be translated]:src/components/Card.tsx",
+              "footer": "[to be translated]:src/components/Footer.tsx",
+              "header": "[to be translated]:src/components/Header.tsx",
+              "layout": "[to be translated]:src/components/Layout.tsx",
+              "modifiedMeta": "[to be translated]:modified",
+              "newMeta": "[to be translated]:new",
+              "updatedMeta": "[to be translated]:updated"
+            },
+            "title": "[to be translated]:Write components"
+          },
+          "writePages": {
+            "resources": {
+              "about": "[to be translated]:src/pages/About.tsx",
+              "home": "[to be translated]:src/pages/Home.tsx",
+              "newMeta": "[to be translated]:new"
+            },
+            "title": "[to be translated]:Write pages"
+          }
+        },
+        "progress": "[to be translated]:{{completed}}/{{total}} tasks completed",
+        "tasks": {
+          "addLinting": "[to be translated]:Add ESLint + Prettier",
+          "addRouter": "[to be translated]:Add React Router",
+          "buildDeploy": "[to be translated]:Build and deploy",
+          "configureProject": "[to be translated]:Configure project",
+          "finish": "[to be translated]:Finish",
+          "installDependencies": "[to be translated]:Install dependencies",
+          "reviewReferences": "[to be translated]:Review references",
+          "searchWeb": "[to be translated]:Search web references",
+          "writeComponents": "[to be translated]:Write components",
+          "writePages": "[to be translated]:Write pages"
+        },
+        "title": "[to be translated]:Tasks"
+      },
       "panel": {
         "title": "{{completed}}/{{total}} tarefas concluídas"
       },
@@ -3931,6 +4030,9 @@
         "title": "Seletor de Agente",
         "triggerPlaceholder": "Selecione um agente",
         "valueProp": "Valor atual"
+      },
+      "agentTodoList": {
+        "title": "[to be translated]:Agent Todo List"
       },
       "assistantSelector": {
         "clearSelection": "Limpo",

--- a/src/renderer/src/i18n/translate/ro-ro.json
+++ b/src/renderer/src/i18n/translate/ro-ro.json
@@ -576,8 +576,107 @@
         }
       }
     },
+    "shell": {
+      "enablePowerShell": "[to be translated]:Enable PowerShell tool",
+      "enablePowerShellTooltip": "[to be translated]:Adds PowerShell as an additional shell tool alongside Bash. The agent can use both.",
+      "ps5": "[to be translated]:Windows PowerShell (Built-in)",
+      "ps7": "[to be translated]:PowerShell 7",
+      "ps7NotDetected": "[to be translated]:PowerShell 7 not detected. Install from github.com/PowerShell/PowerShell or select Windows PowerShell."
+    },
     "sidebar_title": "Agenți",
     "todo": {
+      "mock": {
+        "actions": {
+          "complete": "[to be translated]:Complete",
+          "dismiss": "[to be translated]:Dismiss"
+        },
+        "details": {
+          "addRouter": {
+            "summary": "[to be translated]:Configuring client routing with react-router-dom v6...",
+            "title": "[to be translated]:Add React Router"
+          },
+          "configureProject": {
+            "resources": {
+              "createdMeta": "[to be translated]:created",
+              "postcssConfig": "[to be translated]:postcss.config.js",
+              "tailwindConfig": "[to be translated]:tailwind.config.js",
+              "updatedMeta": "[to be translated]:updated",
+              "viteConfig": "[to be translated]:vite.config.ts - port 3001"
+            },
+            "title": "[to be translated]:Configure project"
+          },
+          "installDependencies": {
+            "resources": {
+              "dependenciesMeta": "[to be translated]:dependencies",
+              "devDependenciesMeta": "[to be translated]:devDependencies",
+              "reactDeps": "[to be translated]:react@18.3.1, react-dom@18.3.1",
+              "tailwindDeps": "[to be translated]:tailwindcss@3.4.4, postcss@8.4.38",
+              "typescriptDeps": "[to be translated]:typescript@5.4.5, vite@5.3.0"
+            },
+            "summary": "[to be translated]:Installed react, react-dom, tailwindcss, postcss, autoprefixer, and TypeScript.",
+            "title": "[to be translated]:Install dependencies"
+          },
+          "reviewReferences": {
+            "collectionTitle": "[to be translated]:Reviewed references",
+            "resources": {
+              "npmCreateVite": "[to be translated]:npm create vite - Official Scaffolding",
+              "npmMeta": "[to be translated]:npmjs.com",
+              "reactDocs": "[to be translated]:React Documentation - Quick Start",
+              "reactMeta": "[to be translated]:react.dev",
+              "tailwindDocs": "[to be translated]:Tailwind CSS - Installation Guide",
+              "tailwindMeta": "[to be translated]:tailwindcss.com",
+              "viteDocs": "[to be translated]:Vite - Next Generation Frontend Tooling",
+              "viteMeta": "[to be translated]:vitejs.dev"
+            },
+            "title": "[to be translated]:Review references"
+          },
+          "searchWeb": {
+            "resources": {
+              "reactViteQuery": "[to be translated]:React Vite TypeScript starter 2025 best practices"
+            },
+            "summary": "[to be translated]:Collected current references for React + Vite scaffolding and best practices.",
+            "title": "[to be translated]:Search web references"
+          },
+          "title": "[to be translated]:Execution details",
+          "writeComponents": {
+            "collectionTitle": "[to be translated]:Created files",
+            "resources": {
+              "app": "[to be translated]:src/App.tsx",
+              "button": "[to be translated]:src/components/Button.tsx",
+              "card": "[to be translated]:src/components/Card.tsx",
+              "footer": "[to be translated]:src/components/Footer.tsx",
+              "header": "[to be translated]:src/components/Header.tsx",
+              "layout": "[to be translated]:src/components/Layout.tsx",
+              "modifiedMeta": "[to be translated]:modified",
+              "newMeta": "[to be translated]:new",
+              "updatedMeta": "[to be translated]:updated"
+            },
+            "title": "[to be translated]:Write components"
+          },
+          "writePages": {
+            "resources": {
+              "about": "[to be translated]:src/pages/About.tsx",
+              "home": "[to be translated]:src/pages/Home.tsx",
+              "newMeta": "[to be translated]:new"
+            },
+            "title": "[to be translated]:Write pages"
+          }
+        },
+        "progress": "[to be translated]:{{completed}}/{{total}} tasks completed",
+        "tasks": {
+          "addLinting": "[to be translated]:Add ESLint + Prettier",
+          "addRouter": "[to be translated]:Add React Router",
+          "buildDeploy": "[to be translated]:Build and deploy",
+          "configureProject": "[to be translated]:Configure project",
+          "finish": "[to be translated]:Finish",
+          "installDependencies": "[to be translated]:Install dependencies",
+          "reviewReferences": "[to be translated]:Review references",
+          "searchWeb": "[to be translated]:Search web references",
+          "writeComponents": "[to be translated]:Write components",
+          "writePages": "[to be translated]:Write pages"
+        },
+        "title": "[to be translated]:Tasks"
+      },
       "panel": {
         "title": "{{completed}}/{{total}} sarcini finalizate"
       },
@@ -3931,6 +4030,9 @@
         "title": "Selector Agent",
         "triggerPlaceholder": "Selectați un agent",
         "valueProp": "Valoare curentă"
+      },
+      "agentTodoList": {
+        "title": "[to be translated]:Agent Todo List"
       },
       "assistantSelector": {
         "clearSelection": "Clar",

--- a/src/renderer/src/i18n/translate/ru-ru.json
+++ b/src/renderer/src/i18n/translate/ru-ru.json
@@ -576,8 +576,107 @@
         }
       }
     },
+    "shell": {
+      "enablePowerShell": "[to be translated]:Enable PowerShell tool",
+      "enablePowerShellTooltip": "[to be translated]:Adds PowerShell as an additional shell tool alongside Bash. The agent can use both.",
+      "ps5": "[to be translated]:Windows PowerShell (Built-in)",
+      "ps7": "[to be translated]:PowerShell 7",
+      "ps7NotDetected": "[to be translated]:PowerShell 7 not detected. Install from github.com/PowerShell/PowerShell or select Windows PowerShell."
+    },
     "sidebar_title": "Агенты",
     "todo": {
+      "mock": {
+        "actions": {
+          "complete": "[to be translated]:Complete",
+          "dismiss": "[to be translated]:Dismiss"
+        },
+        "details": {
+          "addRouter": {
+            "summary": "[to be translated]:Configuring client routing with react-router-dom v6...",
+            "title": "[to be translated]:Add React Router"
+          },
+          "configureProject": {
+            "resources": {
+              "createdMeta": "[to be translated]:created",
+              "postcssConfig": "[to be translated]:postcss.config.js",
+              "tailwindConfig": "[to be translated]:tailwind.config.js",
+              "updatedMeta": "[to be translated]:updated",
+              "viteConfig": "[to be translated]:vite.config.ts - port 3001"
+            },
+            "title": "[to be translated]:Configure project"
+          },
+          "installDependencies": {
+            "resources": {
+              "dependenciesMeta": "[to be translated]:dependencies",
+              "devDependenciesMeta": "[to be translated]:devDependencies",
+              "reactDeps": "[to be translated]:react@18.3.1, react-dom@18.3.1",
+              "tailwindDeps": "[to be translated]:tailwindcss@3.4.4, postcss@8.4.38",
+              "typescriptDeps": "[to be translated]:typescript@5.4.5, vite@5.3.0"
+            },
+            "summary": "[to be translated]:Installed react, react-dom, tailwindcss, postcss, autoprefixer, and TypeScript.",
+            "title": "[to be translated]:Install dependencies"
+          },
+          "reviewReferences": {
+            "collectionTitle": "[to be translated]:Reviewed references",
+            "resources": {
+              "npmCreateVite": "[to be translated]:npm create vite - Official Scaffolding",
+              "npmMeta": "[to be translated]:npmjs.com",
+              "reactDocs": "[to be translated]:React Documentation - Quick Start",
+              "reactMeta": "[to be translated]:react.dev",
+              "tailwindDocs": "[to be translated]:Tailwind CSS - Installation Guide",
+              "tailwindMeta": "[to be translated]:tailwindcss.com",
+              "viteDocs": "[to be translated]:Vite - Next Generation Frontend Tooling",
+              "viteMeta": "[to be translated]:vitejs.dev"
+            },
+            "title": "[to be translated]:Review references"
+          },
+          "searchWeb": {
+            "resources": {
+              "reactViteQuery": "[to be translated]:React Vite TypeScript starter 2025 best practices"
+            },
+            "summary": "[to be translated]:Collected current references for React + Vite scaffolding and best practices.",
+            "title": "[to be translated]:Search web references"
+          },
+          "title": "[to be translated]:Execution details",
+          "writeComponents": {
+            "collectionTitle": "[to be translated]:Created files",
+            "resources": {
+              "app": "[to be translated]:src/App.tsx",
+              "button": "[to be translated]:src/components/Button.tsx",
+              "card": "[to be translated]:src/components/Card.tsx",
+              "footer": "[to be translated]:src/components/Footer.tsx",
+              "header": "[to be translated]:src/components/Header.tsx",
+              "layout": "[to be translated]:src/components/Layout.tsx",
+              "modifiedMeta": "[to be translated]:modified",
+              "newMeta": "[to be translated]:new",
+              "updatedMeta": "[to be translated]:updated"
+            },
+            "title": "[to be translated]:Write components"
+          },
+          "writePages": {
+            "resources": {
+              "about": "[to be translated]:src/pages/About.tsx",
+              "home": "[to be translated]:src/pages/Home.tsx",
+              "newMeta": "[to be translated]:new"
+            },
+            "title": "[to be translated]:Write pages"
+          }
+        },
+        "progress": "[to be translated]:{{completed}}/{{total}} tasks completed",
+        "tasks": {
+          "addLinting": "[to be translated]:Add ESLint + Prettier",
+          "addRouter": "[to be translated]:Add React Router",
+          "buildDeploy": "[to be translated]:Build and deploy",
+          "configureProject": "[to be translated]:Configure project",
+          "finish": "[to be translated]:Finish",
+          "installDependencies": "[to be translated]:Install dependencies",
+          "reviewReferences": "[to be translated]:Review references",
+          "searchWeb": "[to be translated]:Search web references",
+          "writeComponents": "[to be translated]:Write components",
+          "writePages": "[to be translated]:Write pages"
+        },
+        "title": "[to be translated]:Tasks"
+      },
       "panel": {
         "title": "{{completed}}/{{total}} задач выполнено"
       },
@@ -3931,6 +4030,9 @@
         "title": "Селектор агентов",
         "triggerPlaceholder": "Выберите агента",
         "valueProp": "Текущее значение"
+      },
+      "agentTodoList": {
+        "title": "[to be translated]:Agent Todo List"
       },
       "assistantSelector": {
         "clearSelection": "Прозрачный",

--- a/src/renderer/src/i18n/translate/vi-vn.json
+++ b/src/renderer/src/i18n/translate/vi-vn.json
@@ -576,8 +576,107 @@
         }
       }
     },
+    "shell": {
+      "enablePowerShell": "[to be translated]:Enable PowerShell tool",
+      "enablePowerShellTooltip": "[to be translated]:Adds PowerShell as an additional shell tool alongside Bash. The agent can use both.",
+      "ps5": "[to be translated]:Windows PowerShell (Built-in)",
+      "ps7": "[to be translated]:PowerShell 7",
+      "ps7NotDetected": "[to be translated]:PowerShell 7 not detected. Install from github.com/PowerShell/PowerShell or select Windows PowerShell."
+    },
     "sidebar_title": "Đại lý",
     "todo": {
+      "mock": {
+        "actions": {
+          "complete": "[to be translated]:Complete",
+          "dismiss": "[to be translated]:Dismiss"
+        },
+        "details": {
+          "addRouter": {
+            "summary": "[to be translated]:Configuring client routing with react-router-dom v6...",
+            "title": "[to be translated]:Add React Router"
+          },
+          "configureProject": {
+            "resources": {
+              "createdMeta": "[to be translated]:created",
+              "postcssConfig": "[to be translated]:postcss.config.js",
+              "tailwindConfig": "[to be translated]:tailwind.config.js",
+              "updatedMeta": "[to be translated]:updated",
+              "viteConfig": "[to be translated]:vite.config.ts - port 3001"
+            },
+            "title": "[to be translated]:Configure project"
+          },
+          "installDependencies": {
+            "resources": {
+              "dependenciesMeta": "[to be translated]:dependencies",
+              "devDependenciesMeta": "[to be translated]:devDependencies",
+              "reactDeps": "[to be translated]:react@18.3.1, react-dom@18.3.1",
+              "tailwindDeps": "[to be translated]:tailwindcss@3.4.4, postcss@8.4.38",
+              "typescriptDeps": "[to be translated]:typescript@5.4.5, vite@5.3.0"
+            },
+            "summary": "[to be translated]:Installed react, react-dom, tailwindcss, postcss, autoprefixer, and TypeScript.",
+            "title": "[to be translated]:Install dependencies"
+          },
+          "reviewReferences": {
+            "collectionTitle": "[to be translated]:Reviewed references",
+            "resources": {
+              "npmCreateVite": "[to be translated]:npm create vite - Official Scaffolding",
+              "npmMeta": "[to be translated]:npmjs.com",
+              "reactDocs": "[to be translated]:React Documentation - Quick Start",
+              "reactMeta": "[to be translated]:react.dev",
+              "tailwindDocs": "[to be translated]:Tailwind CSS - Installation Guide",
+              "tailwindMeta": "[to be translated]:tailwindcss.com",
+              "viteDocs": "[to be translated]:Vite - Next Generation Frontend Tooling",
+              "viteMeta": "[to be translated]:vitejs.dev"
+            },
+            "title": "[to be translated]:Review references"
+          },
+          "searchWeb": {
+            "resources": {
+              "reactViteQuery": "[to be translated]:React Vite TypeScript starter 2025 best practices"
+            },
+            "summary": "[to be translated]:Collected current references for React + Vite scaffolding and best practices.",
+            "title": "[to be translated]:Search web references"
+          },
+          "title": "[to be translated]:Execution details",
+          "writeComponents": {
+            "collectionTitle": "[to be translated]:Created files",
+            "resources": {
+              "app": "[to be translated]:src/App.tsx",
+              "button": "[to be translated]:src/components/Button.tsx",
+              "card": "[to be translated]:src/components/Card.tsx",
+              "footer": "[to be translated]:src/components/Footer.tsx",
+              "header": "[to be translated]:src/components/Header.tsx",
+              "layout": "[to be translated]:src/components/Layout.tsx",
+              "modifiedMeta": "[to be translated]:modified",
+              "newMeta": "[to be translated]:new",
+              "updatedMeta": "[to be translated]:updated"
+            },
+            "title": "[to be translated]:Write components"
+          },
+          "writePages": {
+            "resources": {
+              "about": "[to be translated]:src/pages/About.tsx",
+              "home": "[to be translated]:src/pages/Home.tsx",
+              "newMeta": "[to be translated]:new"
+            },
+            "title": "[to be translated]:Write pages"
+          }
+        },
+        "progress": "[to be translated]:{{completed}}/{{total}} tasks completed",
+        "tasks": {
+          "addLinting": "[to be translated]:Add ESLint + Prettier",
+          "addRouter": "[to be translated]:Add React Router",
+          "buildDeploy": "[to be translated]:Build and deploy",
+          "configureProject": "[to be translated]:Configure project",
+          "finish": "[to be translated]:Finish",
+          "installDependencies": "[to be translated]:Install dependencies",
+          "reviewReferences": "[to be translated]:Review references",
+          "searchWeb": "[to be translated]:Search web references",
+          "writeComponents": "[to be translated]:Write components",
+          "writePages": "[to be translated]:Write pages"
+        },
+        "title": "[to be translated]:Tasks"
+      },
       "panel": {
         "title": "{{completed}}/{{total}} nhiệm vụ đã hoàn thành"
       },
@@ -3931,6 +4030,9 @@
         "title": "Bộ chọn tác nhân",
         "triggerPlaceholder": "Chọn một đại lý",
         "valueProp": "Giá trị hiện tại"
+      },
+      "agentTodoList": {
+        "title": "[to be translated]:Agent Todo List"
       },
       "assistantSelector": {
         "clearSelection": "Rõ ràng",


### PR DESCRIPTION
## What this PR does

**Before this PR:**
- Agent sessions on Windows only had the Bash tool available. No option to use PowerShell.
- PowerShell's `$PROFILE` (which many Windows users configure to dynamically load fnm/nvm/mise) was never loaded.

**After this PR:**
- Windows users can enable PowerShell as an additional shell tool alongside Bash (both tools coexist).
- When enabled, the SDK's PowerShell tool is activated (`CLAUDE_CODE_USE_POWERSHELL_TOOL=1`) and the user's PowerShell `$PROFILE` is loaded to capture environment variables and PATH modifications.
- Users can choose between PowerShell 7 (`pwsh`) and Windows PowerShell 5.1 (built-in `powershell.exe`). This matters because the two versions have separate `$PROFILE` paths — some users have PATH configured in one but not the other.
- On non-Windows platforms, this option is not shown (no behavior change).

**Related:** #14597, #14893

---

## Why we need it and why it was done in this way

**Background:** #14597 reported that on Windows, shell profile files are never sourced, breaking fnm/nvm/mise users. #14893 proposed bundling portable runtimes (uv, Git, Node) into the installer.

**How this PR helps #14597:** Most Windows users configure their development environment in PowerShell's `$PROFILE`, not in Git Bash's `~/.bash_profile`. When the PowerShell tool is enabled, `getPowerShellProfileEnvironment()` spawns the selected PowerShell **without** `-NoProfile`, capturing the user's `$PROFILE` environment — including PATH entries from fnm, nvm, mise, and other tools. This addresses the core pain point of #14597 for the majority of Windows users.

**Why Bash is not disabled:** The Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`) has an unconditional dependency on `bash.exe` on Windows — the `_Q6()` function calls `process.exit(1)` if `bash.exe` is not found during SDK initialization. This means:
- Git for Windows is **always required** on Windows, regardless of PowerShell selection.
- Disabling the Bash tool would be misleading since the SDK still uses bash internally for hooks.
- Both tools coexist — the agent can use PowerShell cmdlets or Bash commands as appropriate.

**Why this does NOT replace #14893:** The SDK's hard dependency on `bash.exe` means PowerShell cannot replace Git Bash. #14893 (bundling portable runtimes) remains essential — it eliminates the need for users to manually install Git, Node, and uv. This PR complements #14893 by adding PowerShell as an additional capability, not as a substitute.

**Why Git Bash profile loading is not in this PR:** Sourcing Git Bash's `~/.bash_profile` on Windows is addressed separately in PR #14626 (`fix(shell): source Git Bash profile on Windows`). That PR extracts `git-bash.ts` to avoid circular dependencies — a different scope from this PR. Together, both PRs ensure that profile files from both shells are loaded.

**Design decisions:**

| Decision | Rationale |
|---|---|
| Toggle (not dropdown) | PowerShell is an optional addition, not a replacement for Bash |
| PS5/PS7 version selector | Different `$PROFILE` paths; user may prefer one over the other |
| `getPowerShellProfileEnvironment()` as separate function | Avoids contaminating the module-level cached env shared by MCP and other consumers |
| `CLAUDE_CODE_USE_POWERSHELL_TOOL` added to `BLOCKED_ENV_KEYS` | Prevents user `env_vars` from overriding the system-controlled setting |
| Windows-only (`isWin` guard) | macOS/Linux shell profile loading already works via `getLoginShellEnvironment()` |

---

## Breaking changes

None. The `enable_powershell` field is optional and defaults to `false`. Existing agents behave identically.

---

## Special notes for your reviewer

- The SDK's PowerShell tool was introduced as an opt-in preview in Claude Code 2.1.84. `CLAUDE_CODE_USE_POWERSHELL_TOOL` is the official environment variable to enable it (verified via SDK source and CHANGELOG).
- The `disallowedTools` list is **NOT** modified — Bash remains available alongside PowerShell. This is intentional: the SDK uses bash internally regardless.
- Pre-existing test failures in `userDataLocation.test.ts` and `KnowledgeVectorMigrator.test.ts` are unrelated to this PR.

---

## Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Written for human readability, kept simple
- [x] Refactor: Code is cleaner than before
- [x] Upgrade: No breaking changes, backward compatible
- [x] Documentation: i18n keys added for all user-facing strings
- [x] Self-review: Reviewed via diff, typecheck, and lint

---

## Release note

Added an optional PowerShell tool for agent sessions on Windows. When enabled, the agent can use both Bash and PowerShell commands. The user's PowerShell `$PROFILE` is loaded to capture environment variables from fnm/nvm/mise. Users can choose between PowerShell 7 and Windows PowerShell 5.1.

---

## 这个 PR 做了什么

**修改前：**
- Windows 上的 Agent 会话只有 Bash 工具可用，无法使用 PowerShell。
- PowerShell 的 `$PROFILE`（很多 Windows 用户在里面配置了 动态加载fnm/nvm/mise）从未被加载。

**修改后：**
- Windows 用户可以在 Bash 之外额外启用 PowerShell 工具（两个工具共存）。
- 启用后，SDK 的 PowerShell 工具通过 `CLAUDE_CODE_USE_POWERSHELL_TOOL=1` 激活，用户的 PowerShell `$PROFILE` 被加载以捕获环境变量和 PATH 修改。
- 用户可以选择 PowerShell 7（`pwsh`）或 Windows PowerShell 5.1（内置 `powershell.exe`）。两者 `$PROFILE` 路径不同——有些用户在其中一个里配了 PATH。
- 非 Windows 平台不显示此选项（行为不变）。

**关联 Issue：** #14597, #14893

---

## 为什么需要这个 PR，以及为什么采用这种方式

**背景：** #14597 报告了 Windows 上 shell profile 文件不会被加载，导致 fnm/nvm/mise 用户无法正常使用。#14893 提议将便携运行时（uv、Git、Node）打包到安装程序中。

**对 #14597 的帮助：** 大多数 Windows 用户在 PowerShell 的 `$PROFILE` 中配置开发环境，而不是 Git Bash 的 `~/.bash_profile`。启用 PowerShell 工具后，`getPowerShellProfileEnvironment()` 以不带 `-NoProfile` 的方式启动 PowerShell，捕获用户的 `$PROFILE` 环境——包括 fnm、nvm、mise 等工具的 PATH 条目。这解决了 #14597 对大多数 Windows 用户的核心痛点。

**为什么不禁用 Bash：** Claude Agent SDK（`@anthropic-ai/claude-agent-sdk`）在 Windows 上无条件依赖 `bash.exe`——`_Q6()` 函数在 SDK 初始化时找不到 `bash.exe` 就会调用 `process.exit(1)`。这意味着：
- Windows 上始终需要安装 Git for Windows，无论是否选择 PowerShell。
- 禁用 Bash 工具会产生误导，因为 SDK 内部仍然通过 hooks 使用 bash。
- 两个工具共存——Agent 可以根据场景使用 PowerShell cmdlet 或 Bash 命令。

**为什么不能替代 #14893：** SDK 对 `bash.exe` 的硬依赖意味着 PowerShell 无法替代 Git Bash。#14893（打包便携运行时）仍然至关重要——它消除了用户手动安装 Git、Node、uv 的需要。本 PR 是对 #14893 的补充，而非替代。

**为什么 Git Bash profile 加载不在本 PR 中：** 在 Windows 上加载 Git Bash 的 `~/.bash_profile` 由 PR #14626（`fix(shell): source Git Bash profile on Windows`）单独处理。该 PR 提取了 `git-bash.ts` 以避免循环依赖——与本 PR 范围不同。两个 PR 合在一起，确保两种 shell 的 profile 文件都会被加载。

---

## 破坏性变更

无。`enable_powershell` 字段是可选的，默认为 `false`。现有 Agent 表现与之前完全一致。

---

## 给审查者的特别说明

- SDK 的 PowerShell 工具在 Claude Code 2.1.84 版本作为 opt-in preview 引入。`CLAUDE_CODE_USE_POWERSHELL_TOOL` 是启用它的官方环境变量（通过 SDK 源码和 CHANGELOG 确认）。
- `disallowedTools` 列表未被修改——Bash 与 PowerShell 共存。这是有意为之：SDK 无论是否启用 PowerShell 都会在内部使用 bash。
- `userDataLocation.test.ts` 和 `KnowledgeVectorMigrator.test.ts` 中的测试失败是预先存在的，与本 PR 无关。

---

## 发布说明

为 Windows 上的 Agent 会话添加了可选的 PowerShell 工具。启用后，Agent 可以同时使用 Bash 和 PowerShell 命令。用户的 PowerShell `$PROFILE` 被加载以捕获来自 fnm/nvm/mise 的环境变量。用户可以在 PowerShell 7 和 Windows PowerShell 5.1 之间选择。