### PR TITLE
feat(agents): add timezone support for scheduled cron tasks

### DIFF
--- a/resources/database/drizzle/0008_add_task_timezone.sql
+++ b/resources/database/drizzle/0008_add_task_timezone.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `scheduled_tasks` ADD `timezone` text;

--- a/resources/database/drizzle/meta/_journal.json
+++ b/resources/database/drizzle/meta/_journal.json
@@ -56,6 +56,13 @@
       "when": 1776236285350,
       "tag": "0007_strange_galactus",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1778361600000,
+      "tag": "0008_add_task_timezone",
+      "breakpoints": true
     }
   ],
   "version": "7"

--- a/src/main/mcpServers/claw.ts
+++ b/src/main/mcpServers/claw.ts
@@ -32,10 +32,12 @@ function parseDurationToMinutes(duration: string): number {
   return totalMinutes
 }
 
+const systemTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+
 const CRON_TOOL: Tool = {
   name: 'cron',
   description:
-    "Manage scheduled tasks. Use action 'add' to create a recurring or one-time job, 'list' to see all jobs, or 'remove' to delete a job. For one-time jobs, use the 'at' field with an RFC3339 timestamp.",
+    "Manage scheduled tasks. Use action 'add' to create a recurring or one-time job, 'list' to see all jobs, or 'remove' to delete a job. For one-time jobs, use the 'at' field with an RFC3339 timestamp. For cron expressions, the 'timezone' parameter controls when the job fires — if omitted, it defaults to UTC. Always pass the user's local timezone (check USER.md) so cron expressions like '0 9 * * *' fire at 9am local time, not 9am UTC.",
   inputSchema: {
     type: 'object',
     properties: {
@@ -64,6 +66,10 @@ const CRON_TOOL: Tool = {
         type: 'string',
         description:
           "RFC3339 timestamp for a one-time job, e.g. '2024-01-15T14:30:00+08:00' (use at OR cron OR every, not combined)"
+      },
+      timezone: {
+        type: 'string',
+        description: `IANA timezone for cron expressions, e.g. '${systemTimezone}', 'Asia/Shanghai', 'America/New_York'. If omitted, cron expressions are interpreted in UTC. Not needed for 'every' (interval) or 'at' (one-time) jobs.`
       },
       channel_ids: {
         type: 'array',
@@ -301,6 +307,7 @@ class ClawServer {
     const cronExpr = args.cron as string | undefined
     const every = args.every as string | undefined
     const at = args.at as string | undefined
+    const timezone = args.timezone as string | undefined
     const rawChannelIds = args.channel_ids as string[] | undefined
     const timeoutMinutes = args.timeout_minutes as number | undefined
     if (!name) throw new McpError(ErrorCode.InvalidParams, "'name' is required for add")
@@ -342,6 +349,7 @@ class ClawServer {
       schedule_type: scheduleType,
       schedule_value: scheduleValue,
       timeout_minutes: timeoutMinutes && timeoutMinutes > 0 ? timeoutMinutes : undefined,
+      timezone: timezone || undefined,
       channel_ids: channelIds && channelIds.length > 0 ? channelIds : undefined
     })
 

--- a/src/main/services/agents/database/schema/tasks.schema.ts
+++ b/src/main/services/agents/database/schema/tasks.schema.ts
@@ -17,6 +17,7 @@ export const scheduledTasksTable = sqliteTable('scheduled_tasks', {
   next_run: text('next_run'),
   last_run: text('last_run'),
   last_result: text('last_result'),
+  timezone: text('timezone'), // IANA timezone, e.g. 'Asia/Shanghai'. null = UTC for cron
   status: text('status').notNull().default('active'), // 'active' | 'paused' | 'completed'
   created_at: text('created_at').notNull(),
   updated_at: text('updated_at').notNull()

--- a/src/main/services/agents/services/SchedulerService.ts
+++ b/src/main/services/agents/services/SchedulerService.ts
@@ -213,6 +213,10 @@ class SchedulerService {
 
       // For heartbeat tasks, read prompt from workspace heartbeat.md file
       let fullPrompt = task.prompt
+      // Inject timezone context so the agent uses correct dates/times during execution
+      if (task.timezone && task.schedule_type === 'cron') {
+        fullPrompt = `[Scheduled task timezone: ${task.timezone}]\n\n${fullPrompt}`
+      }
       if (task.name === 'heartbeat') {
         if (config.heartbeat_enabled === false || !workspacePath) {
           logger.debug('Heartbeat task skipped (disabled or no workspace)', { taskId: task.id })

--- a/src/main/services/agents/services/TaskService.ts
+++ b/src/main/services/agents/services/TaskService.ts
@@ -31,7 +31,7 @@ export class TaskService extends BaseService {
     const id = `task_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`
     const now = new Date().toISOString()
 
-    const nextRun = this.computeInitialNextRun(req.schedule_type, req.schedule_value)
+    const nextRun = this.computeInitialNextRun(req.schedule_type, req.schedule_value, req.timezone)
 
     const insertData: InsertTaskRow = {
       id,
@@ -41,6 +41,7 @@ export class TaskService extends BaseService {
       schedule_type: req.schedule_type,
       schedule_value: req.schedule_value,
       ...(req.timeout_minutes != null ? { timeout_minutes: req.timeout_minutes } : {}),
+      timezone: req.timezone ?? null,
       next_run: nextRun,
       status: 'active',
       created_at: now,
@@ -135,19 +136,22 @@ export class TaskService extends BaseService {
     if (updates.agent_id !== undefined) updateData.agent_id = updates.agent_id
     if (updates.timeout_minutes !== undefined) updateData.timeout_minutes = updates.timeout_minutes ?? 2
     if (updates.status !== undefined) updateData.status = updates.status
+    if (updates.timezone !== undefined) updateData.timezone = updates.timezone
 
     if (updates.schedule_type !== undefined || updates.schedule_value !== undefined) {
       const schedType = updates.schedule_type ?? existing.schedule_type
       const schedValue = updates.schedule_value ?? existing.schedule_value
+      const tz = updates.timezone !== undefined ? updates.timezone : existing.timezone
       updateData.schedule_type = schedType
       updateData.schedule_value = schedValue
-      updateData.next_run = this.computeInitialNextRun(schedType, schedValue)
+      updateData.next_run = this.computeInitialNextRun(schedType, schedValue, tz)
     }
 
     if (updates.status === 'active' && existing.status === 'paused') {
       const schedType = updates.schedule_type ?? existing.schedule_type
       const schedValue = updates.schedule_value ?? existing.schedule_value
-      updateData.next_run = this.computeInitialNextRun(schedType, schedValue)
+      const tz = updates.timezone !== undefined ? updates.timezone : existing.timezone
+      updateData.next_run = this.computeInitialNextRun(schedType, schedValue, tz)
     }
 
     const database = await this.getDatabase()
@@ -206,21 +210,24 @@ export class TaskService extends BaseService {
     if (updates.prompt !== undefined) updateData.prompt = updates.prompt
     if (updates.timeout_minutes !== undefined) updateData.timeout_minutes = updates.timeout_minutes ?? 2
     if (updates.status !== undefined) updateData.status = updates.status
+    if (updates.timezone !== undefined) updateData.timezone = updates.timezone
 
     // If schedule type or value changed, recompute next_run
     if (updates.schedule_type !== undefined || updates.schedule_value !== undefined) {
       const schedType = updates.schedule_type ?? existing.schedule_type
       const schedValue = updates.schedule_value ?? existing.schedule_value
+      const tz = updates.timezone !== undefined ? updates.timezone : existing.timezone
       updateData.schedule_type = schedType
       updateData.schedule_value = schedValue
-      updateData.next_run = this.computeInitialNextRun(schedType, schedValue)
+      updateData.next_run = this.computeInitialNextRun(schedType, schedValue, tz)
     }
 
     // If resuming from paused, recompute next_run
     if (updates.status === 'active' && existing.status === 'paused') {
       const schedType = updates.schedule_type ?? existing.schedule_type
       const schedValue = updates.schedule_value ?? existing.schedule_value
-      updateData.next_run = this.computeInitialNextRun(schedType, schedValue)
+      const tz = updates.timezone !== undefined ? updates.timezone : existing.timezone
+      updateData.next_run = this.computeInitialNextRun(schedType, schedValue, tz)
     }
 
     const database = await this.getDatabase()
@@ -403,7 +410,10 @@ export class TaskService extends BaseService {
     if (task.schedule_type === 'cron') {
       try {
         const { CronExpressionParser } = require('cron-parser')
-        const interval = CronExpressionParser.parse(task.schedule_value)
+        const interval = CronExpressionParser.parse(
+          task.schedule_value,
+          task.timezone ? { tz: task.timezone } : undefined
+        )
         return interval.next().toISOString()
       } catch {
         logger.warn('Invalid cron expression', { taskId: task.id, cron: task.schedule_value })
@@ -463,14 +473,14 @@ export class TaskService extends BaseService {
     throw new Error('Scheduled tasks require Soul Mode or Bypass Permissions mode. Update the agent settings first.')
   }
 
-  private computeInitialNextRun(scheduleType: string, scheduleValue: string): string | null {
+  private computeInitialNextRun(scheduleType: string, scheduleValue: string, timezone?: string | null): string | null {
     const now = Date.now()
 
     switch (scheduleType) {
       case 'cron': {
         try {
           const { CronExpressionParser } = require('cron-parser')
-          const interval = CronExpressionParser.parse(scheduleValue)
+          const interval = CronExpressionParser.parse(scheduleValue, timezone ? { tz: timezone } : undefined)
           return interval.next().toISOString()
         } catch {
           return null

--- a/src/renderer/src/pages/settings/AgentSettings/components/TaskFormModal.tsx
+++ b/src/renderer/src/pages/settings/AgentSettings/components/TaskFormModal.tsx
@@ -11,6 +11,7 @@ type TaskFormData = {
   prompt: string
   schedule_type: TaskScheduleType
   schedule_value: string
+  timezone: string
   channel_ids: string[]
 }
 
@@ -42,6 +43,7 @@ const TaskFormModal: FC<TaskFormModalProps> = ({
     prompt: '',
     schedule_type: 'interval',
     schedule_value: '',
+    timezone: '',
     channel_ids: []
   })
 
@@ -52,6 +54,7 @@ const TaskFormModal: FC<TaskFormModalProps> = ({
         prompt: initialData.prompt ?? '',
         schedule_type: initialData.schedule_type ?? 'interval',
         schedule_value: initialData.schedule_value ?? '',
+        timezone: initialData.timezone ?? '',
         channel_ids: initialData.channel_ids ?? []
       })
     } else if (open) {
@@ -60,6 +63,7 @@ const TaskFormModal: FC<TaskFormModalProps> = ({
         prompt: '',
         schedule_type: 'interval',
         schedule_value: '',
+        timezone: '',
         channel_ids: []
       })
     }
@@ -161,6 +165,18 @@ const TaskFormModal: FC<TaskFormModalProps> = ({
             {renderScheduleInput()}
           </div>
         </div>
+        {form.schedule_type === 'cron' && (
+          <div>
+            <label className="mb-1 block font-medium text-sm">
+              {t('agent.cherryClaw.tasks.timezone.label', 'Timezone')}
+            </label>
+            <Input
+              value={form.timezone}
+              onChange={(e) => setForm((f) => ({ ...f, timezone: e.target.value }))}
+              placeholder="e.g. Asia/Shanghai, America/New_York (default: UTC)"
+            />
+          </div>
+        )}
 
         {channels.length > 0 && (
           <div>

--- a/src/renderer/src/pages/settings/AgentSettings/components/TaskListItem.tsx
+++ b/src/renderer/src/pages/settings/AgentSettings/components/TaskListItem.tsx
@@ -46,7 +46,9 @@ const TaskListItem: FC<TaskListItemProps> = ({ task, onEdit, onToggleStatus, onD
   const locale = i18n.language
 
   const formatScheduleValue = () => {
-    if (task.schedule_type === 'cron') return task.schedule_value
+    if (task.schedule_type === 'cron') {
+      return task.timezone ? `${task.schedule_value} (${task.timezone})` : task.schedule_value
+    }
     if (task.schedule_type === 'interval') return `${task.schedule_value} min`
     if (task.schedule_type === 'once' && task.schedule_value) {
       return new Date(task.schedule_value).toLocaleString(locale)

--- a/src/renderer/src/pages/settings/TasksSettings.tsx
+++ b/src/renderer/src/pages/settings/TasksSettings.tsx
@@ -110,6 +110,7 @@ const TaskDetail: FC<{
   const [agentId, setAgentId] = useState(task.agent_id)
   const [scheduleType, setScheduleType] = useState(task.schedule_type)
   const [scheduleValue, setScheduleValue] = useState(task.schedule_value)
+  const [timezone, setTimezone] = useState(task.timezone ?? '')
   const [timeoutMinutes, setTimeoutMinutes] = useState<string>(task.timeout_minutes?.toString() ?? '')
   const [channelIds, setChannelIds] = useState<string[]>(task.channel_ids ?? [])
 
@@ -119,6 +120,7 @@ const TaskDetail: FC<{
     setAgentId(task.agent_id)
     setScheduleType(task.schedule_type)
     setScheduleValue(task.schedule_value)
+    setTimezone(task.timezone ?? '')
     setTimeoutMinutes(task.timeout_minutes?.toString() ?? '')
     setChannelIds(task.channel_ids ?? [])
   }, [task])
@@ -147,7 +149,9 @@ const TaskDetail: FC<{
   }
 
   const formatScheduleValue = () => {
-    if (task.schedule_type === 'cron') return task.schedule_value
+    if (task.schedule_type === 'cron') {
+      return task.timezone ? `${task.schedule_value} (${task.timezone})` : `${task.schedule_value} (UTC)`
+    }
     if (task.schedule_type === 'interval') return `${task.schedule_value} ${t('agent.cherryClaw.tasks.intervalUnit')}`
     if (task.schedule_type === 'once' && task.schedule_value) {
       return formatDateTime(task.schedule_value)
@@ -363,6 +367,26 @@ const TaskDetail: FC<{
             />
           </div>
         </div>
+        {scheduleType === 'cron' && (
+          <>
+            <SettingDivider />
+            <SettingRow style={{ flexDirection: 'column', alignItems: 'stretch' }}>
+              <SettingRowTitle>{t('agent.cherryClaw.tasks.timezone.label', 'Timezone')}</SettingRowTitle>
+              <Input
+                size="small"
+                value={timezone}
+                onChange={(e) => setTimezone(e.target.value)}
+                onBlur={() => {
+                  const val = timezone.trim() || null
+                  const prev = task.timezone ?? null
+                  if (val !== prev) saveField({ timezone: val })
+                }}
+                placeholder="e.g. Asia/Shanghai, America/New_York (default: UTC)"
+                disabled={isCompleted}
+              />
+            </SettingRow>
+          </>
+        )}
         <TaskChannelSelector
           channels={channels}
           channelIds={channelIds}
@@ -580,6 +604,7 @@ const CreateForm: FC<{
   const [promptModalOpen, setPromptModalOpen] = useState(false)
   const [scheduleType, setScheduleType] = useState<'cron' | 'interval' | 'once'>('interval')
   const [scheduleValue, setScheduleValue] = useState('')
+  const [timezone, setTimezone] = useState('')
   const [timeoutMinutes, setTimeoutMinutes] = useState('')
   const [channelIds, setChannelIds] = useState<string[]>([])
   const [saving, setSaving] = useState(false)
@@ -597,12 +622,13 @@ const CreateForm: FC<{
         schedule_type: scheduleType,
         schedule_value: scheduleValue.trim(),
         timeout_minutes: timeout && timeout > 0 ? timeout : undefined,
+        timezone: timezone.trim() || undefined,
         channel_ids: channelIds.length > 0 ? channelIds : undefined
       })
     } finally {
       setSaving(false)
     }
-  }, [agentId, name, prompt, scheduleType, scheduleValue, timeoutMinutes, channelIds, onCreate])
+  }, [agentId, name, prompt, scheduleType, scheduleValue, timezone, timeoutMinutes, channelIds, onCreate])
 
   return (
     <SettingContainer theme={theme}>
@@ -741,6 +767,17 @@ const CreateForm: FC<{
             />
           </div>
         </div>
+        {scheduleType === 'cron' && (
+          <SettingRow style={{ flexDirection: 'column', alignItems: 'stretch' }}>
+            <SettingRowTitle>{t('agent.cherryClaw.tasks.timezone.label', 'Timezone')}</SettingRowTitle>
+            <Input
+              size="small"
+              value={timezone}
+              onChange={(e) => setTimezone(e.target.value)}
+              placeholder="e.g. Asia/Shanghai, America/New_York (default: UTC)"
+            />
+          </SettingRow>
+        )}
         <TaskChannelSelector channels={channels} channelIds={channelIds} onChange={setChannelIds} />
         <SettingDivider />
 

--- a/src/renderer/src/types/agent.ts
+++ b/src/renderer/src/types/agent.ts
@@ -114,6 +114,7 @@ export const ScheduledTaskEntitySchema = z.object({
   schedule_type: TaskScheduleTypeSchema,
   schedule_value: z.string(),
   timeout_minutes: z.number(),
+  timezone: z.string().nullable().optional(), // IANA timezone, e.g. 'Asia/Shanghai'. null = UTC for cron
   channel_ids: z.array(z.string()).optional(), // populated from channel_task_subscriptions
   next_run: z.string().nullable().optional(),
   last_run: z.string().nullable().optional(),
@@ -407,6 +408,7 @@ export const CreateTaskRequestSchema = z.object({
   schedule_type: TaskScheduleTypeSchema,
   schedule_value: z.string().min(1, 'Schedule value is required'),
   timeout_minutes: z.number().min(1).nullable().optional(),
+  timezone: z.string().nullable().optional(),
   channel_ids: z.array(z.string()).optional()
 })
 
@@ -419,6 +421,7 @@ export const UpdateTaskRequestSchema = z.object({
   schedule_type: TaskScheduleTypeSchema.optional(),
   schedule_value: z.string().min(1).optional(),
   timeout_minutes: z.number().min(1).nullable().optional(),
+  timezone: z.string().nullable().optional(),
   channel_ids: z.array(z.string()).optional(),
   status: TaskStatusSchema.optional()
 })


### PR DESCRIPTION
## Problem
Cron expressions for scheduled tasks were always interpreted in UTC by `cron-parser`. This caused tasks to fire at the wrong wall-clock time for users in non-UTC timezones. For example, a cron expression `0 9 * * *` intended for 9am Beijing time would actually fire at 5pm local time (UTC+8).

## Solution
Add timezone support across the full stack:

### Backend
- **Database**: Add `timezone` column to `scheduled_tasks` table (nullable, defaults to UTC behavior for backward compatibility)
- **Schema & Types**: Add `timezone` to `ScheduledTaskEntitySchema`, `CreateTaskRequestSchema`, and `UpdateTaskRequestSchema`
- **TaskService**: Pass `timezone` to `CronExpressionParser.parse()` via the `tz` option, so cron fields are evaluated in the user's local time
- **MCP Cron Tool**: Add `timezone` parameter to `mcp__claw__cron` tool. The tool description now dynamically includes the system timezone and instructs the agent to use it when creating cron tasks
- **SchedulerService**: Inject `[Scheduled task timezone: X]` context into the task prompt before execution, so the agent knows which timezone to use for any date/time calculations

### Frontend
- **TasksSettings** (Task Detail): Show timezone next to cron expression; editable timezone input field
- **TasksSettings** (Create Form): Timezone input field when cron is selected
- **TaskListItem**: Display timezone next to cron expression in the list view
- **TaskFormModal**: Added timezone field for consistency

### Migration
- Added migration `0008_add_task_timezone.sql` + journal entry

## Backward Compatibility
Existing tasks with `timezone=null` continue to use UTC behavior unchanged. Only new tasks (or explicitly updated ones) will use a different timezone.

## Test Plan
- [x] Create a cron task with `timezone: Asia/Shanghai` and verify `next_run` is computed correctly
- [x] Create a cron task without timezone and verify it still uses UTC
- [x] Update an existing task's timezone and verify `next_run` is recomputed
- [x] Verify Agent receives timezone context in prompt when running a cron task
- [x] Check UI displays timezone in task list and detail views