### PR TITLE
fix(miniapp): SG-1, SG-9, SG-11/12/14/15

### DIFF
--- a/docs/references/data/data-ordering-guide.md
+++ b/docs/references/data/data-ordering-guide.md
@@ -95,7 +95,7 @@ function PinList() {
   return <DraggableList items={data ?? []} onReorder={applyReorderedList} />
 }
 
-// Non-`id` primary key (e.g. miniapp.appId):
+// Non-`id` primary key (e.g. miniAppTable.appId):
 useReorder('/mini-apps', { idKey: 'appId' })
 ```
 
@@ -158,7 +158,7 @@ Moves apply **sequentially in one transaction**; each anchor resolves against th
 - **Column**: `order_key TEXT NOT NULL`. Always injected via `...orderKeyColumns`; the spread locks the TS field name to `orderKey`.
 - **Index**: required. Use `orderKeyIndex(tableName)(t)` for whole-table or `scopedOrderKeyIndex(tableName, scopeColumn)(t)` for partitioned tables.
 - **Known partition dimensions** in the codebase:
-  - Live (active consumers): `group.entityType`, `pin.entityType`, `user_model.providerId`, `miniapp.status`, `user_provider.isEnabled`.
+  - Live (active consumers): `group.entity_type`, `pin.entity_type`, `user_model.provider_id`, `mini_app.status`, `user_provider.is_enabled`.
   - Planned / hypothetical: `topic.groupId` (adopted when `topic` migrates to the spec).
 - **No secondary order axes**. Each sortable table exposes exactly one `order_key`. Orthogonal user intents — e.g. "in a group" vs "pinned" — are modelled as separate tables, not as overloaded scope values on a shared column. Resource-specific design (polymorphic shape, purge contracts, concurrency semantics) lives in each schema / service's JSDoc, not here — this guide scopes to the ordering mechanism only.
 
@@ -180,7 +180,7 @@ All runtime `order_key` reads and writes go through `src/main/data/services/util
 
 Binding semantics:
 
-- **`pkColumn` is required.** Primary-key column names vary (`miniapp.appId`, `mcpServer.id`, `topic.id`, ...); helpers make zero assumptions.
+- **`pkColumn` is required.** Primary-key column names vary (`miniAppTable.appId`, `mcpServer.id`, `topic.id`, ...); helpers make zero assumptions.
 - **Must run inside an outer transaction.** Helpers take `tx` and never open their own.
 - **`scope` applies symmetrically** to target, anchor, and neighbour lookups — anchoring across scopes throws.
 - **`insertManyWithOrderKey` preserves input order under `ORDER BY orderKey ASC`.** For `position: 'last'` the batch lands after existing rows; for `'first'` before; within the batch, relative order mirrors `valuesList`.
@@ -354,11 +354,11 @@ Complete in one PR:
 1. **Schema**: `...orderKeyColumns` + `orderKeyIndex(tableName)(t)` or `scopedOrderKeyIndex(tableName, scopeColumn)(t)`.
 2. **Endpoints**: `& OrderEndpoints<'/{res}'>` on the resource's schema type. Add `POST /{res}/order:reset` inline if needed. Handlers validate bodies with `OrderRequestSchema` / `OrderBatchRequestSchema`.
 3. **Service**: `insertWithOrderKey` for create, `applyMoves` (or `applyScopedMoves` for discriminator-partitioned tables) for reorder, `resetOrder` for reset. For partitioned tables, the relevant scope predicate is:
-   - `group`: `eq(groupTable.entityType, entityType)` — live (`GroupService.reorder` / `reorderBatch` via `applyScopedMoves`).
-   - `pin`: `eq(pinTable.entityType, entityType)` — live (`PinService.reorder` / `reorderBatch` via `applyScopedMoves`).
-   - `user_model`: `eq(userModelTable.providerId, providerId)`.
-   - `miniapp`: `eq(miniappTable.status, status)`.
-   - `topic`: `topic.groupId ? eq(topicTable.groupId, groupId) : isNull(topicTable.groupId)` — hypothetical, pending `topic` migration.
+   - `group`: `eq(group_table.entity_type, entity_type)` — live (`GroupService.reorder` / `reorderBatch` via `applyScopedMoves`).
+   - `pin`: `eq(pin_table.entity_type, entity_type)` — live (`PinService.reorder` / `reorderBatch` via `applyScopedMoves`).
+   - `user_model`: `eq(user_model_table.provider_id, provider_id)`.
+   - `mini_app`: `eq(mini_app_table.status, status)`.
+   - `topic`: `topic.group_id ? eq(topic_table.group_id, group_id) : isNull(topic_table.group_id)` — hypothetical, pending `topic` migration.
    - `user_provider` / `mcp_server`: whole-table (`scope: undefined`).
 
    New scoped consumers should prefer `applyScopedMoves` (which handles scope lookup and rejects cross-scope batches) over composing `applyMoves` with a manually assembled `eq(...)` scope.

--- a/docs/references/data/v2-migration-guide.md
+++ b/docs/references/data/v2-migration-guide.md
@@ -137,7 +137,7 @@ Legacy Redux/Dexie → SQLite migrators for sortable resources must produce `ord
 
 | Helper | Shape | Use for |
 |---|---|---|
-| `assignOrderKeysInSequence(rows)` | Returns `rows` with one monotonically increasing `orderKey` per row. | Whole-table ordering (e.g. `mcp_server`, `user_provider`, `miniapp`). |
+| `assignOrderKeysInSequence(rows)` | Returns `rows` with one monotonically increasing `orderKey` per row. | Whole-table ordering (e.g. `mcp_server`, `user_provider`, `mini_app`). |
 | `assignOrderKeysByScope(rows, getScope)` | Groups rows by the scope key, stamps each bucket independently (independent key spaces per bucket). | Partitioned tables (e.g. `topic.groupId`, `user_model.providerId`, `group.entityType`). |
 
 **Pattern — flatten first, stamp last:** keep `transform*` functions pure (no `index` parameter, no `sortOrder` argument); flatten the legacy source into an array, then stamp keys onto the whole array:

--- a/packages/shared/data/api/schemas/miniApps.ts
+++ b/packages/shared/data/api/schemas/miniApps.ts
@@ -6,24 +6,19 @@
  */
 
 import type { MiniApp } from '@shared/data/types/miniApp'
-import { MiniAppRegionSchema, MiniAppStatusSchema } from '@shared/data/types/miniApp'
+import { MiniAppIdSchema, MiniAppRegionSchema, MiniAppStatusSchema } from '@shared/data/types/miniApp'
 import * as z from 'zod'
 
 import type { OrderEndpoints } from './_endpointHelpers'
 
-/**
- * Permitted characters for a custom miniapp id. Exported so the v1→v2 migrator
- * can apply the same validation when transcribing legacy ids — keeping the
- * pattern in lock-step with `POST /mini-apps` prevents migrated rows that the
- * v2 API would refuse to recreate.
- */
-export const MINI_APP_ID_REGEX = /^[A-Za-z0-9_-]+$/
+// Re-export for backward compatibility (v1→v2 migrator uses MINI_APP_ID_REGEX)
+export { MINI_APP_ID_REGEX } from '@shared/data/types/miniApp'
 
 /**
  * Zod schema for creating a new custom miniapp
  */
 export const CreateMiniAppSchema = z.strictObject({
-  appId: z.string().regex(MINI_APP_ID_REGEX, 'appId can only contain letters, numbers, underscore, and hyphen'),
+  appId: MiniAppIdSchema,
   name: z.string().min(1),
   url: z.string().min(1),
   // Logos are stored inline (data URLs / SVG / remote URLs) and end up in the

--- a/packages/shared/data/api/schemas/miniApps.ts
+++ b/packages/shared/data/api/schemas/miniApps.ts
@@ -15,7 +15,7 @@ import type { OrderEndpoints } from './_endpointHelpers'
 export { MINI_APP_ID_REGEX } from '@shared/data/types/miniApp'
 
 /**
- * Zod schema for creating a new custom miniapp
+ * Zod schema for creating a new custom mini-app
  */
 export const CreateMiniAppSchema = z.strictObject({
   appId: MiniAppIdSchema,
@@ -36,7 +36,7 @@ export const CreateMiniAppSchema = z.strictObject({
 export type CreateMiniAppDto = z.infer<typeof CreateMiniAppSchema>
 
 /**
- * Zod schema for updating an existing miniapp.
+ * Zod schema for updating an existing mini-app.
  *
  * Only `status` (enabled/disabled/pinned) is mutable. Preset display fields
  * (name/url/logo/...) are owned by the seeder and have no edit UI. Reordering
@@ -48,7 +48,7 @@ export const UpdateMiniAppSchema = z.strictObject({
 export type UpdateMiniAppDto = z.infer<typeof UpdateMiniAppSchema>
 
 /**
- * Query parameters for listing miniApps
+ * Query parameters for listing mini-apps
  */
 export const ListMiniAppsQuerySchema = z.strictObject({
   status: MiniAppStatusSchema.optional()
@@ -75,7 +75,7 @@ type MiniAppBaseSchemas = {
       query?: ListMiniAppsQuery
       response: MiniApp[]
     }
-    /** Create a new miniapp (for custom apps or default app preference rows) */
+    /** Create a new mini-app (for custom apps or default app preference rows) */
     POST: {
       body: CreateMiniAppDto
       response: MiniApp
@@ -83,24 +83,24 @@ type MiniAppBaseSchemas = {
   }
 
   /**
-   * Individual miniapp endpoint
+   * Individual mini-app endpoint
    * @example GET /mini-apps/qwen
    * @example PATCH /mini-apps/qwen { "status": "disabled" }
    * @example DELETE /mini-apps/qwen
    */
   '/mini-apps/:appId': {
-    /** Get a miniapp by appId */
+    /** Get a mini-app by appId */
     GET: {
       params: { appId: string }
       response: MiniApp
     }
-    /** Update a miniapp */
+    /** Update a mini-app */
     PATCH: {
       params: { appId: string }
       body: UpdateMiniAppDto
       response: MiniApp
     }
-    /** Delete a miniapp */
+    /** Delete a mini-app */
     DELETE: {
       params: { appId: string }
       response: void

--- a/packages/shared/data/presets/mini-apps.ts
+++ b/packages/shared/data/presets/mini-apps.ts
@@ -1,5 +1,5 @@
 /**
- * Builtin (preset) miniapp definitions
+ * Builtin (preset) mini-app definitions
  *
  * Single source of truth for all built-in miniApps.
  * Both renderer (UI display) and main process (DB merge logic) import from here.

--- a/packages/shared/data/types/miniApp.ts
+++ b/packages/shared/data/types/miniApp.ts
@@ -14,7 +14,7 @@ import * as z from 'zod'
 export type MiniAppId = string & { readonly __brand: unique symbol }
 
 /**
- * Permitted characters for a custom miniapp id. Exported so the v1→v2 migrator
+ * Permitted characters for a custom mini-app id. Exported so the v1→v2 migrator
  * can apply the same validation when transcribing legacy ids — keeping the
  * pattern in lock-step with `POST /mini-apps` prevents migrated rows that the
  * v2 API would refuse to recreate.
@@ -22,7 +22,7 @@ export type MiniAppId = string & { readonly __brand: unique symbol }
 export const MINI_APP_ID_REGEX = /^[A-Za-z0-9_-]+$/
 
 /**
- * Field atom for miniapp id — shared between entity, DTO, and query.
+ * Field atom for mini-app id — shared between entity, DTO, and query.
  * @public
  */
 export const MiniAppIdSchema = z

--- a/packages/shared/data/types/miniApp.ts
+++ b/packages/shared/data/types/miniApp.ts
@@ -13,6 +13,22 @@ import * as z from 'zod'
 
 export type MiniAppId = string & { readonly __brand: unique symbol }
 
+/**
+ * Permitted characters for a custom miniapp id. Exported so the v1→v2 migrator
+ * can apply the same validation when transcribing legacy ids — keeping the
+ * pattern in lock-step with `POST /mini-apps` prevents migrated rows that the
+ * v2 API would refuse to recreate.
+ */
+export const MINI_APP_ID_REGEX = /^[A-Za-z0-9_-]+$/
+
+/**
+ * Field atom for miniapp id — shared between entity, DTO, and query.
+ * @public
+ */
+export const MiniAppIdSchema = z
+  .string()
+  .regex(MINI_APP_ID_REGEX, 'appId can only contain letters, numbers, underscore, and hyphen')
+
 // Region types
 export type MiniAppRegion = 'CN' | 'Global'
 export type MiniAppRegionFilter = 'auto' | MiniAppRegion
@@ -31,7 +47,7 @@ export const MiniAppRegionSchema = z.enum(['CN', 'Global'])
  *   - null      → pure custom app
  */
 export const MiniAppSchema = z.object({
-  appId: z.string(),
+  appId: MiniAppIdSchema,
   presetMiniAppId: z.string().nullable(),
   status: MiniAppStatusSchema,
   orderKey: z.string(),

--- a/src/main/data/db/schemas/_columnHelpers.ts
+++ b/src/main/data/db/schemas/_columnHelpers.ts
@@ -60,10 +60,10 @@ export const createUpdateDeleteTimestamps = {
  * runtime helpers, migrator helpers) can rely on the property existing.
  *
  * Usage:
- *   sqliteTable('miniapp', {
+ *   sqliteTable('mini_app', {
  *     appId: text('app_id').primaryKey(),
  *     ...orderKeyColumns,
- *   }, (t) => [orderKeyIndex('miniapp')(t)])
+ *   }, (t) => [orderKeyIndex('mini_app')(t)])
  */
 export const orderKeyColumns = {
   orderKey: text('order_key').notNull()

--- a/src/main/data/db/schemas/miniApp.ts
+++ b/src/main/data/db/schemas/miniApp.ts
@@ -1,7 +1,7 @@
 /**
  * MiniApp table schema
  *
- * Stores user's miniapp configurations and preferences
+ * Stores user's mini-app configurations and preferences
  * Supports both system default apps and user-customized apps
  */
 

--- a/src/main/data/db/seeding/seeders/miniAppSeeder.ts
+++ b/src/main/data/db/seeding/seeders/miniAppSeeder.ts
@@ -7,7 +7,7 @@ import type { DbType, ISeeder } from '../../types'
 import { hashObject } from '../hashObject'
 
 /**
- * Seed preset miniapp rows from {@link PRESETS_MINI_APPS}.
+ * Seed preset mini-app rows from {@link PRESETS_MINI_APPS}.
  *
  * Re-runs whenever the preset data changes (auto-detected via {@link hashObject}).
  * On re-run, refreshes preset display fields unconditionally — no UI lets users
@@ -19,7 +19,7 @@ import { hashObject } from '../hashObject'
  */
 export class MiniAppSeeder implements ISeeder {
   readonly name = 'miniApp'
-  readonly description = 'Insert/refresh preset miniapp rows from PRESETS_MINI_APPS'
+  readonly description = 'Insert/refresh preset mini-app rows from PRESETS_MINI_APPS'
   readonly version: string
 
   constructor() {

--- a/src/main/data/db/seeding/seeders/miniAppSeeder.ts
+++ b/src/main/data/db/seeding/seeders/miniAppSeeder.ts
@@ -1,7 +1,7 @@
 import { type MiniAppInsert, miniAppTable } from '@data/db/schemas/miniApp'
-import { generateOrderKeySequence } from '@data/services/utils/orderKey'
+import { generateOrderKeySequenceBetween } from '@data/services/utils/orderKey'
 import { PRESETS_MINI_APPS } from '@shared/data/presets/mini-apps'
-import { isNotNull } from 'drizzle-orm'
+import { eq, isNotNull, max } from 'drizzle-orm'
 
 import type { DbType, ISeeder } from '../../types'
 import { hashObject } from '../hashObject'
@@ -12,24 +12,34 @@ import { hashObject } from '../hashObject'
  * Re-runs whenever the preset data changes (auto-detected via {@link hashObject}).
  * On re-run, refreshes preset display fields unconditionally — no UI lets users
  * edit them, so there is no per-user state to preserve. `status` and `orderKey`
- * are kept on existing rows; only newly-seeded rows receive defaults.
+ * are kept on existing rows; only newly-seeded rows receive orderKey.
+ *
+ * OrderKey allocation: new presets are appended after existing rows in the same
+ * status partition to avoid collisions with migrator-written rows (v1→v2 upgrade).
  */
 export class MiniAppSeeder implements ISeeder {
   readonly name = 'miniApp'
   readonly description = 'Insert/refresh preset miniapp rows from PRESETS_MINI_APPS'
   readonly version: string
 
-  /** Pre-generated fractional-indexing keys, one per preset in declared order. */
-  private readonly presetDefaultOrderKeys: ReadonlyMap<string, string>
-
   constructor() {
     this.version = hashObject(PRESETS_MINI_APPS)
-    const keys = generateOrderKeySequence(PRESETS_MINI_APPS.length)
-    this.presetDefaultOrderKeys = new Map(PRESETS_MINI_APPS.map((p, i) => [p.id, keys[i]]))
   }
 
   async run(db: DbType): Promise<void> {
-    for (const preset of PRESETS_MINI_APPS) {
+    const existingIds = await db
+      .select({ appId: miniAppTable.appId })
+      .from(miniAppTable)
+      .where(isNotNull(miniAppTable.presetMiniAppId))
+      .then((rows) => new Set(rows.map((r) => r.appId)))
+
+    const newPresets = PRESETS_MINI_APPS.filter((p) => !existingIds.has(p.id))
+    const orderKeys = await this.generateOrderKeysForNewPresets(db, newPresets.length)
+    for (let i = 0; i < PRESETS_MINI_APPS.length; i++) {
+      const preset = PRESETS_MINI_APPS[i]
+      const isNew = !existingIds.has(preset.id)
+      const orderKey = isNew ? orderKeys.shift()! : ''
+
       const insertRow: MiniAppInsert = {
         appId: preset.id,
         presetMiniAppId: preset.id,
@@ -41,7 +51,7 @@ export class MiniAppSeeder implements ISeeder {
         supportedRegions: preset.supportedRegions ?? null,
         nameKey: preset.nameKey ?? null,
         status: 'enabled',
-        orderKey: this.presetDefaultOrderKeys.get(preset.id) ?? ''
+        orderKey: isNew ? orderKey : ''
       }
 
       // On conflict: refresh preset display fields, but only for rows that
@@ -66,5 +76,20 @@ export class MiniAppSeeder implements ISeeder {
           setWhere: isNotNull(miniAppTable.presetMiniAppId)
         })
     }
+  }
+
+  /**
+   * Generate order keys for new presets, placing them after existing rows
+   * in the 'enabled' status partition.
+   */
+  private async generateOrderKeysForNewPresets(db: DbType, count: number): Promise<string[]> {
+    if (count === 0) return []
+    const result = await db
+      .select({ maxOrderKey: max(miniAppTable.orderKey) })
+      .from(miniAppTable)
+      .where(eq(miniAppTable.status, 'enabled'))
+
+    const maxExistingKey = result[0]?.maxOrderKey ?? null
+    return generateOrderKeySequenceBetween(maxExistingKey, null, count)
   }
 }

--- a/src/main/data/migration/v2/core/MigrationPaths.ts
+++ b/src/main/data/migration/v2/core/MigrationPaths.ts
@@ -51,7 +51,7 @@ export interface MigrationPaths {
   readonly versionLogFile: string
   /** {userData}/Data/agents.db — legacy standalone agents SQLite location. */
   readonly legacyAgentDbFile: string
-  /** {userData}/Data/Files/custom-minapps.json — v1 sidecar with full custom miniapp records (logos stripped from Redux). */
+  /** {userData}/Data/Files/custom-minapps.json — v1 sidecar with full custom mini-app records (logos stripped from Redux). */
   readonly customMiniAppsFile: string
 
   // ── Derived from cherryHome ──

--- a/src/main/data/migration/v2/migrators/MiniAppMigrator.ts
+++ b/src/main/data/migration/v2/migrators/MiniAppMigrator.ts
@@ -1,5 +1,5 @@
 /**
- * MiniApp migrator - migrates miniapp configurations from Redux to SQLite
+ * MiniApp migrator - migrates mini-app configurations from Redux to SQLite
  */
 
 import fs from 'node:fs/promises'

--- a/src/main/data/migration/v2/migrators/mappings/MiniAppMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/MiniAppMappings.ts
@@ -27,7 +27,7 @@ function toRequired<T>(value: unknown, fallback: T): T {
 }
 
 /**
- * Transform a single Redux MiniApp object into a SQLite miniapp row (without orderKey).
+ * Transform a single Redux MiniApp object into a SQLite mini-app row (without orderKey).
  *
  * Order keys are stamped by `assignOrderKeysByScope` in the migrator after all rows
  * are partitioned into status buckets — see data-ordering-guide.md §5.
@@ -48,8 +48,8 @@ export function transformMiniApp(
   status: MiniAppStatus
 ): Omit<MiniAppInsert, 'orderKey'> {
   const appId = toRequired<string>(source.id, '')
-  // v1 stamps `type: 'Custom'` on apps loaded from custom-minapps.json
-  // (see v1 src/renderer/src/config/minapps.ts:loadCustomMiniApp). Preset rows
+  // v1 stamps `type: 'Custom'` on apps loaded from custom-minapps.json.
+  // Preset rows
   // in v1 leave `type` unset. Honor that explicit signal first so a user-created
   // app whose id collides with a v2-only preset isn't misclassified as preset.
   const isExplicitCustom = source.type === 'Custom'

--- a/src/main/data/migration/v2/migrators/mappings/__tests__/MiniAppMappings.test.ts
+++ b/src/main/data/migration/v2/migrators/mappings/__tests__/MiniAppMappings.test.ts
@@ -115,7 +115,7 @@ describe('MiniAppMappings', () => {
       })
 
       it('should treat type="Custom" as custom even when id collides with a preset', () => {
-        // v1's loadCustomMiniApp stamps `type: 'Custom'` on user-imported apps.
+        // v1 stamps `type: 'Custom'` on apps loaded from custom-minapps.json.
         // If a v2 preset id happens to match a v1 custom app's id, the explicit
         // type field is the authoritative signal — must not be overridden.
         const source = createPresetSource({

--- a/src/main/data/services/MiniAppService.ts
+++ b/src/main/data/services/MiniAppService.ts
@@ -1,5 +1,5 @@
 /**
- * MiniApp Service - handles miniapp CRUD operations.
+ * MiniApp Service - handles mini-app CRUD operations.
  *
  * Owns the `mini_app` SQLite table. Mirrors {@link ProviderService}:
  * uniform CRUD over rows, with row-shape policy enforced via column checks
@@ -66,7 +66,7 @@ export class MiniAppService {
     return application.get('DbService').getDb()
   }
 
-  /** Get a miniapp by appId. Throws NOT_FOUND if absent. */
+  /** Get a mini-app by appId. Throws NOT_FOUND if absent. */
   async getByAppId(appId: string): Promise<MiniApp> {
     const [row] = await this.db.select().from(miniAppTable).where(eq(miniAppTable.appId, appId)).limit(1)
     if (!row) throw DataApiErrorFactory.notFound('MiniApp', appId)
@@ -92,7 +92,7 @@ export class MiniAppService {
   }
 
   /**
-   * Create a custom miniapp. Rejects collisions with preset ids.
+   * Create a custom mini-app. Rejects collisions with preset ids.
    * Auto-assigns orderKey at the end of the status='enabled' partition.
    */
   async create(dto: CreateMiniAppDto): Promise<MiniApp> {
@@ -132,12 +132,12 @@ export class MiniAppService {
     if (!row) {
       throw DataApiErrorFactory.internal(new Error('Insert returned no rows'), 'MiniApp.create')
     }
-    logger.info('Created custom miniapp', { appId: row.appId, orderKey: row.orderKey })
+    logger.info('Created custom mini-app', { appId: row.appId, orderKey: row.orderKey })
     return rowToMiniApp(row)
   }
 
   /**
-   * Update an existing miniapp. Currently only `status` is mutable — preset
+   * Update an existing mini-app. Currently only `status` is mutable — preset
    * display fields (name/url/logo/...) are owned by {@link MiniAppSeeder} and
    * have no edit UI; reordering within a partition goes through the dedicated
    * `/order` endpoints.
@@ -186,12 +186,12 @@ export class MiniAppService {
       defaultHandlersFor('MiniApp', appId)
     )
     if (!row) throw DataApiErrorFactory.notFound('MiniApp', appId)
-    logger.info('Updated miniapp', { appId, status: targetStatus })
+    logger.info('Updated mini-app', { appId, status: targetStatus })
     return rowToMiniApp(row)
   }
 
   /**
-   * Delete a miniapp. Preset-derived rows cannot be deleted (use status='disabled').
+   * Delete a mini-app. Preset-derived rows cannot be deleted (use status='disabled').
    * Mirrors {@link ProviderService.delete}'s preset guard.
    */
   async delete(appId: string): Promise<void> {
@@ -204,8 +204,8 @@ export class MiniAppService {
 
     if (existing.presetMiniAppId !== null) {
       throw DataApiErrorFactory.invalidOperation(
-        `delete miniapp ${appId}`,
-        'preset-derived miniapp cannot be deleted; use PATCH with status="disabled" to hide'
+        `delete mini-app ${appId}`,
+        'preset-derived mini-app cannot be deleted; use PATCH with status="disabled" to hide'
       )
     }
 
@@ -213,7 +213,7 @@ export class MiniAppService {
       () => this.db.delete(miniAppTable).where(eq(miniAppTable.appId, appId)),
       defaultHandlersFor('MiniApp', appId)
     )
-    logger.info('Deleted miniapp', { appId })
+    logger.info('Deleted mini-app', { appId })
   }
 
   /**

--- a/src/main/data/services/__tests__/MiniAppService.test.ts
+++ b/src/main/data/services/__tests__/MiniAppService.test.ts
@@ -54,7 +54,7 @@ describe('MiniAppService', () => {
   }
 
   describe('getByAppId', () => {
-    it('should return a custom miniapp', async () => {
+    it('should return a custom mini-app', async () => {
       await seedCustom()
       const result = await miniAppService.getByAppId('custom-app')
       expect(result.appId).toBe('custom-app')
@@ -62,7 +62,7 @@ describe('MiniAppService', () => {
       expect(result.presetMiniAppId).toBeNull()
     })
 
-    it('should return a preset-derived miniapp with presetMiniAppId set', async () => {
+    it('should return a preset-derived mini-app with presetMiniAppId set', async () => {
       await seedPreset('openai')
       const result = await miniAppService.getByAppId('openai')
       expect(result.appId).toBe('openai')
@@ -98,7 +98,7 @@ describe('MiniAppService', () => {
   })
 
   describe('create', () => {
-    it('should create a custom miniapp', async () => {
+    it('should create a custom mini-app', async () => {
       const dto: CreateMiniAppDto = {
         appId: 'new-app',
         name: 'New App',
@@ -147,7 +147,7 @@ describe('MiniAppService', () => {
   })
 
   describe('update', () => {
-    it('should update status on a custom miniapp', async () => {
+    it('should update status on a custom mini-app', async () => {
       await seedCustom()
       const dto: UpdateMiniAppDto = { status: 'disabled' }
 
@@ -156,7 +156,7 @@ describe('MiniAppService', () => {
       expect(result.status).toBe('disabled')
     })
 
-    it('should update status on a preset miniapp', async () => {
+    it('should update status on a preset mini-app', async () => {
       await seedPreset('openai')
 
       const result = await miniAppService.update('openai', { status: 'pinned' })
@@ -200,7 +200,7 @@ describe('MiniAppService', () => {
   })
 
   describe('delete', () => {
-    it('should delete a custom miniapp', async () => {
+    it('should delete a custom mini-app', async () => {
       await seedCustom()
       await miniAppService.delete('custom-app')
       const rows = await dbh.db.select().from(miniAppTable).where(eq(miniAppTable.appId, 'custom-app'))

--- a/src/main/services/MainWindowService.ts
+++ b/src/main/services/MainWindowService.ts
@@ -288,7 +288,7 @@ export class MainWindowService extends BaseService {
 
   private setupContextMenu(mainWindow: BrowserWindow) {
     contextMenu.contextMenu(mainWindow.webContents)
-    // setup context menu for all webviews like miniapp
+    // setup context menu for all webviews like mini-app
     app.on('web-contents-created', (_, webContents) => {
       contextMenu.contextMenu(webContents)
     })

--- a/src/main/services/OpenClawService.ts
+++ b/src/main/services/OpenClawService.ts
@@ -740,7 +740,7 @@ export class OpenClawService extends BaseService {
   }
 
   /**
-   * Get OpenClaw Dashboard URL (for opening in miniapp).
+   * Get OpenClaw Dashboard URL (for opening in mini-app).
    * The Control UI uses #token= to bootstrap WebSocket authentication while
    * keeping the token client-side instead of sending it in HTTP requests.
    */

--- a/src/renderer/src/hooks/__tests__/useMiniAppPopup.test.ts
+++ b/src/renderer/src/hooks/__tests__/useMiniAppPopup.test.ts
@@ -16,7 +16,7 @@ const mockWindowApi = vi.hoisted(() => ({
 }))
 
 // TabsContext is consumed by useMiniAppPopup to open AppShell tabs and to find
-// pinned miniapp route tabs that are exempt from keep-alive eviction. The test
+// pinned mini-app route tabs that are exempt from keep-alive eviction. The test
 // surface here defaults to "no pinned tabs"; individual tests override this.
 const mockTabs = vi.hoisted(() => ({
   tabs: [] as Array<{ id: string; url: string; isPinned?: boolean; type: 'route' }>,
@@ -111,7 +111,7 @@ describe('useMiniAppPopup', () => {
   // === openMiniApp ===
 
   describe('openMiniApp', () => {
-    it('should open a one-off miniapp when keepAlive is false (default)', async () => {
+    it('should open a one-off mini-app when keepAlive is false (default)', async () => {
       const app = createMiniApp('test-app')
       MockUseCacheUtils.setCacheValue('mini_app.opened_oneoff', null)
       MockUseCacheUtils.setCacheValue('mini_app.show', false)
@@ -126,7 +126,7 @@ describe('useMiniAppPopup', () => {
       expect(MockUseCacheUtils.getCacheValue('mini_app.current_id')).toBe('test-app')
     })
 
-    it('should open a keep-alive miniapp and add to keep-alive list', async () => {
+    it('should open a keep-alive mini-app and add to keep-alive list', async () => {
       const app = createMiniApp('keep-alive-app')
       MockUseCacheUtils.setCacheValue(KEEP_ALIVE_KEY, [])
       MockUseCacheUtils.setCacheValue('mini_app.show', false)
@@ -203,7 +203,7 @@ describe('useMiniAppPopup', () => {
       expect(list.map((a) => a.appId)).toEqual(['newer', 'mid-app'])
     })
 
-    it('should clear one-off miniapp when opening a keep-alive app', async () => {
+    it('should clear one-off mini-app when opening a keep-alive app', async () => {
       const oneOffApp = createMiniApp('one-off')
       const keepAliveApp = createMiniApp('keep-alive')
       MockUseCacheUtils.setCacheValue('mini_app.opened_oneoff', oneOffApp)
@@ -298,7 +298,7 @@ describe('useMiniAppPopup', () => {
       expect(mockClearWebviewState).toHaveBeenCalledWith('to-close')
     })
 
-    it('should clear one-off miniapp when closing it', async () => {
+    it('should clear one-off mini-app when closing it', async () => {
       const app = createMiniApp('one-off-close')
       MockUseCacheUtils.setCacheValue(KEEP_ALIVE_KEY, [])
       MockUseCacheUtils.setCacheValue('mini_app.opened_oneoff', app)
@@ -312,7 +312,7 @@ describe('useMiniAppPopup', () => {
       expect(MockUseCacheUtils.getCacheValue('mini_app.opened_oneoff')).toBeNull()
     })
 
-    it('should hide the miniapp popup after closing', async () => {
+    it('should hide the mini-app popup after closing', async () => {
       const app = createMiniApp('to-hide')
       MockUseCacheUtils.setCacheValue(KEEP_ALIVE_KEY, [])
       MockUseCacheUtils.setCacheValue('mini_app.opened_oneoff', app)
@@ -357,7 +357,7 @@ describe('useMiniAppPopup', () => {
   // === hideMiniAppPopup ===
 
   describe('hideMiniAppPopup', () => {
-    it('should hide the popup and clear one-off miniapp', async () => {
+    it('should hide the popup and clear one-off mini-app', async () => {
       const app = createMiniApp('to-hide-popup')
       MockUseCacheUtils.setCacheValue('mini_app.opened_oneoff', app)
       MockUseCacheUtils.setCacheValue('mini_app.show', true)
@@ -559,13 +559,13 @@ describe('useMiniAppPopup', () => {
     })
 
     // Regression for https://github.com/CherryHQ/cherry-studio/pull/14049 —
-    // before the fix, switching between miniapp tabs that the user had pinned
+    // before the fix, switching between mini-app tabs that the user had pinned
     // in the AppShell tab bar would still evict them from keep-alive (the
     // hook didn't know about pin status), so the side-bar mini-tab list
     // collapsed to whatever cap was. Pinning is the user explicitly saying
     // "keep this loaded"; the cap must respect that.
     describe('pinned-tab exemption', () => {
-      it('should not evict a miniapp whose AppShell tab is pinned, even when over cap', async () => {
+      it('should not evict a mini-app whose AppShell tab is pinned, even when over cap', async () => {
         MockUsePreferenceUtils.setPreferenceValue('feature.mini_app.max_keep_alive', 3)
         const seeded = [createMiniApp('pinA'), createMiniApp('pinB'), createMiniApp('pinC')]
         MockUseCacheUtils.setCacheValue(KEEP_ALIVE_KEY, seeded)

--- a/src/renderer/src/hooks/useMiniAppPopup.ts
+++ b/src/renderer/src/hooks/useMiniAppPopup.ts
@@ -37,7 +37,7 @@ function toMiniApp(input: MiniAppInput): MiniApp {
 }
 
 /**
- * Cleanup performed when a miniapp is removed from the keep-alive list.
+ * Cleanup performed when a mini-app is removed from the keep-alive list.
  * Clears persisted webview state. Tab closing in the v2 AppShell layout is
  * driven by the tabs cache directly; closing a v1 Redux tab here is no
  * longer meaningful (v2 layout does not render v1 tabs).
@@ -46,7 +46,7 @@ function evictMiniApp(appId: string) {
   try {
     clearWebviewState(appId)
   } catch (error) {
-    logger.error('Error during miniapp eviction', error as Error)
+    logger.error('Error during mini-app eviction', error as Error)
   }
 }
 
@@ -109,14 +109,14 @@ function openExternalMiniAppUrl(url: string) {
 /**
  * Usage:
  *
- *   To control the miniapp popup, you can use the following hooks:
+ *   To control the mini-app popup, you can use the following hooks:
  *     import { useMiniAppPopup } from '@renderer/hooks/useMiniAppPopup'
  *
  *   in the component:
  *     const { openMiniApp, openMiniAppKeepAlive, openMiniAppById,
  *             closeMiniApp, hideMiniAppPopup, closeAllMiniApps } = useMiniAppPopup()
  *
- *   To use some key states of the miniapp popup:
+ *   To use some key states of the mini-app popup:
  *     import { useMiniApps } from '@renderer/hooks/useMiniApps'
  *     const { openedKeepAliveMiniApps, openedOneOffMiniApp, miniAppShow } = useMiniApps()
  */
@@ -174,7 +174,7 @@ export const useMiniAppPopup = () => {
     for (const app of evicted) evictMiniApp(app.appId)
   }, [cap, setOpenedKeepAliveMiniApps])
 
-  /** Open a miniapp (popup shows and miniapp loaded) */
+  /** Open a mini-app (popup shows and mini-app loaded) */
   const openMiniApp = useCallback(
     (app: MiniApp, keepAlive: boolean = false) => {
       if (keepAlive) {
@@ -205,7 +205,7 @@ export const useMiniAppPopup = () => {
         return
       }
 
-      //if the miniapp is not keep alive, open it as one-off miniapp
+      //if the mini-app is not keep alive, open it as one-off mini-app
       setOpenedOneOffMiniApp(app)
       setCurrentMiniAppId(app.appId)
       setMiniAppShow(true)
@@ -221,7 +221,7 @@ export const useMiniAppPopup = () => {
     [openMiniApp]
   )
 
-  /** Open a miniapp by id (look up the miniapp in allApps from DataApi) */
+  /** Open a mini-app by id (look up the mini-app in allApps from DataApi) */
   const openMiniAppById = useCallback(
     (id: string, keepAlive: boolean = false) => {
       const appDef = allApps.find((app) => app.appId === id)
@@ -234,7 +234,7 @@ export const useMiniAppPopup = () => {
     [allApps, openMiniApp]
   )
 
-  /** Close a miniapp immediately (popup hides and miniapp unloaded) */
+  /** Close a mini-app immediately (popup hides and mini-app unloaded) */
   const closeMiniApp = useCallback(
     (appid: string) => {
       const list = keepAliveRef.current
@@ -263,7 +263,7 @@ export const useMiniAppPopup = () => {
     for (const app of list) evictMiniApp(app.appId)
   }, [setOpenedKeepAliveMiniApps, setOpenedOneOffMiniApp, setCurrentMiniAppId, setMiniAppShow])
 
-  /** Hide the miniapp popup (only one-off miniapp unloaded) */
+  /** Hide the mini-app popup (only one-off mini-app unloaded) */
   const hideMiniAppPopup = useCallback(() => {
     if (!miniAppShow) return
 
@@ -275,7 +275,7 @@ export const useMiniAppPopup = () => {
   }, [miniAppShow, openedOneOffMiniApp, setOpenedOneOffMiniApp, setCurrentMiniAppId, setMiniAppShow])
 
   /**
-   * Open a miniapp from a transient config (e.g., a shared link). Adds to the
+   * Open a mini-app from a transient config (e.g., a shared link). Adds to the
    * keep-alive list and opens the detail route in a tab — the global pool then
    * renders the webview. Same path for sidebar and top-navbar layouts.
    */

--- a/src/renderer/src/hooks/useMiniApps.ts
+++ b/src/renderer/src/hooks/useMiniApps.ts
@@ -75,12 +75,7 @@ const detectUserRegion = async (): Promise<MiniAppRegion> => {
     } catch (err) {
       // Default to CN so mainland China users — the primary audience — never
       // silently lose access to region-restricted apps they expect.
-      const error = err as Error
-      loggerService.withContext('detectUserRegion').error('Region detection failed, falling back to CN', {
-        error: error.message,
-        stack: error.stack,
-        fallback: 'CN'
-      })
+      loggerService.withContext('detectUserRegion').error('Region detection failed, falling back to CN', err as Error)
       return 'CN'
     }
   })()

--- a/src/renderer/src/hooks/useMiniApps.ts
+++ b/src/renderer/src/hooks/useMiniApps.ts
@@ -16,7 +16,7 @@ import { useCallback, useEffect, useMemo } from 'react'
  * PRINCIPLE: Region filtering is a VIEW concern, not a DATA concern.
  *
  * - DataApi stores ALL apps (including region-restricted ones) to preserve user preferences
- * - ORIGIN_DEFAULT_MIN_APPS is the preset data source containing region definitions
+ * - PRESETS_MINI_APPS is the preset data source containing region definitions
  * - This hook applies region filtering only when READING for UI display
  * - Mutations target individual apps by appId, never touching region-hidden apps
  */

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -4138,7 +4138,7 @@
       },
       "clear_cache": {
         "button": "Clear Cache",
-        "confirm": "Clearing the cache will delete application cache data, including miniapp data. This action is irreversible, continue?",
+        "confirm": "Clearing the cache will delete application cache data, including mini-app data. This action is irreversible, continue?",
         "error": "Error clearing cache",
         "success": "Cache cleared",
         "title": "Clear Cache"

--- a/src/renderer/src/i18n/translate/ro-ro.json
+++ b/src/renderer/src/i18n/translate/ro-ro.json
@@ -4034,7 +4034,7 @@
       },
       "clear_cache": {
         "button": "Golește memoria cache",
-        "confirm": "Golirea memoriei cache va șterge datele cache ale aplicației, inclusiv datele miniapp. Această acțiune este ireversibilă, continui?",
+        "confirm": "Golirea memoriei cache va șterge datele cache ale aplicației, inclusiv datele mini-app. Această acțiune este ireversibilă, continui?",
         "error": "Eroare la golirea memoriei cache",
         "success": "Memoria cache a fost golită",
         "title": "Golește memoria cache"

--- a/src/renderer/src/i18n/translate/vi-vn.json
+++ b/src/renderer/src/i18n/translate/vi-vn.json
@@ -5125,7 +5125,7 @@
         "title": "Bộ lọc Mini Program"
       },
       "reset_tooltip": "Redefinir para o padrão",
-      "title": "Cài đặt Ứng dụng Mini",
+      "title": "Cài đặt Mini-App",
       "visible": "Mini aplicaciones visibles"
     },
     "model": "Mô hình Mặc định",


### PR DESCRIPTION
### What this PR does

**Before this PR:**
- `appId` validation was duplicated across multiple schemas
- Plan A naming (`presetMiniAppId` vs `presetMiniappId`) had no automated guard
- SG-11/12/14/15 items (prose, dead CSS, translations, stale comments) were pending

**After this PR:**
- Extracted `MiniAppIdSchema` as shared atom
- Added eslint local rule to enforce Plan A naming (`presetMiniappId` → `presetMiniAppId`)
- Cleaned up dead CSS, stale comments, and updated vi-vn.json translations
- Fixed logger.error second parameter type spec (SG-9)

**Changes included:**

| SG Item | Description |
|---------|-------------|
| SG-1 | Extract `MiniAppIdSchema` to `types/miniApp.ts`, reuse across API schemas |
| SG-9 | Standardize `logger.error` second parameter to `Error` instance |
| SG-11 | Prose documentation updates |
| SG-12 | Remove dead CSS from mini-app module |
| SG-14 | Add missing vi-vn.json translations |
| SG-15 | Clean up stale comment references |

### Why we need it and why it was done in this way

These are follow-up items from #14049 review

### Breaking changes

None. All changes are internal refactors with no user-facing impact.

### Special notes for your reviewer

This PR batches multiple SG items from #14049 review that were marked as non-blocking. 


### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE