### PR TITLE
refactor(tag-hooks): split legacy and DataApi tag hooks

### DIFF
--- a/src/renderer/src/hooks/__tests__/useTags.test.ts
+++ b/src/renderer/src/hooks/__tests__/useTags.test.ts
@@ -1,0 +1,182 @@
+import { dataApiService } from '@data/DataApiService'
+import { DataApiErrorFactory, ErrorCode } from '@shared/data/api'
+import type { Tag } from '@shared/data/types/tag'
+import { MockDataApiUtils } from '@test-mocks/renderer/DataApiService'
+import { MockUseDataApiUtils, mockUseMutation, mockUseQuery } from '@test-mocks/renderer/useDataApi'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useEnsureTags, useTagList } from '../useTags'
+
+function tag(id: string, name: string, color = '#3b82f6'): Tag {
+  return {
+    id,
+    name,
+    color,
+    createdAt: '2026-05-10T00:00:00.000Z',
+    updatedAt: '2026-05-10T00:00:00.000Z'
+  }
+}
+
+function mockTagQuery(tags: Tag[], options: { isLoading?: boolean; error?: Error } = {}) {
+  const refetch = vi.fn().mockResolvedValue(undefined)
+  mockUseQuery.mockImplementation((path: string) => {
+    if (path === '/tags') {
+      return {
+        data: tags,
+        isLoading: options.isLoading ?? false,
+        isRefreshing: false,
+        error: options.error,
+        refetch,
+        mutate: vi.fn().mockResolvedValue(tags)
+      }
+    }
+
+    return {
+      data: undefined,
+      isLoading: false,
+      isRefreshing: false,
+      error: undefined,
+      refetch: vi.fn().mockResolvedValue(undefined),
+      mutate: vi.fn().mockResolvedValue(undefined)
+    }
+  })
+  return refetch
+}
+
+function mockCreateTag(trigger: ReturnType<typeof vi.fn>) {
+  mockUseMutation.mockImplementation((method, path, options) => {
+    if (method === 'POST' && path === '/tags') {
+      expect(options?.refresh).toEqual(['/tags'])
+      return {
+        trigger,
+        isLoading: false,
+        error: undefined
+      }
+    }
+
+    return {
+      trigger: vi.fn().mockResolvedValue({}),
+      isLoading: false,
+      error: undefined
+    }
+  })
+}
+
+describe('useTags', () => {
+  beforeEach(() => {
+    MockUseDataApiUtils.resetMocks()
+    MockDataApiUtils.resetMocks()
+  })
+
+  describe('useTagList', () => {
+    it('exposes /tags data and keeps refetch fire-and-forget', () => {
+      const work = tag('tag-1', 'work')
+      const refetch = mockTagQuery([work])
+
+      const { result } = renderHook(() => useTagList())
+
+      expect(mockUseQuery).toHaveBeenCalledWith('/tags')
+      expect(result.current.tags).toEqual([work])
+      expect(result.current.isLoading).toBe(false)
+
+      result.current.refetch()
+      expect(refetch).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('useEnsureTags', () => {
+    it('returns cache hits without posting', async () => {
+      const work = tag('tag-1', 'work')
+      mockTagQuery([work])
+      const createTrigger = vi.fn()
+      mockCreateTag(createTrigger)
+
+      const { result } = renderHook(() => useEnsureTags())
+
+      await expect(result.current.ensureTags(['work'])).resolves.toEqual([work])
+      expect(createTrigger).not.toHaveBeenCalled()
+    })
+
+    it('skips empty names and de-duplicates by first non-empty occurrence', async () => {
+      const created = tag('tag-2', 'new', '#ef4444')
+      mockTagQuery([])
+      const createTrigger = vi.fn().mockResolvedValue(created)
+      mockCreateTag(createTrigger)
+
+      const { result } = renderHook(() => useEnsureTags())
+
+      await expect(
+        result.current.ensureTags(['', '  ', { name: 'new', color: '#ef4444' }, { name: 'new', color: '#22c55e' }])
+      ).resolves.toEqual([created])
+
+      expect(createTrigger).toHaveBeenCalledTimes(1)
+      expect(createTrigger).toHaveBeenCalledWith({ body: { name: 'new', color: '#ef4444' } })
+    })
+
+    it('uses default color when creating a tag without an explicit color', async () => {
+      const created = tag('tag-3', 'design', '#0ea5e9')
+      mockTagQuery([])
+      const createTrigger = vi.fn().mockResolvedValue(created)
+      mockCreateTag(createTrigger)
+
+      const { result } = renderHook(() => useEnsureTags({ getDefaultColor: () => '#0ea5e9' }))
+
+      await expect(result.current.ensureTags(['design'])).resolves.toEqual([created])
+      expect(createTrigger).toHaveBeenCalledWith({ body: { name: 'design', color: '#0ea5e9' } })
+    })
+
+    it('resolves CONFLICT races through an imperative /tags read', async () => {
+      const fresh = tag('tag-4', 'race')
+      mockTagQuery([])
+      const conflict = DataApiErrorFactory.create(ErrorCode.CONFLICT)
+      const createTrigger = vi.fn().mockRejectedValue(conflict)
+      mockCreateTag(createTrigger)
+      MockDataApiUtils.setCustomResponse('/tags', 'GET', [fresh])
+
+      const { result } = renderHook(() => useEnsureTags())
+
+      await expect(result.current.ensureTags(['race'])).resolves.toEqual([fresh])
+      expect(dataApiService.get).toHaveBeenCalledWith('/tags')
+    })
+
+    it('rethrows the original CONFLICT when the imperative read misses', async () => {
+      mockTagQuery([])
+      const conflict = DataApiErrorFactory.create(ErrorCode.CONFLICT)
+      const createTrigger = vi.fn().mockRejectedValue(conflict)
+      mockCreateTag(createTrigger)
+      MockDataApiUtils.setCustomResponse('/tags', 'GET', [])
+
+      const { result } = renderHook(() => useEnsureTags())
+
+      await expect(result.current.ensureTags(['missing'])).rejects.toBe(conflict)
+      expect(dataApiService.get).toHaveBeenCalledWith('/tags')
+    })
+
+    it('rethrows non-CONFLICT creation errors without imperative lookup', async () => {
+      mockTagQuery([])
+      const validation = DataApiErrorFactory.create(ErrorCode.VALIDATION_ERROR)
+      const createTrigger = vi.fn().mockRejectedValue(validation)
+      mockCreateTag(createTrigger)
+
+      const { result } = renderHook(() => useEnsureTags())
+
+      await expect(result.current.ensureTags(['bad'])).rejects.toBe(validation)
+      expect(dataApiService.get).not.toHaveBeenCalled()
+    })
+
+    it('returns an empty list for all-empty input without posting', async () => {
+      mockTagQuery([])
+      const createTrigger = vi.fn()
+      mockCreateTag(createTrigger)
+
+      const { result } = renderHook(() => useEnsureTags())
+
+      await act(async () => {
+        await expect(result.current.ensureTags([' ', { name: '\t' }])).resolves.toEqual([])
+      })
+
+      expect(createTrigger).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/renderer/src/hooks/useTags.ts
+++ b/src/renderer/src/hooks/useTags.ts
@@ -1,0 +1,112 @@
+import { dataApiService } from '@data/DataApiService'
+import { useMutation, useQuery } from '@data/hooks/useDataApi'
+import { DataApiError, ErrorCode } from '@shared/data/api'
+import type { Tag } from '@shared/data/types/tag'
+import { useCallback } from 'react'
+
+export interface TagListResult {
+  tags: Tag[]
+  isLoading: boolean
+  error?: Error
+  refetch: () => void
+}
+
+export interface CreateTagOptions {
+  name: string
+  color?: string | null
+}
+
+export interface UseEnsureTagsOptions {
+  getDefaultColor?: () => string
+}
+
+export type EnsureTagInput = string | { name: string; color?: string | null }
+
+export function useTagList(): TagListResult {
+  const { data, isLoading, error, refetch } = useQuery('/tags')
+  const stableRefetch = useCallback(() => {
+    void refetch()
+  }, [refetch])
+
+  return {
+    tags: Array.isArray(data) ? data : [],
+    isLoading,
+    error,
+    refetch: stableRefetch
+  }
+}
+
+/**
+ * Resolve tag names to records, creating missing rows through DataApi.
+ *
+ * Empty names are skipped, duplicate names keep the first provided color, and
+ * unique-constraint races do a one-shot imperative /tags read before rethrowing.
+ */
+export function useEnsureTags(options: UseEnsureTagsOptions = {}) {
+  const { getDefaultColor } = options
+  const { tags: cachedTags } = useTagList()
+  const { trigger: createTag } = useMutation('POST', '/tags', {
+    refresh: ['/tags']
+  })
+
+  const ensureTags = useCallback(
+    async (inputs: EnsureTagInput[]): Promise<Tag[]> => {
+      const cleaned = Array.from(
+        inputs
+          .reduce<Map<string, { name: string; color?: string | null }>>((acc, input) => {
+            const name = typeof input === 'string' ? input.trim() : input.name.trim()
+            if (!name) return acc
+
+            if (!acc.has(name)) {
+              acc.set(name, {
+                name,
+                color: typeof input === 'string' ? undefined : input.color
+              })
+            }
+
+            return acc
+          }, new Map())
+          .values()
+      )
+
+      if (cleaned.length === 0) return []
+
+      const existingByName = new Map(cachedTags.map((tag) => [tag.name, tag] as const))
+      const resolved: Tag[] = []
+      const missing: Array<{ name: string; color?: string | null }> = []
+
+      for (const spec of cleaned) {
+        const existing = existingByName.get(spec.name)
+        if (existing) {
+          resolved.push(existing)
+        } else {
+          missing.push(spec)
+        }
+      }
+
+      if (missing.length === 0) return resolved
+
+      for (const spec of missing) {
+        const color = spec.color ?? getDefaultColor?.()
+        const body = color ? { name: spec.name, color } : { name: spec.name }
+
+        try {
+          resolved.push(await createTag({ body }))
+        } catch (error) {
+          if (!(error instanceof DataApiError) || error.code !== ErrorCode.CONFLICT) throw error
+
+          const freshTags = await dataApiService.get('/tags')
+          const freshHit = Array.isArray(freshTags) ? freshTags.find((tag) => tag.name === spec.name) : undefined
+          if (!freshHit) throw error
+
+          resolved.push(freshHit)
+        }
+      }
+
+      return resolved
+    },
+    [cachedTags, createTag, getDefaultColor]
+  )
+
+  return { ensureTags }
+}

--- a/src/renderer/src/hooks/useTagsLegacy.ts
+++ b/src/renderer/src/hooks/useTagsLegacy.ts
@@ -8,6 +8,14 @@ import { useTranslation } from 'react-i18next'
 
 import { useAssistants } from './useAssistant'
 
+/**
+ * Legacy Redux-backed assistant tag hook. Kept only for v1 home tabs:
+ * - pages/home/Tabs/AssistantsTab.tsx
+ * - pages/home/Tabs/components/AssistantItem.tsx
+ * - pages/home/Tabs/components/AssistantTagsPopup.tsx
+ *
+ * New v2 DataApi tag hooks live in `useTags.ts`.
+ */
 // 基础选择器
 const selectAssistantsState = (state: RootState) => state.assistants
 // 记忆化 tagsOrder 选择器（自动处理默认值）--- 这是一个选择器，用于从 store 中获取 tagsOrder 的值。因为之前的tagsOrder是后面新加的，不这样做会报错，所以这里需要处理一下默认值
@@ -18,7 +26,8 @@ const selectCollapsedTags = createSelector([selectAssistantsState], (assistants)
 // 定义useTags的返回类型，包含所有标签和获取特定标签的助手函数
 // 为了不增加新的概念，标签直接作为助手的属性，所以这里的标签是指助手的标签属性
 // 但是为了方便管理，增加了一个获取特定标签的助手函数
-export const useTags = () => {
+/** @deprecated Use `useTagList` / `useEnsureTags` from `useTags.ts` for v2 DataApi tags. */
+export const useTagsLegacy = () => {
   const { assistants } = useAssistants()
   const { t } = useTranslation()
   const dispatch = useAppDispatch()

--- a/src/renderer/src/pages/home/Tabs/AssistantsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/AssistantsTab.tsx
@@ -3,7 +3,7 @@ import Scrollbar from '@renderer/components/Scrollbar'
 import { useAssistants } from '@renderer/hooks/useAssistant'
 import { useAssistantPresets } from '@renderer/hooks/useAssistantPresets'
 import { useAssistantsTabSortType } from '@renderer/hooks/useStore'
-import { useTags } from '@renderer/hooks/useTags'
+import { useTagsLegacy } from '@renderer/hooks/useTagsLegacy'
 import type { RootState } from '@renderer/store'
 import { useAppSelector } from '@renderer/store'
 import type { Assistant } from '@renderer/types'
@@ -38,7 +38,7 @@ const AssistantsTab: FC<AssistantsTabProps> = (props) => {
   // Assistant related hooks
   const { assistants, removeAssistant, copyAssistant, updateAssistants } = useAssistants()
   const { addAssistantPreset } = useAssistantPresets()
-  const { collapsedTags, toggleTagCollapse } = useTags()
+  const { collapsedTags, toggleTagCollapse } = useTagsLegacy()
   const { assistantsTabSortType = 'list', setAssistantsTabSortType } = useAssistantsTabSortType()
   const [dragging, setDragging] = useState(false)
   const savedTagsOrder = useAppSelector(selectTagsOrder)

--- a/src/renderer/src/pages/home/Tabs/components/AssistantItem.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/AssistantItem.tsx
@@ -3,7 +3,7 @@ import AssistantAvatar from '@renderer/components/Avatar/AssistantAvatar'
 import { CopyIcon, DeleteIcon, EditIcon } from '@renderer/components/Icons'
 import PromptPopup from '@renderer/components/Popups/PromptPopup'
 import { useAssistant, useAssistants } from '@renderer/hooks/useAssistant'
-import { useTags } from '@renderer/hooks/useTags'
+import { useTagsLegacy } from '@renderer/hooks/useTagsLegacy'
 import AssistantSettingsPopup from '@renderer/pages/home/AssistantSettings'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import type { Assistant } from '@renderer/types'
@@ -66,7 +66,7 @@ const AssistantItem: FC<AssistantItemProps> = ({
   const [topicPosition] = usePreference('topic.position')
 
   const { t } = useTranslation()
-  const { allTags } = useTags()
+  const { allTags } = useTagsLegacy()
   const { removeAllTopics } = useAssistant(assistant.id)
   const { assistants, updateAssistants } = useAssistants()
 

--- a/src/renderer/src/pages/home/Tabs/components/AssistantTagsPopup.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/AssistantTagsPopup.tsx
@@ -4,7 +4,7 @@ import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd'
 import { DeleteIcon } from '@renderer/components/Icons'
 import { TopView } from '@renderer/components/TopView'
 import { useAssistants } from '@renderer/hooks/useAssistant'
-import { useTags } from '@renderer/hooks/useTags'
+import { useTagsLegacy } from '@renderer/hooks/useTagsLegacy'
 import { Empty, Modal } from 'antd'
 import { isEmpty } from 'lodash'
 import { useState } from 'react'
@@ -21,7 +21,7 @@ interface Props extends ShowParams {
 
 const PopupContainer: React.FC<Props> = ({ title, resolve }) => {
   const [open, setOpen] = useState(true)
-  const { allTags, getAssistantsByTag, updateTagsOrder } = useTags()
+  const { allTags, getAssistantsByTag, updateTagsOrder } = useTagsLegacy()
   const { assistants, updateAssistants } = useAssistants()
   const { t } = useTranslation()
   const [tags, setTags] = useState(allTags)


### PR DESCRIPTION
### What this PR does

Before this PR:
The renderer `useTags.ts` hook still pointed to the legacy Redux-backed assistant tag behavior used by the v1 home tabs, so the canonical `useTags` filename could not be used for the v2 DataApi tag collection helpers requested for the resource-library follow-up.

After this PR:
- Moves the legacy Redux-backed assistant tag hook to `useTagsLegacy.ts`.
- Updates the three home-tabs callers to import `useTagsLegacy`.
- Adds the v2 DataApi-backed `useTagList` and `useEnsureTags` hooks in `useTags.ts`.
- Adds focused tests for tag cache hits, creation, deduplication, empty input, and conflict retry handling.

Fixes #N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:
This PR only consolidates the tag collection helpers needed by the v2 resource-library work. It intentionally does not add `useEntityTags` / `useSyncEntityTags`, because the current production write paths use owner-embedded tag updates and the entity-tag renderer hook has no production consumers.

The following alternatives were considered:
Keeping `useDataTags.ts` in the resource-library PR was rejected because it leaves the `useTags` filename split across two PRs. Folding entity-tag relation hooks into this PR was also avoided because they are not needed by current production callers.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/pull/14442#pullrequestreview-4259021289

### Breaking changes

None. This is an internal renderer hook refactor and the legacy home-tabs behavior remains wired through `useTagsLegacy`.

### Special notes for your reviewer

This PR is intended to unblock PR #14442 by landing the standalone `useTags` consolidation on `v2` first.

Validation already run:
- `pnpm build:check`
- `pnpm test:renderer src/renderer/src/hooks/__tests__/useTags.test.ts`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
