### PR TITLE
fix: resolve ENOENT in OpenMinerU preprocessing caused by MinerU ZIP structure change

### DIFF
--- a/src/main/knowledge/preprocess/OpenMineruPreprocessProvider.ts
+++ b/src/main/knowledge/preprocess/OpenMineruPreprocessProvider.ts
@@ -85,12 +85,10 @@ export default class OpenMineruPreprocessProvider extends BasePreprocessProvider
     // Find the main file after extraction
     let finalPath = ''
     let finalName = file.origin_name.replace('.pdf', '.md')
-    // Find the corresponding folder by file id
-    outputPath = path.join(outputPath, file.id)
     try {
-      const files = fs.readdirSync(outputPath)
-
-      const mdFile = files.find((f) => f.endsWith('.md'))
+      // MinerU's ZIP output structure changed from {name}/{name}.md to {name}/{parse_method}/{name}.md
+      // (see opendatalab/MinerU commit 40a52da3cf, 2026-03-25), so we need to search recursively.
+      const mdFile = this.findMdFileRecursively(outputPath)
       if (mdFile) {
         const originalMdPath = path.join(outputPath, mdFile)
         const newMdPath = path.join(outputPath, finalName)
@@ -104,12 +102,16 @@ export default class OpenMineruPreprocessProvider extends BasePreprocessProvider
           logger.warn(`Failed to rename file ${mdFile} to ${finalName}: ${renameError}`)
           // If rename fails, use the original file
           finalPath = originalMdPath
-          finalName = mdFile
+          finalName = path.basename(mdFile)
         }
       }
     } catch (error) {
       logger.warn(`Failed to read output directory ${outputPath}:`, error as Error)
-      finalPath = path.join(outputPath, `${file.id}.md`)
+    }
+
+    if (!finalPath) {
+      logger.warn(`No markdown file found in ${outputPath}`)
+      finalPath = path.join(outputPath, finalName)
     }
 
     return {
@@ -119,6 +121,25 @@ export default class OpenMineruPreprocessProvider extends BasePreprocessProvider
       ext: '.md',
       size: fs.existsSync(finalPath) ? fs.statSync(finalPath).size : 0
     }
+  }
+
+  /**
+   * Recursively search for the first .md file in the output directory.
+   * Returns the relative path from outputPath to the .md file, or undefined if not found.
+   */
+  private findMdFileRecursively(dir: string, basePath: string = ''): string | undefined {
+    const entries = fs.readdirSync(dir, { withFileTypes: true })
+    for (const entry of entries) {
+      const relativePath = basePath ? `${basePath}/${entry.name}` : entry.name
+      if (entry.isFile() && entry.name.endsWith('.md')) {
+        return relativePath
+      }
+      if (entry.isDirectory()) {
+        const found = this.findMdFileRecursively(path.join(dir, entry.name), relativePath)
+        if (found) return found
+      }
+    }
+    return undefined
   }
 
   private async uploadFileAndExtract(


### PR DESCRIPTION
### What this PR does

Before this PR:
The `OpenMineruPreprocessProvider` always fails with `ENOENT: no such file or directory` when processing PDFs with a self-hosted MinerU instance (v3.0+), because the code cannot locate the `.md` file inside the extracted ZIP output.

After this PR:
The `.md` file is found correctly regardless of MinerU ZIP internal directory structure, by using recursive search instead of single-level `readdirSync`.

### Why we need it and why it was done in this way

**Root cause: MinerU changed its ZIP output structure.**

The self-hosted MinerU `/file_parse` API (with `response_format_zip=true`) changed its ZIP internal layout:

| MinerU version | ZIP internal path | Commit |
|---|---|---|
| Original (2025-08) | `{name}/{name}.md` | `4a237eef36` |
| Current (2026-03+) | `{name}/{parse_method}/{name}.md` | [`40a52da3cf`](https://github.com/opendatalab/MinerU/commit/40a52da3cf) |

For example, a file named `test.pdf` now produces: `test/hybrid_auto/test.md` instead of `test/test.md`.

Verified with MinerU 3.1.9:
```
$ unzip -l mineru-result.zip
  test-mineru/hybrid_auto/test-mineru.md
```

**Bug history in Cherry Studio:**

1. **Initial implementation** ([`888a183`](https://github.com/CherryHQ/cherry-studio/commit/888a183328), 2025-10-29): Used `path.join(outputPath, pdf_name)` to build the subdirectory — matched the original single-level MinerU ZIP structure correctly at the time.

2. **PR #11315** ([`90b0c8b`](https://github.com/CherryHQ/cherry-studio/commit/90b0c8b4a6), 2025-11-16): Attempted to fix non-English filename issues by switching to `path.join(outputPath, file.id)`. This created a path `{storageDir}/{file.id}/{file.id}` that never exists, causing the ENOENT error.

**Actual path trace:**

```
uploadFileAndExtract() extracts ZIP to: {storageDir}/{file.id}/
  → ZIP contents: {name}/{parse_method}/{name}.md

createProcessedFileInfo() receives outputPath = {storageDir}/{file.id}

Old code: path.join(outputPath, file.id)
  → reads: {storageDir}/{file.id}/{file.id}/  ← ENOENT (never exists)

This fix: findMdFileRecursively(outputPath)
  → finds: {name}/{parse_method}/{name}.md relative to outputPath  ✓
```

**The fix:**

Replace the hardcoded single-level `readdirSync` + `find(f => f.endsWith(".md"))` with a recursive `findMdFileRecursively()` method that traverses the extraction directory tree to locate the `.md` file. This works with:
- Old MinerU structure: `{name}/{name}.md`
- New MinerU structure: `{name}/{parse_method}/{name}.md`
- Any future nesting changes

The following tradeoffs were made:
- Recursive search is slightly slower than flat readdir, but the directory tree is shallow (2-3 levels) and this runs once per file — negligible impact.

The following alternatives were considered:
- Hardcode the `{parse_method}` directory level — fragile, would break if MinerU changes structure again.
- Flatten the ZIP on extraction — more invasive change.

### Breaking changes

None. This is a bug fix with no API changes.

### Special notes for your reviewer

- The SaaS `MineruPreprocessProvider` uses the same `readdirSync` + `find` pattern in its `createProcessedFileInfo`, but it works because the SaaS endpoint returns a differently structured ZIP (single-level). If MinerU SaaS also adopts the nested structure, that provider will need the same fix.
- AGENTS.md indicates `main` is under code freeze accepting only critical bug fixes via `hotfix/*` branches — this qualifies as a critical bug (OpenMinerU preprocessing is completely broken).

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix OpenMinerU preprocessing always failing with ENOENT due to MinerU ZIP output structure change (nested subdirectory)
```
