### PR TITLE
hotfix(aiCore): prevent crash when model.provider not found (#14999)

### DIFF
--- a/src/renderer/src/aiCore/utils/__tests__/options.test.ts
+++ b/src/renderer/src/aiCore/utils/__tests__/options.test.ts
@@ -230,6 +230,22 @@ describe('options utils', () => {
         expect(result.providerOptions.openai).toHaveProperty('serviceTier')
         expect(result.providerOptions.openai.serviceTier).toBe(OpenAIServiceTiers.auto)
       })
+
+      it('should not throw when model.provider is not in the provider store (regression: issue #14999)', () => {
+        const gpt5Model: Model = {
+          id: 'gpt-5',
+          name: 'GPT-5',
+          provider: 'orphaned-provider-id'
+        } as Model
+
+        expect(() =>
+          buildProviderOptions(mockAssistant, gpt5Model, openaiProvider, {
+            enableReasoning: false,
+            enableWebSearch: false,
+            enableGenerateImage: false
+          })
+        ).not.toThrow()
+      })
     })
 
     describe('Anthropic provider', () => {

--- a/src/renderer/src/aiCore/utils/options.ts
+++ b/src/renderer/src/aiCore/utils/options.ts
@@ -101,7 +101,8 @@ function getServiceTier<T extends Provider>(model: Model, provider: T): OpenAISe
 }
 
 function getVerbosity(model: Model): OpenAIVerbosity {
-  if (!isSupportVerbosityModel(model) || !isSupportVerbosityProvider(getProviderById(model.provider)!)) {
+  const provider = getProviderById(model.provider)
+  if (!provider || !isSupportVerbosityModel(model) || !isSupportVerbosityProvider(provider)) {
     return undefined
   }
   const openAI = getStoreSetting('openAI')
@@ -338,11 +339,7 @@ function buildOpenAIProviderOptions(
   }
   const provider = getProviderById(model.provider)
 
-  if (!provider) {
-    throw new Error(`Provider ${model.provider} not found`)
-  }
-
-  if (isSupportVerbosityModel(model) && isSupportVerbosityProvider(provider)) {
+  if (provider && isSupportVerbosityModel(model) && isSupportVerbosityProvider(provider)) {
     const openAI = getStoreSetting<'openAI'>('openAI')
     const userVerbosity = openAI?.verbosity
 


### PR DESCRIPTION
### What this PR does

Before this PR:
Sending any chat message could throw `TypeError: Cannot read properties of undefined (reading 'apiOptions')` from `isSupportVerbosityProvider`, breaking the conversation. This happens when a model's stored `provider` id no longer matches any provider in the store (e.g. the provider was deleted/renamed), because `getProviderById(model.provider)!` was non-null-asserted in `getVerbosity`, and `buildOpenAIProviderOptions` explicitly threw when the lookup returned `undefined`.

After this PR:
Both call sites in `src/renderer/src/aiCore/utils/options.ts` treat a missing provider as "verbosity not applicable" and skip the option instead of crashing. Verbosity is a purely additive request option, so omitting it is safe. A regression test exercises `buildProviderOptions` with a `gpt-5` model whose `provider` id has no match in the store.

Fixes #14999

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Chose to silently skip verbosity when the provider lookup fails, rather than surfacing the inconsistency to the user. This unblocks chat immediately for users with orphaned `model.provider` references; reconciling the model/provider mismatch is out of scope for a hotfix.
- Removed the `throw new Error('Provider ... not found')` in `buildOpenAIProviderOptions` because that branch was only used to gate the verbosity check; an unrelated provider-lookup failure should not block the OpenAI Responses request.

The following alternatives were considered:
- Use the `actualProvider` already passed into `buildProviderOptions` instead of re-resolving via `getProviderById(model.provider)`. Rejected for a hotfix because `model.provider` and `actualProvider` are semantically different (model's owning provider vs. the provider being called, e.g. gateways), and changing which one drives the verbosity decision would be a behavior change beyond a crash fix.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/14999

### Breaking changes

None.

### Special notes for your reviewer

Scope is intentionally minimal per the `main`-branch hotfix policy: two guard changes in one file, plus one regression test. No refactoring.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix a crash on chat send when a chat model's stored provider id no longer matches any configured provider (TypeError on `apiOptions`).
```
