### PR TITLE
fix: recognize ctrl by uniKey value

### DIFF
--- a/src/main/services/SelectionService.ts
+++ b/src/main/services/SelectionService.ts
@@ -1072,7 +1072,7 @@ export class SelectionService {
    */
   private handleKeyDownHide = (data: KeyboardEventData) => {
     //dont hide toolbar when ctrlkey is pressed
-    if (this.triggerMode === TriggerMode.Ctrlkey && this.isCtrlkey(data.vkCode)) {
+    if (this.triggerMode === TriggerMode.Ctrlkey && this.isCtrlkey(data)) {
       return
     }
     //dont hide toolbar when shiftkey or altkey is pressed, because it's used for selection
@@ -1089,7 +1089,7 @@ export class SelectionService {
    * @param data Keyboard event data
    */
   private handleKeyDownCtrlkeyMode = (data: KeyboardEventData) => {
-    if (!this.isCtrlkey(data.vkCode)) {
+    if (!this.isCtrlkey(data)) {
       // reset the lastCtrlkeyDownTime if any other key is pressed
       if (this.lastCtrlkeyDownTime > 0) {
         this.lastCtrlkeyDownTime = -1
@@ -1128,7 +1128,7 @@ export class SelectionService {
    * @param data Keyboard event data
    */
   private handleKeyUpCtrlkeyMode = (data: KeyboardEventData) => {
-    if (!this.isCtrlkey(data.vkCode)) return
+    if (!this.isCtrlkey(data)) return
     //remove the mouse-wheel&mouse-down listener
     this.selectionHook!.off('mouse-wheel', this.handleMouseWheelCtrlkeyMode)
     this.selectionHook!.off('mouse-down', this.handleMouseDownCtrlkeyMode)
@@ -1156,7 +1156,13 @@ export class SelectionService {
   // Check if the key is ctrl key
   // Windows: VK_LCONTROL(162), VK_RCONTROL(163)
   // macOS: kVK_Control(59), kVK_RightControl(62)
-  private isCtrlkey(vkCode: number) {
+  private isCtrlkey(data: KeyboardEventData) {
+    if (data.uniKey === 'Control') {
+      return true
+    }
+
+    const { vkCode } = data
+
     if (isMac) {
       return vkCode === 59 || vkCode === 62
     }


### PR DESCRIPTION
### What this PR does

Ref: https://github.com/0xfullex/selection-hook/blob/main/examples/node-demo.js


Before this PR:

On Windows, the Selection Assistant Ctrl trigger only checked platform-specific `vkCode` values. After `selection-hook` exposed unified keyboard event data, Ctrl key events could fail to match the existing check, so holding Ctrl after selecting text did not open the selection toolbar.

After this PR:

The Ctrl trigger now recognizes `selection-hook`'s unified `uniKey: 'Control'` value first, while keeping the existing left/right Ctrl `vkCode` fallback for compatibility.

### Why we need it and why it was done in this way


### Breaking changes

None.

### Special notes for your reviewer


### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed the Selection Assistant Ctrl trigger not opening after selecting text on Windows.
```