### PR TITLE
fix(image): convert assistant image blocks to base64 for multi-turn editing

### DIFF
--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -330,7 +330,10 @@ async function collectImagesFromMessages(userMessage: Message, assistantMessage?
   if (assistantMessage) {
     const assistantImageBlocks = findImageBlocks(assistantMessage)
     for (const block of assistantImageBlocks) {
-      if (block.url) {
+      if (block.file) {
+        const { data } = await window.api.file.base64Image(block.file.name)
+        images.push(data)
+      } else if (block.url) {
         images.push(block.url)
       }
     }

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -331,8 +331,15 @@ async function collectImagesFromMessages(userMessage: Message, assistantMessage?
     const assistantImageBlocks = findImageBlocks(assistantMessage)
     for (const block of assistantImageBlocks) {
       if (block.file) {
-        const { data } = await window.api.file.base64Image(block.file.name)
-        images.push(data)
+        try {
+          const { data } = await window.api.file.base64Image(block.file.name)
+          images.push(data)
+        } catch (error) {
+          logger.error('Failed to load assistant image file, image will be excluded:', {
+            fileName: block.file.name,
+            error: error as Error
+          })
+        }
       } else if (block.url) {
         images.push(block.url)
       }


### PR DESCRIPTION
### What this PR does

Before this PR:

When using `gpt-image-2` for multi-turn image editing, the second round fails with `AI_InvalidDataContentError: Invalid data content. Content string is not a base64-encoded media` because `collectImagesFromMessages()` pushes raw `file://` URLs from assistant image blocks directly into `inputImages`.

After this PR:

Assistant image blocks with `file` metadata are converted to base64 via `base64Image()` before being passed to `editImage()`, consistent with how user image blocks are already handled. Remote URLs (without file metadata) are still passed through as-is.

Fixes #14960

### Why we need it and why it was done in this way

The `collectImagesFromMessages` function already converts user image blocks correctly (using `block.file` → `base64Image()`), but the assistant image block branch only read `block.url` — which is a `file://` path for locally-saved generated images. The AI SDK's `convertDataContentToUint8Array` cannot parse `file://` URLs, causing the error.

The fix mirrors the existing user image block logic, keeping the change minimal and consistent.

The following alternatives were considered:

- Fetching the file from the `file://` URL directly — rejected because `base64Image()` is the established pattern and handles MIME detection.

### Breaking changes

None.

### Special notes for your reviewer

- The fix is 3 lines, scoped to `src/renderer/src/services/ApiService.ts`.
- Only the assistant image block collection path is changed; user image blocks were already correct.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: Not required — no user-facing feature or behavior change beyond the bug fix.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix gpt-image-2 multi-turn editing crash (AI_InvalidDataContentError) by converting assistant image blocks to base64 before passing to editImage
```
