### PR TITLE
fix(agents): use task name as session name for cron task sessions

### DIFF
--- a/src/main/services/agents/services/SchedulerService.ts
+++ b/src/main/services/agents/services/SchedulerService.ts
@@ -251,7 +251,7 @@ class SchedulerService {
         sessionId = session.id
         logger.debug('Reusing session from last run', { taskId: task.id, sessionId })
       } else {
-        const newSession = await sessionService.createSession(task.agent_id, {})
+        const newSession = await sessionService.createSession(task.agent_id, { name: task.name })
         sessionId = newSession!.id
         session = await sessionService.getSession(task.agent_id, sessionId)
         if (!session) {


### PR DESCRIPTION
## Summary

One-line fix to make cron task sessions use the task name instead of the agent name.

## Problem

When scheduled cron tasks run,  calls  with , causing all sessions to inherit the agent name. Users with multiple scheduled tasks cannot distinguish which session belongs to which task.

## Fix



 is already populated from .

## Verification

- No new fields or schema changes
- Backward compatible: existing sessions unaffected
- Session name now reflects the task name (e.g. "Daily Report" instead of "MyBot")

Closes #15052