### PR TITLE
fix(ai): thread idle timeout handle to stream chunk adapter

### DIFF
--- a/src/renderer/src/aiCore/AiProvider.ts
+++ b/src/renderer/src/aiCore/AiProvider.ts
@@ -257,7 +257,8 @@ export default class AiProvider {
         middlewareConfig.enableWebSearch,
         undefined,
         undefined,
-        providerConfig.providerId
+        providerConfig.providerId,
+        middlewareConfig.idleTimeout
       )
 
       const streamResult = await executor.streamText({

--- a/src/renderer/src/aiCore/types/middlewareConfig.ts
+++ b/src/renderer/src/aiCore/types/middlewareConfig.ts
@@ -2,6 +2,7 @@ import type { WebSearchPluginConfig } from '@cherrystudio/ai-core/built-in/plugi
 import type { MCPTool } from '@renderer/types'
 import type { Assistant, Message } from '@renderer/types'
 import type { Chunk } from '@renderer/types/chunk'
+import type { IdleTimeoutHandle } from '@renderer/utils/IdleTimeoutController'
 
 /**
  * AI SDK 中间件配置项（用于插件构建）
@@ -26,4 +27,6 @@ export interface AiSdkMiddlewareConfig {
   urlContextConfig?: Record<string, any>
   knowledgeRecognition?: 'off' | 'on'
   mcpMode?: string
+  /** Resettable idle timeout handle — reset() on each chunk, cleanup() on stream end */
+  idleTimeout?: IdleTimeoutHandle
 }

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -255,7 +255,8 @@ export async function fetchChatCompletion({
     params: aiSdkParams,
     modelId,
     capabilities,
-    webSearchPluginConfig
+    webSearchPluginConfig,
+    idleTimeout
   } = await buildStreamTextParams(messages, assistant, provider, {
     mcpTools: mcpTools,
     allowedTools,
@@ -281,7 +282,8 @@ export async function fetchChatCompletion({
     mcpMode,
     mcpTools,
     uiMessages,
-    knowledgeRecognition: assistant.knowledgeRecognition
+    knowledgeRecognition: assistant.knowledgeRecognition,
+    idleTimeout
   }
 
   // Wrap onChunkReceived to automatically track token usage on completion


### PR DESCRIPTION
### What this PR does

Before this PR:

The `IdleTimeoutController` creates an abort signal that fires after 30 minutes of "idle" time. The signal is correctly passed into `streamText()` via `params.abortSignal`, but the `IdleTimeoutHandle` (with `reset()`/`cleanup()` methods) was never threaded through to `AiSdkToChunkAdapter`, which is the only place that calls `this.idleTimeout?.reset()` on each chunk. Since the handle was always `undefined`, the timeout never reset, and any stream lasting longer than 30 minutes got aborted — even if actively receiving data (e.g., DeepSeek extended thinking at ~1799s).

After this PR:

The `idleTimeout` handle is now forwarded from `buildStreamTextParams()` → `ApiService` → `AiProvider.modernCompletions()` → `AiSdkToChunkAdapter` constructor. The adapter calls `reset()` on each stream chunk and `cleanup()` on stream end, so the idle timeout only fires when the stream is genuinely idle for 30 minutes.

Fixes #14921

### Why we need it and why it was done in this way

Users reported DeepSeek extended thinking being aborted at exactly 1799 seconds. The `IdleTimeoutController` was introduced in v1.8.0 (#13497) with a resettable design, but the reset handle was never wired to the actual stream consumer. In v1.7.x there was no `IdleTimeoutController` at all — streams never timed out, which is why users report v1.7.3 could handle long connections.

The following tradeoffs were made:

- Minimal fix: only threads the existing handle through 3 files (+9/-3 lines). No new timeout configuration UI or per-provider settings — deferred to v2.
- `_completionsForTrace` path automatically benefits because it passes `middlewareConfig` through to `modernCompletions()` without changes.

The following alternatives were considered:

- Per-provider/user-configurable timeout settings — deferred to v2
- Removing `IdleTimeoutController` entirely (v2 approach) — too invasive for a hotfix on `main`

Links to places where the discussion took place: #14921

### Breaking changes

None. `idleTimeout` is an optional field — all existing call paths that don't set it continue to pass `undefined`, and the adapter's `this.idleTimeout?.reset()` calls are already null-safe.

### Special notes for your reviewer

- The `AiSdkToChunkAdapter` already had the `idleTimeout` constructor parameter, `reset()` on chunk, and `cleanup()` on stream end implemented — it just never received the handle.
- Agent streaming path (`messageThunk.ts`) is unaffected — it has independent abort signal management.
- `pnpm build:check` passed: 238 test files, 4295 tests, 0 lint errors.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed a bug where streaming requests were aborted after 30 minutes even during active data transfer, which affected models with extended thinking (e.g., DeepSeek). The idle timeout now correctly resets on each received chunk.
```