### PR TITLE
hotfix(image-generation): route requests by endpoint_type, not just model id

### DIFF
--- a/src/renderer/src/config/models/__tests__/vision.test.ts
+++ b/src/renderer/src/config/models/__tests__/vision.test.ts
@@ -8,6 +8,7 @@ import {
   isDedicatedImageGenerationModel,
   isGenerateImageModel,
   isImageEnhancementModel,
+  isImageGenerationEndpoint,
   isPureGenerateImageModel,
   isTextToImageModel,
   isVisionModel
@@ -133,6 +134,24 @@ describe('vision helpers', () => {
     it('returns false when models are not in dedicated or auto-enable sets', () => {
       expect(isDedicatedImageGenerationModel(createModel({ id: 'gpt-4o' }))).toBe(false)
       expect(isAutoEnableImageGenerationModel(createModel({ id: 'gpt-4o' }))).toBe(false)
+    })
+  })
+
+  describe('isImageGenerationEndpoint', () => {
+    it('routes models tagged with endpoint_type=image-generation regardless of id', () => {
+      expect(
+        isImageGenerationEndpoint(createModel({ id: 'custom-vendor-image-pro', endpoint_type: 'image-generation' }))
+      ).toBe(true)
+    })
+
+    it('still routes dedicated image ids when endpoint_type is unset', () => {
+      expect(isImageGenerationEndpoint(createModel({ id: 'gpt-image-2' }))).toBe(true)
+      expect(isImageGenerationEndpoint(createModel({ id: 'dall-e-3' }))).toBe(true)
+    })
+
+    it('does not route plain chat models without the tag', () => {
+      expect(isImageGenerationEndpoint(createModel({ id: 'gpt-4o' }))).toBe(false)
+      expect(isImageGenerationEndpoint(createModel({ id: 'gpt-4o', endpoint_type: 'openai' }))).toBe(false)
     })
   })
 })

--- a/src/renderer/src/config/models/vision.ts
+++ b/src/renderer/src/config/models/vision.ts
@@ -182,6 +182,21 @@ export function isDedicatedImageModel(model: Model): boolean {
 // Backward compatible aliases
 export const isDedicatedImageGenerationModel = isDedicatedImageModel
 
+/**
+ * Whether a chat send should be routed to the image generation endpoint
+ * (`/v1/images/generations`) instead of `/v1/chat/completions`.
+ *
+ * Returns true when either:
+ * 1. The model id matches `DEDICATED_IMAGE_MODEL_REGEX`, or
+ * 2. The user explicitly tagged the model with `endpoint_type: 'image-generation'`
+ *    (currently surfaced in the UI for NewAPI / CherryIN providers).
+ */
+export function isImageGenerationEndpoint(model: Model): boolean {
+  if (!model) return false
+  if (isDedicatedImageModel(model)) return true
+  return model.endpoint_type === 'image-generation'
+}
+
 export const isAutoEnableImageGenerationModel = (model: Model): boolean => {
   if (!model) return false
 

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -5,7 +5,7 @@ import { loggerService } from '@logger'
 import { buildStreamTextParams } from '@renderer/aiCore/prepareParams'
 import type { AiSdkMiddlewareConfig } from '@renderer/aiCore/types/middlewareConfig'
 import { buildProviderOptions } from '@renderer/aiCore/utils/options'
-import { isDedicatedImageGenerationModel, isEmbeddingModel, isFunctionCallingModel } from '@renderer/config/models'
+import { isEmbeddingModel, isFunctionCallingModel, isImageGenerationEndpoint } from '@renderer/config/models'
 import { getStoreSetting } from '@renderer/hooks/useSettings'
 import i18n from '@renderer/i18n'
 import store from '@renderer/store'
@@ -164,9 +164,9 @@ export async function transformMessagesAndFetch(
     // replace prompt variables
     assistant.prompt = await replacePromptVariables(assistant.prompt, assistant.model?.name)
 
-    // 专用图像生成模型直接走 fetchImageGeneration
+    // 专用图像生成模型 or 用户显式标记为图像生成端点的模型，直接走 fetchImageGeneration
     const model = assistant.model || getDefaultModel()
-    if (isDedicatedImageGenerationModel(model)) {
+    if (isImageGenerationEndpoint(model)) {
       await fetchImageGeneration({
         messages: uiMessages,
         assistant,

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -850,6 +850,21 @@ export async function checkApi(provider: Provider, model: Model, timeout = 15000
     logger.info('checkApi: embedding model detected, calling getEmbeddingDimensions', { modelId: model.id })
     const timerPromise = new Promise<never>((_, reject) => setTimeout(() => reject(new Error('Timeout')), timeout))
     await Promise.race([ai.getEmbeddingDimensions(model), timerPromise])
+  } else if (isImageGenerationEndpoint(model)) {
+    logger.info('checkApi: image generation endpoint detected, calling generateImage', { modelId: model.id })
+    const abortId = uuid()
+    const signal = readyToAbort(abortId)
+    const timerPromise = new Promise<never>((_, reject) => setTimeout(() => reject(new Error('Timeout')), timeout))
+    await Promise.race([
+      ai.generateImage({
+        model: model.id,
+        prompt: 'hi',
+        imageSize: '1024x1024',
+        batchSize: 1,
+        signal
+      }),
+      timerPromise
+    ])
   } else {
     const abortId = uuid()
     const signal = readyToAbort(abortId)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR:

- A NewAPI / CherryIN model with `endpoint_type: 'image-generation'` (selected as "Image Generation (OpenAI)" in the Edit Model dialog) was still POSTed to `/v1/chat/completions`, returning `500 this channel only supports image generation, please use POST /v1/images/generations instead of /v1/chat/completions` from the upstream gateway.
- The routing branch in `transformMessagesAndFetch` only looked at the model id via `isDedicatedImageGenerationModel(model)` (which tests `model.id` against `DEDICATED_IMAGE_MODEL_REGEX`). The user's explicit `endpoint_type` tag was ignored at the routing layer. Any model whose id didn't match the hardcoded regex — custom-named image channels, or cases where the regex unexpectedly failed to apply — was sent down the chat path.

After this PR:

- A new predicate `isImageGenerationEndpoint(model)` is added next to the existing image helpers in `src/renderer/src/config/models/vision.ts`. It returns true when **either** `isDedicatedImageModel(model)` matches **or** `model.endpoint_type === 'image-generation'`.
- `ApiService.transformMessagesAndFetch` now uses this predicate, so an explicitly tagged image model flows through `fetchImageGeneration → aiProvider.generateImage → provider.imageModel(...)` and hits `/v1/images/generations` regardless of how the id is named.
- Existing behaviour for models that already match the regex (`gpt-image-*`, `dall-e-*`, `flux-*`, etc.) is unchanged.

Fixes #15069

### Why we need it and why it was done in this way

The UI exposes the endpoint-type dropdown as the user's authoritative signal for which channel a model talks to, but routing was secretly relying on a static model-name allowlist instead, which silently drops the signal whenever a name doesn't match. Treating `endpoint_type === 'image-generation'` as a first-class routing input fixes this with minimal blast radius.

The following tradeoffs were made:

- Kept the change to a single new predicate plus a one-line condition update in `ApiService`. No changes to `newapi-provider.ts` / `aiCore/utils/options.ts` (which still have `case 'image-generation'` falling through to a chat model in the chat-model factory) — those branches only act as a defensive fallback now that the routing layer no longer reaches them for tagged image models. Touching them would push the diff into refactor territory, which `main` does not accept under the current code freeze.
- The new predicate is named `isImageGenerationEndpoint` to keep it clearly distinct from `isDedicatedImageGenerationModel` (which is id-only) without renaming the existing helper.

The following alternatives were considered:

- Inlining `isDedicatedImageGenerationModel(model) || model.endpoint_type === 'image-generation'` directly in `ApiService`. Rejected because the rule then has no test home and would have to be duplicated if another caller (e.g. quick-model summary) needs the same routing decision in a follow-up fix.
- Reworking `endpoint_type === 'image-generation'` end-to-end so the NewAPI provider also exposes an image model from `createChatModel`. Rejected as out of scope for a hotfix on `main`; that belongs on `v2`.

Links to places where the discussion took place: N/A

### Breaking changes

None. Routing behaviour only changes for models that were already misrouted (id did not match the dedicated regex but `endpoint_type` was explicitly set to `image-generation`); those now reach the correct endpoint instead of failing with a 500.

### Special notes for your reviewer

Reproduction with the fix:

1. Add a NewAPI provider (e.g. AIFAST gateway).
2. Add a model with id `gpt-image-2` (or any custom-named image channel), set Endpoint Type to "Image Generation (OpenAI)".
3. Open a chat with that model and send any prompt — request goes to `POST /v1/images/generations` instead of `/v1/chat/completions`.

Unit test added in `src/renderer/src/config/models/__tests__/vision.test.ts` covering:

- `endpoint_type: 'image-generation'` on a non-matching id routes to image generation.
- Dedicated id (`gpt-image-2`, `dall-e-3`) still routes when `endpoint_type` is unset.
- Plain chat models (`gpt-4o`, `gpt-4o` + `endpoint_type: 'openai'`) do not.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix image generation routing for NewAPI / CherryIN models whose endpoint type is set to "Image Generation (OpenAI)": the chat send path now honors `endpoint_type: 'image-generation'` regardless of whether the model id matches the built-in image-model name list, so requests reach `/v1/images/generations` instead of failing with `this channel only supports image generation, please use POST /v1/images/generations instead of /v1/chat/completions`.
```
