### PR TITLE
feat(assistant): add order key management

### DIFF
--- a/migrations/sqlite-drizzle/0023_tough_guardian.sql
+++ b/migrations/sqlite-drizzle/0023_tough_guardian.sql
@@ -15,8 +15,30 @@ CREATE TABLE `__new_agent_session` (
 INSERT INTO `__new_agent_session`("id", "agent_id", "name", "description", "accessible_paths", "order_key", "created_at", "updated_at") SELECT "id", "agent_id", "name", "description", "accessible_paths", "order_key", "created_at", "updated_at" FROM `agent_session`;--> statement-breakpoint
 DROP TABLE `agent_session`;--> statement-breakpoint
 ALTER TABLE `__new_agent_session` RENAME TO `agent_session`;--> statement-breakpoint
+CREATE TABLE `__new_assistant` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`prompt` text DEFAULT '' NOT NULL,
+	`emoji` text NOT NULL,
+	`description` text DEFAULT '' NOT NULL,
+	`model_id` text,
+	`settings` text NOT NULL,
+	`order_key` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	`deleted_at` integer,
+	FOREIGN KEY (`model_id`) REFERENCES `user_model`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+INSERT INTO `__new_assistant`("id", "name", "prompt", "emoji", "description", "model_id", "settings", "order_key", "created_at", "updated_at", "deleted_at") SELECT "id", "name", "prompt", "emoji", "description", "model_id", "settings", 'a0', "created_at", "updated_at", "deleted_at" FROM `assistant`;--> statement-breakpoint
+DROP TABLE `assistant`;--> statement-breakpoint
+ALTER TABLE `__new_assistant` RENAME TO `assistant`;--> statement-breakpoint
 PRAGMA foreign_keys=ON;--> statement-breakpoint
 CREATE INDEX `agent_session_order_key_idx` ON `agent_session` (`order_key`);--> statement-breakpoint
+CREATE INDEX `assistant_created_at_idx` ON `assistant` (`created_at`);--> statement-breakpoint
+CREATE INDEX `assistant_order_key_idx` ON `assistant` (`order_key`);--> statement-breakpoint
+DROP INDEX `topic_group_id_order_key_idx`;--> statement-breakpoint
+CREATE INDEX `topic_order_key_idx` ON `topic` (`order_key`);--> statement-breakpoint
 CREATE TABLE `__new_agent` (
 	`id` text PRIMARY KEY NOT NULL,
 	`type` text NOT NULL,

--- a/migrations/sqlite-drizzle/0023_tough_guardian.sql
+++ b/migrations/sqlite-drizzle/0023_tough_guardian.sql
@@ -30,7 +30,58 @@ CREATE TABLE `__new_assistant` (
 	FOREIGN KEY (`model_id`) REFERENCES `user_model`(`id`) ON UPDATE no action ON DELETE set null
 );
 --> statement-breakpoint
-INSERT INTO `__new_assistant`("id", "name", "prompt", "emoji", "description", "model_id", "settings", "order_key", "created_at", "updated_at", "deleted_at") SELECT "id", "name", "prompt", "emoji", "description", "model_id", "settings", 'a0', "created_at", "updated_at", "deleted_at" FROM `assistant`;--> statement-breakpoint
+WITH `ordered_assistant` AS (
+	SELECT
+		"id",
+		"name",
+		"prompt",
+		"emoji",
+		"description",
+		"model_id",
+		"settings",
+		"created_at",
+		"updated_at",
+		"deleted_at",
+		ROW_NUMBER() OVER (ORDER BY "created_at", "id") - 1 AS "order_index"
+	FROM `assistant`
+),
+`base62_digits` AS (
+	SELECT '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz' AS "digits"
+),
+`assistant_with_order_key` AS (
+	SELECT
+		"id",
+		"name",
+		"prompt",
+		"emoji",
+		"description",
+		"model_id",
+		"settings",
+		CASE
+			WHEN "order_index" < 62 THEN
+				'a' || substr("digits", "order_index" + 1, 1)
+			WHEN "order_index" < 3906 THEN
+				'b' ||
+				substr("digits", CAST(("order_index" - 62) / 62 AS INTEGER) + 1, 1) ||
+				substr("digits", (("order_index" - 62) % 62) + 1, 1)
+			WHEN "order_index" < 242234 THEN
+				'c' ||
+				substr("digits", CAST(("order_index" - 3906) / 3844 AS INTEGER) + 1, 1) ||
+				substr("digits", (CAST(("order_index" - 3906) / 62 AS INTEGER) % 62) + 1, 1) ||
+				substr("digits", (("order_index" - 3906) % 62) + 1, 1)
+			ELSE
+				'd' ||
+				substr("digits", CAST(("order_index" - 242234) / 238328 AS INTEGER) + 1, 1) ||
+				substr("digits", (CAST(("order_index" - 242234) / 3844 AS INTEGER) % 62) + 1, 1) ||
+				substr("digits", (CAST(("order_index" - 242234) / 62 AS INTEGER) % 62) + 1, 1) ||
+				substr("digits", (("order_index" - 242234) % 62) + 1, 1)
+		END AS "order_key",
+		"created_at",
+		"updated_at",
+		"deleted_at"
+	FROM `ordered_assistant`, `base62_digits`
+)
+INSERT INTO `__new_assistant`("id", "name", "prompt", "emoji", "description", "model_id", "settings", "order_key", "created_at", "updated_at", "deleted_at") SELECT "id", "name", "prompt", "emoji", "description", "model_id", "settings", "order_key", "created_at", "updated_at", "deleted_at" FROM `assistant_with_order_key`;--> statement-breakpoint
 DROP TABLE `assistant`;--> statement-breakpoint
 ALTER TABLE `__new_assistant` RENAME TO `assistant`;--> statement-breakpoint
 PRAGMA foreign_keys=ON;--> statement-breakpoint

--- a/migrations/sqlite-drizzle/meta/0023_snapshot.json
+++ b/migrations/sqlite-drizzle/meta/0023_snapshot.json
@@ -1050,6 +1050,13 @@
           "notNull": true,
           "autoincrement": false
         },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
         "created_at": {
           "name": "created_at",
           "type": "integer",
@@ -1076,6 +1083,11 @@
         "assistant_created_at_idx": {
           "name": "assistant_created_at_idx",
           "columns": ["created_at"],
+          "isUnique": false
+        },
+        "assistant_order_key_idx": {
+          "name": "assistant_order_key_idx",
+          "columns": ["order_key"],
           "isUnique": false
         }
       },
@@ -2518,9 +2530,9 @@
           "columns": ["updated_at"],
           "isUnique": false
         },
-        "topic_group_id_order_key_idx": {
-          "name": "topic_group_id_order_key_idx",
-          "columns": ["group_id", "order_key"],
+        "topic_order_key_idx": {
+          "name": "topic_order_key_idx",
+          "columns": ["order_key"],
           "isUnique": false
         },
         "topic_assistant_id_idx": {

--- a/packages/shared/data/api/schemas/assistants.ts
+++ b/packages/shared/data/api/schemas/assistants.ts
@@ -10,6 +10,7 @@ import * as z from 'zod'
 import { type Assistant, AssistantSchema, AssistantSettingsSchema } from '../../types/assistant'
 import { TagIdSchema } from '../../types/tag'
 import type { OffsetPaginationResponse } from '../apiTypes'
+import type { OrderEndpoints } from './_endpointHelpers'
 
 // ============================================================================
 // DTO Derivation
@@ -24,6 +25,7 @@ import type { OffsetPaginationResponse } from '../apiTypes'
  * - `tags` is embedded on read via inline join; writes use `tagIds` below.
  * - `modelName` is resolved at read time from `user_model.name`; edits go via
  *   `modelId`.
+ * - `orderKey` is service-owned; writes go through `/assistants/:id/order`.
  */
 const ASSISTANT_MUTABLE_FIELDS = {
   name: true,
@@ -163,4 +165,4 @@ export type AssistantSchemas = {
       response: void
     }
   }
-}
+} & OrderEndpoints<'/assistants'>

--- a/packages/shared/data/types/__tests__/assistant.test.ts
+++ b/packages/shared/data/types/__tests__/assistant.test.ts
@@ -32,6 +32,7 @@ describe('AssistantSchema', () => {
     description: '',
     settings: DEFAULT_ASSISTANT_SETTINGS,
     modelId: null,
+    orderKey: 'a0',
     mcpServerIds: [],
     knowledgeBaseIds: [],
     createdAt: '2026-01-01T00:00:00.000Z',

--- a/packages/shared/data/types/assistant.ts
+++ b/packages/shared/data/types/assistant.ts
@@ -121,6 +121,8 @@ export const AssistantSchema = z.strictObject({
   settings: AssistantSettingsSchema,
   /** Default/primary model ID in UniqueModelId format ("providerId::modelId") */
   modelId: UniqueModelIdSchema.nullable(),
+  /** Persistent ordering key. Read-only; modified only through order endpoints. */
+  orderKey: z.string(),
   /** Ordered MCP server IDs linked through assistant_mcp_server */
   mcpServerIds: z.array(z.string()),
   /** Ordered knowledge base IDs linked through assistant_knowledge_base */

--- a/src/main/data/api/handlers/__tests__/assistants.test.ts
+++ b/src/main/data/api/handlers/__tests__/assistants.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { listMock, createMock, getByIdMock, updateMock, deleteMock } = vi.hoisted(() => ({
+const { listMock, createMock, getByIdMock, updateMock, deleteMock, reorderMock, reorderBatchMock } = vi.hoisted(() => ({
   listMock: vi.fn(),
   createMock: vi.fn(),
   getByIdMock: vi.fn(),
   updateMock: vi.fn(),
-  deleteMock: vi.fn()
+  deleteMock: vi.fn(),
+  reorderMock: vi.fn(),
+  reorderBatchMock: vi.fn()
 }))
 
 vi.mock('@data/services/AssistantService', () => ({
@@ -14,13 +16,16 @@ vi.mock('@data/services/AssistantService', () => ({
     create: createMock,
     getById: getByIdMock,
     update: updateMock,
-    delete: deleteMock
+    delete: deleteMock,
+    reorder: reorderMock,
+    reorderBatch: reorderBatchMock
   }
 }))
 
 import { assistantHandlers } from '../assistants'
 
 const ASSISTANT_ID = '11111111-1111-4111-8111-111111111111'
+const OTHER_ASSISTANT_ID = '33333333-3333-4333-8333-333333333333'
 const TAG_ID = '22222222-2222-4222-8222-222222222222'
 
 describe('assistantHandlers', () => {
@@ -50,6 +55,16 @@ describe('assistantHandlers', () => {
             name: 'New Assistant',
             settings: { maxTokens: 8192 }
           }
+        } as never)
+      ).rejects.toHaveProperty('name', 'ZodError')
+
+      expect(createMock).not.toHaveBeenCalled()
+    })
+
+    it('should reject direct orderKey writes on create', async () => {
+      await expect(
+        assistantHandlers['/assistants'].POST({
+          body: { name: 'New Assistant', orderKey: 'a0' }
         } as never)
       ).rejects.toHaveProperty('name', 'ZodError')
 
@@ -100,15 +115,17 @@ describe('assistantHandlers', () => {
       expect(updateMock).toHaveBeenCalledWith(ASSISTANT_ID, {})
     })
 
-    it('should reject partial settings updates before calling the service', async () => {
+    it('should forward partial settings updates without injecting unrelated defaults', async () => {
+      updateMock.mockResolvedValueOnce({ id: ASSISTANT_ID, name: 'Existing Assistant' })
+
       await expect(
         assistantHandlers['/assistants/:id'].PATCH({
           params: { id: ASSISTANT_ID },
           body: { settings: { maxTokens: 8192 } }
         } as never)
-      ).rejects.toHaveProperty('name', 'ZodError')
+      ).resolves.toMatchObject({ id: ASSISTANT_ID })
 
-      expect(updateMock).not.toHaveBeenCalled()
+      expect(updateMock).toHaveBeenCalledWith(ASSISTANT_ID, { settings: { maxTokens: 8192 } })
     })
 
     it('should reject invalid tag ids before calling the service', async () => {
@@ -120,6 +137,73 @@ describe('assistantHandlers', () => {
       ).rejects.toHaveProperty('name', 'ZodError')
 
       expect(updateMock).not.toHaveBeenCalled()
+    })
+
+    it('should reject direct orderKey writes on update', async () => {
+      await expect(
+        assistantHandlers['/assistants/:id'].PATCH({
+          params: { id: ASSISTANT_ID },
+          body: { orderKey: 'a0' }
+        } as never)
+      ).rejects.toHaveProperty('name', 'ZodError')
+
+      expect(updateMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('/assistants/:id/order', () => {
+    it('should forward a parsed single reorder anchor', async () => {
+      reorderMock.mockResolvedValueOnce(undefined)
+
+      await expect(
+        assistantHandlers['/assistants/:id/order'].PATCH({
+          params: { id: ASSISTANT_ID },
+          body: { before: OTHER_ASSISTANT_ID }
+        } as never)
+      ).resolves.toBeUndefined()
+
+      expect(reorderMock).toHaveBeenCalledWith(ASSISTANT_ID, { before: OTHER_ASSISTANT_ID })
+    })
+
+    it('should reject malformed anchors before calling the service', async () => {
+      await expect(
+        assistantHandlers['/assistants/:id/order'].PATCH({
+          params: { id: ASSISTANT_ID },
+          body: { before: OTHER_ASSISTANT_ID, after: OTHER_ASSISTANT_ID }
+        } as never)
+      ).rejects.toHaveProperty('name', 'ZodError')
+
+      expect(reorderMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('/assistants/order:batch', () => {
+    it('should forward parsed batch reorder moves', async () => {
+      reorderBatchMock.mockResolvedValueOnce(undefined)
+
+      await expect(
+        assistantHandlers['/assistants/order:batch'].PATCH({
+          body: {
+            moves: [
+              { id: ASSISTANT_ID, anchor: { position: 'first' } },
+              { id: OTHER_ASSISTANT_ID, anchor: { after: ASSISTANT_ID } }
+            ]
+          }
+        } as never)
+      ).resolves.toBeUndefined()
+
+      expect(reorderBatchMock).toHaveBeenCalledWith([
+        { id: ASSISTANT_ID, anchor: { position: 'first' } },
+        { id: OTHER_ASSISTANT_ID, anchor: { after: ASSISTANT_ID } }
+      ])
+    })
+
+    it('should reject an empty move list before calling the service', async () => {
+      await expect(
+        assistantHandlers['/assistants/order:batch'].PATCH({ body: { moves: [] } } as never)
+      ).rejects.toHaveProperty('name', 'ZodError')
+
+      expect(reorderBatchMock).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/main/data/api/handlers/assistants.ts
+++ b/src/main/data/api/handlers/assistants.ts
@@ -10,6 +10,7 @@
 
 import { assistantDataService } from '@data/services/AssistantService'
 import type { HandlersFor } from '@shared/data/api/apiTypes'
+import { OrderBatchRequestSchema, OrderRequestSchema } from '@shared/data/api/schemas/_endpointHelpers'
 import type { AssistantSchemas } from '@shared/data/api/schemas/assistants'
 import {
   CreateAssistantSchema,
@@ -48,6 +49,22 @@ export const assistantHandlers: HandlersFor<AssistantSchemas> = {
 
     DELETE: async ({ params }) => {
       await assistantDataService.delete(params.id)
+      return undefined
+    }
+  },
+
+  '/assistants/:id/order': {
+    PATCH: async ({ params, body }) => {
+      const anchor = OrderRequestSchema.parse(body)
+      await assistantDataService.reorder(params.id, anchor)
+      return undefined
+    }
+  },
+
+  '/assistants/order:batch': {
+    PATCH: async ({ body }) => {
+      const parsed = OrderBatchRequestSchema.parse(body)
+      await assistantDataService.reorderBatch(parsed.moves)
       return undefined
     }
   }

--- a/src/main/data/db/schemas/assistant.ts
+++ b/src/main/data/db/schemas/assistant.ts
@@ -1,7 +1,7 @@
 import type { AssistantSettings } from '@shared/data/types/assistant'
 import { index, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
-import { createUpdateDeleteTimestamps, uuidPrimaryKey } from './_columnHelpers'
+import { createUpdateDeleteTimestamps, orderKeyColumns, orderKeyIndex, uuidPrimaryKey } from './_columnHelpers'
 import { userModelTable } from './userModel'
 
 /**
@@ -27,9 +27,10 @@ export const assistantTable = sqliteTable(
     // JSON blob: inference params + context source toggles
     // Tunable product value: AssistantService.create() supplies DEFAULT_ASSISTANT_SETTINGS
     settings: text({ mode: 'json' }).$type<AssistantSettings>().notNull(),
+    ...orderKeyColumns,
     ...createUpdateDeleteTimestamps
   },
-  (t) => [index('assistant_created_at_idx').on(t.createdAt)]
+  (t) => [index('assistant_created_at_idx').on(t.createdAt), orderKeyIndex('assistant')(t)]
 )
 
 export type AssistantInsert = typeof assistantTable.$inferInsert

--- a/src/main/data/migration/v2/core/__tests__/migration0011.test.ts
+++ b/src/main/data/migration/v2/core/__tests__/migration0011.test.ts
@@ -53,7 +53,7 @@ async function getForeignKeyCheckRows(client: Client) {
   return result.rows
 }
 
-describe('migration 0011', () => {
+describe('schema migrations', () => {
   let tempRoot: string
   let dbPath: string
   let client: Client
@@ -242,5 +242,48 @@ describe('migration 0011', () => {
     const cascadeModels = await client.execute("SELECT id FROM user_model WHERE provider_id = 'cascade-provider'")
     expect(cascadeModels.rows).toEqual([])
     expect(await getForeignKeyCheckRows(client)).toEqual([])
+  })
+
+  it('backfills assistant order keys in createdAt order when migrating 0022 data to 0023', async () => {
+    const db = drizzle({ client, casing: 'snake_case' })
+    const migrations0022 = await createMigrationFolder(tempRoot, 22)
+    const migrations0023 = await createMigrationFolder(tempRoot, 23)
+    const sourceRows = Array.from({ length: 65 }, (_, index) => ({
+      id: `ast-${String(65 - index).padStart(3, '0')}`,
+      name: `Assistant ${index}`,
+      createdAt: (index + 1) * 100
+    }))
+
+    await migrate(db, { migrationsFolder: migrations0022 })
+
+    await client.execute(`
+      INSERT INTO assistant (
+        id,
+        name,
+        prompt,
+        emoji,
+        description,
+        settings,
+        created_at,
+        updated_at,
+        deleted_at
+      ) VALUES
+        ${sourceRows
+          .map((row) => `('${row.id}', '${row.name}', '', ':)', '', '{}', ${row.createdAt}, ${row.createdAt}, NULL)`)
+          .join(',\n')}
+    `)
+
+    await migrate(db, { migrationsFolder: migrations0023 })
+
+    const assistants = await client.execute('SELECT id, order_key FROM assistant ORDER BY order_key, id')
+
+    expect(assistants.rows.map((row) => row.id)).toEqual(sourceRows.map((row) => row.id))
+
+    const orderKeys = assistants.rows.map((row) => String(row.order_key))
+    expect(orderKeys.every((orderKey) => orderKey.length > 0)).toBe(true)
+    expect(new Set(orderKeys).size).toBe(orderKeys.length)
+    for (let i = 1; i < orderKeys.length; i++) {
+      expect(orderKeys[i - 1] < orderKeys[i]).toBe(true)
+    }
   })
 })

--- a/src/main/data/migration/v2/migrators/AssistantMigrator.ts
+++ b/src/main/data/migration/v2/migrators/AssistantMigrator.ts
@@ -13,6 +13,7 @@ import { sql } from 'drizzle-orm'
 import { v4 as uuidv4 } from 'uuid'
 
 import type { MigrationContext } from '../core/MigrationContext'
+import { assignOrderKeysInSequence } from '../utils/orderKey'
 import { BaseMigrator } from './BaseMigrator'
 import { type AssistantTransformResult, type OldAssistant, transformAssistant } from './mappings/AssistantMappings'
 import { resolveModelReference } from './transformers/ModelTransformers'
@@ -235,10 +236,11 @@ export class AssistantMigrator extends BaseMigrator {
 
         return { ...row, modelId: null }
       })
+      const orderedAssistantRows = assignOrderKeysInSequence(sanitizedAssistantRows)
 
       await ctx.db.transaction(async (tx) => {
-        for (let i = 0; i < sanitizedAssistantRows.length; i += BATCH_SIZE) {
-          const batch = sanitizedAssistantRows.slice(i, i + BATCH_SIZE)
+        for (let i = 0; i < orderedAssistantRows.length; i += BATCH_SIZE) {
+          const batch = orderedAssistantRows.slice(i, i + BATCH_SIZE)
           await tx.insert(assistantTable).values(batch)
           processed += batch.length
         }

--- a/src/main/data/migration/v2/migrators/__tests__/AssistantMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/AssistantMigrator.test.ts
@@ -437,6 +437,50 @@ describe('AssistantMigrator', () => {
       expect(ctx.db.transaction).toHaveBeenCalled()
     })
 
+    it('should stamp assistant order keys in source order during execute', async () => {
+      const ctx = createMockContext({ assistants: { assistants: SAMPLE_ASSISTANTS, presets: [] } })
+      ctx.sharedData.set('mcpServerIdMapping', new Map([['srv-1', 'new-srv-uuid']]))
+      const inserted: unknown[][] = []
+      ctx.db.transaction = vi.fn(async (fn: (tx: any) => Promise<void>) => {
+        const tx = {
+          insert: vi.fn().mockReturnValue({
+            values: vi.fn().mockImplementation((vals: unknown[]) => {
+              inserted.push(Array.isArray(vals) ? vals : [vals])
+              return {
+                onConflictDoNothing: vi.fn().mockReturnValue({
+                  returning: vi.fn().mockResolvedValue([]),
+                  then: (r: (v: unknown) => unknown) => Promise.resolve(undefined).then(r)
+                }),
+                returning: vi.fn().mockResolvedValue([]),
+                then: (r: (v: unknown) => unknown) => Promise.resolve(undefined).then(r)
+              }
+            })
+          }),
+          select: vi.fn().mockReturnValue({
+            from: vi
+              .fn()
+              .mockReturnValue(Object.assign([], { then: (r: (v: unknown) => unknown) => Promise.resolve([]).then(r) }))
+          })
+        }
+        await fn(tx)
+      }) as any
+
+      await migrator.prepare(ctx as any)
+      const result = await migrator.execute(ctx as any)
+
+      expect(result.success).toBe(true)
+      const assistantRows = (inserted.flat() as Array<Record<string, unknown>>).filter((row) =>
+        String(row.id).startsWith('ast-')
+      )
+      expect(assistantRows.map((row) => row.id)).toEqual(['ast-1', 'ast-2'])
+      const orderKeys = assistantRows
+        .map((row) => row.orderKey)
+        .filter((orderKey): orderKey is string => typeof orderKey === 'string')
+      expect(orderKeys).toHaveLength(2)
+      expect(orderKeys.every((orderKey) => orderKey.length > 0)).toBe(true)
+      expect(orderKeys[0] < orderKeys[1]).toBe(true)
+    })
+
     it('should store assistantIds in sharedData (only migrated user assistants — no synthetic default)', async () => {
       const ctx = createMockContext({ assistants: { assistants: SAMPLE_ASSISTANTS, presets: [] } })
       ctx.sharedData.set('mcpServerIdMapping', new Map([['srv-1', 'new-srv-uuid']]))

--- a/src/main/data/migration/v2/migrators/mappings/AssistantMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/AssistantMappings.ts
@@ -130,7 +130,7 @@ export interface OldAssistant {
 // ============================================================================
 
 export interface AssistantTransformResult {
-  assistant: AssistantInsert
+  assistant: Omit<AssistantInsert, 'orderKey'>
   mcpServers: (typeof assistantMcpServerTable.$inferInsert)[]
   knowledgeBases: (typeof assistantKnowledgeBaseTable.$inferInsert)[]
   tags: string[]

--- a/src/main/data/services/AssistantService.ts
+++ b/src/main/data/services/AssistantService.ts
@@ -13,6 +13,7 @@ import { userModelTable } from '@data/db/schemas/userModel'
 import type { DbType } from '@data/db/types'
 import { loggerService } from '@logger'
 import { DataApiErrorFactory } from '@shared/data/api'
+import type { OrderRequest } from '@shared/data/api/schemas/_endpointHelpers'
 import type { CreateAssistantDto, ListAssistantsQuery, UpdateAssistantDto } from '@shared/data/api/schemas/assistants'
 import { type Assistant, DEFAULT_ASSISTANT_SETTINGS } from '@shared/data/types/assistant'
 import type { UniqueModelId } from '@shared/data/types/model'
@@ -22,6 +23,7 @@ import { and, asc, eq, inArray, isNull, or, type SQL, sql } from 'drizzle-orm'
 import { modelService } from './ModelService'
 import { pinService } from './PinService'
 import { tagService } from './TagService'
+import { applyMoves, insertWithOrderKey } from './utils/orderKey'
 import { nullsToUndefined, timestampToISO } from './utils/rowMappers'
 
 const logger = loggerService.withContext('DataApi:AssistantService')
@@ -238,7 +240,7 @@ export class AssistantDataService {
         .from(assistantTable)
         .leftJoin(userModelTable, eq(assistantTable.modelId, userModelTable.id))
         .where(whereClause)
-        .orderBy(asc(assistantTable.createdAt))
+        .orderBy(asc(assistantTable.orderKey), asc(assistantTable.id))
         .limit(limit)
         .offset(offset),
       this.db.select({ count: sql<number>`count(*)` }).from(assistantTable).where(whereClause)
@@ -279,14 +281,17 @@ export class AssistantDataService {
       // Split relation/tag fields from columns. Service owns emoji/settings
       // defaults; prompt/description stay omitted when undefined so DB DEFAULTs apply.
       const { mcpServerIds, knowledgeBaseIds, tagIds, ...columnDto } = dto
-      const insertValues: typeof assistantTable.$inferInsert = {
+      const insertValues = {
         ...columnDto,
         modelId,
         emoji: dto.emoji ?? '🌟',
         settings: dto.settings ?? DEFAULT_ASSISTANT_SETTINGS
-      }
+      } satisfies Omit<typeof assistantTable.$inferInsert, 'orderKey'>
 
-      const [inserted] = await tx.insert(assistantTable).values(insertValues).returning()
+      const inserted = (await insertWithOrderKey(tx, assistantTable, insertValues, {
+        pkColumn: assistantTable.id,
+        scope: isNull(assistantTable.deletedAt)
+      })) as AssistantRow
 
       // Insert junction table rows
       await this.syncRelationsTx(tx, inserted.id, { mcpServerIds, knowledgeBaseIds })
@@ -415,6 +420,28 @@ export class AssistantDataService {
     logger.info('Updated assistant', { id, changes: Object.keys(dto) })
 
     return rowToAssistant(row, nextRelations, tags, modelName)
+  }
+
+  /** Move a single assistant within the active (non-deleted) assistant list. */
+  async reorder(id: string, anchor: OrderRequest): Promise<void> {
+    await this.db.transaction(async (tx) => {
+      await applyMoves(tx, assistantTable, [{ id, anchor }], {
+        pkColumn: assistantTable.id,
+        scope: isNull(assistantTable.deletedAt)
+      })
+    })
+  }
+
+  /** Apply multiple assistant moves atomically within the active assistant list. */
+  async reorderBatch(moves: Array<{ id: string; anchor: OrderRequest }>): Promise<void> {
+    if (moves.length === 0) return
+
+    await this.db.transaction(async (tx) => {
+      await applyMoves(tx, assistantTable, moves, {
+        pkColumn: assistantTable.id,
+        scope: isNull(assistantTable.deletedAt)
+      })
+    })
   }
 
   /**

--- a/src/main/data/services/__tests__/AssistantService.test.ts
+++ b/src/main/data/services/__tests__/AssistantService.test.ts
@@ -7,13 +7,14 @@ import { entityTagTable, tagTable } from '@data/db/schemas/tagging'
 import { userModelTable } from '@data/db/schemas/userModel'
 import { userProviderTable } from '@data/db/schemas/userProvider'
 import { AssistantDataService, assistantDataService } from '@data/services/AssistantService'
+import { generateOrderKeySequence } from '@data/services/utils/orderKey'
 import { ErrorCode } from '@shared/data/api'
 import { type ListAssistantsQuery, ListAssistantsQuerySchema } from '@shared/data/api/schemas/assistants'
 import { DEFAULT_ASSISTANT_SETTINGS } from '@shared/data/types/assistant'
 import { createUniqueModelId } from '@shared/data/types/model'
 import { setupTestDatabase } from '@test-helpers/db'
 import { MockMainPreferenceServiceUtils } from '@test-mocks/main/PreferenceService'
-import { eq } from 'drizzle-orm'
+import { asc, eq } from 'drizzle-orm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 /**
@@ -99,11 +100,13 @@ describe('AssistantDataService', () => {
   type SeedAssistantValues = Partial<typeof assistantTable.$inferInsert>
   async function seedAssistantRow(values: SeedAssistantValues | SeedAssistantValues[]) {
     const rows = Array.isArray(values) ? values : [values]
+    const orderKeys = generateOrderKeySequence(rows.length)
     await dbh.db.insert(assistantTable).values(
-      rows.map((v) => ({
+      rows.map((v, index) => ({
         emoji: '🌟',
         settings: DEFAULT_ASSISTANT_SETTINGS,
         name: 'test',
+        orderKey: orderKeys[index],
         ...v
       }))
     )
@@ -373,15 +376,16 @@ describe('AssistantDataService', () => {
       expect(result.items[1].id).toBe('ast-3')
     })
 
-    it('should order by createdAt ascending', async () => {
+    it('should order by orderKey ascending with id tiebreaker', async () => {
       await seedAssistantRow([
-        { id: 'ast-new', name: 'new', createdAt: 300 },
-        { id: 'ast-old', name: 'old', createdAt: 100 },
-        { id: 'ast-mid', name: 'mid', createdAt: 200 }
+        { id: 'ast-later-created', name: 'first-by-key', orderKey: 'a0', createdAt: 300 },
+        { id: 'ast-a', name: 'tie-a', orderKey: 'a1', createdAt: 100 },
+        { id: 'ast-b', name: 'tie-b', orderKey: 'a1', createdAt: 200 },
+        { id: 'ast-earlier-created', name: 'last-by-key', orderKey: 'a2', createdAt: 50 }
       ])
 
       const result = await assistantDataService.list(listQuery())
-      expect(result.items.map((a) => a.id)).toEqual(['ast-old', 'ast-mid', 'ast-new'])
+      expect(result.items.map((a) => a.id)).toEqual(['ast-later-created', 'ast-a', 'ast-b', 'ast-earlier-created'])
     })
 
     it('should embed tags per assistant via inline JOIN', async () => {
@@ -507,7 +511,23 @@ describe('AssistantDataService', () => {
       expect(result.id).toBeTruthy()
       expect(result.name).toBe('test-assistant')
       expect(result.modelId).toBeNull()
+      expect(result.orderKey.length).toBeGreaterThan(0)
       expect(typeof result.createdAt).toBe('string')
+    })
+
+    it('should assign strictly increasing order keys on successive creates', async () => {
+      const first = await assistantDataService.create({ name: 'first' })
+      const second = await assistantDataService.create({ name: 'second' })
+      const third = await assistantDataService.create({ name: 'third' })
+
+      const rows = await dbh.db
+        .select({ id: assistantTable.id, orderKey: assistantTable.orderKey })
+        .from(assistantTable)
+        .orderBy(asc(assistantTable.orderKey), asc(assistantTable.id))
+
+      expect(rows.map((row) => row.id)).toEqual([first.id, second.id, third.id])
+      expect(first.orderKey < second.orderKey).toBe(true)
+      expect(second.orderKey < third.orderKey).toBe(true)
     })
 
     it('should persist assistant to database', async () => {
@@ -683,6 +703,66 @@ describe('AssistantDataService', () => {
       const result = await assistantDataService.create({ name: 'explicit-null', modelId: null })
 
       expect(result.modelId).toBeNull()
+    })
+  })
+
+  describe('reorder', () => {
+    it("should move an assistant to the first position via { position: 'first' }", async () => {
+      await seedAssistantRow([
+        { id: 'ast-1', name: 'A', orderKey: 'a0' },
+        { id: 'ast-2', name: 'B', orderKey: 'a1' },
+        { id: 'ast-3', name: 'C', orderKey: 'a2' }
+      ])
+
+      await assistantDataService.reorder('ast-3', { position: 'first' })
+
+      const result = await assistantDataService.list(listQuery())
+      expect(result.items.map((a) => a.id)).toEqual(['ast-3', 'ast-1', 'ast-2'])
+    })
+
+    it('should move an assistant before an anchor', async () => {
+      await seedAssistantRow([
+        { id: 'ast-1', name: 'A', orderKey: 'a0' },
+        { id: 'ast-2', name: 'B', orderKey: 'a1' },
+        { id: 'ast-3', name: 'C', orderKey: 'a2' }
+      ])
+
+      await assistantDataService.reorder('ast-3', { before: 'ast-2' })
+
+      const result = await assistantDataService.list(listQuery())
+      expect(result.items.map((a) => a.id)).toEqual(['ast-1', 'ast-3', 'ast-2'])
+    })
+
+    it('should reject soft-deleted targets and anchors as NOT_FOUND', async () => {
+      await seedAssistantRow([
+        { id: 'ast-1', name: 'A', orderKey: 'a0' },
+        { id: 'ast-2', name: 'B', orderKey: 'a1', deletedAt: Date.now() }
+      ])
+
+      await expect(assistantDataService.reorder('ast-2', { position: 'first' })).rejects.toMatchObject({
+        code: ErrorCode.NOT_FOUND
+      })
+      await expect(assistantDataService.reorder('ast-1', { before: 'ast-2' })).rejects.toMatchObject({
+        code: ErrorCode.NOT_FOUND
+      })
+    })
+  })
+
+  describe('reorderBatch', () => {
+    it('should apply multiple assistant moves atomically', async () => {
+      await seedAssistantRow([
+        { id: 'ast-1', name: 'A', orderKey: 'a0' },
+        { id: 'ast-2', name: 'B', orderKey: 'a1' },
+        { id: 'ast-3', name: 'C', orderKey: 'a2' }
+      ])
+
+      await assistantDataService.reorderBatch([
+        { id: 'ast-3', anchor: { position: 'first' } },
+        { id: 'ast-1', anchor: { position: 'last' } }
+      ])
+
+      const result = await assistantDataService.list(listQuery())
+      expect(result.items.map((a) => a.id)).toEqual(['ast-3', 'ast-2', 'ast-1'])
     })
   })
 

--- a/src/main/data/services/__tests__/TopicService.test.ts
+++ b/src/main/data/services/__tests__/TopicService.test.ts
@@ -19,8 +19,24 @@ describe('TopicService', () => {
       const service = new TopicService()
       // FK: topic.assistantId → assistant.id — seed both assistants first.
       await dbh.db.insert(assistantTable).values([
-        { id: 'asst-1', name: 'A', emoji: '🌟', settings: DEFAULT_ASSISTANT_SETTINGS, createdAt: 1, updatedAt: 1 },
-        { id: 'asst-2', name: 'B', emoji: '🌟', settings: DEFAULT_ASSISTANT_SETTINGS, createdAt: 1, updatedAt: 1 }
+        {
+          id: 'asst-1',
+          name: 'A',
+          emoji: '🌟',
+          settings: DEFAULT_ASSISTANT_SETTINGS,
+          orderKey: 'a0',
+          createdAt: 1,
+          updatedAt: 1
+        },
+        {
+          id: 'asst-2',
+          name: 'B',
+          emoji: '🌟',
+          settings: DEFAULT_ASSISTANT_SETTINGS,
+          orderKey: 'a1',
+          createdAt: 1,
+          updatedAt: 1
+        }
       ])
       await dbh.db.insert(topicTable).values({
         id: 't1',

--- a/src/renderer/src/components/chat/adapters/__tests__/adapters.test.ts
+++ b/src/renderer/src/components/chat/adapters/__tests__/adapters.test.ts
@@ -50,8 +50,11 @@ function createAssistant(overrides: Partial<Assistant> = {}): Assistant {
     description: 'Assistant description',
     settings: DEFAULT_ASSISTANT_SETTINGS,
     modelId: null,
+    modelName: null,
+    orderKey: 'a0',
     mcpServerIds: [],
     knowledgeBaseIds: [],
+    tags: [],
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:01.000Z',
     ...overrides

--- a/src/renderer/src/pages/agents/components/AgentSessionInputbar.tsx
+++ b/src/renderer/src/pages/agents/components/AgentSessionInputbar.tsx
@@ -98,6 +98,7 @@ const AgentSessionInputbar = ({
       settings: DEFAULT_ASSISTANT_SETTINGS,
       modelId: sessionModel ? createUniqueModelId(sessionModel.provider, sessionModel.id) : null,
       modelName: sessionModel?.name ?? null,
+      orderKey: '',
       mcpServerIds: [],
       knowledgeBaseIds: [],
       tags: [],

--- a/src/renderer/src/pages/home/Inputbar/tools/components/__tests__/ThinkingButton.test.tsx
+++ b/src/renderer/src/pages/home/Inputbar/tools/components/__tests__/ThinkingButton.test.tsx
@@ -167,6 +167,7 @@ const createAssistant = (overrides: AssistantTestOverrides = {}): Assistant => (
   description: '',
   modelId: null,
   modelName: null,
+  orderKey: 'a0',
   mcpServerIds: [],
   knowledgeBaseIds: [],
   tags: [],

--- a/src/renderer/src/pages/library/adapters/__tests__/assistantAdapter.test.ts
+++ b/src/renderer/src/pages/library/adapters/__tests__/assistantAdapter.test.ts
@@ -58,6 +58,7 @@ function createAssistant(overrides: Partial<Assistant> = {}): Assistant {
       customParameters: []
     },
     modelId: 'openai::gpt-4o',
+    orderKey: 'a0',
     mcpServerIds: ['mcp-1'],
     knowledgeBaseIds: ['kb-1'],
     createdAt: '2026-04-20T00:00:00.000Z',

--- a/src/renderer/src/pages/library/editor/assistant/__tests__/descriptor.test.ts
+++ b/src/renderer/src/pages/library/editor/assistant/__tests__/descriptor.test.ts
@@ -32,6 +32,7 @@ function createAssistant(overrides: Partial<Assistant> = {}): Assistant {
     description: '',
     settings: { ...DEFAULT_ASSISTANT_SETTINGS } as AssistantSettings,
     modelId: null,
+    orderKey: 'a0',
     mcpServerIds: [],
     knowledgeBaseIds: [],
     createdAt: '2026-04-20T00:00:00.000Z',

--- a/src/renderer/src/pages/library/editor/assistant/__tests__/transfer.test.ts
+++ b/src/renderer/src/pages/library/editor/assistant/__tests__/transfer.test.ts
@@ -38,6 +38,7 @@ function createAssistant(overrides: Partial<Assistant> = {}): Assistant {
       customParameters: []
     },
     modelId: 'openai::gpt-4o',
+    orderKey: 'a0',
     mcpServerIds: ['mcp-1'],
     knowledgeBaseIds: ['kb-1'],
     createdAt: '2026-04-20T00:00:00.000Z',

--- a/src/renderer/src/services/defaultAssistant.ts
+++ b/src/renderer/src/services/defaultAssistant.ts
@@ -23,6 +23,7 @@ export function composeDefaultAssistant(modelId: UniqueModelId | null): Assistan
     settings: DEFAULT_ASSISTANT_SETTINGS,
     modelId,
     modelName: null,
+    orderKey: '',
     mcpServerIds: [],
     knowledgeBaseIds: [],
     tags: [],

--- a/src/renderer/src/utils/__tests__/assistant.test.ts
+++ b/src/renderer/src/utils/__tests__/assistant.test.ts
@@ -31,6 +31,7 @@ describe('assistant', () => {
     settings: DEFAULT_SETTINGS,
     modelId: null,
     modelName: null,
+    orderKey: 'a0',
     mcpServerIds: [],
     knowledgeBaseIds: [],
     tags: [],


### PR DESCRIPTION
### What this PR does

Before this PR:

Assistant DataApi rows did not have a service-owned `orderKey`, so assistant list ordering still depended on the older created-time ordering and had no relative reorder endpoints.

After this PR:

Assistant rows store `orderKey`, list results are ordered by `orderKey` with an id tiebreaker, create/reorder paths use the shared order-key helpers, and the DataApi exposes single and batch reorder endpoints.

The v2 assistant migrator stamps order keys in source order, and the 0022 -> 0023 schema migration backfills deterministic non-duplicate order keys for existing assistant rows.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Keep `orderKey` service-owned so direct create/update payloads cannot write ordering state.
- Keep API handlers thin and put ordering behavior in `AssistantService`, matching the DataApi contract.
- Use a deterministic SQL backfill in the Drizzle migration because schema migration SQL cannot call the TypeScript `generateOrderKeySequence` helper directly.

The following alternatives were considered:

- Accepting client-provided `orderKey` values was rejected because it would split ordering invariants across callers.
- Leaving the generated migration with a constant historical `order_key` was rejected because it would collapse existing assistant ordering to the id tiebreaker.

Links to places where the discussion took place: N/A

### Breaking changes

N/A

### Special notes for your reviewer

Target base branch: `feat/chat-page`.

Validation:

- `pnpm test:main src/main/data/migration/v2/core/__tests__/migration0011.test.ts`
- `pnpm exec biome check src/main/data/migration/v2/core/__tests__/migration0011.test.ts`
- `git diff --check`

`pnpm build:check` was attempted, but it currently fails on unrelated existing typecheck blockers:

- `src/main/ai/provider/claude-code/claude-code-language-model.ts`: Anthropic SDK dual-version type mismatch.
- `src/renderer/src/components/chat/resources/ResourceList.tsx`: `ResourceListMeta` is not defined.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
