### PR TITLE
fix: align provider model list actions

### DIFF
--- a/src/renderer/src/pages/settings/ProviderSettings/ModelList/ModelList.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ModelList/ModelList.tsx
@@ -162,10 +162,9 @@ const ModelList: React.FC<ModelListProps> = ({ providerId }) => {
               </>
             )}
           </HStack>
-          {!hasNoModels && actionButtons}
+          {actionButtons}
         </HStack>
       </SettingSubtitle>
-      {hasNoModels && <div style={{ marginBottom: 12 }}>{actionButtons}</div>}
       <Spin spinning={isLoading} indicator={<LoadingIcon color="var(--color-text-2)" />}>
         {displayedModelGroups && !isEmpty(displayedModelGroups) && (
           <Flex gap={12} vertical>


### PR DESCRIPTION
### What this PR does

Before this PR: the provider settings model list actions were rendered in different positions depending on whether the provider already had models; empty model lists placed the fetch action on a separate row.

After this PR: the model list actions are always rendered on the right side of the model section header, including empty model lists.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes

#None

<img width="1307" height="920" alt="image" src="https://github.com/user-attachments/assets/3dc244ec-8e24-401d-b0e6-ec00e6d09ea9" />


### Why we need it and why it was done in this way

The following tradeoffs were made: this keeps the change limited to the existing `ModelList` header layout and does not alter model fetching, add/download actions, or popup behavior.

The following alternatives were considered: changing the button style was considered but intentionally left unchanged.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None

### Special notes for your reviewer

<!-- optional -->

This is a focused UI alignment fix for the provider settings page. Documentation was considered and is not required for this layout-only change.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed the provider settings model list actions so the fetch model list button stays on the right side of the model section header.
```
