### PR TITLE
fix: auto-expand MCP tool approval card so action buttons are immediately visible

### DIFF
--- a/src/renderer/src/pages/home/Messages/Blocks/ToolBlockGroup.tsx
+++ b/src/renderer/src/pages/home/Messages/Blocks/ToolBlockGroup.tsx
@@ -275,6 +275,13 @@ const ToolBlockGroup: React.FC<Props> = ({ blocks }) => {
     })
   }, [blocks])
 
+  // Auto-expand group when there are active tools (pending/waiting for approval, streaming)
+  useEffect(() => {
+    if (!allCompleted) {
+      setActiveKey((prev) => (prev.includes('tool-group') ? prev : [...prev, 'tool-group']))
+    }
+  }, [allCompleted])
+
   const currentRunningBlock = useMemo(() => {
     return blocks.find((block) => {
       const status = block.metadata?.rawMcpToolResponse?.status

--- a/src/renderer/src/pages/home/Messages/Tools/MessageMcpTool.tsx
+++ b/src/renderer/src/pages/home/Messages/Tools/MessageMcpTool.tsx
@@ -78,16 +78,16 @@ const MessageMcpTool: FC<Props> = ({ block }) => {
     }
   }, [id])
 
-  // Auto-expand when streaming, auto-collapse when done
+  // Auto-expand when pending (waiting for approval) or streaming, auto-collapse when done
   useEffect(() => {
-    if (isStreaming) {
-      // Expand when streaming starts
+    if (isStreaming || isPending) {
+      // Expand when streaming starts or waiting for approval
       setActiveKeys((prev) => (prev.includes(id) ? prev : [...prev, id]))
     } else if (isDone || isError) {
       // Collapse when streaming ends
       setActiveKeys((prev) => prev.filter((key) => key !== id))
     }
-  }, [isStreaming, isDone, isError, id])
+  }, [isStreaming, isDone, isError, id, isPending])
 
   if (!toolResponse) {
     return null


### PR DESCRIPTION
### What this PR does

Before this PR: When a built-in Agent calls an MCP tool that requires user authorization, the approval card appears collapsed. Users see only the tool-name summary line and have to manually click to expand the card before the Cancel/Run buttons become visible. The conversation stalls indefinitely with no visual cue that action is needed.

After this PR: The approval card auto-expands when the tool enters pending (waiting-for-approval) state. The Cancel/Run buttons and tool arguments are immediately visible. The same auto-expand applies to grouped tool cards in `ToolBlockGroup` — the group Collapse expands automatically when any tool inside is still active.

Fixes #15038

### Why we need it and why it was done in this way

The existing code already rendered the approval action buttons below the Collapse component (they were technically visible), but a collapsed card strongly signals "done/minimized" rather than "action needed". Users consistently failed to notice the buttons.

The fix is minimal and surgical:
- **`MessageMcpTool.tsx`**: Added `isPending` to the existing auto-expand `useEffect` condition (which already handled `isStreaming`). The four status flags derive from the same `status` field and are mutually exclusive, so no conflicts arise.
- **`ToolBlockGroup.tsx`**: Added a new `useEffect` that auto-expands the group Collapse when `allCompleted` is `false`. Uses functional state update, so it won't override a user's manual collapse.

The following tradeoffs were made:
- Cards auto-collapse on completion (existing behavior preserved). Users can re-expand manually if they want to review results.
- Group auto-expansion re-triggers on every `allCompleted` transition — this is intentional so that when a new tool arrives after previous ones finished, the group re-opens.

The following alternatives were considered:
- **Expanded by default via initial state (`useState([id])`)**: Rejected because `id` isn't available at initialization time, requiring the same effect-based approach anyway.
- **Visual badge/banner on collapsed card**: More complex, less consistent with existing UX patterns.
- **Always expanded, never collapse**: Would clutter the chat with large tool response boxes after completion.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/15038

### Breaking changes

None

### Special notes for your reviewer

The review via `/gh-pr-review` confirmed no bugs in either change.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix: MCP tool approval card now auto-expands so the Run/Cancel buttons are immediately visible, preventing the conversation from stalling indefinitely.