### PR TITLE
feat(web-search-tools): add fetch builtin tool

### DIFF
--- a/packages/shared/ai/builtinTools.ts
+++ b/packages/shared/ai/builtinTools.ts
@@ -80,6 +80,7 @@ export type KbSearchOutput = z.infer<typeof kbSearchOutputSchema>
 // ── web__search ───────────────────────────────────────────────────
 
 export const WEB_SEARCH_TOOL_NAME = 'web__search'
+export const WEB_FETCH_TOOL_NAME = 'web__fetch'
 
 export const webSearchInputSchema = z.object({
   query: z
@@ -103,6 +104,18 @@ export const webSearchOutputItemSchema = z.object({
 
 export const webSearchOutputSchema = z.array(webSearchOutputItemSchema)
 
+export const webFetchInputSchema = z.object({
+  urls: z
+    .array(z.string().trim().url('URL must be valid'))
+    .min(1)
+    .max(20, 'Fetch at most 20 URLs per call')
+    .describe('Absolute web page URLs to fetch and summarize. Use web__search first when you do not know the URL.')
+})
+
+export const webFetchOutputSchema = webSearchOutputSchema
+
 export type WebSearchInput = z.infer<typeof webSearchInputSchema>
 export type WebSearchOutputItem = z.infer<typeof webSearchOutputItemSchema>
 export type WebSearchOutput = z.infer<typeof webSearchOutputSchema>
+export type WebFetchInput = z.infer<typeof webFetchInputSchema>
+export type WebFetchOutput = z.infer<typeof webFetchOutputSchema>

--- a/src/main/ai/tools/builtin/WebSearchTool.ts
+++ b/src/main/ai/tools/builtin/WebSearchTool.ts
@@ -1,12 +1,9 @@
 /**
  * Web search tool — agentic.
  *
- * The model picks the query and may call multiple times with refined terms.
- * Provider id is resolved at execute time by picking the first configured-and-
- * usable web search provider (matching Cherry's renderer UX where any
- * configured provider works). If the user has none configured, the tool
- * returns an empty array — the model sees that and can fall back to its
- * own knowledge.
+ * The model picks search queries or URLs and may call multiple times with
+ * refined terms. Provider ids are resolved inside WebSearchService from the
+ * user's configured default provider for each capability.
  *
  * Replaces the deleted workflow-style `webSearchToolWithPreExtractedKeywords`
  * factory whose intent analyzer pre-baked queries into the tool itself.
@@ -14,14 +11,17 @@
 
 import { loggerService } from '@logger'
 import { application } from '@main/core/application'
-import { getResolvedConfig } from '@main/services/webSearch/utils/config'
 import {
+  WEB_FETCH_TOOL_NAME,
   WEB_SEARCH_TOOL_NAME,
+  webFetchInputSchema,
+  type WebFetchOutput,
+  webFetchOutputSchema,
   webSearchInputSchema,
   type WebSearchOutput,
   webSearchOutputSchema
 } from '@shared/ai/builtinTools'
-import type { ResolvedWebSearchProvider } from '@shared/data/types/webSearch'
+import type { WebSearchResponse } from '@shared/data/types/webSearch'
 import { type InferToolInput, type InferToolOutput, tool } from 'ai'
 
 import { getToolCallContext } from '../context'
@@ -29,7 +29,16 @@ import type { ToolEntry } from '../types'
 
 const logger = loggerService.withContext('WebSearchTool')
 
-export { WEB_SEARCH_TOOL_NAME }
+export { WEB_FETCH_TOOL_NAME, WEB_SEARCH_TOOL_NAME }
+
+function mapWebSearchOutput(response: WebSearchResponse): WebSearchOutput {
+  return response.results.map((result, index) => ({
+    id: index + 1,
+    title: result.title,
+    url: result.url,
+    content: result.content
+  }))
+}
 
 const webSearchTool = tool({
   description: `Search the web for current information, news, and real-time data.
@@ -57,29 +66,19 @@ Cite sources by [id] in your final answer.`,
   // (in AiService) handles providers that don't honour `strict`.
   strict: true,
   execute: async ({ query }, options): Promise<WebSearchOutput> => {
-    getToolCallContext(options)
-
-    const provider = await pickFirstUsableProvider()
-    if (!provider) {
-      logger.warn('No usable web search provider configured', { query })
-      return []
-    }
+    const { request } = getToolCallContext(options)
 
     try {
       const webSearchService = application.get('WebSearchService')
-      const response = await webSearchService.searchKeywords({
-        providerId: provider.id,
-        keywords: [query]
-      })
-      return response.results.map((r, index) => ({
-        id: index + 1,
-        title: r.title,
-        url: r.url,
-        content: r.content
-      }))
+      const response = await webSearchService.searchKeywords(
+        {
+          keywords: [query]
+        },
+        { signal: request.abortSignal }
+      )
+      return mapWebSearchOutput(response)
     } catch (error) {
-      logger.error('webSearchService.search failed', error as Error, {
-        providerId: provider.id,
+      logger.error('webSearchService.searchKeywords failed', error as Error, {
         query
       })
       return []
@@ -87,22 +86,40 @@ Cite sources by [id] in your final answer.`,
   }
 })
 
-/**
- * Pick the first provider that's usable: either an API-key-free "local-*"
- * provider, or one with at least one non-empty API key, or one with a
- * configured apiHost (e.g. self-hosted SearXNG). Mirrors the renderer's
- * `webSearchService.isWebSearchEnabled` selection logic.
- */
-async function pickFirstUsableProvider(): Promise<ResolvedWebSearchProvider | undefined> {
-  const prefs = application.get('PreferenceService')
-  const config = await getResolvedConfig(prefs)
-  return config.providers.find(
-    (p) =>
-      p.id.startsWith('local-') ||
-      p.apiKeys.length > 0 ||
-      p.capabilities.some((cap) => cap.apiHost !== undefined && cap.apiHost.length > 0)
-  )
-}
+const webFetchTool = tool({
+  description: `Fetch the readable content from one or more known web page URLs.
+
+Use this when:
+- You already have specific URLs from the user, prior context, or web__search
+- You need page content from an article, documentation page, or reference URL
+- Search snippets are not enough and you need the source page text
+
+Don't use this when you only have a topic or question; call web__search first.
+
+Cite sources by [id] in your final answer.`,
+  inputSchema: webFetchInputSchema,
+  outputSchema: webFetchOutputSchema,
+  strict: true,
+  execute: async ({ urls }, options): Promise<WebFetchOutput> => {
+    const { request } = getToolCallContext(options)
+
+    try {
+      const webSearchService = application.get('WebSearchService')
+      const response = await webSearchService.fetchUrls(
+        {
+          urls
+        },
+        { signal: request.abortSignal }
+      )
+      return mapWebSearchOutput(response)
+    } catch (error) {
+      logger.error('webSearchService.fetchUrls failed', error as Error, {
+        urls
+      })
+      return []
+    }
+  }
+})
 
 export function createWebSearchToolEntry(): ToolEntry {
   return {
@@ -115,5 +132,18 @@ export function createWebSearchToolEntry(): ToolEntry {
   }
 }
 
+export function createWebFetchToolEntry(): ToolEntry {
+  return {
+    name: WEB_FETCH_TOOL_NAME,
+    namespace: 'web',
+    description: 'Fetch readable content from known web page URLs',
+    defer: 'auto',
+    tool: webFetchTool,
+    applies: (scope) => Boolean(scope.assistant?.settings?.enableWebSearch)
+  }
+}
+
 export type WebSearchToolInput = InferToolInput<typeof webSearchTool>
 export type WebSearchToolOutput = InferToolOutput<typeof webSearchTool>
+export type WebFetchToolInput = InferToolInput<typeof webFetchTool>
+export type WebFetchToolOutput = InferToolOutput<typeof webFetchTool>

--- a/src/main/ai/tools/builtin/__tests__/WebSearchTool.test.ts
+++ b/src/main/ai/tools/builtin/__tests__/WebSearchTool.test.ts
@@ -1,126 +1,91 @@
 import type { ToolExecutionOptions } from '@ai-sdk/provider-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { webSearchSearch, getResolvedConfig } = vi.hoisted(() => ({
-  webSearchSearch: vi.fn(),
-  getResolvedConfig: vi.fn()
-}))
-
-vi.mock('@main/services/webSearch/WebSearchService', () => ({
-  webSearchService: { search: webSearchSearch }
-}))
-
-vi.mock('@main/services/webSearch/utils/config', () => ({
-  getResolvedConfig
+const { fetchUrls, searchKeywords } = vi.hoisted(() => ({
+  fetchUrls: vi.fn(),
+  searchKeywords: vi.fn()
 }))
 
 vi.mock('@main/core/application', () => ({
   application: {
     get: (name: string) => {
-      if (name === 'PreferenceService') return { get: () => null }
+      if (name === 'WebSearchService') return { fetchUrls, searchKeywords }
       throw new Error(`unexpected service: ${name}`)
     }
   }
 }))
 
-import { createWebSearchToolEntry, WEB_SEARCH_TOOL_NAME } from '../WebSearchTool'
+import {
+  createWebFetchToolEntry,
+  createWebSearchToolEntry,
+  WEB_FETCH_TOOL_NAME,
+  WEB_SEARCH_TOOL_NAME
+} from '../WebSearchTool'
 
-const entry = createWebSearchToolEntry()
+const searchEntry = createWebSearchToolEntry()
+const fetchEntry = createWebFetchToolEntry()
 
-const usableProvider = {
-  id: 'tavily',
-  name: 'Tavily',
-  type: 'tavily',
-  apiKeys: ['key-1'],
-  apiHost: '',
-  engines: [],
-  basicAuthUsername: '',
-  basicAuthPassword: ''
-}
-
-const localProvider = {
-  id: 'local-google',
-  name: 'Local Google',
-  type: 'local',
-  apiKeys: [],
-  apiHost: '',
-  engines: [],
-  basicAuthUsername: '',
-  basicAuthPassword: ''
-}
-
-const unusableProvider = {
-  id: 'exa',
-  name: 'Exa',
-  type: 'exa',
-  apiKeys: [],
-  apiHost: '',
-  engines: [],
-  basicAuthUsername: '',
-  basicAuthPassword: ''
-}
-
-function callExecute(args: { query: string }): Promise<unknown> {
-  const execute = entry.tool.execute as (args: { query: string }, options: ToolExecutionOptions) => Promise<unknown>
-  return execute(args, {
+function makeOptions(abortSignal = new AbortController().signal): ToolExecutionOptions {
+  return {
     toolCallId: 'tc-1',
     messages: [],
-    experimental_context: { requestId: 'req-1', abortSignal: new AbortController().signal }
-  } as ToolExecutionOptions)
+    experimental_context: { requestId: 'req-1', abortSignal }
+  } as ToolExecutionOptions
+}
+
+function response() {
+  return {
+    providerId: 'tavily',
+    capability: 'searchKeywords',
+    inputs: ['q'],
+    results: [
+      { title: 'A', url: 'https://a.com', content: 'about A', sourceInput: 'q' },
+      { title: 'B', url: 'https://b.com', content: 'about B', sourceInput: 'q' }
+    ]
+  }
+}
+
+function callSearchExecute(args: { query: string }, abortSignal?: AbortSignal): Promise<unknown> {
+  const execute = searchEntry.tool.execute as (
+    args: { query: string },
+    options: ToolExecutionOptions
+  ) => Promise<unknown>
+  return execute(args, makeOptions(abortSignal))
+}
+
+function callFetchExecute(args: { urls: string[] }, abortSignal?: AbortSignal): Promise<unknown> {
+  const execute = fetchEntry.tool.execute as (
+    args: { urls: string[] },
+    options: ToolExecutionOptions
+  ) => Promise<unknown>
+  return execute(args, makeOptions(abortSignal))
 }
 
 describe('web__search', () => {
   beforeEach(() => {
-    webSearchSearch.mockReset()
-    getResolvedConfig.mockReset()
+    fetchUrls.mockReset()
+    searchKeywords.mockReset()
   })
 
   it('builds an entry with the agreed namespace + defer policy', () => {
-    expect(entry.name).toBe(WEB_SEARCH_TOOL_NAME)
-    expect(entry.namespace).toBe('web')
-    expect(entry.defer).toBe('auto')
+    expect(searchEntry.name).toBe(WEB_SEARCH_TOOL_NAME)
+    expect(searchEntry.namespace).toBe('web')
+    expect(searchEntry.defer).toBe('auto')
   })
 
-  it('returns [] when no provider is configured', async () => {
-    getResolvedConfig.mockResolvedValue({ providers: [unusableProvider], runtime: {}, providerOverrides: {} })
-    const result = await callExecute({ query: 'hello' })
-    expect(result).toEqual([])
-    expect(webSearchSearch).not.toHaveBeenCalled()
-  })
+  it('calls WebSearchService.searchKeywords with the request abort signal', async () => {
+    const abortSignal = new AbortController().signal
+    searchKeywords.mockResolvedValue(response())
 
-  it('picks the first provider with API keys', async () => {
-    webSearchSearch.mockResolvedValue({ query: 'hello', results: [] })
-    getResolvedConfig.mockResolvedValue({
-      providers: [unusableProvider, usableProvider],
-      runtime: {},
-      providerOverrides: {}
-    })
-    await callExecute({ query: 'hello' })
-    expect(webSearchSearch).toHaveBeenCalledWith({ providerId: 'tavily', questions: ['hello'], requestId: 'req-1' })
-  })
+    await callSearchExecute({ query: 'hello' }, abortSignal)
 
-  it('treats local-* providers as usable without API keys', async () => {
-    webSearchSearch.mockResolvedValue({ query: 'hello', results: [] })
-    getResolvedConfig.mockResolvedValue({
-      providers: [localProvider],
-      runtime: {},
-      providerOverrides: {}
-    })
-    await callExecute({ query: 'hello' })
-    expect(webSearchSearch).toHaveBeenCalledWith(expect.objectContaining({ providerId: 'local-google' }))
+    expect(searchKeywords).toHaveBeenCalledWith({ keywords: ['hello'] }, { signal: abortSignal })
   })
 
   it('maps WebSearchResponse to indexed output items', async () => {
-    webSearchSearch.mockResolvedValue({
-      query: 'q',
-      results: [
-        { title: 'A', url: 'https://a.com', content: 'about A' },
-        { title: 'B', url: 'https://b.com', content: 'about B' }
-      ]
-    })
-    getResolvedConfig.mockResolvedValue({ providers: [usableProvider], runtime: {}, providerOverrides: {} })
+    searchKeywords.mockResolvedValue(response())
 
-    const result = await callExecute({ query: 'q' })
+    const result = await callSearchExecute({ query: 'q' })
     expect(result).toEqual([
       { id: 1, title: 'A', url: 'https://a.com', content: 'about A' },
       { id: 2, title: 'B', url: 'https://b.com', content: 'about B' }
@@ -128,14 +93,70 @@ describe('web__search', () => {
   })
 
   it('returns [] when webSearchService throws', async () => {
-    webSearchSearch.mockRejectedValue(new Error('upstream 503'))
-    getResolvedConfig.mockResolvedValue({ providers: [usableProvider], runtime: {}, providerOverrides: {} })
-    expect(await callExecute({ query: 'q' })).toEqual([])
+    searchKeywords.mockRejectedValue(new Error('upstream 503'))
+    expect(await callSearchExecute({ query: 'q' })).toEqual([])
   })
 
   describe('applies', () => {
     it('returns true only when assistant.settings.enableWebSearch is set', () => {
-      const applies = entry.applies!
+      const applies = searchEntry.applies!
+      expect(applies({ assistant: undefined, mcpToolIds: new Set() })).toBe(false)
+      expect(
+        applies({
+          assistant: { id: 'a', settings: {} } as never,
+          mcpToolIds: new Set()
+        })
+      ).toBe(false)
+      expect(
+        applies({
+          assistant: { id: 'a', settings: { enableWebSearch: true } } as never,
+          mcpToolIds: new Set()
+        })
+      ).toBe(true)
+    })
+  })
+})
+
+describe('web__fetch', () => {
+  beforeEach(() => {
+    fetchUrls.mockReset()
+    searchKeywords.mockReset()
+  })
+
+  it('builds an entry with the agreed namespace + defer policy', () => {
+    expect(fetchEntry.name).toBe(WEB_FETCH_TOOL_NAME)
+    expect(fetchEntry.namespace).toBe('web')
+    expect(fetchEntry.defer).toBe('auto')
+  })
+
+  it('calls WebSearchService.fetchUrls with the request abort signal', async () => {
+    const abortSignal = new AbortController().signal
+    fetchUrls.mockResolvedValue(response())
+
+    await callFetchExecute({ urls: ['https://example.com'] }, abortSignal)
+
+    expect(fetchUrls).toHaveBeenCalledWith({ urls: ['https://example.com'] }, { signal: abortSignal })
+  })
+
+  it('maps WebSearchResponse to indexed output items', async () => {
+    fetchUrls.mockResolvedValue(response())
+
+    const result = await callFetchExecute({ urls: ['https://a.com', 'https://b.com'] })
+
+    expect(result).toEqual([
+      { id: 1, title: 'A', url: 'https://a.com', content: 'about A' },
+      { id: 2, title: 'B', url: 'https://b.com', content: 'about B' }
+    ])
+  })
+
+  it('returns [] when webSearchService throws', async () => {
+    fetchUrls.mockRejectedValue(new Error('upstream 503'))
+    expect(await callFetchExecute({ urls: ['https://example.com'] })).toEqual([])
+  })
+
+  describe('applies', () => {
+    it('returns true only when assistant.settings.enableWebSearch is set', () => {
+      const applies = fetchEntry.applies!
       expect(applies({ assistant: undefined, mcpToolIds: new Set() })).toBe(false)
       expect(
         applies({

--- a/src/main/ai/tools/builtin/__tests__/index.test.ts
+++ b/src/main/ai/tools/builtin/__tests__/index.test.ts
@@ -8,7 +8,7 @@ import { ToolRegistry } from '../../registry'
 import { registerBuiltinTools } from '../index'
 import { KB_LIST_TOOL_NAME } from '../KnowledgeListTool'
 import { KB_SEARCH_TOOL_NAME } from '../KnowledgeSearchTool'
-import { WEB_SEARCH_TOOL_NAME } from '../WebSearchTool'
+import { WEB_FETCH_TOOL_NAME, WEB_SEARCH_TOOL_NAME } from '../WebSearchTool'
 
 describe('registerBuiltinTools', () => {
   it('populates the given registry with every builtin entry', () => {
@@ -16,6 +16,7 @@ describe('registerBuiltinTools', () => {
     registerBuiltinTools(reg)
     expect(reg.has(KB_LIST_TOOL_NAME)).toBe(true)
     expect(reg.has(KB_SEARCH_TOOL_NAME)).toBe(true)
+    expect(reg.has(WEB_FETCH_TOOL_NAME)).toBe(true)
     expect(reg.has(WEB_SEARCH_TOOL_NAME)).toBe(true)
   })
 })

--- a/src/main/ai/tools/builtin/index.ts
+++ b/src/main/ai/tools/builtin/index.ts
@@ -12,10 +12,11 @@
 import { registry, type ToolRegistry } from '../registry'
 import { createKbListToolEntry } from './KnowledgeListTool'
 import { createKbSearchToolEntry } from './KnowledgeSearchTool'
-import { createWebSearchToolEntry } from './WebSearchTool'
+import { createWebFetchToolEntry, createWebSearchToolEntry } from './WebSearchTool'
 
 export function registerBuiltinTools(reg: ToolRegistry = registry): void {
   reg.register(createKbListToolEntry())
   reg.register(createKbSearchToolEntry())
+  reg.register(createWebFetchToolEntry())
   reg.register(createWebSearchToolEntry())
 }


### PR DESCRIPTION
### What this PR does

Before this PR:

The agentic web search builtin only exposed `web__search`, and provider selection was partially handled in the tool layer.

After this PR:

The web builtin tools expose `web__search` and `web__fetch`. Both tools delegate capability/provider resolution to `WebSearchService`, pass the request abort signal through, and return indexed citation-ready results.

Fixes #N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The tool layer stays thin and does not duplicate provider selection logic. Failures are logged and returned as empty results so tool failures do not interrupt the chat flow.

The following alternatives were considered:

Keeping provider selection in `WebSearchTool` was considered, but `WebSearchService` already owns capability-specific default provider resolution for `searchKeywords` and `fetchUrls`.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

`pnpm build:check` currently fails on existing repository-wide typecheck issues unrelated to this PR. Focused web tool tests pass.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Adds backend support for the agentic web fetch tool, allowing the model to fetch readable content from known URLs through the configured web search service.
```
