### PR TITLE
feat: text diff highlighting for Refine action

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -4399,17 +4399,17 @@
       },
       "window": {
         "c_copy": "C: Copy",
+        "diff_view": "Diff View",
         "esc_close": "Esc: Close",
         "esc_stop": "Esc: Stop",
         "opacity": "Window Opacity",
-        "diff_view": "Diff View",
         "original_copy": "Copy Original",
         "original_hide": "Hide Original",
         "original_show": "Show Original",
-        "result_view": "Result View",
         "pin": "Pin",
         "pinned": "Pinned",
-        "r_regenerate": "R: Regenerate"
+        "r_regenerate": "R: Regenerate",
+        "result_view": "Result View"
       }
     },
     "name": "Selection Assistant",

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -4402,9 +4402,11 @@
         "esc_close": "Esc: Close",
         "esc_stop": "Esc: Stop",
         "opacity": "Window Opacity",
+        "diff_view": "Diff View",
         "original_copy": "Copy Original",
         "original_hide": "Hide Original",
         "original_show": "Show Original",
+        "result_view": "Result View",
         "pin": "Pin",
         "pinned": "Pinned",
         "r_regenerate": "R: Regenerate"

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -4399,17 +4399,17 @@
       },
       "window": {
         "c_copy": "C 复制",
+        "diff_view": "差异视图",
         "esc_close": "Esc 关闭",
         "esc_stop": "Esc 停止",
         "opacity": "窗口透明度",
-        "diff_view": "差异视图",
         "original_copy": "复制原文",
         "original_hide": "隐藏原文",
         "original_show": "显示原文",
-        "result_view": "结果视图",
         "pin": "置顶",
         "pinned": "已置顶",
-        "r_regenerate": "R 重新生成"
+        "r_regenerate": "R 重新生成",
+        "result_view": "结果视图"
       }
     },
     "name": "划词助手",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -4402,9 +4402,11 @@
         "esc_close": "Esc 关闭",
         "esc_stop": "Esc 停止",
         "opacity": "窗口透明度",
+        "diff_view": "差异视图",
         "original_copy": "复制原文",
         "original_hide": "隐藏原文",
         "original_show": "显示原文",
+        "result_view": "结果视图",
         "pin": "置顶",
         "pinned": "已置顶",
         "r_regenerate": "R 重新生成"

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -4402,9 +4402,11 @@
         "esc_close": "Esc 關閉",
         "esc_stop": "Esc 停止",
         "opacity": "視窗透明度",
+        "diff_view": "差異檢視",
         "original_copy": "複製原文",
         "original_hide": "隱藏原文",
         "original_show": "顯示原文",
+        "result_view": "結果檢視",
         "pin": "置頂",
         "pinned": "已置頂",
         "r_regenerate": "R 重新產生"

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -4399,17 +4399,17 @@
       },
       "window": {
         "c_copy": "C 複製",
+        "diff_view": "差異檢視",
         "esc_close": "Esc 關閉",
         "esc_stop": "Esc 停止",
         "opacity": "視窗透明度",
-        "diff_view": "差異檢視",
         "original_copy": "複製原文",
         "original_hide": "隱藏原文",
         "original_show": "顯示原文",
-        "result_view": "結果檢視",
         "pin": "置頂",
         "pinned": "已置頂",
-        "r_regenerate": "R 重新產生"
+        "r_regenerate": "R 重新產生",
+        "result_view": "結果檢視"
       }
     },
     "name": "劃詞助手",

--- a/src/renderer/src/windows/selection/action/components/ActionGeneral.tsx
+++ b/src/renderer/src/windows/selection/action/components/ActionGeneral.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 import { processMessages } from './ActionUtils'
+import TextDiffDisplay from './TextDiffDisplay'
 import WindowFooter from './WindowFooter'
 
 const logger = loggerService.withContext('ActionGeneral')
@@ -35,6 +36,7 @@ const ActionGeneral: FC<Props> = React.memo(({ action, scrollToBottom }) => {
   const [language] = usePreference('app.language')
   const [error, setError] = useState<string | null>(null)
   const [showOriginal, setShowOriginal] = useState(false)
+  const [showDiff, setShowDiff] = useState(true)
   const [status, setStatus] = useState<'preparing' | 'streaming' | 'finished'>('preparing')
   const [contentToCopy, setContentToCopy] = useState('')
   const initialized = useRef(false)
@@ -174,13 +176,24 @@ const ActionGeneral: FC<Props> = React.memo(({ action, scrollToBottom }) => {
 
   const handleRegenerate = () => {
     setContentToCopy('')
+    setShowDiff(true)
     fetchResult()
   }
+
+  const isRefineFinished = action.id === 'refine' && status === 'finished'
 
   return (
     <>
       <Container>
         <MenuContainer>
+          {isRefineFinished && (
+            <DiffToggle onClick={() => setShowDiff(!showDiff)}>
+              <span>
+                {showDiff ? t('selection.action.window.result_view') : t('selection.action.window.diff_view')}
+              </span>
+              <ChevronDown size={14} className={showDiff ? 'expanded' : ''} />
+            </DiffToggle>
+          )}
           <OriginalHeader onClick={() => setShowOriginal(!showOriginal)}>
             <span>
               {showOriginal ? t('selection.action.window.original_hide') : t('selection.action.window.original_show')}
@@ -202,9 +215,13 @@ const ActionGeneral: FC<Props> = React.memo(({ action, scrollToBottom }) => {
         )}
         <Result>
           {isPreparing && <LoadingOutlined style={{ fontSize: 16 }} spin />}
-          {!isPreparing && currentAssistantMessage && (
-            <MessageContent key={currentAssistantMessage.id} message={currentAssistantMessage} />
-          )}
+          {!isPreparing &&
+            currentAssistantMessage &&
+            (isRefineFinished && showDiff && contentToCopy ? (
+              <TextDiffDisplay original={action.selectedText ?? ''} refined={contentToCopy} />
+            ) : (
+              <MessageContent key={currentAssistantMessage.id} message={currentAssistantMessage} />
+            ))}
         </Result>
         {error && <ErrorMsg>{error}</ErrorMsg>}
       </Container>
@@ -238,6 +255,28 @@ const MenuContainer = styled.div`
   flex-direction: row;
   align-items: center;
   justify-content: flex-end;
+  gap: 8px;
+`
+
+const DiffToggle = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  font-size: 12px;
+
+  &:hover {
+    color: var(--color-primary);
+  }
+
+  .lucide {
+    transition: transform 0.2s ease;
+    margin-left: 2px;
+    &.expanded {
+      transform: rotate(180deg);
+    }
+  }
 `
 
 const OriginalHeader = styled.div`

--- a/src/renderer/src/windows/selection/action/components/TextDiffDisplay.tsx
+++ b/src/renderer/src/windows/selection/action/components/TextDiffDisplay.tsx
@@ -1,0 +1,50 @@
+import type { Change } from 'diff'
+import { diffChars } from 'diff'
+import { useMemo } from 'react'
+import styled from 'styled-components'
+
+interface TextDiffDisplayProps {
+  original: string
+  refined: string
+}
+
+function TextDiffDisplay({ original, refined }: TextDiffDisplayProps) {
+  const changes: Change[] = useMemo(() => diffChars(original, refined), [original, refined])
+
+  return (
+    <DiffContainer>
+      {changes.map((part, index) => {
+        if (part.added) {
+          return <Added key={index}>{part.value}</Added>
+        }
+        if (part.removed) {
+          return <Removed key={index}>{part.value}</Removed>
+        }
+        return <Unchanged key={index}>{part.value}</Unchanged>
+      })}
+    </DiffContainer>
+  )
+}
+
+const DiffContainer = styled.div`
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.6;
+`
+
+const Added = styled.span`
+  background-color: rgba(0, 200, 83, 0.15);
+  border-radius: 2px;
+  padding: 0 1px;
+`
+
+const Removed = styled.span`
+  background-color: rgba(244, 67, 54, 0.15);
+  border-radius: 2px;
+  padding: 0 1px;
+  text-decoration: line-through;
+`
+
+const Unchanged = styled.span``
+
+export default TextDiffDisplay


### PR DESCRIPTION
### What this PR does

Before this PR:
The "Refine" selection action showed only the AI-polished result with no visual comparison to the original text. Users had to manually compare word-for-word to verify what changed.

After this PR:
The Refine action now defaults to a **diff view** that highlights changes using inline green (added) and red/strikethrough (removed) text, computed via character-level diff. A "Diff View" / "Result View" toggle lets users switch between the highlighted diff and the clean AI output. The existing "Show Original" toggle remains available.

Fixes #15040

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Uses `diffChars` from the `diff` package (already a dependency) instead of `@pierre/diffs` `FileDiff` component, since `FileDiff` is designed for file/line-level code diffs and is heavyweight for prose text. Character-level diff works universally across languages (CJK and Western).
- The diff uses `contentToCopy` (already tracked in the component via the `onFinish` callback) as the refined text source, avoiding the need to extract content from message blocks.
- The toggle defaults to "Diff View" to make changes immediately visible, with a one-click switch to "Result View" for the clean output.

The following alternatives were considered:
- Using `@pierre/diffs` `FileDiff` with `parseDiffFromFile` — rejected because it's designed for file-level diffs with syntax highlighting and doesn't suit plain prose.
- Using `diffWords` instead of `diffChars` — rejected because `diffWords` treats CJK text as single tokens, producing meaningless diffs for Chinese/Japanese/Korean refinements.

### Breaking changes

None.

### Special notes for your reviewer

The `DiffToggle` styled-component intentionally mirrors `OriginalHeader`'s styling. These could be extracted into a shared `MenuToggle` component in a follow-up refactor.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required.
- [x] Self-review: I have reviewed my own code

### Release note

```release-note
Added text diff highlighting for the "Refine" action. Changes between the original selected text and the AI-refined result are now highlighted with green (additions) and red/strikethrough (removals). A "Diff View" / "Result View" toggle allows switching between the diff and the clean output.