### PR TITLE
hotfix: add environment variable for claude code provider management

### DIFF
--- a/src/renderer/src/pages/code/index.ts
+++ b/src/renderer/src/pages/code/index.ts
@@ -154,6 +154,8 @@ export const generateToolEnvironment = ({
 
   switch (tool) {
     case codeTools.claudeCode: {
+      // https://code.claude.com/docs/en/env-vars
+      env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST = '1'
       env.ANTHROPIC_BASE_URL =
         getCodeToolsApiBaseUrl(model, 'anthropic') || modelProvider.anthropicApiHost || modelProvider.apiHost
       env.ANTHROPIC_MODEL = model.id


### PR DESCRIPTION
### What this PR does

Before this PR:

Launching Claude Code from Cherry Studio could fail when the user's `~/.claude/settings.json` also defined provider/auth environment variables such as `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY`, or `ANTHROPIC_BASE_URL`.

After this PR:

Cherry Studio marks Claude Code's provider environment as host-managed, so Claude Code ignores provider routing/auth variables from user settings while still allowing non-provider settings to load.

Fixes #13924

### Why we need it and why it was done in this way

Cherry Studio already injects the selected model provider, base URL, model ID, and credentials when launching Claude Code. Without marking those values as host-managed, Claude Code can also load provider/auth variables from the user's `~/.claude/settings.json`, causing both `ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_API_KEY` to exist in the same process and triggering an auth conflict.

This PR uses Claude Code's native `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST` environment variable instead of parsing or mutating the user's settings file. This keeps Cherry Studio's selected provider authoritative while preserving unrelated Claude Code settings.

The following tradeoffs were made:

The fix relies on Claude Code's supported host-managed provider behavior rather than adding Cherry Studio-specific filtering logic. This keeps the change small, but it depends on Claude Code continuing to support this environment variable.

The following alternatives were considered:

- Filtering `ANTHROPIC_*` variables from `~/.claude/settings.json` in Cherry Studio. This was rejected because Cherry Studio should not parse or modify Claude Code's user settings.
- Unsetting only one of `ANTHROPIC_AUTH_TOKEN` or `ANTHROPIC_API_KEY`. This was rejected because endpoint and model override variables could still conflict with Cherry Studio's selected provider.
- Using a separate Claude config directory. This was rejected because users should still be able to keep their non-provider Claude Code settings.

Links to places where the discussion took place:

- https://github.com/CherryHQ/cherry-studio/issues/13924
- https://code.claude.com/docs/en/env-vars

### Breaking changes

None.

### Special notes for your reviewer


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: No refactoring was included; this hotfix keeps the change minimal
- [x] Upgrade: Impact of this change on upgrade flows was considered and no migration is required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required for this bug fix
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed Claude Code launch failures caused by auth conflicts with provider environment variables from the user's Claude Code settings.
```