### PR TITLE
fix(aiCore): Qiniu PDF fallback for GPT-5.4

### DIFF
--- a/src/renderer/src/aiCore/plugins/__tests__/pdfCompatibilityPlugin.test.ts
+++ b/src/renderer/src/aiCore/plugins/__tests__/pdfCompatibilityPlugin.test.ts
@@ -43,8 +43,8 @@ function makeProvider(id: string, type: ProviderType): Provider {
   return { id, name: id, type, apiKey: 'test', apiHost: 'https://test.com', isSystem: false, models: [] } as Provider
 }
 
-function makeModel(): Model {
-  return { id: 'test-model', provider: 'test', name: 'Test', group: 'test' } as Model
+function makeModel(overrides: Partial<Model> = {}): Model {
+  return { id: 'test-model', provider: 'test', name: 'Test', group: 'test', ...overrides } as Model
 }
 
 function makePdfFilePart(filename = 'test.pdf') {
@@ -147,6 +147,26 @@ describe('pdfCompatibilityPlugin', () => {
     } as unknown as LanguageModelV3CallOptions
 
     const result = await runMiddleware(provider, params)
+    expect(mockExtractPdfText).toHaveBeenCalledWith('base64pdfdata')
+    expect(result.prompt[0]).toMatchObject({
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Hello' },
+        { type: 'text', text: 'report.pdf\nExtracted PDF content' }
+      ]
+    })
+  })
+
+  it('should convert PDF for qiniu openai-compatible GPT models', async () => {
+    const provider = makeProvider('qiniu', 'openai')
+    const model = makeModel({ id: 'gpt-5.4', name: 'gpt-5.4' })
+    mockExtractPdfText.mockResolvedValue('Extracted PDF content')
+
+    const params = {
+      prompt: [{ role: 'user' as const, content: [makeTextPart('Hello'), makePdfFilePart('report.pdf')] }]
+    } as unknown as LanguageModelV3CallOptions
+
+    const result = await runMiddleware(provider, params, model)
     expect(mockExtractPdfText).toHaveBeenCalledWith('base64pdfdata')
     expect(result.prompt[0]).toMatchObject({
       role: 'user',

--- a/src/renderer/src/aiCore/plugins/pdfCompatibilityPlugin.ts
+++ b/src/renderer/src/aiCore/plugins/pdfCompatibilityPlugin.ts
@@ -10,6 +10,7 @@ import { loggerService } from '@logger'
 import { isAnthropicModel, isGeminiModel } from '@renderer/config/models'
 import { isOpenAILLMModel } from '@renderer/config/models/openai'
 import type { Model, Provider, ProviderType } from '@renderer/types'
+import { SystemProviderIds } from '@renderer/types'
 import { extractPdfText } from '@shared/utils/pdf'
 import type { LanguageModelMiddleware } from 'ai'
 import i18n from 'i18next'
@@ -34,11 +35,17 @@ const PDF_NATIVE_PROVIDER_TYPES = new Set<ProviderType>([
   'vertex-anthropic' // Vertex AI with Anthropic models
 ])
 
+const PDF_FORCE_TEXT_EXTRACTION_PROVIDER_IDS = new Set<string>([SystemProviderIds.qiniu])
+
 function isPdfFilePart(part: ContentPart): part is LanguageModelV3FilePart & { mediaType: 'application/pdf' } {
   return part.type === 'file' && part.mediaType === 'application/pdf'
 }
 
 function supportsNativePdf(provider: Provider, model: Model): boolean {
+  if (PDF_FORCE_TEXT_EXTRACTION_PROVIDER_IDS.has(provider.id)) {
+    return false
+  }
+
   // OpenAI, Claude, and Gemini models always support native PDF regardless of provider
   if (isOpenAILLMModel(model) || isAnthropicModel(model) || isGeminiModel(model)) {
     return true


### PR DESCRIPTION
## What
- Force Qiniu OpenAI-compatible models to use PDF text extraction instead of native PDF file parts.
- Add a regression test for Qiniu GPT-5.4 PDF uploads.

## Why
- Qiniu GPT-5.4 regressed in v1.9.5 when PDFs were sent natively, breaking document analysis.

## Notes
- `pnpm build:check` still fails because of an unrelated pre-existing test failure in `src/main/services/agents/services/cherryclaw/__tests__/prompt.test.ts`.