### PR TITLE
hotfix(agents): hot-switch SDK permissionMode on active sessions

### DIFF
--- a/packages/shared/IpcChannel.ts
+++ b/packages/shared/IpcChannel.ts
@@ -113,6 +113,7 @@ export enum IpcChannel {
   AgentSessionStream_Subscribe = 'agent-session-stream:subscribe',
   AgentSessionStream_Unsubscribe = 'agent-session-stream:unsubscribe',
   AgentSessionStream_Abort = 'agent-session-stream:abort',
+  AgentSessionStream_SetPermissionMode = 'agent-session-stream:set-permission-mode',
   AgentSessionStream_Chunk = 'agent-session-stream:chunk',
   AgentSession_Changed = 'agent-session:changed',
 

--- a/src/main/services/agents/services/channels/sessionStreamIpc.ts
+++ b/src/main/services/agents/services/channels/sessionStreamIpc.ts
@@ -1,9 +1,14 @@
+import type { PermissionMode } from '@anthropic-ai/claude-agent-sdk'
+import { loggerService } from '@logger'
 import { IpcChannel } from '@shared/IpcChannel'
 import { ipcMain } from 'electron'
 
 import { windowService } from '../../../WindowService'
+import { setActiveSessionPermissionMode } from '../claudecode/active-queries'
 import { channelMessageHandler } from './ChannelMessageHandler'
 import { sessionStreamBus, type SessionStreamChunk } from './SessionStreamBus'
+
+const logger = loggerService.withContext('SessionStreamIpc')
 
 const activeSubscriptions = new Map<string, () => void>()
 
@@ -35,6 +40,23 @@ export function registerSessionStreamIpc(): void {
     const aborted = channelMessageHandler.abortSession(sessionId)
     return { success: aborted }
   })
+
+  ipcMain.handle(
+    IpcChannel.AgentSessionStream_SetPermissionMode,
+    async (_event, { sessionId, mode }: { sessionId: string; mode: PermissionMode }) => {
+      try {
+        const switched = await setActiveSessionPermissionMode(sessionId, mode)
+        return { success: switched }
+      } catch (error) {
+        logger.warn('Failed to set permission mode on active query', {
+          sessionId,
+          mode,
+          error: error instanceof Error ? error.message : String(error)
+        })
+        return { success: false }
+      }
+    }
+  )
 }
 
 export function broadcastSessionChanged(agentId: string, sessionId: string, headless?: boolean): void {

--- a/src/main/services/agents/services/claudecode/__tests__/setActiveSessionPermissionMode.test.ts
+++ b/src/main/services/agents/services/claudecode/__tests__/setActiveSessionPermissionMode.test.ts
@@ -1,0 +1,30 @@
+import type { PermissionMode, Query } from '@anthropic-ai/claude-agent-sdk'
+import { describe, expect, it, vi } from 'vitest'
+
+import { registerActiveQuery, setActiveSessionPermissionMode, unregisterActiveQuery } from '../active-queries'
+
+const makeFakeQuery = (): Pick<Query, 'setPermissionMode'> & { setPermissionMode: ReturnType<typeof vi.fn> } => ({
+  setPermissionMode: vi.fn().mockResolvedValue(undefined)
+})
+
+describe('setActiveSessionPermissionMode', () => {
+  it('returns false when no query is registered for the session id', async () => {
+    const result = await setActiveSessionPermissionMode('non-existent-session', 'bypassPermissions')
+    expect(result).toBe(false)
+  })
+
+  it('forwards mode to the registered query and returns true', async () => {
+    const sessionId = 'session-active'
+    const fakeQuery = makeFakeQuery()
+    registerActiveQuery(sessionId, fakeQuery as unknown as Query)
+
+    try {
+      const mode: PermissionMode = 'bypassPermissions'
+      const result = await setActiveSessionPermissionMode(sessionId, mode)
+      expect(result).toBe(true)
+      expect(fakeQuery.setPermissionMode).toHaveBeenCalledExactlyOnceWith(mode)
+    } finally {
+      unregisterActiveQuery(sessionId)
+    }
+  })
+})

--- a/src/main/services/agents/services/claudecode/active-queries.ts
+++ b/src/main/services/agents/services/claudecode/active-queries.ts
@@ -1,0 +1,29 @@
+import type { PermissionMode, Query } from '@anthropic-ai/claude-agent-sdk'
+
+/**
+ * Active `Query` instances keyed by Cherry session id. Populated for the
+ * lifetime of an in-flight `processSDKQuery` so runtime controls (e.g.
+ * `setPermissionMode`) can reach the SDK without waiting for the next turn.
+ */
+const activeQueries = new Map<string, Query>()
+
+export function registerActiveQuery(sessionId: string, query: Query): void {
+  activeQueries.set(sessionId, query)
+}
+
+export function unregisterActiveQuery(sessionId: string): void {
+  activeQueries.delete(sessionId)
+}
+
+/**
+ * Hot-switch the SDK permission mode on the currently running query for a
+ * session. Returns `false` when no query is in flight — that's the normal case
+ * when the user changes mode between turns; DB is the source of truth and the
+ * next `invoke()` will read it.
+ */
+export async function setActiveSessionPermissionMode(sessionId: string, mode: PermissionMode): Promise<boolean> {
+  const q = activeQueries.get(sessionId)
+  if (!q) return false
+  await q.setPermissionMode(mode)
+  return true
+}

--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -58,6 +58,7 @@ import { isProvisioned, provisionBuiltinAgent } from '../builtin/BuiltinAgentPro
 import { channelService } from '../ChannelService'
 import { PromptBuilder } from '../cherryclaw/prompt'
 import { sessionService } from '../SessionService'
+import { registerActiveQuery, unregisterActiveQuery } from './active-queries'
 import { buildNamespacedToolCallId } from './claude-stream-state'
 import { promptForToolApproval } from './tool-permissions'
 import { ClaudeStreamState, transformSDKMessageToStreamParts } from './transform'
@@ -928,8 +929,11 @@ class ClaudeCodeService implements AgentServiceInterface {
     const startTime = Date.now()
     const streamState = new ClaudeStreamState({ agentSessionId: sessionId })
 
+    const q = query({ prompt: promptStream, options })
+    registerActiveQuery(sessionId, q)
+
     try {
-      for await (const message of query({ prompt: promptStream, options })) {
+      for await (const message of q) {
         if (hasCompleted) break
 
         jsonOutput.push(message)
@@ -1060,6 +1064,7 @@ class ClaudeCodeService implements AgentServiceInterface {
         error: new Error(errorMessage)
       })
     } finally {
+      unregisterActiveQuery(sessionId)
       closePromptStream()
     }
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,4 @@
-import type { PermissionUpdate } from '@anthropic-ai/claude-agent-sdk'
+import type { PermissionMode, PermissionUpdate } from '@anthropic-ai/claude-agent-sdk'
 import type { TokenUsageData } from '@cherrystudio/analytics-client'
 import { electronAPI } from '@electron-toolkit/preload'
 import type { SpanEntity, TokenUsage } from '@mcp-trace/trace-core'
@@ -552,6 +552,8 @@ const api = {
     subscribe: (sessionId: string) => ipcRenderer.invoke(IpcChannel.AgentSessionStream_Subscribe, { sessionId }),
     unsubscribe: (sessionId: string) => ipcRenderer.invoke(IpcChannel.AgentSessionStream_Unsubscribe, { sessionId }),
     abort: (sessionId: string) => ipcRenderer.invoke(IpcChannel.AgentSessionStream_Abort, { sessionId }),
+    setPermissionMode: (sessionId: string, mode: PermissionMode) =>
+      ipcRenderer.invoke(IpcChannel.AgentSessionStream_SetPermissionMode, { sessionId, mode }),
     onChunk: (
       callback: (chunk: {
         sessionId: string

--- a/src/renderer/src/hooks/agents/useUpdateSession.ts
+++ b/src/renderer/src/hooks/agents/useUpdateSession.ts
@@ -1,3 +1,4 @@
+import { loggerService } from '@logger'
 import { DEFAULT_SESSION_PAGE_SIZE } from '@renderer/api/agent'
 import type { AgentSessionEntity, ListAgentSessionsResponse, UpdateSessionForm } from '@renderer/types'
 import type { UpdateAgentBaseOptions, UpdateAgentSessionFunction } from '@renderer/types/agent'
@@ -8,6 +9,8 @@ import { mutate } from 'swr'
 import { unstable_serialize } from 'swr/infinite'
 
 import { useAgentClient } from './useAgentClient'
+
+const logger = loggerService.withContext('useUpdateSession')
 
 type InfiniteData = ListAgentSessionsResponse[]
 
@@ -53,6 +56,16 @@ export const useUpdateSession = (agentId: string | null) => {
         void mutate(itemKey, result, { revalidate: false })
         if (options?.showSuccessToast ?? true) {
           window.toast.success(t('common.update_success'))
+        }
+        const nextPermissionMode = form.configuration?.permission_mode
+        if (nextPermissionMode) {
+          window.api.agentSessionStream.setPermissionMode(sessionId, nextPermissionMode).catch((err) => {
+            logger.warn('Failed to hot-switch permission mode on active session', {
+              sessionId,
+              mode: nextPermissionMode,
+              error: err instanceof Error ? err.message : String(err)
+            })
+          })
         }
         return result
       } catch (error) {


### PR DESCRIPTION
### What this PR does

Before this PR:

Switching an agent's permission mode (default / acceptEdits / bypassPermissions / plan) from the UI only takes effect on the next user turn. The in-flight Claude Agent SDK query keeps using the mode it was started with, so after a user clicks "Bypass Permissions" mid-stream, the running tool loop still pops approval prompts for the rest of the turn.

Root cause: `ClaudeCodeService.processSDKQuery` consumed `query({ prompt, options })` directly via `for await` without ever capturing the returned `Query` reference, so the SDK's runtime control method `Query.setPermissionMode(mode)` (available in streaming-input mode, which Cherry already uses) was never reachable.

After this PR:

- The `Query` reference is captured for each active session in a module-level `Map<sessionId, Query>` (`active-queries.ts`), populated in `processSDKQuery`'s `try` and cleared in `finally`.
- A new IPC channel `AgentSessionStream_SetPermissionMode` forwards a renderer request to `Query.setPermissionMode()` on the active query for that session id; returns `{ success: false }` when no query is in flight (which is normal — DB is still the source of truth for the next turn).
- `useUpdateSession` fires the IPC whenever a session config patch contains `permission_mode`. Failures are swallowed and logged — DB write is authoritative.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Active-query state lives at module scope rather than as `ClaudeCodeService` instance state. This mirrors `tool-permissions.ts`' module-level `pendingRequests` map and keeps the helper independently testable without instantiating the heavy service.
- `Cherry`'s own `autoAllowTools` Set is intentionally NOT hot-updated. The `PreToolUse` hook reads `input.permission_mode` directly from the SDK each invocation, so SDK-level mode flips already drive correct allow/deny behavior; refreshing the closure-captured Set would add complexity for no behavior gain.
- Renderer hook swallows IPC errors instead of surfacing them. Since the DB write succeeded by the time the IPC fires, the worst case is the current in-flight turn keeps the old mode — which is what users get today anyway. Throwing here would only confuse them after a successful update toast.

The following alternatives were considered:

- Adding turn-level hooks that re-read session config before each tool call: rejected because `Query.setPermissionMode` already covers the same intent natively and is cheaper.
- Restarting the active session when the mode changes: rejected because it would interrupt user-visible streaming and lose in-progress turn state.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- The fix targets `main` (v1) because users on the released line are reporting this UX issue. The same change is straightforward to port to `v2` later.
- Added a tiny new file `active-queries.ts` rather than keeping the helper inside `claudecode/index.ts` so the unit test does not need to load the full service module (which pulls in electron / app singletons).

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
fix(agents): permission-mode switches now take effect on the in-flight agent turn instead of waiting for the next message.
```
