### PR TITLE
fix(citation): prevent citation tags from corrupting math rendering

### DIFF
--- a/src/renderer/src/utils/__tests__/citation.test.ts
+++ b/src/renderer/src/utils/__tests__/citation.test.ts
@@ -266,6 +266,20 @@ Numbered list:
       expect(result).toContain('citation [cite:3]')
     })
 
+    it('should normalize citations in currency-like dollar text with dash', () => {
+      const content = 'From $5[1]-$10[2]'
+      const result = normalizeCitationMarks(content, citationMap)
+
+      expect(result).toBe('From $5[cite:1]-$10[cite:2]')
+    })
+
+    it('should normalize citations in currency-like dollar text with slash', () => {
+      const content = '$5[1]/$10[2]'
+      const result = normalizeCitationMarks(content, citationMap)
+
+      expect(result).toBe('$5[cite:1]/$10[cite:2]')
+    })
+
     it('should skip citations inside dollar display math $$...$$', () => {
       const content = '$$[2]+[3]\\equiv[1]\\pmod{4}$$\nSee [1]'
       const result = normalizeCitationMarks(content, citationMap)

--- a/src/renderer/src/utils/__tests__/citation.test.ts
+++ b/src/renderer/src/utils/__tests__/citation.test.ts
@@ -266,18 +266,12 @@ Numbered list:
       expect(result).toContain('citation [cite:3]')
     })
 
-    it('should normalize citations in currency-like dollar text with dash', () => {
-      const content = 'From $5[1]-$10[2]'
+    it('should skip citations inside digit-leading dollar inline math', () => {
+      const content = 'Math $2 + [1] = 3$ and citation [2]'
       const result = normalizeCitationMarks(content, citationMap)
 
-      expect(result).toBe('From $5[cite:1]-$10[cite:2]')
-    })
-
-    it('should normalize citations in currency-like dollar text with slash', () => {
-      const content = '$5[1]/$10[2]'
-      const result = normalizeCitationMarks(content, citationMap)
-
-      expect(result).toBe('$5[cite:1]/$10[cite:2]')
+      expect(result).toContain('$2 + [1] = 3$')
+      expect(result).toContain('citation [cite:2]')
     })
 
     it('should skip citations inside dollar display math $$...$$', () => {

--- a/src/renderer/src/utils/__tests__/citation.test.ts
+++ b/src/renderer/src/utils/__tests__/citation.test.ts
@@ -220,7 +220,6 @@ Numbered list:
 1. item with [2]`
 
       const result = normalizeCitationMarks(content, citationMap)
-      console.log(result)
 
       expect(result).toContain('citation [cite:1]')
       expect(result).toContain('blockquote with [cite:2]')
@@ -230,6 +229,144 @@ Numbered list:
       expect(result).toContain('Subheading with [cite:2]')
       expect(result).toContain('list item with citation [cite:1]')
       expect(result).toContain('item with [cite:2]')
+    })
+  })
+
+  describe('normalizeCitationMarks math skip (issue #14619)', () => {
+    const citations: Citation[] = [
+      { number: 1, url: 'https://example1.com', title: 'Example 1' },
+      { number: 2, url: 'https://example2.com', title: 'Example 2' },
+      { number: 3, url: 'https://example3.com', title: 'Example 3' }
+    ]
+    const citationMap = createCitationMap(citations)
+
+    it('should skip citations inside native inline LaTeX math \\(...\\)', () => {
+      const content = 'Math \\([2]+[3]\\equiv[1]\\pmod{4}\\), source [1]'
+      const result = normalizeCitationMarks(content, citationMap)
+
+      expect(result).toContain('\\([2]+[3]\\equiv[1]\\pmod{4}\\)')
+      expect(result).not.toContain('[cite:2]')
+      expect(result).not.toContain('[cite:3]')
+      expect(result).toContain('source [cite:1]')
+    })
+
+    it('should skip citations inside native display LaTeX math \\[...\\]', () => {
+      const content = 'Formula:\n\\[[2]+[3]\\equiv[1]\\pmod{4}\\]\nReference [2]'
+      const result = normalizeCitationMarks(content, citationMap)
+
+      expect(result).toContain('\\[[2]+[3]\\equiv[1]\\pmod{4}\\]')
+      expect(result).toContain('Reference [cite:2]')
+    })
+
+    it('should skip citations inside dollar inline math $...$', () => {
+      const content = 'Math $[2]+[3]\\equiv[1]\\pmod{4}$ and citation [3]'
+      const result = normalizeCitationMarks(content, citationMap)
+
+      expect(result).toContain('$[2]+[3]\\equiv[1]\\pmod{4}$')
+      expect(result).toContain('citation [cite:3]')
+    })
+
+    it('should skip citations inside dollar display math $$...$$', () => {
+      const content = '$$[2]+[3]\\equiv[1]\\pmod{4}$$\nSee [1]'
+      const result = normalizeCitationMarks(content, citationMap)
+
+      expect(result).toContain('$$[2]+[3]\\equiv[1]\\pmod{4}$$')
+      expect(result).toContain('See [cite:1]')
+    })
+
+    it('should handle multiple math ranges and normal citations correctly', () => {
+      const content = 'A [1], math \\([2]\\), B [2], display $$[3]$$, C [3]'
+      const result = normalizeCitationMarks(content, citationMap)
+
+      expect(result).toBe('A [cite:1], math \\([2]\\), B [cite:2], display $$[3]$$, C [cite:3]')
+    })
+  })
+
+  describe('withCitationTags regression (issue #14619)', () => {
+    it('should not inject citation tags into math content', () => {
+      const content = '\\(\\mathbf{[2]+[3] \\equiv [1] \\pmod{4}}\\) and source [1]'
+      const citations: Citation[] = [
+        { number: 1, url: 'https://example.com', title: 'Source' },
+        { number: 2, url: 'https://example.com', title: 'Source 2' },
+        { number: 3, url: 'https://example.com', title: 'Source 3' }
+      ]
+
+      const result = withCitationTags(content, citations)
+
+      // Math section should not contain citation HTML
+      const mathSection = result.substring(result.indexOf('\\('), result.indexOf('\\)') + '\\)'.length)
+      expect(mathSection).not.toContain('<sup')
+      expect(mathSection).not.toContain('data-citation')
+      expect(mathSection).not.toContain('](')
+
+      // Normal citation outside math should render
+      expect(result).toContain('source [<sup data-citation=')
+    })
+  })
+
+  describe('source-specific citation math skip (issue #14619)', () => {
+    const citations: Citation[] = [
+      { number: 1, url: 'https://example.com', title: 'Source' },
+      { number: 2, url: 'https://example.com', title: 'Source 2' }
+    ]
+
+    it('should skip OpenAI citation syntax inside math', () => {
+      const content = 'Math \\([<sup>1</sup>](https://example.com)+1\\), source [<sup>1</sup>](https://example.com)'
+      const citationMap = createCitationMap(citations)
+
+      for (const sourceType of [
+        WEB_SEARCH_SOURCE.OPENAI,
+        WEB_SEARCH_SOURCE.OPENAI_RESPONSE,
+        WEB_SEARCH_SOURCE.PERPLEXITY
+      ]) {
+        const result = normalizeCitationMarks(content, citationMap, sourceType)
+
+        // Math range should keep OpenAI syntax unchanged
+        expect(result).toContain('\\([<sup>1</sup>](https://example.com)+1\\)')
+        // Outside math should be normalized
+        expect(result).toContain('source [cite:1]')
+      }
+    })
+
+    it('should skip Grok citation syntax inside math', () => {
+      const content = 'Math \\([[1]](https://example.com)+1\\), source [[1]](https://example.com)'
+      const citationMap = createCitationMap(citations)
+
+      const result = normalizeCitationMarks(content, citationMap, WEB_SEARCH_SOURCE.GROK)
+
+      // Math range should keep Grok syntax unchanged
+      expect(result).toContain('\\([[1]](https://example.com)+1\\)')
+      // Outside math should be normalized
+      expect(result).toContain('source [cite:1]')
+    })
+
+    it('should skip Gemini metadata insertion inside math ranges', () => {
+      const content = 'Math \\([2]+[3]\\) then normal text'
+      const metadata: GroundingSupport[] = [
+        {
+          // endIndex points inside the math range at char offset 14 (inside "\\([2]+[3]\\)")
+          segment: { startIndex: 0, endIndex: 7, text: 'Math \\(' },
+          groundingChunkIndices: [0]
+        },
+        {
+          // endIndex points after math range, in normal text
+          segment: { startIndex: 15, endIndex: 31, text: 'then normal text' },
+          groundingChunkIndices: [1]
+        }
+      ]
+      const geminiCitations: Citation[] = [
+        { number: 1, url: 'https://example.com', title: 'Test 1', metadata },
+        { number: 2, url: 'https://example.com', title: 'Test 2' }
+      ]
+      const citationMap = createCitationMap(geminiCitations)
+
+      const result = normalizeCitationMarks(content, citationMap, WEB_SEARCH_SOURCE.GEMINI)
+
+      // Math range should not contain citation markers
+      const mathSection = result.substring(result.indexOf('\\('), result.indexOf('\\)') + '\\)'.length)
+      expect(mathSection).not.toContain('[cite:')
+      // Normal text should have insertion
+      expect(result).toContain('[cite:2]')
     })
   })
 
@@ -595,6 +732,48 @@ Numbered list:
         const citationData = JSON.parse(match[1].replace(/&quot;/g, '"'))
         expect(citationData.content.length).toBe(200)
         expect(citationData.content).toBe(longContent.substring(0, 200))
+      }
+    })
+
+    it('should handle local file URL as non-clickable', () => {
+      const citation: Citation = {
+        number: 1,
+        url: 'file:///C:/Users/test/math.pdf',
+        title: 'Local PDF'
+      }
+
+      const result = generateCitationTag(citation)
+
+      expect(result).toContain('[<sup data-citation=')
+      expect(result).toContain('1</sup>]()')
+      expect(result).not.toContain('](file:///C:/Users/test/math.pdf)')
+    })
+
+    it('should safely encode citation content with LaTeX commands', () => {
+      const citation: Citation = {
+        number: 1,
+        url: '',
+        title: 'Formula source',
+        content: 'Contains \\frac{[2]}{(3)} and \\pmod{4}'
+      }
+
+      const result = generateCitationTag(citation)
+
+      // Should produce a valid tag with empty URL
+      expect(result).toContain('[<sup data-citation=')
+      expect(result).toContain('1</sup>]()')
+      // data-citation should contain properly HTML-encoded JSON
+      const match = result.match(/data-citation='([^']+)'/)
+      expect(match).not.toBeNull()
+      if (match) {
+        // Verify the JSON is parseable after HTML decode
+        const decoded = match[1]
+          .replace(/&quot;/g, '"')
+          .replace(/&amp;/g, '&')
+          .replace(/&lt;/g, '<')
+          .replace(/&gt;/g, '>')
+        const parsed = JSON.parse(decoded)
+        expect(parsed.content).toBe('Contains \\frac{[2]}{(3)} and \\pmod{4}')
       }
     })
   })

--- a/src/renderer/src/utils/__tests__/markdown.test.ts
+++ b/src/renderer/src/utils/__tests__/markdown.test.ts
@@ -607,6 +607,31 @@ $$
         expect(processLatexBrackets(complexInput)).toBe(expectedOutput)
       })
     })
+
+    describe('citation tag protection', () => {
+      it('should protect citation tags with empty URL', () => {
+        const input = "[<sup data-citation='{&quot;id&quot;:1,&quot;url&quot;:&quot;&quot;}'>1</sup>]() and \\(x+1\\)"
+        expect(processLatexBrackets(input)).toBe(
+          "[<sup data-citation='{&quot;id&quot;:1,&quot;url&quot;:&quot;&quot;}'>1</sup>]() and $x+1$"
+        )
+      })
+
+      it('should protect citation data-citation with LaTeX-like content', () => {
+        const input =
+          "[<sup data-citation='{&quot;content&quot;:&quot;\\\\frac{1}{2}&quot;}'>1</sup>](https://example.com) and \\(y+2\\)"
+        expect(processLatexBrackets(input)).toBe(
+          "[<sup data-citation='{&quot;content&quot;:&quot;\\\\frac{1}{2}&quot;}'>1</sup>](https://example.com) and $y+2$"
+        )
+      })
+
+      it('should keep ordinary Markdown links near math intact', () => {
+        const input = 'Read [docs](https://example.com/path_(1)) and \\(x+1\\)'
+        // processLatexBrackets protects the link and converts LaTeX
+        const result = processLatexBrackets(input)
+        expect(result).toContain('[docs](https://example.com/path_(1))')
+        expect(result).toContain('$x+1$')
+      })
+    })
   })
 
   describe('isHtmlCode', () => {

--- a/src/renderer/src/utils/citation.ts
+++ b/src/renderer/src/utils/citation.ts
@@ -71,8 +71,8 @@ function collectProtectedRanges(content: string): Array<{ start: number; end: nu
     ranges.push({ start: m.index, end: m.index + m[0].length })
   }
 
-  // Dollar inline math $...$ — conservative to avoid currency false positives
-  const dollarInlineRegex = /(?<!\$)\$(?!\$)([^\s$](?:[^\n$]*[^\s$])?)\$(?!\$)/g
+  // Dollar inline math $...$ — exclude $<digit> to avoid currency false positives
+  const dollarInlineRegex = /(?<!\$)\$(?!\$)([^\s$\d](?:[^\n$]*[^\s$])?)\$(?!\$)/g
   while ((m = dollarInlineRegex.exec(content)) !== null) {
     ranges.push({ start: m.index, end: m.index + m[0].length })
   }

--- a/src/renderer/src/utils/citation.ts
+++ b/src/renderer/src/utils/citation.ts
@@ -46,6 +46,43 @@ export function withCitationTags(content: string, citations: Citation[], sourceT
 }
 
 /**
+ * Collect protected ranges where citation normalization should not operate.
+ * Covers fenced/inline code and common math delimiters.
+ */
+function collectProtectedRanges(content: string): Array<{ start: number; end: number }> {
+  const ranges: Array<{ start: number; end: number }> = []
+
+  // Fenced code blocks and inline code
+  const codeRegex = /```[\s\S]*?```|`[^`\n]*`/gm
+  let m: RegExpExecArray | null
+  while ((m = codeRegex.exec(content)) !== null) {
+    ranges.push({ start: m.index, end: m.index + m[0].length })
+  }
+
+  // Native LaTeX inline math \(...\) and display math \[...\]
+  const latexRegex = /\\\(.*?\\\)|\\\[.*?\\\]/gs
+  while ((m = latexRegex.exec(content)) !== null) {
+    ranges.push({ start: m.index, end: m.index + m[0].length })
+  }
+
+  // Dollar display math $$...$$
+  const dollarDisplayRegex = /\$\$[\s\S]*?\$\$/g
+  while ((m = dollarDisplayRegex.exec(content)) !== null) {
+    ranges.push({ start: m.index, end: m.index + m[0].length })
+  }
+
+  // Dollar inline math $...$ — conservative to avoid currency false positives
+  const dollarInlineRegex = /(?<!\$)\$(?!\$)([^\s$](?:[^\n$]*[^\s$])?)\$(?!\$)/g
+  while ((m = dollarInlineRegex.exec(content)) !== null) {
+    ranges.push({ start: m.index, end: m.index + m[0].length })
+  }
+
+  // Sort by start position for efficient range checking
+  ranges.sort((a, b) => a.start - b.start)
+  return ranges
+}
+
+/**
  * 标准化引用标记，统一转换为 [cite:N] 格式：
  * - OpenAI 格式: [<sup>N</sup>](url) → [cite:N]
  * - Gemini 格式: 根据metadata添加 [cite:N]
@@ -53,7 +90,7 @@ export function withCitationTags(content: string, citations: Citation[], sourceT
  *
  * 算法：
  * - one pass + 正则替换
- * - 跳过代码块等特殊上下文
+ * - 跳过代码块和数学公式等特殊上下文
  *
  * @param content 原始文本内容
  * @param citationMap 引用映射表
@@ -65,23 +102,14 @@ export function normalizeCitationMarks(
   citationMap: Map<number, Citation>,
   sourceType?: WebSearchSource
 ): string {
-  // 识别需要跳过的代码区域，注意：indented code block已被禁用，不需要跳过
-  const codeBlockRegex = /```[\s\S]*?```|`[^`\n]*`/gm
-  const skipRanges: Array<{ start: number; end: number }> = []
+  // Collect protected ranges (code + math)
+  const skipRanges = collectProtectedRanges(content)
 
-  let match
-  while ((match = codeBlockRegex.exec(content)) !== null) {
-    skipRanges.push({
-      start: match.index,
-      end: match.index + match[0].length
-    })
-  }
-
-  // 检查位置是否在代码块内
+  // Check whether a position falls inside any protected range
   const shouldSkip = (pos: number): boolean => {
     for (const range of skipRanges) {
       if (pos >= range.start && pos < range.end) return true
-      if (range.start > pos) break // 已排序，可以提前结束
+      if (range.start > pos) break // sorted, early exit
     }
     return false
   }

--- a/src/renderer/src/utils/citation.ts
+++ b/src/renderer/src/utils/citation.ts
@@ -71,8 +71,8 @@ function collectProtectedRanges(content: string): Array<{ start: number; end: nu
     ranges.push({ start: m.index, end: m.index + m[0].length })
   }
 
-  // Dollar inline math $...$ — exclude $<digit> to avoid currency false positives
-  const dollarInlineRegex = /(?<!\$)\$(?!\$)([^\s$\d](?:[^\n$]*[^\s$])?)\$(?!\$)/g
+  // Dollar inline math $...$ — prioritize formula preservation, including digit-leading math.
+  const dollarInlineRegex = /(?<!\$)\$(?!\$)([^\s$](?:[^\n$]*[^\s$])?)\$(?!\$)/g
   while ((m = dollarInlineRegex.exec(content)) !== null) {
     ranges.push({ start: m.index, end: m.index + m[0].length })
   }


### PR DESCRIPTION
### What this PR does

Before this PR:
When a response contains mathematical notation like `\(\mathbf{[2]+[3] \equiv [1] \pmod{4}}\)`, citation normalization treats bracketed numbers inside math as citation markers and converts them into `<sup data-citation>` tags. This corrupts the formula rendering — KaTeX receives HTML where it expects LaTeX, producing garbled output with raw `]()` and `data-citation` attributes visible to the user.

After this PR:
Citation normalization now recognizes and skips math ranges (inline/display LaTeX, dollar-delimited math) before processing citation markers. Mathematical notation renders correctly while citations outside formulas still function normally with tooltips.

Fixes #14619

### Why we need it and why it was done in this way

The root cause is that `normalizeCitationMarks()` runs before `processLatexBrackets()` and KaTeX rendering. It only skipped code blocks but not math ranges, so `[1]`, `[2]`, `[3]` in equivalence-class notation were treated as citation markers.

The following tradeoffs were made:
- **Math-priority dollar matching**: Dollar inline math regex (`$...$`) allows digit-leading content (e.g. `$2 + [1] = 3$`). This means ambiguous currency-like prose such as `$5[1]-$10[2]` may also be treated as math rather than normalizing every citation. Math rendering correctness takes priority over currency edge cases.
- **Minimal blast radius**: The fix only extends the existing skip-range mechanism in `normalizeCitationMarks()` — no changes to Markdown rendering order, KaTeX configuration, `Link.tsx`, or `generateCitationTag()`.

The following alternatives were considered:
- Change Markdown/KaTeX rendering to tolerate citation HTML inside math — broader, harder to reason about, could introduce rendering regressions.
- Add raw LaTeX command argument parsing — too broad, risks skipping legitimate prose citations.

### Breaking changes

None. The change only affects citation normalization behavior within math ranges; citations outside math remain identical.

### Special notes for your reviewer

- Three commits on this branch, all focused on the same issue. The second and third commits refine the dollar inline math regex based on review feedback.
- Protected ranges cover: fenced/inline code (preserved), `\(...\)`, `\[...\]`, `$$...$$`, `$...$`
- All source-specific citation formats (default, OpenAI/Perplexity, Grok, Gemini) share the same skip logic.
- 126 tests pass including 14 new tests for math protection across all citation source types.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix mathematical formulas being corrupted by citation markers when both appear in the same response. Formulas like `[2]+[3] ≡ [1] (mod4)` now render correctly while citations outside formulas continue to work.
```