### PR TITLE
fix: exclude deepseek-r1 models from function_calling capability

### DIFF
--- a/src/renderer/src/config/models/__tests__/tooluse.test.ts
+++ b/src/renderer/src/config/models/__tests__/tooluse.test.ts
@@ -121,6 +121,15 @@ describe('isFunctionCallingModel', () => {
     expect(isFunctionCallingModel(createModel({ id: 'deepseek/deepseek-v3.2-speciale' }))).toBe(false)
   })
 
+  it('excludes deepseek-r1 reasoning models', () => {
+    expect(isFunctionCallingModel(createModel({ id: 'deepseek-r1:1.5b' }))).toBe(false)
+    expect(isFunctionCallingModel(createModel({ id: 'deepseek-r1:7b' }))).toBe(false)
+    expect(isFunctionCallingModel(createModel({ id: 'deepseek-r1:70b' }))).toBe(false)
+    expect(isFunctionCallingModel(createModel({ id: 'deepseek-r1' }))).toBe(false)
+    expect(isFunctionCallingModel(createModel({ id: 'deepseek-r1-16k' }))).toBe(false)
+    expect(isFunctionCallingModel(createModel({ id: 'ollama/deepseek-r1:1.5b' }))).toBe(false)
+  })
+
   it('returns true when identified as deepseek hybrid inference model', () => {
     deepSeekHybridMock.mockReturnValueOnce(true)
     expect(isFunctionCallingModel(createModel({ id: 'deepseek-v3-1', provider: 'custom' }))).toBe(true)

--- a/src/renderer/src/config/models/tooluse.ts
+++ b/src/renderer/src/config/models/tooluse.ts
@@ -56,7 +56,8 @@ const FUNCTION_CALLING_EXCLUDED_MODELS = [
   'gemini-2.5-flash-image(?:-[\\w-]+)?',
   'gemini-2.0-flash-preview-image-generation',
   'gemini-3(?:\\.\\d+)?-pro-image(?:-[\\w-]+)?',
-  'deepseek-v3.2-speciale'
+  'deepseek-v3.2-speciale',
+  'deepseek-r1(?:[-:][\\w.-]+)?'
 ]
 
 export const FUNCTION_CALLING_REGEX = new RegExp(


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR:
The `deepseek-r1` model series (e.g., `deepseek-r1:1.5b`, `deepseek-r1:7b`) incorrectly displayed the `function_calling` label in the model list. These are reasoning-only models that do not support tool calling. When users selected these models in Agent mode, they received runtime errors: `API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"registry.ollama.ai/library/deepseek-r1:1.5b does not support tools"}}`

After this PR:
All `deepseek-r1` variants are excluded from function calling capability detection. The model list will no longer show the `function_calling` label for these models, preventing the runtime error.

Fixes #15084

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Used a single regex pattern `deepseek-r1(?:[-:][\\w.-]+)?` to cover all deepseek-r1 variants (hyphen suffixes like `deepseek-r1-16k`, colon suffixes like `deepseek-r1:1.5b`, and the bare name `deepseek-r1`)
- The generic `deepseek` pattern in FUNCTION_CALLING_MODELS remains for models like `deepseek-chat` and `deepseek-coder` which do support function calling

The following alternatives were considered:
- Adding deepseek-r1 to the positive match list with explicit capabilities - rejected because Ollama's `/api/tags` endpoint doesn't return capability information
- Removing the generic `deepseek` pattern entirely - rejected because it would break function calling detection for `deepseek-chat`, `deepseek-coder`, etc.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/15084

### Breaking changes

No breaking changes. Users who manually overrode the function_calling capability for deepseek-r1 models will see no change (user overrides are respected).

### Special notes for your reviewer

The fix adds a single exclusion pattern to `FUNCTION_CALLING_EXCLUDED_MODELS` in `src/renderer/src/config/models/tooluse.ts`. Test coverage was added for 6 deepseek-r1 variants to prevent regression.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed deepseek-r1 models incorrectly showing function_calling label, which caused "does not support tools" errors in Agent mode.
```
