### PR TITLE
fix(mcp): invalidate network-backed MCP clients on proxy change (#14454)

### DIFF
--- a/src/main/services/MCPService.ts
+++ b/src/main/services/MCPService.ts
@@ -62,7 +62,14 @@ import DxtService from './DxtService'
 import { CallBackServer } from './mcp/oauth/callback'
 import { McpOAuthClientProvider } from './mcp/oauth/provider'
 import { ServerLogBuffer } from './mcp/ServerLogBuffer'
+import { proxyManager } from './ProxyManager'
 import { windowService } from './WindowService'
+
+// MCP transports whose connections are bound to the current proxy / session
+// config. When the user changes the proxy, cached clients of these types
+// must be closed so the next request rebuilds with the new dispatcher.
+// stdio / inmemory transports are local IPC and unaffected by HTTP proxy.
+const NETWORK_BACKED_MCP_TYPES = new Set(['sse', 'streamableHttp', 'http'])
 
 // Generic type for caching wrapped functions
 type CachedFunction<T extends unknown[], R> = (...args: T) => Promise<R>
@@ -150,6 +157,7 @@ function withCache<T extends unknown[], R>(
 
 class McpService {
   private clients: Map<string, Client> = new Map()
+  private clientServerTypes: Map<string, string> = new Map()
   private pendingClients: Map<string, Promise<Client>> = new Map()
   private dxtService = new DxtService()
   private activeToolCalls: Map<string, AbortController> = new Map()
@@ -172,6 +180,29 @@ class McpService {
     this.checkMcpConnectivity = this.checkMcpConnectivity.bind(this)
     this.getServerVersion = this.getServerVersion.bind(this)
     this.getServerLogs = this.getServerLogs.bind(this)
+    this.invalidateNetworkClients = this.invalidateNetworkClients.bind(this)
+
+    // When the user changes the global proxy, cached MCP clients of
+    // network-backed transports are still bound to the previous
+    // dispatcher / session config — close them so the next request
+    // rebuilds against the new proxy boundary (fixes #14454).
+    proxyManager.on('change', this.invalidateNetworkClients)
+  }
+
+  private async invalidateNetworkClients(): Promise<void> {
+    const targets: string[] = []
+    for (const [serverKey, serverType] of this.clientServerTypes) {
+      if (NETWORK_BACKED_MCP_TYPES.has(serverType)) {
+        targets.push(serverKey)
+      }
+    }
+    if (targets.length === 0) {
+      return
+    }
+    logger.info(`Proxy changed — closing ${targets.length} network-backed MCP client(s)`, {
+      serverKeys: targets
+    })
+    await Promise.allSettled(targets.map((serverKey) => this.closeClient(serverKey)))
   }
 
   /**
@@ -283,12 +314,14 @@ class McpService {
         // and create a new one
         if (!pingResult) {
           this.clients.delete(serverKey)
+          this.clientServerTypes.delete(serverKey)
         } else {
           return existingClient
         }
       } catch (error: any) {
         getServerLogger(server).error(`Error pinging server ${server.name}`, error as Error)
         this.clients.delete(serverKey)
+        this.clientServerTypes.delete(serverKey)
       }
     }
 
@@ -633,6 +666,7 @@ class McpService {
 
           // Store the new client in the cache
           this.clients.set(serverKey, client)
+          this.clientServerTypes.set(serverKey, server.type ?? '')
 
           // Set up notification handlers
           this.setupNotificationHandlers(client, server)
@@ -758,6 +792,7 @@ class McpService {
       await client.close()
       logger.debug(`Closed server`, { serverKey })
       this.clients.delete(serverKey)
+      this.clientServerTypes.delete(serverKey)
       // Clear all caches for this server
       this.clearServerCache(serverKey)
       this.serverLogs.remove(serverKey)

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -1,13 +1,14 @@
 import { loggerService } from '@logger'
 import type { ProxyConfig } from 'electron'
 import { app, session } from 'electron'
+import { EventEmitter } from 'events'
 import { getSystemProxy } from 'os-proxy-config'
 
 import { NodeProxyController } from './proxy/nodeProxy'
 
 const logger = loggerService.withContext('ProxyManager')
 
-export class ProxyManager {
+export class ProxyManager extends EventEmitter {
   private config: ProxyConfig = { mode: 'direct' }
   private systemProxyInterval: NodeJS.Timeout | null = null
   private isSettingProxy = false
@@ -65,6 +66,10 @@ export class ProxyManager {
 
       this.setGlobalProxy(config)
       this.config = config
+      // Notify long-lived consumers (MCP clients, etc.) that the proxy
+      // boundary has changed so they can drop cached connections that
+      // were bound to the previous dispatcher / session config.
+      this.emit('change', this.config)
     } catch (error) {
       logger.error('Failed to config proxy:', error as Error)
       throw error

--- a/src/main/services/__tests__/MCPService.test.ts
+++ b/src/main/services/__tests__/MCPService.test.ts
@@ -1,4 +1,5 @@
 import type { MCPServer, MCPTool } from '@types'
+import { EventEmitter } from 'events'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@main/apiServer/utils/mcp', () => ({
@@ -11,8 +12,14 @@ vi.mock('@main/services/WindowService', () => ({
   }
 }))
 
+vi.mock('@main/services/ProxyManager', () => {
+  const emitter = new EventEmitter()
+  return { proxyManager: emitter }
+})
+
 import { getMCPServersFromRedux } from '@main/apiServer/utils/mcp'
 import mcpService from '@main/services/MCPService'
+import { proxyManager } from '@main/services/ProxyManager'
 
 const baseInputSchema: { type: 'object'; properties: Record<string, unknown>; required: string[] } = {
   type: 'object',
@@ -71,5 +78,64 @@ describe('MCPService.listAllActiveServerTools', () => {
 
     expect(listToolsSpy).toHaveBeenCalledTimes(2)
     expect(tools.map((tool) => tool.name)).toEqual(['enabled_tool', 'beta_tool'])
+  })
+})
+
+describe('MCPService proxy invalidation (regression for #14454)', () => {
+  beforeEach(() => {
+    ;(mcpService as any).clients.clear()
+    ;(mcpService as any).clientServerTypes.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const seedClient = (key: string, type: string) => {
+    const close = vi.fn().mockResolvedValue(undefined)
+    ;(mcpService as any).clients.set(key, { close })
+    ;(mcpService as any).clientServerTypes.set(key, type)
+    return close
+  }
+
+  it('closes only network-backed clients on proxy change', async () => {
+    const closeStreamable = seedClient('http-1', 'streamableHttp')
+    const closeSse = seedClient('http-2', 'sse')
+    const closeHttp = seedClient('http-3', 'http')
+    const closeStdio = seedClient('stdio-1', 'stdio')
+    const closeInMemory = seedClient('inmem-1', 'inmemory')
+
+    await (mcpService as any).invalidateNetworkClients()
+
+    expect(closeStreamable).toHaveBeenCalledOnce()
+    expect(closeSse).toHaveBeenCalledOnce()
+    expect(closeHttp).toHaveBeenCalledOnce()
+    expect(closeStdio).not.toHaveBeenCalled()
+    expect(closeInMemory).not.toHaveBeenCalled()
+
+    // closeClient() removes entries from both maps; verify cleanup.
+    expect((mcpService as any).clients.has('http-1')).toBe(false)
+    expect((mcpService as any).clients.has('http-2')).toBe(false)
+    expect((mcpService as any).clients.has('http-3')).toBe(false)
+    expect((mcpService as any).clients.has('stdio-1')).toBe(true)
+    expect((mcpService as any).clients.has('inmem-1')).toBe(true)
+    expect((mcpService as any).clientServerTypes.has('http-1')).toBe(false)
+    expect((mcpService as any).clientServerTypes.has('stdio-1')).toBe(true)
+  })
+
+  it('reacts to a proxyManager change event', async () => {
+    const closeStreamable = seedClient('streamable-evt', 'streamableHttp')
+    const closeStdio = seedClient('stdio-evt', 'stdio')
+
+    ;(proxyManager as unknown as EventEmitter).emit('change', { mode: 'direct' })
+    // The handler is async; flush the microtask queue.
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(closeStreamable).toHaveBeenCalledOnce()
+    expect(closeStdio).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op when there are no clients to invalidate', async () => {
+    await expect((mcpService as any).invalidateNetworkClients()).resolves.toBeUndefined()
   })
 })


### PR DESCRIPTION
Closes #14454.

## Bug

`MCPService` caches `Client` instances in `this.clients` for the lifetime of the app. SSE / streamable-HTTP / HTTP transports use `net.fetch`, so their open connections are bound to the Electron session and Node dispatcher that were configured **at construction time**. When the user adds or removes a custom proxy in settings, `ProxyManager.configureProxy` updates the session + global agent, but the cached clients keep talking through the previous configuration — MCP traffic keeps going through the old proxy until the app restarts, even after the proxy is deleted.

Reporter's repro matches exactly:

> Delete custom proxy → use mcp  (MCP still goes through the deleted proxy)
> Add custom proxy → use mcp     (MCP doesn't pick up the new proxy until the next chat)

## Fix

- `ProxyManager` now extends `EventEmitter` and emits `'change'` after a new proxy is in effect.
- `MCPService` subscribes at construction time. On `'change'`, it closes every cached client whose server `type` is `sse` / `streamableHttp` / `http` so the next request rebuilds the transport against the new proxy boundary.
- `stdio` and `inmemory` clients are left alone — they don't go through the network proxy and re-spawning them would be wasted churn (and would re-shell every stdio MCP just because the user toggled an HTTP proxy).
- A parallel `clientServerTypes` map tracks the transport type per `serverKey` so the invalidation handler doesn't need an out-of-band lookup. The map is kept in lockstep with `this.clients` at every set/delete site (ping-failure paths and `closeClient` included).

OAuth tokens persisted by the work in #14083 survive client re-creation, so authenticated MCP servers stay logged in across the invalidation.

## Test plan

```
$ pnpm test:main src/main/services/__tests__/MCPService.test.ts
✓ 4/4 pass
   - closes only network-backed clients on proxy change
   - reacts to a proxyManager change event
   - is a no-op when there are no clients to invalidate
   - filters disabled tools per server (existing test still passes)

$ pnpm test:main src/main/services/__tests__/ProxyManager.test.ts
✓ 14/14 pass (no regression in bypass-rule matcher)
```

Manual repro from the issue body should now do the right thing: deleting the proxy causes the active MCP servers to drop their cached HTTP clients within the next event-loop tick, and the next tool call rebuilds against direct routing. Same the other way for adding a proxy.

cc @kangfenmao for the MCP / proxy lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)