### PR TITLE
feat(chat-page): reveal history selections and reorder assistant groups

### DIFF
--- a/src/renderer/src/assets/styles/animation.css
+++ b/src/renderer/src/assets/styles/animation.css
@@ -89,6 +89,38 @@
   animation: animation-locate-highlight 2.5s ease-in-out;
 }
 
+@keyframes animation-resource-list-reveal-focus {
+  0%,
+  70% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.animation-resource-list-reveal-focus {
+  position: relative;
+  overflow: hidden;
+}
+
+.animation-resource-list-reveal-focus::after {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-primary) 62%, transparent);
+  content: '';
+  pointer-events: none;
+  animation: animation-resource-list-reveal-focus 1s ease-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animation-resource-list-reveal-focus::after {
+    opacity: 1;
+    animation: none;
+  }
+}
+
 /* 流光动画 */
 @keyframes animation-shimmer {
   0% {

--- a/src/renderer/src/components/VirtualList/__tests__/GroupedSortableVirtualList.test.tsx
+++ b/src/renderer/src/components/VirtualList/__tests__/GroupedSortableVirtualList.test.tsx
@@ -516,6 +516,9 @@ describe('GroupedSortableVirtualList', () => {
     const indicator = targetRow?.querySelector('[data-drop-indicator="after"]')
     expect(indicator).toBeInTheDocument()
     expect(indicator).toHaveClass('right-2', 'left-2', 'h-0.5', 'bg-sidebar-ring')
+    expect(screen.getAllByText('Header First')[0].parentElement).toHaveStyle({ opacity: '0.5' })
+    expect(screen.getByText('Item Alpha').parentElement).toHaveStyle({ opacity: '0.5' })
+    expect(screen.getByText('Item Beta').parentElement).toHaveStyle({ opacity: '0.5' })
   })
 
   it('shows the group insertion line before the target group when moving upward', () => {

--- a/src/renderer/src/components/VirtualList/__tests__/GroupedSortableVirtualList.test.tsx
+++ b/src/renderer/src/components/VirtualList/__tests__/GroupedSortableVirtualList.test.tsx
@@ -460,7 +460,7 @@ describe('GroupedSortableVirtualList', () => {
     expect(indicator).not.toHaveClass('bg-sidebar-primary', 'bg-sidebar-border')
   })
 
-  it('disables sortable projection for item drags while preserving group sorting', () => {
+  it('disables sortable projection and shows insertion lines for item and group drags', () => {
     renderList(vi.fn(), { dragCapabilities: { groups: true }, canDragGroup: () => true })
 
     startDragging('item:a')
@@ -509,8 +509,28 @@ describe('GroupedSortableVirtualList', () => {
         overIndex: 3,
         rects: []
       })
-    ).toEqual({ scaleX: 1, scaleY: 1, x: 0, y: 12 })
-    expect(dndMocks.verticalListSortingStrategy).toHaveBeenCalledTimes(1)
+    ).toBeNull()
+    expect(dndMocks.verticalListSortingStrategy).not.toHaveBeenCalled()
+
+    const targetRow = screen.getByText('Item Gamma').parentElement
+    const indicator = targetRow?.querySelector('[data-drop-indicator="after"]')
+    expect(indicator).toBeInTheDocument()
+    expect(indicator).toHaveClass('right-2', 'left-2', 'h-0.5', 'bg-sidebar-ring')
+  })
+
+  it('shows the group insertion line before the target group when moving upward', () => {
+    renderList(vi.fn(), { dragCapabilities: { groups: true }, canDragGroup: () => true })
+
+    startDragging('group:second')
+
+    act(() => {
+      dndMocks.onDragOver?.(dragEvent('group:second', 'group:first'))
+    })
+
+    const targetHeader = screen.getByText('Header First').parentElement
+    const indicator = targetHeader?.querySelector('[data-drop-indicator="before"]')
+    expect(indicator).toBeInTheDocument()
+    expect(indicator).toHaveClass('right-2', 'left-2', 'h-0.5', 'bg-sidebar-ring')
   })
 
   it('keeps same-group item drops enabled independently from cross-group drops', () => {

--- a/src/renderer/src/components/VirtualList/grouped-sortable.tsx
+++ b/src/renderer/src/components/VirtualList/grouped-sortable.tsx
@@ -73,6 +73,11 @@ type GroupAppendIndicatorTarget = {
   rowType: 'group-footer' | 'group-header' | 'item'
 }
 
+type GroupBoundaryIndicatorTargets = {
+  after: GroupAppendIndicatorTarget
+  before: GroupAppendIndicatorTarget
+}
+
 export type GroupedSortableVirtualListItemDragPayload<TGroup, TItem> = {
   type: 'item'
   activeId: UniqueIdentifier
@@ -371,15 +376,28 @@ function getItemDropPosition<TGroup, TItem>(
   return 'after'
 }
 
+function getDropPosition<TGroup, TItem>(
+  event: Pick<DragEndEvent, 'active' | 'over'>,
+  active: RowDragData<TGroup, TItem>,
+  over: RowDragData<TGroup, TItem>
+): 'before' | 'after' {
+  if (!isItemDragData(active)) {
+    return active.groupIndex < over.groupIndex ? 'after' : 'before'
+  }
+
+  return getItemDropPosition(event, active, over)
+}
+
 function buildDropPayloadFromEvent<TGroup, TItem>(event: Pick<DragEndEvent, 'active' | 'over'>) {
   const active = getEventData<TGroup, TItem>(event.active.data.current)
   const over = getEventData<TGroup, TItem>(event.over?.data.current)
   if (!active || !over) return null
 
-  const payload = buildDragEndPayload(active, over, getItemDropPosition(event, active, over))
+  const position = getDropPosition(event, active, over)
+  const payload = buildDragEndPayload(active, over, position)
   if (!payload) return null
 
-  return { active, over, payload }
+  return { active, over, payload, position }
 }
 
 function getDropPositionFromState<TGroup, TItem>(over: RowDragData<TGroup, TItem>, dropState: OverDropState | null) {
@@ -408,11 +426,11 @@ function buildDropPayloadFromStateOrEvent<TGroup, TItem>(
       ? groupAppendDropTargets?.get(over.groupId)
       : undefined
   const payloadOver = appendDropTarget ?? over
-  const position = appendDropTarget ? 'after' : (statePosition ?? getItemDropPosition(event, active, over))
+  const position = appendDropTarget ? 'after' : (statePosition ?? getDropPosition(event, active, over))
   const payload = buildDragEndPayload(active, payloadOver, position)
   if (!payload) return null
 
-  return { active, over: payloadOver, payload }
+  return { active, over: payloadOver, payload, position }
 }
 
 function getOverDropState<TGroup, TItem>(
@@ -554,7 +572,7 @@ function SortableItemRow<TGroup, TItem>({
       ref={setNodeRef}
       data-dragging={isDragging || undefined}
       {...dropTargetRowState.props}
-      className={joinClassNames(dropTargetRowState.props.className, dropIndicatorPosition && 'relative')}
+      className={joinClassNames(dropTargetRowState.props.className, dropIndicatorPosition ? 'relative' : undefined)}
       style={{
         opacity: isDragging ? 0.5 : undefined,
         transform: dropTargetRowState.isBlocked || freezeTransform ? undefined : CSS.Transform.toString(transform),
@@ -642,7 +660,7 @@ function SortableGroupHeaderRow<TGroup, TItem>({
       ref={setNodeRef}
       data-dragging={isDragging || undefined}
       {...dropTargetRowState.props}
-      className={joinClassNames(dropTargetRowState.props.className, dropIndicatorPosition && 'relative')}
+      className={joinClassNames(dropTargetRowState.props.className, dropIndicatorPosition ? 'relative' : undefined)}
       style={{
         opacity: isDragging ? 0 : undefined,
         transform: dropTargetRowState.isBlocked || freezeTransform ? undefined : CSS.Transform.toString(transform),
@@ -682,7 +700,7 @@ function DroppableGroupHeaderRow<TGroup, TItem>({
       ref={setNodeRef}
       data-over={isOver || undefined}
       {...dropTargetRowState.props}
-      className={joinClassNames(dropTargetRowState.props.className, dropIndicatorPosition && 'relative')}>
+      className={joinClassNames(dropTargetRowState.props.className, dropIndicatorPosition ? 'relative' : undefined)}>
       {dropIndicatorPosition ? <DropIndicator position={dropIndicatorPosition} /> : null}
       {children}
     </div>
@@ -719,7 +737,7 @@ function GroupFooterRow<TGroup, TItem>({
     <div
       ref={setNodeRef}
       {...dropTargetRowState.props}
-      className={joinClassNames(dropTargetRowState.props.className, dropIndicatorPosition && 'relative')}>
+      className={joinClassNames(dropTargetRowState.props.className, dropIndicatorPosition ? 'relative' : undefined)}>
       {dropIndicatorPosition ? <DropIndicator position={dropIndicatorPosition} /> : null}
       {children}
     </div>
@@ -835,6 +853,38 @@ function GroupedSortableVirtualList<TGroup, TItem, THeader = TGroup, TFooter = u
           itemIndexInGroup: row.itemIndexInGroup
         })
       )
+    }
+
+    return targets
+  }, [getGroupId, getItemId, rows])
+
+  const groupBoundaryIndicatorTargets = useMemo(() => {
+    const targets = new Map<UniqueIdentifier, GroupBoundaryIndicatorTargets>()
+
+    for (const row of rows) {
+      const groupId = getGroupId(row.group, row.groupIndex)
+
+      if (row.type === 'group-header') {
+        targets.set(groupId, {
+          before: { position: 'before', rowType: 'group-header' },
+          after: { position: 'after', rowType: 'group-header' }
+        })
+        continue
+      }
+
+      const groupTargets = targets.get(groupId)
+      if (!groupTargets) continue
+
+      if (row.type === 'item') {
+        groupTargets.after = {
+          itemId: getItemId(row.item, row.itemIndex, row.group, row.groupIndex, row.itemIndexInGroup),
+          position: 'after',
+          rowType: 'item'
+        }
+        continue
+      }
+
+      groupTargets.after = { position: 'after', rowType: 'group-footer' }
     }
 
     return targets
@@ -957,8 +1007,7 @@ function GroupedSortableVirtualList<TGroup, TItem, THeader = TGroup, TFooter = u
 
   const sortingStrategy = useCallback<SortingStrategy>(
     (args) => {
-      const active = activeDragState?.active
-      if (active && isItemDragData(active)) {
+      if (activeDragState?.active) {
         return null
       }
 
@@ -1006,18 +1055,34 @@ function GroupedSortableVirtualList<TGroup, TItem, THeader = TGroup, TFooter = u
         return
       }
 
-      updateOverDropState(getOverDropState(result.over, result.payload.position))
+      updateOverDropState(getOverDropState(result.over, result.position))
     },
     [canDragActive, canDropGroup, canDropItem, clearOverDropState, effectiveDragCapabilities, updateOverDropState]
   )
 
-  const isItemDragProjection = activeDragState?.active !== undefined && isItemDragData(activeDragState.active)
+  const isDragProjectionFrozen = activeDragState?.active !== undefined
 
   const getDropIndicatorPosition = useCallback(
     (row: GroupedSortableVirtualListRow<TGroup, TItem, THeader, TFooter>): DropIndicatorPosition | null => {
       if (!overDropState) return null
 
       const groupId = getGroupId(row.group, row.groupIndex)
+      const isGroupDrag = activeDragState?.active !== undefined && !isItemDragData(activeDragState.active)
+
+      if (isGroupDrag) {
+        if (overDropState.targetGroupId !== groupId) return null
+
+        const target = groupBoundaryIndicatorTargets.get(groupId)?.[overDropState.position]
+        if (!target || target.rowType !== row.type) return null
+
+        if (row.type === 'item') {
+          const itemId = getItemId(row.item, row.itemIndex, row.group, row.groupIndex, row.itemIndexInGroup)
+          if (target.itemId !== itemId) return null
+        }
+
+        return target.position
+      }
+
       if (overDropState.rowType === 'item') {
         if (row.type !== 'item') return null
 
@@ -1037,7 +1102,7 @@ function GroupedSortableVirtualList<TGroup, TItem, THeader = TGroup, TFooter = u
 
       return target.position
     },
-    [getGroupId, getItemId, groupAppendIndicatorTargets, overDropState]
+    [activeDragState, getGroupId, getItemId, groupAppendIndicatorTargets, groupBoundaryIndicatorTargets, overDropState]
   )
 
   const handleDragEnd = useCallback(
@@ -1079,7 +1144,7 @@ function GroupedSortableVirtualList<TGroup, TItem, THeader = TGroup, TFooter = u
             data={data}
             disabled={disabled}
             dropIndicatorPosition={getDropIndicatorPosition(row)}
-            freezeTransform={isItemDragProjection}
+            freezeTransform={isDragProjectionFrozen}
             overDropState={overDropState}
             draggable={
               !disabled && effectiveDragCapabilities.groups && (canDragGroup?.(row.group, row.groupIndex) ?? true)
@@ -1125,7 +1190,7 @@ function GroupedSortableVirtualList<TGroup, TItem, THeader = TGroup, TFooter = u
           data={data}
           disabled={itemDisabled}
           dropIndicatorPosition={getDropIndicatorPosition(row)}
-          freezeTransform={isItemDragProjection}
+          freezeTransform={isDragProjectionFrozen}
           overDropState={overDropState}>
           {renderItem(row.item, row.itemIndex, row.group, row.groupIndex, row.itemIndexInGroup)}
         </SortableItemRow>
@@ -1141,7 +1206,7 @@ function GroupedSortableVirtualList<TGroup, TItem, THeader = TGroup, TFooter = u
       getDropIndicatorPosition,
       getGroupId,
       getItemId,
-      isItemDragProjection,
+      isDragProjectionFrozen,
       overDropState,
       renderGroupFooter,
       renderGroupHeader,

--- a/src/renderer/src/components/VirtualList/grouped-sortable.tsx
+++ b/src/renderer/src/components/VirtualList/grouped-sortable.tsx
@@ -539,6 +539,7 @@ type SortableItemRowProps<TGroup, TItem> = {
   dropIndicatorPosition?: DropIndicatorPosition | null
   freezeTransform?: boolean
   overDropState: OverDropState | null
+  sourcePlaceholder?: boolean
 }
 
 function SortableItemRow<TGroup, TItem>({
@@ -548,7 +549,8 @@ function SortableItemRow<TGroup, TItem>({
   disabled,
   dropIndicatorPosition,
   freezeTransform = false,
-  overDropState
+  overDropState,
+  sourcePlaceholder = false
 }: SortableItemRowProps<TGroup, TItem>) {
   const dropTargetRowState = getDropTargetRowState({
     activeDragState,
@@ -574,7 +576,7 @@ function SortableItemRow<TGroup, TItem>({
       {...dropTargetRowState.props}
       className={joinClassNames(dropTargetRowState.props.className, dropIndicatorPosition ? 'relative' : undefined)}
       style={{
-        opacity: isDragging ? 0.5 : undefined,
+        opacity: isDragging || sourcePlaceholder ? 0.5 : undefined,
         transform: dropTargetRowState.isBlocked || freezeTransform ? undefined : CSS.Transform.toString(transform),
         transition: dropTargetRowState.isBlocked || freezeTransform ? undefined : transition
       }}
@@ -595,6 +597,7 @@ type GroupHeaderRowProps<TGroup, TItem> = {
   dropIndicatorPosition?: DropIndicatorPosition | null
   freezeTransform?: boolean
   overDropState: OverDropState | null
+  sourcePlaceholder?: boolean
 }
 
 function GroupHeaderRow<TGroup, TItem>({
@@ -605,7 +608,8 @@ function GroupHeaderRow<TGroup, TItem>({
   disabled,
   dropIndicatorPosition,
   freezeTransform,
-  overDropState
+  overDropState,
+  sourcePlaceholder
 }: GroupHeaderRowProps<TGroup, TItem>) {
   if (draggable) {
     return (
@@ -615,7 +619,8 @@ function GroupHeaderRow<TGroup, TItem>({
         disabled={disabled}
         dropIndicatorPosition={dropIndicatorPosition}
         freezeTransform={freezeTransform}
-        overDropState={overDropState}>
+        overDropState={overDropState}
+        sourcePlaceholder={sourcePlaceholder}>
         {children}
       </SortableGroupHeaderRow>
     )
@@ -627,7 +632,8 @@ function GroupHeaderRow<TGroup, TItem>({
       data={data}
       disabled={disabled}
       dropIndicatorPosition={dropIndicatorPosition}
-      overDropState={overDropState}>
+      overDropState={overDropState}
+      sourcePlaceholder={sourcePlaceholder}>
       {children}
     </DroppableGroupHeaderRow>
   )
@@ -640,7 +646,8 @@ function SortableGroupHeaderRow<TGroup, TItem>({
   disabled,
   dropIndicatorPosition,
   freezeTransform = false,
-  overDropState
+  overDropState,
+  sourcePlaceholder = false
 }: Omit<GroupHeaderRowProps<TGroup, TItem>, 'draggable'>) {
   const dropTargetRowState = getDropTargetRowState({
     activeDragState,
@@ -662,7 +669,7 @@ function SortableGroupHeaderRow<TGroup, TItem>({
       {...dropTargetRowState.props}
       className={joinClassNames(dropTargetRowState.props.className, dropIndicatorPosition ? 'relative' : undefined)}
       style={{
-        opacity: isDragging ? 0 : undefined,
+        opacity: isDragging || sourcePlaceholder ? 0.5 : undefined,
         transform: dropTargetRowState.isBlocked || freezeTransform ? undefined : CSS.Transform.toString(transform),
         transition: dropTargetRowState.isBlocked || freezeTransform ? undefined : transition
       }}
@@ -680,7 +687,8 @@ function DroppableGroupHeaderRow<TGroup, TItem>({
   data,
   disabled,
   dropIndicatorPosition,
-  overDropState
+  overDropState,
+  sourcePlaceholder = false
 }: Omit<GroupHeaderRowProps<TGroup, TItem>, 'draggable'>) {
   const dropTargetRowState = getDropTargetRowState({
     activeDragState,
@@ -700,7 +708,8 @@ function DroppableGroupHeaderRow<TGroup, TItem>({
       ref={setNodeRef}
       data-over={isOver || undefined}
       {...dropTargetRowState.props}
-      className={joinClassNames(dropTargetRowState.props.className, dropIndicatorPosition ? 'relative' : undefined)}>
+      className={joinClassNames(dropTargetRowState.props.className, dropIndicatorPosition ? 'relative' : undefined)}
+      style={{ opacity: sourcePlaceholder ? 0.5 : undefined }}>
       {dropIndicatorPosition ? <DropIndicator position={dropIndicatorPosition} /> : null}
       {children}
     </div>
@@ -713,6 +722,7 @@ type GroupFooterRowProps<TGroup, TItem> = {
   data: GroupDragData<TGroup>
   disabled: boolean
   dropIndicatorPosition?: DropIndicatorPosition | null
+  sourcePlaceholder?: boolean
 }
 
 function GroupFooterRow<TGroup, TItem>({
@@ -720,7 +730,8 @@ function GroupFooterRow<TGroup, TItem>({
   children,
   data,
   disabled,
-  dropIndicatorPosition
+  dropIndicatorPosition,
+  sourcePlaceholder = false
 }: GroupFooterRowProps<TGroup, TItem>) {
   const dropTargetRowState = getDropTargetRowState({
     activeDragState,
@@ -737,7 +748,8 @@ function GroupFooterRow<TGroup, TItem>({
     <div
       ref={setNodeRef}
       {...dropTargetRowState.props}
-      className={joinClassNames(dropTargetRowState.props.className, dropIndicatorPosition ? 'relative' : undefined)}>
+      className={joinClassNames(dropTargetRowState.props.className, dropIndicatorPosition ? 'relative' : undefined)}
+      style={{ opacity: sourcePlaceholder ? 0.5 : undefined }}>
       {dropIndicatorPosition ? <DropIndicator position={dropIndicatorPosition} /> : null}
       {children}
     </div>
@@ -1061,6 +1073,10 @@ function GroupedSortableVirtualList<TGroup, TItem, THeader = TGroup, TFooter = u
   )
 
   const isDragProjectionFrozen = activeDragState?.active !== undefined
+  const activeGroupPlaceholderId =
+    activeDragState?.active !== undefined && !isItemDragData(activeDragState.active)
+      ? activeDragState.active.groupId
+      : null
 
   const getDropIndicatorPosition = useCallback(
     (row: GroupedSortableVirtualListRow<TGroup, TItem, THeader, TFooter>): DropIndicatorPosition | null => {
@@ -1134,8 +1150,10 @@ function GroupedSortableVirtualList<TGroup, TItem, THeader = TGroup, TFooter = u
 
   const renderRow = useCallback(
     (row: GroupedSortableVirtualListRow<TGroup, TItem, THeader, TFooter>) => {
+      const groupId = getGroupId(row.group, row.groupIndex)
+      const sourcePlaceholder = activeGroupPlaceholderId === groupId
+
       if (row.type === 'group-header') {
-        const groupId = getGroupId(row.group, row.groupIndex)
         const data = buildGroupDragData(row.group, groupId, row.groupIndex)
 
         return (
@@ -1146,6 +1164,7 @@ function GroupedSortableVirtualList<TGroup, TItem, THeader = TGroup, TFooter = u
             dropIndicatorPosition={getDropIndicatorPosition(row)}
             freezeTransform={isDragProjectionFrozen}
             overDropState={overDropState}
+            sourcePlaceholder={sourcePlaceholder}
             draggable={
               !disabled && effectiveDragCapabilities.groups && (canDragGroup?.(row.group, row.groupIndex) ?? true)
             }>
@@ -1155,7 +1174,6 @@ function GroupedSortableVirtualList<TGroup, TItem, THeader = TGroup, TFooter = u
       }
 
       if (row.type === 'group-footer') {
-        const groupId = getGroupId(row.group, row.groupIndex)
         const data = buildGroupDragData(row.group, groupId, row.groupIndex)
 
         return (
@@ -1163,7 +1181,8 @@ function GroupedSortableVirtualList<TGroup, TItem, THeader = TGroup, TFooter = u
             activeDragState={activeDragState}
             data={data}
             disabled={disabled}
-            dropIndicatorPosition={getDropIndicatorPosition(row)}>
+            dropIndicatorPosition={getDropIndicatorPosition(row)}
+            sourcePlaceholder={sourcePlaceholder}>
             {renderGroupFooter?.(row.footer, row.group, row.groupIndex) ?? null}
           </GroupFooterRow>
         )
@@ -1176,7 +1195,7 @@ function GroupedSortableVirtualList<TGroup, TItem, THeader = TGroup, TFooter = u
         !(canDragItem?.(row.item, row.itemIndex, row.group, row.groupIndex, row.itemIndexInGroup) ?? true)
       const data = buildItemDragData({
         group: row.group,
-        groupId: getGroupId(row.group, row.groupIndex),
+        groupId,
         groupIndex: row.groupIndex,
         item: row.item,
         itemId,
@@ -1191,13 +1210,15 @@ function GroupedSortableVirtualList<TGroup, TItem, THeader = TGroup, TFooter = u
           disabled={itemDisabled}
           dropIndicatorPosition={getDropIndicatorPosition(row)}
           freezeTransform={isDragProjectionFrozen}
-          overDropState={overDropState}>
+          overDropState={overDropState}
+          sourcePlaceholder={sourcePlaceholder}>
           {renderItem(row.item, row.itemIndex, row.group, row.groupIndex, row.itemIndexInGroup)}
         </SortableItemRow>
       )
     },
     [
       activeDragState,
+      activeGroupPlaceholderId,
       canDragGroup,
       canDragItem,
       disabled,

--- a/src/renderer/src/components/chat/resources/ResourceList.tsx
+++ b/src/renderer/src/components/chat/resources/ResourceList.tsx
@@ -12,6 +12,8 @@ import {
   Skeleton
 } from '@cherrystudio/ui'
 import {
+  buildGroupedVirtualRows,
+  type DynamicVirtualListRef,
   GroupedSortableVirtualList,
   type GroupedSortableVirtualListDragPayload,
   GroupedVirtualList,
@@ -19,7 +21,7 @@ import {
 } from '@renderer/components/VirtualList'
 import { cn } from '@renderer/utils/style'
 import { CalendarDays, ChevronsDown, ChevronsUp, SearchIcon } from 'lucide-react'
-import type { ComponentProps, ReactNode, Ref } from 'react'
+import type { ComponentProps, ReactNode, Ref, RefObject } from 'react'
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 
 import { ActionMenu } from '../actions/ActionMenu'
@@ -33,6 +35,7 @@ import {
   type ResourceListItemBase,
   type ResourceListMeta,
   type ResourceListReorderPayload,
+  type ResourceListRevealRequest,
   type ResourceListSortOption,
   type ResourceListState,
   type ResourceListStatus,
@@ -86,6 +89,7 @@ export type {
   ResourceListItemBase,
   ResourceListMeta,
   ResourceListReorderPayload,
+  ResourceListRevealRequest,
   ResourceListSortOption,
   ResourceListState,
   ResourceListStatus,
@@ -110,6 +114,7 @@ type ResourceListProviderProps<T extends ResourceListItemBase> = {
   getGroupHeaderAction?: (group: ResourceListGroup) => ReactNode
   getGroupHeaderIcon?: ResourceListMeta<T>['getGroupHeaderIcon']
   collapsedGroupIds?: readonly string[]
+  revealRequest?: ResourceListRevealRequest
   dragCapabilities?: ResourceListDragCapabilities
   canDragGroup?: (group: ResourceListGroup, groupIndex: number) => boolean
   canDragItem?: (args: {
@@ -162,6 +167,16 @@ type ProviderAction =
   | { type: 'showMoreInGroup'; groupId: string; defaultCount: number; step: number }
   | { type: 'collapseGroupItems'; groupId: string; defaultCount: number }
   | { type: 'toggleGroup'; groupId: string }
+  | {
+      type: 'revealItem'
+      clearFilters?: boolean
+      clearQuery?: boolean
+      groupId: string | null
+      itemId: string
+      requestId: number
+      visibleCount?: number
+    }
+  | { type: 'clearRevealFocus'; itemId: string; requestId: number }
   | { type: 'startDrag'; id: string }
   | { type: 'endDrag' }
   | { type: 'setStatus'; status: ResourceListStatus }
@@ -206,6 +221,34 @@ function reducer(state: ResourceListState, action: ProviderAction): ResourceList
         : [...state.collapsedGroups, action.groupId]
       return { ...state, collapsedGroups }
     }
+    case 'revealItem': {
+      const nextGroupVisibleCounts = { ...state.groupVisibleCounts }
+
+      if (action.groupId && action.visibleCount !== undefined) {
+        nextGroupVisibleCounts[action.groupId] = Math.max(
+          nextGroupVisibleCounts[action.groupId] ?? 0,
+          action.visibleCount
+        )
+      }
+
+      return {
+        ...state,
+        query: action.clearQuery ? '' : state.query,
+        filters: action.clearFilters ? [] : state.filters,
+        collapsedGroups: action.groupId
+          ? state.collapsedGroups.filter((groupId) => groupId !== action.groupId)
+          : state.collapsedGroups,
+        groupVisibleCounts: nextGroupVisibleCounts,
+        revealFocus: { itemId: action.itemId, requestId: action.requestId }
+      }
+    }
+    case 'clearRevealFocus': {
+      if (state.revealFocus?.itemId !== action.itemId || state.revealFocus.requestId !== action.requestId) {
+        return state
+      }
+
+      return { ...state, revealFocus: null }
+    }
     case 'startDrag':
       return { ...state, draggingId: action.id }
     case 'endDrag':
@@ -230,6 +273,7 @@ function ResourceListProvider<T extends ResourceListItemBase>({
   getGroupHeaderAction,
   getGroupHeaderIcon,
   collapsedGroupIds,
+  revealRequest,
   dragCapabilities,
   canDragGroup,
   canDragItem,
@@ -252,6 +296,7 @@ function ResourceListProvider<T extends ResourceListItemBase>({
     sort: defaultSortId ?? null,
     selectedId: selectedIdProp ?? null,
     hoveredId: null,
+    revealFocus: null,
     renamingId: null,
     collapsedGroups: [],
     groupVisibleCounts: {},
@@ -263,6 +308,96 @@ function ResourceListProvider<T extends ResourceListItemBase>({
   const filterById = useMemo(() => new Map(filterOptions.map((option) => [option.id, option])), [filterOptions])
   const sortById = useMemo(() => new Map(sortOptions.map((option) => [option.id, option])), [sortOptions])
   const effectiveCollapsedGroupIds = collapsedGroupIds ?? state.collapsedGroups
+  const handledRevealRequestRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!revealRequest) return
+
+    const requestKey = `${revealRequest.requestId}:${revealRequest.itemId}`
+    if (handledRevealRequestRef.current === requestKey) return
+
+    const query = revealRequest.clearQuery ? '' : state.query.trim().toLowerCase()
+    const filters = revealRequest.clearFilters ? [] : state.filters
+    let revealItems = [...items]
+
+    if (query) {
+      revealItems = revealItems.filter((item) => getItemLabel(item).toLowerCase().includes(query))
+    }
+
+    if (filters.length > 0) {
+      revealItems = revealItems.filter((item) =>
+        filters.every((filterId) => filterById.get(filterId)?.predicate(item) ?? true)
+      )
+    }
+
+    const sort = state.sort ? sortById.get(state.sort) : null
+    if (sort) {
+      revealItems.sort(sort.comparator)
+    }
+
+    const targetItem = revealItems.find((item) => getItemId(item) === revealRequest.itemId)
+    if (!targetItem) return
+
+    const targetGroup = groupBy ? (groupBy(targetItem) ?? { id: 'ungrouped', label: '' }) : null
+    const targetGroupId = targetGroup?.id ?? null
+    let visibleCount: number | undefined
+
+    if (targetGroupId && groupBy) {
+      const groupItems = revealItems.filter(
+        (item) => (groupBy(item) ?? { id: 'ungrouped', label: '' }).id === targetGroupId
+      )
+      const targetIndexInGroup = groupItems.findIndex((item) => getItemId(item) === revealRequest.itemId)
+      if (targetIndexInGroup >= 0) {
+        const currentVisibleCount = state.groupVisibleCounts[targetGroupId] ?? defaultGroupVisibleCount
+        const targetVisibleCount = targetIndexInGroup + 1
+        visibleCount = targetVisibleCount > currentVisibleCount ? targetVisibleCount : undefined
+      }
+
+      if (collapsedGroupIds && effectiveCollapsedGroupIds.includes(targetGroupId)) {
+        onCollapsedGroupIdsChange?.(effectiveCollapsedGroupIds.filter((groupId) => groupId !== targetGroupId))
+      }
+    }
+
+    handledRevealRequestRef.current = requestKey
+    dispatch({
+      type: 'revealItem',
+      clearFilters: revealRequest.clearFilters,
+      clearQuery: revealRequest.clearQuery,
+      groupId: targetGroupId,
+      itemId: revealRequest.itemId,
+      requestId: revealRequest.requestId,
+      visibleCount
+    })
+  }, [
+    collapsedGroupIds,
+    effectiveCollapsedGroupIds,
+    filterById,
+    defaultGroupVisibleCount,
+    getItemId,
+    getItemLabel,
+    groupBy,
+    items,
+    onCollapsedGroupIdsChange,
+    revealRequest,
+    sortById,
+    state.filters,
+    state.groupVisibleCounts,
+    state.query,
+    state.sort
+  ])
+
+  useEffect(() => {
+    if (!state.revealFocus) return
+
+    const { itemId, requestId } = state.revealFocus
+    const timeout = window.setTimeout(() => {
+      dispatch({ type: 'clearRevealFocus', itemId, requestId })
+    }, 1000)
+
+    return () => {
+      window.clearTimeout(timeout)
+    }
+  }, [state.revealFocus])
 
   const viewItems = useMemo(() => {
     const normalizedQuery = state.query.trim().toLowerCase()
@@ -422,6 +557,7 @@ function ResourceListProvider<T extends ResourceListItemBase>({
         groupLoadStep,
         groupShowMoreLabel,
         groupCollapseLabel,
+        revealRequest,
         dragCapabilities: {
           groups: false,
           items: true,
@@ -459,6 +595,7 @@ function ResourceListProvider<T extends ResourceListItemBase>({
       groupLoadStep,
       groupCollapseLabel,
       groupShowMoreLabel,
+      revealRequest,
       items,
       selectedIdProp,
       sortOptions,
@@ -755,6 +892,7 @@ function Item<T extends ResourceListItemBase>({
   const id = meta.getItemId(item)
   const selected = state.selectedId === id
   const hovered = state.hoveredId === id
+  const revealFocused = state.revealFocus?.itemId === id
 
   return (
     <div
@@ -763,11 +901,13 @@ function Item<T extends ResourceListItemBase>({
       aria-selected={selected}
       data-selected={selected || undefined}
       data-hovered={hovered || undefined}
+      data-reveal-focus={revealFocused || undefined}
       tabIndex={tabIndex ?? 0}
       className={cn(
         'group flex min-h-8 w-full cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-1.5 text-sm outline-none transition-colors',
         'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:bg-sidebar-accent focus-visible:text-sidebar-accent-foreground focus-visible:ring-1 focus-visible:ring-ring',
         selected && 'bg-sidebar-accent text-sidebar-accent-foreground',
+        revealFocused && 'animation-resource-list-reveal-focus',
         className
       )}
       onClick={(event) => {
@@ -979,9 +1119,41 @@ function buildVirtualGroups<T extends ResourceListItemBase>(
   return groups
 }
 
+function getRevealRowIndex<T extends ResourceListItemBase>(
+  groups: ResourceListVirtualGroup<T>[],
+  itemId: string,
+  getItemId: (item: T) => string
+) {
+  const rows = buildGroupedVirtualRows(groups, true, true)
+  return rows.findIndex((row) => row.type === 'item' && getItemId(row.item.item) === itemId)
+}
+
+function useRevealRequestScroll<T extends ResourceListItemBase>(
+  context: ResourceListContextValue<T>,
+  groups: ResourceListVirtualGroup<T>[],
+  virtualListRef: RefObject<DynamicVirtualListRef | null>
+) {
+  const scrolledRequestRef = useRef<string | null>(null)
+  const revealRequest = context.meta.revealRequest
+
+  useEffect(() => {
+    if (!revealRequest) return
+
+    const requestKey = `${revealRequest.requestId}:${revealRequest.itemId}`
+    if (scrolledRequestRef.current === requestKey) return
+
+    const rowIndex = getRevealRowIndex(groups, revealRequest.itemId, context.meta.getItemId)
+    if (rowIndex < 0) return
+
+    scrolledRequestRef.current = requestKey
+    virtualListRef.current?.scrollToIndex(rowIndex, { align: 'center' })
+  }, [context.meta.getItemId, groups, revealRequest, virtualListRef])
+}
+
 function VirtualItems<T extends ResourceListItemBase>({ className, ref, renderItem }: VirtualItemsProps<T>) {
   const context = useResourceList<T>()
   const groups = useMemo(() => buildVirtualGroups(context), [context])
+  const virtualListRef = useRef<DynamicVirtualListRef>(null)
   const { stage, handleScroll } = useAutoHideScrollbar()
   const isScrolling = stage !== 'idle'
   const estimateVirtualItemSize = useCallback(
@@ -997,9 +1169,11 @@ function VirtualItems<T extends ResourceListItemBase>({ className, ref, renderIt
     (footer: ResourceListVirtualFooter) => <GroupShowMore groupId={footer.groupId} />,
     []
   )
+  useRevealRequestScroll(context, groups, virtualListRef)
 
   return (
     <GroupedVirtualList
+      ref={virtualListRef}
       scrollElementRef={ref}
       role="listbox"
       groups={groups}
@@ -1142,6 +1316,7 @@ function VirtualDraggableItems<T extends ResourceListItemBase>({
 }: VirtualDraggableItemsProps<T>) {
   const context = useResourceList<T>()
   const groups = useMemo(() => buildVirtualGroups(context), [context])
+  const virtualListRef = useRef<DynamicVirtualListRef>(null)
   const { stage, handleScroll } = useAutoHideScrollbar()
   const isScrolling = stage !== 'idle'
   const getGroupId = useCallback((group: ResourceListGroup) => group.id, [])
@@ -1258,9 +1433,11 @@ function VirtualDraggableItems<T extends ResourceListItemBase>({
     (footer: ResourceListVirtualFooter) => <GroupShowMore groupId={footer.groupId} />,
     []
   )
+  useRevealRequestScroll(context, groups, virtualListRef)
 
   return (
     <GroupedSortableVirtualList
+      ref={virtualListRef}
       scrollElementRef={ref}
       role="listbox"
       groups={groups}

--- a/src/renderer/src/components/chat/resources/ResourceListContext.ts
+++ b/src/renderer/src/components/chat/resources/ResourceListContext.ts
@@ -8,6 +8,13 @@ export type ResourceListItemBase = {
 
 export type ResourceListStatus = 'idle' | 'loading' | 'error' | 'empty'
 
+export type ResourceListRevealRequest = {
+  clearFilters?: boolean
+  clearQuery?: boolean
+  itemId: string
+  requestId: number
+}
+
 export type ResourceListGroup = {
   id: string
   label: string
@@ -70,6 +77,7 @@ export type ResourceListState = {
   sort: string | null
   selectedId: string | null
   hoveredId: string | null
+  revealFocus: { itemId: string; requestId: number } | null
   renamingId: string | null
   collapsedGroups: string[]
   groupVisibleCounts: Record<string, number>
@@ -108,6 +116,7 @@ export type ResourceListMeta<T extends ResourceListItemBase> = {
   groupLoadStep: number
   groupShowMoreLabel?: string
   groupCollapseLabel?: string
+  revealRequest?: ResourceListRevealRequest
   dragCapabilities: ResourceListDragCapabilities
   canDragGroup?: (group: ResourceListGroup, groupIndex: number) => boolean
   canDragItem?: (args: {

--- a/src/renderer/src/components/chat/resources/__tests__/ResourceList.test.tsx
+++ b/src/renderer/src/components/chat/resources/__tests__/ResourceList.test.tsx
@@ -1,6 +1,11 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
 import { act, fireEvent, render, screen, within } from '@testing-library/react'
-import type { ReactNode } from 'react'
+import { type ReactNode, useState } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const animationStyles = readFileSync(join(process.cwd(), 'src/renderer/src/assets/styles/animation.css'), 'utf8')
 
 const virtualMocks = vi.hoisted(() => ({
   useVirtualizer: vi.fn((options: { count: number }) => ({
@@ -13,8 +18,10 @@ const virtualMocks = vi.hoisted(() => ({
       })),
     getTotalSize: () => options.count * 40,
     measureElement: vi.fn(),
-    scrollElement: null
-  }))
+    scrollElement: null,
+    scrollToIndex: virtualMocks.scrollToIndex
+  })),
+  scrollToIndex: vi.fn()
 }))
 
 const dndMocks = vi.hoisted(() => ({
@@ -115,6 +122,7 @@ afterEach(() => {
   dndMocks.onDragOver = undefined
   dndMocks.onDragStart = undefined
   dndMocks.sortableData.clear()
+  virtualMocks.scrollToIndex.mockClear()
   vi.useRealTimers()
 })
 
@@ -136,9 +144,12 @@ function Inspector() {
     <output data-testid="inspector">
       {JSON.stringify({
         query: state.query,
+        filters: state.filters,
+        collapsedGroups: state.collapsedGroups,
         selectedId: state.selectedId,
         renamingId: state.renamingId,
         names: view.items.map((item) => item.name),
+        visibleNames: view.visibleItems.map((item) => item.name),
         groups: view.groups.map((group) => group.group.id)
       })}
     </output>
@@ -162,6 +173,18 @@ function droppableData(id: string) {
 }
 
 describe('ResourceList', () => {
+  it('uses a border-only reveal focus animation without changing row background', () => {
+    const revealFocusStart = animationStyles.indexOf('@keyframes animation-resource-list-reveal-focus')
+    const revealFocusEnd = animationStyles.indexOf('/* 流光动画 */', revealFocusStart)
+    const revealFocusStyle = animationStyles.slice(revealFocusStart, revealFocusEnd)
+
+    expect(revealFocusStart).toBeGreaterThanOrEqual(0)
+    expect(revealFocusEnd).toBeGreaterThan(revealFocusStart)
+    expect(revealFocusStyle).toContain('.animation-resource-list-reveal-focus::after')
+    expect(revealFocusStyle).toContain('box-shadow: inset')
+    expect(revealFocusStyle).not.toMatch(/\bbackground(?:-color)?\s*:/)
+  })
+
   it('derives search, filter, sort, and group state without mutating items', () => {
     const originalOrder = ITEMS.map((item) => item.id).join(',')
     const Provider = ResourceList.Provider<TestItem>
@@ -840,6 +863,140 @@ describe('ResourceList', () => {
 
     expect(screen.getByRole('button', { name: 'Topics' })).toHaveAttribute('aria-expanded', 'true')
     expect(screen.getByText('Topic 1')).toBeInTheDocument()
+  })
+
+  it('reveals a requested item by clearing local filters, expanding its group, loading enough rows, and scrolling', async () => {
+    const Provider = ResourceList.Provider<TestItem>
+    const items = Array.from({ length: 8 }, (_, index) => ({
+      id: `topic-${index + 1}`,
+      name: `Topic ${index + 1}`,
+      kind: 'topic' as const,
+      pinned: index === 0,
+      updatedAt: index
+    }))
+
+    function RevealHarness({ requestId }: { requestId?: number }) {
+      const [collapsedGroupIds, setCollapsedGroupIds] = useState(['topics'])
+
+      return (
+        <Provider
+          items={items}
+          collapsedGroupIds={collapsedGroupIds}
+          defaultGroupVisibleCount={5}
+          filterOptions={[
+            {
+              id: 'pinned',
+              label: 'Pinned',
+              predicate: (item) => item.pinned === true
+            }
+          ]}
+          groupBy={() => ({ id: 'topics', label: 'Topics' })}
+          groupShowMoreLabel="Show more"
+          onCollapsedGroupIdsChange={setCollapsedGroupIds}
+          revealRequest={
+            requestId ? { itemId: 'topic-6', requestId, clearFilters: true, clearQuery: true } : undefined
+          }>
+          <ResourceList.Frame>
+            <ResourceList.Search placeholder="Search resources" />
+            <ResourceList.FilterBar />
+            <Inspector />
+            <ResourceList.VirtualItems<TestItem>
+              renderItem={(item) => (
+                <ResourceList.Item item={item}>
+                  <span>{item.name}</span>
+                </ResourceList.Item>
+              )}
+            />
+          </ResourceList.Frame>
+        </Provider>
+      )
+    }
+
+    const view = render(<RevealHarness />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pinned' }))
+    fireEvent.change(screen.getByPlaceholderText('Search resources'), { target: { value: 'missing' } })
+
+    expect(screen.getByPlaceholderText('Search resources')).toHaveValue('missing')
+    expect(JSON.parse(screen.getByTestId('inspector').textContent ?? '{}')).toMatchObject({
+      collapsedGroups: ['topics']
+    })
+    expect(screen.queryByText('Topic 6')).not.toBeInTheDocument()
+
+    vi.useFakeTimers()
+    view.rerender(<RevealHarness requestId={1} />)
+
+    expect(screen.getByText('Topic 6')).toBeInTheDocument()
+    const revealedRow = screen.getByText('Topic 6').closest('[role="option"]')
+    expect(revealedRow).not.toBeNull()
+    expect(revealedRow!).toHaveAttribute('data-reveal-focus', 'true')
+    expect(revealedRow!).toHaveClass('animation-resource-list-reveal-focus')
+    expect(screen.getByPlaceholderText('Search resources')).toHaveValue('')
+    expect(screen.getByRole('button', { name: 'Topics' })).toHaveAttribute('aria-expanded', 'true')
+    expect(JSON.parse(screen.getByTestId('inspector').textContent ?? '{}')).toMatchObject({
+      collapsedGroups: [],
+      filters: [],
+      visibleNames: expect.arrayContaining(['Topic 6'])
+    })
+    expect(virtualMocks.scrollToIndex).toHaveBeenCalledWith(expect.any(Number), { align: 'center' })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(999)
+    })
+    expect(revealedRow!).toHaveAttribute('data-reveal-focus', 'true')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    expect(revealedRow!).not.toHaveAttribute('data-reveal-focus')
+  })
+
+  it('does not shrink the default group window when the revealed item is already visible', () => {
+    const Provider = ResourceList.Provider<TestItem>
+    const items = Array.from({ length: 6 }, (_, index) => ({
+      id: `topic-${index + 1}`,
+      name: `Topic ${index + 1}`,
+      kind: 'topic' as const,
+      updatedAt: index
+    }))
+
+    function RevealHarness({ requestId }: { requestId?: number }) {
+      return (
+        <Provider
+          items={items}
+          defaultGroupVisibleCount={5}
+          groupBy={() => ({ id: 'topics', label: 'Topics' })}
+          groupShowMoreLabel="Show more"
+          revealRequest={requestId ? { itemId: 'topic-4', requestId } : undefined}>
+          <ResourceList.Frame>
+            <Inspector />
+            <ResourceList.VirtualItems<TestItem>
+              renderItem={(item) => (
+                <ResourceList.Item item={item}>
+                  <span>{item.name}</span>
+                </ResourceList.Item>
+              )}
+            />
+          </ResourceList.Frame>
+        </Provider>
+      )
+    }
+
+    const view = render(<RevealHarness />)
+
+    expect(screen.getByText('Topic 4')).toBeInTheDocument()
+    expect(screen.getByText('Topic 5')).toBeInTheDocument()
+    expect(screen.queryByText('Topic 6')).not.toBeInTheDocument()
+
+    vi.useFakeTimers()
+    view.rerender(<RevealHarness requestId={1} />)
+
+    expect(screen.getByText('Topic 4').closest('[role="option"]')).toHaveAttribute('data-reveal-focus', 'true')
+    expect(JSON.parse(screen.getByTestId('inspector').textContent ?? '{}')).toMatchObject({
+      visibleNames: ['Topic 1', 'Topic 2', 'Topic 3', 'Topic 4', 'Topic 5']
+    })
+    expect(screen.queryByText('Topic 6')).not.toBeInTheDocument()
+    expect(virtualMocks.scrollToIndex).toHaveBeenCalledWith(expect.any(Number), { align: 'center' })
   })
 
   it('provides shared header, search, and item presentation parts', () => {

--- a/src/renderer/src/components/chat/resources/index.ts
+++ b/src/renderer/src/components/chat/resources/index.ts
@@ -9,6 +9,7 @@ export type {
   ResourceListItemReorderPayload,
   ResourceListMeta,
   ResourceListReorderPayload,
+  ResourceListRevealRequest,
   ResourceListSortOption,
   ResourceListState,
   ResourceListStatus,

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -1009,6 +1009,11 @@
       },
       "title": "Assistants Library"
     },
+    "reorder": {
+      "error": {
+        "failed": "Failed to reorder assistants"
+      }
+    },
     "save": {
       "success": "Saved successfully",
       "title": "Save to assistant library"

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -1009,6 +1009,11 @@
       },
       "title": "助手库"
     },
+    "reorder": {
+      "error": {
+        "failed": "助手排序失败"
+      }
+    },
     "save": {
       "success": "保存成功",
       "title": "保存到助手库"

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -1009,6 +1009,11 @@
       },
       "title": "助手庫"
     },
+    "reorder": {
+      "error": {
+        "failed": "助手排序失敗"
+      }
+    },
     "save": {
       "success": "儲存成功",
       "title": "儲存到助手庫"

--- a/src/renderer/src/pages/agents/AgentPage.tsx
+++ b/src/renderer/src/pages/agents/AgentPage.tsx
@@ -1,5 +1,6 @@
 import { usePreference } from '@data/hooks/usePreference'
 import { Navbar, NavbarCenter } from '@renderer/components/app/Navbar'
+import type { ResourceListRevealRequest } from '@renderer/components/chat/resources'
 import { useCache } from '@renderer/data/hooks/useCache'
 import { useAgents } from '@renderer/hooks/agents/useAgentDataApi'
 import { useAgentSessionInitializer } from '@renderer/hooks/agents/useAgentSessionInitializer'
@@ -11,7 +12,7 @@ import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import { cn } from '@renderer/utils'
 import { MIN_WINDOW_HEIGHT, MIN_WINDOW_WIDTH, SECOND_MIN_WINDOW_WIDTH } from '@shared/config/constant'
 import type { PropsWithChildren } from 'react'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import AgentChat from './AgentChat'
@@ -28,6 +29,8 @@ const AgentPage = () => {
   const { topicPosition } = useSettings()
   const { agents } = useAgents()
   const [activeSessionId, setActiveSessionId] = useCache('agent.active_session_id')
+  const [sessionRevealRequest, setSessionRevealRequest] = useState<ResourceListRevealRequest>()
+  const sessionRevealRequestIdRef = useRef(0)
   const { t } = useTranslation()
 
   // Seed `agent.active_session_id` to the most-recent session when nothing is set.
@@ -62,6 +65,23 @@ const AgentPage = () => {
     setHistoryOpen(true)
   }, [])
   const closeHistory = useCallback(() => setHistoryOpen(false), [])
+  const handleHistorySessionSelect = useCallback(
+    (sessionId: string | null) => {
+      void setShowSidebar(true)
+      setActiveSessionId(sessionId)
+
+      if (!sessionId) return
+
+      sessionRevealRequestIdRef.current += 1
+      setSessionRevealRequest({
+        clearFilters: true,
+        clearQuery: true,
+        itemId: sessionId,
+        requestId: sessionRevealRequestIdRef.current
+      })
+    },
+    [setActiveSessionId, setShowSidebar]
+  )
   const historyOverlay = (
     <HistoryRecordsPage
       mode="agent"
@@ -69,7 +89,7 @@ const AgentPage = () => {
       activeRecordId={activeSessionId}
       origin={historyOrigin}
       onClose={closeHistory}
-      onRecordSelect={setActiveSessionId}
+      onRecordSelect={handleHistorySessionSelect}
     />
   )
 
@@ -94,7 +114,9 @@ const AgentPage = () => {
         id={isLeftNavbar ? 'content-container' : undefined}
         className="flex min-w-0 flex-1 shrink flex-row overflow-hidden">
         <AgentChat
-          pane={<AgentSidePanel position={panePosition} onOpenHistory={openHistory} />}
+          pane={
+            <AgentSidePanel position={panePosition} onOpenHistory={openHistory} revealRequest={sessionRevealRequest} />
+          }
           paneOpen={showSidebar}
           panePosition={panePosition}
         />

--- a/src/renderer/src/pages/agents/AgentSidePanel.tsx
+++ b/src/renderer/src/pages/agents/AgentSidePanel.tsx
@@ -1,4 +1,5 @@
 import type { ChatPanePosition } from '@renderer/components/chat'
+import type { ResourceListRevealRequest } from '@renderer/components/chat/resources'
 import { useNavbarPosition } from '@renderer/hooks/useNavbar'
 
 import Sessions from './components/Sessions'
@@ -7,9 +8,10 @@ interface AgentSidePanelProps {
   onOpenHistory?: (origin?: DOMRectReadOnly) => void
   onSelectItem?: () => void
   position?: ChatPanePosition
+  revealRequest?: ResourceListRevealRequest
 }
 
-const AgentSidePanel = ({ onOpenHistory, onSelectItem, position = 'left' }: AgentSidePanelProps) => {
+const AgentSidePanel = ({ onOpenHistory, onSelectItem, position = 'left', revealRequest }: AgentSidePanelProps) => {
   const { isLeftNavbar } = useNavbarPosition()
   const borderStyle = '0.5px solid var(--color-border)'
 
@@ -24,7 +26,7 @@ const AgentSidePanel = ({ onOpenHistory, onSelectItem, position = 'left' }: Agen
         backgroundColor: isLeftNavbar ? 'var(--color-background)' : undefined
       }}>
       <div className="flex flex-1 flex-col overflow-hidden">
-        <Sessions onOpenHistory={onOpenHistory} onSelectItem={onSelectItem} />
+        <Sessions onOpenHistory={onOpenHistory} onSelectItem={onSelectItem} revealRequest={revealRequest} />
       </div>
     </div>
   )

--- a/src/renderer/src/pages/agents/__tests__/AgentPage.test.tsx
+++ b/src/renderer/src/pages/agents/__tests__/AgentPage.test.tsx
@@ -1,0 +1,173 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const agentPageMocks = vi.hoisted(() => ({
+  activeSessionId: 'session-initial' as string | null,
+  setActiveSessionId: vi.fn(),
+  setShowSidebar: vi.fn()
+}))
+
+vi.mock('@data/hooks/usePreference', async () => {
+  const React = await import('react')
+
+  return {
+    usePreference: (key: string) => {
+      const [value, setValue] = React.useState<unknown>(key === 'topic.tab.show' ? false : undefined)
+      const setPreference = vi.fn(async (nextValue: unknown) => {
+        if (key === 'topic.tab.show') {
+          agentPageMocks.setShowSidebar(nextValue)
+        }
+        setValue(nextValue)
+      })
+
+      return [value, setPreference]
+    }
+  }
+})
+
+vi.mock('@renderer/components/app/Navbar', () => ({
+  Navbar: ({ children }: { children?: ReactNode }) => <nav>{children}</nav>,
+  NavbarCenter: ({ children }: { children?: ReactNode }) => <div>{children}</div>
+}))
+
+vi.mock('@renderer/data/hooks/useCache', async () => {
+  const React = await import('react')
+
+  return {
+    useCache: (key: string) => {
+      const [activeSessionId, setActiveSessionId] = React.useState(agentPageMocks.activeSessionId)
+      if (key !== 'agent.active_session_id') return [undefined, vi.fn()]
+
+      const setCache = vi.fn((nextSessionId: string | null) => {
+        agentPageMocks.activeSessionId = nextSessionId
+        agentPageMocks.setActiveSessionId(nextSessionId)
+        setActiveSessionId(nextSessionId)
+      })
+
+      return [activeSessionId, setCache]
+    }
+  }
+})
+
+vi.mock('@renderer/hooks/agents/useAgentDataApi', () => ({
+  useAgents: () => ({
+    agents: [{ id: 'agent-a', model: 'model-a', name: 'Agent A' }]
+  })
+}))
+
+vi.mock('@renderer/hooks/agents/useAgentSessionInitializer', () => ({
+  useAgentSessionInitializer: vi.fn()
+}))
+
+vi.mock('@renderer/hooks/useNavbar', () => ({
+  useNavbarPosition: () => ({ isLeftNavbar: false })
+}))
+
+vi.mock('@renderer/hooks/useSettings', () => ({
+  useSettings: () => ({ topicPosition: 'left' })
+}))
+
+vi.mock('@renderer/hooks/useShortcuts', () => ({
+  useShortcut: vi.fn()
+}))
+
+vi.mock('@renderer/pages/history/HistoryRecordsPage', () => ({
+  default: ({ onClose, onRecordSelect, open }: any) =>
+    open ? (
+      <button
+        type="button"
+        onClick={() => {
+          onRecordSelect?.('session-history')
+          onClose?.()
+        }}>
+        Select history session
+      </button>
+    ) : null
+}))
+
+vi.mock('@renderer/services/EventService', () => ({
+  EVENT_NAMES: {
+    SHOW_ASSISTANTS: 'SHOW_ASSISTANTS',
+    SHOW_TOPIC_SIDEBAR: 'SHOW_TOPIC_SIDEBAR'
+  },
+  EventEmitter: {
+    emit: vi.fn()
+  }
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: {
+    init: vi.fn(),
+    type: '3rdParty'
+  },
+  useTranslation: () => ({
+    t: (key: string) => key
+  })
+}))
+
+vi.mock('../AgentChat', () => ({
+  default: ({ pane, paneOpen }: { pane?: ReactNode; paneOpen?: boolean }) => (
+    <section>
+      <output data-testid="pane-open">{String(paneOpen)}</output>
+      {pane}
+    </section>
+  )
+}))
+
+vi.mock('../AgentNavbar', () => ({
+  default: () => <nav />
+}))
+
+vi.mock('../AgentSidePanel', () => ({
+  default: ({ onOpenHistory, revealRequest }: any) => (
+    <div data-reveal-request={JSON.stringify(revealRequest ?? null)} data-testid="agent-side-panel">
+      <button type="button" onClick={() => onOpenHistory?.()}>
+        Open agent history
+      </button>
+    </div>
+  )
+}))
+
+vi.mock('../components/status', () => ({
+  AgentEmpty: () => <div>No agents</div>
+}))
+
+import AgentPage from '../AgentPage'
+
+describe('AgentPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    agentPageMocks.activeSessionId = 'session-initial'
+
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        window: {
+          resetMinimumSize: vi.fn().mockResolvedValue(undefined),
+          setMinimumSize: vi.fn().mockResolvedValue(undefined)
+        }
+      }
+    })
+  })
+
+  it('opens the agent sidebar and forwards a reveal request after selecting a history session', async () => {
+    render(<AgentPage />)
+
+    expect(screen.getByTestId('pane-open')).toHaveTextContent('false')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open agent history' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Select history session' }))
+
+    await waitFor(() => expect(agentPageMocks.setActiveSessionId).toHaveBeenCalledWith('session-history'))
+
+    expect(agentPageMocks.setShowSidebar).toHaveBeenCalledWith(true)
+    expect(screen.getByTestId('pane-open')).toHaveTextContent('true')
+    expect(JSON.parse(screen.getByTestId('agent-side-panel').getAttribute('data-reveal-request') ?? 'null')).toEqual({
+      clearFilters: true,
+      clearQuery: true,
+      itemId: 'session-history',
+      requestId: 1
+    })
+  })
+})

--- a/src/renderer/src/pages/agents/components/Sessions.tsx
+++ b/src/renderer/src/pages/agents/components/Sessions.tsx
@@ -4,6 +4,7 @@ import {
   ResourceList,
   type ResourceListItemReorderPayload,
   type ResourceListReorderPayload,
+  type ResourceListRevealRequest,
   SessionResourceList,
   useResourceList
 } from '@renderer/components/chat/resources'
@@ -43,6 +44,7 @@ import {
 interface SessionsProps {
   onOpenHistory?: (origin?: DOMRectReadOnly) => void
   onSelectItem?: () => void
+  revealRequest?: ResourceListRevealRequest
 }
 
 const logger = loggerService.withContext('AgentSessions')
@@ -118,7 +120,7 @@ export function resolveCreateSessionAgentId(
   return activeAgentId ?? sessions[0]?.agentId ?? agents[0]?.id ?? null
 }
 
-const Sessions = ({ onOpenHistory, onSelectItem }: SessionsProps) => {
+const Sessions = ({ onOpenHistory, onSelectItem, revealRequest }: SessionsProps) => {
   const { t } = useTranslation()
   const [groupNow] = useState(() => new Date())
   const [showSidebar, setShowSidebar] = usePreference('topic.tab.show')
@@ -432,6 +434,7 @@ const Sessions = ({ onOpenHistory, onSelectItem }: SessionsProps) => {
       estimateItemSize={() => 34}
       groupBy={sessionGroupBy}
       collapsedGroupIds={collapsedSessionGroupIds}
+      revealRequest={revealRequest}
       defaultGroupVisibleCount={5}
       groupLoadStep={5}
       getGroupHeaderAction={getGroupHeaderAction}

--- a/src/renderer/src/pages/agents/components/__tests__/Sessions.test.tsx
+++ b/src/renderer/src/pages/agents/components/__tests__/Sessions.test.tsx
@@ -52,8 +52,10 @@ const virtualMocks = vi.hoisted(() => ({
       })),
     getTotalSize: () => options.count * 40,
     measureElement: vi.fn(),
-    scrollElement: null
-  }))
+    scrollElement: null,
+    scrollToIndex: virtualMocks.scrollToIndex
+  })),
+  scrollToIndex: vi.fn()
 }))
 
 const dndMocks = vi.hoisted(() => ({
@@ -402,6 +404,7 @@ describe('Sessions', () => {
   afterEach(() => {
     dndMocks.droppableData.clear()
     dndMocks.sortableData.clear()
+    virtualMocks.scrollToIndex.mockClear()
     vi.useRealTimers()
   })
 
@@ -505,6 +508,45 @@ describe('Sessions', () => {
     expect(onOpenHistory).toHaveBeenCalledTimes(1)
     expect(onOpenHistory).toHaveBeenCalledWith({ x: 14, y: 24, width: 34, height: 44 })
     expect(preferenceMocks.setPreference).not.toHaveBeenCalledWith('topic.tab.show', false)
+  })
+
+  it('reveals a history-selected session hidden by search and show-more with row focus', async () => {
+    setupSessions({
+      sessions: Array.from({ length: 6 }, (_, index) =>
+        createSession({
+          id: `session-${index + 1}`,
+          name: `Session ${index + 1}`,
+          orderKey: `${index + 1}`
+        })
+      )
+    })
+
+    const { rerender } = render(<Sessions />)
+
+    fireEvent.change(screen.getByPlaceholderText('Search sessions'), { target: { value: 'missing' } })
+    expect(screen.getByPlaceholderText('Search sessions')).toHaveValue('missing')
+    expect(screen.queryByText('Session 6')).not.toBeInTheDocument()
+
+    vi.useFakeTimers()
+    rerender(<Sessions revealRequest={{ itemId: 'session-6', requestId: 1, clearFilters: true, clearQuery: true }} />)
+
+    expect(screen.getByText('Session 6')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Search sessions')).toHaveValue('')
+    const revealedRow = screen.getByText('Session 6').closest('[role="option"]')
+    expect(revealedRow).not.toBeNull()
+    expect(revealedRow!).toHaveAttribute('data-reveal-focus', 'true')
+    expect(revealedRow!).toHaveClass('animation-resource-list-reveal-focus')
+    expect(virtualMocks.scrollToIndex).toHaveBeenCalledWith(expect.any(Number), { align: 'center' })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(999)
+    })
+    expect(revealedRow!).toHaveAttribute('data-reveal-focus', 'true')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    expect(revealedRow!).not.toHaveAttribute('data-reveal-focus')
   })
 
   it('renames sessions through the shared update session hook', async () => {

--- a/src/renderer/src/pages/history/HistoryRecordsPage.tsx
+++ b/src/renderer/src/pages/history/HistoryRecordsPage.tsx
@@ -31,7 +31,6 @@ import type { AgentEntity } from '@shared/data/types/agent'
 import type { Assistant } from '@shared/data/types/assistant'
 import type { Topic } from '@shared/data/types/topic'
 import { Bot, History, Wrench, X } from 'lucide-react'
-import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
@@ -52,12 +51,6 @@ const UNKNOWN_AGENT_SOURCE_ID = '__unknown_agent__'
 const EMPTY_ASSISTANT_BY_ID: ReadonlyMap<string, Assistant> = new Map()
 const EMPTY_AGENT_BY_ID: ReadonlyMap<string, AgentEntity> = new Map()
 const logger = loggerService.withContext('HistoryRecordsPage')
-const HISTORY_OVERLAY_OPEN_RADIUS = 12
-const HISTORY_OVERLAY_RADIUS_PADDING = 24
-const HISTORY_OVERLAY_TRANSITION = {
-  duration: 0.28,
-  ease: [0.22, 1, 0.36, 1]
-} as const
 type AgentHistorySessionStatus = Exclude<HistorySourceStatus, 'all'>
 
 interface HistoryRecordsPageBaseProps {
@@ -79,47 +72,30 @@ type HistoryRecordsPageProps =
     })
 
 const HistoryRecordsPage = (props: HistoryRecordsPageProps) => {
-  const { mode, open, origin } = props
-  const prefersReducedMotion = useReducedMotion()
+  const { mode, open } = props
   const portalRootId = mode === 'assistant' ? 'home-page' : 'agent-page'
   const portalRoot = document.getElementById(portalRootId)
-  const overlayMotion = useMemo(
-    () => getHistoryOverlayMotion(portalRoot, origin, prefersReducedMotion === true),
-    [origin, portalRoot, prefersReducedMotion]
-  )
 
-  if (!portalRoot) return null
+  if (!portalRoot || !open) return null
 
   return createPortal(
-    <AnimatePresence initial={false}>
-      {open && (
-        <motion.div
-          key="history-records-page"
-          initial={overlayMotion.initial}
-          animate={overlayMotion.animate}
-          exit={overlayMotion.exit}
-          transition={HISTORY_OVERLAY_TRANSITION}
-          className="absolute inset-0 z-40 flex bg-background [-webkit-app-region:none]"
-          data-testid="history-records-page-motion"
-          style={{ willChange: 'opacity, clip-path' }}>
-          {props.mode === 'assistant' ? (
-            <HistoryRecordsContent
-              mode="assistant"
-              activeRecordId={props.activeRecordId}
-              onClose={props.onClose}
-              onRecordSelect={props.onRecordSelect}
-            />
-          ) : (
-            <HistoryRecordsContent
-              mode="agent"
-              activeRecordId={props.activeRecordId}
-              onClose={props.onClose}
-              onRecordSelect={props.onRecordSelect}
-            />
-          )}
-        </motion.div>
+    <div className="absolute inset-0 z-40 flex bg-card [-webkit-app-region:none]" data-testid="history-records-page">
+      {props.mode === 'assistant' ? (
+        <HistoryRecordsContent
+          mode="assistant"
+          activeRecordId={props.activeRecordId}
+          onClose={props.onClose}
+          onRecordSelect={props.onRecordSelect}
+        />
+      ) : (
+        <HistoryRecordsContent
+          mode="agent"
+          activeRecordId={props.activeRecordId}
+          onClose={props.onClose}
+          onRecordSelect={props.onRecordSelect}
+        />
       )}
-    </AnimatePresence>,
+    </div>,
     portalRoot
   )
 }
@@ -622,12 +598,10 @@ const HistoryRecordsLayout = ({
       : t('history.records.agentTitle', '智能体历史记录')
 
   return (
-    <section
-      className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background pb-3 text-foreground"
-      aria-label={title}>
-      <header className="flex h-[52px] shrink-0 items-center justify-between bg-background px-5 [border-bottom:0.5px_solid_var(--color-border-subtle)]">
+    <section className="flex min-h-0 flex-1 flex-col overflow-hidden bg-card pb-3 text-foreground" aria-label={title}>
+      <header className="flex h-[52px] shrink-0 items-center justify-between bg-card px-5 [border-bottom:0.5px_solid_var(--color-border-subtle)]">
         <div className="flex min-w-0 items-center gap-2.5">
-          <div className="flex size-8 shrink-0 items-center justify-center rounded-md border border-border-subtle bg-background text-foreground-secondary">
+          <div className="flex size-8 shrink-0 items-center justify-center rounded-md border border-border-subtle bg-card text-foreground-secondary">
             <History size={16} />
           </div>
           <div className="min-w-0">
@@ -669,45 +643,6 @@ const HistoryRecordsLayout = ({
         </main>
       </div>
     </section>
-  )
-}
-
-function getHistoryOverlayMotion(
-  portalRoot: HTMLElement | null,
-  origin: DOMRectReadOnly | undefined,
-  prefersReducedMotion: boolean
-) {
-  if (!portalRoot || !origin || prefersReducedMotion) {
-    return {
-      initial: { opacity: 0 },
-      animate: { opacity: 1 },
-      exit: { opacity: 0 }
-    }
-  }
-
-  const rootRect = portalRoot.getBoundingClientRect()
-  const rootWidth = rootRect.width || window.innerWidth
-  const rootHeight = rootRect.height || window.innerHeight
-  const originX = origin.x - rootRect.left + origin.width / 2
-  const originY = origin.y - rootRect.top + origin.height / 2
-  const closedClipPath = `circle(${HISTORY_OVERLAY_OPEN_RADIUS}px at ${originX}px ${originY}px)`
-  const openClipPath = `circle(${getHistoryOverlayRadius(rootWidth, rootHeight, originX, originY)}px at ${originX}px ${originY}px)`
-
-  return {
-    initial: { opacity: 0, clipPath: closedClipPath },
-    animate: { opacity: 1, clipPath: openClipPath },
-    exit: { opacity: 0, clipPath: closedClipPath }
-  }
-}
-
-function getHistoryOverlayRadius(width: number, height: number, originX: number, originY: number) {
-  return Math.ceil(
-    Math.max(
-      Math.hypot(originX, originY),
-      Math.hypot(width - originX, originY),
-      Math.hypot(originX, height - originY),
-      Math.hypot(width - originX, height - originY)
-    ) + HISTORY_OVERLAY_RADIUS_PADDING
   )
 }
 

--- a/src/renderer/src/pages/history/__tests__/HistoryRecordsPage.assistant.test.tsx
+++ b/src/renderer/src/pages/history/__tests__/HistoryRecordsPage.assistant.test.tsx
@@ -401,17 +401,9 @@ describe('HistoryRecordsPage assistant mode', () => {
     expect(hookMocks.useAgents).not.toHaveBeenCalled()
   })
 
-  it('renders the animated overlay shell from the trigger origin', () => {
+  it('renders the overlay shell without transition animation', () => {
     hookMocks.useAllTopics.mockReturnValue({ topics: [createTopic()], error: undefined, isLoading: false })
     hookMocks.useAssistants.mockReturnValue({ assistants: [createAssistant()] })
-
-    const portalRoot = document.getElementById('home-page')
-    vi.spyOn(portalRoot!, 'getBoundingClientRect').mockReturnValue({
-      left: 0,
-      top: 0,
-      width: 1200,
-      height: 800
-    } as DOMRect)
 
     render(
       <HistoryRecordsPage
@@ -423,10 +415,12 @@ describe('HistoryRecordsPage assistant mode', () => {
       />
     )
 
-    expect(screen.getByTestId('history-records-page-motion')).toHaveClass('z-40')
+    const overlay = screen.getByTestId('history-records-page')
+    expect(overlay).toHaveClass('z-40')
+    expect(overlay).not.toHaveStyle({ willChange: 'clip-path' })
   })
 
-  it('keeps the overlay mounted long enough for the close animation', () => {
+  it('unmounts the overlay immediately when closed', () => {
     hookMocks.useAllTopics.mockReturnValue({ topics: [createTopic()], error: undefined, isLoading: false })
     hookMocks.useAssistants.mockReturnValue({ assistants: [createAssistant()] })
 
@@ -438,10 +432,10 @@ describe('HistoryRecordsPage assistant mode', () => {
     }
 
     const { rerender } = render(<HistoryRecordsPage {...props} open />)
-    expect(screen.getByTestId('history-records-page-motion')).toBeInTheDocument()
+    expect(screen.getByTestId('history-records-page')).toBeInTheDocument()
 
     rerender(<HistoryRecordsPage {...props} open={false} />)
-    expect(screen.getByTestId('history-records-page-motion')).toBeInTheDocument()
+    expect(screen.queryByTestId('history-records-page')).not.toBeInTheDocument()
   })
 
   it('renders the external topic context menu for history rows', () => {

--- a/src/renderer/src/pages/history/components/HistoryQueryForm.tsx
+++ b/src/renderer/src/pages/history/components/HistoryQueryForm.tsx
@@ -18,7 +18,7 @@ const HistoryQueryForm = ({ mode, resultCount, searchText, onSearchTextChange }:
       : t('history.records.searchSession', '搜索会话...')
 
   return (
-    <div className="flex h-11 shrink-0 items-center justify-between gap-3 bg-background px-5 [border-bottom:0.5px_solid_var(--color-border-subtle)]">
+    <div className="flex h-11 shrink-0 items-center justify-between gap-3 bg-card px-5 [border-bottom:0.5px_solid_var(--color-border-subtle)]">
       <div className="flex min-w-0 items-center gap-3">
         <div className="font-medium text-foreground text-sm leading-5">
           {t('history.records.resultCount', '{{count}} 条结果', { count: resultCount })}
@@ -33,7 +33,7 @@ const HistoryQueryForm = ({ mode, resultCount, searchText, onSearchTextChange }:
           />
           <Input
             value={searchText}
-            className="h-8 rounded-md border-border-subtle bg-background pl-8 text-xs shadow-none"
+            className="h-8 rounded-md border-border-subtle bg-card pl-8 text-xs shadow-none"
             placeholder={searchPlaceholder}
             aria-label={searchPlaceholder}
             onChange={(event) => onSearchTextChange(event.target.value)}

--- a/src/renderer/src/pages/history/components/HistoryResultList.tsx
+++ b/src/renderer/src/pages/history/components/HistoryResultList.tsx
@@ -89,7 +89,7 @@ const HistoryResultList = ({
       : t('history.records.empty.sessionsDescription', '当前筛选下没有可展示的会话。')
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-card">
       <div className="flex min-h-0 flex-1 overflow-x-auto overflow-y-hidden [scrollbar-gutter:stable] [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border/30 [&::-webkit-scrollbar]:h-1.5">
         <div className="flex min-h-0 min-w-[760px] flex-1 flex-col">
           <HistoryListHeader
@@ -108,7 +108,7 @@ const HistoryResultList = ({
                 list={topicList}
                 estimateSize={() => 44}
                 overscan={6}
-                className="min-h-0 flex-1 bg-background"
+                className="min-h-0 flex-1 bg-card"
                 scrollerStyle={{ overflowX: 'hidden', padding: '4px 12px' }}>
                 {(topic) => {
                   const assistant = topic.assistantId ? assistantById.get(topic.assistantId) : undefined
@@ -136,7 +136,7 @@ const HistoryResultList = ({
                 list={sessionList}
                 estimateSize={() => 52}
                 overscan={6}
-                className="min-h-0 flex-1 bg-background"
+                className="min-h-0 flex-1 bg-card"
                 scrollerStyle={{ overflowX: 'hidden', padding: '4px 12px' }}>
                 {(session) => {
                   const agent = session.agentId ? agentById.get(session.agentId) : undefined
@@ -174,7 +174,7 @@ interface HistoryListHeaderProps {
 }
 
 const HistoryListHeader = ({ titleLabel, sourceLabel, timeLabel }: HistoryListHeaderProps) => (
-  <div className="shrink-0 overflow-hidden bg-background [border-bottom:0.5px_solid_var(--color-border-subtle)]">
+  <div className="shrink-0 overflow-hidden bg-card [border-bottom:0.5px_solid_var(--color-border-subtle)]">
     <div className={HISTORY_HEADER_GRID_CLASS}>
       <div>{titleLabel}</div>
       <div>{sourceLabel}</div>
@@ -221,7 +221,7 @@ const HistoryTopicRow = ({
       className={cn(
         HISTORY_ROW_GRID_CLASS,
         'min-h-11 text-left',
-        'bg-background text-foreground-secondary transition-colors hover:bg-muted/45'
+        'bg-card text-foreground-secondary transition-colors hover:bg-muted/45'
       )}
       onClick={() => onPress?.(topic)}>
       <div className="flex min-w-0 items-center gap-2.5">
@@ -298,7 +298,7 @@ const HistorySessionRow = ({
       className={cn(
         HISTORY_ROW_GRID_CLASS,
         'min-h-13 text-left',
-        'bg-background text-foreground-secondary transition-colors hover:bg-muted/45'
+        'bg-card text-foreground-secondary transition-colors hover:bg-muted/45'
       )}
       onClick={() => onPress?.(session.id)}>
       <div className="flex min-w-0 items-center gap-2.5">

--- a/src/renderer/src/pages/history/components/HistorySourceSidebar.tsx
+++ b/src/renderer/src/pages/history/components/HistorySourceSidebar.tsx
@@ -53,7 +53,7 @@ const HistorySourceSidebar = ({
   }, [assistantSearchText, sources])
 
   return (
-    <aside className="flex w-[284px] shrink-0 flex-col bg-background [border-right:0.5px_solid_var(--color-border-subtle)]">
+    <aside className="flex w-[284px] shrink-0 flex-col bg-card [border-right:0.5px_solid_var(--color-border-subtle)]">
       <Scrollbar className="min-h-0 flex-1 px-3 py-3.5">
         {mode === 'agent' && statusItems.length > 0 && selectedStatus && onStatusSelect && (
           <SidebarSection title={t('history.records.sidebar.status', '状态')}>
@@ -85,7 +85,7 @@ const HistorySourceSidebar = ({
               />
               <Input
                 value={assistantSearchText}
-                className="h-8 rounded-md border-border-subtle bg-background pl-8 text-xs shadow-none"
+                className="h-8 rounded-md border-border-subtle bg-card pl-8 text-xs shadow-none"
                 placeholder={t('history.records.sidebar.searchAssistant', '搜索助手...')}
                 aria-label={t('history.records.sidebar.searchAssistant', '搜索助手...')}
                 onChange={(event) => setAssistantSearchText(event.target.value)}

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -1,5 +1,6 @@
 import { cacheService } from '@data/CacheService'
 import { usePreference } from '@data/hooks/usePreference'
+import type { ResourceListRevealRequest } from '@renderer/components/chat/resources'
 import { useNavbarPosition } from '@renderer/hooks/useNavbar'
 import { useShortcut } from '@renderer/hooks/useShortcuts'
 import { useTemporaryTopic } from '@renderer/hooks/useTemporaryTopic'
@@ -12,7 +13,7 @@ import type { Topic } from '@renderer/types'
 import { MIN_WINDOW_HEIGHT, MIN_WINDOW_WIDTH, SECOND_MIN_WINDOW_WIDTH } from '@shared/config/constant'
 import { useLocation, useNavigate } from '@tanstack/react-router'
 import type { FC } from 'react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
 
 import Chat from './Chat'
@@ -43,6 +44,8 @@ const HomePage: FC = () => {
   const { isLeftNavbar } = useNavbarPosition()
   const [historyOpen, setHistoryOpen] = useState(false)
   const [historyOrigin, setHistoryOrigin] = useState<DOMRectReadOnly>()
+  const [topicRevealRequest, setTopicRevealRequest] = useState<ResourceListRevealRequest>()
+  const topicRevealRequestIdRef = useRef(0)
 
   const location = useLocation()
   const state = location.state as { topic?: Topic } | undefined
@@ -145,6 +148,20 @@ const HomePage: FC = () => {
     setHistoryOpen(true)
   }, [])
   const closeHistory = useCallback(() => setHistoryOpen(false), [])
+  const handleHistoryTopicSelect = useCallback(
+    (topic: Topic) => {
+      void setShowSidebar(true)
+      setActiveTopic(topic)
+      topicRevealRequestIdRef.current += 1
+      setTopicRevealRequest({
+        clearFilters: true,
+        clearQuery: true,
+        itemId: topic.id,
+        requestId: topicRevealRequestIdRef.current
+      })
+    },
+    [setActiveTopic, setShowSidebar]
+  )
   const historyOverlay = (
     <HistoryRecordsPage
       mode="assistant"
@@ -152,7 +169,7 @@ const HomePage: FC = () => {
       activeRecordId={activeTopic?.id}
       origin={historyOrigin}
       onClose={closeHistory}
-      onRecordSelect={setActiveTopic}
+      onRecordSelect={handleHistoryTopicSelect}
     />
   )
 
@@ -175,6 +192,7 @@ const HomePage: FC = () => {
               setActiveTopic={setActiveTopic}
               position={panePosition}
               onOpenHistory={openHistory}
+              revealRequest={topicRevealRequest}
             />
           }
           paneOpen={showSidebar}

--- a/src/renderer/src/pages/home/Tabs/TopicsTab.tsx
+++ b/src/renderer/src/pages/home/Tabs/TopicsTab.tsx
@@ -1,3 +1,4 @@
+import type { ResourceListRevealRequest } from '@renderer/components/chat/resources'
 import type { Topic } from '@renderer/types'
 import type { FC } from 'react'
 
@@ -6,6 +7,7 @@ import { Topics } from './components/Topics'
 interface Props {
   activeTopic: Topic
   onOpenHistory?: (origin?: DOMRectReadOnly) => void
+  revealRequest?: ResourceListRevealRequest
   setActiveTopic: (topic: Topic) => void
   position: 'left' | 'right'
 }

--- a/src/renderer/src/pages/home/Tabs/components/Topics.helpers.ts
+++ b/src/renderer/src/pages/home/Tabs/components/Topics.helpers.ts
@@ -4,6 +4,7 @@ import {
   createTimeGroupResolver,
   getResourceTimeBucket,
   type ResourceListGroup,
+  type ResourceListGroupReorderPayload,
   type ResourceListGroupResolver,
   type ResourceListItemReorderPayload,
   type ResourceListTimeBucket,
@@ -130,6 +131,34 @@ export function buildTopicDropAnchor(payload: ResourceListItemReorderPayload): O
   return { position: 'last' }
 }
 
+export function buildAssistantGroupDropAnchor(
+  payload: ResourceListGroupReorderPayload,
+  overAssistantId: string
+): OrderRequest {
+  return payload.sourceIndex < payload.targetIndex ? { after: overAssistantId } : { before: overAssistantId }
+}
+
+export function moveAssistantGroupAfterDrop(
+  assistantIds: readonly string[],
+  activeAssistantId: string,
+  overAssistantId: string,
+  payload: Pick<ResourceListGroupReorderPayload, 'sourceIndex' | 'targetIndex'>
+): string[] {
+  const activeIndex = assistantIds.indexOf(activeAssistantId)
+  const overIndex = assistantIds.indexOf(overAssistantId)
+
+  if (activeIndex < 0 || overIndex < 0 || activeIndex === overIndex) {
+    return [...assistantIds]
+  }
+
+  const next = assistantIds.filter((assistantId) => assistantId !== activeAssistantId)
+  const adjustedOverIndex = next.indexOf(overAssistantId)
+  const insertIndex = payload.sourceIndex < payload.targetIndex ? adjustedOverIndex + 1 : adjustedOverIndex
+  next.splice(insertIndex, 0, activeAssistantId)
+
+  return next
+}
+
 export function normalizeTopicDropPayload(payload: ResourceListItemReorderPayload): ResourceListItemReorderPayload {
   return payload
 }
@@ -244,12 +273,16 @@ function getAssistantGroupRank<T extends Pick<Topic, 'assistantId' | 'pinned'>>(
     return 0
   }
 
-  if (!topic.assistantId) {
-    return 1
+  const assistantRank = topic.assistantId ? assistantRankById?.get(topic.assistantId) : undefined
+  if (assistantRank !== undefined) {
+    return assistantRank + 1
   }
 
-  const assistantRank = assistantRankById?.get(topic.assistantId)
-  return assistantRank === undefined ? TOPIC_UNKNOWN_ASSISTANT_RANK : assistantRank + 2
+  if (!topic.assistantId) {
+    return TOPIC_UNKNOWN_ASSISTANT_RANK - 1
+  }
+
+  return TOPIC_UNKNOWN_ASSISTANT_RANK
 }
 
 export function sortTopicsForDisplayGroups<T extends Pick<Topic, 'assistantId' | 'pinned' | 'updatedAt'>>(

--- a/src/renderer/src/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/Topics.tsx
@@ -26,6 +26,7 @@ import { useTopicStreamStatus } from '@renderer/hooks/useTopicStreamStatus'
 import { fetchMessagesSummary } from '@renderer/services/ApiService'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import type { Topic } from '@renderer/types'
+import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
 import { getLeadingEmoji } from '@renderer/utils/naming'
 import { cn } from '@renderer/utils/style'
 import dayjs from 'dayjs'
@@ -627,6 +628,7 @@ export function Topics({ activeTopic, onOpenHistory, revealRequest, setActiveTop
         } catch (err) {
           setOptimisticAssistantOrderIds(null)
           logger.error('Failed to reorder assistant topic group', { activeAssistantId, err, overAssistantId })
+          window.toast.error(formatErrorMessageWithPrefix(err, t('assistants.reorder.error.failed')))
 
           try {
             await refreshAssistants()

--- a/src/renderer/src/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/Topics.tsx
@@ -53,10 +53,12 @@ import type { TopicExportMenuOptions } from './topicContextMenuActions'
 import { TopicManagePanel, useTopicManageMode } from './TopicManageMode'
 import {
   applyOptimisticTopicDisplayMove,
+  buildAssistantGroupDropAnchor,
   buildTopicDropAnchor,
   createTopicDisplayGroupResolver,
   filterTopicsForManageMode,
   getAssistantIdFromTopicGroupId,
+  moveAssistantGroupAfterDrop,
   normalizeTopicDropPayload,
   sortTopicsForDisplayGroups,
   TOPIC_DEFAULT_ASSISTANT_GROUP_ID,
@@ -184,7 +186,8 @@ export function Topics({ activeTopic, onOpenHistory, revealRequest, setActiveTop
   const {
     assistants,
     isLoading: isAssistantsLoading,
-    error: assistantsError
+    error: assistantsError,
+    refetch: refreshAssistants
   } = useAssistantsApi({ enabled: isAssistantDisplayMode })
   const listRef = useRef<HTMLDivElement>(null)
   const deleteTimerRef = useRef<NodeJS.Timeout>(null)
@@ -215,10 +218,43 @@ export function Topics({ activeTopic, onOpenHistory, revealRequest, setActiveTop
     setOptimisticMove(null)
   }, [apiTopicOrderSignature])
 
-  const assistantById = useMemo(() => new Map(assistants.map((assistant) => [assistant.id, assistant])), [assistants])
-  const assistantRankById = useMemo(
-    () => new Map(assistants.map((assistant, index) => [assistant.id, index])),
+  const [optimisticAssistantOrderIds, setOptimisticAssistantOrderIds] = useState<readonly string[] | null>(null)
+  const assistantOrderSignature = useMemo(
+    () => assistants.map((assistant) => `${assistant.id}:${assistant.orderKey ?? ''}`).join('|'),
     [assistants]
+  )
+
+  useEffect(() => {
+    setOptimisticAssistantOrderIds(null)
+  }, [assistantOrderSignature])
+
+  const orderedAssistants = useMemo(() => {
+    if (!optimisticAssistantOrderIds) {
+      return assistants
+    }
+
+    const assistantById = new Map(assistants.map((assistant) => [assistant.id, assistant]))
+    const ordered = optimisticAssistantOrderIds.flatMap((assistantId) => {
+      const assistant = assistantById.get(assistantId)
+      return assistant ? [assistant] : []
+    })
+    const optimisticIds = new Set(optimisticAssistantOrderIds)
+
+    for (const assistant of assistants) {
+      if (!optimisticIds.has(assistant.id)) {
+        ordered.push(assistant)
+      }
+    }
+
+    return ordered
+  }, [assistants, optimisticAssistantOrderIds])
+  const assistantById = useMemo(
+    () => new Map(orderedAssistants.map((assistant) => [assistant.id, assistant])),
+    [orderedAssistants]
+  )
+  const assistantRankById = useMemo(
+    () => new Map(orderedAssistants.map((assistant, index) => [assistant.id, index])),
+    [orderedAssistants]
   )
 
   const manageState = useTopicManageMode()
@@ -524,10 +560,87 @@ export function Topics({ activeTopic, onOpenHistory, revealRequest, setActiveTop
     [assistantById, isAssistantDisplayMode, isManageMode]
   )
 
+  const canDragTopicGroup = useCallback(
+    (group: { id: string }) => {
+      if (!isAssistantDisplayMode || isManageMode) return false
+
+      const assistantId = getAssistantIdFromTopicGroupId(group.id)
+      return !!assistantId && assistantById.has(assistantId)
+    },
+    [assistantById, isAssistantDisplayMode, isManageMode]
+  )
+
+  const canDropTopicGroup = useCallback(
+    ({
+      activeGroupId,
+      overGroupId
+    }: {
+      activeGroupId: string
+      overGroupId: string
+      overType: 'group' | 'item'
+      sourceIndex: number
+      targetIndex: number
+    }) => {
+      if (!isAssistantDisplayMode || isManageMode) return false
+
+      const activeAssistantId = getAssistantIdFromTopicGroupId(activeGroupId)
+      const overAssistantId = getAssistantIdFromTopicGroupId(overGroupId)
+
+      return (
+        !!activeAssistantId &&
+        !!overAssistantId &&
+        assistantById.has(activeAssistantId) &&
+        assistantById.has(overAssistantId)
+      )
+    },
+    [assistantById, isAssistantDisplayMode, isManageMode]
+  )
+
   const handleTopicReorder = useCallback(
     async (payload: ResourceListReorderPayload) => {
-      if (payload.type !== 'item') return
       if (!isAssistantDisplayMode || isManageMode) return
+
+      if (payload.type === 'group') {
+        const activeAssistantId = getAssistantIdFromTopicGroupId(payload.activeGroupId)
+        const overAssistantId = getAssistantIdFromTopicGroupId(payload.overGroupId)
+
+        if (
+          !activeAssistantId ||
+          !overAssistantId ||
+          !assistantById.has(activeAssistantId) ||
+          !assistantById.has(overAssistantId)
+        ) {
+          return
+        }
+
+        const assistantIds = orderedAssistants.map((assistant) => assistant.id)
+        const nextAssistantIds = moveAssistantGroupAfterDrop(assistantIds, activeAssistantId, overAssistantId, payload)
+        const anchor = buildAssistantGroupDropAnchor(payload, overAssistantId)
+
+        setOptimisticAssistantOrderIds(nextAssistantIds)
+
+        try {
+          await dataApiService.patch(`/assistants/${activeAssistantId}/order`, {
+            body: anchor
+          })
+          await refreshAssistants()
+        } catch (err) {
+          setOptimisticAssistantOrderIds(null)
+          logger.error('Failed to reorder assistant topic group', { activeAssistantId, err, overAssistantId })
+
+          try {
+            await refreshAssistants()
+          } catch (refreshErr) {
+            logger.error('Failed to refresh assistants after group reorder failure', {
+              activeAssistantId,
+              refreshErr
+            })
+          }
+        }
+
+        return
+      }
+
       if (payload.sourceGroupId === TOPIC_PINNED_GROUP_ID || payload.targetGroupId === TOPIC_PINNED_GROUP_ID) return
       if (payload.targetGroupId === TOPIC_UNKNOWN_ASSISTANT_GROUP_ID) return
 
@@ -568,7 +681,7 @@ export function Topics({ activeTopic, onOpenHistory, revealRequest, setActiveTop
         }
       }
     },
-    [assistantById, isAssistantDisplayMode, isManageMode, refreshTopics, topics]
+    [assistantById, isAssistantDisplayMode, isManageMode, orderedAssistants, refreshAssistants, refreshTopics, topics]
   )
 
   return (
@@ -586,11 +699,13 @@ export function Topics({ activeTopic, onOpenHistory, revealRequest, setActiveTop
         getGroupHeaderAction={getGroupHeaderAction}
         getGroupHeaderIcon={getGroupHeaderIcon}
         dragCapabilities={{
-          groups: false,
+          groups: isAssistantDisplayMode && !isManageMode,
           items: isAssistantDisplayMode && !isManageMode,
           itemSameGroup: isAssistantDisplayMode && !isManageMode,
           itemCrossGroup: isAssistantDisplayMode && !isManageMode
         }}
+        canDragGroup={canDragTopicGroup}
+        canDropGroup={canDropTopicGroup}
         canDragItem={canDragTopicItem}
         canDropItem={canDropTopicItem}
         groupShowMoreLabel={t('chat.topics.group.show_more')}

--- a/src/renderer/src/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/Topics.tsx
@@ -8,6 +8,7 @@ import {
   ResourceList,
   type ResourceListItemReorderPayload,
   type ResourceListReorderPayload,
+  type ResourceListRevealRequest,
   TopicResourceList,
   useResourceList,
   useResourceListPinnedState
@@ -71,6 +72,7 @@ const logger = loggerService.withContext('Topics')
 interface Props {
   activeTopic: Topic
   onOpenHistory?: (origin?: DOMRectReadOnly) => void
+  revealRequest?: ResourceListRevealRequest
   setActiveTopic: (topic: Topic) => void
   position: 'left' | 'right'
 }
@@ -139,7 +141,7 @@ function TopicDisplayModeMenu({
   )
 }
 
-export function Topics({ activeTopic, onOpenHistory, setActiveTopic, position }: Props) {
+export function Topics({ activeTopic, onOpenHistory, revealRequest, setActiveTopic, position }: Props) {
   const { t } = useTranslation()
   const [groupNow] = useState(() => dayjs())
   const { notesPath } = useNotesSettings()
@@ -221,6 +223,7 @@ export function Topics({ activeTopic, onOpenHistory, setActiveTopic, position }:
 
   const manageState = useTopicManageMode()
   const { isManageMode, selectedIds, searchText, enterManageMode, exitManageMode, toggleSelectTopic } = manageState
+  const handledRevealModeExitRef = useRef<string | null>(null)
   const deferredSearchText = useDeferredValue(searchText)
   const { isFulfilled: isActiveTopicStreamFulfilled, markSeen: markActiveTopicStreamSeen } = useTopicStreamStatus(
     activeTopic.id
@@ -231,6 +234,18 @@ export function Topics({ activeTopic, onOpenHistory, setActiveTopic, position }:
       markActiveTopicStreamSeen()
     }
   }, [isActiveTopicStreamFulfilled, markActiveTopicStreamSeen])
+
+  useEffect(() => {
+    if (!revealRequest) return
+
+    const requestKey = `${revealRequest.requestId}:${revealRequest.itemId}`
+    if (handledRevealModeExitRef.current === requestKey) return
+
+    handledRevealModeExitRef.current = requestKey
+    if (isManageMode) {
+      exitManageMode()
+    }
+  }, [exitManageMode, isManageMode, revealRequest])
 
   const updateTopic = useCallback(
     (topic: Topic) =>
@@ -565,6 +580,7 @@ export function Topics({ activeTopic, onOpenHistory, setActiveTopic, position }:
         estimateItemSize={() => 34}
         groupBy={topicGroupBy}
         collapsedGroupIds={collapsedTopicGroupIds}
+        revealRequest={revealRequest}
         defaultGroupVisibleCount={5}
         groupLoadStep={5}
         getGroupHeaderAction={getGroupHeaderAction}

--- a/src/renderer/src/pages/home/Tabs/components/__tests__/Topics.helpers.test.ts
+++ b/src/renderer/src/pages/home/Tabs/components/__tests__/Topics.helpers.test.ts
@@ -1,14 +1,19 @@
-import type { ResourceListItemReorderPayload } from '@renderer/components/chat/resources'
+import type {
+  ResourceListGroupReorderPayload,
+  ResourceListItemReorderPayload
+} from '@renderer/components/chat/resources'
 import type { Topic } from '@renderer/types'
 import { describe, expect, it } from 'vitest'
 
 import {
   applyOptimisticTopicDisplayMove,
+  buildAssistantGroupDropAnchor,
   buildTopicDropAnchor,
   createTopicDisplayGroupResolver,
   filterTopicsForManageMode,
   getTopicTimeBucket,
   groupTopicByPinned,
+  moveAssistantGroupAfterDrop,
   moveTopicAfterDrop,
   normalizeTopicDropPayload,
   sortTopicsForDisplayGroups,
@@ -66,6 +71,37 @@ describe('Topics helpers', () => {
     expect(buildTopicDropAnchor({ ...basePayload, overId: 'topic:assistant:assistant-1', overType: 'group' })).toEqual({
       position: 'last'
     })
+  })
+
+  it('translates assistant group drops into persisted order anchors', () => {
+    const basePayload: ResourceListGroupReorderPayload = {
+      type: 'group',
+      activeGroupId: 'topic:assistant:assistant-a',
+      overGroupId: 'topic:assistant:assistant-b',
+      overType: 'group',
+      sourceIndex: 1,
+      targetIndex: 2
+    }
+
+    expect(buildAssistantGroupDropAnchor(basePayload, 'assistant-b')).toEqual({ after: 'assistant-b' })
+    expect(buildAssistantGroupDropAnchor({ ...basePayload, sourceIndex: 2, targetIndex: 1 }, 'assistant-b')).toEqual({
+      before: 'assistant-b'
+    })
+  })
+
+  it('projects assistant group drops into optimistic assistant order', () => {
+    expect(
+      moveAssistantGroupAfterDrop(['assistant-a', 'assistant-b', 'assistant-c'], 'assistant-a', 'assistant-c', {
+        sourceIndex: 0,
+        targetIndex: 2
+      })
+    ).toEqual(['assistant-b', 'assistant-c', 'assistant-a'])
+    expect(
+      moveAssistantGroupAfterDrop(['assistant-a', 'assistant-b', 'assistant-c'], 'assistant-c', 'assistant-a', {
+        sourceIndex: 2,
+        targetIndex: 0
+      })
+    ).toEqual(['assistant-c', 'assistant-a', 'assistant-b'])
   })
 
   it('preserves same-group item drop positions from the insertion line', () => {
@@ -250,11 +286,10 @@ describe('Topics helpers', () => {
     })
   })
 
-  it('sorts assistant display groups by pinned, default, assistant rank, then unknown while preserving group order', () => {
+  it('sorts assistant display groups by pinned, assistant rank, then unknown while preserving group order', () => {
     const topics = [
       createTopic({ id: 'assistant-b-1', assistantId: 'assistant-b' }),
       createTopic({ id: 'unknown-1', assistantId: 'missing-assistant' }),
-      createTopic({ id: 'default-1', assistantId: undefined }),
       createTopic({ id: 'assistant-a-1', assistantId: 'assistant-a' }),
       createTopic({ id: 'pinned-1', assistantId: 'missing-assistant', pinned: true }),
       createTopic({ id: 'assistant-b-2', assistantId: 'assistant-b' })
@@ -268,7 +303,7 @@ describe('Topics helpers', () => {
         ]),
         mode: 'assistant'
       }).map((topic) => topic.id)
-    ).toEqual(['pinned-1', 'default-1', 'assistant-a-1', 'assistant-b-1', 'assistant-b-2', 'unknown-1'])
+    ).toEqual(['pinned-1', 'assistant-a-1', 'assistant-b-1', 'assistant-b-2', 'unknown-1'])
   })
 
   it('sorts assistant group topics by persisted orderKey descending when available', () => {

--- a/src/renderer/src/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -13,8 +13,10 @@ const virtualMocks = vi.hoisted(() => ({
       })),
     getTotalSize: () => options.count * 56,
     measureElement: vi.fn(),
-    scrollElement: null
-  }))
+    scrollElement: null,
+    scrollToIndex: virtualMocks.scrollToIndex
+  })),
+  scrollToIndex: vi.fn()
 }))
 
 const dndMocks = vi.hoisted(() => ({
@@ -245,6 +247,7 @@ vi.mock('react-i18next', () => ({
 
 import { cacheService } from '@data/CacheService'
 import { dataApiService } from '@data/DataApiService'
+import type { ResourceListRevealRequest } from '@renderer/components/chat/resources'
 import type * as TopicDataApiModule from '@renderer/hooks/useTopicDataApi'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import type { Topic } from '@renderer/types'
@@ -312,18 +315,29 @@ function createTopicPin(overrides: Partial<Pin> = {}): Pin {
   }
 }
 
-function renderTopicList({ onOpenHistory }: { onOpenHistory?: () => void } = {}) {
+function renderTopicList({
+  onOpenHistory,
+  revealRequest
+}: {
+  onOpenHistory?: () => void
+  revealRequest?: ResourceListRevealRequest
+} = {}) {
   const setActiveTopic = vi.fn()
-  const renderNode = () => (
+  const renderNode = (nextRevealRequest = revealRequest) => (
     <Topics
       activeTopic={createRendererTopic()}
       setActiveTopic={setActiveTopic}
       position="left"
       onOpenHistory={onOpenHistory}
+      revealRequest={nextRevealRequest}
     />
   )
   const view = render(renderNode())
-  return { ...view, rerenderTopicList: () => view.rerender(renderNode()), setActiveTopic }
+  return {
+    ...view,
+    rerenderTopicList: (nextRevealRequest = revealRequest) => view.rerender(renderNode(nextRevealRequest)),
+    setActiveTopic
+  }
 }
 
 function getTopicRow(topicName: string) {
@@ -879,6 +893,51 @@ describe('Topics', () => {
 
     expect(onOpenHistory).toHaveBeenCalledTimes(1)
     expect(onOpenHistory).toHaveBeenCalledWith({ x: 10, y: 20, width: 30, height: 40 })
+  })
+
+  it('reveals a history-selected topic hidden by manage search, a collapsed group, and show-more', async () => {
+    MockUsePreferenceUtils.setPreferenceValue('topic.tab.collapsed_group_ids' as never, ['topic:time:today'])
+    mockUseInfiniteQuery.mockReturnValue({
+      pages: [
+        {
+          items: createTopicPageItems(6)
+        }
+      ],
+      isLoading: false,
+      isRefreshing: false,
+      error: undefined,
+      hasNext: false,
+      loadNext: vi.fn(),
+      refresh: vi.fn(),
+      reset: vi.fn(),
+      mutate: vi.fn()
+    })
+
+    const { rerenderTopicList } = renderTopicList()
+
+    expect(screen.getByRole('button', { name: 'Today' })).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByText('Topic 6')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Manage topics'))
+    const manageSearchButton = document.querySelector('[data-title="Search topics"] button')
+    expect(manageSearchButton).toBeInTheDocument()
+    fireEvent.click(manageSearchButton as HTMLElement)
+    const manageSearch = screen.getAllByPlaceholderText('Search topics').at(-1)
+    expect(manageSearch).toBeInTheDocument()
+    fireEvent.change(manageSearch as HTMLElement, { target: { value: 'missing' } })
+    expect(screen.queryByText('Topic 6')).not.toBeInTheDocument()
+
+    rerenderTopicList({ itemId: 'topic-6', requestId: 1, clearFilters: true, clearQuery: true })
+
+    expect(await screen.findByText('Topic 6')).toBeInTheDocument()
+    const revealedRow = screen.getByText('Topic 6').closest('[role="option"]')
+    expect(revealedRow).not.toBeNull()
+    expect(revealedRow!).toHaveAttribute('data-reveal-focus', 'true')
+    expect(revealedRow!).toHaveClass('animation-resource-list-reveal-focus')
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Today' })).toHaveAttribute('aria-expanded', 'true')
+    expect(MockUsePreferenceUtils.getPreferenceValue('topic.tab.collapsed_group_ids' as never)).toEqual([])
+    expect(virtualMocks.scrollToIndex).toHaveBeenCalledWith(expect.any(Number), { align: 'center' })
   })
 
   it('adds a new topic from the search-area create bar', () => {

--- a/src/renderer/src/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -238,6 +238,7 @@ vi.mock('react-i18next', () => ({
       if (key === 'chat.default.name') return 'Default Assistant'
       if (key === 'common.prompt') return 'Prompt'
       if (key === 'history.records.title') return 'Topic History'
+      if (key === 'assistants.reorder.error.failed') return 'Failed to reorder assistants'
       if (key === 'settings.topic.position.label') return 'Topic position'
       if (key === 'chat.topics.delete.shortcut') return `Hold ${options?.key ?? 'Ctrl'} to delete directly`
       return key
@@ -1204,6 +1205,29 @@ describe('Topics', () => {
       expect(patchSpy).toHaveBeenCalledWith('/assistants/assistant-1/order', { body: { after: 'assistant-2' } })
     )
     expect(patchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows a toast when assistant group reorder persistence fails', async () => {
+    const patchSpy = vi.spyOn(dataApiService, 'patch').mockRejectedValue(new Error('order failed'))
+    MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
+
+    renderTopicList()
+
+    dndMocks.onDragEnd?.({
+      active: {
+        data: sortableData('group:topic:assistant:assistant-1'),
+        id: 'group:topic:assistant:assistant-1'
+      },
+      over: {
+        data: sortableData('group:topic:assistant:assistant-2'),
+        id: 'group:topic:assistant:assistant-2'
+      }
+    })
+
+    await vi.waitFor(() =>
+      expect(window.toast.error).toHaveBeenCalledWith('Failed to reorder assistants: order failed')
+    )
+    expect(patchSpy).toHaveBeenCalledWith('/assistants/assistant-1/order', { body: { after: 'assistant-2' } })
   })
 
   it('treats the default assistant database row as a normal draggable assistant group', async () => {

--- a/src/renderer/src/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/src/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -354,6 +354,14 @@ function sortableData(id: string) {
   return { current: data }
 }
 
+function droppableData(id: string) {
+  const data = dndMocks.droppableData.get(id)
+  if (!data) {
+    throw new Error(`Expected droppable data for ${id}`)
+  }
+  return { current: data }
+}
+
 const topicStreamStatusCacheKey = (topicId: string) => `topic.stream.statuses.${topicId}` as never
 const topicStreamSeenCacheKey = (topicId: string) => `topic.stream.seen.${topicId}` as never
 
@@ -1167,6 +1175,200 @@ describe('Topics', () => {
     expect(MockUsePreferenceUtils.getPreferenceValue('topic.tab.collapsed_group_ids' as never)).toEqual([
       'topic:time:today'
     ])
+  })
+
+  it('persists assistant group reorder and applies the assistant order optimistically', async () => {
+    const patchSpy = vi.spyOn(dataApiService, 'patch').mockResolvedValue(undefined as never)
+    MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
+
+    renderTopicList()
+
+    dndMocks.onDragEnd?.({
+      active: {
+        data: sortableData('group:topic:assistant:assistant-1'),
+        id: 'group:topic:assistant:assistant-1'
+      },
+      over: {
+        data: sortableData('group:topic:assistant:assistant-2'),
+        id: 'group:topic:assistant:assistant-2'
+      }
+    })
+
+    await vi.waitFor(() => {
+      const rowTexts = screen.getAllByTestId('topic-list-row').map((row) => row.textContent ?? '')
+      expect(rowTexts.findIndex((text) => text.includes('Alpha topic'))).toBeGreaterThan(
+        rowTexts.findIndex((text) => text.includes('Gamma topic'))
+      )
+    })
+    await vi.waitFor(() =>
+      expect(patchSpy).toHaveBeenCalledWith('/assistants/assistant-1/order', { body: { after: 'assistant-2' } })
+    )
+    expect(patchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats the default assistant database row as a normal draggable assistant group', async () => {
+    const patchSpy = vi.spyOn(dataApiService, 'patch').mockResolvedValue(undefined as never)
+    MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
+    mockUseQuery.mockImplementation((path) => {
+      if (path === '/pins') {
+        return {
+          data: [],
+          isLoading: false,
+          isRefreshing: false,
+          error: undefined,
+          refetch: vi.fn().mockResolvedValue(undefined),
+          mutate: vi.fn().mockResolvedValue(undefined)
+        }
+      }
+      if (path === '/assistants') {
+        return {
+          data: {
+            items: [
+              {
+                id: 'assistant-default',
+                name: 'Default Assistant',
+                emoji: '😀',
+                orderKey: 'a',
+                createdAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z'
+              },
+              {
+                id: 'assistant-2',
+                name: 'Beta Assistant',
+                emoji: '✍️',
+                orderKey: 'b',
+                createdAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z'
+              }
+            ],
+            total: 2
+          },
+          isLoading: false,
+          isRefreshing: false,
+          error: undefined,
+          refetch: vi.fn().mockResolvedValue(undefined),
+          mutate: vi.fn().mockResolvedValue(undefined)
+        }
+      }
+      return {
+        data: undefined,
+        isLoading: false,
+        isRefreshing: false,
+        error: undefined,
+        refetch: vi.fn().mockResolvedValue(undefined),
+        mutate: vi.fn().mockResolvedValue(undefined)
+      }
+    })
+    mockUseInfiniteQuery.mockReturnValue({
+      pages: [
+        {
+          items: [
+            createApiTopic({
+              id: 'topic-default',
+              name: 'Default row topic',
+              assistantId: 'assistant-default',
+              orderKey: 'a'
+            }),
+            createApiTopic({ id: 'topic-beta', name: 'Beta row topic', assistantId: 'assistant-2', orderKey: 'b' })
+          ]
+        }
+      ],
+      isLoading: false,
+      isRefreshing: false,
+      error: undefined,
+      hasNext: false,
+      loadNext: vi.fn(),
+      refresh: vi.fn(),
+      reset: vi.fn(),
+      mutate: vi.fn()
+    })
+
+    renderTopicList()
+
+    dndMocks.onDragEnd?.({
+      active: {
+        data: sortableData('group:topic:assistant:assistant-default'),
+        id: 'group:topic:assistant:assistant-default'
+      },
+      over: {
+        data: sortableData('group:topic:assistant:assistant-2'),
+        id: 'group:topic:assistant:assistant-2'
+      }
+    })
+
+    await vi.waitFor(() =>
+      expect(patchSpy).toHaveBeenCalledWith('/assistants/assistant-default/order', {
+        body: { after: 'assistant-2' }
+      })
+    )
+    expect(patchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not allow pinned or unknown groups to participate in assistant group reorder', () => {
+    const patchSpy = vi.spyOn(dataApiService, 'patch').mockResolvedValue(undefined as never)
+    MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
+    mockUseInfiniteQuery.mockReturnValue({
+      pages: [
+        {
+          items: [
+            createApiTopic({ id: 'topic-a', name: 'Known alpha', assistantId: 'assistant-1', orderKey: 'a' }),
+            createApiTopic({ id: 'topic-b', name: 'Pinned topic', assistantId: 'assistant-1', orderKey: 'b' }),
+            createApiTopic({
+              id: 'topic-e',
+              name: 'Unknown topic',
+              assistantId: 'missing-assistant',
+              orderKey: 'e'
+            })
+          ]
+        }
+      ],
+      isLoading: false,
+      isRefreshing: false,
+      error: undefined,
+      hasNext: false,
+      loadNext: vi.fn(),
+      refresh: vi.fn(),
+      reset: vi.fn(),
+      mutate: vi.fn()
+    })
+
+    renderTopicList()
+
+    expect(dndMocks.sortableData.has('group:topic:pinned')).toBe(false)
+    expect(dndMocks.sortableData.has('group:topic:assistant:unknown')).toBe(false)
+
+    dndMocks.onDragEnd?.({
+      active: {
+        data: sortableData('group:topic:assistant:assistant-1'),
+        id: 'group:topic:assistant:assistant-1'
+      },
+      over: { data: droppableData('group:topic:pinned'), id: 'group:topic:pinned' }
+    })
+    dndMocks.onDragEnd?.({
+      active: {
+        data: sortableData('group:topic:assistant:assistant-1'),
+        id: 'group:topic:assistant:assistant-1'
+      },
+      over: {
+        data: droppableData('group:topic:assistant:unknown'),
+        id: 'group:topic:assistant:unknown'
+      }
+    })
+
+    expect(patchSpy).not.toHaveBeenCalled()
+  })
+
+  it('disables assistant group reorder in manage mode', () => {
+    const patchSpy = vi.spyOn(dataApiService, 'patch').mockResolvedValue(undefined as never)
+    MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
+
+    renderTopicList()
+
+    expect(screen.getByTestId('dnd-context')).toBeInTheDocument()
+    fireEvent.click(screen.getByLabelText('Manage topics'))
+
+    expect(screen.queryByTestId('dnd-context')).not.toBeInTheDocument()
+    expect(patchSpy).not.toHaveBeenCalled()
   })
 
   it('moves only the active topic in the optimistic display overlay without rewriting order keys', () => {

--- a/src/renderer/src/pages/home/Tabs/index.tsx
+++ b/src/renderer/src/pages/home/Tabs/index.tsx
@@ -1,4 +1,5 @@
 import { usePreference } from '@data/hooks/usePreference'
+import type { ResourceListRevealRequest } from '@renderer/components/chat/resources'
 import { useNavbarPosition } from '@renderer/hooks/useNavbar'
 import type { Topic } from '@renderer/types'
 import { classNames } from '@renderer/utils'
@@ -12,10 +13,11 @@ interface Props {
   onOpenHistory?: (origin?: DOMRectReadOnly) => void
   setActiveTopic: (topic: Topic) => void
   position: 'left' | 'right'
+  revealRequest?: ResourceListRevealRequest
   style?: React.CSSProperties
 }
 
-const HomeTabs: FC<Props> = ({ activeTopic, onOpenHistory, setActiveTopic, position, style }) => {
+const HomeTabs: FC<Props> = ({ activeTopic, onOpenHistory, setActiveTopic, position, revealRequest, style }) => {
   const [topicPosition] = usePreference('topic.position')
   const { isLeftNavbar } = useNavbarPosition()
 
@@ -35,6 +37,7 @@ const HomeTabs: FC<Props> = ({ activeTopic, onOpenHistory, setActiveTopic, posit
           setActiveTopic={setActiveTopic}
           position={position}
           onOpenHistory={onOpenHistory}
+          revealRequest={revealRequest}
         />
       </TabContent>
     </Container>

--- a/src/renderer/src/pages/home/__tests__/HomePage.test.tsx
+++ b/src/renderer/src/pages/home/__tests__/HomePage.test.tsx
@@ -1,0 +1,199 @@
+import type { Topic } from '@renderer/types'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const initialTopic: Topic = {
+  id: 'topic-initial',
+  assistantId: 'assistant-1',
+  name: 'Initial topic',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  messages: [],
+  pinned: false,
+  isNameManuallyEdited: false
+}
+
+const historyTopic: Topic = {
+  id: 'topic-history',
+  assistantId: 'assistant-1',
+  name: 'History topic',
+  createdAt: '2026-01-02T00:00:00.000Z',
+  updatedAt: '2026-01-02T00:00:00.000Z',
+  messages: [],
+  pinned: false,
+  isNameManuallyEdited: false
+}
+
+const homeMocks = vi.hoisted(() => ({
+  cacheGet: vi.fn(),
+  cacheSet: vi.fn(),
+  historyTopic: undefined as Topic | undefined,
+  locationState: undefined as { topic: Topic } | undefined,
+  preferenceValues: new Map<string, unknown>(),
+  refreshTopics: vi.fn(),
+  setShowSidebar: vi.fn()
+}))
+
+vi.mock('@data/CacheService', () => ({
+  cacheService: {
+    get: homeMocks.cacheGet,
+    set: homeMocks.cacheSet
+  }
+}))
+
+vi.mock('@data/hooks/usePreference', async () => {
+  const React = await import('react')
+
+  return {
+    usePreference: (key: string) => {
+      const [value, setValue] = React.useState(() => homeMocks.preferenceValues.get(key))
+      const setPreference = vi.fn(async (nextValue: unknown) => {
+        homeMocks.preferenceValues.set(key, nextValue)
+        if (key === 'topic.tab.show') {
+          homeMocks.setShowSidebar(nextValue)
+        }
+        setValue(nextValue)
+      })
+
+      return [value, setPreference]
+    }
+  }
+})
+
+vi.mock('@renderer/hooks/useNavbar', () => ({
+  useNavbarPosition: () => ({ isLeftNavbar: false })
+}))
+
+vi.mock('@renderer/hooks/useShortcuts', () => ({
+  useShortcut: vi.fn()
+}))
+
+vi.mock('@renderer/hooks/useTemporaryTopic', () => ({
+  useTemporaryTopic: () => ({
+    topicId: undefined,
+    persist: vi.fn().mockResolvedValue(undefined)
+  })
+}))
+
+vi.mock('@renderer/hooks/useTopicDataApi', () => ({
+  useTopicMutations: () => ({
+    refreshTopics: homeMocks.refreshTopics
+  })
+}))
+
+vi.mock('@renderer/hooks/useTopic', async () => {
+  const React = await import('react')
+
+  return {
+    useActiveTopic: (topic?: Topic) => {
+      const [activeTopic, setActiveTopic] = React.useState<Topic | undefined>(topic)
+      return { activeTopic, setActiveTopic }
+    }
+  }
+})
+
+vi.mock('@renderer/pages/history/HistoryRecordsPage', () => ({
+  default: ({ onClose, onRecordSelect, open }: any) =>
+    open ? (
+      <button
+        type="button"
+        onClick={() => {
+          onRecordSelect?.(homeMocks.historyTopic)
+          onClose?.()
+        }}>
+        Select history topic
+      </button>
+    ) : null
+}))
+
+vi.mock('@renderer/services/EventService', () => ({
+  EVENT_NAMES: {
+    SHOW_ASSISTANTS: 'SHOW_ASSISTANTS',
+    SHOW_TOPIC_SIDEBAR: 'SHOW_TOPIC_SIDEBAR'
+  },
+  EventEmitter: {
+    emit: vi.fn()
+  }
+}))
+
+vi.mock('@renderer/services/NavigationService', () => ({
+  default: {
+    setNavigate: vi.fn()
+  }
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useLocation: () => ({
+    state: homeMocks.locationState
+  }),
+  useNavigate: () => vi.fn()
+}))
+
+vi.mock('../Chat', () => ({
+  default: ({ activeTopic, pane, paneOpen }: { activeTopic: Topic; pane?: ReactNode; paneOpen?: boolean }) => (
+    <section>
+      <output data-testid="active-topic">{activeTopic.id}</output>
+      <output data-testid="pane-open">{String(paneOpen)}</output>
+      {pane}
+    </section>
+  )
+}))
+
+vi.mock('../Navbar', () => ({
+  default: () => <nav />
+}))
+
+vi.mock('../Tabs', () => ({
+  default: ({ onOpenHistory, revealRequest }: any) => (
+    <div data-reveal-request={JSON.stringify(revealRequest ?? null)} data-testid="home-tabs">
+      <button type="button" onClick={() => onOpenHistory?.()}>
+        Open history
+      </button>
+    </div>
+  )
+}))
+
+import HomePage from '../HomePage'
+
+describe('HomePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    homeMocks.historyTopic = historyTopic
+    homeMocks.locationState = { topic: initialTopic }
+    homeMocks.preferenceValues.clear()
+    homeMocks.preferenceValues.set('topic.tab.show', false)
+    homeMocks.preferenceValues.set('topic.position', 'left')
+
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        window: {
+          resetMinimumSize: vi.fn().mockResolvedValue(undefined),
+          setMinimumSize: vi.fn().mockResolvedValue(undefined)
+        }
+      }
+    })
+  })
+
+  it('opens the topic sidebar and forwards a reveal request after selecting a history topic', async () => {
+    render(<HomePage />)
+
+    expect(screen.getByTestId('active-topic')).toHaveTextContent('topic-initial')
+    expect(screen.getByTestId('pane-open')).toHaveTextContent('false')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open history' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Select history topic' }))
+
+    await waitFor(() => expect(screen.getByTestId('active-topic')).toHaveTextContent('topic-history'))
+
+    expect(homeMocks.setShowSidebar).toHaveBeenCalledWith(true)
+    expect(screen.getByTestId('pane-open')).toHaveTextContent('true')
+    expect(JSON.parse(screen.getByTestId('home-tabs').getAttribute('data-reveal-request') ?? 'null')).toEqual({
+      clearFilters: true,
+      clearQuery: true,
+      itemId: 'topic-history',
+      requestId: 1
+    })
+  })
+})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR:

History-record selections could switch to the selected topic/session, but sidebar lists could still hide the target behind collapsed groups, search filters, show-more limits, or virtual scrolling. Assistant-grouped topic lists also only supported item-level topic drag ordering.

After this PR:

History selections reveal the matching sidebar row end-to-end: the sidebar opens, hiding filters are cleared, collapsed groups expand, show-more limits grow as needed, and the target row scrolls into view with a border-only focus hint. Assistant-grouped topic lists now support dragging real assistant groups, including the default assistant when it is backed by a real assistant row, with optimistic ordering and persistence through `/assistants/{id}/order`. Group dragging also uses insertion indicators and keeps a source placeholder for the dragged group.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The reveal behavior is implemented in `ResourceList` so query clearing, group expansion, show-more, virtual scrolling, and focus feedback stay owned by the list component that has the right layout context.
- Assistant group ordering is wired in `Topics` without adding new preferences, public APIs, or DataApi schema changes; assistant order remains the source of truth.
- Group drag visuals reuse the virtual list drag infrastructure and add insertion/source placeholder feedback without introducing a separate sidebar-specific drag layer.

The following alternatives were considered:

- Handling reveal entirely inside `Topics`, but that would duplicate ResourceList and virtual-list knowledge in a business component.
- Adding a global reveal event flow for every possible entry point, but the current changes keep the history-to-sidebar path direct while preserving a reusable ResourceList reveal request.
- Treating the default assistant as a virtual group, but current product data models it as a real assistant row and it should reorder like any other real assistant group.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- `pnpm build:check` was attempted locally but is currently blocked by existing repository typecheck issues unrelated to this PR: Anthropic SDK beta type version conflicts in `claude-code-language-model.ts` and Selector test type errors.
- Targeted renderer tests for the changed ResourceList, VirtualList, Topics, HomePage, AgentPage, Sessions, and HistoryRecordsPage flows pass locally.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
History selections now reveal the matching sidebar topic or session automatically, and assistant-grouped topic lists support dragging real assistant groups to reorder them.
```
