### PR TITLE
fix(ai-core): surface Ollama thinking blocks

### DIFF
--- a/src/renderer/src/aiCore/plugins/PluginBuilder.ts
+++ b/src/renderer/src/aiCore/plugins/PluginBuilder.ts
@@ -5,6 +5,7 @@ import {
   isDeepSeekModel,
   isGemini3Model,
   isQwen35to39Model,
+  isReasoningModel,
   isSupportedThinkingTokenQwenModel
 } from '@renderer/config/models'
 import { getEnableDeveloperMode } from '@renderer/hooks/useSettings'
@@ -69,9 +70,13 @@ export function buildPlugins({ provider, model, config }: BuildPluginsContext): 
   // 这样反转后 extractReasoning 在外层，其 wrapStream（状态机）
   // 能处理 simulateStreaming 生成的模拟流中的未闭合 <think> 标签。
 
-  // 0.1 Reasoning extraction for OpenAI/Azure providers
+  // 0.1 Reasoning extraction for providers that stream raw reasoning tags.
   const providerType = provider.type
-  if (providerType === 'openai' || providerType === 'azure-openai') {
+  if (
+    providerType === 'openai' ||
+    providerType === 'azure-openai' ||
+    (isOllamaProvider(provider) && isReasoningModel(model))
+  ) {
     const tagName = getReasoningTagName(model.id.toLowerCase())
     plugins.push(createReasoningExtractionPlugin({ tagName }))
   }

--- a/src/renderer/src/aiCore/plugins/__tests__/PluginBuilder.test.ts
+++ b/src/renderer/src/aiCore/plugins/__tests__/PluginBuilder.test.ts
@@ -1,0 +1,162 @@
+import type { Model, Provider } from '@renderer/types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockCreateReasoningExtractionPlugin, mockCreatePdfCompatibilityPlugin } = vi.hoisted(() => ({
+  mockCreateReasoningExtractionPlugin: vi.fn((options: { tagName?: string } = {}) => ({
+    name: 'reasoningExtraction',
+    options
+  })),
+  mockCreatePdfCompatibilityPlugin: vi.fn(() => ({
+    name: 'pdfCompatibility'
+  }))
+}))
+
+vi.mock('@renderer/hooks/useSettings', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@renderer/hooks/useSettings')>()
+  return {
+    ...actual,
+    getEnableDeveloperMode: vi.fn(() => false)
+  }
+})
+
+vi.mock('@renderer/config/models', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@renderer/config/models')>()
+  return {
+    ...actual,
+    isDeepSeekModel: vi.fn(() => false),
+    isGemini3Model: vi.fn(() => false),
+    isReasoningModel: vi.fn((model: Model) => model.id.includes('glm-4.7') || model.id.includes('gpt-oss')),
+    isQwen35to39Model: vi.fn(() => false),
+    isSupportedThinkingTokenQwenModel: vi.fn(() => false)
+  }
+})
+
+vi.mock('@renderer/utils/provider', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@renderer/utils/provider')>()
+  return {
+    ...actual,
+    isOllamaProvider: vi.fn((provider: Provider) => provider.id === 'ollama' || provider.type === 'ollama'),
+    isSupportEnableThinkingProvider: vi.fn(() => false)
+  }
+})
+
+vi.mock('../reasoningExtractionPlugin', () => ({
+  createReasoningExtractionPlugin: mockCreateReasoningExtractionPlugin
+}))
+
+vi.mock('../pdfCompatibilityPlugin', () => ({
+  createPdfCompatibilityPlugin: mockCreatePdfCompatibilityPlugin
+}))
+
+vi.mock('../anthropicCachePlugin', () => ({
+  createAnthropicCachePlugin: vi.fn(() => ({ name: 'anthropicCache' }))
+}))
+
+vi.mock('../deepseekDsmlParserPlugin', () => ({
+  createDeepseekDsmlParserPlugin: vi.fn(() => ({ name: 'deepseekDsmlParser' }))
+}))
+
+vi.mock('../noThinkPlugin', () => ({
+  createNoThinkPlugin: vi.fn(() => ({ name: 'noThink' }))
+}))
+
+vi.mock('../openrouterReasoningPlugin', () => ({
+  createOpenrouterReasoningPlugin: vi.fn(() => ({ name: 'openrouterReasoning' }))
+}))
+
+vi.mock('../qwenThinkingPlugin', () => ({
+  createQwenThinkingPlugin: vi.fn(() => ({ name: 'qwenThinking' }))
+}))
+
+vi.mock('../simulateStreamingPlugin', () => ({
+  createSimulateStreamingPlugin: vi.fn(() => ({ name: 'simulateStreaming' }))
+}))
+
+vi.mock('../skipGeminiThoughtSignaturePlugin', () => ({
+  createSkipGeminiThoughtSignaturePlugin: vi.fn(() => ({ name: 'skipGeminiThoughtSignature' }))
+}))
+
+vi.mock('../telemetryPlugin', () => ({
+  createTelemetryPlugin: vi.fn(() => ({ name: 'telemetry' }))
+}))
+
+vi.mock('@cherrystudio/ai-core/built-in/plugins', () => ({
+  createPromptToolUsePlugin: vi.fn(() => ({ name: 'promptToolUse' })),
+  providerToolPlugin: vi.fn(() => ({ name: 'providerTool' }))
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({
+      debug: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn()
+    })
+  }
+}))
+
+import { buildPlugins } from '../PluginBuilder'
+
+function makeProvider(overrides: Partial<Provider> = {}): Provider {
+  return {
+    id: 'ollama',
+    name: 'Ollama',
+    type: 'ollama',
+    apiKey: '',
+    apiHost: 'http://localhost:11434',
+    isSystem: false,
+    models: [],
+    extra_headers: {},
+    ...overrides
+  } as Provider
+}
+
+function makeModel(id: string): Model {
+  return {
+    id,
+    name: id,
+    provider: 'ollama'
+  } as Model
+}
+
+function makeConfig() {
+  return {
+    assistant: {} as never,
+    streamOutput: true,
+    enableReasoning: false,
+    enableGenerateImage: false,
+    enableWebSearch: false,
+    enableUrlContext: false,
+    isSupportedToolUse: false,
+    isPromptToolUse: false,
+    mcpTools: []
+  }
+}
+
+describe('PluginBuilder reasoning extraction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('enables reasoning extraction for Ollama thinking models', () => {
+    const plugins = buildPlugins({
+      provider: makeProvider(),
+      model: makeModel('glm-4.7-flash:q4_K_M'),
+      config: makeConfig()
+    })
+
+    expect(plugins.map((plugin) => plugin.name)).toContain('reasoningExtraction')
+    expect(mockCreateReasoningExtractionPlugin).toHaveBeenCalledWith({ tagName: 'think' })
+  })
+
+  it('does not enable reasoning extraction for non-thinking Ollama models', () => {
+    const plugins = buildPlugins({
+      provider: makeProvider(),
+      model: makeModel('llama3.1'),
+      config: makeConfig()
+    })
+
+    expect(plugins.map((plugin) => plugin.name)).not.toContain('reasoningExtraction')
+  })
+})


### PR DESCRIPTION
### What this PR does

Before this PR:
- Ollama reasoning-capable local models could stream thinking content without creating a visible thinking block in chat.
- GLM-style local models such as `glm-4.7-flash:q4_K_M` appeared to answer normally, but their reasoning stayed hidden.

After this PR:
- Ollama reasoning-capable models now run through reasoning extraction in the renderer plugin pipeline.
- Thinking output is surfaced in chat as a dedicated thinking block, matching the existing UI behavior for other reasoning providers.
- Added a regression test for the plugin builder to cover reasoning-capable and non-reasoning Ollama models.

Fixes #15109

### Why we need it and why it was done in this way

The following tradeoffs were made:
- The change is scoped to reasoning-capable Ollama models instead of all Ollama models, so ordinary local models keep the existing behavior.
- The fix reuses the existing reasoning extraction middleware instead of adding a separate Ollama-specific streaming path.

The following alternatives were considered:
- Adding a dedicated Ollama stream parser.
- Relying on model-specific prompt/template changes instead of handling the output in the client pipeline.

Links to places where the discussion took place: None

### Breaking changes

None

### Special notes for your reviewer

The new test covers the plugin selection path only; the runtime behavior follows the existing reasoning extraction middleware and thinking block renderer.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others)

### Release note

```release-note
Ollama reasoning-capable local models now surface their thinking blocks in chat, including GLM-style models such as glm-4.7-flash:q4_K_M.
```