### PR TITLE
fix(websearch): add Tavily raw content support with double gate control

### DIFF
--- a/src/renderer/src/aiCore/tools/WebSearchTool.ts
+++ b/src/renderer/src/aiCore/tools/WebSearchTool.ts
@@ -44,7 +44,7 @@ export const webSearchToolWithPreExtractedKeywords = (
   requestId: string
 ) => {
   const webSearchProvider = WebSearchService.getWebSearchProvider(webSearchProviderId)
-  let cachedSearchResultsPromise: Promise<WebSearchProviderResponse> | undefined
+  const cachedSearchResultsPromises = new Map<string, Promise<WebSearchProviderResponse>>()
 
   return tool({
     description: `Web search tool for finding current information, news, and real-time data from the internet.
@@ -73,14 +73,9 @@ You can use this tool as-is to search with the prepared queries, or provide addi
     }),
 
     execute: async ({ additionalContext, fullContent }) => {
-      if (cachedSearchResultsPromise) {
-        return cachedSearchResultsPromise
-      }
-
       let finalQueries = normalizeWebSearchQueries(extractedKeywords.question)
 
       if (additionalContext?.trim()) {
-        // 如果大模型提供了额外上下文，使用更具体的描述
         const cleanContext = additionalContext.trim()
         if (cleanContext) {
           finalQueries = normalizeWebSearchQueries([cleanContext])
@@ -92,6 +87,17 @@ You can use this tool as-is to search with the prepared queries, or provide addi
         return { query: '', results: [] }
       }
 
+      const cacheKey = JSON.stringify({
+        question: finalQueries,
+        links: extractedKeywords.links ?? [],
+        fullContent: fullContent === true
+      })
+
+      const cached = cachedSearchResultsPromises.get(cacheKey)
+      if (cached) {
+        return cached
+      }
+
       // 构建 ExtractResults 结构用于 processWebsearch
       const extractResults: ExtractResults = {
         websearch: {
@@ -99,16 +105,17 @@ You can use this tool as-is to search with the prepared queries, or provide addi
           links: extractedKeywords.links
         }
       }
-      cachedSearchResultsPromise = WebSearchService.processWebsearch(
+      const searchPromise = WebSearchService.processWebsearch(
         webSearchProvider!,
         extractResults,
         requestId,
         fullContent
       )
+      cachedSearchResultsPromises.set(cacheKey, searchPromise)
       try {
-        return await cachedSearchResultsPromise
+        return await searchPromise
       } catch (error) {
-        cachedSearchResultsPromise = undefined
+        cachedSearchResultsPromises.delete(cacheKey)
         throw error
       }
     },

--- a/src/renderer/src/aiCore/tools/WebSearchTool.ts
+++ b/src/renderer/src/aiCore/tools/WebSearchTool.ts
@@ -63,10 +63,16 @@ You can use this tool as-is to search with the prepared queries, or provide addi
       additionalContext: z
         .string()
         .optional()
-        .describe('Optional additional context, keywords, or specific focus to enhance the search')
+        .describe('Optional additional context, keywords, or specific focus to enhance the search'),
+      fullContent: z
+        .boolean()
+        .optional()
+        .describe(
+          'Set to true to request full page content instead of snippets. Use only when detailed page analysis is needed.'
+        )
     }),
 
-    execute: async ({ additionalContext }) => {
+    execute: async ({ additionalContext, fullContent }) => {
       if (cachedSearchResultsPromise) {
         return cachedSearchResultsPromise
       }
@@ -93,7 +99,12 @@ You can use this tool as-is to search with the prepared queries, or provide addi
           links: extractedKeywords.links
         }
       }
-      cachedSearchResultsPromise = WebSearchService.processWebsearch(webSearchProvider!, extractResults, requestId)
+      cachedSearchResultsPromise = WebSearchService.processWebsearch(
+        webSearchProvider!,
+        extractResults,
+        requestId,
+        fullContent
+      )
       try {
         return await cachedSearchResultsPromise
       } catch (error) {

--- a/src/renderer/src/aiCore/tools/__tests__/WebSearchTool.test.ts
+++ b/src/renderer/src/aiCore/tools/__tests__/WebSearchTool.test.ts
@@ -47,7 +47,8 @@ describe('webSearchToolWithPreExtractedKeywords', () => {
           links: undefined
         }
       },
-      'request-1'
+      'request-1',
+      undefined
     )
     expect(firstResult.results[0].url).toBe('https://example.com/path?utm_source=newsletter#details')
     expect(secondResult).toBe(firstResult)
@@ -96,7 +97,8 @@ describe('webSearchToolWithPreExtractedKeywords', () => {
           links: undefined
         }
       },
-      'request-1'
+      'request-1',
+      undefined
     )
     expect(firstResult).toBe(searchResponse)
     expect(secondResult).toBe(searchResponse)

--- a/src/renderer/src/aiCore/tools/__tests__/WebSearchTool.test.ts
+++ b/src/renderer/src/aiCore/tools/__tests__/WebSearchTool.test.ts
@@ -35,8 +35,7 @@ describe('webSearchToolWithPreExtractedKeywords', () => {
       'request-1'
     ) as any
 
-    const firstResult = await searchTool.execute({})
-    const secondResult = await searchTool.execute({ additionalContext: 'new context' })
+    const result = await searchTool.execute({})
 
     expect(WebSearchService.processWebsearch).toHaveBeenCalledTimes(1)
     expect(WebSearchService.processWebsearch).toHaveBeenCalledWith(
@@ -50,17 +49,110 @@ describe('webSearchToolWithPreExtractedKeywords', () => {
       'request-1',
       undefined
     )
-    expect(firstResult.results[0].url).toBe('https://example.com/path?utm_source=newsletter#details')
-    expect(secondResult).toBe(firstResult)
+    expect(result.results[0].url).toBe('https://example.com/path?utm_source=newsletter#details')
 
-    const modelOutput = searchTool.toModelOutput({ output: firstResult })
+    const modelOutput = searchTool.toModelOutput({ output: result })
     const modelText = modelOutput.value.map((part: { text: string }) => part.text).join('\n')
 
     expect(modelText).toContain('"url": "https://example.com"')
     expect(modelText).not.toContain('utm_source')
   })
 
-  it('reuses the in-flight search request for concurrent executions', async () => {
+  it('reuses cached result for identical queries', async () => {
+    const searchTool = webSearchToolWithPreExtractedKeywords(
+      'tavily',
+      {
+        question: ['test query']
+      },
+      'request-1'
+    ) as any
+
+    const firstResult = await searchTool.execute({})
+    const secondResult = await searchTool.execute({})
+
+    // Same queries + no additionalContext = cache hit
+    expect(WebSearchService.processWebsearch).toHaveBeenCalledTimes(1)
+    expect(firstResult).toBe(secondResult)
+  })
+
+  it('does not reuse cache when additionalContext produces different queries', async () => {
+    vi.mocked(WebSearchService.processWebsearch).mockResolvedValue({
+      query: 'result',
+      results: [{ title: 'R', content: 'C', url: 'https://example.com' }]
+    })
+
+    const searchTool = webSearchToolWithPreExtractedKeywords(
+      'tavily',
+      {
+        question: ['original']
+      },
+      'request-1'
+    ) as any
+
+    await searchTool.execute({})
+    await searchTool.execute({ additionalContext: 'different context' })
+
+    // Different finalQueries = separate cache entries
+    expect(WebSearchService.processWebsearch).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not reuse cache when fullContent mode differs', async () => {
+    vi.mocked(WebSearchService.processWebsearch).mockResolvedValue({
+      query: 'result',
+      results: [{ title: 'R', content: 'C', url: 'https://example.com' }]
+    })
+
+    const searchTool = webSearchToolWithPreExtractedKeywords(
+      'tavily',
+      {
+        question: ['test']
+      },
+      'request-1'
+    ) as any
+
+    await searchTool.execute({})
+    await searchTool.execute({ fullContent: true })
+
+    // fullContent=false vs fullContent=true = separate cache entries
+    expect(WebSearchService.processWebsearch).toHaveBeenCalledTimes(2)
+    expect(WebSearchService.processWebsearch).toHaveBeenNthCalledWith(
+      1,
+      { id: 'tavily' },
+      expect.anything(),
+      'request-1',
+      undefined
+    )
+    expect(WebSearchService.processWebsearch).toHaveBeenNthCalledWith(
+      2,
+      { id: 'tavily' },
+      expect.anything(),
+      'request-1',
+      true
+    )
+  })
+
+  it('reuses cache for same fullContent mode', async () => {
+    vi.mocked(WebSearchService.processWebsearch).mockResolvedValue({
+      query: 'result',
+      results: [{ title: 'R', content: 'C', url: 'https://example.com' }]
+    })
+
+    const searchTool = webSearchToolWithPreExtractedKeywords(
+      'tavily',
+      {
+        question: ['test']
+      },
+      'request-1'
+    ) as any
+
+    await searchTool.execute({ fullContent: true })
+    await searchTool.execute({ fullContent: true })
+
+    // Same fullContent mode = cache hit
+    expect(WebSearchService.processWebsearch).toHaveBeenCalledTimes(1)
+  })
+
+  it('reuses in-flight search request for concurrent executions', async () => {
     const searchResponse = {
       query: 'first',
       results: [
@@ -85,21 +177,11 @@ describe('webSearchToolWithPreExtractedKeywords', () => {
 
     const [firstResult, secondResult] = await Promise.all([
       searchTool.execute({ additionalContext: 'first context' }),
-      searchTool.execute({ additionalContext: 'second context' })
+      searchTool.execute({ additionalContext: 'first context' })
     ])
 
+    // Concurrent calls with same cache key = single search
     expect(WebSearchService.processWebsearch).toHaveBeenCalledTimes(1)
-    expect(WebSearchService.processWebsearch).toHaveBeenCalledWith(
-      { id: 'tavily' },
-      {
-        websearch: {
-          question: ['first context'],
-          links: undefined
-        }
-      },
-      'request-1',
-      undefined
-    )
     expect(firstResult).toBe(searchResponse)
     expect(secondResult).toBe(searchResponse)
   })

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -5772,6 +5772,10 @@
             "placeholder": "Enter Tavily API Key"
           },
           "description": "Tavily is a search engine tailored for AI agents, delivering real-time, accurate results, intelligent query suggestions, and in-depth research capabilities.",
+          "include_raw_content": {
+            "label": "Get Full Page Content",
+            "tip": "When enabled, allows the AI to request full page content when needed. Disable to save tokens."
+          },
           "title": "Tavily"
         },
         "title": "Web Search",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -5772,6 +5772,10 @@
             "placeholder": "请输入 Tavily API 密钥"
           },
           "description": "Tavily 是一个为 AI 代理量身定制的搜索引擎，提供实时、准确的结果、智能查询建议和深入的研究能力",
+          "include_raw_content": {
+            "label": "获取完整网页内容",
+            "tip": "开启后，允许 AI 在需要时请求完整网页内容。关闭可节省 token。"
+          },
           "title": "Tavily"
         },
         "title": "网络搜索",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -5772,6 +5772,10 @@
             "placeholder": "請輸入 Tavily API 金鑰"
           },
           "description": "Tavily 是一個為 AI 代理量身訂製的搜尋引擎，提供即時、準確的結果、智慧查詢建議和深入的研究能力",
+          "include_raw_content": {
+            "label": "[to be translated]:Get Full Page Content",
+            "tip": "[to be translated]:When enabled, allows the AI to request full page content when needed. Disable to save tokens."
+          },
           "title": "Tavily"
         },
         "title": "網路搜尋",

--- a/src/renderer/src/i18n/translate/de-de.json
+++ b/src/renderer/src/i18n/translate/de-de.json
@@ -5772,6 +5772,10 @@
             "placeholder": "Bitte Tavily API-Schlüssel eingeben"
           },
           "description": "Tavily ist ein für AI-Agenten spezifiziertes Suchmaschinen-Tool, das realtime, präzise Ergebnisse, intelligente Suchvorschläge und tiefergehende Forschungsmöglichkeiten bietet",
+          "include_raw_content": {
+            "label": "[to be translated]:Get Full Page Content",
+            "tip": "[to be translated]:When enabled, allows the AI to request full page content when needed. Disable to save tokens."
+          },
           "title": "Tavily"
         },
         "title": "Websuche",

--- a/src/renderer/src/i18n/translate/el-gr.json
+++ b/src/renderer/src/i18n/translate/el-gr.json
@@ -5772,6 +5772,10 @@
             "placeholder": "Παρακαλώ εισάγετε το κλειδί Tavily API"
           },
           "description": "Το Tavily είναι μια μηχανή αναζήτησης που εξατομικεύεται για AI πράκτορες, παρέχοντας πραγματικού χρόνου, ακριβή αποτελέσματα, έξυπνες προτάσεις ερωτημάτων και δυνατότητες εμβάθυνσης έρευνας",
+          "include_raw_content": {
+            "label": "[to be translated]:Get Full Page Content",
+            "tip": "[to be translated]:When enabled, allows the AI to request full page content when needed. Disable to save tokens."
+          },
           "title": "Tavily"
         },
         "title": "Διαδικτυακή Αναζήτηση",

--- a/src/renderer/src/i18n/translate/es-es.json
+++ b/src/renderer/src/i18n/translate/es-es.json
@@ -5772,6 +5772,10 @@
             "placeholder": "Por favor ingrese la clave API de Tavily"
           },
           "description": "Tavily es un motor de búsqueda diseñado especialmente para agentes de inteligencia artificial, que ofrece resultados precisos y en tiempo real, sugerencias inteligentes de consultas y capacidades avanzadas de investigación",
+          "include_raw_content": {
+            "label": "[to be translated]:Get Full Page Content",
+            "tip": "[to be translated]:When enabled, allows the AI to request full page content when needed. Disable to save tokens."
+          },
           "title": "Tavily"
         },
         "title": "Búsqueda web",

--- a/src/renderer/src/i18n/translate/fr-fr.json
+++ b/src/renderer/src/i18n/translate/fr-fr.json
@@ -5772,6 +5772,10 @@
             "placeholder": "Veuillez saisir la clé API Tavily"
           },
           "description": "Tavily est un moteur de recherche spécialement conçu pour les agents d'intelligence artificielle, offrant des résultats en temps réel, précis, des suggestions intelligentes de requêtes et des capacités de recherche approfondie",
+          "include_raw_content": {
+            "label": "[to be translated]:Get Full Page Content",
+            "tip": "[to be translated]:When enabled, allows the AI to request full page content when needed. Disable to save tokens."
+          },
           "title": "Tavily"
         },
         "title": "Recherche web",

--- a/src/renderer/src/i18n/translate/ja-jp.json
+++ b/src/renderer/src/i18n/translate/ja-jp.json
@@ -5772,6 +5772,10 @@
             "placeholder": "Tavily API キーを入力してください"
           },
           "description": "Tavily は、AI エージェントのために特別に開発された検索エンジンで、最新の結果、インテリジェントな検索提案、そして深い研究能力を提供します",
+          "include_raw_content": {
+            "label": "[to be translated]:Get Full Page Content",
+            "tip": "[to be translated]:When enabled, allows the AI to request full page content when needed. Disable to save tokens."
+          },
           "title": "Tavily"
         },
         "title": "ウェブ検索",

--- a/src/renderer/src/i18n/translate/pt-pt.json
+++ b/src/renderer/src/i18n/translate/pt-pt.json
@@ -5772,6 +5772,10 @@
             "placeholder": "Por favor, insira a chave API Tavily"
           },
           "description": "Tavily é um mecanismo de busca personalizado para agentes de IA, que oferece resultados precisos e em tempo real, sugestões inteligentes de consulta e capacidades avançadas de pesquisa",
+          "include_raw_content": {
+            "label": "[to be translated]:Get Full Page Content",
+            "tip": "[to be translated]:When enabled, allows the AI to request full page content when needed. Disable to save tokens."
+          },
           "title": "Tavily"
         },
         "title": "Pesquisa na Web",

--- a/src/renderer/src/i18n/translate/ro-ro.json
+++ b/src/renderer/src/i18n/translate/ro-ro.json
@@ -5772,6 +5772,10 @@
             "placeholder": "Introdu cheia API Tavily"
           },
           "description": "Tavily este un motor de căutare adaptat pentru agenți AI, oferind rezultate în timp real, precise, sugestii inteligente de interogare și capacități de cercetare aprofundată.",
+          "include_raw_content": {
+            "label": "[to be translated]:Get Full Page Content",
+            "tip": "[to be translated]:When enabled, allows the AI to request full page content when needed. Disable to save tokens."
+          },
           "title": "Tavily"
         },
         "title": "Căutare web",

--- a/src/renderer/src/i18n/translate/ru-ru.json
+++ b/src/renderer/src/i18n/translate/ru-ru.json
@@ -5772,6 +5772,10 @@
             "placeholder": "Введите ключ API Tavily"
           },
           "description": "Tavily — это поисковая система, специально разработанная для ИИ-агентов, предоставляющая актуальные результаты, умные предложения по запросам и глубокие исследовательские возможности",
+          "include_raw_content": {
+            "label": "[to be translated]:Get Full Page Content",
+            "tip": "[to be translated]:When enabled, allows the AI to request full page content when needed. Disable to save tokens."
+          },
           "title": "Tavily"
         },
         "title": "Поиск в Интернете",

--- a/src/renderer/src/i18n/translate/vi-vn.json
+++ b/src/renderer/src/i18n/translate/vi-vn.json
@@ -5772,6 +5772,10 @@
             "placeholder": "Introduce la clave de API de Tavily"
           },
           "description": "Tavily là một công cụ tìm kiếm được thiết kế dành cho các tác nhân AI, cung cấp kết quả thời gian thực chính xác, gợi ý truy vấn thông minh và khả năng nghiên cứu chuyên sâu.",
+          "include_raw_content": {
+            "label": "[to be translated]:Get Full Page Content",
+            "tip": "[to be translated]:When enabled, allows the AI to request full page content when needed. Disable to save tokens."
+          },
           "title": "Tavily"
         },
         "title": "Tìm kiếm Web",

--- a/src/renderer/src/pages/settings/WebSearchSettings/WebSearchProviderSetting.tsx
+++ b/src/renderer/src/pages/settings/WebSearchSettings/WebSearchProviderSetting.tsx
@@ -17,7 +17,7 @@ import { useDefaultWebSearchProvider, useWebSearchProvider } from '@renderer/hoo
 import WebSearchService from '@renderer/services/WebSearchService'
 import type { WebSearchProviderId } from '@renderer/types'
 import { formatApiKeys, hasObjectKey } from '@renderer/utils'
-import { Button, Divider, Flex, Form, Input, Space, Tooltip } from 'antd'
+import { Button, Divider, Flex, Form, Input, Space, Switch, Tooltip } from 'antd'
 import Link from 'antd/es/typography/Link'
 import { Info, List } from 'lucide-react'
 import type { FC } from 'react'
@@ -168,6 +168,7 @@ const WebSearchProviderSetting: FC<Props> = ({ providerId }) => {
   }
 
   const isLocalProvider = provider.id.startsWith('local')
+  const isTavilyProvider = provider.id === 'tavily'
 
   const openLocalProviderSettings = async () => {
     if (officialWebsite) {
@@ -342,6 +343,22 @@ const WebSearchProviderSetting: FC<Props> = ({ providerId }) => {
               </Form.Item>
             </Form>
           </Flex>
+        </>
+      )}
+      {isTavilyProvider && (
+        <>
+          <SettingDivider style={{ marginTop: 12, marginBottom: 12 }} />
+          <SettingSubtitle
+            style={{ marginTop: 5, marginBottom: 10, display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
+            {t('settings.tool.websearch.tavily.include_raw_content.label')}
+            <Tooltip title={t('settings.tool.websearch.tavily.include_raw_content.tip')} placement="right">
+              <Info size={16} color="var(--color-icon)" style={{ marginLeft: 5, cursor: 'pointer' }} />
+            </Tooltip>
+          </SettingSubtitle>
+          <Switch
+            checked={provider.includeRawContent !== false}
+            onChange={(checked) => updateProvider({ includeRawContent: checked })}
+          />
         </>
       )}
     </>

--- a/src/renderer/src/providers/WebSearchProvider/BaseWebSearchProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/BaseWebSearchProvider.ts
@@ -1,6 +1,8 @@
 import type { WebSearchState } from '@renderer/store/websearch'
 import type { WebSearchProvider, WebSearchProviderResponse } from '@renderer/types'
 
+export type WebSearchRuntimeConfig = WebSearchState & { fullContent?: boolean }
+
 export default abstract class BaseWebSearchProvider {
   // @ts-ignore this
   protected provider: WebSearchProvider
@@ -15,7 +17,7 @@ export default abstract class BaseWebSearchProvider {
 
   abstract search(
     query: string,
-    websearch: WebSearchState,
+    websearch: WebSearchRuntimeConfig,
     httpOptions?: RequestInit
   ): Promise<WebSearchProviderResponse>
 

--- a/src/renderer/src/providers/WebSearchProvider/BochaProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/BochaProvider.ts
@@ -1,9 +1,8 @@
 import { loggerService } from '@logger'
-import type { WebSearchState } from '@renderer/store/websearch'
 import type { WebSearchProvider, WebSearchProviderResponse } from '@renderer/types'
 import type { BochaSearchParams, BochaSearchResponse } from '@renderer/utils/bocha'
 
-import BaseWebSearchProvider from './BaseWebSearchProvider'
+import BaseWebSearchProvider, { type WebSearchRuntimeConfig } from './BaseWebSearchProvider'
 
 const logger = loggerService.withContext('BochaProvider')
 
@@ -18,7 +17,7 @@ export default class BochaProvider extends BaseWebSearchProvider {
     }
   }
 
-  public async search(query: string, websearch: WebSearchState): Promise<WebSearchProviderResponse> {
+  public async search(query: string, websearch: WebSearchRuntimeConfig): Promise<WebSearchProviderResponse> {
     try {
       if (!query.trim()) {
         throw new Error('Search query cannot be empty')

--- a/src/renderer/src/providers/WebSearchProvider/ExaMcpProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/ExaMcpProvider.ts
@@ -1,8 +1,7 @@
 import { loggerService } from '@logger'
-import type { WebSearchState } from '@renderer/store/websearch'
 import type { WebSearchProvider, WebSearchProviderResponse } from '@renderer/types'
 
-import BaseWebSearchProvider from './BaseWebSearchProvider'
+import BaseWebSearchProvider, { type WebSearchRuntimeConfig } from './BaseWebSearchProvider'
 
 const logger = loggerService.withContext('ExaMcpProvider')
 
@@ -55,7 +54,7 @@ export default class ExaMcpProvider extends BaseWebSearchProvider {
 
   public async search(
     query: string,
-    websearch: WebSearchState,
+    websearch: WebSearchRuntimeConfig,
     httpOptions?: RequestInit
   ): Promise<WebSearchProviderResponse> {
     try {

--- a/src/renderer/src/providers/WebSearchProvider/ExaProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/ExaProvider.ts
@@ -1,9 +1,8 @@
 import { ExaClient } from '@agentic/exa'
 import { loggerService } from '@logger'
-import type { WebSearchState } from '@renderer/store/websearch'
 import type { WebSearchProvider, WebSearchProviderResponse } from '@renderer/types'
 
-import BaseWebSearchProvider from './BaseWebSearchProvider'
+import BaseWebSearchProvider, { type WebSearchRuntimeConfig } from './BaseWebSearchProvider'
 
 const logger = loggerService.withContext('ExaProvider')
 export default class ExaProvider extends BaseWebSearchProvider {
@@ -20,7 +19,7 @@ export default class ExaProvider extends BaseWebSearchProvider {
     this.exa = new ExaClient({ apiKey: this.apiKey, apiBaseUrl: this.apiHost })
   }
 
-  public async search(query: string, websearch: WebSearchState): Promise<WebSearchProviderResponse> {
+  public async search(query: string, websearch: WebSearchRuntimeConfig): Promise<WebSearchProviderResponse> {
     try {
       if (!query.trim()) {
         throw new Error('Search query cannot be empty')

--- a/src/renderer/src/providers/WebSearchProvider/LocalSearchProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/LocalSearchProvider.ts
@@ -1,13 +1,12 @@
 import { loggerService } from '@logger'
 import { nanoid } from '@reduxjs/toolkit'
 import store from '@renderer/store'
-import type { WebSearchState } from '@renderer/store/websearch'
 import type { WebSearchProvider, WebSearchProviderResponse, WebSearchProviderResult } from '@renderer/types'
 import { createAbortPromise } from '@renderer/utils/abortController'
 import { isAbortError } from '@renderer/utils/error'
 import { fetchWebContent, noContent } from '@renderer/utils/fetch'
 
-import BaseWebSearchProvider from './BaseWebSearchProvider'
+import BaseWebSearchProvider, { type WebSearchRuntimeConfig } from './BaseWebSearchProvider'
 
 const logger = loggerService.withContext('LocalSearchProvider')
 
@@ -26,7 +25,7 @@ export default class LocalSearchProvider extends BaseWebSearchProvider {
 
   public async search(
     query: string,
-    websearch: WebSearchState,
+    websearch: WebSearchRuntimeConfig,
     httpOptions?: RequestInit
   ): Promise<WebSearchProviderResponse> {
     const uid = nanoid()

--- a/src/renderer/src/providers/WebSearchProvider/QueritProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/QueritProvider.ts
@@ -1,8 +1,7 @@
 import { loggerService } from '@logger'
-import type { WebSearchState } from '@renderer/store/websearch'
 import type { WebSearchProvider, WebSearchProviderResponse } from '@renderer/types'
 
-import BaseWebSearchProvider from './BaseWebSearchProvider'
+import BaseWebSearchProvider, { type WebSearchRuntimeConfig } from './BaseWebSearchProvider'
 
 const logger = loggerService.withContext('QueritProvider')
 interface QueritSearchParams {
@@ -48,7 +47,7 @@ export default class QueritProvider extends BaseWebSearchProvider {
   }
   public async search(
     query: string,
-    websearch: WebSearchState,
+    websearch: WebSearchRuntimeConfig,
     httpOptions?: RequestInit
   ): Promise<WebSearchProviderResponse> {
     try {

--- a/src/renderer/src/providers/WebSearchProvider/SearxngProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/SearxngProvider.ts
@@ -1,12 +1,11 @@
 import { SearxngClient } from '@agentic/searxng'
 import { loggerService } from '@logger'
-import type { WebSearchState } from '@renderer/store/websearch'
 import type { WebSearchProvider, WebSearchProviderResponse } from '@renderer/types'
 import { fetchWebContent, noContent } from '@renderer/utils/fetch'
 import axios from 'axios'
 import ky from 'ky'
 
-import BaseWebSearchProvider from './BaseWebSearchProvider'
+import BaseWebSearchProvider, { type WebSearchRuntimeConfig } from './BaseWebSearchProvider'
 
 const logger = loggerService.withContext('SearxngProvider')
 
@@ -95,7 +94,7 @@ export default class SearxngProvider extends BaseWebSearchProvider {
     }
   }
 
-  public async search(query: string, websearch: WebSearchState): Promise<WebSearchProviderResponse> {
+  public async search(query: string, websearch: WebSearchRuntimeConfig): Promise<WebSearchProviderResponse> {
     try {
       if (!query) {
         throw new Error('Search query cannot be empty')

--- a/src/renderer/src/providers/WebSearchProvider/TavilyProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/TavilyProvider.ts
@@ -8,6 +8,8 @@ import BaseWebSearchProvider from './BaseWebSearchProvider'
 const logger = loggerService.withContext('TavilyProvider')
 export default class TavilyProvider extends BaseWebSearchProvider {
   private tvly: TavilyClient
+  // Gate 1: provider-level switch (default enabled)
+  private includeRawContent: boolean
 
   constructor(provider: WebSearchProvider) {
     super(provider)
@@ -18,6 +20,7 @@ export default class TavilyProvider extends BaseWebSearchProvider {
       throw new Error('API host is required for Tavily provider')
     }
     this.tvly = new TavilyClient({ apiKey: this.apiKey, apiBaseUrl: this.apiHost })
+    this.includeRawContent = provider.includeRawContent !== false
   }
 
   public async search(query: string, websearch: WebSearchState): Promise<WebSearchProviderResponse> {
@@ -26,17 +29,21 @@ export default class TavilyProvider extends BaseWebSearchProvider {
         throw new Error('Search query cannot be empty')
       }
 
+      // Double gate: Gate 1 (provider config) AND Gate 2 (per-request, default false)
+      const shouldIncludeRawContent = this.includeRawContent && websearch.fullContent === true
+
       const result = await this.tvly.search({
         query,
-        max_results: Math.max(1, websearch.maxResults)
+        max_results: Math.max(1, websearch.maxResults),
+        ...(shouldIncludeRawContent ? { include_raw_content: true } : {})
       })
       return {
         query: result.query,
-        results: result.results.slice(0, websearch.maxResults).map((result) => {
+        results: result.results.slice(0, websearch.maxResults).map((item) => {
           return {
-            title: result.title || 'No title',
-            content: result.content || '',
-            url: result.url || ''
+            title: item.title || 'No title',
+            content: shouldIncludeRawContent && item.raw_content ? item.raw_content : item.content || '',
+            url: item.url || ''
           }
         })
       }

--- a/src/renderer/src/providers/WebSearchProvider/TavilyProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/TavilyProvider.ts
@@ -1,9 +1,8 @@
 import { TavilyClient } from '@agentic/tavily'
 import { loggerService } from '@logger'
-import type { WebSearchState } from '@renderer/store/websearch'
 import type { WebSearchProvider, WebSearchProviderResponse } from '@renderer/types'
 
-import BaseWebSearchProvider from './BaseWebSearchProvider'
+import BaseWebSearchProvider, { type WebSearchRuntimeConfig } from './BaseWebSearchProvider'
 
 const logger = loggerService.withContext('TavilyProvider')
 export default class TavilyProvider extends BaseWebSearchProvider {
@@ -23,7 +22,7 @@ export default class TavilyProvider extends BaseWebSearchProvider {
     this.includeRawContent = provider.includeRawContent !== false
   }
 
-  public async search(query: string, websearch: WebSearchState): Promise<WebSearchProviderResponse> {
+  public async search(query: string, websearch: WebSearchRuntimeConfig): Promise<WebSearchProviderResponse> {
     try {
       if (!query.trim()) {
         throw new Error('Search query cannot be empty')

--- a/src/renderer/src/providers/WebSearchProvider/ZhipuProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/ZhipuProvider.ts
@@ -1,8 +1,7 @@
 import { loggerService } from '@logger'
-import type { WebSearchState } from '@renderer/store/websearch'
 import type { WebSearchProvider, WebSearchProviderResponse } from '@renderer/types'
 
-import BaseWebSearchProvider from './BaseWebSearchProvider'
+import BaseWebSearchProvider, { type WebSearchRuntimeConfig } from './BaseWebSearchProvider'
 
 const logger = loggerService.withContext('ZhipuProvider')
 
@@ -43,7 +42,7 @@ export default class ZhipuProvider extends BaseWebSearchProvider {
     }
   }
 
-  public async search(query: string, websearch: WebSearchState): Promise<WebSearchProviderResponse> {
+  public async search(query: string, websearch: WebSearchRuntimeConfig): Promise<WebSearchProviderResponse> {
     try {
       if (!query.trim()) {
         throw new Error('Search query cannot be empty')

--- a/src/renderer/src/providers/WebSearchProvider/__tests__/TavilyProvider.test.ts
+++ b/src/renderer/src/providers/WebSearchProvider/__tests__/TavilyProvider.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import TavilyProvider from '../TavilyProvider'
+
+// Mock TavilyClient
+vi.mock('@agentic/tavily', () => ({
+  TavilyClient: vi.fn().mockImplementation(() => ({
+    search: vi.fn()
+  }))
+}))
+
+// Mock logger
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({
+      error: vi.fn(),
+      info: vi.fn()
+    })
+  }
+}))
+
+function createMockProvider(overrides: Record<string, any> = {}) {
+  return {
+    id: 'tavily',
+    name: 'Tavily',
+    apiKey: 'test-key',
+    apiHost: 'https://api.tavily.com',
+    ...overrides
+  } as any
+}
+
+function createMockWebsearch(overrides: Record<string, any> = {}) {
+  return {
+    maxResults: 5,
+    searchWithTime: false,
+    excludeDomains: [],
+    providers: [],
+    defaultProvider: 'tavily',
+    subscribeSources: [],
+    overwrite: false,
+    providerConfig: {},
+    ...overrides
+  } as any
+}
+
+describe('TavilyProvider double gate', () => {
+  let provider: TavilyProvider
+  let mockSearch: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function createProvider(providerConfig = {}) {
+    provider = new TavilyProvider(createMockProvider(providerConfig))
+    mockSearch = (provider as any).tvly.search
+  }
+
+  it('should NOT request raw content when both gates are default (gate2=false)', async () => {
+    createProvider()
+    mockSearch.mockResolvedValue({
+      query: 'test',
+      results: [{ title: 'Test', content: 'snippet', url: 'https://example.com' }]
+    })
+
+    const result = await provider.search('test', createMockWebsearch())
+
+    expect(mockSearch).toHaveBeenCalledWith(expect.objectContaining({ query: 'test', max_results: 5 }))
+    expect(mockSearch).not.toHaveBeenCalledWith(expect.objectContaining({ include_raw_content: true }))
+    expect(result.results[0].content).toBe('snippet')
+  })
+
+  it('should request raw content when both gates are open', async () => {
+    createProvider() // gate1 default = true
+    mockSearch.mockResolvedValue({
+      query: 'test',
+      results: [{ title: 'Test', content: 'snippet', raw_content: 'full page content', url: 'https://example.com' }]
+    })
+
+    const result = await provider.search('test', createMockWebsearch({ fullContent: true }))
+
+    expect(mockSearch).toHaveBeenCalledWith(expect.objectContaining({ include_raw_content: true }))
+    expect(result.results[0].content).toBe('full page content')
+  })
+
+  it('should NOT request raw content when gate1 is closed (includeRawContent=false)', async () => {
+    createProvider({ includeRawContent: false })
+    mockSearch.mockResolvedValue({
+      query: 'test',
+      results: [{ title: 'Test', content: 'snippet', url: 'https://example.com' }]
+    })
+
+    await provider.search('test', createMockWebsearch({ fullContent: true }))
+
+    expect(mockSearch).not.toHaveBeenCalledWith(expect.objectContaining({ include_raw_content: true }))
+  })
+
+  it('should NOT request raw content when gate2 is not activated', async () => {
+    createProvider()
+    mockSearch.mockResolvedValue({
+      query: 'test',
+      results: [{ title: 'Test', content: 'snippet', url: 'https://example.com' }]
+    })
+
+    await provider.search('test', createMockWebsearch({ fullContent: false }))
+
+    expect(mockSearch).not.toHaveBeenCalledWith(expect.objectContaining({ include_raw_content: true }))
+  })
+
+  it('should fallback to content when raw_content is empty', async () => {
+    createProvider()
+    mockSearch.mockResolvedValue({
+      query: 'test',
+      results: [{ title: 'Test', content: 'snippet', raw_content: '', url: 'https://example.com' }]
+    })
+
+    const result = await provider.search('test', createMockWebsearch({ fullContent: true }))
+
+    expect(mockSearch).toHaveBeenCalledWith(expect.objectContaining({ include_raw_content: true }))
+    expect(result.results[0].content).toBe('snippet')
+  })
+
+  it('should fallback to content when raw_content is undefined', async () => {
+    createProvider()
+    mockSearch.mockResolvedValue({
+      query: 'test',
+      results: [{ title: 'Test', content: 'snippet', url: 'https://example.com' }]
+    })
+
+    const result = await provider.search('test', createMockWebsearch({ fullContent: true }))
+
+    expect(result.results[0].content).toBe('snippet')
+  })
+
+  it('should throw on empty query', async () => {
+    createProvider()
+    await expect(provider.search('  ', createMockWebsearch())).rejects.toThrow('Search query cannot be empty')
+  })
+
+  it('should handle search failure', async () => {
+    createProvider()
+    mockSearch.mockRejectedValue(new Error('API error'))
+
+    await expect(provider.search('test', createMockWebsearch())).rejects.toThrow('Search failed: API error')
+  })
+})

--- a/src/renderer/src/providers/WebSearchProvider/index.ts
+++ b/src/renderer/src/providers/WebSearchProvider/index.ts
@@ -1,9 +1,9 @@
 import { withSpanResult } from '@renderer/services/SpanManagerService'
-import type { WebSearchState } from '@renderer/store/websearch'
 import type { WebSearchProvider, WebSearchProviderResponse } from '@renderer/types'
 import { filterResultWithBlacklist } from '@renderer/utils/blacklistMatchPattern'
 
 import type BaseWebSearchProvider from './BaseWebSearchProvider'
+import type { WebSearchRuntimeConfig } from './BaseWebSearchProvider'
 import WebSearchProviderFactory from './WebSearchProviderFactory'
 
 export default class WebSearchEngineProvider {
@@ -23,7 +23,7 @@ export default class WebSearchEngineProvider {
 
   public async search(
     query: string,
-    websearch: WebSearchState,
+    websearch: WebSearchRuntimeConfig,
     httpOptions?: RequestInit
   ): Promise<WebSearchProviderResponse> {
     const callSearch = async ({ query, websearch }) => {

--- a/src/renderer/src/services/WebSearchService.ts
+++ b/src/renderer/src/services/WebSearchService.ts
@@ -2,6 +2,7 @@ import { loggerService } from '@logger'
 import { DEFAULT_WEBSEARCH_RAG_DOCUMENT_COUNT } from '@renderer/config/constant'
 import i18n from '@renderer/i18n'
 import WebSearchEngineProvider from '@renderer/providers/WebSearchProvider'
+import type { WebSearchRuntimeConfig } from '@renderer/providers/WebSearchProvider/BaseWebSearchProvider'
 import { addSpan, endSpan } from '@renderer/services/SpanManagerService'
 import store from '@renderer/store'
 import { setWebSearchStatus } from '@renderer/store/runtime'
@@ -159,7 +160,7 @@ class WebSearchService {
     spanId?: string,
     fullContent?: boolean
   ): Promise<WebSearchProviderResponse> {
-    const websearch = { ...this.getWebSearchState(), fullContent }
+    const websearch: WebSearchRuntimeConfig = { ...this.getWebSearchState(), fullContent }
     const webSearchEngine = new WebSearchEngineProvider(provider, spanId)
 
     let formattedQuery = query

--- a/src/renderer/src/services/WebSearchService.ts
+++ b/src/renderer/src/services/WebSearchService.ts
@@ -156,9 +156,10 @@ class WebSearchService {
     provider: WebSearchProvider,
     query: string,
     httpOptions?: RequestInit,
-    spanId?: string
+    spanId?: string,
+    fullContent?: boolean
   ): Promise<WebSearchProviderResponse> {
-    const websearch = this.getWebSearchState()
+    const websearch = { ...this.getWebSearchState(), fullContent }
     const webSearchEngine = new WebSearchEngineProvider(provider, spanId)
 
     let formattedQuery = query
@@ -412,7 +413,8 @@ class WebSearchService {
   public async processWebsearch(
     webSearchProvider: WebSearchProvider,
     extractResults: ExtractResults,
-    requestId: string
+    requestId: string,
+    fullContent?: boolean
   ): Promise<WebSearchProviderResponse> {
     // 重置状态
     await this.setWebSearchStatus(requestId, { phase: 'default' })
@@ -458,7 +460,7 @@ class WebSearchService {
     }
 
     const searchPromises = questions.map((q) =>
-      this.search(webSearchProvider, q, { signal }, span?.spanContext().spanId)
+      this.search(webSearchProvider, q, { signal }, span?.spanContext().spanId, fullContent)
     )
     const searchResults = await Promise.allSettled(searchPromises)
 

--- a/src/renderer/src/store/websearch.ts
+++ b/src/renderer/src/store/websearch.ts
@@ -56,6 +56,8 @@ export interface WebSearchState {
   compressionConfig?: CompressionConfig
   // 具体供应商的配置
   providerConfig: Record<string, any>
+  // Whether to request full page content (Gate 2, default false)
+  fullContent?: boolean
 }
 
 export type CherryWebSearchConfig = Pick<WebSearchState, 'searchWithTime' | 'maxResults' | 'excludeDomains'>

--- a/src/renderer/src/store/websearch.ts
+++ b/src/renderer/src/store/websearch.ts
@@ -56,8 +56,6 @@ export interface WebSearchState {
   compressionConfig?: CompressionConfig
   // 具体供应商的配置
   providerConfig: Record<string, any>
-  // Whether to request full page content (Gate 2, default false)
-  fullContent?: boolean
 }
 
 export type CherryWebSearchConfig = Pick<WebSearchState, 'searchWithTime' | 'maxResults' | 'excludeDomains'>

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -734,6 +734,7 @@ export type WebSearchProvider = {
   allowedTools?: string[]
   parentSpanId?: string
   modelName?: string
+  includeRawContent?: boolean
 }
 
 export type WebSearchProviderResult = {


### PR DESCRIPTION
### What this PR does

Before this PR:
- Tavily provider only returned search snippets (`result.content`), never full page content
- No way for AI models to request detailed page content from Tavily
- WebSearchTool cache was a single-slot variable, causing incorrect cache reuse across different query/content modes
- `fullContent` runtime parameter was incorrectly placed in Redux `WebSearchState`, violating the v2 refactor block

After this PR:
- Tavily provider supports `include_raw_content` via Tavily SDK's native API parameter
- Double gate control: Gate 1 (provider config toggle, default on) × Gate 2 (per-request `fullContent` parameter, default off)
- WebSearchTool uses keyed `Map` cache with key = `finalQueries + links + fullContent`
- Runtime config (`WebSearchRuntimeConfig`) is a local type, not persisted in Redux state
- All provider search signatures updated to use `WebSearchRuntimeConfig`

Fixes #15064

### Why we need it and why it was done in this way

Tavily SDK (`@agentic/tavily@7.6.9`) natively supports `include_raw_content: boolean` in search options, which returns a `raw_content` field with cleaned full page text. This is more stable and cost-effective than per-URL fetching via `fetchWebContent`.

The following tradeoffs were made:
- **Double gate (default off for Gate 2)**: Raw content can be very long and consume many tokens. Gate 2 defaults to `false` so the AI only requests full content when it determines deep analysis is needed, saving tokens by default.
- **Runtime config vs Redux state**: `fullContent` is a per-tool-call transient parameter. Adding it to `WebSearchState` would change the Redux state shape in a file that is explicitly blocked during v2 refactor. Using a local `WebSearchRuntimeConfig` type avoids this.

The following alternatives were considered:
- Per-URL `fetchWebContent` for Tavily results: Adds network requests, may hit anti-crawl/timeout issues. Tavily already provides native `include_raw_content`.
- Single gate (provider-only): Would always fetch raw content or never fetch it. No middle ground for token cost control.

### Breaking changes

None. All new fields are optional with safe defaults.

### Special notes for your reviewer

- `store/websearch.ts` is **NOT modified** — `fullContent` was temporarily added then removed per Codex review feedback. The runtime config type lives in `BaseWebSearchProvider.ts`.
- All 7 provider subclasses (Exa, ExaMcp, Searxng, Local, Bocha, Querit, Zhipu) received a type-only signature change from `WebSearchState` to `WebSearchRuntimeConfig`. No logic changes.
- Exa/ExaMcp behavior is **unchanged** — only Tavily got new functionality.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and keep it simple
- [ ] Refactor: N/A — no refactoring
- [ ] Upgrade: N/A — no upgrade impact
- [ ] Documentation: Not required — toggle label is self-explanatory in UI
- [x] Self-review: Reviewed via Codex review (passed with no issues)

### Release note

```release-note
Tavily web search provider now supports fetching full page content (raw_content) with a double gate control: a provider-level toggle (default on) and a per-request AI parameter (default off). The toggle is available in Tavily provider settings as "获取完整网页内容".
```