### PR TITLE
feat: add display of cache hit token count in message tokens

### DIFF
--- a/packages/shared/data/types/message.ts
+++ b/packages/shared/data/types/message.ts
@@ -11,6 +11,9 @@ export const MessageStatsSchema = z.strictObject({
   totalTokens: z.number().optional(),
   thoughtsTokens: z.number().optional(),
 
+  // Cache hit tokens from API (e.g. prompt_tokens_details.cached_tokens)
+  cachedTokens: z.number().optional(),
+
   // Cost (calculated at message completion time)
   cost: z.number().optional(),
 

--- a/src/main/data/migration/v2/migrators/mappings/ChatMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/ChatMappings.ts
@@ -175,6 +175,9 @@ export interface OldUsage {
   total_tokens?: number
   thoughts_tokens?: number
   cost?: number
+  prompt_tokens_details?: {
+    cached_tokens?: number
+  }
 }
 
 /**
@@ -599,6 +602,8 @@ export function mergeStats(usage?: OldUsage, metrics?: OldMetrics): MessageStats
     if (usage.total_tokens !== undefined) stats.totalTokens = usage.total_tokens
     if (usage.thoughts_tokens !== undefined) stats.thoughtsTokens = usage.thoughts_tokens
     if (usage.cost !== undefined) stats.cost = usage.cost
+    if (usage.prompt_tokens_details?.cached_tokens !== undefined)
+      stats.cachedTokens = usage.prompt_tokens_details.cached_tokens
   }
 
   // Performance metrics

--- a/src/renderer/src/aiCore/chunk/AiSdkToChunkAdapter.ts
+++ b/src/renderer/src/aiCore/chunk/AiSdkToChunkAdapter.ts
@@ -371,10 +371,12 @@ export class AiSdkToChunkAdapter {
           final.text = clearMessage
         }
 
+        const cachedTokens = chunk.totalUsage?.inputTokenDetails?.cacheReadTokens
         const usage = {
           completion_tokens: chunk.totalUsage?.outputTokens || 0,
           prompt_tokens: chunk.totalUsage?.inputTokens || 0,
-          total_tokens: chunk.totalUsage?.totalTokens || 0
+          total_tokens: chunk.totalUsage?.totalTokens || 0,
+          ...(cachedTokens ? { prompt_tokens_details: { cached_tokens: cachedTokens } } : {})
         }
         const metrics = this.buildMetrics(chunk.totalUsage)
         const baseResponse = {

--- a/src/renderer/src/pages/home/Messages/MessageTokens.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageTokens.tsx
@@ -75,12 +75,14 @@ const MessageTokens: React.FC<MessageTokensProps> = ({ message }) => {
       })
     }
 
+    const cachedTokens = message?.usage?.prompt_tokens_details?.cached_tokens
     const tokensInfo = (
       <span className="tokens">
         Tokens:
         <span>{message?.usage?.total_tokens}</span>
         <span>↑{message?.usage?.prompt_tokens}</span>
         <span>↓{message?.usage?.completion_tokens}</span>
+        {cachedTokens ? <span>+{cachedTokens} cached</span> : null}
         <span>{getPriceString()}</span>
       </span>
     )

--- a/src/renderer/src/services/db/DataApiMessageDataSource.ts
+++ b/src/renderer/src/services/db/DataApiMessageDataSource.ts
@@ -117,7 +117,10 @@ function convertSharedMessage(
       usage: {
         prompt_tokens: shared.stats.promptTokens ?? 0,
         completion_tokens: shared.stats.completionTokens ?? 0,
-        total_tokens: shared.stats.totalTokens ?? 0
+        total_tokens: shared.stats.totalTokens ?? 0,
+        ...(shared.stats.cachedTokens !== undefined && {
+          prompt_tokens_details: { cached_tokens: shared.stats.cachedTokens }
+        })
       },
       metrics: {
         completion_tokens: shared.stats.completionTokens ?? 0,

--- a/src/renderer/src/services/messageStreaming/StreamingService.ts
+++ b/src/renderer/src/services/messageStreaming/StreamingService.ts
@@ -710,6 +710,7 @@ class StreamingService {
             promptTokens: task.message.usage?.prompt_tokens,
             completionTokens: task.message.usage?.completion_tokens,
             totalTokens: task.message.usage?.total_tokens,
+            cachedTokens: task.message.usage?.prompt_tokens_details?.cached_tokens,
             timeFirstTokenMs: task.message.metrics?.time_first_token_millsec,
             timeCompletionMs: task.message.metrics?.time_completion_millsec
           }


### PR DESCRIPTION
### What this PR does

Before this PR: Token usage display only showed total, prompt (input), and completion (output) tokens. Cache hit tokens returned by the API (e.g. `prompt_tokens_details.cached_tokens` from OpenAI) were silently discarded and never shown.

After this PR: Cache hit tokens are propagated through the full data pipeline — AI SDK chunk adapter → renderer Usage type → DB persistence (MessageStats) → UI display. When the API returns cache token data, the message token line shows `+X cached` inline.

Fixes #15095 

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Cache hit tokens are not estimated by `TokenService` for providers that don't return usage data, since server-side caching can't be predicted client-side.
- Only `cacheReadTokens` (AI SDK) / `cached_tokens` (OpenAI) are tracked; `cacheWriteTokens` is not included as it's less relevant for billing display.

The following alternatives were considered:
- Showing cache tokens in a separate line — decided against to keep the compact inline format consistent with other token metadata.
- Showing cache tokens via tooltip only — rejected as users explicitly want visible cache hit info.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/15095

### Breaking changes

None. This is purely additive — cache tokens are displayed only when the API provides them. No existing behavior changes.

### Special notes for your reviewer

The data flow spans 6 files across shared types (DB schema), renderer (adapter, persistence, read-back, UI), and main process (migration). All typechecks pass (`typecheck:web`, `typecheck:node`, `typecheck`).

### Checklist

- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [X] Self-review: I have reviewed my own code (e.g., via `/gh-pr-review`, `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Added display of cache hit token count (e.g. "+30 cached") in conversation token statistics for providers that return cache token data.