### PR TITLE
feat: Make generated Markdown and HTML artifact paths clickable in Ag…

### DIFF
--- a/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
+++ b/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
@@ -55,7 +55,9 @@ vi.mock('@renderer/config/constant', () => ({
   DEFAULT_MAX_TOKENS: 4096,
   isMac: false,
   isWin: false,
-  TOKENFLUX_HOST: 'mock-host'
+  TOKENFLUX_HOST: 'mock-host',
+  ARTIFACT_EXT:
+    '\\.(md|html?|txt|json|csv|pdf|xml|ya?ml|toml|ini|cfg|conf|log|svg|png|jpe?g|gif|bmp|ico|css|jsx?|tsx?|py|rb|go|rs|java|sql|sh|bat|ps1|pptx?|xlsx?|docx?)'
 }))
 
 vi.mock('@renderer/utils/provider', () => ({

--- a/src/renderer/src/config/constant.ts
+++ b/src/renderer/src/config/constant.ts
@@ -39,3 +39,7 @@ export const MAX_CONTEXT_COUNT = 100
 export const UNLIMITED_CONTEXT_COUNT = 100000
 
 export const MAX_COLLAPSED_CODE_HEIGHT = 350
+
+// File extensions recognized as generated artifact paths
+export const ARTIFACT_EXT =
+  '\\.(md|html?|txt|json|csv|pdf|xml|ya?ml|toml|ini|cfg|conf|log|svg|png|jpe?g|gif|bmp|ico|css|jsx?|tsx?|py|rb|go|rs|java|sql|sh|bat|ps1|pptx?|xlsx?|docx?)'

--- a/src/renderer/src/pages/home/Markdown/CodeBlock.tsx
+++ b/src/renderer/src/pages/home/Markdown/CodeBlock.tsx
@@ -1,5 +1,5 @@
 import { CodeBlockView, HtmlArtifactsCard } from '@renderer/components/CodeBlockView'
-import { isWin } from '@renderer/config/constant'
+import { ARTIFACT_EXT } from '@renderer/config/constant'
 import { useSettings } from '@renderer/hooks/useSettings'
 import { ClickableFilePath } from '@renderer/pages/home/Messages/Tools/MessageAgentTools/ClickableFilePath'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
@@ -9,6 +9,23 @@ import { MessageBlockStatus } from '@renderer/types/newMessage'
 import { getCodeBlockId, isOpenFenceBlock } from '@renderer/utils/markdown'
 import type { Node } from 'mdast'
 import React, { memo, useCallback, useMemo } from 'react'
+
+const artifactExtRe = new RegExp(`${ARTIFACT_EXT}$`, 'i')
+
+function isLikelyFilePath(text: string): boolean {
+  if (!text) return false
+  // Exclude URLs
+  if (/^https?:\/\//i.test(text)) return false
+  // Must not contain whitespace
+  if (/\s/.test(text)) return false
+  // Must have a recognizable file extension
+  if (!artifactExtRe.test(text)) return false
+  // Must contain at least one directory separator
+  if (!text.includes('/') && !text.includes('\\')) return false
+  // Must not end with a separator
+  if (/[/\\]$/.test(text)) return false
+  return true
+}
 
 interface Props {
   children: string
@@ -67,9 +84,10 @@ const CodeBlock: React.FC<Props> = ({ children, className, node, blockId }) => {
     )
   }
 
-  // Detect inline code that looks like an absolute file path (e.g. /Users/foo/bar.tsx)
-  // On Windows, Unix-style paths are not valid local paths, so skip detection there.
-  if (!isWin && typeof children === 'string' && /^\/[\w.-]+(?:\/[\w.-]+)+$/.test(children)) {
+  // Detect inline code that looks like a file path (absolute or relative)
+  // Supports Unix paths (/Users/foo/bar.md), Windows paths (C:\Users\foo\bar.md),
+  // and relative paths (output/黄金价格分析报告.md, ./file.html)
+  if (typeof children === 'string' && isLikelyFilePath(children)) {
     return (
       <code className={className} style={{ textWrap: 'wrap', fontSize: '95%', padding: '2px 4px' }}>
         <ClickableFilePath path={children} />

--- a/src/renderer/src/pages/home/Markdown/__tests__/CodeBlock.test.tsx
+++ b/src/renderer/src/pages/home/Markdown/__tests__/CodeBlock.test.tsx
@@ -1,3 +1,4 @@
+import type * as RendererConstantModule from '@renderer/config/constant'
 import { MessageBlockStatus } from '@renderer/types/newMessage'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -65,7 +66,7 @@ vi.mock('@renderer/components/CodeBlockView', () => ({
 }))
 
 vi.mock('@renderer/config/constant', async (importOriginal) => {
-  const mod = await importOriginal<typeof import('@renderer/config/constant')>()
+  const mod = await importOriginal<typeof RendererConstantModule>()
   return {
     ...mod,
     get isWin() {

--- a/src/renderer/src/pages/home/Markdown/__tests__/CodeBlock.test.tsx
+++ b/src/renderer/src/pages/home/Markdown/__tests__/CodeBlock.test.tsx
@@ -64,11 +64,15 @@ vi.mock('@renderer/components/CodeBlockView', () => ({
   HtmlArtifactsCard: mocks.HtmlArtifactsCard
 }))
 
-vi.mock('@renderer/config/constant', () => ({
-  get isWin() {
-    return mocks.isWin
+vi.mock('@renderer/config/constant', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@renderer/config/constant')>()
+  return {
+    ...mod,
+    get isWin() {
+      return mocks.isWin
+    }
   }
-}))
+})
 
 // Mock ClickableFilePath
 vi.mock('@renderer/pages/home/Messages/Tools/MessageAgentTools/ClickableFilePath', () => ({
@@ -144,15 +148,6 @@ describe('CodeBlock', () => {
       'should NOT detect %s as a file path',
       (text) => {
         render(<CodeBlock {...defaultProps} className={undefined} children={text} />)
-        expect(screen.queryByTestId('clickable-file-path')).not.toBeInTheDocument()
-      }
-    )
-
-    it.each(['/home/user/project/src/index.ts', '/tmp/test.log', '/var/log/app.log', '/etc/nginx/nginx.conf'])(
-      'should NOT detect %s as a file path on Windows',
-      (path) => {
-        mocks.isWin = true
-        render(<CodeBlock {...defaultProps} className={undefined} children={path} />)
         expect(screen.queryByTestId('clickable-file-path')).not.toBeInTheDocument()
       }
     )

--- a/src/renderer/src/pages/home/Messages/Blocks/MainTextBlock.tsx
+++ b/src/renderer/src/pages/home/Messages/Blocks/MainTextBlock.tsx
@@ -1,5 +1,6 @@
 import { Flex } from '@cherrystudio/ui'
 import { usePreference } from '@data/hooks/usePreference'
+import { ARTIFACT_EXT } from '@renderer/config/constant'
 import { getModelUniqId } from '@renderer/services/ModelService'
 import type { RootState } from '@renderer/store'
 import { selectFormattedCitationsByBlockId } from '@renderer/store/messageBlock'
@@ -11,6 +12,32 @@ import { useSelector } from 'react-redux'
 import styled from 'styled-components'
 
 import Markdown from '../../Markdown/Markdown'
+
+const filePathRe = new RegExp(
+  `(?<![\\w])(?:(?:/?|[a-zA-Z]:[/\\\\]|(?:\\./)?))(?:[^\\s/\\\\]+(?:[/\\\\][^\\s/\\\\]+)+)${ARTIFACT_EXT}(?![\\w/.])`,
+  'gi'
+)
+
+// Protects fenced code blocks, inline code, and markdown links from file path wrapping.
+// Uses the same placeholder convention as processLatexBrackets in utils/markdown.
+const PROTECT_RE = /(```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`]*`|\[(?:[^[\]]*(?:\[[^\]]*\][^[\]]*)*)\]\([^)]*?\))/g
+const RESTORE_RE = /__CHERRY_STUDIO_PROTECTED_(\d+)__/g
+
+// Wraps un-backticked file paths in backticks so they render as <code>
+// and get handled by CodeBlock's ClickableFilePath.
+function wrapFilePathsInBackticks(text: string): string {
+  const protectedSpans: string[] = []
+  const protected_ = text.replace(PROTECT_RE, (match) => {
+    const index = protectedSpans.length
+    protectedSpans.push(match)
+    return `__CHERRY_STUDIO_PROTECTED_${index}__`
+  })
+  const result = protected_.replace(filePathRe, '`$&`')
+  return result.replace(RESTORE_RE, (_, indexStr) => {
+    const index = parseInt(indexStr, 10)
+    return index >= 0 && index < protectedSpans.length ? protectedSpans[index] : indexStr
+  })
+}
 
 interface Props {
   block: MainTextMessageBlock
@@ -28,14 +55,18 @@ const MainTextBlock: React.FC<Props> = ({ block, citationBlockId, role, mentions
   // 创建引用处理函数，传递给 Markdown 组件在流式渲染中使用
   const processContent = useCallback(
     (rawText: string) => {
-      if (!block.citationReferences?.length || !citationBlockId || rawCitations.length === 0) {
-        return rawText
+      let text = rawText
+
+      // Process citations
+      if (block.citationReferences?.length && citationBlockId && rawCitations.length > 0) {
+        const sourceType = determineCitationSource(block.citationReferences)
+        text = withCitationTags(text, rawCitations, sourceType)
       }
 
-      // 确定最适合的 source
-      const sourceType = determineCitationSource(block.citationReferences)
+      // Wrap file paths in backticks so they become clickable via CodeBlock
+      text = wrapFilePathsInBackticks(text)
 
-      return withCitationTags(rawText, rawCitations, sourceType)
+      return text
     },
     [block.citationReferences, citationBlockId, rawCitations]
   )

--- a/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/ClickableFilePath.tsx
+++ b/src/renderer/src/pages/home/Messages/Tools/MessageAgentTools/ClickableFilePath.tsx
@@ -1,5 +1,6 @@
 import { MoreOutlined } from '@ant-design/icons'
 import { Icon } from '@iconify/react'
+import { useActiveSession } from '@renderer/hooks/agents/useActiveSession'
 import { useExternalApps } from '@renderer/hooks/useExternalApps'
 import { buildEditorUrl, getEditorIcon } from '@renderer/utils/editorUtils'
 import { getFileIconName } from '@renderer/utils/fileIconName'
@@ -9,6 +10,30 @@ import { FolderOpen } from 'lucide-react'
 import { memo, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
+function isAbsolutePath(p: string): boolean {
+  return p.startsWith('/') || /^[a-zA-Z]:[/\\]/.test(p)
+}
+
+function resolveRelativePath(relativePath: string, basePath: string): string {
+  const normalizedBase = basePath.replace(/\\/g, '/')
+  const normalizedRel = relativePath.replace(/\\/g, '/').replace(/^\.\//, '')
+  const joined = normalizedBase.endsWith('/') ? normalizedBase + normalizedRel : normalizedBase + '/' + normalizedRel
+  const parts = joined.split('/')
+  const result: string[] = []
+  for (const part of parts) {
+    if (part === '.' || part === '') continue
+    if (part === '..') {
+      if (result.length > 0 && !/^[a-zA-Z]:$/.test(result[result.length - 1])) {
+        result.pop()
+      }
+      continue
+    }
+    result.push(part)
+  }
+  const prefix = normalizedBase.startsWith('/') ? '/' : ''
+  return prefix + result.join('/')
+}
+
 interface ClickableFilePathProps {
   path: string
   displayName?: string
@@ -17,6 +42,15 @@ interface ClickableFilePathProps {
 export const ClickableFilePath = memo(function ClickableFilePath({ path, displayName }: ClickableFilePathProps) {
   const { t } = useTranslation()
   const { data: externalApps } = useExternalApps()
+  const { session } = useActiveSession()
+
+  const resolvedPath = useMemo(() => {
+    if (isAbsolutePath(path)) return path
+    const workspacePath = session?.accessiblePaths?.[0]
+    if (!workspacePath) return path
+    return resolveRelativePath(path, workspacePath)
+  }, [path, session?.accessiblePaths?.[0]])
+
   const iconName = useMemo(() => getFileIconName(path), [path])
 
   const availableEditors = useMemo(
@@ -26,19 +60,19 @@ export const ClickableFilePath = memo(function ClickableFilePath({ path, display
 
   const openInEditor = useCallback(
     (app: ExternalAppInfo) => {
-      window.open(buildEditorUrl(app, path))
+      window.open(buildEditorUrl(app, resolvedPath))
     },
-    [path]
+    [resolvedPath]
   )
 
   const handleOpen = useCallback(
     (e: React.MouseEvent | React.KeyboardEvent) => {
       e.stopPropagation()
-      window.api.file.openPath(path).catch(() => {
+      window.api.file.openPath(resolvedPath).catch(() => {
         window.toast.error(t('chat.input.tools.open_file_error', { path }))
       })
     },
-    [path, t]
+    [resolvedPath, path, t]
   )
 
   const handleKeyDown = useCallback(
@@ -59,7 +93,7 @@ export const ClickableFilePath = memo(function ClickableFilePath({ path, display
         icon: <FolderOpen size={16} />,
         onClick: ({ domEvent }) => {
           domEvent.stopPropagation()
-          window.api.file.showInFolder(path).catch(() => {
+          window.api.file.showInFolder(resolvedPath).catch(() => {
             window.toast.error(t('chat.input.tools.file_not_found', { path }))
           })
         }
@@ -82,7 +116,7 @@ export const ClickableFilePath = memo(function ClickableFilePath({ path, display
     }
 
     return items
-  }, [path, t, availableEditors, openInEditor])
+  }, [resolvedPath, t, availableEditors, openInEditor])
 
   return (
     <span className="inline-flex items-center gap-0.5">

--- a/src/renderer/src/pages/home/Messages/Tools/__tests__/ClickableFilePath.test.tsx
+++ b/src/renderer/src/pages/home/Messages/Tools/__tests__/ClickableFilePath.test.tsx
@@ -15,6 +15,10 @@ vi.stubGlobal('api', {
   }
 })
 
+vi.mock('@renderer/hooks/agents/useActiveSession', () => ({
+  useActiveSession: () => ({ session: undefined })
+}))
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => {


### PR DESCRIPTION
### What this PR does

Before this PR:

Agent-generated file paths like `output/黄金价格分析报告.md` or `output/gold_ppt.html` appeared as plain text or code-styled text in the agent's final answer. Users had to manually locate the output directory and open files — no clickable path, no "Reveal in Finder", no "Open in Editor" actions available.

After this PR:

File paths in agent responses are now rendered as clickable links with:
- **Click to open** the file with the default OS application
- **Right-click menu** with "Reveal in Finder" and "Open in Editor" options
- **Workspace-aware path resolution** — relative paths (like `output/report.md`) are resolved against the agent session's workspace directory (`accessiblePaths[0]`)
- **Full markdown safety** — fenced code blocks and markdown links are protected from path wrapping

Fixes #15120

### Why we need it and why it was done in this way

The agent generates files (reports, HTML slides, markdown docs) during tasks and reports their paths in the final answer. Without clickable paths, users must manually navigate the filesystem — a poor UX for what should be a direct handoff.

The implementation uses a three-layer approach:
1. **`CodeBlock.tsx`** — Detects file paths in inline code (`` `output/xxx.md` ``) using a broadened `isLikelyFilePath()` check that supports relative paths, Unix/Win absolute paths, and CJK characters. Passes matched paths to the existing `ClickableFilePath` component.
2. **`MainTextBlock.tsx`** — Pre-processes plain text before ReactMarkdown rendering: wraps file-path-like strings in backticks (protecting fenced code blocks, inline code, and markdown links first) so they route through `CodeBlock`.
3. **`ClickableFilePath.tsx`** — Resolves relative paths against the agent's workspace directory (`accessiblePaths[0]`) before calling `openPath`/`showInFolder`.

The following tradeoffs were made:

- Regex-based path detection in `wrapFilePathsInBackticks` may produce false positives on unusual text patterns, but is constrained by requiring a recognizable file extension and at least one directory separator. This matches the expected output format of agent-generated artifact paths.
- Relative path resolution allows `../` traversal (no clamping), deferring security to `shell.openPath` at the OS level. This is appropriate for a UI convenience feature where the user sees the path before clicking.

The following alternatives were considered:

- **Remark plugin** — Transform text nodes in the AST. More complex to implement and debug with streaming, and can't easily inject `ClickableFilePath` React components.
- **Dedicated artifact block type** — Modify the agent message pipeline to include structured artifact data. More robust but requires significant upstream changes to the agent session stream.
- **Only handle inline code** — Simplest but misses paths in plain text (not wrapped in backticks by the LLM).

Links to places where the discussion took place: #15120

### Breaking changes

None.

### Special notes for your reviewer

The extension list in `ARTIFACT_EXT` (`src/renderer/src/config/constant.ts:44`) defines which file extensions trigger clickable path detection. If new artifact types are added in the future, extensions should be added here.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Agent-generated file paths (Markdown, HTML, etc.) are now clickable in chat responses — open files directly, reveal in Finder, or open in your preferred editor.