### PR TITLE
fix: add agent tooling reset recovery

### DIFF
--- a/src/renderer/src/pages/agents/components/AgentItem.tsx
+++ b/src/renderer/src/pages/agents/components/AgentItem.tsx
@@ -1,8 +1,9 @@
 import { DeleteIcon, EditIcon } from '@renderer/components/Icons'
 import MarqueeText from '@renderer/components/MarqueeText'
+import { useUpdateAgent } from '@renderer/hooks/agents/useUpdateAgent'
 import { useSettings } from '@renderer/hooks/useSettings'
 import AgentSettingsPopup from '@renderer/pages/settings/AgentSettings/AgentSettingsPopup'
-import { AgentLabel } from '@renderer/pages/settings/AgentSettings/shared'
+import { AgentLabel, buildResetToolingUpdate } from '@renderer/pages/settings/AgentSettings/shared'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import type { AgentEntity } from '@renderer/types'
 import { cn } from '@renderer/utils'
@@ -24,7 +25,9 @@ interface AgentItemProps {
 const AgentItem = ({ agent, isActive, onDelete, onPress }: AgentItemProps) => {
   const { t } = useTranslation()
   const { clickAssistantToShowTopic, topicPosition, assistantIconType } = useSettings()
+  const { updateAgent } = useUpdateAgent()
   const [isHovered, setIsHovered] = useState(false)
+  const [isResetting, setIsResetting] = useState(false)
 
   const handlePress = useCallback(() => {
     // Show session sidebar if setting is enabled (reusing the assistant setting for consistency)
@@ -39,6 +42,33 @@ const AgentItem = ({ agent, isActive, onDelete, onPress }: AgentItemProps) => {
   const handleMenuButtonClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation()
   }, [])
+
+  const handleResetTooling = useCallback(() => {
+    if (isResetting) {
+      return
+    }
+
+    window.modal.confirm({
+      title: t('agent.settings.tooling.reset', 'Reset tools & MCP'),
+      content: t(
+        'agent.settings.tooling.reset.confirm',
+        'This will clear the agent MCP connections and restore the default tool approvals for its current permission mode.'
+      ),
+      okText: t('common.reset'),
+      cancelText: t('common.cancel'),
+      centered: true,
+      onOk: async () => {
+        setIsResetting(true)
+        try {
+          const selectedMode = agent.configuration?.permission_mode ?? 'default'
+          const resetUpdate = buildResetToolingUpdate(selectedMode, agent.tools ?? [])
+          await updateAgent({ id: agent.id, ...resetUpdate }, { showSuccessToast: true })
+        } finally {
+          setIsResetting(false)
+        }
+      }
+    })
+  }, [agent.configuration?.permission_mode, agent.id, agent.tools, isResetting, t, updateAgent])
 
   const menuItems: MenuProps['items'] = useMemo(
     () => [
@@ -62,9 +92,14 @@ const AgentItem = ({ agent, isActive, onDelete, onPress }: AgentItemProps) => {
             onOk: () => onDelete(agent)
           })
         }
+      },
+      {
+        label: t('agent.settings.tooling.reset', 'Reset tools & MCP'),
+        key: 'reset-tooling',
+        onClick: handleResetTooling
       }
     ],
-    [t, agent, onDelete]
+    [agent, handleResetTooling, onDelete, t]
   )
 
   return (

--- a/src/renderer/src/pages/agents/components/AgentItem.tsx
+++ b/src/renderer/src/pages/agents/components/AgentItem.tsx
@@ -5,7 +5,7 @@ import { useSettings } from '@renderer/hooks/useSettings'
 import AgentSettingsPopup from '@renderer/pages/settings/AgentSettings/AgentSettingsPopup'
 import { AgentLabel, buildResetToolingUpdate } from '@renderer/pages/settings/AgentSettings/shared'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
-import type { AgentEntity } from '@renderer/types'
+import type { GetAgentResponse } from '@renderer/types'
 import { cn } from '@renderer/utils'
 import type { MenuProps } from 'antd'
 import { Dropdown, Tooltip } from 'antd'
@@ -16,9 +16,9 @@ import { useTranslation } from 'react-i18next'
 // const logger = loggerService.withContext('AgentItem')
 
 interface AgentItemProps {
-  agent: AgentEntity
+  agent: GetAgentResponse
   isActive: boolean
-  onDelete: (agent: AgentEntity) => void
+  onDelete: (agent: GetAgentResponse) => void
   onPress: () => void
 }
 

--- a/src/renderer/src/pages/settings/AgentSettings/components/ToolsSettings.tsx
+++ b/src/renderer/src/pages/settings/AgentSettings/components/ToolsSettings.tsx
@@ -4,7 +4,7 @@ import { useMCPServers } from '@renderer/hooks/useMCPServers'
 import type { UpdateAgentBaseForm } from '@renderer/types'
 import { GLOBALLY_DISALLOWED_TOOLS, SOUL_MODE_DISALLOWED_TOOLS } from '@shared/agents/claudecode/constants'
 import type { CardProps } from 'antd'
-import { Card, Switch, Tag, Tooltip } from 'antd'
+import { Button, Card, Switch, Tag, Tooltip } from 'antd'
 import { uniq } from 'lodash'
 import { Wrench } from 'lucide-react'
 import type { FC } from 'react'
@@ -13,6 +13,7 @@ import { useTranslation } from 'react-i18next'
 
 import {
   type AgentOrSessionSettingsProps,
+  buildResetToolingUpdate,
   computeModeDefaults,
   defaultConfiguration,
   isSoulModeEnabled,
@@ -65,6 +66,7 @@ export const ToolsSettings: FC<AgentOrSessionSettingsProps> = ({ agentBase, upda
   const [searchTerm, setSearchTerm] = useState('')
   const [isUpdatingTools, setIsUpdatingTools] = useState(false)
   const [isUpdatingMcp, setIsUpdatingMcp] = useState(false)
+  const [isResetting, setIsResetting] = useState(false)
 
   const selectedMode = useMemo(
     () => agentBase?.configuration?.permission_mode ?? defaultConfiguration.permission_mode,
@@ -102,7 +104,7 @@ export const ToolsSettings: FC<AgentOrSessionSettingsProps> = ({ agentBase, upda
 
   const handleToggleTool = useCallback(
     async (toolId: string, isApproved: boolean) => {
-      if (!agentBase || isUpdatingTools) {
+      if (!agentBase || isUpdatingTools || isResetting) {
         return
       }
 
@@ -119,12 +121,12 @@ export const ToolsSettings: FC<AgentOrSessionSettingsProps> = ({ agentBase, upda
         setIsUpdatingTools(false)
       }
     },
-    [agentBase, isUpdatingTools, approvedToolIds, autoToolIds, availableTools, update]
+    [agentBase, isResetting, isUpdatingTools, approvedToolIds, autoToolIds, availableTools, update]
   )
 
   const handleToggleMcp = useCallback(
     async (serverId: string, enabled: boolean) => {
-      if (!agentBase || isUpdatingMcp) {
+      if (!agentBase || isUpdatingMcp || isResetting) {
         return
       }
       const exists = selectedMcpIds.includes(serverId)
@@ -140,8 +142,30 @@ export const ToolsSettings: FC<AgentOrSessionSettingsProps> = ({ agentBase, upda
         setIsUpdatingMcp(false)
       }
     },
-    [agentBase, isUpdatingMcp, selectedMcpIds, update]
+    [agentBase, isResetting, isUpdatingMcp, selectedMcpIds, update]
   )
+
+  const handleResetTooling = useCallback(() => {
+    if (!agentBase || isResetting || isUpdatingTools || isUpdatingMcp) {
+      return
+    }
+
+    window.modal.confirm({
+      title: t('common.reset'),
+      okText: t('common.reset'),
+      cancelText: t('common.cancel'),
+      centered: true,
+      onOk: async () => {
+        setIsResetting(true)
+        try {
+          const resetUpdate = buildResetToolingUpdate(selectedMode, availableTools)
+          await update({ id: agentBase.id, ...resetUpdate } satisfies UpdateAgentBaseForm)
+        } finally {
+          setIsResetting(false)
+        }
+      }
+    })
+  }, [agentBase, availableTools, isResetting, isUpdatingMcp, isUpdatingTools, selectedMode, t, update])
 
   if (!agentBase) {
     return null
@@ -152,12 +176,21 @@ export const ToolsSettings: FC<AgentOrSessionSettingsProps> = ({ agentBase, upda
       <SettingsItem divider={false}>
         <SettingsTitle
           contentAfter={
-            <CollapsibleSearchBar
-              onSearch={setSearchTerm}
-              placeholder={t('agent.settings.tooling.preapproved.search', 'Search tools')}
-              tooltip={t('agent.settings.tooling.preapproved.search', 'Search tools')}
-              style={{ borderRadius: 20 }}
-            />
+            <div className="flex items-center gap-2">
+              <CollapsibleSearchBar
+                onSearch={setSearchTerm}
+                placeholder={t('agent.settings.tooling.preapproved.search', 'Search tools')}
+                tooltip={t('agent.settings.tooling.preapproved.search', 'Search tools')}
+                style={{ borderRadius: 20 }}
+              />
+              <Button
+                danger
+                size="small"
+                disabled={isResetting || isUpdatingTools || isUpdatingMcp}
+                onClick={handleResetTooling}>
+                {t('common.reset')}
+              </Button>
+            </div>
           }>
           {t('agent.settings.toolsMcp.tools.title', 'Pre-approved Tools')}
         </SettingsTitle>

--- a/src/renderer/src/pages/settings/AgentSettings/components/__tests__/ToolsSettings.test.ts
+++ b/src/renderer/src/pages/settings/AgentSettings/components/__tests__/ToolsSettings.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildResetToolingUpdate } from '../../shared'
+
+describe('buildResetToolingUpdate', () => {
+  it('removes MCP servers and restores non-MCP tool defaults for the selected mode', () => {
+    const update = buildResetToolingUpdate('acceptEdits', [
+      { id: 'Read', name: 'Read', type: 'builtin' },
+      { id: 'Write', name: 'Write', type: 'builtin', requirePermissions: true },
+      { id: 'mcp__example__search', name: 'search', type: 'mcp', requirePermissions: true },
+      { id: 'CustomTool', name: 'CustomTool', type: 'custom', requirePermissions: true }
+    ])
+
+    expect(update.mcps).toEqual([])
+    expect(update.allowed_tools).toEqual([
+      'Read',
+      'Edit',
+      'MultiEdit',
+      'NotebookEdit',
+      'Write',
+      'Bash(mkdir:*)',
+      'Bash(touch:*)',
+      'Bash(rm:*)',
+      'Bash(mv:*)',
+      'Bash(cp:*)'
+    ])
+  })
+})

--- a/src/renderer/src/pages/settings/AgentSettings/shared.tsx
+++ b/src/renderer/src/pages/settings/AgentSettings/shared.tsx
@@ -26,6 +26,15 @@ import { SettingDivider } from '..'
 export type AgentConfigurationState = AgentConfiguration & Record<string, unknown>
 export const defaultConfiguration: AgentConfigurationState = AgentConfigurationSchema.parse({})
 
+export const buildResetToolingUpdate = (selectedMode: PermissionMode, tools: Tool[]) => {
+  const nonMcpTools = tools.filter((tool) => tool.type !== 'mcp')
+
+  return {
+    allowed_tools: computeModeDefaults(selectedMode, nonMcpTools),
+    mcps: []
+  }
+}
+
 /**
  * Unified props type for settings components that work with both Agent and Session
  */


### PR DESCRIPTION
### What this PR does

Before this PR:
- A bad MCP/tool configuration could leave an agent difficult to recover from, and the only reset action lived inside the agent settings tab.
- If the active agent view was already broken, that reset path was not reliably reachable.

After this PR:
- Agents have a confirmed Reset tools & MCP action in the sidebar item menu.
- The action clears attached MCP servers and restores default tool approvals for the current permission mode.
- The existing Tools & MCP settings tab reuses the same reset logic.

Fixes #15106

### Why we need it and why it was done in this way

The following tradeoffs were made:
- The reset action only touches tooling state (mcps and allowed_tools) so it can recover the agent without changing identity, model, prompts, or workspace settings.
- The entry point lives in the agent list menu because it stays available even when the active agent page is degraded.

The following alternatives were considered:
- Adding reset only inside agent settings, which still leaves users without a recovery path when the agent view is already broken.
- Broadly resetting the entire agent configuration, which would be riskier and more destructive than needed for this bug.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/15106

### Breaking changes

None.

### Special notes for your reviewer

The reset helper is shared between the sidebar menu and the agent settings tab so both entry points stay consistent.

### Checklist

This checklist is not enforcing, but it is a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Add a confirmed Reset tools & MCP action for agents so users can recover from broken MCP/tool configurations without changing the agent itself.
```