### PR TITLE
fix(test): enable tests and pnpm install in git worktrees

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "bench:aicore": "vitest bench --run --project aiCore",
     "bench:shared": "vitest bench --run --project shared",
     "docs:check-links": "tsx scripts/check-doc-links.ts",
-    "prepare": "git config blame.ignoreRevsFile .git-blame-ignore-revs && prek install",
+    "prepare": "tsx scripts/install-hooks.ts",
     "claude": "dotenv -e .env -- claude",
     "db:migrations:generate": "drizzle-kit generate --config ./migrations/sqlite-drizzle.config.ts",
     "db:migrations:check": "drizzle-kit check --config ./migrations/sqlite-drizzle.config.ts",

--- a/scripts/__tests__/install-hooks.test.ts
+++ b/scripts/__tests__/install-hooks.test.ts
@@ -1,108 +1,300 @@
 import { execFileSync } from 'node:child_process'
 import { normalize, resolve } from 'node:path'
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import {
+  getDefaultHooksDir,
+  getLocalHooksPath,
+  isDefaultGitHooksPath,
+  isLinkedWorktree,
+  main,
+  runPrekInstall,
+  unsetHooksPath
+} from '../install-hooks'
+
+// Mock child_process so git/pnpm calls are intercepted
 vi.mock('node:child_process', () => ({
   execFileSync: vi.fn(() => '')
 }))
 
-const mockExecFileSync = vi.mocked(execFileSync)
+const mockExec = vi.mocked(execFileSync)
 
-// Helper mirroring the production path comparison logic
-function platformPathsEqual(pathA: string, pathB: string, isWindows: boolean): boolean {
-  const a = normalize(resolve(pathA))
-  const b = normalize(resolve(pathB))
-  return isWindows ? a.toLowerCase() === b.toLowerCase() : a === b
+// Helper: configure mock to respond to specific git commands
+function mockGitResponses(responses: Record<string, string | null>): void {
+  mockExec.mockImplementation(((cmd: string, args: string[]) => {
+    if (cmd !== 'git') throw new Error(`unexpected command: ${cmd}`)
+    const key = args.join(' ')
+    const val = responses[key]
+    if (val === null) {
+      throw new Error(`ENOENT: git ${key}`)
+    }
+    return val
+  }) as never)
 }
 
-describe('install-hooks: Windows path comparison', () => {
-  describe('linked worktree detection', () => {
-    it('identical paths are equal regardless of platform', () => {
-      const a = normalize(resolve('/Users/dev/repo/.git'))
-      const b = normalize(resolve('/Users/dev/repo/.git'))
-      expect(a).toBe(b)
-    })
+// Suppress console output during main() tests
+let logSpy: ReturnType<typeof vi.spyOn>
+let warnSpy: ReturnType<typeof vi.spyOn>
+let errorSpy: ReturnType<typeof vi.spyOn>
 
-    it('different paths are not equal on non-Windows', () => {
-      expect(platformPathsEqual('/Users/dev/repo/.git', '/Users/dev/other/.git', false)).toBe(false)
-    })
+beforeEach(() => {
+  logSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  vi.spyOn(process, 'exit').mockImplementation(((code?: number | string | null) => {
+    throw new Error(`process.exit(${code})`)
+  }) as never)
+  delete process.env.npm_execpath
+})
 
-    it('different paths are not equal on Windows', () => {
-      expect(platformPathsEqual('D:\\Repo\\.git', 'D:\\Other\\.git', true)).toBe(false)
-    })
+afterEach(() => {
+  vi.restoreAllMocks()
+  mockExec.mockReset()
+})
 
-    it('Windows: same logical path with different drive casing is equal', () => {
-      const a = 'D:\\Repo\\.git'
-      const b = 'd:\\repo\\.git'
-      expect(a.toLowerCase()).toBe(b.toLowerCase())
+describe('isLinkedWorktree', () => {
+  it('returns false when git-dir equals git-common-dir (primary worktree)', () => {
+    mockGitResponses({
+      'rev-parse --absolute-git-dir': '/repo/.git',
+      'rev-parse --git-common-dir': '/repo/.git'
     })
+    expect(isLinkedWorktree()).toBe(false)
+  })
 
-    it('Windows: same logical path with mixed directory casing is equal', () => {
-      const a = 'C:\\Users\\Developer\\MyProject\\.git'
-      const b = 'c:\\users\\DEVELOPER\\myproject\\.git'
-      expect(a.toLowerCase()).toBe(b.toLowerCase())
+  it('returns true when git-dir differs from git-common-dir (linked worktree)', () => {
+    mockGitResponses({
+      'rev-parse --absolute-git-dir': '/repo/.git/worktrees/wt1',
+      'rev-parse --git-common-dir': '/repo/.git'
     })
+    expect(isLinkedWorktree()).toBe(true)
+  })
 
-    it('non-Windows: case-sensitive comparison preserves distinction', () => {
-      const a = '/Users/Dev/repo/.git'
-      const b = '/users/dev/repo/.git'
-      expect(a).not.toBe(b)
+  it('returns null when git commands fail (detection failure)', () => {
+    mockGitResponses({})
+    expect(isLinkedWorktree()).toBeNull()
+  })
+})
+
+describe('isDefaultGitHooksPath', () => {
+  it('returns true when hooksPath matches default hooks dir', () => {
+    mockGitResponses({
+      'rev-parse --git-common-dir': '/repo/.git'
+    })
+    expect(isDefaultGitHooksPath(normalize(resolve('/repo/.git/hooks')))).toBe(true)
+  })
+
+  it('returns false when hooksPath is a custom path', () => {
+    mockGitResponses({
+      'rev-parse --git-common-dir': '/repo/.git'
+    })
+    expect(isDefaultGitHooksPath('/repo/.husky')).toBe(false)
+  })
+
+  it('returns false when git-common-dir is unavailable', () => {
+    mockGitResponses({})
+    expect(isDefaultGitHooksPath('/repo/.git/hooks')).toBe(false)
+  })
+})
+
+describe('getDefaultHooksDir', () => {
+  it('computes hooks dir from git-common-dir', () => {
+    mockGitResponses({
+      'rev-parse --git-common-dir': '/repo/.git'
+    })
+    expect(getDefaultHooksDir()).toBe(normalize(resolve('/repo/.git/hooks')))
+  })
+
+  it('returns null when git-common-dir fails', () => {
+    mockGitResponses({})
+    expect(getDefaultHooksDir()).toBeNull()
+  })
+})
+
+describe('getLocalHooksPath', () => {
+  it('returns hooksPath value when set', () => {
+    mockGitResponses({
+      'config --local --get core.hooksPath': '.husky'
+    })
+    expect(getLocalHooksPath()).toBe('.husky')
+  })
+
+  it('returns null when not set', () => {
+    mockGitResponses({})
+    expect(getLocalHooksPath()).toBeNull()
+  })
+})
+
+describe('unsetHooksPath', () => {
+  it('returns true when unset succeeds', () => {
+    mockGitResponses({
+      'config --local --unset-all core.hooksPath': ''
+    })
+    expect(unsetHooksPath()).toBe(true)
+  })
+
+  it('returns false when unset fails', () => {
+    mockGitResponses({})
+    expect(unsetHooksPath()).toBe(false)
+  })
+})
+
+describe('runPrekInstall', () => {
+  it('uses npm_execpath when set', () => {
+    process.env.npm_execpath = '/path/to/pnpm.cjs'
+    mockExec.mockReturnValue('')
+    expect(runPrekInstall()).toBe(true)
+    expect(mockExec).toHaveBeenCalledWith(
+      process.execPath,
+      expect.arrayContaining([expect.stringContaining('pnpm'), 'exec', 'prek', 'install']),
+      { stdio: 'inherit' }
+    )
+  })
+
+  it('falls back to pnpm when npm_execpath is not set', () => {
+    mockExec.mockReturnValue('')
+    expect(runPrekInstall()).toBe(true)
+    // On non-Windows, shell should be false
+    expect(mockExec).toHaveBeenCalledWith('pnpm', ['exec', 'prek', 'install'], {
+      stdio: 'inherit',
+      shell: process.platform === 'win32'
     })
   })
 
-  describe('hooksPath cleanup', () => {
-    it('does not match a custom hooksPath on non-Windows', () => {
-      expect(platformPathsEqual('/Users/dev/repo/.husky', '/Users/dev/repo/.git/hooks', false)).toBe(false)
+  it('returns false on exec failure', () => {
+    mockExec.mockImplementation(() => {
+      throw new Error('prek refused')
     })
+    expect(runPrekInstall()).toBe(false)
+  })
+})
 
-    it('does not match a custom hooksPath on Windows', () => {
-      expect(platformPathsEqual('D:\\Repo\\.husky', 'D:\\Repo\\.git\\hooks', true)).toBe(false)
-    })
-
-    it('Windows: hooksPath matching uses toLowerCase for comparison', () => {
-      const hooksPath = 'D:\\REPO\\.GIT\\HOOKS'
-      const defaultDir = 'd:\\repo\\.git\\hooks'
-      expect(hooksPath.toLowerCase() === defaultDir.toLowerCase()).toBe(true)
-    })
+describe('main', () => {
+  it('skips setup when not a git repo', () => {
+    mockGitResponses({})
+    main()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('not a git repository'))
   })
 
-  describe('shell option for pnpm fallback', () => {
-    beforeEach(() => {
-      vi.clearAllMocks()
+  it('aborts when worktree detection fails', () => {
+    mockGitResponses({
+      'rev-parse --git-dir': '.git',
+      'config blame.ignoreRevsFile .git-blame-ignore-revs': ''
     })
+    // git-dir and git-common-dir commands will fail (not in responses)
+    mockExec.mockImplementation(((cmd: string, args: string[]) => {
+      if (cmd === 'pnpm') return ''
+      const key = args.join(' ')
+      const responses: Record<string, string> = {
+        'rev-parse --git-dir': '.git',
+        'config blame.ignoreRevsFile .git-blame-ignore-revs': ''
+      }
+      const val = responses[key]
+      if (val === undefined) throw new Error(`ENOENT: git ${key}`)
+      return val
+    }) as never)
 
-    it('passes shell: true on win32 platform', () => {
-      const platform = 'win32'
-      const isWindows = platform === 'win32'
-      const opts = { stdio: 'inherit' as const, shell: isWindows }
-      mockExecFileSync('pnpm', ['exec', 'prek', 'install'], opts)
-      expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['exec', 'prek', 'install'], {
-        stdio: 'inherit',
-        shell: true
-      })
-    })
+    expect(() => main()).toThrow('process.exit(1)')
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('could not determine worktree status'))
+  })
 
-    it('passes shell: false on darwin platform', () => {
-      const platform: string = 'darwin'
-      const isWindows = platform === 'win32'
-      const opts = { stdio: 'inherit' as const, shell: isWindows }
-      mockExecFileSync('pnpm', ['exec', 'prek', 'install'], opts)
-      expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['exec', 'prek', 'install'], {
-        stdio: 'inherit',
-        shell: false
-      })
+  it('skips prek install in linked worktree', () => {
+    mockGitResponses({
+      'rev-parse --git-dir': '.git',
+      'config blame.ignoreRevsFile .git-blame-ignore-revs': '',
+      'rev-parse --absolute-git-dir': '/repo/.git/worktrees/wt1',
+      'rev-parse --git-common-dir': '/repo/.git'
     })
+    main()
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('linked worktree detected'))
+  })
 
-    it('passes shell: false on linux platform', () => {
-      const platform: string = 'linux'
-      const isWindows = platform === 'win32'
-      const opts = { stdio: 'inherit' as const, shell: isWindows }
-      mockExecFileSync('pnpm', ['exec', 'prek', 'install'], opts)
-      expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['exec', 'prek', 'install'], {
-        stdio: 'inherit',
-        shell: false
-      })
-    })
+  it('cleans default hooksPath and proceeds with install', () => {
+    const hooksDir = normalize(resolve('/repo/.git/hooks'))
+    mockExec.mockImplementation(((cmd: string, args: string[]) => {
+      if (cmd === 'pnpm') return ''
+      const key = args.join(' ')
+      const responses: Record<string, string | null> = {
+        'rev-parse --git-dir': '.git',
+        'config blame.ignoreRevsFile .git-blame-ignore-revs': '',
+        'rev-parse --absolute-git-dir': '/repo/.git',
+        'rev-parse --git-common-dir': '/repo/.git',
+        'config --local --get core.hooksPath': hooksDir,
+        'config --local --unset-all core.hooksPath': ''
+      }
+      const val = responses[key]
+      if (val === undefined) throw new Error(`ENOENT: git ${key}`)
+      if (val === null) throw new Error(`ENOENT: git ${key}`)
+      return val
+    }) as never)
+
+    main()
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('cleaned default core.hooksPath'))
+  })
+
+  it('aborts when unsetHooksPath fails', () => {
+    const hooksDir = normalize(resolve('/repo/.git/hooks'))
+    mockExec.mockImplementation(((cmd: string, args: string[]) => {
+      if (cmd === 'pnpm') return ''
+      const key = args.join(' ')
+      const responses: Record<string, string | null> = {
+        'rev-parse --git-dir': '.git',
+        'config blame.ignoreRevsFile .git-blame-ignore-revs': '',
+        'rev-parse --absolute-git-dir': '/repo/.git',
+        'rev-parse --git-common-dir': '/repo/.git',
+        'config --local --get core.hooksPath': hooksDir
+        // unset intentionally missing — will fail
+      }
+      const val = responses[key]
+      if (val === undefined) throw new Error(`ENOENT: git ${key}`)
+      if (val === null) throw new Error(`ENOENT: git ${key}`)
+      return val
+    }) as never)
+
+    expect(() => main()).toThrow('process.exit(1)')
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('failed to unset core.hooksPath'))
+  })
+
+  it('preserves custom hooksPath and accepts prek refusal', () => {
+    mockExec.mockImplementation(((cmd: string, args: string[]) => {
+      if (cmd === 'pnpm') throw new Error('prek refused')
+      const key = args.join(' ')
+      const responses: Record<string, string | null> = {
+        'rev-parse --git-dir': '.git',
+        'config blame.ignoreRevsFile .git-blame-ignore-revs': '',
+        'rev-parse --absolute-git-dir': '/repo/.git',
+        'rev-parse --git-common-dir': '/repo/.git',
+        'config --local --get core.hooksPath': '.husky'
+      }
+      const val = responses[key]
+      if (val === undefined) throw new Error(`ENOENT: git ${key}`)
+      if (val === null) throw new Error(`ENOENT: git ${key}`)
+      return val
+    }) as never)
+
+    // prek refusal with custom hooksPath is acceptable
+    main()
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('prek skipped'))
+  })
+
+  it('exits non-zero when prek fails without custom hooksPath', () => {
+    mockExec.mockImplementation(((cmd: string, args: string[]) => {
+      if (cmd === 'pnpm') throw new Error('prek crashed')
+      const key = args.join(' ')
+      const responses: Record<string, string | null> = {
+        'rev-parse --git-dir': '.git',
+        'config blame.ignoreRevsFile .git-blame-ignore-revs': '',
+        'rev-parse --absolute-git-dir': '/repo/.git',
+        'rev-parse --git-common-dir': '/repo/.git',
+        'config --local --get core.hooksPath': null
+      }
+      const val = responses[key]
+      if (val === undefined) throw new Error(`ENOENT: git ${key}`)
+      if (val === null) throw new Error(`ENOENT: git ${key}`)
+      return val
+    }) as never)
+
+    expect(() => main()).toThrow('process.exit(1)')
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('prek install failed unexpectedly'))
   })
 })

--- a/scripts/__tests__/install-hooks.test.ts
+++ b/scripts/__tests__/install-hooks.test.ts
@@ -1,0 +1,105 @@
+import { execFileSync } from 'node:child_process'
+import { normalize, resolve } from 'node:path'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(() => '')
+}))
+
+const mockExecFileSync = vi.mocked(execFileSync)
+
+// Helper mirroring the production path comparison logic
+function platformPathsEqual(pathA: string, pathB: string, isWindows: boolean): boolean {
+  const a = normalize(resolve(pathA))
+  const b = normalize(resolve(pathB))
+  return isWindows ? a.toLowerCase() === b.toLowerCase() : a === b
+}
+
+describe('install-hooks: Windows path comparison', () => {
+  describe('linked worktree detection', () => {
+    it('identical paths are equal regardless of platform', () => {
+      const a = normalize(resolve('/Users/dev/repo/.git'))
+      const b = normalize(resolve('/Users/dev/repo/.git'))
+      expect(a).toBe(b)
+    })
+
+    it('different paths are not equal on non-Windows', () => {
+      expect(platformPathsEqual('/Users/dev/repo/.git', '/Users/dev/other/.git', false)).toBe(false)
+    })
+
+    it('different paths are not equal on Windows', () => {
+      expect(platformPathsEqual('D:\\Repo\\.git', 'D:\\Other\\.git', true)).toBe(false)
+    })
+
+    it('Windows: same logical path with different drive casing is equal', () => {
+      const a = 'D:\\Repo\\.git'
+      const b = 'd:\\repo\\.git'
+      expect(a.toLowerCase()).toBe(b.toLowerCase())
+    })
+
+    it('Windows: same logical path with mixed directory casing is equal', () => {
+      const a = 'C:\\Users\\Developer\\MyProject\\.git'
+      const b = 'c:\\users\\DEVELOPER\\myproject\\.git'
+      expect(a.toLowerCase()).toBe(b.toLowerCase())
+    })
+
+    it('non-Windows: case-sensitive comparison preserves distinction', () => {
+      const a = '/Users/Dev/repo/.git'
+      const b = '/users/dev/repo/.git'
+      expect(a).not.toBe(b)
+    })
+  })
+
+  describe('hooksPath cleanup', () => {
+    it('does not match a custom hooksPath on non-Windows', () => {
+      expect(platformPathsEqual('/Users/dev/repo/.husky', '/Users/dev/repo/.git/hooks', false)).toBe(false)
+    })
+
+    it('does not match a custom hooksPath on Windows', () => {
+      expect(platformPathsEqual('D:\\Repo\\.husky', 'D:\\Repo\\.git\\hooks', true)).toBe(false)
+    })
+
+    it('Windows: hooksPath matching uses toLowerCase for comparison', () => {
+      const hooksPath = 'D:\\REPO\\.GIT\\HOOKS'
+      const defaultDir = 'd:\\repo\\.git\\hooks'
+      expect(hooksPath.toLowerCase() === defaultDir.toLowerCase()).toBe(true)
+    })
+  })
+
+  describe('shell option for pnpm fallback', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+    })
+
+    it('passes shell: true on win32 platform', () => {
+      const isWindows = 'win32' === 'win32'
+      const opts = { stdio: 'inherit' as const, shell: isWindows }
+      mockExecFileSync('pnpm', ['exec', 'prek', 'install'], opts)
+      expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['exec', 'prek', 'install'], {
+        stdio: 'inherit',
+        shell: true
+      })
+    })
+
+    it('passes shell: false on darwin platform', () => {
+      const isWindows = 'darwin' === 'win32'
+      const opts = { stdio: 'inherit' as const, shell: isWindows }
+      mockExecFileSync('pnpm', ['exec', 'prek', 'install'], opts)
+      expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['exec', 'prek', 'install'], {
+        stdio: 'inherit',
+        shell: false
+      })
+    })
+
+    it('passes shell: false on linux platform', () => {
+      const isWindows = 'linux' === 'win32'
+      const opts = { stdio: 'inherit' as const, shell: isWindows }
+      mockExecFileSync('pnpm', ['exec', 'prek', 'install'], opts)
+      expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['exec', 'prek', 'install'], {
+        stdio: 'inherit',
+        shell: false
+      })
+    })
+  })
+})

--- a/scripts/__tests__/install-hooks.test.ts
+++ b/scripts/__tests__/install-hooks.test.ts
@@ -1,12 +1,16 @@
 import { execFileSync } from 'node:child_process'
 import { normalize, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  arePathsEqual,
   getDefaultHooksDir,
   getLocalHooksPath,
   isDefaultGitHooksPath,
+  isDirectRun,
+  isGitRepo,
   isLinkedWorktree,
   main,
   runPrekInstall,
@@ -143,7 +147,7 @@ describe('runPrekInstall', () => {
   it('uses npm_execpath when set', () => {
     process.env.npm_execpath = '/path/to/pnpm.cjs'
     mockExec.mockReturnValue('')
-    expect(runPrekInstall()).toBe(true)
+    expect(runPrekInstall()).toBe('success')
     expect(mockExec).toHaveBeenCalledWith(
       process.execPath,
       expect.arrayContaining([expect.stringContaining('pnpm'), 'exec', 'prek', 'install']),
@@ -153,7 +157,7 @@ describe('runPrekInstall', () => {
 
   it('falls back to pnpm when npm_execpath is not set', () => {
     mockExec.mockReturnValue('')
-    expect(runPrekInstall()).toBe(true)
+    expect(runPrekInstall()).toBe('success')
     // On non-Windows, shell should be false
     expect(mockExec).toHaveBeenCalledWith('pnpm', ['exec', 'prek', 'install'], {
       stdio: 'inherit',
@@ -161,11 +165,105 @@ describe('runPrekInstall', () => {
     })
   })
 
-  it('returns false on exec failure', () => {
+  it('returns failed on exec failure', () => {
     mockExec.mockImplementation(() => {
       throw new Error('prek refused')
     })
-    expect(runPrekInstall()).toBe(false)
+    expect(runPrekInstall()).toBe('failed')
+  })
+
+  it('returns command-not-found on ENOENT', () => {
+    mockExec.mockImplementation(() => {
+      const err = new Error('pnpm not found') as NodeJS.ErrnoException
+      err.code = 'ENOENT'
+      throw err
+    })
+    expect(runPrekInstall()).toBe('command-not-found')
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('command not found'))
+  })
+})
+
+describe('arePathsEqual', () => {
+  it('returns true when paths resolve to the same location (POSIX)', () => {
+    expect(arePathsEqual('/foo/bar', '/foo/bar')).toBe(true)
+  })
+
+  it('returns true when one path has trailing slash or dots', () => {
+    expect(arePathsEqual('/foo/bar', '/foo/baz/../bar')).toBe(true)
+  })
+
+  it('returns false when paths differ', () => {
+    expect(arePathsEqual('/foo/bar', '/foo/baz')).toBe(false)
+  })
+
+  it('handles empty strings gracefully', () => {
+    expect(arePathsEqual('', '')).toBe(true)
+  })
+})
+
+describe('isDirectRun', () => {
+  it('returns true when argv[1] matches the actual module path', () => {
+    const originalArgv1 = process.argv[1]
+    // Set argv[1] to the resolved path of this test file's neighbor (install-hooks.ts)
+    const testModuleDir = resolve(fileURLToPath(import.meta.url), '..')
+    const installHooksPath = resolve(testModuleDir, 'install-hooks.ts')
+    // We can't make isDirectRun return true for install-hooks.ts from this file
+    // because import.meta.url points here. But we CAN test arePathsEqual directly.
+    // For isDirectRun, verify the false case is solid.
+    process.argv[1] = installHooksPath
+    // import.meta.url in install-hooks.ts points to install-hooks.ts,
+    // but in this test context it points to this test file
+    expect(isDirectRun()).toBe(false)
+    process.argv[1] = originalArgv1
+  })
+
+  it('returns false when import.meta.url does not match argv[1]', () => {
+    const originalArgv1 = process.argv[1]
+    process.argv[1] = '/completely/different/path.ts'
+    expect(isDirectRun()).toBe(false)
+    process.argv[1] = originalArgv1
+  })
+
+  it('returns false when argv[1] is empty', () => {
+    const originalArgv1 = process.argv[1]
+    process.argv[1] = ''
+    expect(isDirectRun()).toBe(false)
+    process.argv[1] = originalArgv1
+  })
+
+  it('true path covered by arePathsEqual + structural guard', () => {
+    // isDirectRun's true path relies on arePathsEqual returning true
+    // when both paths resolve to the same file. Verify the core logic:
+    const testPath = fileURLToPath(import.meta.url)
+    expect(arePathsEqual(testPath, testPath)).toBe(true)
+    // import.meta.url in install-hooks.ts resolves to scripts/install-hooks.ts,
+    // so set argv[1] to that path to trigger the true case
+    const testDir = resolve(fileURLToPath(import.meta.url), '..')
+    const installHooksPath = resolve(testDir, '..', 'install-hooks.ts')
+    const originalArgv1 = process.argv[1]
+    process.argv[1] = installHooksPath
+    expect(isDirectRun()).toBe(true)
+    process.argv[1] = originalArgv1
+  })
+})
+
+describe('git ENOENT handling', () => {
+  it('warns when git binary is not found (ENOENT)', () => {
+    mockExec.mockImplementation(() => {
+      const err = new Error('spawn git ENOENT') as NodeJS.ErrnoException
+      err.code = 'ENOENT'
+      throw err
+    })
+    expect(isGitRepo()).toBe(false)
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('git not found'))
+  })
+
+  it('does not warn on non-ENOENT git failures', () => {
+    mockExec.mockImplementation(() => {
+      throw new Error('fatal: not a git repository')
+    })
+    expect(isGitRepo()).toBe(false)
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('git not found'))
   })
 })
 
@@ -296,5 +394,30 @@ describe('main', () => {
 
     expect(() => main()).toThrow('process.exit(1)')
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('prek install failed unexpectedly'))
+  })
+
+  it('exits non-zero on ENOENT even with custom hooksPath', () => {
+    mockExec.mockImplementation(((cmd: string, args: string[]) => {
+      if (cmd === 'pnpm') {
+        const err = new Error('pnpm not found') as NodeJS.ErrnoException
+        err.code = 'ENOENT'
+        throw err
+      }
+      const key = args.join(' ')
+      const responses: Record<string, string | null> = {
+        'rev-parse --git-dir': '.git',
+        'config blame.ignoreRevsFile .git-blame-ignore-revs': '',
+        'rev-parse --absolute-git-dir': '/repo/.git',
+        'rev-parse --git-common-dir': '/repo/.git',
+        'config --local --get core.hooksPath': '.husky'
+      }
+      const val = responses[key]
+      if (val === undefined) throw new Error(`ENOENT: git ${key}`)
+      if (val === null) throw new Error(`ENOENT: git ${key}`)
+      return val
+    }) as never)
+
+    expect(() => main()).toThrow('process.exit(1)')
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('command not found'))
   })
 })

--- a/scripts/__tests__/install-hooks.test.ts
+++ b/scripts/__tests__/install-hooks.test.ts
@@ -73,7 +73,8 @@ describe('install-hooks: Windows path comparison', () => {
     })
 
     it('passes shell: true on win32 platform', () => {
-      const isWindows = 'win32' === 'win32'
+      const platform = 'win32'
+      const isWindows = platform === 'win32'
       const opts = { stdio: 'inherit' as const, shell: isWindows }
       mockExecFileSync('pnpm', ['exec', 'prek', 'install'], opts)
       expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['exec', 'prek', 'install'], {
@@ -83,7 +84,8 @@ describe('install-hooks: Windows path comparison', () => {
     })
 
     it('passes shell: false on darwin platform', () => {
-      const isWindows = 'darwin' === 'win32'
+      const platform: string = 'darwin'
+      const isWindows = platform === 'win32'
       const opts = { stdio: 'inherit' as const, shell: isWindows }
       mockExecFileSync('pnpm', ['exec', 'prek', 'install'], opts)
       expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['exec', 'prek', 'install'], {
@@ -93,7 +95,8 @@ describe('install-hooks: Windows path comparison', () => {
     })
 
     it('passes shell: false on linux platform', () => {
-      const isWindows = 'linux' === 'win32'
+      const platform: string = 'linux'
+      const isWindows = platform === 'win32'
       const opts = { stdio: 'inherit' as const, shell: isWindows }
       mockExecFileSync('pnpm', ['exec', 'prek', 'install'], opts)
       expect(mockExecFileSync).toHaveBeenCalledWith('pnpm', ['exec', 'prek', 'install'], {

--- a/scripts/install-hooks.ts
+++ b/scripts/install-hooks.ts
@@ -65,17 +65,22 @@ function unsetHooksPath(): void {
 }
 
 // Execute prek install via the current package manager
-function runPrekInstall(): void {
+// Returns true on success, false if prek refused (e.g. custom hooksPath set)
+function runPrekInstall(): boolean {
   const execPath = process.env.npm_execpath
   const args = ['exec', 'prek', 'install']
 
-  if (execPath) {
-    execFileSync(process.execPath, [resolve(execPath), ...args], {
-      stdio: 'inherit'
-    })
-  } else {
-    // Fallback: try pnpm directly
-    execFileSync('pnpm', args, { stdio: 'inherit' })
+  try {
+    if (execPath) {
+      execFileSync(process.execPath, [resolve(execPath), ...args], {
+        stdio: 'inherit'
+      })
+    } else {
+      execFileSync('pnpm', args, { stdio: 'inherit' })
+    }
+    return true
+  } catch {
+    return false
   }
 }
 
@@ -102,7 +107,16 @@ function main(): void {
   }
 
   // Install hooks
-  runPrekInstall()
+  const hooksPathBeforeInstall = getLocalHooksPath()
+  if (!runPrekInstall()) {
+    // prek may refuse when custom hooksPath is set (e.g. .husky) — that's fine
+    if (hooksPathBeforeInstall) {
+      console.info(`install-hooks: prek skipped (core.hooksPath is set to "${hooksPathBeforeInstall}")`)
+    } else {
+      console.error('install-hooks: prek install failed unexpectedly')
+      process.exit(1)
+    }
+  }
 }
 
 main()

--- a/scripts/install-hooks.ts
+++ b/scripts/install-hooks.ts
@@ -1,19 +1,42 @@
 import { execFileSync } from 'node:child_process'
 import { normalize, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-// Whether the current platform treats file paths as case-insensitive
+// Windows path comparison requires case-insensitive matching
 const isWindows: boolean = process.platform === 'win32'
 
-// Run a git command and return trimmed stdout, or null on failure
+function arePathsEqual(a: string, b: string): boolean {
+  const na = normalize(resolve(a))
+  const nb = normalize(resolve(b))
+  return isWindows ? na.toLowerCase() === nb.toLowerCase() : na === nb
+}
+
+/**
+ * Cross-platform check for whether this module was invoked directly
+ * (not imported by a test file). Compares normalized absolute paths
+ * from `import.meta.url` and `process.argv[1]`.
+ */
+function isDirectRun(): boolean {
+  try {
+    const modulePath = fileURLToPath(import.meta.url)
+    const scriptPath = process.argv[1] ?? ''
+    return arePathsEqual(modulePath, scriptPath)
+  } catch {
+    return false
+  }
+}
+
 function git(...args: string[]): string | null {
   try {
     return execFileSync('git', args, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim()
-  } catch {
+  } catch (error: unknown) {
+    if (error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT') {
+      console.warn('install-hooks: git not found on PATH — hook setup will be skipped')
+    }
     return null
   }
 }
 
-// Check if current directory is inside a git repository
 function isGitRepo(): boolean {
   return git('rev-parse', '--git-dir') !== null
 }
@@ -71,11 +94,14 @@ function unsetHooksPath(): boolean {
   return result !== null
 }
 
+type PrekResult = 'success' | 'command-not-found' | 'failed'
+
 /**
  * Execute prek install via the current package manager.
- * Returns true on success, false on failure or when prek refused.
+ * Returns 'success' on success, 'command-not-found' when the binary
+ * is missing, or 'failed' for any other error (including prek refusal).
  */
-function runPrekInstall(): boolean {
+function runPrekInstall(): PrekResult {
   const execPath = process.env.npm_execpath
   const args = ['exec', 'prek', 'install']
 
@@ -87,14 +113,14 @@ function runPrekInstall(): boolean {
     } else {
       execFileSync('pnpm', args, { stdio: 'inherit', shell: isWindows })
     }
-    return true
+    return 'success'
   } catch (err: unknown) {
-    // Surface ENOENT so users know which command is missing
     if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
       const cmd = execPath ? process.execPath : 'pnpm'
       console.error(`install-hooks: command not found: ${cmd}`)
+      return 'command-not-found'
     }
-    return false
+    return 'failed'
   }
 }
 
@@ -133,7 +159,12 @@ function main(): void {
 
   // Install hooks
   const hooksPathBeforeInstall = getLocalHooksPath()
-  if (!runPrekInstall()) {
+  const result = runPrekInstall()
+  if (result === 'command-not-found') {
+    console.error('install-hooks: aborting — package manager not found')
+    process.exit(1)
+  }
+  if (result === 'failed') {
     // prek may refuse when custom hooksPath is set (e.g. .husky) — acceptable
     if (hooksPathBeforeInstall) {
       console.info(`install-hooks: prek skipped (core.hooksPath is set to "${hooksPathBeforeInstall}")`)
@@ -144,19 +175,19 @@ function main(): void {
   }
 }
 
-// Run main() only when executed directly, not when imported by tests
-const isDirectRun = process.argv[1]?.endsWith('scripts/install-hooks.ts') ?? false
-if (isDirectRun) {
+if (isDirectRun()) {
   main()
 }
 
 // Export for testing
 export {
+  arePathsEqual,
   configureBlameIgnoreRevs,
   getDefaultHooksDir,
   getLocalHooksPath,
   git,
   isDefaultGitHooksPath,
+  isDirectRun,
   isGitRepo,
   isLinkedWorktree,
   isWindows,

--- a/scripts/install-hooks.ts
+++ b/scripts/install-hooks.ts
@@ -1,0 +1,108 @@
+import { execFileSync } from 'node:child_process'
+import { normalize, resolve } from 'node:path'
+
+/**
+ * Prepare script for git hook installation.
+ *
+ * Handles three scenarios:
+ * 1. Linked worktree → skip prek install (hooks shared via commondir)
+ * 2. Primary worktree with Claude Code hooksPath pollution → clean up, then install
+ * 3. Primary worktree, normal → install hooks normally
+ */
+
+// Run a git command and return trimmed stdout, or null on failure
+function git(...args: string[]): string | null {
+  try {
+    return execFileSync('git', args, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim()
+  } catch {
+    return null
+  }
+}
+
+// Check if current directory is inside a git repository
+function isGitRepo(): boolean {
+  return git('rev-parse', '--git-dir') !== null
+}
+
+// Check if running inside a linked worktree (git-dir !== git-common-dir)
+function isLinkedWorktree(): boolean {
+  const gitDir = git('rev-parse', '--absolute-git-dir')
+  const commonDir = git('rev-parse', '--git-common-dir')
+  if (!gitDir || !commonDir) return false
+  return normalize(resolve(gitDir)) !== normalize(resolve(commonDir))
+}
+
+// Set blame.ignoreRevsFile (best-effort, non-fatal)
+function configureBlameIgnoreRevs(): void {
+  const result = git('config', 'blame.ignoreRevsFile', '.git-blame-ignore-revs')
+  if (result === null) {
+    console.warn('install-hooks: could not set blame.ignoreRevsFile (non-fatal)')
+  }
+}
+
+// Get the local core.hooksPath, or null if not set
+function getLocalHooksPath(): string | null {
+  return git('config', '--local', '--get', 'core.hooksPath')
+}
+
+// Compute the default hooks directory (<git-common-dir>/hooks)
+function getDefaultHooksDir(): string | null {
+  const commonDir = git('rev-parse', '--git-common-dir')
+  if (!commonDir) return null
+  return normalize(resolve(commonDir, 'hooks'))
+}
+
+// Check if hooksPath is the Git default hooks directory (Claude Code pollution)
+function isClaudeCodeHooksPath(hooksPath: string): boolean {
+  const defaultDir = getDefaultHooksDir()
+  if (!defaultDir) return false
+  return normalize(resolve(hooksPath)) === defaultDir
+}
+
+// Unset local core.hooksPath
+function unsetHooksPath(): void {
+  git('config', '--local', '--unset-all', 'core.hooksPath')
+}
+
+// Execute prek install via the current package manager
+function runPrekInstall(): void {
+  const execPath = process.env.npm_execpath
+  const args = ['exec', 'prek', 'install']
+
+  if (execPath) {
+    execFileSync(process.execPath, [resolve(execPath), ...args], {
+      stdio: 'inherit'
+    })
+  } else {
+    // Fallback: try pnpm directly
+    execFileSync('pnpm', args, { stdio: 'inherit' })
+  }
+}
+
+// Main
+function main(): void {
+  // Best-effort blame config
+  if (!isGitRepo()) {
+    console.warn('install-hooks: not a git repository, skipping hook setup')
+    return
+  }
+  configureBlameIgnoreRevs()
+
+  // Linked worktree: skip prek install entirely
+  if (isLinkedWorktree()) {
+    console.info('install-hooks: linked worktree detected, skipping prek install (hooks managed by primary worktree)')
+    return
+  }
+
+  // Primary worktree: clean Claude Code hooksPath pollution if present
+  const hooksPath = getLocalHooksPath()
+  if (hooksPath && isClaudeCodeHooksPath(hooksPath)) {
+    unsetHooksPath()
+    console.info('install-hooks: cleaned Claude Code core.hooksPath pollution')
+  }
+
+  // Install hooks
+  runPrekInstall()
+}
+
+main()

--- a/scripts/install-hooks.ts
+++ b/scripts/install-hooks.ts
@@ -1,6 +1,9 @@
 import { execFileSync } from 'node:child_process'
 import { normalize, resolve } from 'node:path'
 
+// Windows path comparison requires case-insensitive matching
+const isWindows: boolean = process.platform === 'win32'
+
 /**
  * Prepare script for git hook installation.
  *
@@ -29,7 +32,9 @@ function isLinkedWorktree(): boolean {
   const gitDir = git('rev-parse', '--absolute-git-dir')
   const commonDir = git('rev-parse', '--git-common-dir')
   if (!gitDir || !commonDir) return false
-  return normalize(resolve(gitDir)) !== normalize(resolve(commonDir))
+  const a = normalize(resolve(gitDir))
+  const b = normalize(resolve(commonDir))
+  return isWindows ? a.toLowerCase() !== b.toLowerCase() : a !== b
 }
 
 // Set blame.ignoreRevsFile (best-effort, non-fatal)
@@ -56,7 +61,8 @@ function getDefaultHooksDir(): string | null {
 function isClaudeCodeHooksPath(hooksPath: string): boolean {
   const defaultDir = getDefaultHooksDir()
   if (!defaultDir) return false
-  return normalize(resolve(hooksPath)) === defaultDir
+  const resolved = normalize(resolve(hooksPath))
+  return isWindows ? resolved.toLowerCase() === defaultDir.toLowerCase() : resolved === defaultDir
 }
 
 // Unset local core.hooksPath
@@ -76,7 +82,7 @@ function runPrekInstall(): boolean {
         stdio: 'inherit'
       })
     } else {
-      execFileSync('pnpm', args, { stdio: 'inherit' })
+      execFileSync('pnpm', args, { stdio: 'inherit', shell: isWindows })
     }
     return true
   } catch {

--- a/scripts/install-hooks.ts
+++ b/scripts/install-hooks.ts
@@ -1,17 +1,8 @@
 import { execFileSync } from 'node:child_process'
 import { normalize, resolve } from 'node:path'
 
-// Windows path comparison requires case-insensitive matching
+// Whether the current platform treats file paths as case-insensitive
 const isWindows: boolean = process.platform === 'win32'
-
-/**
- * Prepare script for git hook installation.
- *
- * Handles three scenarios:
- * 1. Linked worktree → skip prek install (hooks shared via commondir)
- * 2. Primary worktree with Claude Code hooksPath pollution → clean up, then install
- * 3. Primary worktree, normal → install hooks normally
- */
 
 // Run a git command and return trimmed stdout, or null on failure
 function git(...args: string[]): string | null {
@@ -27,11 +18,14 @@ function isGitRepo(): boolean {
   return git('rev-parse', '--git-dir') !== null
 }
 
-// Check if running inside a linked worktree (git-dir !== git-common-dir)
-function isLinkedWorktree(): boolean {
+/**
+ * Detect linked worktree status by comparing git-dir and git-common-dir.
+ * Returns true if linked, false if primary, null if detection failed.
+ */
+function isLinkedWorktree(): boolean | null {
   const gitDir = git('rev-parse', '--absolute-git-dir')
   const commonDir = git('rev-parse', '--git-common-dir')
-  if (!gitDir || !commonDir) return false
+  if (!gitDir || !commonDir) return null
   const a = normalize(resolve(gitDir))
   const b = normalize(resolve(commonDir))
   return isWindows ? a.toLowerCase() !== b.toLowerCase() : a !== b
@@ -57,21 +51,30 @@ function getDefaultHooksDir(): string | null {
   return normalize(resolve(commonDir, 'hooks'))
 }
 
-// Check if hooksPath is the Git default hooks directory (Claude Code pollution)
-function isClaudeCodeHooksPath(hooksPath: string): boolean {
+/**
+ * Check if hooksPath points to the Git default hooks directory.
+ * On Windows, comparison is case-insensitive.
+ */
+function isDefaultGitHooksPath(hooksPath: string): boolean {
   const defaultDir = getDefaultHooksDir()
   if (!defaultDir) return false
   const resolved = normalize(resolve(hooksPath))
   return isWindows ? resolved.toLowerCase() === defaultDir.toLowerCase() : resolved === defaultDir
 }
 
-// Unset local core.hooksPath
-function unsetHooksPath(): void {
-  git('config', '--local', '--unset-all', 'core.hooksPath')
+/**
+ * Unset local core.hooksPath. Returns true if unset succeeded
+ * or hooksPath was not set, false if the git command itself failed.
+ */
+function unsetHooksPath(): boolean {
+  const result = git('config', '--local', '--unset-all', 'core.hooksPath')
+  return result !== null
 }
 
-// Execute prek install via the current package manager
-// Returns true on success, false if prek refused (e.g. custom hooksPath set)
+/**
+ * Execute prek install via the current package manager.
+ * Returns true on success, false on failure or when prek refused.
+ */
 function runPrekInstall(): boolean {
   const execPath = process.env.npm_execpath
   const args = ['exec', 'prek', 'install']
@@ -85,14 +88,21 @@ function runPrekInstall(): boolean {
       execFileSync('pnpm', args, { stdio: 'inherit', shell: isWindows })
     }
     return true
-  } catch {
+  } catch (err: unknown) {
+    // Surface ENOENT so users know which command is missing
+    if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
+      const cmd = execPath ? process.execPath : 'pnpm'
+      console.error(`install-hooks: command not found: ${cmd}`)
+    }
     return false
   }
 }
 
-// Main
+/**
+ * Main entry point for the prepare lifecycle script.
+ * Handles worktree detection, hooksPath cleanup, and prek install.
+ */
 function main(): void {
-  // Best-effort blame config
   if (!isGitRepo()) {
     console.warn('install-hooks: not a git repository, skipping hook setup')
     return
@@ -100,22 +110,31 @@ function main(): void {
   configureBlameIgnoreRevs()
 
   // Linked worktree: skip prek install entirely
-  if (isLinkedWorktree()) {
+  const linked = isLinkedWorktree()
+  if (linked === null) {
+    // Cannot determine worktree status — abort rather than risk polluting shared hooks
+    console.error('install-hooks: could not determine worktree status, aborting hook setup')
+    process.exit(1)
+  }
+  if (linked) {
     console.info('install-hooks: linked worktree detected, skipping prek install (hooks managed by primary worktree)')
     return
   }
 
-  // Primary worktree: clean Claude Code hooksPath pollution if present
+  // Primary worktree: clean default hooksPath if present
   const hooksPath = getLocalHooksPath()
-  if (hooksPath && isClaudeCodeHooksPath(hooksPath)) {
-    unsetHooksPath()
-    console.info('install-hooks: cleaned Claude Code core.hooksPath pollution')
+  if (hooksPath && isDefaultGitHooksPath(hooksPath)) {
+    if (!unsetHooksPath()) {
+      console.error('install-hooks: failed to unset core.hooksPath, aborting hook setup')
+      process.exit(1)
+    }
+    console.info('install-hooks: cleaned default core.hooksPath')
   }
 
   // Install hooks
   const hooksPathBeforeInstall = getLocalHooksPath()
   if (!runPrekInstall()) {
-    // prek may refuse when custom hooksPath is set (e.g. .husky) — that's fine
+    // prek may refuse when custom hooksPath is set (e.g. .husky) — acceptable
     if (hooksPathBeforeInstall) {
       console.info(`install-hooks: prek skipped (core.hooksPath is set to "${hooksPathBeforeInstall}")`)
     } else {
@@ -125,4 +144,23 @@ function main(): void {
   }
 }
 
-main()
+// Run main() only when executed directly, not when imported by tests
+const isDirectRun = process.argv[1]?.endsWith('scripts/install-hooks.ts') ?? false
+if (isDirectRun) {
+  main()
+}
+
+// Export for testing
+export {
+  configureBlameIgnoreRevs,
+  getDefaultHooksDir,
+  getLocalHooksPath,
+  git,
+  isDefaultGitHooksPath,
+  isGitRepo,
+  isLinkedWorktree,
+  isWindows,
+  main,
+  runPrekInstall,
+  unsetHooksPath
+}


### PR DESCRIPTION
## Problem

Inside a Claude Code-created git worktree, `pnpm install` fails during the `prepare` lifecycle with:

```
error: Cowardly refusing to install hooks with `core.hooksPath` set.
```

## Root Cause

Three independent issues conspire:

1. **Claude Code pollution** ([claude-code#27474](https://github.com/anthropics/claude-code/issues/27474)) — `EnterWorktree` writes `core.hooksPath = <git-common-dir>/hooks` into the primary worktree's local config. Once `core.hooksPath` is set, `prek install` refuses (by design) to avoid clobbering a user's custom hook setup. This breaks `pnpm install` in the main repo, not the worktree.

2. **Worktree-shared hooks get poisoned by `prek install`** — Even if step 1 didn't happen, running `prek install` from a linked worktree succeeds, but the generated hook scripts hardcode absolute paths pointing into the worktree's `node_modules`. Since `.git/hooks/` is shared via `commondir`, deleting that worktree later silently breaks the main repo's hooks. Skipping `prek install` in linked worktrees is safe because hooks are already shared.

3. **Vite walks up to parent `node_modules`** (independent issue) — In nested worktree layouts, Vite resolves `@vitest/web-worker` from an ancestor directory, failing all renderer tests. Pinning the absolute path in `vitest.config.ts` fixes this.

## Why the TS wrapper

The fix needs three conditional branches (linked worktree / polluted primary / custom hooksPath like `.husky`) and must work on Windows. Inline bash in `package.json` can't carry the logic portably (Codex review caught the non-portable shell syntax). `scripts/install-hooks.ts` consolidates the decision tree using Node's `child_process` + `path` APIs.

## Changes

| File | Change |
|------|--------|
| `scripts/install-hooks.ts` | **New** — Cross-platform prepare wrapper with worktree detection, hooksPath cleanup, and error handling |
| `package.json` | `prepare` script changed from inline bash to `tsx scripts/install-hooks.ts` |
| `vitest.config.ts` | `@vitest/web-worker` resolved with `resolve('node_modules/...')` for worktree compatibility |

## Test Plan

- [x] Main repo: `pnpm install` with Claude Code `core.hooksPath` pollution → auto-cleaned, prek installed successfully
- [x] Main repo: custom `core.hooksPath` (`.husky`) → preserved, prek gracefully skipped
- [x] Fresh worktree: `pnpm install` → worktree detected, prek skipped, shared hooks untouched
- [x] Fresh worktree: `pnpm test` → 239 test files / 4314 tests all pass
- [x] `pnpm lint`, `pnpm test`, `pnpm format` pass all quality gates

## Related Issues

- [anthropics/claude-code#27474](https://github.com/anthropics/claude-code/issues/27474) — Claude Code `EnterWorktree` overwrites shared `core.hooksPath`
- [anthropics/claude-code#30251](https://github.com/anthropics/claude-code/issues/30251) — Worktree setup modifies main repo git config