### PR TITLE
fix(aiCore): support URL response format in image generation

### DIFF
--- a/patches/@ai-sdk__openai-compatible@2.0.37.patch
+++ b/patches/@ai-sdk__openai-compatible@2.0.37.patch
@@ -1,11 +1,11 @@
 diff --git a/dist/index.js b/dist/index.js
+index d73573b..30c42aa 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -571,6 +571,17 @@
-         type: "reasoning",
+@@ -572,6 +572,17 @@ var OpenAICompatibleChatLanguageModel = class {
          text: reasoning
        });
-+    }
+     }
 +    if (choice.message.images) {
 +      for (const image of choice.message.images) {
 +        const match1 = image.image_url.url.match(/^data:([^;]+)/);
@@ -16,10 +16,11 @@ diff --git a/dist/index.js b/dist/index.js
 +          data: match2 ? match2[1] : image.image_url.url,
 +        });
 +      }
-     }
++    }
      if (choice.message.tool_calls != null) {
        for (const toolCall of choice.message.tool_calls) {
-@@ -732,6 +743,17 @@
+         const thoughtSignature = (_c = (_b = toolCall.extra_content) == null ? void 0 : _b.google) == null ? void 0 : _c.thought_signature;
+@@ -732,6 +743,17 @@ var OpenAICompatibleChatLanguageModel = class {
                  delta: delta.content
                });
              }
@@ -37,11 +38,10 @@ diff --git a/dist/index.js b/dist/index.js
              if (delta.tool_calls != null) {
                if (isActiveReasoning) {
                  controller.enqueue({
-@@ -927,6 +949,14 @@
-                 thought_signature: import_v43.z.string().nullish()
+@@ -928,6 +950,14 @@ var OpenAICompatibleChatResponseSchema = import_v43.z.looseObject({
                }).nullish()
              }).nullish()
-+          })
+           })
 +        ).nullish(),
 +        images: import_v43.z.array(
 +          import_v43.z.object({
@@ -49,14 +49,14 @@ diff --git a/dist/index.js b/dist/index.js
 +            image_url: import_v43.z.object({
 +              url: import_v43.z.string(),
 +            })
-           })
++          })
          ).nullish()
        }),
-@@ -963,6 +993,14 @@
-                 thought_signature: import_v43.z.string().nullish()
+       finish_reason: import_v43.z.string().nullish()
+@@ -964,6 +994,14 @@ var chunkBaseSchema = import_v43.z.looseObject({
                }).nullish()
              }).nullish()
-+          })
+           })
 +        ).nullish(),
 +        images: import_v43.z.array(
 +          import_v43.z.object({
@@ -64,10 +64,11 @@ diff --git a/dist/index.js b/dist/index.js
 +            image_url: import_v43.z.object({
 +              url: import_v43.z.string(),
 +            })
-           })
++          })
          ).nullish()
        }).nullish(),
-@@ -1529,6 +1567,16 @@
+       finish_reason: import_v43.z.string().nullish()
+@@ -1529,6 +1567,16 @@ var openaiTextEmbeddingResponseSchema = import_v47.z.object({
  // src/image/openai-compatible-image-model.ts
  var import_provider_utils5 = require("@ai-sdk/provider-utils");
  var import_v48 = require("zod/v4");
@@ -84,7 +85,16 @@ diff --git a/dist/index.js b/dist/index.js
  var OpenAICompatibleImageModel = class {
    constructor(modelId, config) {
      this.modelId = modelId;
-@@ -1625,7 +1673,7 @@
+@@ -1604,7 +1652,7 @@ var OpenAICompatibleImageModel = class {
+         fetch: this.config.fetch
+       });
+       return {
+-        images: response2.data.map((item) => item.b64_json),
++        images: response2.data.map((item) => item.b64_json ?? item.url),
+         warnings,
+         response: {
+           timestamp: currentDate,
+@@ -1625,7 +1673,7 @@ var OpenAICompatibleImageModel = class {
          n,
          size,
          ...args,
@@ -93,14 +103,32 @@ diff --git a/dist/index.js b/dist/index.js
        },
        failedResponseHandler: (0, import_provider_utils5.createJsonErrorResponseHandler)(
          (_e = this.config.errorStructure) != null ? _e : defaultOpenAICompatibleErrorStructure
+@@ -1637,7 +1685,7 @@ var OpenAICompatibleImageModel = class {
+       fetch: this.config.fetch
+     });
+     return {
+-      images: response.data.map((item) => item.b64_json),
++      images: response.data.map((item) => item.b64_json ?? item.url),
+       warnings,
+       response: {
+         timestamp: currentDate,
+@@ -1648,7 +1696,7 @@ var OpenAICompatibleImageModel = class {
+   }
+ };
+ var openaiCompatibleImageResponseSchema = import_v48.z.object({
+-  data: import_v48.z.array(import_v48.z.object({ b64_json: import_v48.z.string() }))
++  data: import_v48.z.array(import_v48.z.object({ b64_json: import_v48.z.string().optional(), url: import_v48.z.string().optional() }))
+ });
+ async function fileToBlob(file) {
+   if (file.type === "url") {
 diff --git a/dist/index.mjs b/dist/index.mjs
+index 237c9e2..9bedba2 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
-@@ -558,6 +558,17 @@
-         type: "reasoning",
+@@ -559,6 +559,17 @@ var OpenAICompatibleChatLanguageModel = class {
          text: reasoning
        });
-+    }
+     }
 +    if (choice.message.images) {
 +      for (const image of choice.message.images) {
 +        const match1 = image.image_url.url.match(/^data:([^;]+)/);
@@ -111,10 +139,11 @@ diff --git a/dist/index.mjs b/dist/index.mjs
 +          data: match2 ? match2[1] : image.image_url.url,
 +        });
 +      }
-     }
++    }
      if (choice.message.tool_calls != null) {
        for (const toolCall of choice.message.tool_calls) {
-@@ -719,6 +730,17 @@
+         const thoughtSignature = (_c = (_b = toolCall.extra_content) == null ? void 0 : _b.google) == null ? void 0 : _c.thought_signature;
+@@ -719,6 +730,17 @@ var OpenAICompatibleChatLanguageModel = class {
                  delta: delta.content
                });
              }
@@ -132,11 +161,10 @@ diff --git a/dist/index.mjs b/dist/index.mjs
              if (delta.tool_calls != null) {
                if (isActiveReasoning) {
                  controller.enqueue({
-@@ -914,6 +936,14 @@
-                 thought_signature: z3.string().nullish()
+@@ -915,6 +937,14 @@ var OpenAICompatibleChatResponseSchema = z3.looseObject({
                }).nullish()
              }).nullish()
-+          })
+           })
 +        ).nullish(),
 +        images: z3.array(
 +          z3.object({
@@ -144,14 +172,14 @@ diff --git a/dist/index.mjs b/dist/index.mjs
 +            image_url: z3.object({
 +              url: z3.string(),
 +            })
-           })
++          })
          ).nullish()
        }),
-@@ -950,6 +980,14 @@
-                 thought_signature: z3.string().nullish()
+       finish_reason: z3.string().nullish()
+@@ -951,6 +981,14 @@ var chunkBaseSchema = z3.looseObject({
                }).nullish()
              }).nullish()
-+          })
+           })
 +        ).nullish(),
 +        images: z3.array(
 +          z3.object({
@@ -159,10 +187,11 @@ diff --git a/dist/index.mjs b/dist/index.mjs
 +            image_url: z3.object({
 +              url: z3.string(),
 +            })
-           })
++          })
          ).nullish()
        }).nullish(),
-@@ -1543,6 +1581,16 @@
+       finish_reason: z3.string().nullish()
+@@ -1543,6 +1581,16 @@ import {
    postJsonToApi as postJsonToApi4
  } from "@ai-sdk/provider-utils";
  import { z as z8 } from "zod/v4";
@@ -179,7 +208,16 @@ diff --git a/dist/index.mjs b/dist/index.mjs
  var OpenAICompatibleImageModel = class {
    constructor(modelId, config) {
      this.modelId = modelId;
-@@ -1639,7 +1687,7 @@
+@@ -1618,7 +1666,7 @@ var OpenAICompatibleImageModel = class {
+         fetch: this.config.fetch
+       });
+       return {
+-        images: response2.data.map((item) => item.b64_json),
++        images: response2.data.map((item) => item.b64_json ?? item.url),
+         warnings,
+         response: {
+           timestamp: currentDate,
+@@ -1639,7 +1687,7 @@ var OpenAICompatibleImageModel = class {
          n,
          size,
          ...args,
@@ -188,3 +226,21 @@ diff --git a/dist/index.mjs b/dist/index.mjs
        },
        failedResponseHandler: createJsonErrorResponseHandler4(
          (_e = this.config.errorStructure) != null ? _e : defaultOpenAICompatibleErrorStructure
+@@ -1651,7 +1699,7 @@ var OpenAICompatibleImageModel = class {
+       fetch: this.config.fetch
+     });
+     return {
+-      images: response.data.map((item) => item.b64_json),
++      images: response.data.map((item) => item.b64_json ?? item.url),
+       warnings,
+       response: {
+         timestamp: currentDate,
+@@ -1662,7 +1710,7 @@ var OpenAICompatibleImageModel = class {
+   }
+ };
+ var openaiCompatibleImageResponseSchema = z8.object({
+-  data: z8.array(z8.object({ b64_json: z8.string() }))
++  data: z8.array(z8.object({ b64_json: z8.string().optional(), url: z8.string().optional() }))
+ });
+ async function fileToBlob(file) {
+   if (file.type === "url") {

--- a/patches/@ai-sdk__openai@3.0.53.patch
+++ b/patches/@ai-sdk__openai@3.0.53.patch
@@ -1,8 +1,18 @@
 diff --git a/dist/index.js b/dist/index.js
-index 1c78d6f..a81c976 100644
+index 1c78d6f..d760d7c 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -1753,13 +1753,15 @@ var modelMaxImagesPerCall = {
+@@ -1725,7 +1725,8 @@ var openaiImageResponseSchema = (0, import_provider_utils12.lazySchema)(
+       created: import_v48.z.number().nullish(),
+       data: import_v48.z.array(
+         import_v48.z.object({
+-          b64_json: import_v48.z.string(),
++          b64_json: import_v48.z.string().optional(),
++          url: import_v48.z.string().optional(),
+           revised_prompt: import_v48.z.string().nullish()
+         })
+       ),
+@@ -1753,13 +1754,15 @@ var modelMaxImagesPerCall = {
    "gpt-image-1": 10,
    "gpt-image-1-mini": 10,
    "gpt-image-1.5": 10,
@@ -19,11 +29,39 @@ index 1c78d6f..a81c976 100644
  ];
  function hasDefaultResponseFormat(modelId) {
    return defaultResponseFormatPrefixes.some(
+@@ -1843,7 +1846,7 @@ var OpenAIImageModel = class {
+         fetch: this.config.fetch
+       });
+       return {
+-        images: response2.data.map((item) => item.b64_json),
++        images: response2.data.map((item) => item.b64_json ?? item.url),
+         warnings,
+         usage: response2.usage != null ? {
+           inputTokens: (_e = response2.usage.input_tokens) != null ? _e : void 0,
+@@ -1899,7 +1902,7 @@ var OpenAIImageModel = class {
+       fetch: this.config.fetch
+     });
+     return {
+-      images: response.data.map((item) => item.b64_json),
++      images: response.data.map((item) => item.b64_json ?? item.url),
+       warnings,
+       usage: response.usage != null ? {
+         inputTokens: (_i = response.usage.input_tokens) != null ? _i : void 0,
 diff --git a/dist/index.mjs b/dist/index.mjs
-index 3dee885..441a6af 100644
+index 3dee885..660c865 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
-@@ -1768,13 +1768,15 @@ var modelMaxImagesPerCall = {
+@@ -1740,7 +1740,8 @@ var openaiImageResponseSchema = lazySchema7(
+       created: z8.number().nullish(),
+       data: z8.array(
+         z8.object({
+-          b64_json: z8.string(),
++          b64_json: z8.string().optional(),
++          url: z8.string().optional(),
+           revised_prompt: z8.string().nullish()
+         })
+       ),
+@@ -1768,13 +1769,15 @@ var modelMaxImagesPerCall = {
    "gpt-image-1": 10,
    "gpt-image-1-mini": 10,
    "gpt-image-1.5": 10,
@@ -40,11 +78,39 @@ index 3dee885..441a6af 100644
  ];
  function hasDefaultResponseFormat(modelId) {
    return defaultResponseFormatPrefixes.some(
+@@ -1858,7 +1861,7 @@ var OpenAIImageModel = class {
+         fetch: this.config.fetch
+       });
+       return {
+-        images: response2.data.map((item) => item.b64_json),
++        images: response2.data.map((item) => item.b64_json ?? item.url),
+         warnings,
+         usage: response2.usage != null ? {
+           inputTokens: (_e = response2.usage.input_tokens) != null ? _e : void 0,
+@@ -1914,7 +1917,7 @@ var OpenAIImageModel = class {
+       fetch: this.config.fetch
+     });
+     return {
+-      images: response.data.map((item) => item.b64_json),
++      images: response.data.map((item) => item.b64_json ?? item.url),
+       warnings,
+       usage: response.usage != null ? {
+         inputTokens: (_i = response.usage.input_tokens) != null ? _i : void 0,
 diff --git a/dist/internal/index.js b/dist/internal/index.js
-index 27527ce..b359aa3 100644
+index 27527ce..6360f77 100644
 --- a/dist/internal/index.js
 +++ b/dist/internal/index.js
-@@ -1780,13 +1780,15 @@ var modelMaxImagesPerCall = {
+@@ -1752,7 +1752,8 @@ var openaiImageResponseSchema = (0, import_provider_utils12.lazySchema)(
+       created: import_v48.z.number().nullish(),
+       data: import_v48.z.array(
+         import_v48.z.object({
+-          b64_json: import_v48.z.string(),
++          b64_json: import_v48.z.string().optional(),
++          url: import_v48.z.string().optional(),
+           revised_prompt: import_v48.z.string().nullish()
+         })
+       ),
+@@ -1780,13 +1781,15 @@ var modelMaxImagesPerCall = {
    "gpt-image-1": 10,
    "gpt-image-1-mini": 10,
    "gpt-image-1.5": 10,
@@ -61,11 +127,39 @@ index 27527ce..b359aa3 100644
  ];
  function hasDefaultResponseFormat(modelId) {
    return defaultResponseFormatPrefixes.some(
+@@ -1870,7 +1873,7 @@ var OpenAIImageModel = class {
+         fetch: this.config.fetch
+       });
+       return {
+-        images: response2.data.map((item) => item.b64_json),
++        images: response2.data.map((item) => item.b64_json ?? item.url),
+         warnings,
+         usage: response2.usage != null ? {
+           inputTokens: (_e = response2.usage.input_tokens) != null ? _e : void 0,
+@@ -1926,7 +1929,7 @@ var OpenAIImageModel = class {
+       fetch: this.config.fetch
+     });
+     return {
+-      images: response.data.map((item) => item.b64_json),
++      images: response.data.map((item) => item.b64_json ?? item.url),
+       warnings,
+       usage: response.usage != null ? {
+         inputTokens: (_i = response.usage.input_tokens) != null ? _i : void 0,
 diff --git a/dist/internal/index.mjs b/dist/internal/index.mjs
-index db50bed..04b9e17 100644
+index db50bed..7a04af6 100644
 --- a/dist/internal/index.mjs
 +++ b/dist/internal/index.mjs
-@@ -1760,13 +1760,15 @@ var modelMaxImagesPerCall = {
+@@ -1732,7 +1732,8 @@ var openaiImageResponseSchema = lazySchema7(
+       created: z8.number().nullish(),
+       data: z8.array(
+         z8.object({
+-          b64_json: z8.string(),
++          b64_json: z8.string().optional(),
++          url: z8.string().optional(),
+           revised_prompt: z8.string().nullish()
+         })
+       ),
+@@ -1760,13 +1761,15 @@ var modelMaxImagesPerCall = {
    "gpt-image-1": 10,
    "gpt-image-1-mini": 10,
    "gpt-image-1.5": 10,
@@ -82,3 +176,21 @@ index db50bed..04b9e17 100644
  ];
  function hasDefaultResponseFormat(modelId) {
    return defaultResponseFormatPrefixes.some(
+@@ -1850,7 +1853,7 @@ var OpenAIImageModel = class {
+         fetch: this.config.fetch
+       });
+       return {
+-        images: response2.data.map((item) => item.b64_json),
++        images: response2.data.map((item) => item.b64_json ?? item.url),
+         warnings,
+         usage: response2.usage != null ? {
+           inputTokens: (_e = response2.usage.input_tokens) != null ? _e : void 0,
+@@ -1906,7 +1909,7 @@ var OpenAIImageModel = class {
+       fetch: this.config.fetch
+     });
+     return {
+-      images: response.data.map((item) => item.b64_json),
++      images: response.data.map((item) => item.b64_json ?? item.url),
+       warnings,
+       usage: response.usage != null ? {
+         inputTokens: (_i = response.usage.input_tokens) != null ? _i : void 0,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,10 +44,10 @@ patchedDependencies:
     hash: 3dbdd2fbbe5a44bc23a04b1195329dd8d78043447e925342ad5ed53c8c3b96ec
     path: patches/@ai-sdk__google@3.0.64.patch
   '@ai-sdk/openai-compatible@2.0.37':
-    hash: 50ffd57b3f7d2de99f0315f0b3bca05cde1dc3d9f760d4f1be4143d8c6f260c7
+    hash: 5a179b2dab40b16a1c6c30afc15134138203b19c77d4ca1428e9efc29074c90d
     path: patches/@ai-sdk__openai-compatible@2.0.37.patch
   '@ai-sdk/openai@3.0.53':
-    hash: 83a4d486601eff47ad8b5e22024878be2ced05b5b86e09884199a3f47fd53530
+    hash: 0a7ad0f544ed571daa39b1141d27008f7da1be8ed83ab63094b66f793d92745e
     path: patches/@ai-sdk__openai@3.0.53.patch
   '@ai-sdk/xai@3.0.83':
     hash: cea8532677e6ed5c42055d3f359c447d0eff682ae359d922da2f891a61518a45
@@ -219,10 +219,10 @@ importers:
         version: 3.0.30(zod@4.3.4)
       '@ai-sdk/openai':
         specifier: ^3.0.53
-        version: 3.0.53(patch_hash=83a4d486601eff47ad8b5e22024878be2ced05b5b86e09884199a3f47fd53530)(zod@4.3.4)
+        version: 3.0.53(patch_hash=0a7ad0f544ed571daa39b1141d27008f7da1be8ed83ab63094b66f793d92745e)(zod@4.3.4)
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.37
-        version: 2.0.37(patch_hash=50ffd57b3f7d2de99f0315f0b3bca05cde1dc3d9f760d4f1be4143d8c6f260c7)(zod@4.3.4)
+        version: 2.0.37(patch_hash=5a179b2dab40b16a1c6c30afc15134138203b19c77d4ca1428e9efc29074c90d)(zod@4.3.4)
       '@ai-sdk/perplexity':
         specifier: ^3.0.29
         version: 3.0.29(zod@4.3.4)
@@ -1309,10 +1309,10 @@ importers:
         version: 3.0.64(patch_hash=3dbdd2fbbe5a44bc23a04b1195329dd8d78043447e925342ad5ed53c8c3b96ec)(zod@4.3.6)
       '@ai-sdk/openai':
         specifier: ^3.0.53
-        version: 3.0.53(patch_hash=83a4d486601eff47ad8b5e22024878be2ced05b5b86e09884199a3f47fd53530)(zod@4.3.6)
+        version: 3.0.53(patch_hash=0a7ad0f544ed571daa39b1141d27008f7da1be8ed83ab63094b66f793d92745e)(zod@4.3.6)
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.37
-        version: 2.0.37(patch_hash=50ffd57b3f7d2de99f0315f0b3bca05cde1dc3d9f760d4f1be4143d8c6f260c7)(zod@4.3.6)
+        version: 2.0.37(patch_hash=5a179b2dab40b16a1c6c30afc15134138203b19c77d4ca1428e9efc29074c90d)(zod@4.3.6)
       '@ai-sdk/provider':
         specifier: ^3.0.8
         version: 3.0.8
@@ -1346,10 +1346,10 @@ importers:
         version: 3.0.64(patch_hash=3dbdd2fbbe5a44bc23a04b1195329dd8d78043447e925342ad5ed53c8c3b96ec)(zod@4.3.4)
       '@ai-sdk/openai':
         specifier: ^3.0.53
-        version: 3.0.53(patch_hash=83a4d486601eff47ad8b5e22024878be2ced05b5b86e09884199a3f47fd53530)(zod@4.3.4)
+        version: 3.0.53(patch_hash=0a7ad0f544ed571daa39b1141d27008f7da1be8ed83ab63094b66f793d92745e)(zod@4.3.4)
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.37
-        version: 2.0.37(patch_hash=50ffd57b3f7d2de99f0315f0b3bca05cde1dc3d9f760d4f1be4143d8c6f260c7)(zod@4.3.4)
+        version: 2.0.37(patch_hash=5a179b2dab40b16a1c6c30afc15134138203b19c77d4ca1428e9efc29074c90d)(zod@4.3.4)
       '@ai-sdk/provider':
         specifier: ^3.0.8
         version: 3.0.8
@@ -12955,7 +12955,7 @@ snapshots:
 
   '@ai-sdk/azure@3.0.54(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/openai': 3.0.53(patch_hash=83a4d486601eff47ad8b5e22024878be2ced05b5b86e09884199a3f47fd53530)(zod@4.3.4)
+      '@ai-sdk/openai': 3.0.53(patch_hash=0a7ad0f544ed571daa39b1141d27008f7da1be8ed83ab63094b66f793d92745e)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.4)
       zod: 4.3.4
@@ -13036,13 +13036,13 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/openai-compatible@2.0.37(patch_hash=50ffd57b3f7d2de99f0315f0b3bca05cde1dc3d9f760d4f1be4143d8c6f260c7)(zod@4.3.4)':
+  '@ai-sdk/openai-compatible@2.0.37(patch_hash=5a179b2dab40b16a1c6c30afc15134138203b19c77d4ca1428e9efc29074c90d)(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/openai-compatible@2.0.37(patch_hash=50ffd57b3f7d2de99f0315f0b3bca05cde1dc3d9f760d4f1be4143d8c6f260c7)(zod@4.3.6)':
+  '@ai-sdk/openai-compatible@2.0.37(patch_hash=5a179b2dab40b16a1c6c30afc15134138203b19c77d4ca1428e9efc29074c90d)(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
@@ -13054,13 +13054,13 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/openai@3.0.53(patch_hash=83a4d486601eff47ad8b5e22024878be2ced05b5b86e09884199a3f47fd53530)(zod@4.3.4)':
+  '@ai-sdk/openai@3.0.53(patch_hash=0a7ad0f544ed571daa39b1141d27008f7da1be8ed83ab63094b66f793d92745e)(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/openai@3.0.53(patch_hash=83a4d486601eff47ad8b5e22024878be2ced05b5b86e09884199a3f47fd53530)(zod@4.3.6)':
+  '@ai-sdk/openai@3.0.53(patch_hash=0a7ad0f544ed571daa39b1141d27008f7da1be8ed83ab63094b66f793d92745e)(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
@@ -16007,7 +16007,7 @@ snapshots:
 
   '@opeoginni/github-copilot-openai-compatible@1.0.0(patch_hash=4bea0e526136ed32d0be4849ec5cbb41bd5de7b7418dd6920598357438cfef25)(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/openai-compatible': 2.0.37(patch_hash=50ffd57b3f7d2de99f0315f0b3bca05cde1dc3d9f760d4f1be4143d8c6f260c7)(zod@4.3.4)
+      '@ai-sdk/openai-compatible': 2.0.37(patch_hash=5a179b2dab40b16a1c6c30afc15134138203b19c77d4ca1428e9efc29074c90d)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.4)
     transitivePeerDependencies:

--- a/src/renderer/src/aiCore/AiProvider.ts
+++ b/src/renderer/src/aiCore/AiProvider.ts
@@ -450,7 +450,11 @@ export default class AiProvider {
     if (result.images) {
       for (const image of result.images) {
         if (image.base64) {
-          images.push(`data:${image.mediaType || 'image/png'};base64,${image.base64}`)
+          if (image.base64.startsWith('http://') || image.base64.startsWith('https://')) {
+            images.push(image.base64)
+          } else {
+            images.push(`data:${image.mediaType || 'image/png'};base64,${image.base64}`)
+          }
         }
       }
     }

--- a/src/renderer/src/aiCore/__tests__/AiProvider.test.ts
+++ b/src/renderer/src/aiCore/__tests__/AiProvider.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import AiProvider from '../AiProvider'
+
+const convertImageResult = AiProvider.prototype['convertImageResult'] as (result: {
+  images?: Array<{ base64?: string; mediaType?: string }>
+}) => string[]
+
+describe('AiProvider.convertImageResult', () => {
+  it('should convert base64 images to data URIs', () => {
+    const result = convertImageResult({
+      images: [{ base64: 'aGVsbG8=', mediaType: 'image/png' }]
+    })
+
+    expect(result).toEqual(['data:image/png;base64,aGVsbG8='])
+  })
+
+  it('should default mediaType to image/png when not provided', () => {
+    const result = convertImageResult({
+      images: [{ base64: 'aGVsbG8=' }]
+    })
+
+    expect(result).toEqual(['data:image/png;base64,aGVsbG8='])
+  })
+
+  it('should pass through HTTP URLs as-is', () => {
+    const result = convertImageResult({
+      images: [{ base64: 'https://example.com/image.png' }]
+    })
+
+    expect(result).toEqual(['https://example.com/image.png'])
+  })
+
+  it('should pass through HTTPS URLs as-is', () => {
+    const result = convertImageResult({
+      images: [{ base64: 'http://example.com/image.png' }]
+    })
+
+    expect(result).toEqual(['http://example.com/image.png'])
+  })
+
+  it('should handle mixed base64 and URL results', () => {
+    const result = convertImageResult({
+      images: [{ base64: 'aGVsbG8=', mediaType: 'image/jpeg' }, { base64: 'https://cdn.example.com/img.png' }]
+    })
+
+    expect(result).toEqual(['data:image/jpeg;base64,aGVsbG8=', 'https://cdn.example.com/img.png'])
+  })
+
+  it('should skip images without base64', () => {
+    const result = convertImageResult({
+      images: [{ mediaType: 'image/png' }]
+    })
+
+    expect(result).toEqual([])
+  })
+
+  it('should return empty array when no images', () => {
+    const result = convertImageResult({ images: [] })
+    expect(result).toEqual([])
+  })
+
+  it('should return empty array when images is undefined', () => {
+    const result = convertImageResult({})
+    expect(result).toEqual([])
+  })
+})


### PR DESCRIPTION
### What this PR does

Before this PR:

When an image generation request is routed through a relay/proxy API (中转站) that returns the response in URL format (`{ data: [{ url: "https://..." }] }`) instead of base64 format (`{ data: [{ b64_json: "..." }] }`), the AI SDK's Zod schema validation fails with `AI_TypeValidationError: Invalid JSON response`. The image is unreachable even though the underlying URL is valid. This affects models like `gpt-image-2*` whose patched logic does not send `response_format: "b64_json"`, leaving the relay free to default to URL responses (which is the OpenAI Images API default).

After this PR:

- `@ai-sdk/openai-compatible` and `@ai-sdk/openai` response schemas accept either `b64_json` or `url` (both optional).
- Response mapping falls back to `item.url` when `item.b64_json` is absent.
- `AiProvider.convertImageResult` detects `http://` / `https://` strings and passes them through as-is instead of wrapping them in a `data:` URI.
- Added unit tests covering base64, URL, mixed, and empty result paths.

Fixes #15127

### Why we need it and why it was done in this way

Returning a URL is the OpenAI Images API default (`response_format` defaults to `url`), and many relay/proxy services ignore the `response_format` parameter and always return URLs to save bandwidth. The previous schema treated URL responses as a hard error, which broke a common real-world setup. Relaxing the schema to accept both formats and propagating URLs through the existing return path is the minimum change that resolves the bug without altering behavior for base64 responses.

The following tradeoffs were made:

- Patch the bundled `dist/*.js`/`dist/*.mjs` files rather than the source `.ts` files, since pnpm patches operate on what is shipped. This keeps the change set small and matches the existing patch convention in this repo.
- Pass URLs through unchanged rather than downloading and converting to base64 in the SDK layer. Avoids new network requests inside the SDK and matches how the `ai` package already handles URL-format images downstream.

The following alternatives were considered:

- Downloading the image inside the patched SDK and re-encoding to base64. Rejected — extra network I/O, more invasive patch, and the application layer already handles raw URLs.
- Removing `response_format` for all models. Rejected — would change behavior for non-relay OpenAI calls where requesting base64 is preferred.

Links to places where the discussion took place: N/A

### Breaking changes

None. The schema change is strictly additive (required → optional with new alternative field). Existing base64 responses continue to validate and flow through the original `data:` URI path unchanged.

### Special notes for your reviewer

- This is a hotfix targeting `main` per the branch strategy.
- Patch files were regenerated using `git diff` format; context line shifts in the existing hunks are cosmetic only — the previously patched additions are preserved verbatim.
- The new unit test reaches the private `convertImageResult` via `AiProvider.prototype` to avoid constructing a full `AiProvider` (which has heavy provider/model dependencies). The method does not reference `this`, so this is safe.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix image generation failing with `AI_TypeValidationError` when the provider/relay API returns image URLs instead of base64 (`b64_json`).
```
