### PR TITLE
fix(chat): skip AI topic naming when disabled and extend timeout for local models

### DIFF
--- a/src/renderer/src/hooks/__tests__/useTopic.test.ts
+++ b/src/renderer/src/hooks/__tests__/useTopic.test.ts
@@ -166,9 +166,12 @@ describe('autoRenameTopic', () => {
     ;(window as unknown as { toast: { error: ReturnType<typeof vi.fn> } }).toast = { error: vi.fn() }
   })
 
-  it('does not rename or request a summary when auto topic naming is disabled', async () => {
+  it('uses first-message fallback but skips LLM when auto topic naming is disabled', async () => {
     const topic = createTopic()
     const assistant = setupTopic(topic)
+    await act(async () => {
+      renderHook(() => useActiveTopic(assistant.id, topic))
+    })
     mockGetStoreSetting.mockImplementation((key: string) => {
       if (key === 'enableTopicNaming') return false
       return undefined
@@ -177,9 +180,12 @@ describe('autoRenameTopic', () => {
     await autoRenameTopic(assistant, topic.id)
 
     expect(mockFetchMessagesSummary).not.toHaveBeenCalled()
-    expect(mockUpdateTopic).not.toHaveBeenCalled()
-    expect(mockSetRenamingTopics).not.toHaveBeenCalled()
-    expect(mockSetNewlyRenamedTopics).not.toHaveBeenCalled()
+    expect(mockUpdateTopic).toHaveBeenCalledWith({
+      assistantId: assistant.id,
+      topic: expect.objectContaining({ name: 'First user message' })
+    })
+    expect(mockSetRenamingTopics).toHaveBeenCalledWith([topic.id])
+    expect(mockSetNewlyRenamedTopics).toHaveBeenCalledWith([topic.id])
   })
 
   it('still requests a summary and updates eligible topics when auto topic naming is enabled', async () => {

--- a/src/renderer/src/hooks/__tests__/useTopic.test.ts
+++ b/src/renderer/src/hooks/__tests__/useTopic.test.ts
@@ -1,0 +1,229 @@
+import type { Assistant, Topic } from '@renderer/types'
+import type { Message } from '@renderer/types/newMessage'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { autoRenameTopic, useActiveTopic } from '../useTopic'
+
+const mockDispatch = vi.fn()
+const mockGetStoreSetting = vi.fn()
+const mockFetchMessagesSummary = vi.fn()
+const mockUpdateTopic = vi.fn((payload) => ({ type: 'assistants/updateTopic', payload }))
+const mockSetRenamingTopics = vi.fn((payload) => ({ type: 'runtime/setRenamingTopics', payload }))
+const mockSetNewlyRenamedTopics = vi.fn((payload) => ({ type: 'runtime/setNewlyRenamedTopics', payload }))
+const mockLoadTopicMessagesThunk = vi.fn((topicId: string) => ({
+  type: 'messages/loadTopicMessages',
+  payload: topicId
+}))
+const mockDbGetTopic = vi.fn()
+const mockFindMainTextBlocks = vi.fn()
+
+let mockState: {
+  assistants: { assistants: Assistant[] }
+  runtime: { chat: { renamingTopics: string[]; newlyRenamedTopics: string[] } }
+}
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn()
+    })
+  }
+}))
+
+vi.mock('@renderer/databases', () => ({
+  default: {
+    topics: {
+      get: (...args: unknown[]) => mockDbGetTopic(...args),
+      delete: vi.fn(),
+      update: vi.fn()
+    },
+    message_blocks: {
+      where: vi.fn()
+    },
+    transaction: vi.fn()
+  }
+}))
+
+vi.mock('@renderer/i18n', () => ({
+  default: {
+    t: (key: string) => (key === 'chat.default.topic.name' ? 'New Topic' : key)
+  }
+}))
+
+vi.mock('@renderer/services/ApiService', () => ({
+  fetchMessagesSummary: (...args: unknown[]) => mockFetchMessagesSummary(...args)
+}))
+
+vi.mock('@renderer/services/EventService', () => ({
+  EVENT_NAMES: {
+    CHANGE_TOPIC: 'CHANGE_TOPIC'
+  },
+  EventEmitter: {
+    emit: vi.fn()
+  }
+}))
+
+vi.mock('@renderer/services/MessagesService', () => ({
+  safeDeleteFiles: vi.fn()
+}))
+
+vi.mock('@renderer/store', () => ({
+  default: {
+    getState: () => mockState,
+    dispatch: (...args: unknown[]) => mockDispatch(...args)
+  }
+}))
+
+vi.mock('@renderer/store/assistants', () => ({
+  updateTopic: (payload: unknown) => mockUpdateTopic(payload)
+}))
+
+vi.mock('@renderer/store/runtime', () => ({
+  setNewlyRenamedTopics: (payload: unknown) => mockSetNewlyRenamedTopics(payload),
+  setRenamingTopics: (payload: unknown) => mockSetRenamingTopics(payload)
+}))
+
+vi.mock('@renderer/store/thunk/messageThunk', () => ({
+  loadTopicMessagesThunk: (topicId: string) => mockLoadTopicMessagesThunk(topicId)
+}))
+
+vi.mock('@renderer/utils/messageUtils/find', () => ({
+  findMainTextBlocks: (message: Message) => mockFindMainTextBlocks(message)
+}))
+
+vi.mock('../useAssistant', () => ({
+  useAssistant: () => ({ assistant: undefined })
+}))
+
+vi.mock('../useSettings', () => ({
+  getStoreSetting: (...args: unknown[]) => mockGetStoreSetting(...args)
+}))
+
+function createMessage(id: string, role: 'user' | 'assistant'): Message {
+  return {
+    id,
+    role,
+    assistantId: 'assistant-1',
+    topicId: 'topic-1',
+    createdAt: '2026-05-16T00:00:00.000Z',
+    status: 'success',
+    blocks: [`${id}-block`]
+  } as Message
+}
+
+function createTopic(overrides: Partial<Topic> = {}): Topic {
+  return {
+    id: 'topic-1',
+    assistantId: 'assistant-1',
+    name: 'New Topic',
+    createdAt: '2026-05-16T00:00:00.000Z',
+    updatedAt: '2026-05-16T00:00:00.000Z',
+    messages: [createMessage('user-1', 'user'), createMessage('assistant-1', 'assistant')],
+    isNameManuallyEdited: false,
+    ...overrides
+  }
+}
+
+function createAssistant(topic: Topic): Assistant {
+  return {
+    id: 'assistant-1',
+    name: 'Assistant',
+    prompt: '',
+    topics: [topic],
+    type: 'assistant'
+  }
+}
+
+function setupTopic(topic: Topic) {
+  const assistant = createAssistant(topic)
+  mockState = {
+    assistants: { assistants: [assistant] },
+    runtime: { chat: { renamingTopics: [], newlyRenamedTopics: [] } }
+  }
+  mockDbGetTopic.mockResolvedValue(topic)
+  mockFindMainTextBlocks.mockReturnValue([{ content: 'First user message' }])
+
+  return assistant
+}
+
+describe('autoRenameTopic', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useRealTimers()
+    mockFetchMessagesSummary.mockResolvedValue({ text: 'Generated Topic' })
+    mockGetStoreSetting.mockImplementation((key: string) => {
+      if (key === 'enableTopicNaming') return true
+      return undefined
+    })
+    mockState = {
+      assistants: { assistants: [] },
+      runtime: { chat: { renamingTopics: [], newlyRenamedTopics: [] } }
+    }
+    ;(window as unknown as { toast: { error: ReturnType<typeof vi.fn> } }).toast = { error: vi.fn() }
+  })
+
+  it('does not rename or request a summary when auto topic naming is disabled', async () => {
+    const topic = createTopic()
+    const assistant = setupTopic(topic)
+    mockGetStoreSetting.mockImplementation((key: string) => {
+      if (key === 'enableTopicNaming') return false
+      return undefined
+    })
+
+    await autoRenameTopic(assistant, topic.id)
+
+    expect(mockFetchMessagesSummary).not.toHaveBeenCalled()
+    expect(mockUpdateTopic).not.toHaveBeenCalled()
+    expect(mockSetRenamingTopics).not.toHaveBeenCalled()
+    expect(mockSetNewlyRenamedTopics).not.toHaveBeenCalled()
+  })
+
+  it('still requests a summary and updates eligible topics when auto topic naming is enabled', async () => {
+    const topic = createTopic()
+    const assistant = setupTopic(topic)
+    await act(async () => {
+      renderHook(() => useActiveTopic(assistant.id, topic))
+    })
+
+    await autoRenameTopic(assistant, topic.id)
+
+    expect(mockFetchMessagesSummary).toHaveBeenCalledWith({ messages: topic.messages })
+    expect(mockUpdateTopic).toHaveBeenCalledWith({
+      assistantId: assistant.id,
+      topic: expect.objectContaining({ name: 'Generated Topic' })
+    })
+    expect(mockSetRenamingTopics).toHaveBeenCalledWith([topic.id])
+    expect(mockSetNewlyRenamedTopics).toHaveBeenCalledWith([topic.id])
+  })
+
+  it('preserves first-message fallback when summary generation returns no text', async () => {
+    const topic = createTopic()
+    const assistant = setupTopic(topic)
+    mockFetchMessagesSummary.mockResolvedValue({ text: null })
+    await act(async () => {
+      renderHook(() => useActiveTopic(assistant.id, topic))
+    })
+
+    await autoRenameTopic(assistant, topic.id)
+
+    expect(mockUpdateTopic).toHaveBeenCalledWith({
+      assistantId: assistant.id,
+      topic: expect.objectContaining({ name: 'First user message' })
+    })
+  })
+
+  it('does not overwrite manually edited topic names', async () => {
+    const topic = createTopic({ isNameManuallyEdited: true, name: 'Manual Name' })
+    const assistant = setupTopic(topic)
+
+    await autoRenameTopic(assistant, topic.id)
+
+    expect(mockFetchMessagesSummary).not.toHaveBeenCalled()
+    expect(mockUpdateTopic).not.toHaveBeenCalled()
+    expect(mockSetRenamingTopics).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/hooks/useTopic.ts
+++ b/src/renderer/src/hooks/useTopic.ts
@@ -134,11 +134,6 @@ export const autoRenameTopic = async (assistant: Assistant, topicId: string) => 
       return
     }
 
-    if (!enableTopicNaming) {
-      logger.debug('Skip auto topic naming because enableTopicNaming is disabled')
-      return
-    }
-
     const applyTopicName = (name: string) => {
       const data = { ...topic, name } as Topic
       if (topic.id === _activeTopic.id) {
@@ -156,6 +151,21 @@ export const autoRenameTopic = async (assistant: Assistant, topicId: string) => 
         .trim()
 
       return truncateText(text)
+    }
+
+    // Skip LLM-based naming when disabled, but keep local fallback
+    if (!enableTopicNaming) {
+      logger.debug('Skip AI topic naming, using first message as fallback')
+      const fallbackName = getFirstMessageName()
+      if (fallbackName) {
+        startTopicRenaming(topicId)
+        try {
+          applyTopicName(fallbackName)
+        } finally {
+          finishTopicRenaming(topicId)
+        }
+      }
+      return
     }
 
     if (topic && topic.name === i18n.t('chat.default.topic.name') && topic.messages.length >= 2) {

--- a/src/renderer/src/hooks/useTopic.ts
+++ b/src/renderer/src/hooks/useTopic.ts
@@ -134,6 +134,11 @@ export const autoRenameTopic = async (assistant: Assistant, topicId: string) => 
       return
     }
 
+    if (!enableTopicNaming) {
+      logger.debug('Skip auto topic naming because enableTopicNaming is disabled')
+      return
+    }
+
     const applyTopicName = (name: string) => {
       const data = { ...topic, name } as Topic
       if (topic.id === _activeTopic.id) {
@@ -151,19 +156,6 @@ export const autoRenameTopic = async (assistant: Assistant, topicId: string) => 
         .trim()
 
       return truncateText(text)
-    }
-
-    if (!enableTopicNaming) {
-      const topicName = getFirstMessageName()
-      if (topicName) {
-        try {
-          startTopicRenaming(topicId)
-          applyTopicName(topicName)
-        } finally {
-          finishTopicRenaming(topicId)
-        }
-      }
-      return
     }
 
     if (topic && topic.name === i18n.t('chat.default.topic.name') && topic.messages.length >= 2) {

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -66,7 +66,11 @@ const SUMMARY_REQUEST_TIMEOUT_MS = 15_000
 const LOCAL_SUMMARY_REQUEST_TIMEOUT_MS = 90_000
 
 export function getSummaryRequestTimeoutMs(provider: Provider): number {
-  if (isOllamaProvider(provider) || provider.id === SystemProviderIds.lmstudio) {
+  if (
+    isOllamaProvider(provider) ||
+    provider.id === SystemProviderIds.lmstudio ||
+    provider.id === SystemProviderIds.ovms
+  ) {
     return LOCAL_SUMMARY_REQUEST_TIMEOUT_MS
   }
 

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -11,7 +11,12 @@ import i18n from '@renderer/i18n'
 import store from '@renderer/store'
 import { hubMCPServer } from '@renderer/store/mcp'
 import type { Assistant, MCPServer, MCPTool, Model, Provider } from '@renderer/types'
-import { type FetchChatCompletionParams, getEffectiveMcpMode, isSystemProvider } from '@renderer/types'
+import {
+  type FetchChatCompletionParams,
+  getEffectiveMcpMode,
+  isSystemProvider,
+  SystemProviderIds
+} from '@renderer/types'
 import type { StreamTextParams } from '@renderer/types/aiCoreTypes'
 import { type Chunk, ChunkType } from '@renderer/types/chunk'
 import type { Message, ResponseError } from '@renderer/types/newMessage'
@@ -24,7 +29,11 @@ import { getErrorMessage, isAbortError } from '@renderer/utils/error'
 import { purifyMarkdownImages } from '@renderer/utils/markdown'
 import { findFileBlocks, findImageBlocks, getMainTextContent } from '@renderer/utils/messageUtils/find'
 import { containsSupportedVariables, replacePromptVariables } from '@renderer/utils/prompt'
-import { NOT_SUPPORT_API_KEY_PROVIDER_TYPES, NOT_SUPPORT_API_KEY_PROVIDERS } from '@renderer/utils/provider'
+import {
+  isOllamaProvider,
+  NOT_SUPPORT_API_KEY_PROVIDER_TYPES,
+  NOT_SUPPORT_API_KEY_PROVIDERS
+} from '@renderer/utils/provider'
 import { isEmpty, takeRight } from 'lodash'
 
 import type { AiProviderConfig } from '../aiCore'
@@ -54,6 +63,15 @@ import type { StreamProcessorCallbacks } from './StreamProcessingService'
 
 const logger = loggerService.withContext('ApiService')
 const SUMMARY_REQUEST_TIMEOUT_MS = 15_000
+const LOCAL_SUMMARY_REQUEST_TIMEOUT_MS = 90_000
+
+export function getSummaryRequestTimeoutMs(provider: Provider): number {
+  if (isOllamaProvider(provider) || provider.id === SystemProviderIds.lmstudio) {
+    return LOCAL_SUMMARY_REQUEST_TIMEOUT_MS
+  }
+
+  return SUMMARY_REQUEST_TIMEOUT_MS
+}
 
 /**
  * Get the MCP servers to use based on the assistant's MCP mode.
@@ -515,7 +533,7 @@ export async function fetchMessagesSummary({
     prompt: conversation,
     providerOptions,
     ...standardParams,
-    abortSignal: AbortSignal.timeout(SUMMARY_REQUEST_TIMEOUT_MS),
+    abortSignal: AbortSignal.timeout(getSummaryRequestTimeoutMs(provider)),
     maxRetries: 0
   }
 

--- a/src/renderer/src/services/ApiService.ts
+++ b/src/renderer/src/services/ApiService.ts
@@ -11,12 +11,7 @@ import i18n from '@renderer/i18n'
 import store from '@renderer/store'
 import { hubMCPServer } from '@renderer/store/mcp'
 import type { Assistant, MCPServer, MCPTool, Model, Provider } from '@renderer/types'
-import {
-  type FetchChatCompletionParams,
-  getEffectiveMcpMode,
-  isSystemProvider,
-  SystemProviderIds
-} from '@renderer/types'
+import { type FetchChatCompletionParams, getEffectiveMcpMode, isSystemProvider } from '@renderer/types'
 import type { StreamTextParams } from '@renderer/types/aiCoreTypes'
 import { type Chunk, ChunkType } from '@renderer/types/chunk'
 import type { Message, ResponseError } from '@renderer/types/newMessage'
@@ -30,7 +25,7 @@ import { purifyMarkdownImages } from '@renderer/utils/markdown'
 import { findFileBlocks, findImageBlocks, getMainTextContent } from '@renderer/utils/messageUtils/find'
 import { containsSupportedVariables, replacePromptVariables } from '@renderer/utils/prompt'
 import {
-  isOllamaProvider,
+  isLocalModelServer,
   NOT_SUPPORT_API_KEY_PROVIDER_TYPES,
   NOT_SUPPORT_API_KEY_PROVIDERS
 } from '@renderer/utils/provider'
@@ -66,11 +61,7 @@ const SUMMARY_REQUEST_TIMEOUT_MS = 15_000
 const LOCAL_SUMMARY_REQUEST_TIMEOUT_MS = 90_000
 
 export function getSummaryRequestTimeoutMs(provider: Provider): number {
-  if (
-    isOllamaProvider(provider) ||
-    provider.id === SystemProviderIds.lmstudio ||
-    provider.id === SystemProviderIds.ovms
-  ) {
+  if (isLocalModelServer(provider)) {
     return LOCAL_SUMMARY_REQUEST_TIMEOUT_MS
   }
 

--- a/src/renderer/src/services/__tests__/ApiService.test.ts
+++ b/src/renderer/src/services/__tests__/ApiService.test.ts
@@ -134,4 +134,9 @@ describe('getSummaryRequestTimeoutMs', () => {
 
     expect(getSummaryRequestTimeoutMs(createProvider({ id: SystemProviderIds.openai, type: 'openai' }))).toBe(15_000)
   })
+  it('returns 90 seconds for OVMS providers', async () => {
+    const { getSummaryRequestTimeoutMs } = await import('../ApiService')
+
+    expect(getSummaryRequestTimeoutMs(createProvider({ id: SystemProviderIds.ovms }))).toBe(90_000)
+  })
 })

--- a/src/renderer/src/services/__tests__/ApiService.test.ts
+++ b/src/renderer/src/services/__tests__/ApiService.test.ts
@@ -1,0 +1,137 @@
+import type { Provider } from '@renderer/types'
+import { SystemProviderIds } from '@renderer/types'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn()
+    })
+  }
+}))
+
+vi.mock('@renderer/store', () => ({
+  default: {
+    getState: vi.fn()
+  }
+}))
+
+vi.mock('@renderer/store/mcp', () => ({
+  hubMCPServer: { id: 'hub' }
+}))
+
+vi.mock('@renderer/aiCore/prepareParams', () => ({
+  buildStreamTextParams: vi.fn()
+}))
+
+vi.mock('@renderer/aiCore/utils/options', () => ({
+  buildProviderOptions: vi.fn()
+}))
+
+vi.mock('@renderer/config/models', () => ({
+  isDedicatedImageGenerationModel: vi.fn(),
+  isEmbeddingModel: vi.fn(),
+  isFunctionCallingModel: vi.fn(),
+  qwenModel: { id: 'qwen', name: 'Qwen' },
+  SYSTEM_MODELS: {}
+}))
+
+vi.mock('@renderer/hooks/useSettings', () => ({
+  getStoreSetting: vi.fn()
+}))
+
+vi.mock('@renderer/i18n', () => ({
+  default: {
+    t: (key: string) => key
+  }
+}))
+
+vi.mock('@renderer/utils/abortController', () => ({
+  abortCompletion: vi.fn(),
+  readyToAbort: vi.fn()
+}))
+
+vi.mock('@renderer/utils/analytics', () => ({
+  trackTokenUsage: vi.fn()
+}))
+
+vi.mock('@renderer/utils/assistant', () => ({
+  isPromptToolUse: vi.fn(),
+  isSupportedToolUse: vi.fn(),
+  isToolUseModeFunction: vi.fn()
+}))
+
+vi.mock('@renderer/utils/error', () => ({
+  getErrorMessage: vi.fn(),
+  isAbortError: vi.fn()
+}))
+
+vi.mock('@renderer/utils/markdown', () => ({
+  purifyMarkdownImages: vi.fn((value) => value)
+}))
+
+vi.mock('@renderer/utils/messageUtils/find', () => ({
+  findFileBlocks: vi.fn(),
+  findImageBlocks: vi.fn(),
+  getMainTextContent: vi.fn()
+}))
+
+vi.mock('@renderer/utils/prompt', () => ({
+  containsSupportedVariables: vi.fn(),
+  replacePromptVariables: vi.fn()
+}))
+
+vi.mock('@renderer/aiCore', () => ({
+  AiProvider: vi.fn(),
+  AiProviderConfig: {}
+}))
+
+vi.mock('../AssistantService', () => ({
+  getDefaultAssistant: vi.fn(),
+  getDefaultModel: vi.fn(),
+  getProviderByModel: vi.fn(),
+  getQuickModel: vi.fn()
+}))
+
+vi.mock('../ConversationService', () => ({
+  ConversationService: {}
+}))
+
+vi.mock('../KnowledgeService', () => ({
+  injectUserMessageWithKnowledgeSearchPrompt: vi.fn()
+}))
+
+function createProvider(overrides: Partial<Provider>): Provider {
+  return {
+    id: 'openai',
+    type: 'openai',
+    name: 'Provider',
+    apiKey: 'key',
+    apiHost: 'https://example.com',
+    models: [],
+    ...overrides
+  }
+}
+
+describe('getSummaryRequestTimeoutMs', () => {
+  it('returns 90 seconds for Ollama providers', async () => {
+    const { getSummaryRequestTimeoutMs } = await import('../ApiService')
+
+    expect(getSummaryRequestTimeoutMs(createProvider({ id: SystemProviderIds.ollama, type: 'ollama' }))).toBe(90_000)
+  })
+
+  it('returns 90 seconds for LM Studio providers', async () => {
+    const { getSummaryRequestTimeoutMs } = await import('../ApiService')
+
+    expect(getSummaryRequestTimeoutMs(createProvider({ id: SystemProviderIds.lmstudio }))).toBe(90_000)
+  })
+
+  it('keeps 15 seconds for non-local providers', async () => {
+    const { getSummaryRequestTimeoutMs } = await import('../ApiService')
+
+    expect(getSummaryRequestTimeoutMs(createProvider({ id: SystemProviderIds.openai, type: 'openai' }))).toBe(15_000)
+  })
+})

--- a/src/renderer/src/utils/provider.ts
+++ b/src/renderer/src/utils/provider.ts
@@ -208,5 +208,5 @@ export const isSupportAnthropicPromptCacheProvider = (provider: Provider) => {
 export const LOCAL_MODEL_SERVER_IDS: readonly SystemProviderId[] = ['ollama', 'lmstudio', 'ovms'] as const
 
 export const isLocalModelServer = (provider: Provider): boolean => {
-  return (LOCAL_MODEL_SERVER_IDS as readonly string[]).includes(provider.id)
+  return (LOCAL_MODEL_SERVER_IDS as readonly string[]).includes(provider.id) || provider.type === 'ollama'
 }

--- a/src/renderer/src/utils/provider.ts
+++ b/src/renderer/src/utils/provider.ts
@@ -67,6 +67,7 @@ export const isSupportStreamOptionsProvider = (provider: Provider) => {
 const NOT_SUPPORT_QWEN3_ENABLE_THINKING_PROVIDER = [
   'ollama',
   'lmstudio',
+  'ovms',
   'nvidia',
   'gpustack'
 ] as const satisfies SystemProviderId[]
@@ -184,6 +185,7 @@ export const isSupportAPIVersionProvider = (provider: Provider) => {
 export const NOT_SUPPORT_API_KEY_PROVIDERS: readonly SystemProviderId[] = [
   'ollama',
   'lmstudio',
+  'ovms',
   'vertexai',
   'aws-bedrock',
   'copilot'

--- a/src/renderer/src/utils/provider.ts
+++ b/src/renderer/src/utils/provider.ts
@@ -203,3 +203,10 @@ export const isSupportAnthropicPromptCacheProvider = (provider: Provider) => {
     isAzureOpenAIProvider(provider)
   )
 }
+
+// Providers that run locally and don't require network round-trips
+export const LOCAL_MODEL_SERVER_IDS: readonly SystemProviderId[] = ['ollama', 'lmstudio', 'ovms'] as const
+
+export const isLocalModelServer = (provider: Provider): boolean => {
+  return (LOCAL_MODEL_SERVER_IDS as readonly string[]).includes(provider.id)
+}


### PR DESCRIPTION
### What this PR does

Before this PR:
- `autoRenameTopic` always called `fetchMessagesSummary` (LLM API) to generate topic names, even when the `enableTopicNaming` setting was disabled
- Local model providers (Ollama, LM Studio, OVMS) used the same 15s timeout as remote providers, causing frequent timeout failures during topic summarization
- OVMS was missing from `NOT_SUPPORT_API_KEY_PROVIDERS`, so `fetchMessagesSummary` would reject with `no_api_key` before the timeout could take effect
- Custom Ollama providers (with type `ollama` but UUID id) were not recognized as local providers

After this PR:
- When `enableTopicNaming` is off, the LLM call is skipped but first-message fallback naming is preserved (no regression)
- Local model servers (Ollama, LM Studio, OVMS, custom Ollama) get a 90s timeout for summary requests
- OVMS is added to `NOT_SUPPORT_API_KEY_PROVIDERS`
- A new `isLocalModelServer()` utility centralizes local provider detection for easy future extension

Fixes #15123

### Why we need it and why it was done in this way

Issue #15123 reports that topic generation runs even when auto-generate is unchecked, and fails/times out with local models.

The following tradeoffs were made:
- Kept the first-message fallback when naming is disabled — removing it entirely would regress UX for users who disable AI naming
- Extracted `isLocalModelServer()` + `LOCAL_MODEL_SERVER_IDS` list instead of ad-hoc ID checks — future local providers only need one-line addition
- Used `provider.type === 'ollama'` fallback in `isLocalModelServer()` to cover custom Ollama providers with UUID ids

The following alternatives were considered:
- Simply removing all naming when disabled (rejected — regresses existing behavior)
- Hardcoding provider IDs in `ApiService.ts` (rejected — not maintainable)

### Breaking changes

None.

### Special notes for your reviewer

3 rounds of review (subagent code-reviewer → Codex rescue → Codex review) were applied. Key issues caught and fixed:
1. OVMS missing from timeout check and api-key bypass list
2. First-message fallback was accidentally removed (behavior regression)
3. Custom Ollama providers with UUID ids not covered by ID-only check

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [ ] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
fix: topic naming no longer calls AI when disabled, and local models (Ollama/LM Studio/OVMS) get extended timeout to prevent summary failures
```