### PR TITLE
fix: make GitCode release upload retryable

### DIFF
--- a/.github/workflows/sync-to-gitcode.yml
+++ b/.github/workflows/sync-to-gitcode.yml
@@ -274,13 +274,36 @@ jobs:
           HTTP_CODE=$(echo "$RELEASE_RESPONSE" | tail -n1)
           RESPONSE_BODY=$(echo "$RELEASE_RESPONSE" | sed '$d')
 
+          release_already_exists() {
+            [ "$HTTP_CODE" = "409" ] && return 0
+            if [ "$HTTP_CODE" = "400" ] || [ "$HTTP_CODE" = "422" ]; then
+              echo "$RESPONSE_BODY" | grep -Eiq '(already.*exist|exist.*already|has already been taken|release.*exist|tag.*exist|已存在|已经存在)'
+              return $?
+            fi
+            return 1
+          }
+
           if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
             echo "Release created successfully"
+          elif release_already_exists; then
+            echo "Release already exists, continuing with asset upload"
           else
             echo "Warning: Release creation returned HTTP $HTTP_CODE"
             echo "$RESPONSE_BODY"
             exit 1
           fi
+
+          asset_already_exists() {
+            local status="$1"
+            local body="$2"
+
+            [ "$status" = "409" ] && return 0
+            if [ -z "$status" ] || [ "$status" = "400" ] || [ "$status" = "422" ]; then
+              echo "$body" | grep -Eiq '(already.*exist|exist.*already|has already been taken|asset.*exist|file.*exist|已存在|已经存在)'
+              return $?
+            fi
+            return 1
+          }
 
           # Step 2: Upload files to release
           echo "Uploading files to GitCode release..."
@@ -301,11 +324,15 @@ jobs:
             while [ $retry -lt $max_retries ]; do
               # Get upload URL
               curl_status=0
-              UPLOAD_INFO=$(curl -s --connect-timeout 30 --max-time 60 \
+              UPLOAD_INFO=""
+              UPLOAD_INFO_HTTP_CODE=""
+              UPLOAD_INFO_RESPONSE=$(curl -s -w "\n%{http_code}" --connect-timeout 30 --max-time 60 \
                 -H "Authorization: Bearer ${GITCODE_TOKEN}" \
                 "${API_URL}/repos/${GITCODE_OWNER}/${GITCODE_REPO}/releases/${TAG_NAME}/upload_url?file_name=${encoded_filename}") || curl_status=$?
 
               if [ $curl_status -eq 0 ]; then
+                UPLOAD_INFO_HTTP_CODE=$(echo "$UPLOAD_INFO_RESPONSE" | tail -n1)
+                UPLOAD_INFO=$(echo "$UPLOAD_INFO_RESPONSE" | sed '$d')
                 UPLOAD_URL=$(echo "$UPLOAD_INFO" | jq -r '.url // empty')
 
                 if [ -n "$UPLOAD_URL" ]; then
@@ -315,6 +342,7 @@ jobs:
                   # Upload file using PUT with headers from file
                   curl_status=0
                   UPLOAD_RESPONSE=$(curl -s -w "\n%{http_code}" -X PUT \
+                    --connect-timeout 30 --max-time 900 \
                     -K /tmp/upload_headers.txt \
                     --data-binary "@${file}" \
                     "$UPLOAD_URL") || curl_status=$?
@@ -326,6 +354,9 @@ jobs:
                     if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
                       echo "  Uploaded: $filename"
                       return 0
+                    elif asset_already_exists "$HTTP_CODE" "$RESPONSE_BODY"; then
+                      echo "  Already exists: $filename"
+                      return 0
                     else
                       echo "  Failed (HTTP $HTTP_CODE), retry $((retry + 1))/$max_retries"
                       echo "  Response: $RESPONSE_BODY"
@@ -333,6 +364,9 @@ jobs:
                   else
                     echo "  Upload request failed (curl exit $curl_status), retry $((retry + 1))/$max_retries"
                   fi
+                elif asset_already_exists "$UPLOAD_INFO_HTTP_CODE" "$UPLOAD_INFO"; then
+                  echo "  Already exists: $filename"
+                  return 0
                 else
                   echo "  Failed to get upload URL, retry $((retry + 1))/$max_retries"
                   echo "  Response: $UPLOAD_INFO"


### PR DESCRIPTION
### What this PR does

Before this PR:

GitCode release syncing failed hard when the release already existed, which made reruns after a partial sync difficult. Asset uploads could also hang indefinitely during the PUT request because the upload step had no request timeout.

After this PR:

The workflow treats an existing GitCode release as resumable and continues uploading assets. Asset upload also handles already-existing files as successful, and PUT uploads now have connection and total timeouts so the existing retry loop can recover from stalled uploads.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # None

### Why we need it and why it was done in this way

The following tradeoffs were made:

This keeps the fix scoped to the release sync workflow and preserves the existing upload order and retry structure.

The following alternatives were considered:

Deleting the GitCode release before rerunning was considered, but making the workflow resumable is safer for partial uploads and manual reruns.

Links to places where the discussion took place: N/A

### Breaking changes

None

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

This is a GitHub Actions-only hotfix for GitCode release syncing.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
