### PR TITLE
fix(renderer): preserve buffered Gemini web-search text at stream end

### DIFF
--- a/src/renderer/src/aiCore/chunk/AiSdkToChunkAdapter.ts
+++ b/src/renderer/src/aiCore/chunk/AiSdkToChunkAdapter.ts
@@ -119,17 +119,7 @@ export class AiSdkToChunkAdapter {
         this.idleTimeout?.reset()
 
         if (done) {
-          // Flush any remaining content from link converter buffer if web search is enabled
-          if (this.enableWebSearch) {
-            const remainingText = flushLinkConverterBuffer()
-            if (remainingText) {
-              this.markFirstTokenIfNeeded()
-              this.onChunk({
-                type: ChunkType.TEXT_DELTA,
-                text: remainingText
-              })
-            }
-          }
+          this.flushWebSearchBuffer(final)
           break
         }
 
@@ -157,6 +147,24 @@ export class AiSdkToChunkAdapter {
       })
       final.reasoningContent = ''
     }
+  }
+
+  private flushWebSearchBuffer(final: { text: string }): void {
+    if (!this.enableWebSearch) {
+      return
+    }
+
+    const remainingText = flushLinkConverterBuffer()
+    if (!remainingText) {
+      return
+    }
+
+    this.markFirstTokenIfNeeded()
+    final.text += remainingText
+    this.onChunk({
+      type: ChunkType.TEXT_DELTA,
+      text: remainingText
+    })
   }
 
   /**
@@ -352,6 +360,8 @@ export class AiSdkToChunkAdapter {
       }
 
       case 'finish': {
+        this.flushWebSearchBuffer(final)
+
         // Check if session was cleared (e.g., /clear command) and no text was output
         const sessionCleared = this.getSessionWasCleared?.() ?? false
         if (sessionCleared && !this.hasTextContent) {

--- a/src/renderer/src/aiCore/chunk/__tests__/AiSdkToChunkAdapter.test.ts
+++ b/src/renderer/src/aiCore/chunk/__tests__/AiSdkToChunkAdapter.test.ts
@@ -1,0 +1,47 @@
+import { ChunkType } from '@renderer/types/chunk'
+import { describe, expect, it } from 'vitest'
+
+import { AiSdkToChunkAdapter } from '../AiSdkToChunkAdapter'
+
+describe('AiSdkToChunkAdapter', () => {
+  it('preserves buffered web-search text in the final response', async () => {
+    const chunks: any[] = []
+    const adapter = new AiSdkToChunkAdapter(
+      (chunk) => {
+        chunks.push(chunk)
+      },
+      [],
+      false,
+      true
+    )
+
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({ type: 'text-start' })
+        controller.enqueue({ type: 'text-delta', text: 'See [GitHub](' })
+        controller.enqueue({
+          type: 'finish',
+          finishReason: 'stop',
+          totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 }
+        })
+        controller.close()
+      }
+    })
+
+    await adapter.processStream({
+      fullStream: stream,
+      text: Promise.resolve('See [GitHub](')
+    })
+
+    const blockComplete = chunks.find((chunk) => chunk.type === ChunkType.BLOCK_COMPLETE)
+    const textDeltas = chunks.filter((chunk) => chunk.type === ChunkType.TEXT_DELTA)
+
+    expect(textDeltas.map((chunk) => chunk.text)).toEqual(['See ', '[GitHub]('])
+    expect(blockComplete?.response?.text).toBe('See [GitHub](')
+    expect(blockComplete?.response?.usage).toEqual({
+      completion_tokens: 1,
+      prompt_tokens: 1,
+      total_tokens: 2
+    })
+  })
+})


### PR DESCRIPTION
### What this PR does

Before this PR:

- Gemini responses could lose buffered text at stream end when web search was enabled, which could leave the message truncated or the generation state incomplete.

After this PR:

- The stream adapter flushes buffered web-search text into the final response payload before completion, so Gemini responses finish with the full text.
- Added a regression test covering the buffered web-search tail case in the adapter.

Fixes #15130

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The fix stays localized to the stream adapter so it only changes finalization behavior for buffered web-search text.
- The helper appends the flushed tail to the tracked final response text, which keeps both delta-mode and accumulate-mode callers correct.

The following alternatives were considered:

- Flushing only at stream end. Rejected because the completion path also needs the buffered tail in the final response payload.
- Limiting the fix to Gemini-only logic. Rejected because the underlying completion bug is in the shared adapter path.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/15130

### Breaking changes

None.

### Special notes for your reviewer

The regression is easiest to see with Gemini models using web search, where the stream can end with a buffered markdown link fragment.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and keep it simple
- [x] Refactor: You have left the code cleaner than you found it
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present or not required
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed Gemini web-search responses truncating or getting stuck incomplete when buffered text reached stream end.
```
