### PR TITLE
fix(mcp): preserve tool content with structured output

### DIFF
--- a/src/main/mcpServers/hub/__tests__/mcp-bridge.test.ts
+++ b/src/main/mcpServers/hub/__tests__/mcp-bridge.test.ts
@@ -244,13 +244,13 @@ describe('callMcpTool result extraction', () => {
     expect(result).toEqual({ result: [{ id: 'x' }, { id: 'y' }] })
   })
 
-  it('prefers structuredContent over the content array when both are present', async () => {
+  it('preserves the content array when structuredContent is also present', async () => {
     const result = await callWithMockedResponse({
       content: [{ type: 'text', text: '{"fromContent":true}' }],
       structuredContent: { fromStructured: true }
     })
 
-    expect(result).toEqual({ fromStructured: true })
+    expect(result).toEqual({ fromContent: true })
   })
 
   it('returns null when both content and structuredContent are empty', async () => {

--- a/src/main/mcpServers/hub/mcp-bridge.ts
+++ b/src/main/mcpServers/hub/mcp-bridge.ts
@@ -119,13 +119,13 @@ export const abortMcpTool = async (callId: string): Promise<boolean> => {
 }
 
 function extractToolResult(result: MCPCallToolResponse): unknown {
-  // Some MCP tools deliver their payload exclusively via structuredContent
-  // with an empty content array; surface it instead of returning null.
-  if (result.structuredContent !== undefined && result.structuredContent !== null) {
-    return result.structuredContent
-  }
-
   if (!result.content || result.content.length === 0) {
+    // Some MCP tools deliver their payload exclusively via structuredContent
+    // with an empty content array; surface it instead of returning null.
+    if (result.structuredContent !== undefined && result.structuredContent !== null) {
+      return result.structuredContent
+    }
+
     return null
   }
 


### PR DESCRIPTION
### What this PR does

Before this PR:

MCP hub tool results that included both `content` and `structuredContent` returned only `structuredContent`, so primary text content could be dropped before reaching the agent.

After this PR:

`content` remains the primary result when present. `structuredContent` is still returned as a fallback for tools that provide it with an empty content array.

Fixes #15105

### Why we need it and why it was done in this way

The following tradeoffs were made:

This keeps the existing fallback behavior for structured-only tool results while aligning mixed responses with MCP semantics: `structuredContent` is additive and should not replace `content`.

The following alternatives were considered:

Returning a combined wrapper with both fields would change the value shape consumed by existing agent paths. Preserving the current parsed-content shape is the narrower hotfix.

Links to places where the discussion took place: #15105

### Breaking changes

None.

### Special notes for your reviewer

Validation:

- `pnpm exec vitest run src/main/mcpServers/hub/__tests__/mcp-bridge.test.ts`
- `pnpm exec biome check src/main/mcpServers/hub/mcp-bridge.ts src/main/mcpServers/hub/__tests__/mcp-bridge.test.ts`
- `pnpm typecheck:node`
- `git diff --check`

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and keep it simple
- [x] Refactor: Not applicable; this is a narrow hotfix
- [x] Upgrade: No upgrade impact expected
- [x] Documentation: Not required for this bug fix
- [x] Self-review: I have reviewed the diff locally

### Release note

```release-note
Fix MCP hub tool results so primary text content is preserved when structured output metadata is also present.
```