### PR TITLE
fix(code): keep light theme tokens readable

### DIFF
--- a/src/renderer/src/components/CodeViewer.tsx
+++ b/src/renderer/src/components/CodeViewer.tsx
@@ -467,6 +467,7 @@ const CodeViewer = ({
                   tokenLine={tokenLines[virtualItem.index]}
                   showLineNumbers={lineNumbers}
                   index={virtualItem.index}
+                  isDarkTheme={isShikiThemeDark}
                 />
               </div>
             ))}
@@ -491,13 +492,14 @@ interface VirtualizedRowData {
   rawLine: string
   tokenLine?: ThemedToken[]
   showLineNumbers: boolean
+  isDarkTheme: boolean
 }
 
 /**
  * 单行代码渲染
  */
 const VirtualizedRow = memo(
-  ({ rawLine, tokenLine, showLineNumbers, index }: VirtualizedRowData & { index: number }) => {
+  ({ rawLine, tokenLine, showLineNumbers, index, isDarkTheme }: VirtualizedRowData & { index: number }) => {
     // 补全代码行 tokens，把原始内容拼接到高亮内容之后，确保渲染出整行来。
     const completeTokenLine = useMemo(() => {
       // 如果出现空行，补一个空元素保证行高
@@ -535,7 +537,7 @@ const VirtualizedRow = memo(
         {showLineNumbers && <span className="line-number">{index + 1}</span>}
         <span className="line-content">
           {completeTokenLine.map((token, tokenIndex) => (
-            <span key={tokenIndex} style={getReactStyleFromToken(token)}>
+            <span key={tokenIndex} style={getReactStyleFromToken(token, { isDarkTheme })}>
               {token.content}
             </span>
           ))}

--- a/src/renderer/src/utils/__tests__/shiki.test.ts
+++ b/src/renderer/src/utils/__tests__/shiki.test.ts
@@ -194,5 +194,29 @@ describe('shiki', () => {
 
       expect(result).toEqual({})
     })
+
+    it('should use readable text color for white tokens in light themes', () => {
+      const token = createThemedToken({
+        content: 'LogPage',
+        offset: 0,
+        color: 'white'
+      })
+
+      const result = getReactStyleFromToken(token, { isDarkTheme: false })
+
+      expect(result.color).toBe('var(--color-text)')
+    })
+
+    it('should preserve white tokens in dark themes', () => {
+      const token = createThemedToken({
+        content: 'LogPage',
+        offset: 0,
+        color: 'white'
+      })
+
+      const result = getReactStyleFromToken(token, { isDarkTheme: true })
+
+      expect(result.color).toBe('white')
+    })
   })
 })

--- a/src/renderer/src/utils/shiki.ts
+++ b/src/renderer/src/utils/shiki.ts
@@ -107,10 +107,18 @@ export async function loadThemeIfNeeded(highlighter: HighlighterGeneric<any, any
  * @param token Shiki themed token
  * @returns React 样式对象
  */
-export function getReactStyleFromToken(token: ThemedToken): Record<string, string> {
+export function getReactStyleFromToken(
+  token: ThemedToken,
+  options?: { isDarkTheme?: boolean }
+): Record<string, string> {
   const style = token.htmlStyle || getTokenStyleObject(token)
   const reactStyle: Record<string, string> = {}
   for (const [key, value] of Object.entries(style)) {
+    if (key === 'color' && !options?.isDarkTheme && ['white', '#fff', '#ffffff'].includes(value.toLowerCase())) {
+      reactStyle.color = 'var(--color-text)'
+      continue
+    }
+
     switch (key) {
       case 'font-style':
         reactStyle.fontStyle = value


### PR DESCRIPTION
### What this PR does

Before this PR:

Razor component names that Shiki returns as `white` tokens can disappear in the light code theme because they are rendered on a light background.

After this PR:

Light-theme code rendering maps white syntax tokens to the app text color while preserving white tokens in dark themes.

Fixes #15141

### Why we need it and why it was done in this way

The following tradeoffs were made:

This keeps the fix localized to token style conversion instead of changing the bundled Shiki theme or Razor grammar. The guard only applies in light themes and only to white token colors.

The following alternatives were considered:

Changing the default Shiki theme or adding language-specific Razor styling would be broader and more likely to affect unrelated code blocks.

Links to places where the discussion took place: #15141

### Breaking changes

None.

### Special notes for your reviewer

Verified that Shiki returns `LogPage:white` for Razor under `one-light`, matching the reported invisible token.

Validation:

- `pnpm exec vitest run src/renderer/src/utils/__tests__/shiki.test.ts src/renderer/src/pages/home/Markdown/__tests__/CodeBlock.test.tsx`
- `pnpm exec biome check src/renderer/src/utils/shiki.ts src/renderer/src/components/CodeViewer.tsx src/renderer/src/utils/__tests__/shiki.test.ts`
- `pnpm typecheck:web`
- `git diff --check`

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required for this bug fix
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix code block tokens that could disappear in light theme syntax highlighting.
```
