### PR TITLE
fix(stream): merge adjacent thinking segments

### DIFF
--- a/src/renderer/src/services/messageStreaming/callbacks/thinkingCallbacks.ts
+++ b/src/renderer/src/services/messageStreaming/callbacks/thinkingCallbacks.ts
@@ -17,6 +17,8 @@ export const createThinkingCallbacks = (deps: ThinkingCallbacksDependencies) => 
   // 内部维护的状态
   let thinkingBlockId: string | null = null
   let thinking_millsec_now: number = 0
+  let lastCompletedThinkingBlockId: string | null = null
+  let thinkingPrefix = ''
 
   return {
     // 获取当前思考时间（用于停止回复时保留思考时间）
@@ -39,13 +41,31 @@ export const createThinkingCallbacks = (deps: ThinkingCallbacksDependencies) => 
           thinking_millsec: 0
         }
         thinkingBlockId = blockManager.initialPlaceholderBlockId!
+        lastCompletedThinkingBlockId = null
+        thinkingPrefix = ''
         blockManager.smartBlockUpdate(thinkingBlockId, changes, MessageBlockType.THINKING, true)
+      } else if (
+        !thinkingBlockId &&
+        blockManager.lastBlockType === MessageBlockType.THINKING &&
+        lastCompletedThinkingBlockId
+      ) {
+        thinkingBlockId = lastCompletedThinkingBlockId
+        blockManager.smartBlockUpdate(
+          thinkingBlockId,
+          {
+            status: MessageBlockStatus.STREAMING,
+            thinking_millsec: 0
+          },
+          MessageBlockType.THINKING
+        )
       } else if (!thinkingBlockId) {
         const newBlock = createThinkingBlock(assistantMsgId, '', {
           status: MessageBlockStatus.STREAMING,
           thinking_millsec: 0
         })
         thinkingBlockId = newBlock.id
+        lastCompletedThinkingBlockId = null
+        thinkingPrefix = ''
         await blockManager.handleBlockTransition(newBlock, MessageBlockType.THINKING)
       }
     },
@@ -53,7 +73,7 @@ export const createThinkingCallbacks = (deps: ThinkingCallbacksDependencies) => 
     onThinkingChunk: async (text: string) => {
       if (thinkingBlockId) {
         const blockChanges: Partial<MessageBlock> = {
-          content: text,
+          content: thinkingPrefix + text,
           status: MessageBlockStatus.STREAMING,
           thinking_millsec: thinking_millsec_now > 0 ? performance.now() - thinking_millsec_now : 0
         }
@@ -64,12 +84,15 @@ export const createThinkingCallbacks = (deps: ThinkingCallbacksDependencies) => 
     onThinkingComplete: (finalText: string) => {
       if (thinkingBlockId) {
         const now = performance.now()
+        const content = thinkingPrefix + finalText
         const changes: Partial<MessageBlock> = {
-          content: finalText,
+          content,
           status: MessageBlockStatus.SUCCESS,
           thinking_millsec: now - thinking_millsec_now
         }
         blockManager.smartBlockUpdate(thinkingBlockId, changes, MessageBlockType.THINKING, true)
+        lastCompletedThinkingBlockId = thinkingBlockId
+        thinkingPrefix = content
         thinkingBlockId = null
         thinking_millsec_now = 0
       } else {

--- a/src/renderer/src/store/thunk/__tests__/streamCallback.integration.test.ts
+++ b/src/renderer/src/store/thunk/__tests__/streamCallback.integration.test.ts
@@ -473,6 +473,32 @@ describe('streamCallback Integration Tests', () => {
     expect((thinkingBlock as any)?.thinking_millsec).toBeGreaterThanOrEqual(0)
   })
 
+  it('should merge adjacent thinking segments into one block', async () => {
+    const callbacks = createMockCallbacks(mockAssistantMsgId, mockTopicId, mockAssistant, dispatch, getState)
+
+    const chunks: Chunk[] = [
+      { type: ChunkType.LLM_RESPONSE_CREATED },
+      { type: ChunkType.THINKING_START },
+      { type: ChunkType.THINKING_DELTA, text: 'First part ' },
+      { type: ChunkType.THINKING_COMPLETE, text: 'First part ' },
+      { type: ChunkType.THINKING_START },
+      { type: ChunkType.THINKING_DELTA, text: 'second part' },
+      { type: ChunkType.THINKING_COMPLETE, text: 'second part' },
+      { type: ChunkType.BLOCK_COMPLETE }
+    ]
+
+    await processChunks(chunks, callbacks)
+
+    const state = getState()
+    const thinkingBlocks = Object.values(state.messageBlocks.entities).filter(
+      (block) => block.type === MessageBlockType.THINKING
+    )
+
+    expect(thinkingBlocks).toHaveLength(1)
+    expect(thinkingBlocks[0]?.content).toBe('First part second part')
+    expect(thinkingBlocks[0]?.status).toBe(MessageBlockStatus.SUCCESS)
+  })
+
   it('should handle tool call flow', async () => {
     const callbacks = createMockCallbacks(mockAssistantMsgId, mockTopicId, mockAssistant, dispatch, getState)
 


### PR DESCRIPTION
### What this PR does

Before this PR:

Adjacent reasoning summary segments could create multiple thinking blocks when the stream emitted a complete thinking segment and then immediately started another thinking segment.

After this PR:

Adjacent thinking segments are merged into the same thinking block until another block type, such as text or tool output, interrupts the stream.

Fixes #15128

### Why we need it and why it was done in this way

The following tradeoffs were made:

The fix stays in the message streaming callbacks so existing chunk adapters can keep emitting normal `thinking.start`, `thinking.delta`, and `thinking.complete` events. It only reuses the previous thinking block when the previous block type is still thinking.

The following alternatives were considered:

Changing provider-specific raw event handling would be narrower to one backend but would not cover other providers that emit adjacent reasoning segments through the same chunk shape.

Links to places where the discussion took place: #15128

### Breaking changes

None.

### Special notes for your reviewer

Validation:

- `pnpm exec vitest run src/renderer/src/store/thunk/__tests__/streamCallback.integration.test.ts`
- `pnpm exec biome check src/renderer/src/services/messageStreaming/callbacks/thinkingCallbacks.ts src/renderer/src/store/thunk/__tests__/streamCallback.integration.test.ts`
- `pnpm typecheck:web`
- `git diff --check`

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required for this bug fix
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix adjacent reasoning summary segments creating multiple thinking blocks.
```
