### PR TITLE
fix: include local time in cron tool responses

### DIFF
--- a/src/main/mcpServers/__tests__/claw.test.ts
+++ b/src/main/mcpServers/__tests__/claw.test.ts
@@ -170,10 +170,15 @@ describe('ClawServer', () => {
     })
 
     it('should create a one-time task with at', async () => {
-      mockCreateTask.mockResolvedValue({ id: 'task_4' })
+      mockCreateTask.mockResolvedValue({
+        id: 'task_4',
+        schedule_type: 'once',
+        schedule_value: '2024-01-15T06:30:00.000Z',
+        next_run: '2024-01-15T06:30:00.000Z'
+      })
 
       const server = createServer()
-      await callTool(server, {
+      const result = await callTool(server, {
         action: 'add',
         name: 'Deploy',
         message: 'Deploy to prod',
@@ -186,6 +191,8 @@ describe('ClawServer', () => {
           schedule_type: 'once'
         })
       )
+      expect(result.content[0].text).toContain('schedule_value_local')
+      expect(result.content[0].text).toContain('next_run_local')
     })
 
     it('should reject when no schedule is provided', async () => {

--- a/src/main/mcpServers/claw.ts
+++ b/src/main/mcpServers/claw.ts
@@ -32,6 +32,33 @@ function parseDurationToMinutes(duration: string): number {
   return totalMinutes
 }
 
+function formatLocalDateTime(value?: string | null): string | undefined {
+  if (!value) return undefined
+
+  const date = new Date(value)
+  if (isNaN(date.getTime())) return undefined
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    hour12: false
+  }).format(date)
+}
+
+function formatTaskForToolResponse(task: Record<string, unknown>) {
+  const nextRunLocal = typeof task.next_run === 'string' ? formatLocalDateTime(task.next_run) : undefined
+  const scheduleValueLocal =
+    task.schedule_type === 'once' && typeof task.schedule_value === 'string'
+      ? formatLocalDateTime(task.schedule_value)
+      : undefined
+
+  return {
+    ...task,
+    ...(scheduleValueLocal ? { schedule_value_local: scheduleValueLocal } : {}),
+    ...(nextRunLocal ? { next_run_local: nextRunLocal } : {})
+  }
+}
+
 const CRON_TOOL: Tool = {
   name: 'cron',
   description:
@@ -347,7 +374,9 @@ class ClawServer {
 
     logger.info('Cron job created via tool', { agentId: this.agentId, taskId: task.id })
     return {
-      content: [{ type: 'text' as const, text: `Job created:\n${JSON.stringify(task, null, 2)}` }]
+      content: [
+        { type: 'text' as const, text: `Job created:\n${JSON.stringify(formatTaskForToolResponse(task), null, 2)}` }
+      ]
     }
   }
 


### PR DESCRIPTION
### What this PR does

Before this PR:

`mcp__claw__cron` returned only raw task JSON after creating a scheduled task. For one-time jobs, `schedule_value` and `next_run` are stored as UTC ISO strings, which can lead the agent confirmation text to quote the UTC clock time instead of the user's local clock time.

After this PR:

The cron tool response still preserves the raw task fields, and also includes local display fields for one-time schedules and next runs:

- `schedule_value_local`
- `next_run_local`

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #14419

### Why we need it and why it was done in this way

The following tradeoffs were made:

This keeps scheduling/storage unchanged and only improves the MCP tool response that the agent uses to compose the confirmation message. The raw ISO values remain available for debugging and machine use.

The following alternatives were considered:

Changing task storage or scheduler timezone handling was avoided because the issue reports that the actual trigger time is already correct.

Links to places where the discussion took place: #14419

### Breaking changes

None.

### Special notes for your reviewer

The change is intentionally limited to the Claw cron MCP tool response and its existing test coverage.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix scheduled task creation responses so one-time reminder confirmations can use the user's local time instead of the raw UTC timestamp.
```
