### PR TITLE
fix: refresh cached miniapp urls

### DIFF
--- a/src/renderer/src/hooks/useMinappPopup.ts
+++ b/src/renderer/src/hooks/useMinappPopup.ts
@@ -87,9 +87,9 @@ export const useMinappPopup = () => {
   const openMinapp = useCallback(
     (app: MinAppType, keepAlive: boolean = false) => {
       if (keepAlive) {
-        // 通过 get 和 set 去更新缓存，避免重复添加
-        const cacheApp = minAppsCache.get(app.id)
-        if (!cacheApp) minAppsCache.set(app.id, app)
+        // Always refresh the cached config. Some apps, such as OpenClaw, use
+        // short-lived URLs with auth tokens and must not reuse a stale entry.
+        minAppsCache.set(app.id, app)
 
         // 如果小程序已经打开，只切换显示
         if (openedKeepAliveMinapps.some((item) => item.id === app.id)) {
@@ -173,12 +173,9 @@ export const useMinappPopup = () => {
   const openSmartMinapp = useCallback(
     (config: MinAppType, keepAlive: boolean = false) => {
       if (isTopNavbar) {
-        // For top navbar mode, need to add to cache first for temporary apps
-        const cacheApp = minAppsCache.get(config.id)
-        if (!cacheApp) {
-          // Add temporary app to cache so MinAppPage can find it
-          minAppsCache.set(config.id, config)
-        }
+        // Refresh temporary app config so dynamic URLs such as OpenClaw's
+        // dashboard token are propagated when the tab already exists.
+        minAppsCache.set(config.id, config)
 
         // Set current minapp and show state
         dispatch(setCurrentMinappId(config.id))


### PR DESCRIPTION
### What this PR does

Before this PR:

Opening a keep-alive mini-app with an existing id reused the cached app config without refreshing its URL. Dynamic mini-app URLs, including the OpenClaw dashboard URL with its auth token, could therefore reopen with a stale tokenless URL.

After this PR:

Keep-alive mini-app opens always refresh the cached config before showing the app. Existing OpenClaw dashboard tabs now receive the latest tokenized URL from `getDashboardUrl()`.

Fixes #14415

### Why we need it and why it was done in this way

The following tradeoffs were made:

This keeps the fix in the shared mini-app cache path instead of adding OpenClaw-specific reload code, so every dynamic mini-app URL benefits from the same behavior.

The following alternatives were considered:

Closing and recreating the OpenClaw dashboard tab on every open was considered, but refreshing the cached config is smaller and preserves the existing keep-alive behavior.

Links to places where the discussion took place: #14415

### Breaking changes

None.

### Special notes for your reviewer

Touched surface: renderer mini-app popup cache behavior. Validation run:

- `corepack pnpm biome check src/renderer/src/hooks/useMinappPopup.ts`
- `corepack pnpm exec tsc --noEmit -p tsconfig.web.json --composite false`

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and keep it simple
- [x] Refactor: The change is minimal and scoped to the bug
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: Not required; this fixes existing behavior
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix OpenClaw dashboard mini-app opens so the cached tab uses the latest authenticated URL.
```
