### PR TITLE
fix: clarify OpenClaw external install prompt

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -2947,7 +2947,7 @@
     "install_progress": "Install Progress",
     "installed_at": "OpenClaw installed at",
     "migration": {
-      "description": "An outdated version of OpenClaw installed via npm has been detected. Please reinstall to get the latest official version.",
+      "description": "An external OpenClaw installation was detected in PATH, but Cherry Studio uses its managed OpenClaw binary. Install the managed version to continue.",
       "install_button": "Reinstall OpenClaw",
       "title": "OpenClaw Needs Update"
     },

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -2947,7 +2947,7 @@
     "install_progress": "安装进度",
     "installed_at": "OpenClaw 安装路径",
     "migration": {
-      "description": "检测到通过 npm 安装的旧版本 OpenClaw，请重新安装以获取最新官方版本。",
+      "description": "检测到 PATH 中存在外部 OpenClaw 安装，但 Cherry Studio 只使用托管的 OpenClaw 二进制文件。请安装托管版本后继续。",
       "install_button": "重新安装 OpenClaw",
       "title": "OpenClaw 需要更新"
     },

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -2947,7 +2947,7 @@
     "install_progress": "安裝進度",
     "installed_at": "OpenClaw 安裝路徑",
     "migration": {
-      "description": "偵測到透過 npm 安裝的舊版本 OpenClaw，請重新安裝以取得最新官方版本。",
+      "description": "偵測到 PATH 中存在外部 OpenClaw 安裝，但 Cherry Studio 只使用受管理的 OpenClaw 二進位檔。請安裝受管理版本後繼續。",
       "install_button": "重新安裝 OpenClaw",
       "title": "OpenClaw 需要更新"
     },


### PR DESCRIPTION
### What this PR does

Before this PR:

OpenClaw's migration state told users that any PATH/npm OpenClaw install was an outdated version and asked them to reinstall for the latest official version.

After this PR:

The message explains that Cherry Studio detected an external OpenClaw install in PATH, but uses its own managed OpenClaw binary. The install action stays the same, but the prompt no longer implies that the user's npm install is necessarily old.

Fixes #14122

### Why we need it and why it was done in this way

The following tradeoffs were made:

This keeps the existing managed-binary safety behavior unchanged and only adjusts the user-facing migration copy in English, Simplified Chinese, and Traditional Chinese.

The following alternatives were considered:

Allowing PATH binaries would change the OpenClaw execution policy and is outside the scope of this bug fix.

Links to places where the discussion took place: #14122

### Breaking changes

None.

### Special notes for your reviewer

Validation:

- `corepack pnpm biome check src/renderer/src/i18n/locales/en-us.json src/renderer/src/i18n/locales/zh-cn.json src/renderer/src/i18n/locales/zh-tw.json`
- `node -e "for (const f of ['src/renderer/src/i18n/locales/en-us.json','src/renderer/src/i18n/locales/zh-cn.json','src/renderer/src/i18n/locales/zh-tw.json']) JSON.parse(require('fs').readFileSync(f,'utf8')); console.log('ok')"`

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: No refactor included; hotfix scope only
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: User-guide update not required for copy-only clarification
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Clarified the OpenClaw migration prompt when Cherry Studio detects an external PATH installation.
```
