### PR TITLE
fix(agent): resolve CherryIN provider alias

### DIFF
--- a/src/main/apiServer/services/models.ts
+++ b/src/main/apiServer/services/models.ts
@@ -3,6 +3,7 @@ import { isEmpty } from 'lodash'
 import type { ApiModel, ApiModelsFilter, ApiModelsResponse } from '../../../renderer/src/types/apiModels'
 import { loggerService } from '../../services/LoggerService'
 import {
+  findProviderForModel,
   getAvailableProviders,
   getProviderAnthropicModelChecker,
   listAllAvailableModels,
@@ -31,7 +32,7 @@ export class ModelsService {
       const uniqueModels = new Map<string, ApiModel>()
 
       for (const model of models) {
-        const provider = providers.find((p) => p.id === model.provider)
+        const provider = findProviderForModel(providers, model.provider, model.id)
         // logger.debug(`Processing model ${model.id}`)
         if (!provider) {
           logger.debug(`Skipping model ${model.id} . Reason: Provider not found.`)

--- a/src/main/apiServer/utils/__tests__/index.test.ts
+++ b/src/main/apiServer/utils/__tests__/index.test.ts
@@ -1,0 +1,73 @@
+import type { Model, Provider } from '@types'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@main/aiCore/provider/providerConfig', () => ({
+  formatProviderApiHost: vi.fn((provider: Provider) => Promise.resolve(provider))
+}))
+
+vi.mock('@main/services/CacheService', () => ({
+  CacheService: {
+    get: vi.fn(),
+    set: vi.fn()
+  }
+}))
+
+vi.mock('@main/services/LoggerService', () => ({
+  loggerService: {
+    withContext: vi.fn(() => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    }))
+  }
+}))
+
+vi.mock('@main/services/ReduxService', () => ({
+  reduxService: {
+    select: vi.fn()
+  }
+}))
+
+vi.mock('@shared/config/providers', () => ({
+  isSiliconAnthropicCompatibleModel: vi.fn(() => false)
+}))
+
+import { findProviderForModel, transformModelToOpenAI } from '..'
+
+describe('api server model utilities', () => {
+  it('exposes legacy CherryAI models under the CherryIN provider id', () => {
+    const model = {
+      id: 'agent/glm-5',
+      name: 'GLM 5',
+      provider: 'cherryai'
+    } as Model
+    const provider = {
+      id: 'cherryin',
+      name: 'CherryIN',
+      type: 'openai',
+      models: [model]
+    } as Provider
+
+    const result = transformModelToOpenAI(model, provider)
+
+    expect(result.id).toBe('cherryin:agent/glm-5')
+    expect(result.provider).toBe('cherryin')
+    expect(result.provider_name).toBe('CherryIN')
+  })
+
+  it('resolves legacy CherryAI model lookups to matching CherryIN provider config', () => {
+    const providers = [
+      {
+        id: 'cherryin',
+        name: 'CherryIN',
+        type: 'openai',
+        models: [{ id: 'agent/glm-5', provider: 'cherryai' }]
+      }
+    ] as Provider[]
+
+    const provider = findProviderForModel(providers, 'cherryai', 'agent/glm-5')
+
+    expect(provider?.id).toBe('cherryin')
+  })
+})

--- a/src/main/apiServer/utils/index.ts
+++ b/src/main/apiServer/utils/index.ts
@@ -10,6 +10,32 @@ const logger = loggerService.withContext('ApiServerUtils')
 // Cache configuration
 const PROVIDERS_CACHE_KEY = 'api-server:providers'
 const PROVIDERS_CACHE_TTL = 10 * 1000 // 10 seconds
+const MODEL_PROVIDER_ALIASES: Record<string, string> = {
+  cherryai: 'cherryin'
+}
+
+function resolveModelProviderAlias(providerId: string): string {
+  return MODEL_PROVIDER_ALIASES[providerId] ?? providerId
+}
+
+export function findProviderForModel(
+  providers: Provider[],
+  providerId: string,
+  modelId?: string
+): Provider | undefined {
+  const resolvedProviderId = resolveModelProviderAlias(providerId)
+
+  if (resolvedProviderId !== providerId) {
+    const aliasedProvider = providers.find((p: Provider) => {
+      return p.id === resolvedProviderId && (!modelId || p.models?.some((m) => m.id === modelId))
+    })
+    if (aliasedProvider) {
+      return aliasedProvider
+    }
+  }
+
+  return providers.find((p: Provider) => p.id === providerId)
+}
 
 export async function getAvailableProviders(): Promise<Provider[]> {
   try {
@@ -97,7 +123,8 @@ export async function getProviderByModel(model: string): Promise<Provider | unde
     }
 
     const providerId = modelInfo[0]
-    const provider = providers.find((p: Provider) => p.id === providerId)
+    const modelId = getRealProviderModel(model)
+    const provider = findProviderForModel(providers, providerId, modelId)
 
     if (!provider) {
       logger.warn('Provider not found for model', {
@@ -214,14 +241,15 @@ export async function validateModelId(model: string): Promise<{
 }
 
 export function transformModelToOpenAI(model: Model, provider?: Provider): ApiModel {
+  const providerId = provider?.id ?? resolveModelProviderAlias(model.provider)
   const providerDisplayName = provider?.name
   return {
-    id: `${model.provider}:${model.id}`,
+    id: `${providerId}:${model.id}`,
     object: 'model',
     name: model.name,
     created: Math.floor(Date.now() / 1000),
-    owned_by: model.owned_by || providerDisplayName || model.provider,
-    provider: model.provider,
+    owned_by: model.owned_by || providerDisplayName || providerId,
+    provider: providerId,
     provider_name: providerDisplayName,
     provider_type: provider?.type,
     provider_model_id: model.id


### PR DESCRIPTION
### What this PR does

Before this PR:
Agent sessions could expose legacy `cherryai` model provider IDs through the API server model list and lookup path, so CherryIN-backed agent models could fail provider resolution.

After this PR:
The API server resolves legacy CherryAI model IDs to the matching CherryIN provider config and exposes those models with the CherryIN provider ID.

Fixes #14418

### Why we need it and why it was done in this way

The following tradeoffs were made:
Kept the fix limited to the API-server model translation and lookup layer so existing stored model IDs keep working without changing provider storage or migrations.

The following alternatives were considered:
A broader provider migration was avoided because main is in code freeze and this bug only needs compatibility at the Agent API boundary.

Links to places where the discussion took place: #14418

### Breaking changes

None.

### Special notes for your reviewer

Validation run:
- `corepack pnpm biome check --write src/main/apiServer/services/models.ts src/main/apiServer/utils/index.ts src/main/apiServer/utils/__tests__/index.test.ts`
- `corepack pnpm exec vitest run src/main/apiServer/utils/__tests__/index.test.ts src/main/services/__tests__/OpenClawService.test.ts`
- `corepack pnpm typecheck:node`

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and keep it simple
- [x] Refactor: Left the touched code focused and minimal
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: Not required; this is a bug fix
- [x] Self-review: I have reviewed my own code before requesting review

### Release note

```release-note
Fixes CherryIN-backed Agent models failing because a legacy provider ID could be used in the Agent API path.
```