### PR TITLE
fix: remove color override in code blocks to fix light theme visibility

### DIFF
--- a/src/renderer/src/assets/styles/richtext.css
+++ b/src/renderer/src/assets/styles/richtext.css
@@ -108,7 +108,6 @@
 .tiptap pre {
   background: var(--color-code-background);
   border-radius: 0.5rem;
-  color: var(--color-text);
   font-family: var(--code-font-family);
   margin: 1.5rem 0;
   padding: 0.75rem 1rem;


### PR DESCRIPTION
### What this PR does

Before this PR:
- In light theme, code blocks had some syntax-highlighted tokens that were invisible due to color conflicts
- The `pre` tag's `color: var(--color-text)` property was overriding Shiki's inline syntax highlighting colors
- Some tokens with light colors became invisible against the light gray background (`#e3e3e3`)

After this PR:
- Removed the `color` property from `.tiptap pre` selector
- Shiki's inline styles now work correctly in both light and dark themes
- All syntax-highlighted code is now visible in light theme

Fixes #15141

### Why we need it and why it was done in this way

**Problem**: Users reported that in light theme (v1.9.6), some code content in code blocks was completely invisible because the text color matched the background color.

**Root cause**: The CSS rule `.tiptap pre { color: var(--color-text); }` was overriding Shiki's syntax highlighting colors. In light theme, `--color-text` is black (`rgba(0, 0, 0, 1)`), but Shiki generates various colors for different tokens. Some of these colors are light and become invisible on the light gray background.

**Solution**: Remove the `color` property and let Shiki's inline styles take precedence. This is the correct approach because:
1. Shiki already generates appropriate colors for each theme (`one-light` for light mode, `material-theme-darker` for dark mode)
2. The `pre code` selector already has `color: inherit`, so removing the parent color doesn't break anything
3. This aligns with how Shiki is designed to work

The following tradeoffs were made:
- None. This is a pure bug fix with no tradeoffs.

The following alternatives were considered:
- Adjusting individual token colors: Too complex and would require maintaining custom color mappings
- Changing the background color: Would affect the overall design and doesn't solve the root cause

### Breaking changes

None. This is a visual bug fix that improves readability.

### Special notes for your reviewer

- This is a minimal CSS change (1 line removed)
- The fix applies to both the rich text editor and code preview areas
- Tested scenario: Light theme with various programming languages (JavaScript, Python, etc.)
- The `pre code` selector already inherits color, so this change is safe

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed code block visibility issue in light theme where some syntax-highlighted text was invisible due to color conflicts.
```