### PR TITLE
fix(claudecode): apply [1m] context suffix for DeepSeek V4 Flash and MiMo V2.5+

### DIFF
--- a/src/main/services/agents/services/claudecode/__tests__/utils.test.ts
+++ b/src/main/services/agents/services/claudecode/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { isDeepSeekOfficialHost, withDeepSeek1mSuffix } from '../utils'
+import { isDeepSeekOfficialHost, isMiMoOfficialHost, with1mContextSuffix } from '../utils'
 
 describe('isDeepSeekOfficialHost', () => {
   it('matches the canonical DeepSeek Anthropic endpoint', () => {
@@ -27,40 +27,98 @@ describe('isDeepSeekOfficialHost', () => {
   })
 })
 
-describe('withDeepSeek1mSuffix', () => {
-  const officialHost = 'https://api.deepseek.com/anthropic'
+describe('isMiMoOfficialHost', () => {
+  it('matches the canonical MiMo Anthropic endpoint', () => {
+    expect(isMiMoOfficialHost('https://api.xiaomimimo.com/anthropic')).toBe(true)
+    expect(isMiMoOfficialHost('https://api.xiaomimimo.com')).toBe(true)
+    expect(isMiMoOfficialHost('  https://api.xiaomimimo.com/anthropic  ')).toBe(true)
+  })
+
+  it('matches Token Plan regional endpoints', () => {
+    expect(isMiMoOfficialHost('https://token-plan-cn.xiaomimimo.com/anthropic')).toBe(true)
+    expect(isMiMoOfficialHost('https://token-plan-sg.xiaomimimo.com/anthropic')).toBe(true)
+    expect(isMiMoOfficialHost('https://token-plan-eu.xiaomimimo.com/anthropic')).toBe(true)
+  })
+
+  it('rejects third-party and lookalike hosts', () => {
+    expect(isMiMoOfficialHost('https://openrouter.ai/api/v1')).toBe(false)
+    expect(isMiMoOfficialHost('https://token-plan-cn.xiaomimimo.com.evil.com')).toBe(false)
+    expect(isMiMoOfficialHost('https://notxiaomimimo.com/anthropic')).toBe(false)
+  })
+
+  it('handles missing or malformed hosts gracefully', () => {
+    expect(isMiMoOfficialHost(undefined)).toBe(false)
+    expect(isMiMoOfficialHost('')).toBe(false)
+    expect(isMiMoOfficialHost('not a url')).toBe(false)
+  })
+})
+
+describe('with1mContextSuffix', () => {
+  const deepSeekHost = 'https://api.deepseek.com/anthropic'
+  const mimoHost = 'https://api.xiaomimimo.com/anthropic'
   const thirdPartyHost = 'https://openrouter.ai/api/v1'
 
-  it('appends [1m] to V4+ pro models on the official host', () => {
-    expect(withDeepSeek1mSuffix('deepseek-v4-pro', officialHost)).toBe('deepseek-v4-pro[1m]')
-    expect(withDeepSeek1mSuffix('deepseek-v4', officialHost)).toBe('deepseek-v4[1m]')
-    expect(withDeepSeek1mSuffix('deepseek-v5-pro', officialHost)).toBe('deepseek-v5-pro[1m]')
+  it('appends [1m] to DeepSeek V4+ Pro models on the official host', () => {
+    expect(with1mContextSuffix('deepseek-v4-pro', deepSeekHost)).toBe('deepseek-v4-pro[1m]')
+    expect(with1mContextSuffix('deepseek-v4', deepSeekHost)).toBe('deepseek-v4[1m]')
+    expect(with1mContextSuffix('deepseek-v5-pro', deepSeekHost)).toBe('deepseek-v5-pro[1m]')
+  })
+
+  it('appends [1m] to DeepSeek V4+ Flash (also 1M context)', () => {
+    expect(with1mContextSuffix('deepseek-v4-flash', deepSeekHost)).toBe('deepseek-v4-flash[1m]')
+    expect(with1mContextSuffix('deepseek-v5-flash', deepSeekHost)).toBe('deepseek-v5-flash[1m]')
+  })
+
+  it('appends [1m] to MiMo V2.5+ Pro/base models on the official host', () => {
+    expect(with1mContextSuffix('mimo-v2.5-pro', mimoHost)).toBe('mimo-v2.5-pro[1m]')
+    expect(with1mContextSuffix('mimo-v2.5', mimoHost)).toBe('mimo-v2.5[1m]')
+    expect(with1mContextSuffix('mimo-v2.6-pro', mimoHost)).toBe('mimo-v2.6-pro[1m]')
+    expect(with1mContextSuffix('mimo-v3-pro', mimoHost)).toBe('mimo-v3-pro[1m]')
+  })
+
+  it('appends [1m] to MiMo models on Token Plan endpoints', () => {
+    const tokenPlanHost = 'https://token-plan-cn.xiaomimimo.com/anthropic'
+    expect(with1mContextSuffix('mimo-v2.5-pro', tokenPlanHost)).toBe('mimo-v2.5-pro[1m]')
+  })
+
+  it('does not append [1m] for MiMo flash variants (256K context, not 1M)', () => {
+    expect(with1mContextSuffix('mimo-v2.5-flash', mimoHost)).toBe('mimo-v2.5-flash')
+  })
+
+  it('leaves pre-2.5 MiMo models untouched', () => {
+    expect(with1mContextSuffix('mimo-v2-flash', mimoHost)).toBe('mimo-v2-flash')
+    expect(with1mContextSuffix('mimo-v2-omni', mimoHost)).toBe('mimo-v2-omni')
+    expect(with1mContextSuffix('mimo-v2.4-pro', mimoHost)).toBe('mimo-v2.4-pro')
   })
 
   it('leaves the id alone when an existing [1m] suffix is present', () => {
-    expect(withDeepSeek1mSuffix('deepseek-v4-pro[1m]', officialHost)).toBe('deepseek-v4-pro[1m]')
-    expect(withDeepSeek1mSuffix('deepseek-v4-pro[1M]', officialHost)).toBe('deepseek-v4-pro[1M]')
+    expect(with1mContextSuffix('deepseek-v4-pro[1m]', deepSeekHost)).toBe('deepseek-v4-pro[1m]')
+    expect(with1mContextSuffix('deepseek-v4-pro[1M]', deepSeekHost)).toBe('deepseek-v4-pro[1M]')
+    expect(with1mContextSuffix('mimo-v2.5-pro[1m]', mimoHost)).toBe('mimo-v2.5-pro[1m]')
   })
 
-  it('does not append [1m] for flash variants (64K context, not 1M)', () => {
-    expect(withDeepSeek1mSuffix('deepseek-v4-flash', officialHost)).toBe('deepseek-v4-flash')
-    expect(withDeepSeek1mSuffix('deepseek-v5-flash', officialHost)).toBe('deepseek-v5-flash')
+  it('does not append [1m] when host is not an official 1M host', () => {
+    expect(with1mContextSuffix('deepseek-v4-pro', thirdPartyHost)).toBe('deepseek-v4-pro')
+    expect(with1mContextSuffix('deepseek-v4-pro', undefined)).toBe('deepseek-v4-pro')
+    expect(with1mContextSuffix('mimo-v2.5-pro', thirdPartyHost)).toBe('mimo-v2.5-pro')
   })
 
-  it('does not append [1m] when host is not DeepSeek-official', () => {
-    expect(withDeepSeek1mSuffix('deepseek-v4-pro', thirdPartyHost)).toBe('deepseek-v4-pro')
-    expect(withDeepSeek1mSuffix('deepseek-v4-pro', undefined)).toBe('deepseek-v4-pro')
+  it('does not cross-apply provider rules between official hosts', () => {
+    // MiMo id on DeepSeek host: not a DeepSeek V4+ id, left untouched
+    expect(with1mContextSuffix('mimo-v2.5-pro', deepSeekHost)).toBe('mimo-v2.5-pro')
+    // DeepSeek id on MiMo host: not a MiMo id, left untouched
+    expect(with1mContextSuffix('deepseek-v4-pro', mimoHost)).toBe('deepseek-v4-pro')
   })
 
-  it('leaves non-DeepSeek-V4+ models untouched', () => {
-    expect(withDeepSeek1mSuffix('deepseek-v3.2', officialHost)).toBe('deepseek-v3.2')
-    expect(withDeepSeek1mSuffix('deepseek-chat', officialHost)).toBe('deepseek-chat')
-    expect(withDeepSeek1mSuffix('claude-opus-4-7', officialHost)).toBe('claude-opus-4-7')
-    expect(withDeepSeek1mSuffix('gpt-4', officialHost)).toBe('gpt-4')
+  it('leaves non-1M models untouched on the DeepSeek host', () => {
+    expect(with1mContextSuffix('deepseek-v3.2', deepSeekHost)).toBe('deepseek-v3.2')
+    expect(with1mContextSuffix('deepseek-chat', deepSeekHost)).toBe('deepseek-chat')
+    expect(with1mContextSuffix('claude-opus-4-7', deepSeekHost)).toBe('claude-opus-4-7')
+    expect(with1mContextSuffix('gpt-4', deepSeekHost)).toBe('gpt-4')
   })
 
   it('returns empty string when modelId is missing', () => {
-    expect(withDeepSeek1mSuffix(undefined, officialHost)).toBe('')
-    expect(withDeepSeek1mSuffix('', officialHost)).toBe('')
+    expect(with1mContextSuffix(undefined, deepSeekHost)).toBe('')
+    expect(with1mContextSuffix('', deepSeekHost)).toBe('')
   })
 })

--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -61,7 +61,7 @@ import { sessionService } from '../SessionService'
 import { buildNamespacedToolCallId } from './claude-stream-state'
 import { promptForToolApproval } from './tool-permissions'
 import { ClaudeStreamState, transformSDKMessageToStreamParts } from './transform'
-import { withDeepSeek1mSuffix } from './utils'
+import { with1mContextSuffix } from './utils'
 
 const require_ = createRequire(import.meta.url)
 const logger = loggerService.withContext('ClaudeCodeService')
@@ -195,7 +195,7 @@ class ClaudeCodeService implements AgentServiceInterface {
       return withoutTrailingApiVersion(provider.anthropicApiHost?.trim() || provider.apiHost)
     }
     const anthropicBaseUrl = resolveAnthropicBaseUrl()
-    const sdkModelId = withDeepSeek1mSuffix(modelInfo.modelId, provider.anthropicApiHost)
+    const sdkModelId = with1mContextSuffix(modelInfo.modelId, provider.anthropicApiHost)
 
     const env = {
       ...loginShellEnv,

--- a/src/main/services/agents/services/claudecode/utils.ts
+++ b/src/main/services/agents/services/claudecode/utils.ts
@@ -110,15 +110,20 @@ export function convertClaudeCodeUsage(usage: ClaudeCodeUsage): LanguageModelUsa
   }
 }
 
-// DeepSeek V4+ "pro" models on api.deepseek.com support a 1M context window,
-// but Claude Code CLI only knows about it via the `[1m]` model-id suffix
-// (parsed locally to switch /context budgeting to 1e6 tokens, then stripped
-// before the API call). DeepSeek's official Claude Code integration docs
-// recommend appending it; gating on the official host keeps third-party
-// DeepSeek deployments (OpenRouter / Fireworks / etc.) from claiming a
-// capacity their backend may not actually serve.
+// Several providers expose a 1M context window, but the Claude Code CLI only
+// budgets for it when the model id carries the `[1m]` suffix (parsed locally
+// to switch /context budgeting to 1e6 tokens, then stripped before the API
+// call). We append it for the providers/models we know serve 1M, gated on the
+// official host so third-party redeployments (OpenRouter / Fireworks / etc.)
+// don't claim a capacity their backend may not actually serve.
+//
+// DeepSeek: V4+ Pro and Flash both ship a 1M window.
 // https://api-docs.deepseek.com/zh-cn/quick_start/agent_integrations/claude_code
-const DEEPSEEK_V4_PLUS_PRO_REGEX = /(\w+-)?deepseek-v([4-9]|\d{2,})([.-]\w+)*$/i
+const DEEPSEEK_V4_PLUS_REGEX = /(\w+-)?deepseek-v([4-9]|\d{2,})([.-]\w+)*$/i
+// MiMo: V2.5+ Pro/base support 1M; flash variants cap at 256K. MiMo's
+// official Claude Code docs document the same `[1m]` suffix convention.
+// https://platform.xiaomimimo.com/docs/zh-CN/integration/claudecode
+const MIMO_V25_PLUS_REGEX = /(\w+-)?mimo-v(2\.[5-9]|2\.\d{2,}|[3-9]|\d{2,})([.-]\w+)*$/i
 
 export function isDeepSeekOfficialHost(host: string | undefined): boolean {
   const trimmed = host?.trim()
@@ -130,11 +135,35 @@ export function isDeepSeekOfficialHost(host: string | undefined): boolean {
   }
 }
 
-export function withDeepSeek1mSuffix(modelId: string | undefined, anthropicHost: string | undefined): string {
+export function isMiMoOfficialHost(host: string | undefined): boolean {
+  const trimmed = host?.trim()
+  if (!trimmed) return false
+  try {
+    // Covers the standard endpoint (api.xiaomimimo.com) and Token Plan
+    // regional endpoints (token-plan-cn / token-plan-sg / ... .xiaomimimo.com).
+    // The leading-dot boundary keeps lookalikes (notxiaomimimo.com,
+    // xiaomimimo.com.evil.com) from matching.
+    const { hostname } = new URL(trimmed)
+    return hostname === 'xiaomimimo.com' || hostname.endsWith('.xiaomimimo.com')
+  } catch {
+    return false
+  }
+}
+
+export function with1mContextSuffix(modelId: string | undefined, anthropicHost: string | undefined): string {
   if (!modelId) return ''
-  if (!isDeepSeekOfficialHost(anthropicHost)) return modelId
   if (/\[1m\]$/i.test(modelId)) return modelId
-  if (/flash/i.test(modelId)) return modelId
-  if (!DEEPSEEK_V4_PLUS_PRO_REGEX.test(modelId)) return modelId
-  return `${modelId}[1m]`
+
+  if (isDeepSeekOfficialHost(anthropicHost)) {
+    if (!DEEPSEEK_V4_PLUS_REGEX.test(modelId)) return modelId
+    return `${modelId}[1m]`
+  }
+
+  if (isMiMoOfficialHost(anthropicHost)) {
+    if (/flash/i.test(modelId)) return modelId
+    if (!MIMO_V25_PLUS_REGEX.test(modelId)) return modelId
+    return `${modelId}[1m]`
+  }
+
+  return modelId
 }


### PR DESCRIPTION
### What this PR does

Before this PR:

- The Claude Code `[1m]` context-budgeting suffix was only applied to DeepSeek V4+ **Pro** models on `api.deepseek.com`; all `flash` variants were explicitly excluded.
- MiMo (Xiaomi) models on `api.xiaomimimo.com` never received the suffix, so Claude Code's `/context` budgeted for the wrong (smaller) window even though `mimo-v2.5-pro` serves 1M.

After this PR:

- DeepSeek V4+ **Flash** now also gets `[1m]` — DeepSeek V4 shipped Pro and Flash both with a 1M-token context window (the flash exclusion was outdated; the regex still gates to V4+, so `deepseek-v3` flash etc. stay untouched).
- MiMo V2.5+ Pro/base (`mimo-v2.5-pro`, `mimo-v2.5`, future v2.6+/v3+) now get `[1m]`. `mimo-*-flash` (256K) and pre-2.5 ids are left untouched.
- MiMo host detection covers both the standard endpoint and Token Plan regional endpoints (`token-plan-cn/sg/eu.xiaomimimo.com`), with a leading-dot boundary so lookalike domains are rejected.
- `withDeepSeek1mSuffix` generalized to `with1mContextSuffix` with per-provider dispatch; provider rules do not cross-apply between official hosts.

Fixes #

### Why we need it and why it was done in this way

DeepSeek V4 Flash and MiMo V2.5-Pro genuinely serve a 1M context window, but Claude Code only budgets `/context` for 1M when the model id carries the `[1m]` suffix (parsed CLI-side, stripped before the API call). Without it the agent under-uses the available context. Both DeepSeek's and MiMo's official Claude Code integration docs document the same `[1m]` suffix convention.

The following tradeoffs were made:

- The suffix is gated on the official host so third-party redeployments (OpenRouter / Fireworks / etc.) don't claim a capacity their backend may not serve.

The following alternatives were considered:

- Keeping DeepSeek-only logic and special-casing MiMo inline — rejected in favor of a single per-provider dispatch for clarity.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

The rename `withDeepSeek1mSuffix` -> `with1mContextSuffix` touches only its single call site in `claudecode/index.ts` and the test file; no external consumers. Sources: DeepSeek V4 Claude Code docs (api-docs.deepseek.com), Xiaomi MiMo Claude Code integration docs (platform.xiaomimimo.com/docs/zh-CN/integration/claudecode, which documents the `[1m]` suffix).

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Agents using DeepSeek V4 Flash (api.deepseek.com) or MiMo V2.5+ Pro/base (api.xiaomimimo.com, including Token Plan endpoints) now correctly budget for their full 1M-token context window in Claude Code.
```
