### PR TITLE
fix(mimo): surface thinking & honor token-plan host for Xiaomi MiMo

### DIFF
--- a/src/renderer/src/config/models/__tests__/reasoning.test.ts
+++ b/src/renderer/src/config/models/__tests__/reasoning.test.ts
@@ -2539,6 +2539,26 @@ describe('isInterleavedThinkingModel', () => {
       expect(isSupportedThinkingTokenMiMoModel(createModel({ id: 'mimo-v2.5-tts-voiceclone' }))).toBe(false)
     })
 
+    it('should match the whole MiMo chat family by prefix (current + future releases)', () => {
+      // Previously hardcoded allowlist
+      expect(isSupportedThinkingTokenMiMoModel(createModel({ id: 'mimo-v2-flash' }))).toBe(true)
+      expect(isSupportedThinkingTokenMiMoModel(createModel({ id: 'mimo-v2-pro' }))).toBe(true)
+      expect(isSupportedThinkingTokenMiMoModel(createModel({ id: 'mimo-v2-omni' }))).toBe(true)
+      // Future / custom-deployed ids that the exact allowlist used to drop
+      expect(isSupportedThinkingTokenMiMoModel(createModel({ id: 'mimo-v3' }))).toBe(true)
+      expect(isSupportedThinkingTokenMiMoModel(createModel({ id: 'mimo-v2.5-flash' }))).toBe(true)
+      expect(isSupportedThinkingTokenMiMoModel(createModel({ id: 'custom/mimo-v2.6-pro' }))).toBe(true)
+      expect(isSupportedThinkingTokenMiMoModel(createModel({ id: 'MiMo-V3-Pro' }))).toBe(true)
+    })
+
+    it('should exclude non-reasoning MiMo modalities', () => {
+      expect(isSupportedThinkingTokenMiMoModel(createModel({ id: 'mimo-v3-tts' }))).toBe(false)
+      expect(isSupportedThinkingTokenMiMoModel(createModel({ id: 'mimo-embedding' }))).toBe(false)
+      expect(isSupportedThinkingTokenMiMoModel(createModel({ id: 'mimo-rerank-v1' }))).toBe(false)
+      expect(isSupportedThinkingTokenMiMoModel(createModel({ id: 'gpt-4' }))).toBe(false)
+      expect(isSupportedThinkingTokenMiMoModel(createModel({ id: 'mimoo-chat' }))).toBe(false)
+    })
+
     it('should return true for mimo-v2-flash', () => {
       expect(isInterleavedThinkingModel(createModel({ id: 'mimo-v2-flash' }))).toBe(true)
     })

--- a/src/renderer/src/config/models/reasoning.ts
+++ b/src/renderer/src/config/models/reasoning.ts
@@ -673,7 +673,16 @@ export const isSupportedThinkingTokenZhipuModel = (model: Model): boolean => {
 
 export const isSupportedThinkingTokenMiMoModel = (model: Model): boolean => {
   const modelId = getLowerBaseModelName(model.id, '/')
-  return ['mimo-v2-flash', 'mimo-v2-pro', 'mimo-v2-omni', 'mimo-v2.5', 'mimo-v2.5-pro'].includes(modelId)
+  // Match the whole MiMo chat family by prefix instead of an exact-id allowlist.
+  // MiMo is served via an Anthropic-compatible endpoint where reasoning is gated
+  // behind isReasoningModel(); an exact list silently drops thinking for any new
+  // MiMo release or custom-deployed id and breaks multi-turn reasoning_content
+  // pass-back (sendReasoning), which MiMo requires for reasoning quality.
+  // Non-text modalities (TTS / voice clone / embedding / rerank) are not reasoning models.
+  if (!modelId.startsWith('mimo-')) {
+    return false
+  }
+  return !/(?:tts|voiceclone|embed|rerank)/.test(modelId)
 }
 
 /**

--- a/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
@@ -223,6 +223,15 @@ const ProviderSetting: FC<Props> = ({ providerId, isOnboarding = false }) => {
       if (isNewApiProvider(provider)) {
         updateProvider({ apiHost, anthropicApiHost: apiHost })
         setAnthropicHost(apiHost)
+      } else if (provider.id === SystemProviderIds.mimo) {
+        // MiMo's Anthropic-compatible endpoint is always `${apiHost}/anthropic`.
+        // The system default hardcodes it, so agent mode (which prefers
+        // anthropicApiHost) keeps hitting the stale pay-as-you-go host even
+        // after the user switches API Host to a token-plan host. Derive it
+        // from apiHost so a single host edit applies to both modes.
+        const anthropicHost = `${apiHost.trim().replace(/\/+$/, '')}/anthropic`
+        updateProvider({ apiHost, anthropicApiHost: anthropicHost })
+        setAnthropicHost(anthropicHost)
       } else {
         updateProvider({ apiHost })
       }


### PR DESCRIPTION
### What this PR does

Before this PR:

- **Assistant mode**: A custom Anthropic-type provider with a MiMo model never
  surfaced `thinking`. `isSupportedThinkingTokenMiMoModel()` was an exact-id
  allowlist (`mimo-v2-flash/pro/omni`, `mimo-v2.5/-pro`). Any new MiMo release or
  custom-deployed id failed `isReasoningModel()`, so `getAnthropicReasoningParams()`
  early-returned `{}` and never set `thinking: { type: 'enabled' }` nor
  `sendReasoning: true` — breaking both first-turn thinking display and the
  multi-turn `reasoning_content` pass-back MiMo requires for reasoning quality.
- **Agent mode**: The `mimo` system provider hardcodes `anthropicApiHost` as an
  independent constant. The Claude Agent SDK path prefers `anthropicApiHost`, so a
  token-plan user who switched the visible "API Host" kept hitting the stale
  pay-as-you-go endpoint (token-plan requires both a different host and key).

After this PR:

- MiMo reasoning models are matched by `^mimo-` prefix, excluding non-reasoning
  modalities (`tts` / `voiceclone` / `embed` / `rerank`). New/custom MiMo chat ids
  now get thinking + multi-turn `reasoning_content` pass-back automatically.
- Editing the MiMo provider's API Host now derives `anthropicApiHost` as
  `${apiHost}/anthropic` (mirroring the existing new-api sync), so a single host
  edit applies to both assistant and agent modes and the token-plan host is honored.

Fixes #

### Why we need it and why it was done in this way

Reported by the Xiaomi MiMo model team. Both bugs share one root cause: the app
re-derives protocol/capability from hardcoded model-name lists or system-default
host constants, overriding the user's explicit provider configuration.

The following tradeoffs were made:

- Kept the `reasoning_effort !== 'default'` gate unchanged — consistent with all
  other Anthropic-compatible reasoning models (Kimi/MiniMax); out of hotfix scope.
- Scoped the host derivation to `provider.id === 'mimo'` rather than a general
  abstraction, to stay within hotfix scope (no refactor under code freeze).

The following alternatives were considered:

- Extending `isAnthropicModel()` or tagging `endpoint_type` per model — still
  name/data-driven and fragile; rejected.
- Removing the hardcoded `mimo.anthropicApiHost` default — breaks out-of-box agent
  mode for non-customizing users (the `/anthropic` suffix would be lost); rejected.

Links to places where the discussion took place: Xiaomi MiMo team report (email)

### Breaking changes

None.

### Special notes for your reviewer

- The full test suite passes except one pre-existing flaky **performance timing**
  test in `packages/shared/__tests__/utils.test.ts` (`parseDataUrl` expected
  ~26ms < 10ms), unrelated to these changes.
- `ProviderSetting.tsx` mirrors the adjacent untested `isNewApiProvider` sync
  branch; no component test harness exists there, so coverage focuses on the
  substantive `reasoning.ts` logic (extended `reasoning.test.ts`, 400 pass).

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed Xiaomi MiMo models not showing reasoning/thinking content in assistant mode, and the token-plan API Host being ignored in agent mode.
```
