### PR TITLE
fix(dev): prevent TS composite emit from polluting source directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,18 @@ vitest.config.*.timestamp-*
 # TypeScript incremental build
 .tsbuildinfo
 
+# TypeScript build artifacts in source dirs (tsgo/tsc outputs .js/.d.ts next to .ts)
+# Prevents VS Code TS Language Server from polluting source directories
+src/**/*.js
+src/**/*.d.ts
+src/**/*.d.ts.map
+packages/**/*.js
+packages/**/*.d.ts
+packages/**/*.d.ts.map
+tests/**/*.js
+tests/**/*.d.ts
+tests/**/*.d.ts.map
+
 # playwright
 playwright-report
 test-results

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -81,6 +81,7 @@ export default defineConfig({
       ...visualizerPlugin('renderer')
     ],
     resolve: {
+      extensions: ['.tsx', '.ts', '.mts', '.mjs', '.js', '.jsx', '.json', '.wasm'],
       alias: {
         '@renderer': resolve('src/renderer/src'),
         '@shared': resolve('packages/shared'),

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -16,6 +16,8 @@
     "incremental": true,
     "moduleResolution": "bundler",
     "tsBuildInfoFile": ".tsbuildinfo/tsconfig.node.tsbuildinfo",
+    "outDir": ".tsbuildinfo/node",
+    "declarationDir": ".tsbuildinfo/node",
     "types": ["electron-vite/node", "vitest/globals"],
     "paths": {
       "@logger": ["./src/main/services/LoggerService"],

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -17,6 +17,8 @@
     "composite": true,
     "incremental": true,
     "tsBuildInfoFile": ".tsbuildinfo/tsconfig.web.tsbuildinfo",
+    "outDir": ".tsbuildinfo/web",
+    "declarationDir": ".tsbuildinfo/web",
     "jsx": "react-jsx",
     "moduleResolution": "bundler",
     "paths": {


### PR DESCRIPTION
## Summary

When `composite: true` + `incremental: true` is enabled in tsconfig without `outDir`, VS Code's TS Language Server emits `.js/.d.ts` files alongside `.tsx` source files. Vite's default `resolve.extensions` order (`.js` before `.tsx`) then loads stale compiled artifacts instead of modified sources, creating a "shadow codebase" that silently overrides runtime behavior.

This only manifests when changing **values** without changing **logic** (e.g. `false → true`), because VS Code re-compiles `.js` when logic changes but stale `.js` retains old values. Changes to logic appear to work correctly because the re-compiled `.js` contains the new logic, masking the underlying issue.

This is a latent bug that affects all downstream developers — any fork of Cherry Studio will encounter this in local development.

## Changes

1. **tsconfig.web.json / tsconfig.node.json**: Add `outDir` and `declarationDir` pointing to `.tsbuildinfo/web` and `.tsbuildinfo/node` respectively. This redirects VS Code TS Server emit output away from source directories (root cause fix).

2. **electron.vite.config.ts**: Set `resolve.extensions` with `.tsx/.ts` before `.js` for the renderer environment. Defense-in-depth — even if stray `.js` files somehow reappear, Vite will prefer source files over compiled artifacts.

3. **.gitignore**: Add exclusion rules for `src/**/*.js`, `src/**/*.d.ts`, `packages/**/*.js`, etc. Prevents stray artifacts from being tracked in git.

## Test plan

- [ ] Verify `pnpm dev` works correctly with the new tsconfig outDir
- [ ] Verify `pnpm build` succeeds
- [ ] Verify `pnpm typecheck` passes
- [ ] Confirm no `.js/.d.ts` files appear in `src/renderer/src/` after VS Code opens the project
- [ ] Confirm existing `.js` files in source dirs (e.g. `cherryai/index.js`) are unaffected by the resolve order change

🤖 Generated with [Claude Code](https://claude.com/claude-code)