### PR TITLE
feat(agents): add Claude OpenAI proxy for OpenAI-compatible providers

### DIFF
--- a/src/main/apiServer/app.ts
+++ b/src/main/apiServer/app.ts
@@ -9,6 +9,7 @@ import { errorHandler } from './middleware/error'
 import { setupOpenAPIDocumentation } from './middleware/openapi'
 import { agentRoutes } from './routes/agents'
 import { chatRoutes } from './routes/chat'
+import { claudeOpenAIProxyRoutes } from './routes/claude-openai-proxy'
 import { clawMcpRoutes } from './routes/claw-mcp'
 import { knowledgeRoutes } from './routes/knowledge'
 import { mcpRoutes } from './routes/mcp'
@@ -133,6 +134,8 @@ export function createApp(): express.Application {
         chat_completions: 'POST /v1/chat/completions',
         messages: 'POST /v1/messages',
         messages_provider: 'POST /:provider/v1/messages',
+        claude_openai_proxy_messages: 'POST /v1/agents/claude-proxy/:providerId/v1/messages',
+        claude_openai_proxy_count_tokens: 'POST /v1/agents/claude-proxy/:providerId/v1/messages/count_tokens',
         mcps: 'GET /v1/mcps',
         mcp_server: 'GET /v1/mcps/:server_id',
         knowledge_bases: 'GET /v1/knowledge-bases',
@@ -151,6 +154,7 @@ export function createApp(): express.Application {
   const apiRouter = express.Router()
   apiRouter.use(authMiddleware)
   // Mount routes
+  apiRouter.use('/agents/claude-proxy', extendMessagesTimeout, claudeOpenAIProxyRoutes)
   apiRouter.use('/agents', agentRoutes)
   apiRouter.use('/chat', chatRoutes)
   apiRouter.use('/mcps', mcpRoutes)

--- a/src/main/apiServer/generated/openapi-spec.json
+++ b/src/main/apiServer/generated/openapi-spec.json
@@ -537,6 +537,147 @@
         }
       }
     },
+    "/v1/agents/claude-proxy/{providerId}/v1/messages": {
+      "post": {
+        "summary": "Proxy Anthropic Messages requests to OpenAI-compatible providers",
+        "description": "Internal Cherry Claw compatibility endpoint used by Claude Agent SDK when the selected provider exposes only OpenAI Chat Completions format.",
+        "tags": ["Agents"],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "providerId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "OpenAI-compatible provider ID, such as a configured NewAPI provider."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["model", "max_tokens", "messages"],
+                "properties": {
+                  "model": {
+                    "type": "string",
+                    "example": "gpt-5.5"
+                  },
+                  "max_tokens": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "messages": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    }
+                  },
+                  "system": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array"
+                      }
+                    ]
+                  },
+                  "stream": {
+                    "type": "boolean"
+                  },
+                  "tools": {
+                    "type": "array"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Anthropic Messages response or server-sent Anthropic Messages events."
+          },
+          "400": {
+            "description": "Invalid request or unsupported provider."
+          },
+          "401": {
+            "description": "Unauthorized."
+          },
+          "500": {
+            "description": "Internal proxy error."
+          }
+        }
+      }
+    },
+    "/v1/agents/claude-proxy/{providerId}/v1/messages/count_tokens": {
+      "post": {
+        "summary": "Estimate Anthropic Messages token count for OpenAI-compatible providers",
+        "description": "Internal Cherry Claw compatibility endpoint that returns a conservative input token estimate for Claude Agent SDK context management.",
+        "tags": ["Agents"],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "providerId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["model", "messages"],
+                "properties": {
+                  "model": {
+                    "type": "string"
+                  },
+                  "messages": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    }
+                  },
+                  "system": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Estimated token count.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "input_tokens": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/knowledge-bases": {
       "get": {
         "summary": "List all knowledge bases",

--- a/src/main/apiServer/routes/claude-openai-proxy.ts
+++ b/src/main/apiServer/routes/claude-openai-proxy.ts
@@ -1,0 +1,168 @@
+import { loggerService } from '@logger'
+import type { Request, Response } from 'express'
+import express from 'express'
+
+import {
+  type AnthropicMessagesRequest,
+  ClaudeOpenAIProxyProviderError,
+  claudeOpenAIProxyService,
+  ClaudeOpenAIProxyValidationError
+} from '../services/claude-openai-proxy'
+
+const logger = loggerService.withContext('ClaudeOpenAIProxyRoutes')
+const router = express.Router({ mergeParams: true })
+
+const mapError = (error: unknown): { status: number; body: unknown } => {
+  if (error instanceof ClaudeOpenAIProxyValidationError) {
+    return {
+      status: 400,
+      body: { type: 'error', error: { type: 'invalid_request_error', message: error.message } }
+    }
+  }
+
+  if (error instanceof ClaudeOpenAIProxyProviderError) {
+    return {
+      status: 400,
+      body: { type: 'error', error: { type: 'invalid_request_error', message: error.message } }
+    }
+  }
+
+  if (error instanceof Error) {
+    return {
+      status: 500,
+      body: { type: 'error', error: { type: 'api_error', message: error.message } }
+    }
+  }
+
+  return {
+    status: 500,
+    body: { type: 'error', error: { type: 'api_error', message: 'Internal server error' } }
+  }
+}
+
+/**
+ * @swagger
+ * /v1/agents/claude-proxy/{providerId}/v1/messages:
+ *   post:
+ *     summary: Proxy Anthropic Messages requests to OpenAI-compatible providers
+ *     description: Internal Cherry Claw compatibility endpoint used by Claude Agent SDK when the selected provider exposes only OpenAI Chat Completions format.
+ *     tags: [Agents]
+ *     parameters:
+ *       - in: path
+ *         name: providerId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: OpenAI-compatible provider ID, such as a configured NewAPI provider.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [model, max_tokens, messages]
+ *             properties:
+ *               model:
+ *                 type: string
+ *                 example: gpt-5.5
+ *               max_tokens:
+ *                 type: integer
+ *                 minimum: 1
+ *               messages:
+ *                 type: array
+ *                 items:
+ *                   type: object
+ *               system:
+ *                 oneOf:
+ *                   - type: string
+ *                   - type: array
+ *               stream:
+ *                 type: boolean
+ *               tools:
+ *                 type: array
+ *     responses:
+ *       200:
+ *         description: Anthropic Messages response or server-sent Anthropic Messages events.
+ *       400:
+ *         description: Invalid request or unsupported provider.
+ *       401:
+ *         description: Unauthorized.
+ *       500:
+ *         description: Internal proxy error.
+ */
+router.post('/:providerId/v1/messages', async (req: Request, res: Response) => {
+  const providerId = req.params.providerId
+  const request = req.body as AnthropicMessagesRequest
+
+  try {
+    if (request.stream) {
+      await claudeOpenAIProxyService.streamMessage(providerId, request, res)
+      return
+    }
+
+    const response = await claudeOpenAIProxyService.createMessage(providerId, request)
+    return res.json(response)
+  } catch (error) {
+    logger.error('Claude OpenAI proxy message failed', { error, providerId, model: request?.model })
+    const { status, body } = mapError(error)
+    return res.status(status).json(body)
+  }
+})
+
+/**
+ * @swagger
+ * /v1/agents/claude-proxy/{providerId}/v1/messages/count_tokens:
+ *   post:
+ *     summary: Estimate Anthropic Messages token count for OpenAI-compatible providers
+ *     description: Internal Cherry Claw compatibility endpoint that returns a conservative input token estimate for Claude Agent SDK context management.
+ *     tags: [Agents]
+ *     parameters:
+ *       - in: path
+ *         name: providerId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [model, messages]
+ *             properties:
+ *               model:
+ *                 type: string
+ *               messages:
+ *                 type: array
+ *                 items:
+ *                   type: object
+ *               system:
+ *                 oneOf:
+ *                   - type: string
+ *                   - type: array
+ *     responses:
+ *       200:
+ *         description: Estimated token count.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 input_tokens:
+ *                   type: integer
+ */
+router.post('/:providerId/v1/messages/count_tokens', async (req: Request, res: Response) => {
+  try {
+    const response = await claudeOpenAIProxyService.countTokens(
+      req.params.providerId,
+      req.body as AnthropicMessagesRequest
+    )
+    return res.json(response)
+  } catch (error) {
+    logger.error('Claude OpenAI proxy token count failed', { error, providerId: req.params.providerId })
+    const { status, body } = mapError(error)
+    return res.status(status).json(body)
+  }
+})
+
+export { router as claudeOpenAIProxyRoutes }

--- a/src/main/apiServer/services/__tests__/claude-openai-proxy.test.ts
+++ b/src/main/apiServer/services/__tests__/claude-openai-proxy.test.ts
@@ -1,0 +1,166 @@
+import type { Provider } from '@types'
+import type { Response } from 'express'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { createMock, getProviderByIdMock } = vi.hoisted(() => ({
+  createMock: vi.fn(),
+  getProviderByIdMock: vi.fn()
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), silly: vi.fn() })
+  }
+}))
+
+vi.mock('@cherrystudio/openai', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    chat: {
+      completions: {
+        create: createMock
+      }
+    }
+  }))
+}))
+
+vi.mock('../../utils', () => ({
+  getProviderById: getProviderByIdMock
+}))
+
+import { type AnthropicMessagesRequest, claudeOpenAIProxyService } from '../claude-openai-proxy'
+
+const provider: Provider = {
+  id: 'newapi',
+  name: 'NewAPI',
+  type: 'new-api',
+  apiHost: 'https://newapi.example/v1',
+  apiKey: 'key-1',
+  enabled: true,
+  models: []
+}
+
+describe('ClaudeOpenAIProxyService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getProviderByIdMock.mockResolvedValue(provider)
+  })
+
+  it('converts Anthropic messages requests to OpenAI-compatible chat requests', async () => {
+    createMock.mockResolvedValueOnce({
+      id: 'chatcmpl-1',
+      model: 'gpt-5.5',
+      choices: [{ message: { role: 'assistant', content: 'hello' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 12, completion_tokens: 3 }
+    })
+
+    const request: AnthropicMessagesRequest = {
+      model: 'gpt-5.5',
+      max_tokens: 100,
+      system: 'You are helpful.',
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+      tools: [
+        {
+          name: 'read_file',
+          description: 'Read a file',
+          input_schema: { type: 'object', properties: { path: { type: 'string' } } }
+        }
+      ]
+    }
+
+    const response = await claudeOpenAIProxyService.createMessage('newapi', request)
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'gpt-5.5',
+        stream: false,
+        max_tokens: 100,
+        messages: [
+          { role: 'system', content: 'You are helpful.' },
+          { role: 'user', content: 'Hi' }
+        ],
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'read_file',
+              description: 'Read a file',
+              parameters: { type: 'object', properties: { path: { type: 'string' } } }
+            }
+          }
+        ]
+      })
+    )
+    expect(response).toMatchObject({
+      type: 'message',
+      role: 'assistant',
+      model: 'gpt-5.5',
+      content: [{ type: 'text', text: 'hello' }],
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 12, output_tokens: 3 }
+    })
+  })
+
+  it('streams OpenAI text chunks as Anthropic Messages events', async () => {
+    async function* stream() {
+      yield { choices: [{ delta: { role: 'assistant' }, finish_reason: null }] }
+      yield { choices: [{ delta: { content: 'hel' }, finish_reason: null }] }
+      yield {
+        choices: [{ delta: { content: 'lo' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 8, completion_tokens: 2 }
+      }
+    }
+
+    createMock.mockResolvedValueOnce(stream())
+    const writes: string[] = []
+    type StreamResponse = Pick<Response, 'writableEnded' | 'destroyed' | 'setHeader' | 'flushHeaders' | 'write' | 'end'>
+    const res = {
+      writableEnded: false,
+      destroyed: false,
+      setHeader: vi.fn(),
+      flushHeaders: vi.fn(),
+      write: vi.fn((chunk: string) => {
+        writes.push(chunk)
+        return true
+      }),
+      end: vi.fn()
+    } satisfies StreamResponse
+
+    await claudeOpenAIProxyService.streamMessage(
+      'newapi',
+      { model: 'gpt-5.5', max_tokens: 100, stream: true, messages: [{ role: 'user', content: 'Hi' }] },
+      res as unknown as Response
+    )
+
+    const output = writes.join('')
+    expect(output).toContain('event: message_start')
+    expect(output).toContain('event: content_block_start')
+    expect(output).toContain('"text":"hel"')
+    expect(output).toContain('"text":"lo"')
+    expect(output).toContain('event: message_delta')
+    expect(output).toContain('event: message_stop')
+    expect(output).toContain('data: [DONE]')
+    expect(res.end).toHaveBeenCalled()
+  })
+
+  it('rejects providers that are not OpenAI-compatible', async () => {
+    getProviderByIdMock.mockResolvedValueOnce({ ...provider, type: 'anthropic' })
+
+    await expect(
+      claudeOpenAIProxyService.createMessage('anthropic', {
+        model: 'claude-3',
+        max_tokens: 100,
+        messages: [{ role: 'user', content: 'Hi' }]
+      })
+    ).rejects.toThrow("Provider 'newapi' of type 'anthropic' is not OpenAI-compatible")
+  })
+
+  it('validates provider before estimating token count', async () => {
+    const response = await claudeOpenAIProxyService.countTokens('newapi', {
+      model: 'gpt-5.5',
+      messages: [{ role: 'user', content: 'Hello world' }]
+    })
+
+    expect(getProviderByIdMock).toHaveBeenCalledWith('newapi')
+    expect(response.input_tokens).toBeGreaterThan(0)
+  })
+})

--- a/src/main/apiServer/services/claude-openai-proxy.ts
+++ b/src/main/apiServer/services/claude-openai-proxy.ts
@@ -1,0 +1,492 @@
+import OpenAI from '@cherrystudio/openai'
+import type { ChatCompletionCreateParams, ChatCompletionCreateParamsStreaming } from '@cherrystudio/openai/resources'
+import { loggerService } from '@logger'
+import type { Provider } from '@types'
+import type { Response } from 'express'
+
+import { getProviderById } from '../utils'
+
+const logger = loggerService.withContext('ClaudeOpenAIProxyService')
+
+type AnthropicContentBlock =
+  | { type: 'text'; text?: string }
+  | { type: 'tool_use'; id?: string; name?: string; input?: unknown }
+  | { type: 'tool_result'; tool_use_id?: string; content?: unknown }
+  | { type: string; [key: string]: unknown }
+
+type AnthropicTextBlock = Extract<AnthropicContentBlock, { type: 'text' }>
+type AnthropicToolUseBlock = Extract<AnthropicContentBlock, { type: 'tool_use' }>
+type AnthropicToolResultBlock = Extract<AnthropicContentBlock, { type: 'tool_result' }>
+
+type AnthropicMessage = {
+  role: 'user' | 'assistant'
+  content: string | AnthropicContentBlock[]
+}
+
+type AnthropicTool = {
+  name: string
+  description?: string
+  input_schema?: Record<string, unknown>
+}
+
+export type AnthropicMessagesRequest = {
+  model: string
+  max_tokens?: number
+  messages: AnthropicMessage[]
+  system?: string | AnthropicContentBlock[]
+  stream?: boolean
+  temperature?: number
+  top_p?: number
+  stop_sequences?: string[]
+  tools?: AnthropicTool[]
+  tool_choice?: { type: string; name?: string }
+}
+
+type OpenAIMessage = NonNullable<ChatCompletionCreateParams['messages']>[number]
+type OpenAITool = NonNullable<ChatCompletionCreateParams['tools']>[number]
+type OpenAIChunk = OpenAI.Chat.Completions.ChatCompletionChunk
+type OpenAICompletion = OpenAI.Chat.Completions.ChatCompletion
+
+const OPENAI_COMPATIBLE_PROVIDER_TYPES = new Set(['openai', 'openai-response', 'new-api'])
+
+const isTextBlock = (block: AnthropicContentBlock): block is AnthropicTextBlock => block.type === 'text'
+
+const isToolUseBlock = (block: AnthropicContentBlock): block is AnthropicToolUseBlock => block.type === 'tool_use'
+
+const isToolResultBlock = (block: AnthropicContentBlock): block is AnthropicToolResultBlock =>
+  block.type === 'tool_result'
+
+const toText = (value: unknown): string => {
+  if (typeof value === 'string') return value
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => {
+        if (typeof item === 'string') return item
+        if (item && typeof item === 'object' && 'text' in item) return String((item as { text?: unknown }).text ?? '')
+        return JSON.stringify(item)
+      })
+      .filter(Boolean)
+      .join('\n')
+  }
+  if (value === undefined || value === null) return ''
+  return JSON.stringify(value)
+}
+
+const createId = (prefix: string): string =>
+  `${prefix}_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`
+
+const mapStopReason = (finishReason: string | null | undefined): string => {
+  switch (finishReason) {
+    case 'length':
+      return 'max_tokens'
+    case 'tool_calls':
+    case 'function_call':
+      return 'tool_use'
+    case 'stop':
+    default:
+      return 'end_turn'
+  }
+}
+
+export class ClaudeOpenAIProxyValidationError extends Error {
+  constructor(public readonly errors: string[]) {
+    super(errors.join('; '))
+    this.name = 'ClaudeOpenAIProxyValidationError'
+  }
+}
+
+export class ClaudeOpenAIProxyProviderError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ClaudeOpenAIProxyProviderError'
+  }
+}
+
+export class ClaudeOpenAIProxyService {
+  validateRequest(request: AnthropicMessagesRequest, options: { requireMaxTokens?: boolean } = {}): void {
+    const requireMaxTokens = options.requireMaxTokens ?? true
+    const errors: string[] = []
+
+    if (!request || typeof request !== 'object') errors.push('Request body is required')
+    if (!request.model || typeof request.model !== 'string') errors.push('model is required')
+    if (!Array.isArray(request.messages) || request.messages.length === 0) {
+      errors.push('messages is required and must be a non-empty array')
+    }
+    if (
+      requireMaxTokens &&
+      (typeof request.max_tokens !== 'number' || !Number.isFinite(request.max_tokens) || request.max_tokens < 1)
+    ) {
+      errors.push('max_tokens is required and must be a positive number')
+    }
+
+    if (errors.length > 0) throw new ClaudeOpenAIProxyValidationError(errors)
+  }
+
+  async resolveProvider(providerId: string): Promise<Provider> {
+    const provider = await getProviderById(providerId)
+    if (!provider) {
+      throw new ClaudeOpenAIProxyProviderError(`Provider '${providerId}' not found or not enabled`)
+    }
+    if (!OPENAI_COMPATIBLE_PROVIDER_TYPES.has(provider.type)) {
+      throw new ClaudeOpenAIProxyProviderError(
+        `Provider '${provider.id}' of type '${provider.type}' is not OpenAI-compatible for Claude proxy requests`
+      )
+    }
+    if (!provider.apiHost) {
+      throw new ClaudeOpenAIProxyProviderError(`Provider '${provider.id}' is missing apiHost`)
+    }
+    return provider
+  }
+
+  createClient(provider: Provider): OpenAI {
+    const apiKey = provider.apiKey ? provider.apiKey.split(',')[0].trim() : provider.id
+    return new OpenAI({ baseURL: provider.apiHost, apiKey })
+  }
+
+  toOpenAIRequest(request: AnthropicMessagesRequest, stream: boolean): ChatCompletionCreateParams {
+    const messages: OpenAIMessage[] = []
+
+    const system = this.systemToText(request.system)
+    if (system) {
+      messages.push({ role: 'system', content: system } as OpenAIMessage)
+    }
+
+    for (const message of request.messages) {
+      messages.push(...this.toOpenAIMessages(message))
+    }
+
+    const openAIRequest: ChatCompletionCreateParams = {
+      model: request.model,
+      messages,
+      stream,
+      temperature: request.temperature,
+      top_p: request.top_p,
+      max_tokens: request.max_tokens,
+      stop: request.stop_sequences,
+      tools: request.tools?.map(this.toOpenAITool),
+      tool_choice: this.toOpenAIToolChoice(request.tool_choice)
+    }
+
+    return Object.fromEntries(
+      Object.entries(openAIRequest).filter(([, value]) => value !== undefined)
+    ) as ChatCompletionCreateParams
+  }
+
+  async createMessage(providerId: string, request: AnthropicMessagesRequest): Promise<unknown> {
+    this.validateRequest(request)
+    const provider = await this.resolveProvider(providerId)
+    const client = this.createClient(provider)
+    const openAIRequest = this.toOpenAIRequest(request, false)
+    const response = (await client.chat.completions.create(openAIRequest)) as OpenAICompletion
+    return this.toAnthropicMessage(response, request.model)
+  }
+
+  async streamMessage(providerId: string, request: AnthropicMessagesRequest, response: Response): Promise<void> {
+    this.validateRequest(request)
+    const provider = await this.resolveProvider(providerId)
+    const client = this.createClient(provider)
+    const openAIRequest = this.toOpenAIRequest(request, true) as ChatCompletionCreateParamsStreaming
+
+    response.setHeader('Content-Type', 'text/event-stream; charset=utf-8')
+    response.setHeader('Cache-Control', 'no-cache, no-transform')
+    response.setHeader('Connection', 'keep-alive')
+    response.setHeader('X-Accel-Buffering', 'no')
+    response.flushHeaders()
+
+    const stream = (await client.chat.completions.create(openAIRequest)) as AsyncIterable<OpenAIChunk>
+    const messageId = createId('msg_proxy')
+    const state = new AnthropicStreamState(response, messageId, request.model)
+
+    try {
+      state.writeMessageStart()
+
+      for await (const chunk of stream) {
+        state.consume(chunk)
+      }
+
+      state.finish()
+    } catch (error) {
+      logger.error('Claude OpenAI proxy stream failed', { error, providerId, model: request.model })
+      state.writeError(error)
+    } finally {
+      if (!response.writableEnded) response.end()
+    }
+  }
+
+  async countTokens(providerId: string, request: AnthropicMessagesRequest): Promise<{ input_tokens: number }> {
+    this.validateRequest(request, { requireMaxTokens: false })
+    await this.resolveProvider(providerId)
+    const text = [this.systemToText(request.system), ...request.messages.map((message) => toText(message.content))]
+      .filter(Boolean)
+      .join('\n')
+    return { input_tokens: Math.max(1, Math.ceil(text.length / 4)) }
+  }
+
+  private systemToText(system: AnthropicMessagesRequest['system']): string {
+    if (!system) return ''
+    if (typeof system === 'string') return system
+    return system
+      .filter(isTextBlock)
+      .map((block) => toText(block.text))
+      .filter(Boolean)
+      .join('\n')
+  }
+
+  private toOpenAIMessages(message: AnthropicMessage): OpenAIMessage[] {
+    if (typeof message.content === 'string') {
+      return [{ role: message.role, content: message.content } as OpenAIMessage]
+    }
+
+    const result: OpenAIMessage[] = []
+    const textParts: string[] = []
+    const toolCalls: Array<{ id: string; type: 'function'; function: { name: string; arguments: string } }> = []
+
+    for (const block of message.content) {
+      if (isTextBlock(block)) {
+        const text = toText(block.text)
+        if (text) textParts.push(text)
+      } else if (isToolUseBlock(block)) {
+        toolCalls.push({
+          id: block.id || createId('call_proxy'),
+          type: 'function',
+          function: {
+            name: block.name || 'unknown_tool',
+            arguments: JSON.stringify(block.input ?? {})
+          }
+        })
+      } else if (isToolResultBlock(block)) {
+        result.push({
+          role: 'tool',
+          tool_call_id: block.tool_use_id || createId('call_proxy'),
+          content: toText(block.content)
+        } as OpenAIMessage)
+      }
+    }
+
+    if (message.role === 'assistant' && toolCalls.length > 0) {
+      result.unshift({
+        role: 'assistant',
+        content: textParts.join('\n') || null,
+        tool_calls: toolCalls
+      } as OpenAIMessage)
+    } else if (textParts.length > 0) {
+      result.unshift({ role: message.role, content: textParts.join('\n') } as OpenAIMessage)
+    }
+
+    return result
+  }
+
+  private toOpenAITool(tool: AnthropicTool): OpenAITool {
+    return {
+      type: 'function',
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.input_schema || { type: 'object', properties: {} }
+      }
+    } as OpenAITool
+  }
+
+  private toOpenAIToolChoice(
+    toolChoice: AnthropicMessagesRequest['tool_choice']
+  ): ChatCompletionCreateParams['tool_choice'] {
+    if (!toolChoice) return undefined
+    if (toolChoice.type === 'auto') return 'auto'
+    if (toolChoice.type === 'any') return 'required'
+    if (toolChoice.type === 'tool' && toolChoice.name) {
+      return { type: 'function', function: { name: toolChoice.name } }
+    }
+    return undefined
+  }
+
+  private toAnthropicMessage(response: OpenAICompletion, fallbackModel: string): unknown {
+    const choice = response.choices?.[0]
+    const message = choice?.message
+    const content: unknown[] = []
+    const text = typeof message?.content === 'string' ? message.content : ''
+
+    if (text) content.push({ type: 'text', text })
+    for (const toolCall of message?.tool_calls ?? []) {
+      if (!('function' in toolCall)) continue
+      content.push({
+        type: 'tool_use',
+        id: toolCall.id,
+        name: toolCall.function.name,
+        input: this.safeJsonParse(toolCall.function.arguments)
+      })
+    }
+
+    return {
+      id: createId('msg_proxy'),
+      type: 'message',
+      role: 'assistant',
+      model: response.model || fallbackModel,
+      content,
+      stop_reason: mapStopReason(choice?.finish_reason),
+      stop_sequence: null,
+      usage: {
+        input_tokens: response.usage?.prompt_tokens ?? 0,
+        output_tokens: response.usage?.completion_tokens ?? 0
+      }
+    }
+  }
+
+  private safeJsonParse(value: string): unknown {
+    try {
+      return value ? JSON.parse(value) : {}
+    } catch {
+      return {}
+    }
+  }
+}
+
+class AnthropicStreamState {
+  private textBlockStarted = false
+  private textBlockStopped = false
+  private textBlockIndex: number | undefined
+  private nextBlockIndex = 0
+  private stopReason = 'end_turn'
+  private usage = { input_tokens: 0, output_tokens: 0 }
+  private readonly toolBlocks = new Map<number, { blockIndex: number; id: string; name: string; stopped: boolean }>()
+
+  constructor(
+    private readonly response: Response,
+    private readonly messageId: string,
+    private readonly model: string
+  ) {}
+
+  writeMessageStart(): void {
+    this.write('message_start', {
+      type: 'message_start',
+      message: {
+        id: this.messageId,
+        type: 'message',
+        role: 'assistant',
+        model: this.model,
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: this.usage
+      }
+    })
+  }
+
+  consume(chunk: OpenAIChunk): void {
+    const usage = chunk.usage
+    if (usage) {
+      this.usage = {
+        input_tokens: usage.prompt_tokens ?? this.usage.input_tokens,
+        output_tokens: usage.completion_tokens ?? this.usage.output_tokens
+      }
+    }
+
+    const choice = chunk.choices?.[0]
+    if (!choice) return
+
+    const delta = choice.delta
+    if (delta?.content) this.writeTextDelta(delta.content)
+
+    for (const toolCall of delta?.tool_calls ?? []) {
+      this.writeToolDelta(toolCall)
+    }
+
+    if (choice.finish_reason) {
+      this.stopReason = mapStopReason(choice.finish_reason)
+    }
+  }
+
+  finish(): void {
+    this.stopOpenBlocks()
+    this.write('message_delta', {
+      type: 'message_delta',
+      delta: { stop_reason: this.stopReason, stop_sequence: null },
+      usage: { output_tokens: this.usage.output_tokens }
+    })
+    this.write('message_stop', { type: 'message_stop' })
+    this.write(undefined, '[DONE]')
+  }
+
+  writeError(error: unknown): void {
+    this.write('error', {
+      type: 'error',
+      error: {
+        type: 'api_error',
+        message: error instanceof Error ? error.message : 'Claude OpenAI proxy stream failed'
+      }
+    })
+  }
+
+  private writeTextDelta(text: string): void {
+    if (!this.textBlockStarted) {
+      this.textBlockStarted = true
+      const index = this.nextBlockIndex++
+      this.textBlockIndex = index
+      this.write('content_block_start', {
+        type: 'content_block_start',
+        index,
+        content_block: { type: 'text', text: '' }
+      })
+    }
+
+    this.write('content_block_delta', {
+      type: 'content_block_delta',
+      index: this.textBlockIndex ?? 0,
+      delta: { type: 'text_delta', text }
+    })
+  }
+
+  private writeToolDelta(
+    toolCall: NonNullable<NonNullable<OpenAIChunk['choices'][number]['delta']['tool_calls']>[number]>
+  ): void {
+    const openAIIndex = toolCall.index ?? 0
+    let block = this.toolBlocks.get(openAIIndex)
+
+    if (!block) {
+      block = {
+        blockIndex: this.nextBlockIndex++,
+        id: toolCall.id || createId('call_proxy'),
+        name: toolCall.function?.name || 'unknown_tool',
+        stopped: false
+      }
+      this.toolBlocks.set(openAIIndex, block)
+      this.write('content_block_start', {
+        type: 'content_block_start',
+        index: block.blockIndex,
+        content_block: { type: 'tool_use', id: block.id, name: block.name, input: {} }
+      })
+    }
+
+    const partialJson = toolCall.function?.arguments
+    if (partialJson) {
+      this.write('content_block_delta', {
+        type: 'content_block_delta',
+        index: block.blockIndex,
+        delta: { type: 'input_json_delta', partial_json: partialJson }
+      })
+    }
+  }
+
+  private stopOpenBlocks(): void {
+    if (this.textBlockStarted && !this.textBlockStopped) {
+      this.write('content_block_stop', { type: 'content_block_stop', index: this.textBlockIndex ?? 0 })
+      this.textBlockStopped = true
+    }
+
+    for (const block of this.toolBlocks.values()) {
+      if (!block.stopped) {
+        this.write('content_block_stop', { type: 'content_block_stop', index: block.blockIndex })
+        block.stopped = true
+      }
+    }
+  }
+
+  private write(eventType: string | undefined, payload: unknown): void {
+    if (this.response.writableEnded || this.response.destroyed) return
+    if (eventType) this.response.write(`event: ${eventType}\n`)
+    this.response.write(`data: ${typeof payload === 'string' ? payload : JSON.stringify(payload)}\n\n`)
+    const flushable = this.response as Response & { flush?: () => void }
+    flushable.flush?.()
+  }
+}
+
+export const claudeOpenAIProxyService = new ClaudeOpenAIProxyService()

--- a/src/main/apiServer/utils/index.ts
+++ b/src/main/apiServer/utils/index.ts
@@ -32,7 +32,7 @@ export async function getAvailableProviders(): Promise<Provider[]> {
     }
 
     // Support OpenAI-compatible and Anthropic-compatible providers for API server
-    const supportedTypes: ProviderType[] = ['openai', 'anthropic', 'ollama', 'new-api']
+    const supportedTypes: ProviderType[] = ['openai', 'openai-response', 'anthropic', 'ollama', 'new-api']
     const supportedProviders = providers.filter((p: Provider) => p.enabled && supportedTypes.includes(p.type))
 
     // Format provider apiHost according to their type

--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -75,6 +75,17 @@ const IMAGE_MAX_DIMENSION = 2000
 const IMAGE_MAX_BYTES = 5 * 1024 * 1024 // 5MB API limit
 const shouldAutoApproveTools = process.env.CHERRY_AUTO_ALLOW_TOOLS === '1'
 const NO_RESUME_COMMANDS = ['/clear']
+const OPENAI_COMPATIBLE_PROVIDER_TYPES = new Set(['openai', 'openai-response', 'new-api'])
+
+const buildLocalApiServerBaseUrl = (host: unknown, port: unknown): string => {
+  const rawHost = String(host || '127.0.0.1').trim()
+  const protocolHost = rawHost.startsWith('http://') || rawHost.startsWith('https://') ? rawHost : `http://${rawHost}`
+  const url = new URL(protocolHost)
+  if (!url.port) {
+    url.port = String(port || 23333)
+  }
+  return url.toString().replace(/\/$/, '')
+}
 
 const getLanguageInstruction = () => {
   const lang = getAppLanguage()
@@ -161,15 +172,18 @@ class ClaudeCodeService implements AgentServiceInterface {
     const isAzureOpenAI = provider.type === 'azure-openai'
     const isAnthropicType = provider.type === 'anthropic'
     const hasAnthropicHost = provider.anthropicApiHost?.trim()
+    const isOpenAICompatibleType = OPENAI_COMPATIBLE_PROVIDER_TYPES.has(provider.type)
 
-    if (!isAnthropicType && !isAzureOpenAI && !hasAnthropicHost) {
+    if (!isAnthropicType && !isAzureOpenAI && !hasAnthropicHost && !isOpenAICompatibleType) {
       logger.error('Anthropic provider configuration is missing', {
         modelInfo
       })
 
       aiStream.emit('data', {
         type: 'error',
-        error: new Error(`Invalid provider type '${provider.type}'. Expected 'anthropic' provider type.`)
+        error: new Error(
+          `Invalid provider type '${provider.type}'. Expected Anthropic-compatible or OpenAI-compatible provider type.`
+        )
       })
       return aiStream
     }
@@ -191,6 +205,12 @@ class ClaudeCodeService implements AgentServiceInterface {
     // by stripping any trailing API version (e.g. `/v1`).
     // For Azure OpenAI providers, the Anthropic endpoint lives under /anthropic.
     const resolveAnthropicBaseUrl = (): string => {
+      if (isOpenAICompatibleType && !hasAnthropicHost) {
+        const preferenceService = application.get('PreferenceService')
+        const host = preferenceService.get('feature.csaas.host') || '127.0.0.1'
+        const port = preferenceService.get('feature.csaas.port') || 23333
+        return `${buildLocalApiServerBaseUrl(host, port)}/v1/agents/claude-proxy/${provider.id}`
+      }
       if (isAzureOpenAI) {
         const host = withoutTrailingApiVersion(provider.apiHost).replace(/\/openai$/, '')
         return `${host}/anthropic`
@@ -199,6 +219,10 @@ class ClaudeCodeService implements AgentServiceInterface {
     }
     const anthropicBaseUrl = resolveAnthropicBaseUrl()
     const sdkModelId = withDeepSeek1mSuffix(modelInfo.modelId, provider.anthropicApiHost)
+    const apiKey =
+      isOpenAICompatibleType && !hasAnthropicHost
+        ? await application.get('ApiServerService').ensureValidApiKey()
+        : provider.apiKey
 
     const env = {
       ...loginShellEnv,
@@ -209,8 +233,8 @@ class ClaudeCodeService implements AgentServiceInterface {
       // ANTHROPIC_API_KEY: apiConfig['feature.csaas.api_key'],
       // ANTHROPIC_AUTH_TOKEN: apiConfig['feature.csaas.api_key'],
       // ANTHROPIC_BASE_URL: `http://${apiConfig['feature.csaas.host']}:${apiConfig['feature.csaas.port']}/${modelInfo.provider.id}`,
-      ANTHROPIC_API_KEY: provider.apiKey,
-      ANTHROPIC_AUTH_TOKEN: provider.apiKey,
+      ANTHROPIC_API_KEY: apiKey,
+      ANTHROPIC_AUTH_TOKEN: apiKey,
       ANTHROPIC_BASE_URL: anthropicBaseUrl,
       ANTHROPIC_MODEL: sdkModelId,
       ANTHROPIC_DEFAULT_OPUS_MODEL: sdkModelId,
@@ -1033,10 +1057,10 @@ class ClaudeCodeService implements AgentServiceInterface {
       hasCompleted = true
 
       const duration = Date.now() - startTime
-      const errorObj = error as any
+      const errorObj = error as Error | { name?: unknown; message?: unknown }
       const isAborted =
         errorObj?.name === 'AbortError' ||
-        errorObj?.message?.includes('aborted') ||
+        (typeof errorObj?.message === 'string' && errorObj.message.includes('aborted')) ||
         options.abortController?.signal.aborted
 
       if (isAborted) {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR:

Claude Code agents could only call Anthropic-compatible provider endpoints directly. OpenAI-compatible providers configured in Cherry Studio could not be used by Claude Agent SDK because the SDK sends Anthropic Messages requests.

After this PR:

Claude Code agents can use OpenAI-compatible providers through an internal API Server proxy. The proxy converts Anthropic Messages requests to OpenAI Chat Completions requests, forwards them to the selected provider, and converts both streaming and non-streaming responses back to Anthropic Messages format.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #15176

### Why we need it and why it was done in this way

The following tradeoffs were made:

This keeps the compatibility layer inside the local API Server instead of changing Claude Agent SDK behavior or requiring users to run an external gateway. The proxy is scoped to OpenAI-compatible provider types and reuses the existing API Server authentication path.

The following alternatives were considered:

Users could configure a separate Anthropic-compatible gateway for each OpenAI-compatible provider, but that duplicates setup outside Cherry Studio and makes the agent provider experience inconsistent.

Links to places where the discussion took place: #15176

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Validation performed locally:

- `pnpm format`
- `pnpm test` (656 files passed, 9356 tests passed, 76 skipped)
- `pnpm lint` (completed successfully; repository has existing warnings unrelated to this PR)

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Claude Code agents can now use OpenAI-compatible providers through Cherry Studio's internal compatibility proxy.
```
