### PR TITLE
fix: increase scrollbar width for better usability on Windows

### DIFF
--- a/src/renderer/src/assets/styles/scrollbar.css
+++ b/src/renderer/src/assets/styles/scrollbar.css
@@ -7,8 +7,8 @@
   --color-scrollbar-thumb: var(--color-scrollbar-thumb-dark);
   --color-scrollbar-thumb-hover: var(--color-scrollbar-thumb-dark-hover);
 
-  --scrollbar-width: 6px;
-  --scrollbar-height: 6px;
+  --scrollbar-width: 10px;
+  --scrollbar-height: 10px;
   --scrollbar-thumb-radius: 10px;
 }
 


### PR DESCRIPTION
## Summary

This PR increases the scrollbar width from 6px to 10px to improve usability on Windows, where the narrow scrollbar is difficult to click and drag.

## Changes

- Increased  from 6px to 10px
- Increased  from 6px to 10px

## Problem

As reported in #15157, the current 6px scrollbar is too narrow on Windows:
- Difficult to position the mouse cursor on the scrollbar
- Hard to drag for scrolling through long conversations
- Mouse cursor changes to window resize mode when hovering near the edge
- Forces users to rely solely on mouse wheel, which is inefficient for long conversations

## Solution

Increasing the scrollbar width to 10px provides:
- Better clickability and drag interaction
- Easier to target with the mouse cursor
- Still maintains a clean, modern appearance
- Consistent with common UI/UX practices for desktop applications

## Testing

- Visual inspection of scrollbar appearance
- Verified scrollbar is easier to click and drag
- Checked that the change applies globally across the application

Fixes #15157