### PR TITLE
fix(agents): pass custom headers to claude code

### DIFF
--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -72,6 +72,11 @@ const IMAGE_MAX_BYTES = 5 * 1024 * 1024 // 5MB API limit
 const shouldAutoApproveTools = process.env.CHERRY_AUTO_ALLOW_TOOLS === '1'
 const NO_RESUME_COMMANDS = ['/clear']
 
+const getAnthropicCustomHeaders = (headers?: Record<string, string>) => {
+  const lines = Object.entries(headers ?? {}).map(([name, value]) => `${name}: ${value}`)
+  return lines.length > 0 ? lines.join('\n') : undefined
+}
+
 const getLanguageInstruction = () => {
   const lang = configManager.getLanguage()
   return `
@@ -196,6 +201,7 @@ class ClaudeCodeService implements AgentServiceInterface {
     }
     const anthropicBaseUrl = resolveAnthropicBaseUrl()
     const sdkModelId = with1mContextSuffix(modelInfo.modelId, provider.anthropicApiHost)
+    const customHeaders = getAnthropicCustomHeaders(provider.extra_headers)
 
     const env = {
       ...loginShellEnv,
@@ -209,6 +215,7 @@ class ClaudeCodeService implements AgentServiceInterface {
       ANTHROPIC_API_KEY: provider.apiKey,
       ANTHROPIC_AUTH_TOKEN: provider.apiKey,
       ANTHROPIC_BASE_URL: anthropicBaseUrl,
+      ANTHROPIC_CUSTOM_HEADERS: customHeaders,
       ANTHROPIC_MODEL: sdkModelId,
       ANTHROPIC_DEFAULT_OPUS_MODEL: sdkModelId,
       ANTHROPIC_DEFAULT_SONNET_MODEL: sdkModelId,


### PR DESCRIPTION
### What this PR does

Before this PR:

Agent mode did not forward custom headers configured on a model provider to Claude Code. Providers that require custom headers, such as `x-bf-vk`, worked in normal chat and model list requests but failed during Agent conversations with authentication errors.

After this PR:

Agent mode forwards provider custom headers to Claude Code through `ANTHROPIC_CUSTOM_HEADERS`, so Anthropic-compatible Agent conversations use the same provider header configuration as the rest of Cherry Studio.

Fixes #15171

### Why we need it and why it was done in this way


### Breaking changes

None.

### Special notes for your reviewer

This is a minimal bug fix for the Agent/Claude Code path. It only converts provider `extra_headers` into Claude Code's `ANTHROPIC_CUSTOM_HEADERS` environment variable format.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed Agent mode not forwarding custom provider headers to Claude Code.
```