### PR TITLE
fix: launch opencode from package-local executable

### DIFF
--- a/src/main/services/CodeToolsService.ts
+++ b/src/main/services/CodeToolsService.ts
@@ -161,6 +161,31 @@ class CodeToolsService {
   }
 
   /**
+   * Prefer OpenCode's package-local executable on Windows.
+   *
+   * Bun global bins can fail with "Bun failed to remap this bin" after updates,
+   * while opencode-ai's postinstall places the real executable under the package.
+   */
+  private async getOpenCodeCommand(): Promise<string> {
+    const globalInstallDir = path.join(os.homedir(), HOME_CHERRY_DIR, 'install', 'global')
+    const openCodeExecutablePath = path.join(globalInstallDir, 'node_modules', 'opencode-ai', 'bin', 'opencode.exe')
+
+    if (fs.existsSync(openCodeExecutablePath)) {
+      logger.debug(`Using package-local executable for opencode: ${openCodeExecutablePath}`)
+      return `"${openCodeExecutablePath}"`
+    }
+
+    // Fallback: try to execute the Bun global bin directly.
+    const binDir = path.join(os.homedir(), HOME_CHERRY_DIR, 'bin')
+    const executableName = await this.getCliExecutableName(codeTools.openCode)
+    const executablePath = path.join(binDir, executableName + (isWin ? '.exe' : ''))
+    logger.warn(
+      `opencode package-local executable not found at ${openCodeExecutablePath}, falling back to direct execution: ${executablePath}`
+    )
+    return `"${executablePath}"`
+  }
+
+  /**
    * Generate opencode.json config file for OpenCode CLI
    * Merge approach:
    * 1. Parse existing config (if any) with JSONC support
@@ -692,6 +717,8 @@ class CodeToolsService {
         if (cliTool === codeTools.claudeCode) {
           const bunPath = await this.getBunPath()
           versionCommand = await this.getClaudeCodeCommand(bunPath)
+        } else if (cliTool === codeTools.openCode) {
+          versionCommand = await this.getOpenCodeCommand()
         } else {
           const executableName = await this.getCliExecutableName(cliTool)
           const binDir = path.join(os.homedir(), HOME_CHERRY_DIR, 'bin')
@@ -967,6 +994,8 @@ class CodeToolsService {
     // Use cli-wrapper.cjs (via Bun) on all platforms for reliable execution.
     if (cliTool === codeTools.claudeCode) {
       baseCommand = await this.getClaudeCodeCommand(bunPath)
+    } else if (cliTool === codeTools.openCode) {
+      baseCommand = await this.getOpenCodeCommand()
     } else if (isWin) {
       baseCommand = `"${executablePath}"`
     } else {


### PR DESCRIPTION
### What this PR does

Before this PR:

Cherry Studio launched OpenCode through the Bun global bin path. After an OpenCode update, that bin could point to a native executable or a broken Bun shim, causing launch failures such as `Bun failed to remap this bin` or `Unexpected �`.

After this PR:

Cherry Studio launches OpenCode from the package-local executable installed under `opencode-ai/bin/opencode.exe`, with a fallback to the existing global bin path when the package-local executable is unavailable. OpenCode version checks use the same command path.

Fixes #15175

### Why we need it and why it was done in this way

OpenCode’s package installs a native executable during postinstall. Running that executable through Bun can fail because Bun tries to parse the binary as JavaScript. Running the package-local executable directly matches how the package is meant to be launched after installation.

The following tradeoffs were made:

This keeps the change scoped to OpenCode command resolution instead of changing the shared install or update flow. The fallback to the global bin path is preserved for incomplete or older installs.

The following alternatives were considered:

We considered repairing the Bun global shim after updates, but that would still depend on Bun’s global bin mapping. We also considered a shared helper for Claude Code and OpenCode command resolution, but a dedicated OpenCode method is clearer and keeps the fix small.

Links to places where the discussion took place: #15175

### Breaking changes

None.

### Special notes for your reviewer

The main behavior change is that OpenCode now follows a package-local executable path, similar to how Claude Code already uses its package-local wrapper.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix OpenCode launch failures after CLI updates by running the package-local executable instead of the Bun global shim.
```