### PR TITLE
chore(gitignore): Ignore Antigravity CLI local files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ local
 .trae/*
 .claude-code-router/*
 .codebuddy/*
+.antigravitycli/*
 .zed/*
 !.zed/settings.json.example
 CLAUDE.local.md


### PR DESCRIPTION
### What this PR does

Before this PR:
Local Antigravity CLI files were not ignored and could appear in `git status`.

After this PR:
`.antigravitycli/*` is ignored so local Antigravity CLI files stay out of the repository status.

Fixes #N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:
This keeps the fix scoped to a single ignore rule and avoids touching any runtime or product code.

The following alternatives were considered:
Leaving these files unignored or requiring each contributor to maintain a personal global ignore rule.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.
N/A

### Special notes for your reviewer

None.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
