### PR TITLE
hotfix(model): align Gemini 3.x UI and sampling handling

### DIFF
--- a/src/renderer/src/aiCore/prepareParams/__tests__/model-parameters.test.ts
+++ b/src/renderer/src/aiCore/prepareParams/__tests__/model-parameters.test.ts
@@ -203,6 +203,27 @@ describe('modelParameters', () => {
 
       expect(getTemperature(assistant, model)).toBeUndefined()
     })
+
+    it('returns undefined for Gemini 3.x models', () => {
+      const assistant = createAssistant({ enableTemperature: true, temperature: 0.5 })
+      const model = createModel({ id: 'gemini-3.5-flash', provider: 'gemini', group: 'Google' })
+
+      expect(getTemperature(assistant, model)).toBeUndefined()
+    })
+
+    it('returns undefined for Gemini 3.x aliases', () => {
+      const assistant = createAssistant({ enableTemperature: true, temperature: 0.5 })
+      const model = createModel({ id: 'gemini-flash-latest', provider: 'gemini', group: 'Google' })
+
+      expect(getTemperature(assistant, model)).toBeUndefined()
+    })
+
+    it('returns undefined for Gemini 3.x model ids on non-Gemini providers', () => {
+      const assistant = createAssistant({ enableTemperature: true, temperature: 0.5 })
+      const model = createModel({ id: 'gemini-3.5-flash', provider: 'openai', group: 'Google' })
+
+      expect(getTemperature(assistant, model)).toBeUndefined()
+    })
   })
 
   describe('getTopP', () => {
@@ -285,6 +306,13 @@ describe('modelParameters', () => {
 
       expect(getTopP(assistant, model)).toBe(0.97)
     })
+
+    it('returns undefined for Gemini 3.x models', () => {
+      const assistant = createAssistant({ enableTopP: true, topP: 0.95 })
+      const model = createModel({ id: 'gemini-pro-latest', provider: 'gemini', group: 'Google' })
+
+      expect(getTopP(assistant, model)).toBeUndefined()
+    })
   })
 
   describe('filterStandardParams', () => {
@@ -318,6 +346,18 @@ describe('modelParameters', () => {
     it('returns the same object when standardParams is empty', () => {
       const input = {}
       expect(filterStandardParams(input, opus47)).toBe(input)
+    })
+
+    it('drops topK for Gemini 3.x models', () => {
+      const gemini35 = createModel({ id: 'gemini-3.5-flash', provider: 'gemini', group: 'Google' })
+
+      expect(filterStandardParams({ topK: 40, frequencyPenalty: 0.1 }, gemini35)).toEqual({ frequencyPenalty: 0.1 })
+    })
+
+    it('drops topK for Gemini 3.x model ids on non-Gemini providers', () => {
+      const proxyGemini = createModel({ id: 'gemini-3.5-flash', provider: 'openai', group: 'Google' })
+
+      expect(filterStandardParams({ topK: 40, frequencyPenalty: 0.1 }, proxyGemini)).toEqual({ frequencyPenalty: 0.1 })
     })
   })
 

--- a/src/renderer/src/aiCore/prepareParams/modelParameters.ts
+++ b/src/renderer/src/aiCore/prepareParams/modelParameters.ts
@@ -8,6 +8,7 @@ import {
   isClaude46SeriesModel,
   isClaude47SeriesModel,
   isClaudeReasoningModel,
+  isGemini3Model,
   isMaxTemperatureOneModel,
   isSupportedFlexServiceTier,
   isSupportedThinkingTokenClaudeModel,
@@ -30,6 +31,7 @@ const logger = loggerService.withContext('modelParameters')
 
 /**
  * Retrieves the temperature parameter, adapting it based on assistant.settings and model capabilities.
+ * - Disabled for Gemini 3.x models.
  * - Disabled when enableTemperature is off.
  * - Disabled unconditionally for Claude Opus 4.7 (rejects sampling params with HTTP 400).
  * - Disabled for Claude reasoning models when reasoning effort is set (excluding 'default' and 'none').
@@ -38,6 +40,11 @@ const logger = loggerService.withContext('modelParameters')
  * Otherwise, returns the temperature value.
  */
 export function getTemperature(assistant: Assistant, model: Model): number | undefined {
+  if (isGemini3Model(model)) {
+    logger.info(`Gemini 3.x model ${model.id} uses default sampling settings, disabling temperature`)
+    return undefined
+  }
+
   const enableTemperature = assistant.settings?.enableTemperature ?? DEFAULT_ASSISTANT_SETTINGS.enableTemperature
   if (!enableTemperature) {
     return undefined
@@ -83,6 +90,7 @@ export function getTemperature(assistant: Assistant, model: Model): number | und
 
 /**
  * Retrieves the TopP parameter, adapting it based on assistant.settings and model capabilities.
+ * - Disabled for Gemini 3.x models.
  * - Disabled when enableTopP is off.
  * - Disabled unconditionally for Claude Opus 4.7 (rejects sampling params with HTTP 400).
  * - Disabled for models that do not support TopP.
@@ -91,6 +99,11 @@ export function getTemperature(assistant: Assistant, model: Model): number | und
  * Otherwise, returns the TopP value.
  */
 export function getTopP(assistant: Assistant, model: Model): number | undefined {
+  if (isGemini3Model(model)) {
+    logger.info(`Gemini 3.x model ${model.id} uses default sampling settings, disabling topP`)
+    return undefined
+  }
+
   const enableTopP = assistant.settings?.enableTopP ?? DEFAULT_ASSISTANT_SETTINGS.enableTopP
   if (!enableTopP) {
     return undefined
@@ -135,13 +148,19 @@ export function getTopP(assistant: Assistant, model: Model): number | undefined 
 
 /**
  * Filters AI SDK standard parameters extracted from custom parameters, removing any
- * the model rejects. Currently strips `topK` for Claude Opus 4.7 since it rejects
- * sampling params (temperature/top_p/top_k) with HTTP 400. See `getTemperature`.
+ * the model rejects. Currently strips `topK` for Gemini 3.x models and Claude Opus 4.7
+ * since both reject or discourage sampling params.
  */
 export function filterStandardParams(
   standardParams: Partial<Record<AiSdkParam, any>>,
   model: Model
 ): Partial<Record<AiSdkParam, any>> {
+  if (isGemini3Model(model) && 'topK' in standardParams) {
+    const { topK, ...rest } = standardParams
+    logger.info(`Gemini 3.x model ${model.id} uses default sampling settings, dropping topK=${topK} from custom params`)
+    return rest
+  }
+
   if (isClaude47SeriesModel(model) && 'topK' in standardParams) {
     const { topK, ...rest } = standardParams
     logger.info(`Model ${model.id} rejects sampling parameters, dropping topK=${topK} from custom params`)

--- a/src/renderer/src/config/models/__tests__/reasoning.test.ts
+++ b/src/renderer/src/config/models/__tests__/reasoning.test.ts
@@ -1882,6 +1882,22 @@ describe('isGemini3ThinkingTokenModel', () => {
         group: ''
       })
     ).toBe(true)
+    expect(
+      isGemini3ThinkingTokenModel({
+        id: 'gemini-flash-latest',
+        name: '',
+        provider: '',
+        group: ''
+      })
+    ).toBe(true)
+    expect(
+      isGemini3ThinkingTokenModel({
+        id: 'gemini-pro-latest',
+        name: '',
+        provider: '',
+        group: ''
+      })
+    ).toBe(true)
   })
 
   it('should return false for Gemini 3 image models', () => {

--- a/src/renderer/src/config/models/__tests__/utils.test.ts
+++ b/src/renderer/src/config/models/__tests__/utils.test.ts
@@ -13,6 +13,7 @@ import {
   isClaude47SeriesModel,
   isDeepSeekModel,
   isGemini3FlashModel,
+  isGemini3Model,
   isGemini3ProModel,
   isGemini31ProModel,
   isGeminiModel,
@@ -394,6 +395,24 @@ describe('model utils', () => {
     describe('isGeminiModel', () => {
       it('detects Gemini models', () => {
         expect(isGeminiModel(createModel({ id: 'Gemini-2.0' }))).toBe(true)
+      })
+    })
+
+    describe('isGemini3Model', () => {
+      it('detects explicit Gemini 3.x models', () => {
+        expect(isGemini3Model(createModel({ id: 'gemini-3-flash' }))).toBe(true)
+        expect(isGemini3Model(createModel({ id: 'gemini-3.5-flash' }))).toBe(true)
+        expect(isGemini3Model(createModel({ id: 'gemini-3.1-pro-preview' }))).toBe(true)
+      })
+
+      it('detects Gemini 3.x latest aliases', () => {
+        expect(isGemini3Model(createModel({ id: 'gemini-flash-latest' }))).toBe(true)
+        expect(isGemini3Model(createModel({ id: 'gemini-pro-latest' }))).toBe(true)
+      })
+
+      it('returns false for non-Gemini 3 models', () => {
+        expect(isGemini3Model(createModel({ id: 'gemini-2.5-flash' }))).toBe(false)
+        expect(isGemini3Model(createModel({ id: 'gemini-flash-lite-latest' }))).toBe(false)
       })
     })
 

--- a/src/renderer/src/config/models/utils.ts
+++ b/src/renderer/src/config/models/utils.ts
@@ -321,24 +321,29 @@ export const isMaxTemperatureOneModel = (model: Model): boolean => {
   return false
 }
 
-// major version, including 3.x
+// major version, including current 3.x aliases.
+// NOTE: gemini-flash-latest and gemini-pro-latest are treated as Gemini 3.x based on
+// current upstream alias targets and product expectations. Downstream UI capability
+// gates, reasoning behavior, and sampling-parameter filtering all depend on this helper.
+// If upstream repoints either alias to a non-3.x model, revisit this check and the
+// related Gemini UI / reasoning / sampling tests before updating the mapping.
 export const isGemini3Model = (model: Model) => {
   const modelId = getLowerBaseModelName(model.id)
-  return modelId.includes('gemini-3')
+  return modelId.includes('gemini-3') || modelId === 'gemini-flash-latest' || modelId === 'gemini-pro-latest'
 }
 
-// major version, including 3.x
+// major version, including 3.x aliases
 export const isGemini3ThinkingTokenModel = (model: Model) => {
   const modelId = getLowerBaseModelName(model.id)
   return isGemini3Model(model) && !modelId.includes('image')
 }
 
 /**
- * Check if the model is a Gemini 3 Flash model
- * Matches: gemini-3-flash, gemini-3-flash-preview, gemini-3-flash-preview-09-2025, gemini-flash-latest (alias)
- * Excludes: gemini-3-flash-image-preview, 3.x flash versions
+ * Check if the model is a Gemini 3.x Flash model
+ * Matches: gemini-3-flash, gemini-3.1-flash-preview, gemini-3.2-flash-preview-09-2025, gemini-flash-latest (alias)
+ * Excludes: gemini-3-flash-image-preview, gemini-3.1-flash-image-preview
  * @param model - The model to check
- * @returns true if the model is a Gemini 3 Flash model
+ * @returns true if the model is a Gemini 3.x Flash model
  */
 export const isGemini3FlashModel = (model: Model | undefined | null): boolean => {
   if (!model) {
@@ -350,7 +355,7 @@ export const isGemini3FlashModel = (model: Model | undefined | null): boolean =>
     return true
   }
   // Check for gemini-3-flash with optional suffixes, excluding image variants
-  return /gemini-3-flash(?!-image)(?:-[\w-]+)*$/i.test(modelId)
+  return /gemini-3(?:\.\d+)?-flash(?!-image)(?:-[\w-]+)*$/i.test(modelId)
 }
 
 /**


### PR DESCRIPTION
### What this PR does

Before this PR:
- Gemini 3.5 Flash and the current Gemini latest aliases could miss the Gemini 3 reasoning UI path because `isGemini3FlashModel()` was stricter than the actual Gemini 3.x naming range.
- Gemini 3.x requests could still carry sampling parameters even though the official Gemini 3.x docs no longer recommend sending `temperature`, `top_p`, or `top_k`.

After this PR:
- `isGemini3Model()` now treats `gemini-flash-latest` and `gemini-pro-latest` as Gemini 3.x aliases, so Gemini 3.5 Flash and the current Gemini latest aliases consistently land in the Gemini 3 UI / reasoning path.
- Gemini 3.x requests no longer send sampling parameters; the request builder drops `temperature`, `topP`, and `topK`.
- The Gemini model utils / reasoning / parameter-preparation tests were updated to cover the alias and request-shaping behavior.

Fixes # N/A

### Why we need it and why it was done in this way

Google's Gemini 3.5 docs explicitly state that `temperature`, `top_p`, and `top_k` are no longer recommended for Gemini 3.x models because Gemini 3 reasoning is optimized for the default settings:
https://ai.google.dev/gemini-api/docs/whats-new-gemini-3.5#sampling-parameters

The previous `isGemini3FlashModel()` regex was also too strict for this use case because it only reliably modeled `gemini-3-flash...` shapes, while the UI and reasoning behavior needed Gemini 3.x family classification that also covers `gemini-3.5-flash` and the current latest aliases.

The following tradeoffs were made:
- The current `gemini-flash-latest` and `gemini-pro-latest` aliases are treated as Gemini 3.x in one central helper. If upstream repoints either alias to a non-3.x model, this mapping and the related UI / reasoning / sampling tests must be revisited.
- Gemini 3.x request shaping now depends on the same family helper used by related UI capability checks, so classification and request behavior stay aligned.

The following alternatives were considered:
- Keeping the old `isGemini3FlashModel()`-based gating. This was rejected because it was too narrow for versioned Gemini 3.x IDs and the current latest aliases.
- Adding one-off alias checks only in the request builder. This was rejected because it would duplicate Gemini 3 family logic and make UI behavior easier to drift from request behavior.

Links to places where the discussion took place: https://ai.google.dev/gemini-api/docs/whats-new-gemini-3.5#sampling-parameters

### Breaking changes

None.

### Special notes for your reviewer

- This PR is intentionally minimal and scoped to the Gemini 3.x UI / request-shaping fix.
- The latest-alias assumption is documented in code comments and covered by tests so it is easy to revisit if upstream changes the alias targets.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed Gemini 3 family detection so Gemini 3.5 Flash and the current Gemini latest aliases use the Gemini 3 reasoning UI, and stopped sending deprecated sampling parameters (`temperature`, `top_p`, `top_k`) for Gemini 3.x requests.
```
