### PR TITLE
fix: use the global OpenCode shim on macOS

### DIFF
--- a/src/main/services/CodeToolsService.ts
+++ b/src/main/services/CodeToolsService.ts
@@ -161,27 +161,33 @@ class CodeToolsService {
   }
 
   /**
-   * Prefer OpenCode's package-local executable on Windows.
+   * Prefer OpenCode's package-local executable on Windows only.
    *
-   * Bun global bins can fail with "Bun failed to remap this bin" after updates,
-   * while opencode-ai's postinstall places the real executable under the package.
+   * On Windows, Bun global bins can fail with "Bun failed to remap this bin" after
+   * updates, while opencode-ai's postinstall places the real executable under the
+   * package. On macOS/Linux, keep using the global shim in ~/.cherrystudio/bin so
+   * we do not bind non-Windows launches to the package-local opencode.exe path.
    */
   private async getOpenCodeCommand(): Promise<string> {
     const globalInstallDir = path.join(os.homedir(), HOME_CHERRY_DIR, 'install', 'global')
     const openCodeExecutablePath = path.join(globalInstallDir, 'node_modules', 'opencode-ai', 'bin', 'opencode.exe')
 
-    if (fs.existsSync(openCodeExecutablePath)) {
+    if (isWin && fs.existsSync(openCodeExecutablePath)) {
       logger.debug(`Using package-local executable for opencode: ${openCodeExecutablePath}`)
       return `"${openCodeExecutablePath}"`
     }
 
-    // Fallback: try to execute the Bun global bin directly.
+    // On non-Windows platforms, prefer the Bun global shim directly.
     const binDir = path.join(os.homedir(), HOME_CHERRY_DIR, 'bin')
     const executableName = await this.getCliExecutableName(codeTools.openCode)
     const executablePath = path.join(binDir, executableName + (isWin ? '.exe' : ''))
-    logger.warn(
-      `opencode package-local executable not found at ${openCodeExecutablePath}, falling back to direct execution: ${executablePath}`
-    )
+    if (isWin) {
+      logger.warn(
+        `opencode package-local executable not found at ${openCodeExecutablePath}, falling back to direct execution: ${executablePath}`
+      )
+    } else {
+      logger.debug(`Using direct opencode executable: ${executablePath}`)
+    }
     return `"${executablePath}"`
   }
 

--- a/src/main/services/__tests__/CodeToolsService.opencode.test.ts
+++ b/src/main/services/__tests__/CodeToolsService.opencode.test.ts
@@ -1,0 +1,69 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { HOME_CHERRY_DIR } from '@shared/config/constant'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const createLogger = () => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn()
+})
+
+async function loadCodeToolsService({ isMac = false, isWin = false } = {}) {
+  vi.resetModules()
+
+  vi.doMock('@logger', () => ({
+    loggerService: {
+      withContext: () => createLogger()
+    }
+  }))
+
+  vi.doMock('@main/constant', () => ({
+    isMac,
+    isWin
+  }))
+
+  vi.doMock('@main/utils/process', () => ({
+    findCommandInShellEnv: vi.fn(),
+    getBinaryName: vi.fn(async (name: string) => name),
+    getBinaryPath: vi.fn(),
+    isBinaryExists: vi.fn()
+  }))
+
+  vi.doMock('@main/utils/shell-env', () => ({
+    default: vi.fn(async () => ({}))
+  }))
+
+  vi.doMock('@main/utils/ipService', () => ({
+    isUserInChina: vi.fn(async () => false)
+  }))
+
+  const mod = await import('../CodeToolsService')
+  return mod.codeToolsService
+}
+
+describe('CodeToolsService - OpenCode command resolution', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it('uses the global opencode shim on non-Windows even if package-local opencode.exe exists', async () => {
+    const service = await loadCodeToolsService()
+    const globalInstallDir = path.join(os.homedir(), HOME_CHERRY_DIR, 'install', 'global')
+    const packageLocalExecutablePath = path.join(globalInstallDir, 'node_modules', 'opencode-ai', 'bin', 'opencode.exe')
+    const globalExecutablePath = path.join(os.homedir(), HOME_CHERRY_DIR, 'bin', 'opencode')
+
+    vi.spyOn(fs, 'existsSync').mockImplementation((targetPath) => {
+      const normalizedPath = String(targetPath)
+      return normalizedPath === packageLocalExecutablePath || normalizedPath === globalExecutablePath
+    })
+
+    const command = await (service as any).getOpenCodeCommand()
+
+    expect(command).toBe(`"${globalExecutablePath}"`)
+  })
+})


### PR DESCRIPTION
### What this PR does

Before this PR:

On macOS, Cherry Studio could resolve OpenCode to the package-local `opencode.exe` path under `~/.cherrystudio/install/global/node_modules/opencode-ai/bin/`. That path worked for the Windows-specific fallback, but on macOS it caused OpenCode launches from the Code tools panel to fail with `error: Unexpected at ~/.cherrystudio/install/global/node_modules/opencode-ai/bin/opencode.exe:1:1`.

After this PR:

On macOS and Linux, Cherry Studio now resolves OpenCode through the global `~/.cherrystudio/bin/opencode` shim again, while keeping the existing package-local fallback for Windows only. This PR also adds a regression test covering the non-Windows resolution path.

### Why we need it and why it was done in this way

This is a user-facing macOS launch regression in the Code tools panel. The fix keeps the original Windows-specific workaround for `opencode-ai` intact, but narrows it to the platform where it is actually needed. That keeps the change minimal and avoids altering unrelated launcher behavior.

The following tradeoffs were made:

- We kept the package-local OpenCode executable path for Windows because it still protects against Bun remap issues there.
- We restored the global shim path for non-Windows platforms to match the expected macOS/Linux launch behavior.
- We added a focused regression test instead of expanding the launcher abstraction more broadly.

The following alternatives were considered:

- Using the package-local OpenCode executable on every platform. This keeps the current regression on macOS.
- Reverting all OpenCode command resolution to the global shim on every platform. This would risk reintroducing the Windows-specific remap problem that the earlier workaround addressed.

Links to places where the discussion took place: None.

### Breaking changes

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

- This change is intentionally limited to OpenCode command resolution.
- The new regression test verifies that non-Windows environments do not select the package-local `opencode.exe` path.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed OpenCode launch failures on macOS by resolving the CLI through the global Cherry Studio shim instead of the package-local binary path.
```
