### PR TITLE
fix(agent): preserve prompt drafts across settings tabs

### DIFF
--- a/src/renderer/src/pages/settings/AgentSettings/AgentSettingsPopup.tsx
+++ b/src/renderer/src/pages/settings/AgentSettings/AgentSettingsPopup.tsx
@@ -1,7 +1,7 @@
 import { TopView } from '@renderer/components/TopView'
 import { useAgent } from '@renderer/hooks/agents/useAgent'
 import { useUpdateAgent } from '@renderer/hooks/agents/useUpdateAgent'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { BaseSettingsPopup, type SettingsMenuItem, type SettingsPopupTab } from './BaseSettingsPopup'
@@ -26,8 +26,15 @@ const AgentSettingPopupContainer: React.FC<AgentSettingPopupParams> = ({ tab, ag
   const { t } = useTranslation()
   const { agent, isLoading, error } = useAgent(agentId)
   const { updateAgent } = useUpdateAgent()
+  const [instructionsDraft, setInstructionsDraft] = useState<string>()
 
   const isSoul = isSoulModeEnabled(agent?.configuration)
+
+  useEffect(() => {
+    if (agent && instructionsDraft === undefined) {
+      setInstructionsDraft(agent.instructions ?? '')
+    }
+  }, [agent, instructionsDraft])
 
   const menuItems: SettingsMenuItem[] = useMemo(
     () =>
@@ -49,7 +56,14 @@ const AgentSettingPopupContainer: React.FC<AgentSettingPopupParams> = ({ tab, ag
       case 'essential':
         return <EssentialSettings agentBase={agent} update={updateAgent} />
       case 'prompt':
-        return <PromptSettings agentBase={agent} update={updateAgent} />
+        return (
+          <PromptSettings
+            agentBase={agent}
+            update={updateAgent}
+            instructionsDraft={instructionsDraft}
+            setInstructionsDraft={setInstructionsDraft}
+          />
+        )
       case 'permission-mode':
         return <PermissionModeSettings agentBase={agent} update={updateAgent} />
       case 'tools-mcp':

--- a/src/renderer/src/pages/settings/AgentSettings/SessionSettingsPopup.tsx
+++ b/src/renderer/src/pages/settings/AgentSettings/SessionSettingsPopup.tsx
@@ -1,7 +1,7 @@
 import { TopView } from '@renderer/components/TopView'
 import { useSession } from '@renderer/hooks/agents/useSession'
 import { useUpdateSession } from '@renderer/hooks/agents/useUpdateSession'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { BaseSettingsPopup, type SettingsMenuItem, type SettingsPopupTab } from './BaseSettingsPopup'
@@ -26,6 +26,13 @@ const SessionSettingPopupContainer: React.FC<SessionSettingPopupParams> = ({ tab
   const { t } = useTranslation()
   const { session, isLoading, error } = useSession(agentId, sessionId)
   const { updateSession } = useUpdateSession(agentId)
+  const [instructionsDraft, setInstructionsDraft] = useState<string>()
+
+  useEffect(() => {
+    if (session && instructionsDraft === undefined) {
+      setInstructionsDraft(session.instructions ?? '')
+    }
+  }, [session, instructionsDraft])
 
   const menuItems: SettingsMenuItem[] = useMemo(
     () => [
@@ -45,7 +52,14 @@ const SessionSettingPopupContainer: React.FC<SessionSettingPopupParams> = ({ tab
       case 'essential':
         return <EssentialSettings agentBase={session} update={updateSession} />
       case 'prompt':
-        return <PromptSettings agentBase={session} update={updateSession} />
+        return (
+          <PromptSettings
+            agentBase={session}
+            update={updateSession}
+            instructionsDraft={instructionsDraft}
+            setInstructionsDraft={setInstructionsDraft}
+          />
+        )
       case 'permission-mode':
         return <PermissionModeSettings agentBase={session} update={updateSession} />
       case 'tools-mcp':

--- a/src/renderer/src/pages/settings/AgentSettings/components/PromptSettings.tsx
+++ b/src/renderer/src/pages/settings/AgentSettings/components/PromptSettings.tsx
@@ -14,11 +14,18 @@ import styled from 'styled-components'
 
 import { type AgentOrSessionSettingsProps, SettingsContainer, SettingsItem, SettingsTitle } from '../shared'
 
-const PromptSettings: FC<AgentOrSessionSettingsProps> = ({ agentBase, update }) => {
+type PromptSettingsProps = AgentOrSessionSettingsProps & {
+  instructionsDraft?: string
+  setInstructionsDraft?: (value: string) => void
+}
+
+const PromptSettings: FC<PromptSettingsProps> = ({ agentBase, update, instructionsDraft, setInstructionsDraft }) => {
   const { t } = useTranslation()
-  const [instructions, setInstructions] = useState<string>(agentBase?.instructions ?? '')
+  const [localInstructions, setLocalInstructions] = useState<string>(agentBase?.instructions ?? '')
   const [showPreview, setShowPreview] = useState<boolean>(!!agentBase?.instructions?.length)
   const [tokenCount, setTokenCount] = useState(0)
+  const instructions = instructionsDraft ?? localInstructions
+  const setInstructions = setInstructionsDraft ?? setLocalInstructions
 
   useEffect(() => {
     const updateTokenCount = async () => {


### PR DESCRIPTION
## Summary
- Preserve unsaved agent and session prompt edits while switching settings tabs.
- Keep draft prompt state at the settings popup level so the prompt editor can unmount without losing text.

Closes #14939

## Validation
- pnpm exec eslint src/renderer/src/pages/settings/AgentSettings/AgentSettingsPopup.tsx src/renderer/src/pages/settings/AgentSettings/SessionSettingsPopup.tsx src/renderer/src/pages/settings/AgentSettings/components/PromptSettings.tsx
- pnpm exec biome format src/renderer/src/pages/settings/AgentSettings/AgentSettingsPopup.tsx src/renderer/src/pages/settings/AgentSettings/SessionSettingsPopup.tsx src/renderer/src/pages/settings/AgentSettings/components/PromptSettings.tsx
- pnpm typecheck:web
- git diff --check