### PR TITLE
fix: warn when regenerating messages with images using non-vision models

### DIFF
--- a/src/renderer/src/aiCore/prepareParams/__tests__/model-parameters.test.ts
+++ b/src/renderer/src/aiCore/prepareParams/__tests__/model-parameters.test.ts
@@ -203,6 +203,27 @@ describe('modelParameters', () => {
 
       expect(getTemperature(assistant, model)).toBeUndefined()
     })
+
+    it('returns undefined for Gemini 3.x models', () => {
+      const assistant = createAssistant({ enableTemperature: true, temperature: 0.5 })
+      const model = createModel({ id: 'gemini-3.5-flash', provider: 'gemini', group: 'Google' })
+
+      expect(getTemperature(assistant, model)).toBeUndefined()
+    })
+
+    it('returns undefined for Gemini 3.x aliases', () => {
+      const assistant = createAssistant({ enableTemperature: true, temperature: 0.5 })
+      const model = createModel({ id: 'gemini-flash-latest', provider: 'gemini', group: 'Google' })
+
+      expect(getTemperature(assistant, model)).toBeUndefined()
+    })
+
+    it('returns undefined for Gemini 3.x model ids on non-Gemini providers', () => {
+      const assistant = createAssistant({ enableTemperature: true, temperature: 0.5 })
+      const model = createModel({ id: 'gemini-3.5-flash', provider: 'openai', group: 'Google' })
+
+      expect(getTemperature(assistant, model)).toBeUndefined()
+    })
   })
 
   describe('getTopP', () => {
@@ -285,6 +306,13 @@ describe('modelParameters', () => {
 
       expect(getTopP(assistant, model)).toBe(0.97)
     })
+
+    it('returns undefined for Gemini 3.x models', () => {
+      const assistant = createAssistant({ enableTopP: true, topP: 0.95 })
+      const model = createModel({ id: 'gemini-pro-latest', provider: 'gemini', group: 'Google' })
+
+      expect(getTopP(assistant, model)).toBeUndefined()
+    })
   })
 
   describe('filterStandardParams', () => {
@@ -318,6 +346,18 @@ describe('modelParameters', () => {
     it('returns the same object when standardParams is empty', () => {
       const input = {}
       expect(filterStandardParams(input, opus47)).toBe(input)
+    })
+
+    it('drops topK for Gemini 3.x models', () => {
+      const gemini35 = createModel({ id: 'gemini-3.5-flash', provider: 'gemini', group: 'Google' })
+
+      expect(filterStandardParams({ topK: 40, frequencyPenalty: 0.1 }, gemini35)).toEqual({ frequencyPenalty: 0.1 })
+    })
+
+    it('drops topK for Gemini 3.x model ids on non-Gemini providers', () => {
+      const proxyGemini = createModel({ id: 'gemini-3.5-flash', provider: 'openai', group: 'Google' })
+
+      expect(filterStandardParams({ topK: 40, frequencyPenalty: 0.1 }, proxyGemini)).toEqual({ frequencyPenalty: 0.1 })
     })
   })
 

--- a/src/renderer/src/aiCore/prepareParams/modelParameters.ts
+++ b/src/renderer/src/aiCore/prepareParams/modelParameters.ts
@@ -8,6 +8,7 @@ import {
   isClaude46SeriesModel,
   isClaude47SeriesModel,
   isClaudeReasoningModel,
+  isGemini3Model,
   isMaxTemperatureOneModel,
   isSupportedFlexServiceTier,
   isSupportedThinkingTokenClaudeModel,
@@ -30,6 +31,7 @@ const logger = loggerService.withContext('modelParameters')
 
 /**
  * Retrieves the temperature parameter, adapting it based on assistant.settings and model capabilities.
+ * - Disabled for Gemini 3.x models.
  * - Disabled when enableTemperature is off.
  * - Disabled unconditionally for Claude Opus 4.7 (rejects sampling params with HTTP 400).
  * - Disabled for Claude reasoning models when reasoning effort is set (excluding 'default' and 'none').
@@ -38,6 +40,11 @@ const logger = loggerService.withContext('modelParameters')
  * Otherwise, returns the temperature value.
  */
 export function getTemperature(assistant: Assistant, model: Model): number | undefined {
+  if (isGemini3Model(model)) {
+    logger.info(`Gemini 3.x model ${model.id} uses default sampling settings, disabling temperature`)
+    return undefined
+  }
+
   const enableTemperature = assistant.settings?.enableTemperature ?? DEFAULT_ASSISTANT_SETTINGS.enableTemperature
   if (!enableTemperature) {
     return undefined
@@ -83,6 +90,7 @@ export function getTemperature(assistant: Assistant, model: Model): number | und
 
 /**
  * Retrieves the TopP parameter, adapting it based on assistant.settings and model capabilities.
+ * - Disabled for Gemini 3.x models.
  * - Disabled when enableTopP is off.
  * - Disabled unconditionally for Claude Opus 4.7 (rejects sampling params with HTTP 400).
  * - Disabled for models that do not support TopP.
@@ -91,6 +99,11 @@ export function getTemperature(assistant: Assistant, model: Model): number | und
  * Otherwise, returns the TopP value.
  */
 export function getTopP(assistant: Assistant, model: Model): number | undefined {
+  if (isGemini3Model(model)) {
+    logger.info(`Gemini 3.x model ${model.id} uses default sampling settings, disabling topP`)
+    return undefined
+  }
+
   const enableTopP = assistant.settings?.enableTopP ?? DEFAULT_ASSISTANT_SETTINGS.enableTopP
   if (!enableTopP) {
     return undefined
@@ -135,13 +148,19 @@ export function getTopP(assistant: Assistant, model: Model): number | undefined 
 
 /**
  * Filters AI SDK standard parameters extracted from custom parameters, removing any
- * the model rejects. Currently strips `topK` for Claude Opus 4.7 since it rejects
- * sampling params (temperature/top_p/top_k) with HTTP 400. See `getTemperature`.
+ * the model rejects. Currently strips `topK` for Gemini 3.x models and Claude Opus 4.7
+ * since both reject or discourage sampling params.
  */
 export function filterStandardParams(
   standardParams: Partial<Record<AiSdkParam, any>>,
   model: Model
 ): Partial<Record<AiSdkParam, any>> {
+  if (isGemini3Model(model) && 'topK' in standardParams) {
+    const { topK, ...rest } = standardParams
+    logger.info(`Gemini 3.x model ${model.id} uses default sampling settings, dropping topK=${topK} from custom params`)
+    return rest
+  }
+
   if (isClaude47SeriesModel(model) && 'topK' in standardParams) {
     const { topK, ...rest } = standardParams
     logger.info(`Model ${model.id} rejects sampling parameters, dropping topK=${topK} from custom params`)

--- a/src/renderer/src/config/models/__tests__/reasoning.test.ts
+++ b/src/renderer/src/config/models/__tests__/reasoning.test.ts
@@ -1882,6 +1882,22 @@ describe('isGemini3ThinkingTokenModel', () => {
         group: ''
       })
     ).toBe(true)
+    expect(
+      isGemini3ThinkingTokenModel({
+        id: 'gemini-flash-latest',
+        name: '',
+        provider: '',
+        group: ''
+      })
+    ).toBe(true)
+    expect(
+      isGemini3ThinkingTokenModel({
+        id: 'gemini-pro-latest',
+        name: '',
+        provider: '',
+        group: ''
+      })
+    ).toBe(true)
   })
 
   it('should return false for Gemini 3 image models', () => {

--- a/src/renderer/src/config/models/__tests__/utils.test.ts
+++ b/src/renderer/src/config/models/__tests__/utils.test.ts
@@ -13,6 +13,7 @@ import {
   isClaude47SeriesModel,
   isDeepSeekModel,
   isGemini3FlashModel,
+  isGemini3Model,
   isGemini3ProModel,
   isGemini31ProModel,
   isGeminiModel,
@@ -394,6 +395,24 @@ describe('model utils', () => {
     describe('isGeminiModel', () => {
       it('detects Gemini models', () => {
         expect(isGeminiModel(createModel({ id: 'Gemini-2.0' }))).toBe(true)
+      })
+    })
+
+    describe('isGemini3Model', () => {
+      it('detects explicit Gemini 3.x models', () => {
+        expect(isGemini3Model(createModel({ id: 'gemini-3-flash' }))).toBe(true)
+        expect(isGemini3Model(createModel({ id: 'gemini-3.5-flash' }))).toBe(true)
+        expect(isGemini3Model(createModel({ id: 'gemini-3.1-pro-preview' }))).toBe(true)
+      })
+
+      it('detects Gemini 3.x latest aliases', () => {
+        expect(isGemini3Model(createModel({ id: 'gemini-flash-latest' }))).toBe(true)
+        expect(isGemini3Model(createModel({ id: 'gemini-pro-latest' }))).toBe(true)
+      })
+
+      it('returns false for non-Gemini 3 models', () => {
+        expect(isGemini3Model(createModel({ id: 'gemini-2.5-flash' }))).toBe(false)
+        expect(isGemini3Model(createModel({ id: 'gemini-flash-lite-latest' }))).toBe(false)
       })
     })
 

--- a/src/renderer/src/config/models/utils.ts
+++ b/src/renderer/src/config/models/utils.ts
@@ -321,24 +321,29 @@ export const isMaxTemperatureOneModel = (model: Model): boolean => {
   return false
 }
 
-// major version, including 3.x
+// major version, including current 3.x aliases.
+// NOTE: gemini-flash-latest and gemini-pro-latest are treated as Gemini 3.x based on
+// current upstream alias targets and product expectations. Downstream UI capability
+// gates, reasoning behavior, and sampling-parameter filtering all depend on this helper.
+// If upstream repoints either alias to a non-3.x model, revisit this check and the
+// related Gemini UI / reasoning / sampling tests before updating the mapping.
 export const isGemini3Model = (model: Model) => {
   const modelId = getLowerBaseModelName(model.id)
-  return modelId.includes('gemini-3')
+  return modelId.includes('gemini-3') || modelId === 'gemini-flash-latest' || modelId === 'gemini-pro-latest'
 }
 
-// major version, including 3.x
+// major version, including 3.x aliases
 export const isGemini3ThinkingTokenModel = (model: Model) => {
   const modelId = getLowerBaseModelName(model.id)
   return isGemini3Model(model) && !modelId.includes('image')
 }
 
 /**
- * Check if the model is a Gemini 3 Flash model
- * Matches: gemini-3-flash, gemini-3-flash-preview, gemini-3-flash-preview-09-2025, gemini-flash-latest (alias)
- * Excludes: gemini-3-flash-image-preview, 3.x flash versions
+ * Check if the model is a Gemini 3.x Flash model
+ * Matches: gemini-3-flash, gemini-3.1-flash-preview, gemini-3.2-flash-preview-09-2025, gemini-flash-latest (alias)
+ * Excludes: gemini-3-flash-image-preview, gemini-3.1-flash-image-preview
  * @param model - The model to check
- * @returns true if the model is a Gemini 3 Flash model
+ * @returns true if the model is a Gemini 3.x Flash model
  */
 export const isGemini3FlashModel = (model: Model | undefined | null): boolean => {
   if (!model) {
@@ -350,7 +355,7 @@ export const isGemini3FlashModel = (model: Model | undefined | null): boolean =>
     return true
   }
   // Check for gemini-3-flash with optional suffixes, excluding image variants
-  return /gemini-3-flash(?!-image)(?:-[\w-]+)*$/i.test(modelId)
+  return /gemini-3(?:\.\d+)?-flash(?!-image)(?:-[\w-]+)*$/i.test(modelId)
 }
 
 /**

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -1803,13 +1803,13 @@
     "maxEmbeddingsPerCall": "Max Embeddings Per Call",
     "message": "Error Message",
     "missing_user_message": "Cannot switch model response: The original user message has been deleted. Please send a new message to get a response with this model.",
-    "model_not_support_image": "The selected model does not support image input. Please switch to a model that supports images (e.g., GPT-4o, Claude 3, Gemini) to regenerate.",
     "model": {
       "exists": "Model already exists",
       "not_exists": "Model does not exist"
     },
     "modelId": "Model ID",
     "modelType": "Model Type",
+    "model_not_support_image": "The selected model does not support image input. Please switch to a model that supports images (e.g., GPT-4o, Claude 3, Gemini) to regenerate.",
     "name": "Error name",
     "no_api_key": "API key is not configured",
     "no_response": "No response",

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -1803,6 +1803,7 @@
     "maxEmbeddingsPerCall": "Max Embeddings Per Call",
     "message": "Error Message",
     "missing_user_message": "Cannot switch model response: The original user message has been deleted. Please send a new message to get a response with this model.",
+    "model_not_support_image": "The selected model does not support image input. Please switch to a model that supports images (e.g., GPT-4o, Claude 3, Gemini) to regenerate.",
     "model": {
       "exists": "Model already exists",
       "not_exists": "Model does not exist"

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -1803,13 +1803,13 @@
     "maxEmbeddingsPerCall": "每次调用的最大嵌入",
     "message": "错误信息",
     "missing_user_message": "无法切换模型响应：原始用户消息已被删除。请发送新消息以获取此模型的响应",
-    "model_not_support_image": "所选模型不支持图片输入。请切换到支持图片的模型（如 GPT-4o、Claude 3、Gemini）来重新生成。",
     "model": {
       "exists": "模型已存在",
       "not_exists": "模型不存在"
     },
     "modelId": "模型 ID",
     "modelType": "模型类型",
+    "model_not_support_image": "所选模型不支持图片输入。请切换到支持图片的模型（如 GPT-4o、Claude 3、Gemini）来重新生成。",
     "name": "错误名称",
     "no_api_key": "API 密钥未配置",
     "no_response": "无响应",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -1803,6 +1803,7 @@
     "maxEmbeddingsPerCall": "每次调用的最大嵌入",
     "message": "错误信息",
     "missing_user_message": "无法切换模型响应：原始用户消息已被删除。请发送新消息以获取此模型的响应",
+    "model_not_support_image": "所选模型不支持图片输入。请切换到支持图片的模型（如 GPT-4o、Claude 3、Gemini）来重新生成。",
     "model": {
       "exists": "模型已存在",
       "not_exists": "模型不存在"

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -1803,13 +1803,13 @@
     "maxEmbeddingsPerCall": "每次呼叫的最大嵌入",
     "message": "錯誤訊息",
     "missing_user_message": "無法切換模型回應：原始使用者訊息已被刪除。請傳送新訊息以獲得此模型回應。",
-    "model_not_support_image": "所選模型不支援圖片輸入。請切換至支援圖片的模型（如 GPT-4o、Claude 3、Gemini）來重新生成。",
     "model": {
       "exists": "模型已存在",
       "not_exists": "模型不存在"
     },
     "modelId": "模型 ID",
     "modelType": "模型類型",
+    "model_not_support_image": "所選模型不支援圖片輸入。請切換至支援圖片的模型（如 GPT-4o、Claude 3、Gemini）來重新生成。",
     "name": "錯誤名稱",
     "no_api_key": "API 金鑰未設定",
     "no_response": "無回應",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -1803,6 +1803,7 @@
     "maxEmbeddingsPerCall": "每次呼叫的最大嵌入",
     "message": "錯誤訊息",
     "missing_user_message": "無法切換模型回應：原始使用者訊息已被刪除。請傳送新訊息以獲得此模型回應。",
+    "model_not_support_image": "所選模型不支援圖片輸入。請切換至支援圖片的模型（如 GPT-4o、Claude 3、Gemini）來重新生成。",
     "model": {
       "exists": "模型已存在",
       "not_exists": "模型不存在"

--- a/src/renderer/src/i18n/translate/de-de.json
+++ b/src/renderer/src/i18n/translate/de-de.json
@@ -1809,6 +1809,7 @@
     },
     "modelId": "Modell-ID",
     "modelType": "Modelltyp",
+    "model_not_support_image": "[to be translated]:The selected model does not support image input. Please switch to a model that supports images (e.g., GPT-4o, Claude 3, Gemini) to regenerate.",
     "name": "Fehlername",
     "no_api_key": "API-Schlüssel nicht konfiguriert",
     "no_response": "Keine Antwort",

--- a/src/renderer/src/i18n/translate/el-gr.json
+++ b/src/renderer/src/i18n/translate/el-gr.json
@@ -1809,6 +1809,7 @@
     },
     "modelId": "Αναγνωριστικό μοντέλου",
     "modelType": "Τύπος μοντέλου",
+    "model_not_support_image": "[to be translated]:The selected model does not support image input. Please switch to a model that supports images (e.g., GPT-4o, Claude 3, Gemini) to regenerate.",
     "name": "Λάθος όνομα",
     "no_api_key": "Δεν έχετε ρυθμίσει το κλειδί API",
     "no_response": "Καμία απάντηση",

--- a/src/renderer/src/i18n/translate/es-es.json
+++ b/src/renderer/src/i18n/translate/es-es.json
@@ -1809,6 +1809,7 @@
     },
     "modelId": "ID del modelo",
     "modelType": "Tipo de modelo",
+    "model_not_support_image": "[to be translated]:The selected model does not support image input. Please switch to a model that supports images (e.g., GPT-4o, Claude 3, Gemini) to regenerate.",
     "name": "Nombre de error",
     "no_api_key": "La clave API no está configurada",
     "no_response": "Sin respuesta",

--- a/src/renderer/src/i18n/translate/fr-fr.json
+++ b/src/renderer/src/i18n/translate/fr-fr.json
@@ -1809,6 +1809,7 @@
     },
     "modelId": "ID du modèle",
     "modelType": "Type de modèle",
+    "model_not_support_image": "[to be translated]:The selected model does not support image input. Please switch to a model that supports images (e.g., GPT-4o, Claude 3, Gemini) to regenerate.",
     "name": "Nom d'erreur",
     "no_api_key": "La clé API n'est pas configurée",
     "no_response": "Pas de réponse",

--- a/src/renderer/src/i18n/translate/ja-jp.json
+++ b/src/renderer/src/i18n/translate/ja-jp.json
@@ -1809,6 +1809,7 @@
     },
     "modelId": "モデル ID",
     "modelType": "モデルの種類",
+    "model_not_support_image": "[to be translated]:The selected model does not support image input. Please switch to a model that supports images (e.g., GPT-4o, Claude 3, Gemini) to regenerate.",
     "name": "エラー名",
     "no_api_key": "APIキーが設定されていません",
     "no_response": "応答なし",

--- a/src/renderer/src/i18n/translate/pt-pt.json
+++ b/src/renderer/src/i18n/translate/pt-pt.json
@@ -1809,6 +1809,7 @@
     },
     "modelId": "ID do modelo",
     "modelType": "Tipo de modelo",
+    "model_not_support_image": "[to be translated]:The selected model does not support image input. Please switch to a model that supports images (e.g., GPT-4o, Claude 3, Gemini) to regenerate.",
     "name": "Nome do erro",
     "no_api_key": "A chave da API não foi configurada",
     "no_response": "Sem resposta",

--- a/src/renderer/src/i18n/translate/ro-ro.json
+++ b/src/renderer/src/i18n/translate/ro-ro.json
@@ -1809,6 +1809,7 @@
     },
     "modelId": "ID model",
     "modelType": "Tip model",
+    "model_not_support_image": "[to be translated]:The selected model does not support image input. Please switch to a model that supports images (e.g., GPT-4o, Claude 3, Gemini) to regenerate.",
     "name": "Nume eroare",
     "no_api_key": "Cheia API nu este configurată",
     "no_response": "Niciun răspuns",

--- a/src/renderer/src/i18n/translate/ru-ru.json
+++ b/src/renderer/src/i18n/translate/ru-ru.json
@@ -1809,6 +1809,7 @@
     },
     "modelId": "ID модели",
     "modelType": "Тип модели",
+    "model_not_support_image": "[to be translated]:The selected model does not support image input. Please switch to a model that supports images (e.g., GPT-4o, Claude 3, Gemini) to regenerate.",
     "name": "Название ошибки",
     "no_api_key": "Ключ API не настроен",
     "no_response": "Нет ответа",

--- a/src/renderer/src/i18n/translate/vi-vn.json
+++ b/src/renderer/src/i18n/translate/vi-vn.json
@@ -1809,6 +1809,7 @@
     },
     "modelId": "ID mô hình",
     "modelType": "Loại mô hình",
+    "model_not_support_image": "[to be translated]:The selected model does not support image input. Please switch to a model that supports images (e.g., GPT-4o, Claude 3, Gemini) to regenerate.",
     "name": "Tên lỗi",
     "no_api_key": "Khóa API chưa được cấu hình",
     "no_response": "Không có phản hồi",

--- a/src/renderer/src/pages/settings/ProviderSettings/ModelList/ManageModelsPopup.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ModelList/ManageModelsPopup.tsx
@@ -174,7 +174,7 @@ const PopupContainer: React.FC<Props> = ({ providerId, resolve }) => {
         }
       }
     })
-  }, [list, models, onAddModel, provider, t])
+  }, [list, onAddModel, provider, t])
 
   const loadModels = useCallback(async (provider: Provider) => {
     setLoadingModels(true)

--- a/src/renderer/src/store/thunk/messageThunk.ts
+++ b/src/renderer/src/store/thunk/messageThunk.ts
@@ -17,6 +17,7 @@
 import { loggerService } from '@logger'
 import { AiSdkToChunkAdapter } from '@renderer/aiCore/chunk/AiSdkToChunkAdapter'
 import { AgentApiClient } from '@renderer/api/agent'
+import { isVisionModel } from '@renderer/config/models'
 import db from '@renderer/databases'
 import { getModel } from '@renderer/hooks/useModel'
 import { fetchMessagesSummary, transformMessagesAndFetch } from '@renderer/services/ApiService'
@@ -56,7 +57,7 @@ import {
   createTranslationBlock,
   resetAssistantMessage
 } from '@renderer/utils/messageUtils/create'
-import { getMainTextContent } from '@renderer/utils/messageUtils/find'
+import { findImageBlocks, getMainTextContent } from '@renderer/utils/messageUtils/find'
 import { getTopicQueue, waitForTopicQueue } from '@renderer/utils/queue'
 import { IpcChannel } from '@shared/IpcChannel'
 import { defaultAppHeaders } from '@shared/utils'
@@ -1227,6 +1228,43 @@ export const resendMessageThunk =
         logger.warn(`Failed to clear keyv cache for message ${userMessageToResend.id}:`, error as Error)
       }
 
+      // Check if user message has images and validate model support
+      const userImageBlocks = findImageBlocks(userMessageToResend)
+      if (userImageBlocks.length > 0) {
+        // Check assistant model for single message case (no existing assistant messages)
+        if (assistantMessagesToReset.length === 0 && !userMessageToResend?.mentions?.length) {
+          if (assistant.model && !isVisionModel(assistant.model)) {
+            window.toast.error(t('error.model_not_support_image'))
+            logger.warn(
+              `[resendMessageThunk] Model ${assistant.model.name} does not support images, but user message has image blocks.`
+            )
+            return
+          }
+        }
+        // Check existing assistant messages' models
+        if (assistantMessagesToReset.length > 0 && !userMessageToResend?.mentions?.length) {
+          const invalidModels = assistantMessagesToReset.filter((m) => m.model && !isVisionModel(m.model))
+          if (invalidModels.length > 0) {
+            window.toast.error(t('error.model_not_support_image'))
+            logger.warn(
+              `[resendMessageThunk] Model ${invalidModels.map((m) => m.model!.name).join(', ')} does not support images, but user message has image blocks.`
+            )
+            return
+          }
+        }
+        // Check mentioned models for multi-model case
+        if (userMessageToResend?.mentions?.length) {
+          const invalidModels = userMessageToResend.mentions.filter((m) => !isVisionModel(m))
+          if (invalidModels.length > 0) {
+            window.toast.error(t('error.model_not_support_image'))
+            logger.warn(
+              `[resendMessageThunk] Mentioned models ${invalidModels.map((m) => m.name).join(', ')} do not support images, but user message has image blocks.`
+            )
+            return
+          }
+        }
+      }
+
       const resetDataList: Message[] = []
 
       if (assistantMessagesToReset.length === 0 && !userMessageToResend?.mentions?.length) {
@@ -1368,6 +1406,19 @@ export const regenerateAssistantResponseThunk =
           `[regenerateAssistantResponseThunk] Original user query (askId: ${assistantMessageToRegenerate.askId}) not found for assistant message ${assistantMessageToRegenerate.id}. Cannot regenerate.`
         )
         return
+      }
+
+      // 2.5. Check if user message has images and new model supports vision
+      const userImageBlocks = findImageBlocks(originalUserQuery)
+      if (userImageBlocks.length > 0) {
+        const modelToUse = assistantMessageToRegenerate.modelId ? assistantMessageToRegenerate.model : assistant.model
+        if (modelToUse && !isVisionModel(modelToUse)) {
+          window.toast.error(t('error.model_not_support_image'))
+          logger.warn(
+            `[regenerateAssistantResponseThunk] Model ${modelToUse.name} does not support images, but user message has image blocks.`
+          )
+          return
+        }
       }
 
       // 3. Verify the assistant message itself exists in entities


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR:
When a user sends a message with an image using a vision-capable model (e.g., GPT-4o, Claude 3), then switches to a non-vision model and clicks regenerate, the app silently regenerates the response without warning. The model generates unrelated content because it cannot process the image input.

After this PR:
The app now validates whether the target model supports image input before regenerating or resending a message that contains images. If the model doesn't support vision, an error toast is shown and the regeneration is aborted, preventing confusing behavior.

Fixes #13624

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Validation is added at the thunk level (`regenerateAssistantResponseThunk` and `resendMessageThunk`) rather than at the UI layer, ensuring all code paths that trigger regeneration are covered.
- The check uses existing utilities (`findImageBlocks`, `isVisionModel`) to maintain consistency with existing model capability detection.

The following alternatives were considered:
- Adding validation at the UI layer (e.g., in `SelectModelButton` or `MessageMenubar`): This would miss programmatic regeneration paths and could be bypassed.
- Adding validation in the Redux reducer: Would require access to message context which is not available at that level.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/13624

### Breaking changes

None.

### Special notes for your reviewer

The fix covers three scenarios in `resendMessageThunk`:
1. No existing assistant messages → validates `assistant.model`
2. Existing assistant messages → validates each existing message's model
3. Multi-model (mentions) → validates all mentioned models

And one scenario in `regenerateAssistantResponseThunk`:
- Validates the model that will be used for regeneration against the original user message's image blocks.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed a bug where regenerating a message with images using a non-vision model would silently produce unrelated content. The app now shows an error message when the selected model does not support image input.
```
