### PR TITLE
fix(agents): add model selection guidance for Agent setup

### DIFF
--- a/src/renderer/src/components/AnthropicProviderListPopover.tsx
+++ b/src/renderer/src/components/AnthropicProviderListPopover.tsx
@@ -6,7 +6,6 @@ import { getFancyProviderName } from '@renderer/utils'
 import { getClaudeSupportedProviders } from '@renderer/utils/provider'
 import type { PopoverProps } from 'antd'
 import { Popover } from 'antd'
-import { Divider } from 'antd'
 import { ArrowUpRight, HelpCircle } from 'lucide-react'
 import type { FC, ReactNode } from 'react'
 import { useEffect, useState } from 'react'
@@ -72,13 +71,8 @@ const AnthropicProviderListPopover: FC<AnthropicProviderListPopoverProps> = ({
   const content = (
     <PopoverContent>
       <PopoverTitle>{t('code.supported_providers')}</PopoverTitle>
-      {extraTopItem && (
-        <>
-          {extraTopItem}
-          {providers.length > 0 && <Divider />}
-        </>
-      )}
       <ProviderListContainer>
+        {extraTopItem}
         {providers.map((provider) =>
           useWindowNavigate ? (
             <ProviderItem key={provider.id} onClick={() => handleClick(provider.id)}>

--- a/src/renderer/src/components/AnthropicProviderListPopover.tsx
+++ b/src/renderer/src/components/AnthropicProviderListPopover.tsx
@@ -6,6 +6,7 @@ import { getFancyProviderName } from '@renderer/utils'
 import { getClaudeSupportedProviders } from '@renderer/utils/provider'
 import type { PopoverProps } from 'antd'
 import { Popover } from 'antd'
+import { Divider } from 'antd'
 import { ArrowUpRight, HelpCircle } from 'lucide-react'
 import type { FC, ReactNode } from 'react'
 import { useEffect, useState } from 'react'
@@ -23,6 +24,8 @@ interface AnthropicProviderListPopoverProps {
   placement?: PopoverProps['placement']
   /** Custom filter function for providers, defaults to getClaudeSupportedProviders */
   filterProviders?: (providers: Provider[]) => Provider[]
+  /** Optional item rendered at the top of the provider list (e.g. docs link) */
+  extraTopItem?: ReactNode
 }
 
 const AnthropicProviderListPopover: FC<AnthropicProviderListPopoverProps> = ({
@@ -30,7 +33,8 @@ const AnthropicProviderListPopover: FC<AnthropicProviderListPopoverProps> = ({
   useWindowNavigate = false,
   children,
   placement = 'right',
-  filterProviders = getClaudeSupportedProviders
+  filterProviders = getClaudeSupportedProviders,
+  extraTopItem
 }) => {
   const { t } = useTranslation()
   const allProviders = useAllProviders()
@@ -68,6 +72,12 @@ const AnthropicProviderListPopover: FC<AnthropicProviderListPopoverProps> = ({
   const content = (
     <PopoverContent>
       <PopoverTitle>{t('code.supported_providers')}</PopoverTitle>
+      {extraTopItem && (
+        <>
+          {extraTopItem}
+          {providers.length > 0 && <Divider />}
+        </>
+      )}
       <ProviderListContainer>
         {providers.map((provider) =>
           useWindowNavigate ? (

--- a/src/renderer/src/components/Popups/SelectModelPopup/agent-model-popup.tsx
+++ b/src/renderer/src/components/Popups/SelectModelPopup/agent-model-popup.tsx
@@ -4,6 +4,7 @@ import type { AdaptedApiModel, ApiModel, ApiModelsFilter, Model, Provider } from
 import { apiModelAdapter } from '@renderer/utils/model'
 import { groupBy, sortBy } from 'lodash'
 import React, { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import SelectModelPopupView, { createModelPopup } from './base-popup'
 
@@ -42,6 +43,7 @@ const buildFallbackProvider = (providerId: string, model: AdaptedApiModel): Prov
 }
 
 const PopupContainer: React.FC<Props> = ({ model, apiFilter, modelFilter, showTagFilter = true, resolve }) => {
+  const { t } = useTranslation()
   const { models, isLoading } = useApiModels(apiFilter)
   const allProviders = useAllProviders()
 
@@ -85,6 +87,22 @@ const PopupContainer: React.FC<Props> = ({ model, apiFilter, modelFilter, showTa
       showTagFilter={showTagFilter}
       showPinnedModels={false}
       prioritizedProviderIds={['cherryin']}
+      emptyDescription={
+        <span>
+          {t('agent.add.model.empty', 'No compatible models found for this Agent type.')}{' '}
+          <a
+            href="https://docs.cherry-ai.com/advanced-basic/agent"
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              window.api.openWebsite('https://docs.cherry-ai.com/advanced-basic/agent')
+            }}>
+            {t('agent.add.model.empty_docs', 'View setup guide')}
+          </a>
+        </span>
+      }
       resolve={(value) => {
         if (value && isAdaptedApiModel(value)) {
           resolve(value.origin)

--- a/src/renderer/src/components/Popups/SelectModelPopup/agent-model-popup.tsx
+++ b/src/renderer/src/components/Popups/SelectModelPopup/agent-model-popup.tsx
@@ -97,7 +97,7 @@ const PopupContainer: React.FC<Props> = ({ model, apiFilter, modelFilter, showTa
             onClick={(e) => {
               e.preventDefault()
               e.stopPropagation()
-              window.api.openWebsite('https://docs.cherry-ai.com/advanced-basic/agent')
+              void window.api.openWebsite('https://docs.cherry-ai.com/advanced-basic/agent')
             }}>
             {t('agent.add.model.empty_docs', 'View setup guide')}
           </a>

--- a/src/renderer/src/components/Popups/SelectModelPopup/base-popup.tsx
+++ b/src/renderer/src/components/Popups/SelectModelPopup/base-popup.tsx
@@ -43,6 +43,8 @@ export interface SelectModelPopupParams {
   showTagFilter?: boolean
   showPinnedModels?: boolean
   prioritizedProviderIds?: string[]
+  /** Optional custom description for the empty state */
+  emptyDescription?: React.ReactNode
 }
 
 interface Props extends SelectModelPopupParams {
@@ -56,6 +58,7 @@ const SelectModelPopupView: React.FC<Props> = ({
   showTagFilter = true,
   showPinnedModels = true,
   prioritizedProviderIds = [],
+  emptyDescription,
   resolve
 }) => {
   const { t } = useTranslation()
@@ -492,7 +495,7 @@ const SelectModelPopupView: React.FC<Props> = ({
         </ListContainer>
       ) : (
         <EmptyState>
-          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
+          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={emptyDescription} />
         </EmptyState>
       )}
     </Modal>

--- a/src/renderer/src/components/Popups/agent/AgentModal.tsx
+++ b/src/renderer/src/components/Popups/agent/AgentModal.tsx
@@ -405,7 +405,7 @@ const PopupContainer: React.FC<Props> = ({ agent, afterSubmit, resolve }) => {
                     <DocsLinkItem
                       onClick={(e) => {
                         e.stopPropagation()
-                        window.api.openWebsite('https://docs.cherry-ai.com/advanced-basic/agent')
+                        void window.api.openWebsite('https://docs.cherry-ai.com/advanced-basic/agent')
                       }}>
                       <DocsIconWrapper>
                         <BookOpenText size={14} />

--- a/src/renderer/src/components/Popups/agent/AgentModal.tsx
+++ b/src/renderer/src/components/Popups/agent/AgentModal.tsx
@@ -23,7 +23,7 @@ import { parseKeyValueString, serializeKeyValueString } from '@renderer/utils/en
 import { getAnthropicSupportedProviders } from '@renderer/utils/provider'
 import type { GitBashPathInfo } from '@shared/config/constant'
 import { Button, Input, Modal, Select, Switch, Tooltip } from 'antd'
-import { ExternalLink, Info } from 'lucide-react'
+import { ArrowUpRight, BookOpenText, Info } from 'lucide-react'
 import type { ChangeEvent, FormEvent } from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -407,8 +407,11 @@ const PopupContainer: React.FC<Props> = ({ agent, afterSubmit, resolve }) => {
                         e.stopPropagation()
                         window.api.openWebsite('https://docs.cherry-ai.com/advanced-basic/agent')
                       }}>
-                      <ExternalLink size={14} />
-                      {t('agent.add.model.docs_link', 'Custom Anthropic-compatible provider')}
+                      <DocsIconWrapper>
+                        <BookOpenText size={14} />
+                      </DocsIconWrapper>
+                      {t('agent.add.model.docs_link', 'Custom provider')}
+                      <ArrowUpRight size={14} />
                     </DocsLinkItem>
                   }
                 />
@@ -650,7 +653,7 @@ const HelpText = styled.div`
   color: var(--color-text-3);
 `
 
-// Documentation link styled like a popover provider item
+// Documentation link styled identical to popover provider rows
 const DocsLinkItem = styled.div`
   color: var(--color-text);
   display: flex;
@@ -660,6 +663,16 @@ const DocsLinkItem = styled.div`
   &:hover {
     color: var(--color-link);
   }
+`
+
+// Wrapper to match ProviderAvatar 20x20 size
+const DocsIconWrapper = styled.span`
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
 `
 
 const LabelWithButton = styled.div`

--- a/src/renderer/src/components/Popups/agent/AgentModal.tsx
+++ b/src/renderer/src/components/Popups/agent/AgentModal.tsx
@@ -23,7 +23,7 @@ import { parseKeyValueString, serializeKeyValueString } from '@renderer/utils/en
 import { getAnthropicSupportedProviders } from '@renderer/utils/provider'
 import type { GitBashPathInfo } from '@shared/config/constant'
 import { Button, Input, Modal, Select, Switch, Tooltip } from 'antd'
-import { Info } from 'lucide-react'
+import { ExternalLink, Info } from 'lucide-react'
 import type { ChangeEvent, FormEvent } from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -401,6 +401,16 @@ const PopupContainer: React.FC<Props> = ({ agent, afterSubmit, resolve }) => {
                     setOpen(false)
                     resolve(undefined)
                   }}
+                  extraTopItem={
+                    <DocsLinkItem
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        window.api.openWebsite('https://docs.cherry-ai.com/advanced-basic/agent')
+                      }}>
+                      <ExternalLink size={14} />
+                      {t('agent.add.model.docs_link', 'Custom Anthropic-compatible provider')}
+                    </DocsLinkItem>
+                  }
                 />
               </div>
               <SelectAgentBaseModelButton
@@ -638,6 +648,18 @@ const RequiredMark = styled.span`
 const HelpText = styled.div`
   font-size: 12px;
   color: var(--color-text-3);
+`
+
+// Documentation link styled like a popover provider item
+const DocsLinkItem = styled.div`
+  color: var(--color-text);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  &:hover {
+    color: var(--color-link);
+  }
 `
 
 const LabelWithButton = styled.div`

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -7,12 +7,12 @@
         "invalid_agent": "Invalid Agent"
       },
       "model": {
-        "supported_providers": "Supported Providers",
-        "tooltip": "Currently, only models that support Anthropic endpoints are available for the Agent feature.",
-        "view_providers": "View supported providers",
         "docs_link": "Custom provider",
         "empty": "No compatible models found for this Agent type.",
-        "empty_docs": "View setup guide"
+        "empty_docs": "View setup guide",
+        "supported_providers": "Supported Providers",
+        "tooltip": "Currently, only models that support Anthropic endpoints are available for the Agent feature.",
+        "view_providers": "View supported providers"
       },
       "title": "Add Agent",
       "type": {
@@ -5180,6 +5180,7 @@
         "remove_model": "Remove model",
         "remove_whole_group": "Remove the whole group"
       },
+      "possibly_removed": "This model may no longer be available from the provider",
       "provider_id": "Provider ID",
       "provider_key_add_confirm": "Do you want to add the API key for {{provider}}?",
       "provider_key_add_failed_by_empty_data": "Failed to add provider API key, data is empty",

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -10,7 +10,7 @@
         "supported_providers": "Supported Providers",
         "tooltip": "Currently, only models that support Anthropic endpoints are available for the Agent feature.",
         "view_providers": "View supported providers",
-        "docs_link": "Custom Anthropic-compatible provider",
+        "docs_link": "Custom provider",
         "empty": "No compatible models found for this Agent type.",
         "empty_docs": "View setup guide"
       },

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -9,7 +9,10 @@
       "model": {
         "supported_providers": "Supported Providers",
         "tooltip": "Currently, only models that support Anthropic endpoints are available for the Agent feature.",
-        "view_providers": "View supported providers"
+        "view_providers": "View supported providers",
+        "docs_link": "Custom Anthropic-compatible provider",
+        "empty": "No compatible models found for this Agent type.",
+        "empty_docs": "View setup guide"
       },
       "title": "Add Agent",
       "type": {

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -10,7 +10,7 @@
         "supported_providers": "支持的服务商",
         "tooltip": "目前，只有支持 Anthropic 端点的模型可用于 Agent 功能。",
         "view_providers": "查看支持的服务商",
-        "docs_link": "自定义 Anthropic 兼容服务商",
+        "docs_link": "自定义供应商",
         "empty": "未找到适用于当前 Agent 类型的模型。",
         "empty_docs": "查看配置指南"
       },

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -7,12 +7,12 @@
         "invalid_agent": "无效的 Agent"
       },
       "model": {
-        "supported_providers": "支持的服务商",
-        "tooltip": "目前，只有支持 Anthropic 端点的模型可用于 Agent 功能。",
-        "view_providers": "查看支持的服务商",
         "docs_link": "自定义供应商",
         "empty": "未找到适用于当前 Agent 类型的模型。",
-        "empty_docs": "查看配置指南"
+        "empty_docs": "查看配置指南",
+        "supported_providers": "支持的服务商",
+        "tooltip": "目前，只有支持 Anthropic 端点的模型可用于 Agent 功能。",
+        "view_providers": "查看支持的服务商"
       },
       "title": "添加 Agent",
       "type": {
@@ -5180,6 +5180,7 @@
         "remove_model": "移除模型",
         "remove_whole_group": "移除整个分组"
       },
+      "possibly_removed": "该模型可能已从上游下架",
       "provider_id": "服务商 ID",
       "provider_key_add_confirm": "是否要为 {{provider}} 添加 API 密钥？",
       "provider_key_add_failed_by_empty_data": "添加服务商 API 密钥失败，数据为空",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -9,7 +9,10 @@
       "model": {
         "supported_providers": "支持的服务商",
         "tooltip": "目前，只有支持 Anthropic 端点的模型可用于 Agent 功能。",
-        "view_providers": "查看支持的服务商"
+        "view_providers": "查看支持的服务商",
+        "docs_link": "自定义 Anthropic 兼容服务商",
+        "empty": "未找到适用于当前 Agent 类型的模型。",
+        "empty_docs": "查看配置指南"
       },
       "title": "添加 Agent",
       "type": {

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -10,7 +10,7 @@
         "supported_providers": "支援的服務商",
         "tooltip": "目前，僅支援 Anthropic 端點的模型可供 Agent 功能使用。",
         "view_providers": "檢視支援的服務商",
-        "docs_link": "自訂 Anthropic 相容服務商",
+        "docs_link": "自訂供應商",
         "empty": "未找到適用於目前 Agent 類型的模型。",
         "empty_docs": "檢視設定指南"
       },

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -9,7 +9,10 @@
       "model": {
         "supported_providers": "支援的服務商",
         "tooltip": "目前，僅支援 Anthropic 端點的模型可供 Agent 功能使用。",
-        "view_providers": "檢視支援的服務商"
+        "view_providers": "檢視支援的服務商",
+        "docs_link": "自訂 Anthropic 相容服務商",
+        "empty": "未找到適用於目前 Agent 類型的模型。",
+        "empty_docs": "檢視設定指南"
       },
       "title": "新增 Agent",
       "type": {

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -7,12 +7,12 @@
         "invalid_agent": "無效的 Agent"
       },
       "model": {
-        "supported_providers": "支援的服務商",
-        "tooltip": "目前，僅支援 Anthropic 端點的模型可供 Agent 功能使用。",
-        "view_providers": "檢視支援的服務商",
         "docs_link": "自訂供應商",
         "empty": "未找到適用於目前 Agent 類型的模型。",
-        "empty_docs": "檢視設定指南"
+        "empty_docs": "檢視設定指南",
+        "supported_providers": "支援的服務商",
+        "tooltip": "目前，僅支援 Anthropic 端點的模型可供 Agent 功能使用。",
+        "view_providers": "檢視支援的服務商"
       },
       "title": "新增 Agent",
       "type": {
@@ -5180,6 +5180,7 @@
         "remove_model": "移除模型",
         "remove_whole_group": "移除整個分組"
       },
+      "possibly_removed": "[to be translated]:This model may no longer be available from the provider",
       "provider_id": "提供者 ID",
       "provider_key_add_confirm": "是否要為 {{provider}} 新增 API 金鑰？",
       "provider_key_add_failed_by_empty_data": "新增提供者 API 金鑰失敗，資料為空",

--- a/src/renderer/src/i18n/translate/de-de.json
+++ b/src/renderer/src/i18n/translate/de-de.json
@@ -7,6 +7,9 @@
         "invalid_agent": "Ungültiger Agent"
       },
       "model": {
+        "docs_link": "[to be translated]:Custom provider",
+        "empty": "[to be translated]:No compatible models found for this Agent type.",
+        "empty_docs": "[to be translated]:View setup guide",
         "supported_providers": "Unterstützte Anbieter",
         "tooltip": "Derzeit sind für die Agent-Funktion nur Modelle verfügbar, die Anthropic-Endpunkte unterstützen.",
         "view_providers": "Unterstützte Anbieter anzeigen"
@@ -5167,6 +5170,7 @@
         "remove_model": "Modell entfernen",
         "remove_whole_group": "Gesamte Gruppe entfernen"
       },
+      "possibly_removed": "[to be translated]:This model may no longer be available from the provider",
       "provider_id": "Dienstanbieter-ID",
       "provider_key_add_confirm": "API-Schlüssel für {{provider}} hinzufügen?",
       "provider_key_add_failed_by_empty_data": "API-Schlüssel für Dienstanbieter hinzufügen fehlgeschlagen, Daten sind leer",

--- a/src/renderer/src/i18n/translate/de-de.json
+++ b/src/renderer/src/i18n/translate/de-de.json
@@ -7,9 +7,9 @@
         "invalid_agent": "Ungültiger Agent"
       },
       "model": {
-        "docs_link": "[to be translated]:Custom provider",
-        "empty": "[to be translated]:No compatible models found for this Agent type.",
-        "empty_docs": "[to be translated]:View setup guide",
+        "docs_link": "Benutzerdefinierter Anbieter",
+        "empty": "Für diesen Agent-Typ wurden keine kompatiblen Modelle gefunden.",
+        "empty_docs": "Einrichtungsanleitung anzeigen",
         "supported_providers": "Unterstützte Anbieter",
         "tooltip": "Derzeit sind für die Agent-Funktion nur Modelle verfügbar, die Anthropic-Endpunkte unterstützen.",
         "view_providers": "Unterstützte Anbieter anzeigen"

--- a/src/renderer/src/i18n/translate/el-gr.json
+++ b/src/renderer/src/i18n/translate/el-gr.json
@@ -7,6 +7,9 @@
         "invalid_agent": "Μη έγκυρος Agent"
       },
       "model": {
+        "docs_link": "[to be translated]:Custom provider",
+        "empty": "[to be translated]:No compatible models found for this Agent type.",
+        "empty_docs": "[to be translated]:View setup guide",
         "supported_providers": "Υποστηριζόμενοι Πάροχοι",
         "tooltip": "Προς το παρόν, μόνο μοντέλα που υποστηρίζουν τελικά σημεία Anthropic είναι διαθέσιμα για τη λειτουργία Agent.",
         "view_providers": "Δείτε τους υποστηριζόμενους παρόχους"
@@ -5167,6 +5170,7 @@
         "remove_model": "Αφαίρεση Μοντέλου",
         "remove_whole_group": "Αφαίρεση ολόκληρης ομάδας"
       },
+      "possibly_removed": "[to be translated]:This model may no longer be available from the provider",
       "provider_id": "Αναγνωριστικό Παρόχου",
       "provider_key_add_confirm": "Θέλετε να προσθέσετε κλειδί API για τον {{provider}};",
       "provider_key_add_failed_by_empty_data": "Η προσθήκη κλειδιού API παρόχου απέτυχε, τα δεδομένα είναι κενά",

--- a/src/renderer/src/i18n/translate/el-gr.json
+++ b/src/renderer/src/i18n/translate/el-gr.json
@@ -7,9 +7,9 @@
         "invalid_agent": "Μη έγκυρος Agent"
       },
       "model": {
-        "docs_link": "[to be translated]:Custom provider",
-        "empty": "[to be translated]:No compatible models found for this Agent type.",
-        "empty_docs": "[to be translated]:View setup guide",
+        "docs_link": "Προσαρμοσμένος πάροχος",
+        "empty": "Δεν βρέθηκαν συμβατά μοντέλα για αυτόν τον τύπο Agent.",
+        "empty_docs": "Προβολή οδηγού ρύθμισης",
         "supported_providers": "Υποστηριζόμενοι Πάροχοι",
         "tooltip": "Προς το παρόν, μόνο μοντέλα που υποστηρίζουν τελικά σημεία Anthropic είναι διαθέσιμα για τη λειτουργία Agent.",
         "view_providers": "Δείτε τους υποστηριζόμενους παρόχους"

--- a/src/renderer/src/i18n/translate/es-es.json
+++ b/src/renderer/src/i18n/translate/es-es.json
@@ -7,9 +7,9 @@
         "invalid_agent": "Agent inválido"
       },
       "model": {
-        "docs_link": "[to be translated]:Custom provider",
-        "empty": "[to be translated]:No compatible models found for this Agent type.",
-        "empty_docs": "[to be translated]:View setup guide",
+        "docs_link": "Proveedor personalizado",
+        "empty": "No se encontraron modelos compatibles para este tipo de agente.",
+        "empty_docs": "Ver guía de configuración",
         "supported_providers": "Proveedores Admitidos",
         "tooltip": "Actualmente, solo los modelos que admiten puntos finales de Anthropic están disponibles para la función Agente.",
         "view_providers": "Ver proveedores compatibles"

--- a/src/renderer/src/i18n/translate/es-es.json
+++ b/src/renderer/src/i18n/translate/es-es.json
@@ -7,6 +7,9 @@
         "invalid_agent": "Agent inválido"
       },
       "model": {
+        "docs_link": "[to be translated]:Custom provider",
+        "empty": "[to be translated]:No compatible models found for this Agent type.",
+        "empty_docs": "[to be translated]:View setup guide",
         "supported_providers": "Proveedores Admitidos",
         "tooltip": "Actualmente, solo los modelos que admiten puntos finales de Anthropic están disponibles para la función Agente.",
         "view_providers": "Ver proveedores compatibles"
@@ -5167,6 +5170,7 @@
         "remove_model": "Eliminar modelo",
         "remove_whole_group": "Eliminar todo el grupo"
       },
+      "possibly_removed": "[to be translated]:This model may no longer be available from the provider",
       "provider_id": "ID del proveedor",
       "provider_key_add_confirm": "¿Desea agregar una clave API para {{provider}}?",
       "provider_key_add_failed_by_empty_data": "Error al agregar la clave API del proveedor: los datos están vacíos",

--- a/src/renderer/src/i18n/translate/fr-fr.json
+++ b/src/renderer/src/i18n/translate/fr-fr.json
@@ -7,6 +7,9 @@
         "invalid_agent": "Agent invalide"
       },
       "model": {
+        "docs_link": "[to be translated]:Custom provider",
+        "empty": "[to be translated]:No compatible models found for this Agent type.",
+        "empty_docs": "[to be translated]:View setup guide",
         "supported_providers": "Fournisseurs pris en charge",
         "tooltip": "Actuellement, seuls les modèles qui prennent en charge les points de terminaison Anthropic sont disponibles pour la fonctionnalité Agent.",
         "view_providers": "Afficher les fournisseurs pris en charge"
@@ -5167,6 +5170,7 @@
         "remove_model": "Supprimer le modèle",
         "remove_whole_group": "Supprimer tout le groupe"
       },
+      "possibly_removed": "[to be translated]:This model may no longer be available from the provider",
       "provider_id": "Identifiant du fournisseur",
       "provider_key_add_confirm": "Voulez-vous ajouter une clé API pour {{provider}} ?",
       "provider_key_add_failed_by_empty_data": "Échec de l'ajout de la clé API du fournisseur, les données sont vides",

--- a/src/renderer/src/i18n/translate/fr-fr.json
+++ b/src/renderer/src/i18n/translate/fr-fr.json
@@ -7,9 +7,9 @@
         "invalid_agent": "Agent invalide"
       },
       "model": {
-        "docs_link": "[to be translated]:Custom provider",
-        "empty": "[to be translated]:No compatible models found for this Agent type.",
-        "empty_docs": "[to be translated]:View setup guide",
+        "docs_link": "Fournisseur personnalisé",
+        "empty": "Aucun modèle compatible trouvé pour ce type d'Agent.",
+        "empty_docs": "Voir le guide d'installation",
         "supported_providers": "Fournisseurs pris en charge",
         "tooltip": "Actuellement, seuls les modèles qui prennent en charge les points de terminaison Anthropic sont disponibles pour la fonctionnalité Agent.",
         "view_providers": "Afficher les fournisseurs pris en charge"

--- a/src/renderer/src/i18n/translate/ja-jp.json
+++ b/src/renderer/src/i18n/translate/ja-jp.json
@@ -7,6 +7,9 @@
         "invalid_agent": "無効なエージェント"
       },
       "model": {
+        "docs_link": "[to be translated]:Custom provider",
+        "empty": "[to be translated]:No compatible models found for this Agent type.",
+        "empty_docs": "[to be translated]:View setup guide",
         "supported_providers": "サポートされているプロバイダー",
         "tooltip": "現在、エージェント機能では、Anthropicエンドポイントをサポートするモデルのみが利用可能です。",
         "view_providers": "サポートされているプロバイダーを表示"
@@ -5167,6 +5170,7 @@
         "remove_model": "モデルを削除",
         "remove_whole_group": "グループ全体を削除"
       },
+      "possibly_removed": "[to be translated]:This model may no longer be available from the provider",
       "provider_id": "プロバイダー ID",
       "provider_key_add_confirm": "{{provider}} の API キーを追加しますか？",
       "provider_key_add_failed_by_empty_data": "{{provider}} の API キーを追加できませんでした。データが空です。",

--- a/src/renderer/src/i18n/translate/ja-jp.json
+++ b/src/renderer/src/i18n/translate/ja-jp.json
@@ -7,9 +7,9 @@
         "invalid_agent": "無効なエージェント"
       },
       "model": {
-        "docs_link": "[to be translated]:Custom provider",
-        "empty": "[to be translated]:No compatible models found for this Agent type.",
-        "empty_docs": "[to be translated]:View setup guide",
+        "docs_link": "カスタムプロバイダー",
+        "empty": "この Agent タイプに対応するモデルが見つかりません。",
+        "empty_docs": "セットアップガイドを表示",
         "supported_providers": "サポートされているプロバイダー",
         "tooltip": "現在、エージェント機能では、Anthropicエンドポイントをサポートするモデルのみが利用可能です。",
         "view_providers": "サポートされているプロバイダーを表示"

--- a/src/renderer/src/i18n/translate/pt-pt.json
+++ b/src/renderer/src/i18n/translate/pt-pt.json
@@ -7,9 +7,9 @@
         "invalid_agent": "Agent inválido"
       },
       "model": {
-        "docs_link": "[to be translated]:Custom provider",
-        "empty": "[to be translated]:No compatible models found for this Agent type.",
-        "empty_docs": "[to be translated]:View setup guide",
+        "docs_link": "Fornecedor personalizado",
+        "empty": "Não foram encontrados modelos compatíveis para este tipo de agente.",
+        "empty_docs": "Ver guia de configuração",
         "supported_providers": "Provedores Suportados",
         "tooltip": "Atualmente, apenas modelos que suportam endpoints da Anthropic estão disponíveis para o recurso Agente.",
         "view_providers": "Ver provedores suportados"

--- a/src/renderer/src/i18n/translate/pt-pt.json
+++ b/src/renderer/src/i18n/translate/pt-pt.json
@@ -7,6 +7,9 @@
         "invalid_agent": "Agent inválido"
       },
       "model": {
+        "docs_link": "[to be translated]:Custom provider",
+        "empty": "[to be translated]:No compatible models found for this Agent type.",
+        "empty_docs": "[to be translated]:View setup guide",
         "supported_providers": "Provedores Suportados",
         "tooltip": "Atualmente, apenas modelos que suportam endpoints da Anthropic estão disponíveis para o recurso Agente.",
         "view_providers": "Ver provedores suportados"
@@ -5167,6 +5170,7 @@
         "remove_model": "Remover Modelo",
         "remove_whole_group": "Remover todo o grupo"
       },
+      "possibly_removed": "[to be translated]:This model may no longer be available from the provider",
       "provider_id": "ID do Provedor",
       "provider_key_add_confirm": "Deseja adicionar uma chave API para {{provider}}?",
       "provider_key_add_failed_by_empty_data": "Falha ao adicionar chave API do provedor: dados vazios",

--- a/src/renderer/src/i18n/translate/ro-ro.json
+++ b/src/renderer/src/i18n/translate/ro-ro.json
@@ -7,6 +7,9 @@
         "invalid_agent": "Agent invalid"
       },
       "model": {
+        "docs_link": "[to be translated]:Custom provider",
+        "empty": "[to be translated]:No compatible models found for this Agent type.",
+        "empty_docs": "[to be translated]:View setup guide",
         "supported_providers": "Furnizori acceptați",
         "tooltip": "Momentan, doar modelele care acceptă endpoint-uri Anthropic sunt disponibile pentru funcția Agent.",
         "view_providers": "Vizualizați furnizorii acceptați"
@@ -5167,6 +5170,7 @@
         "remove_model": "Elimină modelul",
         "remove_whole_group": "Elimină întregul grup"
       },
+      "possibly_removed": "[to be translated]:This model may no longer be available from the provider",
       "provider_id": "ID furnizor",
       "provider_key_add_confirm": "Vrei să adaugi cheia API pentru {{provider}}?",
       "provider_key_add_failed_by_empty_data": "Adăugarea cheii API a furnizorului a eșuat, datele sunt goale",

--- a/src/renderer/src/i18n/translate/ro-ro.json
+++ b/src/renderer/src/i18n/translate/ro-ro.json
@@ -7,9 +7,9 @@
         "invalid_agent": "Agent invalid"
       },
       "model": {
-        "docs_link": "[to be translated]:Custom provider",
-        "empty": "[to be translated]:No compatible models found for this Agent type.",
-        "empty_docs": "[to be translated]:View setup guide",
+        "docs_link": "Furnizor personalizat",
+        "empty": "Nu s-au găsit modele compatibile pentru acest tip de Agent.",
+        "empty_docs": "Vezi ghidul de configurare",
         "supported_providers": "Furnizori acceptați",
         "tooltip": "Momentan, doar modelele care acceptă endpoint-uri Anthropic sunt disponibile pentru funcția Agent.",
         "view_providers": "Vizualizați furnizorii acceptați"

--- a/src/renderer/src/i18n/translate/ru-ru.json
+++ b/src/renderer/src/i18n/translate/ru-ru.json
@@ -7,6 +7,9 @@
         "invalid_agent": "Недействительный агент"
       },
       "model": {
+        "docs_link": "[to be translated]:Custom provider",
+        "empty": "[to be translated]:No compatible models found for this Agent type.",
+        "empty_docs": "[to be translated]:View setup guide",
         "supported_providers": "Поддерживаемые поставщики",
         "tooltip": "В настоящее время для функции агента доступны только модели, поддерживающие конечные точки Anthropic.",
         "view_providers": "Просмотреть поддерживаемых поставщиков"
@@ -5167,6 +5170,7 @@
         "remove_model": "Удалить модель",
         "remove_whole_group": "Удалить всю группу"
       },
+      "possibly_removed": "[to be translated]:This model may no longer be available from the provider",
       "provider_id": "ID провайдера",
       "provider_key_add_confirm": "Добавить API ключ для {{provider}}?",
       "provider_key_add_failed_by_empty_data": "Не удалось добавить API ключ для {{provider}}, данные пусты",

--- a/src/renderer/src/i18n/translate/ru-ru.json
+++ b/src/renderer/src/i18n/translate/ru-ru.json
@@ -7,9 +7,9 @@
         "invalid_agent": "Недействительный агент"
       },
       "model": {
-        "docs_link": "[to be translated]:Custom provider",
-        "empty": "[to be translated]:No compatible models found for this Agent type.",
-        "empty_docs": "[to be translated]:View setup guide",
+        "docs_link": "Пользовательский провайдер",
+        "empty": "Для этого типа агента не найдено совместимых моделей.",
+        "empty_docs": "Открыть руководство по настройке",
         "supported_providers": "Поддерживаемые поставщики",
         "tooltip": "В настоящее время для функции агента доступны только модели, поддерживающие конечные точки Anthropic.",
         "view_providers": "Просмотреть поддерживаемых поставщиков"

--- a/src/renderer/src/i18n/translate/vi-vn.json
+++ b/src/renderer/src/i18n/translate/vi-vn.json
@@ -7,9 +7,9 @@
         "invalid_agent": "Đại lý không hợp lệ"
       },
       "model": {
-        "docs_link": "[to be translated]:Custom provider",
-        "empty": "[to be translated]:No compatible models found for this Agent type.",
-        "empty_docs": "[to be translated]:View setup guide",
+        "docs_link": "Nhà cung cấp tùy chỉnh",
+        "empty": "Không tìm thấy mô hình tương thích cho loại Agent này.",
+        "empty_docs": "Xem hướng dẫn thiết lập",
         "supported_providers": "Nhà cung cấp được hỗ trợ",
         "tooltip": "Hiện tại, chỉ những mô hình hỗ trợ các điểm cuối Anthropic mới có sẵn cho tính năng Agent.",
         "view_providers": "Xem các nhà cung cấp được hỗ trợ"

--- a/src/renderer/src/i18n/translate/vi-vn.json
+++ b/src/renderer/src/i18n/translate/vi-vn.json
@@ -7,6 +7,9 @@
         "invalid_agent": "Đại lý không hợp lệ"
       },
       "model": {
+        "docs_link": "[to be translated]:Custom provider",
+        "empty": "[to be translated]:No compatible models found for this Agent type.",
+        "empty_docs": "[to be translated]:View setup guide",
         "supported_providers": "Nhà cung cấp được hỗ trợ",
         "tooltip": "Hiện tại, chỉ những mô hình hỗ trợ các điểm cuối Anthropic mới có sẵn cho tính năng Agent.",
         "view_providers": "Xem các nhà cung cấp được hỗ trợ"
@@ -5167,6 +5170,7 @@
         "remove_model": "Xóa mô hình",
         "remove_whole_group": "Xóa toàn bộ nhóm"
       },
+      "possibly_removed": "[to be translated]:This model may no longer be available from the provider",
       "provider_id": "ID Nhà cung cấp",
       "provider_key_add_confirm": "Bạn có muốn thêm khóa API cho {{provider}} không?",
       "provider_key_add_failed_by_empty_data": "Không thể thêm khóa API của nhà cung cấp, dữ liệu trống",


### PR DESCRIPTION
### What this PR does

Before this PR:
Users adding an Agent see an incomplete or empty model list without understanding that Agent model selection is intentionally limited to Anthropic-compatible models. The help popover only lists configured providers but provides no guidance on how to set up a compatible provider. The model picker shows a generic empty state when no compatible models are found.

After this PR:
- The Agent model help popover includes a "Custom provider" docs entry (with a document icon) that opens the Agent setup documentation without closing the dialog. It visually matches the provider rows for consistency.
- The Agent model picker shows an Agent-specific empty-state explanation with a link to the setup documentation when no compatible models are found.
- All new text is localized in English, Simplified Chinese, and Traditional Chinese.
- Existing provider navigation, model filtering, and model selection behavior remain unchanged.

Fixes #15041

### Why we need it and why it was done in this way

Issue #15041 reports that users cannot understand why the Agent model list is empty or incomplete. The root cause is an onboarding and explanation gap, not a filtering defect.

The following tradeoffs were made:
- The docs entry is injected via an optional `extraTopItem` prop on `AnthropicProviderListPopover` rather than hardcoded, so other callers remain unaffected.
- The docs entry uses the same visual style as provider rows (document icon + text + arrow) for consistency, rather than a distinct CTA card.
- Empty-state description is passed as an optional `emptyDescription` parameter to the generic model popup, avoiding changes to non-Agent pickers.

The following alternatives were considered:
- Standalone help text below the model selector — less discoverable.
- Hardcoding the docs entry inside `AnthropicProviderListPopover` — would affect all popover usages.
- A visually distinct CTA card style — rejected after user testing as inconsistent with the popover layout.

### Breaking changes

None.

### Special notes for your reviewer

This is a minimal hotfix scoped to renderer UI only. No changes to:
- Agent model filtering logic (`agentModelFilter`, `useApiModels`)
- Provider compatibility rules (`getAnthropicSupportedProviders`)
- Agent runtime behavior, Redux state, or database schema

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Agent model help popover now includes a documentation link for configuring custom Anthropic-compatible providers. Agent model picker shows an explanatory empty state when no compatible models are found.
```