### PR TITLE
fix: add missing key prop to SendMessageButton in InputbarCore (v2)

### DIFF
--- a/src/renderer/src/pages/home/Inputbar/components/InputbarCore.tsx
+++ b/src/renderer/src/pages/home/Inputbar/components/InputbarCore.tsx
@@ -595,7 +595,7 @@ export const InputbarCore: FC<InputbarCoreProps> = ({
         isLoading={isTranslating}
       />
     )
-    extras.push(<SendMessageButton sendMessage={handleSendMessage} disabled={isSendDisabled} />)
+    extras.push(<SendMessageButton key="send-message" sendMessage={handleSendMessage} disabled={isSendDisabled} />)
 
     if (isLoading) {
       extras.push(


### PR DESCRIPTION
Fixes React key warning for elements in the extras array.

### What this PR does

Before this PR:

`SendMessageButton` rendered inside the `extras` array in `InputbarCore` had no `key` prop, causing a React warning about missing keys on array elements.

After this PR:

`SendMessageButton` is rendered with a stable `key="send-message"` prop, resolving the React key warning.

### Why we need it and why it was done in this way

This silences a React key warning in the browser console.

### Breaking changes

None.

### Special notes for your reviewer

None.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others