### PR TITLE
hotfix(models): support capabilities for grok-build-0.1

### DIFF
--- a/src/renderer/src/config/models/__tests__/reasoning.test.ts
+++ b/src/renderer/src/config/models/__tests__/reasoning.test.ts
@@ -751,6 +751,10 @@ describe('isReasoningModel', () => {
     expect(isReasoningModel(createModel({ id: 'mistral-small-2603' }))).toBe(true)
   })
 
+  it('should return true for grok-build-0.1', () => {
+    expect(isReasoningModel(createModel({ id: 'grok-build-0.1' }))).toBe(true)
+  })
+
   it('excludes non-fixed reasoning models from isFixedReasoningModel', () => {
     // Models that support thinking tokens or reasoning effort should NOT be fixed reasoning models
     const nonFixedModels = [

--- a/src/renderer/src/config/models/reasoning.ts
+++ b/src/renderer/src/config/models/reasoning.ts
@@ -35,7 +35,7 @@ import { isTextToImageModel } from './vision'
 
 // Reasoning models
 export const REASONING_REGEX =
-  /^(?!.*-non-reasoning\b)(o\d+(?:-[\w-]+)?|.*\b(?:reasoning|reasoner|thinking|think)\b.*|.*-[rR]\d+.*|.*\bqwq(?:-[\w-]+)?\b.*|.*\bhunyuan-t1(?:-[\w-]+)?\b.*|.*\bglm-zero-preview\b.*|.*\bgrok-(?:3-mini|4|4-fast)(?:-[\w-]+)?\b.*)$/i
+  /^(?!.*-non-reasoning\b)(o\d+(?:-[\w-]+)?|.*\b(?:reasoning|reasoner|thinking|think)\b.*|.*-[rR]\d+.*|.*\bqwq(?:-[\w-]+)?\b.*|.*\bhunyuan-t1(?:-[\w-]+)?\b.*|.*\bglm-zero-preview\b.*|.*\bgrok-(?:3-mini|4|4-fast|build)(?:-[\w-]+)?\b.*)$/i
 
 // 模型类型到支持的reasoning_effort的映射表
 // TODO: refactor this. too many identical options
@@ -417,7 +417,8 @@ export function isGrokReasoningModel(model?: Model): boolean {
   const modelId = getLowerBaseModelName(model.id)
   if (
     isSupportedReasoningEffortGrokModel(model) ||
-    (modelId.includes('grok-4') && !modelId.includes('non-reasoning'))
+    (modelId.includes('grok-4') && !modelId.includes('non-reasoning')) ||
+    modelId.includes('grok-build')
   ) {
     return true
   }

--- a/src/renderer/src/config/models/tooluse.ts
+++ b/src/renderer/src/config/models/tooluse.ts
@@ -29,6 +29,7 @@ export const FUNCTION_CALLING_MODELS = [
   'gemma-?4(?:[-.\\w]+)?',
   'grok-3(?:-[\\w-]+)?',
   'grok-4(?:-[\\w-]+)?',
+  'grok-build(?:-[\\w-]+)?',
   'doubao-seed-1[.-][68](?:-[\\w-]+)?',
   'doubao-seed-2[.-]0(?:-[\\w-]+)?',
   'doubao-seed-code(?:-[\\w-]+)?',

--- a/src/renderer/src/config/models/vision.ts
+++ b/src/renderer/src/config/models/vision.ts
@@ -33,6 +33,7 @@ const visionAllowedModels = [
   'internvl2',
   'grok-vision-beta',
   'grok-4(?:-[\\w-]+)?',
+  'grok-build(?:-[\\w-]+)?',
   'pixtral',
   'gpt-4(?:-[\\w-]+)',
   'gpt-4.1(?:-[\\w-]+)?',


### PR DESCRIPTION
### What this PR does

Before this PR:
The newly released x.ai model `grok-build-0.1` was not fully recognized for its advanced capabilities such as reasoning (thinking/reasoning chain rendering), tool use (function calling), and vision (multimodality), because its model ID pattern was not registered in Cherry Studio's model configuration regexes.

After this PR:
- Updated the reasoning model regular expression and added `grok-build` base model checks in `reasoning.ts` to ensure `grok-build-0.1` is correctly recognized as a reasoning model (renders thinking process block in UI).
- Added `grok-build(?:-[\w-]+)?` pattern to `FUNCTION_CALLING_MODELS` in `tooluse.ts` to support tool use.
- Added `grok-build(?:-[\w-]+)?` pattern to `visionAllowedModels` in `vision.ts` to support image input / multimodal vision capabilities.
- Added unit tests for `grok-build-0.1` reasoning detection in `reasoning.test.ts`.

Fixes # None

### Why we need it and why it was done in this way

The model `grok-build-0.1` is a new coding/reasoning model released by x.ai. Supporting this model enables Cherry Studio users to leverage its vision, tool use, and reasoning capabilities natively when configured as a custom model.

The following tradeoffs were made:
- We did not add `grok-build-0.1` to the default model list (`default.ts`) as per user constraints, so users will configure it manually by inserting the model ID.
- Since x.ai does not currently expose a `reasoning_effort` API parameter for `grok-build-0.1`, we did not whitelist it in `isSupportedReasoningEffortGrokModel`. It will behave as a fixed reasoning model (renders reasoning tokens but doesn't allow adjusting thinking levels), which aligns with the x.ai API capabilities.

The following alternatives were considered:
- Adding `grok-build-0.1` as a default model under x.ai. This was rejected per the user's explicit instructions.

Links to places where the discussion took place:
https://docs.x.ai/developers/models/grok-build-0.1

### Breaking changes

None

### Special notes for your reviewer

Please note that testing this model requires configuring a custom x.ai model in Cherry Studio settings with the ID `grok-build-0.1`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
feat(models): support capabilities (reasoning, tool use, vision) for grok-build-0.1
```
