### PR TITLE
hotfix(model): enable standard reasoning effort levels for gemma-4 on non-gemini providers

### DIFF
--- a/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
+++ b/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
@@ -194,6 +194,53 @@ describe('reasoning utils', () => {
       expect(result).toEqual({ reasoning: { enabled: false, exclude: true } })
     })
 
+    it('should map reasoning effort for OpenRouter Gemma 4 model correctly', async () => {
+      const { isReasoningModel, isSupportedThinkingTokenModel } = await import('@renderer/config/models')
+
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+      vi.mocked(isSupportedThinkingTokenModel).mockReturnValue(true)
+
+      const model: Model = {
+        id: 'google/gemma-4-9b-it',
+        name: 'Gemma 4 9B IT',
+        provider: SystemProviderIds.openrouter
+      } as Model
+
+      const createAssistantWithEffort = (effort: string) =>
+        ({
+          id: 'test',
+          name: 'Test',
+          settings: {
+            reasoning_effort: effort
+          }
+        }) as Assistant
+
+      // none -> disabled
+      expect(getReasoningEffort(createAssistantWithEffort('none'), model)).toEqual({
+        reasoning: { enabled: false, exclude: true }
+      })
+
+      // low -> reasoning: { effort: 'low' }
+      expect(getReasoningEffort(createAssistantWithEffort('low'), model)).toEqual({
+        reasoning: { effort: 'low' }
+      })
+
+      // medium -> reasoning: { effort: 'medium' }
+      expect(getReasoningEffort(createAssistantWithEffort('medium'), model)).toEqual({
+        reasoning: { effort: 'medium' }
+      })
+
+      // high -> reasoning: { effort: 'high' }
+      expect(getReasoningEffort(createAssistantWithEffort('high'), model)).toEqual({
+        reasoning: { effort: 'high' }
+      })
+
+      // auto -> reasoning: { effort: 'medium' }
+      expect(getReasoningEffort(createAssistantWithEffort('auto'), model)).toEqual({
+        reasoning: { effort: 'medium' }
+      })
+    })
+
     it('should handle Qwen models with enable_thinking', async () => {
       const { isReasoningModel, isSupportedThinkingTokenQwenModel, isQwenReasoningModel } = await import(
         '@renderer/config/models'

--- a/src/renderer/src/aiCore/utils/reasoning.ts
+++ b/src/renderer/src/aiCore/utils/reasoning.ts
@@ -421,18 +421,6 @@ export function getReasoningEffort(assistant: Assistant, model: Model): Reasonin
     }
   }
 
-  // OpenRouter models, use reasoning
-  // FIXME: duplicated openrouter handling. remove one
-  if (model.provider === SystemProviderIds.openrouter) {
-    if (isSupportedReasoningEffortModel(model) || isSupportedThinkingTokenModel(model)) {
-      return {
-        reasoning: {
-          effort: reasoningEffort === 'auto' ? 'medium' : reasoningEffort
-        }
-      }
-    }
-  }
-
   // https://help.aliyun.com/zh/model-studio/deep-thinking
   if (provider.id === SystemProviderIds.dashscope) {
     // For dashscope: Qwen, DeepSeek, and GLM models use enable_thinking to control thinking

--- a/src/renderer/src/config/models/__tests__/reasoning.test.ts
+++ b/src/renderer/src/config/models/__tests__/reasoning.test.ts
@@ -1411,17 +1411,17 @@ describe('Gemini Models', () => {
       ).toBe(false)
     })
 
-    it('should return true for hosted gemma 4 models on Gemini provider', () => {
+    it('should return true for hosted gemma 4 models on Gemini provider and other providers', () => {
       expect(isSupportedThinkingTokenGeminiModel(createModel({ id: 'gemma-4-31b-it', provider: 'gemini' }))).toBe(true)
       expect(
         isSupportedThinkingTokenGeminiModel(createModel({ id: 'google/gemma-4-e2b-it', provider: 'gemini' }))
       ).toBe(true)
+      expect(isSupportedThinkingTokenGeminiModel(createModel({ id: 'gemma-4-31b-it', provider: 'openrouter' }))).toBe(
+        true
+      )
     })
 
-    it('should keep non-Gemini Gemma 4 ids out of Gemini thinking token detection', () => {
-      expect(isSupportedThinkingTokenGeminiModel(createModel({ id: 'gemma-4-31b-it', provider: 'openrouter' }))).toBe(
-        false
-      )
+    it('should keep non-Gemma 4 formatted ids out of Gemini thinking token detection', () => {
       expect(isSupportedThinkingTokenGeminiModel(createModel({ id: 'gemma4:31b' }))).toBe(false)
       expect(isSupportedThinkingTokenGeminiModel(createModel({ id: 'gemma4:e2b' }))).toBe(false)
     })
@@ -2237,6 +2237,12 @@ describe('getModelSupportedReasoningEffortOptions', () => {
       expect(
         getModelSupportedReasoningEffortOptions(createModel({ id: 'gemma-4-31b-it', provider: 'gemini' }))
       ).toEqual(['default', 'minimal', 'high'])
+    })
+
+    it('should return low/medium/high options for hosted Gemma 4 on OpenRouter provider', () => {
+      expect(
+        getModelSupportedReasoningEffortOptions(createModel({ id: 'gemma-4-31b-it', provider: 'openrouter' }))
+      ).toEqual(['default', 'none', 'low', 'medium', 'high'])
     })
   })
 

--- a/src/renderer/src/config/models/reasoning.ts
+++ b/src/renderer/src/config/models/reasoning.ts
@@ -188,6 +188,8 @@ const _getThinkModelType = (model: Model): ThinkingModelType => {
   } else if (isSupportedThinkingTokenGeminiModel(model)) {
     if (isHostedGemma4ThinkingModel(model)) {
       thinkingModelType = 'gemma4_hosted'
+    } else if (model.provider?.toLowerCase() !== 'gemini' && modelId.startsWith('gemma-4-')) {
+      thinkingModelType = 'default'
     } else if (isGemini3FlashModel(model) || isGemini31FlashLiteModel(model)) {
       thinkingModelType = 'gemini3_flash'
     } else if (isGemini3ProModel(model)) {
@@ -457,7 +459,7 @@ export const isHostedGemma4ThinkingModel = (model?: Model): boolean => {
 
 export const isSupportedThinkingTokenGeminiModel = (model: Model): boolean => {
   const modelId = getLowerBaseModelName(model.id, '/')
-  if (isHostedGemma4ThinkingModel(model)) {
+  if (modelId.startsWith('gemma-4-') || isHostedGemma4ThinkingModel(model)) {
     return true
   }
 


### PR DESCRIPTION
### What this PR does

Before this PR:
Gemma 4 models on non-Gemini providers (such as OpenRouter) were incorrectly classified as `gemma4_hosted` models. This caused them to display incorrect UI reasoning options (e.g., restricted to `default`, `minimal`, `high`) and fallback to improper configurations, preventing standard reasoning options from showing up.

After this PR:
Gemma 4 models on non-Gemini providers are correctly classified as `'default'` thinking models, which restores the standard reasoning options (`default`, `none`, `low`, `medium`, `high`) in the UI, and packages request payloads using standard `reasoning.effort` mapping. The special handling for Gemma 4 is restricted only to the native `gemini` provider.

Fixes #14870
Fixes #15248

### Why we need it and why it was done in this way

To align with user-facing expectations where non-native providers (such as OpenRouter or SiliconFlow) for Gemma 4 should support regular reasoning efforts. The fix restricts the specialized `gemma4_hosted` categorization to only when `model.provider?.toLowerCase() === 'gemini'`, while ensuring non-Gemini Gemma 4 models can still be mapped as supporting reasoning options.

The following tradeoffs were made:
None.

The following alternatives were considered:
None.

Links to places where the discussion took place: 
- https://github.com/CherryHQ/cherry-studio/issues/14870
- https://github.com/CherryHQ/cherry-studio/issues/15248

### Breaking changes

None.

### Special notes for your reviewer

None.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed Gemma 4 models on non-Gemini providers (e.g., OpenRouter) having restricted reasoning effort levels. They now support full standard reasoning effort levels.
```
