### PR TITLE
hotfix(channels): integrate WeCom (企业微信) channel adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@napi-rs/system-ocr": "1.0.2",
     "@paymoapp/electron-shutdown-handler": "1.1.2",
     "cron-parser": "^5.0.8",
+    "dingtalk-stream": "^2.1.5",
     "express": "5.1.0",
     "font-list": "2.0.0",
     "graceful-fs": "4.2.11",

--- a/packages/shared/IpcChannel.ts
+++ b/packages/shared/IpcChannel.ts
@@ -123,6 +123,9 @@ export enum IpcChannel {
   // Feishu channel
   Feishu_QrLogin = 'feishu:qr-login',
 
+  // WeCom channel
+  WeCom_QrLogin = 'wecom:qr-login',
+
   // Channel status & logs
   Channel_StatusChange = 'channel:status-change',
   Channel_Log = 'channel:log',

--- a/packages/shared/IpcChannel.ts
+++ b/packages/shared/IpcChannel.ts
@@ -126,6 +126,9 @@ export enum IpcChannel {
   // WeCom channel
   WeCom_QrLogin = 'wecom:qr-login',
 
+  // DingTalk channel
+  DingTalk_QrLogin = 'dingtalk:qr-login',
+
   // Channel status & logs
   Channel_StatusChange = 'channel:status-change',
   Channel_Log = 'channel:log',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       cron-parser:
         specifier: ^5.0.8
         version: 5.5.0
+      dingtalk-stream:
+        specifier: ^2.1.5
+        version: 2.1.5
       express:
         specifier: 5.1.0
         version: 5.1.0
@@ -1957,28 +1960,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.2.4':
     resolution: {integrity: sha512-M/Iz48p4NAzMXOuH+tsn5BvG/Jb07KOMTdSVwJpicmhN309BeEyRyQX+n1XDF0JVSlu28+hiTQ2L4rZPvu7nMw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.2.4':
     resolution: {integrity: sha512-m41nFDS0ksXK2gwXL6W6yZTYPMH0LughqbsxInSKetoH6morVj43szqKx79Iudkp8WRT5SxSh7qVb8KCUiewGg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.2.4':
     resolution: {integrity: sha512-orr3nnf2Dpb2ssl6aihQtvcKtLySLta4E2UcXdp7+RTa7mfJjBgIsbS0B9GC8gVu0hjOu021aU8b3/I1tn+pVQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.2.4':
     resolution: {integrity: sha512-NXnfTeKHDFUWfxAefa57DiGmu9VyKi0cDqFpdI+1hJWQjGJhJutHPX0b5m+eXvTKOaf+brU+P0JrQAZMb5yYaQ==}
@@ -2773,105 +2772,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -3622,35 +3605,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.97':
     resolution: {integrity: sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.97':
     resolution: {integrity: sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.97':
     resolution: {integrity: sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.97':
     resolution: {integrity: sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.97':
     resolution: {integrity: sha512-u883Yr6A6fO7Vpsy9YE4FVCIxzzo5sO+7pIUjjoDLjS3vQaNMkVzx5bdIpEL+ob+gU88WDK4VcxYMZ6nmnoX9A==}
@@ -3938,56 +3916,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.56.0':
     resolution: {integrity: sha512-rkTZkBfJ4TYLjansjSzL6mgZOdN5IvUnSq3oNJSLwBcNvy3dlgQtpHPrRxrCEbbcp7oQ6If0tkNaqfOsphYZ9g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.56.0':
     resolution: {integrity: sha512-uqL1kMH3u69/e1CH2EJhP3CP28jw2ExLsku4o8RVAZ7fySo9zOyI2fy9pVlTAp4voBLVgzndXi3SgtdyCTa2aA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.56.0':
     resolution: {integrity: sha512-j0CcMBOgV6KsRaBdsebIeiy7hCjEvq2KdEsiULf2LZqAq0v1M1lWjelhCV57LxsqaIGChXFuFJ0RiFrSRHPhSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.56.0':
     resolution: {integrity: sha512-7VDOiL8cDG3DQ/CY3yKjbV1c4YPvc4vH8qW09Vv+5ukq3l/Kcyr6XGCd5NvxUmxqDb2vjMpM+eW/4JrEEsUetA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.56.0':
     resolution: {integrity: sha512-JGRpX0M+ikD3WpwJ7vKcHKV6Kg0dT52BW2Eu2BupXotYeqGXBrbY+QPkAyKO6MNgKozyTNaRh3r7g+VWgyAQYQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.56.0':
     resolution: {integrity: sha512-dNaICPvtmuxFP/VbqdofrLqdS3bM/AKJN3LMJD52si44ea7Be1cBk6NpfIahaysG9Uo+L98QKddU9CD5L8UHnQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.56.0':
     resolution: {integrity: sha512-pF1vOtM+GuXmbklM1hV8WMsn6tCNPvkUzklj/Ej98JhlanbmA2RB1BILgOpwSuCTRTIYx2MXssmEyQQ90QF5aA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.56.0':
     resolution: {integrity: sha512-bp8NQ4RE6fDIFLa4bdBiOA+TAvkNkg+rslR+AvvjlLTYXLy9/uKAYLQudaQouWihLD/hgkrXIKKzXi5IXOewwg==}
@@ -4512,56 +4482,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.3':
     resolution: {integrity: sha512-kWXkoxxarYISBJ4bLNf5vFkEbb4JvccOwxWDxuK9yee8lg5XA7OpvlTptfRuwEvYcOZf+7VS69Uenpmpyo5Bjw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.53':
     resolution: {integrity: sha512-bGe5EBB8FVjHBR1mOLOPEFg1Lp3//7geqWkU5NIhxe+yH0W8FVrQ6WRYOap4SUTKdklD/dC4qPLREkMMQ855FA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.3':
     resolution: {integrity: sha512-Z03/wrqau9Bicfgb3Dbs6SYTHliELk2PM2LpG2nFd+cGupTMF5kanLEcj2vuuJLLhptNyS61rtk7SOZ+lPsTUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.53':
     resolution: {integrity: sha512-qL+63WKVQs1CMvFedlPt0U9PiEKJOAL/bsHMKUDS6Vp2Q+YAv/QLPu8rcvkfIMvQ0FPU2WL0aX4eWwF6e/GAnA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.3':
     resolution: {integrity: sha512-iSXXZsQp08CSilff/DCTFZHSVEpEwdicV3W8idHyrByrcsRDVh9sGC3sev6d8BygSGj3vt8GvUKBPCoyMA4tgQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.53':
     resolution: {integrity: sha512-VGl9JIGjoJh3H8Mb+7xnVqODajBmrdOOb9lxWXdcmxyI+zjB2sux69br0hZJDTyLJfvBoYm439zPACYbCjGRmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.3':
     resolution: {integrity: sha512-qaj+MFudtdCv9xZo9znFvkgoajLdc+vwf0Kz5N44g+LU5XMe+IsACgn3UG7uTRlCCvhMAGXm1XlpEA5bZBrOcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.53':
     resolution: {integrity: sha512-B4iIserJXuSnNzA5xBLFUIjTfhNy7d9sq4FUMQY3GhQWGVhS2RWWzzDnkSU6MUt7/aHUrep0CdQfXUJI9D3W7A==}
@@ -4622,7 +4584,6 @@ packages:
     resolution: {integrity: sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
@@ -4949,28 +4910,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.8':
     resolution: {integrity: sha512-koiCqL09EwOP1S2RShCI7NbsQuG6r2brTqUYE7pV7kZm9O17wZ0LSz22m6gVibpwEnw8jI3IE1yYsQTVpluALw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.8':
     resolution: {integrity: sha512-4p6lOMU3bC+Vd5ARtKJ/FxpIC5G8v3XLoPEZ5s7mLR8h7411HWC/LmTXDHcrSXRC55zvAVia1eldy6zDLz8iFQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.8':
     resolution: {integrity: sha512-z3XBnbrZAL+6xDGAhJoN4lOueIxC/8rGrJ9tg+fEaeqLEuAtHSW2QHDHxDwkxZMjuF/pZ6MUTjHjbp8wLbuRLA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.8':
     resolution: {integrity: sha512-djQPJ9Rh9vP8GTS/Df3hcc6XP6xnG5c8qsngWId/BLA9oX6C7UzCPAn74BG/wGb9a6j4w3RINuoaieJB3t+7iQ==}
@@ -5054,28 +5011,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -7355,6 +7308,9 @@ packages:
   dingbat-to-unicode@1.0.1:
     resolution: {integrity: sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==}
 
+  dingtalk-stream@2.1.5:
+    resolution: {integrity: sha512-6H3tSc/mE6hMj4RBB5ntkI4ycC498RobmtMxfLS8eBTRPjBZlhUdDYEHA0asOoTLSzC2PHqupr4D4HVoaU7bRQ==}
+
   dir-compare@4.2.0:
     resolution: {integrity: sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==}
 
@@ -9284,28 +9240,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -11991,6 +11943,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.5.9:
     resolution: {integrity: sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==}
@@ -12527,6 +12480,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -12539,11 +12493,12 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uzip@0.20201231.0:
@@ -20189,6 +20144,16 @@ snapshots:
   dijkstrajs@1.0.3: {}
 
   dingbat-to-unicode@1.0.1: {}
+
+  dingtalk-stream@2.1.5:
+    dependencies:
+      axios: 1.15.2(debug@4.4.3)
+      debug: 4.4.3
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   dir-compare@4.2.0:
     dependencies:

--- a/resources/database/drizzle/0008_bouncy_romulus.sql
+++ b/resources/database/drizzle/0008_bouncy_romulus.sql
@@ -1,0 +1,26 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_channels` (
+	`id` text PRIMARY KEY NOT NULL,
+	`type` text NOT NULL,
+	`name` text NOT NULL,
+	`agent_id` text,
+	`session_id` text,
+	`config` text NOT NULL,
+	`is_active` integer DEFAULT true NOT NULL,
+	`active_chat_ids` text DEFAULT '[]',
+	`permission_mode` text,
+	`created_at` integer,
+	`updated_at` integer,
+	FOREIGN KEY (`agent_id`) REFERENCES `agents`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`session_id`) REFERENCES `sessions`(`id`) ON UPDATE no action ON DELETE set null,
+	CONSTRAINT "channels_type_check" CHECK("__new_channels"."type" IN ('telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack', 'wecom')),
+	CONSTRAINT "channels_permission_mode_check" CHECK("__new_channels"."permission_mode" IS NULL OR "__new_channels"."permission_mode" IN ('default', 'acceptEdits', 'bypassPermissions', 'plan'))
+);
+--> statement-breakpoint
+INSERT INTO `__new_channels`("id", "type", "name", "agent_id", "session_id", "config", "is_active", "active_chat_ids", "permission_mode", "created_at", "updated_at") SELECT "id", "type", "name", "agent_id", "session_id", "config", "is_active", "active_chat_ids", "permission_mode", "created_at", "updated_at" FROM `channels`;--> statement-breakpoint
+DROP TABLE `channels`;--> statement-breakpoint
+ALTER TABLE `__new_channels` RENAME TO `channels`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `channels_agent_id_idx` ON `channels` (`agent_id`);--> statement-breakpoint
+CREATE INDEX `channels_type_idx` ON `channels` (`type`);--> statement-breakpoint
+CREATE INDEX `channels_session_id_idx` ON `channels` (`session_id`);

--- a/resources/database/drizzle/0009_unusual_mentor.sql
+++ b/resources/database/drizzle/0009_unusual_mentor.sql
@@ -1,0 +1,26 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_channels` (
+	`id` text PRIMARY KEY NOT NULL,
+	`type` text NOT NULL,
+	`name` text NOT NULL,
+	`agent_id` text,
+	`session_id` text,
+	`config` text NOT NULL,
+	`is_active` integer DEFAULT true NOT NULL,
+	`active_chat_ids` text DEFAULT '[]',
+	`permission_mode` text,
+	`created_at` integer,
+	`updated_at` integer,
+	FOREIGN KEY (`agent_id`) REFERENCES `agents`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`session_id`) REFERENCES `sessions`(`id`) ON UPDATE no action ON DELETE set null,
+	CONSTRAINT "channels_type_check" CHECK("__new_channels"."type" IN ('telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack', 'wecom', 'dingtalk')),
+	CONSTRAINT "channels_permission_mode_check" CHECK("__new_channels"."permission_mode" IS NULL OR "__new_channels"."permission_mode" IN ('default', 'acceptEdits', 'bypassPermissions', 'plan'))
+);
+--> statement-breakpoint
+INSERT INTO `__new_channels`("id", "type", "name", "agent_id", "session_id", "config", "is_active", "active_chat_ids", "permission_mode", "created_at", "updated_at") SELECT "id", "type", "name", "agent_id", "session_id", "config", "is_active", "active_chat_ids", "permission_mode", "created_at", "updated_at" FROM `channels`;--> statement-breakpoint
+DROP TABLE `channels`;--> statement-breakpoint
+ALTER TABLE `__new_channels` RENAME TO `channels`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `channels_agent_id_idx` ON `channels` (`agent_id`);--> statement-breakpoint
+CREATE INDEX `channels_type_idx` ON `channels` (`type`);--> statement-breakpoint
+CREATE INDEX `channels_session_id_idx` ON `channels` (`session_id`);

--- a/resources/database/drizzle/meta/0008_snapshot.json
+++ b/resources/database/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,979 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "688540ee-047b-41ab-baf7-6d4f9f9c48af",
+  "prevId": "bd05ea4b-4ff1-4666-a98d-7ce82fe68548",
+  "tables": {
+    "agents": {
+      "name": "agents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessible_paths": {
+          "name": "accessible_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_model": {
+          "name": "plan_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "small_model": {
+          "name": "small_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcps": {
+          "name": "mcps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_skills": {
+      "name": "agent_skills",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_agent_skills_agent_id": {
+          "name": "idx_agent_skills_agent_id",
+          "columns": [
+            "agent_id"
+          ],
+          "isUnique": false
+        },
+        "idx_agent_skills_skill_id": {
+          "name": "idx_agent_skills_skill_id",
+          "columns": [
+            "skill_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_skills_agent_id_agents_id_fk": {
+          "name": "agent_skills_agent_id_agents_id_fk",
+          "tableFrom": "agent_skills",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_skills_skill_id_skills_id_fk": {
+          "name": "agent_skills_skill_id_skills_id_fk",
+          "tableFrom": "agent_skills",
+          "tableTo": "skills",
+          "columnsFrom": [
+            "skill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_skills_agent_id_skill_id_pk": {
+          "columns": [
+            "agent_id",
+            "skill_id"
+          ],
+          "name": "agent_skills_agent_id_skill_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_task_subscriptions": {
+      "name": "channel_task_subscriptions",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cts_channel_id_idx": {
+          "name": "cts_channel_id_idx",
+          "columns": [
+            "channel_id"
+          ],
+          "isUnique": false
+        },
+        "cts_task_id_idx": {
+          "name": "cts_task_id_idx",
+          "columns": [
+            "task_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_task_subscriptions_channel_id_channels_id_fk": {
+          "name": "channel_task_subscriptions_channel_id_channels_id_fk",
+          "tableFrom": "channel_task_subscriptions",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_task_subscriptions_task_id_scheduled_tasks_id_fk": {
+          "name": "channel_task_subscriptions_task_id_scheduled_tasks_id_fk",
+          "tableFrom": "channel_task_subscriptions",
+          "tableTo": "scheduled_tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_task_subscriptions_channel_id_task_id_pk": {
+          "columns": [
+            "channel_id",
+            "task_id"
+          ],
+          "name": "channel_task_subscriptions_channel_id_task_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channels": {
+      "name": "channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "active_chat_ids": {
+          "name": "active_chat_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channels_agent_id_idx": {
+          "name": "channels_agent_id_idx",
+          "columns": [
+            "agent_id"
+          ],
+          "isUnique": false
+        },
+        "channels_type_idx": {
+          "name": "channels_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "channels_session_id_idx": {
+          "name": "channels_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channels_agent_id_agents_id_fk": {
+          "name": "channels_agent_id_agents_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channels_session_id_sessions_id_fk": {
+          "name": "channels_session_id_sessions_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "channels_type_check": {
+          "name": "channels_type_check",
+          "value": "\"channels\".\"type\" IN ('telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack', 'wecom')"
+        },
+        "channels_permission_mode_check": {
+          "name": "channels_permission_mode_check",
+          "value": "\"channels\".\"permission_mode\" IS NULL OR \"channels\".\"permission_mode\" IN ('default', 'acceptEdits', 'bypassPermissions', 'plan')"
+        }
+      }
+    },
+    "session_messages": {
+      "name": "session_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "migrations": {
+      "name": "migrations",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_type": {
+          "name": "agent_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessible_paths": {
+          "name": "accessible_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_model": {
+          "name": "plan_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "small_model": {
+          "name": "small_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcps": {
+          "name": "mcps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slash_commands": {
+          "name": "slash_commands",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skills": {
+      "name": "skills",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folder_name": {
+          "name": "folder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "skills_folder_name_unique": {
+          "name": "skills_folder_name_unique",
+          "columns": [
+            "folder_name"
+          ],
+          "isUnique": true
+        },
+        "idx_skills_source": {
+          "name": "idx_skills_source",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "idx_skills_is_enabled": {
+          "name": "idx_skills_is_enabled",
+          "columns": [
+            "is_enabled"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_value": {
+          "name": "schedule_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeout_minutes": {
+          "name": "timeout_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "next_run": {
+          "name": "next_run",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_result": {
+          "name": "last_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "task_run_logs": {
+      "name": "task_run_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/resources/database/drizzle/meta/0009_snapshot.json
+++ b/resources/database/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,979 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d6973cce-681f-4d06-ae79-1d0669196a67",
+  "prevId": "688540ee-047b-41ab-baf7-6d4f9f9c48af",
+  "tables": {
+    "agents": {
+      "name": "agents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessible_paths": {
+          "name": "accessible_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_model": {
+          "name": "plan_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "small_model": {
+          "name": "small_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcps": {
+          "name": "mcps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_skills": {
+      "name": "agent_skills",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_agent_skills_agent_id": {
+          "name": "idx_agent_skills_agent_id",
+          "columns": [
+            "agent_id"
+          ],
+          "isUnique": false
+        },
+        "idx_agent_skills_skill_id": {
+          "name": "idx_agent_skills_skill_id",
+          "columns": [
+            "skill_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_skills_agent_id_agents_id_fk": {
+          "name": "agent_skills_agent_id_agents_id_fk",
+          "tableFrom": "agent_skills",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_skills_skill_id_skills_id_fk": {
+          "name": "agent_skills_skill_id_skills_id_fk",
+          "tableFrom": "agent_skills",
+          "tableTo": "skills",
+          "columnsFrom": [
+            "skill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_skills_agent_id_skill_id_pk": {
+          "columns": [
+            "agent_id",
+            "skill_id"
+          ],
+          "name": "agent_skills_agent_id_skill_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_task_subscriptions": {
+      "name": "channel_task_subscriptions",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cts_channel_id_idx": {
+          "name": "cts_channel_id_idx",
+          "columns": [
+            "channel_id"
+          ],
+          "isUnique": false
+        },
+        "cts_task_id_idx": {
+          "name": "cts_task_id_idx",
+          "columns": [
+            "task_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_task_subscriptions_channel_id_channels_id_fk": {
+          "name": "channel_task_subscriptions_channel_id_channels_id_fk",
+          "tableFrom": "channel_task_subscriptions",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_task_subscriptions_task_id_scheduled_tasks_id_fk": {
+          "name": "channel_task_subscriptions_task_id_scheduled_tasks_id_fk",
+          "tableFrom": "channel_task_subscriptions",
+          "tableTo": "scheduled_tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_task_subscriptions_channel_id_task_id_pk": {
+          "columns": [
+            "channel_id",
+            "task_id"
+          ],
+          "name": "channel_task_subscriptions_channel_id_task_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channels": {
+      "name": "channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "active_chat_ids": {
+          "name": "active_chat_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channels_agent_id_idx": {
+          "name": "channels_agent_id_idx",
+          "columns": [
+            "agent_id"
+          ],
+          "isUnique": false
+        },
+        "channels_type_idx": {
+          "name": "channels_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "channels_session_id_idx": {
+          "name": "channels_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channels_agent_id_agents_id_fk": {
+          "name": "channels_agent_id_agents_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channels_session_id_sessions_id_fk": {
+          "name": "channels_session_id_sessions_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "channels_type_check": {
+          "name": "channels_type_check",
+          "value": "\"channels\".\"type\" IN ('telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack', 'wecom', 'dingtalk')"
+        },
+        "channels_permission_mode_check": {
+          "name": "channels_permission_mode_check",
+          "value": "\"channels\".\"permission_mode\" IS NULL OR \"channels\".\"permission_mode\" IN ('default', 'acceptEdits', 'bypassPermissions', 'plan')"
+        }
+      }
+    },
+    "session_messages": {
+      "name": "session_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "migrations": {
+      "name": "migrations",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_type": {
+          "name": "agent_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessible_paths": {
+          "name": "accessible_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_model": {
+          "name": "plan_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "small_model": {
+          "name": "small_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcps": {
+          "name": "mcps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slash_commands": {
+          "name": "slash_commands",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skills": {
+      "name": "skills",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folder_name": {
+          "name": "folder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "skills_folder_name_unique": {
+          "name": "skills_folder_name_unique",
+          "columns": [
+            "folder_name"
+          ],
+          "isUnique": true
+        },
+        "idx_skills_source": {
+          "name": "idx_skills_source",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "idx_skills_is_enabled": {
+          "name": "idx_skills_is_enabled",
+          "columns": [
+            "is_enabled"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_value": {
+          "name": "schedule_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeout_minutes": {
+          "name": "timeout_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "next_run": {
+          "name": "next_run",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_result": {
+          "name": "last_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "task_run_logs": {
+      "name": "task_run_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/resources/database/drizzle/meta/_journal.json
+++ b/resources/database/drizzle/meta/_journal.json
@@ -63,6 +63,13 @@
       "when": 1779443790665,
       "tag": "0008_bouncy_romulus",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1779450844836,
+      "tag": "0009_unusual_mentor",
+      "breakpoints": true
     }
   ],
   "version": "7"

--- a/resources/database/drizzle/meta/_journal.json
+++ b/resources/database/drizzle/meta/_journal.json
@@ -56,6 +56,13 @@
       "when": 1776236285350,
       "tag": "0007_strange_galactus",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1779443790665,
+      "tag": "0008_bouncy_romulus",
+      "breakpoints": true
     }
   ],
   "version": "7"

--- a/src/main/mcpServers/__tests__/claw.test.ts
+++ b/src/main/mcpServers/__tests__/claw.test.ts
@@ -373,14 +373,15 @@ describe('ClawServer', () => {
         expect(parsed.model).toBe('claude-sonnet-4-20250514')
         expect(parsed.channels).toHaveLength(1)
         expect(parsed.channels[0].type).toBe('telegram')
-        expect(parsed.supported_channel_types).toHaveLength(6)
+        expect(parsed.supported_channel_types).toHaveLength(7)
         expect(parsed.supported_channel_types.map((t: any) => t.type)).toEqual([
           'telegram',
           'feishu',
           'qq',
           'wechat',
           'discord',
-          'slack'
+          'slack',
+          'wecom'
         ])
         expect(parsed.soul_enabled).toBe(true)
       })

--- a/src/main/mcpServers/__tests__/claw.test.ts
+++ b/src/main/mcpServers/__tests__/claw.test.ts
@@ -373,7 +373,7 @@ describe('ClawServer', () => {
         expect(parsed.model).toBe('claude-sonnet-4-20250514')
         expect(parsed.channels).toHaveLength(1)
         expect(parsed.channels[0].type).toBe('telegram')
-        expect(parsed.supported_channel_types).toHaveLength(7)
+        expect(parsed.supported_channel_types).toHaveLength(8)
         expect(parsed.supported_channel_types.map((t: any) => t.type)).toEqual([
           'telegram',
           'feishu',
@@ -381,7 +381,8 @@ describe('ClawServer', () => {
           'wechat',
           'discord',
           'slack',
-          'wecom'
+          'wecom',
+          'dingtalk'
         ])
         expect(parsed.soul_enabled).toBe(true)
       })

--- a/src/main/mcpServers/claw.ts
+++ b/src/main/mcpServers/claw.ts
@@ -159,15 +159,15 @@ const CHANNEL_CONFIG_SCHEMAS: Record<string, { required: string[]; optional: str
     ].join(' ')
   },
   wecom: {
-    required: ['bot_id', 'bot_secret'],
-    optional: ['allowed_chat_ids'],
+    required: [],
+    optional: ['bot_id', 'bot_secret', 'allowed_chat_ids'],
     description: [
       'WeCom (企业微信 / WeChat Work) smart bot via the official Bot Open API. Uses 30s polling — no webhook needed.',
-      'Setup steps:',
-      '1. In WeCom admin console, create or open a smart bot (智能机器人) and obtain its Bot ID and Secret. Docs: https://open.work.weixin.qq.com/help2/pc/cat?doc_id=21677',
-      '2. Pass bot_id and bot_secret in config.',
-      '3. allowed_chat_ids is required for receiving messages — each entry uses the format "<chat_type>:<chatid>" where chat_type is 1 (single-user DM, chatid = userid) or 2 (group, chatid = group id). Example: ["1:zhangsan", "2:wrxxxxxx"].',
-      '4. WeCom enforces a 7-day history window on get_message; the adapter clamps queries accordingly and only delivers messages newer than the connect time on first poll.'
+      'Two setup paths:',
+      'A) QR scan (recommended): omit bot_id and bot_secret entirely — a QR code is returned for the user to scan with WeCom. Credentials are auto-obtained and saved.',
+      'B) Manual: obtain Bot ID and Secret from the WeCom admin console (https://open.work.weixin.qq.com/help2/pc/cat?doc_id=21677) and pass them as bot_id / bot_secret.',
+      'allowed_chat_ids format: ["<chat_type>:<chatid>", ...] where chat_type is 1 (DM, chatid = userid) or 2 (group, chatid = group id). Example: ["1:zhangsan", "2:wrxxxxxx"].',
+      'WeCom enforces a 7-day history window on get_message; the adapter clamps queries accordingly and only delivers messages newer than the connect time on first poll.'
     ].join(' ')
   }
 }
@@ -505,10 +505,13 @@ class ClawServer {
       isActive: enabled ?? true
     })
 
-    // For channels that use QR-based setup (WeChat login, Feishu app registration),
-    // connect is blocking (waits for QR scan), so run sync in background
-    // and wait only for the QR URL to return it to the agent.
-    const needsQr = type === 'wechat' || (type === 'feishu' && !cfg.app_id && !cfg.app_secret)
+    // For channels that use QR-based setup (WeChat login, Feishu app registration,
+    // WeCom smart bot binding), connect is blocking (waits for QR scan), so run
+    // sync in background and wait only for the QR URL to return it to the agent.
+    const needsQr =
+      type === 'wechat' ||
+      (type === 'feishu' && !cfg.app_id && !cfg.app_secret) ||
+      (type === 'wecom' && !cfg.bot_id && !cfg.bot_secret)
 
     if (needsQr) {
       const qrPromise = channelManager.waitForQrUrl(this.agentId, newChannel.id, 30_000)
@@ -521,11 +524,13 @@ class ClawServer {
         })
       })
 
-      const channelLabel = type === 'wechat' ? 'WeChat' : 'Feishu'
+      const channelLabel = type === 'wechat' ? 'WeChat' : type === 'wecom' ? 'WeCom' : 'Feishu'
       const scanHint =
         type === 'wechat'
           ? 'scan with WeChat to log in'
-          : 'scan with Feishu to create a bot app and obtain credentials automatically'
+          : type === 'wecom'
+            ? 'scan with WeCom to bind the smart bot and obtain credentials automatically'
+            : 'scan with Feishu to create a bot app and obtain credentials automatically'
 
       try {
         const qrUrl = await qrPromise
@@ -630,8 +635,11 @@ class ClawServer {
     const channel = await channelService.getChannel(channelId)
     if (!channel) throw new McpError(ErrorCode.InvalidParams, `Channel "${channelId}" not found`)
 
+    const cfg = channel.config as Record<string, unknown>
     const needsQr =
-      channel.type === 'wechat' || (channel.type === 'feishu' && !(channel.config as Record<string, unknown>).app_id)
+      channel.type === 'wechat' ||
+      (channel.type === 'feishu' && !cfg.app_id) ||
+      (channel.type === 'wecom' && !cfg.bot_id)
 
     if (!needsQr) {
       await channelManager.syncChannel(channelId)
@@ -650,7 +658,7 @@ class ClawServer {
       })
     })
 
-    const channelLabel = channel.type === 'wechat' ? 'WeChat' : 'Feishu'
+    const channelLabel = channel.type === 'wechat' ? 'WeChat' : channel.type === 'wecom' ? 'WeCom' : 'Feishu'
 
     try {
       const qrUrl = await qrPromise

--- a/src/main/mcpServers/claw.ts
+++ b/src/main/mcpServers/claw.ts
@@ -157,6 +157,18 @@ const CHANNEL_CONFIG_SCHEMAS: Record<string, { required: string[]; optional: str
       '6. Invite the bot to channels by typing /invite @YourBotName in the desired Slack channel.',
       '7. allowed_channel_ids is optional — leave empty to allow all channels the bot is in.'
     ].join(' ')
+  },
+  wecom: {
+    required: ['bot_id', 'bot_secret'],
+    optional: ['allowed_chat_ids'],
+    description: [
+      'WeCom (企业微信 / WeChat Work) smart bot via the official Bot Open API. Uses 30s polling — no webhook needed.',
+      'Setup steps:',
+      '1. In WeCom admin console, create or open a smart bot (智能机器人) and obtain its Bot ID and Secret. Docs: https://open.work.weixin.qq.com/help2/pc/cat?doc_id=21677',
+      '2. Pass bot_id and bot_secret in config.',
+      '3. allowed_chat_ids is required for receiving messages — each entry uses the format "<chat_type>:<chatid>" where chat_type is 1 (single-user DM, chatid = userid) or 2 (group, chatid = group id). Example: ["1:zhangsan", "2:wrxxxxxx"].',
+      '4. WeCom enforces a 7-day history window on get_message; the adapter clamps queries accordingly and only delivers messages newer than the connect time on first poll.'
+    ].join(' ')
   }
 }
 
@@ -183,7 +195,7 @@ const CONFIG_TOOL: Tool = {
       },
       type: {
         type: 'string',
-        enum: ['telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack'],
+        enum: ['telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack', 'wecom'],
         description: "Channel adapter type (required for 'add_channel')"
       },
       name: {

--- a/src/main/mcpServers/claw.ts
+++ b/src/main/mcpServers/claw.ts
@@ -169,6 +169,18 @@ const CHANNEL_CONFIG_SCHEMAS: Record<string, { required: string[]; optional: str
       'allowed_chat_ids format: ["<chat_type>:<chatid>", ...] where chat_type is 1 (DM, chatid = userid) or 2 (group, chatid = group id). Example: ["1:zhangsan", "2:wrxxxxxx"].',
       'WeCom enforces a 7-day history window on get_message; the adapter clamps queries accordingly and only delivers messages newer than the connect time on first poll.'
     ].join(' ')
+  },
+  dingtalk: {
+    required: [],
+    optional: ['client_id', 'client_secret', 'allowed_chat_ids'],
+    description: [
+      'DingTalk (钉钉) enterprise inner-app bot via Stream mode (WebSocket — no public IP required).',
+      'Two setup paths:',
+      'A) QR scan (recommended): omit client_id and client_secret — a QR code is returned for the user to scan with DingTalk to authorize. Credentials are auto-obtained.',
+      'B) Manual: create an enterprise inner-app at https://open-dev.dingtalk.com/, enable Stream mode, and pass the App Key as client_id and App Secret as client_secret.',
+      'allowed_chat_ids format: ["p2p:<staffId>", "group:<openConversationId>", ...]. Empty list auto-tracks chats the bot receives messages from. Use /whoami in DingTalk to see your staff/group IDs.',
+      'Replies within ~5 minutes of an inbound message route through the session webhook; older replies fall back to proactive send.'
+    ].join(' ')
   }
 }
 
@@ -195,7 +207,7 @@ const CONFIG_TOOL: Tool = {
       },
       type: {
         type: 'string',
-        enum: ['telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack', 'wecom'],
+        enum: ['telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack', 'wecom', 'dingtalk'],
         description: "Channel adapter type (required for 'add_channel')"
       },
       name: {
@@ -506,12 +518,14 @@ class ClawServer {
     })
 
     // For channels that use QR-based setup (WeChat login, Feishu app registration,
-    // WeCom smart bot binding), connect is blocking (waits for QR scan), so run
-    // sync in background and wait only for the QR URL to return it to the agent.
+    // WeCom smart bot binding, DingTalk Device Flow), connect is blocking (waits
+    // for QR scan), so run sync in background and wait only for the QR URL to
+    // return it to the agent.
     const needsQr =
       type === 'wechat' ||
       (type === 'feishu' && !cfg.app_id && !cfg.app_secret) ||
-      (type === 'wecom' && !cfg.bot_id && !cfg.bot_secret)
+      (type === 'wecom' && !cfg.bot_id && !cfg.bot_secret) ||
+      (type === 'dingtalk' && !cfg.client_id && !cfg.client_secret)
 
     if (needsQr) {
       const qrPromise = channelManager.waitForQrUrl(this.agentId, newChannel.id, 30_000)
@@ -524,13 +538,16 @@ class ClawServer {
         })
       })
 
-      const channelLabel = type === 'wechat' ? 'WeChat' : type === 'wecom' ? 'WeCom' : 'Feishu'
+      const channelLabel =
+        type === 'wechat' ? 'WeChat' : type === 'wecom' ? 'WeCom' : type === 'dingtalk' ? 'DingTalk' : 'Feishu'
       const scanHint =
         type === 'wechat'
           ? 'scan with WeChat to log in'
           : type === 'wecom'
             ? 'scan with WeCom to bind the smart bot and obtain credentials automatically'
-            : 'scan with Feishu to create a bot app and obtain credentials automatically'
+            : type === 'dingtalk'
+              ? 'scan with DingTalk to authorize the bot and obtain credentials automatically'
+              : 'scan with Feishu to create a bot app and obtain credentials automatically'
 
       try {
         const qrUrl = await qrPromise
@@ -639,7 +656,8 @@ class ClawServer {
     const needsQr =
       channel.type === 'wechat' ||
       (channel.type === 'feishu' && !cfg.app_id) ||
-      (channel.type === 'wecom' && !cfg.bot_id)
+      (channel.type === 'wecom' && !cfg.bot_id) ||
+      (channel.type === 'dingtalk' && !cfg.client_id)
 
     if (!needsQr) {
       await channelManager.syncChannel(channelId)
@@ -658,7 +676,14 @@ class ClawServer {
       })
     })
 
-    const channelLabel = channel.type === 'wechat' ? 'WeChat' : channel.type === 'wecom' ? 'WeCom' : 'Feishu'
+    const channelLabel =
+      channel.type === 'wechat'
+        ? 'WeChat'
+        : channel.type === 'wecom'
+          ? 'WeCom'
+          : channel.type === 'dingtalk'
+            ? 'DingTalk'
+            : 'Feishu'
 
     try {
       const qrUrl = await qrPromise

--- a/src/main/services/agents/database/schema/channelConfig.ts
+++ b/src/main/services/agents/database/schema/channelConfig.ts
@@ -59,6 +59,17 @@ export const SlackChannelConfigSchema = z.object({
 
 export type SlackChannelConfig = z.infer<typeof SlackChannelConfigSchema>
 
+export const WeComChannelConfigSchema = z.object({
+  type: z.literal('wecom'),
+  bot_id: z.string(),
+  bot_secret: z.string(),
+  // Each entry is "chat_type:chatid", e.g. "1:zhangsan" (DM) or "2:wrxxxx" (group).
+  // chat_type is required because WeCom does not return it from get_msg_chat_list.
+  allowed_chat_ids: z.array(z.string()).default([])
+})
+
+export type WeComChannelConfig = z.infer<typeof WeComChannelConfigSchema>
+
 // ---- Discriminated union ----
 
 export const ChannelConfigSchema = z.discriminatedUnion('type', [
@@ -67,10 +78,11 @@ export const ChannelConfigSchema = z.discriminatedUnion('type', [
   QQChannelConfigSchema,
   WeChatChannelConfigSchema,
   DiscordChannelConfigSchema,
-  SlackChannelConfigSchema
+  SlackChannelConfigSchema,
+  WeComChannelConfigSchema
 ])
 
 export type ChannelConfig = z.infer<typeof ChannelConfigSchema>
 
-export const CHANNEL_TYPES = ['telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack'] as const
+export const CHANNEL_TYPES = ['telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack', 'wecom'] as const
 export type ChannelType = (typeof CHANNEL_TYPES)[number]

--- a/src/main/services/agents/database/schema/channelConfig.ts
+++ b/src/main/services/agents/database/schema/channelConfig.ts
@@ -61,8 +61,11 @@ export type SlackChannelConfig = z.infer<typeof SlackChannelConfigSchema>
 
 export const WeComChannelConfigSchema = z.object({
   type: z.literal('wecom'),
-  bot_id: z.string(),
-  bot_secret: z.string(),
+  // Empty bot_id / bot_secret means "not yet bound" — the adapter will start the
+  // QR registration flow on connect, and persist credentials via the
+  // 'credentials' event once the user scans.
+  bot_id: z.string().default(''),
+  bot_secret: z.string().default(''),
   // Each entry is "chat_type:chatid", e.g. "1:zhangsan" (DM) or "2:wrxxxx" (group).
   // chat_type is required because WeCom does not return it from get_msg_chat_list.
   allowed_chat_ids: z.array(z.string()).default([])

--- a/src/main/services/agents/database/schema/channelConfig.ts
+++ b/src/main/services/agents/database/schema/channelConfig.ts
@@ -73,6 +73,21 @@ export const WeComChannelConfigSchema = z.object({
 
 export type WeComChannelConfig = z.infer<typeof WeComChannelConfigSchema>
 
+export const DingTalkChannelConfigSchema = z.object({
+  type: z.literal('dingtalk'),
+  // Empty client_id / client_secret means "not yet bound" — the adapter will
+  // start the Device Flow registration on connect and persist credentials via
+  // the 'credentials' event once the user authorizes.
+  client_id: z.string().default(''),
+  client_secret: z.string().default(''),
+  // Each entry is "<conversation_type>:<id>" — "p2p:<staffId>" (DM) or
+  // "group:<openConversationId>" (group). Empty allows any chat (auto-tracked
+  // into activeChatIds the first time a message arrives, mirroring Telegram).
+  allowed_chat_ids: z.array(z.string()).default([])
+})
+
+export type DingTalkChannelConfig = z.infer<typeof DingTalkChannelConfigSchema>
+
 // ---- Discriminated union ----
 
 export const ChannelConfigSchema = z.discriminatedUnion('type', [
@@ -82,10 +97,11 @@ export const ChannelConfigSchema = z.discriminatedUnion('type', [
   WeChatChannelConfigSchema,
   DiscordChannelConfigSchema,
   SlackChannelConfigSchema,
-  WeComChannelConfigSchema
+  WeComChannelConfigSchema,
+  DingTalkChannelConfigSchema
 ])
 
 export type ChannelConfig = z.infer<typeof ChannelConfigSchema>
 
-export const CHANNEL_TYPES = ['telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack', 'wecom'] as const
+export const CHANNEL_TYPES = ['telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack', 'wecom', 'dingtalk'] as const
 export type ChannelType = (typeof CHANNEL_TYPES)[number]

--- a/src/main/services/agents/database/schema/channels.schema.ts
+++ b/src/main/services/agents/database/schema/channels.schema.ts
@@ -16,7 +16,8 @@ import {
   type QQChannelConfig,
   type SlackChannelConfig,
   type TelegramChannelConfig,
-  type WeChatChannelConfig
+  type WeChatChannelConfig,
+  type WeComChannelConfig
 } from './channelConfig'
 import { sessionsTable } from './sessions.schema'
 import { scheduledTasksTable } from './tasks.schema'
@@ -29,7 +30,8 @@ export type {
   QQChannelConfig,
   SlackChannelConfig,
   TelegramChannelConfig,
-  WeChatChannelConfig
+  WeChatChannelConfig,
+  WeComChannelConfig
 }
 export { ChannelConfigSchema }
 
@@ -58,7 +60,7 @@ export const channelsTable = sqliteTable(
     index('channels_agent_id_idx').on(t.agentId),
     index('channels_type_idx').on(t.type),
     index('channels_session_id_idx').on(t.sessionId),
-    check('channels_type_check', sql`${t.type} IN ('telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack')`),
+    check('channels_type_check', sql`${t.type} IN ('telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack', 'wecom')`),
     check(
       'channels_permission_mode_check',
       sql`${t.permissionMode} IS NULL OR ${t.permissionMode} IN ('default', 'acceptEdits', 'bypassPermissions', 'plan')`

--- a/src/main/services/agents/database/schema/channels.schema.ts
+++ b/src/main/services/agents/database/schema/channels.schema.ts
@@ -10,6 +10,7 @@ import { agentsTable } from './agents.schema'
 import {
   type ChannelConfig,
   ChannelConfigSchema,
+  type DingTalkChannelConfig,
   type DiscordChannelConfig,
   type FeishuChannelConfig,
   type FeishuDomain,
@@ -24,6 +25,7 @@ import { scheduledTasksTable } from './tasks.schema'
 
 export type {
   ChannelConfig,
+  DingTalkChannelConfig,
   DiscordChannelConfig,
   FeishuChannelConfig,
   FeishuDomain,
@@ -60,7 +62,10 @@ export const channelsTable = sqliteTable(
     index('channels_agent_id_idx').on(t.agentId),
     index('channels_type_idx').on(t.type),
     index('channels_session_id_idx').on(t.sessionId),
-    check('channels_type_check', sql`${t.type} IN ('telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack', 'wecom')`),
+    check(
+      'channels_type_check',
+      sql`${t.type} IN ('telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack', 'wecom', 'dingtalk')`
+    ),
     check(
       'channels_permission_mode_check',
       sql`${t.permissionMode} IS NULL OR ${t.permissionMode} IN ('default', 'acceptEdits', 'bypassPermissions', 'plan')`

--- a/src/main/services/agents/services/channels/ChannelManager.ts
+++ b/src/main/services/agents/services/channels/ChannelManager.ts
@@ -30,7 +30,8 @@ const adapterImportMap: Record<string, () => Promise<unknown>> = {
   qq: () => import('./adapters/qq/QQAdapter'),
   slack: () => import('./adapters/slack/SlackAdapter'),
   telegram: () => import('./adapters/telegram/TelegramAdapter'),
-  wechat: () => import('./adapters/wechat/WeChatAdapter')
+  wechat: () => import('./adapters/wechat/WeChatAdapter'),
+  wecom: () => import('./adapters/wecom/WeComAdapter')
 }
 
 /** Ensure the adapter factory for the given type is loaded (idempotent). */

--- a/src/main/services/agents/services/channels/ChannelManager.ts
+++ b/src/main/services/agents/services/channels/ChannelManager.ts
@@ -25,6 +25,7 @@ export function registerAdapterFactory(type: string, factory: AdapterFactory): v
  * This avoids eagerly importing all 6 heavy adapter modules at startup.
  */
 const adapterImportMap: Record<string, () => Promise<unknown>> = {
+  dingtalk: () => import('./adapters/dingtalk/DingTalkAdapter'),
   discord: () => import('./adapters/discord/DiscordAdapter'),
   feishu: () => import('./adapters/feishu/FeishuAdapter'),
   qq: () => import('./adapters/qq/QQAdapter'),
@@ -232,12 +233,15 @@ class ChannelManager {
     if (!channel) return
 
     // Different channel types persist QR-obtained credentials under different
-    // field names. Feishu uses app_id/app_secret; WeCom uses bot_id/bot_secret.
+    // field names. Feishu uses app_id/app_secret; WeCom uses bot_id/bot_secret;
+    // DingTalk uses client_id/client_secret.
     const config = channel.config as ChannelConfig & Record<string, unknown>
     const credentialUpdate =
       channel.type === 'wecom'
         ? { bot_id: creds.appId, bot_secret: creds.appSecret }
-        : { app_id: creds.appId, app_secret: creds.appSecret }
+        : channel.type === 'dingtalk'
+          ? { client_id: creds.appId, client_secret: creds.appSecret }
+          : { app_id: creds.appId, app_secret: creds.appSecret }
     await channelService.updateChannel(channelId, {
       config: { ...config, ...credentialUpdate } as ChannelConfig
     })

--- a/src/main/services/agents/services/channels/ChannelManager.ts
+++ b/src/main/services/agents/services/channels/ChannelManager.ts
@@ -231,12 +231,18 @@ class ChannelManager {
     const channel = await channelService.getChannel(channelId)
     if (!channel) return
 
+    // Different channel types persist QR-obtained credentials under different
+    // field names. Feishu uses app_id/app_secret; WeCom uses bot_id/bot_secret.
     const config = channel.config as ChannelConfig & Record<string, unknown>
+    const credentialUpdate =
+      channel.type === 'wecom'
+        ? { bot_id: creds.appId, bot_secret: creds.appSecret }
+        : { app_id: creds.appId, app_secret: creds.appSecret }
     await channelService.updateChannel(channelId, {
-      config: { ...config, app_id: creds.appId, app_secret: creds.appSecret } as ChannelConfig
+      config: { ...config, ...credentialUpdate } as ChannelConfig
     })
 
-    logger.info('Saved QR registration credentials, reconnecting', { agentId, channelId })
+    logger.info('Saved QR registration credentials, reconnecting', { agentId, channelId, type: channel.type })
     await this.syncChannel(channelId)
   }
 

--- a/src/main/services/agents/services/channels/adapters/__tests__/DingTalkAdapter.test.ts
+++ b/src/main/services/agents/services/channels/adapters/__tests__/DingTalkAdapter.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), silly: vi.fn() })
+  }
+}))
+
+vi.mock('../../ChannelManager', () => ({
+  registerAdapterFactory: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: { getVersion: () => '0.0.0-test', getPath: () => '/mock/userData' },
+  nativeTheme: { themeSource: '', shouldUseDarkColors: false },
+  net: { fetch: vi.fn() }
+}))
+
+vi.mock('../../../../../WindowService', () => ({
+  windowService: { getMainWindow: () => null }
+}))
+
+// Mock DWClient so the adapter doesn't try a real WebSocket connection.
+const dwClientInstances: Array<{
+  connect: ReturnType<typeof vi.fn>
+  disconnect: ReturnType<typeof vi.fn>
+  registerCallbackListener: ReturnType<typeof vi.fn>
+  socketCallBackResponse: ReturnType<typeof vi.fn>
+  _handler?: (downstream: any) => void
+}> = []
+
+vi.mock('dingtalk-stream', () => {
+  class DWClient {
+    connect = vi.fn().mockResolvedValue(undefined)
+    disconnect = vi.fn()
+    socketCallBackResponse = vi.fn()
+    registerCallbackListener = vi.fn((_topic: string, handler: (downstream: any) => void) => {
+      ;(this as any)._handler = handler
+      return this
+    })
+    constructor() {
+      dwClientInstances.push(this as any)
+    }
+  }
+  return {
+    DWClient,
+    TOPIC_ROBOT: '/v1.0/im/bot/messages/get'
+  }
+})
+
+// Import to trigger self-registration.
+import '../dingtalk/DingTalkAdapter'
+
+import { net } from 'electron'
+
+import { registerAdapterFactory } from '../../ChannelManager'
+
+function getFactory() {
+  const call = vi.mocked(registerAdapterFactory).mock.calls.find((c) => c[0] === 'dingtalk')
+  if (!call) throw new Error('registerAdapterFactory was not called for dingtalk')
+  return call[1] as (channel: any, agentId: string) => any
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+    headers: { get: () => null }
+  } as unknown as Response
+}
+
+describe('DingTalkAdapter', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.mocked(net.fetch)
+    fetchMock.mockReset()
+    dwClientInstances.length = 0
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function createAdapter(overrides: Record<string, unknown> = {}) {
+    const factory = getFactory()
+    return factory(
+      {
+        id: (overrides.channelId as string) ?? 'ch-1',
+        type: 'dingtalk',
+        enabled: true,
+        config: {
+          client_id: (overrides.client_id as string) ?? 'CLIENT_ID',
+          client_secret: (overrides.client_secret as string) ?? 'CLIENT_SECRET',
+          allowed_chat_ids: (overrides.allowed_chat_ids as string[]) ?? []
+        }
+      },
+      (overrides.agentId as string) ?? 'agent-1'
+    )
+  }
+
+  it('checkReady returns true only when both credentials are present', async () => {
+    const empty = createAdapter({ client_id: '', client_secret: '' })
+    expect(await empty.checkReady()).toBe(false)
+    const ok = createAdapter()
+    expect(await ok.checkReady()).toBe(true)
+  })
+
+  it('connect starts DWClient and registers the robot listener', async () => {
+    const adapter = createAdapter({ allowed_chat_ids: ['p2p:zhangsan'] })
+    await adapter.connect()
+
+    expect(dwClientInstances).toHaveLength(1)
+    const dw = dwClientInstances[0]
+    expect(dw.connect).toHaveBeenCalledTimes(1)
+    expect(dw.registerCallbackListener).toHaveBeenCalledTimes(1)
+    expect(dw.registerCallbackListener.mock.calls[0][0]).toBe('/v1.0/im/bot/messages/get')
+    expect(adapter.connected).toBe(true)
+
+    await adapter.disconnect()
+    expect(dw.disconnect).toHaveBeenCalled()
+  })
+
+  it('emits message event for an allowed p2p text and acks the message', async () => {
+    const adapter = createAdapter({ allowed_chat_ids: ['p2p:staff-001'] })
+    const received: any[] = []
+    adapter.on('message', (msg: any) => received.push(msg))
+    await adapter.connect()
+
+    const dw = dwClientInstances[0]
+    dw._handler?.({
+      headers: { messageId: 'mid-1' },
+      data: JSON.stringify({
+        msgId: 'in-1',
+        msgtype: 'text',
+        conversationType: '1',
+        conversationId: 'conv-1',
+        senderId: 'staff-001',
+        senderStaffId: 'staff-001',
+        senderNick: 'Zhang San',
+        sessionWebhook: 'https://oapi.dingtalk.com/robot/sendBySession?token=xxx',
+        text: { content: 'hello' }
+      })
+    })
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(dw.socketCallBackResponse).toHaveBeenCalledWith('mid-1', { success: true })
+    expect(received).toHaveLength(1)
+    expect(received[0]).toMatchObject({
+      chatId: 'p2p:staff-001',
+      userId: 'staff-001',
+      userName: 'Zhang San',
+      text: 'hello'
+    })
+
+    await adapter.disconnect()
+  })
+
+  it('drops inbound messages from non-allowed chats', async () => {
+    const adapter = createAdapter({ allowed_chat_ids: ['p2p:other'] })
+    const received: any[] = []
+    adapter.on('message', (msg: any) => received.push(msg))
+    await adapter.connect()
+
+    dwClientInstances[0]._handler?.({
+      headers: { messageId: 'mid-2' },
+      data: JSON.stringify({
+        msgId: 'in-2',
+        msgtype: 'text',
+        conversationType: '1',
+        conversationId: 'conv-2',
+        senderId: 'staff-002',
+        senderStaffId: 'staff-002',
+        sessionWebhook: 'https://oapi.dingtalk.com/robot/sendBySession?token=yyy',
+        text: { content: 'sneak' }
+      })
+    })
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(received).toHaveLength(0)
+    await adapter.disconnect()
+  })
+
+  it('sendMessage uses the captured session webhook when fresh', async () => {
+    const adapter = createAdapter({ allowed_chat_ids: ['group:cid-1'] })
+    await adapter.connect()
+
+    // Webhook will respond with { errcode: 0 }.
+    fetchMock.mockResolvedValue(jsonResponse({ errcode: 0, errmsg: 'ok' }))
+
+    dwClientInstances[0]._handler?.({
+      headers: { messageId: 'mid-3' },
+      data: JSON.stringify({
+        msgId: 'in-3',
+        msgtype: 'text',
+        conversationType: '2',
+        conversationId: 'cid-1',
+        senderId: 'staff-003',
+        senderStaffId: 'staff-003',
+        sessionWebhook: 'https://oapi.dingtalk.com/robot/sendBySession?token=zzz',
+        text: { content: 'hi bot' }
+      })
+    })
+    await new Promise((resolve) => setImmediate(resolve))
+
+    await adapter.sendMessage('group:cid-1', 'reply text')
+
+    expect(fetchMock).toHaveBeenCalled()
+    const sendCall = fetchMock.mock.calls.find((c) =>
+      String(c[0]).startsWith('https://oapi.dingtalk.com/robot/sendBySession')
+    )
+    expect(sendCall).toBeDefined()
+    const body = JSON.parse((sendCall![1] as { body: string }).body)
+    expect(body).toEqual({ msgtype: 'text', text: { content: 'reply text' } })
+
+    await adapter.disconnect()
+  })
+
+  it('sendMessage falls back to proactive p2p send when no fresh webhook exists', async () => {
+    const adapter = createAdapter({ allowed_chat_ids: ['p2p:staff-x'] })
+    await adapter.connect()
+
+    // First call is the access token fetch; second is the proactive send.
+    fetchMock.mockImplementation(async (url: string) => {
+      if (String(url).includes('/oauth2/accessToken')) {
+        return jsonResponse({ accessToken: 'tok', expireIn: 7200 })
+      }
+      if (String(url).includes('/oToMessages/batchSend')) {
+        return jsonResponse({ processQueryKey: 'pqk-1' })
+      }
+      return jsonResponse({})
+    })
+
+    await adapter.sendMessage('p2p:staff-x', 'proactive hello')
+
+    const proactiveCall = fetchMock.mock.calls.find((c) => String(c[0]).includes('/oToMessages/batchSend'))
+    expect(proactiveCall).toBeDefined()
+    const body = JSON.parse((proactiveCall![1] as { body: string }).body)
+    expect(body.userIds).toEqual(['staff-x'])
+    expect(body.msgKey).toBe('sampleText')
+    expect(JSON.parse(body.msgParam)).toEqual({ content: 'proactive hello' })
+
+    await adapter.disconnect()
+  })
+
+  it('rejects sendMessage with malformed chat id', async () => {
+    const adapter = createAdapter()
+    await adapter.connect()
+    await expect(adapter.sendMessage('not-a-valid-id', 'x')).rejects.toThrow(/Invalid DingTalk chat id/)
+    await adapter.disconnect()
+  })
+})

--- a/src/main/services/agents/services/channels/adapters/__tests__/WeComAdapter.test.ts
+++ b/src/main/services/agents/services/channels/adapters/__tests__/WeComAdapter.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), silly: vi.fn() })
+  }
+}))
+
+vi.mock('../../ChannelManager', () => ({
+  registerAdapterFactory: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getVersion: () => '0.0.0-test'
+  },
+  net: {
+    fetch: vi.fn()
+  }
+}))
+
+// Import to trigger self-registration side effect.
+import '../wecom/WeComAdapter'
+
+import { net } from 'electron'
+
+import { registerAdapterFactory } from '../../ChannelManager'
+import { genReqId, sign, WeComClient } from '../wecom/WeComClient'
+
+function getFactory() {
+  const call = vi.mocked(registerAdapterFactory).mock.calls.find((c) => c[0] === 'wecom')
+  if (!call) throw new Error('registerAdapterFactory was not called for wecom')
+  return call[1] as (channel: any, agentId: string) => any
+}
+
+function bizPayload(payload: Record<string, unknown>): { result: { content: [{ type: 'text'; text: string }] } } {
+  return { result: { content: [{ type: 'text', text: JSON.stringify(payload) }] } }
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body)
+  } as unknown as Response
+}
+
+describe('WeComClient signature', () => {
+  it('concatenates inputs as secret + bot_id + time + nonce', () => {
+    // wecom-cli src/mcp/config.rs:99 — sign = sha256(secret + bot_id + time + nonce).
+    // sha256("secbot100nonce") = 6e8a64...; verify the same node:crypto result matches.
+    const expected = require('node:crypto').createHash('sha256').update('secbot100nonce').digest('hex')
+    expect(sign('sec', 'bot', 100, 'nonce')).toBe(expected)
+  })
+
+  it('is deterministic and varies with inputs', () => {
+    expect(sign('sec', 'bot', 100, 'nonce')).toBe(sign('sec', 'bot', 100, 'nonce'))
+    expect(sign('sec', 'bot', 100, 'nonce')).toHaveLength(64)
+    expect(sign('sec', 'bot', 100, 'nonce1')).not.toBe(sign('sec', 'bot', 100, 'nonce2'))
+  })
+
+  it('genReqId follows {prefix}_{ts}_{8hex} format', () => {
+    const id = genReqId('mcp')
+    expect(id).toMatch(/^mcp_\d+_[0-9a-f]{8}$/)
+  })
+})
+
+describe('WeComClient HTTP', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.mocked(net.fetch)
+    fetchMock.mockReset()
+  })
+
+  it('bootstrap caches per-category URLs', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        errcode: 0,
+        list: [
+          { biz_type: 'msg', url: 'https://example.com/msg', type: 'streamable-http', is_authed: true },
+          { biz_type: 'contact', url: 'https://example.com/contact' }
+        ]
+      })
+    )
+    const client = new WeComClient({ botId: 'bot', botSecret: 'sec' })
+    const list = await client.bootstrap()
+    expect(list).toHaveLength(2)
+    expect(client.isBootstrapped()).toBe(true)
+  })
+
+  it('bootstrap throws WeComBusinessError on errcode !== 0', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ errcode: 40029, errmsg: 'invalid signature' }))
+    const client = new WeComClient({ botId: 'bot', botSecret: 'wrong' })
+    await expect(client.bootstrap()).rejects.toThrow(/Bootstrap failed.*invalid signature.*errcode=40029/)
+  })
+
+  it('callTool unwraps JSON-RPC content[0].text and parses business JSON', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ errcode: 0, list: [{ biz_type: 'msg', url: 'https://example.com/msg' }] })
+    )
+    const client = new WeComClient({ botId: 'bot', botSecret: 'sec' })
+    await client.bootstrap()
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(bizPayload({ errcode: 0, errmsg: 'ok' })))
+    const res = await client.callTool('msg', 'send_message', { x: 1 })
+    expect(res).toEqual({ errcode: 0, errmsg: 'ok' })
+
+    // Verify the request envelope was a tools/call JSON-RPC.
+    const [, init] = fetchMock.mock.calls[1]
+    const body = JSON.parse((init as { body: string }).body)
+    expect(body.jsonrpc).toBe('2.0')
+    expect(body.method).toBe('tools/call')
+    expect(body.params).toEqual({ name: 'send_message', arguments: { x: 1 } })
+  })
+
+  it('callTool throws business error when inner errcode !== 0', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ errcode: 0, list: [{ biz_type: 'msg', url: 'https://example.com/msg' }] })
+    )
+    const client = new WeComClient({ botId: 'bot', botSecret: 'sec' })
+    await client.bootstrap()
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(bizPayload({ errcode: 60011, errmsg: 'no permission' })))
+    await expect(client.callTool('msg', 'send_message', {})).rejects.toThrow(/errcode=60011/)
+  })
+})
+
+describe('WeComAdapter', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.mocked(net.fetch)
+    fetchMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function createAdapter(overrides: Record<string, unknown> = {}) {
+    const factory = getFactory()
+    return factory(
+      {
+        id: (overrides.channelId as string) ?? 'ch-1',
+        type: 'wecom',
+        enabled: true,
+        config: {
+          bot_id: (overrides.bot_id as string) ?? 'BOT_ID',
+          bot_secret: (overrides.bot_secret as string) ?? 'BOT_SECRET',
+          allowed_chat_ids: (overrides.allowed_chat_ids as string[]) ?? []
+        }
+      },
+      (overrides.agentId as string) ?? 'agent-1'
+    )
+  }
+
+  function mockBootstrap() {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ errcode: 0, list: [{ biz_type: 'msg', url: 'https://example.com/msg' }] })
+    )
+  }
+
+  it('checkReady returns true only when bot_id and bot_secret are present', async () => {
+    const empty = createAdapter({ bot_id: '', bot_secret: '' })
+    // protected method — access via prototype
+    expect(await empty.checkReady()).toBe(false)
+
+    const ok = createAdapter()
+    expect(await ok.checkReady()).toBe(true)
+  })
+
+  it('connect bootstraps then starts polling', async () => {
+    mockBootstrap()
+    // First poll: get_message returns no messages.
+    fetchMock.mockResolvedValueOnce(jsonResponse(bizPayload({ errcode: 0, messages: [] })))
+
+    const adapter = createAdapter({ allowed_chat_ids: ['1:zhangsan'] })
+    await adapter.connect()
+
+    expect(adapter.connected).toBe(true)
+    // bootstrap + first immediate poll
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(fetchMock).toHaveBeenCalled()
+    await adapter.disconnect()
+  })
+
+  it('sendMessage chunks long text and serializes WeCom args', async () => {
+    mockBootstrap()
+    // First poll (no messages) + send_message calls
+    fetchMock.mockResolvedValue(jsonResponse(bizPayload({ errcode: 0, messages: [] })))
+
+    const adapter = createAdapter({ allowed_chat_ids: ['1:zhangsan'] })
+    await adapter.connect()
+
+    await adapter.sendMessage('2:wrxxxx', 'hello world')
+
+    const sendCall = fetchMock.mock.calls.find((c) => {
+      try {
+        const body = JSON.parse((c[1] as { body?: string }).body ?? '{}')
+        return body?.params?.name === 'send_message'
+      } catch {
+        return false
+      }
+    })
+    expect(sendCall).toBeDefined()
+    const body = JSON.parse((sendCall![1] as { body: string }).body)
+    expect(body.params.arguments).toEqual({
+      chat_type: 2,
+      chatid: 'wrxxxx',
+      msgtype: 'text',
+      text: { content: 'hello world' }
+    })
+
+    await adapter.disconnect()
+  })
+
+  it('skips invalid allowed_chat_ids gracefully', async () => {
+    mockBootstrap()
+    const adapter = createAdapter({ allowed_chat_ids: ['malformed', '3:bad-type'] })
+    await adapter.connect()
+    // No additional fetch calls beyond bootstrap — invalid ids are dropped
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    await adapter.disconnect()
+  })
+
+  it('suppresses echoes of recently sent outgoing text', async () => {
+    mockBootstrap()
+    // Stub all subsequent fetches (poll + send) with empty success.
+    fetchMock.mockResolvedValue(jsonResponse(bizPayload({ errcode: 0, messages: [] })))
+
+    const adapter = createAdapter({ allowed_chat_ids: ['1:zhangsan'] })
+    await adapter.connect()
+    await adapter.sendMessage('1:zhangsan', 'echo me')
+
+    expect(adapter.isEcho('echo me')).toBe(true)
+    expect(adapter.isEcho('different')).toBe(false)
+
+    await adapter.disconnect()
+  })
+})

--- a/src/main/services/agents/services/channels/adapters/__tests__/WeComAdapter.test.ts
+++ b/src/main/services/agents/services/channels/adapters/__tests__/WeComAdapter.test.ts
@@ -12,10 +12,16 @@ vi.mock('../../ChannelManager', () => ({
 
 vi.mock('electron', () => ({
   app: {
-    getVersion: () => '0.0.0-test'
+    getVersion: () => '0.0.0-test',
+    getPath: () => '/mock/userData'
   },
-  net: {
-    fetch: vi.fn()
+  nativeTheme: { themeSource: '', shouldUseDarkColors: false },
+  net: { fetch: vi.fn() }
+}))
+
+vi.mock('../../../../../WindowService', () => ({
+  windowService: {
+    getMainWindow: () => null
   }
 }))
 

--- a/src/main/services/agents/services/channels/adapters/dingtalk/DingTalkAdapter.ts
+++ b/src/main/services/agents/services/channels/adapters/dingtalk/DingTalkAdapter.ts
@@ -15,6 +15,7 @@ import { isSlashCommand } from '../../constants'
 import { FILE_EXTENSION_MIME_MAP, splitMessage } from '../../utils'
 import { DingTalkClient } from './DingTalkClient'
 import { registrationBegin, registrationPoll } from './DingTalkDeviceRegistration'
+import { DingTalkInboundMessageSchema, JsonStringSchema } from './DingTalkSchemas'
 
 /** DingTalk text message limit — conservative chunking to stay under the documented 5000-char cap. */
 const DINGTALK_MAX_LENGTH = 4000
@@ -100,24 +101,28 @@ class DingTalkAdapter extends ChannelAdapter {
 
     dw.registerCallbackListener(TOPIC_ROBOT, (downstream) => {
       const messageId = downstream.headers?.messageId
-      try {
-        const msg = JSON.parse(downstream.data) as DingTalkInboundMessage
-        // Ack first so DingTalk doesn't retry while we're processing.
-        if (messageId) {
-          try {
-            dw.socketCallBackResponse(messageId, { success: true })
-          } catch (err) {
-            this.log.warn(`Failed to ack message ${messageId}`, {
-              error: err instanceof Error ? err.message : String(err)
-            })
-          }
-        }
-        this.handleInbound(msg).catch((err) => {
-          this.log.warn(`Inbound handler error: ${err instanceof Error ? err.message : String(err)}`)
-        })
-      } catch (err) {
-        this.log.warn(`Failed to parse DingTalk inbound: ${err instanceof Error ? err.message : String(err)}`)
+      // `downstream.data` is a JSON-encoded string. Pipe JsonStringSchema into
+      // the inbound message schema so a single safeParse handles both "invalid
+      // JSON" and "schema mismatch".
+      const parsed = JsonStringSchema.pipe(DingTalkInboundMessageSchema).safeParse(downstream.data)
+      if (!parsed.success) {
+        this.log.warn(`DingTalk inbound parse failed: ${parsed.error.message}`)
+        return
       }
+      const msg = parsed.data as DingTalkInboundMessage
+      // Ack first so DingTalk doesn't retry while we're processing.
+      if (messageId) {
+        try {
+          dw.socketCallBackResponse(messageId, { success: true })
+        } catch (err) {
+          this.log.warn(`Failed to ack message ${messageId}`, {
+            error: err instanceof Error ? err.message : String(err)
+          })
+        }
+      }
+      this.handleInbound(msg).catch((err) => {
+        this.log.warn(`Inbound handler error: ${err instanceof Error ? err.message : String(err)}`)
+      })
     })
 
     try {

--- a/src/main/services/agents/services/channels/adapters/dingtalk/DingTalkAdapter.ts
+++ b/src/main/services/agents/services/channels/adapters/dingtalk/DingTalkAdapter.ts
@@ -1,0 +1,358 @@
+import { windowService } from '@main/services/WindowService'
+import { IpcChannel } from '@shared/IpcChannel'
+import { DWClient, TOPIC_ROBOT } from 'dingtalk-stream'
+
+import {
+  ChannelAdapter,
+  type ChannelAdapterConfig,
+  type FileAttachment,
+  type ImageAttachment,
+  MAX_FILE_SIZE_BYTES,
+  type SendMessageOptions
+} from '../../ChannelAdapter'
+import { registerAdapterFactory } from '../../ChannelManager'
+import { isSlashCommand } from '../../constants'
+import { FILE_EXTENSION_MIME_MAP, splitMessage } from '../../utils'
+import { DingTalkClient } from './DingTalkClient'
+import { registrationBegin, registrationPoll } from './DingTalkDeviceRegistration'
+
+/** DingTalk text message limit — conservative chunking to stay under the documented 5000-char cap. */
+const DINGTALK_MAX_LENGTH = 4000
+
+/** How long to remember a chat's `sessionWebhook` after the last inbound message (DingTalk gives ~5 min). */
+const SESSION_WEBHOOK_TTL_MS = 4 * 60_000
+
+/** Encoded chat id format: "p2p:<staffId>" (DM) or "group:<openConversationId>" (group). */
+type DecodedChatId = { kind: 'p2p'; staffId: string } | { kind: 'group'; openConversationId: string }
+
+function encodeChatId(msg: DingTalkInboundMessage): string {
+  if (msg.conversationType === '1') return `p2p:${msg.senderStaffId ?? msg.senderId}`
+  return `group:${msg.conversationId}`
+}
+
+function decodeChatId(encoded: string): DecodedChatId | null {
+  if (encoded.startsWith('p2p:')) {
+    const staffId = encoded.slice(4)
+    return staffId ? { kind: 'p2p', staffId } : null
+  }
+  if (encoded.startsWith('group:')) {
+    const openConversationId = encoded.slice(6)
+    return openConversationId ? { kind: 'group', openConversationId } : null
+  }
+  return null
+}
+
+/** Subset of DingTalk's inbound payload we care about; matches the stream JSON shape. */
+interface DingTalkInboundMessage {
+  msgId?: string
+  msgtype?: string
+  conversationType?: string
+  conversationId?: string
+  senderId?: string
+  senderStaffId?: string
+  senderNick?: string
+  sessionWebhook?: string
+  text?: { content?: string }
+  content?: { downloadCode?: string; fileName?: string; recognition?: string }
+}
+
+class DingTalkAdapter extends ChannelAdapter {
+  private dw: DWClient | null = null
+  private client: DingTalkClient | null = null
+  private qrAbort: AbortController | null = null
+
+  private readonly clientId: string
+  private readonly clientSecret: string
+  private readonly allowedChatIds: string[]
+
+  /** Per-encoded-chat: most recent sessionWebhook + when it was observed. */
+  private readonly sessionWebhooks = new Map<string, { url: string; expiresAt: number }>()
+
+  constructor(config: ChannelAdapterConfig) {
+    super(config)
+    const { client_id, client_secret, allowed_chat_ids } = config.channelConfig
+    this.clientId = (client_id as string) ?? ''
+    this.clientSecret = (client_secret as string) ?? ''
+    const rawIds = allowed_chat_ids as string[] | undefined
+    this.allowedChatIds = Array.isArray(rawIds) ? rawIds.map(String) : []
+    this.notifyChatIds = [...this.allowedChatIds]
+  }
+
+  protected override async checkReady(): Promise<boolean> {
+    return !!(this.clientId && this.clientSecret)
+  }
+
+  protected override async performConnect(signal: AbortSignal): Promise<void> {
+    if (!this.clientId || !this.clientSecret) {
+      this.startRegistrationInBackground()
+      return
+    }
+
+    this.client = new DingTalkClient({ clientId: this.clientId, clientSecret: this.clientSecret })
+
+    const dw = new DWClient({
+      clientId: this.clientId,
+      clientSecret: this.clientSecret,
+      ua: 'CherryStudio',
+      keepAlive: true
+    })
+    this.dw = dw
+
+    dw.registerCallbackListener(TOPIC_ROBOT, (downstream) => {
+      const messageId = downstream.headers?.messageId
+      try {
+        const msg = JSON.parse(downstream.data) as DingTalkInboundMessage
+        // Ack first so DingTalk doesn't retry while we're processing.
+        if (messageId) {
+          try {
+            dw.socketCallBackResponse(messageId, { success: true })
+          } catch (err) {
+            this.log.warn(`Failed to ack message ${messageId}`, {
+              error: err instanceof Error ? err.message : String(err)
+            })
+          }
+        }
+        this.handleInbound(msg).catch((err) => {
+          this.log.warn(`Inbound handler error: ${err instanceof Error ? err.message : String(err)}`)
+        })
+      } catch (err) {
+        this.log.warn(`Failed to parse DingTalk inbound: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    })
+
+    try {
+      await dw.connect()
+    } catch (err) {
+      this.dw = null
+      throw new Error(`DingTalk stream connect failed: ${err instanceof Error ? err.message : String(err)}`)
+    }
+    if (signal.aborted) return
+
+    this.markConnected()
+    this.log.info('DingTalk bot connected (stream)')
+  }
+
+  protected override async performDisconnect(): Promise<void> {
+    if (this.qrAbort) {
+      this.qrAbort.abort()
+      this.qrAbort = null
+    }
+    if (this.dw) {
+      try {
+        this.dw.disconnect()
+      } catch (err) {
+        this.log.warn(`Error disconnecting DingTalk client: ${err instanceof Error ? err.message : String(err)}`)
+      }
+      this.dw = null
+    }
+    this.client = null
+    this.sessionWebhooks.clear()
+    this.sendQrToRenderer('', 'disconnected')
+    this.log.info('DingTalk bot disconnected')
+  }
+
+  // oxlint-disable-next-line no-unused-vars -- abstract method signature
+  async sendMessage(chatId: string, text: string, _opts?: SendMessageOptions): Promise<void> {
+    if (!this.client) throw new Error('DingTalk client is not connected')
+    const target = decodeChatId(chatId)
+    if (!target) throw new Error(`Invalid DingTalk chat id: ${chatId}`)
+
+    const chunks = splitMessage(text, DINGTALK_MAX_LENGTH)
+    // Prefer the most recent sessionWebhook if it's still alive — DingTalk only
+    // accepts replies via session webhook within ~5 min of an inbound message.
+    const webhook = this.getFreshSessionWebhook(chatId)
+
+    for (let i = 0; i < chunks.length; i++) {
+      const content = chunks[i]
+      if (webhook) {
+        await this.client.sendBySessionWebhook(webhook, { msgtype: 'text', text: { content } })
+      } else if (target.kind === 'group') {
+        await this.client.sendProactiveGroupText(target.openConversationId, content)
+      } else {
+        await this.client.sendProactiveP2PText([target.staffId], content)
+      }
+      if (i < chunks.length - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 100))
+      }
+    }
+  }
+
+  // oxlint-disable-next-line no-unused-vars -- abstract method signature
+  async sendTypingIndicator(_chatId: string): Promise<void> {
+    // DingTalk has no public typing API for stream bots — no-op.
+  }
+
+  // ---- QR registration ----
+
+  private startRegistrationInBackground(): void {
+    this.log.info('Starting DingTalk Device Flow registration (background)')
+    this.sendQrToRenderer('', 'pending')
+
+    registrationBegin()
+      .then((begin) => {
+        this.emit('qr', begin.verificationUrl)
+        this.sendQrToRenderer(begin.verificationUrl, 'pending')
+
+        this.qrAbort = new AbortController()
+        return registrationPoll(begin, this.qrAbort.signal)
+      })
+      .then((result) => {
+        this.qrAbort = null
+        this.sendQrToRenderer('', 'confirmed', result.clientId, result.clientSecret)
+        // ChannelManager.saveCredentialsAndReconnect dispatches by channel type,
+        // writes client_id/client_secret for dingtalk, and triggers a fresh adapter.
+        this.emit('credentials', { appId: result.clientId, appSecret: result.clientSecret })
+        this.log.info('DingTalk registration completed')
+      })
+      .catch((err) => {
+        this.qrAbort = null
+        const msg = err instanceof Error ? err.message : String(err)
+        this.sendQrToRenderer('', 'expired')
+        this.log.warn(`DingTalk registration failed: ${msg}`)
+      })
+  }
+
+  private sendQrToRenderer(
+    url: string,
+    status: 'pending' | 'confirmed' | 'expired' | 'disconnected',
+    clientId?: string,
+    clientSecret?: string
+  ): void {
+    const mainWindow = windowService.getMainWindow()
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send(IpcChannel.DingTalk_QrLogin, {
+        channelId: this.channelId,
+        url,
+        status,
+        clientId,
+        clientSecret
+      })
+    }
+  }
+
+  // ---- Inbound ----
+
+  private async handleInbound(msg: DingTalkInboundMessage): Promise<void> {
+    const encoded = encodeChatId(msg)
+    if (this.allowedChatIds.length > 0 && !this.allowedChatIds.includes(encoded)) {
+      this.log.debug('Dropping message from unauthorized chat', { encoded })
+      return
+    }
+
+    // Capture sessionWebhook so subsequent replies stay in-thread.
+    if (msg.sessionWebhook) {
+      this.sessionWebhooks.set(encoded, {
+        url: msg.sessionWebhook,
+        expiresAt: Date.now() + SESSION_WEBHOOK_TTL_MS
+      })
+    }
+
+    const userId = msg.senderStaffId ?? msg.senderId ?? ''
+    const userName = msg.senderNick ?? userId
+
+    if (msg.msgtype === 'text') {
+      const text = (msg.text?.content ?? '').trim()
+      if (!text) return
+
+      if (isSlashCommand(text)) {
+        const parts = text.split(/\s+/)
+        const cmd = parts[0].slice(1).toLowerCase() as 'new' | 'compact' | 'help' | 'whoami'
+        this.emit('command', {
+          chatId: encoded,
+          userId,
+          userName,
+          command: cmd,
+          args: parts.slice(1).join(' ') || undefined
+        })
+        return
+      }
+
+      this.emit('message', { chatId: encoded, userId, userName, text })
+      return
+    }
+
+    if (msg.msgtype === 'picture' || msg.msgtype === 'file' || msg.msgtype === 'audio' || msg.msgtype === 'video') {
+      const downloadCode = msg.content?.downloadCode
+      const fileName = msg.content?.fileName ?? msg.msgtype
+      if (!downloadCode || !this.client) {
+        this.emit('message', { chatId: encoded, userId, userName, text: `[${msg.msgtype}: ${fileName}]` })
+        return
+      }
+
+      const media = await this.client.downloadMedia(downloadCode).catch((err) => {
+        this.log.warn(`Failed to download DingTalk media: ${err instanceof Error ? err.message : String(err)}`)
+        return null
+      })
+
+      if (!media) {
+        this.emit('message', {
+          chatId: encoded,
+          userId,
+          userName,
+          text: `[${msg.msgtype}: ${fileName} — download failed]`
+        })
+        return
+      }
+      if (media.buffer.length > MAX_FILE_SIZE_BYTES) {
+        this.log.warn('DingTalk media too large, skipping', { fileName, size: media.buffer.length })
+        this.emit('message', {
+          chatId: encoded,
+          userId,
+          userName,
+          text: `[${msg.msgtype}: ${fileName} — too large]`
+        })
+        return
+      }
+
+      if (msg.msgtype === 'picture') {
+        const image: ImageAttachment = {
+          data: media.buffer.toString('base64'),
+          media_type: media.contentType || 'image/png'
+        }
+        this.emit('message', { chatId: encoded, userId, userName, text: '', images: [image] })
+        return
+      }
+
+      const ext = fileName.includes('.') ? fileName.split('.').pop()!.toLowerCase() : ''
+      const file: FileAttachment = {
+        filename: fileName,
+        data: media.buffer.toString('base64'),
+        media_type: media.contentType || FILE_EXTENSION_MIME_MAP[ext] || 'application/octet-stream',
+        size: media.buffer.length
+      }
+      this.emit('message', {
+        chatId: encoded,
+        userId,
+        userName,
+        text: `[${msg.msgtype}: ${fileName}]`,
+        files: [file]
+      })
+      return
+    }
+
+    // Unknown msgtype — emit a marker so the operator can see something arrived.
+    this.emit('message', { chatId: encoded, userId, userName, text: `[unsupported DingTalk msgtype: ${msg.msgtype}]` })
+  }
+
+  private getFreshSessionWebhook(encoded: string): string | undefined {
+    const entry = this.sessionWebhooks.get(encoded)
+    if (!entry) return undefined
+    if (entry.expiresAt <= Date.now()) {
+      this.sessionWebhooks.delete(encoded)
+      return undefined
+    }
+    return entry.url
+  }
+}
+
+// Self-registration
+registerAdapterFactory('dingtalk', (channel, agentId) => {
+  return new DingTalkAdapter({
+    channelId: channel.id,
+    channelType: channel.type,
+    agentId,
+    channelConfig: channel.config
+  })
+})
+
+export { DingTalkAdapter }

--- a/src/main/services/agents/services/channels/adapters/dingtalk/DingTalkClient.ts
+++ b/src/main/services/agents/services/channels/adapters/dingtalk/DingTalkClient.ts
@@ -12,6 +12,12 @@
  */
 import { net } from 'electron'
 
+import {
+  DingTalkMediaDownloadResponseSchema,
+  DingTalkSessionAckSchema,
+  DingTalkTokenResponseSchema
+} from './DingTalkSchemas'
+
 const TOKEN_URL = 'https://api.dingtalk.com/v1.0/oauth2/accessToken'
 const GROUP_SEND_URL = 'https://api.dingtalk.com/v1.0/robot/groupMessages/send'
 const P2P_SEND_URL = 'https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend'
@@ -76,7 +82,11 @@ export class DingTalkClient {
     if (!res.ok) {
       throw new DingTalkApiError(`Token request failed (HTTP ${res.status})`, res.status)
     }
-    const data = (await res.json()) as { accessToken?: string; expireIn?: number; code?: string; message?: string }
+    const parsed = DingTalkTokenResponseSchema.safeParse(await res.json())
+    if (!parsed.success) {
+      throw new DingTalkApiError(`Token response schema mismatch: ${parsed.error.message}`)
+    }
+    const data = parsed.data
     if (!data.accessToken) {
       throw new DingTalkApiError(`Token response missing accessToken: ${data.message ?? data.code ?? 'unknown'}`)
     }
@@ -101,22 +111,21 @@ export class DingTalkClient {
     if (!res.ok) {
       throw new DingTalkApiError(`Session webhook send failed (HTTP ${res.status})`, res.status)
     }
-    // Some DingTalk endpoints return a JSON body with errcode != 0 even with 200.
-    const text = await res.text()
-    if (text) {
-      try {
-        const json = JSON.parse(text) as { errcode?: number; errmsg?: string }
-        if (json.errcode !== undefined && json.errcode !== 0) {
-          throw new DingTalkApiError(
-            `Session webhook send errcode=${json.errcode}: ${json.errmsg ?? ''}`,
-            res.status,
-            json.errcode
-          )
-        }
-      } catch (err) {
-        if (err instanceof DingTalkApiError) throw err
-        // Non-JSON body — webhook accepted, ignore.
-      }
+    // Some DingTalk endpoints return a JSON body with errcode != 0 even with
+    // a 200 status. Treat non-JSON or schema-mismatched bodies as accepted.
+    let body: unknown
+    try {
+      body = await res.json()
+    } catch {
+      return
+    }
+    const parsed = DingTalkSessionAckSchema.safeParse(body)
+    if (parsed.success && parsed.data.errcode !== undefined && parsed.data.errcode !== 0) {
+      throw new DingTalkApiError(
+        `Session webhook send errcode=${parsed.data.errcode}: ${parsed.data.errmsg ?? ''}`,
+        res.status,
+        parsed.data.errcode
+      )
     }
   }
 
@@ -169,10 +178,10 @@ export class DingTalkClient {
       body: JSON.stringify({ downloadCode, robotCode: this.clientId })
     })
     if (!res.ok) return null
-    const data = (await res.json()) as { downloadUrl?: string }
-    if (!data.downloadUrl) return null
+    const parsed = DingTalkMediaDownloadResponseSchema.safeParse(await res.json())
+    if (!parsed.success || !parsed.data.downloadUrl) return null
 
-    const fileRes = await net.fetch(data.downloadUrl, { method: 'GET' })
+    const fileRes = await net.fetch(parsed.data.downloadUrl, { method: 'GET' })
     if (!fileRes.ok) return null
     const contentType = (fileRes.headers.get('content-type') || 'application/octet-stream').split(';')[0].trim()
     const buffer = Buffer.from(await fileRes.arrayBuffer())

--- a/src/main/services/agents/services/channels/adapters/dingtalk/DingTalkClient.ts
+++ b/src/main/services/agents/services/channels/adapters/dingtalk/DingTalkClient.ts
@@ -1,0 +1,189 @@
+/**
+ * DingTalk HTTP helpers used by the channel adapter.
+ *
+ * Covers:
+ *   - access token cache (`POST /v1.0/oauth2/accessToken`)
+ *   - reply via session webhook (per-message URL, valid ~5 min)
+ *   - proactive group/DM send (`/v1.0/robot/groupMessages/send`, `/oToMessages/batchSend`)
+ *   - media download (`/v1.0/robot/messageFiles/download` -> follow downloadUrl)
+ *
+ * The Stream/WebSocket inbound path lives in DingTalkAdapter via `DWClient`
+ * from the `dingtalk-stream` package.
+ */
+import { net } from 'electron'
+
+const TOKEN_URL = 'https://api.dingtalk.com/v1.0/oauth2/accessToken'
+const GROUP_SEND_URL = 'https://api.dingtalk.com/v1.0/robot/groupMessages/send'
+const P2P_SEND_URL = 'https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend'
+const MEDIA_DOWNLOAD_URL = 'https://api.dingtalk.com/v1.0/robot/messageFiles/download'
+
+const TOKEN_REFRESH_LEAD_MS = 60_000
+
+export interface DingTalkClientOptions {
+  clientId: string
+  clientSecret: string
+}
+
+export interface SessionTextPayload {
+  msgtype: 'text'
+  text: { content: string }
+}
+
+export interface MediaDownloadResult {
+  /** Raw bytes of the downloaded media. */
+  buffer: Buffer
+  /** MIME type from the second-hop URL response, or `application/octet-stream`. */
+  contentType: string
+}
+
+interface TokenCache {
+  accessToken: string
+  expiresAt: number
+}
+
+export class DingTalkApiError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+    readonly code?: string | number
+  ) {
+    super(message)
+    this.name = 'DingTalkApiError'
+  }
+}
+
+export class DingTalkClient {
+  private readonly clientId: string
+  private readonly clientSecret: string
+  private tokenCache: TokenCache | null = null
+
+  constructor(opts: DingTalkClientOptions) {
+    this.clientId = opts.clientId
+    this.clientSecret = opts.clientSecret
+  }
+
+  /** Get a cached access token, refreshing one minute before expiry. */
+  async getAccessToken(): Promise<string> {
+    const now = Date.now()
+    if (this.tokenCache && this.tokenCache.expiresAt > now + TOKEN_REFRESH_LEAD_MS) {
+      return this.tokenCache.accessToken
+    }
+    const res = await net.fetch(TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ appKey: this.clientId, appSecret: this.clientSecret })
+    })
+    if (!res.ok) {
+      throw new DingTalkApiError(`Token request failed (HTTP ${res.status})`, res.status)
+    }
+    const data = (await res.json()) as { accessToken?: string; expireIn?: number; code?: string; message?: string }
+    if (!data.accessToken) {
+      throw new DingTalkApiError(`Token response missing accessToken: ${data.message ?? data.code ?? 'unknown'}`)
+    }
+    this.tokenCache = {
+      accessToken: data.accessToken,
+      expiresAt: now + (data.expireIn ?? 7200) * 1000
+    }
+    return data.accessToken
+  }
+
+  /**
+   * Reply via a `sessionWebhook` URL captured from an inbound message.
+   * The webhook is the cheapest and most reliable way to deliver a reply
+   * within ~5 minutes of receiving the user message.
+   */
+  async sendBySessionWebhook(sessionWebhook: string, payload: SessionTextPayload): Promise<void> {
+    const res = await net.fetch(sessionWebhook, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+    if (!res.ok) {
+      throw new DingTalkApiError(`Session webhook send failed (HTTP ${res.status})`, res.status)
+    }
+    // Some DingTalk endpoints return a JSON body with errcode != 0 even with 200.
+    const text = await res.text()
+    if (text) {
+      try {
+        const json = JSON.parse(text) as { errcode?: number; errmsg?: string }
+        if (json.errcode !== undefined && json.errcode !== 0) {
+          throw new DingTalkApiError(
+            `Session webhook send errcode=${json.errcode}: ${json.errmsg ?? ''}`,
+            res.status,
+            json.errcode
+          )
+        }
+      } catch (err) {
+        if (err instanceof DingTalkApiError) throw err
+        // Non-JSON body — webhook accepted, ignore.
+      }
+    }
+  }
+
+  /** Proactive send to a group conversation. */
+  async sendProactiveGroupText(openConversationId: string, content: string): Promise<void> {
+    await this.proactiveSend(GROUP_SEND_URL, {
+      robotCode: this.clientId,
+      openConversationId,
+      msgKey: 'sampleText',
+      msgParam: JSON.stringify({ content })
+    })
+  }
+
+  /** Proactive send to one or more user staffIds (DM). */
+  async sendProactiveP2PText(userIds: string[], content: string): Promise<void> {
+    if (userIds.length === 0) return
+    await this.proactiveSend(P2P_SEND_URL, {
+      robotCode: this.clientId,
+      userIds,
+      msgKey: 'sampleText',
+      msgParam: JSON.stringify({ content })
+    })
+  }
+
+  private async proactiveSend(url: string, body: Record<string, unknown>): Promise<void> {
+    const token = await this.getAccessToken()
+    const res = await net.fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-acs-dingtalk-access-token': token
+      },
+      body: JSON.stringify(body)
+    })
+    if (!res.ok) {
+      const text = await safeText(res)
+      throw new DingTalkApiError(`Proactive send failed (HTTP ${res.status}): ${text}`, res.status)
+    }
+  }
+
+  /** Download an inbound media file (image / file / voice / video). */
+  async downloadMedia(downloadCode: string): Promise<MediaDownloadResult | null> {
+    const token = await this.getAccessToken()
+    const res = await net.fetch(MEDIA_DOWNLOAD_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-acs-dingtalk-access-token': token
+      },
+      body: JSON.stringify({ downloadCode, robotCode: this.clientId })
+    })
+    if (!res.ok) return null
+    const data = (await res.json()) as { downloadUrl?: string }
+    if (!data.downloadUrl) return null
+
+    const fileRes = await net.fetch(data.downloadUrl, { method: 'GET' })
+    if (!fileRes.ok) return null
+    const contentType = (fileRes.headers.get('content-type') || 'application/octet-stream').split(';')[0].trim()
+    const buffer = Buffer.from(await fileRes.arrayBuffer())
+    return { buffer, contentType }
+  }
+}
+
+async function safeText(res: Response): Promise<string> {
+  try {
+    return await res.text()
+  } catch {
+    return '<unreadable>'
+  }
+}

--- a/src/main/services/agents/services/channels/adapters/dingtalk/DingTalkDeviceRegistration.ts
+++ b/src/main/services/agents/services/channels/adapters/dingtalk/DingTalkDeviceRegistration.ts
@@ -1,0 +1,146 @@
+/**
+ * DingTalk Device Authorization Grant flow.
+ *
+ * Ported from @soimy/openclaw-channel-dingtalk `src/device-registration.ts`.
+ * Three endpoints on `oapi.dingtalk.com`:
+ *   1. POST /app/registration/init  -> { nonce }
+ *   2. POST /app/registration/begin -> { device_code, verification_uri_complete, expires_in, interval }
+ *   3. POST /app/registration/poll  -> { status: WAITING|SUCCESS|FAIL|EXPIRED, client_id?, client_secret? }
+ */
+import { loggerService } from '@logger'
+import { net } from 'electron'
+
+const logger = loggerService.withContext('DingTalkDeviceRegistration')
+
+const REGISTRATION_BASE_URL = 'https://oapi.dingtalk.com'
+const REGISTRATION_SOURCE = 'CherryStudio'
+
+/** Window during which transient errors are retried before giving up. */
+const RETRY_WINDOW_MS = 120_000
+
+export interface DingTalkBeginResult {
+  deviceCode: string
+  /** URL to render as a QR code; users scan it with DingTalk to authorize. */
+  verificationUrl: string
+  expiresIn: number
+  interval: number
+}
+
+export interface DingTalkRegistrationResult {
+  clientId: string
+  clientSecret: string
+}
+
+type PollStatus = 'WAITING' | 'SUCCESS' | 'FAIL' | 'EXPIRED'
+
+async function apiPost(path: string, payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const url = `${REGISTRATION_BASE_URL}${path}`
+  const res = await net.fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  })
+  if (!res.ok) {
+    throw new Error(`DingTalk registration HTTP ${res.status} for ${path}`)
+  }
+  const data = (await res.json()) as Record<string, unknown>
+  const errcode = data.errcode
+  if (errcode !== undefined && errcode !== 0) {
+    const errmsg = typeof data.errmsg === 'string' ? data.errmsg : 'unknown error'
+    throw new Error(`DingTalk registration error [${path}]: ${errmsg} (errcode=${String(errcode)})`)
+  }
+  return data
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+export async function registrationBegin(): Promise<DingTalkBeginResult> {
+  const initData = await apiPost('/app/registration/init', { source: REGISTRATION_SOURCE })
+  const nonce = asString(initData.nonce).trim()
+  if (!nonce) throw new Error('DingTalk registration init: missing nonce')
+
+  const beginData = await apiPost('/app/registration/begin', { nonce })
+  const deviceCode = asString(beginData.device_code).trim()
+  const verificationUrl = asString(beginData.verification_uri_complete).trim()
+  if (!deviceCode) throw new Error('DingTalk registration begin: missing device_code')
+  if (!verificationUrl) throw new Error('DingTalk registration begin: missing verification_uri_complete')
+
+  const expiresIn = Number(beginData.expires_in ?? 7200) || 7200
+  const interval = Math.max(Number(beginData.interval ?? 3) || 3, 2)
+
+  logger.info('DingTalk QR generated', { expiresIn, interval })
+  return { deviceCode, verificationUrl, expiresIn, interval }
+}
+
+export async function registrationPoll(
+  begin: DingTalkBeginResult,
+  signal?: AbortSignal
+): Promise<DingTalkRegistrationResult> {
+  const deadline = Date.now() + begin.expiresIn * 1000
+  const intervalMs = begin.interval * 1000
+  let networkRetryStart = 0
+  let statusRetryStart = 0
+
+  while (Date.now() < deadline) {
+    if (signal?.aborted) throw new Error('DingTalk registration cancelled')
+
+    await sleep(intervalMs, signal)
+    if (signal?.aborted) throw new Error('DingTalk registration cancelled')
+
+    let data: Record<string, unknown>
+    try {
+      data = await apiPost('/app/registration/poll', { device_code: begin.deviceCode })
+    } catch (err) {
+      if (!networkRetryStart) networkRetryStart = Date.now()
+      if (Date.now() - networkRetryStart < RETRY_WINDOW_MS) {
+        logger.warn('DingTalk poll network error, retrying', {
+          error: err instanceof Error ? err.message : String(err)
+        })
+        continue
+      }
+      throw new Error('DingTalk registration polling failed after retry window')
+    }
+    networkRetryStart = 0
+
+    const status = asString(data.status).trim().toUpperCase() as PollStatus
+
+    if (status === 'WAITING') {
+      statusRetryStart = 0
+      continue
+    }
+    if (status === 'SUCCESS') {
+      const clientId = asString(data.client_id).trim()
+      const clientSecret = asString(data.client_secret).trim()
+      if (!clientId || !clientSecret) {
+        throw new Error('DingTalk authorization succeeded but credentials missing')
+      }
+      logger.info('DingTalk registration completed')
+      return { clientId, clientSecret }
+    }
+    if (status === 'EXPIRED') {
+      throw new Error('DingTalk authorization expired')
+    }
+    // FAIL — retry within window
+    if (!statusRetryStart) statusRetryStart = Date.now()
+    if (Date.now() - statusRetryStart < RETRY_WINDOW_MS) continue
+    throw new Error(`DingTalk authorization failed: ${asString(data.fail_reason) || status}`)
+  }
+
+  throw new Error('DingTalk authorization timed out')
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(resolve, ms)
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer)
+        reject(new Error('aborted'))
+      },
+      { once: true }
+    )
+  })
+}

--- a/src/main/services/agents/services/channels/adapters/dingtalk/DingTalkDeviceRegistration.ts
+++ b/src/main/services/agents/services/channels/adapters/dingtalk/DingTalkDeviceRegistration.ts
@@ -9,6 +9,13 @@
  */
 import { loggerService } from '@logger'
 import { net } from 'electron'
+import type * as z from 'zod'
+
+import {
+  DingTalkRegistrationBeginResponseSchema,
+  DingTalkRegistrationInitResponseSchema,
+  DingTalkRegistrationPollResponseSchema
+} from './DingTalkSchemas'
 
 const logger = loggerService.withContext('DingTalkDeviceRegistration')
 
@@ -33,7 +40,11 @@ export interface DingTalkRegistrationResult {
 
 type PollStatus = 'WAITING' | 'SUCCESS' | 'FAIL' | 'EXPIRED'
 
-async function apiPost(path: string, payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+async function apiPost<S extends z.ZodTypeAny>(
+  path: string,
+  payload: Record<string, unknown>,
+  schema: S
+): Promise<z.infer<S>> {
   const url = `${REGISTRATION_BASE_URL}${path}`
   const res = await net.fetch(url, {
     method: 'POST',
@@ -43,32 +54,36 @@ async function apiPost(path: string, payload: Record<string, unknown>): Promise<
   if (!res.ok) {
     throw new Error(`DingTalk registration HTTP ${res.status} for ${path}`)
   }
-  const data = (await res.json()) as Record<string, unknown>
-  const errcode = data.errcode
-  if (errcode !== undefined && errcode !== 0) {
-    const errmsg = typeof data.errmsg === 'string' ? data.errmsg : 'unknown error'
-    throw new Error(`DingTalk registration error [${path}]: ${errmsg} (errcode=${String(errcode)})`)
+  const parsed = schema.safeParse(await res.json())
+  if (!parsed.success) {
+    throw new Error(`DingTalk registration response schema mismatch [${path}]: ${parsed.error.message}`)
   }
-  return data
-}
-
-function asString(value: unknown): string {
-  return typeof value === 'string' ? value : ''
+  const data = parsed.data as { errcode?: number | string; errmsg?: string }
+  if (data.errcode !== undefined && data.errcode !== 0 && data.errcode !== '0') {
+    throw new Error(
+      `DingTalk registration error [${path}]: ${data.errmsg ?? 'unknown error'} (errcode=${String(data.errcode)})`
+    )
+  }
+  return parsed.data
 }
 
 export async function registrationBegin(): Promise<DingTalkBeginResult> {
-  const initData = await apiPost('/app/registration/init', { source: REGISTRATION_SOURCE })
-  const nonce = asString(initData.nonce).trim()
+  const initData = await apiPost(
+    '/app/registration/init',
+    { source: REGISTRATION_SOURCE },
+    DingTalkRegistrationInitResponseSchema
+  )
+  const nonce = (initData.nonce ?? '').trim()
   if (!nonce) throw new Error('DingTalk registration init: missing nonce')
 
-  const beginData = await apiPost('/app/registration/begin', { nonce })
-  const deviceCode = asString(beginData.device_code).trim()
-  const verificationUrl = asString(beginData.verification_uri_complete).trim()
+  const beginData = await apiPost('/app/registration/begin', { nonce }, DingTalkRegistrationBeginResponseSchema)
+  const deviceCode = (beginData.device_code ?? '').trim()
+  const verificationUrl = (beginData.verification_uri_complete ?? '').trim()
   if (!deviceCode) throw new Error('DingTalk registration begin: missing device_code')
   if (!verificationUrl) throw new Error('DingTalk registration begin: missing verification_uri_complete')
 
-  const expiresIn = Number(beginData.expires_in ?? 7200) || 7200
-  const interval = Math.max(Number(beginData.interval ?? 3) || 3, 2)
+  const expiresIn = beginData.expires_in ?? 7200
+  const interval = Math.max(beginData.interval ?? 3, 2)
 
   logger.info('DingTalk QR generated', { expiresIn, interval })
   return { deviceCode, verificationUrl, expiresIn, interval }
@@ -89,9 +104,13 @@ export async function registrationPoll(
     await sleep(intervalMs, signal)
     if (signal?.aborted) throw new Error('DingTalk registration cancelled')
 
-    let data: Record<string, unknown>
+    let data: z.infer<typeof DingTalkRegistrationPollResponseSchema>
     try {
-      data = await apiPost('/app/registration/poll', { device_code: begin.deviceCode })
+      data = await apiPost(
+        '/app/registration/poll',
+        { device_code: begin.deviceCode },
+        DingTalkRegistrationPollResponseSchema
+      )
     } catch (err) {
       if (!networkRetryStart) networkRetryStart = Date.now()
       if (Date.now() - networkRetryStart < RETRY_WINDOW_MS) {
@@ -104,15 +123,15 @@ export async function registrationPoll(
     }
     networkRetryStart = 0
 
-    const status = asString(data.status).trim().toUpperCase() as PollStatus
+    const status = (data.status ?? '').trim().toUpperCase() as PollStatus
 
     if (status === 'WAITING') {
       statusRetryStart = 0
       continue
     }
     if (status === 'SUCCESS') {
-      const clientId = asString(data.client_id).trim()
-      const clientSecret = asString(data.client_secret).trim()
+      const clientId = (data.client_id ?? '').trim()
+      const clientSecret = (data.client_secret ?? '').trim()
       if (!clientId || !clientSecret) {
         throw new Error('DingTalk authorization succeeded but credentials missing')
       }
@@ -125,7 +144,7 @@ export async function registrationPoll(
     // FAIL — retry within window
     if (!statusRetryStart) statusRetryStart = Date.now()
     if (Date.now() - statusRetryStart < RETRY_WINDOW_MS) continue
-    throw new Error(`DingTalk authorization failed: ${asString(data.fail_reason) || status}`)
+    throw new Error(`DingTalk authorization failed: ${data.fail_reason ?? status}`)
   }
 
   throw new Error('DingTalk authorization timed out')

--- a/src/main/services/agents/services/channels/adapters/dingtalk/DingTalkSchemas.ts
+++ b/src/main/services/agents/services/channels/adapters/dingtalk/DingTalkSchemas.ts
@@ -1,0 +1,110 @@
+/**
+ * Zod schemas for every DingTalk HTTP response and stream payload we parse.
+ *
+ * External payloads can drift, so validate at the boundary with safeParse and
+ * fail soft. Schemas are intentionally permissive (`.loose()`) so unknown
+ * keys pass through and the adapter keeps working.
+ */
+import * as z from 'zod'
+
+/**
+ * Accept a JSON-encoded string and return the parsed JS value. Compose with
+ * `.pipe(<schema>)` so a single `safeParse` covers both "not JSON" and
+ * "wrong shape" failure modes.
+ */
+export const JsonStringSchema = z.string().transform((value, ctx) => {
+  try {
+    return JSON.parse(value) as unknown
+  } catch (err) {
+    ctx.issues.push({
+      code: 'custom',
+      message: `Invalid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      input: value
+    })
+    return z.NEVER
+  }
+})
+
+// ---- OAuth token: POST /v1.0/oauth2/accessToken ----
+
+export const DingTalkTokenResponseSchema = z
+  .object({
+    accessToken: z.string().optional(),
+    expireIn: z.number().optional(),
+    code: z.string().optional(),
+    message: z.string().optional()
+  })
+  .loose()
+
+// ---- Media download metadata: POST /v1.0/robot/messageFiles/download ----
+
+export const DingTalkMediaDownloadResponseSchema = z
+  .object({
+    downloadUrl: z.string().optional()
+  })
+  .loose()
+
+// ---- Session webhook ack (most responses are empty or { errcode, errmsg }) ----
+
+export const DingTalkSessionAckSchema = z
+  .object({
+    errcode: z.number().optional(),
+    errmsg: z.string().optional()
+  })
+  .loose()
+
+// ---- Device Flow: POST /app/registration/{init,begin,poll} ----
+
+export const DingTalkRegistrationEnvelopeSchema = z
+  .object({
+    errcode: z.union([z.number(), z.string()]).optional(),
+    errmsg: z.string().optional()
+  })
+  .loose()
+
+export const DingTalkRegistrationInitResponseSchema = DingTalkRegistrationEnvelopeSchema.extend({
+  nonce: z.string().optional()
+})
+
+export const DingTalkRegistrationBeginResponseSchema = DingTalkRegistrationEnvelopeSchema.extend({
+  device_code: z.string().optional(),
+  verification_uri_complete: z.string().optional(),
+  expires_in: z.number().optional(),
+  interval: z.number().optional()
+})
+
+export const DingTalkRegistrationPollResponseSchema = DingTalkRegistrationEnvelopeSchema.extend({
+  status: z.string().optional(),
+  client_id: z.string().optional(),
+  client_secret: z.string().optional(),
+  fail_reason: z.string().optional()
+})
+
+// ---- Inbound stream message: DWClient callback `downstream.data` (JSON string) ----
+
+export const DingTalkInboundMessageSchema = z
+  .object({
+    msgId: z.string().optional(),
+    msgtype: z.string().optional(),
+    conversationType: z.string().optional(),
+    conversationId: z.string().optional(),
+    senderId: z.string().optional(),
+    senderStaffId: z.string().optional(),
+    senderNick: z.string().optional(),
+    sessionWebhook: z.string().optional(),
+    text: z
+      .object({
+        content: z.string().optional()
+      })
+      .loose()
+      .optional(),
+    content: z
+      .object({
+        downloadCode: z.string().optional(),
+        fileName: z.string().optional(),
+        recognition: z.string().optional()
+      })
+      .loose()
+      .optional()
+  })
+  .loose()

--- a/src/main/services/agents/services/channels/adapters/wecom/WeComAdapter.ts
+++ b/src/main/services/agents/services/channels/adapters/wecom/WeComAdapter.ts
@@ -15,6 +15,7 @@ import { isSlashCommand } from '../../constants'
 import { FILE_EXTENSION_MIME_MAP, splitMessage } from '../../utils'
 import { WeComClient } from './WeComClient'
 import { registrationBegin, registrationPoll } from './WeComQrRegistration'
+import { GetMessageResponseSchema, GetMsgMediaResponseSchema } from './WeComSchemas'
 import type {
   GetMessageResponse,
   GetMsgMediaResponse,
@@ -258,13 +259,18 @@ class WeComAdapter extends ChannelAdapter {
     const endMs = Date.now()
     if (beginMs >= endMs) return
 
-    const res = await this.client.callTool<unknown, GetMessageResponse>('msg', 'get_message', {
+    const raw = await this.client.callTool<unknown, GetMessageResponse>('msg', 'get_message', {
       chat_type: chatType,
       chatid,
       begin_time: toWeComTime(new Date(beginMs)),
       end_time: toWeComTime(new Date(endMs))
     })
-
+    const parsed = GetMessageResponseSchema.safeParse(raw)
+    if (!parsed.success) {
+      this.log.warn(`get_message schema mismatch: ${parsed.error.message}`)
+      return
+    }
+    const res = parsed.data as GetMessageResponse
     const messages = res.messages ?? []
     if (messages.length === 0) {
       this.lastSeen.set(encoded, endMs)
@@ -360,8 +366,13 @@ class WeComAdapter extends ChannelAdapter {
     mediaId: string
   ): Promise<{ base64: string; contentType: string; size: number; name: string } | null> {
     if (!this.client) return null
-    const res = await this.client.callTool<unknown, GetMsgMediaResponse>('msg', 'get_msg_media', { media_id: mediaId })
-    const item = res.media_item
+    const raw = await this.client.callTool<unknown, GetMsgMediaResponse>('msg', 'get_msg_media', { media_id: mediaId })
+    const parsed = GetMsgMediaResponseSchema.safeParse(raw)
+    if (!parsed.success) {
+      this.log.warn(`get_msg_media schema mismatch: ${parsed.error.message}`)
+      return null
+    }
+    const item = parsed.data.media_item
     if (!item || !item.base64_data) return null
 
     // Enforce size cap before decoding (base64 is ~4/3 of raw).

--- a/src/main/services/agents/services/channels/adapters/wecom/WeComAdapter.ts
+++ b/src/main/services/agents/services/channels/adapters/wecom/WeComAdapter.ts
@@ -1,0 +1,358 @@
+import { app } from 'electron'
+
+import {
+  ChannelAdapter,
+  type ChannelAdapterConfig,
+  type FileAttachment,
+  type ImageAttachment,
+  MAX_FILE_SIZE_BYTES,
+  type SendMessageOptions
+} from '../../ChannelAdapter'
+import { registerAdapterFactory } from '../../ChannelManager'
+import { isSlashCommand } from '../../constants'
+import { FILE_EXTENSION_MIME_MAP, splitMessage } from '../../utils'
+import { WeComClient } from './WeComClient'
+import type {
+  GetMessageResponse,
+  GetMsgMediaResponse,
+  SendMessageArgs,
+  WeComChatType,
+  WeComMessageItem
+} from './WeComTypes'
+
+/** WeCom send_message content limit (2048 bytes, per send-message.md). Conservative char limit. */
+const WECOM_MAX_LENGTH = 1800
+
+/** Polling cadence. */
+const POLL_INTERVAL_MS = 30_000
+
+/** Lookback window on first connect — avoid flooding the agent with a week of history. */
+const INITIAL_LOOKBACK_MS = 60_000
+
+/** Window for echo-suppression of our own outgoing text. */
+const ECHO_SUPPRESS_MS = 60_000
+
+/** Encoded chat id format: "<chat_type>:<chatid>" — e.g. "1:zhangsan" or "2:wrxxxx". */
+function decodeChatId(encoded: string): { chatType: WeComChatType; chatid: string } | null {
+  const idx = encoded.indexOf(':')
+  if (idx <= 0) return null
+  const typeStr = encoded.slice(0, idx)
+  const chatid = encoded.slice(idx + 1)
+  if (!chatid) return null
+  if (typeStr === '1') return { chatType: 1, chatid }
+  if (typeStr === '2') return { chatType: 2, chatid }
+  return null
+}
+
+/** WeCom uses Beijing time strings (`YYYY-MM-DD HH:mm:ss`) in UTC+8. */
+function toWeComTime(date: Date): string {
+  const beijing = new Date(date.getTime() + 8 * 60 * 60 * 1000)
+  return beijing.toISOString().slice(0, 19).replace('T', ' ')
+}
+
+function parseWeComTime(s: string | undefined): number {
+  if (!s) return 0
+  // Treat as UTC+8 → convert to epoch ms.
+  const utcIso = `${s.replace(' ', 'T')}+08:00`
+  const t = Date.parse(utcIso)
+  return Number.isNaN(t) ? 0 : t
+}
+
+class WeComAdapter extends ChannelAdapter {
+  private client: WeComClient | null = null
+  private readonly botId: string
+  private readonly botSecret: string
+  private readonly allowedChatIds: string[]
+
+  private pollTimer: ReturnType<typeof setInterval> | null = null
+  private polling = false
+
+  /** Per-encoded-chat: last-seen `send_time` (epoch ms). Messages at or before this are dropped. */
+  private lastSeen = new Map<string, number>()
+
+  /** Recently-sent text contents (epoch ms expiry). Used to suppress echoes of our own replies. */
+  private readonly outgoingEchoes = new Map<string, number>()
+
+  constructor(config: ChannelAdapterConfig) {
+    super(config)
+    const { bot_id, bot_secret, allowed_chat_ids } = config.channelConfig
+    this.botId = (bot_id as string) ?? ''
+    this.botSecret = (bot_secret as string) ?? ''
+    const rawIds = allowed_chat_ids as string[] | undefined
+    this.allowedChatIds = Array.isArray(rawIds) ? rawIds.map(String) : []
+    this.notifyChatIds = [...this.allowedChatIds]
+  }
+
+  protected override async checkReady(): Promise<boolean> {
+    return !!(this.botId && this.botSecret)
+  }
+
+  protected override async performConnect(signal: AbortSignal): Promise<void> {
+    if (!this.botId || !this.botSecret) {
+      throw new Error('Missing bot_id or bot_secret')
+    }
+
+    const client = new WeComClient({
+      botId: this.botId,
+      botSecret: this.botSecret,
+      clientVersion: `CherryStudio/${getAppVersion()} ${process.platform}/${process.arch}`
+    })
+    this.client = client
+
+    await client.bootstrap()
+    if (signal.aborted) return
+
+    // Seed lastSeen to "now - INITIAL_LOOKBACK_MS" so we don't replay a week of history on first connect.
+    const seed = Date.now() - INITIAL_LOOKBACK_MS
+    for (const encoded of this.allowedChatIds) {
+      if (!this.lastSeen.has(encoded)) this.lastSeen.set(encoded, seed)
+    }
+
+    if (this.allowedChatIds.length === 0) {
+      this.log.warn(
+        'No allowed_chat_ids configured — WeCom polling is disabled. Add entries like "1:zhangsan" or "2:wrxxxx" to receive messages.'
+      )
+    }
+
+    this.markConnected()
+    this.log.info('WeCom bot connected', { chatCount: this.allowedChatIds.length })
+
+    this.pollTimer = setInterval(() => {
+      void this.runPoll()
+    }, POLL_INTERVAL_MS)
+    // Kick off the first poll immediately for responsiveness.
+    void this.runPoll()
+  }
+
+  protected override async performDisconnect(): Promise<void> {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer)
+      this.pollTimer = null
+    }
+    this.client = null
+    this.outgoingEchoes.clear()
+    this.log.info('WeCom bot disconnected')
+  }
+
+  // oxlint-disable-next-line no-unused-vars -- abstract method signature
+  async sendMessage(chatId: string, text: string, _opts?: SendMessageOptions): Promise<void> {
+    if (!this.client) throw new Error('WeCom client is not connected')
+    const target = decodeChatId(chatId)
+    if (!target) throw new Error(`Invalid WeCom chat id: ${chatId}`)
+
+    const chunks = splitMessage(text, WECOM_MAX_LENGTH)
+    for (let i = 0; i < chunks.length; i++) {
+      const content = chunks[i]
+      const args: SendMessageArgs = {
+        chat_type: target.chatType,
+        chatid: target.chatid,
+        msgtype: 'text',
+        text: { content }
+      }
+      await this.client.callTool('msg', 'send_message', args)
+      this.rememberOutgoing(content)
+
+      if (i < chunks.length - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 100))
+      }
+    }
+  }
+
+  async sendTypingIndicator(_chatId: string): Promise<void> {
+    // WeCom has no typing API — no-op.
+  }
+
+  // ---- Polling ----
+
+  private async runPoll(): Promise<void> {
+    if (!this.client || this.polling) return
+    if (this.allowedChatIds.length === 0) return
+    this.polling = true
+    try {
+      for (const encoded of this.allowedChatIds) {
+        const target = decodeChatId(encoded)
+        if (!target) {
+          this.log.warn(`Skipping invalid allowed_chat_id "${encoded}" (expected format "1:userid" or "2:groupid")`)
+          continue
+        }
+        await this.pollChat(encoded, target.chatType, target.chatid).catch((err) => {
+          const msg = err instanceof Error ? err.message : String(err)
+          this.log.warn(`Poll failed for ${encoded}: ${msg}`)
+        })
+      }
+    } finally {
+      this.polling = false
+    }
+  }
+
+  private async pollChat(encoded: string, chatType: WeComChatType, chatid: string): Promise<void> {
+    if (!this.client) return
+
+    const last = this.lastSeen.get(encoded) ?? Date.now() - INITIAL_LOOKBACK_MS
+    const beginMs = Math.max(last + 1000, Date.now() - 6 * 24 * 60 * 60 * 1000) // never go past WeCom's 7-day limit
+    const endMs = Date.now()
+    if (beginMs >= endMs) return
+
+    const res = await this.client.callTool<unknown, GetMessageResponse>('msg', 'get_message', {
+      chat_type: chatType,
+      chatid,
+      begin_time: toWeComTime(new Date(beginMs)),
+      end_time: toWeComTime(new Date(endMs))
+    })
+
+    const messages = res.messages ?? []
+    if (messages.length === 0) {
+      this.lastSeen.set(encoded, endMs)
+      return
+    }
+
+    let newestSeen = last
+    for (const msg of messages) {
+      const ts = parseWeComTime(msg.send_time)
+      if (ts > newestSeen) newestSeen = ts
+      await this.dispatchIncoming(encoded, msg).catch((err) => {
+        this.log.warn(`Failed to dispatch WeCom message: ${err instanceof Error ? err.message : String(err)}`)
+      })
+    }
+    this.lastSeen.set(encoded, newestSeen || endMs)
+  }
+
+  private async dispatchIncoming(encoded: string, msg: WeComMessageItem): Promise<void> {
+    const userId = msg.userid?.trim() ?? ''
+    const userName = userId
+    const msgType = msg.msgtype
+
+    if (msgType === 'text') {
+      const content = msg.text?.content ?? ''
+      const text = content.trim()
+      if (!text) return
+      if (this.isEcho(text)) {
+        this.log.debug('Suppressing echoed outgoing message', { content: text.slice(0, 64) })
+        return
+      }
+
+      if (isSlashCommand(text)) {
+        const parts = text.split(/\s+/)
+        const cmd = parts[0].slice(1).toLowerCase() as 'new' | 'compact' | 'help' | 'whoami'
+        this.emit('command', {
+          chatId: encoded,
+          userId,
+          userName,
+          command: cmd,
+          args: parts.slice(1).join(' ') || undefined
+        })
+        return
+      }
+
+      this.emit('message', { chatId: encoded, userId, userName, text })
+      return
+    }
+
+    if (msgType === 'image' || msgType === 'file' || msgType === 'voice' || msgType === 'video') {
+      const ref = msg[msgType] as { media_id?: string; name?: string } | undefined
+      const mediaId = ref?.media_id
+      const name = ref?.name ?? `${msgType}`
+      if (!mediaId) {
+        this.emit('message', { chatId: encoded, userId, userName, text: `[${msgType}: ${name} — no media_id]` })
+        return
+      }
+
+      const media = await this.downloadMedia(mediaId).catch((err) => {
+        this.log.warn(`Failed to download media ${mediaId}: ${err instanceof Error ? err.message : String(err)}`)
+        return null
+      })
+
+      if (!media) {
+        this.emit('message', { chatId: encoded, userId, userName, text: `[${msgType}: ${name} — download failed]` })
+        return
+      }
+
+      if (msgType === 'image') {
+        const image: ImageAttachment = {
+          data: media.base64,
+          media_type: media.contentType || 'image/png'
+        }
+        this.emit('message', { chatId: encoded, userId, userName, text: '', images: [image] })
+        return
+      }
+
+      const ext = name.includes('.') ? name.split('.').pop()!.toLowerCase() : ''
+      const file: FileAttachment = {
+        filename: media.name || name,
+        data: media.base64,
+        media_type: media.contentType || FILE_EXTENSION_MIME_MAP[ext] || 'application/octet-stream',
+        size: media.size
+      }
+      this.emit('message', { chatId: encoded, userId, userName, text: `[${msgType}: ${file.filename}]`, files: [file] })
+      return
+    }
+
+    // Unknown msgtype — surface as a plain text marker rather than dropping silently.
+    this.emit('message', { chatId: encoded, userId, userName, text: `[unsupported WeCom msgtype: ${msgType}]` })
+  }
+
+  private async downloadMedia(
+    mediaId: string
+  ): Promise<{ base64: string; contentType: string; size: number; name: string } | null> {
+    if (!this.client) return null
+    const res = await this.client.callTool<unknown, GetMsgMediaResponse>('msg', 'get_msg_media', { media_id: mediaId })
+    const item = res.media_item
+    if (!item || !item.base64_data) return null
+
+    // Enforce size cap before decoding (base64 is ~4/3 of raw).
+    if (item.size && item.size > MAX_FILE_SIZE_BYTES) {
+      this.log.warn(`WeCom media too large, skipping`, { mediaId, size: item.size })
+      return null
+    }
+
+    return {
+      base64: item.base64_data,
+      contentType: item.content_type ?? '',
+      size: item.size ?? 0,
+      name: item.name ?? mediaId
+    }
+  }
+
+  // ---- Echo suppression ----
+
+  private rememberOutgoing(content: string): void {
+    const now = Date.now()
+    this.outgoingEchoes.set(content, now + ECHO_SUPPRESS_MS)
+    // Opportunistic cleanup.
+    if (this.outgoingEchoes.size > 256) {
+      for (const [key, expiry] of this.outgoingEchoes) {
+        if (expiry <= now) this.outgoingEchoes.delete(key)
+      }
+    }
+  }
+
+  private isEcho(content: string): boolean {
+    const expiry = this.outgoingEchoes.get(content)
+    if (!expiry) return false
+    if (expiry <= Date.now()) {
+      this.outgoingEchoes.delete(content)
+      return false
+    }
+    return true
+  }
+}
+
+function getAppVersion(): string {
+  try {
+    return app.getVersion()
+  } catch {
+    return 'unknown'
+  }
+}
+
+// Self-registration
+registerAdapterFactory('wecom', (channel, agentId) => {
+  return new WeComAdapter({
+    channelId: channel.id,
+    channelType: channel.type,
+    agentId,
+    channelConfig: channel.config
+  })
+})
+
+export { WeComAdapter }

--- a/src/main/services/agents/services/channels/adapters/wecom/WeComAdapter.ts
+++ b/src/main/services/agents/services/channels/adapters/wecom/WeComAdapter.ts
@@ -1,3 +1,5 @@
+import { windowService } from '@main/services/WindowService'
+import { IpcChannel } from '@shared/IpcChannel'
 import { app } from 'electron'
 
 import {
@@ -12,6 +14,7 @@ import { registerAdapterFactory } from '../../ChannelManager'
 import { isSlashCommand } from '../../constants'
 import { FILE_EXTENSION_MIME_MAP, splitMessage } from '../../utils'
 import { WeComClient } from './WeComClient'
+import { registrationBegin, registrationPoll } from './WeComQrRegistration'
 import type {
   GetMessageResponse,
   GetMsgMediaResponse,
@@ -66,6 +69,7 @@ class WeComAdapter extends ChannelAdapter {
 
   private pollTimer: ReturnType<typeof setInterval> | null = null
   private polling = false
+  private qrAbort: AbortController | null = null
 
   /** Per-encoded-chat: last-seen `send_time` (epoch ms). Messages at or before this are dropped. */
   private lastSeen = new Map<string, number>()
@@ -89,7 +93,11 @@ class WeComAdapter extends ChannelAdapter {
 
   protected override async performConnect(signal: AbortSignal): Promise<void> {
     if (!this.botId || !this.botSecret) {
-      throw new Error('Missing bot_id or bot_secret')
+      // No credentials yet — kick off QR registration in the background.
+      // ChannelManager's 'credentials' handler will persist them and re-sync,
+      // which creates a fresh adapter that takes the credentialed path below.
+      this.startRegistrationInBackground()
+      return
     }
 
     const client = new WeComClient({
@@ -129,9 +137,65 @@ class WeComAdapter extends ChannelAdapter {
       clearInterval(this.pollTimer)
       this.pollTimer = null
     }
+    if (this.qrAbort) {
+      this.qrAbort.abort()
+      this.qrAbort = null
+    }
     this.client = null
     this.outgoingEchoes.clear()
+    this.sendQrToRenderer('', 'disconnected')
     this.log.info('WeCom bot disconnected')
+  }
+
+  /**
+   * Start the WeCom QR-based bot registration in the background.
+   * Emits the QR URL immediately and polls the server until the user scans.
+   * On success, emits 'credentials' so ChannelManager can persist + reconnect.
+   */
+  private startRegistrationInBackground(): void {
+    this.log.info('Starting WeCom QR registration (background)')
+    this.sendQrToRenderer('', 'pending')
+
+    registrationBegin()
+      .then(({ scode, authUrl }) => {
+        this.emit('qr', authUrl)
+        this.sendQrToRenderer(authUrl, 'pending')
+
+        this.qrAbort = new AbortController()
+        return registrationPoll(scode, this.qrAbort.signal)
+      })
+      .then((result) => {
+        this.qrAbort = null
+        this.sendQrToRenderer('', 'confirmed', result.botId, result.botSecret)
+        // ChannelManager listens for 'credentials' and calls saveCredentialsAndReconnect,
+        // which writes the values into channel.config and recreates this adapter.
+        this.emit('credentials', { appId: result.botId, appSecret: result.botSecret })
+        this.log.info('WeCom QR registration completed')
+      })
+      .catch((err) => {
+        this.qrAbort = null
+        const msg = err instanceof Error ? err.message : String(err)
+        this.sendQrToRenderer('', 'expired')
+        this.log.warn(`WeCom QR registration failed: ${msg}`)
+      })
+  }
+
+  private sendQrToRenderer(
+    url: string,
+    status: 'pending' | 'confirmed' | 'expired' | 'disconnected',
+    botId?: string,
+    botSecret?: string
+  ): void {
+    const mainWindow = windowService.getMainWindow()
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send(IpcChannel.WeCom_QrLogin, {
+        channelId: this.channelId,
+        url,
+        status,
+        botId,
+        botSecret
+      })
+    }
   }
 
   // oxlint-disable-next-line no-unused-vars -- abstract method signature

--- a/src/main/services/agents/services/channels/adapters/wecom/WeComAdapter.ts
+++ b/src/main/services/agents/services/channels/adapters/wecom/WeComAdapter.ts
@@ -158,6 +158,7 @@ class WeComAdapter extends ChannelAdapter {
     }
   }
 
+  // oxlint-disable-next-line no-unused-vars -- abstract method signature
   async sendTypingIndicator(_chatId: string): Promise<void> {
     // WeCom has no typing API — no-op.
   }

--- a/src/main/services/agents/services/channels/adapters/wecom/WeComClient.ts
+++ b/src/main/services/agents/services/channels/adapters/wecom/WeComClient.ts
@@ -2,14 +2,8 @@ import { createHash, randomBytes } from 'node:crypto'
 
 import { net } from 'electron'
 
-import type {
-  BizResponse,
-  GetMcpConfigRequest,
-  GetMcpConfigResponse,
-  JsonRpcRequest,
-  JsonRpcResponse,
-  McpConfigItem
-} from './WeComTypes'
+import { BizResponseSchema, GetMcpConfigResponseSchema, JsonRpcResponseSchema, JsonStringSchema } from './WeComSchemas'
+import type { BizResponse, GetMcpConfigRequest, JsonRpcRequest, McpConfigItem } from './WeComTypes'
 
 /** WeCom MCP config bootstrap endpoint. */
 const DEFAULT_MCP_CONFIG_ENDPOINT = 'https://qyapi.weixin.qq.com/cgi-bin/aibot/cli/get_mcp_config'
@@ -86,7 +80,11 @@ export class WeComClient {
       throw new Error(`Bootstrap HTTP ${response.status}: ${await safeReadText(response)}`)
     }
 
-    const data = (await response.json()) as GetMcpConfigResponse
+    const parsed = GetMcpConfigResponseSchema.safeParse(await response.json())
+    if (!parsed.success) {
+      throw new Error(`Bootstrap response schema mismatch: ${parsed.error.message}`)
+    }
+    const data = parsed.data
     if (data.errcode !== 0) {
       throw new WeComBusinessError(
         data.errcode,
@@ -95,7 +93,7 @@ export class WeComClient {
       )
     }
 
-    const list = data.list ?? []
+    const list = (data.list ?? []) as McpConfigItem[]
     this.categoryUrls.clear()
     for (const item of list) {
       if (item.biz_type && item.url) this.categoryUrls.set(item.biz_type, item.url)
@@ -147,13 +145,19 @@ export class WeComClient {
       throw new Error(`WeCom RPC HTTP ${response.status} (${category}.${method}): ${await safeReadText(response)}`)
     }
 
-    const json = (await response.json()) as JsonRpcResponse
+    const envelopeParsed = JsonRpcResponseSchema.safeParse(await response.json())
+    if (!envelopeParsed.success) {
+      throw new Error(`WeCom RPC envelope schema mismatch (${category}.${method}): ${envelopeParsed.error.message}`)
+    }
+    const envelope = envelopeParsed.data
 
-    if (json.error && json.error.code !== undefined && json.error.code !== 0) {
-      throw new Error(`WeCom RPC error code=${json.error.code} (${category}.${method}): ${json.error.message ?? ''}`)
+    if (envelope.error && envelope.error.code !== undefined && envelope.error.code !== 0) {
+      throw new Error(
+        `WeCom RPC error code=${envelope.error.code} (${category}.${method}): ${envelope.error.message ?? ''}`
+      )
     }
 
-    const result = json.result
+    const result = envelope.result
     if (!result) {
       throw new Error(`WeCom RPC malformed response (${category}.${method}): missing result`)
     }
@@ -166,12 +170,14 @@ export class WeComClient {
       throw new Error(`WeCom RPC malformed content (${category}.${method})`)
     }
 
-    let parsed: TResult
-    try {
-      parsed = JSON.parse(content[0].text) as TResult
-    } catch {
-      throw new Error(`WeCom RPC content is not JSON (${category}.${method})`)
+    // `content[0].text` is a JSON-encoded business payload. Pipe through
+    // JsonStringSchema so a single safeParse covers both "not JSON" and
+    // "wrong shape" failures.
+    const bizParsed = JsonStringSchema.pipe(BizResponseSchema).safeParse(content[0].text)
+    if (!bizParsed.success) {
+      throw new Error(`WeCom RPC business payload schema mismatch (${category}.${method}): ${bizParsed.error.message}`)
     }
+    const parsed = bizParsed.data as TResult
 
     const errcode = parsed.errcode
     if (typeof errcode === 'number' && errcode !== 0) {

--- a/src/main/services/agents/services/channels/adapters/wecom/WeComClient.ts
+++ b/src/main/services/agents/services/channels/adapters/wecom/WeComClient.ts
@@ -1,0 +1,207 @@
+import { createHash, randomBytes } from 'node:crypto'
+
+import { net } from 'electron'
+
+import type {
+  BizResponse,
+  GetMcpConfigRequest,
+  GetMcpConfigResponse,
+  JsonRpcRequest,
+  JsonRpcResponse,
+  McpConfigItem
+} from './WeComTypes'
+
+/** WeCom MCP config bootstrap endpoint. */
+const DEFAULT_MCP_CONFIG_ENDPOINT = 'https://qyapi.weixin.qq.com/cgi-bin/aibot/cli/get_mcp_config'
+
+/** Default tool-call timeout (ms). */
+const DEFAULT_TIMEOUT_MS = 30_000
+
+/** Extended timeout for media downloads (ms) — matches wecom-cli. */
+const MEDIA_TIMEOUT_MS = 120_000
+
+const MEDIA_METHODS = new Set(['get_msg_media'])
+
+export interface WeComClientOptions {
+  botId: string
+  botSecret: string
+  /** Identifier sent as `cli_version`; recognizable from server logs. */
+  clientVersion?: string
+  /** Override the bootstrap endpoint (used in tests). */
+  endpoint?: string
+}
+
+export class WeComBusinessError extends Error {
+  constructor(
+    readonly errcode: number,
+    message: string,
+    readonly payload: BizResponse
+  ) {
+    super(message)
+    this.name = 'WeComBusinessError'
+  }
+}
+
+/**
+ * Native Node port of wecom-cli's HTTP/JSON-RPC client.
+ * Stateless per call apart from an in-memory URL cache populated by `bootstrap()`.
+ */
+export class WeComClient {
+  private readonly botId: string
+  private readonly botSecret: string
+  private readonly clientVersion: string
+  private readonly endpoint: string
+  private categoryUrls = new Map<string, string>()
+
+  constructor(opts: WeComClientOptions) {
+    this.botId = opts.botId
+    this.botSecret = opts.botSecret
+    this.clientVersion = opts.clientVersion ?? 'CherryStudio/unknown'
+    this.endpoint = opts.endpoint ?? DEFAULT_MCP_CONFIG_ENDPOINT
+  }
+
+  /**
+   * Fetch the per-category MCP URLs and cache them. Validates credentials —
+   * an invalid bot_id/secret pair will surface here as a business error.
+   */
+  async bootstrap(): Promise<McpConfigItem[]> {
+    const time = Math.floor(Date.now() / 1000)
+    const nonce = genReqId('mcp')
+    const body: GetMcpConfigRequest = {
+      bot_id: this.botId,
+      time,
+      nonce,
+      signature: sign(this.botSecret, this.botId, time, nonce),
+      bind_source: 1,
+      cli_version: this.clientVersion
+    }
+
+    const response = await net.fetch(this.endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': this.clientVersion },
+      body: JSON.stringify(body)
+    })
+
+    if (!response.ok) {
+      throw new Error(`Bootstrap HTTP ${response.status}: ${await safeReadText(response)}`)
+    }
+
+    const data = (await response.json()) as GetMcpConfigResponse
+    if (data.errcode !== 0) {
+      throw new WeComBusinessError(
+        data.errcode,
+        `Bootstrap failed: ${data.errmsg ?? 'unknown error'} (errcode=${data.errcode})`,
+        data as unknown as BizResponse
+      )
+    }
+
+    const list = data.list ?? []
+    this.categoryUrls.clear()
+    for (const item of list) {
+      if (item.biz_type && item.url) this.categoryUrls.set(item.biz_type, item.url)
+    }
+    return list
+  }
+
+  /** True iff `bootstrap()` has successfully populated at least one category URL. */
+  isBootstrapped(): boolean {
+    return this.categoryUrls.size > 0
+  }
+
+  /** Call a remote tool: `category`/`method` (e.g. 'msg' / 'send_message'). */
+  async callTool<TArgs, TResult extends BizResponse>(category: string, method: string, args: TArgs): Promise<TResult> {
+    const url = this.categoryUrls.get(category)
+    if (!url) {
+      throw new Error(`No MCP URL for category "${category}" — call bootstrap() first`)
+    }
+
+    const req: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id: genReqId('mcp_rpc'),
+      method: 'tools/call',
+      params: { name: method, arguments: args }
+    }
+
+    const timeoutMs = MEDIA_METHODS.has(method) ? MEDIA_TIMEOUT_MS : DEFAULT_TIMEOUT_MS
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), timeoutMs)
+
+    let response: Response
+    try {
+      response = await net.fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json', 'User-Agent': this.clientVersion },
+        body: JSON.stringify(req),
+        signal: controller.signal
+      })
+    } catch (err) {
+      if ((err as { name?: string })?.name === 'AbortError') {
+        throw new Error(`WeCom RPC timed out after ${timeoutMs}ms (${category}.${method})`)
+      }
+      throw err
+    } finally {
+      clearTimeout(timer)
+    }
+
+    if (!response.ok) {
+      throw new Error(`WeCom RPC HTTP ${response.status} (${category}.${method}): ${await safeReadText(response)}`)
+    }
+
+    const json = (await response.json()) as JsonRpcResponse
+
+    if (json.error && json.error.code !== undefined && json.error.code !== 0) {
+      throw new Error(`WeCom RPC error code=${json.error.code} (${category}.${method}): ${json.error.message ?? ''}`)
+    }
+
+    const result = json.result
+    if (!result) {
+      throw new Error(`WeCom RPC malformed response (${category}.${method}): missing result`)
+    }
+    if (result.isError) {
+      throw new Error(`WeCom RPC tool error (${category}.${method}): ${JSON.stringify(result)}`)
+    }
+
+    const content = result.content
+    if (!Array.isArray(content) || content.length !== 1 || content[0]?.type !== 'text' || !content[0].text) {
+      throw new Error(`WeCom RPC malformed content (${category}.${method})`)
+    }
+
+    let parsed: TResult
+    try {
+      parsed = JSON.parse(content[0].text) as TResult
+    } catch {
+      throw new Error(`WeCom RPC content is not JSON (${category}.${method})`)
+    }
+
+    const errcode = parsed.errcode
+    if (typeof errcode === 'number' && errcode !== 0) {
+      throw new WeComBusinessError(
+        errcode,
+        `${category}.${method} failed: ${parsed.errmsg ?? 'unknown error'} (errcode=${errcode})`,
+        parsed
+      )
+    }
+
+    return parsed
+  }
+}
+
+/** `sha256_hex(secret + bot_id + time + nonce)` — see wecom-cli `src/mcp/config.rs:99`. */
+export function sign(secret: string, botId: string, time: number, nonce: string): string {
+  return createHash('sha256').update(`${secret}${botId}${time}${nonce}`).digest('hex')
+}
+
+/** Mirrors wecom-cli `gen_req_id`: `{prefix}_{ts_ms}_{8 hex chars}`. */
+export function genReqId(prefix: string): string {
+  const ts = Date.now()
+  const hex = randomBytes(4).toString('hex')
+  return `${prefix}_${ts}_${hex}`
+}
+
+async function safeReadText(res: Response): Promise<string> {
+  try {
+    return await res.text()
+  } catch {
+    return '<unreadable body>'
+  }
+}

--- a/src/main/services/agents/services/channels/adapters/wecom/WeComQrRegistration.ts
+++ b/src/main/services/agents/services/channels/adapters/wecom/WeComQrRegistration.ts
@@ -11,6 +11,8 @@
 import { loggerService } from '@logger'
 import { net } from 'electron'
 
+import { QrGenerateResponseSchema, QrQueryResponseSchema } from './WeComSchemas'
+
 const logger = loggerService.withContext('WeComQrRegistration')
 
 const SOURCE = 'wecom_cli_external'
@@ -51,11 +53,14 @@ export async function registrationBegin(): Promise<WeComQrBeginResult> {
   if (!res.ok) {
     throw new Error(`WeCom QR generate HTTP ${res.status}`)
   }
-  const payload = (await res.json()) as { data?: { scode?: string; auth_url?: string } }
-  const scode = payload.data?.scode
-  const authUrl = payload.data?.auth_url
+  const parsed = QrGenerateResponseSchema.safeParse(await res.json())
+  if (!parsed.success) {
+    throw new Error(`WeCom QR generate schema mismatch: ${parsed.error.message}`)
+  }
+  const scode = parsed.data.data?.scode
+  const authUrl = parsed.data.data?.auth_url
   if (!scode || !authUrl) {
-    throw new Error(`WeCom QR generate malformed response: ${JSON.stringify(payload).slice(0, 200)}`)
+    throw new Error('WeCom QR generate response missing scode or auth_url')
   }
   logger.info('WeCom QR generated', { scode })
   return { scode, authUrl }
@@ -76,13 +81,15 @@ export async function registrationPoll(scode: string, signal?: AbortSignal): Pro
       logger.warn('WeCom QR poll non-OK status', { status: res.status })
       continue
     }
-    const payload = (await res.json()) as {
-      data?: { status?: string; bot_info?: { botid?: string; secret?: string } }
+    const parsed = QrQueryResponseSchema.safeParse(await res.json())
+    if (!parsed.success) {
+      logger.warn('WeCom QR poll schema mismatch', { error: parsed.error.message })
+      continue
     }
-    const status = payload.data?.status
-    if (status === 'success') {
-      const botId = payload.data?.bot_info?.botid
-      const botSecret = payload.data?.bot_info?.secret
+    const data = parsed.data.data
+    if (data?.status === 'success') {
+      const botId = data.bot_info?.botid
+      const botSecret = data.bot_info?.secret
       if (!botId || !botSecret) {
         throw new Error('WeCom QR success but bot credentials missing in response')
       }

--- a/src/main/services/agents/services/channels/adapters/wecom/WeComQrRegistration.ts
+++ b/src/main/services/agents/services/channels/adapters/wecom/WeComQrRegistration.ts
@@ -1,0 +1,109 @@
+/**
+ * WeCom QR-based smart bot registration.
+ *
+ * Ported from wecom-cli `src/auth/qrcode.rs`. The flow is:
+ *   1. POST /ai/qc/generate  -> { scode, auth_url }
+ *   2. Render `auth_url` as a QR (user scans with the WeCom mobile app)
+ *   3. Poll /ai/qc/query_result?scode=<scode> every 3 s until
+ *      data.status === 'success', then read data.bot_info.{botid,secret}.
+ *   4. Timeout after 5 min.
+ */
+import { loggerService } from '@logger'
+import { net } from 'electron'
+
+const logger = loggerService.withContext('WeComQrRegistration')
+
+const SOURCE = 'wecom_cli_external'
+const QR_GENERATE_URL = 'https://work.weixin.qq.com/ai/qc/generate'
+const QR_QUERY_URL = 'https://work.weixin.qq.com/ai/qc/query_result'
+
+const POLL_INTERVAL_MS = 3_000
+const POLL_TIMEOUT_MS = 5 * 60_000
+
+export interface WeComQrBeginResult {
+  scode: string
+  /** The encoded URL to render inside a QR code; users scan it with WeCom. */
+  authUrl: string
+}
+
+export interface WeComQrPollResult {
+  botId: string
+  botSecret: string
+}
+
+/** Map `process.platform` to the `plat` value the upstream server expects. */
+function getPlatCode(): number {
+  switch (process.platform) {
+    case 'darwin':
+      return 1
+    case 'win32':
+      return 2
+    case 'linux':
+      return 3
+    default:
+      return 0
+  }
+}
+
+export async function registrationBegin(): Promise<WeComQrBeginResult> {
+  const url = `${QR_GENERATE_URL}?source=${encodeURIComponent(SOURCE)}&plat=${getPlatCode()}`
+  const res = await net.fetch(url, { method: 'GET' })
+  if (!res.ok) {
+    throw new Error(`WeCom QR generate HTTP ${res.status}`)
+  }
+  const payload = (await res.json()) as { data?: { scode?: string; auth_url?: string } }
+  const scode = payload.data?.scode
+  const authUrl = payload.data?.auth_url
+  if (!scode || !authUrl) {
+    throw new Error(`WeCom QR generate malformed response: ${JSON.stringify(payload).slice(0, 200)}`)
+  }
+  logger.info('WeCom QR generated', { scode })
+  return { scode, authUrl }
+}
+
+export async function registrationPoll(scode: string, signal?: AbortSignal): Promise<WeComQrPollResult> {
+  const url = `${QR_QUERY_URL}?scode=${encodeURIComponent(scode)}`
+  const deadline = Date.now() + POLL_TIMEOUT_MS
+
+  while (Date.now() < deadline) {
+    if (signal?.aborted) throw new Error('WeCom QR polling aborted')
+
+    await sleep(POLL_INTERVAL_MS, signal)
+    if (signal?.aborted) throw new Error('WeCom QR polling aborted')
+
+    const res = await net.fetch(url, { method: 'GET' })
+    if (!res.ok) {
+      logger.warn('WeCom QR poll non-OK status', { status: res.status })
+      continue
+    }
+    const payload = (await res.json()) as {
+      data?: { status?: string; bot_info?: { botid?: string; secret?: string } }
+    }
+    const status = payload.data?.status
+    if (status === 'success') {
+      const botId = payload.data?.bot_info?.botid
+      const botSecret = payload.data?.bot_info?.secret
+      if (!botId || !botSecret) {
+        throw new Error('WeCom QR success but bot credentials missing in response')
+      }
+      logger.info('WeCom QR registration completed')
+      return { botId, botSecret }
+    }
+  }
+
+  throw new Error('WeCom QR registration timed out (5 minutes)')
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(resolve, ms)
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer)
+        reject(new Error('aborted'))
+      },
+      { once: true }
+    )
+  })
+}

--- a/src/main/services/agents/services/channels/adapters/wecom/WeComSchemas.ts
+++ b/src/main/services/agents/services/channels/adapters/wecom/WeComSchemas.ts
@@ -1,0 +1,174 @@
+/**
+ * Zod schemas for every WeCom HTTP response we parse.
+ *
+ * External payloads can drift, so we validate them at the boundary and fail
+ * soft (return null / throw a typed error) rather than `as`-casting into the
+ * consumer. Keep schemas permissive — unknown fields pass through — but
+ * require the keys the adapter relies on.
+ */
+import * as z from 'zod'
+
+/**
+ * Accept a JSON-encoded string and return the parsed JS value. Use with
+ * `.pipe(<schema>)` so a single `safeParse` call covers both "not JSON" and
+ * "wrong shape" failure modes.
+ */
+export const JsonStringSchema = z.string().transform((value, ctx) => {
+  try {
+    return JSON.parse(value) as unknown
+  } catch (err) {
+    ctx.issues.push({
+      code: 'custom',
+      message: `Invalid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      input: value
+    })
+    return z.NEVER
+  }
+})
+
+// ---- Bootstrap: POST /cgi-bin/aibot/cli/get_mcp_config ----
+
+export const McpConfigItemSchema = z
+  .object({
+    url: z.string().optional(),
+    type: z.string().optional(),
+    is_authed: z.boolean().optional(),
+    biz_type: z.string().optional()
+  })
+  .loose()
+
+export const GetMcpConfigResponseSchema = z
+  .object({
+    errcode: z.number(),
+    errmsg: z.string().optional(),
+    list: z.array(McpConfigItemSchema).optional()
+  })
+  .loose()
+
+// ---- JSON-RPC envelope for tool calls ----
+
+export const JsonRpcContentItemSchema = z
+  .object({
+    type: z.string().optional(),
+    text: z.string().optional()
+  })
+  .loose()
+
+export const JsonRpcResultSchema = z
+  .object({
+    isError: z.boolean().optional(),
+    content: z.array(JsonRpcContentItemSchema).optional()
+  })
+  .loose()
+
+export const JsonRpcErrorSchema = z
+  .object({
+    code: z.number().optional(),
+    message: z.string().optional(),
+    data: z.unknown().optional()
+  })
+  .loose()
+
+export const JsonRpcResponseSchema = z
+  .object({
+    jsonrpc: z.string().optional(),
+    id: z.string().optional(),
+    result: JsonRpcResultSchema.optional(),
+    error: JsonRpcErrorSchema.optional()
+  })
+  .loose()
+
+// ---- Generic business response (errcode 0 success contract) ----
+
+export const BizResponseSchema = z
+  .object({
+    errcode: z.number().optional(),
+    errmsg: z.string().optional()
+  })
+  .loose()
+
+// ---- msg.get_msg_chat_list ----
+
+export const MsgChatListItemSchema = z
+  .object({
+    chat_id: z.string(),
+    chat_name: z.string().optional(),
+    last_msg_time: z.string().optional(),
+    msg_count: z.number().optional()
+  })
+  .loose()
+
+export const GetMsgChatListResponseSchema = BizResponseSchema.extend({
+  chats: z.array(MsgChatListItemSchema).optional(),
+  has_more: z.boolean().optional(),
+  next_cursor: z.string().optional()
+})
+
+// ---- msg.get_message ----
+
+export const WeComMessageItemSchema = z
+  .object({
+    userid: z.string().optional(),
+    send_time: z.string().optional(),
+    msgtype: z.enum(['text', 'image', 'file', 'voice', 'video']).optional(),
+    text: z.object({ content: z.string().optional() }).loose().optional(),
+    image: z.object({ media_id: z.string().optional(), name: z.string().optional() }).loose().optional(),
+    file: z.object({ media_id: z.string().optional(), name: z.string().optional() }).loose().optional(),
+    voice: z.object({ media_id: z.string().optional(), name: z.string().optional() }).loose().optional(),
+    video: z.object({ media_id: z.string().optional(), name: z.string().optional() }).loose().optional()
+  })
+  .loose()
+
+export const GetMessageResponseSchema = BizResponseSchema.extend({
+  messages: z.array(WeComMessageItemSchema).optional(),
+  next_cursor: z.string().optional()
+})
+
+// ---- msg.get_msg_media ----
+
+export const MediaItemSchema = z
+  .object({
+    media_id: z.string().optional(),
+    name: z.string().optional(),
+    type: z.enum(['image', 'file', 'voice', 'video']).optional(),
+    size: z.number().optional(),
+    content_type: z.string().optional(),
+    base64_data: z.string().optional()
+  })
+  .loose()
+
+export const GetMsgMediaResponseSchema = BizResponseSchema.extend({
+  media_item: MediaItemSchema.optional()
+})
+
+// ---- QR registration (work.weixin.qq.com/ai/qc/*) ----
+
+export const QrGenerateResponseSchema = z
+  .object({
+    data: z
+      .object({
+        scode: z.string().optional(),
+        auth_url: z.string().optional()
+      })
+      .loose()
+      .optional()
+  })
+  .loose()
+
+export const QrQueryResponseSchema = z
+  .object({
+    data: z
+      .object({
+        status: z.string().optional(),
+        bot_info: z
+          .object({
+            botid: z.string().optional(),
+            secret: z.string().optional()
+          })
+          .loose()
+          .optional()
+      })
+      .loose()
+      .optional()
+  })
+  .loose()

--- a/src/main/services/agents/services/channels/adapters/wecom/WeComTypes.ts
+++ b/src/main/services/agents/services/channels/adapters/wecom/WeComTypes.ts
@@ -1,0 +1,131 @@
+/**
+ * WeCom (企业微信) MCP JSON-RPC request/response types.
+ *
+ * The wire format is documented in the wecom-cli Rust source:
+ *   - Bootstrap:  src/mcp/config.rs
+ *   - JSON-RPC:   src/json_rpc.rs
+ *   - Tools:      skills/wecomcli-msg/references/*.md
+ */
+
+/** chat_type 1 = single-user DM, 2 = group chat. */
+export type WeComChatType = 1 | 2
+
+/** Bootstrap request to `qyapi.weixin.qq.com/cgi-bin/aibot/cli/get_mcp_config`. */
+export interface GetMcpConfigRequest {
+  bot_id: string
+  time: number
+  nonce: string
+  signature: string
+  bind_source: 1 | 2 // 1 = Interactive (manual creds), 2 = QR
+  cli_version: string
+}
+
+export interface McpConfigItem {
+  url?: string
+  type?: string
+  is_authed?: boolean
+  biz_type?: string
+}
+
+export interface GetMcpConfigResponse {
+  errcode: number
+  errmsg?: string
+  list?: McpConfigItem[]
+}
+
+/** JSON-RPC 2.0 envelope. */
+export interface JsonRpcRequest {
+  jsonrpc: '2.0'
+  id: string
+  method: string
+  params?: unknown
+}
+
+export interface JsonRpcResponse {
+  jsonrpc?: '2.0'
+  id?: string
+  result?: {
+    isError?: boolean
+    content?: Array<{ type?: string; text?: string }>
+  }
+  error?: { code?: number; message?: string; data?: unknown }
+}
+
+/** Business-layer response shape (the JSON inside `result.content[0].text`). */
+export interface BizResponse {
+  errcode?: number
+  errmsg?: string
+  [k: string]: unknown
+}
+
+// ---- msg.* tool I/O shapes ----
+
+export interface GetMsgChatListArgs {
+  begin_time: string
+  end_time: string
+  cursor?: string
+}
+
+export interface MsgChatListItem {
+  chat_id: string
+  chat_name?: string
+  last_msg_time?: string
+  msg_count?: number
+}
+
+export interface GetMsgChatListResponse extends BizResponse {
+  chats?: MsgChatListItem[]
+  has_more?: boolean
+  next_cursor?: string
+}
+
+export interface GetMessageArgs {
+  chat_type: WeComChatType
+  chatid: string
+  begin_time: string
+  end_time: string
+  cursor?: string
+}
+
+export type WeComMessageType = 'text' | 'image' | 'file' | 'voice' | 'video'
+
+export interface WeComMessageItem {
+  userid?: string
+  send_time?: string
+  msgtype?: WeComMessageType
+  text?: { content?: string }
+  image?: { media_id?: string; name?: string }
+  file?: { media_id?: string; name?: string }
+  voice?: { media_id?: string; name?: string }
+  video?: { media_id?: string; name?: string }
+}
+
+export interface GetMessageResponse extends BizResponse {
+  messages?: WeComMessageItem[]
+  next_cursor?: string
+}
+
+export interface GetMsgMediaArgs {
+  media_id: string
+}
+
+export interface MediaItem {
+  media_id?: string
+  name?: string
+  type?: 'image' | 'file' | 'voice' | 'video'
+  size?: number
+  content_type?: string
+  /** Base64-encoded payload (returned by the MCP server before CLI interception). */
+  base64_data?: string
+}
+
+export interface GetMsgMediaResponse extends BizResponse {
+  media_item?: MediaItem
+}
+
+export interface SendMessageArgs {
+  chat_type: WeComChatType
+  chatid: string
+  msgtype: 'text'
+  text: { content: string }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -663,6 +663,34 @@ const api = {
       return () => ipcRenderer.off(IpcChannel.WeCom_QrLogin, listener)
     }
   },
+  dingtalk: {
+    onQrLogin: (
+      callback: (data: {
+        channelId: string
+        agentId: string
+        url: string
+        status: string
+        clientId?: string
+        clientSecret?: string
+      }) => void
+    ): (() => void) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        data: {
+          channelId: string
+          agentId: string
+          url: string
+          status: string
+          clientId?: string
+          clientSecret?: string
+        }
+      ) => {
+        callback(data)
+      }
+      ipcRenderer.on(IpcChannel.DingTalk_QrLogin, listener)
+      return () => ipcRenderer.off(IpcChannel.DingTalk_QrLogin, listener)
+    }
+  },
   channel: {
     onLog: (
       callback: (log: { timestamp: number; level: string; message: string; channelId: string }) => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -642,6 +642,27 @@ const api = {
       return () => ipcRenderer.off(IpcChannel.Feishu_QrLogin, listener)
     }
   },
+  wecom: {
+    onQrLogin: (
+      callback: (data: {
+        channelId: string
+        agentId: string
+        url: string
+        status: string
+        botId?: string
+        botSecret?: string
+      }) => void
+    ): (() => void) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        data: { channelId: string; agentId: string; url: string; status: string; botId?: string; botSecret?: string }
+      ) => {
+        callback(data)
+      }
+      ipcRenderer.on(IpcChannel.WeCom_QrLogin, listener)
+      return () => ipcRenderer.off(IpcChannel.WeCom_QrLogin, listener)
+    }
+  },
   channel: {
     onLog: (
       callback: (log: { timestamp: number; level: string; message: string; channelId: string }) => void

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -38,6 +38,23 @@
         "connecting": "Connecting",
         "deleteConfirm": "Delete channel \"{{name}}\"?",
         "description": "Connect your agent to messaging platforms.",
+        "dingtalk": {
+          "chatIds": "Allowed Chats",
+          "chatIdsHint": "Format \"p2p:<staffId>\" (DM) or \"group:<openConversationId>\" (group), comma-separated. Empty allows any chat the bot receives.",
+          "chatIdsPlaceholder": "p2p:0123456789, group:cidXXXXXX==",
+          "clientId": "App Key",
+          "clientIdPlaceholder": "DingTalk inner-app Client ID / App Key (auto-filled after QR scan)",
+          "clientSecret": "App Secret",
+          "clientSecretPlaceholder": "DingTalk inner-app Client Secret / App Secret (auto-filled after QR scan)",
+          "connected": "Connected",
+          "description": "Receive and respond to messages via a DingTalk enterprise inner-app bot using Stream mode (no public IP needed).",
+          "loginHint": "Leave App Key / App Secret blank and enable the channel to bind via QR code with DingTalk.",
+          "qrExpired": "QR code expired. Disable and re-enable the channel to retry.",
+          "qrHint": "Scan with DingTalk to authorize the bot.",
+          "qrScanHint": "Open DingTalk on your phone and scan to authorize the inner-app bot.",
+          "qrTitle": "DingTalk QR Login",
+          "title": "DingTalk"
+        },
         "disconnected": "Disconnected",
         "discord": {
           "botToken": "Bot Token",

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -137,13 +137,19 @@
         },
         "wecom": {
           "botId": "Bot ID",
-          "botIdPlaceholder": "WeCom smart bot ID",
+          "botIdPlaceholder": "WeCom smart bot ID (auto-filled after QR scan)",
           "botSecret": "Bot Secret",
-          "botSecretPlaceholder": "WeCom smart bot secret",
+          "botSecretPlaceholder": "WeCom smart bot secret (auto-filled after QR scan)",
           "chatIds": "Allowed Chats",
           "chatIdsHint": "Format \"1:userid\" (DM) or \"2:groupid\" (group), comma-separated. WeCom requires explicit chats for polling.",
           "chatIdsPlaceholder": "1:zhangsan, 2:wrxxxxxx",
+          "connected": "Connected",
           "description": "Receive and respond to messages via a WeCom smart bot (30 s polling).",
+          "loginHint": "Leave Bot ID / Secret blank and enable the channel to bind via QR code with WeCom.",
+          "qrExpired": "QR code expired. Disable and re-enable the channel to retry.",
+          "qrHint": "Scan with WeCom to bind the smart bot.",
+          "qrScanHint": "Open WeCom on your phone and scan to authorize the smart bot.",
+          "qrTitle": "WeCom QR Login",
           "title": "WeCom"
         }
       },

--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -134,6 +134,17 @@
           "qrTitle": "WeChat QR Login",
           "title": "WeChat",
           "whoamiTip": "Tip: Send /whoami in WeChat to get a user's ID."
+        },
+        "wecom": {
+          "botId": "Bot ID",
+          "botIdPlaceholder": "WeCom smart bot ID",
+          "botSecret": "Bot Secret",
+          "botSecretPlaceholder": "WeCom smart bot secret",
+          "chatIds": "Allowed Chats",
+          "chatIdsHint": "Format \"1:userid\" (DM) or \"2:groupid\" (group), comma-separated. WeCom requires explicit chats for polling.",
+          "chatIdsPlaceholder": "1:zhangsan, 2:wrxxxxxx",
+          "description": "Receive and respond to messages via a WeCom smart bot (30 s polling).",
+          "title": "WeCom"
         }
       },
       "heartbeat": {

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -134,6 +134,17 @@
           "qrTitle": "微信扫码登录",
           "title": "微信",
           "whoamiTip": "提示：在微信中发送 /whoami 可获取用户 ID。"
+        },
+        "wecom": {
+          "botId": "Bot ID",
+          "botIdPlaceholder": "企业微信智能机器人 Bot ID",
+          "botSecret": "Bot Secret",
+          "botSecretPlaceholder": "企业微信智能机器人 Secret",
+          "chatIds": "允许的会话",
+          "chatIdsHint": "格式 \"1:userid\"（单聊）或 \"2:groupid\"（群聊），用逗号分隔。企业微信需显式指定会话才能轮询消息。",
+          "chatIdsPlaceholder": "1:zhangsan, 2:wrxxxxxx",
+          "description": "通过企业微信智能机器人接收和回复消息（30 秒轮询）。",
+          "title": "企业微信"
         }
       },
       "heartbeat": {

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -137,13 +137,19 @@
         },
         "wecom": {
           "botId": "Bot ID",
-          "botIdPlaceholder": "企业微信智能机器人 Bot ID",
+          "botIdPlaceholder": "企业微信智能机器人 Bot ID（扫码后自动填入）",
           "botSecret": "Bot Secret",
-          "botSecretPlaceholder": "企业微信智能机器人 Secret",
+          "botSecretPlaceholder": "企业微信智能机器人 Secret（扫码后自动填入）",
           "chatIds": "允许的会话",
           "chatIdsHint": "格式 \"1:userid\"（单聊）或 \"2:groupid\"（群聊），用逗号分隔。企业微信需显式指定会话才能轮询消息。",
           "chatIdsPlaceholder": "1:zhangsan, 2:wrxxxxxx",
+          "connected": "已连接",
           "description": "通过企业微信智能机器人接收和回复消息（30 秒轮询）。",
+          "loginHint": "留空 Bot ID / Secret 并启用频道，即可使用企业微信扫码绑定。",
+          "qrExpired": "二维码已过期，请关闭后重新启用频道再试。",
+          "qrHint": "请使用企业微信扫描二维码完成绑定。",
+          "qrScanHint": "请打开手机企业微信并扫描以授权智能机器人。",
+          "qrTitle": "企业微信扫码绑定",
           "title": "企业微信"
         }
       },

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -38,6 +38,23 @@
         "connecting": "连接中",
         "deleteConfirm": "确定删除频道「{{name}}」？",
         "description": "将您的 Agent 连接到消息平台。",
+        "dingtalk": {
+          "chatIds": "允许的会话",
+          "chatIdsHint": "格式 \"p2p:<staffId>\"（单聊）或 \"group:<openConversationId>\"（群聊），用逗号分隔。留空则自动跟踪所有有消息的会话。",
+          "chatIdsPlaceholder": "p2p:0123456789, group:cidXXXXXX==",
+          "clientId": "App Key",
+          "clientIdPlaceholder": "钉钉企业内部应用 Client ID / App Key（扫码后自动填入）",
+          "clientSecret": "App Secret",
+          "clientSecretPlaceholder": "钉钉企业内部应用 Client Secret / App Secret（扫码后自动填入）",
+          "connected": "已连接",
+          "description": "通过钉钉企业内部机器人接收和回复消息（Stream 模式，无需公网 IP）。",
+          "loginHint": "留空 App Key / App Secret 并启用频道，即可使用钉钉扫码授权。",
+          "qrExpired": "二维码已过期，请关闭后重新启用频道再试。",
+          "qrHint": "请使用钉钉扫描二维码完成授权。",
+          "qrScanHint": "请打开手机钉钉并扫描以授权企业内部应用机器人。",
+          "qrTitle": "钉钉扫码授权",
+          "title": "钉钉"
+        },
         "disconnected": "已断开",
         "discord": {
           "botToken": "Bot Token",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -137,13 +137,19 @@
         },
         "wecom": {
           "botId": "Bot ID",
-          "botIdPlaceholder": "企業微信智能機器人 Bot ID",
+          "botIdPlaceholder": "企業微信智能機器人 Bot ID（掃碼後自動填入）",
           "botSecret": "Bot Secret",
-          "botSecretPlaceholder": "企業微信智能機器人 Secret",
+          "botSecretPlaceholder": "企業微信智能機器人 Secret（掃碼後自動填入）",
           "chatIds": "允許的會話",
           "chatIdsHint": "格式 \"1:userid\"（單聊）或 \"2:groupid\"（群聊），用逗號分隔。企業微信需顯式指定會話才能輪詢消息。",
           "chatIdsPlaceholder": "1:zhangsan, 2:wrxxxxxx",
+          "connected": "已連線",
           "description": "透過企業微信智能機器人接收和回覆消息（30 秒輪詢）。",
+          "loginHint": "留空 Bot ID / Secret 並啟用頻道，即可使用企業微信掃碼綁定。",
+          "qrExpired": "QR 碼已過期，請關閉後重新啟用頻道再試。",
+          "qrHint": "請使用企業微信掃描 QR 碼完成綁定。",
+          "qrScanHint": "請打開手機企業微信並掃描以授權智能機器人。",
+          "qrTitle": "企業微信掃碼綁定",
           "title": "企業微信"
         }
       },

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -38,6 +38,23 @@
         "connecting": "連接",
         "deleteConfirm": "確定刪除頻道「{{name}}」？",
         "description": "將您的 Agent 連接到訊息平台。",
+        "dingtalk": {
+          "chatIds": "允許的會話",
+          "chatIdsHint": "格式 \"p2p:<staffId>\"（單聊）或 \"group:<openConversationId>\"（群聊），用逗號分隔。留空則自動追蹤所有有訊息的會話。",
+          "chatIdsPlaceholder": "p2p:0123456789, group:cidXXXXXX==",
+          "clientId": "App Key",
+          "clientIdPlaceholder": "釘釘企業內部應用 Client ID / App Key（掃碼後自動填入）",
+          "clientSecret": "App Secret",
+          "clientSecretPlaceholder": "釘釘企業內部應用 Client Secret / App Secret（掃碼後自動填入）",
+          "connected": "已連線",
+          "description": "透過釘釘企業內部機器人接收和回覆訊息（Stream 模式，無需公網 IP）。",
+          "loginHint": "留空 App Key / App Secret 並啟用頻道，即可使用釘釘掃碼授權。",
+          "qrExpired": "QR 碼已過期，請關閉後重新啟用頻道再試。",
+          "qrHint": "請使用釘釘掃描 QR 碼完成授權。",
+          "qrScanHint": "請打開手機釘釘並掃描以授權企業內部應用機器人。",
+          "qrTitle": "釘釘掃碼授權",
+          "title": "釘釘"
+        },
         "disconnected": "已中斷連線",
         "discord": {
           "botToken": "Bot Token",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -134,6 +134,17 @@
           "qrTitle": "微信 QR 碼登入",
           "title": "微信",
           "whoamiTip": "提示：在微信中發送 /whoami 可取得使用者的 ID。"
+        },
+        "wecom": {
+          "botId": "Bot ID",
+          "botIdPlaceholder": "企業微信智能機器人 Bot ID",
+          "botSecret": "Bot Secret",
+          "botSecretPlaceholder": "企業微信智能機器人 Secret",
+          "chatIds": "允許的會話",
+          "chatIdsHint": "格式 \"1:userid\"（單聊）或 \"2:groupid\"（群聊），用逗號分隔。企業微信需顯式指定會話才能輪詢消息。",
+          "chatIdsPlaceholder": "1:zhangsan, 2:wrxxxxxx",
+          "description": "透過企業微信智能機器人接收和回覆消息（30 秒輪詢）。",
+          "title": "企業微信"
         }
       },
       "heartbeat": {

--- a/src/renderer/src/i18n/translate/de-de.json
+++ b/src/renderer/src/i18n/translate/de-de.json
@@ -38,6 +38,23 @@
         "connecting": "Verbinden",
         "deleteConfirm": "Kanal „{{name}}“ löschen?",
         "description": "Verbinden Sie Ihren Agenten mit Messaging-Plattformen.",
+        "dingtalk": {
+          "chatIds": "[to be translated]:Allowed Chats",
+          "chatIdsHint": "[to be translated]:Format \"p2p:<staffId>\" (DM) or \"group:<openConversationId>\" (group), comma-separated. Empty allows any chat the bot receives.",
+          "chatIdsPlaceholder": "[to be translated]:p2p:0123456789, group:cidXXXXXX==",
+          "clientId": "[to be translated]:App Key",
+          "clientIdPlaceholder": "[to be translated]:DingTalk inner-app Client ID / App Key (auto-filled after QR scan)",
+          "clientSecret": "[to be translated]:App Secret",
+          "clientSecretPlaceholder": "[to be translated]:DingTalk inner-app Client Secret / App Secret (auto-filled after QR scan)",
+          "connected": "[to be translated]:Connected",
+          "description": "[to be translated]:Receive and respond to messages via a DingTalk enterprise inner-app bot using Stream mode (no public IP needed).",
+          "loginHint": "[to be translated]:Leave App Key / App Secret blank and enable the channel to bind via QR code with DingTalk.",
+          "qrExpired": "[to be translated]:QR code expired. Disable and re-enable the channel to retry.",
+          "qrHint": "[to be translated]:Scan with DingTalk to authorize the bot.",
+          "qrScanHint": "[to be translated]:Open DingTalk on your phone and scan to authorize the inner-app bot.",
+          "qrTitle": "[to be translated]:DingTalk QR Login",
+          "title": "[to be translated]:DingTalk"
+        },
         "disconnected": "Getrennt",
         "discord": {
           "botToken": "Bot-Token",
@@ -134,6 +151,23 @@
           "qrTitle": "WeChat-QR-Login",
           "title": "WeChat",
           "whoamiTip": "Tipp: Sende /whoami in WeChat, um die ID eines Benutzers zu erhalten."
+        },
+        "wecom": {
+          "botId": "[to be translated]:Bot ID",
+          "botIdPlaceholder": "[to be translated]:WeCom smart bot ID (auto-filled after QR scan)",
+          "botSecret": "[to be translated]:Bot Secret",
+          "botSecretPlaceholder": "[to be translated]:WeCom smart bot secret (auto-filled after QR scan)",
+          "chatIds": "[to be translated]:Allowed Chats",
+          "chatIdsHint": "[to be translated]:Format \"1:userid\" (DM) or \"2:groupid\" (group), comma-separated. WeCom requires explicit chats for polling.",
+          "chatIdsPlaceholder": "[to be translated]:1:zhangsan, 2:wrxxxxxx",
+          "connected": "[to be translated]:Connected",
+          "description": "[to be translated]:Receive and respond to messages via a WeCom smart bot (30 s polling).",
+          "loginHint": "[to be translated]:Leave Bot ID / Secret blank and enable the channel to bind via QR code with WeCom.",
+          "qrExpired": "[to be translated]:QR code expired. Disable and re-enable the channel to retry.",
+          "qrHint": "[to be translated]:Scan with WeCom to bind the smart bot.",
+          "qrScanHint": "[to be translated]:Open WeCom on your phone and scan to authorize the smart bot.",
+          "qrTitle": "[to be translated]:WeCom QR Login",
+          "title": "[to be translated]:WeCom"
         }
       },
       "heartbeat": {

--- a/src/renderer/src/i18n/translate/el-gr.json
+++ b/src/renderer/src/i18n/translate/el-gr.json
@@ -38,6 +38,23 @@
         "connecting": "Σύνδεση",
         "deleteConfirm": "Διαγραφή καναλιού \"{{name}}\";",
         "description": "Συνδέστε τον πράκτορά σας σε πλατφόρμες μηνυμάτων.",
+        "dingtalk": {
+          "chatIds": "[to be translated]:Allowed Chats",
+          "chatIdsHint": "[to be translated]:Format \"p2p:<staffId>\" (DM) or \"group:<openConversationId>\" (group), comma-separated. Empty allows any chat the bot receives.",
+          "chatIdsPlaceholder": "[to be translated]:p2p:0123456789, group:cidXXXXXX==",
+          "clientId": "[to be translated]:App Key",
+          "clientIdPlaceholder": "[to be translated]:DingTalk inner-app Client ID / App Key (auto-filled after QR scan)",
+          "clientSecret": "[to be translated]:App Secret",
+          "clientSecretPlaceholder": "[to be translated]:DingTalk inner-app Client Secret / App Secret (auto-filled after QR scan)",
+          "connected": "[to be translated]:Connected",
+          "description": "[to be translated]:Receive and respond to messages via a DingTalk enterprise inner-app bot using Stream mode (no public IP needed).",
+          "loginHint": "[to be translated]:Leave App Key / App Secret blank and enable the channel to bind via QR code with DingTalk.",
+          "qrExpired": "[to be translated]:QR code expired. Disable and re-enable the channel to retry.",
+          "qrHint": "[to be translated]:Scan with DingTalk to authorize the bot.",
+          "qrScanHint": "[to be translated]:Open DingTalk on your phone and scan to authorize the inner-app bot.",
+          "qrTitle": "[to be translated]:DingTalk QR Login",
+          "title": "[to be translated]:DingTalk"
+        },
         "disconnected": "Αποσυνδέθηκε",
         "discord": {
           "botToken": "Διακριτικό Bot",
@@ -134,6 +151,23 @@
           "qrTitle": "Σύνδεση με QR code στο WeChat",
           "title": "WeChat",
           "whoamiTip": "Συμβουλή: Στείλτε /whoami στο WeChat για να λάβετε το αναγνωριστικό ενός χρήστη."
+        },
+        "wecom": {
+          "botId": "[to be translated]:Bot ID",
+          "botIdPlaceholder": "[to be translated]:WeCom smart bot ID (auto-filled after QR scan)",
+          "botSecret": "[to be translated]:Bot Secret",
+          "botSecretPlaceholder": "[to be translated]:WeCom smart bot secret (auto-filled after QR scan)",
+          "chatIds": "[to be translated]:Allowed Chats",
+          "chatIdsHint": "[to be translated]:Format \"1:userid\" (DM) or \"2:groupid\" (group), comma-separated. WeCom requires explicit chats for polling.",
+          "chatIdsPlaceholder": "[to be translated]:1:zhangsan, 2:wrxxxxxx",
+          "connected": "[to be translated]:Connected",
+          "description": "[to be translated]:Receive and respond to messages via a WeCom smart bot (30 s polling).",
+          "loginHint": "[to be translated]:Leave Bot ID / Secret blank and enable the channel to bind via QR code with WeCom.",
+          "qrExpired": "[to be translated]:QR code expired. Disable and re-enable the channel to retry.",
+          "qrHint": "[to be translated]:Scan with WeCom to bind the smart bot.",
+          "qrScanHint": "[to be translated]:Open WeCom on your phone and scan to authorize the smart bot.",
+          "qrTitle": "[to be translated]:WeCom QR Login",
+          "title": "[to be translated]:WeCom"
         }
       },
       "heartbeat": {

--- a/src/renderer/src/i18n/translate/es-es.json
+++ b/src/renderer/src/i18n/translate/es-es.json
@@ -38,6 +38,23 @@
         "connecting": "Conectando",
         "deleteConfirm": "¿Eliminar canal \"{{name}}\"?",
         "description": "Conecte su agente a plataformas de mensajería.",
+        "dingtalk": {
+          "chatIds": "[to be translated]:Allowed Chats",
+          "chatIdsHint": "[to be translated]:Format \"p2p:<staffId>\" (DM) or \"group:<openConversationId>\" (group), comma-separated. Empty allows any chat the bot receives.",
+          "chatIdsPlaceholder": "[to be translated]:p2p:0123456789, group:cidXXXXXX==",
+          "clientId": "[to be translated]:App Key",
+          "clientIdPlaceholder": "[to be translated]:DingTalk inner-app Client ID / App Key (auto-filled after QR scan)",
+          "clientSecret": "[to be translated]:App Secret",
+          "clientSecretPlaceholder": "[to be translated]:DingTalk inner-app Client Secret / App Secret (auto-filled after QR scan)",
+          "connected": "[to be translated]:Connected",
+          "description": "[to be translated]:Receive and respond to messages via a DingTalk enterprise inner-app bot using Stream mode (no public IP needed).",
+          "loginHint": "[to be translated]:Leave App Key / App Secret blank and enable the channel to bind via QR code with DingTalk.",
+          "qrExpired": "[to be translated]:QR code expired. Disable and re-enable the channel to retry.",
+          "qrHint": "[to be translated]:Scan with DingTalk to authorize the bot.",
+          "qrScanHint": "[to be translated]:Open DingTalk on your phone and scan to authorize the inner-app bot.",
+          "qrTitle": "[to be translated]:DingTalk QR Login",
+          "title": "[to be translated]:DingTalk"
+        },
         "disconnected": "Desconectado",
         "discord": {
           "botToken": "Token del Bot",
@@ -134,6 +151,23 @@
           "qrTitle": "Inicio de sesión con código QR de WeChat",
           "title": "WeChat",
           "whoamiTip": "Consejo: Envía /whoami en WeChat para obtener el ID de un usuario."
+        },
+        "wecom": {
+          "botId": "[to be translated]:Bot ID",
+          "botIdPlaceholder": "[to be translated]:WeCom smart bot ID (auto-filled after QR scan)",
+          "botSecret": "[to be translated]:Bot Secret",
+          "botSecretPlaceholder": "[to be translated]:WeCom smart bot secret (auto-filled after QR scan)",
+          "chatIds": "[to be translated]:Allowed Chats",
+          "chatIdsHint": "[to be translated]:Format \"1:userid\" (DM) or \"2:groupid\" (group), comma-separated. WeCom requires explicit chats for polling.",
+          "chatIdsPlaceholder": "[to be translated]:1:zhangsan, 2:wrxxxxxx",
+          "connected": "[to be translated]:Connected",
+          "description": "[to be translated]:Receive and respond to messages via a WeCom smart bot (30 s polling).",
+          "loginHint": "[to be translated]:Leave Bot ID / Secret blank and enable the channel to bind via QR code with WeCom.",
+          "qrExpired": "[to be translated]:QR code expired. Disable and re-enable the channel to retry.",
+          "qrHint": "[to be translated]:Scan with WeCom to bind the smart bot.",
+          "qrScanHint": "[to be translated]:Open WeCom on your phone and scan to authorize the smart bot.",
+          "qrTitle": "[to be translated]:WeCom QR Login",
+          "title": "[to be translated]:WeCom"
         }
       },
       "heartbeat": {

--- a/src/renderer/src/i18n/translate/fr-fr.json
+++ b/src/renderer/src/i18n/translate/fr-fr.json
@@ -38,6 +38,23 @@
         "connecting": "Connexion",
         "deleteConfirm": "Supprimer le canal \"{{name}}\" ?",
         "description": "Connectez votre agent aux plateformes de messagerie.",
+        "dingtalk": {
+          "chatIds": "[to be translated]:Allowed Chats",
+          "chatIdsHint": "[to be translated]:Format \"p2p:<staffId>\" (DM) or \"group:<openConversationId>\" (group), comma-separated. Empty allows any chat the bot receives.",
+          "chatIdsPlaceholder": "[to be translated]:p2p:0123456789, group:cidXXXXXX==",
+          "clientId": "[to be translated]:App Key",
+          "clientIdPlaceholder": "[to be translated]:DingTalk inner-app Client ID / App Key (auto-filled after QR scan)",
+          "clientSecret": "[to be translated]:App Secret",
+          "clientSecretPlaceholder": "[to be translated]:DingTalk inner-app Client Secret / App Secret (auto-filled after QR scan)",
+          "connected": "[to be translated]:Connected",
+          "description": "[to be translated]:Receive and respond to messages via a DingTalk enterprise inner-app bot using Stream mode (no public IP needed).",
+          "loginHint": "[to be translated]:Leave App Key / App Secret blank and enable the channel to bind via QR code with DingTalk.",
+          "qrExpired": "[to be translated]:QR code expired. Disable and re-enable the channel to retry.",
+          "qrHint": "[to be translated]:Scan with DingTalk to authorize the bot.",
+          "qrScanHint": "[to be translated]:Open DingTalk on your phone and scan to authorize the inner-app bot.",
+          "qrTitle": "[to be translated]:DingTalk QR Login",
+          "title": "[to be translated]:DingTalk"
+        },
         "disconnected": "Déconnecté",
         "discord": {
           "botToken": "Jeton de bot",
@@ -134,6 +151,23 @@
           "qrTitle": "Connexion par QR WeChat",
           "title": "WeChat",
           "whoamiTip": "Astuce : envoyez /whoami dans WeChat pour obtenir l'ID d'un utilisateur."
+        },
+        "wecom": {
+          "botId": "[to be translated]:Bot ID",
+          "botIdPlaceholder": "[to be translated]:WeCom smart bot ID (auto-filled after QR scan)",
+          "botSecret": "[to be translated]:Bot Secret",
+          "botSecretPlaceholder": "[to be translated]:WeCom smart bot secret (auto-filled after QR scan)",
+          "chatIds": "[to be translated]:Allowed Chats",
+          "chatIdsHint": "[to be translated]:Format \"1:userid\" (DM) or \"2:groupid\" (group), comma-separated. WeCom requires explicit chats for polling.",
+          "chatIdsPlaceholder": "[to be translated]:1:zhangsan, 2:wrxxxxxx",
+          "connected": "[to be translated]:Connected",
+          "description": "[to be translated]:Receive and respond to messages via a WeCom smart bot (30 s polling).",
+          "loginHint": "[to be translated]:Leave Bot ID / Secret blank and enable the channel to bind via QR code with WeCom.",
+          "qrExpired": "[to be translated]:QR code expired. Disable and re-enable the channel to retry.",
+          "qrHint": "[to be translated]:Scan with WeCom to bind the smart bot.",
+          "qrScanHint": "[to be translated]:Open WeCom on your phone and scan to authorize the smart bot.",
+          "qrTitle": "[to be translated]:WeCom QR Login",
+          "title": "[to be translated]:WeCom"
         }
       },
       "heartbeat": {

--- a/src/renderer/src/i18n/translate/ja-jp.json
+++ b/src/renderer/src/i18n/translate/ja-jp.json
@@ -38,6 +38,23 @@
         "connecting": "接続",
         "deleteConfirm": "チャンネル「{{name}}」を削除しますか？",
         "description": "エージェントをメッセージングプラットフォームに接続します。",
+        "dingtalk": {
+          "chatIds": "[to be translated]:Allowed Chats",
+          "chatIdsHint": "[to be translated]:Format \"p2p:<staffId>\" (DM) or \"group:<openConversationId>\" (group), comma-separated. Empty allows any chat the bot receives.",
+          "chatIdsPlaceholder": "[to be translated]:p2p:0123456789, group:cidXXXXXX==",
+          "clientId": "[to be translated]:App Key",
+          "clientIdPlaceholder": "[to be translated]:DingTalk inner-app Client ID / App Key (auto-filled after QR scan)",
+          "clientSecret": "[to be translated]:App Secret",
+          "clientSecretPlaceholder": "[to be translated]:DingTalk inner-app Client Secret / App Secret (auto-filled after QR scan)",
+          "connected": "[to be translated]:Connected",
+          "description": "[to be translated]:Receive and respond to messages via a DingTalk enterprise inner-app bot using Stream mode (no public IP needed).",
+          "loginHint": "[to be translated]:Leave App Key / App Secret blank and enable the channel to bind via QR code with DingTalk.",
+          "qrExpired": "[to be translated]:QR code expired. Disable and re-enable the channel to retry.",
+          "qrHint": "[to be translated]:Scan with DingTalk to authorize the bot.",
+          "qrScanHint": "[to be translated]:Open DingTalk on your phone and scan to authorize the inner-app bot.",
+          "qrTitle": "[to be translated]:DingTalk QR Login",
+          "title": "[to be translated]:DingTalk"
+        },
         "disconnected": "切断済み",
         "discord": {
           "botToken": "ボットトークン",
@@ -134,6 +151,23 @@
           "qrTitle": "WeChat QRコードログイン",
           "title": "WeChat",
           "whoamiTip": "ヒント：WeChatで/whoamiを送信すると、ユーザーのIDが取得できます。"
+        },
+        "wecom": {
+          "botId": "[to be translated]:Bot ID",
+          "botIdPlaceholder": "[to be translated]:WeCom smart bot ID (auto-filled after QR scan)",
+          "botSecret": "[to be translated]:Bot Secret",
+          "botSecretPlaceholder": "[to be translated]:WeCom smart bot secret (auto-filled after QR scan)",
+          "chatIds": "[to be translated]:Allowed Chats",
+          "chatIdsHint": "[to be translated]:Format \"1:userid\" (DM) or \"2:groupid\" (group), comma-separated. WeCom requires explicit chats for polling.",
+          "chatIdsPlaceholder": "[to be translated]:1:zhangsan, 2:wrxxxxxx",
+          "connected": "[to be translated]:Connected",
+          "description": "[to be translated]:Receive and respond to messages via a WeCom smart bot (30 s polling).",
+          "loginHint": "[to be translated]:Leave Bot ID / Secret blank and enable the channel to bind via QR code with WeCom.",
+          "qrExpired": "[to be translated]:QR code expired. Disable and re-enable the channel to retry.",
+          "qrHint": "[to be translated]:Scan with WeCom to bind the smart bot.",
+          "qrScanHint": "[to be translated]:Open WeCom on your phone and scan to authorize the smart bot.",
+          "qrTitle": "[to be translated]:WeCom QR Login",
+          "title": "[to be translated]:WeCom"
         }
       },
       "heartbeat": {

--- a/src/renderer/src/i18n/translate/pt-pt.json
+++ b/src/renderer/src/i18n/translate/pt-pt.json
@@ -38,6 +38,23 @@
         "connecting": "Conectando",
         "deleteConfirm": "Excluir canal \"{{name}}\"?",
         "description": "Conecte o seu agente a plataformas de mensagens.",
+        "dingtalk": {
+          "chatIds": "[to be translated]:Allowed Chats",
+          "chatIdsHint": "[to be translated]:Format \"p2p:<staffId>\" (DM) or \"group:<openConversationId>\" (group), comma-separated. Empty allows any chat the bot receives.",
+          "chatIdsPlaceholder": "[to be translated]:p2p:0123456789, group:cidXXXXXX==",
+          "clientId": "[to be translated]:App Key",
+          "clientIdPlaceholder": "[to be translated]:DingTalk inner-app Client ID / App Key (auto-filled after QR scan)",
+          "clientSecret": "[to be translated]:App Secret",
+          "clientSecretPlaceholder": "[to be translated]:DingTalk inner-app Client Secret / App Secret (auto-filled after QR scan)",
+          "connected": "[to be translated]:Connected",
+          "description": "[to be translated]:Receive and respond to messages via a DingTalk enterprise inner-app bot using Stream mode (no public IP needed).",
+          "loginHint": "[to be translated]:Leave App Key / App Secret blank and enable the channel to bind via QR code with DingTalk.",
+          "qrExpired": "[to be translated]:QR code expired. Disable and re-enable the channel to retry.",
+          "qrHint": "[to be translated]:Scan with DingTalk to authorize the bot.",
+          "qrScanHint": "[to be translated]:Open DingTalk on your phone and scan to authorize the inner-app bot.",
+          "qrTitle": "[to be translated]:DingTalk QR Login",
+          "title": "[to be translated]:DingTalk"
+        },
         "disconnected": "Desconectado",
         "discord": {
           "botToken": "Token do Bot",
@@ -134,6 +151,23 @@
           "qrTitle": "Login por QR Code do WeChat",
           "title": "WeChat",
           "whoamiTip": "Dica: Envie /whoami no WeChat para obter o ID de um usuário."
+        },
+        "wecom": {
+          "botId": "[to be translated]:Bot ID",
+          "botIdPlaceholder": "[to be translated]:WeCom smart bot ID (auto-filled after QR scan)",
+          "botSecret": "[to be translated]:Bot Secret",
+          "botSecretPlaceholder": "[to be translated]:WeCom smart bot secret (auto-filled after QR scan)",
+          "chatIds": "[to be translated]:Allowed Chats",
+          "chatIdsHint": "[to be translated]:Format \"1:userid\" (DM) or \"2:groupid\" (group), comma-separated. WeCom requires explicit chats for polling.",
+          "chatIdsPlaceholder": "[to be translated]:1:zhangsan, 2:wrxxxxxx",
+          "connected": "[to be translated]:Connected",
+          "description": "[to be translated]:Receive and respond to messages via a WeCom smart bot (30 s polling).",
+          "loginHint": "[to be translated]:Leave Bot ID / Secret blank and enable the channel to bind via QR code with WeCom.",
+          "qrExpired": "[to be translated]:QR code expired. Disable and re-enable the channel to retry.",
+          "qrHint": "[to be translated]:Scan with WeCom to bind the smart bot.",
+          "qrScanHint": "[to be translated]:Open WeCom on your phone and scan to authorize the smart bot.",
+          "qrTitle": "[to be translated]:WeCom QR Login",
+          "title": "[to be translated]:WeCom"
         }
       },
       "heartbeat": {

--- a/src/renderer/src/i18n/translate/ro-ro.json
+++ b/src/renderer/src/i18n/translate/ro-ro.json
@@ -38,6 +38,23 @@
         "connecting": "Conectare",
         "deleteConfirm": "Șterge canalul „{{name}}”?",
         "description": "Conectați agentul la platforme de mesagerie.",
+        "dingtalk": {
+          "chatIds": "[to be translated]:Allowed Chats",
+          "chatIdsHint": "[to be translated]:Format \"p2p:<staffId>\" (DM) or \"group:<openConversationId>\" (group), comma-separated. Empty allows any chat the bot receives.",
+          "chatIdsPlaceholder": "[to be translated]:p2p:0123456789, group:cidXXXXXX==",
+          "clientId": "[to be translated]:App Key",
+          "clientIdPlaceholder": "[to be translated]:DingTalk inner-app Client ID / App Key (auto-filled after QR scan)",
+          "clientSecret": "[to be translated]:App Secret",
+          "clientSecretPlaceholder": "[to be translated]:DingTalk inner-app Client Secret / App Secret (auto-filled after QR scan)",
+          "connected": "[to be translated]:Connected",
+          "description": "[to be translated]:Receive and respond to messages via a DingTalk enterprise inner-app bot using Stream mode (no public IP needed).",
+          "loginHint": "[to be translated]:Leave App Key / App Secret blank and enable the channel to bind via QR code with DingTalk.",
+          "qrExpired": "[to be translated]:QR code expired. Disable and re-enable the channel to retry.",
+          "qrHint": "[to be translated]:Scan with DingTalk to authorize the bot.",
+          "qrScanHint": "[to be translated]:Open DingTalk on your phone and scan to authorize the inner-app bot.",
+          "qrTitle": "[to be translated]:DingTalk QR Login",
+          "title": "[to be translated]:DingTalk"
+        },
         "disconnected": "Deconectat",
         "discord": {
           "botToken": "Token Bot",
@@ -134,6 +151,23 @@
           "qrTitle": "Autentificare WeChat cu cod QR",
           "title": "WeChat",
           "whoamiTip": "Sfat: Trimiteți /whoami în WeChat pentru a obține ID-ul unui utilizator."
+        },
+        "wecom": {
+          "botId": "[to be translated]:Bot ID",
+          "botIdPlaceholder": "[to be translated]:WeCom smart bot ID (auto-filled after QR scan)",
+          "botSecret": "[to be translated]:Bot Secret",
+          "botSecretPlaceholder": "[to be translated]:WeCom smart bot secret (auto-filled after QR scan)",
+          "chatIds": "[to be translated]:Allowed Chats",
+          "chatIdsHint": "[to be translated]:Format \"1:userid\" (DM) or \"2:groupid\" (group), comma-separated. WeCom requires explicit chats for polling.",
+          "chatIdsPlaceholder": "[to be translated]:1:zhangsan, 2:wrxxxxxx",
+          "connected": "[to be translated]:Connected",
+          "description": "[to be translated]:Receive and respond to messages via a WeCom smart bot (30 s polling).",
+          "loginHint": "[to be translated]:Leave Bot ID / Secret blank and enable the channel to bind via QR code with WeCom.",
+          "qrExpired": "[to be translated]:QR code expired. Disable and re-enable the channel to retry.",
+          "qrHint": "[to be translated]:Scan with WeCom to bind the smart bot.",
+          "qrScanHint": "[to be translated]:Open WeCom on your phone and scan to authorize the smart bot.",
+          "qrTitle": "[to be translated]:WeCom QR Login",
+          "title": "[to be translated]:WeCom"
         }
       },
       "heartbeat": {

--- a/src/renderer/src/i18n/translate/ru-ru.json
+++ b/src/renderer/src/i18n/translate/ru-ru.json
@@ -38,6 +38,23 @@
         "connecting": "Подключение",
         "deleteConfirm": "Удалить канал \"{{name}}\"?",
         "description": "Подключите вашего агента к платформам обмена сообщениями.",
+        "dingtalk": {
+          "chatIds": "[to be translated]:Allowed Chats",
+          "chatIdsHint": "[to be translated]:Format \"p2p:<staffId>\" (DM) or \"group:<openConversationId>\" (group), comma-separated. Empty allows any chat the bot receives.",
+          "chatIdsPlaceholder": "[to be translated]:p2p:0123456789, group:cidXXXXXX==",
+          "clientId": "[to be translated]:App Key",
+          "clientIdPlaceholder": "[to be translated]:DingTalk inner-app Client ID / App Key (auto-filled after QR scan)",
+          "clientSecret": "[to be translated]:App Secret",
+          "clientSecretPlaceholder": "[to be translated]:DingTalk inner-app Client Secret / App Secret (auto-filled after QR scan)",
+          "connected": "[to be translated]:Connected",
+          "description": "[to be translated]:Receive and respond to messages via a DingTalk enterprise inner-app bot using Stream mode (no public IP needed).",
+          "loginHint": "[to be translated]:Leave App Key / App Secret blank and enable the channel to bind via QR code with DingTalk.",
+          "qrExpired": "[to be translated]:QR code expired. Disable and re-enable the channel to retry.",
+          "qrHint": "[to be translated]:Scan with DingTalk to authorize the bot.",
+          "qrScanHint": "[to be translated]:Open DingTalk on your phone and scan to authorize the inner-app bot.",
+          "qrTitle": "[to be translated]:DingTalk QR Login",
+          "title": "[to be translated]:DingTalk"
+        },
         "disconnected": "Отключено",
         "discord": {
           "botToken": "Токен бота",
@@ -134,6 +151,23 @@
           "qrTitle": "Вход по QR-коду WeChat",
           "title": "WeChat",
           "whoamiTip": "Совет: Отправьте /whoami в WeChat, чтобы получить ID пользователя."
+        },
+        "wecom": {
+          "botId": "[to be translated]:Bot ID",
+          "botIdPlaceholder": "[to be translated]:WeCom smart bot ID (auto-filled after QR scan)",
+          "botSecret": "[to be translated]:Bot Secret",
+          "botSecretPlaceholder": "[to be translated]:WeCom smart bot secret (auto-filled after QR scan)",
+          "chatIds": "[to be translated]:Allowed Chats",
+          "chatIdsHint": "[to be translated]:Format \"1:userid\" (DM) or \"2:groupid\" (group), comma-separated. WeCom requires explicit chats for polling.",
+          "chatIdsPlaceholder": "[to be translated]:1:zhangsan, 2:wrxxxxxx",
+          "connected": "[to be translated]:Connected",
+          "description": "[to be translated]:Receive and respond to messages via a WeCom smart bot (30 s polling).",
+          "loginHint": "[to be translated]:Leave Bot ID / Secret blank and enable the channel to bind via QR code with WeCom.",
+          "qrExpired": "[to be translated]:QR code expired. Disable and re-enable the channel to retry.",
+          "qrHint": "[to be translated]:Scan with WeCom to bind the smart bot.",
+          "qrScanHint": "[to be translated]:Open WeCom on your phone and scan to authorize the smart bot.",
+          "qrTitle": "[to be translated]:WeCom QR Login",
+          "title": "[to be translated]:WeCom"
         }
       },
       "heartbeat": {

--- a/src/renderer/src/i18n/translate/vi-vn.json
+++ b/src/renderer/src/i18n/translate/vi-vn.json
@@ -38,6 +38,23 @@
         "connecting": "Kết nối",
         "deleteConfirm": "Xóa kênh \"{{name}}\"?",
         "description": "Kết nối tác nhân của bạn với các nền tảng nhắn tin.",
+        "dingtalk": {
+          "chatIds": "[to be translated]:Allowed Chats",
+          "chatIdsHint": "[to be translated]:Format \"p2p:<staffId>\" (DM) or \"group:<openConversationId>\" (group), comma-separated. Empty allows any chat the bot receives.",
+          "chatIdsPlaceholder": "[to be translated]:p2p:0123456789, group:cidXXXXXX==",
+          "clientId": "[to be translated]:App Key",
+          "clientIdPlaceholder": "[to be translated]:DingTalk inner-app Client ID / App Key (auto-filled after QR scan)",
+          "clientSecret": "[to be translated]:App Secret",
+          "clientSecretPlaceholder": "[to be translated]:DingTalk inner-app Client Secret / App Secret (auto-filled after QR scan)",
+          "connected": "[to be translated]:Connected",
+          "description": "[to be translated]:Receive and respond to messages via a DingTalk enterprise inner-app bot using Stream mode (no public IP needed).",
+          "loginHint": "[to be translated]:Leave App Key / App Secret blank and enable the channel to bind via QR code with DingTalk.",
+          "qrExpired": "[to be translated]:QR code expired. Disable and re-enable the channel to retry.",
+          "qrHint": "[to be translated]:Scan with DingTalk to authorize the bot.",
+          "qrScanHint": "[to be translated]:Open DingTalk on your phone and scan to authorize the inner-app bot.",
+          "qrTitle": "[to be translated]:DingTalk QR Login",
+          "title": "[to be translated]:DingTalk"
+        },
         "disconnected": "Ngắt kết nối",
         "discord": {
           "botToken": "Mã thông báo Bot",
@@ -134,6 +151,23 @@
           "qrTitle": "Đăng nhập bằng mã QR WeChat",
           "title": "WeChat",
           "whoamiTip": "Mẹo: Gửi /whoami trong WeChat để lấy ID của người dùng."
+        },
+        "wecom": {
+          "botId": "[to be translated]:Bot ID",
+          "botIdPlaceholder": "[to be translated]:WeCom smart bot ID (auto-filled after QR scan)",
+          "botSecret": "[to be translated]:Bot Secret",
+          "botSecretPlaceholder": "[to be translated]:WeCom smart bot secret (auto-filled after QR scan)",
+          "chatIds": "[to be translated]:Allowed Chats",
+          "chatIdsHint": "[to be translated]:Format \"1:userid\" (DM) or \"2:groupid\" (group), comma-separated. WeCom requires explicit chats for polling.",
+          "chatIdsPlaceholder": "[to be translated]:1:zhangsan, 2:wrxxxxxx",
+          "connected": "[to be translated]:Connected",
+          "description": "[to be translated]:Receive and respond to messages via a WeCom smart bot (30 s polling).",
+          "loginHint": "[to be translated]:Leave Bot ID / Secret blank and enable the channel to bind via QR code with WeCom.",
+          "qrExpired": "[to be translated]:QR code expired. Disable and re-enable the channel to retry.",
+          "qrHint": "[to be translated]:Scan with WeCom to bind the smart bot.",
+          "qrScanHint": "[to be translated]:Open WeCom on your phone and scan to authorize the smart bot.",
+          "qrTitle": "[to be translated]:WeCom QR Login",
+          "title": "[to be translated]:WeCom"
         }
       },
       "heartbeat": {

--- a/src/renderer/src/pages/settings/ChannelsSettings/ChannelForms.tsx
+++ b/src/renderer/src/pages/settings/ChannelsSettings/ChannelForms.tsx
@@ -493,32 +493,100 @@ export const SlackForm: FC<ChannelFormProps> = ({ channel, onConfigChange }) => 
   )
 }
 
+type WeComStatus = 'idle' | 'pending' | 'confirmed' | 'expired' | 'disconnected'
+
 export const WeComForm: FC<ChannelFormProps> = ({ channel, onConfigChange }) => {
   const { t } = useTranslation()
+  const cfg = channel.config
+  const hasCredentials = !!(cfg.bot_id && cfg.bot_secret)
+  const [qrUrl, setQrUrl] = useState<string | null>(null)
+  const [status, setStatus] = useState<WeComStatus>(hasCredentials ? 'confirmed' : 'idle')
+
+  useEffect(() => {
+    const cleanup = window.api.wecom.onQrLogin((data) => {
+      if (data.channelId !== channel.id) return
+      if (data.status === 'confirmed') {
+        setQrUrl(null)
+        setStatus('confirmed')
+      } else if (data.status === 'expired') {
+        setQrUrl(null)
+        setStatus('expired')
+      } else if (data.status === 'disconnected') {
+        setQrUrl(null)
+        setStatus('disconnected')
+      } else if (data.url) {
+        setQrUrl(data.url)
+        setStatus('pending')
+      }
+    })
+    return cleanup
+  }, [channel.id])
+
   return (
-    <ChannelFieldsForm
-      channel={channel}
-      onConfigChange={onConfigChange}
-      fields={[
-        {
-          key: 'bot_id',
-          label: t('agent.cherryClaw.channels.wecom.botId'),
-          placeholder: t('agent.cherryClaw.channels.wecom.botIdPlaceholder')
-        },
-        {
-          key: 'bot_secret',
-          label: t('agent.cherryClaw.channels.wecom.botSecret'),
-          placeholder: t('agent.cherryClaw.channels.wecom.botSecretPlaceholder'),
-          secret: true
-        }
-      ]}
-      chatIds={{
-        label: t('agent.cherryClaw.channels.wecom.chatIds'),
-        placeholder: t('agent.cherryClaw.channels.wecom.chatIdsPlaceholder'),
-        hint: t('agent.cherryClaw.channels.wecom.chatIdsHint'),
-        fullWidth: true
-      }}
-    />
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        {status === 'confirmed' && (
+          <>
+            <span className="inline-block h-2 w-2 rounded-full bg-green-500" />
+            <span className="text-green-600 text-xs">{t('agent.cherryClaw.channels.wecom.connected')}</span>
+          </>
+        )}
+        {status === 'pending' && (
+          <span className="text-blue-400 text-xs">{t('agent.cherryClaw.channels.wecom.qrHint')}</span>
+        )}
+        {status === 'expired' && (
+          <>
+            <span className="inline-block h-2 w-2 rounded-full bg-red-500" />
+            <span className="text-red-500 text-xs">{t('agent.cherryClaw.channels.wecom.qrExpired')}</span>
+          </>
+        )}
+        {(status === 'idle' || status === 'disconnected') && !hasCredentials && (
+          <span className="text-blue-400 text-xs">{t('agent.cherryClaw.channels.wecom.loginHint')}</span>
+        )}
+      </div>
+
+      <ChannelFieldsForm
+        channel={channel}
+        onConfigChange={onConfigChange}
+        fields={[
+          {
+            key: 'bot_id',
+            label: t('agent.cherryClaw.channels.wecom.botId'),
+            placeholder: t('agent.cherryClaw.channels.wecom.botIdPlaceholder')
+          },
+          {
+            key: 'bot_secret',
+            label: t('agent.cherryClaw.channels.wecom.botSecret'),
+            placeholder: t('agent.cherryClaw.channels.wecom.botSecretPlaceholder'),
+            secret: true
+          }
+        ]}
+        chatIds={{
+          label: t('agent.cherryClaw.channels.wecom.chatIds'),
+          placeholder: t('agent.cherryClaw.channels.wecom.chatIdsPlaceholder'),
+          hint: t('agent.cherryClaw.channels.wecom.chatIdsHint'),
+          fullWidth: true
+        }}
+      />
+
+      <Modal
+        open={!!qrUrl}
+        title={t('agent.cherryClaw.channels.wecom.qrTitle')}
+        footer={null}
+        onCancel={() => {
+          setQrUrl(null)
+          if (status === 'pending') setStatus('idle')
+        }}
+        centered
+        width={360}>
+        <div className="flex flex-col items-center gap-4 py-4">
+          {qrUrl && <QRCodeSVG value={qrUrl} size={240} level="M" />}
+          <span className="text-center text-foreground-500 text-xs">
+            {t('agent.cherryClaw.channels.wecom.qrScanHint')}
+          </span>
+        </div>
+      </Modal>
+    </div>
   )
 }
 

--- a/src/renderer/src/pages/settings/ChannelsSettings/ChannelForms.tsx
+++ b/src/renderer/src/pages/settings/ChannelsSettings/ChannelForms.tsx
@@ -493,6 +493,35 @@ export const SlackForm: FC<ChannelFormProps> = ({ channel, onConfigChange }) => 
   )
 }
 
+export const WeComForm: FC<ChannelFormProps> = ({ channel, onConfigChange }) => {
+  const { t } = useTranslation()
+  return (
+    <ChannelFieldsForm
+      channel={channel}
+      onConfigChange={onConfigChange}
+      fields={[
+        {
+          key: 'bot_id',
+          label: t('agent.cherryClaw.channels.wecom.botId'),
+          placeholder: t('agent.cherryClaw.channels.wecom.botIdPlaceholder')
+        },
+        {
+          key: 'bot_secret',
+          label: t('agent.cherryClaw.channels.wecom.botSecret'),
+          placeholder: t('agent.cherryClaw.channels.wecom.botSecretPlaceholder'),
+          secret: true
+        }
+      ]}
+      chatIds={{
+        label: t('agent.cherryClaw.channels.wecom.chatIds'),
+        placeholder: t('agent.cherryClaw.channels.wecom.chatIdsPlaceholder'),
+        hint: t('agent.cherryClaw.channels.wecom.chatIdsHint'),
+        fullWidth: true
+      }}
+    />
+  )
+}
+
 export const getFormForType = (type: string) => {
   switch (type) {
     case 'telegram':
@@ -507,6 +536,8 @@ export const getFormForType = (type: string) => {
       return SlackForm
     case 'wechat':
       return WeChatForm
+    case 'wecom':
+      return WeComForm
     default:
       return null
   }

--- a/src/renderer/src/pages/settings/ChannelsSettings/ChannelForms.tsx
+++ b/src/renderer/src/pages/settings/ChannelsSettings/ChannelForms.tsx
@@ -590,6 +590,103 @@ export const WeComForm: FC<ChannelFormProps> = ({ channel, onConfigChange }) => 
   )
 }
 
+type DingTalkStatus = 'idle' | 'pending' | 'confirmed' | 'expired' | 'disconnected'
+
+export const DingTalkForm: FC<ChannelFormProps> = ({ channel, onConfigChange }) => {
+  const { t } = useTranslation()
+  const cfg = channel.config
+  const hasCredentials = !!(cfg.client_id && cfg.client_secret)
+  const [qrUrl, setQrUrl] = useState<string | null>(null)
+  const [status, setStatus] = useState<DingTalkStatus>(hasCredentials ? 'confirmed' : 'idle')
+
+  useEffect(() => {
+    const cleanup = window.api.dingtalk.onQrLogin((data) => {
+      if (data.channelId !== channel.id) return
+      if (data.status === 'confirmed') {
+        setQrUrl(null)
+        setStatus('confirmed')
+      } else if (data.status === 'expired') {
+        setQrUrl(null)
+        setStatus('expired')
+      } else if (data.status === 'disconnected') {
+        setQrUrl(null)
+        setStatus('disconnected')
+      } else if (data.url) {
+        setQrUrl(data.url)
+        setStatus('pending')
+      }
+    })
+    return cleanup
+  }, [channel.id])
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        {status === 'confirmed' && (
+          <>
+            <span className="inline-block h-2 w-2 rounded-full bg-green-500" />
+            <span className="text-green-600 text-xs">{t('agent.cherryClaw.channels.dingtalk.connected')}</span>
+          </>
+        )}
+        {status === 'pending' && (
+          <span className="text-blue-400 text-xs">{t('agent.cherryClaw.channels.dingtalk.qrHint')}</span>
+        )}
+        {status === 'expired' && (
+          <>
+            <span className="inline-block h-2 w-2 rounded-full bg-red-500" />
+            <span className="text-red-500 text-xs">{t('agent.cherryClaw.channels.dingtalk.qrExpired')}</span>
+          </>
+        )}
+        {(status === 'idle' || status === 'disconnected') && !hasCredentials && (
+          <span className="text-blue-400 text-xs">{t('agent.cherryClaw.channels.dingtalk.loginHint')}</span>
+        )}
+      </div>
+
+      <ChannelFieldsForm
+        channel={channel}
+        onConfigChange={onConfigChange}
+        fields={[
+          {
+            key: 'client_id',
+            label: t('agent.cherryClaw.channels.dingtalk.clientId'),
+            placeholder: t('agent.cherryClaw.channels.dingtalk.clientIdPlaceholder')
+          },
+          {
+            key: 'client_secret',
+            label: t('agent.cherryClaw.channels.dingtalk.clientSecret'),
+            placeholder: t('agent.cherryClaw.channels.dingtalk.clientSecretPlaceholder'),
+            secret: true
+          }
+        ]}
+        chatIds={{
+          label: t('agent.cherryClaw.channels.dingtalk.chatIds'),
+          placeholder: t('agent.cherryClaw.channels.dingtalk.chatIdsPlaceholder'),
+          hint: t('agent.cherryClaw.channels.dingtalk.chatIdsHint'),
+          fullWidth: true
+        }}
+      />
+
+      <Modal
+        open={!!qrUrl}
+        title={t('agent.cherryClaw.channels.dingtalk.qrTitle')}
+        footer={null}
+        onCancel={() => {
+          setQrUrl(null)
+          if (status === 'pending') setStatus('idle')
+        }}
+        centered
+        width={360}>
+        <div className="flex flex-col items-center gap-4 py-4">
+          {qrUrl && <QRCodeSVG value={qrUrl} size={240} level="M" />}
+          <span className="text-center text-foreground-500 text-xs">
+            {t('agent.cherryClaw.channels.dingtalk.qrScanHint')}
+          </span>
+        </div>
+      </Modal>
+    </div>
+  )
+}
+
 export const getFormForType = (type: string) => {
   switch (type) {
     case 'telegram':
@@ -606,6 +703,8 @@ export const getFormForType = (type: string) => {
       return WeChatForm
     case 'wecom':
       return WeComForm
+    case 'dingtalk':
+      return DingTalkForm
     default:
       return null
   }

--- a/src/renderer/src/pages/settings/ChannelsSettings/channelTypes.ts
+++ b/src/renderer/src/pages/settings/ChannelsSettings/channelTypes.ts
@@ -1,5 +1,5 @@
 export type AvailableChannel = {
-  type: 'telegram' | 'feishu' | 'qq' | 'wechat' | 'discord' | 'slack'
+  type: 'telegram' | 'feishu' | 'qq' | 'wechat' | 'discord' | 'slack' | 'wecom'
   name: string
   titleKey: string
   description: string
@@ -62,6 +62,14 @@ export const AVAILABLE_CHANNELS: AvailableChannel[] = [
     description: 'agent.cherryClaw.channels.slack.description',
     available: true,
     defaultConfig: { bot_token: '', app_token: '', allowed_channel_ids: [] }
+  },
+  {
+    type: 'wecom',
+    name: 'WeCom',
+    titleKey: 'agent.cherryClaw.channels.wecom.title',
+    description: 'agent.cherryClaw.channels.wecom.description',
+    available: true,
+    defaultConfig: { bot_id: '', bot_secret: '', allowed_chat_ids: [] }
   }
 ]
 

--- a/src/renderer/src/pages/settings/ChannelsSettings/channelTypes.ts
+++ b/src/renderer/src/pages/settings/ChannelsSettings/channelTypes.ts
@@ -1,5 +1,5 @@
 export type AvailableChannel = {
-  type: 'telegram' | 'feishu' | 'qq' | 'wechat' | 'discord' | 'slack' | 'wecom'
+  type: 'telegram' | 'feishu' | 'qq' | 'wechat' | 'discord' | 'slack' | 'wecom' | 'dingtalk'
   name: string
   titleKey: string
   description: string
@@ -70,6 +70,14 @@ export const AVAILABLE_CHANNELS: AvailableChannel[] = [
     description: 'agent.cherryClaw.channels.wecom.description',
     available: true,
     defaultConfig: { bot_id: '', bot_secret: '', allowed_chat_ids: [] }
+  },
+  {
+    type: 'dingtalk',
+    name: 'DingTalk',
+    titleKey: 'agent.cherryClaw.channels.dingtalk.title',
+    description: 'agent.cherryClaw.channels.dingtalk.description',
+    available: true,
+    defaultConfig: { client_id: '', client_secret: '', allowed_chat_ids: [] }
   }
 ]
 


### PR DESCRIPTION
### What this PR does

Before this PR:

Cherry Studio's agents subsystem shipped six channel adapters (Telegram, Feishu, QQ, WeChat, Discord, Slack). There was no way to receive or reply to messages through a 企业微信 (WeCom / WeChat Work) smart bot from an enterprise context.

After this PR:

Adds a seventh `ChannelAdapter` for WeCom, implemented natively in Node (no extra runtime dependency). The adapter ports the HTTP/JSON-RPC protocol used by the public `wecom-cli` Rust client, so it talks directly to the WeCom MCP endpoints:

- Bootstrap: `POST https://qyapi.weixin.qq.com/cgi-bin/aibot/cli/get_mcp_config` with `signature = sha256(secret + bot_id + time + nonce)`
- Per-category JSON-RPC `tools/call` (only `msg.*` is used by this adapter)

Operations supported:

- Inbound: `msg.get_message` polled every 30 s per allowed chat; text emitted as `message` events, slash commands routed via the existing `isSlashCommand` helper
- Outbound: `msg.send_message` (`msgtype: "text"`), chunked to 1800 chars
- Media: `msg.get_msg_media` decoded from base64 into `ImageAttachment` / `FileAttachment`
- Echo suppression: outgoing text is fingerprinted for 60 s so the bot's own replies are not re-emitted as user messages

Surfaced through the existing Channels settings UI with a Bot ID / Bot Secret form, an "allowed chats" list in `"<chat_type>:<chatid>"` format (e.g. `1:zhangsan` for DM, `2:wrxxxx` for group), and full i18n in en-US / zh-CN / zh-TW.

Wiring:

- New: `src/main/services/agents/services/channels/adapters/wecom/{WeComAdapter,WeComClient,WeComTypes}.ts`
- New tests: `adapters/__tests__/WeComAdapter.test.ts` (12 cases)
- Updated: `ChannelManager.ts` (adapter import map), `channelConfig.ts` (Zod schema + `CHANNEL_TYPES`), `channels.schema.ts` (CHECK constraint) with Drizzle migration `0008_bouncy_romulus.sql`
- Renderer: `channelTypes.ts`, `ChannelForms.tsx` (new `WeComForm`)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

Enterprise users on WeCom need their Cherry Studio agents to read and reply through their existing smart bot, the same way Feishu and WeChat work today. Going via `main` as a hotfix branch (rather than `v2`) is required by the enterprise rollout schedule.

The following tradeoffs were made:

- **Native Node port over CLI subprocess**: Avoids bundling the `@wecom/cli` binary and a per-platform native dependency; keeps the adapter consistent with the other adapters' "talk to provider HTTP directly" pattern.
- **Polling instead of webhook**: WeCom's smart bot APIs do not expose webhooks/streams to clients. 30 s polling matches the cadence enterprises expect for chat-driven workflows and stays well under server rate limits.
- **Explicit `allowed_chat_ids`**: `get_message` is per-conversation, so we cannot auto-discover chats the way Telegram/Slack do. The `"<type>:<id>"` format keeps a single string field while encoding the chat type WeCom requires.
- **Echo suppression via content fingerprint**: WeCom does not expose `msg_id` in `get_message`, so we use a recent-outgoing-text set with a 60 s TTL. Best-effort but adequate for the conversational pattern.

The following alternatives were considered:

- Shelling out to `@wecom/cli` — rejected to avoid native binary bundling and subprocess management
- Adding a streaming reply pattern (incremental edits) — WeCom has no edit-message API, so final replies are delivered in one `send_message` call (mirrors `WeChatAdapter`)

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

Internal enterprise request.

### Breaking changes

<!-- optional -->

None. The change is additive: a new channel type, schema entry, and migration that only widens the existing `channels_type_check` to include `'wecom'`.

### Special notes for your reviewer

<!-- optional -->

- The Drizzle migration `0008_bouncy_romulus.sql` rebuilds the `channels` table (standard SQLite pattern for adding a CHECK value) and is auto-generated by `pnpm agents:generate`.
- `msg.get_message` has a hard 7-day window; the adapter clamps the begin time accordingly and seeds `lastSeen` to `now - 60s` on first connect so it doesn't replay history.
- `sendTypingIndicator` is a no-op — WeCom has no typing API, matching `WeChatAdapter`'s behavior.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Added a new agent channel for 企业微信 (WeCom / WeChat Work). Configure your smart bot's Bot ID and Secret under Agent Settings → Channels → WeCom, then list allowed chats as "1:userid" (DM) or "2:groupid" (group) to enable 30s message polling and replies.
```
