### PR TITLE
fix(ui-icons): stop compound icons rendering both light and dark variants

### DIFF
--- a/packages/ui/scripts/__tests__/codegen.test.ts
+++ b/packages/ui/scripts/__tests__/codegen.test.ts
@@ -30,4 +30,52 @@ describe('generateIconIndex', () => {
       rmSync(dir, { recursive: true, force: true })
     }
   })
+
+  it('keeps visibility classes after className so a caller display utility cannot clobber them', () => {
+    // Regression: with `cn('dark:hidden', className)`, a caller-supplied display
+    // utility (e.g. `block`) wins via tailwind-merge and renders both icons.
+    const dir = mkdtempSync(join(tmpdir(), 'cherry-ui-codegen-'))
+    const outPath = join(dir, 'index.tsx')
+
+    try {
+      generateIconIndex({
+        outPath,
+        colorName: 'Kimi',
+        hasAvatar: true,
+        hasDark: true,
+        usesCurrentColor: false,
+        colorPrimary: '#000000'
+      })
+
+      const content = readFileSync(outPath, 'utf-8')
+      expect(content).toContain("className={cn(className, 'dark:hidden')}")
+      expect(content).toContain("className={cn(className, 'hidden dark:block')}")
+      expect(content).not.toContain("cn('dark:hidden', className)")
+      expect(content).not.toContain("cn('hidden dark:block', className)")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps text-foreground overridable while visibility classes stay fixed for mono dark logos', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cherry-ui-codegen-'))
+    const outPath = join(dir, 'index.tsx')
+
+    try {
+      generateIconIndex({
+        outPath,
+        colorName: 'Mimo',
+        hasAvatar: true,
+        hasDark: true,
+        usesCurrentColor: true,
+        colorPrimary: '#000000'
+      })
+
+      const content = readFileSync(outPath, 'utf-8')
+      expect(content).toContain("className={cn('text-foreground', className, 'dark:hidden')}")
+      expect(content).toContain("className={cn('text-foreground', className, 'hidden dark:block')}")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
 })

--- a/packages/ui/scripts/codegen.ts
+++ b/packages/ui/scripts/codegen.ts
@@ -43,12 +43,15 @@ export function generateIconIndex(opts: {
   const darkImport = hasDark ? `import { ${darkName} } from './dark'\n` : ''
   const lightClassName = usesCurrentColor ? `cn('text-foreground', className)` : 'className'
   const darkClassName = usesCurrentColor ? `cn('text-foreground', className)` : 'className'
+  // Visibility classes (`dark:hidden` / `hidden dark:block`) must come AFTER
+  // `className` so a caller-supplied display utility (e.g. `block`) cannot
+  // clobber them via tailwind-merge — otherwise both light/dark icons render.
   const autoLightClassName = usesCurrentColor
-    ? `cn('text-foreground dark:hidden', className)`
-    : `cn('dark:hidden', className)`
+    ? `cn('text-foreground', className, 'dark:hidden')`
+    : `cn(className, 'dark:hidden')`
   const autoDarkClassName = usesCurrentColor
-    ? `cn('text-foreground hidden dark:block', className)`
-    : `cn('hidden dark:block', className)`
+    ? `cn('text-foreground', className, 'hidden dark:block')`
+    : `cn(className, 'hidden dark:block')`
   const autoRender = hasDark
     ? `return (
     <>

--- a/packages/ui/src/components/icons/models/grok/index.tsx
+++ b/packages/ui/src/components/icons/models/grok/index.tsx
@@ -9,8 +9,8 @@ const Grok = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <GrokDark {...props} className={className} />
   return (
     <>
-      <GrokLight className={cn('dark:hidden', className)} {...props} />
-      <GrokDark className={cn('hidden dark:block', className)} {...props} />
+      <GrokLight className={cn(className, 'dark:hidden')} {...props} />
+      <GrokDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/models/kimi/index.tsx
+++ b/packages/ui/src/components/icons/models/kimi/index.tsx
@@ -9,8 +9,8 @@ const Kimi = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <KimiDark {...props} className={className} />
   return (
     <>
-      <KimiLight className={cn('dark:hidden', className)} {...props} />
-      <KimiDark className={cn('hidden dark:block', className)} {...props} />
+      <KimiLight className={cn(className, 'dark:hidden')} {...props} />
+      <KimiDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/models/mimo/index.tsx
+++ b/packages/ui/src/components/icons/models/mimo/index.tsx
@@ -9,8 +9,8 @@ const Mimo = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <MimoDark {...props} className={cn('text-foreground', className)} />
   return (
     <>
-      <MimoLight className={cn('text-foreground dark:hidden', className)} {...props} />
-      <MimoDark className={cn('text-foreground hidden dark:block', className)} {...props} />
+      <MimoLight className={cn('text-foreground', className, 'dark:hidden')} {...props} />
+      <MimoDark className={cn('text-foreground', className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/models/trinity/index.tsx
+++ b/packages/ui/src/components/icons/models/trinity/index.tsx
@@ -9,8 +9,8 @@ const Trinity = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <TrinityDark {...props} className={cn('text-foreground', className)} />
   return (
     <>
-      <TrinityLight className={cn('text-foreground dark:hidden', className)} {...props} />
-      <TrinityDark className={cn('text-foreground hidden dark:block', className)} {...props} />
+      <TrinityLight className={cn('text-foreground', className, 'dark:hidden')} {...props} />
+      <TrinityDark className={cn('text-foreground', className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/ai-studio/index.tsx
+++ b/packages/ui/src/components/icons/providers/ai-studio/index.tsx
@@ -9,8 +9,8 @@ const AiStudio = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <AiStudioDark {...props} className={className} />
   return (
     <>
-      <AiStudioLight className={cn('dark:hidden', className)} {...props} />
-      <AiStudioDark className={cn('hidden dark:block', className)} {...props} />
+      <AiStudioLight className={cn(className, 'dark:hidden')} {...props} />
+      <AiStudioDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/baai/index.tsx
+++ b/packages/ui/src/components/icons/providers/baai/index.tsx
@@ -9,8 +9,8 @@ const Baai = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <BaaiDark {...props} className={className} />
   return (
     <>
-      <BaaiLight className={cn('dark:hidden', className)} {...props} />
-      <BaaiDark className={cn('hidden dark:block', className)} {...props} />
+      <BaaiLight className={cn(className, 'dark:hidden')} {...props} />
+      <BaaiDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/baidu/index.tsx
+++ b/packages/ui/src/components/icons/providers/baidu/index.tsx
@@ -9,8 +9,8 @@ const Baidu = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <BaiduDark {...props} className={className} />
   return (
     <>
-      <BaiduLight className={cn('dark:hidden', className)} {...props} />
-      <BaiduDark className={cn('hidden dark:block', className)} {...props} />
+      <BaiduLight className={cn(className, 'dark:hidden')} {...props} />
+      <BaiduDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/bolt-new/index.tsx
+++ b/packages/ui/src/components/icons/providers/bolt-new/index.tsx
@@ -9,8 +9,8 @@ const BoltNew = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <BoltNewDark {...props} className={className} />
   return (
     <>
-      <BoltNewLight className={cn('dark:hidden', className)} {...props} />
-      <BoltNewDark className={cn('hidden dark:block', className)} {...props} />
+      <BoltNewLight className={cn(className, 'dark:hidden')} {...props} />
+      <BoltNewDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/cephalon/index.tsx
+++ b/packages/ui/src/components/icons/providers/cephalon/index.tsx
@@ -9,8 +9,8 @@ const Cephalon = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <CephalonDark {...props} className={className} />
   return (
     <>
-      <CephalonLight className={cn('dark:hidden', className)} {...props} />
-      <CephalonDark className={cn('hidden dark:block', className)} {...props} />
+      <CephalonLight className={cn(className, 'dark:hidden')} {...props} />
+      <CephalonDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/coze/index.tsx
+++ b/packages/ui/src/components/icons/providers/coze/index.tsx
@@ -9,8 +9,8 @@ const Coze = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <CozeDark {...props} className={className} />
   return (
     <>
-      <CozeLight className={cn('dark:hidden', className)} {...props} />
-      <CozeDark className={cn('hidden dark:block', className)} {...props} />
+      <CozeLight className={cn(className, 'dark:hidden')} {...props} />
+      <CozeDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/devv/index.tsx
+++ b/packages/ui/src/components/icons/providers/devv/index.tsx
@@ -9,8 +9,8 @@ const Devv = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <DevvDark {...props} className={className} />
   return (
     <>
-      <DevvLight className={cn('dark:hidden', className)} {...props} />
-      <DevvDark className={cn('hidden dark:block', className)} {...props} />
+      <DevvLight className={cn(className, 'dark:hidden')} {...props} />
+      <DevvDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/dolphin-ai/index.tsx
+++ b/packages/ui/src/components/icons/providers/dolphin-ai/index.tsx
@@ -9,8 +9,8 @@ const DolphinAi = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <DolphinAiDark {...props} className={className} />
   return (
     <>
-      <DolphinAiLight className={cn('dark:hidden', className)} {...props} />
-      <DolphinAiDark className={cn('hidden dark:block', className)} {...props} />
+      <DolphinAiLight className={cn(className, 'dark:hidden')} {...props} />
+      <DolphinAiDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/essential-ai/index.tsx
+++ b/packages/ui/src/components/icons/providers/essential-ai/index.tsx
@@ -9,8 +9,8 @@ const EssentialAi = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <EssentialAiDark {...props} className={className} />
   return (
     <>
-      <EssentialAiLight className={cn('dark:hidden', className)} {...props} />
-      <EssentialAiDark className={cn('hidden dark:block', className)} {...props} />
+      <EssentialAiLight className={cn(className, 'dark:hidden')} {...props} />
+      <EssentialAiDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/fireworks/index.tsx
+++ b/packages/ui/src/components/icons/providers/fireworks/index.tsx
@@ -9,8 +9,8 @@ const Fireworks = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <FireworksDark {...props} className={className} />
   return (
     <>
-      <FireworksLight className={cn('dark:hidden', className)} {...props} />
-      <FireworksDark className={cn('hidden dark:block', className)} {...props} />
+      <FireworksLight className={cn(className, 'dark:hidden')} {...props} />
+      <FireworksDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/gitee-ai/index.tsx
+++ b/packages/ui/src/components/icons/providers/gitee-ai/index.tsx
@@ -9,8 +9,8 @@ const GiteeAi = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <GiteeAiDark {...props} className={className} />
   return (
     <>
-      <GiteeAiLight className={cn('dark:hidden', className)} {...props} />
-      <GiteeAiDark className={cn('hidden dark:block', className)} {...props} />
+      <GiteeAiLight className={cn(className, 'dark:hidden')} {...props} />
+      <GiteeAiDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/github/index.tsx
+++ b/packages/ui/src/components/icons/providers/github/index.tsx
@@ -9,8 +9,8 @@ const Github = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <GithubDark {...props} className={className} />
   return (
     <>
-      <GithubLight className={cn('dark:hidden', className)} {...props} />
-      <GithubDark className={cn('hidden dark:block', className)} {...props} />
+      <GithubLight className={cn(className, 'dark:hidden')} {...props} />
+      <GithubDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/hyperbolic/index.tsx
+++ b/packages/ui/src/components/icons/providers/hyperbolic/index.tsx
@@ -9,8 +9,8 @@ const Hyperbolic = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <HyperbolicDark {...props} className={className} />
   return (
     <>
-      <HyperbolicLight className={cn('dark:hidden', className)} {...props} />
-      <HyperbolicDark className={cn('hidden dark:block', className)} {...props} />
+      <HyperbolicLight className={cn(className, 'dark:hidden')} {...props} />
+      <HyperbolicDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/internlm/index.tsx
+++ b/packages/ui/src/components/icons/providers/internlm/index.tsx
@@ -9,8 +9,8 @@ const Internlm = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <InternlmDark {...props} className={className} />
   return (
     <>
-      <InternlmLight className={cn('dark:hidden', className)} {...props} />
-      <InternlmDark className={cn('hidden dark:block', className)} {...props} />
+      <InternlmLight className={cn(className, 'dark:hidden')} {...props} />
+      <InternlmDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/macos/index.tsx
+++ b/packages/ui/src/components/icons/providers/macos/index.tsx
@@ -9,8 +9,8 @@ const Macos = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <MacosDark {...props} className={className} />
   return (
     <>
-      <MacosLight className={cn('dark:hidden', className)} {...props} />
-      <MacosDark className={cn('hidden dark:block', className)} {...props} />
+      <MacosLight className={cn(className, 'dark:hidden')} {...props} />
+      <MacosDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/mineru/index.tsx
+++ b/packages/ui/src/components/icons/providers/mineru/index.tsx
@@ -9,8 +9,8 @@ const Mineru = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <MineruDark {...props} className={className} />
   return (
     <>
-      <MineruLight className={cn('dark:hidden', className)} {...props} />
-      <MineruDark className={cn('hidden dark:block', className)} {...props} />
+      <MineruLight className={cn(className, 'dark:hidden')} {...props} />
+      <MineruDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/minimax-agent/index.tsx
+++ b/packages/ui/src/components/icons/providers/minimax-agent/index.tsx
@@ -9,8 +9,8 @@ const MinimaxAgent = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <MinimaxAgentDark {...props} className={className} />
   return (
     <>
-      <MinimaxAgentLight className={cn('dark:hidden', className)} {...props} />
-      <MinimaxAgentDark className={cn('hidden dark:block', className)} {...props} />
+      <MinimaxAgentLight className={cn(className, 'dark:hidden')} {...props} />
+      <MinimaxAgentDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/moonshot/index.tsx
+++ b/packages/ui/src/components/icons/providers/moonshot/index.tsx
@@ -9,8 +9,8 @@ const Moonshot = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <MoonshotDark {...props} className={className} />
   return (
     <>
-      <MoonshotLight className={cn('dark:hidden', className)} {...props} />
-      <MoonshotDark className={cn('hidden dark:block', className)} {...props} />
+      <MoonshotLight className={cn(className, 'dark:hidden')} {...props} />
+      <MoonshotDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/nomic/index.tsx
+++ b/packages/ui/src/components/icons/providers/nomic/index.tsx
@@ -9,8 +9,8 @@ const Nomic = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <NomicDark {...props} className={className} />
   return (
     <>
-      <NomicLight className={cn('dark:hidden', className)} {...props} />
-      <NomicDark className={cn('hidden dark:block', className)} {...props} />
+      <NomicLight className={cn(className, 'dark:hidden')} {...props} />
+      <NomicDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/nousresearch/index.tsx
+++ b/packages/ui/src/components/icons/providers/nousresearch/index.tsx
@@ -9,8 +9,8 @@ const Nousresearch = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <NousresearchDark {...props} className={className} />
   return (
     <>
-      <NousresearchLight className={cn('dark:hidden', className)} {...props} />
-      <NousresearchDark className={cn('hidden dark:block', className)} {...props} />
+      <NousresearchLight className={cn(className, 'dark:hidden')} {...props} />
+      <NousresearchDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/ocoolai/index.tsx
+++ b/packages/ui/src/components/icons/providers/ocoolai/index.tsx
@@ -9,8 +9,8 @@ const Ocoolai = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <OcoolaiDark {...props} className={className} />
   return (
     <>
-      <OcoolaiLight className={cn('dark:hidden', className)} {...props} />
-      <OcoolaiDark className={cn('hidden dark:block', className)} {...props} />
+      <OcoolaiLight className={cn(className, 'dark:hidden')} {...props} />
+      <OcoolaiDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/openai/index.tsx
+++ b/packages/ui/src/components/icons/providers/openai/index.tsx
@@ -9,8 +9,8 @@ const Openai = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <OpenaiDark {...props} className={className} />
   return (
     <>
-      <OpenaiLight className={cn('dark:hidden', className)} {...props} />
-      <OpenaiDark className={cn('hidden dark:block', className)} {...props} />
+      <OpenaiLight className={cn(className, 'dark:hidden')} {...props} />
+      <OpenaiDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/openrouter/index.tsx
+++ b/packages/ui/src/components/icons/providers/openrouter/index.tsx
@@ -9,8 +9,8 @@ const Openrouter = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <OpenrouterDark {...props} className={className} />
   return (
     <>
-      <OpenrouterLight className={cn('dark:hidden', className)} {...props} />
-      <OpenrouterDark className={cn('hidden dark:block', className)} {...props} />
+      <OpenrouterLight className={cn(className, 'dark:hidden')} {...props} />
+      <OpenrouterDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/perplexity/index.tsx
+++ b/packages/ui/src/components/icons/providers/perplexity/index.tsx
@@ -9,8 +9,8 @@ const Perplexity = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <PerplexityDark {...props} className={className} />
   return (
     <>
-      <PerplexityLight className={cn('dark:hidden', className)} {...props} />
-      <PerplexityDark className={cn('hidden dark:block', className)} {...props} />
+      <PerplexityLight className={cn(className, 'dark:hidden')} {...props} />
+      <PerplexityDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/poe/index.tsx
+++ b/packages/ui/src/components/icons/providers/poe/index.tsx
@@ -9,8 +9,8 @@ const Poe = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <PoeDark {...props} className={className} />
   return (
     <>
-      <PoeLight className={cn('dark:hidden', className)} {...props} />
-      <PoeDark className={cn('hidden dark:block', className)} {...props} />
+      <PoeLight className={cn(className, 'dark:hidden')} {...props} />
+      <PoeDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/qwen/index.tsx
+++ b/packages/ui/src/components/icons/providers/qwen/index.tsx
@@ -9,8 +9,8 @@ const Qwen = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <QwenDark {...props} className={className} />
   return (
     <>
-      <QwenLight className={cn('dark:hidden', className)} {...props} />
-      <QwenDark className={cn('hidden dark:block', className)} {...props} />
+      <QwenLight className={cn(className, 'dark:hidden')} {...props} />
+      <QwenDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/recraft/index.tsx
+++ b/packages/ui/src/components/icons/providers/recraft/index.tsx
@@ -9,8 +9,8 @@ const Recraft = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <RecraftDark {...props} className={className} />
   return (
     <>
-      <RecraftLight className={cn('dark:hidden', className)} {...props} />
-      <RecraftDark className={cn('hidden dark:block', className)} {...props} />
+      <RecraftLight className={cn(className, 'dark:hidden')} {...props} />
+      <RecraftDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/riverflow/index.tsx
+++ b/packages/ui/src/components/icons/providers/riverflow/index.tsx
@@ -9,8 +9,8 @@ const Riverflow = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <RiverflowDark {...props} className={className} />
   return (
     <>
-      <RiverflowLight className={cn('dark:hidden', className)} {...props} />
-      <RiverflowDark className={cn('hidden dark:block', className)} {...props} />
+      <RiverflowLight className={cn(className, 'dark:hidden')} {...props} />
+      <RiverflowDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/together/index.tsx
+++ b/packages/ui/src/components/icons/providers/together/index.tsx
@@ -9,8 +9,8 @@ const Together = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <TogetherDark {...props} className={className} />
   return (
     <>
-      <TogetherLight className={cn('dark:hidden', className)} {...props} />
-      <TogetherDark className={cn('hidden dark:block', className)} {...props} />
+      <TogetherLight className={cn(className, 'dark:hidden')} {...props} />
+      <TogetherDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/voyage/index.tsx
+++ b/packages/ui/src/components/icons/providers/voyage/index.tsx
@@ -9,8 +9,8 @@ const Voyage = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <VoyageDark {...props} className={className} />
   return (
     <>
-      <VoyageLight className={cn('dark:hidden', className)} {...props} />
-      <VoyageDark className={cn('hidden dark:block', className)} {...props} />
+      <VoyageLight className={cn(className, 'dark:hidden')} {...props} />
+      <VoyageDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }

--- a/packages/ui/src/components/icons/providers/zhipu/index.tsx
+++ b/packages/ui/src/components/icons/providers/zhipu/index.tsx
@@ -9,8 +9,8 @@ const Zhipu = ({ variant, className, ...props }: CompoundIconProps) => {
   if (variant === 'dark') return <ZhipuDark {...props} className={className} />
   return (
     <>
-      <ZhipuLight className={cn('dark:hidden', className)} {...props} />
-      <ZhipuDark className={cn('hidden dark:block', className)} {...props} />
+      <ZhipuLight className={cn(className, 'dark:hidden')} {...props} />
+      <ZhipuDark className={cn(className, 'hidden dark:block')} {...props} />
     </>
   )
 }


### PR DESCRIPTION
### What this PR does

Before this PR:

Compound provider/model icons (`<ProviderIcon />` / `<ModelIcon />` in
auto light/dark mode) render **both** the light and dark SVG side by side
when the caller passes a display utility class such as `block`.

After this PR:

The compound's visibility classes always win, so exactly one variant
renders regardless of the caller's `className`.

Fixes #

### Why we need it and why it was done in this way

Root cause is in the icon code generator (`packages/ui/scripts/codegen.ts`),
which emitted `cn('dark:hidden', className)` — placing the caller's
`className` last. `tailwind-merge` resolves conflicting display utilities
last-wins, so a caller's `block` clobbered the internal `hidden` /
`dark:hidden`, leaving both icons visible.

The following tradeoffs were made:

- Fixed at the generator (root cause): `className` now comes before the
  visibility classes — `cn(className, 'dark:hidden')` — so `dark:hidden` /
  `hidden dark:block` can no longer be overridden. `text-foreground` stays
  before `className` so callers can still override the icon's text color.
- Regenerated only the 35 affected dark-variant compound `index.tsx`
  files. `avatar.tsx` / barrel / `catalog.ts` were intentionally left
  untouched — regenerating them surfaces pre-existing formatting drift
  unrelated to this fix.

The following alternatives were considered:

- Passing `variant` at each call site — rejected: patches one call site,
  leaves the footgun for every other caller.
- Dropping the offending `block` class at the call site — rejected: fixes
  one symptom, not the cause.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

The 35 `index.tsx` changes are a mechanical `cn()` argument reorder and
match the output of the fixed generator. A regression test was added in
`packages/ui/scripts/__tests__/codegen.test.ts`.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed provider and model icons that could render both their light and dark variants at the same time.
```
