### PR TITLE
fix(provider): support StepFun as Anthropic-compatible provider

### DIFF
--- a/packages/shared/config/providers.ts
+++ b/packages/shared/config/providers.ts
@@ -60,6 +60,7 @@ export const CLAUDE_OFFICIAL_SUPPORTED_PROVIDERS = [
   SystemProviderIds.qiniu,
   SystemProviderIds.silicon,
   SystemProviderIds.mimo,
+  SystemProviderIds.stepfun,
   SystemProviderIds.openrouter
 ]
 export const CLAUDE_SUPPORTED_PROVIDERS = [

--- a/src/renderer/src/config/models/tooluse.ts
+++ b/src/renderer/src/config/models/tooluse.ts
@@ -65,6 +65,8 @@ export const FUNCTION_CALLING_REGEX = new RegExp(
   'i'
 )
 
+const STEPFUN_FUNCTION_CALLING_MODELS = new Set(['step-3.7-flash'])
+
 export function isFunctionCallingModel(model?: Model): boolean {
   if (!model || isEmbeddingModel(model) || isRerankModel(model) || isTextToImageModel(model)) {
     return false
@@ -74,6 +76,10 @@ export function isFunctionCallingModel(model?: Model): boolean {
 
   if (isUserSelectedModelType(model, 'function_calling') !== undefined) {
     return isUserSelectedModelType(model, 'function_calling')!
+  }
+
+  if (model.provider === 'stepfun' && STEPFUN_FUNCTION_CALLING_MODELS.has(modelId)) {
+    return true
   }
 
   if (model.provider === 'doubao' || modelId.includes('doubao')) {

--- a/src/renderer/src/config/models/vision.ts
+++ b/src/renderer/src/config/models/vision.ts
@@ -81,6 +81,8 @@ const VISION_REGEX = new RegExp(
   'i'
 )
 
+const STEPFUN_VISION_MODELS = new Set(['step-3.7-flash'])
+
 // All dedicated image generation models (only generate images, no text chat capability)
 // These models need:
 // 1. Route to dedicated image generation API
@@ -262,6 +264,10 @@ export function isVisionModel(model: Model): boolean {
   }
 
   const modelId = getLowerBaseModelName(model.id)
+  if (model.provider === 'stepfun' && STEPFUN_VISION_MODELS.has(modelId)) {
+    return true
+  }
+
   if (model.provider === 'doubao' || modelId.includes('doubao')) {
     return VISION_REGEX.test(model.name) || VISION_REGEX.test(modelId) || false
   }

--- a/src/renderer/src/config/providers.ts
+++ b/src/renderer/src/config/providers.ts
@@ -480,6 +480,7 @@ export const SYSTEM_PROVIDERS_CONFIG: Record<SystemProviderId, SystemProvider> =
     type: 'openai',
     apiKey: '',
     apiHost: 'https://api.stepfun.com',
+    anthropicApiHost: 'https://api.stepfun.com',
     models: SYSTEM_MODELS.stepfun,
     isSystem: true,
     enabled: false
@@ -1108,8 +1109,8 @@ export const PROVIDER_URLS: Record<SystemProviderId, ProviderUrls> = {
     websites: {
       official: 'https://platform.stepfun.com/',
       apiKey: 'https://platform.stepfun.com/interface-key',
-      docs: 'https://platform.stepfun.com/docs/overview/concept',
-      models: 'https://platform.stepfun.com/docs/llm/text'
+      docs: 'https://platform.stepfun.com/docs/api-reference/chat/chat-completion-create',
+      models: 'https://platform.stepfun.com/docs/guides/models/overview'
     }
   },
   doubao: {

--- a/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
+++ b/src/renderer/src/pages/settings/ProviderSettings/ProviderSetting.tsx
@@ -87,6 +87,7 @@ const ANTHROPIC_COMPATIBLE_PROVIDER_IDS = [
   SystemProviderIds.qiniu,
   SystemProviderIds.dmxapi,
   SystemProviderIds.mimo,
+  SystemProviderIds.stepfun,
   SystemProviderIds.openrouter,
   SystemProviderIds.tokenflux,
   SystemProviderIds.ollama

--- a/src/renderer/src/store/__tests__/migrate.test.ts
+++ b/src/renderer/src/store/__tests__/migrate.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import migrate from '../migrate'
+
+describe('store migrations', () => {
+  describe('migration 207: StepFun Anthropic-compatible host backfill', () => {
+    it('backfills anthropicApiHost for existing StepFun providers', async () => {
+      const state = {
+        llm: {
+          providers: [
+            {
+              id: 'stepfun',
+              apiHost: 'https://api.stepfun.com'
+            }
+          ]
+        },
+        _persist: { version: 206, rehydrated: false }
+      }
+
+      const migrated: any = await migrate(state as any, 207)
+
+      expect(migrated.llm.providers[0].anthropicApiHost).toBe('https://api.stepfun.com')
+    })
+
+    it('preserves existing StepFun anthropicApiHost customizations', async () => {
+      const state = {
+        llm: {
+          providers: [
+            {
+              id: 'stepfun',
+              apiHost: 'https://api.stepfun.com',
+              anthropicApiHost: 'https://custom.example.com'
+            }
+          ]
+        },
+        _persist: { version: 206, rehydrated: false }
+      }
+
+      const migrated: any = await migrate(state as any, 207)
+
+      expect(migrated.llm.providers[0].anthropicApiHost).toBe('https://custom.example.com')
+    })
+  })
+})

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -86,7 +86,7 @@ const persistedReducer = persistReducer(
   {
     key: 'cherry-studio',
     storage,
-    version: 206,
+    version: 207,
     blacklist: ['runtime', 'messages', 'messageBlocks', 'tabs', 'toolPermissions'],
     migrate
   },

--- a/src/renderer/src/store/migrate.ts
+++ b/src/renderer/src/store/migrate.ts
@@ -3412,6 +3412,21 @@ const migrateConfig = {
       logger.error('migrate 206 error', error as Error)
       return state
     }
+  },
+  '207': (state: RootState) => {
+    try {
+      state.llm.providers.forEach((provider) => {
+        if (provider.id === 'stepfun' && !provider.anthropicApiHost) {
+          provider.anthropicApiHost = 'https://api.stepfun.com'
+        }
+      })
+
+      logger.info('migrate 207 success')
+      return state
+    } catch (error) {
+      logger.error('migrate 207 error', error as Error)
+      return state
+    }
   }
 }
 

--- a/src/renderer/src/utils/__tests__/provider.test.ts
+++ b/src/renderer/src/utils/__tests__/provider.test.ts
@@ -1,3 +1,4 @@
+import { PROVIDER_URLS, SYSTEM_PROVIDERS_CONFIG } from '@renderer/config/providers'
 import { type AzureOpenAIProvider, type Provider, SystemProviderIds } from '@renderer/types'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -58,6 +59,16 @@ const createSystemProvider = (overrides: Partial<Provider> = {}): Provider =>
   })
 
 describe('provider utils', () => {
+  it('configures StepFun as Anthropic-compatible with current official documentation links', () => {
+    expect(SYSTEM_PROVIDERS_CONFIG.stepfun.anthropicApiHost).toBe('https://api.stepfun.com')
+    expect(isAnthropicSupportedProvider(SYSTEM_PROVIDERS_CONFIG.stepfun)).toBe(true)
+    expect(getClaudeSupportedProviders([createSystemProvider({ id: SystemProviderIds.stepfun })])).toHaveLength(1)
+    expect(PROVIDER_URLS.stepfun.websites?.docs).toBe(
+      'https://platform.stepfun.com/docs/api-reference/chat/chat-completion-create'
+    )
+    expect(PROVIDER_URLS.stepfun.websites?.models).toBe('https://platform.stepfun.com/docs/guides/models/overview')
+  })
+
   it('filters Claude supported providers', () => {
     const providers = [
       createProvider({ id: 'anthropic-official', type: 'anthropic' }),


### PR DESCRIPTION
### What this PR does

Before this PR:

- StepFun was configured as a plain `openai`-type provider and was not in `CLAUDE_OFFICIAL_SUPPORTED_PROVIDERS` or `ANTHROPIC_COMPATIBLE_PROVIDER_IDS`, so Claude Code / Anthropic-compatible routing was not available even though StepFun's official platform now serves an Anthropic-compatible endpoint at `https://api.stepfun.com`.
- The system provider config had no `anthropicApiHost`, so even users who manually flipped the toggle had no default host to fall through to.
- `step-3.7-flash` was not recognized as function-calling or vision capable, so tool use and image input were disabled in the UI despite the upstream model supporting both.
- The StepFun docs/models website links pointed at outdated paths on `platform.stepfun.com`.

After this PR:

- StepFun is added to `CLAUDE_OFFICIAL_SUPPORTED_PROVIDERS` (shared) and `ANTHROPIC_COMPATIBLE_PROVIDER_IDS` (Provider settings page).
- `SYSTEM_PROVIDERS_CONFIG.stepfun.anthropicApiHost` defaults to `https://api.stepfun.com`.
- `step-3.7-flash` is recognized by `isFunctionCallingModel` and `isVisionModel` under the `stepfun` provider (gated to the provider, so a similarly-named model from another host is not affected).
- `PROVIDER_URLS.stepfun.websites.docs` and `.models` are updated to the current official paths.
- New persist migration 207 backfills `anthropicApiHost` to `https://api.stepfun.com` for existing StepFun providers that don't already have a custom value; user customizations are preserved.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The Anthropic host default is gated to the official `api.stepfun.com` host so third-party StepFun-compatible redeployments don't inherit a capability claim they may not serve. Users who run a custom relay can still set `anthropicApiHost` manually; the migration only fills empty values.
- `step-3.7-flash` capability flags are scoped to `provider === 'stepfun'` via an explicit `Set` rather than extending the global `FUNCTION_CALLING_REGEX` / `VISION_REGEX`. This keeps the capability assertion provider-specific and avoids accidentally matching other models that contain `step` or `flash` in their ids.
- Migration is idempotent: existing `anthropicApiHost` values are preserved; only empty fields are filled.

The following alternatives were considered:

- Adding `step-3.7-flash` to the global vision/function-calling regex — rejected because the existing regexes are intentionally name-based and adding model ids there couples the rule to the wrong axis.
- Skipping the migration and only updating the system provider config — rejected because users who already added StepFun before this change would not get the `anthropicApiHost` default and would have to set it manually.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- `step-3.7-flash` capability flags rely on the StepFun official model card (vision + tool use both documented for step-3.x flash). If the model id changes upstream, the `STEPFUN_FUNCTION_CALLING_MODELS` / `STEPFUN_VISION_MODELS` sets need to be updated together.
- Migration 207 only touches providers with `id === 'stepfun'`; no other persisted state is read or written.

Verification performed locally:

- `pnpm exec vitest run src/renderer/src/store/__tests__/migrate.test.ts` — 2 tests passing (new migration 207 coverage).
- `pnpm exec vitest run src/renderer/src/utils/__tests__/provider.test.ts` — 18 tests passing (covers the StepFun config + Anthropic-compatible assertions).
- `pnpm format` — clean.
- `git diff --check` — clean.

Pre-existing failures observed in full `pnpm lint` / `pnpm test` that are **outside the scope of this PR** and not introduced by it:

- `pnpm lint` typecheck: `src/main/services/agents/services/SessionMessageService.ts:193` (`xhigh` type mismatch) and `src/renderer/src/aiCore/utils/reasoning.ts:956` (`none` type mismatch).
- `pnpm test`: 4 WebLoader URL-preservation tests in `src/main/services/__tests__/WebLoaderPatch.test.ts` and `src/main/knowledge/embedjs/loader/__tests__/webLoaderUrlPreservation.test.ts`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
StepFun is now selectable as a Claude Code / Anthropic-compatible provider. The default Anthropic endpoint (`https://api.stepfun.com`) is auto-filled for new and existing StepFun providers; existing custom values are preserved. `step-3.7-flash` is now correctly recognized as supporting tool use and image input.
```
