### PR TITLE
fix: correct provider ID for AIHubMix reasoning effort

### DIFF
--- a/src/renderer/src/aiCore/provider/custom/aihubmix-provider.ts
+++ b/src/renderer/src/aiCore/provider/custom/aihubmix-provider.ts
@@ -89,7 +89,7 @@ export function createAihubmix(options: AihubmixProviderSettings = {}): Aihubmix
 
   const createOpenAICompatibleChatModel = (modelId: string): LanguageModelV3 =>
     new OpenAICompatibleChatLanguageModel(modelId, {
-      provider: `${AIHUBMIX_PROVIDER_NAME}.openai-compatible-chat`,
+      provider: `openai-compatible.${AIHUBMIX_PROVIDER_NAME}`,
       url,
       headers: authHeaders,
       fetch: customFetch
@@ -97,7 +97,7 @@ export function createAihubmix(options: AihubmixProviderSettings = {}): Aihubmix
 
   const createOpenAIChatModel = (modelId: string): LanguageModelV3 =>
     new OpenAIChatLanguageModel(modelId, {
-      provider: `${AIHUBMIX_PROVIDER_NAME}.openai-compatible-chat`,
+      provider: `openai-compatible.${AIHUBMIX_PROVIDER_NAME}`,
       url,
       headers: authHeaders,
       fetch: customFetch


### PR DESCRIPTION
Fixes #15268

## Problem

The reasoning effort configuration was not working for AIHubMix models (e.g., DeepSeek 4 series) because of a provider ID mismatch between option building and option retrieval.

**Root cause analysis (credit to @Aulddays):**
- `buildProviderOptions()` builds options with `providerId='openai-compatible'`
- `OpenAICompatibleChatLanguageModel` used `provider='aihubmix.openai-compatible-chat'`
- AI SDK's `providerOptionsName()` extracts `'aihubmix'` from the provider string and fails to find the options built with `'openai-compatible'`

## Solution

Change the provider ID format from `aihubmix.openai-compatible-chat` to `openai-compatible.aihubmix` so the AI SDK correctly extracts `'openai-compatible'` as the provider name and successfully retrieves the reasoning effort parameters.

## Changes

- Updated `createOpenAICompatibleChatModel` provider ID
- Updated `createOpenAIChatModel` provider ID

Both now use `openai-compatible.${AIHUBMIX_PROVIDER_NAME}` format.

## Testing

Manual testing recommended:
1. Select a DeepSeek 4 model from AIHubMix
2. Set Reasoning Effort to "off"
3. Verify in DevTools that the reasoning effort parameters are present in the request
4. Verify that reasoning is disabled in the response