### PR TITLE
feat(paintings): add custom image size option to Silicon Flow provider

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -3163,7 +3163,10 @@
     "guidance_scale": "Guidance Scale",
     "guidance_scale_tip": "Classifier Free Guidance. How close you want the model to stick to your prompt when looking for a related image to show you",
     "image": {
-      "size": "Image Size"
+      "size": "Image Size",
+      "size_custom": "Custom",
+      "size_width": "Width",
+      "size_height": "Height"
     },
     "image_file_required": "Please upload an image first",
     "image_file_retry": "Please re-upload an image first",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -3163,7 +3163,10 @@
     "guidance_scale": "引导比例",
     "guidance_scale_tip": "无分类器指导。控制模型在寻找相关图像时对提示词的遵循程度",
     "image": {
-      "size": "图片尺寸"
+      "size": "图片尺寸",
+      "size_custom": "自定义",
+      "size_width": "宽度",
+      "size_height": "高度"
     },
     "image_file_required": "请先上传图片",
     "image_file_retry": "请重新上传图片",

--- a/src/renderer/src/i18n/locales/zh-tw.json
+++ b/src/renderer/src/i18n/locales/zh-tw.json
@@ -3163,7 +3163,10 @@
     "guidance_scale": "引導比例",
     "guidance_scale_tip": "無分類器指導。控制模型在尋找相關影像時對提示詞的遵循程度",
     "image": {
-      "size": "影像尺寸"
+      "size": "影像尺寸",
+      "size_custom": "自訂",
+      "size_width": "寬度",
+      "size_height": "高度"
     },
     "image_file_required": "請先上傳圖片",
     "image_file_retry": "請重新上傳圖片",

--- a/src/renderer/src/pages/paintings/SiliconPage.tsx
+++ b/src/renderer/src/pages/paintings/SiliconPage.tsx
@@ -99,6 +99,8 @@ const DEFAULT_PAINTING: Painting = {
   prompt: '',
   negativePrompt: '',
   imageSize: '1024x1024',
+  customWidth: 1024,
+  customHeight: 1024,
   numImages: 1,
   seed: '',
   steps: 25,
@@ -196,11 +198,16 @@ const SiliconPage: FC<{ Options: string[] }> = ({ Options }) => {
     }
 
     try {
+      const imageSize =
+        painting.imageSize === 'custom'
+          ? `${painting.customWidth || 1024}x${painting.customHeight || 1024}`
+          : painting.imageSize || '1024x1024'
+
       const urls = await AI.generateImage({
         model: painting.model,
         prompt,
         negativePrompt: painting.negativePrompt || '',
-        imageSize: painting.imageSize || '1024x1024',
+        imageSize,
         batchSize: painting.numImages || 1,
         seed: painting.seed || undefined,
         numInferenceSteps: painting.steps || 25,
@@ -257,8 +264,15 @@ const SiliconPage: FC<{ Options: string[] }> = ({ Options }) => {
   }
 
   const onSelectImageSize = (v: string) => {
-    const size = IMAGE_SIZES.find((i) => i.value === v)
-    size && updatePaintingState({ imageSize: size.value })
+    if (v === 'custom') {
+      updatePaintingState({ imageSize: 'custom' })
+    } else {
+      const size = IMAGE_SIZES.find((i) => i.value === v)
+      if (size) {
+        const [width, height] = size.value.split('x').map(Number)
+        updatePaintingState({ imageSize: size.value, customWidth: width, customHeight: height })
+      }
+    }
   }
 
   const nextImage = () => {
@@ -390,7 +404,43 @@ const SiliconPage: FC<{ Options: string[] }> = ({ Options }) => {
                 </VStack>
               </RadioButton>
             ))}
+            <RadioButton value="custom" key="custom">
+              <VStack alignItems="center" style={{ justifyContent: 'center', height: '100%' }}>
+                <span>{t('paintings.image.size_custom')}</span>
+              </VStack>
+            </RadioButton>
           </Radio.Group>
+
+          {painting.imageSize === 'custom' && (
+            <HStack style={{ marginTop: 10, gap: 10 }}>
+              <div style={{ flex: 1 }}>
+                <div style={{ marginBottom: 5, fontSize: '12px', color: 'var(--color-text-2)' }}>
+                  {t('paintings.image.size_width')}
+                </div>
+                <InputNumber
+                  min={256}
+                  max={2048}
+                  step={64}
+                  value={painting.customWidth || 1024}
+                  onChange={(v) => updatePaintingState({ customWidth: v || 1024 })}
+                  style={{ width: '100%' }}
+                />
+              </div>
+              <div style={{ flex: 1 }}>
+                <div style={{ marginBottom: 5, fontSize: '12px', color: 'var(--color-text-2)' }}>
+                  {t('paintings.image.size_height')}
+                </div>
+                <InputNumber
+                  min={256}
+                  max={2048}
+                  step={64}
+                  value={painting.customHeight || 1024}
+                  onChange={(v) => updatePaintingState({ customHeight: v || 1024 })}
+                  style={{ width: '100%' }}
+                />
+              </div>
+            </HStack>
+          )}
 
           <SettingTitle style={{ marginBottom: 5, marginTop: 15 }}>
             {t('paintings.number_images')}

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -354,6 +354,8 @@ export interface Painting extends PaintingParams {
   prompt?: string
   negativePrompt?: string
   imageSize?: string
+  customWidth?: number
+  customHeight?: number
   numImages?: number
   seed?: string
   steps?: number


### PR DESCRIPTION
## Description

This PR adds custom image size functionality to the Silicon Flow painting provider, allowing users to specify custom width and height dimensions beyond the 6 preset options.

## Changes

- ✨ Add "Custom" option to the image size radio group
- 🎨 Display width/height input fields when custom size is selected
- 🔢 Support custom dimensions from 256x256 to 2048x2048 with 64px steps
- 🌐 Add i18n keys for custom size labels (en-us, zh-cn, zh-tw)
- 📝 Update `Painting` type to include `customWidth` and `customHeight` fields
- 🔄 Sync custom dimensions when switching between preset and custom sizes

## Screenshots

The UI follows the existing Radio.Group pattern with icon buttons for preset sizes, and adds a "Custom" button at the end. When selected, two input fields appear below for width and height.

## Testing

- [x] Custom size selection works
- [x] Width/height inputs accept valid values (256-2048, step 64)
- [x] Switching between preset and custom sizes updates dimensions correctly
- [x] Image generation uses custom dimensions when selected
- [x] i18n keys display correctly in all three locales

## Related Issue

Closes #15276