### PR TITLE
fix(cron): reuse session across failed runs instead of creating new ones

### DIFF
--- a/src/main/services/agents/services/SessionMessageService.ts
+++ b/src/main/services/agents/services/SessionMessageService.ts
@@ -282,22 +282,21 @@ export class SessionMessageService extends BaseService {
                 if (options?.persist) {
                   const resolvedSessionId = claudeStream.sdkSessionId || agentSessionId
                   const partialText = accumulator.getText()
-                  if (partialText) {
-                    this.persistHeadlessExchange(
-                      session,
-                      options?.displayContent ?? req.content,
-                      partialText,
-                      resolvedSessionId,
-                      options?.images
-                    )
-                      .then(resolveCompletion)
-                      .catch((err) => {
-                        logger.error('Failed to persist cancelled exchange', err as Error)
-                        resolveCompletion({})
-                      })
-                  } else {
-                    resolveCompletion({})
-                  }
+                  // Always persist on cancellation so agent_session_id is saved.
+                  // Without this, timeouts before text production lose the session
+                  // linkage, causing the next run to create a brand-new session.
+                  this.persistHeadlessExchange(
+                    session,
+                    options?.displayContent ?? req.content,
+                    partialText || '[cancelled - no response generated]',
+                    resolvedSessionId,
+                    options?.images
+                  )
+                    .then(resolveCompletion)
+                    .catch((err) => {
+                      logger.error('Failed to persist cancelled exchange', err as Error)
+                      resolveCompletion({})
+                    })
                 } else {
                   resolveCompletion({})
                 }

--- a/src/main/services/agents/services/TaskService.ts
+++ b/src/main/services/agents/services/TaskService.ts
@@ -378,15 +378,20 @@ export class TaskService extends BaseService {
   }
 
   /**
-   * Get the session_id from the most recent successful run of a task.
+   * Get the session_id from the most recent run of a task (any status).
    * Used by SchedulerService to reuse an existing session for context continuity.
+   *
+   * Previously this only matched 'success' runs, which meant failed runs
+   * (timeout, error) caused the next invocation to create a brand-new session,
+   * losing conversation context. Now we match the most recent run regardless
+   * of outcome so the session is reused even after failures.
    */
   async getLastRunSessionId(taskId: string): Promise<string | null> {
     const database = await this.getDatabase()
     const result = await database
       .select({ session_id: taskRunLogsTable.session_id })
       .from(taskRunLogsTable)
-      .where(and(eq(taskRunLogsTable.task_id, taskId), eq(taskRunLogsTable.status, 'success')))
+      .where(and(eq(taskRunLogsTable.task_id, taskId), ne(taskRunLogsTable.status, 'running')))
       .orderBy(desc(taskRunLogsTable.run_at))
       .limit(1)
 


### PR DESCRIPTION
## Summary

- Fix cron tasks creating a new session on every failed run (timeout/error), which caused the session list to grow unboundedly
- Two interlocking bugs identified and fixed:
  1. **SessionMessageService**: `cancelled` handler skipped `persistHeadlessExchange` when no text was accumulated, so `agent_session_id` was never saved. Timeouts before text production lost the session linkage entirely.
  2. **TaskService**: `getLastRunSessionId` only queried `status = 'success'`, making failed runs' session IDs invisible to the next invocation.

## Fix

- **SessionMessageService.ts**: Always call `persistHeadlessExchange` on cancellation, even when text is empty (uses placeholder text). The critical data — `agent_session_id` — is now always saved.
- **TaskService.ts**: Change query from `eq(status, 'success')` to `ne(status, 'running')` so the most recent run's session_id is found regardless of outcome.

## Test plan

- [x] TypeScript type check passes
- [x] Biome lint passes
- [ ] Create a cron task with `session_mode: 'reuse'` and a short timeout
- [ ] Verify that after a timeout, the next run reuses the same session (check session list doesn't grow)
- [ ] Verify successful runs still reuse sessions as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)