### PR TITLE
fix(proxy): restore bootstrap entry

### DIFF
--- a/src/main/services/proxy/bootstrap.ts
+++ b/src/main/services/proxy/bootstrap.ts
@@ -1,0 +1,10 @@
+import { applyNodeProxyFromEnvironment } from './nodeProxy'
+
+try {
+  applyNodeProxyFromEnvironment()
+} catch (error) {
+  const message = error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+  process.stderr.write(
+    `[CherryStudioProxyBootstrap] Proxy bootstrap failed - child process will run WITHOUT proxy: ${message}\n`
+  )
+}


### PR DESCRIPTION
### What this PR does

Before this PR:

`pnpm run dev` failed because `scripts/buildProxyBootstrapPlugin.ts` still used `src/main/services/proxy/bootstrap.ts` as the Vite build entry, but that file had been deleted.

After this PR:

`src/main/services/proxy/bootstrap.ts` is restored so the plugin can build `out/proxy/index.js` for Claude Code child process proxy bootstrap loading.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

This restores only the missing build/runtime entry instead of changing the plugin or Claude Code `--require` path, preserving existing proxy support with the smallest possible fix.

The following alternatives were considered:

Removing the proxy bootstrap build entry and Claude Code preload path was considered, but that would remove proxy support from Claude Code child processes and is not desired for this bug fix.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

The restored file is the same minimal bootstrap behavior: apply proxy settings from environment and write a stderr warning if bootstrap fails.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
