### PR TITLE
fix(proxy): bootstrap node proxy for child processes

### DIFF
--- a/src/main/services/proxy/bootstrap.ts
+++ b/src/main/services/proxy/bootstrap.ts
@@ -1,0 +1,10 @@
+import { applyNodeProxyFromEnvironment } from './nodeProxy'
+
+try {
+  applyNodeProxyFromEnvironment()
+} catch (error) {
+  const message = error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+  process.stderr.write(
+    `[CherryStudioProxyBootstrap] Proxy bootstrap failed - child process will run WITHOUT proxy: ${message}\n`
+  )
+}


### PR DESCRIPTION
### What this PR does

Before this PR:
<img width="1858" height="740" alt="CleanShot 2026-05-25 at 09 55 51@2x" src="https://github.com/user-attachments/assets/7a4e8ae2-3f32-4c14-a9a6-8e277c9a031d" />

After this PR:
Claude Code child processes can load the packaged proxy bootstrap module and initialize Cherry Studio's existing Node proxy settings before the SDK CLI starts. If the bootstrap fails, the child process continues without proxy and prints a stderr diagnostic instead of failing during startup.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #<issue-number>

### Why we need it and why it was done in this way

Claude Code child processes already inject `--require out/proxy/index.js` when a Node proxy configuration is active, and the build pipeline already expects `src/main/services/proxy/bootstrap.ts` as the entry for that packaged bootstrap file. This PR adds the missing bootstrap entry and delegates the actual proxy setup to the existing `applyNodeProxyFromEnvironment()` implementation.

The following tradeoffs were made:
- Keep the bootstrap file minimal and reuse the existing proxy implementation instead of duplicating proxy parsing or dispatcher setup logic.
- Write bootstrap failures to stderr because the preload runs before the normal service logger is available in the child process.
- Let the child process continue without proxy if bootstrap fails, so proxy setup problems do not prevent Claude Code from starting entirely.

The following alternatives were considered:
- Inline the proxy setup directly in the Claude Code launch path, but that would duplicate logic already owned by the proxy module.
- Fail the child process when bootstrap fails, but that would make a proxy bootstrap issue block agent startup even though the process can still run without proxy.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This PR only adds the bootstrap entry expected by the existing build and launch paths. It does not change proxy rule parsing, bypass behavior, or Claude Code process spawning logic.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed Claude Code child processes not loading Cherry Studio's Node proxy bootstrap.