### PR TITLE
refactor(ai-core): use quick-lru for provider cache

### DIFF
--- a/packages/aiCore/package.json
+++ b/packages/aiCore/package.json
@@ -45,7 +45,7 @@
     "@ai-sdk/xai": "^3.0.83",
     "@cherrystudio/ai-sdk-provider": "workspace:*",
     "@openrouter/ai-sdk-provider": "^2.3.3",
-    "lru-cache": "^11.2.4",
+    "quick-lru": "^5.1.1",
     "zod": "^4.1.5"
   },
   "devDependencies": {

--- a/packages/aiCore/src/core/providers/core/ProviderExtension.ts
+++ b/packages/aiCore/src/core/providers/core/ProviderExtension.ts
@@ -1,5 +1,5 @@
 import type { ProviderV3 } from '@ai-sdk/provider'
-import { LRUCache } from 'lru-cache'
+import QuickLRU from 'quick-lru'
 
 import { deepMergeObjects } from '../../utils'
 import type { ProviderVariant, ToolFactoryMap } from '../types'
@@ -116,7 +116,7 @@ export class ProviderExtension<
   >
 > {
   /** Provider 实例缓存 - 按 settings hash 存储，LRU 自动清理 */
-  private instances: LRUCache<string, TProvider>
+  private instances: QuickLRU<string, TProvider>
 
   /** In-flight promise map - 防止并发创建相同 settings 的 provider */
   private pendingCreations: Map<string, Promise<TProvider>> = new Map()
@@ -126,9 +126,8 @@ export class ProviderExtension<
       throw new Error('ProviderExtension: name is required')
     }
 
-    this.instances = new LRUCache<string, TProvider>({
-      max: 10,
-      updateAgeOnGet: true
+    this.instances = new QuickLRU<string, TProvider>({
+      maxSize: 10
     })
   }
 
@@ -327,10 +326,10 @@ export class ProviderExtension<
    * 获取已缓存的 provider 实例（如果存在）
    */
   getCachedProvider(): TProvider | undefined {
-    for (const [key, value] of this.instances.entries()) {
+    for (const [key, value] of this.instances) {
       if (!key.includes(':')) return value
     }
-    for (const [, value] of this.instances.entries()) {
+    for (const [, value] of this.instances) {
       return value
     }
     return undefined

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1407,9 +1407,9 @@ importers:
       ai:
         specifier: ^6.0.116
         version: 6.0.143(zod@4.3.4)
-      lru-cache:
-        specifier: ^11.2.4
-        version: 11.2.4
+      quick-lru:
+        specifier: ^5.1.1
+        version: 5.1.1
       zod:
         specifier: ^4.1.5
         version: 4.3.4


### PR DESCRIPTION
### What this PR does

Before this PR:

`@cherrystudio/ai-core` used `lru-cache` for `ProviderExtension`'s provider instance cache.

After this PR:

`@cherrystudio/ai-core` uses `quick-lru` for the same provider instance cache and updates the package dependency/lockfile accordingly.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- `quick-lru@^5.1.1` is used because aiCore currently emits both ESM and CJS builds, and this version is compatible with that packaging shape.
- The cache remains capped at 10 entries and still refreshes recency on `get()`.

The following alternatives were considered:

- Keeping `lru-cache`, but it keeps a heavier provider cache dependency in aiCore.
- Using the latest `quick-lru`, but current latest is ESM-only and requires broader validation against aiCore's CJS export.
- Replacing the dependency with a custom Map-based LRU, but this PR follows the requested library replacement.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Validation performed:

- `pnpm --filter @cherrystudio/ai-core typecheck` passed
- `pnpm --filter @cherrystudio/ai-core test` passed
- `pnpm format` passed

`pnpm lint` was also attempted. It reached the full repository typecheck and failed on existing missing node-side modules unrelated to this change:

- `src/main/ai/observability/sinks/ObservabilitySinkRegistry.ts` cannot resolve `../local/LocalTraceWindowSink`
- `src/main/core/application/serviceRegistry.ts` cannot resolve `@main/ai/observability/local/SpanCacheService`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
