### PR TITLE
fix(analytics): respect enableDataCollection setting in renderer

### DIFF
--- a/src/main/services/ConfigManager.ts
+++ b/src/main/services/ConfigManager.ts
@@ -186,7 +186,7 @@ export class ConfigManager {
   }
 
   getEnableDataCollection(): boolean {
-    return this.get<boolean>(ConfigKeys.EnableDataCollection, true)
+    return this.get<boolean>(ConfigKeys.EnableDataCollection, false)
   }
 
   setEnableDataCollection(value: boolean) {

--- a/src/renderer/src/hooks/useAppInit.ts
+++ b/src/renderer/src/hooks/useAppInit.ts
@@ -265,7 +265,7 @@ export function useAppInit() {
   }, [dispatch, t])
 
   useEffect(() => {
-    // TODO: init data collection
+    window.api.config.set('enableDataCollection', enableDataCollection)
   }, [enableDataCollection])
 
   // Update memory service configuration when it changes

--- a/src/renderer/src/hooks/useAppInit.ts
+++ b/src/renderer/src/hooks/useAppInit.ts
@@ -265,7 +265,7 @@ export function useAppInit() {
   }, [dispatch, t])
 
   useEffect(() => {
-    window.api.config.set('enableDataCollection', enableDataCollection)
+    void window.api.config.set('enableDataCollection', enableDataCollection)
   }, [enableDataCollection])
 
   // Update memory service configuration when it changes

--- a/src/renderer/src/utils/__tests__/analytics.test.ts
+++ b/src/renderer/src/utils/__tests__/analytics.test.ts
@@ -8,6 +8,10 @@ vi.mock('@renderer/services/ProviderService', () => ({
   getProviderById: vi.fn()
 }))
 
+vi.mock('@renderer/store', () => ({
+  default: { getState: vi.fn() }
+}))
+
 vi.mock('@renderer/types', async (importOriginal) => {
   const actual = await importOriginal()
   return {
@@ -17,21 +21,24 @@ vi.mock('@renderer/types', async (importOriginal) => {
 })
 
 import { getProviderById } from '@renderer/services/ProviderService'
+import store from '@renderer/store'
 import { isSystemProvider } from '@renderer/types'
 
 describe('trackTokenUsage', () => {
   const mockTrackTokenUsage = vi.fn()
   const mockGetProviderById = vi.mocked(getProviderById)
   const mockIsSystemProvider = vi.mocked(isSystemProvider)
+  const mockGetState = vi.mocked(store.getState)
 
   beforeEach(() => {
     vi.clearAllMocks()
     vi.stubGlobal('window', {
       api: { analytics: { trackTokenUsage: mockTrackTokenUsage } }
     })
-    // Default: system provider
+    // Default: system provider, data collection enabled
     mockGetProviderById.mockReturnValue({ id: 'openai', isSystem: true } as Provider)
     mockIsSystemProvider.mockReturnValue(true)
+    mockGetState.mockReturnValue({ settings: { enableDataCollection: true } } as any)
   })
 
   const createModel = (provider: string, id: string): Model => ({ provider, id }) as Model
@@ -73,6 +80,14 @@ describe('trackTokenUsage', () => {
       output_tokens: 100,
       source: 'chat'
     })
+  })
+
+  it('should not track when data collection is disabled', () => {
+    mockGetState.mockReturnValue({ settings: { enableDataCollection: false } } as any)
+
+    trackTokenUsage({ usage: createUsage(100, 50), model: createModel('openai', 'gpt-4') })
+
+    expect(mockTrackTokenUsage).not.toHaveBeenCalled()
   })
 
   it('should not track when usage or model is invalid', () => {

--- a/src/renderer/src/utils/analytics.ts
+++ b/src/renderer/src/utils/analytics.ts
@@ -1,4 +1,5 @@
 import { getProviderById } from '@renderer/services/ProviderService'
+import store from '@renderer/store'
 import { isSystemProvider, type Model, type Usage } from '@renderer/types'
 import type { LanguageModelUsage } from 'ai'
 
@@ -53,6 +54,7 @@ function getProviderTrackId(id: string): string {
  * Handles both OpenAI format (prompt_tokens) and AI SDK format (inputTokens)
  */
 export function trackTokenUsage({ usage, model, source = 'chat' }: TokenUsageParams): void {
+  if (!store.getState().settings.enableDataCollection) return
   if (!usage || !model?.provider || !model?.id) return
 
   const [inputTokens, outputTokens] = isAiSdkUsage(usage)


### PR DESCRIPTION
### What this PR does

Before this PR:

1. `trackTokenUsage()` in the renderer was called unconditionally, firing IPC requests even when data collection was disabled.
2. ConfigManager defaulted `enableDataCollection` to `true` while Redux defaulted to `false`, causing a permanent desync for new users who never toggled the setting.
3. No startup sync existed between Redux and ConfigManager — the TODO in `useAppInit.ts` was unimplemented.

After this PR:

1. `trackTokenUsage()` checks `store.getState().settings.enableDataCollection` before doing anything — no IPC call when disabled.
2. ConfigManager default is aligned to `false`, matching the Redux default.
3. `useAppInit` syncs the Redux `enableDataCollection` value to ConfigManager on mount and on change, ensuring both sides stay consistent.

Fixes #15267

### Why we need it and why it was done in this way

Users who disable data collection in Settings → Privacy expect **zero** analytics traffic. Three independent issues prevented that:

- The renderer-side `trackTokenUsage` lacked a privacy check (most visible symptom — IPC calls on every chat).
- ConfigManager and Redux had mismatched defaults (`true` vs `false`), so new users who never toggled the setting had analytics silently enabled in the main process.
- No sync mechanism existed to reconcile the two stores on startup.

The following tradeoffs were made:

- Upgrading users (who never toggled the setting) will miss one `app_launch` event on the first launch after this update, because ConfigManager now defaults to `false` before the renderer syncs the persisted Redux `true`. This is a one-time, one-session gap and is acceptable.
- A deeper fix (destroying/re-creating `AnalyticsClient` mid-session when the setting changes) is deferred to v2.

The following alternatives were considered:

- Only fixing the renderer-side check — insufficient because `app_launch` and `trackAppUpdate` in the main process would still fire for desync'd users.
- Only changing the default without adding sync — would break upgrading users in the opposite direction (Redux `true`, ConfigManager `false`).

### Breaking changes

None.

### Special notes for your reviewer

- The main process `AnalyticsService.trackTokenUsage()` already has a `configManager.getEnableDataCollection()` guard (defense-in-depth), so the renderer-side check is the primary gate.
- The startup sync (`useAppInit`) runs after `analyticsService.init()` in the main process. This means the sync takes effect on the *next* launch, not the current one. This is by design — re-initializing the analytics client mid-startup adds complexity better suited for v2.
- See the [investigation comment](https://github.com/CherryHQ/cherry-studio/issues/15267#issuecomment-4533702850) for full root-cause analysis.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed analytics requests being sent even when data collection was disabled in privacy settings. Also fixed a default-value mismatch between renderer and main process that caused analytics to be silently enabled for new users.
```
