### PR TITLE
fix(paintings): use dynamic model list for AihubmixPage instead of hardcoded IDs

### DIFF
--- a/src/renderer/src/pages/paintings/AihubmixPage.tsx
+++ b/src/renderer/src/pages/paintings/AihubmixPage.tsx
@@ -35,13 +35,16 @@ import { SettingHelpLink, SettingTitle } from '../settings'
 import Artboard from './components/Artboard'
 import PaintingsList from './components/PaintingsList'
 import ProviderSelect from './components/ProviderSelect'
-import { type ConfigItem, createModeConfigs, DEFAULT_PAINTING } from './config/aihubmixConfig'
+import {
+  type ConfigItem,
+  createModeConfigs,
+  DEFAULT_PAINTING,
+  getAihubmixGenerateModels,
+  getAihubmixRemixModels
+} from './config/aihubmixConfig'
 import { checkProviderEnabled } from './utils'
 
 const logger = loggerService.withContext('AihubmixPage')
-
-// 使用函数创建配置项
-const modeConfigs = createModeConfigs()
 
 const AihubmixPage: FC<{ Options: string[] }> = ({ Options }) => {
   const [mode, setMode] = useState<keyof PaintingsState>('aihubmix_image_generate')
@@ -83,6 +86,14 @@ const AihubmixPage: FC<{ Options: string[] }> = ({ Options }) => {
   const { autoTranslateWithSpace } = useSettings()
   const spaceClickTimer = useRef<NodeJS.Timeout>(null)
   const aihubmixProvider = providers.find((p) => p.id === 'aihubmix')!
+
+  const [modeConfigs, setModeConfigs] = useState(createModeConfigs())
+
+  useEffect(() => {
+    const generateModels = getAihubmixGenerateModels(aihubmixProvider.models || [])
+    const remixModels = getAihubmixRemixModels(aihubmixProvider.models || [])
+    setModeConfigs(createModeConfigs(generateModels, remixModels))
+  }, [aihubmixProvider.models])
 
   const modeOptions = [
     { label: t('paintings.mode.generate'), value: 'aihubmix_image_generate' },
@@ -362,14 +373,14 @@ const AihubmixPage: FC<{ Options: string[] }> = ({ Options }) => {
           }
         } else {
           let requestData: any = {}
-          if (painting.model === 'gpt-image-1' || painting.model === 'gpt-image-2') {
+          if (painting.model.startsWith('gpt-image-')) {
             requestData = {
               prompt,
               model: painting.model,
               size: painting.size === 'auto' ? undefined : painting.size,
               n: painting.n,
               quality: painting.quality,
-              ...(painting.model === 'gpt-image-1' ? { moderation: painting.moderation } : {})
+              ...(painting.model.startsWith('gpt-image-1') ? { moderation: painting.moderation } : {})
             }
             url = aihubmixProvider.apiHost + `/v1/images/generations`
             headers = {

--- a/src/renderer/src/pages/paintings/config/aihubmixConfig.tsx
+++ b/src/renderer/src/pages/paintings/config/aihubmixConfig.tsx
@@ -1,4 +1,4 @@
-import type { PaintingAction } from '@renderer/types'
+import type { Model, PaintingAction } from '@renderer/types'
 
 import {
   ASPECT_RATIOS,
@@ -10,6 +10,134 @@ import {
   STYLE_TYPES,
   V3_STYLE_TYPES
 } from './constants'
+
+type ModelOption = {
+  labelKey?: string
+  label?: string
+  title?: string
+  value: string | number
+  icon?: string
+  onlyV2?: boolean
+  options?: ModelOption[]
+}
+
+type GenerateModelOption = {
+  labelKey?: string
+  label?: string
+  title?: string
+  value?: string | number
+  icon?: string
+  onlyV2?: boolean
+  options?: ModelOption[]
+}
+
+const FALLBACK_GENERATE_MODELS: GenerateModelOption[] = [
+  {
+    label: 'OpenAI',
+    title: 'OpenAI',
+    options: [
+      { label: 'gpt-image-2', value: 'gpt-image-2' },
+      { label: 'gpt-image-1', value: 'gpt-image-1' }
+    ]
+  },
+  {
+    label: 'Gemini',
+    title: 'Gemini',
+    options: [
+      { label: 'Nano Banana Pro', value: 'gemini-3-pro-image-preview' },
+      { label: 'imagen-4.0-preview', value: 'imagen-4.0-generate-preview-06-06' },
+      { label: 'imagen-4.0-ultra', value: 'imagen-4.0-ultra-generate-preview-06-06' }
+    ]
+  },
+  {
+    label: 'ideogram',
+    title: 'ideogram',
+    options: [
+      { label: 'ideogram_V_3', value: 'V_3' },
+      { label: 'ideogram_V_2', value: 'V_2' },
+      { label: 'ideogram_V_2_TURBO', value: 'V_2_TURBO' },
+      { label: 'ideogram_V_2A', value: 'V_2A' },
+      { label: 'ideogram_V_2A_TURBO', value: 'V_2A_TURBO' },
+      { label: 'ideogram_V_1', value: 'V_1' },
+      { label: 'ideogram_V_1_TURBO', value: 'V_1_TURBO' }
+    ]
+  },
+  {
+    label: 'Flux',
+    title: 'Flux',
+    options: [{ label: 'FLUX.1-Kontext-pro', value: 'FLUX.1-Kontext-pro' }]
+  }
+]
+
+const FALLBACK_REMIX_MODELS: ModelOption[] = [
+  { label: 'ideogram_V_3', value: 'V_3' },
+  { label: 'ideogram_V_2', value: 'V_2' },
+  { label: 'ideogram_V_2_TURBO', value: 'V_2_TURBO' },
+  { label: 'ideogram_V_2A', value: 'V_2A' },
+  { label: 'ideogram_V_2A_TURBO', value: 'V_2A_TURBO' },
+  { label: 'ideogram_V_1', value: 'V_1' },
+  { label: 'ideogram_V_1_TURBO', value: 'V_1_TURBO' }
+]
+
+const isImageModel = (model: Model): boolean => {
+  const name = (model.id || model.name || '').toLowerCase()
+  return (
+    name.startsWith('gpt-image-') ||
+    (name.startsWith('gemini-') && name.includes('image')) ||
+    name.startsWith('imagen-') ||
+    name.startsWith('v_') ||
+    name.startsWith('flux')
+  )
+}
+
+const isRemixModel = (model: Model): boolean => {
+  const name = (model.id || model.name || '').toLowerCase()
+  return name.startsWith('v_')
+}
+
+const GROUP_ORDER = ['OpenAI', 'Google', 'ideogram', 'Flux']
+
+const getGroupName = (model: Model): string => {
+  if (model.group) return model.group
+  const name = (model.id || model.name || '').toLowerCase()
+  if (name.startsWith('gpt-image-')) return 'OpenAI'
+  if (name.startsWith('gemini-') || name.startsWith('imagen-')) return 'Google'
+  if (name.startsWith('v_')) return 'ideogram'
+  if (name.startsWith('flux')) return 'Flux'
+  return model.group || 'Other'
+}
+
+export const getAihubmixGenerateModels = (providerModels: Model[]): GenerateModelOption[] => {
+  const imageModels = providerModels.filter(isImageModel)
+  if (imageModels.length === 0) return FALLBACK_GENERATE_MODELS
+
+  const grouped: Record<string, ModelOption[]> = {}
+  for (const model of imageModels) {
+    const group = getGroupName(model)
+    if (!grouped[group]) grouped[group] = []
+    grouped[group].push({ label: model.name || model.id, value: model.id })
+  }
+
+  const result: GenerateModelOption[] = []
+  for (const group of GROUP_ORDER) {
+    if (grouped[group]) {
+      result.push({ label: group, title: group, options: grouped[group] })
+    }
+  }
+  for (const [group, options] of Object.entries(grouped)) {
+    if (!GROUP_ORDER.includes(group)) {
+      result.push({ label: group, title: group, options })
+    }
+  }
+
+  return result.length > 0 ? result : FALLBACK_GENERATE_MODELS
+}
+
+export const getAihubmixRemixModels = (providerModels: Model[]): ModelOption[] => {
+  const remixModels = providerModels.filter(isRemixModel)
+  if (remixModels.length === 0) return FALLBACK_REMIX_MODELS
+  return remixModels.map((m) => ({ label: m.name || m.id, value: m.id }))
+}
 
 // 配置项类型定义
 export type ConfigItem = {
@@ -56,8 +184,10 @@ export type ConfigItem = {
 
 export type AihubmixMode = 'aihubmix_image_generate' | 'aihubmix_image_remix' | 'aihubmix_image_upscale'
 
-// 创建配置项函数
-export const createModeConfigs = (): Record<AihubmixMode, ConfigItem[]> => {
+export const createModeConfigs = (
+  generateModels?: GenerateModelOption[],
+  remixModels?: ModelOption[]
+): Record<AihubmixMode, ConfigItem[]> => {
   return {
     aihubmix_image_generate: [
       {
@@ -65,43 +195,7 @@ export const createModeConfigs = (): Record<AihubmixMode, ConfigItem[]> => {
         key: 'model',
         title: 'paintings.model',
         tooltip: 'paintings.generate.model_tip',
-        options: [
-          {
-            label: 'OpenAI',
-            title: 'OpenAI',
-            options: [
-              { label: 'gpt-image-2', value: 'gpt-image-2' },
-              { label: 'gpt-image-1', value: 'gpt-image-1' }
-            ]
-          },
-          {
-            label: 'Gemini',
-            title: 'Gemini',
-            options: [
-              { label: 'Nano Banana Pro', value: 'gemini-3-pro-image-preview' },
-              { label: 'imagen-4.0-preview', value: 'imagen-4.0-generate-preview-06-06' },
-              { label: 'imagen-4.0-ultra', value: 'imagen-4.0-ultra-generate-preview-06-06' }
-            ]
-          },
-          {
-            label: 'ideogram',
-            title: 'ideogram',
-            options: [
-              { label: 'ideogram_V_3', value: 'V_3' },
-              { label: 'ideogram_V_2', value: 'V_2' },
-              { label: 'ideogram_V_2_TURBO', value: 'V_2_TURBO' },
-              { label: 'ideogram_V_2A', value: 'V_2A' },
-              { label: 'ideogram_V_2A_TURBO', value: 'V_2A_TURBO' },
-              { label: 'ideogram_V_1', value: 'V_1' },
-              { label: 'ideogram_V_1_TURBO', value: 'V_1_TURBO' }
-            ]
-          },
-          {
-            label: 'Flux',
-            title: 'Flux',
-            options: [{ label: 'FLUX.1-Kontext-pro', value: 'FLUX.1-Kontext-pro' }]
-          }
-        ]
+        options: generateModels || FALLBACK_GENERATE_MODELS
       },
       {
         type: 'select',
@@ -172,7 +266,7 @@ export const createModeConfigs = (): Record<AihubmixMode, ConfigItem[]> => {
           { label: '2:3', value: '1024x1536' }
         ],
         initialValue: '1024x1024',
-        condition: (painting) => painting.model === 'gpt-image-1' || painting.model === 'gpt-image-2'
+        condition: (painting) => Boolean(painting.model?.startsWith('gpt-image-'))
       },
       {
         type: 'slider',
@@ -182,7 +276,7 @@ export const createModeConfigs = (): Record<AihubmixMode, ConfigItem[]> => {
         min: 1,
         max: 10,
         initialValue: 1,
-        condition: (painting) => painting.model === 'gpt-image-1' || painting.model === 'gpt-image-2'
+        condition: (painting) => Boolean(painting.model?.startsWith('gpt-image-'))
       },
       {
         type: 'select',
@@ -190,7 +284,7 @@ export const createModeConfigs = (): Record<AihubmixMode, ConfigItem[]> => {
         title: 'paintings.quality',
         options: QUALITY_OPTIONS,
         initialValue: 'auto',
-        condition: (painting) => painting.model === 'gpt-image-1' || painting.model === 'gpt-image-2'
+        condition: (painting) => Boolean(painting.model?.startsWith('gpt-image-'))
       },
       {
         type: 'select',
@@ -198,18 +292,18 @@ export const createModeConfigs = (): Record<AihubmixMode, ConfigItem[]> => {
         title: 'paintings.moderation',
         options: MODERATION_OPTIONS,
         initialValue: 'auto',
-        condition: (painting) => painting.model === 'gpt-image-1'
+        condition: (painting) => Boolean(painting.model?.startsWith('gpt-image-1'))
       },
       {
         type: 'select',
         key: 'background',
         title: 'paintings.background',
         options: (_config, painting) =>
-          painting?.model === 'gpt-image-2'
+          painting?.model?.startsWith('gpt-image-2')
             ? BACKGROUND_OPTIONS.filter((opt) => opt.value !== 'transparent')
             : BACKGROUND_OPTIONS,
         initialValue: 'auto',
-        condition: (painting) => painting.model === 'gpt-image-1' || painting.model === 'gpt-image-2'
+        condition: (painting) => Boolean(painting.model?.startsWith('gpt-image-'))
       },
       {
         type: 'slider',
@@ -300,15 +394,7 @@ export const createModeConfigs = (): Record<AihubmixMode, ConfigItem[]> => {
         key: 'model',
         title: 'paintings.model',
         tooltip: 'paintings.remix.model_tip',
-        options: [
-          { label: 'ideogram_V_3', value: 'V_3' },
-          { label: 'ideogram_V_2', value: 'V_2' },
-          { label: 'ideogram_V_2_TURBO', value: 'V_2_TURBO' },
-          { label: 'ideogram_V_2A', value: 'V_2A' },
-          { label: 'ideogram_V_2A_TURBO', value: 'V_2A_TURBO' },
-          { label: 'ideogram_V_1', value: 'V_1' },
-          { label: 'ideogram_V_1_TURBO', value: 'V_1_TURBO' }
-        ]
+        options: remixModels || FALLBACK_REMIX_MODELS
       },
       {
         type: 'select',


### PR DESCRIPTION
### What this PR does

Before this PR:
The AihubmixPage hardcoded model IDs (`gpt-image-1`, `gpt-image-2`) in the painting config dropdown and API routing logic. When AiHubMix returns variant model IDs like `gpt-image-2-text-to-image`, the dropdown cannot list them and the API call sends the wrong model ID, causing failures.

After this PR:
The model dropdown dynamically loads options from `provider.models`, filtered by known image model ID patterns, with a hardcoded fallback. API routing uses prefix matching (`startsWith('gpt-image-')`) instead of exact equality to handle variant model IDs. Version-sensitive checks (moderation for v1, transparent background exclusion for v2) are preserved with version-specific prefixes.

Fixes #15304

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Model filtering uses ID prefix matching (`startsWith`) rather than a structured field like `endpoint_type`, because AiHubMix's model fetcher (`aiHubMixFetcher` in `listModels.ts`) does not map the `types`/`endpoints` fields from the API response to the `Model` type. ID matching is the only viable approach given current data.
- A hardcoded fallback is retained for when `provider.models` is empty (user hasn't fetched models yet), ensuring the UI remains functional.

The following alternatives were considered:
- Using `Model.endpoint_type === 'image-generation'` (as NewApiPage does) — not feasible because AiHubMix models lack this field.
- Making all API routing fully dynamic — rejected because the 5 different API protocols (ideogram V1/V2, ideogram V3, Gemini native, OpenAI, Google Imagen) require fundamentally different request formats. The model→protocol mapping is business logic, not configuration.

Links to places where the discussion took place:
https://github.com/CherryHQ/cherry-studio/issues/15304

### Breaking changes

None. Existing behavior is preserved for all currently supported model IDs. The prefix matching is strictly more permissive than the previous exact matching.

### Special notes for your reviewer

- The `isImageModel` filter covers: `gpt-image-*`, `gemini-*image*`, `imagen-*`, `V_*` (ideogram), `flux*`. These match the hardcoded models that existed before this PR.
- Two files changed: `aihubmixConfig.tsx` (+97 lines, mostly the new filter/group functions and fallback arrays) and `AihubmixPage.tsx` (config creation moved from module-level to component-level via `useState` + `useEffect`).

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix AiHubMix painting page failing when provider returns variant model IDs (e.g. `gpt-image-2-text-to-image`). Model dropdown now dynamically loads from provider model list instead of hardcoded values.
```
