### PR TITLE
fix(websearch): align ExaMCP response parser with server field names

### DIFF
--- a/src/renderer/src/providers/WebSearchProvider/ExaMcpProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/ExaMcpProvider.ts
@@ -144,15 +144,13 @@ export default class ExaMcpProvider extends BaseWebSearchProvider {
       lines.forEach((line, idx) => {
         if (line.startsWith('Title:')) {
           title = line.replace(/^Title:\s*/, '')
-        } else if (line.startsWith('Published Date:')) {
-          publishedDate = line.replace(/^Published Date:\s*/, '')
+        } else if (line.startsWith('Published:')) {
+          publishedDate = line.replace(/^Published:\s*/, '')
         } else if (line.startsWith('URL:')) {
           url = line.replace(/^URL:\s*/, '')
-        } else if (line.startsWith('Text:') && textStartIndex === -1) {
-          // mark where "Text:" starts
+        } else if ((line.startsWith('Text:') || line.startsWith('Highlights:')) && textStartIndex === -1) {
           textStartIndex = idx
-          // text on the same line after "Text: "
-          fullText = line.replace(/^Text:\s*/, '')
+          fullText = line.replace(/^(?:Text|Highlights):\s*/, '')
         }
       })
       if (textStartIndex !== -1) {

--- a/src/renderer/src/providers/WebSearchProvider/__tests__/ExaMcpProvider.test.ts
+++ b/src/renderer/src/providers/WebSearchProvider/__tests__/ExaMcpProvider.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.stubGlobal('keyv', {
+  get: vi.fn(),
+  set: vi.fn()
+})
+
+import ExaMcpProvider from '../ExaMcpProvider'
+
+function createProvider(overrides = {}) {
+  return new ExaMcpProvider({
+    id: 'exa-mcp',
+    name: 'ExaMCP',
+    apiHost: 'https://mcp.exa.ai/mcp',
+    ...overrides
+  })
+}
+
+const defaultWebsearch = { maxResults: 5 } as any
+
+const HIGHLIGHTS_RESPONSE = [
+  'Title: Hello, world',
+  'URL: https://en.wikipedia.org/wiki/Hello_world',
+  'Published: 2024-01-15T00:00:00.000Z',
+  'Author: Wikipedia',
+  'Highlights:',
+  'A "Hello, world" program is a simple computer program.',
+  '[...]',
+  'The tradition was influenced by the 1978 book The C Programming Language.',
+  '',
+  '---',
+  '',
+  'Title: Second Result',
+  'URL: https://example.com/second',
+  'Published: N/A',
+  'Author: N/A',
+  'Highlights:',
+  'This is the second result content.'
+].join('\n')
+
+const TEXT_RESPONSE = [
+  'Title: Text-based Result',
+  'URL: https://example.com/text',
+  'Published: 2024-06-01',
+  'Author: Test',
+  'Text: Full article text content here.',
+  'More text on another line.'
+].join('\n')
+
+function wrapAsJsonRpc(text: string) {
+  return JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    result: {
+      content: [{ type: 'text', text }]
+    }
+  })
+}
+
+function wrapAsSse(text: string) {
+  return `event: message\ndata: ${wrapAsJsonRpc(text)}\n\n`
+}
+
+describe('ExaMcpProvider', () => {
+  let provider: ExaMcpProvider
+
+  beforeEach(() => {
+    provider = createProvider()
+  })
+
+  describe('search with Highlights: format (current Exa MCP response)', () => {
+    it('parses SSE response with Highlights fields correctly', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+        ok: true,
+        text: async () => wrapAsSse(HIGHLIGHTS_RESPONSE)
+      } as Response)
+
+      const result = await provider.search('hello world', defaultWebsearch)
+
+      expect(result.results).toHaveLength(2)
+      expect(result.results[0]).toEqual({
+        title: 'Hello, world',
+        url: 'https://en.wikipedia.org/wiki/Hello_world',
+        content: expect.stringContaining('A "Hello, world" program is a simple computer program.')
+      })
+      expect(result.results[0].content).toContain('The tradition was influenced by')
+      expect(result.results[1]).toEqual({
+        title: 'Second Result',
+        url: 'https://example.com/second',
+        content: 'This is the second result content.'
+      })
+    })
+
+    it('parses direct JSON response with Highlights fields correctly', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+        ok: true,
+        text: async () => wrapAsJsonRpc(HIGHLIGHTS_RESPONSE)
+      } as Response)
+
+      const result = await provider.search('hello world', defaultWebsearch)
+
+      expect(result.results).toHaveLength(2)
+      expect(result.results[0].title).toBe('Hello, world')
+      expect(result.results[0].content).toContain('A "Hello, world" program')
+    })
+  })
+
+  describe('search with Text: format (legacy fallback)', () => {
+    it('parses Text field correctly', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+        ok: true,
+        text: async () => wrapAsJsonRpc(TEXT_RESPONSE)
+      } as Response)
+
+      const result = await provider.search('test', defaultWebsearch)
+
+      expect(result.results).toHaveLength(1)
+      expect(result.results[0]).toEqual({
+        title: 'Text-based Result',
+        url: 'https://example.com/text',
+        content: expect.stringContaining('Full article text content here.')
+      })
+      expect(result.results[0].content).toContain('More text on another line.')
+    })
+  })
+
+  describe('respects maxResults', () => {
+    it('limits results to maxResults', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+        ok: true,
+        text: async () => wrapAsJsonRpc(HIGHLIGHTS_RESPONSE)
+      } as Response)
+
+      const result = await provider.search('test', { maxResults: 1 } as any)
+
+      expect(result.results).toHaveLength(1)
+    })
+  })
+
+  describe('error handling', () => {
+    it('throws on empty query', async () => {
+      await expect(provider.search('  ', defaultWebsearch)).rejects.toThrow('Search failed')
+    })
+
+    it('throws on HTTP error', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        text: async () => 'Rate limited'
+      } as Response)
+
+      await expect(provider.search('test', defaultWebsearch)).rejects.toThrow('Search failed')
+    })
+  })
+})


### PR DESCRIPTION
### What this PR does

Before this PR:

`ExaMcpProvider.parsetextChunk` used incorrect field names (`Published Date:` and `Text:`) that did not match the Exa MCP server's actual response format, causing search result `content` to always be empty.

After this PR:

Parser field names align with the Exa MCP server source ([`exa-labs/exa-mcp-server`](https://github.com/exa-labs/exa-mcp-server) `src/tools/webSearch.ts`): `Published:` for date and `Highlights:` / `Text:` for content. Search results now correctly populate the `content` field.

### Why we need it and why it was done in this way

The Exa MCP server formats responses with `Published:` (not `Published Date:`) and prioritizes `Highlights:` (highlighted excerpts) over `Text:` (full text). The parser was written against an assumed format that never matched the actual server output.

The following tradeoffs were made:

- `Published Date:` was removed entirely (not kept as fallback) since the server never used it.
- Both `Text:` and `Highlights:` are supported because the server uses both — `Highlights:` when highlight excerpts exist, `Text:` as fallback.

The following alternatives were considered:

None — this is a direct alignment with the upstream server's documented behavior.

### Breaking changes

None.

### Special notes for your reviewer

Verified against the live Exa MCP endpoint (`https://mcp.exa.ai/mcp`) and the official server source code at `exa-labs/exa-mcp-server`.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix: ExaMCP web search now correctly returns result content by aligning parser with server response format
```