### PR TITLE
fix(channels): auto-retry on stale SDK session ID

### DIFF
--- a/src/main/services/agents/services/SessionMessageService.ts
+++ b/src/main/services/agents/services/SessionMessageService.ts
@@ -429,6 +429,32 @@ export class SessionMessageService extends BaseService {
     return result
   }
 
+  /**
+   * Clear the stale agent_session_id for a session so the next SDK call starts fresh.
+   * Called when the SDK reports "No conversation found with session ID" — the stored
+   * ID references a conversation that no longer exists in the SDK's internal state.
+   */
+  async clearStaleAgentSessionId(sessionId: string): Promise<void> {
+    try {
+      const database = await this.getDatabase()
+      await database
+        .update(sessionMessagesTable)
+        .set({ agent_session_id: '' })
+        .where(
+          and(
+            eq(sessionMessagesTable.session_id, sessionId),
+            not(eq(sessionMessagesTable.agent_session_id, ''))
+          )
+        )
+      logger.info('Cleared stale agent_session_id for session', { sessionId })
+    } catch (error) {
+      logger.warn('Failed to clear stale agent_session_id', {
+        sessionId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+  }
+
   private async getLastAgentSessionId(sessionId: string): Promise<string> {
     try {
       const database = await this.getDatabase()

--- a/src/main/services/agents/services/channels/ChannelMessageHandler.ts
+++ b/src/main/services/agents/services/channels/ChannelMessageHandler.ts
@@ -568,6 +568,20 @@ export class ChannelMessageHandler {
     images?: ImageAttachment[],
     rendererIsWatching: boolean = false
   ): Promise<string> {
+    return this.doCollectStreamResponse(session, content, abortController, adapter, chatId, displayContent, images, rendererIsWatching, false)
+  }
+
+  private async doCollectStreamResponse(
+    session: GetAgentSessionResponse,
+    content: string,
+    abortController: AbortController,
+    adapter: ChannelAdapter,
+    chatId: string,
+    displayContent: string | undefined,
+    images: ImageAttachment[] | undefined,
+    rendererIsWatching: boolean,
+    isRetry: boolean
+  ): Promise<string> {
     // Use the pre-computed rendererIsWatching flag from processIncoming.
     // When renderer is watching: persist=false (renderer handles rich block persistence),
     //   stream chunks and events are forwarded to the renderer via the bus.
@@ -642,12 +656,32 @@ export class ChannelMessageHandler {
       // Trim trailing separator
       return (completedText + currentBlockText).replace(/\n+$/, '')
     } catch (error) {
+      // Auto-retry when the SDK reports a stale resume session ID.
+      // This happens when Cherry Studio's database still references a conversation
+      // that was cleared from the SDK's internal state (e.g., after SDK process restart).
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      if (
+        !isRetry &&
+        /No conversation found with session ID/i.test(errorMsg) &&
+        !abortController.signal.aborted
+      ) {
+        logger.warn('SDK resume failed (stale session ID), clearing and retrying without resume', {
+          sessionId: session.id,
+          agentId: session.agent_id
+        })
+        await sessionMessageService.clearStaleAgentSessionId(session.id)
+        return this.doCollectStreamResponse(
+          session, content, abortController, adapter, chatId,
+          displayContent, images, rendererIsWatching, true
+        )
+      }
+
       if (rendererIsWatching) {
         sessionStreamBus.publish(session.id, {
           sessionId: session.id,
           agentId: session.agent_id,
           type: 'error',
-          error: { message: error instanceof Error ? error.message : String(error) }
+          error: { message: errorMsg }
         })
       }
       throw error


### PR DESCRIPTION
## Summary

- Add `clearStaleAgentSessionId()` to `SessionMessageService` to clear stale `agent_session_id` from the database
- Add auto-retry logic in `ChannelMessageHandler.collectStreamResponse`: when the SDK reports "No conversation found with session ID", clear the stale ID and retry without resume (once)

## Problem

When the Claude Code SDK process restarts (e.g., Cherry Studio restart, SDK subprocess recycling), the SDK's in-memory conversation state is lost. However, the database still stores the old `agent_session_id` in the `session_messages` table. On the next channel message:

1. `getLastAgentSessionId()` retrieves the stale ID from the database
2. `claudeCodeService.invoke()` sets `options.resume = staleId`
3. SDK subprocess can't find the conversation → throws "No conversation found with session ID"
4. Every subsequent message hits the same error — the stale ID is never cleared

The `/clear` command doesn't help because it only skips resume for that single call (it's in `NO_RESUME_COMMANDS`) but doesn't clear the stale ID from the database.

## Fix

When the specific "No conversation found with session ID" error is detected:

1. Call `clearStaleAgentSessionId()` to clear all stale `agent_session_id` entries for the session
2. Retry the stream once — `getLastAgentSessionId()` now returns empty, so no resume is attempted
3. SDK starts a fresh conversation, and the new `agent_session_id` is persisted for future resume

The retry is guarded by `isRetry` flag to prevent infinite loops, and skipped if the user has already aborted.

## Test plan

- [ ] Start a channel conversation, verify normal operation
- [ ] Restart Cherry Studio, send another message — should auto-recover instead of erroring
- [ ] Verify old session history is preserved (not deleted)
- [ ] Verify the retry only happens once (if retry also fails, error propagates normally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)