### PR TITLE
fix: keep note toolbar static at top during scroll

### DIFF
--- a/src/renderer/src/components/RichEditor/styles.ts
+++ b/src/renderer/src/components/RichEditor/styles.ts
@@ -14,6 +14,7 @@ export const RichEditorWrapper = styled.div<{
   border-radius: 6px;
   background: var(--color-background);
   overflow-y: hidden;
+  min-height: 0;
   .ProseMirror table,
   .tiptap table {
     table-layout: auto !important;
@@ -59,6 +60,9 @@ export const ToolbarWrapper = styled.div`
   overflow-x: auto;
   overflow-y: hidden;
   white-space: nowrap;
+  position: sticky;
+  top: 0;
+  z-index: 10;
 
   &::-webkit-scrollbar-track {
     background: var(--color-background-soft);

--- a/src/renderer/src/pages/notes/NotesEditor.tsx
+++ b/src/renderer/src/pages/notes/NotesEditor.tsx
@@ -161,7 +161,7 @@ const RichEditorContainer = styled.div`
     flex: 1;
     background: transparent;
 
-    .rich-editor-wrapper {
+    &.rich-editor-wrapper {
       height: 100%;
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
### What this PR does

Before this PR:
When editing long notes, the styling toolbar scrolled up and disappeared as the user scrolled down the content, making it hard to apply text styles to content further in the note.

After this PR:
The toolbar stays fixed at the top of the editor regardless of scroll position.

Fixes #15294

### Why we need it and why it was done in this way

The toolbar was structurally placed outside the scroll container in the DOM, which was architecturally correct. However, two issues undermined this:

1. **Invalid CSS selector** — The CSS in `NotesEditor.tsx` used `.notes-rich-editor .rich-editor-wrapper`, a descendant selector. Since the `RichEditorWrapper` element carries both classes (`rich-editor-wrapper notes-rich-editor`), an element cannot be a descendant of itself. The overrides (`height: 100%`, flex properties) never applied, breaking height propagation in the flex chain.

2. **No sticky fallback** — `ToolbarWrapper` lacked `position: sticky`, so when any ancestor became the effective scroll container due to the broken flex chain, the toolbar scrolled away.

The following tradeoffs were made:
- `position: sticky` on the toolbar is a defensive fix that handles any ancestor becoming the scroll container, not just the known broken-flex-chain scenario.

The following alternatives were considered:
- Moving the toolbar outside `RichEditorWrapper` entirely (more invasive, requires restructuring)
- Fixing the height chain at every ancestor level (fragile, easy to regress)

Links to places where the discussion took place:
- https://github.com/CherryHQ/cherry-studio/issues/15294

### Breaking changes

None.

### Special notes for your reviewer

The `min-height: 0` on `RichEditorWrapper` is a standard flexbox fix that allows the flex container to shrink below its content height. Without it, a flex child with `display: flex; flex-direction: column` defaults to `min-height: auto`, preventing proper shrink.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via `/gh-pr-review`, `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix note toolbar scrolling away when editing long notes — toolbar now stays fixed at the top of the editor.
```