### PR TITLE
fix: add CherryIN DeepSeek 1m suffix

### DIFF
--- a/src/main/services/agents/services/claudecode/__tests__/utils.test.ts
+++ b/src/main/services/agents/services/claudecode/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { isDeepSeekOfficialHost, isMiMoOfficialHost, with1mContextSuffix } from '../utils'
+import { isCherryInOfficialHost, isDeepSeekOfficialHost, isMiMoOfficialHost, with1mContextSuffix } from '../utils'
 
 describe('isDeepSeekOfficialHost', () => {
   it('matches the canonical DeepSeek Anthropic endpoint', () => {
@@ -53,8 +53,30 @@ describe('isMiMoOfficialHost', () => {
   })
 })
 
+describe('isCherryInOfficialHost', () => {
+  it('matches CherryIN official endpoints', () => {
+    expect(isCherryInOfficialHost('https://open.cherryin.cc')).toBe(true)
+    expect(isCherryInOfficialHost('https://open.cherryin.net/anthropic')).toBe(true)
+    expect(isCherryInOfficialHost('  https://open.cherryin.ai/v1  ')).toBe(true)
+    expect(isCherryInOfficialHost('https://open.cherryin.dev')).toBe(true)
+  })
+
+  it('rejects third-party and lookalike hosts', () => {
+    expect(isCherryInOfficialHost('https://openrouter.ai/api/v1')).toBe(false)
+    expect(isCherryInOfficialHost('https://open.cherryin.net.evil.com')).toBe(false)
+    expect(isCherryInOfficialHost('https://notopen.cherryin.net')).toBe(false)
+  })
+
+  it('handles missing or malformed hosts gracefully', () => {
+    expect(isCherryInOfficialHost(undefined)).toBe(false)
+    expect(isCherryInOfficialHost('')).toBe(false)
+    expect(isCherryInOfficialHost('not a url')).toBe(false)
+  })
+})
+
 describe('with1mContextSuffix', () => {
   const deepSeekHost = 'https://api.deepseek.com/anthropic'
+  const cherryInHost = 'https://open.cherryin.cc'
   const mimoHost = 'https://api.xiaomimimo.com/anthropic'
   const thirdPartyHost = 'https://openrouter.ai/api/v1'
 
@@ -67,6 +89,13 @@ describe('with1mContextSuffix', () => {
   it('appends [1m] to DeepSeek V4+ Flash (also 1M context)', () => {
     expect(with1mContextSuffix('deepseek-v4-flash', deepSeekHost)).toBe('deepseek-v4-flash[1m]')
     expect(with1mContextSuffix('deepseek-v5-flash', deepSeekHost)).toBe('deepseek-v5-flash[1m]')
+  })
+
+  it('appends [1m] to CherryIN DeepSeek V4+ agent models', () => {
+    expect(with1mContextSuffix('agent/deepseek-v4-flash', cherryInHost)).toBe('agent/deepseek-v4-flash[1m]')
+    expect(with1mContextSuffix('deepseek/deepseek-v4-flash', cherryInHost)).toBe('deepseek/deepseek-v4-flash[1m]')
+    expect(with1mContextSuffix('agent/deepseek-v4-pro', cherryInHost)).toBe('agent/deepseek-v4-pro[1m]')
+    expect(with1mContextSuffix('deepseek/deepseek-v4-pro', cherryInHost)).toBe('deepseek/deepseek-v4-pro[1m]')
   })
 
   it('appends [1m] to MiMo V2.5+ Pro/base models on the official host', () => {
@@ -100,6 +129,7 @@ describe('with1mContextSuffix', () => {
   it('does not append [1m] when host is not an official 1M host', () => {
     expect(with1mContextSuffix('deepseek-v4-pro', thirdPartyHost)).toBe('deepseek-v4-pro')
     expect(with1mContextSuffix('deepseek-v4-pro', undefined)).toBe('deepseek-v4-pro')
+    expect(with1mContextSuffix('agent/deepseek-v4-flash', thirdPartyHost)).toBe('agent/deepseek-v4-flash')
     expect(with1mContextSuffix('mimo-v2.5-pro', thirdPartyHost)).toBe('mimo-v2.5-pro')
   })
 

--- a/src/main/services/agents/services/claudecode/utils.ts
+++ b/src/main/services/agents/services/claudecode/utils.ts
@@ -124,12 +124,28 @@ const DEEPSEEK_V4_PLUS_REGEX = /(\w+-)?deepseek-v([4-9]|\d{2,})([.-]\w+)*$/i
 // official Claude Code docs document the same `[1m]` suffix convention.
 // https://platform.xiaomimimo.com/docs/zh-CN/integration/claudecode
 const MIMO_V25_PLUS_REGEX = /(\w+-)?mimo-v(2\.[5-9]|2\.\d{2,}|[3-9]|\d{2,})([.-]\w+)*$/i
+const CHERRYIN_OFFICIAL_HOSTNAMES = new Set([
+  'open.cherryin.ai',
+  'open.cherryin.cc',
+  'open.cherryin.dev',
+  'open.cherryin.net'
+])
 
 export function isDeepSeekOfficialHost(host: string | undefined): boolean {
   const trimmed = host?.trim()
   if (!trimmed) return false
   try {
     return new URL(trimmed).hostname.endsWith('api.deepseek.com')
+  } catch {
+    return false
+  }
+}
+
+export function isCherryInOfficialHost(host: string | undefined): boolean {
+  const trimmed = host?.trim()
+  if (!trimmed) return false
+  try {
+    return CHERRYIN_OFFICIAL_HOSTNAMES.has(new URL(trimmed).hostname)
   } catch {
     return false
   }
@@ -154,7 +170,7 @@ export function with1mContextSuffix(modelId: string | undefined, anthropicHost: 
   if (!modelId) return ''
   if (/\[1m\]$/i.test(modelId)) return modelId
 
-  if (isDeepSeekOfficialHost(anthropicHost)) {
+  if (isDeepSeekOfficialHost(anthropicHost) || isCherryInOfficialHost(anthropicHost)) {
     if (!DEEPSEEK_V4_PLUS_REGEX.test(modelId)) return modelId
     return `${modelId}[1m]`
   }


### PR DESCRIPTION
### What this PR does

Before this PR:
DeepSeek V4+ models accessed through CherryIN official endpoints (`open.cherryin.ai`, `open.cherryin.cc`, `open.cherryin.dev`, `open.cherryin.net`) did not receive the `[1m]` context suffix, preventing 1M context window activation.

After this PR:
The `with1mContextSuffix` utility correctly recognizes CherryIN official hosts and appends the `[1m]` suffix to qualifying DeepSeek V4+ models (e.g., `agent/deepseek-v4-flash`, `deepseek/deepseek-v4-pro`).

Fixes #

### Why we need it and why it was done in this way

CherryIN is an official provider that supports the same `[1m]` suffix convention as DeepSeek's own API. Without this fix, users on CherryIN endpoints miss out on 1M context window support for eligible models.

The implementation follows the existing pattern: a hostname set + helper function (`isCherryInOfficialHost`), mirroring how DeepSeek and MiMo official hosts are already handled. The `with1mContextSuffix` function is extended to also check CherryIN hosts when applying the DeepSeek V4+ regex.

The following tradeoffs were made:
None — this is a minimal addition that reuses existing patterns.

The following alternatives were considered:
None — the existing architecture clearly defines how to add new official hosts.

### Breaking changes

None.

### Special notes for your reviewer

The CherryIN model IDs include path prefixes like `agent/` or `deepseek/` (e.g., `agent/deepseek-v4-flash`). The existing `DEEPSEEK_V4_PLUS_REGEX` already handles these via the `(\w+-)?` prefix group, but the test cases explicitly verify this behavior.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
