### PR TITLE
Hotfix/fix bocha web search schema

### DIFF
--- a/src/renderer/src/providers/WebSearchProvider/BochaProvider.ts
+++ b/src/renderer/src/providers/WebSearchProvider/BochaProvider.ts
@@ -34,8 +34,7 @@ export default class BochaProvider extends BaseWebSearchProvider {
         count: websearch.maxResults,
         exclude: websearch.excludeDomains.join(','),
         freshness: websearch.searchWithTime ? 'oneDay' : 'noLimit',
-        summary: true,
-        page: 1
+        summary: true
       }
 
       const response = await fetch(`${this.apiHost}/v1/web-search`, {

--- a/src/renderer/src/providers/WebSearchProvider/__tests__/BochaProvider.test.ts
+++ b/src/renderer/src/providers/WebSearchProvider/__tests__/BochaProvider.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn()
+    })
+  }
+}))
+
+vi.stubGlobal('keyv', {
+  get: vi.fn(),
+  set: vi.fn()
+})
+
+import BochaProvider from '../BochaProvider'
+
+function createProvider() {
+  return new BochaProvider({
+    id: 'bocha',
+    name: 'Bocha',
+    apiHost: 'https://api.bochaai.com',
+    apiKey: 'test-key'
+  } as any)
+}
+
+const defaultWebsearch = {
+  maxResults: 5,
+  excludeDomains: ['example.com', 'foo.bar'],
+  searchWithTime: true
+} as any
+
+describe('BochaProvider', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('sends supported request params without page', async () => {
+    const provider = createProvider()
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        code: 200,
+        log_id: 'test-log-id',
+        msg: null,
+        data: {
+          _type: 'SearchResponse',
+          queryContext: {
+            originalQuery: '阿里巴巴2024年的esg报告'
+          },
+          webPages: {
+            webSearchUrl: '',
+            totalEstimatedMatches: 1,
+            value: [
+              {
+                id: null,
+                name: '结果标题',
+                url: 'https://example.com/result',
+                displayUrl: 'https://example.com/result',
+                snippet: '摘要片段',
+                siteName: 'example.com',
+                siteIcon: 'https://example.com/favicon.ico',
+                dateLastCrawled: '2024-07-22T00:00:00Z',
+                cachedPageUrl: null,
+                language: null,
+                isFamilyFriendly: null,
+                isNavigational: null
+              }
+            ],
+            someResultsRemoved: true
+          },
+          images: {
+            id: null,
+            readLink: null,
+            webSearchUrl: null,
+            isFamilyFriendly: null,
+            value: []
+          },
+          videos: null
+        }
+      })
+    } as Response)
+
+    await provider.search('阿里巴巴2024年的esg报告', defaultWebsearch)
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    const [, requestInit] = vi.mocked(fetch).mock.calls[0]
+    const body = JSON.parse(String(requestInit?.body))
+
+    expect(body).toEqual({
+      query: '阿里巴巴2024年的esg报告',
+      count: 5,
+      exclude: 'example.com,foo.bar',
+      freshness: 'oneDay',
+      summary: true
+    })
+    expect(body).not.toHaveProperty('page')
+  })
+
+  it('maps latest response fields into search results', async () => {
+    const provider = createProvider()
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        code: 200,
+        log_id: 'test-log-id',
+        msg: null,
+        data: {
+          _type: 'SearchResponse',
+          queryContext: {
+            originalQuery: '测试查询'
+          },
+          webPages: {
+            webSearchUrl: '',
+            totalEstimatedMatches: 2,
+            value: [
+              {
+                id: null,
+                name: '第一条结果',
+                url: 'https://example.com/1',
+                displayUrl: 'https://example.com/1',
+                snippet: '第一条 snippet',
+                summary: '第一条 summary',
+                siteName: 'example.com',
+                siteIcon: 'https://example.com/favicon.ico',
+                dateLastCrawled: '2024-07-22T00:00:00Z',
+                cachedPageUrl: null,
+                language: null,
+                isFamilyFriendly: null,
+                isNavigational: null
+              },
+              {
+                id: null,
+                name: '第二条结果',
+                url: 'https://example.com/2',
+                displayUrl: 'https://example.com/2',
+                snippet: '第二条 snippet',
+                siteName: 'example.com',
+                siteIcon: 'https://example.com/favicon.ico',
+                dateLastCrawled: '2024-07-22T00:00:00Z',
+                cachedPageUrl: null,
+                language: null,
+                isFamilyFriendly: null,
+                isNavigational: null
+              }
+            ],
+            someResultsRemoved: true
+          },
+          images: {
+            id: null,
+            readLink: null,
+            webSearchUrl: null,
+            isFamilyFriendly: null,
+            value: []
+          },
+          videos: null
+        }
+      })
+    } as Response)
+
+    const result = await provider.search('测试查询', defaultWebsearch)
+
+    expect(result).toEqual({
+      query: '测试查询',
+      results: [
+        {
+          title: '第一条结果',
+          content: '第一条 summary',
+          url: 'https://example.com/1'
+        },
+        {
+          title: '第二条结果',
+          content: '第二条 snippet',
+          url: 'https://example.com/2'
+        }
+      ]
+    })
+  })
+})

--- a/src/renderer/src/utils/__tests__/bocha.test.ts
+++ b/src/renderer/src/utils/__tests__/bocha.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import { BochaSearchResponseSchema } from '../bocha'
+
+describe('BochaSearchResponseSchema', () => {
+  it('accepts image thumbnail objects from the latest Bocha response', () => {
+    const result = BochaSearchResponseSchema.safeParse({
+      code: 200,
+      log_id: 'test-log-id',
+      msg: null,
+      data: {
+        _type: 'SearchResponse',
+        queryContext: {
+          originalQuery: '测试查询'
+        },
+        webPages: {
+          webSearchUrl: '',
+          totalEstimatedMatches: 1,
+          value: [
+            {
+              id: null,
+              name: '网页结果',
+              url: 'https://example.com/page',
+              displayUrl: 'https://example.com/page',
+              snippet: '网页摘要',
+              summary: '网页总结',
+              siteName: 'example.com',
+              siteIcon: 'https://example.com/favicon.ico',
+              datePublished: '2025-02-23T08:18:30+08:00',
+              dateLastCrawled: '2025-02-23T08:18:30Z',
+              cachedPageUrl: null,
+              language: null,
+              isFamilyFriendly: null,
+              isNavigational: null
+            }
+          ],
+          someResultsRemoved: false
+        },
+        images: {
+          id: null,
+          readLink: null,
+          webSearchUrl: null,
+          isFamilyFriendly: null,
+          value: [
+            {
+              webSearchUrl: null,
+              name: '图片结果',
+              thumbnailUrl: 'https://example.com/thumbnail.jpg',
+              datePublished: null,
+              contentUrl: 'https://example.com/image.jpg',
+              hostPageUrl: 'https://example.com/page',
+              contentSize: null,
+              encodingFormat: null,
+              hostPageDisplayUrl: null,
+              width: 553,
+              height: 311,
+              thumbnail: {
+                height: 311,
+                width: 553
+              }
+            }
+          ]
+        },
+        videos: null
+      }
+    })
+
+    expect(result.success).toBe(true)
+  })
+})

--- a/src/renderer/src/utils/bocha.ts
+++ b/src/renderer/src/utils/bocha.ts
@@ -100,12 +100,11 @@ const BochaSearchParamsSchema = z.object({
       message:
         'Invalid exclude format. Please provide valid domain names separated by | or ,. Maximum 20 domains allowed.'
     }),
-  page: z.number().optional().default(1),
   count: z.number().optional().default(10)
 })
 
 const BochaSearchResponseDataSchema = z.object({
-  type: z.string(),
+  _type: z.string(),
   queryContext: z.object({
     originalQuery: z.string()
   }),
@@ -114,7 +113,7 @@ const BochaSearchResponseDataSchema = z.object({
     totalEstimatedMatches: z.number(),
     value: z.array(
       z.object({
-        id: z.string(),
+        id: z.string().nullable(),
         name: z.string(),
         url: z.string(),
         displayUrl: z.string(),
@@ -122,84 +121,88 @@ const BochaSearchResponseDataSchema = z.object({
         summary: z.string().optional(),
         siteName: z.string(),
         siteIcon: z.string(),
-        datePublished: z.string(),
+        datePublished: z.string().optional(),
         dateLastCrawled: z.string(),
-        cachedPageUrl: z.string(),
-        language: z.string(),
-        isFamilyFriendly: z.boolean(),
-        isNavigational: z.boolean()
+        cachedPageUrl: z.string().nullable(),
+        language: z.string().nullable(),
+        isFamilyFriendly: z.boolean().nullable(),
+        isNavigational: z.boolean().nullable()
       })
     ),
-    someResultsRemoved: z.boolean()
+    someResultsRemoved: z.boolean().optional()
   }),
   images: z.object({
-    id: z.string(),
-    readLink: z.string(),
-    webSearchUrl: z.string(),
-    name: z.string(),
+    id: z.string().nullable(),
+    readLink: z.string().nullable().optional(),
+    webSearchUrl: z.string().nullable(),
+    isFamilyFriendly: z.boolean().nullable().optional(),
     value: z.array(
       z.object({
-        webSearchUrl: z.string(),
-        name: z.string(),
+        webSearchUrl: z.string().nullable(),
+        name: z.string().nullable(),
         thumbnailUrl: z.string(),
-        datePublished: z.string(),
+        datePublished: z.string().nullable(),
         contentUrl: z.string(),
         hostPageUrl: z.string(),
-        contentSize: z.string(),
-        encodingFormat: z.string(),
-        hostPageDisplayUrl: z.string(),
+        contentSize: z.string().nullable(),
+        encodingFormat: z.string().nullable(),
+        hostPageDisplayUrl: z.string().nullable(),
         width: z.number(),
         height: z.number(),
-        thumbnail: z.object({
-          width: z.number(),
-          height: z.number()
-        })
+        thumbnail: z.string().nullable()
       })
     )
   }),
-  videos: z.object({
-    id: z.string(),
-    readLink: z.string(),
-    webSearchUrl: z.string(),
-    isFamilyFriendly: z.boolean(),
-    scenario: z.string(),
-    name: z.string(),
-    value: z.array(
-      z.object({
-        webSearchUrl: z.string(),
-        name: z.string(),
-        description: z.string(),
-        thumbnailUrl: z.string(),
-        publisher: z.string(),
-        creator: z.string(),
-        contentUrl: z.string(),
-        hostPageUrl: z.string(),
-        encodingFormat: z.string(),
-        hostPageDisplayUrl: z.string(),
-        width: z.number(),
-        height: z.number(),
-        duration: z.number(),
-        motionThumbnailUrl: z.string(),
-        embedHtml: z.string(),
-        allowHttpsEmbed: z.boolean(),
-        viewCount: z.number(),
-        thumbnail: z.object({
+  videos: z
+    .object({
+      id: z.string().nullable(),
+      readLink: z.string().nullable(),
+      webSearchUrl: z.string().nullable(),
+      isFamilyFriendly: z.boolean(),
+      scenario: z.string(),
+      value: z.array(
+        z.object({
+          webSearchUrl: z.string(),
+          name: z.string(),
+          description: z.string(),
+          thumbnailUrl: z.string(),
+          publisher: z.array(
+            z.object({
+              name: z.string()
+            })
+          ),
+          creator: z.object({
+            name: z.string()
+          }),
+          contentUrl: z.string(),
+          hostPageUrl: z.string(),
+          encodingFormat: z.string(),
+          hostPageDisplayUrl: z.string(),
           width: z.number(),
-          height: z.number()
-        }),
-        allowMobileEmbed: z.boolean(),
-        isSuperfresh: z.boolean(),
-        datePublished: z.string()
-      })
-    )
-  })
+          height: z.number(),
+          duration: z.string(),
+          motionThumbnailUrl: z.string(),
+          embedHtml: z.string(),
+          allowHttpsEmbed: z.boolean(),
+          viewCount: z.number(),
+          thumbnail: z.object({
+            width: z.number(),
+            height: z.number()
+          }),
+          allowMobileEmbed: z.boolean(),
+          isSuperfresh: z.boolean(),
+          datePublished: z.string()
+        })
+      )
+    })
+    .nullable()
 })
 
 const BochaSearchResponseSchema = z.object({
   code: z.number(),
-  logId: z.string(),
+  log_id: z.string(),
   data: BochaSearchResponseDataSchema,
-  msg: z.string().optional()
+  msg: z.string().nullable().optional()
 })
 
 export type BochaSearchParams = z.infer<typeof BochaSearchParamsSchema>

--- a/src/renderer/src/utils/bocha.ts
+++ b/src/renderer/src/utils/bocha.ts
@@ -149,7 +149,12 @@ const BochaSearchResponseDataSchema = z.object({
         hostPageDisplayUrl: z.string().nullable(),
         width: z.number(),
         height: z.number(),
-        thumbnail: z.string().nullable()
+        thumbnail: z
+          .object({
+            height: z.number(),
+            width: z.number()
+          })
+          .nullable()
       })
     )
   }),


### PR DESCRIPTION
### What this PR does

Before this PR:

Bocha web search requests still sent the deprecated `page` parameter, and the local response schema was out of sync with the latest Bocha API response fields and nullability.

After this PR:

- Removed the unsupported `page` request parameter from `BochaProvider`
- Synced Bocha web search response schema with the latest official response contract
- Added focused unit tests to verify supported request params and latest response mapping

Fixes #

### Why we need it and why it was done in this way

This is a minimal hotfix for the `main` branch code-freeze policy.

Bocha officially confirmed that the public web search parameters no longer support `page`. The fix keeps the change minimal by:
- removing only the unsupported `page` parameter
- not introducing `include`, because the public API does not support it
- aligning the local Zod schema with the current official response structure and nullability
- adding focused unit tests to prevent regressions

The following tradeoffs were made:

- Kept the provider logic minimal and did not expand request options beyond the officially supported parameters
- Limited the fix scope to request compatibility, response typing, and regression tests

The following alternatives were considered:

- Adding new request parameters such as `include`
- Refactoring the provider to add stricter runtime schema parsing

These alternatives were not used because they would expand scope beyond a minimal hotfix.

Links to places where the discussion took place:

N/A

### Breaking changes

If this PR introduces breaking changes, please describe the changes and the impact on users.

No breaking changes.

### Special notes for your reviewer

- This PR targets `main` via a `hotfix/*` branch as required by the current branch strategy
- Verified locally with `pnpm format`, `pnpm test`, and `pnpm lint`
- Added targeted tests for Bocha request params and latest response mapping

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed Bocha web search compatibility by removing the unsupported `page` request parameter and syncing the local response schema with the latest official API response.
```