### PR TITLE
fix: validate MCP OAuth callback state

### DIFF
--- a/src/main/services/MCPService.ts
+++ b/src/main/services/MCPService.ts
@@ -564,6 +564,7 @@ class McpService {
           const callbackServer = new CallBackServer({
             port: authProvider.config.callbackPort,
             path: authProvider.config.callbackPath || '/oauth/callback',
+            expectedState: authProvider.getExpectedState(),
             events
           })
 
@@ -596,6 +597,7 @@ class McpService {
           } finally {
             // Clear the timeout and close the callback server
             clearTimeout(timeoutId)
+            authProvider.clearExpectedState()
             void callbackServer.close()
           }
         }

--- a/src/main/services/mcp/oauth/__tests__/callback.test.ts
+++ b/src/main/services/mcp/oauth/__tests__/callback.test.ts
@@ -1,0 +1,115 @@
+import { EventEmitter } from 'events'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@main/services/ConfigManager', () => ({
+  configManager: {
+    getLanguage: vi.fn(() => 'en-US')
+  }
+}))
+
+vi.mock('@main/utils/locales', () => ({
+  locales: {
+    'en-US': {
+      translation: {
+        settings: {
+          mcp: {
+            oauth: {
+              callback: {
+                title: 'OAuth complete',
+                message: 'You can return to Cherry Studio.'
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}))
+
+import { CallBackServer } from '../callback'
+
+async function request(url: string) {
+  const response = await fetch(url)
+  return {
+    status: response.status,
+    body: await response.text()
+  }
+}
+
+describe('CallBackServer', () => {
+  let callbackServer: CallBackServer | undefined
+
+  afterEach(async () => {
+    await callbackServer?.close()
+    callbackServer = undefined
+  })
+
+  async function startServer(expectedState = 'expected-state') {
+    const events = new EventEmitter()
+    const receivedCodes: string[] = []
+    events.on('auth-code-received', (code) => {
+      receivedCodes.push(code)
+    })
+
+    callbackServer = new CallBackServer({
+      port: 0,
+      path: '/oauth/callback',
+      expectedState,
+      events
+    })
+
+    const server = await callbackServer.getServer
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Unexpected callback server address')
+    }
+
+    return {
+      baseUrl: `http://127.0.0.1:${address.port}`,
+      receivedCodes
+    }
+  }
+
+  it('accepts callbacks with the expected OAuth state', async () => {
+    const { baseUrl, receivedCodes } = await startServer()
+
+    const response = await request(`${baseUrl}/oauth/callback?code=AUTH_CODE&state=expected-state`)
+
+    expect(response.status).toBe(200)
+    expect(receivedCodes).toEqual(['AUTH_CODE'])
+  })
+
+  it('rejects callbacks with missing or mismatched OAuth state', async () => {
+    const { baseUrl, receivedCodes } = await startServer()
+
+    const missingState = await request(`${baseUrl}/oauth/callback?code=ATTACKER_CODE`)
+    const wrongState = await request(`${baseUrl}/oauth/callback?code=ATTACKER_CODE&state=wrong-state`)
+
+    expect(missingState.status).toBe(400)
+    expect(missingState.body).toBe('Invalid OAuth state')
+    expect(wrongState.status).toBe(400)
+    expect(wrongState.body).toBe('Invalid OAuth state')
+    expect(receivedCodes).toEqual([])
+  })
+
+  it('ignores an attacker callback and waits for the matching OAuth state', async () => {
+    const { baseUrl } = await startServer()
+    const authCodePromise = callbackServer!.waitForAuthCode()
+
+    const attackerResponse = await request(`${baseUrl}/oauth/callback?code=ATTACKER_CODE&state=wrong-state`)
+    const legitimateResponse = await request(`${baseUrl}/oauth/callback?code=VICTIM_CODE&state=expected-state`)
+
+    await expect(authCodePromise).resolves.toBe('VICTIM_CODE')
+    expect(attackerResponse.status).toBe(400)
+    expect(legitimateResponse.status).toBe(200)
+  })
+
+  it('requires an exact callback path match', async () => {
+    const { baseUrl, receivedCodes } = await startServer()
+
+    const response = await request(`${baseUrl}/oauth/callback.extra?code=AUTH_CODE&state=expected-state`)
+
+    expect(response.status).toBe(404)
+    expect(receivedCodes).toEqual([])
+  })
+})

--- a/src/main/services/mcp/oauth/__tests__/provider.test.ts
+++ b/src/main/services/mcp/oauth/__tests__/provider.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { McpOAuthClientProvider } from '../provider'
+
+describe('McpOAuthClientProvider OAuth state', () => {
+  it('generates and exposes a high-entropy pending state', () => {
+    const provider = new McpOAuthClientProvider({
+      serverUrlHash: 'server-hash',
+      configDir: '/tmp/cherry-studio-oauth-test'
+    })
+
+    expect(() => provider.getExpectedState()).toThrow('No OAuth state saved for session')
+
+    const state = provider.state()
+
+    expect(state).toHaveLength(43)
+    expect(provider.getExpectedState()).toBe(state)
+    expect(state).toMatch(/^[A-Za-z0-9_-]+$/)
+  })
+
+  it('clears the pending state after the flow finishes', () => {
+    const provider = new McpOAuthClientProvider({
+      serverUrlHash: 'server-hash',
+      configDir: '/tmp/cherry-studio-oauth-test'
+    })
+
+    provider.state()
+    provider.clearExpectedState()
+
+    expect(() => provider.getExpectedState()).toThrow('No OAuth state saved for session')
+  })
+})

--- a/src/main/services/mcp/oauth/callback.ts
+++ b/src/main/services/mcp/oauth/callback.ts
@@ -44,19 +44,27 @@ export class CallBackServer {
   private events: EventEmitter
 
   constructor(options: OAuthCallbackServerOptions) {
-    const { port, path, events } = options
+    const { port, path, expectedState, events } = options
     this.events = events
-    this.server = this.initialize(port, path)
+    this.server = this.initialize(port, path, expectedState)
   }
 
-  initialize(port: number, path: string): Promise<http.Server> {
+  initialize(port: number, path: string, expectedState: string): Promise<http.Server> {
     const server = http.createServer((req, res) => {
-      // Only handle requests to the callback path
-      if (req.url?.startsWith(path)) {
-        try {
-          // Parse the URL to extract the authorization code
-          const url = new URL(req.url, `http://127.0.0.1:${port}`)
+      try {
+        const url = req.url ? new URL(req.url, `http://127.0.0.1:${port}`) : undefined
+
+        // Only handle requests to the exact callback path
+        if (url?.pathname === path) {
           const code = url.searchParams.get('code')
+          const state = url.searchParams.get('state')
+
+          if (state !== expectedState) {
+            res.writeHead(400, { 'Content-Type': 'text/plain' })
+            res.end('Invalid OAuth state')
+            return
+          }
+
           if (code) {
             // Emit the code event
             this.events.emit('auth-code-received', code)
@@ -110,15 +118,16 @@ export class CallBackServer {
             res.writeHead(400, { 'Content-Type': 'text/plain' })
             res.end('Missing authorization code')
           }
-        } catch (error) {
-          logger.error('Error processing OAuth callback:', error as Error)
-          res.writeHead(500, { 'Content-Type': 'text/plain' })
-          res.end('Internal Server Error')
+          return
         }
-      } else {
+
         // Not a callback request
         res.writeHead(404, { 'Content-Type': 'text/plain' })
         res.end('Not Found')
+      } catch (error) {
+        logger.error('Error processing OAuth callback:', error as Error)
+        res.writeHead(500, { 'Content-Type': 'text/plain' })
+        res.end('Internal Server Error')
       }
     })
 

--- a/src/main/services/mcp/oauth/provider.ts
+++ b/src/main/services/mcp/oauth/provider.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto'
 import path from 'node:path'
 
 import { loggerService } from '@logger'
@@ -18,6 +19,7 @@ const logger = loggerService.withContext('MCP:OAuthClientProvider')
 
 export class McpOAuthClientProvider implements OAuthClientProvider {
   private storage: JsonFileStorage
+  private pendingState?: string
   public readonly config: Required<OAuthProviderOptions>
 
   constructor(options: OAuthProviderOptions) {
@@ -46,6 +48,22 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
       client_name: this.config.clientName,
       client_uri: this.config.clientUri
     }
+  }
+
+  state(): string {
+    this.pendingState = randomBytes(32).toString('base64url')
+    return this.pendingState
+  }
+
+  getExpectedState(): string {
+    if (!this.pendingState) {
+      throw new Error('No OAuth state saved for session')
+    }
+    return this.pendingState
+  }
+
+  clearExpectedState(): void {
+    this.pendingState = undefined
   }
 
   async clientInformation(): Promise<OAuthClientInformation | undefined> {

--- a/src/main/services/mcp/oauth/types.ts
+++ b/src/main/services/mcp/oauth/types.ts
@@ -38,6 +38,8 @@ export interface OAuthCallbackServerOptions {
   port: number
   /** Path for the callback endpoint */
   path: string
+  /** OAuth state value expected from the pending authorization flow */
+  expectedState: string
   /** Event emitter to signal when auth code is received */
   events: EventEmitter
 }


### PR DESCRIPTION
### What this PR does

Before this PR:

MCP OAuth callbacks accepted the first request that reached the local callback path with a `code` parameter. The callback server did not validate OAuth `state`, and it accepted path-prefix matches such as `/oauth/callback.extra`.

After this PR:

MCP OAuth authorization now generates a per-flow state value, requires the local callback to return that exact state before emitting the authorization code, and matches the callback path exactly.

Fixes #15372

### Why we need it and why it was done in this way

The previous flow allowed OAuth callback injection / login CSRF during the pending local callback window. A malicious or unintended loopback request could win the first-code race and cause Cherry Studio to exchange the wrong authorization code.

The fix is intentionally scoped to the MCP OAuth flow:

- `McpOAuthClientProvider.state()` generates a high-entropy state value for the SDK authorization URL.
- `MCPService` passes the pending state into the callback server and clears it after the flow completes or fails.
- `CallBackServer` validates the returned `state` and requires an exact callback pathname before emitting the code.
- Unit tests cover valid state, missing/wrong state, first-code attack behavior, and path-prefix rejection.

The following tradeoffs were made:

The pending OAuth state is kept in memory rather than persisted to the OAuth storage file. This keeps the hotfix small and avoids storage migration risk; the callback server and OAuth flow are already process-local and time-limited.

The following alternatives were considered:

Persisting pending state in the existing OAuth JSON storage was considered, but it would broaden the change and require additional cleanup semantics for a short-lived transaction value.

Links to places where the discussion took place: #15372

### Breaking changes

None.

### Special notes for your reviewer

Tested in a temporary worktree because the NAS checkout failed to create `node_modules` symlinks during install. The temp worktree used Node `24.11.1` and pnpm `10.27.0`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix MCP OAuth callback handling to validate OAuth state and reject unrelated local callback requests.
```
