### PR TITLE
fix: align bocha web search handling on v2

### DIFF
--- a/src/main/services/webSearch/providers/__tests__/ApiProviders.test.ts
+++ b/src/main/services/webSearch/providers/__tests__/ApiProviders.test.ts
@@ -814,6 +814,93 @@ describe('main web search API providers', () => {
     })
   })
 
+  it('allows the maximum supported Bocha count and preserves an empty exclude string', async () => {
+    fetchMock.mockResolvedValue(createJsonResponse(loadFixtureJson('bocha-response.json')))
+
+    const provider = createProviderDriver(
+      BochaProvider,
+      createProvider({
+        id: 'bocha',
+        name: 'Bocha',
+        apiKeys: ['bocha-key'],
+        apiHost: 'https://api.bochaai.com'
+      })
+    )
+
+    await provider.searchKeywords('hello', {
+      ...runtimeConfig,
+      maxResults: 50,
+      excludeDomains: []
+    })
+
+    expect(toRequestSnapshot(fetchMock.mock.lastCall as [string, RequestInit | undefined]).body).toEqual({
+      query: 'hello',
+      count: 50,
+      exclude: '',
+      summary: true
+    })
+  })
+
+  it('includes the upstream code when Bocha returns a non-200 payload', async () => {
+    fetchMock.mockResolvedValue(
+      createJsonResponse({
+        code: 429,
+        log_id: 'rate-limited-log-id',
+        msg: null,
+        data: {
+          _type: 'SearchResponse',
+          queryContext: {
+            originalQuery: 'hello'
+          },
+          webPages: {
+            value: []
+          }
+        }
+      })
+    )
+
+    const provider = createProviderDriver(
+      BochaProvider,
+      createProvider({
+        id: 'bocha',
+        name: 'Bocha',
+        apiKeys: ['bocha-key'],
+        apiHost: 'https://api.bochaai.com'
+      })
+    )
+
+    await expect(provider.searchKeywords('hello', runtimeConfig)).rejects.toThrow(
+      'Bocha search failed (code: 429): unknown error'
+    )
+  })
+
+  it('formats Bocha HTTP JSON errors with code and log id', async () => {
+    fetchMock.mockResolvedValue(
+      createJsonResponse(
+        {
+          code: '403',
+          message: 'You do not have enough money',
+          log_id: 'c66aac17eab1bb7e'
+        },
+        403
+      )
+    )
+
+    const provider = createProviderDriver(
+      BochaProvider,
+      createProvider({
+        id: 'bocha',
+        name: 'Bocha',
+        apiKeys: ['bocha-key'],
+        apiHost: 'https://api.bochaai.com'
+      })
+    )
+
+    await expect(provider.searchKeywords('hello', runtimeConfig)).rejects.toThrow(
+      'Bocha search failed: HTTP 403 (code: 403, log_id: c66aac17eab1bb7e): You do not have enough money'
+    )
+  })
+
   it('matches Querit request and normalized response snapshots from fixtures', async () => {
     fetchMock.mockResolvedValue(createJsonResponse(loadFixtureJson('querit-response.json')))
 

--- a/src/main/services/webSearch/providers/__tests__/ApiProviders.test.ts
+++ b/src/main/services/webSearch/providers/__tests__/ApiProviders.test.ts
@@ -717,6 +717,103 @@ describe('main web search API providers', () => {
     `)
   })
 
+  it('accepts latest Bocha response fields and falls back to snippet when summary is missing', async () => {
+    fetchMock.mockResolvedValue(
+      createJsonResponse({
+        code: 200,
+        log_id: 'latest-bocha-log-id',
+        msg: null,
+        data: {
+          _type: 'SearchResponse',
+          queryContext: {
+            originalQuery: 'hello'
+          },
+          webPages: {
+            webSearchUrl: 'https://bochaai.com/search?q=hello',
+            totalEstimatedMatches: 42,
+            value: [
+              {
+                id: null,
+                name: 'Bocha Latest Title',
+                url: 'https://bocha.example/latest',
+                displayUrl: 'https://bocha.example/latest',
+                snippet: 'Snippet fallback content',
+                siteName: 'bocha.example',
+                siteIcon: 'https://bocha.example/favicon.ico',
+                datePublished: null,
+                dateLastCrawled: '2025-02-23T08:18:30Z',
+                cachedPageUrl: null,
+                language: null,
+                isFamilyFriendly: null,
+                isNavigational: null
+              }
+            ],
+            someResultsRemoved: true
+          },
+          images: {
+            id: null,
+            readLink: null,
+            webSearchUrl: null,
+            isFamilyFriendly: null,
+            value: [
+              {
+                webSearchUrl: null,
+                name: null,
+                thumbnailUrl: 'http://example.com/thumb.jpg',
+                datePublished: null,
+                contentUrl: 'http://example.com/content.jpg',
+                hostPageUrl: 'https://example.com/page',
+                contentSize: null,
+                encodingFormat: null,
+                hostPageDisplayUrl: null,
+                width: 553,
+                height: 311,
+                thumbnail: {
+                  height: 80,
+                  width: 120
+                }
+              }
+            ]
+          },
+          videos: null
+        }
+      })
+    )
+
+    const provider = createProviderDriver(
+      BochaProvider,
+      createProvider({
+        id: 'bocha',
+        name: 'Bocha',
+        apiKeys: ['bocha-key'],
+        apiHost: 'https://api.bochaai.com'
+      })
+    )
+
+    const result = await provider.searchKeywords('hello', runtimeConfig)
+
+    expect(toRequestSnapshot(fetchMock.mock.lastCall as [string, RequestInit | undefined]).body).toEqual({
+      query: 'hello',
+      count: 4,
+      exclude: 'example.com',
+      summary: true
+    })
+    expect(result).toEqual({
+      query: 'hello',
+      providerId: 'bocha',
+      capability: 'searchKeywords',
+      inputs: ['hello'],
+      results: [
+        {
+          title: 'Bocha Latest Title',
+          content: 'Snippet fallback content',
+          url: 'https://bocha.example/latest',
+          sourceInput: 'hello'
+        }
+      ]
+    })
+  })
+
   it('matches Querit request and normalized response snapshots from fixtures', async () => {
     fetchMock.mockResolvedValue(createJsonResponse(loadFixtureJson('querit-response.json')))
 

--- a/src/main/services/webSearch/providers/__tests__/fixtures/bocha-response.json
+++ b/src/main/services/webSearch/providers/__tests__/fixtures/bocha-response.json
@@ -1,18 +1,60 @@
 {
   "code": 200,
-  "msg": "ok",
+  "log_id": "d71841ad20095f61",
+  "msg": null,
   "data": {
+    "_type": "SearchResponse",
     "queryContext": {
       "originalQuery": "hello"
     },
     "webPages": {
+      "webSearchUrl": "https://bochaai.com/search?q=hello",
+      "totalEstimatedMatches": 1618000,
       "value": [
         {
+          "id": null,
           "name": "Bocha Title",
+          "url": "https://bocha.example/result",
+          "displayUrl": "https://bocha.example/result",
+          "snippet": "Bocha Snippet",
           "summary": "Bocha Content",
-          "url": "https://bocha.example/result"
+          "siteName": "bocha.example",
+          "siteIcon": "https://bocha.example/favicon.ico",
+          "datePublished": "2025-02-23T08:18:30+08:00",
+          "dateLastCrawled": "2025-02-23T08:18:30Z",
+          "cachedPageUrl": null,
+          "language": null,
+          "isFamilyFriendly": null,
+          "isNavigational": null
+        }
+      ],
+      "someResultsRemoved": true
+    },
+    "images": {
+      "id": null,
+      "readLink": null,
+      "webSearchUrl": null,
+      "isFamilyFriendly": null,
+      "value": [
+        {
+          "webSearchUrl": null,
+          "name": null,
+          "thumbnailUrl": "http://example.com/thumb.jpg",
+          "datePublished": null,
+          "contentUrl": "http://example.com/content.jpg",
+          "hostPageUrl": "https://example.com/page",
+          "contentSize": null,
+          "encodingFormat": null,
+          "hostPageDisplayUrl": null,
+          "width": 553,
+          "height": 311,
+          "thumbnail": {
+            "height": 80,
+            "width": 120
+          }
         }
       ]
-    }
+    },
+    "videos": null
   }
 }

--- a/src/main/services/webSearch/providers/api/BochaProvider.ts
+++ b/src/main/services/webSearch/providers/api/BochaProvider.ts
@@ -8,9 +8,15 @@ import type { ApiKeyRequestSearchContext } from '../base/context'
 
 const BochaSearchParamsSchema = z.object({
   query: z.string(),
-  count: z.number().int().positive(),
+  count: z.number().int().min(1).max(50),
   exclude: z.string(),
   summary: z.boolean()
+})
+
+const BochaHttpErrorSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  log_id: z.string().optional()
 })
 
 const BochaThumbnailSchema = z.object({
@@ -164,7 +170,7 @@ export class BochaProvider extends BaseWebSearchProvider {
     })
 
     if (!response.ok) {
-      await this.throwHttpError('Bocha search failed', response)
+      await this.throwBochaHttpError(response)
     }
 
     return this.parseJsonResponse(response, BochaSearchResponseSchema, {
@@ -173,12 +179,39 @@ export class BochaProvider extends BaseWebSearchProvider {
     })
   }
 
+  private async throwBochaHttpError(response: Response): Promise<never> {
+    const errorText = (await response.text()).trim()
+
+    if (!errorText) {
+      throw new Error(`Bocha search failed: HTTP ${response.status}`)
+    }
+
+    let parsedPayload: unknown
+
+    try {
+      parsedPayload = JSON.parse(errorText)
+    } catch {
+      // Fall back to the shared raw-body error formatter below.
+      return this.throwHttpError('Bocha search failed', new Response(errorText, { status: response.status }))
+    }
+
+    const parsedError = BochaHttpErrorSchema.safeParse(parsedPayload)
+
+    if (parsedError.success) {
+      const { code, message, log_id } = parsedError.data
+      const logIdPart = log_id ? `, log_id: ${log_id}` : ''
+      throw new Error(`Bocha search failed: HTTP ${response.status} (code: ${code}${logIdPart}): ${message}`)
+    }
+
+    return this.throwHttpError('Bocha search failed', new Response(errorText, { status: response.status }))
+  }
+
   private buildFinalResponse(
     context: BochaSearchContext,
     searchPayload: z.infer<typeof BochaSearchResponseSchema>
   ): WebSearchResponse {
     if (searchPayload.code !== 200) {
-      throw new Error(`Bocha search failed: ${searchPayload.msg ?? 'unknown error'}`)
+      throw new Error(`Bocha search failed (code: ${searchPayload.code}): ${searchPayload.msg ?? 'unknown error'}`)
     }
 
     return {

--- a/src/main/services/webSearch/providers/api/BochaProvider.ts
+++ b/src/main/services/webSearch/providers/api/BochaProvider.ts
@@ -13,23 +13,107 @@ const BochaSearchParamsSchema = z.object({
   summary: z.boolean()
 })
 
+const BochaThumbnailSchema = z.object({
+  height: z.number(),
+  width: z.number()
+})
+
+const BochaWebPageSchema = z.object({
+  id: z.string().nullable().optional(),
+  name: z.string(),
+  url: z.string(),
+  displayUrl: z.string().optional(),
+  snippet: z.string().nullable().optional(),
+  summary: z.string().nullable().optional(),
+  siteName: z.string().nullable().optional(),
+  siteIcon: z.string().nullable().optional(),
+  datePublished: z.string().nullable().optional(),
+  dateLastCrawled: z.string().nullable().optional(),
+  cachedPageUrl: z.string().nullable().optional(),
+  language: z.string().nullable().optional(),
+  isFamilyFriendly: z.boolean().nullable().optional(),
+  isNavigational: z.boolean().nullable().optional()
+})
+
+const BochaImagesSchema = z.object({
+  id: z.string().nullable().optional(),
+  readLink: z.string().nullable().optional(),
+  webSearchUrl: z.string().nullable().optional(),
+  isFamilyFriendly: z.boolean().nullable().optional(),
+  value: z.array(
+    z.object({
+      webSearchUrl: z.string().nullable().optional(),
+      name: z.string().nullable().optional(),
+      thumbnailUrl: z.string(),
+      datePublished: z.string().nullable().optional(),
+      contentUrl: z.string(),
+      hostPageUrl: z.string(),
+      contentSize: z.string().nullable().optional(),
+      encodingFormat: z.string().nullable().optional(),
+      hostPageDisplayUrl: z.string().nullable().optional(),
+      width: z.number(),
+      height: z.number(),
+      thumbnail: BochaThumbnailSchema.nullable().optional()
+    })
+  )
+})
+
+const BochaVideosSchema = z.object({
+  id: z.string().nullable().optional(),
+  readLink: z.string().nullable().optional(),
+  webSearchUrl: z.string().nullable().optional(),
+  isFamilyFriendly: z.boolean().nullable().optional(),
+  scenario: z.string().optional(),
+  value: z.array(
+    z.object({
+      webSearchUrl: z.string(),
+      name: z.string(),
+      description: z.string(),
+      thumbnailUrl: z.string(),
+      publisher: z.array(
+        z.object({
+          name: z.string()
+        })
+      ),
+      creator: z.object({
+        name: z.string()
+      }),
+      contentUrl: z.string(),
+      hostPageUrl: z.string(),
+      encodingFormat: z.string(),
+      hostPageDisplayUrl: z.string(),
+      width: z.number(),
+      height: z.number(),
+      duration: z.string(),
+      motionThumbnailUrl: z.string(),
+      embedHtml: z.string(),
+      allowHttpsEmbed: z.boolean(),
+      viewCount: z.number(),
+      thumbnail: BochaThumbnailSchema,
+      allowMobileEmbed: z.boolean(),
+      isSuperfresh: z.boolean(),
+      datePublished: z.string()
+    })
+  )
+})
+
 const BochaSearchResponseSchema = z.object({
   code: z.number(),
-  msg: z.string(),
+  log_id: z.string().optional(),
+  msg: z.string().nullable().optional(),
   data: z.object({
+    _type: z.string().optional(),
     queryContext: z.object({
       originalQuery: z.string()
     }),
     webPages: z.object({
-      value: z.array(
-        z.object({
-          name: z.string(),
-          summary: z.string().optional(),
-          snippet: z.string().optional(),
-          url: z.string()
-        })
-      )
-    })
+      webSearchUrl: z.string().optional(),
+      totalEstimatedMatches: z.number().optional(),
+      value: z.array(BochaWebPageSchema),
+      someResultsRemoved: z.boolean().optional()
+    }),
+    images: BochaImagesSchema.optional(),
+    videos: BochaVideosSchema.nullable().optional()
   })
 })
 
@@ -94,7 +178,7 @@ export class BochaProvider extends BaseWebSearchProvider {
     searchPayload: z.infer<typeof BochaSearchResponseSchema>
   ): WebSearchResponse {
     if (searchPayload.code !== 200) {
-      throw new Error(`Bocha search failed: ${searchPayload.msg}`)
+      throw new Error(`Bocha search failed: ${searchPayload.msg ?? 'unknown error'}`)
     }
 
     return {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR:

The v2 Bocha web search provider was not fully aligned with the latest official Bocha API behavior. The runtime response schema did not cover the latest metadata fields and nullable fields, Bocha request bounds were not constrained to the documented range, and HTTP error responses were surfaced only as raw response text.

After this PR:

- aligned the v2 Bocha response schema with the latest official response shape
- kept v2 request behavior compatible with the current public API
- constrained `count` to the documented `1-50` range
- preserved empty `exclude` values as supported by the upstream API
- improved Bocha HTTP error formatting by extracting `code`, `message`, and `log_id` from JSON error payloads
- added regression coverage for latest response parsing, `snippet` fallback, `count=50`, empty `exclude`, non-200 payload handling, and JSON HTTP error formatting

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #
N/A

### Why we need it and why it was done in this way

The v2 branch uses the main-process web search provider implementation, so this fix is applied directly at the current v2 integration point instead of reusing the renderer-side structure from the main-branch hotfix.

This PR keeps the scope intentionally small:
- only updates the Bocha provider and its provider tests
- does not expand request parameters beyond the current public API behavior
- keeps existing successful request flow unchanged while improving compatibility and diagnosability

The following tradeoffs were made:

- kept the implementation local to the Bocha provider instead of changing shared provider infrastructure
- added only minimal structured handling for Bocha HTTP JSON errors and fell back to the shared raw-body formatter for non-JSON upstream responses

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
https://github.com/CherryHQ/cherry-studio/pull/15354

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

No breaking changes.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Aligned the v2 Bocha web search provider with the latest official API behavior, including updated response compatibility, documented request bounds, and clearer upstream HTTP error messages.
```
