### PR TITLE
feat: add voice input support to inputbar

### DIFF
--- a/src/renderer/src/i18n/locales/en-us.json
+++ b/src/renderer/src/i18n/locales/en-us.json
@@ -1161,6 +1161,9 @@
       "topics": " Topics ",
       "translate": "Translate to {{target_language}}",
       "translating": "Translating...",
+      "voice_not_supported": "Voice input is not supported in this environment",
+      "voice_start": "Voice input",
+      "voice_stop": "Click to stop",
       "upload": {
         "attachment": "Upload attachment",
         "document": "Upload document file (model does not support images)",

--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -1161,6 +1161,9 @@
       "topics": "话题",
       "translate": "翻译成 {{target_language}}",
       "translating": "翻译中...",
+      "voice_not_supported": "当前环境不支持语音输入",
+      "voice_start": "语音输入",
+      "voice_stop": "点击停止",
       "upload": {
         "attachment": "上传附件",
         "document": "上传文档（模型不支持图片）",

--- a/src/renderer/src/pages/home/Inputbar/components/InputbarCore.tsx
+++ b/src/renderer/src/pages/home/Inputbar/components/InputbarCore.tsx
@@ -20,7 +20,7 @@ import { IpcChannel } from '@shared/IpcChannel'
 import { Tooltip } from 'antd'
 import TextArea from 'antd/es/input/TextArea'
 import type { TextAreaRef } from 'antd/lib/input/TextArea'
-import { CirclePause, Languages } from 'lucide-react'
+import { CirclePause, Languages, Mic } from 'lucide-react'
 import type { CSSProperties, FC } from 'react'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -604,6 +604,42 @@ export const InputbarCore: FC<InputbarCoreProps> = ({
     }
   }, [])
 
+  // Voice input
+  const [isListening, setIsListening] = useState(false)
+  const recognitionRef = useRef<any>(null)
+
+  const startListening = useCallback(() => {
+    const SpeechRecognition = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition
+    if (!SpeechRecognition) {
+      window.toast.error(t('chat.input.voice_not_supported', 'Voice input is not supported in this environment'))
+      return
+    }
+
+    const recognition = new SpeechRecognition()
+    recognition.lang = 'zh-CN'
+    recognition.continuous = true
+    recognition.interimResults = true
+
+    recognition.onresult = (event: any) => {
+      const transcript = Array.from(event.results)
+        .map((result: any) => result[0].transcript)
+        .join('')
+      setText((prev) => prev + transcript)
+    }
+
+    recognition.onend = () => setIsListening(false)
+    recognition.onerror = () => setIsListening(false)
+
+    recognition.start()
+    recognitionRef.current = recognition
+    setIsListening(true)
+  }, [setText, t])
+
+  const stopListening = useCallback(() => {
+    recognitionRef.current?.stop()
+    setIsListening(false)
+  }, [])
+
   const rightSectionExtras = useMemo(() => {
     const extras: React.ReactNode[] = []
     extras.push(
@@ -614,6 +650,18 @@ export const InputbarCore: FC<InputbarCoreProps> = ({
         onTranslated={onTranslated}
         isLoading={isTranslating}
       />
+    )
+    extras.push(
+      <Tooltip
+        key="voice"
+        placement="top"
+        title={isListening ? t('chat.input.voice_stop', 'Click to stop') : t('chat.input.voice_start', 'Voice input')}
+        mouseLeaveDelay={0}
+        arrow>
+        <ActionIconButton onClick={isListening ? stopListening : startListening}>
+          <Mic size={20} color={isListening ? 'var(--color-error)' : 'var(--color-icon)'} />
+        </ActionIconButton>
+      </Tooltip>
     )
     extras.push(<SendMessageButton key="send-message" sendMessage={handleSendMessage} disabled={isSendDisabled} />)
 
@@ -628,7 +676,7 @@ export const InputbarCore: FC<InputbarCoreProps> = ({
     }
 
     return <>{extras}</>
-  }, [text, onTranslated, isTranslating, handleSendMessage, isSendDisabled, isLoading, t, onPause])
+  }, [text, onTranslated, isTranslating, handleSendMessage, isSendDisabled, isLoading, t, onPause, isListening, startListening, stopListening])
 
   const quickPanelElement = config.enableQuickPanel ? <QuickPanelView setInputText={setText} /> : null
 


### PR DESCRIPTION
## Summary
- Add microphone button to inputbar for voice-to-text input
- Use Web Speech API for speech recognition (free, built-in)
- Support Chinese language (zh-CN) with continuous recording
- Add interim results for real-time transcription

## Changes
1. **InputbarCore.tsx**: Add Mic icon, voice recognition logic, and microphone button
2. **zh-cn.json**: Add Chinese translations for voice input
3. **en-us.json**: Add English translations for voice input

## Features
- Click microphone to start voice input
- Click again to stop recording
- Real-time text transcription while speaking
- Append recognized text to existing input
- Visual feedback (red icon when recording)

## Testing
1. Open Cherry Studio
2. Go to any chat or agent session
3. Click the microphone button in the inputbar
4. Speak in Chinese
5. Click the microphone again to stop
6. The transcribed text should appear in the input field

## Notes
- Uses Web Speech API which requires internet connection
- Only works in Chromium-based browsers (Electron included)
- Default language is Chinese (zh-CN)