### PR TITLE
fix: scope memory deduplication hashes

### DIFF
--- a/src/main/services/memory/MemoryService.ts
+++ b/src/main/services/memory/MemoryService.ts
@@ -52,6 +52,7 @@ export class MemoryService {
   private isInitialized = false
   private embeddings: Embeddings | null = null
   private config: MemoryConfig | null = null
+  private static readonly HASH_SCHEMA_VERSION = 2
   private static readonly UNIFIED_DIMENSION = 1536
   private static readonly SIMILARITY_THRESHOLD = 0.85
 
@@ -72,6 +73,21 @@ export class MemoryService {
     }
     MemoryService.instance = new MemoryService()
     return MemoryService.instance
+  }
+
+  private createMemoryHash(memory: string, userId?: string | null, agentId?: string | null): string {
+    const payload = JSON.stringify({
+      schema: MemoryService.HASH_SCHEMA_VERSION,
+      userId: userId || null,
+      agentId: agentId || null,
+      memory
+    })
+
+    return crypto.createHash('sha256').update(payload).digest('hex')
+  }
+
+  private createLegacyMemoryHash(memory: string): string {
+    return crypto.createHash('sha256').update(memory).digest('hex')
   }
 
   /**
@@ -164,13 +180,27 @@ export class MemoryService {
         const trimmedMemory = memory.trim()
         if (!trimmedMemory) continue
 
-        // Generate hash for deduplication
-        const hash = crypto.createHash('sha256').update(trimmedMemory).digest('hex')
+        // Generate scoped hash for deduplication
+        const hash = this.createMemoryHash(trimmedMemory, userId, agentId)
+        const userScopedHash = this.createMemoryHash(trimmedMemory, userId, null)
+        const legacyHash = this.createLegacyMemoryHash(trimmedMemory)
 
-        // Check if memory already exists
+        // Check if memory already exists in the same user/agent scope.
         const existing = await this.db.execute({
-          sql: MemoryQueries.memory.checkExistsIncludeDeleted,
-          args: [hash]
+          sql: MemoryQueries.memory.checkExistsIncludeDeletedByScope,
+          args: [
+            hash,
+            userScopedHash,
+            legacyHash,
+            userId || null,
+            userId || null,
+            agentId || null,
+            agentId || null,
+            agentId || null,
+            hash,
+            userScopedHash,
+            agentId || null
+          ]
         })
 
         if (existing.rows.length > 0) {
@@ -517,8 +547,8 @@ export class MemoryService {
       const previousMemory = row.memory as string
       const previousMetadata = row.metadata ? JSON.parse(row.metadata as string) : {}
 
-      // Generate new hash
-      const hash = crypto.createHash('sha256').update(memory.trim()).digest('hex')
+      // Generate new scoped hash
+      const hash = this.createMemoryHash(memory.trim(), row.user_id as string | null, row.agent_id as string | null)
 
       // Generate new embedding if model is configured
       let embedding: number[] | null = null

--- a/src/main/services/memory/__tests__/MemoryService.test.ts
+++ b/src/main/services/memory/__tests__/MemoryService.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { createClientMock, state } = vi.hoisted(() => {
+  type MemoryRow = {
+    id: string
+    memory: string
+    hash: string
+    metadata: string | null
+    user_id: string | null
+    agent_id: string | null
+    run_id: string | null
+    created_at: string
+    updated_at: string
+    is_deleted: number
+  }
+
+  const state = {
+    rows: [] as MemoryRow[]
+  }
+
+  const execute = vi.fn(async (query: string | { sql: string; args?: any[] }) => {
+    const sql = typeof query === 'string' ? query : query.sql
+    const args = typeof query === 'string' ? [] : query.args || []
+
+    if (sql.includes('SELECT id, hash, user_id, agent_id, is_deleted FROM memories')) {
+      const hashCandidates = args.slice(0, 3)
+      const userId = args[4] ?? null
+      const agentId = args[7] ?? null
+      const preferredHash = args[8]
+      const preferredUserScopedHash = args[9]
+
+      const rows = state.rows
+        .filter((row) => {
+          const userMatches = userId === null ? row.user_id === null : row.user_id === userId
+          const agentMatches =
+            agentId === null ? row.agent_id === null : row.agent_id === agentId || row.agent_id === null
+
+          return hashCandidates.includes(row.hash) && userMatches && agentMatches
+        })
+        .sort((left, right) => {
+          const hashRank = (row: MemoryRow) => {
+            if (row.hash === preferredHash) return 0
+            if (row.hash === preferredUserScopedHash) return 1
+            return 2
+          }
+          const agentRank = (row: MemoryRow) => {
+            if (row.agent_id === agentId) return 0
+            if (row.agent_id === null) return 1
+            return 2
+          }
+
+          return hashRank(left) - hashRank(right) || agentRank(left) - agentRank(right)
+        })
+
+      return { rows: rows.slice(0, 1) }
+    }
+
+    if (sql.includes('INSERT INTO memories')) {
+      const [id, memory, hash, , metadata, userId, agentId, runId, createdAt, updatedAt] = args
+
+      if (state.rows.some((row) => row.hash === hash)) {
+        throw new Error('UNIQUE constraint failed: memories.hash')
+      }
+
+      state.rows.push({
+        id,
+        memory,
+        hash,
+        metadata,
+        user_id: userId,
+        agent_id: agentId,
+        run_id: runId,
+        created_at: createdAt,
+        updated_at: updatedAt,
+        is_deleted: 0
+      })
+
+      return { rows: [] }
+    }
+
+    if (sql.includes('UPDATE memories') && sql.includes('SET is_deleted = 0')) {
+      const [memory, , metadata, updatedAt, id] = args
+      const row = state.rows.find((row) => row.id === id)
+
+      if (row) {
+        row.is_deleted = 0
+        row.memory = memory
+        row.metadata = metadata
+        row.updated_at = updatedAt
+      }
+
+      return { rows: [] }
+    }
+
+    return { rows: [] }
+  })
+
+  return {
+    createClientMock: vi.fn(() => ({
+      execute,
+      close: vi.fn()
+    })),
+    state
+  }
+})
+
+vi.mock('@libsql/client', () => ({
+  createClient: createClientMock
+}))
+
+describe('MemoryService', () => {
+  beforeEach(() => {
+    state.rows = []
+    createClientMock.mockClear()
+  })
+
+  it('allows identical memory text in different user scopes', async () => {
+    const { default: MemoryService } = await import('../MemoryService')
+    const service = MemoryService.reload()
+
+    const first = await service.add('Meeting PIN is 1234', {
+      userId: 'user_alice',
+      agentId: 'agent_sales'
+    })
+    const second = await service.add('Meeting PIN is 1234', {
+      userId: 'user_bob',
+      agentId: 'agent_support'
+    })
+
+    expect(first.count).toBe(1)
+    expect(second.count).toBe(1)
+    expect(state.rows).toHaveLength(2)
+    expect(new Set(state.rows.map((row) => row.hash))).toHaveLength(2)
+  })
+
+  it('allows identical memory text in different assistant scopes for the same user', async () => {
+    const { default: MemoryService } = await import('../MemoryService')
+    const service = MemoryService.reload()
+
+    const first = await service.add('Project code name is Orion', {
+      userId: 'user_alice',
+      agentId: 'agent_sales'
+    })
+    const second = await service.add('Project code name is Orion', {
+      userId: 'user_alice',
+      agentId: 'agent_support'
+    })
+
+    expect(first.count).toBe(1)
+    expect(second.count).toBe(1)
+    expect(state.rows).toHaveLength(2)
+    expect(new Set(state.rows.map((row) => row.hash))).toHaveLength(2)
+  })
+
+  it('still deduplicates identical memory text in the same user and assistant scope', async () => {
+    const { default: MemoryService } = await import('../MemoryService')
+    const service = MemoryService.reload()
+
+    const first = await service.add('Customer prefers email updates', {
+      userId: 'user_alice',
+      agentId: 'agent_sales'
+    })
+    const second = await service.add('Customer prefers email updates', {
+      userId: 'user_alice',
+      agentId: 'agent_sales'
+    })
+
+    expect(first.count).toBe(1)
+    expect(second.count).toBe(0)
+    expect(state.rows).toHaveLength(1)
+  })
+})

--- a/src/main/services/memory/queries.ts
+++ b/src/main/services/memory/queries.ts
@@ -53,6 +53,28 @@ export const MemoryQueries = {
 
     checkExistsIncludeDeleted: 'SELECT id, is_deleted FROM memories WHERE hash = ?',
 
+    checkExistsIncludeDeletedByScope: `
+      SELECT id, hash, user_id, agent_id, is_deleted FROM memories
+      WHERE hash IN (?, ?, ?)
+        AND ((? IS NULL AND user_id IS NULL) OR user_id = ?)
+        AND (
+          (? IS NULL AND agent_id IS NULL)
+          OR (? IS NOT NULL AND (agent_id = ? OR agent_id IS NULL))
+        )
+      ORDER BY
+        CASE
+          WHEN hash = ? THEN 0
+          WHEN hash = ? THEN 1
+          ELSE 2
+        END,
+        CASE
+          WHEN agent_id = ? THEN 0
+          WHEN agent_id IS NULL THEN 1
+          ELSE 2
+        END
+      LIMIT 1
+    `,
+
     restoreDeleted: `
       UPDATE memories 
       SET is_deleted = 0, memory = ?, embedding = ?, metadata = ?, updated_at = ?
@@ -68,7 +90,7 @@ export const MemoryQueries = {
 
     softDelete: 'UPDATE memories SET is_deleted = 1, updated_at = ? WHERE id = ?',
 
-    getForUpdate: 'SELECT memory, metadata FROM memories WHERE id = ? AND is_deleted = 0',
+    getForUpdate: 'SELECT memory, metadata, user_id, agent_id FROM memories WHERE id = ? AND is_deleted = 0',
 
     update: `
       UPDATE memories 


### PR DESCRIPTION
### What this PR does

Before this PR:

Memory deduplication used `sha256(trimmedMemory)` as a global key. A memory created by one memory user or assistant could block another user or assistant from storing the same text, even though search/list operations are scoped by `user_id` and `agent_id`.

After this PR:

Memory deduplication hashes include a schema version plus the memory user, assistant, and trimmed memory text. Existing legacy text-only hashes are only considered duplicates when they match the caller's user/assistant scope.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #15411

### Why we need it and why it was done in this way

The following tradeoffs were made:

The fix keeps the existing `hash` column and database shape to stay minimal for a hotfix. New records get a scoped hash, while the lookup still recognizes legacy text-only hashes inside the same scope so existing users do not immediately create duplicate memories after upgrade.

The following alternatives were considered:

A database migration to replace the unique hash column with a compound unique key was considered, but that is a larger schema change and riskier for a main-branch hotfix. A full migration can still be added later if the memory schema is revised.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/15411

### Breaking changes

None.

### Special notes for your reviewer

This PR intentionally does not migrate existing rows. Legacy rows are handled at lookup time and new/updated rows use the scoped hash schema.

Verification in this environment was limited:

- `git diff --cached --check` passed.
- `npx pnpm@10.27.0 test:main src/main/services/memory/__tests__/MemoryService.test.ts` could not run because the environment has Node `v18.19.1` while the project requires `>=24.11.1`, and `vitest` was not linked in `node_modules/.bin`.
- Directly invoking the local Vitest package also failed because dependency symlinks are incomplete in this checkout.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix memory deduplication so identical memory text in different users or assistants no longer blocks scoped memory creation.
```
