### PR TITLE
fix: route CherryIN Qwen image edits through generation

### DIFF
--- a/src/renderer/src/pages/paintings/NewApiPage.tsx
+++ b/src/renderer/src/pages/paintings/NewApiPage.tsx
@@ -48,6 +48,31 @@ import { checkProviderEnabled, findPaintingByFiles } from './utils'
 
 const logger = loggerService.withContext('NewApiPage')
 
+const CHERRYIN_HOSTS = new Set(['open.cherryin.ai', 'open.cherryin.cc', 'open.cherryin.dev', 'open.cherryin.net'])
+
+const isCherryInProvider = (apiHost: string) => {
+  try {
+    return CHERRYIN_HOSTS.has(new URL(apiHost).hostname)
+  } catch {
+    return false
+  }
+}
+
+const readFileAsDataUrl = (file: File): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader()
+
+    reader.onload = () => {
+      if (typeof reader.result === 'string') {
+        resolve(reader.result)
+      } else {
+        reject(new Error('Failed to read image file as data URL'))
+      }
+    }
+    reader.onerror = () => reject(reader.error ?? new Error('Failed to read image file as data URL'))
+    reader.readAsDataURL(file)
+  })
+
 const NewApiPage: FC<{ Options: string[] }> = ({ Options }) => {
   const [mode, setMode] = useState<keyof PaintingsState>('openai_image_generate')
   const { addPainting, removePainting, updatePainting, openai_image_generate, openai_image_edit } = usePaintings()
@@ -310,12 +335,24 @@ const NewApiPage: FC<{ Options: string[] }> = ({ Options }) => {
       url = newApiProvider.apiHost.replace(/\/v1$/, '') + `/openai/v1/images/generations`
       editUrl = newApiProvider.apiHost.replace(/\/v1$/, '') + `/openai/v1/images/edits`
     }
+    const shouldUseGenerationForEdit =
+      isCherryInProvider(newApiProvider.apiHost) &&
+      mode === 'openai_image_edit' &&
+      painting.model.toLowerCase().includes('qwen')
+    const shouldUseGenerationEndpoint = mode === 'openai_image_generate' || shouldUseGenerationForEdit
 
     try {
-      if (mode === 'openai_image_generate') {
+      if (shouldUseGenerationEndpoint) {
+        if (shouldUseGenerationForEdit && editImages.length === 0) {
+          window.toast.warning(t('paintings.image_file_required'))
+          return
+        }
+
+        const imageDataUrls = shouldUseGenerationForEdit ? await Promise.all(editImages.map(readFileAsDataUrl)) : []
         const requestData = {
           prompt,
           model: painting.model,
+          image: imageDataUrls.length === 0 ? undefined : imageDataUrls.length === 1 ? imageDataUrls[0] : imageDataUrls,
           size: painting.size === 'auto' ? undefined : painting.size,
           background: painting.background === 'auto' ? undefined : painting.background,
           n: painting.n,
@@ -363,7 +400,7 @@ const NewApiPage: FC<{ Options: string[] }> = ({ Options }) => {
         // For edit mode we do not set content-type; browser will set multipart boundary
       }
 
-      const requestUrl = mode === 'openai_image_edit' ? editUrl : url
+      const requestUrl = shouldUseGenerationEndpoint ? url : editUrl
       const response = await fetch(requestUrl, { method: 'POST', headers, body })
 
       if (!response.ok) {

--- a/src/renderer/src/pages/paintings/NewApiPage.tsx
+++ b/src/renderer/src/pages/paintings/NewApiPage.tsx
@@ -48,16 +48,6 @@ import { checkProviderEnabled, findPaintingByFiles } from './utils'
 
 const logger = loggerService.withContext('NewApiPage')
 
-const CHERRYIN_HOSTS = new Set(['open.cherryin.ai', 'open.cherryin.cc', 'open.cherryin.dev', 'open.cherryin.net'])
-
-const isCherryInProvider = (apiHost: string) => {
-  try {
-    return CHERRYIN_HOSTS.has(new URL(apiHost).hostname)
-  } catch {
-    return false
-  }
-}
-
 const readFileAsDataUrl = (file: File): Promise<string> =>
   new Promise((resolve, reject) => {
     const reader = new FileReader()
@@ -336,7 +326,7 @@ const NewApiPage: FC<{ Options: string[] }> = ({ Options }) => {
       editUrl = newApiProvider.apiHost.replace(/\/v1$/, '') + `/openai/v1/images/edits`
     }
     const shouldUseGenerationForEdit =
-      isCherryInProvider(newApiProvider.apiHost) &&
+      newApiProvider.apiHost.toLowerCase().includes('cherryin') &&
       mode === 'openai_image_edit' &&
       painting.model.toLowerCase().includes('qwen')
     const shouldUseGenerationEndpoint = mode === 'openai_image_generate' || shouldUseGenerationForEdit


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR:

CherryIN Qwen image editing in the painting module used the OpenAI-compatible `/v1/images/edits` multipart endpoint, which is not compatible with CherryIN's Qwen image-generation edit flow.

After this PR:

CherryIN official hosts using Qwen image edit models route edit requests through `/v1/images/generations` and send uploaded images as data URL JSON in the `image` field.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The CherryIN detection uses a small official-host whitelist so built-in and custom CherryIN providers are covered without treating every `new-api` provider as CherryIN.

The following alternatives were considered:

Checking only `provider.id === 'cherryin'` was rejected because it misses user-created CherryIN providers; checking `provider.type === 'cherryin'` was rejected because CherryIN is not persisted as a provider type.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Tested with `pnpm lint` and `pnpm test`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed CherryIN Qwen image editing by routing requests through the image generation endpoint with JSON image data.
```
