### PR TITLE
fix: custom user-agent request header not taking effect

### DIFF
--- a/src/renderer/aiCore/provider/providerConfig.ts
+++ b/src/renderer/aiCore/provider/providerConfig.ts
@@ -1,0 +1,426 @@
+import { formatPrivateKey, hasProviderConfig, type StringKeys } from '@cherrystudio/ai-core/provider'
+import type { AppProviderId, AppProviderSettingsMap } from '@renderer/aiCore/types'
+import {
+  getAwsBedrockAccessKeyId,
+  getAwsBedrockApiKey,
+  getAwsBedrockAuthType,
+  getAwsBedrockRegion,
+  getAwsBedrockSecretAccessKey
+} from '@renderer/hooks/useAwsBedrock'
+import { createVertexProvider, isVertexAiConfigured } from '@renderer/hooks/useVertexAi'
+import { getProviderByModel } from '@renderer/services/AssistantService'
+import { getProviderById } from '@renderer/services/ProviderService'
+import store from '@renderer/store'
+import { type Model, type Provider, SystemProviderIds } from '@renderer/types'
+import {
+  formatApiHost,
+  formatOllamaApiHost,
+  formatVertexApiHost,
+  isWithTrailingSharp,
+  routeToEndpoint
+} from '@renderer/utils/api'
+import {
+  isAnthropicProvider,
+  isAzureOpenAIProvider,
+  isCherryAIProvider,
+  isGeminiProvider,
+  isOllamaProvider,
+  isPerplexityProvider,
+  isSupportStreamOptionsProvider,
+  isVertexProvider
+} from '@renderer/utils/provider'
+import { defaultAppHeaders } from '@shared/utils'
+import { cloneDeep, isEmpty } from 'lodash'
+
+import type { ProviderConfig } from '../types'
+import { COPILOT_DEFAULT_HEADERS } from './constants'
+import { getAiSdkProviderId } from './factory'
+
+// === Helpers ===
+
+function createCustomFetch(extraHeaders: Record<string, string> | undefined): typeof globalThis.fetch | undefined {
+  if (!extraHeaders) return undefined
+  const uaKey = Object.keys(extraHeaders).find((k) => k.toLowerCase() === 'user-agent')
+  if (!uaKey) return undefined
+  const customUA = extraHeaders[uaKey]
+  return async (input: RequestInfo | URL, init?: RequestInit) => {
+    const headers = new Headers(init?.headers)
+    const existing = headers.get('user-agent') || ''
+    headers.set('user-agent', existing ? `${customUA} ${existing}` : customUA)
+    return fetch(input, { ...init, headers })
+  }
+}
+
+// === Types ===
+
+interface BaseConfig {
+  baseURL: string
+  apiKey: string
+}
+
+interface BuilderContext {
+  actualProvider: Provider
+  model: Model
+  baseConfig: BaseConfig
+  endpoint?: string
+  aiSdkProviderId: AppProviderId
+}
+
+// === Host Formatting ===
+
+type HostFormatter = {
+  match: (provider: Provider) => boolean
+  format: (provider: Provider, appendApiVersion: boolean) => string
+}
+
+// WARNING: if any changes are made here, please sync it to src/main/aiCore/provider/providerConfig.ts:formatProviderApiHost
+export function formatProviderApiHost(provider: Provider): Provider {
+  const formatted = { ...provider }
+  const appendApiVersion = !isWithTrailingSharp(provider.apiHost)
+
+  if (formatted.anthropicApiHost) {
+    formatted.anthropicApiHost = formatApiHost(formatted.anthropicApiHost, appendApiVersion)
+  }
+
+  // Anthropic is special: uses anthropicApiHost as source and syncs both fields
+  if (isAnthropicProvider(provider)) {
+    const baseHost = formatted.anthropicApiHost || formatted.apiHost
+    formatted.apiHost = formatApiHost(baseHost, appendApiVersion)
+    if (!formatted.anthropicApiHost) {
+      formatted.anthropicApiHost = formatted.apiHost
+    }
+    return formatted
+  }
+
+  const formatters: HostFormatter[] = [
+    {
+      match: (p) => p.id === SystemProviderIds.copilot || p.id === SystemProviderIds.github,
+      format: (p) => formatApiHost(p.apiHost, false)
+    },
+    { match: isCherryAIProvider, format: (p) => formatApiHost(p.apiHost, false) },
+    { match: isPerplexityProvider, format: (p) => formatApiHost(p.apiHost, false) },
+    { match: isOllamaProvider, format: (p) => formatOllamaApiHost(p.apiHost) },
+    { match: isGeminiProvider, format: (p, av) => formatApiHost(p.apiHost, av, 'v1beta') },
+    { match: isAzureOpenAIProvider, format: (p) => formatApiHost(p.apiHost, false) },
+    { match: isVertexProvider, format: (p) => formatVertexApiHost(p as Parameters<typeof formatVertexApiHost>[0]) }
+  ]
+
+  const formatter = formatters.find((f) => f.match(provider))
+  formatted.apiHost = formatter
+    ? formatter.format(formatted, appendApiVersion)
+    : formatApiHost(formatted.apiHost, appendApiVersion)
+
+  return formatted
+}
+
+// === SDK Config Building ===
+
+type ConfigBuilderEntry = {
+  match: (provider: Provider, aiSdkProviderId: AppProviderId) => boolean
+  build: (ctx: BuilderContext) => ProviderConfig | Promise<ProviderConfig>
+}
+
+export function providerToAiSdkConfig(
+  actualProvider: Provider,
+  model: Model
+): ProviderConfig | Promise<ProviderConfig> {
+  const aiSdkProviderId = getAiSdkProviderId(actualProvider)
+  const { baseURL, endpoint } = routeToEndpoint(actualProvider.apiHost)
+
+  const ctx: BuilderContext = {
+    actualProvider,
+    model,
+    baseConfig: { baseURL, apiKey: actualProvider.apiKey },
+    endpoint,
+    aiSdkProviderId
+  }
+
+  const builders: ConfigBuilderEntry[] = [
+    { match: (p) => p.id === SystemProviderIds.copilot, build: buildCopilotConfig },
+    { match: (p) => p.id === 'cherryai', build: buildCherryAIConfig },
+    { match: (p) => isOllamaProvider(p), build: buildOllamaConfig },
+    { match: (p) => isAzureOpenAIProvider(p), build: buildAzureConfig },
+    { match: (_, id) => id === 'bedrock', build: buildBedrockConfig },
+    { match: (_, id) => id === 'google-vertex', build: buildVertexConfig },
+    { match: (_, id) => id === 'cherryin', build: buildCherryinConfig },
+    { match: (_, id) => id === 'newapi', build: buildNewApiConfig },
+    { match: (_, id) => id === 'aihubmix', build: buildAiHubMixConfig }
+  ]
+
+  const builder = builders.find((b) => b.match(actualProvider, aiSdkProviderId))
+  if (builder) {
+    return builder.build(ctx)
+  }
+
+  // SDK-supported provider → generic config; otherwise → openai-compatible fallback
+  if (hasProviderConfig(aiSdkProviderId) && aiSdkProviderId !== 'openai-compatible') {
+    return buildGenericProviderConfig(ctx)
+  }
+  return buildOpenAICompatibleConfig(ctx)
+}
+
+// === Public API ===
+
+export function getActualProvider(model: Model): Provider {
+  return adaptProvider({ provider: getProviderByModel(model), model })
+}
+
+export function adaptProvider({ provider }: { provider: Provider; model?: Model }): Provider {
+  return formatProviderApiHost(cloneDeep(provider))
+}
+
+export function isModernSdkSupported(provider: Provider): boolean {
+  return hasProviderConfig(getAiSdkProviderId(provider))
+}
+
+// === Config Builders ===
+
+function buildCommonOptions(ctx: BuilderContext) {
+  const options: Record<string, any> = {
+    headers: {
+      ...defaultAppHeaders(),
+      ...ctx.actualProvider.extra_headers
+    },
+    fetch: createCustomFetch(ctx.actualProvider.extra_headers)
+  }
+  if (ctx.aiSdkProviderId === 'openai') {
+    options.headers['X-Api-Key'] = ctx.baseConfig.apiKey
+  }
+  return options
+}
+
+async function buildCopilotConfig(ctx: BuilderContext): Promise<ProviderConfig<'github-copilot-openai-compatible'>> {
+  const storedHeaders = store.getState().copilot.defaultHeaders ?? {}
+  const headers = { ...COPILOT_DEFAULT_HEADERS, ...storedHeaders }
+  const { token } = await window.api.copilot.getToken(headers)
+
+  return {
+    providerId: 'github-copilot-openai-compatible',
+    endpoint: ctx.endpoint,
+    providerSettings: {
+      ...ctx.baseConfig,
+      apiKey: token,
+      headers: { ...headers, ...ctx.actualProvider.extra_headers },
+      name: ctx.actualProvider.id,
+      fetch: createCustomFetch(ctx.actualProvider.extra_headers)
+    }
+  }
+}
+
+function buildOllamaConfig(ctx: BuilderContext): ProviderConfig<'ollama'> {
+  const headers: ProviderConfig<'ollama'>['providerSettings']['headers'] = {
+    ...defaultAppHeaders(),
+    ...ctx.actualProvider.extra_headers
+  }
+  if (!isEmpty(ctx.baseConfig.apiKey)) {
+    headers.Authorization = `Bearer ${ctx.baseConfig.apiKey}`
+  }
+
+  return {
+    providerId: 'ollama',
+    endpoint: ctx.endpoint,
+    providerSettings: { ...ctx.baseConfig, headers, fetch: createCustomFetch(ctx.actualProvider.extra_headers) }
+  }
+}
+
+function buildBedrockConfig(ctx: BuilderContext): ProviderConfig<'bedrock'> {
+  const authType = getAwsBedrockAuthType()
+  const region = getAwsBedrockRegion().trim() || undefined
+
+  const base = { providerId: 'bedrock' as const, endpoint: ctx.endpoint }
+
+  const baseURL = ctx.baseConfig.baseURL || undefined
+
+  if (authType === 'apiKey') {
+    return { ...base, providerSettings: { ...ctx.baseConfig, baseURL, region, apiKey: getAwsBedrockApiKey() } }
+  }
+  return {
+    ...base,
+    providerSettings: {
+      ...ctx.baseConfig,
+      baseURL,
+      region,
+      accessKeyId: getAwsBedrockAccessKeyId(),
+      secretAccessKey: getAwsBedrockSecretAccessKey()
+    }
+  }
+}
+
+function buildVertexConfig(
+  ctx: BuilderContext
+): ProviderConfig<'google-vertex'> | ProviderConfig<'google-vertex-anthropic'> {
+  if (!isVertexAiConfigured()) {
+    throw new Error('VertexAI is not configured. Please configure project, location and service account credentials.')
+  }
+
+  const { project, location, googleCredentials } = createVertexProvider(ctx.actualProvider)
+  // Vertex 上的 Claude 模型走 google-vertex-anthropic variant
+  const isAnthropic = ctx.aiSdkProviderId === 'google-vertex-anthropic' || ctx.model.id.startsWith('claude')
+  const baseURL = ctx.baseConfig.baseURL + (isAnthropic ? '/publishers/anthropic/models' : '/publishers/google')
+  const creds = { ...googleCredentials, privateKey: formatPrivateKey(googleCredentials.privateKey) }
+
+  return {
+    providerId: isAnthropic ? 'google-vertex-anthropic' : 'google-vertex',
+    endpoint: ctx.endpoint,
+    providerSettings: { ...ctx.baseConfig, baseURL, project, location, googleCredentials: creds }
+  } as ProviderConfig<'google-vertex'> | ProviderConfig<'google-vertex-anthropic'>
+}
+
+function buildCherryinConfig(ctx: BuilderContext): ProviderConfig<'cherryin'> {
+  const cherryinProvider = getProviderById(SystemProviderIds.cherryin)
+
+  return {
+    providerId: 'cherryin',
+    endpoint: ctx.endpoint,
+    providerSettings: {
+      ...ctx.baseConfig,
+      endpointType: ctx.model.endpoint_type,
+      anthropicBaseURL: cherryinProvider ? cherryinProvider.anthropicApiHost + '/v1' : undefined,
+      geminiBaseURL: cherryinProvider ? cherryinProvider.apiHost + '/v1beta' : undefined,
+      headers: { ...defaultAppHeaders(), ...ctx.actualProvider.extra_headers },
+      fetch: createCustomFetch(ctx.actualProvider.extra_headers)
+    }
+  }
+}
+
+async function buildCherryAIConfig(ctx: BuilderContext): Promise<ProviderConfig<'openai-compatible'>> {
+  const customFetch = createCustomFetch(ctx.actualProvider.extra_headers)
+  return {
+    providerId: 'openai-compatible',
+    endpoint: ctx.endpoint,
+    providerSettings: {
+      ...ctx.baseConfig,
+      name: ctx.actualProvider.id,
+      headers: { ...defaultAppHeaders(), ...ctx.actualProvider.extra_headers },
+      fetch: customFetch
+        ? async (input: RequestInfo | URL, init?: RequestInit) => {
+            const signature = await window.api.cherryai.generateSignature({
+              method: 'POST',
+              path: '/chat/completions',
+              query: '',
+              body: init?.body && typeof init.body === 'string' ? JSON.parse(init.body) : undefined
+            })
+            return customFetch(input, { ...init, headers: { ...init?.headers, ...signature } })
+          }
+        : async (input: RequestInfo | URL, init?: RequestInit) => {
+            const signature = await window.api.cherryai.generateSignature({
+              method: 'POST',
+              path: '/chat/completions',
+              query: '',
+              body: init?.body && typeof init.body === 'string' ? JSON.parse(init.body) : undefined
+            })
+            return fetch(input, { ...init, headers: { ...init?.headers, ...signature } })
+          }
+    }
+  }
+}
+
+function formatAzureBaseURL(baseURL: string, forAnthropic: boolean): string {
+  // Normalize: strip trailing /v1 and /openai that user may have included
+  const normalized = baseURL.replace(/\/v1$/, '').replace(/\/openai$/, '')
+  // Azure OpenAI endpoints need /openai suffix; Azure Anthropic does not
+  return forAnthropic ? normalized : normalized + '/openai'
+}
+
+function buildAzureConfig(
+  ctx: BuilderContext
+): ProviderConfig<'azure'> | ProviderConfig<'azure-responses'> | ProviderConfig<'azure-anthropic'> {
+  // Azure 上的 Claude 模型走 azure-anthropic variant（内部使用 Anthropic SDK）
+  if (ctx.model.id.startsWith('claude')) {
+    return {
+      providerId: 'azure-anthropic',
+      endpoint: ctx.endpoint,
+      providerSettings: {
+        ...ctx.baseConfig,
+        baseURL: formatAzureBaseURL(ctx.baseConfig.baseURL, true),
+        headers: { ...defaultAppHeaders(), ...ctx.actualProvider.extra_headers },
+        fetch: createCustomFetch(ctx.actualProvider.extra_headers)
+      }
+    }
+  }
+
+  const apiVersion = ctx.actualProvider.apiVersion?.trim()
+  const useResponsesMode = apiVersion && ['preview', 'v1'].includes(apiVersion)
+
+  const providerSettings: ProviderConfig<'azure'>['providerSettings'] = {
+    ...ctx.baseConfig,
+    baseURL: formatAzureBaseURL(ctx.baseConfig.baseURL, false),
+    headers: { ...defaultAppHeaders(), ...ctx.actualProvider.extra_headers },
+    fetch: createCustomFetch(ctx.actualProvider.extra_headers)
+  }
+
+  if (apiVersion) {
+    providerSettings.apiVersion = apiVersion
+    if (!useResponsesMode) {
+      providerSettings.useDeploymentBasedUrls = true
+    }
+  }
+
+  return {
+    providerId: useResponsesMode ? 'azure-responses' : 'azure',
+    endpoint: ctx.endpoint,
+    providerSettings
+  } as ProviderConfig<'azure'> | ProviderConfig<'azure-responses'>
+}
+
+function buildOpenAICompatibleConfig(ctx: BuilderContext): ProviderConfig<'openai-compatible'> {
+  const commonOptions = buildCommonOptions(ctx)
+  const includeUsage = isSupportStreamOptionsProvider(ctx.actualProvider)
+    ? store.getState().settings.openAI?.streamOptions?.includeUsage
+    : undefined
+
+  return {
+    providerId: 'openai-compatible',
+    endpoint: ctx.endpoint,
+    providerSettings: { ...ctx.baseConfig, ...commonOptions, name: ctx.actualProvider.id, includeUsage }
+  }
+}
+
+function buildGenericProviderConfig(ctx: BuilderContext): ProviderConfig {
+  const commonOptions = buildCommonOptions(ctx)
+
+  return {
+    providerId: ctx.aiSdkProviderId as StringKeys<AppProviderSettingsMap>,
+    endpoint: ctx.endpoint,
+    providerSettings: { ...ctx.baseConfig, ...commonOptions }
+  }
+}
+
+function buildAiHubMixConfig(ctx: BuilderContext): ProviderConfig<'aihubmix'> {
+  return {
+    providerId: 'aihubmix',
+    endpoint: ctx.endpoint,
+    providerSettings: {
+      ...ctx.baseConfig,
+      headers: { ...defaultAppHeaders(), ...ctx.actualProvider.extra_headers },
+      fetch: createCustomFetch(ctx.actualProvider.extra_headers)
+    }
+  }
+}
+
+function formatNewApiBaseURL(baseURL: string, endpointType?: string): string {
+  switch (endpointType) {
+    case 'gemini':
+      return formatApiHost(baseURL, true, 'v1beta')
+    case 'anthropic':
+      return formatApiHost(baseURL, false)
+    default:
+      return formatApiHost(baseURL, true)
+  }
+}
+
+function buildNewApiConfig(ctx: BuilderContext): ProviderConfig<'newapi'> {
+  const baseURL = formatNewApiBaseURL(ctx.baseConfig.baseURL, ctx.model.endpoint_type)
+
+  return {
+    providerId: 'newapi',
+    endpoint: ctx.endpoint,
+    providerSettings: {
+      ...ctx.baseConfig,
+      baseURL,
+      endpointType: ctx.model.endpoint_type,
+      headers: { ...defaultAppHeaders(), ...ctx.actualProvider.extra_headers },
+      fetch: createCustomFetch(ctx.actualProvider.extra_headers)
+    }
+  }
+}


### PR DESCRIPTION
### What this PR does

Before this PR:

Setting a custom `User-Agent` header via Provider Settings → Custom Request Headers had no effect. The AI SDK's internal `combineHeaders(this.config.headers(), options.headers)` call uses `{...a, ...b}` spread merging, where `options.headers` (containing `user-agent: ai/6.0.143`) overwrites the config-level headers (containing the user's custom `User-Agent` value). The custom header was lost before the HTTP request was made.

After this PR:

A `createCustomFetch` helper wraps `globalThis.fetch` to inject the custom `User-Agent` at the HTTP layer — after all AI SDK header processing completes. This ensures the user's custom value is always present in the outgoing request, prepended to any SDK suffixes for debugging context.

Fixes #15290

### Why we need it and why it was done in this way

The root cause is in the AI SDK's `combineHeaders` function (`@ai-sdk/openai-compatible`), which is a third-party dependency we cannot modify. The fix operates at the `fetch` wrapper level because:

- It is the last layer before the actual HTTP request, after all AI SDK header merging
- All AI SDK provider settings interfaces (`OpenAICompatibleProviderSettings`, etc.) already accept a `fetch?: FetchFunction` option
- It is transparent to the AI SDK's internal logic and doesn't require patching or forking dependencies

The following tradeoffs were made:

- Slight runtime overhead from the fetch wrapper (negligible — only wraps when a custom `User-Agent` is configured)
- The custom value is prepended to SDK suffixes rather than replacing them entirely, preserving debugging context

The following alternatives were considered:

1. Patching `@ai-sdk/provider-utils` via `patches/` directory — more invasive, risks breaking on SDK upgrades
2. Passing custom headers through `generateText`/`streamText` call-level `headers` parameter — the AI SDK always overwrites call-level headers with `ai/6.0.143` first
3. Intercepting at the `combineHeaders` level — requires modifying node_modules, not maintainable

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/15290

### Breaking changes

None. The change is purely additive: a `fetch` wrapper is passed through `providerSettings.fetch` only when a custom `User-Agent` is configured. All existing behavior is preserved when no custom headers are set.

### Special notes for your reviewer

The `createCustomFetch` helper performs a case-insensitive lookup for the `user-agent` key in `extra_headers` since the Headers API normalizes keys to lowercase. If multiple `user-agent`-like keys exist (e.g., `User-Agent` and `user-agent`), only the first match is used (order of `Object.keys()`).

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Custom fetch wrapper is minimal (~12 lines), focused on a single responsibility
- [x] Refactor: Existing builder functions are unchanged; `createCustomFetch` is a pure helper
- [x] Upgrade: No impact — the fix is opt-in via existing `fetch` config option
- [x] Documentation: No user-guide update required (this fixes existing documented behavior)
- [x] Self-review: All 474 existing aiCore tests pass; code reviewed via `/gh-pr-review`

### Release note

```release-note
fix: custom `User-Agent` request header set via Provider → Custom Request Headers now correctly takes effect on outgoing API requests
```