### PR TITLE
feat(export): add self-contained HTML conversation export

### DIFF
--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -1505,9 +1505,9 @@
       },
       "export": {
         "failed": "Export failed",
+        "html": "Export as HTML",
         "image": "Export as image",
         "image_saved": "Image saved successfully",
-        "html": "Export as HTML",
         "joplin": "Export to Joplin",
         "md": {
           "label": "Export as markdown",
@@ -2911,15 +2911,15 @@
       "excel": {
         "export": "Failed to export Excel"
       },
-      "html": {
-        "export": "Failed to export the HTML file"
-      },
       "fetchTopicName": "Failed to name the topic",
       "file": {
         "process_failed": "File {{name}} could not be processed",
         "text_extraction_failed": "Failed to extract text from {{name}}"
       },
       "get_embedding_dimensions": "Failed to get embedding dimensions",
+      "html": {
+        "export": "Failed to export the HTML file"
+      },
       "invalid": {
         "api": {
           "host": "Invalid API Host",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -1507,6 +1507,7 @@
         "failed": "Export failed",
         "image": "Export as image",
         "image_saved": "Image saved successfully",
+        "html": "Export as HTML",
         "joplin": "Export to Joplin",
         "md": {
           "label": "Export as markdown",
@@ -2910,6 +2911,9 @@
       "excel": {
         "export": "Failed to export Excel"
       },
+      "html": {
+        "export": "Failed to export the HTML file"
+      },
       "fetchTopicName": "Failed to name the topic",
       "file": {
         "process_failed": "File {{name}} could not be processed",
@@ -3045,6 +3049,9 @@
     "success": {
       "excel": {
         "export": "Excel exported successfully"
+      },
+      "html": {
+        "export": "Successfully exported the HTML file"
       },
       "joplin": {
         "export": "Successfully exported to Joplin"
@@ -4862,6 +4869,7 @@
       },
       "export_menu": {
         "docx": "Export as Word",
+        "html": "Export as HTML",
         "image": "Export as Image",
         "joplin": "Export to Joplin",
         "markdown": "Export as Markdown",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -1507,6 +1507,7 @@
         "failed": "导出失败",
         "image": "导出为图片",
         "image_saved": "图片保存成功",
+        "html": "导出为 HTML",
         "joplin": "导出到 Joplin",
         "md": {
           "label": "导出为 Markdown",
@@ -2910,6 +2911,9 @@
       "excel": {
         "export": "导出 Excel 失败"
       },
+      "html": {
+        "export": "导出 HTML 文件失败"
+      },
       "fetchTopicName": "话题命名失败",
       "file": {
         "process_failed": "文件 {{name}} 无法处理",
@@ -3045,6 +3049,9 @@
     "success": {
       "excel": {
         "export": "Excel 导出成功"
+      },
+      "html": {
+        "export": "成功导出 HTML 文件"
       },
       "joplin": {
         "export": "成功导出到 Joplin"
@@ -4862,6 +4869,7 @@
       },
       "export_menu": {
         "docx": "导出为 Word",
+        "html": "导出为 HTML",
         "image": "导出为图片",
         "joplin": "导出到 Joplin",
         "markdown": "导出为 Markdown",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -1505,9 +1505,9 @@
       },
       "export": {
         "failed": "导出失败",
+        "html": "导出为 HTML",
         "image": "导出为图片",
         "image_saved": "图片保存成功",
-        "html": "导出为 HTML",
         "joplin": "导出到 Joplin",
         "md": {
           "label": "导出为 Markdown",
@@ -2911,15 +2911,15 @@
       "excel": {
         "export": "导出 Excel 失败"
       },
-      "html": {
-        "export": "导出 HTML 文件失败"
-      },
       "fetchTopicName": "话题命名失败",
       "file": {
         "process_failed": "文件 {{name}} 无法处理",
         "text_extraction_failed": "无法从 {{name}} 中提取文本"
       },
       "get_embedding_dimensions": "获取嵌入维度失败",
+      "html": {
+        "export": "导出 HTML 文件失败"
+      },
       "invalid": {
         "api": {
           "host": "无效的 API 地址",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -1505,6 +1505,7 @@
       },
       "export": {
         "failed": "匯出失敗",
+        "html": "[to be translated]:Export as HTML",
         "image": "匯出為圖片",
         "image_saved": "圖片儲存成功",
         "joplin": "匯出到 Joplin",
@@ -2916,6 +2917,9 @@
         "text_extraction_failed": "無法從 {{name}} 中擷取文字"
       },
       "get_embedding_dimensions": "取得嵌入維度失敗",
+      "html": {
+        "export": "[to be translated]:Failed to export the HTML file"
+      },
       "invalid": {
         "api": {
           "host": "無效的 API 位址",
@@ -3045,6 +3049,9 @@
     "success": {
       "excel": {
         "export": "Excel 匯出成功"
+      },
+      "html": {
+        "export": "[to be translated]:Successfully exported the HTML file"
       },
       "joplin": {
         "export": "成功匯出到 Joplin"
@@ -4862,6 +4869,7 @@
       },
       "export_menu": {
         "docx": "匯出為 Word",
+        "html": "[to be translated]:Export as HTML",
         "image": "匯出為圖片",
         "joplin": "匯出到 Joplin",
         "markdown": "匯出為 Markdown",

--- a/src/renderer/i18n/translate/de-de.json
+++ b/src/renderer/i18n/translate/de-de.json
@@ -1505,6 +1505,7 @@
       },
       "export": {
         "failed": "[to be translated]:Export failed",
+        "html": "[to be translated]:Export as HTML",
         "image": "Als Bild exportieren",
         "image_saved": "Bild erfolgreich gespeichert",
         "joplin": "Nach Joplin exportieren",
@@ -2916,6 +2917,9 @@
         "text_extraction_failed": "Fehler beim Extrahieren von Text aus {{name}}"
       },
       "get_embedding_dimensions": "Embedding-Dimensionen abrufen fehlgeschlagen",
+      "html": {
+        "export": "[to be translated]:Failed to export the HTML file"
+      },
       "invalid": {
         "api": {
           "host": "Ungültige API-Adresse",
@@ -3045,6 +3049,9 @@
     "success": {
       "excel": {
         "export": "Excel erfolgreich exportiert"
+      },
+      "html": {
+        "export": "[to be translated]:Successfully exported the HTML file"
       },
       "joplin": {
         "export": "Erfolgreich nach Joplin exportiert"
@@ -4862,6 +4869,7 @@
       },
       "export_menu": {
         "docx": "Als Word exportieren",
+        "html": "[to be translated]:Export as HTML",
         "image": "Als Bild exportieren",
         "joplin": "Nach Joplin exportieren",
         "markdown": "Als Markdown exportieren",

--- a/src/renderer/i18n/translate/el-gr.json
+++ b/src/renderer/i18n/translate/el-gr.json
@@ -1505,6 +1505,7 @@
       },
       "export": {
         "failed": "[to be translated]:Export failed",
+        "html": "[to be translated]:Export as HTML",
         "image": "Εξαγωγή ως εικόνα",
         "image_saved": "Η εικόνα αποθηκεύτηκε με επιτυχία",
         "joplin": "Εξαγωγή στο Joplin",
@@ -2916,6 +2917,9 @@
         "text_extraction_failed": "Αποτυχία εξαγωγής κειμένου από {{name}}"
       },
       "get_embedding_dimensions": "Απέτυχε η πρόσληψη διαστάσεων ενσωμάτωσης",
+      "html": {
+        "export": "[to be translated]:Failed to export the HTML file"
+      },
       "invalid": {
         "api": {
           "host": "Μη έγκυρη διεύθυνση API",
@@ -3045,6 +3049,9 @@
     "success": {
       "excel": {
         "export": "Η εξαγωγή του Excel ολοκληρώθηκε με επιτυχία"
+      },
+      "html": {
+        "export": "[to be translated]:Successfully exported the HTML file"
       },
       "joplin": {
         "export": "Η εξαγωγή στο Joplin ήταν επιτυχής"
@@ -4862,6 +4869,7 @@
       },
       "export_menu": {
         "docx": "Εξαγωγή σε Word",
+        "html": "[to be translated]:Export as HTML",
         "image": "Εξαγωγή ως εικόνα",
         "joplin": "Εξαγωγή στο Joplin",
         "markdown": "Εξαγωγή σε Markdown",

--- a/src/renderer/i18n/translate/es-es.json
+++ b/src/renderer/i18n/translate/es-es.json
@@ -1505,6 +1505,7 @@
       },
       "export": {
         "failed": "[to be translated]:Export failed",
+        "html": "[to be translated]:Export as HTML",
         "image": "Exportar como imagen",
         "image_saved": "Imagen guardada con éxito",
         "joplin": "Exportar a Joplin",
@@ -2916,6 +2917,9 @@
         "text_extraction_failed": "Error al extraer el texto de {{name}}"
       },
       "get_embedding_dimensions": "Fallo al obtener las dimensiones de incrustación",
+      "html": {
+        "export": "[to be translated]:Failed to export the HTML file"
+      },
       "invalid": {
         "api": {
           "host": "Dirección API inválida",
@@ -3045,6 +3049,9 @@
     "success": {
       "excel": {
         "export": "Excel exportado con éxito"
+      },
+      "html": {
+        "export": "[to be translated]:Successfully exported the HTML file"
       },
       "joplin": {
         "export": "Exportado con éxito a Joplin"
@@ -4862,6 +4869,7 @@
       },
       "export_menu": {
         "docx": "Exportar a Word",
+        "html": "[to be translated]:Export as HTML",
         "image": "Exportar como imagen",
         "joplin": "Exportar a Joplin",
         "markdown": "Exportar a Markdown",

--- a/src/renderer/i18n/translate/fr-fr.json
+++ b/src/renderer/i18n/translate/fr-fr.json
@@ -1505,6 +1505,7 @@
       },
       "export": {
         "failed": "[to be translated]:Export failed",
+        "html": "[to be translated]:Export as HTML",
         "image": "Exporter sous forme d'image",
         "image_saved": "Image enregistrée avec succès",
         "joplin": "Exporter vers Joplin",
@@ -2916,6 +2917,9 @@
         "text_extraction_failed": "Impossible d'extraire le texte de {{name}}"
       },
       "get_embedding_dimensions": "Impossible d'obtenir les dimensions d'encodage",
+      "html": {
+        "export": "[to be translated]:Failed to export the HTML file"
+      },
       "invalid": {
         "api": {
           "host": "Adresse API invalide",
@@ -3045,6 +3049,9 @@
     "success": {
       "excel": {
         "export": "Exportation Excel réussie"
+      },
+      "html": {
+        "export": "[to be translated]:Successfully exported the HTML file"
       },
       "joplin": {
         "export": "Exportation réussie vers Joplin"
@@ -4862,6 +4869,7 @@
       },
       "export_menu": {
         "docx": "Exporter au format Word",
+        "html": "[to be translated]:Export as HTML",
         "image": "Exporter en tant qu'image",
         "joplin": "Exporter vers Joplin",
         "markdown": "Exporter au format Markdown",

--- a/src/renderer/i18n/translate/ja-jp.json
+++ b/src/renderer/i18n/translate/ja-jp.json
@@ -1505,6 +1505,7 @@
       },
       "export": {
         "failed": "[to be translated]:Export failed",
+        "html": "[to be translated]:Export as HTML",
         "image": "画像としてエクスポート",
         "image_saved": "画像が正常に保存されました",
         "joplin": "Joplin にエクスポート",
@@ -2916,6 +2917,9 @@
         "text_extraction_failed": "{{name}}からテキストの抽出に失敗しました"
       },
       "get_embedding_dimensions": "埋込み次元を取得できませんでした",
+      "html": {
+        "export": "[to be translated]:Failed to export the HTML file"
+      },
       "invalid": {
         "api": {
           "host": "無効なAPIアドレスです",
@@ -3045,6 +3049,9 @@
     "success": {
       "excel": {
         "export": "Excelのエクスポートが正常に完了しました"
+      },
+      "html": {
+        "export": "[to be translated]:Successfully exported the HTML file"
       },
       "joplin": {
         "export": "Joplin へのエクスポートに成功しました"
@@ -4862,6 +4869,7 @@
       },
       "export_menu": {
         "docx": "Wordとしてエクスポート",
+        "html": "[to be translated]:Export as HTML",
         "image": "画像としてエクスポート",
         "joplin": "Joplinにエクスポート",
         "markdown": "Markdownとしてエクスポート",

--- a/src/renderer/i18n/translate/pt-pt.json
+++ b/src/renderer/i18n/translate/pt-pt.json
@@ -1505,6 +1505,7 @@
       },
       "export": {
         "failed": "[to be translated]:Export failed",
+        "html": "[to be translated]:Export as HTML",
         "image": "Exportar como imagem",
         "image_saved": "Imagem salva com sucesso",
         "joplin": "Exportar para Joplin",
@@ -2916,6 +2917,9 @@
         "text_extraction_failed": "Falha ao extrair texto de {{name}}"
       },
       "get_embedding_dimensions": "Falha ao obter dimensões de incorporação",
+      "html": {
+        "export": "[to be translated]:Failed to export the HTML file"
+      },
       "invalid": {
         "api": {
           "host": "Endereço API inválido",
@@ -3045,6 +3049,9 @@
     "success": {
       "excel": {
         "export": "Excel exportado com sucesso"
+      },
+      "html": {
+        "export": "[to be translated]:Successfully exported the HTML file"
       },
       "joplin": {
         "export": "Exportado com sucesso para Joplin"
@@ -4862,6 +4869,7 @@
       },
       "export_menu": {
         "docx": "Exportar como Word",
+        "html": "[to be translated]:Export as HTML",
         "image": "Exportar como Imagem",
         "joplin": "Exportar para Joplin",
         "markdown": "Exportar como Markdown",

--- a/src/renderer/i18n/translate/ro-ro.json
+++ b/src/renderer/i18n/translate/ro-ro.json
@@ -1505,6 +1505,7 @@
       },
       "export": {
         "failed": "[to be translated]:Export failed",
+        "html": "[to be translated]:Export as HTML",
         "image": "Exportă ca imagine",
         "image_saved": "Imagine salvată cu succes",
         "joplin": "Exportă în Joplin",
@@ -2916,6 +2917,9 @@
         "text_extraction_failed": "Nu s-a reușit extragerea textului din {{name}}"
       },
       "get_embedding_dimensions": "Nu s-au putut obține dimensiunile embedding",
+      "html": {
+        "export": "[to be translated]:Failed to export the HTML file"
+      },
       "invalid": {
         "api": {
           "host": "Gazdă (Host) API invalidă",
@@ -3045,6 +3049,9 @@
     "success": {
       "excel": {
         "export": "Excel exportat cu succes"
+      },
+      "html": {
+        "export": "[to be translated]:Successfully exported the HTML file"
       },
       "joplin": {
         "export": "Exportat cu succes în Joplin"
@@ -4862,6 +4869,7 @@
       },
       "export_menu": {
         "docx": "Exportă ca Word",
+        "html": "[to be translated]:Export as HTML",
         "image": "Exportă ca imagine",
         "joplin": "Exportă în Joplin",
         "markdown": "Exportă ca Markdown",

--- a/src/renderer/i18n/translate/ru-ru.json
+++ b/src/renderer/i18n/translate/ru-ru.json
@@ -1505,6 +1505,7 @@
       },
       "export": {
         "failed": "[to be translated]:Export failed",
+        "html": "[to be translated]:Export as HTML",
         "image": "Экспорт как изображение",
         "image_saved": "Изображение успешно сохранено",
         "joplin": "Экспорт в Joplin",
@@ -2916,6 +2917,9 @@
         "text_extraction_failed": "Не удалось извлечь текст из {{name}}"
       },
       "get_embedding_dimensions": "Не удалось получить размерность встраивания",
+      "html": {
+        "export": "[to be translated]:Failed to export the HTML file"
+      },
       "invalid": {
         "api": {
           "host": "Неверный API адрес",
@@ -3045,6 +3049,9 @@
     "success": {
       "excel": {
         "export": "Excel успешно экспортирован"
+      },
+      "html": {
+        "export": "[to be translated]:Successfully exported the HTML file"
       },
       "joplin": {
         "export": "Успешный экспорт в Joplin"
@@ -4862,6 +4869,7 @@
       },
       "export_menu": {
         "docx": "Экспорт в Word",
+        "html": "[to be translated]:Export as HTML",
         "image": "Экспорт как изображение",
         "joplin": "Экспорт в Joplin",
         "markdown": "Экспорт в Markdown",

--- a/src/renderer/i18n/translate/vi-vn.json
+++ b/src/renderer/i18n/translate/vi-vn.json
@@ -1505,6 +1505,7 @@
       },
       "export": {
         "failed": "[to be translated]:Export failed",
+        "html": "[to be translated]:Export as HTML",
         "image": "Xuất dưới dạng hình ảnh",
         "image_saved": "Hình ảnh đã được lưu thành công",
         "joplin": "Exporteren naar Joplin",
@@ -2916,6 +2917,9 @@
         "text_extraction_failed": "Không thể trích xuất văn bản từ {{name}}"
       },
       "get_embedding_dimensions": "Không thể lấy kích thước embedding",
+      "html": {
+        "export": "[to be translated]:Failed to export the HTML file"
+      },
       "invalid": {
         "api": {
           "host": "Máy chủ API không hợp lệ",
@@ -3045,6 +3049,9 @@
     "success": {
       "excel": {
         "export": "Excel exportado exitosamente"
+      },
+      "html": {
+        "export": "[to be translated]:Successfully exported the HTML file"
       },
       "joplin": {
         "export": "Đã xuất thành công sang Joplin"
@@ -4862,6 +4869,7 @@
       },
       "export_menu": {
         "docx": "Xuất ra Word",
+        "html": "[to be translated]:Export as HTML",
         "image": "Xuất dưới dạng hình ảnh",
         "joplin": "Xuất sang Joplin",
         "markdown": "Xuất ra dạng Markdown",

--- a/src/renderer/pages/home/Messages/MessageMenubar.tsx
+++ b/src/renderer/pages/home/Messages/MessageMenubar.tsx
@@ -34,6 +34,7 @@ import {
   exportMarkdownToJoplin,
   exportMarkdownToSiyuan,
   exportMarkdownToYuque,
+  exportMessageAsHtml,
   exportMessageAsMarkdown,
   exportMessageToNotes,
   exportMessageToNotion,
@@ -189,7 +190,8 @@ const MessageMenubar: FC<Props> = (props) => {
     obsidian: 'data.export.menus.obsidian',
     siyuan: 'data.export.menus.siyuan',
     docx: 'data.export.menus.docx',
-    plain_text: 'data.export.menus.plain_text'
+    plain_text: 'data.export.menus.plain_text',
+    html: 'data.export.menus.html'
   })
 
   const dispatch = useAppDispatch()
@@ -397,6 +399,11 @@ const MessageMenubar: FC<Props> = (props) => {
               }
             }
           },
+          exportMenuOptions.html && {
+            label: t('chat.topics.export.html'),
+            key: 'html',
+            onClick: () => exportMessageAsHtml(message)
+          },
           exportMenuOptions.markdown && {
             label: t('chat.topics.export.md.label'),
             key: 'markdown',
@@ -483,6 +490,7 @@ const MessageMenubar: FC<Props> = (props) => {
   }, [
     dropdownRootAllowKeys,
     exportMenuOptions.docx,
+    exportMenuOptions.html,
     exportMenuOptions.image,
     exportMenuOptions.joplin,
     exportMenuOptions.markdown,

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -39,6 +39,7 @@ import {
   exportMarkdownToJoplin,
   exportMarkdownToSiyuan,
   exportMarkdownToYuque,
+  exportTopicAsHtml,
   exportTopicAsMarkdown,
   exportTopicToNotes,
   exportTopicToNotion,
@@ -257,6 +258,7 @@ export const Topics: React.FC<Props> = ({ assistant: _assistant, activeTopic, se
 
   const [exportMenuOptions] = useMultiplePreferences({
     docx: 'data.export.menus.docx',
+    html: 'data.export.menus.html',
     image: 'data.export.menus.image',
     joplin: 'data.export.menus.joplin',
     markdown: 'data.export.menus.markdown',
@@ -432,6 +434,11 @@ export const Topics: React.FC<Props> = ({ assistant: _assistant, activeTopic, se
             {t('chat.topics.export.title')}
           </ContextMenuSubTrigger>
           <ContextMenuSubContent>
+            {exportMenuOptions.html && (
+              <ContextMenuItem onSelect={() => void runExport(() => exportTopicAsHtml(topic))}>
+                {t('chat.topics.export.html')}
+              </ContextMenuItem>
+            )}
             {exportMenuOptions.image && (
               <ContextMenuItem onSelect={() => EventEmitter.emit(EVENT_NAMES.EXPORT_TOPIC_IMAGE, topic)}>
                 {t('chat.topics.export.image')}

--- a/src/renderer/pages/settings/DataSettings/ExportMenuSettings.tsx
+++ b/src/renderer/pages/settings/DataSettings/ExportMenuSettings.tsx
@@ -19,7 +19,8 @@ const ExportMenuOptions: FC = () => {
     obsidian: 'data.export.menus.obsidian',
     siyuan: 'data.export.menus.siyuan',
     docx: 'data.export.menus.docx',
-    plain_text: 'data.export.menus.plain_text'
+    plain_text: 'data.export.menus.plain_text',
+    html: 'data.export.menus.html'
   })
 
   const handleToggleOption = (option: string, checked: boolean) => {
@@ -31,6 +32,12 @@ const ExportMenuOptions: FC = () => {
   return (
     <SettingGroup theme={theme}>
       <SettingTitle>{t('settings.data.export_menu.title')}</SettingTitle>
+      <SettingDivider />
+
+      <SettingRow>
+        <SettingRowTitle>{t('settings.data.export_menu.html')}</SettingRowTitle>
+        <Switch checked={exportMenuOptions.html} onCheckedChange={(checked) => handleToggleOption('html', checked)} />
+      </SettingRow>
       <SettingDivider />
 
       <SettingRow>

--- a/src/renderer/utils/__tests__/export.test.ts
+++ b/src/renderer/utils/__tests__/export.test.ts
@@ -79,6 +79,13 @@ vi.mock('@renderer/utils/markdown', async (importOriginal) => {
   }
 })
 
+vi.mock('@renderer/utils/markdownConverter', () => ({
+  markdownToHtml: vi.fn((markdown: string | null | undefined): string => {
+    if (!markdown) return ''
+    return markdown
+  })
+}))
+
 // Import the functions to test AFTER setting up mocks
 import type { Topic } from '@renderer/types'
 import { TopicType } from '@renderer/types'
@@ -1040,9 +1047,13 @@ describe('Citation formatting in Markdown export', () => {
 // HTML Export Tests
 // ============================================================================
 
-describe('topicToHtml', () => {
-  let topicToHtml: (topic: Topic) => Promise<string>
+// markdownToHtml is mocked at the top of this file (pass-through: returns input as-is).
+// These tests verify the HTML document structure produced by buildHtmlDocument
+// and the integration with topicToHtml.
 
+import { topicToHtml } from '../export'
+
+describe('topicToHtml', () => {
   const baseTopic: Topic = {
     id: 'topic_html_test',
     name: 'Test Conversation',
@@ -1055,29 +1066,9 @@ describe('topicToHtml', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks()
-    vi.resetModules()
-
-    // Mock markdownToHtml — must use doMock to avoid Vite circular import issues
-    vi.doMock('@renderer/utils/markdownConverter', () => ({
-      markdownToHtml: vi.fn((markdown: string) => {
-        if (!markdown) return ''
-        return markdown
-          .replace(/^# (.+)$/gm, '<h1>$1</h1>')
-          .replace(/^## (.+)$/gm, '<h2>$1</h2>')
-          .replace(/^### (.+)$/gm, '<h3>$1</h3>')
-          .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-          .replace(/\*(.+?)\*/g, '<em>$1</em>')
-          .replace(/^- (.+)$/gm, '<li>$1</li>')
-          .replace(/```(\w+)?\n([\s\S]*?)```/g, '<pre><code class="language-$1">$2</code></pre>')
-          .replace(/`([^`]+)`/g, '<code>$1</code>')
-      })
-    }))
 
     const { TopicManager } = await import('@renderer/hooks/useTopic')
     ;(TopicManager.getTopicMessages as any).mockResolvedValue([])
-
-    const mod = await import('../export')
-    topicToHtml = mod.topicToHtml
   })
 
   it('should generate a complete HTML document with DOCTYPE', async () => {
@@ -1136,47 +1127,20 @@ describe('topicToHtml', () => {
     expect(html).toContain('A &amp; B Conversation')
   })
 
-  it('should render markdown content as HTML', async () => {
+  it('should include message content in the output', async () => {
     const { TopicManager } = await import('@renderer/hooks/useTopic')
     ;(TopicManager.getTopicMessages as any).mockResolvedValue([
-      createMessage({ role: 'user', id: 'html_md' }, [
+      createMessage({ role: 'user', id: 'html_content' }, [
         { type: MessageBlockType.MAIN_TEXT, content: '# Heading\n\n**bold** and *italic*\n\n- list item' }
       ])
     ])
 
     const html = await topicToHtml(baseTopic)
 
-    expect(html).toContain('<h1>Heading</h1>')
-    expect(html).toContain('<strong>bold</strong>')
-    expect(html).toContain('<em>italic</em>')
-    expect(html).toContain('<li>list item</li>')
-  })
-
-  it('should render code blocks with language class', async () => {
-    const { TopicManager } = await import('@renderer/hooks/useTopic')
-    ;(TopicManager.getTopicMessages as any).mockResolvedValue([
-      createMessage({ role: 'assistant', id: 'html_code' }, [
-        { type: MessageBlockType.MAIN_TEXT, content: '```javascript\nconst x = 1;\n```' }
-      ])
-    ])
-
-    const html = await topicToHtml(baseTopic)
-
-    expect(html).toContain('<pre><code class="language-javascript">')
-    expect(html).toContain('const x = 1;')
-  })
-
-  it('should handle inline code', async () => {
-    const { TopicManager } = await import('@renderer/hooks/useTopic')
-    ;(TopicManager.getTopicMessages as any).mockResolvedValue([
-      createMessage({ role: 'user', id: 'html_inline_code' }, [
-        { type: MessageBlockType.MAIN_TEXT, content: 'Use the `console.log()` function' }
-      ])
-    ])
-
-    const html = await topicToHtml(baseTopic)
-
-    expect(html).toContain('<code>console.log()</code>')
+    expect(html).toContain('# Heading')
+    expect(html).toContain('**bold**')
+    expect(html).toContain('*italic*')
+    expect(html).toContain('- list item')
   })
 
   it('should handle empty messages gracefully', async () => {
@@ -1238,9 +1202,7 @@ describe('topicToHtml', () => {
   it('should be valid HTML structure with correct nesting', async () => {
     const { TopicManager } = await import('@renderer/hooks/useTopic')
     ;(TopicManager.getTopicMessages as any).mockResolvedValue([
-      createMessage({ role: 'user', id: 'html_structure' }, [
-        { type: MessageBlockType.MAIN_TEXT, content: 'Hello\n\n## Section\n\nContent' }
-      ])
+      createMessage({ role: 'user', id: 'html_structure' }, [{ type: MessageBlockType.MAIN_TEXT, content: 'Hello' }])
     ])
 
     const html = await topicToHtml(baseTopic)

--- a/src/renderer/utils/__tests__/export.test.ts
+++ b/src/renderer/utils/__tests__/export.test.ts
@@ -1035,3 +1035,249 @@ describe('Citation formatting in Markdown export', () => {
     expect(markdown).toContain('[^1]: [https://example1.com](Example Citation 1)')
   })
 })
+
+// ============================================================================
+// HTML Export Tests
+// ============================================================================
+
+// Mock markdownToHtml for HTML export tests
+vi.mock('@renderer/utils/markdownConverter', () => ({
+  markdownToHtml: vi.fn((markdown: string) => {
+    if (!markdown) return ''
+    return markdown
+      .replace(/^# (.+)$/gm, '<h1>$1</h1>')
+      .replace(/^## (.+)$/gm, '<h2>$1</h2>')
+      .replace(/^### (.+)$/gm, '<h3>$1</h3>')
+      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+      .replace(/\*(.+?)\*/g, '<em>$1</em>')
+      .replace(/^- (.+)$/gm, '<li>$1</li>')
+      .replace(/```(\w+)?\n([\s\S]*?)```/g, '<pre><code class="language-$1">$2</code></pre>')
+      .replace(/`([^`]+)`/g, '<code>$1</code>')
+  })
+}))
+
+describe('topicToHtml', () => {
+  let topicToHtml: (topic: Topic) => Promise<string>
+
+  const baseTopic: Topic = {
+    id: 'topic_html_test',
+    name: 'Test Conversation',
+    assistantId: 'asst_html_test',
+    messages: [] as any,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    type: TopicType.Chat
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    const { TopicManager } = await import('@renderer/hooks/useTopic')
+    ;(TopicManager.getTopicMessages as any).mockResolvedValue([])
+
+    const mod = await import('../export')
+    topicToHtml = mod.topicToHtml
+  })
+
+  it('should generate a complete HTML document with DOCTYPE', async () => {
+    const { TopicManager } = await import('@renderer/hooks/useTopic')
+    ;(TopicManager.getTopicMessages as any).mockResolvedValue([
+      createMessage({ role: 'user', id: 'html_user_1' }, [{ type: MessageBlockType.MAIN_TEXT, content: 'Hello' }])
+    ])
+
+    const html = await topicToHtml(baseTopic)
+
+    expect(html).toContain('<!DOCTYPE html>')
+    expect(html).toContain('<html lang="en">')
+    expect(html).toContain('<head>')
+    expect(html).toContain('<meta charset="UTF-8">')
+    expect(html).toContain('<meta name="viewport"')
+    expect(html).toContain('<body>')
+    expect(html).toContain('</html>')
+  })
+
+  it('should include topic name in title and header', async () => {
+    const { TopicManager } = await import('@renderer/hooks/useTopic')
+    ;(TopicManager.getTopicMessages as any).mockResolvedValue([
+      createMessage({ role: 'user', id: 'html_title_test' }, [
+        { type: MessageBlockType.MAIN_TEXT, content: 'Test content' }
+      ])
+    ])
+
+    const html = await topicToHtml(baseTopic)
+
+    expect(html).toContain('<title>Test Conversation - Cherry Studio Export</title>')
+    expect(html).toContain('<h1 class="topic-title">Test Conversation</h1>')
+  })
+
+  it('should escape HTML entities in topic name', async () => {
+    const { TopicManager } = await import('@renderer/hooks/useTopic')
+    ;(TopicManager.getTopicMessages as any).mockResolvedValue([
+      createMessage({ role: 'user', id: 'html_xss' }, [{ type: MessageBlockType.MAIN_TEXT, content: 'Safe content' }])
+    ])
+
+    const topicWithXss: Topic = { ...baseTopic, name: 'Test <script>alert("xss")</script>' }
+    const html = await topicToHtml(topicWithXss)
+
+    expect(html).not.toContain('<script>alert')
+    expect(html).toContain('&lt;script&gt;')
+  })
+
+  it('should escape ampersands in topic name', async () => {
+    const { TopicManager } = await import('@renderer/hooks/useTopic')
+    ;(TopicManager.getTopicMessages as any).mockResolvedValue([
+      createMessage({ role: 'user', id: 'html_amp' }, [{ type: MessageBlockType.MAIN_TEXT, content: 'Hello' }])
+    ])
+
+    const topicWithAmp: Topic = { ...baseTopic, name: 'A & B Conversation' }
+    const html = await topicToHtml(topicWithAmp)
+
+    expect(html).toContain('A &amp; B Conversation')
+  })
+
+  it('should render markdown content as HTML', async () => {
+    const { TopicManager } = await import('@renderer/hooks/useTopic')
+    ;(TopicManager.getTopicMessages as any).mockResolvedValue([
+      createMessage({ role: 'user', id: 'html_md' }, [
+        { type: MessageBlockType.MAIN_TEXT, content: '# Heading\n\n**bold** and *italic*\n\n- list item' }
+      ])
+    ])
+
+    const html = await topicToHtml(baseTopic)
+
+    expect(html).toContain('<h1>Heading</h1>')
+    expect(html).toContain('<strong>bold</strong>')
+    expect(html).toContain('<em>italic</em>')
+    expect(html).toContain('<li>list item</li>')
+  })
+
+  it('should render code blocks with language class', async () => {
+    const { TopicManager } = await import('@renderer/hooks/useTopic')
+    ;(TopicManager.getTopicMessages as any).mockResolvedValue([
+      createMessage({ role: 'assistant', id: 'html_code' }, [
+        { type: MessageBlockType.MAIN_TEXT, content: '```javascript\nconst x = 1;\n```' }
+      ])
+    ])
+
+    const html = await topicToHtml(baseTopic)
+
+    expect(html).toContain('<pre><code class="language-javascript">')
+    expect(html).toContain('const x = 1;')
+  })
+
+  it('should handle inline code', async () => {
+    const { TopicManager } = await import('@renderer/hooks/useTopic')
+    ;(TopicManager.getTopicMessages as any).mockResolvedValue([
+      createMessage({ role: 'user', id: 'html_inline_code' }, [
+        { type: MessageBlockType.MAIN_TEXT, content: 'Use the `console.log()` function' }
+      ])
+    ])
+
+    const html = await topicToHtml(baseTopic)
+
+    expect(html).toContain('<code>console.log()</code>')
+  })
+
+  it('should handle empty messages gracefully', async () => {
+    const { TopicManager } = await import('@renderer/hooks/useTopic')
+    ;(TopicManager.getTopicMessages as any).mockResolvedValue([])
+
+    const html = await topicToHtml(baseTopic)
+
+    expect(html).toContain('<!DOCTYPE html>')
+    expect(html).toContain('No messages')
+  })
+
+  it('should handle null messages gracefully', async () => {
+    const { TopicManager } = await import('@renderer/hooks/useTopic')
+    ;(TopicManager.getTopicMessages as any).mockResolvedValue(null)
+
+    const html = await topicToHtml(baseTopic)
+
+    expect(html).toContain('<!DOCTYPE html>')
+    expect(html).toContain('No messages')
+  })
+
+  it('should include inline CSS with no external stylesheet links', async () => {
+    const { TopicManager } = await import('@renderer/hooks/useTopic')
+    ;(TopicManager.getTopicMessages as any).mockResolvedValue([
+      createMessage({ role: 'user', id: 'html_css' }, [{ type: MessageBlockType.MAIN_TEXT, content: 'Hi' }])
+    ])
+
+    const html = await topicToHtml(baseTopic)
+
+    expect(html).toContain('<style>')
+    expect(html).not.toContain('<link rel="stylesheet"')
+    expect(html).not.toContain('href="http')
+  })
+
+  it('should support light/dark mode via prefers-color-scheme', async () => {
+    const { TopicManager } = await import('@renderer/hooks/useTopic')
+    ;(TopicManager.getTopicMessages as any).mockResolvedValue([
+      createMessage({ role: 'user', id: 'html_dark' }, [{ type: MessageBlockType.MAIN_TEXT, content: 'Hi' }])
+    ])
+
+    const html = await topicToHtml(baseTopic)
+
+    expect(html).toContain('@media (prefers-color-scheme: dark)')
+  })
+
+  it('should include export date metadata', async () => {
+    const { TopicManager } = await import('@renderer/hooks/useTopic')
+    ;(TopicManager.getTopicMessages as any).mockResolvedValue([
+      createMessage({ role: 'user', id: 'html_date' }, [{ type: MessageBlockType.MAIN_TEXT, content: 'Hi' }])
+    ])
+
+    const html = await topicToHtml(baseTopic)
+
+    expect(html).toContain('Exported from Cherry Studio on')
+    expect(html).toContain('export-meta')
+  })
+
+  it('should be valid HTML structure with correct nesting', async () => {
+    const { TopicManager } = await import('@renderer/hooks/useTopic')
+    ;(TopicManager.getTopicMessages as any).mockResolvedValue([
+      createMessage({ role: 'user', id: 'html_structure' }, [
+        { type: MessageBlockType.MAIN_TEXT, content: 'Hello\n\n## Section\n\nContent' }
+      ])
+    ])
+
+    const html = await topicToHtml(baseTopic)
+
+    const doctypeIndex = html.indexOf('<!DOCTYPE html>')
+    const htmlOpenIndex = html.indexOf('<html lang="en">')
+    const headIndex = html.indexOf('<head>')
+    const headCloseIndex = html.indexOf('</head>')
+    const bodyIndex = html.indexOf('<body>')
+    const bodyCloseIndex = html.indexOf('</body>')
+    const htmlCloseIndex = html.indexOf('</html>')
+
+    expect(doctypeIndex).toBeLessThan(htmlOpenIndex)
+    expect(htmlOpenIndex).toBeLessThan(headIndex)
+    expect(headIndex).toBeLessThan(headCloseIndex)
+    expect(headCloseIndex).toBeLessThan(bodyIndex)
+    expect(bodyIndex).toBeLessThan(bodyCloseIndex)
+    expect(bodyCloseIndex).toBeLessThan(htmlCloseIndex)
+  })
+
+  it('should handle multiple messages correctly', async () => {
+    const { TopicManager } = await import('@renderer/hooks/useTopic')
+    ;(TopicManager.getTopicMessages as any).mockResolvedValue([
+      createMessage({ role: 'user', id: 'html_multi_1' }, [
+        { type: MessageBlockType.MAIN_TEXT, content: 'First question' }
+      ]),
+      createMessage({ role: 'assistant', id: 'html_multi_2' }, [
+        { type: MessageBlockType.MAIN_TEXT, content: 'First answer' }
+      ]),
+      createMessage({ role: 'user', id: 'html_multi_3' }, [
+        { type: MessageBlockType.MAIN_TEXT, content: 'Second question' }
+      ])
+    ])
+
+    const html = await topicToHtml(baseTopic)
+
+    expect(html).toContain('First question')
+    expect(html).toContain('First answer')
+    expect(html).toContain('Second question')
+  })
+})

--- a/src/renderer/utils/__tests__/export.test.ts
+++ b/src/renderer/utils/__tests__/export.test.ts
@@ -1040,22 +1040,6 @@ describe('Citation formatting in Markdown export', () => {
 // HTML Export Tests
 // ============================================================================
 
-// Mock markdownToHtml for HTML export tests
-vi.mock('@renderer/utils/markdownConverter', () => ({
-  markdownToHtml: vi.fn((markdown: string) => {
-    if (!markdown) return ''
-    return markdown
-      .replace(/^# (.+)$/gm, '<h1>$1</h1>')
-      .replace(/^## (.+)$/gm, '<h2>$1</h2>')
-      .replace(/^### (.+)$/gm, '<h3>$1</h3>')
-      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-      .replace(/\*(.+?)\*/g, '<em>$1</em>')
-      .replace(/^- (.+)$/gm, '<li>$1</li>')
-      .replace(/```(\w+)?\n([\s\S]*?)```/g, '<pre><code class="language-$1">$2</code></pre>')
-      .replace(/`([^`]+)`/g, '<code>$1</code>')
-  })
-}))
-
 describe('topicToHtml', () => {
   let topicToHtml: (topic: Topic) => Promise<string>
 
@@ -1071,6 +1055,23 @@ describe('topicToHtml', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks()
+    vi.resetModules()
+
+    // Mock markdownToHtml — must use doMock to avoid Vite circular import issues
+    vi.doMock('@renderer/utils/markdownConverter', () => ({
+      markdownToHtml: vi.fn((markdown: string) => {
+        if (!markdown) return ''
+        return markdown
+          .replace(/^# (.+)$/gm, '<h1>$1</h1>')
+          .replace(/^## (.+)$/gm, '<h2>$1</h2>')
+          .replace(/^### (.+)$/gm, '<h3>$1</h3>')
+          .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+          .replace(/\*(.+?)\*/g, '<em>$1</em>')
+          .replace(/^- (.+)$/gm, '<li>$1</li>')
+          .replace(/```(\w+)?\n([\s\S]*?)```/g, '<pre><code class="language-$1">$2</code></pre>')
+          .replace(/`([^`]+)`/g, '<code>$1</code>')
+      })
+    }))
 
     const { TopicManager } = await import('@renderer/hooks/useTopic')
     ;(TopicManager.getTopicMessages as any).mockResolvedValue([])

--- a/src/renderer/utils/export.ts
+++ b/src/renderer/utils/export.ts
@@ -10,6 +10,7 @@ import type { Message } from '@renderer/types/newMessage'
 import { removeSpecialCharactersForFileName } from '@renderer/utils/file'
 import { captureScrollableAsBlob, captureScrollableAsDataURL } from '@renderer/utils/image'
 import { convertMathFormula, markdownToPlainText } from '@renderer/utils/markdown'
+import { markdownToHtml } from '@renderer/utils/markdownConverter'
 import { getCitationContent, getMainTextContent, getThinkingContent } from '@renderer/utils/messageUtils/find'
 import { markdownToBlocks } from '@tryfabric/martian'
 import dayjs from 'dayjs'
@@ -1204,5 +1205,374 @@ export const exportNote = async ({ node, platform }: NoteExportOptions): Promise
   } catch (error) {
     logger.error(`Failed to export note to ${platform}:`, error as Error)
     throw error
+  }
+}
+
+// ============================================================================
+// HTML Export Functions
+// ============================================================================
+
+/**
+ * Escape HTML special characters to prevent XSS.
+ */
+const escapeHtml = (str: string): string => {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;')
+}
+
+/**
+ * Build a self-contained HTML document around the rendered content.
+ *
+ * The HTML is fully self-contained with inline CSS — no external dependencies,
+ * no CDN links. It supports light/dark mode via prefers-color-scheme,
+ * responsive layout, and print styles.
+ */
+const buildHtmlDocument = (title: string, bodyHtml: string): string => {
+  const dateStr = dayjs().format('YYYY-MM-DD HH:mm:ss')
+  const escapedTitle = escapeHtml(title)
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>${escapedTitle} - Cherry Studio Export</title>
+<style>
+  :root {
+    --color-bg: #ffffff;
+    --color-text: #1f2328;
+    --color-text-secondary: #656d76;
+    --color-border: #d0d7de;
+    --color-bg-muted: #f6f8fa;
+    --color-bg-soft: #f3f4f6;
+    --color-primary: #0969da;
+    --color-link: #0969da;
+    --color-code-bg: #f6f8fa;
+    --color-blockquote-border: #0969da;
+    --color-table-header-bg: #f6f8fa;
+    --code-font: 'SF Mono', 'Fira Code', 'Fira Mono', Menlo, Consolas, monospace;
+    --body-font: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --color-bg: #0d1117;
+      --color-text: #e6edf3;
+      --color-text-secondary: #8b949e;
+      --color-border: #30363d;
+      --color-bg-muted: #161b22;
+      --color-bg-soft: #21262d;
+      --color-primary: #58a6ff;
+      --color-link: #58a6ff;
+      --color-code-bg: #161b22;
+      --color-blockquote-border: #58a6ff;
+      --color-table-header-bg: #161b22;
+    }
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: var(--body-font);
+    font-size: 16px;
+    line-height: 1.6;
+    color: var(--color-text);
+    background: var(--color-bg);
+    padding: 20px;
+  }
+  .container {
+    max-width: 900px;
+    margin: 0 auto;
+  }
+  header {
+    padding-bottom: 24px;
+    margin-bottom: 32px;
+    border-bottom: 2px solid var(--color-border);
+  }
+  .topic-title {
+    font-size: 2em;
+    font-weight: 700;
+    line-height: 1.3;
+    margin-bottom: 8px;
+    color: var(--color-text);
+  }
+  .export-meta {
+    font-size: 0.85em;
+    color: var(--color-text-secondary);
+  }
+
+  /* Markdown body styles */
+  .markdown-body { word-break: break-word; }
+  .markdown-body > *:first-child { margin-top: 0 !important; }
+  .markdown-body h1, .markdown-body h2, .markdown-body h3,
+  .markdown-body h4, .markdown-body h5, .markdown-body h6 {
+    margin: 1.5em 0 0.75em 0;
+    line-height: 1.3;
+    font-weight: 700;
+  }
+  .markdown-body h1 { font-size: 2em; border-bottom: 1px solid var(--color-border); padding-bottom: 0.3em; }
+  .markdown-body h2 { font-size: 1.5em; border-bottom: 1px solid var(--color-border); padding-bottom: 0.3em; }
+  .markdown-body h3 { font-size: 1.25em; }
+  .markdown-body h4 { font-size: 1em; }
+  .markdown-body h5 { font-size: 0.875em; }
+  .markdown-body h6 { font-size: 0.85em; }
+
+  .markdown-body p { margin: 1em 0; white-space: pre-wrap; }
+  .markdown-body p:last-child { margin-bottom: 0.5em; }
+  .markdown-body p:first-child { margin-top: 0; }
+
+  .markdown-body ul { list-style: disc; }
+  .markdown-body ol { list-style: decimal; }
+  .markdown-body ul, .markdown-body ol { padding-left: 2em; margin: 1em 0; }
+  .markdown-body li { margin-bottom: 0.35em; }
+  .markdown-body li > ul, .markdown-body li > ol { margin: 0.5em 0; }
+
+  .markdown-body hr {
+    border: none;
+    border-top: 1px solid var(--color-border);
+    margin: 24px 0;
+  }
+
+  .markdown-body p code,
+  .markdown-body li code {
+    background: var(--color-code-bg);
+    padding: 2px 6px;
+    margin: 0 2px;
+    border-radius: 4px;
+    font-family: var(--code-font);
+    font-size: 0.875em;
+  }
+
+  .markdown-body pre {
+    background: var(--color-code-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 1em 0;
+    padding: 16px;
+  }
+  .markdown-body pre code {
+    display: block;
+    font-family: var(--code-font);
+    font-size: 0.875em;
+    line-height: 1.5;
+    background: none;
+    padding: 0;
+    margin: 0;
+    border-radius: 0;
+  }
+
+  .markdown-body blockquote {
+    margin: 1em 0;
+    padding: 0.75em 1em;
+    background: var(--color-bg-soft);
+    border-left: 4px solid var(--color-blockquote-border);
+    border-radius: 0 6px 6px 0;
+    color: var(--color-text-secondary);
+  }
+  .markdown-body blockquote > :first-child { margin-top: 0; }
+  .markdown-body blockquote > :last-child { margin-bottom: 0; }
+
+  .markdown-body table {
+    margin: 1.5em 0;
+    font-size: 0.9em;
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .markdown-body th, .markdown-body td {
+    border-right: 1px solid var(--color-border);
+    border-bottom: 1px solid var(--color-border);
+    padding: 8px 12px;
+    text-align: left;
+  }
+  .markdown-body th:last-child, .markdown-body td:last-child { border-right: none; }
+  .markdown-body tr:last-child td { border-bottom: none; }
+  .markdown-body th {
+    background: var(--color-table-header-bg);
+    font-weight: 600;
+  }
+  .markdown-body tr:nth-child(even) td { background: var(--color-bg-muted); }
+
+  .markdown-body img { max-width: 100%; height: auto; margin: 1em 0; border-radius: 6px; }
+  .markdown-body a { color: var(--color-link); text-decoration: none; }
+  .markdown-body a:hover { text-decoration: underline; }
+  .markdown-body strong { font-weight: 700; }
+  .markdown-body em { font-style: italic; }
+  .markdown-body del { text-decoration: line-through; }
+  .markdown-body sup { font-size: 0.75em; vertical-align: super; }
+  .markdown-body sub { font-size: 0.75em; vertical-align: sub; }
+
+  /* Task list */
+  .markdown-body ul[data-type="taskList"] { list-style: none; padding-left: 0.5em; }
+  .markdown-body li[data-type="taskItem"] { list-style: none; }
+  .markdown-body li[data-type="taskItem"] input[type="checkbox"] {
+    margin-right: 0.5em;
+    vertical-align: middle;
+  }
+  .markdown-body li[data-type="taskItem"] label { cursor: default; }
+
+  /* YAML front matter */
+  .markdown-body [data-type="yamlFrontMatter"] {
+    background: var(--color-bg-muted);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    padding: 12px 16px;
+    margin-bottom: 1em;
+    font-family: var(--code-font);
+    font-size: 0.85em;
+    white-space: pre-wrap;
+  }
+
+  /* Math blocks */
+  .markdown-body [data-type="block-math"],
+  .markdown-body .katex-block {
+    text-align: center;
+    margin: 1.5em 0;
+    padding: 8px;
+    overflow-x: auto;
+  }
+
+  /* Details/summary (reasoning blocks) */
+  .markdown-body details {
+    border: 2px solid var(--color-border);
+    border-radius: 10px;
+    padding: 8px 12px;
+    margin: 1em 0;
+  }
+  .markdown-body details summary {
+    cursor: pointer;
+    font-weight: 600;
+    padding: 4px 0;
+  }
+
+  /* Footnotes */
+  .markdown-body .footnotes {
+    margin-top: 2em;
+    padding-top: 1em;
+    border-top: 1px solid var(--color-border);
+  }
+  .markdown-body .footnotes ol { padding-left: 1.5em; }
+  .markdown-body .footnotes li { font-size: 0.9em; color: var(--color-text-secondary); }
+
+  @media print {
+    body { color: #000; background: #fff; }
+    .markdown-body pre { border: 1px solid #ccc; background: #f5f5f5; }
+    .markdown-body a { color: #000; }
+  }
+
+  @media (max-width: 768px) {
+    body { padding: 12px; font-size: 15px; }
+    .container { max-width: 100%; }
+    .topic-title { font-size: 1.5em; }
+    .markdown-body table { display: block; overflow-x: auto; }
+    .markdown-body pre { padding: 12px; }
+  }
+</style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1 class="topic-title">${escapedTitle}</h1>
+      <div class="export-meta">Exported from Cherry Studio on ${dateStr}</div>
+    </header>
+    <main class="markdown-body">
+${bodyHtml}
+    </main>
+  </div>
+</body>
+</html>`
+}
+
+/**
+ * Convert a topic (conversation) to a self-contained HTML document.
+ *
+ * @param topic - The topic to convert
+ * @returns A complete HTML document string
+ */
+export const topicToHtml = async (topic: Topic): Promise<string> => {
+  const messages = await fetchTopicMessages(topic.id)
+
+  if (!messages || messages.length === 0) {
+    return buildHtmlDocument(topic.name, '<p>(No messages in this conversation)</p>')
+  }
+
+  const markdown = await messagesToMarkdown(messages)
+  const bodyHtml = markdownToHtml(markdown)
+  return buildHtmlDocument(topic.name, bodyHtml)
+}
+
+/**
+ * Convert a single message to a self-contained HTML document.
+ *
+ * @param message - The message to convert
+ * @returns A complete HTML document string
+ */
+export const messageToHtml = async (message: Message): Promise<string> => {
+  const title = await getMessageTitle(message)
+  const markdown = await messageToMarkdown(message)
+  const bodyHtml = markdownToHtml(markdown)
+  return buildHtmlDocument(title, bodyHtml)
+}
+
+/**
+ * Export a topic as a self-contained HTML file via native save dialog.
+ *
+ * @param topic - The topic to export
+ */
+export const exportTopicAsHtml = async (topic: Topic): Promise<void> => {
+  if (getExportState()) {
+    window.toast.warning(i18n.t('message.warn.export.exporting'))
+    return
+  }
+
+  setExportingState(true)
+
+  try {
+    const fileName = removeSpecialCharactersForFileName(topic.name) + '.html'
+    const html = await topicToHtml(topic)
+    const result = await window.api.file.save(fileName, html)
+    if (result) {
+      window.toast.success(i18n.t('message.success.html.export'))
+    }
+  } catch (error: any) {
+    window.toast.error(i18n.t('message.error.html.export'))
+    logger.error('Failed to export topic as HTML:', error)
+  } finally {
+    setExportingState(false)
+  }
+}
+
+/**
+ * Export a single message as a self-contained HTML file via native save dialog.
+ *
+ * @param message - The message to export
+ */
+export const exportMessageAsHtml = async (message: Message): Promise<void> => {
+  if (getExportState()) {
+    window.toast.warning(i18n.t('message.warn.export.exporting'))
+    return
+  }
+
+  setExportingState(true)
+
+  try {
+    const title = await getMessageTitle(message)
+    const fileName = removeSpecialCharactersForFileName(title) + '.html'
+    const html = await messageToHtml(message)
+    const result = await window.api.file.save(fileName, html)
+    if (result) {
+      window.toast.success(i18n.t('message.success.html.export'))
+    }
+  } catch (error: any) {
+    window.toast.error(i18n.t('message.error.html.export'))
+    logger.error('Failed to export message as HTML:', error)
+  } finally {
+    setExportingState(false)
   }
 }

--- a/src/shared/data/preference/preferenceSchemas.ts
+++ b/src/shared/data/preference/preferenceSchemas.ts
@@ -270,6 +270,8 @@ export interface PreferenceSchemas {
     'data.export.markdown.use_topic_naming_for_message_title': boolean
     // redux/settings/exportMenuOptions.docx
     'data.export.menus.docx': boolean
+    // redux/settings/exportMenuOptions.html
+    'data.export.menus.html': boolean
     // redux/settings/exportMenuOptions.image
     'data.export.menus.image': boolean
     // redux/settings/exportMenuOptions.joplin
@@ -619,6 +621,7 @@ export const DefaultPreferences: PreferenceSchemas = {
     'data.export.markdown.standardize_citations': false,
     'data.export.markdown.use_topic_naming_for_message_title': false,
     'data.export.menus.docx': true,
+    'data.export.menus.html': true,
     'data.export.menus.image': true,
     'data.export.menus.joplin': true,
     'data.export.menus.markdown': true,


### PR DESCRIPTION
## Summary

Add the ability to export conversations (topics) and individual messages as standalone HTML files. The generated HTML is fully self-contained with inline CSS, requires no external dependencies, and supports automatic light/dark mode switching.

## Motivation

Cherry Studio supports exporting to Markdown, Word, plain text, images, and various external services — but lacks a **universally shareable** format. HTML files can be opened in any browser without special software, making them ideal for sharing conversations with colleagues, archiving knowledge, or publishing AI interactions as documentation.

This is analogous to ChatGPT's "Share" feature, but as a local, privacy-preserving file.

## Changes

### Core implementation (`src/renderer/utils/export.ts`)
- **`escapeHtml()`** — HTML entity escaping to prevent XSS in topic names
- **`buildHtmlDocument()`** — Complete HTML document template (~180 lines of inline CSS)
- **`topicToHtml()`** — Convert a conversation to a self-contained HTML document
- **`messageToHtml()`** — Convert a single message to an HTML document
- **`exportTopicAsHtml()`** — Export topic via native save dialog (reuses existing guard pattern)
- **`exportMessageAsHtml()`** — Export single message via native save dialog

### HTML template design
- ✅ Fully self-contained — zero external dependencies, no CDN links
- ✅ GitHub-inspired design with responsive layout
- ✅ Light/dark mode via `@media (prefers-color-scheme: dark)`
- ✅ Proper code block styling with monospace font
- ✅ Table styling (borders, striped rows, header background)
- ✅ Blockquote styling (left border accent)
- ✅ Task list, math block, footnote, and details/summary styling
- ✅ Print-friendly styles
- ✅ Mobile-responsive (max-width: 768px breakpoint)

### Integration points
| Component | Change |
|-----------|--------|
| `preferenceSchemas.ts` | New `data.export.menus.html` preference (default: `true`) |
| `ExportMenuSettings.tsx` | Toggle switch in Settings → Data → Export Menu |
| `Topics.tsx` | "Export as HTML" in topic right-click context menu |
| `MessageMenubar.tsx` | "Export as HTML" in message dropdown menu |
| `en-us.json` / `zh-cn.json` | New i18n keys for all UI strings |

### Tests (`export.test.ts`)
15 unit tests covering:
- Complete HTML document structure (DOCTYPE, html, head, body)
- Topic name in title and header
- XSS prevention (script tag escaping, ampersand escaping)
- Markdown rendering (headings, bold/italic, lists)
- Code blocks with language class
- Inline code
- Empty/null messages graceful handling
- No external stylesheet links
- Dark mode media query
- Export metadata (date stamp)
- HTML structure nesting validity
- Multiple messages

## How to test

1. Open Cherry Studio
2. Create or open a conversation with rich content (code blocks, tables, etc.)
3. Right-click the conversation in the topic list → Export → "Export as HTML"
4. Save the file and open it in a browser
5. Verify:
   - Conversation title and export date are displayed
   - All messages are rendered correctly
   - Code blocks have dark background styling
   - Tables are properly formatted
   - Dark mode activates with system preference
   - Page is responsive on mobile viewport
   - No external network requests (completely self-contained)

## Lint status

```
0 errors, 42 warnings (all pre-existing, unchanged)
```