### PR TITLE
fix(migration): resolve FK constraint violations during V2 migration

### DIFF
--- a/src/main/data/migration/v2/migrators/AssistantMigrator.ts
+++ b/src/main/data/migration/v2/migrators/AssistantMigrator.ts
@@ -236,6 +236,15 @@ export class AssistantMigrator extends BaseMigrator {
         return { ...row, modelId: null }
       })
 
+      // @libsql/client creates new DB connections after each transaction()
+      // (this.#db = null). libsql is compiled with SQLITE_DEFAULT_FOREIGN_KEYS=1
+      // (see libsql-ffi/build.rs), so new connections have foreign_keys = ON.
+      // Must disable FK before each batch to prevent
+      // SQLITE_CONSTRAINT_FOREIGNKEY on assistant_mcp_server.mcpServerId and
+      // assistant_knowledge_base.knowledgeBaseId (migration-insert time gaps
+      // before McpServerMigrator/KnowledgeMigrator remap these IDs).
+      await ctx.db.run(sql`PRAGMA foreign_keys = OFF`)
+
       await ctx.db.transaction(async (tx) => {
         for (let i = 0; i < sanitizedAssistantRows.length; i += BATCH_SIZE) {
           const batch = sanitizedAssistantRows.slice(i, i + BATCH_SIZE)

--- a/src/main/data/migration/v2/migrators/__tests__/AssistantMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/AssistantMigrator.test.ts
@@ -22,6 +22,7 @@ function createMockContext(reduxData: Record<string, unknown> = {}) {
       dexieSettings: { keys: vi.fn().mockReturnValue([]), get: vi.fn() }
     },
     db: {
+      run: vi.fn().mockResolvedValue(undefined),
       transaction: vi.fn(async (fn: (tx: any) => Promise<void>) => {
         const tx = {
           insert: vi.fn().mockReturnValue({

--- a/src/main/data/migration/v2/migrators/remapAgentPrefixIds.ts
+++ b/src/main/data/migration/v2/migrators/remapAgentPrefixIds.ts
@@ -72,16 +72,42 @@ export async function remapAgentPrefixIds(db: MigrationContext['db']): Promise<v
     // rows we'd otherwise commit a corrupted state and re-enable FKs as if all
     // were well. PRAGMA foreign_key_check returns one row per violation; an empty
     // result means every (table, rowid, parent, fkid) tuple satisfies its FK.
-    const fkViolations = await db.all<{
+    //
+    // This migrator only touches agent-domain tables. Other migrators (e.g.,
+    // KnowledgeMigrator) run later and have their own FK-on-hold windows —
+    // violations in those tables are expected at this point. Filter them out to
+    // avoid false positives.
+    const AGENT_TABLE_NAMES = new Set([
+      'agent',
+      'agent_session',
+      'agent_skill',
+      'agent_task',
+      'agent_channel',
+      'agent_session_message',
+      'agent_task_run_log',
+      'agent_channel_task'
+    ])
+    const allFkViolations = await db.all<{
       table: string
       rowid: number | null
       parent: string
       fkid: number
     }>(sql.raw('PRAGMA foreign_key_check'))
-    if (fkViolations.length > 0) {
+    const ourViolations = allFkViolations.filter((v) => AGENT_TABLE_NAMES.has(v.table))
+    const otherViolations = allFkViolations.filter((v) => !AGENT_TABLE_NAMES.has(v.table))
+    if (otherViolations.length > 0) {
+      logger.info(
+        `remapAgentPrefixIds: ${otherViolations.length} FK violation(s) in other domains (expected — later migrators resolve these): ` +
+          otherViolations
+            .slice(0, 5)
+            .map((v) => `${v.table}->${v.parent} (rowid=${v.rowid})`)
+            .join(', ')
+      )
+    }
+    if (ourViolations.length > 0) {
       throw new Error(
-        `remapAgentPrefixIds left ${fkViolations.length} foreign-key violation(s): ` +
-          fkViolations
+        `remapAgentPrefixIds left ${ourViolations.length} foreign-key violation(s): ` +
+          ourViolations
             .slice(0, 5)
             .map((v) => `${v.table}->${v.parent} (rowid=${v.rowid})`)
             .join(', ')


### PR DESCRIPTION
## Summary

Fixes two foreign key constraint violations that cause V2 migration to fail on macOS.

## Root Cause

`@libsql/client` nullifies its internal connection after each `transaction()` call (`this.#db = null`). libsql is compiled with `SQLITE_DEFAULT_FOREIGN_KEYS=1`, so every new connection defaults to `foreign_keys = ON`. This means FK enforcement can be re-enabled mid-migration, causing failures when junction table rows reference entities that haven't been migrated yet.

## Changes

### Fix 1: AssistantMigrator — disable FK before transaction

`AssistantMigrator` (order 2) inserts `assistant_knowledge_base` junction rows with **old** knowledge base IDs. `KnowledgeMigrator` (order 3) creates the actual `knowledge_base` rows with **new** UUIDs and remaps the old→new IDs. The gap between these two migrators causes `SQLITE_CONSTRAINT_FOREIGNKEY` on `assistant_knowledge_base.knowledgeBaseId`.

**Fix**: Run `PRAGMA foreign_keys = OFF` before `ctx.db.transaction()` in `AssistantMigrator.execute()`, following the same pattern already applied to `ChatMigrator` in 8291f6b56.

### Fix 2: remapAgentPrefixIds — scope FK check to agent tables

`AgentsMigrator` (order 2.5) calls `remapAgentPrefixIds()` which runs `PRAGMA foreign_key_check` to verify its own ID remapping. However, `KnowledgeMigrator` (order 3) hasn't run yet, so `assistant_knowledge_base` still contains old KB IDs with FK violations. These are **expected** — KnowledgeMigrator resolves them when it executes.

**Fix**: Filter `PRAGMA foreign_key_check` results to only report violations in agent-domain tables (the ones `remapAgentPrefixIds` actually touches). Other-domain violations are logged as informational.

## Files Changed

| File | Change |
|------|--------|
| `src/main/data/migration/v2/migrators/AssistantMigrator.ts` | +9 lines (add FK=OFF pragma) |
| `src/main/data/migration/v2/migrators/remapAgentPrefixIds.ts` | +30/-4 lines (filter FK check) |

## Testing

- `pnpm lint` — passes
- `pnpm format` — passes
- `pnpm test -- src/main/data/migration/v2/migrators/__tests__/remapAgentPrefixIds.test.ts` — 6/6 pass