### PR TITLE
feat(file-manager): content-based dedup detection for internal files

### DIFF
--- a/docs/references/file/architecture.md
+++ b/docs/references/file/architecture.md
@@ -97,7 +97,7 @@ File Module (src/main/services/file/)
 Pure FS primitives (src/main/utils/file/) — sole FS owner, open to the entire main process
 ├── fs.ts         — basic FS: read / write / stat / copy / move / remove
 │                   atomic write: atomicWriteFile / atomicWriteIfUnchanged / createAtomicWriteStream
-│                   version: statVersion / contentHash (xxhash-h64)
+│                   version: statVersion / contentHash (XXH3-64, tagged `xxh3-64:{hex}`)
 ├── shell.ts      — system ops: open / showInFolder
 ├── path.ts       — path utils: resolvePath / isPathInside / canWrite / isNotEmptyDir / canonicalizeExternalPath
 ├── metadata.ts   — type detection: getFileType / isTextFile / mimeToExt
@@ -273,7 +273,7 @@ All operations that can act on any file (FileEntry or arbitrary path) **accept a
 | `read` | Read content | read(userDataPath) | read(externalPath) (live) | read(path) |
 | `getMetadata` | Live physical metadata (`fs.stat`) — entry-id batch variant `batchGetMetadata` (id-only, see below) | resolve + stat | stat(externalPath) — **sole live-size source for external** | stat + getFileType |
 | `getVersion` | FileVersion (live `fs.stat`) | stat userData | stat externalPath | statVersion |
-| `getContentHash` | xxhash-h64 | read userData + hash | read externalPath + hash | contentHash |
+| `getContentHash` | XXH3-64 (tagged `xxh3-64:{hex}`) | read userData + hash | read externalPath + hash | contentHash |
 | `write` | Atomic write | atomic → userData + DB size update | atomic → externalPath (explicit user edit; no DB size column to touch) | atomic → path |
 | `writeIfUnchanged` | Optimistic concurrent write | same as write plus version check | same | same (caller must getVersion first) |
 | `permanentDelete` | Delete entry | unlink userData + delete from DB | **delete from DB only** (physical file untouched; path-level deletion remains available via a `FilePathHandle` to `remove`) | remove(path) |
@@ -739,7 +739,7 @@ Renderer                          Main
 |  |  fs.ts:      read / write / stat / copy / move / remove   |    |
 |  |              atomicWriteFile / atomicWriteIfUnchanged     |    |
 |  |              createAtomicWriteStream                      |    |
-|  |              statVersion / contentHash (xxhash-h64)       |    |
+|  |              statVersion / contentHash (XXH3-64)          |    |
 |  |  shell.ts:   open / showInFolder                          |    |
 |  |  path.ts / metadata.ts / search.ts                        |    |
 |  |  stateless, pure path-based, open to all main modules     |    |

--- a/docs/references/file/file-manager-architecture.md
+++ b/docs/references/file/file-manager-architecture.md
@@ -32,6 +32,7 @@ FileEntry
 ├── name: filename (without extension)
 ├── ext: extension (without leading dot), nullable
 ├── size: bytes
+├── contentHash: '{algo}:{hex}' content-dedup detection hash; internal-only, null until backfilled
 ├── externalPath: absolute path, non-null only when origin='external'
 ├── deletedAt: ms epoch | null
 ├── createdAt / updatedAt
@@ -152,8 +153,19 @@ Invariants:
 | `ext` | SoT | Pure projection of `externalPath` (extname) |
 | `size` | SoT (non-null, ≥ 0) | **Always `null`** — no DB snapshot; live value via `getMetadata` |
 | `externalPath` | NULL | Absolute path (the authoritative identity of external) |
+| `contentHash` | Detection substrate `{algo}:{hex}` (e.g. `xxh3-64:…`); maintained on every write; `null` only until backfilled | **Always `null`** — content lives outside Cherry (`fe_contenthash_external_null` CHECK) |
 
 For external entries the row stores only identity + stable projections. `name` / `ext` do not drift because `externalPath` is fixed for the lifetime of the entry (external rename by the user surfaces as a dangling entry, not an in-place rewrite of `name`). `size` / `mtime` are served live by File IPC `getMetadata(id)` on demand — see [§3 External Entry Liveness Model](#3-external-entry-liveness-model).
+
+#### Content-level dedup detection (`contentHash`)
+
+`contentHash` is a **detection substrate** for content-level dedup — a hash of the backing blob, NOT an identity and NOT a key. It is **orthogonal** to the external-path dedup above: that enforces *path* identity for external rows (DB-unique, upsert); this is *content* sameness for internal rows (best-effort, detection + consumer-decided policy).
+
+- **Format `{algo}:{hex}`** (e.g. `xxh3-64:9a0f…`). The algorithm tag is part of the stored contract, so a future algorithm change coexists with old values via incremental migration instead of a flag-day re-hash. Algorithm today: **XXH3-64** via native `@node-rs/xxhash` (see §12).
+- **Internal-only, maintained-on-write.** Set on `createInternalEntry` and recomputed on every internal `write` / `writeIfUnchanged` / `createWriteStream` (content is mutable, so the hash is not write-once). Hashing is hybrid: in-memory sources hash one-shot (zero extra IO); streaming sources (path-copy / download / stream) read the just-written file back. A consumer may also supply a pre-computed `contentHash` (detect-first), persisted verbatim. External rows never carry one (`fe_contenthash_external_null` CHECK).
+- **NON-unique by design.** `fe_content_hash_idx` is a plain (non-unique) index — multiple internal rows may share a hash (identical content under different names), and a collision must never raise a constraint violation. The detection query `FileEntryService.findInternalByContentHash(contentHash)` (delegated by `FileManager`, exposed to the renderer via File IPC `File_FindInternalByContentHash`) returns active internal candidates oldest-first; the consumer's secondary check (e.g. `(contentHash, name, ext)`) or the user resolves a wrong candidate, so a collision **never mis-serves bytes**.
+- **`createInternalEntry` stays insert-always.** Detection is a layer *above* it: a consumer hashes → queries → decides, then creates (optionally passing the hash). The file module never auto-reuses; reuse-vs-create policy lives with the consumer.
+- **Backfill.** Existing internal rows from v1 migration / before this feature carry `contentHash = null` (a transitional state, not steady). The `file.contenthash-backfill` JobManager handler (`recovery: 'singleton'`, concurrency 1) drains them — keyset-paginating by `id` over `content_hash IS NULL`, hashing each blob and skipping missing/orphan ones (logged, never failing the job). FileManager's `onAllReady` enqueues it whenever `countInternalMissingContentHash() > 0`, which doubles as crash-recovery since the NULL set is itself the resumable work queue. Distinct from the on-demand `getContentHash` / `writeIfUnchanged` deep-compare hash (§4.1), which is ephemeral and never persisted.
 
 ### 1.3 FileRef (Business Reference)
 
@@ -560,7 +572,7 @@ interface FileVersion {
 
 Used as a fast signal for detecting external changes. Two tiers of usage:
 - Fast path: `statVersion(path)` (microsecond-level, covers 99% of cases)
-- Deep path: `contentHash(path)` → xxhash-h64 (millisecond-to-second level, used when mtime/size match but further confirmation is needed)
+- Deep path: `contentHash(path)` → XXH3-64 (millisecond-to-second level, used when mtime/size match but further confirmation is needed). Same library + algorithm as the persisted `contentHash` detection substrate (§1.2 / §12), but this value is computed on demand for the OCC compare and **never persisted**.
 
 Rationale for mtime + size as a signature:
 - Six scenarios where mtime alone fails—multiple writes within the same ms, clock rewind, backup preserving mtime, user touch, low-precision FS (FAT32), in-place 1-byte edit—are covered by size or hash as fallbacks
@@ -919,7 +931,7 @@ CREATE TABLE file_upload (
   file_entry_id   TEXT NOT NULL REFERENCES file_entry(id) ON DELETE CASCADE,
   provider        TEXT NOT NULL,
   remote_id       TEXT NOT NULL,
-  content_version TEXT NOT NULL,   -- xxhash-h64 at upload time
+  content_version TEXT NOT NULL,   -- XXH3-64 at upload time
   uploaded_at     INTEGER NOT NULL,
   expires_at      INTEGER,
   status          TEXT NOT NULL,   -- 'active' | 'expired' | 'failed'
@@ -1394,7 +1406,7 @@ These thresholds are heuristic starting points — tune based on real-world tele
 | **Dangling state carrier** | In-memory singleton DanglingCache | Not in DB (avoids bidirectional DB-FS sync); three states `present/missing/unknown`; TTL-based lazy expiration (§11.6, 30 min); refreshed on query / FS observation / watcher; no periodic background sweep — IO cost scales with query frequency, not entry count |
 | **Dangling exposure method** | File IPC `getDanglingState` / `batchGetDanglingStates` (never DataApi) | DataApi is pure SQL; FS probe lives in IPC where side effects are expected; zero cost by default; parallel stat on demand |
 | **Watcher → DanglingCache wiring** | Factory auto-wires | Business modules unaware of DanglingCache; a single watcher instance serves business events + dangling tracking |
-| **Content hash algorithm** | xxhash-h64 | Optimal cost-performance for non-cryptographic scenarios (~20GB/s). 64-bit collision space is sufficient for distinguishing successive versions within a single file's write history — the `xxhash-wasm` package shipped in this version exposes only h32 / h64, and h64 is the strongest variant available; revisit if a 128-bit variant becomes a dependency-cost tradeoff worth taking. |
+| **Content hash algorithm** | XXH3-64 via native `@node-rs/xxhash`, stored `{algo}:{hex}` | One library + algorithm serves two domains: (a) the persisted `contentHash` dedup-**detection** substrate (§1.2), whose collision domain is the **whole library**, and (b) the on-demand `writeIfUnchanged` deep-compare (§4.1), ephemeral and per-file. XXH3-64 is non-cryptographic, ~tens of GB/s, and native — no WASM throughput ceiling, riding the same napi-rs prebuilt track as `@libsql` / `@napi-rs/*` / `sharp`. **64-bit, not 128**: `@node-rs/xxhash`'s XXH3-128 is one-shot only (no streaming digest), which would force whole-file buffering on the streaming write paths; only the 64-bit variant streams. For a *detection* substrate 64 bits is ample — a collision at worst surfaces a wrong candidate that the consumer's secondary check rejects (never mis-served bytes), and the `{algo}:` tag leaves an incremental upgrade path to 128 if ever needed. |
 | **Does write carry version** | Split into write / writeIfUnchanged | Force the caller to explicitly choose; avoid silent degradation to blind write when version is forgotten |
 | **Atomic write fsync** | On by default | Correctness guarantee takes precedence over performance; Cherry is not a high-throughput scenario |
 | **Trash model** | deletedAt timestamp | parentId unchanged; naturally supports expiry; no system_trash entries |

--- a/migrations/sqlite-drizzle/0001_special_white_tiger.sql
+++ b/migrations/sqlite-drizzle/0001_special_white_tiger.sql
@@ -1,0 +1,40 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_file_entry` (
+	`id` text PRIMARY KEY NOT NULL,
+	`origin` text NOT NULL,
+	`name` text NOT NULL,
+	`ext` text,
+	`size` integer,
+	`content_hash` text,
+	`external_path` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	`deleted_at` integer,
+	CONSTRAINT "fe_origin_check" CHECK("__new_file_entry"."origin" IN ('internal', 'external')),
+	CONSTRAINT "fe_origin_consistency" CHECK(("__new_file_entry"."origin" = 'internal' AND "__new_file_entry"."external_path" IS NULL) OR ("__new_file_entry"."origin" = 'external' AND "__new_file_entry"."external_path" IS NOT NULL)),
+	CONSTRAINT "fe_external_no_delete" CHECK("__new_file_entry"."origin" != 'external' OR "__new_file_entry"."deleted_at" IS NULL),
+	CONSTRAINT "fe_size_internal_only" CHECK(("__new_file_entry"."origin" = 'internal' AND "__new_file_entry"."size" IS NOT NULL AND "__new_file_entry"."size" >= 0) OR ("__new_file_entry"."origin" = 'external' AND "__new_file_entry"."size" IS NULL)),
+	CONSTRAINT "fe_contenthash_external_null" CHECK("__new_file_entry"."origin" != 'external' OR "__new_file_entry"."content_hash" IS NULL)
+);
+--> statement-breakpoint
+-- MANUAL PATCH: drizzle-kit's table-rebuild codegen lists the newly-added
+-- `content_hash` column in the INSERT ... SELECT, but the *old* `file_entry`
+-- has no such column yet, so the SELECT fails with "no such column:
+-- content_hash". Drop `content_hash` from both lists — migrated rows take the
+-- column default (NULL), which is exactly the intended backfill-window state
+-- for pre-feature internal entries. Same rebuild-path drizzle-kit bug the
+-- pre-#15438 0026 migration patched by hand.
+INSERT INTO `__new_file_entry`("id", "origin", "name", "ext", "size", "external_path", "created_at", "updated_at", "deleted_at") SELECT "id", "origin", "name", "ext", "size", "external_path", "created_at", "updated_at", "deleted_at" FROM `file_entry`;--> statement-breakpoint
+DROP TABLE `file_entry`;--> statement-breakpoint
+ALTER TABLE `__new_file_entry` RENAME TO `file_entry`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `fe_deleted_at_idx` ON `file_entry` (`deleted_at`);--> statement-breakpoint
+CREATE INDEX `fe_created_at_idx` ON `file_entry` (`created_at`);--> statement-breakpoint
+-- MANUAL PATCH: drizzle-kit's rebuild path wraps the whole functional-index
+-- expression in backticks (`lower("external_path")`), which SQLite parses as a
+-- single quoted identifier instead of a `lower()` call. Restore the bare
+-- expression so the index matches 0000 and actually backs the case-insensitive
+-- lookup (same fix the pre-#15438 0026 migration applied).
+CREATE UNIQUE INDEX `fe_external_path_lower_unique_idx` ON `file_entry` (lower("external_path"));--> statement-breakpoint
+CREATE INDEX `fe_external_path_idx` ON `file_entry` (`external_path`);--> statement-breakpoint
+CREATE INDEX `fe_content_hash_idx` ON `file_entry` (`content_hash`);

--- a/migrations/sqlite-drizzle/meta/0001_snapshot.json
+++ b/migrations/sqlite-drizzle/meta/0001_snapshot.json
@@ -1,0 +1,3744 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b08b149a-0dc1-4d86-b251-79e861a1d0d1",
+  "prevId": "b2f4f492-7829-40d7-9ac6-94ec9384a926",
+  "tables": {
+    "agent": {
+      "name": "agent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "accessible_paths": {
+          "name": "accessible_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_model": {
+          "name": "plan_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "small_model": {
+          "name": "small_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcps": {
+          "name": "mcps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_name_idx": {
+          "name": "agent_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "agent_type_idx": {
+          "name": "agent_type_idx",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "agent_sort_order_idx": {
+          "name": "agent_sort_order_idx",
+          "columns": ["sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_channel": {
+      "name": "agent_channel",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "active_chat_ids": {
+          "name": "active_chat_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_channel_agent_id_idx": {
+          "name": "agent_channel_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agent_channel_type_idx": {
+          "name": "agent_channel_type_idx",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "agent_channel_session_id_idx": {
+          "name": "agent_channel_session_id_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_channel_agent_id_agent_id_fk": {
+          "name": "agent_channel_agent_id_agent_id_fk",
+          "tableFrom": "agent_channel",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_channel_session_id_agent_session_id_fk": {
+          "name": "agent_channel_session_id_agent_session_id_fk",
+          "tableFrom": "agent_channel",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agent_channel_type_check": {
+          "name": "agent_channel_type_check",
+          "value": "\"agent_channel\".\"type\" IN ('telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack')"
+        },
+        "agent_channel_permission_mode_check": {
+          "name": "agent_channel_permission_mode_check",
+          "value": "\"agent_channel\".\"permission_mode\" IS NULL OR \"agent_channel\".\"permission_mode\" IN ('default', 'acceptEdits', 'bypassPermissions', 'plan')"
+        }
+      }
+    },
+    "agent_channel_task": {
+      "name": "agent_channel_task",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_channel_task_channel_id_idx": {
+          "name": "agent_channel_task_channel_id_idx",
+          "columns": ["channel_id"],
+          "isUnique": false
+        },
+        "agent_channel_task_task_id_idx": {
+          "name": "agent_channel_task_task_id_idx",
+          "columns": ["task_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_channel_task_channel_id_agent_channel_id_fk": {
+          "name": "agent_channel_task_channel_id_agent_channel_id_fk",
+          "tableFrom": "agent_channel_task",
+          "tableTo": "agent_channel",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_channel_task_task_id_agent_task_id_fk": {
+          "name": "agent_channel_task_task_id_agent_task_id_fk",
+          "tableFrom": "agent_channel_task",
+          "tableTo": "agent_task",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_channel_task_channel_id_task_id_pk": {
+          "columns": ["channel_id", "task_id"],
+          "name": "agent_channel_task_channel_id_task_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_global_skill": {
+      "name": "agent_global_skill",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folder_name": {
+          "name": "folder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_global_skill_folder_name_unique": {
+          "name": "agent_global_skill_folder_name_unique",
+          "columns": ["folder_name"],
+          "isUnique": true
+        },
+        "agent_global_skill_source_idx": {
+          "name": "agent_global_skill_source_idx",
+          "columns": ["source"],
+          "isUnique": false
+        },
+        "agent_global_skill_is_enabled_idx": {
+          "name": "agent_global_skill_is_enabled_idx",
+          "columns": ["is_enabled"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_session": {
+      "name": "agent_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_type": {
+          "name": "agent_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "accessible_paths": {
+          "name": "accessible_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_model": {
+          "name": "plan_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "small_model": {
+          "name": "small_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcps": {
+          "name": "mcps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "slash_commands": {
+          "name": "slash_commands",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_session_agent_id_idx": {
+          "name": "agent_session_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agent_session_model_idx": {
+          "name": "agent_session_model_idx",
+          "columns": ["model"],
+          "isUnique": false
+        },
+        "agent_session_sort_order_idx": {
+          "name": "agent_session_sort_order_idx",
+          "columns": ["sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_session_agent_id_agent_id_fk": {
+          "name": "agent_session_agent_id_agent_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_session_message": {
+      "name": "agent_session_message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_session_message_session_id_idx": {
+          "name": "agent_session_message_session_id_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_session_message_session_id_agent_session_id_fk": {
+          "name": "agent_session_message_session_id_agent_session_id_fk",
+          "tableFrom": "agent_session_message",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_skill": {
+      "name": "agent_skill",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_skill_agent_id_idx": {
+          "name": "agent_skill_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agent_skill_skill_id_idx": {
+          "name": "agent_skill_skill_id_idx",
+          "columns": ["skill_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_agent_id_agent_id_fk": {
+          "name": "agent_skill_agent_id_agent_id_fk",
+          "tableFrom": "agent_skill",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_skill_skill_id_agent_global_skill_id_fk": {
+          "name": "agent_skill_skill_id_agent_global_skill_id_fk",
+          "tableFrom": "agent_skill",
+          "tableTo": "agent_global_skill",
+          "columnsFrom": ["skill_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_skill_agent_id_skill_id_pk": {
+          "columns": ["agent_id", "skill_id"],
+          "name": "agent_skill_agent_id_skill_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_task_run_log": {
+      "name": "agent_task_run_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_task_run_log_task_id_idx": {
+          "name": "agent_task_run_log_task_id_idx",
+          "columns": ["task_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_task_run_log_task_id_agent_task_id_fk": {
+          "name": "agent_task_run_log_task_id_agent_task_id_fk",
+          "tableFrom": "agent_task_run_log",
+          "tableTo": "agent_task",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agent_task_run_log_status_check": {
+          "name": "agent_task_run_log_status_check",
+          "value": "\"agent_task_run_log\".\"status\" IN ('running', 'success', 'error')"
+        }
+      }
+    },
+    "agent_task": {
+      "name": "agent_task",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_value": {
+          "name": "schedule_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timeout_minutes": {
+          "name": "timeout_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "next_run": {
+          "name": "next_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_result": {
+          "name": "last_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_task_agent_id_idx": {
+          "name": "agent_task_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agent_task_next_run_idx": {
+          "name": "agent_task_next_run_idx",
+          "columns": ["next_run"],
+          "isUnique": false
+        },
+        "agent_task_status_idx": {
+          "name": "agent_task_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_task_agent_id_agent_id_fk": {
+          "name": "agent_task_agent_id_agent_id_fk",
+          "tableFrom": "agent_task",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agent_task_schedule_type_check": {
+          "name": "agent_task_schedule_type_check",
+          "value": "\"agent_task\".\"schedule_type\" IN ('cron', 'interval', 'once')"
+        },
+        "agent_task_status_check": {
+          "name": "agent_task_status_check",
+          "value": "\"agent_task\".\"status\" IN ('active', 'paused', 'completed')"
+        }
+      }
+    },
+    "app_state": {
+      "name": "app_state",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assistant": {
+      "name": "assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "assistant_created_at_idx": {
+          "name": "assistant_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "assistant_model_id_user_model_id_fk": {
+          "name": "assistant_model_id_user_model_id_fk",
+          "tableFrom": "assistant",
+          "tableTo": "user_model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assistant_knowledge_base": {
+      "name": "assistant_knowledge_base",
+      "columns": {
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "knowledge_base_id": {
+          "name": "knowledge_base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "assistant_knowledge_base_assistant_id_assistant_id_fk": {
+          "name": "assistant_knowledge_base_assistant_id_assistant_id_fk",
+          "tableFrom": "assistant_knowledge_base",
+          "tableTo": "assistant",
+          "columnsFrom": ["assistant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assistant_knowledge_base_knowledge_base_id_knowledge_base_id_fk": {
+          "name": "assistant_knowledge_base_knowledge_base_id_knowledge_base_id_fk",
+          "tableFrom": "assistant_knowledge_base",
+          "tableTo": "knowledge_base",
+          "columnsFrom": ["knowledge_base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "assistant_knowledge_base_assistant_id_knowledge_base_id_pk": {
+          "columns": ["assistant_id", "knowledge_base_id"],
+          "name": "assistant_knowledge_base_assistant_id_knowledge_base_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assistant_mcp_server": {
+      "name": "assistant_mcp_server",
+      "columns": {
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "assistant_mcp_server_assistant_id_assistant_id_fk": {
+          "name": "assistant_mcp_server_assistant_id_assistant_id_fk",
+          "tableFrom": "assistant_mcp_server",
+          "tableTo": "assistant",
+          "columnsFrom": ["assistant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assistant_mcp_server_mcp_server_id_mcp_server_id_fk": {
+          "name": "assistant_mcp_server_mcp_server_id_mcp_server_id_fk",
+          "tableFrom": "assistant_mcp_server",
+          "tableTo": "mcp_server",
+          "columnsFrom": ["mcp_server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "assistant_mcp_server_assistant_id_mcp_server_id_pk": {
+          "columns": ["assistant_id", "mcp_server_id"],
+          "name": "assistant_mcp_server_assistant_id_mcp_server_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_entry": {
+      "name": "file_entry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_path": {
+          "name": "external_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "fe_deleted_at_idx": {
+          "name": "fe_deleted_at_idx",
+          "columns": ["deleted_at"],
+          "isUnique": false
+        },
+        "fe_created_at_idx": {
+          "name": "fe_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "fe_external_path_lower_unique_idx": {
+          "name": "fe_external_path_lower_unique_idx",
+          "columns": ["lower(\"external_path\")"],
+          "isUnique": true
+        },
+        "fe_external_path_idx": {
+          "name": "fe_external_path_idx",
+          "columns": ["external_path"],
+          "isUnique": false
+        },
+        "fe_content_hash_idx": {
+          "name": "fe_content_hash_idx",
+          "columns": ["content_hash"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "fe_origin_check": {
+          "name": "fe_origin_check",
+          "value": "\"file_entry\".\"origin\" IN ('internal', 'external')"
+        },
+        "fe_origin_consistency": {
+          "name": "fe_origin_consistency",
+          "value": "(\"file_entry\".\"origin\" = 'internal' AND \"file_entry\".\"external_path\" IS NULL) OR (\"file_entry\".\"origin\" = 'external' AND \"file_entry\".\"external_path\" IS NOT NULL)"
+        },
+        "fe_external_no_delete": {
+          "name": "fe_external_no_delete",
+          "value": "\"file_entry\".\"origin\" != 'external' OR \"file_entry\".\"deleted_at\" IS NULL"
+        },
+        "fe_size_internal_only": {
+          "name": "fe_size_internal_only",
+          "value": "(\"file_entry\".\"origin\" = 'internal' AND \"file_entry\".\"size\" IS NOT NULL AND \"file_entry\".\"size\" >= 0) OR (\"file_entry\".\"origin\" = 'external' AND \"file_entry\".\"size\" IS NULL)"
+        },
+        "fe_contenthash_external_null": {
+          "name": "fe_contenthash_external_null",
+          "value": "\"file_entry\".\"origin\" != 'external' OR \"file_entry\".\"content_hash\" IS NULL"
+        }
+      }
+    },
+    "file_ref": {
+      "name": "file_ref",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_entry_id": {
+          "name": "file_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "file_ref_entry_id_idx": {
+          "name": "file_ref_entry_id_idx",
+          "columns": ["file_entry_id"],
+          "isUnique": false
+        },
+        "file_ref_source_idx": {
+          "name": "file_ref_source_idx",
+          "columns": ["source_type", "source_id"],
+          "isUnique": false
+        },
+        "file_ref_unique_idx": {
+          "name": "file_ref_unique_idx",
+          "columns": ["file_entry_id", "source_type", "source_id", "role"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "file_ref_file_entry_id_file_entry_id_fk": {
+          "name": "file_ref_file_entry_id_file_entry_id_fk",
+          "tableFrom": "file_ref",
+          "tableTo": "file_entry",
+          "columnsFrom": ["file_entry_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group": {
+      "name": "group",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_entity_type_order_key_idx": {
+          "name": "group_entity_type_order_key_idx",
+          "columns": ["entity_type", "order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "job_schedule": {
+      "name": "job_schedule",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_input_template": {
+          "name": "job_input_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "next_run": {
+          "name": "next_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "catch_up_policy": {
+          "name": "catch_up_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "job_schedule_type_name_uq": {
+          "name": "job_schedule_type_name_uq",
+          "columns": ["type", "name"],
+          "isUnique": true
+        },
+        "job_schedule_enabled_next_run_idx": {
+          "name": "job_schedule_enabled_next_run_idx",
+          "columns": ["enabled", "next_run"],
+          "isUnique": false
+        },
+        "job_schedule_type_idx": {
+          "name": "job_schedule_type_idx",
+          "columns": ["type"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "job": {
+      "name": "job",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "queue": {
+          "name": "queue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_requested": {
+          "name": "cancel_requested",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "job_queue_status_scheduled_at_idx": {
+          "name": "job_queue_status_scheduled_at_idx",
+          "columns": ["queue", "status", "scheduled_at"],
+          "isUnique": false
+        },
+        "job_status_idx": {
+          "name": "job_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "job_schedule_id_finished_at_idx": {
+          "name": "job_schedule_id_finished_at_idx",
+          "columns": ["schedule_id", "finished_at"],
+          "isUnique": false
+        },
+        "job_parent_id_idx": {
+          "name": "job_parent_id_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "job_idempotency_key_partial_uq": {
+          "name": "job_idempotency_key_partial_uq",
+          "columns": ["idempotency_key"],
+          "isUnique": true,
+          "where": "\"job\".\"idempotency_key\" IS NOT NULL AND \"job\".\"status\" NOT IN ('completed','failed','cancelled')"
+        }
+      },
+      "foreignKeys": {
+        "job_schedule_id_job_schedule_id_fk": {
+          "name": "job_schedule_id_job_schedule_id_fk",
+          "tableFrom": "job",
+          "tableTo": "job_schedule",
+          "columnsFrom": ["schedule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "job_parent_id_job_id_fk": {
+          "name": "job_parent_id_job_id_fk",
+          "tableFrom": "job",
+          "tableTo": "job",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "job_status_check": {
+          "name": "job_status_check",
+          "value": "\"job\".\"status\" IN ('pending','delayed','running','completed','failed','cancelled')"
+        }
+      }
+    },
+    "knowledge_base": {
+      "name": "knowledge_base",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_model_id": {
+          "name": "embedding_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rerank_model_id": {
+          "name": "rerank_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_processor_id": {
+          "name": "file_processor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chunk_size": {
+          "name": "chunk_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chunk_overlap": {
+          "name": "chunk_overlap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_mode": {
+          "name": "search_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hybrid_alpha": {
+          "name": "hybrid_alpha",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "knowledge_base_group_id_group_id_fk": {
+          "name": "knowledge_base_group_id_group_id_fk",
+          "tableFrom": "knowledge_base",
+          "tableTo": "group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "knowledge_base_embedding_model_id_user_model_id_fk": {
+          "name": "knowledge_base_embedding_model_id_user_model_id_fk",
+          "tableFrom": "knowledge_base",
+          "tableTo": "user_model",
+          "columnsFrom": ["embedding_model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "knowledge_base_rerank_model_id_user_model_id_fk": {
+          "name": "knowledge_base_rerank_model_id_user_model_id_fk",
+          "tableFrom": "knowledge_base",
+          "tableTo": "user_model",
+          "columnsFrom": ["rerank_model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "knowledge_base_search_mode_check": {
+          "name": "knowledge_base_search_mode_check",
+          "value": "\"knowledge_base\".\"search_mode\" IN ('default', 'bm25', 'hybrid')"
+        },
+        "knowledge_base_status_check": {
+          "name": "knowledge_base_status_check",
+          "value": "\"knowledge_base\".\"status\" IN ('completed', 'failed')"
+        },
+        "knowledge_base_status_error_check": {
+          "name": "knowledge_base_status_error_check",
+          "value": "\n        (\n          \"knowledge_base\".\"status\" = 'completed'\n          AND \"knowledge_base\".\"embedding_model_id\" IS NOT NULL\n          AND \"knowledge_base\".\"dimensions\" IS NOT NULL\n          AND \"knowledge_base\".\"dimensions\" > 0\n          AND \"knowledge_base\".\"error\" IS NULL\n        )\n        OR (\n          \"knowledge_base\".\"status\" = 'failed'\n          AND \"knowledge_base\".\"error\" IS NOT NULL\n          AND length(trim(\"knowledge_base\".\"error\")) > 0\n        )\n      "
+        }
+      }
+    },
+    "knowledge_item": {
+      "name": "knowledge_item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "knowledge_item_base_type_created_idx": {
+          "name": "knowledge_item_base_type_created_idx",
+          "columns": ["base_id", "type", "created_at"],
+          "isUnique": false
+        },
+        "knowledge_item_base_group_created_idx": {
+          "name": "knowledge_item_base_group_created_idx",
+          "columns": ["base_id", "group_id", "created_at"],
+          "isUnique": false
+        },
+        "knowledge_item_baseId_id_unique": {
+          "name": "knowledge_item_baseId_id_unique",
+          "columns": ["base_id", "id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "knowledge_item_base_id_knowledge_base_id_fk": {
+          "name": "knowledge_item_base_id_knowledge_base_id_fk",
+          "tableFrom": "knowledge_item",
+          "tableTo": "knowledge_base",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_item_base_id_group_id_knowledge_item_base_id_id_fk": {
+          "name": "knowledge_item_base_id_group_id_knowledge_item_base_id_id_fk",
+          "tableFrom": "knowledge_item",
+          "tableTo": "knowledge_item",
+          "columnsFrom": ["base_id", "group_id"],
+          "columnsTo": ["base_id", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "knowledge_item_type_check": {
+          "name": "knowledge_item_type_check",
+          "value": "\"knowledge_item\".\"type\" IN ('file', 'url', 'note', 'sitemap', 'directory')"
+        },
+        "knowledge_item_status_check": {
+          "name": "knowledge_item_status_check",
+          "value": "\"knowledge_item\".\"status\" IN ('idle', 'preparing', 'processing', 'reading', 'embedding', 'completed', 'failed', 'deleting')"
+        },
+        "knowledge_item_type_status_check": {
+          "name": "knowledge_item_type_status_check",
+          "value": "\n        (\"knowledge_item\".\"type\" IN ('file', 'url', 'note') AND \"knowledge_item\".\"status\" IN ('idle', 'processing', 'reading', 'embedding', 'completed', 'failed', 'deleting'))\n        OR (\"knowledge_item\".\"type\" IN ('directory', 'sitemap') AND \"knowledge_item\".\"status\" IN ('idle', 'preparing', 'processing', 'completed', 'failed', 'deleting'))\n      "
+        },
+        "knowledge_item_status_error_check": {
+          "name": "knowledge_item_status_error_check",
+          "value": "\n        (\n          \"knowledge_item\".\"status\" IN ('idle', 'preparing', 'processing', 'reading', 'embedding', 'completed', 'deleting')\n          AND \"knowledge_item\".\"error\" IS NULL\n        )\n        OR (\n          \"knowledge_item\".\"status\" = 'failed'\n          AND \"knowledge_item\".\"error\" IS NOT NULL\n          AND length(trim(\"knowledge_item\".\"error\")) > 0\n        )\n      "
+        }
+      }
+    },
+    "mcp_server": {
+      "name": "mcp_server",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_url": {
+          "name": "provider_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "long_running": {
+          "name": "long_running",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dxt_version": {
+          "name": "dxt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dxt_path": {
+          "name": "dxt_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_key": {
+          "name": "search_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config_sample": {
+          "name": "config_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_tools": {
+          "name": "disabled_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_auto_approve_tools": {
+          "name": "disabled_auto_approve_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "should_config": {
+          "name": "should_config",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "install_source": {
+          "name": "install_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_trusted": {
+          "name": "is_trusted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trusted_at": {
+          "name": "trusted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_server_name_idx": {
+          "name": "mcp_server_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "mcp_server_is_active_idx": {
+          "name": "mcp_server_is_active_idx",
+          "columns": ["is_active"],
+          "isUnique": false
+        },
+        "mcp_server_sort_order_idx": {
+          "name": "mcp_server_sort_order_idx",
+          "columns": ["sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "mcp_server_type_check": {
+          "name": "mcp_server_type_check",
+          "value": "\"mcp_server\".\"type\" IS NULL OR \"mcp_server\".\"type\" IN ('stdio', 'sse', 'streamableHttp', 'inMemory')"
+        },
+        "mcp_server_install_source_check": {
+          "name": "mcp_server_install_source_check",
+          "value": "\"mcp_server\".\"install_source\" IS NULL OR \"mcp_server\".\"install_source\" IN ('builtin', 'manual', 'protocol', 'unknown')"
+        }
+      }
+    },
+    "message": {
+      "name": "message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "searchable_text": {
+          "name": "searchable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "siblings_group_id": {
+          "name": "siblings_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_snapshot": {
+          "name": "model_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "message_parent_id_idx": {
+          "name": "message_parent_id_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "message_topic_created_idx": {
+          "name": "message_topic_created_idx",
+          "columns": ["topic_id", "created_at"],
+          "isUnique": false
+        },
+        "message_trace_id_idx": {
+          "name": "message_trace_id_idx",
+          "columns": ["trace_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "message_topic_id_topic_id_fk": {
+          "name": "message_topic_id_topic_id_fk",
+          "tableFrom": "message",
+          "tableTo": "topic",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_model_id_user_model_id_fk": {
+          "name": "message_model_id_user_model_id_fk",
+          "tableFrom": "message",
+          "tableTo": "user_model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "message_parent_id_message_id_fk": {
+          "name": "message_parent_id_message_id_fk",
+          "tableFrom": "message",
+          "tableTo": "message",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "message_role_check": {
+          "name": "message_role_check",
+          "value": "\"message\".\"role\" IN ('user', 'assistant', 'system')"
+        },
+        "message_status_check": {
+          "name": "message_status_check",
+          "value": "\"message\".\"status\" IN ('pending', 'success', 'error', 'paused')"
+        }
+      }
+    },
+    "mini_app": {
+      "name": "mini_app",
+      "columns": {
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_mini_app_id": {
+          "name": "preset_mini_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'enabled'"
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bordered": {
+          "name": "bordered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "background": {
+          "name": "background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supported_regions": {
+          "name": "supported_regions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_key": {
+          "name": "name_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mini_app_status_order_key_idx": {
+          "name": "mini_app_status_order_key_idx",
+          "columns": ["status", "order_key"],
+          "isUnique": false
+        },
+        "mini_app_preset_mini_app_id_idx": {
+          "name": "mini_app_preset_mini_app_id_idx",
+          "columns": ["preset_mini_app_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "mini_app_status_check": {
+          "name": "mini_app_status_check",
+          "value": "\"mini_app\".\"status\" IN ('enabled', 'disabled', 'pinned')"
+        }
+      }
+    },
+    "note": {
+      "name": "note",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "root_path": {
+          "name": "root_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_starred": {
+          "name": "is_starred",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_expanded": {
+          "name": "is_expanded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "note_root_path_path_unique_idx": {
+          "name": "note_root_path_path_unique_idx",
+          "columns": ["root_path", "path"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "note_has_state_check": {
+          "name": "note_has_state_check",
+          "value": "\"note\".\"is_starred\" = 1 OR \"note\".\"is_expanded\" = 1"
+        }
+      }
+    },
+    "pin": {
+      "name": "pin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pin_entity_type_entity_id_unique_idx": {
+          "name": "pin_entity_type_entity_id_unique_idx",
+          "columns": ["entity_type", "entity_id"],
+          "isUnique": true
+        },
+        "pin_entity_type_order_key_idx": {
+          "name": "pin_entity_type_order_key_idx",
+          "columns": ["entity_type", "order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "preference": {
+      "name": "preference",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "preference_scope_key_pk": {
+          "columns": ["scope", "key"],
+          "name": "preference_scope_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt": {
+      "name": "prompt",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prompt_order_key_idx": {
+          "name": "prompt_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "entity_tag": {
+      "name": "entity_tag",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "entity_tag_tag_id_idx": {
+          "name": "entity_tag_tag_id_idx",
+          "columns": ["tag_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "entity_tag_tag_id_tag_id_fk": {
+          "name": "entity_tag_tag_id_tag_id_fk",
+          "tableFrom": "entity_tag",
+          "tableTo": "tag",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "entity_tag_entity_type_entity_id_tag_id_pk": {
+          "columns": ["entity_type", "entity_id", "tag_id"],
+          "name": "entity_tag_entity_type_entity_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag": {
+      "name": "tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tag_name_unique": {
+          "name": "tag_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "topic": {
+      "name": "topic",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "is_name_manually_edited": {
+          "name": "is_name_manually_edited",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_node_id": {
+          "name": "active_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "topic_group_updated_idx": {
+          "name": "topic_group_updated_idx",
+          "columns": ["group_id", "updated_at"],
+          "isUnique": false
+        },
+        "topic_updated_at_idx": {
+          "name": "topic_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "topic_group_id_order_key_idx": {
+          "name": "topic_group_id_order_key_idx",
+          "columns": ["group_id", "order_key"],
+          "isUnique": false
+        },
+        "topic_assistant_id_idx": {
+          "name": "topic_assistant_id_idx",
+          "columns": ["assistant_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "topic_assistant_id_assistant_id_fk": {
+          "name": "topic_assistant_id_assistant_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "assistant",
+          "columnsFrom": ["assistant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "topic_group_id_group_id_fk": {
+          "name": "topic_group_id_group_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translate_history": {
+      "name": "translate_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_text": {
+          "name": "target_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_language": {
+          "name": "source_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "star": {
+          "name": "star",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "translate_history_created_at_idx": {
+          "name": "translate_history_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "translate_history_star_created_at_idx": {
+          "name": "translate_history_star_created_at_idx",
+          "columns": ["star", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "translate_history_source_language_translate_language_lang_code_fk": {
+          "name": "translate_history_source_language_translate_language_lang_code_fk",
+          "tableFrom": "translate_history",
+          "tableTo": "translate_language",
+          "columnsFrom": ["source_language"],
+          "columnsTo": ["lang_code"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translate_history_target_language_translate_language_lang_code_fk": {
+          "name": "translate_history_target_language_translate_language_lang_code_fk",
+          "tableFrom": "translate_history",
+          "tableTo": "translate_language",
+          "columnsFrom": ["target_language"],
+          "columnsTo": ["lang_code"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translate_language": {
+      "name": "translate_language",
+      "columns": {
+        "lang_code": {
+          "name": "lang_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_model": {
+      "name": "user_model",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_model_id": {
+          "name": "preset_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_modalities": {
+          "name": "output_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endpoint_types": {
+          "name": "endpoint_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_endpoint_url": {
+          "name": "custom_endpoint_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_input_tokens": {
+          "name": "max_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supports_streaming": {
+          "name": "supports_streaming",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_deprecated": {
+          "name": "is_deprecated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_overrides": {
+          "name": "user_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_model_preset_idx": {
+          "name": "user_model_preset_idx",
+          "columns": ["preset_model_id"],
+          "isUnique": false
+        },
+        "user_model_provider_enabled_idx": {
+          "name": "user_model_provider_enabled_idx",
+          "columns": ["provider_id", "is_enabled"],
+          "isUnique": false
+        },
+        "user_model_provider_id_order_key_idx": {
+          "name": "user_model_provider_id_order_key_idx",
+          "columns": ["provider_id", "order_key"],
+          "isUnique": false
+        },
+        "user_model_provider_model_unique": {
+          "name": "user_model_provider_model_unique",
+          "columns": ["provider_id", "model_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_model_provider_id_user_provider_provider_id_fk": {
+          "name": "user_model_provider_id_user_provider_provider_id_fk",
+          "tableFrom": "user_model",
+          "tableTo": "user_provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["provider_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_provider": {
+      "name": "user_provider",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_provider_id": {
+          "name": "preset_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint_configs": {
+          "name": "endpoint_configs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_chat_endpoint": {
+          "name": "default_chat_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_keys": {
+          "name": "api_keys",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_features": {
+          "name": "api_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_settings": {
+          "name": "provider_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_provider_preset_idx": {
+          "name": "user_provider_preset_idx",
+          "columns": ["preset_provider_id"],
+          "isUnique": false
+        },
+        "user_provider_enabled_idx": {
+          "name": "user_provider_enabled_idx",
+          "columns": ["is_enabled"],
+          "isUnique": false
+        },
+        "user_provider_order_key_idx": {
+          "name": "user_provider_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "fe_external_path_lower_unique_idx": {
+        "columns": {
+          "lower(\"external_path\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/migrations/sqlite-drizzle/meta/_journal.json
+++ b/migrations/sqlite-drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1780123366362,
       "tag": "0000_loud_sugar_man",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1780126469473,
+      "tag": "0001_special_white_tiger",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@libsql/client": "^0.15.15",
     "@napi-rs/canvas": "0.1.80",
     "@napi-rs/system-ocr": "1.0.2",
+    "@node-rs/xxhash": "1.7.6",
     "@paymoapp/electron-shutdown-handler": "1.1.2",
     "@vectorstores/core": "^0.1.8",
     "@vectorstores/libsql": "workspace:*",
@@ -115,8 +116,7 @@
     "swagger-ui-express": "5.0.1",
     "tesseract.js": "6.0.1",
     "turndown": "7.2.0",
-    "ws": "^8.18.2",
-    "xxhash-wasm": "^1.1.0"
+    "ws": "^8.18.2"
   },
   "devDependencies": {
     "@agentic/exa": "^7.3.3",
@@ -575,6 +575,14 @@
     "@napi-rs/system-ocr-darwin-x64": "1.0.2",
     "@napi-rs/system-ocr-win32-arm64-msvc": "1.0.2",
     "@napi-rs/system-ocr-win32-x64-msvc": "1.0.2",
+    "@node-rs/xxhash-darwin-arm64": "1.7.6",
+    "@node-rs/xxhash-darwin-x64": "1.7.6",
+    "@node-rs/xxhash-linux-arm64-gnu": "1.7.6",
+    "@node-rs/xxhash-linux-arm64-musl": "1.7.6",
+    "@node-rs/xxhash-linux-x64-gnu": "1.7.6",
+    "@node-rs/xxhash-linux-x64-musl": "1.7.6",
+    "@node-rs/xxhash-win32-arm64-msvc": "1.7.6",
+    "@node-rs/xxhash-win32-x64-msvc": "1.7.6",
     "@strongtz/win32-arm64-msvc": "0.4.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       '@napi-rs/system-ocr':
         specifier: 1.0.2
         version: 1.0.2(patch_hash=aa1a73e445ee644774745b620589bb99d85bee6c95cc2a91fe9137e580da5bde)
+      '@node-rs/xxhash':
+        specifier: 1.7.6
+        version: 1.7.6
       '@paymoapp/electron-shutdown-handler':
         specifier: 1.1.2
         version: 1.1.2
@@ -186,9 +189,6 @@ importers:
       ws:
         specifier: ^8.18.2
         version: 8.20.0
-      xxhash-wasm:
-        specifier: ^1.1.0
-        version: 1.1.0
     devDependencies:
       '@agentic/exa':
         specifier: ^7.3.3
@@ -1337,6 +1337,30 @@ importers:
       '@napi-rs/system-ocr-win32-x64-msvc':
         specifier: 1.0.2
         version: 1.0.2
+      '@node-rs/xxhash-darwin-arm64':
+        specifier: 1.7.6
+        version: 1.7.6
+      '@node-rs/xxhash-darwin-x64':
+        specifier: 1.7.6
+        version: 1.7.6
+      '@node-rs/xxhash-linux-arm64-gnu':
+        specifier: 1.7.6
+        version: 1.7.6
+      '@node-rs/xxhash-linux-arm64-musl':
+        specifier: 1.7.6
+        version: 1.7.6
+      '@node-rs/xxhash-linux-x64-gnu':
+        specifier: 1.7.6
+        version: 1.7.6
+      '@node-rs/xxhash-linux-x64-musl':
+        specifier: 1.7.6
+        version: 1.7.6
+      '@node-rs/xxhash-win32-arm64-msvc':
+        specifier: 1.7.6
+        version: 1.7.6
+      '@node-rs/xxhash-win32-x64-msvc':
+        specifier: 1.7.6
+        version: 1.7.6
       '@strongtz/win32-arm64-msvc':
         specifier: 0.4.7
         version: 0.4.7
@@ -2261,28 +2285,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.2.4':
     resolution: {integrity: sha512-M/Iz48p4NAzMXOuH+tsn5BvG/Jb07KOMTdSVwJpicmhN309BeEyRyQX+n1XDF0JVSlu28+hiTQ2L4rZPvu7nMw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.2.4':
     resolution: {integrity: sha512-m41nFDS0ksXK2gwXL6W6yZTYPMH0LughqbsxInSKetoH6morVj43szqKx79Iudkp8WRT5SxSh7qVb8KCUiewGg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.2.4':
     resolution: {integrity: sha512-orr3nnf2Dpb2ssl6aihQtvcKtLySLta4E2UcXdp7+RTa7mfJjBgIsbS0B9GC8gVu0hjOu021aU8b3/I1tn+pVQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.2.4':
     resolution: {integrity: sha512-NXnfTeKHDFUWfxAefa57DiGmu9VyKi0cDqFpdI+1hJWQjGJhJutHPX0b5m+eXvTKOaf+brU+P0JrQAZMb5yYaQ==}
@@ -3098,105 +3118,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -4014,35 +4018,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.97':
     resolution: {integrity: sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.97':
     resolution: {integrity: sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.97':
     resolution: {integrity: sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.97':
     resolution: {integrity: sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.97':
     resolution: {integrity: sha512-u883Yr6A6fO7Vpsy9YE4FVCIxzzo5sO+7pIUjjoDLjS3vQaNMkVzx5bdIpEL+ob+gU88WDK4VcxYMZ6nmnoX9A==}
@@ -4087,6 +4086,9 @@ packages:
   '@napi-rs/system-ocr@1.0.2':
     resolution: {integrity: sha512-L6qM8ybM8RltTjLAG8rAeg/Jxgu13mxko4zL+SEWhhIikMkgjnSgvpThXueXHqt5mI9Ts96Dgc8Kpb3Y9Zj2nQ==}
     engines: {node: '>= 10'}
+
+  '@napi-rs/wasm-runtime@0.2.12':
+    resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
@@ -4182,6 +4184,93 @@ packages:
     resolution: {integrity: sha512-lGXsEYK3xqAQ1U/kKNr3m7ml5cFZMYPfuCD3gj/g+1fqRjO7ornjS39TjY89EgvZFLWOWQEUzo2QCEgIUPlGyg==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@node-rs/xxhash-android-arm-eabi@1.7.6':
+    resolution: {integrity: sha512-ptmfpFZ8SgTef58Us+0HsZ9BKhyX/gZYbhLkuzPt7qUoMqMSJK85NC7LEgzDgjUiG+S5GahEEQ9/tfh9BVvKhw==}
+    engines: {node: '>= 12'}
+    cpu: [arm]
+    os: [android]
+
+  '@node-rs/xxhash-android-arm64@1.7.6':
+    resolution: {integrity: sha512-n4MyZvqifuoARfBvrZ2IBqmsGzwlVI3kb2mB0gVvoHtMsPbl/q94zoDBZ7WgeP3t4Wtli+QS3zgeTCOWUbqqUQ==}
+    engines: {node: '>= 12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@node-rs/xxhash-darwin-arm64@1.7.6':
+    resolution: {integrity: sha512-6xGuE07CiCIry/KT3IiwQd/kykTOmjKzO/ZnHlE5ibGMx64NFE0qDuwJbxQ4rGyUzgJ0KuN9ZdOhUDJmepnpcw==}
+    engines: {node: '>= 12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@node-rs/xxhash-darwin-x64@1.7.6':
+    resolution: {integrity: sha512-Z4oNnhyznDvHhxv+s0ka+5KG8mdfLVucZMZMejj9BL+CPmamClygPiHIRiifRcPAoX9uPZykaCsULngIfLeF3Q==}
+    engines: {node: '>= 12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@node-rs/xxhash-freebsd-x64@1.7.6':
+    resolution: {integrity: sha512-arCDOf3xZ5NfBL5fk5J52sNPjXL2cVWN6nXNB3nrtRFFdPBLsr6YXtshAc6wMVxnIW4VGaEv/5K6IpTA8AFyWw==}
+    engines: {node: '>= 12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@node-rs/xxhash-linux-arm-gnueabihf@1.7.6':
+    resolution: {integrity: sha512-ndLLEW+MwLH3lFS0ahlHCcmkf2ykOv/pbP8OBBeAOlz/Xc3jKztg5IJ9HpkjKOkHk470yYxgHVaw1QMoMzU00A==}
+    engines: {node: '>= 12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@node-rs/xxhash-linux-arm64-gnu@1.7.6':
+    resolution: {integrity: sha512-VX7VkTG87mAdrF2vw4aroiRpFIIN8Lj6NgtGHF+IUVbzQxPudl4kG+FPEjsNH8y04yQxRbPE7naQNgHcTKMrNw==}
+    engines: {node: '>= 12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@node-rs/xxhash-linux-arm64-musl@1.7.6':
+    resolution: {integrity: sha512-AB5m6crGYSllM9F/xZNOQSPImotR5lOa9e4arW99Bv82S+gcpphI8fGMDOVTTCXY/RLRhvvhwzLDxmLB2O8VDg==}
+    engines: {node: '>= 12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@node-rs/xxhash-linux-x64-gnu@1.7.6':
+    resolution: {integrity: sha512-a2A6M+5tc0PVlJlE/nl0XsLEzMpKkwg7Y1lR5urFUbW9uVQnKjJYQDrUojhlXk0Uv3VnYQPa6ThmwlacZA5mvQ==}
+    engines: {node: '>= 12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@node-rs/xxhash-linux-x64-musl@1.7.6':
+    resolution: {integrity: sha512-WioGJSC1GoxQpmdQrG5l/uddSBAS4XCWczHNwXe895J5xadGQzyvmr0r17BNfihvbBUDH1H9jwouNYzDDeA6+A==}
+    engines: {node: '>= 12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@node-rs/xxhash-wasm32-wasi@1.7.6':
+    resolution: {integrity: sha512-WDXXKMMFMrez+esm2DzMPHFNPFYf+wQUtaXrXwtxXeQMFEzleOLwEaqV0+bbXGJTwhPouL3zY1Qo2xmIH4kkTg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@node-rs/xxhash-win32-arm64-msvc@1.7.6':
+    resolution: {integrity: sha512-qjDFUZJT/Zq0yFS+0TApkD86p0NBdPXlOoHur9yNeO9YX2/9/b1sC2P7N27PgOu13h61TUOvTUC00e/82jAZRQ==}
+    engines: {node: '>= 12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@node-rs/xxhash-win32-ia32-msvc@1.7.6':
+    resolution: {integrity: sha512-s7a+mQWOTnU4NiiypRq/vbNGot/il0HheXuy9oxJ0SW2q/e4BJ8j0pnP6UBlAjsk+005A76vOwsEj01qbQw8+A==}
+    engines: {node: '>= 12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@node-rs/xxhash-win32-x64-msvc@1.7.6':
+    resolution: {integrity: sha512-zHOHm2UaIahRhgRPJll+4Xy4Z18aAT/7KNeQW+QJupGvFz+GzOFXMGs3R/3B1Ktob/F5ui3i1MrW9GEob3CWTg==}
+    engines: {node: '>= 12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@node-rs/xxhash@1.7.6':
+    resolution: {integrity: sha512-XMisO+aQHsVpxRp/85EszTtOQTOlhPbd149P/Xa9F55wafA6UM3h2UhOgOs7aAzItnHU/Aw1WQ1FVTEg7WB43Q==}
+    engines: {node: '>= 12'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -4428,56 +4517,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.56.0':
     resolution: {integrity: sha512-rkTZkBfJ4TYLjansjSzL6mgZOdN5IvUnSq3oNJSLwBcNvy3dlgQtpHPrRxrCEbbcp7oQ6If0tkNaqfOsphYZ9g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.56.0':
     resolution: {integrity: sha512-uqL1kMH3u69/e1CH2EJhP3CP28jw2ExLsku4o8RVAZ7fySo9zOyI2fy9pVlTAp4voBLVgzndXi3SgtdyCTa2aA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.56.0':
     resolution: {integrity: sha512-j0CcMBOgV6KsRaBdsebIeiy7hCjEvq2KdEsiULf2LZqAq0v1M1lWjelhCV57LxsqaIGChXFuFJ0RiFrSRHPhSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.56.0':
     resolution: {integrity: sha512-7VDOiL8cDG3DQ/CY3yKjbV1c4YPvc4vH8qW09Vv+5ukq3l/Kcyr6XGCd5NvxUmxqDb2vjMpM+eW/4JrEEsUetA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.56.0':
     resolution: {integrity: sha512-JGRpX0M+ikD3WpwJ7vKcHKV6Kg0dT52BW2Eu2BupXotYeqGXBrbY+QPkAyKO6MNgKozyTNaRh3r7g+VWgyAQYQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.56.0':
     resolution: {integrity: sha512-dNaICPvtmuxFP/VbqdofrLqdS3bM/AKJN3LMJD52si44ea7Be1cBk6NpfIahaysG9Uo+L98QKddU9CD5L8UHnQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.56.0':
     resolution: {integrity: sha512-pF1vOtM+GuXmbklM1hV8WMsn6tCNPvkUzklj/Ej98JhlanbmA2RB1BILgOpwSuCTRTIYx2MXssmEyQQ90QF5aA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.56.0':
     resolution: {integrity: sha512-bp8NQ4RE6fDIFLa4bdBiOA+TAvkNkg+rslR+AvvjlLTYXLy9/uKAYLQudaQouWihLD/hgkrXIKKzXi5IXOewwg==}
@@ -5594,14 +5675,12 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.3':
     resolution: {integrity: sha512-kWXkoxxarYISBJ4bLNf5vFkEbb4JvccOwxWDxuK9yee8lg5XA7OpvlTptfRuwEvYcOZf+7VS69Uenpmpyo5Bjw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.1':
     resolution: {integrity: sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==}
@@ -5626,14 +5705,12 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.3':
     resolution: {integrity: sha512-Z03/wrqau9Bicfgb3Dbs6SYTHliELk2PM2LpG2nFd+cGupTMF5kanLEcj2vuuJLLhptNyS61rtk7SOZ+lPsTUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.1':
     resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
@@ -5670,14 +5747,12 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.3':
     resolution: {integrity: sha512-iSXXZsQp08CSilff/DCTFZHSVEpEwdicV3W8idHyrByrcsRDVh9sGC3sev6d8BygSGj3vt8GvUKBPCoyMA4tgQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.1':
     resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
@@ -5702,14 +5777,12 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.3':
     resolution: {integrity: sha512-qaj+MFudtdCv9xZo9znFvkgoajLdc+vwf0Kz5N44g+LU5XMe+IsACgn3UG7uTRlCCvhMAGXm1XlpEA5bZBrOcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.1':
     resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
@@ -5960,7 +6033,6 @@ packages:
     resolution: {integrity: sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.55.1':
     resolution: {integrity: sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==}
@@ -6476,28 +6548,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.8':
     resolution: {integrity: sha512-koiCqL09EwOP1S2RShCI7NbsQuG6r2brTqUYE7pV7kZm9O17wZ0LSz22m6gVibpwEnw8jI3IE1yYsQTVpluALw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.8':
     resolution: {integrity: sha512-4p6lOMU3bC+Vd5ARtKJ/FxpIC5G8v3XLoPEZ5s7mLR8h7411HWC/LmTXDHcrSXRC55zvAVia1eldy6zDLz8iFQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.8':
     resolution: {integrity: sha512-z3XBnbrZAL+6xDGAhJoN4lOueIxC/8rGrJ9tg+fEaeqLEuAtHSW2QHDHxDwkxZMjuF/pZ6MUTjHjbp8wLbuRLA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.8':
     resolution: {integrity: sha512-djQPJ9Rh9vP8GTS/Df3hcc6XP6xnG5c8qsngWId/BLA9oX6C7UzCPAn74BG/wGb9a6j4w3RINuoaieJB3t+7iQ==}
@@ -6588,28 +6656,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -11200,7 +11264,6 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
@@ -11213,7 +11276,6 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
@@ -11226,7 +11288,6 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
@@ -11239,7 +11300,6 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
@@ -15249,9 +15309,6 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
-  xxhash-wasm@1.1.0:
-    resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
-
   y-protocols@1.0.7:
     resolution: {integrity: sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==}
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
@@ -18455,6 +18512,13 @@ snapshots:
       '@napi-rs/system-ocr-win32-arm64-msvc': 1.0.2
       '@napi-rs/system-ocr-win32-x64-msvc': 1.0.2
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
       '@emnapi/core': 1.8.0
@@ -18528,6 +18592,67 @@ snapshots:
       '@neplex/vectorizer-win32-arm64-msvc': 0.0.5
       '@neplex/vectorizer-win32-ia32-msvc': 0.0.5
       '@neplex/vectorizer-win32-x64-msvc': 0.0.5
+
+  '@node-rs/xxhash-android-arm-eabi@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-android-arm64@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-darwin-arm64@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-darwin-x64@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-freebsd-x64@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-linux-arm-gnueabihf@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-linux-arm64-gnu@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-linux-arm64-musl@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-linux-x64-gnu@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-linux-x64-musl@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-wasm32-wasi@1.7.6':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.12
+    optional: true
+
+  '@node-rs/xxhash-win32-arm64-msvc@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-win32-ia32-msvc@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash-win32-x64-msvc@1.7.6':
+    optional: true
+
+  '@node-rs/xxhash@1.7.6':
+    optionalDependencies:
+      '@node-rs/xxhash-android-arm-eabi': 1.7.6
+      '@node-rs/xxhash-android-arm64': 1.7.6
+      '@node-rs/xxhash-darwin-arm64': 1.7.6
+      '@node-rs/xxhash-darwin-x64': 1.7.6
+      '@node-rs/xxhash-freebsd-x64': 1.7.6
+      '@node-rs/xxhash-linux-arm-gnueabihf': 1.7.6
+      '@node-rs/xxhash-linux-arm64-gnu': 1.7.6
+      '@node-rs/xxhash-linux-arm64-musl': 1.7.6
+      '@node-rs/xxhash-linux-x64-gnu': 1.7.6
+      '@node-rs/xxhash-linux-x64-musl': 1.7.6
+      '@node-rs/xxhash-wasm32-wasi': 1.7.6
+      '@node-rs/xxhash-win32-arm64-msvc': 1.7.6
+      '@node-rs/xxhash-win32-ia32-msvc': 1.7.6
+      '@node-rs/xxhash-win32-x64-msvc': 1.7.6
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -31412,8 +31537,6 @@ snapshots:
   xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
-
-  xxhash-wasm@1.1.0: {}
 
   y-protocols@1.0.7(yjs@13.6.29):
     dependencies:

--- a/src/main/data/db/schemas/file.ts
+++ b/src/main/data/db/schemas/file.ts
@@ -47,6 +47,28 @@ export const fileEntryTable = sqliteTable(
      */
     size: integer(),
 
+    // ─── Content dedup ───
+    /**
+     * Content hash of the backing blob, format `{algo}:{hex}` (e.g.
+     * `xxh3-64:9a0f…`). A **detection substrate** for content-level dedup —
+     * NOT an identity and NOT a unique key. Identity stays `id` (UUID v7); a
+     * hash collision at worst surfaces a wrong candidate that a consumer's
+     * secondary check rejects, never mis-served bytes (hence the non-unique
+     * `fe_content_hash_idx`).
+     *
+     * - internal: maintained on create + every write; NULL only during the
+     *   backfill window (rows created before this feature) — a transitional
+     *   state, not steady.
+     * - external: always NULL — external content lives outside Cherry and is
+     *   never hashed (enforced by `fe_contenthash_external_null`).
+     *
+     * Distinct from `fe_external_path_lower_unique_idx` (external *path*
+     * identity) and from the on-demand hash behind `writeIfUnchanged` (an
+     * ephemeral deep-compare, never persisted). See
+     * `file-manager-architecture.md`.
+     */
+    contentHash: text(),
+
     // ─── External ───
     /** Absolute path to the user-provided file. Non-null iff origin='external' */
     externalPath: text(),
@@ -89,6 +111,12 @@ export const fileEntryTable = sqliteTable(
     // Without this the functional unique index alone cannot serve
     // `WHERE externalPath = ?` — SQLite would fall back to a seq scan.
     index('fe_external_path_idx').on(t.externalPath),
+    // Non-unique index backing the content-dedup detection query
+    // (`findInternalByContentHash`). Deliberately NOT unique: `contentHash` is a
+    // detection substrate, not a key — multiple internal rows may legitimately
+    // share a hash (identical content under different names), and a collision
+    // must never raise a constraint violation.
+    index('fe_content_hash_idx').on(t.contentHash),
     // Origin must be 'internal' or 'external'
     check('fe_origin_check', sql`${t.origin} IN ('internal', 'external')`),
     // externalPath must be non-null iff origin='external'
@@ -109,7 +137,12 @@ export const fileEntryTable = sqliteTable(
     check(
       'fe_size_internal_only',
       sql`(${t.origin} = 'internal' AND ${t.size} IS NOT NULL AND ${t.size} >= 0) OR (${t.origin} = 'external' AND ${t.size} IS NULL)`
-    )
+    ),
+    // contentHash is internal-only: external content lives outside Cherry and is
+    // never hashed. Softer than `fe_size_internal_only` — internal rows MAY
+    // carry a NULL contentHash (backfill window / not yet computed), so this
+    // only forbids the external⇒non-NULL combination.
+    check('fe_contenthash_external_null', sql`${t.origin} != 'external' OR ${t.contentHash} IS NULL`)
   ]
 )
 

--- a/src/main/data/services/FileEntryService.ts
+++ b/src/main/data/services/FileEntryService.ts
@@ -23,7 +23,7 @@ import { fileEntryTable, fileRefTable } from '@data/db/schemas/file'
 import { DataApiErrorFactory } from '@shared/data/api'
 import type { CanonicalExternalPath, FileEntry, FileEntryId, FileEntryOrigin } from '@shared/data/types/file'
 import { AbsolutePathSchema, FileEntrySchema, SafeNameSchema } from '@shared/data/types/file'
-import { and, asc, count, desc, eq, isNotNull, isNull, type SQL, sql } from 'drizzle-orm'
+import { and, asc, count, desc, eq, gt, isNotNull, isNull, type SQL, sql } from 'drizzle-orm'
 import { v7 as uuidv7 } from 'uuid'
 
 /** Columns a caller may provide on insert (id defaults to a fresh UUID v7 when omitted). */
@@ -39,6 +39,13 @@ export interface CreateFileEntryRow {
    * live values come from File IPC `getMetadata`.
    */
   readonly size: number | null
+  /**
+   * Content hash (`{algo}:{hex}`) for the dedup detection substrate. Optional;
+   * defaults to `null` when omitted. Internal entries created via the write
+   * pipeline always supply it; v1-migrated rows omit it (backfilled later).
+   * Must stay `null` for external rows (enforced by `fe_contenthash_external_null`).
+   */
+  readonly contentHash?: string | null
   /** Non-null iff `origin === 'external'`; must be pre-canonicalized. */
   readonly externalPath: string | null
   readonly deletedAt?: number | null
@@ -46,10 +53,11 @@ export interface CreateFileEntryRow {
 
 /**
  * Columns that may be mutated post-insert. Origin / id / externalPath are
- * immutable. Note `size` is included because internal-file writes update the
- * byte count atomically; on external rows it must remain `null`.
+ * immutable. `size` and `contentHash` are included because internal-file writes
+ * update the byte count and recompute the detection hash atomically; on
+ * external rows both must remain `null`.
  */
-export type UpdateFileEntryRow = Partial<Pick<CreateFileEntryRow, 'name' | 'ext' | 'size'>> & {
+export type UpdateFileEntryRow = Partial<Pick<CreateFileEntryRow, 'name' | 'ext' | 'size' | 'contentHash'>> & {
   readonly deletedAt?: number | null
 }
 
@@ -118,6 +126,37 @@ export interface FileEntryService {
    * `file-manager-architecture.md §1.2 Duplicate-entry detection on insert`.
    */
   findCaseInsensitivePeers(canonicalPath: CanonicalExternalPath): Promise<FileEntry[]>
+
+  /**
+   * Active internal entries whose `contentHash` equals `contentHash` — the
+   * detection-query primitive behind content-level dedup.
+   *
+   * NON-unique by design: `contentHash` carries no unique constraint (it is a
+   * detection substrate, not a key), so this may return >1 row — identical
+   * content stored under different names, or a rare hash collision that the
+   * consumer's secondary check (e.g. `(contentHash, name, ext)`) or the user
+   * rejects. Ordered oldest-first (`createdAt`, then `id`) for a stable
+   * candidate list. External rows are excluded (they never carry a
+   * `contentHash`); trashed entries are excluded (only active entries are
+   * reuse targets). Returns `[]` on no match.
+   */
+  findInternalByContentHash(contentHash: string): Promise<FileEntry[]>
+
+  /**
+   * Count of internal entries still missing a `contentHash` — the backfill work
+   * set (v1-migrated / pre-feature rows). Includes trashed entries (their
+   * physical blob is preserved, so they are hashable and become reuse targets
+   * once restored). `> 0` is the startup trigger for the backfill coordinator.
+   */
+  countInternalMissingContentHash(): Promise<number>
+
+  /**
+   * Keyset page (ordered by `id`, `id > afterId`) of internal entries missing a
+   * `contentHash`, for the backfill coordinator. Keyset (not OFFSET) so entries
+   * that fail to hash stay NULL but behind the cursor and are not re-scanned in
+   * the same drain pass. Pass `afterId = null` for the first page.
+   */
+  findInternalMissingContentHash(afterId: string | null, limit: number): Promise<FileEntry[]>
 
   /** Flat listing. Trashed filter defaults to "active only" when `inTrash` is omitted. */
   findMany(query?: FindEntriesQuery): Promise<FileEntry[]>
@@ -200,6 +239,9 @@ function rowToFileEntry(row: FileEntryRow): FileEntry {
       name: row.name,
       ext: row.ext,
       size: row.size,
+      // Detection substrate for content dedup; `null` until backfilled. Carried
+      // straight through from the row (the column is internal-only and nullable).
+      contentHash: row.contentHash,
       // deletedAt is `optional` on the BO — present iff the DB column is
       // non-null. Bypass `nullsToUndefined` so we don't pull in a helper
       // whose project-wide meaning is "every null becomes undefined";
@@ -262,6 +304,43 @@ class FileEntryServiceImpl implements FileEntryService {
       // tests and for the surviving-row selection in any future FileMigrator
       // dedupe pass).
       .orderBy(asc(fileEntryTable.createdAt), asc(fileEntryTable.id))
+    return rows.map(rowToFileEntry)
+  }
+
+  async findInternalByContentHash(contentHash: string): Promise<FileEntry[]> {
+    const rows = await this.getDb()
+      .select()
+      .from(fileEntryTable)
+      .where(
+        and(
+          eq(fileEntryTable.origin, 'internal'),
+          isNull(fileEntryTable.deletedAt),
+          eq(fileEntryTable.contentHash, contentHash)
+        )
+      )
+      // Stable oldest-first ordering so a consumer that reuses "the first
+      // candidate" gets a deterministic pick across runs.
+      .orderBy(asc(fileEntryTable.createdAt), asc(fileEntryTable.id))
+    return rows.map(rowToFileEntry)
+  }
+
+  async countInternalMissingContentHash(): Promise<number> {
+    const rows = await this.getDb()
+      .select({ value: count() })
+      .from(fileEntryTable)
+      .where(and(eq(fileEntryTable.origin, 'internal'), isNull(fileEntryTable.contentHash)))
+    return rows[0]?.value ?? 0
+  }
+
+  async findInternalMissingContentHash(afterId: string | null, limit: number): Promise<FileEntry[]> {
+    const conditions: SQL[] = [eq(fileEntryTable.origin, 'internal'), isNull(fileEntryTable.contentHash)]
+    if (afterId !== null) conditions.push(gt(fileEntryTable.id, afterId))
+    const rows = await this.getDb()
+      .select()
+      .from(fileEntryTable)
+      .where(and(...conditions))
+      .orderBy(asc(fileEntryTable.id))
+      .limit(limit)
     return rows.map(rowToFileEntry)
   }
 
@@ -370,6 +449,7 @@ class FileEntryServiceImpl implements FileEntryService {
         name: values.name,
         ext: values.ext,
         size: values.size,
+        contentHash: values.contentHash ?? null,
         externalPath: values.externalPath,
         deletedAt: values.deletedAt ?? null,
         createdAt: now,
@@ -392,6 +472,7 @@ class FileEntryServiceImpl implements FileEntryService {
     if (values.name !== undefined) updates.name = values.name
     if (values.ext !== undefined) updates.ext = values.ext
     if (values.size !== undefined) updates.size = values.size
+    if (values.contentHash !== undefined) updates.contentHash = values.contentHash
     if (values.deletedAt !== undefined) updates.deletedAt = values.deletedAt
     const rows = await this.getDb().update(fileEntryTable).set(updates).where(eq(fileEntryTable.id, id)).returning()
     if (rows.length === 0) {

--- a/src/main/data/services/FileEntryService.ts
+++ b/src/main/data/services/FileEntryService.ts
@@ -21,7 +21,13 @@
 import { application } from '@application'
 import { fileEntryTable, fileRefTable } from '@data/db/schemas/file'
 import { DataApiErrorFactory } from '@shared/data/api'
-import type { CanonicalExternalPath, FileEntry, FileEntryId, FileEntryOrigin } from '@shared/data/types/file'
+import type {
+  CanonicalExternalPath,
+  ContentHash,
+  FileEntry,
+  FileEntryId,
+  FileEntryOrigin
+} from '@shared/data/types/file'
 import { AbsolutePathSchema, FileEntrySchema, SafeNameSchema } from '@shared/data/types/file'
 import { and, asc, count, desc, eq, gt, isNotNull, isNull, type SQL, sql } from 'drizzle-orm'
 import { v7 as uuidv7 } from 'uuid'
@@ -45,7 +51,7 @@ export interface CreateFileEntryRow {
    * pipeline always supply it; v1-migrated rows omit it (backfilled later).
    * Must stay `null` for external rows (enforced by `fe_contenthash_external_null`).
    */
-  readonly contentHash?: string | null
+  readonly contentHash?: ContentHash | null
   /** Non-null iff `origin === 'external'`; must be pre-canonicalized. */
   readonly externalPath: string | null
   readonly deletedAt?: number | null
@@ -140,7 +146,7 @@ export interface FileEntryService {
    * `contentHash`); trashed entries are excluded (only active entries are
    * reuse targets). Returns `[]` on no match.
    */
-  findInternalByContentHash(contentHash: string): Promise<FileEntry[]>
+  findInternalByContentHash(contentHash: ContentHash): Promise<FileEntry[]>
 
   /**
    * Count of internal entries still missing a `contentHash` — the backfill work
@@ -307,7 +313,7 @@ class FileEntryServiceImpl implements FileEntryService {
     return rows.map(rowToFileEntry)
   }
 
-  async findInternalByContentHash(contentHash: string): Promise<FileEntry[]> {
+  async findInternalByContentHash(contentHash: ContentHash): Promise<FileEntry[]> {
     const rows = await this.getDb()
       .select()
       .from(fileEntryTable)

--- a/src/main/data/services/__tests__/FileEntryService.test.ts
+++ b/src/main/data/services/__tests__/FileEntryService.test.ts
@@ -204,6 +204,125 @@ describe('FileEntryService', () => {
     })
   })
 
+  describe('findInternalByContentHash', () => {
+    const HASH = 'xxh3-64:1111222233334444'
+
+    it('returns active internal entries sharing the hash, oldest-first (non-unique)', async () => {
+      // Two internal entries with identical content (same hash, different names) —
+      // legitimate under a non-unique detection substrate.
+      await fileEntryService.create({
+        id: '019606a0-0000-7000-8000-0000000000c1' as FileEntryId,
+        origin: 'internal',
+        name: 'first',
+        ext: 'bin',
+        size: 3,
+        contentHash: HASH,
+        externalPath: null
+      })
+      await fileEntryService.create({
+        id: '019606a0-0000-7000-8000-0000000000c2' as FileEntryId,
+        origin: 'internal',
+        name: 'second',
+        ext: 'bin',
+        size: 3,
+        contentHash: HASH,
+        externalPath: null
+      })
+      const hits = await fileEntryService.findInternalByContentHash(HASH)
+      expect(hits.map((h) => h.id)).toEqual([
+        '019606a0-0000-7000-8000-0000000000c1',
+        '019606a0-0000-7000-8000-0000000000c2'
+      ])
+    })
+
+    it('returns empty array when no internal entry matches', async () => {
+      await fileEntryService.create({
+        id: '019606a0-0000-7000-8000-0000000000c3' as FileEntryId,
+        origin: 'internal',
+        name: 'other',
+        ext: null,
+        size: 1,
+        contentHash: 'xxh3-64:deadbeefdeadbeef',
+        externalPath: null
+      })
+      expect(await fileEntryService.findInternalByContentHash(HASH)).toEqual([])
+    })
+
+    it('excludes trashed internal entries (only active rows are reuse targets)', async () => {
+      const id = '019606a0-0000-7000-8000-0000000000c4' as FileEntryId
+      await fileEntryService.create({
+        id,
+        origin: 'internal',
+        name: 'trashed',
+        ext: 'bin',
+        size: 3,
+        contentHash: HASH,
+        externalPath: null
+      })
+      await fileEntryService.update(id, { deletedAt: Date.now() })
+      expect(await fileEntryService.findInternalByContentHash(HASH)).toEqual([])
+    })
+  })
+
+  describe('countInternalMissingContentHash / findInternalMissingContentHash', () => {
+    const PREFIX = '019606a0-0000-7000-8000-0000000000'
+
+    it('counts internal NULL-contentHash rows including trashed, excluding external and hashed', async () => {
+      // internal, NULL contentHash
+      await fileEntryService.create({
+        id: `${PREFIX}d1` as FileEntryId,
+        origin: 'internal',
+        name: 'a',
+        ext: 'bin',
+        size: 1,
+        externalPath: null
+      })
+      // internal, NULL, trashed → still counted (blob preserved, hashable)
+      await fileEntryService.create({
+        id: `${PREFIX}d2` as FileEntryId,
+        origin: 'internal',
+        name: 'b',
+        ext: 'bin',
+        size: 1,
+        externalPath: null
+      })
+      await fileEntryService.update(`${PREFIX}d2` as FileEntryId, { deletedAt: Date.now() })
+      // internal, already hashed → excluded
+      await fileEntryService.create({
+        id: `${PREFIX}d3` as FileEntryId,
+        origin: 'internal',
+        name: 'c',
+        ext: 'bin',
+        size: 1,
+        contentHash: 'xxh3-64:1111222233334444',
+        externalPath: null
+      })
+      // external → excluded (never carries a contentHash)
+      await fileEntryService.create({
+        id: `${PREFIX}d4` as FileEntryId,
+        origin: 'external',
+        name: 'd',
+        ext: 'txt',
+        size: null,
+        externalPath: '/tmp/d.txt'
+      })
+
+      expect(await fileEntryService.countInternalMissingContentHash()).toBe(2)
+    })
+
+    it('pages NULL-contentHash internal rows by id keyset', async () => {
+      const ids = [`${PREFIX}e1`, `${PREFIX}e2`, `${PREFIX}e3`] as FileEntryId[]
+      for (const id of ids) {
+        await fileEntryService.create({ id, origin: 'internal', name: 'x', ext: 'bin', size: 1, externalPath: null })
+      }
+      const page1 = await fileEntryService.findInternalMissingContentHash(null, 2)
+      expect(page1.map((e) => e.id)).toEqual([ids[0], ids[1]])
+      const page2 = await fileEntryService.findInternalMissingContentHash(page1[page1.length - 1].id, 2)
+      expect(page2.map((e) => e.id)).toEqual([ids[2]])
+      expect(await fileEntryService.findInternalMissingContentHash(ids[2], 2)).toEqual([])
+    })
+  })
+
   describe('findMany', () => {
     it('returns all active entries when no query is given', async () => {
       const now = Date.now()

--- a/src/main/data/services/__tests__/FileEntryService.test.ts
+++ b/src/main/data/services/__tests__/FileEntryService.test.ts
@@ -720,6 +720,52 @@ describe('FileEntryService', () => {
         })
       ).rejects.toThrow()
     })
+
+    it('rejects an external row carrying a non-null content_hash (CHECK fe_contenthash_external_null)', async () => {
+      // Threat model: a path that bypasses Zod (a v2 migrator / direct Drizzle
+      // insert) attaches a contentHash to an external row. contentHash is an
+      // internal-only detection substrate; the DB CHECK is the last line of
+      // defense. Raw-insert (not via the service) so the constraint itself is
+      // pinned — a typo in the predicate (e.g. IS NOT NULL) would ship green.
+      const id = '019606a0-0000-7000-8000-000000000a05'
+      const now = Date.now()
+      await expect(
+        dbh.db.insert(fileEntryTable).values({
+          id,
+          origin: 'external',
+          name: 'doc',
+          ext: 'pdf',
+          size: null,
+          contentHash: 'xxh3-64:24ccc9acaa9f65e4',
+          externalPath: '/Users/me/doc.pdf',
+          deletedAt: null,
+          createdAt: now,
+          updatedAt: now
+        })
+      ).rejects.toThrow()
+    })
+
+    it('accepts an internal row with a null content_hash (the deliberately-permitted backfill window)', async () => {
+      // Positive control / inverse of the rejection above: an internal row MAY
+      // carry contentHash = NULL (v1-migrated / pre-feature rows the backfill
+      // job fills later). The CHECK must not reject this.
+      const id = '019606a0-0000-7000-8000-000000000a06'
+      const now = Date.now()
+      await dbh.db.insert(fileEntryTable).values({
+        id,
+        origin: 'internal',
+        name: 'legacy',
+        ext: 'txt',
+        size: 1,
+        contentHash: null,
+        externalPath: null,
+        deletedAt: null,
+        createdAt: now,
+        updatedAt: now
+      })
+      const [raw] = await dbh.db.select().from(fileEntryTable).where(eq(fileEntryTable.id, id))
+      expect(raw?.contentHash).toBeNull()
+    })
   })
 
   describe('update', () => {

--- a/src/main/data/services/__tests__/FileEntryService.test.ts
+++ b/src/main/data/services/__tests__/FileEntryService.test.ts
@@ -1,6 +1,6 @@
 import { fileEntryTable, fileRefTable } from '@data/db/schemas/file'
 import { DataApiError, ErrorCode } from '@shared/data/api'
-import type { CanonicalExternalPath, FileEntryId } from '@shared/data/types/file'
+import type { CanonicalExternalPath, ContentHash, FileEntryId } from '@shared/data/types/file'
 import { setupTestDatabase } from '@test-helpers/db'
 import { MockMainDbServiceUtils } from '@test-mocks/main/DbService'
 import { eq } from 'drizzle-orm'
@@ -205,7 +205,7 @@ describe('FileEntryService', () => {
   })
 
   describe('findInternalByContentHash', () => {
-    const HASH = 'xxh3-64:1111222233334444'
+    const HASH = 'xxh3-64:1111222233334444' as ContentHash
 
     it('returns active internal entries sharing the hash, oldest-first (non-unique)', async () => {
       // Two internal entries with identical content (same hash, different names) —
@@ -242,7 +242,7 @@ describe('FileEntryService', () => {
         name: 'other',
         ext: null,
         size: 1,
-        contentHash: 'xxh3-64:deadbeefdeadbeef',
+        contentHash: 'xxh3-64:deadbeefdeadbeef' as ContentHash,
         externalPath: null
       })
       expect(await fileEntryService.findInternalByContentHash(HASH)).toEqual([])
@@ -294,7 +294,7 @@ describe('FileEntryService', () => {
         name: 'c',
         ext: 'bin',
         size: 1,
-        contentHash: 'xxh3-64:1111222233334444',
+        contentHash: 'xxh3-64:1111222233334444' as ContentHash,
         externalPath: null
       })
       // external → excluded (never carries a contentHash)

--- a/src/main/services/file/FileManager.ts
+++ b/src/main/services/file/FileManager.ts
@@ -138,7 +138,7 @@ import { orphanCheckerRegistry } from '@main/services/file/orphanCheckerRegistry
 import { remove as fsRemove, stat as fsStat } from '@main/utils/file/fs'
 import type { DanglingState, FileEntry, FileEntryId } from '@shared/data/types/file'
 import { AbsolutePathSchema, FileEntryIdSchema } from '@shared/data/types/file'
-import { ContentHashSchema, SafeExtSchema, SafeNameSchema } from '@shared/data/types/file/essential'
+import { type ContentHash, ContentHashSchema, SafeExtSchema, SafeNameSchema } from '@shared/data/types/file/essential'
 import type {
   BatchCreateResult,
   BatchMutationResult,
@@ -875,7 +875,7 @@ export class FileManager extends BaseService implements IFileManager {
    * `FileEntryService.findInternalByContentHash`). The reuse-vs-create decision
    * is the consumer's; this only surfaces candidates.
    */
-  async findInternalByContentHash(contentHash: string): Promise<FileEntry[]> {
+  async findInternalByContentHash(contentHash: ContentHash): Promise<FileEntry[]> {
     return this.deps.fileEntryService.findInternalByContentHash(contentHash)
   }
 

--- a/src/main/services/file/FileManager.ts
+++ b/src/main/services/file/FileManager.ts
@@ -129,6 +129,7 @@ import { createReadStream as nodeCreateReadStream } from 'node:fs'
 import type { Readable, Writable } from 'node:stream'
 import { pathToFileURL } from 'node:url'
 
+import { application } from '@application'
 import { fileEntryService } from '@data/services/FileEntryService'
 import { fileRefService } from '@data/services/FileRefService'
 import { loggerService } from '@logger'
@@ -137,7 +138,7 @@ import { orphanCheckerRegistry } from '@main/services/file/orphanCheckerRegistry
 import { remove as fsRemove, stat as fsStat } from '@main/utils/file/fs'
 import type { DanglingState, FileEntry, FileEntryId } from '@shared/data/types/file'
 import { AbsolutePathSchema, FileEntryIdSchema } from '@shared/data/types/file'
-import { SafeExtSchema, SafeNameSchema } from '@shared/data/types/file/essential'
+import { ContentHashSchema, SafeExtSchema, SafeNameSchema } from '@shared/data/types/file/essential'
 import type {
   BatchCreateResult,
   BatchMutationResult,
@@ -187,6 +188,7 @@ import {
 } from './internal/orphanSweep'
 import { open as internalShellOpen, showInFolder as internalShellShowInFolder } from './internal/system/shell'
 import { withTempCopy as internalWithTempCopy } from './internal/system/tempCopy'
+import { contentHashBackfillJobHandler } from './tasks/contentHashBackfillJobHandler'
 import { canonicalizeExternalPath, resolvePhysicalPath } from './utils/pathResolver'
 import { createVersionCacheImpl, type VersionCache } from './versionCache'
 
@@ -243,14 +245,20 @@ export const BatchGetDanglingStatesIpcSchema = z.strictObject({
 const SafeExtNullableSchema = SafeExtSchema.nullable()
 
 export const CreateInternalEntryIpcSchema = z.discriminatedUnion('source', [
-  z.strictObject({ source: z.literal('path'), path: AbsolutePathSchema }),
-  z.strictObject({ source: z.literal('url'), url: z.url() }),
-  z.strictObject({ source: z.literal('base64'), data: z.string().min(1), name: SafeNameSchema.optional() }),
+  z.strictObject({ source: z.literal('path'), path: AbsolutePathSchema, contentHash: ContentHashSchema.optional() }),
+  z.strictObject({ source: z.literal('url'), url: z.url(), contentHash: ContentHashSchema.optional() }),
+  z.strictObject({
+    source: z.literal('base64'),
+    data: z.string().min(1),
+    name: SafeNameSchema.optional(),
+    contentHash: ContentHashSchema.optional()
+  }),
   z.strictObject({
     source: z.literal('bytes'),
     data: z.instanceof(Uint8Array),
     name: SafeNameSchema,
-    ext: SafeExtNullableSchema
+    ext: SafeExtNullableSchema,
+    contentHash: ContentHashSchema.optional()
   })
 ])
 
@@ -279,8 +287,8 @@ export const PermanentDeleteIpcSchema = FileHandleSchema
  *
  * ## Opt-in hash fallback
  *
- * `writeIfUnchanged` accepts an optional `expectedContentHash` (xxhash-h64 hex
- * of the content the caller last observed). When supplied AND the observed
+ * `writeIfUnchanged` accepts an optional `expectedContentHash` (the XXH3-64
+ * `{algo}:{hex}` value of the content the caller last observed). When supplied AND the observed
  * mtime is ambiguous (ms === 0 AND size matches), the implementation re-hashes
  * the file on disk and throws `StaleVersionError` on mismatch. When omitted
  * (the default), `writeIfUnchanged` proceeds optimistically under reduced
@@ -342,7 +350,7 @@ export interface AtomicWriteStream extends Writable {
  * Thrown by `writeIfUnchanged` when the current file version does not match the
  * caller's expected version. Caller should refresh or present a conflict UX.
  *
- * Note: this implementation uses the xxhash-h64 fallback path described on
+ * Note: this implementation uses the XXH3-64 fallback path described on
  * `FileVersion` when mtime resolution is ambiguous — a `StaleVersionError`
  * under that branch means the hash also diverged, i.e. the content genuinely
  * differs even when `(mtime, size)` looked equal.
@@ -477,7 +485,7 @@ export interface IFileManager {
   /** Get FileVersion (stat-based) — live for both origins. */
   getVersion(id: FileEntryId): Promise<FileVersion>
 
-  /** Compute xxhash-h64 of file content. Reads full file. */
+  /** Compute the XXH3-64 content hash (returns the tagged `xxh3-64:{hex}` form). Reads full file. */
   getContentHash(id: FileEntryId): Promise<string>
 
   // ─── Writing ───
@@ -668,6 +676,30 @@ export class FileManager extends BaseService implements IFileManager {
   protected override async onInit(): Promise<void> {
     await this.deps.danglingCache.initFromDb()
     this.registerIpcHandlers()
+    // Register the content-hash backfill handler in onInit (before any
+    // onAllReady fires) so it is in JobManager's registry by the time startup
+    // recovery and our own onAllReady trigger run — see job handler-authoring
+    // §"Registration timing".
+    application.get('JobManager').registerHandler('file.contenthash-backfill', contentHashBackfillJobHandler)
+  }
+
+  /**
+   * Once the whole app is ready, kick a one-shot content-hash backfill for any
+   * internal entries still missing a `contentHash` (v1-migrated / pre-feature
+   * rows). The `count > 0` probe also serves as crash-recovery: a backfill
+   * interrupted by a prior crash is simply re-triggered here, since the
+   * `content_hash IS NULL` set is itself the resumable work queue. No job is
+   * enqueued when nothing is pending (the steady state).
+   */
+  protected override async onAllReady(): Promise<void> {
+    try {
+      const pending = await this.deps.fileEntryService.countInternalMissingContentHash()
+      if (pending === 0) return
+      await application.get('JobManager').enqueue('file.contenthash-backfill', {})
+      fileManagerLogger.info('contentHash backfill: enqueued', { pending })
+    } catch (err) {
+      fileManagerLogger.warn('contentHash backfill: failed to enqueue at startup', { err })
+    }
   }
 
   /**
@@ -701,6 +733,9 @@ export class FileManager extends BaseService implements IFileManager {
     // in this file.
     this.ipcHandle(IpcChannel.File_CreateInternalEntry, async (_e, params: unknown) =>
       this.createInternalEntry(CreateInternalEntryIpcSchema.parse(params) as CreateInternalEntryIpcParams)
+    )
+    this.ipcHandle(IpcChannel.File_FindInternalByContentHash, async (_e, params: unknown) =>
+      this.findInternalByContentHash(ContentHashSchema.parse(params))
     )
     this.ipcHandle(IpcChannel.File_EnsureExternalEntry, async (_e, params: unknown) =>
       this.ensureExternalEntry(EnsureExternalEntryIpcSchema.parse(params) as EnsureExternalEntryIpcParams)
@@ -832,6 +867,16 @@ export class FileManager extends BaseService implements IFileManager {
 
   async findByExternalPath(rawPath: string): Promise<FileEntry | null> {
     return this.deps.fileEntryService.findByExternalPath(canonicalizeExternalPath(rawPath))
+  }
+
+  /**
+   * Detection-query primitive for content-level dedup: active internal entries
+   * whose `contentHash` matches. NON-unique → may return >1 (see
+   * `FileEntryService.findInternalByContentHash`). The reuse-vs-create decision
+   * is the consumer's; this only surfaces candidates.
+   */
+  async findInternalByContentHash(contentHash: string): Promise<FileEntry[]> {
+    return this.deps.fileEntryService.findInternalByContentHash(contentHash)
   }
 
   async ensureExternalEntry(params: EnsureExternalEntryParams): Promise<FileEntry> {

--- a/src/main/services/file/__tests__/FileManager.integration.test.ts
+++ b/src/main/services/file/__tests__/FileManager.integration.test.ts
@@ -6,6 +6,7 @@ import { application } from '@application'
 import { fileEntryTable } from '@data/db/schemas/file'
 import { BaseService } from '@main/core/lifecycle'
 import type { FileEntryId } from '@shared/data/types/file'
+import { ContentHashSchema } from '@shared/data/types/file/essential'
 import { setupTestDatabase } from '@test-helpers/db'
 import { MockMainDbServiceUtils } from '@test-mocks/main/DbService'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -109,7 +110,7 @@ describe('FileManager (integration)', () => {
 
     // Content hash works for external entries
     const hash = await fm.getContentHash(id)
-    expect(hash).toMatch(/^[0-9a-f]+$/)
+    expect(hash).toMatch(/^xxh3-64:[0-9a-f]{16}$/)
   })
 
   it('INT-3: missing-file ENOENT propagates from read', async () => {
@@ -499,5 +500,161 @@ describe('FileManager (integration)', () => {
     const out = await fm.batchGetDanglingStates({ ids: [known, ghost] })
     expect(out[known]).toBe('present')
     expect(out[ghost]).toBe('unknown')
+  })
+
+  // ─── onAllReady content-hash backfill trigger (Gap 1) ───
+  //
+  // `onAllReady` is `protected`; the lifecycle container reaches it through the
+  // public `_doAllReady()` wrapper (BaseService), which is also how INT-10/11
+  // drive `_doInit()`. The backfill is best-effort crash-recovery: it probes
+  // `countInternalMissingContentHash()` and only enqueues `file.contenthash-backfill`
+  // when that count is `> 0`. The JobManager is the unified application mock's
+  // stub (tests/__mocks__/main/application.ts) — its `enqueue` is a shared
+  // module-level `vi.fn`, so we reach it via `application.get('JobManager')` and
+  // clear it before each case to isolate call counts.
+  describe('onAllReady: contentHash backfill trigger', () => {
+    // The shared JobManager mock; `enqueue` / `registerHandler` are vi.fns.
+    // `application.get` is typed to the real JobManager, so route through
+    // `unknown` to view it as the mock surface the tests actually assert on.
+    const jobManager = application.get('JobManager') as unknown as {
+      enqueue: ReturnType<typeof vi.fn>
+      registerHandler: ReturnType<typeof vi.fn>
+    }
+
+    // Invoke the protected onAllReady via the public lifecycle wrapper.
+    const triggerAllReady = (instance: typeof fm) =>
+      (instance as unknown as { _doAllReady(): Promise<void> })._doAllReady()
+
+    beforeEach(() => {
+      // Isolate enqueue call counts per case — the spy is module-level shared.
+      jobManager.enqueue.mockClear()
+      // Restore the happy-path default in case a prior case swapped it for a
+      // rejecting impl via mockRejectedValueOnce (defensive; mockClear keeps
+      // the implementation, but a once-impl could leak if a case didn't consume it).
+      jobManager.enqueue.mockResolvedValue({ id: 'mock-job-id', snapshot: {} })
+    })
+
+    it('does NOT enqueue when no internal rows are missing contentHash (steady state)', async () => {
+      // Seed one fully-hashed internal row so the table is non-empty but the
+      // backfill work set (contentHash IS NULL) is exactly zero.
+      const now = Date.now()
+      await dbh.db.insert(fileEntryTable).values({
+        id: '019606a0-0000-7000-8000-00000000fb01' as FileEntryId,
+        origin: 'internal',
+        name: 'hashed',
+        ext: 'txt',
+        size: 1,
+        contentHash: 'xxh3-64:00000000aaaa0000',
+        externalPath: null,
+        deletedAt: null,
+        createdAt: now,
+        updatedAt: now
+      })
+
+      await triggerAllReady(fm)
+
+      expect(jobManager.enqueue).not.toHaveBeenCalled()
+    })
+
+    it('enqueues file.contenthash-backfill once when ≥1 internal row is missing contentHash', async () => {
+      // A v1-migrated / pre-feature row: internal, contentHash NULL → in the
+      // backfill work set, so onAllReady must kick exactly one backfill job.
+      const now = Date.now()
+      await dbh.db.insert(fileEntryTable).values({
+        id: '019606a0-0000-7000-8000-00000000fb02' as FileEntryId,
+        origin: 'internal',
+        name: 'legacy',
+        ext: 'txt',
+        size: 1,
+        contentHash: null,
+        externalPath: null,
+        deletedAt: null,
+        createdAt: now,
+        updatedAt: now
+      })
+
+      await triggerAllReady(fm)
+
+      expect(jobManager.enqueue).toHaveBeenCalledTimes(1)
+      expect(jobManager.enqueue).toHaveBeenCalledWith('file.contenthash-backfill', {})
+    })
+
+    it('resolves without throwing when enqueue rejects (best-effort: must not fail startup)', async () => {
+      // Pending work exists, so onAllReady reaches the enqueue call...
+      const now = Date.now()
+      await dbh.db.insert(fileEntryTable).values({
+        id: '019606a0-0000-7000-8000-00000000fb03' as FileEntryId,
+        origin: 'internal',
+        name: 'legacy',
+        ext: 'txt',
+        size: 1,
+        contentHash: null,
+        externalPath: null,
+        deletedAt: null,
+        createdAt: now,
+        updatedAt: now
+      })
+      // ...but JobManager.enqueue rejects this once. The try/catch in
+      // onAllReady warn-swallows it so app startup is never blocked.
+      jobManager.enqueue.mockRejectedValueOnce(new Error('job queue offline'))
+
+      await expect(triggerAllReady(fm)).resolves.toBeUndefined()
+      expect(jobManager.enqueue).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // ─── findInternalByContentHash detection-query boundary (Gap 2) ───
+  describe('findInternalByContentHash: detection-query boundary', () => {
+    it('returns every active internal entry sharing the caller-supplied contentHash, oldest-first', async () => {
+      // Two distinct internal entries created under the SAME caller-supplied
+      // contentHash (the detect-first path persists it verbatim — see
+      // create.test.ts "honors a caller-supplied contentHash"). contentHash is
+      // a NON-unique detection substrate, so both rows are legitimate candidates.
+      const sharedHash = 'xxh3-64:1111222233334444'
+      const first = await fm.createInternalEntry({
+        source: 'bytes',
+        data: new Uint8Array([0x10]),
+        name: 'first',
+        ext: 'bin',
+        contentHash: sharedHash
+      })
+      const second = await fm.createInternalEntry({
+        source: 'bytes',
+        data: new Uint8Array([0x20]),
+        name: 'second',
+        ext: 'bin',
+        contentHash: sharedHash
+      })
+
+      const found = await fm.findInternalByContentHash(sharedHash)
+
+      expect(found.map((e) => e.id)).toEqual([first.id, second.id])
+    })
+
+    it('returns [] for a well-formed but absent contentHash', async () => {
+      // Seed an unrelated hashed row so the table is non-empty; the query for a
+      // hash that matches nothing must still come back empty (not null/throw).
+      await fm.createInternalEntry({
+        source: 'bytes',
+        data: new Uint8Array([0x30]),
+        name: 'other',
+        ext: 'bin',
+        contentHash: 'xxh3-64:9999888877776666'
+      })
+
+      const found = await fm.findInternalByContentHash('xxh3-64:0000000000000000')
+
+      expect(found).toEqual([])
+    })
+
+    it('rejects a malformed contentHash at the IPC validation boundary (ContentHashSchema.parse)', async () => {
+      // The File_FindInternalByContentHash handler Zod-parses params before
+      // delegating: `this.findInternalByContentHash(ContentHashSchema.parse(params))`.
+      // ContentHashSchema enforces the `{algo}:{hex}` shape, so a malformed
+      // string is rejected at the boundary rather than reaching the DB query.
+      expect(ContentHashSchema.safeParse('not-valid').success).toBe(false)
+      // Well-formed shapes pass the same gate (positive control).
+      expect(ContentHashSchema.safeParse('xxh3-64:1111222233334444').success).toBe(true)
+    })
   })
 })

--- a/src/main/services/file/__tests__/FileManager.integration.test.ts
+++ b/src/main/services/file/__tests__/FileManager.integration.test.ts
@@ -6,7 +6,7 @@ import { application } from '@application'
 import { fileEntryTable } from '@data/db/schemas/file'
 import { BaseService } from '@main/core/lifecycle'
 import type { FileEntryId } from '@shared/data/types/file'
-import { ContentHashSchema } from '@shared/data/types/file/essential'
+import { type ContentHash, ContentHashSchema } from '@shared/data/types/file/essential'
 import { setupTestDatabase } from '@test-helpers/db'
 import { MockMainDbServiceUtils } from '@test-mocks/main/DbService'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -610,7 +610,7 @@ describe('FileManager (integration)', () => {
       // contentHash (the detect-first path persists it verbatim — see
       // create.test.ts "honors a caller-supplied contentHash"). contentHash is
       // a NON-unique detection substrate, so both rows are legitimate candidates.
-      const sharedHash = 'xxh3-64:1111222233334444'
+      const sharedHash = 'xxh3-64:1111222233334444' as ContentHash
       const first = await fm.createInternalEntry({
         source: 'bytes',
         data: new Uint8Array([0x10]),
@@ -642,7 +642,7 @@ describe('FileManager (integration)', () => {
         contentHash: 'xxh3-64:9999888877776666'
       })
 
-      const found = await fm.findInternalByContentHash('xxh3-64:0000000000000000')
+      const found = await fm.findInternalByContentHash('xxh3-64:0000000000000000' as ContentHash)
 
       expect(found).toEqual([])
     })

--- a/src/main/services/file/internal/content/__tests__/hash.test.ts
+++ b/src/main/services/file/internal/content/__tests__/hash.test.ts
@@ -80,7 +80,7 @@ describe('internal/content/hash', () => {
     const h1 = await hash(deps, id)
     const h2 = await hash(deps, id)
     expect(h1).toBe(h2)
-    expect(h1).toMatch(/^[0-9a-f]+$/)
+    expect(h1).toMatch(/^xxh3-64:[0-9a-f]{16}$/)
   })
 
   it('returns different hashes for different content', async () => {
@@ -143,6 +143,6 @@ describe('internal/content/hash', () => {
     const file = path.join(tmp, 'direct.txt') as FilePath
     await writeFile(file, 'direct')
     const result = await hashByPath(deps, file)
-    expect(result).toMatch(/^[0-9a-f]+$/)
+    expect(result).toMatch(/^xxh3-64:[0-9a-f]{16}$/)
   })
 })

--- a/src/main/services/file/internal/content/__tests__/write.test.ts
+++ b/src/main/services/file/internal/content/__tests__/write.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, readFile, rm, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
+import { hashContent } from '@main/utils/file/contentHash'
 import type { FilePath } from '@shared/file/types'
 import { setupTestDatabase } from '@test-helpers/db'
 import { MockMainDbServiceUtils } from '@test-mocks/main/DbService'
@@ -90,11 +91,14 @@ describe('internal/content/write', () => {
         name: 'a',
         ext: 'bin'
       })
-      const next = await write(deps, e.id, new Uint8Array([0x01, 0x02, 0x03]))
+      const newData = new Uint8Array([0x01, 0x02, 0x03])
+      const next = await write(deps, e.id, newData)
       expect(next.size).toBe(3)
       const refreshed = await fileEntryService.getById(e.id)
       if (refreshed.origin !== 'internal') throw new Error('expected internal entry')
       expect(refreshed.size).toBe(3)
+      // Maintained-on-write: contentHash reflects the NEW content.
+      expect(refreshed.contentHash).toBe(hashContent(newData))
       expect(cacheStore.get(e.id)).toEqual(next)
     })
 
@@ -110,6 +114,8 @@ describe('internal/content/write', () => {
       // from File IPC `getMetadata`). The DB row still stores `size: null`.
       expect(refreshed.origin).toBe('external')
       expect(refreshed).not.toHaveProperty('size')
+      // External rows never carry a contentHash (content lives outside Cherry).
+      expect(refreshed).not.toHaveProperty('contentHash')
     })
 
     it('logs WRITE_DB_DESYNC and rethrows when post-commit metadata sync fails', async () => {
@@ -222,8 +228,9 @@ describe('internal/content/write', () => {
       const physical = path.join(filesDir, `${e.id}.bin`) as FilePath
       await utimes(physical, 1700000000, 1700000000)
       const expected: FileVersion = { mtime: 1700000000_000, size: 4 }
-      // Wrong xxhash-h64 hex (16 chars). With ambiguous mtime + matching size,
-      // the implementation must fall back to hash comparison and reject.
+      // Deliberately wrong hash (won't match the real xxh3-64 digest). With
+      // ambiguous mtime + matching size, the implementation must fall back to
+      // hash comparison and reject.
       const wrongHash = 'deadbeefdeadbeef'
       await expect(
         writeIfUnchanged(deps, e.id, new Uint8Array([9, 8, 7, 6]), expected, wrongHash)
@@ -268,6 +275,8 @@ describe('internal/content/write', () => {
         const refreshed = await fileEntryService.getById(e.id)
         if (refreshed.origin !== 'internal') throw new Error('expected internal entry')
         expect(refreshed.size).toBe(payload.length)
+        // Streaming write maintains contentHash too (post-hoc hash of the file).
+        expect(refreshed.contentHash).toBe(hashContent(payload))
         expect(cacheStore.get(e.id)?.size).toBe(payload.length)
       })
     })

--- a/src/main/services/file/internal/content/hash.ts
+++ b/src/main/services/file/internal/content/hash.ts
@@ -1,7 +1,7 @@
 /**
  * Compute content hash for a managed FileEntry or a raw FilePath.
  *
- * Algorithm: xxhash-h64 streamed via `@main/utils/file/fs.hash` —
+ * Algorithm: XXH3-64 streamed via `@main/utils/file/fs.hash` —
  * non-cryptographic, fast, sufficient for the `writeIfUnchanged`
  * second-precision fallback that compares hashes when mtimes are ambiguous.
  *

--- a/src/main/services/file/internal/content/write.ts
+++ b/src/main/services/file/internal/content/write.ts
@@ -13,11 +13,13 @@
  */
 
 import { loggerService } from '@logger'
+import { hashContent } from '@main/utils/file/contentHash'
 import type { AtomicWriteStream } from '@main/utils/file/fs'
 import {
   atomicWriteFile,
   atomicWriteIfUnchanged,
   createAtomicWriteStream,
+  hash,
   PathStaleVersionError,
   stat as fsStat
 } from '@main/utils/file/fs'
@@ -45,7 +47,9 @@ export async function write(deps: FileManagerDeps, id: FileEntryId, data: string
     const s = await fsStat(physical)
     const version: FileVersion = { mtime: s.modifiedAt, size: s.size }
     if (entry.origin === 'internal') {
-      await deps.fileEntryService.update(id, { size: version.size })
+      // Maintained-on-write: new content → recompute the detection hash. `data`
+      // is already in memory, so this is a one-shot hash with no extra IO.
+      await deps.fileEntryService.update(id, { size: version.size, contentHash: hashContent(data) })
     }
     deps.versionCache.set(id, version)
     return version
@@ -80,7 +84,8 @@ export async function writeIfUnchanged(
   // failed".
   try {
     if (entry.origin === 'internal') {
-      await deps.fileEntryService.update(id, { size: next.size })
+      // Maintained-on-write: `data` is in memory → one-shot hash, no extra IO.
+      await deps.fileEntryService.update(id, { size: next.size, contentHash: hashContent(data) })
     }
     deps.versionCache.set(id, next)
     return next
@@ -99,7 +104,10 @@ export async function createWriteStream(deps: FileManagerDeps, id: FileEntryId):
       const s = await fsStat(physical)
       const version: FileVersion = { mtime: s.modifiedAt, size: s.size }
       if (entry.origin === 'internal') {
-        await deps.fileEntryService.update(id, { size: version.size })
+        // Maintained-on-write. Streaming source (no in-memory bytes) → read the
+        // just-written file back for the hash (page-cache warm), mirroring the
+        // create.ts hybrid strategy.
+        await deps.fileEntryService.update(id, { size: version.size, contentHash: await hash(physical) })
       }
       deps.versionCache.set(id, version)
     } catch (err) {

--- a/src/main/services/file/internal/content/write.ts
+++ b/src/main/services/file/internal/content/write.ts
@@ -111,13 +111,22 @@ export async function createWriteStream(deps: FileManagerDeps, id: FileEntryId):
       }
       deps.versionCache.set(id, version)
     } catch (err) {
-      // The file is committed on disk but the metadata sync (re-stat + DB
-      // size update + versionCache.set) failed. This silently desyncs
-      // `file_entry.size` and any cached `FileVersion` from disk, which the
-      // module-level JSDoc explicitly warns against — surface it at `error`
-      // with a stable code so Sentry can group these for follow-up. The
-      // stream itself does NOT re-throw because the consumer has already
-      // observed `'finish'`; the only mitigation is observability.
+      // The file is committed on disk but the post-commit metadata sync (re-stat
+      // + DB size/contentHash update + versionCache.set) failed. The stream does
+      // NOT re-throw — the consumer has already observed `'finish'` — so on this
+      // fire-and-forget path both synced columns are best-effort by design, and
+      // observability is the only mitigation. Contract for the desync:
+      //   - `size` / cached `FileVersion`: left stale until the next write. The
+      //     module-level JSDoc warns against this; hence the `error` log below
+      //     with a stable code so Sentry can group these for follow-up.
+      //   - `contentHash`: left stale (a prior write's hash) or NULL (entry never
+      //     hashed). A NULL row is repaired by the content-hash backfill job on
+      //     the next startup (the NULL set is its work queue); a stale row
+      //     self-corrects on the next successful write — the backfill job does
+      //     NOT touch it (it scans `contentHash IS NULL` only). Because
+      //     contentHash is a collision-tolerant DETECTION substrate (a wrong
+      //     candidate is rejected by the consumer's secondary check), a transient
+      //     stale value only degrades dedup detection — it never mis-serves bytes.
       logger.error('createWriteStream: post-commit metadata sync failed', {
         code: 'WRITE_STREAM_DB_DESYNC',
         id,

--- a/src/main/services/file/internal/entry/__tests__/create.test.ts
+++ b/src/main/services/file/internal/entry/__tests__/create.test.ts
@@ -3,6 +3,7 @@ import type { Server } from 'node:http'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
+import { hashContent } from '@main/utils/file/contentHash'
 import type { FilePath } from '@shared/file/types'
 import { setupTestDatabase } from '@test-helpers/db'
 import { MockMainDbServiceUtils } from '@test-mocks/main/DbService'
@@ -82,6 +83,34 @@ describe('internal/entry/create.createInternal', () => {
       expect(Buffer.from(onDisk).equals(Buffer.from(data))).toBe(true)
     })
 
+    it('computes and persists the content hash (xxh3-64 of the bytes)', async () => {
+      const data = new Uint8Array([0x01, 0x02, 0x03, 0x04])
+      const entry = await createInternal(deps, { source: 'bytes', data, name: 'doc', ext: 'bin' })
+      if (entry.origin !== 'internal') throw new Error('expected internal entry')
+      expect(entry.contentHash).toBe(hashContent(data))
+      expect(entry.contentHash).toMatch(/^xxh3-64:[0-9a-f]{16}$/)
+      // Round-trips through the DB read path (rowToFileEntry).
+      const found = await fileEntryService.getById(entry.id)
+      if (found.origin !== 'internal') throw new Error('expected internal entry')
+      expect(found.contentHash).toBe(entry.contentHash)
+    })
+
+    it('honors a caller-supplied contentHash without recomputing (detect-first)', async () => {
+      // A detect-first consumer pre-hashed the source and passes the result.
+      // The file module persists it verbatim and does NOT recompute — proven
+      // here by supplying a value that does not match the actual bytes.
+      const precomputed = 'xxh3-64:0123456789abcdef'
+      const entry = await createInternal(deps, {
+        source: 'bytes',
+        data: new Uint8Array([9, 9, 9]),
+        name: 'pre',
+        ext: 'bin',
+        contentHash: precomputed
+      })
+      if (entry.origin !== 'internal') throw new Error('expected internal entry')
+      expect(entry.contentHash).toBe(precomputed)
+    })
+
     it('writes a row that survives schema parse (brand contract)', async () => {
       const entry = await createInternal(deps, { source: 'bytes', data: new Uint8Array([0]), name: 'x', ext: null })
       const found = await fileEntryService.getById(entry.id)
@@ -148,6 +177,9 @@ describe('internal/entry/create.createInternal', () => {
       const physical = path.join(filesDir, `${entry.id}.png`)
       const buf = await readFile(physical)
       expect(Array.from(buf)).toEqual([0x89, 0x50, 0x4e, 0x47])
+      // Streaming source: contentHash is read back from the written file.
+      expect(entry.contentHash).toBe(hashContent(buf))
+      expect(entry.contentHash).toMatch(/^xxh3-64:[0-9a-f]{16}$/)
     })
 
     it('derives ext=null when the URL path has no recognisable extension', async () => {
@@ -195,6 +227,9 @@ describe('internal/entry/create.createInternal', () => {
       expect(entry.size).toBe(4)
       expect(entry.ext).toBe('png')
       expect(entry.name.length).toBeGreaterThan(0)
+      // In-memory source: contentHash is the one-shot hash of the decoded bytes.
+      if (entry.origin !== 'internal') throw new Error('expected internal entry')
+      expect(entry.contentHash).toBe(hashContent(bytes))
     })
   })
 

--- a/src/main/services/file/internal/entry/create.ts
+++ b/src/main/services/file/internal/entry/create.ts
@@ -23,7 +23,7 @@ import {
   remove as fsRemove,
   stat as fsStat
 } from '@main/utils/file/fs'
-import type { FileEntry } from '@shared/data/types/file'
+import { type ContentHash, ContentHashSchema, type FileEntry } from '@shared/data/types/file'
 import type { FilePath } from '@shared/file/types'
 import mime from 'mime'
 import { v7 as uuidv7 } from 'uuid'
@@ -156,14 +156,21 @@ export async function createInternal(deps: FileManagerDeps, params: CreateIntern
   const physical = application.getPath('feature.files.data', filename) as FilePath
   await source.writeTo(physical)
   let stats
-  let contentHash: string
+  let contentHash: ContentHash
   try {
     stats = await fsStat(physical)
     // Content-dedup detection substrate. Prefer a caller-supplied hash (a
-    // detect-first consumer already hashed the source); otherwise hash the
-    // in-memory bytes one-shot (zero extra IO) for resident sources, or read
-    // the just-written file back for streaming sources (page-cache warm).
-    contentHash = params.contentHash ?? (source.bytes !== null ? hashContent(source.bytes) : await hash(physical))
+    // detect-first consumer already hashed the source) — validate+brand it via
+    // ContentHashSchema, as it arrives as a plain string across the IPC boundary
+    // (and this doubles as the pre-persist guard). Otherwise hash the in-memory
+    // bytes one-shot (zero extra IO) for resident sources, or read the
+    // just-written file back for streaming sources (page-cache warm).
+    contentHash =
+      params.contentHash !== undefined
+        ? ContentHashSchema.parse(params.contentHash)
+        : source.bytes !== null
+          ? hashContent(source.bytes)
+          : await hash(physical)
   } catch (err) {
     await bestEffortCleanup(physical, 'createInternal:stat-or-hash-failed')
     throw err

--- a/src/main/services/file/internal/entry/create.ts
+++ b/src/main/services/file/internal/entry/create.ts
@@ -14,7 +14,15 @@ import { realpath } from 'node:fs/promises'
 
 import { application } from '@application'
 import { loggerService } from '@logger'
-import { atomicWriteFile, copy as fsCopy, download, remove as fsRemove, stat as fsStat } from '@main/utils/file/fs'
+import { hashContent } from '@main/utils/file/contentHash'
+import {
+  atomicWriteFile,
+  copy as fsCopy,
+  download,
+  hash,
+  remove as fsRemove,
+  stat as fsStat
+} from '@main/utils/file/fs'
 import type { FileEntry } from '@shared/data/types/file'
 import type { FilePath } from '@shared/file/types'
 import mime from 'mime'
@@ -55,6 +63,13 @@ async function bestEffortCleanup(physical: FilePath, context: string): Promise<v
 interface NormalisedSource {
   name: string
   ext: string | null
+  /**
+   * In-memory content when the source is already resident (`bytes` / `base64`),
+   * enabling a zero-extra-IO one-shot content hash; `null` for streaming
+   * sources (`path` / `url`), whose hash is read back from the just-written
+   * physical file instead.
+   */
+  bytes: Uint8Array | null
   writeTo(target: FilePath): Promise<void>
 }
 
@@ -66,6 +81,7 @@ function normaliseSource(params: CreateInternalEntryParams): NormalisedSource {
     return {
       name: params.name,
       ext: params.ext,
+      bytes: data,
       writeTo: (target) => atomicWriteFile(target, data)
     }
   }
@@ -81,6 +97,7 @@ function normaliseSource(params: CreateInternalEntryParams): NormalisedSource {
     return {
       name: params.name ?? `Pasted ${new Date().toISOString().slice(0, 10)}`,
       ext: ext ?? null,
+      bytes,
       writeTo: (target) => atomicWriteFile(target, new Uint8Array(bytes))
     }
   }
@@ -89,6 +106,7 @@ function normaliseSource(params: CreateInternalEntryParams): NormalisedSource {
     return {
       name: basenameWithoutExt(src),
       ext: extWithoutDot(src),
+      bytes: null,
       writeTo: (target) => fsCopy(src, target)
     }
   }
@@ -97,6 +115,7 @@ function normaliseSource(params: CreateInternalEntryParams): NormalisedSource {
   return {
     name: urlTail(url),
     ext: extWithoutDot(url),
+    bytes: null,
     writeTo: (target) => download(url, target)
   }
 }
@@ -137,10 +156,16 @@ export async function createInternal(deps: FileManagerDeps, params: CreateIntern
   const physical = application.getPath('feature.files.data', filename) as FilePath
   await source.writeTo(physical)
   let stats
+  let contentHash: string
   try {
     stats = await fsStat(physical)
+    // Content-dedup detection substrate. Prefer a caller-supplied hash (a
+    // detect-first consumer already hashed the source); otherwise hash the
+    // in-memory bytes one-shot (zero extra IO) for resident sources, or read
+    // the just-written file back for streaming sources (page-cache warm).
+    contentHash = params.contentHash ?? (source.bytes !== null ? hashContent(source.bytes) : await hash(physical))
   } catch (err) {
-    await bestEffortCleanup(physical, 'createInternal:stat-failed')
+    await bestEffortCleanup(physical, 'createInternal:stat-or-hash-failed')
     throw err
   }
   try {
@@ -150,6 +175,7 @@ export async function createInternal(deps: FileManagerDeps, params: CreateIntern
       name: source.name,
       ext: source.ext,
       size: stats.size,
+      contentHash,
       externalPath: null
     })
   } catch (err) {

--- a/src/main/services/file/tasks/__tests__/contentHashBackfillJobHandler.test.ts
+++ b/src/main/services/file/tasks/__tests__/contentHashBackfillJobHandler.test.ts
@@ -1,0 +1,159 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import type { JobContext } from '@main/core/job/types'
+import { setupTestDatabase } from '@test-helpers/db'
+import { MockMainDbServiceUtils } from '@test-mocks/main/DbService'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@application', async () => {
+  const { mockApplicationFactory } = await import('@test-mocks/main/application')
+  return mockApplicationFactory()
+})
+
+const { application } = await import('@application')
+const { fileEntryService } = await import('@data/services/FileEntryService')
+const { fileEntryTable } = await import('@data/db/schemas/file')
+const { hashContent } = await import('@main/utils/file/contentHash')
+const { contentHashBackfillJobHandler } = await import('../contentHashBackfillJobHandler')
+
+function makeCtx(signal?: AbortSignal): JobContext<Record<string, never>> {
+  return {
+    jobId: 'test-backfill-job',
+    input: {},
+    signal: signal ?? new AbortController().signal,
+    patchMetadata: vi.fn(),
+    reportProgress: vi.fn(),
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+  } as unknown as JobContext<Record<string, never>>
+}
+
+describe('contentHashBackfillJobHandler', () => {
+  const dbh = setupTestDatabase()
+  let tmp: string
+  let filesDir: string
+
+  beforeEach(async () => {
+    MockMainDbServiceUtils.setDb(dbh.db)
+    tmp = await mkdtemp(path.join(tmpdir(), 'cherry-fm-backfill-test-'))
+    filesDir = path.join(tmp, 'Files')
+    await mkdir(filesDir, { recursive: true })
+    vi.spyOn(application, 'getPath').mockImplementation((key: string, filename?: string) => {
+      if (key === 'feature.files.data') return filename ? path.join(filesDir, filename) : filesDir
+      return filename ? `/mock/${key}/${filename}` : `/mock/${key}`
+    })
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await rm(tmp, { recursive: true, force: true })
+  })
+
+  /** Seed a v1-style internal row (contentHash NULL) plus its physical blob. */
+  async function seedInternal(id: string, ext: string, bytes: Uint8Array): Promise<void> {
+    await writeFile(path.join(filesDir, `${id}.${ext}`), bytes)
+    const now = Date.now()
+    await dbh.db.insert(fileEntryTable).values({
+      id,
+      origin: 'internal',
+      name: id.slice(-4),
+      ext,
+      size: bytes.length,
+      contentHash: null,
+      externalPath: null,
+      deletedAt: null,
+      createdAt: now,
+      updatedAt: now
+    })
+  }
+
+  it('backfills contentHash for every NULL internal entry (xxh3-64 of the blob)', async () => {
+    const a = new Uint8Array([1, 2, 3])
+    const b = new Uint8Array([4, 5, 6, 7])
+    await seedInternal('019606a0-0000-7000-8000-0000000000e1', 'bin', a)
+    await seedInternal('019606a0-0000-7000-8000-0000000000e2', 'bin', b)
+
+    const result = await contentHashBackfillJobHandler.execute(makeCtx())
+    expect(result).toEqual({ total: 2, hashed: 2, skippedOrphan: 0, failedIo: 0 })
+
+    const e1 = await fileEntryService.getById('019606a0-0000-7000-8000-0000000000e1')
+    const e2 = await fileEntryService.getById('019606a0-0000-7000-8000-0000000000e2')
+    if (e1.origin !== 'internal' || e2.origin !== 'internal') throw new Error('expected internal entries')
+    expect(e1.contentHash).toBe(hashContent(a))
+    expect(e2.contentHash).toBe(hashContent(b))
+    // NULL set drained.
+    expect(await fileEntryService.countInternalMissingContentHash()).toBe(0)
+  })
+
+  it('classifies an entry whose physical blob is missing as skippedOrphan (ENOENT) and leaves it NULL', async () => {
+    const id = '019606a0-0000-7000-8000-0000000000e3'
+    const now = Date.now()
+    // Row only — no physical file → fsHash throws ENOENT → skippedOrphan.
+    await dbh.db.insert(fileEntryTable).values({
+      id,
+      origin: 'internal',
+      name: 'orphan',
+      ext: 'bin',
+      size: 3,
+      contentHash: null,
+      externalPath: null,
+      deletedAt: null,
+      createdAt: now,
+      updatedAt: now
+    })
+
+    const result = await contentHashBackfillJobHandler.execute(makeCtx())
+    expect(result).toEqual({ total: 1, hashed: 0, skippedOrphan: 1, failedIo: 0 })
+
+    const e = await fileEntryService.getById(id)
+    if (e.origin !== 'internal') throw new Error('expected internal entry')
+    expect(e.contentHash).toBeNull()
+  })
+
+  it('classifies a non-ENOENT hash failure as failedIo (blob path is a directory → EISDIR), leaves it NULL, still completes', async () => {
+    const id = '019606a0-0000-7000-8000-0000000000e5'
+    const now = Date.now()
+    // Place a DIRECTORY where the physical blob is expected. createReadStream
+    // then fails with EISDIR (not ENOENT) → must land in failedIo, not orphan.
+    await mkdir(path.join(filesDir, `${id}.bin`), { recursive: true })
+    await dbh.db.insert(fileEntryTable).values({
+      id,
+      origin: 'internal',
+      name: 'isdir',
+      ext: 'bin',
+      size: 3,
+      contentHash: null,
+      externalPath: null,
+      deletedAt: null,
+      createdAt: now,
+      updatedAt: now
+    })
+
+    const ctx = makeCtx()
+    const result = await contentHashBackfillJobHandler.execute(ctx)
+    expect(result).toEqual({ total: 1, hashed: 0, skippedOrphan: 0, failedIo: 1 })
+    // Surfaced as an error (real IO failure), not a quiet orphan warn.
+    expect(ctx.logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('hash failed for a present-looking blob'),
+      expect.objectContaining({ id, code: 'EISDIR' })
+    )
+
+    const e = await fileEntryService.getById(id)
+    if (e.origin !== 'internal') throw new Error('expected internal entry')
+    expect(e.contentHash).toBeNull()
+  })
+
+  it('is a no-op when no internal entry is missing a contentHash', async () => {
+    const result = await contentHashBackfillJobHandler.execute(makeCtx())
+    expect(result).toEqual({ total: 0, hashed: 0, skippedOrphan: 0, failedIo: 0 })
+  })
+
+  it('aborts promptly when the signal is already aborted', async () => {
+    await seedInternal('019606a0-0000-7000-8000-0000000000e4', 'bin', new Uint8Array([9]))
+    const aborted = AbortSignal.abort()
+    await expect(contentHashBackfillJobHandler.execute(makeCtx(aborted))).rejects.toThrow(/abort/i)
+    // The pending row is untouched (still NULL).
+    expect(await fileEntryService.countInternalMissingContentHash()).toBe(1)
+  })
+})

--- a/src/main/services/file/tasks/__tests__/contentHashBackfillJobHandler.test.ts
+++ b/src/main/services/file/tasks/__tests__/contentHashBackfillJobHandler.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 
 import type { JobContext } from '@main/core/job/types'
+import { DataApiErrorFactory } from '@shared/data/api'
 import { setupTestDatabase } from '@test-helpers/db'
 import { MockMainDbServiceUtils } from '@test-mocks/main/DbService'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -135,13 +136,44 @@ describe('contentHashBackfillJobHandler', () => {
     expect(result).toEqual({ total: 1, hashed: 0, skippedOrphan: 0, failedIo: 1 })
     // Surfaced as an error (real IO failure), not a quiet orphan warn.
     expect(ctx.logger.error).toHaveBeenCalledWith(
-      expect.stringContaining('hash failed for a present-looking blob'),
+      expect.stringContaining('blob hash failed (IO/permission)'),
       expect.objectContaining({ id, code: 'EISDIR' })
     )
 
     const e = await fileEntryService.getById(id)
     if (e.origin !== 'internal') throw new Error('expected internal entry')
     expect(e.contentHash).toBeNull()
+  })
+
+  it('treats a concurrent-delete (NOT_FOUND on persist) as a benign skippedOrphan, never failedIo', async () => {
+    const id = '019606a0-0000-7000-8000-0000000000e6'
+    await seedInternal(id, 'bin', new Uint8Array([1, 1, 2]))
+    // Blob hashes fine, but the row is trashed/permanently-deleted between the
+    // keyset page and the update → update() throws NOT_FOUND. This must be a
+    // benign skip with a distinct warn, NOT an `error`-level failedIo.
+    vi.spyOn(fileEntryService, 'update').mockRejectedValueOnce(DataApiErrorFactory.notFound('FileEntry', id))
+
+    const ctx = makeCtx()
+    const result = await contentHashBackfillJobHandler.execute(ctx)
+    expect(result).toEqual({ total: 1, hashed: 0, skippedOrphan: 1, failedIo: 0 })
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('vanished before persist'),
+      expect.objectContaining({ id })
+    )
+    expect(ctx.logger.error).not.toHaveBeenCalled()
+  })
+
+  it('rethrows an unexpected persist error (SQLITE_BUSY) so the job fails instead of hiding it as failedIo', async () => {
+    const id = '019606a0-0000-7000-8000-0000000000e7'
+    await seedInternal(id, 'bin', new Uint8Array([3, 3, 3]))
+    // A non-DataApiError persist failure (DB contention, a bug) is unexpected:
+    // it must propagate out of execute() (failed job), not be swallowed.
+    const boom = Object.assign(new Error('database is locked'), { code: 'SQLITE_BUSY' })
+    vi.spyOn(fileEntryService, 'update').mockRejectedValueOnce(boom)
+
+    await expect(contentHashBackfillJobHandler.execute(makeCtx())).rejects.toThrow(/database is locked/)
+    // Row stays NULL — it'll be retried on the next backfill run.
+    expect(await fileEntryService.countInternalMissingContentHash()).toBe(1)
   })
 
   it('is a no-op when no internal entry is missing a contentHash', async () => {

--- a/src/main/services/file/tasks/contentHashBackfillJobHandler.ts
+++ b/src/main/services/file/tasks/contentHashBackfillJobHandler.ts
@@ -2,6 +2,7 @@ import { fileEntryService } from '@data/services/FileEntryService'
 import type { JobHandler } from '@main/core/job/types'
 import { hash as fsHash } from '@main/utils/file/fs'
 import { ErrorCode, isDataApiError } from '@shared/data/api'
+import type { ContentHash } from '@shared/data/types/file'
 
 import { resolvePhysicalPath } from '../utils/pathResolver'
 
@@ -88,7 +89,7 @@ export const contentHashBackfillJobHandler: JobHandler<Record<string, never>> = 
         // a non-FS error (e.g. from the persist below) can never be mislabeled as
         // a blob IO failure. ENOENT/ENOTDIR = expected orphan; any other errno =
         // real IO/permission failure. Either leaves the row NULL for a future run.
-        let contentHash: string
+        let contentHash: ContentHash
         try {
           // Same path resolution + streaming hash as the write path, producing
           // the canonical `{algo}:{hex}` value the column expects.

--- a/src/main/services/file/tasks/contentHashBackfillJobHandler.ts
+++ b/src/main/services/file/tasks/contentHashBackfillJobHandler.ts
@@ -1,6 +1,7 @@
 import { fileEntryService } from '@data/services/FileEntryService'
 import type { JobHandler } from '@main/core/job/types'
 import { hash as fsHash } from '@main/utils/file/fs'
+import { ErrorCode, isDataApiError } from '@shared/data/api'
 
 import { resolvePhysicalPath } from '../utils/pathResolver'
 
@@ -21,22 +22,36 @@ const BATCH_SIZE = 200
 /**
  * Backfill the dedup-detection `contentHash` for internal entries created before
  * this feature (v1 migration / pre-feature inserts), which carry `contentHash =
- * null`. New entries always get their hash on create (§7.2); this fills the gap
+ * null`. New entries always get their hash on create (§1.2); this fills the gap
  * for the existing set so legacy files also participate in dedup detection.
  *
  * **Drain strategy — keyset pagination over `id`** (UUID v7, lexicographically
  * time-ordered): each page queries `content_hash IS NULL AND id > cursor`, so an
  * entry that fails to hash (missing/orphan blob → ENOENT) stays NULL but sits
  * behind the cursor and is NOT re-scanned within the same run — otherwise the
- * NULL set would never shrink and the loop would spin. Such rows are left for the
- * orphan sweep (§10) or a future run. Per-entry hash failures never fail the
- * whole job, but are classified by errno so a disk/permission regression is not
- * buried as a benign orphan: ENOENT/ENOTDIR (blob genuinely gone) is the expected
- * quiet case (`skippedOrphan`, warn-logged); any other code (EACCES/EBUSY/EMFILE/
- * EIO/EISDIR — the blob may be hashable) is surfaced as an `error`-level
- * `failedIo` and the row is left NULL for a future run. Includes trashed entries
- * (their blob is preserved, so they are hashable and become reuse targets if
- * restored).
+ * NULL set would never shrink and the loop would spin. A row whose blob is
+ * genuinely gone can never be hashed; it simply persists in the NULL set until
+ * the entry itself is removed by an unrelated flow. (It is NOT reaped by the §10
+ * FS sweep, which deletes on-disk blobs that have NO DB row — the opposite
+ * direction; a DB-row-with-missing-blob is out of scope for both that sweep and
+ * the §7 entry scanner.) Includes trashed entries (their blob is preserved, so
+ * they are hashable and become reuse targets if restored).
+ *
+ * **Per-entry failure handling** — each entry is hashed then persisted, and the
+ * two steps are classified independently so a real regression is never buried as
+ * a benign orphan:
+ *   - **Hash** (`fsHash`) is errno-classified: `ENOENT`/`ENOTDIR` (blob gone) is
+ *     the expected quiet case (`skippedOrphan`, warn); any other errno
+ *     (`EACCES`/`EBUSY`/`EMFILE`/`EIO`/`EISDIR`/…) means the blob couldn't be
+ *     read — a genuine IO/permission `failedIo` (error), row left NULL.
+ *   - **Persist** (`update`): a `NOT_FOUND` means the row was trashed/deleted
+ *     concurrently between the keyset page and the write — benign, counted as
+ *     `skippedOrphan` (the work item is simply gone). Any OTHER persist error
+ *     (`SQLITE_BUSY`, a programming bug) is unexpected and is **rethrown**, so it
+ *     surfaces as a failed job instead of a silent `failedIo` under a green
+ *     terminal status.
+ * A hash failure or a benign concurrent-delete never aborts the drain; only an
+ * unexpected persist error does (the job re-triggers on the next startup).
  *
  * **Lifecycle** — `recovery: 'singleton'` + `defaultConcurrency: 1`: at most one
  * backfill runs at a time. A crash-interrupted run is simply re-triggered on the
@@ -51,7 +66,7 @@ export const contentHashBackfillJobHandler: JobHandler<Record<string, never>> = 
   async execute(ctx) {
     const total = await fileEntryService.countInternalMissingContentHash()
     if (total === 0) {
-      ctx.reportProgress(100, { stage: 'done', total: 0 })
+      ctx.reportProgress(100, { stage: 'done', total: 0, hashed: 0, skippedOrphan: 0, failedIo: 0 })
       return { total: 0, hashed: 0, skippedOrphan: 0, failedIo: 0 }
     }
 
@@ -68,30 +83,51 @@ export const contentHashBackfillJobHandler: JobHandler<Record<string, never>> = 
 
       for (const entry of batch) {
         if (ctx.signal.aborted) throw new DOMException('aborted', 'AbortError')
+
+        // Phase 1 — hash the blob. ONLY the FS read is errno-classified here, so
+        // a non-FS error (e.g. from the persist below) can never be mislabeled as
+        // a blob IO failure. ENOENT/ENOTDIR = expected orphan; any other errno =
+        // real IO/permission failure. Either leaves the row NULL for a future run.
+        let contentHash: string
         try {
           // Same path resolution + streaming hash as the write path, producing
           // the canonical `{algo}:{hex}` value the column expects.
-          const contentHash = await fsHash(resolvePhysicalPath(entry))
-          await fileEntryService.update(entry.id, { contentHash })
-          hashed++
+          contentHash = await fsHash(resolvePhysicalPath(entry))
         } catch (err) {
           const code = (err as NodeJS.ErrnoException).code
           if (code === 'ENOENT' || code === 'ENOTDIR') {
-            // Blob genuinely gone — the expected orphan case. Left NULL for the
-            // orphan sweep (§10); a quiet warn keeps the dashboard uncluttered.
+            // Blob genuinely gone — the expected orphan case. A quiet warn keeps
+            // the dashboard uncluttered; the row stays NULL for a future run.
             ctx.logger.warn('contentHash backfill: skipped orphan entry (blob missing)', { id: entry.id, code })
             skippedOrphan++
           } else {
-            // EACCES / EBUSY / EMFILE / ENFILE / EIO / EISDIR — the blob may be
-            // present and hashable, so this is a real IO/permission failure, not
-            // an orphan. Surface it distinctly; leave the row NULL for a future
-            // run rather than aborting the whole job.
-            ctx.logger.error('contentHash backfill: hash failed for a present-looking blob', {
-              id: entry.id,
-              code,
-              err
-            })
+            // EACCES / EBUSY / EMFILE / ENFILE / EIO / EISDIR — the blob couldn't
+            // be read. A real IO/permission failure, not an orphan; surface it
+            // distinctly and leave the row NULL rather than aborting the job.
+            ctx.logger.error('contentHash backfill: blob hash failed (IO/permission)', { id: entry.id, code, err })
             failedIo++
+          }
+          processed++
+          continue
+        }
+
+        // Phase 2 — persist. A NOT_FOUND means the row was trashed/permanently
+        // deleted concurrently between the keyset page and this write: benign,
+        // the work item is simply gone (counted as a skip, not a blob failure).
+        // Any other persist error (SQLITE_BUSY, a programming bug) is unexpected
+        // and rethrown — a real regression must surface as a FAILED job, never be
+        // buried as a silent `failedIo` under a green terminal status.
+        try {
+          await fileEntryService.update(entry.id, { contentHash })
+          hashed++
+        } catch (err) {
+          if (isDataApiError(err) && err.code === ErrorCode.NOT_FOUND) {
+            ctx.logger.warn('contentHash backfill: entry vanished before persist (concurrent delete)', {
+              id: entry.id
+            })
+            skippedOrphan++
+          } else {
+            throw err
           }
         }
         processed++
@@ -101,8 +137,16 @@ export const contentHashBackfillJobHandler: JobHandler<Record<string, never>> = 
       ctx.reportProgress(Math.min(99, Math.floor((processed / total) * 100)), { stage: 'hashing', processed, total })
     }
 
-    ctx.reportProgress(100, { stage: 'done', hashed, skippedOrphan, failedIo })
-    ctx.logger.info('contentHash backfill complete', { total, hashed, skippedOrphan, failedIo })
-    return { total, hashed, skippedOrphan, failedIo }
+    const summary = { total, hashed, skippedOrphan, failedIo }
+    ctx.reportProgress(100, { stage: 'done', ...summary })
+    // A non-zero `failedIo` is a permanent-until-next-run condition (these rows
+    // fail every startup re-trigger), so raise the terminal log to `warn` — the
+    // count is visible without aggregating per-row error lines.
+    if (failedIo > 0) {
+      ctx.logger.warn('contentHash backfill complete with IO failures', summary)
+    } else {
+      ctx.logger.info('contentHash backfill complete', summary)
+    }
+    return summary
   }
 }

--- a/src/main/services/file/tasks/contentHashBackfillJobHandler.ts
+++ b/src/main/services/file/tasks/contentHashBackfillJobHandler.ts
@@ -1,0 +1,108 @@
+import { fileEntryService } from '@data/services/FileEntryService'
+import type { JobHandler } from '@main/core/job/types'
+import { hash as fsHash } from '@main/utils/file/fs'
+
+import { resolvePhysicalPath } from '../utils/pathResolver'
+
+declare module '@main/core/job/jobRegistry' {
+  interface JobRegistry {
+    /**
+     * Backfill `contentHash` for internal entries that predate the content-dedup
+     * feature (v1-migrated / pre-feature inserts), which carry `contentHash = null`.
+     * Empty payload — the job drains every NULL-contentHash internal row.
+     */
+    'file.contenthash-backfill': Record<string, never>
+  }
+}
+
+/** Rows scanned per keyset page. Bounded so the DB round-trips stay small. */
+const BATCH_SIZE = 200
+
+/**
+ * Backfill the dedup-detection `contentHash` for internal entries created before
+ * this feature (v1 migration / pre-feature inserts), which carry `contentHash =
+ * null`. New entries always get their hash on create (§7.2); this fills the gap
+ * for the existing set so legacy files also participate in dedup detection.
+ *
+ * **Drain strategy — keyset pagination over `id`** (UUID v7, lexicographically
+ * time-ordered): each page queries `content_hash IS NULL AND id > cursor`, so an
+ * entry that fails to hash (missing/orphan blob → ENOENT) stays NULL but sits
+ * behind the cursor and is NOT re-scanned within the same run — otherwise the
+ * NULL set would never shrink and the loop would spin. Such rows are left for the
+ * orphan sweep (§10) or a future run. Per-entry hash failures never fail the
+ * whole job, but are classified by errno so a disk/permission regression is not
+ * buried as a benign orphan: ENOENT/ENOTDIR (blob genuinely gone) is the expected
+ * quiet case (`skippedOrphan`, warn-logged); any other code (EACCES/EBUSY/EMFILE/
+ * EIO/EISDIR — the blob may be hashable) is surfaced as an `error`-level
+ * `failedIo` and the row is left NULL for a future run. Includes trashed entries
+ * (their blob is preserved, so they are hashable and become reuse targets if
+ * restored).
+ *
+ * **Lifecycle** — `recovery: 'singleton'` + `defaultConcurrency: 1`: at most one
+ * backfill runs at a time. A crash-interrupted run is simply re-triggered on the
+ * next startup by `FileManager.onAllReady` (the `content_hash IS NULL` set is
+ * itself the resumable work queue), and re-running is idempotent — it only
+ * touches rows that are still NULL.
+ */
+export const contentHashBackfillJobHandler: JobHandler<Record<string, never>> = {
+  recovery: 'singleton',
+  defaultConcurrency: 1,
+  defaultTimeoutMs: 30 * 60_000,
+  async execute(ctx) {
+    const total = await fileEntryService.countInternalMissingContentHash()
+    if (total === 0) {
+      ctx.reportProgress(100, { stage: 'done', total: 0 })
+      return { total: 0, hashed: 0, skippedOrphan: 0, failedIo: 0 }
+    }
+
+    let cursor: string | null = null
+    let processed = 0
+    let hashed = 0
+    let skippedOrphan = 0
+    let failedIo = 0
+
+    for (;;) {
+      if (ctx.signal.aborted) throw new DOMException('aborted', 'AbortError')
+      const batch = await fileEntryService.findInternalMissingContentHash(cursor, BATCH_SIZE)
+      if (batch.length === 0) break
+
+      for (const entry of batch) {
+        if (ctx.signal.aborted) throw new DOMException('aborted', 'AbortError')
+        try {
+          // Same path resolution + streaming hash as the write path, producing
+          // the canonical `{algo}:{hex}` value the column expects.
+          const contentHash = await fsHash(resolvePhysicalPath(entry))
+          await fileEntryService.update(entry.id, { contentHash })
+          hashed++
+        } catch (err) {
+          const code = (err as NodeJS.ErrnoException).code
+          if (code === 'ENOENT' || code === 'ENOTDIR') {
+            // Blob genuinely gone — the expected orphan case. Left NULL for the
+            // orphan sweep (§10); a quiet warn keeps the dashboard uncluttered.
+            ctx.logger.warn('contentHash backfill: skipped orphan entry (blob missing)', { id: entry.id, code })
+            skippedOrphan++
+          } else {
+            // EACCES / EBUSY / EMFILE / ENFILE / EIO / EISDIR — the blob may be
+            // present and hashable, so this is a real IO/permission failure, not
+            // an orphan. Surface it distinctly; leave the row NULL for a future
+            // run rather than aborting the whole job.
+            ctx.logger.error('contentHash backfill: hash failed for a present-looking blob', {
+              id: entry.id,
+              code,
+              err
+            })
+            failedIo++
+          }
+        }
+        processed++
+      }
+
+      cursor = batch[batch.length - 1].id
+      ctx.reportProgress(Math.min(99, Math.floor((processed / total) * 100)), { stage: 'hashing', processed, total })
+    }
+
+    ctx.reportProgress(100, { stage: 'done', hashed, skippedOrphan, failedIo })
+    ctx.logger.info('contentHash backfill complete', { total, hashed, skippedOrphan, failedIo })
+    return { total, hashed, skippedOrphan, failedIo }
+  }
+}

--- a/src/main/utils/file/__tests__/contentHash.test.ts
+++ b/src/main/utils/file/__tests__/contentHash.test.ts
@@ -1,0 +1,126 @@
+import { ContentHashSchema } from '@shared/data/types/file/essential'
+import { describe, expect, it } from 'vitest'
+
+import { CONTENT_HASH_ALGO, createContentHasher, hashContent, parseContentHash } from '../contentHash'
+
+/**
+ * Official XXH3-64 (seed 0) known-answer vectors from the canonical xxHash
+ * sanity test data (`Cyan4973/xxHash` `tests/sanity_test_vectors.h`,
+ * `XSUM_XXH3_testdata`). Inputs are the first N bytes of xxHash's documented
+ * sanity PRNG buffer (`00 52 92 9b b7 32 a3 24 …`).
+ *
+ * These pin the hash to a cross-platform-stable, implementation-independent
+ * value. Cross-device bit-identical output is a hard requirement (Cherry runs
+ * on Win/mac/Linux × x64/arm64), so the test asserts CANONICAL outputs — not
+ * whatever the locally-installed native binary happens to produce.
+ */
+const PRNG = Uint8Array.from([0x00, 0x52, 0x92, 0x9b, 0xb7, 0x32, 0xa3, 0x24])
+const VECTORS: ReadonlyArray<{ len: number; hex: string }> = [
+  { len: 0, hex: '2d06800538d394c2' },
+  { len: 1, hex: 'c44bdff4074eecdb' },
+  { len: 4, hex: 'e5dc74bc51848a51' },
+  { len: 8, hex: '24ccc9acaa9f65e4' }
+]
+
+describe('contentHash', () => {
+  describe('hashContent — canonical XXH3-64 vectors', () => {
+    it.each(VECTORS)('len=$len → $hex', ({ len, hex }) => {
+      expect(hashContent(PRNG.subarray(0, len))).toBe(`${CONTENT_HASH_ALGO}:${hex}`)
+    })
+  })
+
+  it('tags with the algorithm prefix and pads to 16 hex chars', () => {
+    const h = hashContent(new Uint8Array(0))
+    expect(h.startsWith('xxh3-64:')).toBe(true)
+    expect(h).toMatch(/^xxh3-64:[0-9a-f]{16}$/)
+  })
+
+  it('hashes a string as its UTF-8 bytes (string ≡ Buffer)', () => {
+    expect(hashContent('hello')).toBe(hashContent(Buffer.from('hello', 'utf8')))
+  })
+
+  describe('createContentHasher (streaming) ≡ hashContent (one-shot)', () => {
+    it('agrees over chunked input, matching the canonical len=8 vector', () => {
+      const hasher = createContentHasher()
+      // Feed the 8-byte vector in irregular chunks to exercise incremental state.
+      hasher.update(PRNG.subarray(0, 3))
+      hasher.update(PRNG.subarray(3, 5))
+      hasher.update(PRNG.subarray(5, 8))
+      const out = hasher.digest()
+      expect(out).toBe(`${CONTENT_HASH_ALGO}:24ccc9acaa9f65e4`)
+      expect(out).toBe(hashContent(PRNG.subarray(0, 8)))
+    })
+
+    it('empty stream matches the canonical empty vector', () => {
+      expect(createContentHasher().digest()).toBe(`${CONTENT_HASH_ALGO}:2d06800538d394c2`)
+    })
+
+    it('agrees over a multi-block file fed in irregular chunks straddling the ~240B boundary', () => {
+      // XXH3 switches internal processing at ~240-byte block boundaries; the
+      // dedup correctness contract is that in-pipe streaming agrees with the
+      // in-memory one-shot on REAL multi-block files, not just <240B inputs.
+      // Deterministic 5000-byte buffer (no Math.random — reproducible).
+      const data = Uint8Array.from({ length: 5000 }, (_, i) => (i * 31 + 7) & 0xff)
+      const oneShot = hashContent(data)
+
+      const hasher = createContentHasher()
+      // Irregular chunks that cross the ~240-byte boundary in different places.
+      hasher.update(data.subarray(0, 100))
+      hasher.update(data.subarray(100, 350))
+      hasher.update(data.subarray(350, 1350))
+      hasher.update(data.subarray(1350))
+      expect(hasher.digest()).toBe(oneShot)
+    })
+
+    it('string ≡ Uint8Array equivalence holds at multi-block size', () => {
+      // A long ASCII string and its UTF-8 bytes must hash identically past the
+      // ~240-byte block boundary too (string is hashed as its UTF-8 bytes).
+      const text = 'a'.repeat(5000)
+      expect(hashContent(text)).toBe(hashContent(Buffer.from(text, 'utf8')))
+    })
+  })
+
+  describe('producer output satisfies ContentHashSchema', () => {
+    // Locks the producer↔validator contract: anything hashContent /
+    // createContentHasher emit must pass the reader's `{algo}:{hex}` regex, so
+    // the two can never drift apart silently.
+    it('hashContent output passes the validator', () => {
+      expect(ContentHashSchema.safeParse(hashContent(PRNG)).success).toBe(true)
+      expect(ContentHashSchema.safeParse(hashContent(new Uint8Array(0))).success).toBe(true)
+    })
+
+    it('createContentHasher digest passes the validator', () => {
+      const hasher = createContentHasher()
+      hasher.update(PRNG)
+      expect(ContentHashSchema.safeParse(hasher.digest()).success).toBe(true)
+      expect(ContentHashSchema.safeParse(createContentHasher().digest()).success).toBe(true)
+    })
+  })
+
+  describe('parseContentHash', () => {
+    it('round-trips a real hashContent output into { algo, hex }', () => {
+      const parsed = parseContentHash(hashContent(PRNG.subarray(0, 8)))
+      expect(parsed).toEqual({ algo: CONTENT_HASH_ALGO, hex: '24ccc9acaa9f65e4' })
+      expect(parsed?.algo).toBe('xxh3-64')
+      expect(parsed?.hex).toMatch(/^[0-9a-f]{16}$/)
+    })
+
+    it('recovers both parts from a value composed as `${algo}:${hex}`', () => {
+      const algo = 'sha256-truncated'
+      const hex = 'deadbeef00'
+      expect(parseContentHash(`${algo}:${hex}`)).toEqual({ algo, hex })
+    })
+
+    it.each([
+      ['no colon', 'xxh3-6424ccc9acaa9f65e4'],
+      ['empty algo', ':24ccc9acaa9f65e4'],
+      ['empty hex', 'xxh3-64:'],
+      ['uppercase hex', 'xxh3-64:24CCC9ACAA9F65E4'],
+      ['uppercase algo', 'XXH3-64:24ccc9acaa9f65e4'],
+      ['trailing junk', 'xxh3-64:24ccc9acaa9f65e4 '],
+      ['empty string', '']
+    ])('returns null on malformed input: %s', (_label, value) => {
+      expect(parseContentHash(value)).toBeNull()
+    })
+  })
+})

--- a/src/main/utils/file/__tests__/fs.test.ts
+++ b/src/main/utils/file/__tests__/fs.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path'
 import type { FilePath } from '@shared/file/types'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
+import { hashContent } from '../contentHash'
 import {
   atomicWriteFile,
   atomicWriteIfUnchanged,
@@ -250,26 +251,27 @@ describe('hash', () => {
     expect(await hash(f1 as FilePath)).not.toBe(await hash(f2 as FilePath))
   })
 
-  it('returns lowercase hex string', async () => {
+  it('returns an algorithm-tagged lowercase hex digest', async () => {
     const f = path.join(tmp, 'a.txt')
     await writeFile(f, 'sample')
     const h = await hash(f as FilePath)
-    expect(h).toMatch(/^[0-9a-f]+$/)
+    expect(h).toMatch(/^xxh3-64:[0-9a-f]{16}$/)
   })
 
-  it('returns 16-char xxhash-h64 hex (not 32-char md5)', async () => {
+  it('uses a 64-bit digest (16 hex chars after the algorithm tag)', async () => {
     const f = path.join(tmp, 'a.txt')
     await writeFile(f, 'sample')
     const h = await hash(f as FilePath)
-    expect(h).toHaveLength(16)
+    expect(h.split(':')[1]).toHaveLength(16)
   })
 
-  it('matches the known xxhash-h64 fixture for "hello"', async () => {
+  it('streams to the same digest as the one-shot content hash of the bytes', async () => {
     const f = path.join(tmp, 'a.txt')
     await writeFile(f, 'hello')
     const h = await hash(f as FilePath)
-    // xxhash-h64('hello') = 0x26c7827d889f6da3 (default seed = 0).
-    expect(h).toBe('26c7827d889f6da3')
+    // File-streamed hash ≡ one-shot hashContent over the same bytes; the
+    // canonical XXH3-64 value is pinned in contentHash.test.ts.
+    expect(h).toBe(hashContent(Buffer.from('hello')))
   })
 })
 

--- a/src/main/utils/file/contentHash.ts
+++ b/src/main/utils/file/contentHash.ts
@@ -17,6 +17,7 @@
  */
 
 import { xxh3 } from '@node-rs/xxhash'
+import { CONTENT_HASH_PATTERN } from '@shared/data/types/file/essential'
 
 /** Algorithm tag prefixing every stored content hash (`{CONTENT_HASH_ALGO}:{hex}`). */
 export const CONTENT_HASH_ALGO = 'xxh3-64'
@@ -76,9 +77,6 @@ export interface ParsedContentHash {
   hex: string
 }
 
-/** Mirrors `ContentHashSchema`'s shape (`@shared/data/types/file/essential`): `{algo}:{hex}`, anchored. */
-const CONTENT_HASH_RE = /^([a-z0-9]+(?:-[a-z0-9]+)*):([0-9a-f]+)$/
-
 /**
  * Parse a stored content hash into its `{ algo, hex }` parts — the inverse of
  * the `{algo}:{hex}` format that {@link hashContent} / {@link createContentHasher}
@@ -87,14 +85,14 @@ const CONTENT_HASH_RE = /^([a-z0-9]+(?:-[a-z0-9]+)*):([0-9a-f]+)$/
  * tag is part of the stored contract).
  *
  * Returns `null` — never throws — for a value that doesn't match the
- * `{algo}:{hex}` shape (algo `[a-z0-9]+(?:-[a-z0-9]+)*`, hex `[0-9a-f]+`, both
- * non-empty), mirroring {@link ContentHashSchema}. `null` (not an exception) is
- * the right shape here: a stored value can be malformed (legacy / corrupted
- * data), and callers branch on presence rather than wrap every read in
- * try/catch. Pure function.
+ * `{algo}:{hex}` shape, validated against the same `CONTENT_HASH_PATTERN` that
+ * backs {@link ContentHashSchema} (its `(algo)(hex)` capture groups are what we
+ * decompose here). `null` (not an exception) is the right shape: a stored value
+ * can be malformed (legacy / corrupted data), and callers branch on presence
+ * rather than wrap every read in try/catch. Pure function.
  */
 export function parseContentHash(value: string): ParsedContentHash | null {
-  const match = CONTENT_HASH_RE.exec(value)
+  const match = CONTENT_HASH_PATTERN.exec(value)
   if (!match) return null
   return { algo: match[1], hex: match[2] }
 }

--- a/src/main/utils/file/contentHash.ts
+++ b/src/main/utils/file/contentHash.ts
@@ -17,7 +17,7 @@
  */
 
 import { xxh3 } from '@node-rs/xxhash'
-import { CONTENT_HASH_PATTERN } from '@shared/data/types/file/essential'
+import { CONTENT_HASH_PATTERN, type ContentHash } from '@shared/data/types/file/essential'
 
 /** Algorithm tag prefixing every stored content hash (`{CONTENT_HASH_ALGO}:{hex}`). */
 export const CONTENT_HASH_ALGO = 'xxh3-64'
@@ -26,15 +26,20 @@ export const CONTENT_HASH_ALGO = 'xxh3-64'
 export interface ContentHasher {
   /** Feed the next chunk. Buffers are accepted zero-copy (Buffer ⊂ Uint8Array). */
   update(chunk: Uint8Array | string): void
-  /** Finalize to the `{algo}:{hex}` contract string. */
-  digest(): string
+  /** Finalize to the branded `{algo}:{hex}` contract value. */
+  digest(): ContentHash
 }
 
 const SEED = 0n
 
-/** 64-bit digest → algorithm-tagged, fixed-width 16-char lowercase hex. */
-function format(digest: bigint): string {
-  return `${CONTENT_HASH_ALGO}:${digest.toString(16).padStart(16, '0')}`
+/**
+ * 64-bit digest → algorithm-tagged, fixed-width 16-char lowercase hex. The lone
+ * sanctioned mint site for the `ContentHash` brand (mirrors
+ * `canonicalizeExternalPath` for `CanonicalExternalPath`): the value is, by
+ * construction, the canonical `{algo}:{hex}` form, so the `as` cast is sound.
+ */
+function format(digest: bigint): ContentHash {
+  return `${CONTENT_HASH_ALGO}:${digest.toString(16).padStart(16, '0')}` as ContentHash
 }
 
 /**
@@ -45,7 +50,7 @@ function format(digest: bigint): string {
  * matching `Buffer.from(str)` — so identical content hashed as a string or as
  * bytes yields the same value.
  */
-export function hashContent(data: Uint8Array | string): string {
+export function hashContent(data: Uint8Array | string): ContentHash {
   return format(xxh3.xxh64(data, SEED))
 }
 

--- a/src/main/utils/file/contentHash.ts
+++ b/src/main/utils/file/contentHash.ts
@@ -1,0 +1,100 @@
+/**
+ * Content hashing primitive for file dedup detection.
+ *
+ * Produces the `{algo}:{hex}` value persisted in `file_entry.contentHash` — a
+ * **detection substrate**, not an identity and not a unique key. The algorithm
+ * tag is part of the stored contract: it lets a future algorithm change coexist
+ * with old values via incremental migration instead of a flag-day re-hash.
+ *
+ * Algorithm: **XXH3-64** via the native `@node-rs/xxhash`. 64-bit (not 128)
+ * because `@node-rs/xxhash` only exposes a streaming/incremental digest for the
+ * 64-bit variant (the `Xxh3` class); its 128-bit hash is one-shot only and
+ * would force whole-file buffering on the streaming write paths (copy /
+ * download / createWriteStream). 64 bits is sufficient for a *detection*
+ * substrate: a collision at worst surfaces a wrong candidate that the
+ * consumer's secondary check rejects — never mis-served bytes. See
+ * file-manager-architecture.md.
+ */
+
+import { xxh3 } from '@node-rs/xxhash'
+
+/** Algorithm tag prefixing every stored content hash (`{CONTENT_HASH_ALGO}:{hex}`). */
+export const CONTENT_HASH_ALGO = 'xxh3-64'
+
+/** Incremental content hasher driving the fold-into-pipe streaming path. */
+export interface ContentHasher {
+  /** Feed the next chunk. Buffers are accepted zero-copy (Buffer ⊂ Uint8Array). */
+  update(chunk: Uint8Array | string): void
+  /** Finalize to the `{algo}:{hex}` contract string. */
+  digest(): string
+}
+
+const SEED = 0n
+
+/** 64-bit digest → algorithm-tagged, fixed-width 16-char lowercase hex. */
+function format(digest: bigint): string {
+  return `${CONTENT_HASH_ALGO}:${digest.toString(16).padStart(16, '0')}`
+}
+
+/**
+ * One-shot content hash of in-memory content → `xxh3-64:{hex}`.
+ *
+ * For content already resident in memory (base64 / bytes sources, the
+ * `string | Uint8Array` write paths). A `string` is hashed as its UTF-8 bytes,
+ * matching `Buffer.from(str)` — so identical content hashed as a string or as
+ * bytes yields the same value.
+ */
+export function hashContent(data: Uint8Array | string): string {
+  return format(xxh3.xxh64(data, SEED))
+}
+
+/**
+ * Create an incremental hasher for fold-into-pipe streaming (zero-extra-IO):
+ * feed each chunk as it flows through a copy / download / write pipeline, then
+ * `digest()`. Produces the SAME value as {@link hashContent} over the
+ * concatenated chunks (streaming `Xxh3.digest()` ≡ one-shot `xxh3.xxh64`), so a
+ * detect-first consumer that pre-hashed in memory and a create path that hashed
+ * in-pipe agree on the key.
+ */
+export function createContentHasher(): ContentHasher {
+  const hasher = xxh3.Xxh3.withSeed(SEED)
+  return {
+    update(chunk) {
+      hasher.update(chunk)
+    },
+    digest() {
+      return format(hasher.digest())
+    }
+  }
+}
+
+/** The decomposed parts of a stored `{algo}:{hex}` content hash. */
+export interface ParsedContentHash {
+  /** Algorithm tag (e.g. `xxh3-64`) — lets consumers branch during a future algorithm migration. */
+  algo: string
+  /** Lowercase-hex digest body. */
+  hex: string
+}
+
+/** Mirrors `ContentHashSchema`'s shape (`@shared/data/types/file/essential`): `{algo}:{hex}`, anchored. */
+const CONTENT_HASH_RE = /^([a-z0-9]+(?:-[a-z0-9]+)*):([0-9a-f]+)$/
+
+/**
+ * Parse a stored content hash into its `{ algo, hex }` parts — the inverse of
+ * the `{algo}:{hex}` format that {@link hashContent} / {@link createContentHasher}
+ * produce. Splits on the first `:`; the algorithm tag is surfaced so consumers
+ * can detect/branch during a future algorithm migration (the whole reason the
+ * tag is part of the stored contract).
+ *
+ * Returns `null` — never throws — for a value that doesn't match the
+ * `{algo}:{hex}` shape (algo `[a-z0-9]+(?:-[a-z0-9]+)*`, hex `[0-9a-f]+`, both
+ * non-empty), mirroring {@link ContentHashSchema}. `null` (not an exception) is
+ * the right shape here: a stored value can be malformed (legacy / corrupted
+ * data), and callers branch on presence rather than wrap every read in
+ * try/catch. Pure function.
+ */
+export function parseContentHash(value: string): ParsedContentHash | null {
+  const match = CONTENT_HASH_RE.exec(value)
+  if (!match) return null
+  return { algo: match[1], hex: match[2] }
+}

--- a/src/main/utils/file/fs.ts
+++ b/src/main/utils/file/fs.ts
@@ -42,6 +42,7 @@ import path from 'node:path'
 import { Writable } from 'node:stream'
 
 import { loggerService } from '@logger'
+import type { ContentHash } from '@shared/data/types/file'
 import type { FilePath } from '@shared/file/types'
 import mime from 'mime'
 
@@ -553,7 +554,7 @@ export async function download(url: string, dest: FilePath): Promise<void> {
  * Chunks are fed straight in: a `Buffer` is a `Uint8Array`, so the hasher
  * consumes it without the per-chunk copy the old WASM loop required.
  */
-export async function hash(path: FilePath): Promise<string> {
+export async function hash(path: FilePath): Promise<ContentHash> {
   const hasher = createContentHasher()
   const stream = createReadStream(path)
   for await (const chunk of stream) {

--- a/src/main/utils/file/fs.ts
+++ b/src/main/utils/file/fs.ts
@@ -44,7 +44,8 @@ import { Writable } from 'node:stream'
 import { loggerService } from '@logger'
 import type { FilePath } from '@shared/file/types'
 import mime from 'mime'
-import xxhashLoader from 'xxhash-wasm'
+
+import { createContentHasher } from './contentHash'
 
 const logger = loggerService.withContext('utils/file/fs')
 
@@ -540,28 +541,23 @@ export async function download(url: string, dest: FilePath): Promise<void> {
 }
 
 /**
- * Compute the content hash of a file (streaming).
+ * Compute the content hash of a file (streaming) → `xxh3-64:{hex}`.
  *
- * Algorithm: xxhash-h64 — non-cryptographic, ~10× faster than MD5, and the
- * `writeIfUnchanged` precision-fallback only needs collision resistance under
- * a single file's write history (which h64 trivially satisfies).
+ * Delegates to the shared {@link createContentHasher} primitive (XXH3-64 via
+ * native `@node-rs/xxhash`) so file-streamed and in-memory content hash through
+ * one library and one algorithm. Non-cryptographic; here it backs the
+ * `writeIfUnchanged` second-precision OCC fallback — a freshly streamed digest
+ * compared against the caller's `expectedContentHash` — which only needs
+ * collision resistance under a single file's write history.
  *
- * The architecture doc names xxhash-128 as the conceptual contract; the
- * `xxhash-wasm` package available at this version exposes only h32 / h64,
- * so we ship h64 and revisit if a 128-bit variant becomes necessary.
+ * Chunks are fed straight in: a `Buffer` is a `Uint8Array`, so the hasher
+ * consumes it without the per-chunk copy the old WASM loop required.
  */
-let xxhashApi: Awaited<ReturnType<typeof xxhashLoader>> | undefined
-async function getXxhash() {
-  if (!xxhashApi) xxhashApi = await xxhashLoader()
-  return xxhashApi
-}
-
 export async function hash(path: FilePath): Promise<string> {
-  const api = await getXxhash()
-  const hasher = api.create64()
+  const hasher = createContentHasher()
   const stream = createReadStream(path)
   for await (const chunk of stream) {
-    hasher.update(new Uint8Array(chunk as Buffer))
+    hasher.update(chunk as Buffer)
   }
-  return hasher.digest().toString(16).padStart(16, '0')
+  return hasher.digest()
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -297,6 +297,8 @@ const api = {
     // FileManager v2 surface (Phase 2)
     createInternalEntry: (params: CreateInternalEntryIpcParams) =>
       ipcRenderer.invoke(IpcChannel.File_CreateInternalEntry, params),
+    findInternalByContentHash: (contentHash: string) =>
+      ipcRenderer.invoke(IpcChannel.File_FindInternalByContentHash, contentHash),
     ensureExternalEntry: (params: EnsureExternalEntryIpcParams) =>
       ipcRenderer.invoke(IpcChannel.File_EnsureExternalEntry, params),
     getPhysicalPath: (params: GetPhysicalPathIpcParams) => ipcRenderer.invoke(IpcChannel.File_GetPhysicalPath, params),

--- a/src/shared/IpcChannel.ts
+++ b/src/shared/IpcChannel.ts
@@ -245,6 +245,7 @@ export enum IpcChannel {
   File_BatchGetDanglingStates = 'file:batchGetDanglingStates',
   // FileManager v2 surface (Phase 2)
   File_CreateInternalEntry = 'file:createInternalEntry',
+  File_FindInternalByContentHash = 'file:findInternalByContentHash',
   File_EnsureExternalEntry = 'file:ensureExternalEntry',
   File_GetPhysicalPath = 'file:getPhysicalPath',
   File_PermanentDelete = 'file:permanentDelete',

--- a/src/shared/data/types/__tests__/fileEntry.test.ts
+++ b/src/shared/data/types/__tests__/fileEntry.test.ts
@@ -18,6 +18,7 @@ function makeInternal(overrides: Record<string, unknown> = {}) {
     name: 'readme',
     ext: 'md',
     size: 1024,
+    contentHash: null,
     createdAt: TS,
     updatedAt: TS,
     ...overrides
@@ -270,6 +271,28 @@ describe('FileEntrySchema size/ext boundaries', () => {
     // test just confirms the schema itself allows bare multi-letter extensions.
     expect(FileEntrySchema.safeParse(makeInternal({ ext: 'gz' })).success).toBe(true)
     expect(FileEntrySchema.safeParse(makeInternal({ ext: '7z' })).success).toBe(true)
+  })
+})
+
+// ─── contentHash (dedup detection substrate) ───
+
+describe('FileEntrySchema contentHash', () => {
+  it('accepts internal with null contentHash (backfill window / not yet computed)', () => {
+    expect(FileEntrySchema.safeParse(makeInternal({ contentHash: null })).success).toBe(true)
+  })
+
+  it('accepts internal with a well-formed {algo}:{hex} contentHash', () => {
+    expect(FileEntrySchema.safeParse(makeInternal({ contentHash: 'xxh3-64:24ccc9acaa9f65e4' })).success).toBe(true)
+  })
+
+  it('rejects a malformed contentHash (missing algo tag / uppercase hex)', () => {
+    expect(FileEntrySchema.safeParse(makeInternal({ contentHash: 'deadbeef' })).success).toBe(false)
+    expect(FileEntrySchema.safeParse(makeInternal({ contentHash: 'xxh3-64:DEADBEEF' })).success).toBe(false)
+  })
+
+  it('rejects contentHash on an external entry (field is absent on that arm)', () => {
+    // External is a strictObject without `contentHash` — supplying it is an extra key.
+    expect(FileEntrySchema.safeParse(makeExternal({ contentHash: 'xxh3-64:24ccc9acaa9f65e4' })).success).toBe(false)
   })
 })
 

--- a/src/shared/data/types/file/essential.ts
+++ b/src/shared/data/types/file/essential.ts
@@ -49,3 +49,17 @@ export const SafeExtSchema = z
   .refine((s) => !/[/\\]/.test(s), 'Extension must not contain path separators')
   .refine((s) => !s.startsWith('.'), 'Extension must be bare (no leading dot), e.g. "pdf" not ".pdf"')
   .refine((s) => s.trim().length > 0, 'Extension must not be all whitespace')
+
+/**
+ * Content-hash schema for the dedup detection substrate.
+ *
+ * Stored / transported as `{algo}:{hex}` (e.g. `xxh3-64:24ccc9acaa9f65e4`) —
+ * the algorithm tag is part of the contract, so a future algorithm change can
+ * coexist with old values via incremental migration instead of a flag-day
+ * re-hash. This validates the *shape* only (lowercase `{algo}:{hex}`), never
+ * hash correctness: `contentHash` is a detection substrate, not an identity
+ * (see file-manager-architecture.md).
+ */
+export const ContentHashSchema = z
+  .string()
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*:[0-9a-f]+$/, 'contentHash must be `{algo}:{hex}` (e.g. "xxh3-64:…")')

--- a/src/shared/data/types/file/essential.ts
+++ b/src/shared/data/types/file/essential.ts
@@ -60,6 +60,16 @@ export const SafeExtSchema = z
  * hash correctness: `contentHash` is a detection substrate, not an identity
  * (see file-manager-architecture.md).
  */
+/**
+ * Canonical content-hash format pattern: `{algo}:{hex}`, anchored, lowercase.
+ * Single source of truth for the shape — the two capture groups are
+ * `(algo)(hex)`, which `parseContentHash` (`@main/utils/file/contentHash`) uses
+ * to decompose a stored hash. `ContentHashSchema` only `.test()`s it (capture
+ * groups are inert for `.regex()`); the flag-free regex carries no `lastIndex`
+ * state, so sharing one instance between `.test()` and `.exec()` is safe.
+ */
+export const CONTENT_HASH_PATTERN = /^([a-z0-9]+(?:-[a-z0-9]+)*):([0-9a-f]+)$/
+
 export const ContentHashSchema = z
   .string()
-  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*:[0-9a-f]+$/, 'contentHash must be `{algo}:{hex}` (e.g. "xxh3-64:…")')
+  .regex(CONTENT_HASH_PATTERN, 'contentHash must be `{algo}:{hex}` (e.g. "xxh3-64:…")')

--- a/src/shared/data/types/file/essential.ts
+++ b/src/shared/data/types/file/essential.ts
@@ -73,3 +73,23 @@ export const CONTENT_HASH_PATTERN = /^([a-z0-9]+(?:-[a-z0-9]+)*):([0-9a-f]+)$/
 export const ContentHashSchema = z
   .string()
   .regex(CONTENT_HASH_PATTERN, 'contentHash must be `{algo}:{hex}` (e.g. "xxh3-64:…")')
+  .brand<'ContentHash'>()
+
+/**
+ * A `{algo}:{hex}` content hash that reached this type through the sanctioned
+ * path — never an arbitrary `string`. It is minted only by:
+ *   - the main-process hasher (`format` / `hashContent` / `createContentHasher`
+ *     / `fs.hash` in `@main/utils/file/contentHash` + `@main/utils/file/fs`),
+ *     trusted at compile time as the single producer, and
+ *   - `ContentHashSchema.parse()` at a runtime boundary (e.g. a renderer-supplied
+ *     value validated in the File IPC handler).
+ *
+ * The brand makes "an untagged bare-hex digest / a non-canonical hash / an
+ * unrelated string" a compile error at every DB write + detection-query surface
+ * (`CreateFileEntryRow.contentHash`, `UpdateFileEntryRow.contentHash`,
+ * `FileEntryService.findInternalByContentHash`). It is a TypeScript-only phantom
+ * brand: zero runtime cost and zero wire cost — erased to a plain string in
+ * SQLite and over IPC. Tests/fixtures may cast a known-canonical literal with
+ * `'xxh3-64:…' as ContentHash`.
+ */
+export type ContentHash = z.infer<typeof ContentHashSchema>

--- a/src/shared/data/types/file/fileEntry.ts
+++ b/src/shared/data/types/file/fileEntry.ts
@@ -102,7 +102,7 @@ import { canonicalizeAbsolutePath } from '@shared/file/canonicalize'
 import type { FilePath } from '@shared/file/types/common'
 import * as z from 'zod'
 
-import { SafeExtSchema, SafeNameSchema, TimestampSchema } from './essential'
+import { ContentHashSchema, SafeExtSchema, SafeNameSchema, TimestampSchema } from './essential'
 
 // ─── Entry ID ───
 
@@ -225,7 +225,16 @@ export type CanonicalFilePath = FilePath & CanonicalExternalPath
 const CommonEntryFields = {
   /** Entry ID (UUID v7) */
   id: FileEntryIdSchema,
-  /** User-visible name (without extension) */
+  /**
+   * User-visible name (without extension).
+   *
+   * **NOT unique.** Multiple entries may share a name, and content-level dedup
+   * makes this routine (the same bytes reused under different names, or
+   * best-effort display disambiguation like `foo (1)` which is sugar, not
+   * identity). Downstream MUST NOT key off `name` — or `(name, ext)` — as if it
+   * identified an entry; the only identity is `id`. For content matching use
+   * `contentHash` (also non-unique — a detection substrate; see its field doc).
+   */
   name: SafeNameSchema,
   /**
    * File extension without leading dot (e.g. `'pdf'`, `'md'`). `null` for
@@ -261,6 +270,15 @@ export const InternalEntrySchema = z.strictObject({
    * this value is authoritative and kept in sync with the backing file on disk.
    */
   size: z.int().nonnegative(),
+  /**
+   * Content hash of the backing blob, format `{algo}:{hex}` (e.g.
+   * `xxh3-64:…`). Detection substrate for content-level dedup — NOT an
+   * identity, NOT a unique key (identity is `id`). `null` during the backfill
+   * window for rows created before this feature, so consumers MUST tolerate
+   * `null`. External entries don't carry this field at all (content lives
+   * outside Cherry; the DB row holds `null`, dropped at the BO boundary).
+   */
+  contentHash: ContentHashSchema.nullable(),
   /**
    * Trash timestamp (ms epoch). Optional — present and non-null when the
    * entry is in the trash, absent when it is live. Internal entries are the

--- a/src/shared/file/types/ipc.ts
+++ b/src/shared/file/types/ipc.ts
@@ -76,7 +76,7 @@ export interface ReadResult<T> {
  *
  * See `file-arch-problems-response.md` for the full rationale (extension of A-7).
  */
-export type CreateInternalEntryIpcParams =
+export type CreateInternalEntryIpcParams = (
   | {
       /** Copy the file at `path` into Cherry storage. `name` / `ext` derived from basename+extname. */
       source: 'path'
@@ -103,6 +103,20 @@ export type CreateInternalEntryIpcParams =
       /** File extension without leading dot (e.g. `'pdf'`), or `null` for extensionless. */
       ext: string | null
     }
+) & {
+  /**
+   * Optional pre-computed content hash (`{algo}:{hex}`, e.g. `xxh3-64:…`) for
+   * content-dedup detection. A detect-first consumer that already hashed the
+   * source (e.g. base64 / bytes in the renderer) passes it to skip
+   * recomputation; when omitted, FileManager computes it during the write.
+   *
+   * **Insert-always semantics are unchanged** — supplying this never triggers
+   * reuse. The reuse-vs-create decision is the consumer's, layered on top of
+   * the detection query (`findInternalByContentHash`); the file module only
+   * persists the hash here.
+   */
+  contentHash?: string
+}
 
 /**
  * Params for ensuring an entry exists for a user-provided (external) path.
@@ -274,6 +288,21 @@ export interface FileIpcApi {
   createInternalEntry(params: CreateInternalEntryIpcParams): Promise<FileEntry>
 
   /**
+   * Detection-query primitive for content-level dedup: the active internal
+   * entries whose `contentHash` matches. NON-unique — may return >1 (identical
+   * content under different names, or a rare collision the consumer rejects);
+   * `[]` on no match.
+   *
+   * Surfaces candidates only — the reuse-vs-create decision (and any secondary
+   * key like `(contentHash, name, ext)`) is the consumer's. Obtaining the
+   * `contentHash` is also the consumer's concern (e.g. the value returned by a
+   * prior `createInternalEntry`).
+   *
+   * @phase 2 — wired (`IpcChannel.File_FindInternalByContentHash` → `FileManager.registerIpcHandlers`)
+   */
+  findInternalByContentHash(contentHash: string): Promise<FileEntry[]>
+
+  /**
    * Ensure an external FileEntry exists for the given absolute path.
    *
    * **Pure upsert** semantics keyed by `externalPath`:
@@ -373,7 +402,7 @@ export interface FileIpcApi {
   getVersion(handle: FileHandle): Promise<FileVersion>
 
   /**
-   * Compute xxhash-h64 of file content.
+   * Compute the XXH3-64 content hash (returns the tagged `xxh3-64:{hex}` form).
    * @phase 2 — not yet wired
    */
   getContentHash(handle: FileHandle): Promise<string>
@@ -391,7 +420,7 @@ export interface FileIpcApi {
   /**
    * Optimistic-concurrency write. Throws StaleVersionError on version mismatch.
    *
-   * `expectedContentHash` (xxhash-h64 hex) is optional and only consulted on
+   * `expectedContentHash` (the XXH3-64 tagged `xxh3-64:{hex}` value) is optional and only consulted on
    * second-precision filesystems (FAT32 / SMB / NFS) where the observed mtime
    * truncates to whole seconds — see `FileVersion` JSDoc for the full
    * fallback contract.

--- a/tests/__mocks__/main/application.ts
+++ b/tests/__mocks__/main/application.ts
@@ -57,6 +57,17 @@ const mockWindowManager = {
   onWindowDestroyedByType: vi.fn(() => ({ dispose: vi.fn() }))
 }
 
+/**
+ * Minimal JobManager stub. `registerHandler` (called in owning services' `onInit`)
+ * and `enqueue` (called when a service kicks a job, e.g. FileManager's startup
+ * content-hash backfill) are the only surface most services touch; override
+ * per-test if a richer JobManager is needed.
+ */
+const mockJobManager = {
+  registerHandler: vi.fn(),
+  enqueue: vi.fn(async () => ({ id: 'mock-job-id', snapshot: {} }))
+}
+
 /** Default service instances from existing mock files */
 export const defaultServiceInstances = {
   PreferenceService: MockMainPreferenceServiceExport.preferenceService,
@@ -64,7 +75,8 @@ export const defaultServiceInstances = {
   DataApiService: MockMainDataApiServiceExport.dataApiService,
   DbService: MockMainDbServiceExport.dbService,
   MainWindowService: mockMainWindowService,
-  WindowManager: mockWindowManager
+  WindowManager: mockWindowManager,
+  JobManager: mockJobManager
 } as const
 
 /** Type for per-service overrides */


### PR DESCRIPTION
### What this PR does

Before this PR: internal `FileEntry` rows carry no content fingerprint, so the file module cannot tell whether two internal files hold identical bytes — every paste / import / download creates an independent entry even when the content already exists.

After this PR: the file module gains a **content-hash detection substrate** for internal entries (detection only — the reuse-vs-create decision stays with consumers):

- **`contentHash` column** on `file_entry` — format `{algo}:{hex}` (e.g. `xxh3-64:…`), **non-unique** index, `external -> NULL` CHECK. Maintained on create and on every internal write.
- **XXH3-64 via native `@node-rs/xxhash`** (drops the `xxhash-wasm` dep). One library + one algorithm for both the persisted hash and the existing `writeIfUnchanged` deep-compare.
- **`findInternalByContentHash(contentHash)`** detection query (`FileEntryService` + `FileManager` + File IPC `File_FindInternalByContentHash`) — returns active internal candidates; callers run their own secondary check.
- **`file.contenthash-backfill`** JobManager handler + `FileManager.onAllReady` trigger — fills `contentHash` for pre-feature / v1-migrated rows (keyset drain, skips orphan blobs, singleton recovery, resumable).
- Architecture doc (`file-manager-architecture.md`) updated: FileEntry shape, per-origin invariants, a new "Content-level dedup detection" section, and the §12 hash-algorithm decision.

Refs #15400

### Why we need it and why it was done in this way

The following tradeoffs were made:

- **Detection capability, not policy.** The file module only persists the hash + exposes a query; reuse / overwrite / keep-both is each consumer's decision, and `createInternalEntry` stays insert-always.
- **XXH3-64, not 128.** `@node-rs/xxhash`'s XXH3-128 is one-shot only (no streaming digest), which would force whole-file buffering on the streaming write paths; only the 64-bit variant streams. For a *detection* substrate 64 bits is ample — a collision at worst surfaces a wrong candidate that the consumer's secondary check rejects (never mis-served bytes) — and the `{algo}:` tag leaves an incremental upgrade path to 128.
- **Non-unique by design.** Identical content under different names is legitimate; a hash is a detection substrate, not a key.
- **Hybrid hashing.** In-memory sources hash one-shot (zero extra IO); streaming sources read the just-written file back; a caller may pass a pre-computed hash (detect-first).

The following alternatives were considered:

- **CAS-as-identity** (content hash = entry id): rejected — internal entries are mutable (`write` / `writeIfUnchanged`), so content == identity would break editing.
- **128-bit width / WASM XXH3-128 / BLAKE3**: rejected for the streaming + native-throughput reasons above.

Links to places where the discussion took place: design discussion with the reviewer in #15400.

### Breaking changes

None user-facing. Internal only: the `xxhash-wasm` dependency is replaced by native `@node-rs/xxhash`, and `fs.hash()` now returns an algorithm-tagged `xxh3-64:{hex}` string (previously a bare 16-char hex). That value is ephemeral (the `writeIfUnchanged` OCC deep-compare) and never persisted, so no stored-data migration is required.

### Special notes for your reviewer

- The drizzle-generated `0001` migration needed two manual patches for known drizzle-kit rebuild-path codegen bugs (INSERT…SELECT listing the just-added column on the *source* table; functional index over-quoted into a bare identifier) — the same fixes the pre-#15438 `0026` migration applied; both are documented inline in the SQL.
- Renderer-side detect-first is **not** wired here: hashing is main-only, so a renderer consumer (e.g. the chat-input dedup popover) will need a hash-bytes path on top of the query exposed in this PR — tracked as a follow-up.
- Cross-platform XXH3-64 determinism is pinned to official xxHash sanity vectors, so any platform binary that diverges fails CI.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
