### PR TITLE
fix(ci): add v1 branch to workflow triggers

### DIFF
--- a/.github/workflows/ci-rerun-on-base-change.yml
+++ b/.github/workflows/ci-rerun-on-base-change.yml
@@ -6,6 +6,7 @@ on:
       - main
       - develop
       - v2
+      - v1
     types: [edited]
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,13 @@ on:
   push:
     branches:
       - main
+      - v1
   pull_request:
     branches:
       - main
       - develop
       - v2
+      - v1
     types: [ready_for_review, synchronize, opened]
 
 jobs:

--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -9,6 +9,7 @@ on:
       - main
       - develop
       - v2
+      - v1
     types: [opened, edited, synchronize, ready_for_review]
 
 jobs:


### PR DESCRIPTION
### What this PR does

Before this PR:
v1 分支的三个核心 GitHub Actions workflow（`ci.yml`、`ci-rerun-on-base-change.yml`、`pr-description-check.yml`）的触发分支列表中没有包含 `v1`，导致以 v1 为 base 的 PR 和直接 push 到 v1 都不触发 CI 检查。例如 PR #15425、#15420、#15241 均无任何 CI check run。

After this PR:
三个 workflow 文件均已将 `v1` 添加到触发分支列表。以 v1 为 base 的 PR 将自动触发完整的 CI 流水线（changeset-check、basic-checks、general-test、render-test），以及 CI rerun 和 PR description check 辅助检查。

Fixes #

### Why we need it and why it was done in this way

v1 是项目当前的稳定发布分支，缺少 CI 保护意味着代码质量问题无法在合并前被发现。

The following tradeoffs were made:
- 仅修改触发分支列表，不改变 CI job 行为，保持最小改动范围
- `notify` job 仍只对 `main` 分支发送飞书告警，v1 的 CI 失败不会触发通知（现有行为，不在此次修复范围）

The following alternatives were considered:
- 使用 `**` 通配所有分支 → 会增加不必要的 CI 消耗，未采用

### Breaking changes

NONE

### Special notes for your reviewer

变更仅涉及三个 workflow 文件的 `on:` 触发配置，每个文件仅添加一行 `- v1`。可用 `git diff` 快速验证无超范围修改。

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: N/A — config-only change
- [x] Upgrade: N/A
- [x] Documentation: Not required — CI-only change
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```