### PR TITLE
fix(agent): validate Claude Code session jsonl before resume

### DIFF
--- a/src/main/services/agents/services/claudecode/__tests__/utils.test.ts
+++ b/src/main/services/agents/services/claudecode/__tests__/utils.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-import { isCherryInOfficialHost, isDeepSeekOfficialHost, isMiMoOfficialHost, with1mContextSuffix } from '../utils'
+import {
+  encodeCwdForClaudeProjects,
+  isCherryInOfficialHost,
+  isDeepSeekOfficialHost,
+  isMiMoOfficialHost,
+  with1mContextSuffix
+} from '../utils'
 
 describe('isDeepSeekOfficialHost', () => {
   it('matches the canonical DeepSeek Anthropic endpoint', () => {
@@ -150,5 +156,35 @@ describe('with1mContextSuffix', () => {
   it('returns empty string when modelId is missing', () => {
     expect(with1mContextSuffix(undefined, deepSeekHost)).toBe('')
     expect(with1mContextSuffix('', deepSeekHost)).toBe('')
+  })
+})
+
+describe('encodeCwdForClaudeProjects', () => {
+  it('matches Claude Code SDK project-dir naming for typical POSIX cwds', () => {
+    expect(encodeCwdForClaudeProjects('/home/alice/.config/CherryStudio/Data/Agents/t-default')).toBe(
+      '-home-alice--config-CherryStudio-Data-Agents-t-default'
+    )
+  })
+
+  it('matches the SDK convention for Windows-style cwds (drive letter + backslashes)', () => {
+    expect(encodeCwdForClaudeProjects('C:\\Users\\Administrator\\AppData\\Roaming\\CherryStudio\\Data\\Agents\\t-default')).toBe(
+      'C--Users-Administrator-AppData-Roaming-CherryStudio-Data-Agents-t-default'
+    )
+  })
+
+  it('encodes nested Windows-in-POSIX residue (e.g. unzipped Windows backup under ~/Downloads)', () => {
+    // Real-world case: Cherry Studio backup zip from Windows extracted under
+    // /home/<user>/Downloads/ leaks the original drive-letter prefix into cwd.
+    // The encoded dir must still match what the SDK lays out, otherwise
+    // resume-validation false-positives a fresh session.
+    expect(
+      encodeCwdForClaudeProjects(
+        '/home/bubu/Downloads/C:/Users/Administrator/AppData/Roaming/CherryStudio/Data/Agents/t-default'
+      )
+    ).toBe('-home-bubu-Downloads-C--Users-Administrator-AppData-Roaming-CherryStudio-Data-Agents-t-default')
+  })
+
+  it('preserves alphanumerics, underscores, and existing dashes', () => {
+    expect(encodeCwdForClaudeProjects('plain_dir-name_42')).toBe('plain_dir-name_42')
   })
 })

--- a/src/main/services/agents/services/claudecode/__tests__/utils.test.ts
+++ b/src/main/services/agents/services/claudecode/__tests__/utils.test.ts
@@ -167,9 +167,9 @@ describe('encodeCwdForClaudeProjects', () => {
   })
 
   it('matches the SDK convention for Windows-style cwds (drive letter + backslashes)', () => {
-    expect(encodeCwdForClaudeProjects('C:\\Users\\Administrator\\AppData\\Roaming\\CherryStudio\\Data\\Agents\\t-default')).toBe(
-      'C--Users-Administrator-AppData-Roaming-CherryStudio-Data-Agents-t-default'
-    )
+    expect(
+      encodeCwdForClaudeProjects('C:\\Users\\Administrator\\AppData\\Roaming\\CherryStudio\\Data\\Agents\\t-default')
+    ).toBe('C--Users-Administrator-AppData-Roaming-CherryStudio-Data-Agents-t-default')
   })
 
   it('encodes nested Windows-in-POSIX residue (e.g. unzipped Windows backup under ~/Downloads)', () => {

--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -65,7 +65,7 @@ import { buildNamespacedToolCallId } from './claude-stream-state'
 import { createSdkMcpServerInstance } from './createSdkMcpServerInstance'
 import { promptForToolApproval } from './tool-permissions'
 import { ClaudeStreamState, transformSDKMessageToStreamParts } from './transform'
-import { with1mContextSuffix } from './utils'
+import { encodeCwdForClaudeProjects, with1mContextSuffix } from './utils'
 
 const require_ = createRequire(import.meta.url)
 const logger = loggerService.withContext('ClaudeCodeService')
@@ -673,9 +673,34 @@ class ClaudeCodeService implements AgentServiceInterface {
     }
 
     if (lastAgentSessionId && !NO_RESUME_COMMANDS.some((cmd) => prompt.includes(cmd))) {
-      options.resume = lastAgentSessionId
-      // TODO: use fork session when we support branching sessions
-      // options.forkSession = true
+      // Verify the SDK still has the session jsonl on disk before requesting resume.
+      // If the file is missing (e.g. after backup/restore that didn't include
+      // CLAUDE_CONFIG_DIR, or after the cwd encoding changed), passing `resume`
+      // makes the SDK error out with "No conversation found with session ID: ..."
+      // which permanently breaks the chat. Falling back to a fresh SDK session
+      // loses model context for the next turn but keeps the UI usable; the
+      // visible message history (stored in Cherry Studio's DB) is preserved.
+      const claudeRoot = application.getPath('feature.agents.claude.root')
+      const projectDir = path.join(claudeRoot, 'projects', encodeCwdForClaudeProjects(cwd))
+      const sessionFile = path.join(projectDir, `${lastAgentSessionId}.jsonl`)
+      const resumable = await fs.promises
+        .access(sessionFile, fs.constants.R_OK)
+        .then(() => true)
+        .catch(() => false)
+      if (resumable) {
+        options.resume = lastAgentSessionId
+        // TODO: use fork session when we support branching sessions
+        // options.forkSession = true
+      } else {
+        logger.warn(
+          'Skipping resume — Claude Code session jsonl missing on disk (orphaned agent_session_id). Starting a fresh SDK session.',
+          {
+            sessionId: lastAgentSessionId,
+            cwd,
+            expectedFile: sessionFile
+          }
+        )
+      }
     }
 
     logger.info('Starting Claude Code SDK query', {

--- a/src/main/services/agents/services/claudecode/utils.ts
+++ b/src/main/services/agents/services/claudecode/utils.ts
@@ -183,3 +183,22 @@ export function with1mContextSuffix(modelId: string | undefined, anthropicHost: 
 
   return modelId
 }
+
+/**
+ * Encode a cwd path the way Claude Code SDK does when laying out
+ * `<CLAUDE_CONFIG_DIR>/projects/<encoded-cwd>/<session-id>.jsonl`.
+ *
+ * The SDK replaces every path-separator-ish character (`/`, `\`, `:`, `.`)
+ * with `-` to get a single flat directory name. Mirroring the rule here lets
+ * us probe the SDK's storage to verify a session jsonl exists before issuing
+ * `--resume` — passing a stale id otherwise crashes the stream with
+ * `No conversation found with session ID: <uuid>`.
+ *
+ * Note: the SDK has historically used this collapsing rule across versions;
+ * the heuristic is robust enough that a future encoding change would simply
+ * make us fall back to "fresh session" (which is the safe default), never the
+ * inverse.
+ */
+export function encodeCwdForClaudeProjects(cwd: string): string {
+  return cwd.replace(/[/\\:.]/g, '-')
+}


### PR DESCRIPTION
Fixes #15505

When the agent_session_id stored in agents.db no longer has a matching
session jsonl on disk (backup restore, cross-platform migration, manual
cleanup), passing --resume to the Claude Code SDK throws:

  No conversation found with session ID: <uuid>

This probes the expected jsonl path before opting into resume; on miss,
it falls back to a fresh SDK session. Model context is lost for that turn
but the chat is usable again.

Related: #12459 (same symptom, closed stale), #15297 (adjacent cron bug)