### PR TITLE
docs(branch-strategy): align with #13984 (forward-port, drop v2-line framing)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,12 +5,12 @@
 
 > ### 🚨 Branch strategy — read before opening this PR
 >
-> The v2 refactor has landed: the old `v2` branch is now **merged into `main`**, and `main` is the **active v2 development line** (v1 and v2 code coexist — expect large, breaking changes).
+> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
 >
-> - **v2 work** (features, refactors, optimizations) → target **`main`** (the default base).
-> - **v1 maintenance** (critical user-facing bug fixes only) → branch from and target **`v1`**, _not_ `main`.
+> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
+> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
 >
-> Before doing v2 work, read `docs/references/data/` to see which subsystems are being replaced, and watch for `@deprecated` markers — they flag code being deleted.
+> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.
 
 ### What this PR does
 
@@ -45,7 +45,7 @@ If this PR introduces breaking changes, please describe the changes and the impa
 This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
 Approvers are expected to review this list.
 
-- [ ] Branch: This PR targets the correct branch — `main` for v2 work, `v1` for v1 maintenance fixes
+- [ ] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
 - [ ] PR: The PR description is expressive enough and will help future contributors
 - [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
 - [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Project-specific tools, paths, and conventions.
 - **Write conventional commits**: Commit small, focused changes using Conventional Commit messages (e.g., `feat(data-api):`, `fix(lifecycle):`, `refactor(quick-assistant):`, `docs(testing):`, `chore(deps):`, `test(window-manager):`). Scope must be a specific kebab-case module, never generic like `main` — when `git log` conflicts with this rule, this rule wins.
 - **Keep history linear**: On shared branches, never use plain `git pull` — it creates merge commits. Always `git pull --rebase` (or `git fetch && git rebase origin/<branch>`). Before `git push`, run `git fetch`; if `origin/<branch>` has advanced, rebase your local commits onto it first. If you notice a merge commit in local history that hasn't been pushed yet, rebase it away — cleaning one up after it's public requires a risky force-push on a shared branch.
 - **Sign commits**: Use `git commit --signoff` as required by contributor guidelines.
-- **Target the right branch**: `main` is the active v2 development line — submit features, refactors, and v2 work here. v1 maintenance fixes must branch from and target the `v1` branch (never `main`). See [v2 Refactoring](#v2-refactoring-in-progress).
+- **Target the right branch**: `main` is the default branch for active development — submit features, refactors, optimizations, and fixes for the current codebase here. v1 maintenance fixes (hotfixes and subsequent v1 releases) must branch from and target the `v1` branch (never `main`); a v1 fix does not auto-carry to `main`, so forward-port it with a separate PR if the bug also exists on `main`. See [v2 Refactoring](#v2-refactoring-in-progress).
 
 ## Development
 
@@ -194,7 +194,7 @@ Services without long-lived resources or persistent side effects: use **named ex
 
 ## v2 Refactoring (In Progress)
 
-> **Current state — read before contributing.** The former `v2` branch has been **merged into `main`**; `main` is now the active v2 development line, with v1 and v2 code **coexisting**. Expect large, frequent, breaking changes — code you touch today may be deleted or reshaped tomorrow. Before doing v2 work, read [docs/references/data](docs/references/data/README.md) to learn which subsystems are being replaced (and thus deleted), and heed `@deprecated` annotations in the code — they mark call sites slated for removal. v1 maintenance fixes go to the `v1` branch, not `main`.
+> **Current state — read before contributing.** The former `v2` branch has been **merged into `main`**; `main` is now the default branch for active development, with v1 and v2 code **coexisting**. Expect large, frequent, breaking changes — code you touch today may be deleted or reshaped tomorrow. Before touching subsystems being replaced, read [docs/references/data](docs/references/data/README.md) to learn which are being deleted, and heed `@deprecated` annotations in the code — they mark call sites slated for removal. v1 maintenance fixes (hotfixes and subsequent v1 releases) go to the `v1` branch, not `main`; forward-port to `main` with a separate PR if the bug also exists there.
 
 ### Data Layer
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,14 +76,14 @@ Please review the following critical information before submitting your Pull Req
 
 ### Branch Strategy 🚨
 
-**The v2 refactor has landed on `main`.** The former `v2` branch is now merged into `main`, and `main` is the active v2 development line, where v1 and v2 code coexist. Expect large, frequent, and breaking changes during this phase.
+**The v2 refactor has merged into `main`.** `main` is now the default branch for active development, where v1 and v2 code coexist. Expect large, frequent, and breaking changes during this phase.
 
-*   **`main` branch**: All new feature development, refactoring, and optimizations go here. Before doing v2 work, read [docs/references/data](./docs/references/data/README.md) to learn which subsystems are being replaced (and thus deleted), and heed `@deprecated` annotations in the code — they mark call sites slated for removal.
-*   **`v1` branch**: Maintenance line for the shipped v1 release. Only **critical user-facing bug fixes** go here, via `hotfix/*` branches (e.g., `hotfix/fix-crash-on-startup`), kept minimal in scope. Target your PR to `v1`, not `main`.
+*   **`main` branch**: New feature development, refactoring, optimizations, and fixes for the current codebase go here. Before touching subsystems being replaced, read [docs/references/data](./docs/references/data/README.md) to learn which are being deleted, and heed `@deprecated` annotations in the code — they mark call sites slated for removal.
+*   **`v1` branch**: Maintenance line for the shipped v1 release — its hotfixes and subsequent v1 releases go here, via `hotfix/*` branches (e.g., `hotfix/fix-crash-on-startup`), kept minimal in scope. Target your PR to `v1`, not `main`. A v1 fix does **not** auto-carry to `main`; if the same bug exists on `main`, open a separate forward-port PR targeting `main`.
 
 ### Participate in v2 Development 🚀
 
-v2 is the next major milestone for Cherry Studio, and we invite every developer to actively participate! Whether it's new feature development, architecture optimization, or code refactoring, your contributions to the v2 line on `main` are welcome. Let's build a better Cherry Studio together!
+v2 is the next major milestone for Cherry Studio, and we invite every developer to actively participate! Whether it's new feature development, architecture optimization, or code refactoring, your contributions on `main` are welcome. Let's build a better Cherry Studio together!
 
 We appreciate your understanding and continued support during this important development phase. Thank you!
 

--- a/docs/guides/branching-strategy.md
+++ b/docs/guides/branching-strategy.md
@@ -2,7 +2,7 @@
 
 Cherry Studio implements a structured branching strategy to maintain code quality and streamline the development process.
 
-> **Current model (v2 development).** `main` is the active v2 development line — submit features, refactors, and optimizations here. The `v1` branch is the maintenance line for the shipped v1 release: critical user-facing bug fixes go there via `hotfix/*`, targeting `v1` (not `main`). The generic flow below predates the v2 phase; where it conflicts, this note wins.
+> **Current model.** `main` is the default branch for active development — submit features, refactors, optimizations, and fixes for the current codebase here. The `v1` branch is the maintenance line for the shipped v1 release: its hotfixes and subsequent v1 releases go there via `hotfix/*`, targeting `v1` (not `main`). A v1 fix does not auto-carry to `main`; if the same bug exists on `main`, open a separate forward-port PR targeting `main`. (v1 and v2 code currently coexist on `main` — expect large, breaking changes.) The generic flow below predates this phase; where it conflicts, this note wins.
 
 ## Main Branches
 
@@ -44,9 +44,9 @@ When contributing to Cherry Studio, please follow these guidelines:
 
 4. **Hotfix Branches:**
 
-   - Create from `main` branch
+   - Create from the `v1` branch
    - Naming format: `hotfix/issue-number-brief-description`
-   - Submit PR to both `main` and relevant `release` branches
+   - Submit PR to `v1`, not `main`. A v1 fix does not auto-carry to `main` — if the same bug exists on `main`, open a separate forward-port PR targeting `main`
 
 5. **Release Branches:**
    - Create from `main` branch
@@ -61,7 +61,7 @@ When contributing to Cherry Studio, please follow these guidelines:
 
 ## Pull Request Guidelines
 
-- v2 work (features, refactors, optimizations) goes to `main`; critical v1 production fixes go to the `v1` branch (see the note at the top)
+- Active development (features, refactors, optimizations, fixes for the current codebase) goes to `main`; v1 hotfixes and subsequent v1 releases go to the `v1` branch (see the note at the top). A v1 fix is not auto-carried to `main` — forward-port it with a separate PR if the bug also exists on `main`
 - Ensure your branch is up to date with the latest `main` changes before submitting
 - Include relevant issue numbers in your PR description
 - Make sure all tests pass and code meets our quality standards

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -75,14 +75,14 @@ Please read the following key information before submitting a Pull Request:
 
 ### Branch Strategy
 
-**The v2 refactor has landed on `main`.** The former `v2` branch is now merged into `main`, and `main` is the active v2 development line, where v1 and v2 code coexist. Expect large, frequent, and breaking changes during this phase.
+**The v2 refactor has merged into `main`.** `main` is now the default branch for active development, where v1 and v2 code coexist. Expect large, frequent, and breaking changes during this phase.
 
-- **`main` branch**: All new feature development, refactoring, and optimizations go here. Before doing v2 work, read [docs/references/data](../references/data/README.md) to learn which subsystems are being replaced (and thus deleted), and heed `@deprecated` annotations in the code — they mark call sites slated for removal.
-- **`v1` branch**: Maintenance line for the shipped v1 release. Only **critical user-facing bug fixes** go here, via `hotfix/*` branches (e.g., `hotfix/fix-crash-on-startup`), with minimal scope. Target your PR to `v1`, not `main`.
+- **`main` branch**: New feature development, refactoring, optimizations, and fixes for the current codebase go here. Before touching subsystems being replaced, read [docs/references/data](../references/data/README.md) to learn which are being deleted, and heed `@deprecated` annotations in the code — they mark call sites slated for removal.
+- **`v1` branch**: Maintenance line for the shipped v1 release — its hotfixes and subsequent v1 releases go here, via `hotfix/*` branches (e.g., `hotfix/fix-crash-on-startup`), with minimal scope. Target your PR to `v1`, not `main`. A v1 fix does **not** auto-carry to `main`; if the same bug exists on `main`, open a separate forward-port PR targeting `main`.
 
 ### Participate in v2 Development
 
-v2 is the next major milestone for Cherry Studio, and we invite every developer to actively participate! Whether it's new feature development, architecture optimization, or code refactoring, contributions to the v2 line on `main` are welcome. Let's build a better Cherry Studio together!
+v2 is the next major milestone for Cherry Studio, and we invite every developer to actively participate! Whether it's new feature development, architecture optimization, or code refactoring, contributions on `main` are welcome. Let's build a better Cherry Studio together!
 
 Thank you for your understanding and continued support during this important development phase!
 


### PR DESCRIPTION
### What this PR does

Before this PR:

The branch-strategy docs still framed `main` as "the active v2 development line" (a transitional narrative from when the `v2` branch first merged in) and described the `v1` line as "critical user-facing bug fixes only." None of the docs explained that v1 fixes do **not** automatically reach `main`.

After this PR:

All five places that document the branch strategy are aligned with the policy in #13984:

- De-brand `main`: it is now simply the **default branch for active development**, not "the v2 development line." The still-true v1/v2 coexistence + breaking-change + `@deprecated` context is kept.
- v1 line scope updated to **hotfixes and subsequent v1 releases** (was "critical user-facing bug fixes only").
- New **forward-port** guidance added everywhere: a v1 fix does not auto-carry to `main`; if the same bug exists on `main`, open a separate forward-port PR targeting `main`.

Files touched: `.github/pull_request_template.md`, `docs/guides/branching-strategy.md`, `CONTRIBUTING.md`, `docs/guides/contributing.md`, `CLAUDE.md`.

Refs #13984 — intentionally not auto-closed; that issue is kept open as the canonical policy reference.

### Why we need it and why it was done in this way

The previous wording predated the `v2`→`main` merge becoming the steady state, and it omitted the forward-port rule, which is the actual new information in #13984 — without it, contributors risk fixing a bug on `v1` and forgetting it still exists on `main`.

The following tradeoffs were made:

- Kept (not deleted) the "v1/v2 coexist · expect breaking changes · watch `@deprecated`" context even though #13984 itself is routing-only — that context is still accurate at the code level and useful to contributors.
- In `docs/guides/branching-strategy.md`, also realigned the generic **Hotfix Branches** entry (`Create from v1` / target `v1` + forward-port) so the generic flow no longer literally contradicts the top note.

The following alternatives were considered:

- Editing only the PR template — rejected, it would leave the other four docs inconsistent.
- Fully retiring the v2 narrative (stripping the coexistence/breaking-change warnings) — rejected, those warnings remain true and helpful.

Links to places where the discussion took place: #13984

### Breaking changes

<!-- optional -->

N/A — documentation only.

### Special notes for your reviewer

<!-- optional -->

Pure docs change (19 insertions / 19 deletions). The only addition beyond rewording is the forward-port guidance, which appears in all five files. The `CLAUDE.md` "v2 Refactoring (In Progress)" section's technical narrative (data/UI layers, coexistence mindset) was intentionally left intact — only its branch-routing wording was touched. #13984 is deliberately left open as the policy reference, so this PR does not use a closing keyword.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
