### PR TITLE
fix: remove console.log from production code in browser controller

### DIFF
--- a/src/main/mcpServers/browser/controller.ts
+++ b/src/main/mcpServers/browser/controller.ts
@@ -247,7 +247,7 @@ export class CdpBrowserController {
       (function() {
         window.addEventListener('message', function(e) {
           if (e.data && e.data.channel === 'tabbar-action') {
-            console.log(JSON.stringify(e.data));
+            // TODO: handle tabbar-action messages
           }
         });
       })();


### PR DESCRIPTION
移除 `src/main/mcpServers/browser/controller.ts` 中 Tab bar 消息处理器里的 `console.log` 调用，替换为 TODO 注释。这是一个调试遗留代码，不应出现在生产环境中。