### PR TITLE
fix: correct 'pulish:artifacts' script name to 'publish:artifacts'

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build:linux:x64": "dotenv npm run build && electron-builder --linux --x64",
     "release": "node scripts/version.js",
     "publish": "pnpm build:check && pnpm release patch push",
-    "pulish:artifacts": "cd packages/artifacts && npm publish && cd -",
+    "publish:artifacts": "cd packages/artifacts && npm publish && cd -",
     "analyze:renderer": "VISUALIZER_RENDERER=true pnpm build",
     "analyze:main": "VISUALIZER_MAIN=true pnpm build",
     "typecheck": "pnpm --filter @cherrystudio/ai-sdk-provider build && concurrently -n \"node,web,aicore\" -c \"cyan,magenta,yellow\" \"npm run typecheck:node\" \"npm run typecheck:web\" \"pnpm --filter @cherrystudio/ai-core typecheck\"",


### PR DESCRIPTION
修复 `package.json` 中 `pulish:artifacts` 脚本名为正确的 `publish:artifacts`。拼写错误导致该脚本无法通过 `pnpm publish:artifacts` 调用。