### PR TITLE
fix: replace hardcoded alt text with i18n translation key

### DIFF
--- a/src/renderer/src/pages/paintings/AihubmixPage.tsx
+++ b/src/renderer/src/pages/paintings/AihubmixPage.tsx
@@ -824,7 +824,7 @@ const AihubmixPage: FC<{ Options: string[] }> = ({ Options }) => {
             }}>
             {painting[item.key!] ? (
               <ImagePreview>
-                <img src={painting[item.key!]} alt="预览图" />
+                <img src={painting[item.key!]} alt={t('common.image_preview')} />
               </ImagePreview>
             ) : (
               <ImageSizeImage src={IcImageUp} theme={theme} />

--- a/src/renderer/src/pages/paintings/components/DynamicFormRender.tsx
+++ b/src/renderer/src/pages/paintings/components/DynamicFormRender.tsx
@@ -101,7 +101,7 @@ export const DynamicFormRender: React.FC<DynamicFormRenderProps> = ({
             }}>
             <img
               src={value}
-              alt="Image preview"
+              alt={t('common.image_preview')}
               style={{
                 width: '48px',
                 height: '48px',


### PR DESCRIPTION
将两处硬编码的图片 alt 文本替换为 i18n 翻译 key：

- `AihubmixPage.tsx` — `alt="预览图"` → `t('common.image_preview')`
- `DynamicFormRender.tsx` — `alt="Image preview"` → `t('common.image_preview')`

两个文件已导入 `useTranslation`，改动最小化。