### PR TITLE
fix: remove dead code in logo.ts — eliminate always-true isLight and unused Dark imports

### DIFF
--- a/src/renderer/src/config/models/logo.ts
+++ b/src/renderer/src/config/models/logo.ts
@@ -1,62 +1,32 @@
 import LongCatAppLogo from '@renderer/assets/images/apps/longcat.svg'
 import Ai360ModelLogo from '@renderer/assets/images/models/360.png'
-import Ai360ModelLogoDark from '@renderer/assets/images/models/360_dark.png'
 import AdeptModelLogo from '@renderer/assets/images/models/adept.png'
-import AdeptModelLogoDark from '@renderer/assets/images/models/adept_dark.png'
 import Ai21ModelLogo from '@renderer/assets/images/models/ai21.png'
-import Ai21ModelLogoDark from '@renderer/assets/images/models/ai21_dark.png'
 import AimassModelLogo from '@renderer/assets/images/models/aimass.png'
-import AimassModelLogoDark from '@renderer/assets/images/models/aimass_dark.png'
 import AisingaporeModelLogo from '@renderer/assets/images/models/aisingapore.png'
-import AisingaporeModelLogoDark from '@renderer/assets/images/models/aisingapore_dark.png'
 import BaichuanModelLogo from '@renderer/assets/images/models/baichuan.png'
-import BaichuanModelLogoDark from '@renderer/assets/images/models/baichuan_dark.png'
 import BgeModelLogo from '@renderer/assets/images/models/bge.webp'
 import BigcodeModelLogo from '@renderer/assets/images/models/bigcode.webp'
-import BigcodeModelLogoDark from '@renderer/assets/images/models/bigcode_dark.webp'
 import BytedanceModelLogo from '@renderer/assets/images/models/byte_dance.svg'
 import ChatGLMModelLogo from '@renderer/assets/images/models/chatglm.png'
-import ChatGLMModelLogoDark from '@renderer/assets/images/models/chatglm_dark.png'
 import ChatGptModelLogo from '@renderer/assets/images/models/chatgpt.jpeg'
 import ClaudeModelLogo from '@renderer/assets/images/models/claude.png'
-import ClaudeModelLogoDark from '@renderer/assets/images/models/claude_dark.png'
 import CodegeexModelLogo from '@renderer/assets/images/models/codegeex.png'
-import CodegeexModelLogoDark from '@renderer/assets/images/models/codegeex_dark.png'
 import CodestralModelLogo from '@renderer/assets/images/models/codestral.png'
 import CohereModelLogo from '@renderer/assets/images/models/cohere.png'
-import CohereModelLogoDark from '@renderer/assets/images/models/cohere_dark.png'
 import CopilotModelLogo from '@renderer/assets/images/models/copilot.png'
-import CopilotModelLogoDark from '@renderer/assets/images/models/copilot_dark.png'
 import DalleModelLogo from '@renderer/assets/images/models/dalle.png'
-import DalleModelLogoDark from '@renderer/assets/images/models/dalle_dark.png'
 import DbrxModelLogo from '@renderer/assets/images/models/dbrx.png'
 import DeepSeekModelLogo from '@renderer/assets/images/models/deepseek.png'
-import DeepSeekModelLogoDark from '@renderer/assets/images/models/deepseek_dark.png'
 import DianxinModelLogo from '@renderer/assets/images/models/dianxin.png'
-import DianxinModelLogoDark from '@renderer/assets/images/models/dianxin_dark.png'
 import DoubaoModelLogo from '@renderer/assets/images/models/doubao.png'
-import DoubaoModelLogoDark from '@renderer/assets/images/models/doubao_dark.png'
-import {
-  default as EmbeddingModelLogo,
-  default as EmbeddingModelLogoDark
-} from '@renderer/assets/images/models/embedding.png'
+import EmbeddingModelLogo from '@renderer/assets/images/models/embedding.png'
 import FlashaudioModelLogo from '@renderer/assets/images/models/flashaudio.png'
-import FlashaudioModelLogoDark from '@renderer/assets/images/models/flashaudio_dark.png'
 import FluxModelLogo from '@renderer/assets/images/models/flux.png'
-import FluxModelLogoDark from '@renderer/assets/images/models/flux_dark.png'
 import GeminiModelLogo from '@renderer/assets/images/models/gemini.png'
-import GeminiModelLogoDark from '@renderer/assets/images/models/gemini_dark.png'
 import GemmaModelLogo from '@renderer/assets/images/models/gemma.png'
-import GemmaModelLogoDark from '@renderer/assets/images/models/gemma_dark.png'
-import { default as GoogleModelLogo, default as GoogleModelLogoDark } from '@renderer/assets/images/models/google.png'
 import ChatGPT35ModelLogo from '@renderer/assets/images/models/gpt_3.5.png'
 import ChatGPT4ModelLogo from '@renderer/assets/images/models/gpt_4.png'
-import {
-  default as ChatGPT4ModelLogoDark,
-  default as ChatGPT35ModelLogoDark,
-  default as ChatGptModelLogoDark,
-  default as ChatGPTo1ModelLogoDark
-} from '@renderer/assets/images/models/gpt_dark.png'
 import ChatGPTImageModelLogo from '@renderer/assets/images/models/gpt_image_1.png'
 import ChatGPTImage2ModelLogo from '@renderer/assets/images/models/gpt_image_2.png'
 import ChatGPTo1ModelLogo from '@renderer/assets/images/models/gpt_o1.png'
@@ -70,123 +40,75 @@ import GPT5CodexModelLogo from '@renderer/assets/images/models/gpt-5-codex.png'
 import GPT5MiniModelLogo from '@renderer/assets/images/models/gpt-5-mini.png'
 import GPT5NanoModelLogo from '@renderer/assets/images/models/gpt-5-nano.png'
 import GrokModelLogo from '@renderer/assets/images/models/grok.png'
-import GrokModelLogoDark from '@renderer/assets/images/models/grok_dark.png'
 import GrypheModelLogo from '@renderer/assets/images/models/gryphe.png'
-import GrypheModelLogoDark from '@renderer/assets/images/models/gryphe_dark.png'
 import HailuoModelLogo from '@renderer/assets/images/models/hailuo.png'
-import HailuoModelLogoDark from '@renderer/assets/images/models/hailuo_dark.png'
 import HuggingfaceModelLogo from '@renderer/assets/images/models/huggingface.png'
-import HuggingfaceModelLogoDark from '@renderer/assets/images/models/huggingface_dark.png'
 import HunyuanModelLogo from '@renderer/assets/images/models/hunyuan.png'
-import HunyuanModelLogoDark from '@renderer/assets/images/models/hunyuan_dark.png'
 import IbmModelLogo from '@renderer/assets/images/models/ibm.png'
-import IbmModelLogoDark from '@renderer/assets/images/models/ibm_dark.png'
 import IdeogramModelLogo from '@renderer/assets/images/models/ideogram.svg'
 import InternlmModelLogo from '@renderer/assets/images/models/internlm.png'
-import InternlmModelLogoDark from '@renderer/assets/images/models/internlm_dark.png'
 import InternvlModelLogo from '@renderer/assets/images/models/internvl.png'
 import JinaModelLogo from '@renderer/assets/images/models/jina.png'
-import JinaModelLogoDark from '@renderer/assets/images/models/jina_dark.png'
 import KeLingModelLogo from '@renderer/assets/images/models/keling.png'
-import KeLingModelLogoDark from '@renderer/assets/images/models/keling_dark.png'
 import LingModelLogo from '@renderer/assets/images/models/ling.png'
 import LlamaModelLogo from '@renderer/assets/images/models/llama.png'
-import LlamaModelLogoDark from '@renderer/assets/images/models/llama_dark.png'
 import LLavaModelLogo from '@renderer/assets/images/models/llava.png'
-import LLavaModelLogoDark from '@renderer/assets/images/models/llava_dark.png'
 import LumaModelLogo from '@renderer/assets/images/models/luma.png'
-import LumaModelLogoDark from '@renderer/assets/images/models/luma_dark.png'
 import MagicModelLogo from '@renderer/assets/images/models/magic.png'
-import MagicModelLogoDark from '@renderer/assets/images/models/magic_dark.png'
 import MediatekModelLogo from '@renderer/assets/images/models/mediatek.png'
-import MediatekModelLogoDark from '@renderer/assets/images/models/mediatek_dark.png'
 import MicrosoftModelLogo from '@renderer/assets/images/models/microsoft.png'
-import MicrosoftModelLogoDark from '@renderer/assets/images/models/microsoft_dark.png'
 import MidjourneyModelLogo from '@renderer/assets/images/models/midjourney.png'
-import MidjourneyModelLogoDark from '@renderer/assets/images/models/midjourney_dark.png'
 import MiMoModelLogo from '@renderer/assets/images/models/mimo.svg'
-import {
-  default as MinicpmModelLogo,
-  default as MinicpmModelLogoDark
-} from '@renderer/assets/images/models/minicpm.webp'
+import MinicpmModelLogo from '@renderer/assets/images/models/minicpm.webp'
 import MinimaxModelLogo from '@renderer/assets/images/models/minimax.png'
-import MinimaxModelLogoDark from '@renderer/assets/images/models/minimax_dark.png'
 import MistralModelLogo from '@renderer/assets/images/models/mixtral.png'
-import MistralModelLogoDark from '@renderer/assets/images/models/mixtral_dark.png'
 import MoonshotModelLogo from '@renderer/assets/images/models/moonshot.webp'
-import MoonshotModelLogoDark from '@renderer/assets/images/models/moonshot.webp'
-import {
-  default as NousResearchModelLogo,
-  default as NousResearchModelLogoDark
-} from '@renderer/assets/images/models/nousresearch.png'
+import NousResearchModelLogo from '@renderer/assets/images/models/nousresearch.png'
 import NvidiaModelLogo from '@renderer/assets/images/models/nvidia.png'
-import NvidiaModelLogoDark from '@renderer/assets/images/models/nvidia_dark.png'
 import PalmModelLogo from '@renderer/assets/images/models/palm.png'
-import PalmModelLogoDark from '@renderer/assets/images/models/palm_dark.png'
 import PanguModelLogo from '@renderer/assets/images/models/pangu.svg'
-import {
-  default as PerplexityModelLogo,
-  default as PerplexityModelLogoDark
-} from '@renderer/assets/images/models/perplexity.png'
+import PerplexityModelLogo from '@renderer/assets/images/models/perplexity.png'
 import PixtralModelLogo from '@renderer/assets/images/models/pixtral.png'
-import PixtralModelLogoDark from '@renderer/assets/images/models/pixtral_dark.png'
 import QwenModelLogo from '@renderer/assets/images/models/qwen.png'
-import QwenModelLogoDark from '@renderer/assets/images/models/qwen_dark.png'
 import RakutenaiModelLogo from '@renderer/assets/images/models/rakutenai.png'
-import RakutenaiModelLogoDark from '@renderer/assets/images/models/rakutenai_dark.png'
 import SparkDeskModelLogo from '@renderer/assets/images/models/sparkdesk.png'
-import SparkDeskModelLogoDark from '@renderer/assets/images/models/sparkdesk_dark.png'
 import StabilityModelLogo from '@renderer/assets/images/models/stability.png'
-import StabilityModelLogoDark from '@renderer/assets/images/models/stability_dark.png'
 import StepModelLogo from '@renderer/assets/images/models/step.png'
-import StepModelLogoDark from '@renderer/assets/images/models/step_dark.png'
 import SunoModelLogo from '@renderer/assets/images/models/suno.png'
-import SunoModelLogoDark from '@renderer/assets/images/models/suno_dark.png'
 import TeleModelLogo from '@renderer/assets/images/models/tele.png'
-import TeleModelLogoDark from '@renderer/assets/images/models/tele_dark.png'
 import TokenFluxModelLogo from '@renderer/assets/images/models/tokenflux.png'
-import TokenFluxModelLogoDark from '@renderer/assets/images/models/tokenflux_dark.png'
 import UpstageModelLogo from '@renderer/assets/images/models/upstage.png'
-import UpstageModelLogoDark from '@renderer/assets/images/models/upstage_dark.png'
 import ViduModelLogo from '@renderer/assets/images/models/vidu.png'
-import ViduModelLogoDark from '@renderer/assets/images/models/vidu_dark.png'
 import VoyageModelLogo from '@renderer/assets/images/models/voyageai.png'
 import WenxinModelLogo from '@renderer/assets/images/models/wenxin.png'
-import WenxinModelLogoDark from '@renderer/assets/images/models/wenxin_dark.png'
 import XirangModelLogo from '@renderer/assets/images/models/xirang.png'
-import XirangModelLogoDark from '@renderer/assets/images/models/xirang_dark.png'
 import YiModelLogo from '@renderer/assets/images/models/yi.png'
-import YiModelLogoDark from '@renderer/assets/images/models/yi_dark.png'
 import ZhipuModelLogo from '@renderer/assets/images/models/zhipu.png'
-import ZhipuModelLogoDark from '@renderer/assets/images/models/zhipu_dark.png'
 import YoudaoLogo from '@renderer/assets/images/providers/netease-youdao.svg'
 import NomicLogo from '@renderer/assets/images/providers/nomic.png'
 import ZhipuProviderLogo from '@renderer/assets/images/providers/zhipu.png'
 import type { Model } from '@renderer/types'
 
 export function getModelLogoById(modelId: string): string | undefined {
-  // FIXME: This is always true. Either remove it or fetch it.
-  const isLight = true
-
   if (!modelId) {
     return undefined
   }
 
   // key is regex
   const logoMap = {
-    pixtral: isLight ? PixtralModelLogo : PixtralModelLogoDark,
-    jina: isLight ? JinaModelLogo : JinaModelLogoDark,
-    abab: isLight ? MinimaxModelLogo : MinimaxModelLogoDark,
-    minimax: isLight ? MinimaxModelLogo : MinimaxModelLogoDark,
-    'm2-her': isLight ? MinimaxModelLogo : MinimaxModelLogoDark,
-    veo: isLight ? GeminiModelLogo : GeminiModelLogoDark,
-    o1: isLight ? ChatGPTo1ModelLogo : ChatGPTo1ModelLogoDark,
-    o3: isLight ? ChatGPTo1ModelLogo : ChatGPTo1ModelLogoDark,
-    o4: isLight ? ChatGPTo1ModelLogo : ChatGPTo1ModelLogoDark,
+    pixtral: PixtralModelLogo,
+    jina: JinaModelLogo,
+    abab: MinimaxModelLogo,
+    minimax: MinimaxModelLogo,
+    'm2-her': MinimaxModelLogo,
+    veo: GeminiModelLogo,
+    o1: ChatGPTo1ModelLogo,
+    o3: ChatGPTo1ModelLogo,
+    o4: ChatGPTo1ModelLogo,
     'gpt-image-2': ChatGPTImage2ModelLogo,
     'gpt-image': ChatGPTImageModelLogo,
-    'gpt-3': isLight ? ChatGPT35ModelLogo : ChatGPT35ModelLogoDark,
-    'gpt-4': isLight ? ChatGPT4ModelLogo : ChatGPT4ModelLogoDark,
+    'gpt-3': ChatGPT35ModelLogo,
+    'gpt-4': ChatGPT4ModelLogo,
     'gpt-5-mini': GPT5MiniModelLogo,
     'gpt-5-nano': GPT5NanoModelLogo,
     'gpt-5-chat': GPT5ChatModelLogo,
@@ -196,111 +118,111 @@ export function getModelLogoById(modelId: string): string | undefined {
     'gpt-5.1-chat': GPT51ChatModelLogo,
     'gpt-5.1': GPT51ModelLogo,
     'gpt-5': GPT5ModelLogo,
-    gpts: isLight ? ChatGPT4ModelLogo : ChatGPT4ModelLogoDark,
-    'gpt-oss(?::|-[\\w-]+)': isLight ? ChatGptModelLogo : ChatGptModelLogoDark,
-    'text-moderation': isLight ? ChatGptModelLogo : ChatGptModelLogoDark,
-    'babbage-': isLight ? ChatGptModelLogo : ChatGptModelLogoDark,
-    '(sora-|sora_)': isLight ? ChatGptModelLogo : ChatGptModelLogoDark,
-    '(^|/)omni-': isLight ? ChatGptModelLogo : ChatGptModelLogoDark,
-    'Embedding-V1': isLight ? WenxinModelLogo : WenxinModelLogoDark,
-    'text-embedding-v': isLight ? QwenModelLogo : QwenModelLogoDark,
-    'text-embedding': isLight ? ChatGptModelLogo : ChatGptModelLogoDark,
-    'davinci-': isLight ? ChatGptModelLogo : ChatGptModelLogoDark,
-    glm: isLight ? ChatGLMModelLogo : ChatGLMModelLogoDark,
-    deepseek: isLight ? DeepSeekModelLogo : DeepSeekModelLogoDark,
-    '(qwen|qwq|qwq-|qvq-|wan-|tongyi)': isLight ? QwenModelLogo : QwenModelLogoDark,
-    gemma: isLight ? GemmaModelLogo : GemmaModelLogoDark,
-    '(^|/)yi(?=[\\s-]|$)': isLight ? YiModelLogo : YiModelLogoDark,
-    llama: isLight ? LlamaModelLogo : LlamaModelLogoDark,
-    mixtral: isLight ? MistralModelLogo : MistralModelLogo,
-    mistral: isLight ? MistralModelLogo : MistralModelLogoDark,
+    gpts: ChatGPT4ModelLogo,
+    'gpt-oss(?::|-[\\w-]+)': ChatGptModelLogo,
+    'text-moderation': ChatGptModelLogo,
+    'babbage-': ChatGptModelLogo,
+    '(sora-|sora_)': ChatGptModelLogo,
+    '(^|/)omni-': ChatGptModelLogo,
+    'Embedding-V1': WenxinModelLogo,
+    'text-embedding-v': QwenModelLogo,
+    'text-embedding': ChatGptModelLogo,
+    'davinci-': ChatGptModelLogo,
+    glm: ChatGLMModelLogo,
+    deepseek: DeepSeekModelLogo,
+    '(qwen|qwq|qwq-|qvq-|wan-|tongyi)': QwenModelLogo,
+    gemma: GemmaModelLogo,
+    '(^|/)yi(?=[\\s-]|$)': YiModelLogo,
+    llama: LlamaModelLogo,
+    mixtral: MistralModelLogo,
+    mistral: MistralModelLogo,
     codestral: CodestralModelLogo,
-    ministral: isLight ? MistralModelLogo : MistralModelLogoDark,
-    magistral: isLight ? MistralModelLogo : MistralModelLogoDark,
-    moonshot: isLight ? MoonshotModelLogo : MoonshotModelLogoDark,
-    kimi: isLight ? MoonshotModelLogo : MoonshotModelLogoDark,
-    phi: isLight ? MicrosoftModelLogo : MicrosoftModelLogoDark,
-    baichuan: isLight ? BaichuanModelLogo : BaichuanModelLogoDark,
-    '(claude|anthropic-)': isLight ? ClaudeModelLogo : ClaudeModelLogoDark,
-    gemini: isLight ? GeminiModelLogo : GeminiModelLogoDark,
-    bison: isLight ? PalmModelLogo : PalmModelLogoDark,
-    palm: isLight ? PalmModelLogo : PalmModelLogoDark,
-    step: isLight ? StepModelLogo : StepModelLogoDark,
-    hailuo: isLight ? HailuoModelLogo : HailuoModelLogoDark,
-    doubao: isLight ? DoubaoModelLogo : DoubaoModelLogoDark,
-    seedream: isLight ? DoubaoModelLogo : DoubaoModelLogoDark,
-    'ep-202': isLight ? DoubaoModelLogo : DoubaoModelLogoDark,
-    cohere: isLight ? CohereModelLogo : CohereModelLogoDark,
-    command: isLight ? CohereModelLogo : CohereModelLogoDark,
-    minicpm: isLight ? MinicpmModelLogo : MinicpmModelLogoDark,
-    '360': isLight ? Ai360ModelLogo : Ai360ModelLogoDark,
-    aimass: isLight ? AimassModelLogo : AimassModelLogoDark,
-    codegeex: isLight ? CodegeexModelLogo : CodegeexModelLogoDark,
-    copilot: isLight ? CopilotModelLogo : CopilotModelLogoDark,
-    creative: isLight ? CopilotModelLogo : CopilotModelLogoDark,
-    balanced: isLight ? CopilotModelLogo : CopilotModelLogoDark,
-    precise: isLight ? CopilotModelLogo : CopilotModelLogoDark,
-    dalle: isLight ? DalleModelLogo : DalleModelLogoDark,
-    'dall-e': isLight ? DalleModelLogo : DalleModelLogoDark,
-    dbrx: isLight ? DbrxModelLogo : DbrxModelLogo,
-    flashaudio: isLight ? FlashaudioModelLogo : FlashaudioModelLogoDark,
-    flux: isLight ? FluxModelLogo : FluxModelLogoDark,
-    grok: isLight ? GrokModelLogo : GrokModelLogoDark,
-    hunyuan: isLight ? HunyuanModelLogo : HunyuanModelLogoDark,
-    internlm: isLight ? InternlmModelLogo : InternlmModelLogoDark,
+    ministral: MistralModelLogo,
+    magistral: MistralModelLogo,
+    moonshot: MoonshotModelLogo,
+    kimi: MoonshotModelLogo,
+    phi: MicrosoftModelLogo,
+    baichuan: BaichuanModelLogo,
+    '(claude|anthropic-)': ClaudeModelLogo,
+    gemini: GeminiModelLogo,
+    bison: PalmModelLogo,
+    palm: PalmModelLogo,
+    step: StepModelLogo,
+    hailuo: HailuoModelLogo,
+    doubao: DoubaoModelLogo,
+    seedream: DoubaoModelLogo,
+    'ep-202': DoubaoModelLogo,
+    cohere: CohereModelLogo,
+    command: CohereModelLogo,
+    minicpm: MinicpmModelLogo,
+    '360': Ai360ModelLogo,
+    aimass: AimassModelLogo,
+    codegeex: CodegeexModelLogo,
+    copilot: CopilotModelLogo,
+    creative: CopilotModelLogo,
+    balanced: CopilotModelLogo,
+    precise: CopilotModelLogo,
+    dalle: DalleModelLogo,
+    'dall-e': DalleModelLogo,
+    dbrx: DbrxModelLogo,
+    flashaudio: FlashaudioModelLogo,
+    flux: FluxModelLogo,
+    grok: GrokModelLogo,
+    hunyuan: HunyuanModelLogo,
+    internlm: InternlmModelLogo,
     internvl: InternvlModelLogo,
-    llava: isLight ? LLavaModelLogo : LLavaModelLogoDark,
-    magic: isLight ? MagicModelLogo : MagicModelLogoDark,
-    midjourney: isLight ? MidjourneyModelLogo : MidjourneyModelLogoDark,
-    'mj-': isLight ? MidjourneyModelLogo : MidjourneyModelLogoDark,
-    'tao-': isLight ? WenxinModelLogo : WenxinModelLogoDark,
-    'ernie-': isLight ? WenxinModelLogo : WenxinModelLogoDark,
-    voice: isLight ? FlashaudioModelLogo : FlashaudioModelLogoDark,
-    'tts-1': isLight ? ChatGptModelLogo : ChatGptModelLogoDark,
-    'whisper-': isLight ? ChatGptModelLogo : ChatGptModelLogoDark,
-    'stable-': isLight ? StabilityModelLogo : StabilityModelLogoDark,
-    sd2: isLight ? StabilityModelLogo : StabilityModelLogoDark,
-    sd3: isLight ? StabilityModelLogo : StabilityModelLogoDark,
-    sdxl: isLight ? StabilityModelLogo : StabilityModelLogoDark,
-    sparkdesk: isLight ? SparkDeskModelLogo : SparkDeskModelLogoDark,
-    generalv: isLight ? SparkDeskModelLogo : SparkDeskModelLogoDark,
-    wizardlm: isLight ? MicrosoftModelLogo : MicrosoftModelLogoDark,
-    microsoft: isLight ? MicrosoftModelLogo : MicrosoftModelLogoDark,
-    hermes: isLight ? NousResearchModelLogo : NousResearchModelLogoDark,
-    gryphe: isLight ? GrypheModelLogo : GrypheModelLogoDark,
-    suno: isLight ? SunoModelLogo : SunoModelLogoDark,
-    chirp: isLight ? SunoModelLogo : SunoModelLogoDark,
-    luma: isLight ? LumaModelLogo : LumaModelLogoDark,
-    keling: isLight ? KeLingModelLogo : KeLingModelLogoDark,
-    'vidu-': isLight ? ViduModelLogo : ViduModelLogoDark,
-    ai21: isLight ? Ai21ModelLogo : Ai21ModelLogoDark,
-    'jamba-': isLight ? Ai21ModelLogo : Ai21ModelLogoDark,
-    mythomax: isLight ? GrypheModelLogo : GrypheModelLogoDark,
-    nvidia: isLight ? NvidiaModelLogo : NvidiaModelLogoDark,
-    dianxin: isLight ? DianxinModelLogo : DianxinModelLogoDark,
-    tele: isLight ? TeleModelLogo : TeleModelLogoDark,
-    adept: isLight ? AdeptModelLogo : AdeptModelLogoDark,
-    aisingapore: isLight ? AisingaporeModelLogo : AisingaporeModelLogoDark,
-    bigcode: isLight ? BigcodeModelLogo : BigcodeModelLogoDark,
-    mediatek: isLight ? MediatekModelLogo : MediatekModelLogoDark,
-    upstage: isLight ? UpstageModelLogo : UpstageModelLogoDark,
-    rakutenai: isLight ? RakutenaiModelLogo : RakutenaiModelLogoDark,
-    ibm: isLight ? IbmModelLogo : IbmModelLogoDark,
-    'google/': isLight ? GoogleModelLogo : GoogleModelLogoDark,
-    xirang: isLight ? XirangModelLogo : XirangModelLogoDark,
-    hugging: isLight ? HuggingfaceModelLogo : HuggingfaceModelLogoDark,
+    llava: LLavaModelLogo,
+    magic: MagicModelLogo,
+    midjourney: MidjourneyModelLogo,
+    'mj-': MidjourneyModelLogo,
+    'tao-': WenxinModelLogo,
+    'ernie-': WenxinModelLogo,
+    voice: FlashaudioModelLogo,
+    'tts-1': ChatGptModelLogo,
+    'whisper-': ChatGptModelLogo,
+    'stable-': StabilityModelLogo,
+    sd2: StabilityModelLogo,
+    sd3: StabilityModelLogo,
+    sdxl: StabilityModelLogo,
+    sparkdesk: SparkDeskModelLogo,
+    generalv: SparkDeskModelLogo,
+    wizardlm: MicrosoftModelLogo,
+    microsoft: MicrosoftModelLogo,
+    hermes: NousResearchModelLogo,
+    gryphe: GrypheModelLogo,
+    suno: SunoModelLogo,
+    chirp: SunoModelLogo,
+    luma: LumaModelLogo,
+    keling: KeLingModelLogo,
+    'vidu-': ViduModelLogo,
+    ai21: Ai21ModelLogo,
+    'jamba-': Ai21ModelLogo,
+    mythomax: GrypheModelLogo,
+    nvidia: NvidiaModelLogo,
+    dianxin: DianxinModelLogo,
+    tele: TeleModelLogo,
+    adept: AdeptModelLogo,
+    aisingapore: AisingaporeModelLogo,
+    bigcode: BigcodeModelLogo,
+    mediatek: MediatekModelLogo,
+    upstage: UpstageModelLogo,
+    rakutenai: RakutenaiModelLogo,
+    ibm: IbmModelLogo,
+    'google/': GoogleModelLogo,
+    xirang: XirangModelLogo,
+    hugging: HuggingfaceModelLogo,
     youdao: YoudaoLogo,
     'embedding-3': ZhipuProviderLogo,
-    embedding: isLight ? EmbeddingModelLogo : EmbeddingModelLogoDark,
-    perplexity: isLight ? PerplexityModelLogo : PerplexityModelLogoDark,
-    sonar: isLight ? PerplexityModelLogo : PerplexityModelLogoDark,
+    embedding: EmbeddingModelLogo,
+    perplexity: PerplexityModelLogo,
+    sonar: PerplexityModelLogo,
     'bge-': BgeModelLogo,
     'voyage-': VoyageModelLogo,
-    tokenflux: isLight ? TokenFluxModelLogo : TokenFluxModelLogoDark,
+    tokenflux: TokenFluxModelLogo,
     'nomic-': NomicLogo,
     'pangu-': PanguModelLogo,
-    cogview: isLight ? ZhipuModelLogo : ZhipuModelLogoDark,
-    zhipu: isLight ? ZhipuModelLogo : ZhipuModelLogoDark,
+    cogview: ZhipuModelLogo,
+    zhipu: ZhipuModelLogo,
     longcat: LongCatAppLogo,
     bytedance: BytedanceModelLogo,
     ling: LingModelLogo,


### PR DESCRIPTION
清理 `logo.ts` 中的死代码：

- 移除永远为 `true` 的 `const isLight = true` 和 FIXME 注释
- 将所有 `isLight ? X : Y` 简化为 `X`
- 移除 44 个不再使用的 Dark logo import
- 净减少约 80 行代码

逻辑行为完全不变，仅清理冗余代码。