### PR TITLE
fix: correct return type of getProviderByModelId to Provider | undefined

### DIFF
--- a/src/renderer/src/services/AssistantService.ts
+++ b/src/renderer/src/services/AssistantService.ts
@@ -208,11 +208,10 @@ export function getProviderByModel(model?: Model): Provider {
   return provider
 }
 
-// FIXME: This function may return undefined but as Provider
-export function getProviderByModelId(modelId?: string) {
+export function getProviderByModelId(modelId?: string): Provider | undefined {
   const providers = getStoreProviders()
   const _modelId = modelId || getDefaultModel().id
-  return providers.find((p) => p.models.find((m) => m.id === _modelId)) as Provider
+  return providers.find((p) => p.models.find((m) => m.id === _modelId))
 }
 
 /**


### PR DESCRIPTION
修复 `getProviderByModelId` 的返回类型：

- 移除 `as Provider` 不安全强制转换
- 返回类型修正为 `Provider | undefined`
- 移除 FIXME 注释

该函数使用 `.find()` 查找 provider，可能返回 `undefined`，原类型对调用者不诚实。