### PR TITLE
fix: replace @ts-ignore with @ts-expect-error in messageBlock.ts

### DIFF
--- a/src/renderer/src/store/messageBlock.ts
+++ b/src/renderer/src/store/messageBlock.ts
@@ -47,7 +47,7 @@ const initialState = messageBlocksAdapter.getInitialState({
 })
 
 // 3. 创建 Slice
-// @ts-ignore ignore
+// @ts-expect-error complex generic inference from createSlice
 export const messageBlocksSlice = createSlice({
   name: 'messageBlocks',
   initialState,


### PR DESCRIPTION
将 `messageBlock.ts` 中的 `@ts-ignore` 替换为 `@ts-expect-error`：

- 使用更严格的类型抑制（如果类型修复后会提示移除）
- 注释更清晰：说明原因是 createSlice 的复杂泛型推断