### PR TITLE
fix(models): support Claude Opus 4.8 adaptive thinking

### DIFF
--- a/src/renderer/aiCore/prepareParams/modelParameters.ts
+++ b/src/renderer/aiCore/prepareParams/modelParameters.ts
@@ -6,7 +6,7 @@
 import { loggerService } from '@logger'
 import {
   isClaude46SeriesModel,
-  isClaude47SeriesModel,
+  isClaudeOpus47PlusModel,
   isClaudeReasoningModel,
   isGemini3Model,
   isMaxTemperatureOneModel,
@@ -33,7 +33,7 @@ const logger = loggerService.withContext('modelParameters')
  * Retrieves the temperature parameter, adapting it based on assistant.settings and model capabilities.
  * - Disabled for Gemini 3.x models.
  * - Disabled when enableTemperature is off.
- * - Disabled unconditionally for Claude Opus 4.7 (rejects sampling params with HTTP 400).
+ * - Disabled unconditionally for Claude Opus 4.7+ (rejects sampling params with HTTP 400).
  * - Disabled for Claude reasoning models when reasoning effort is set (excluding 'default' and 'none').
  * - Disabled for models that do not support temperature.
  * - Clamped to 1 for models with max temperature of 1.
@@ -50,9 +50,9 @@ export function getTemperature(assistant: Assistant, model: Model): number | und
     return undefined
   }
 
-  // Claude Opus 4.7 rejects sampling params (temperature/top_p/top_k) with HTTP 400
+  // Claude Opus 4.7+ rejects sampling params (temperature/top_p/top_k) with HTTP 400
   // regardless of reasoning settings. See Vercel AI SDK PR #14529.
-  if (isClaude47SeriesModel(model)) {
+  if (isClaudeOpus47PlusModel(model)) {
     logger.info(`Model ${model.id} rejects sampling parameters, disabling temperature`)
     return undefined
   }
@@ -92,7 +92,7 @@ export function getTemperature(assistant: Assistant, model: Model): number | und
  * Retrieves the TopP parameter, adapting it based on assistant.settings and model capabilities.
  * - Disabled for Gemini 3.x models.
  * - Disabled when enableTopP is off.
- * - Disabled unconditionally for Claude Opus 4.7 (rejects sampling params with HTTP 400).
+ * - Disabled unconditionally for Claude Opus 4.7+ (rejects sampling params with HTTP 400).
  * - Disabled for models that do not support TopP.
  * - Disabled for mutually exclusive models when temperature is enabled.
  * - Clamped to [0.95, 1] for Claude reasoning models with reasoning effort set (excluding 'default' and 'none').
@@ -109,8 +109,8 @@ export function getTopP(assistant: Assistant, model: Model): number | undefined 
     return undefined
   }
 
-  // Claude Opus 4.7 rejects sampling params unconditionally (see getTemperature).
-  if (isClaude47SeriesModel(model)) {
+  // Claude Opus 4.7+ rejects sampling params unconditionally (see getTemperature).
+  if (isClaudeOpus47PlusModel(model)) {
     logger.info(`Model ${model.id} rejects sampling parameters, disabling topP`)
     return undefined
   }
@@ -148,7 +148,7 @@ export function getTopP(assistant: Assistant, model: Model): number | undefined 
 
 /**
  * Filters AI SDK standard parameters extracted from custom parameters, removing any
- * the model rejects. Currently strips `topK` for Gemini 3.x models and Claude Opus 4.7
+ * the model rejects. Currently strips `topK` for Gemini 3.x models and Claude Opus 4.7+
  * since both reject or discourage sampling params.
  */
 export function filterStandardParams(
@@ -161,7 +161,7 @@ export function filterStandardParams(
     return rest
   }
 
-  if (isClaude47SeriesModel(model) && 'topK' in standardParams) {
+  if (isClaudeOpus47PlusModel(model) && 'topK' in standardParams) {
     const { topK, ...rest } = standardParams
     logger.info(`Model ${model.id} rejects sampling parameters, dropping topK=${topK} from custom params`)
     return rest
@@ -192,13 +192,13 @@ export function getMaxTokens(assistant: Assistant, model: Model): number | undef
   }
 
   const provider = getProviderByModel(model)
-  // Claude 4.6 / 4.7 use adaptive thinking and do not send budgetTokens, so the
+  // Claude 4.6 / 4.7+ use adaptive thinking and do not send budgetTokens, so the
   // AI SDK does not add budget back to maxOutputTokens. Skip the subtraction to avoid
   // incorrectly reducing max_tokens.
   if (
     isSupportedThinkingTokenClaudeModel(model) &&
     !isClaude46SeriesModel(model) &&
-    !isClaude47SeriesModel(model) &&
+    !isClaudeOpus47PlusModel(model) &&
     ['anthropic', 'aws-bedrock'].includes(provider.type)
   ) {
     const { reasoning_effort: reasoningEffort } = assistantSettings

--- a/src/renderer/aiCore/utils/__tests__/reasoning.test.ts
+++ b/src/renderer/aiCore/utils/__tests__/reasoning.test.ts
@@ -1014,6 +1014,31 @@ describe('reasoning utils', () => {
       })
     })
 
+    it('should use adaptive thinking with native effort for Claude Opus 4.8 (regression: #15412)', async () => {
+      const { isReasoningModel, isSupportedThinkingTokenClaudeModel } = await import('@renderer/config/models')
+
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+      vi.mocked(isSupportedThinkingTokenClaudeModel).mockReturnValue(true)
+
+      const model: Model = {
+        id: 'claude-opus-4-8',
+        name: 'Claude Opus 4.8',
+        provider: SystemProviderIds.anthropic
+      } as Model
+
+      const assistant: Assistant = {
+        id: 'test',
+        name: 'Test',
+        settings: { reasoning_effort: 'low' }
+      } as Assistant
+
+      const result = getAnthropicReasoningParams(assistant, model)
+      expect(result).toEqual({
+        thinking: { type: 'adaptive', display: 'summarized' },
+        effort: 'low'
+      })
+    })
+
     it('should use fallback budgetTokens when findTokenLimit returns undefined for Claude model', async () => {
       const { isReasoningModel, isSupportedThinkingTokenClaudeModel, findTokenLimit } = await import(
         '@renderer/config/models'

--- a/src/renderer/aiCore/utils/reasoning.ts
+++ b/src/renderer/aiCore/utils/reasoning.ts
@@ -11,7 +11,7 @@ import {
   GEMINI_FLASH_MODEL_REGEX,
   getModelSupportedReasoningEffortOptions,
   isClaude46SeriesModel,
-  isClaude47SeriesModel,
+  isClaudeOpus47PlusModel,
   isDeepSeekHybridInferenceModel,
   isDeepSeekV4PlusModel,
   isDoubaoSeed18Model,
@@ -729,10 +729,10 @@ export function getAnthropicReasoningParams(
 
   // Claude reasoning parameters
   if (isSupportedThinkingTokenClaudeModel(model)) {
-    // Claude 4.7: adaptive thinking + native 'xhigh' effort.
+    // Claude Opus 4.7+: adaptive thinking + native 'xhigh' effort.
     // Also requires thinking.display: 'summarized' — API defaults to 'omitted'
     // (no reasoning text in response), which would break Cherry's thinking UI.
-    if (isClaude47SeriesModel(model)) {
+    if (isClaudeOpus47PlusModel(model)) {
       const effort47Map = {
         default: undefined,
         auto: undefined,
@@ -1005,10 +1005,10 @@ export function getBedrockReasoningParams(
     return {}
   }
 
-  // Claude 4.6 / 4.7 use adaptive thinking + maxReasoningEffort.
-  // Bedrock's maxReasoningEffort enum doesn't yet include 'xhigh', so 4.7 xhigh
+  // Claude 4.6 / 4.7+ use adaptive thinking + maxReasoningEffort.
+  // Bedrock's maxReasoningEffort enum doesn't yet include 'xhigh', so 4.7+ xhigh
   // falls back to 'max' here (matches the 4.6 mapping).
-  if (isClaude46SeriesModel(model) || isClaude47SeriesModel(model)) {
+  if (isClaude46SeriesModel(model) || isClaudeOpus47PlusModel(model)) {
     const effortMap = {
       auto: undefined,
       minimal: 'low',

--- a/src/renderer/config/models/__tests__/utils.test.ts
+++ b/src/renderer/config/models/__tests__/utils.test.ts
@@ -10,7 +10,7 @@ import {
   groupQwenModels,
   isAnthropicModel,
   isClaude46SeriesModel,
-  isClaude47SeriesModel,
+  isClaudeOpus47PlusModel,
   isDeepSeekModel,
   isGemini3FlashModel,
   isGemini3Model,
@@ -789,42 +789,52 @@ describe('model utils', () => {
     })
   })
 
-  describe('Claude 4.7 Models Detection', () => {
-    describe('isClaude47SeriesModel', () => {
+  describe('Claude 4.7+ Models Detection', () => {
+    describe('isClaudeOpus47PlusModel', () => {
       it('detects Opus 4.7 in direct API format', () => {
-        expect(isClaude47SeriesModel(createModel({ id: 'claude-opus-4-7' }))).toBe(true)
-        expect(isClaude47SeriesModel(createModel({ id: 'claude-opus-4.7' }))).toBe(true)
+        expect(isClaudeOpus47PlusModel(createModel({ id: 'claude-opus-4-7' }))).toBe(true)
+        expect(isClaudeOpus47PlusModel(createModel({ id: 'claude-opus-4.7' }))).toBe(true)
       })
 
       it('detects Opus 4.7 with version suffixes', () => {
-        expect(isClaude47SeriesModel(createModel({ id: 'claude-opus-4-7-20260401' }))).toBe(true)
-        expect(isClaude47SeriesModel(createModel({ id: 'claude-opus-4-7-preview' }))).toBe(true)
+        expect(isClaudeOpus47PlusModel(createModel({ id: 'claude-opus-4-7-20260401' }))).toBe(true)
+        expect(isClaudeOpus47PlusModel(createModel({ id: 'claude-opus-4-7-preview' }))).toBe(true)
       })
 
       it('detects Opus 4.7 in AWS Bedrock format', () => {
-        expect(isClaude47SeriesModel(createModel({ id: 'anthropic.claude-opus-4-7-v1' }))).toBe(true)
-        expect(isClaude47SeriesModel(createModel({ id: 'anthropic.claude-opus-4-7-v2:0' }))).toBe(true)
+        expect(isClaudeOpus47PlusModel(createModel({ id: 'anthropic.claude-opus-4-7-v1' }))).toBe(true)
+        expect(isClaudeOpus47PlusModel(createModel({ id: 'anthropic.claude-opus-4-7-v2:0' }))).toBe(true)
       })
 
       it('detects Opus 4.7 with provider prefix', () => {
-        expect(isClaude47SeriesModel(createModel({ id: 'anthropic/claude-opus-4-7' }))).toBe(true)
+        expect(isClaudeOpus47PlusModel(createModel({ id: 'anthropic/claude-opus-4-7' }))).toBe(true)
       })
 
       it('handles case insensitivity', () => {
-        expect(isClaude47SeriesModel(createModel({ id: 'CLAUDE-OPUS-4-7' }))).toBe(true)
-        expect(isClaude47SeriesModel(createModel({ id: 'Claude-Opus-4.7' }))).toBe(true)
+        expect(isClaudeOpus47PlusModel(createModel({ id: 'CLAUDE-OPUS-4-7' }))).toBe(true)
+        expect(isClaudeOpus47PlusModel(createModel({ id: 'Claude-Opus-4.7' }))).toBe(true)
       })
 
       it('returns false for other Claude models', () => {
-        expect(isClaude47SeriesModel(createModel({ id: 'claude-opus-4-6' }))).toBe(false)
-        expect(isClaude47SeriesModel(createModel({ id: 'claude-opus-4-5' }))).toBe(false)
-        expect(isClaude47SeriesModel(createModel({ id: 'claude-sonnet-4-7' }))).toBe(false)
-        expect(isClaude47SeriesModel(createModel({ id: 'claude-haiku-4-7' }))).toBe(false)
+        expect(isClaudeOpus47PlusModel(createModel({ id: 'claude-opus-4-6' }))).toBe(false)
+        expect(isClaudeOpus47PlusModel(createModel({ id: 'claude-opus-4-5' }))).toBe(false)
+        expect(isClaudeOpus47PlusModel(createModel({ id: 'claude-sonnet-4-7' }))).toBe(false)
+        expect(isClaudeOpus47PlusModel(createModel({ id: 'claude-haiku-4-7' }))).toBe(false)
       })
 
       it('returns false for undefined and null', () => {
-        expect(isClaude47SeriesModel(undefined as unknown as Model)).toBe(false)
-        expect(isClaude47SeriesModel(null as unknown as Model)).toBe(false)
+        expect(isClaudeOpus47PlusModel(undefined as unknown as Model)).toBe(false)
+        expect(isClaudeOpus47PlusModel(null as unknown as Model)).toBe(false)
+      })
+
+      it('detects Opus 4.8 and later minor versions', () => {
+        expect(isClaudeOpus47PlusModel(createModel({ id: 'claude-opus-4-8' }))).toBe(true)
+        expect(isClaudeOpus47PlusModel(createModel({ id: 'claude-opus-4.8' }))).toBe(true)
+        expect(isClaudeOpus47PlusModel(createModel({ id: 'claude-opus-4-9' }))).toBe(true)
+        expect(isClaudeOpus47PlusModel(createModel({ id: 'claude-opus-4-10' }))).toBe(true)
+        expect(isClaudeOpus47PlusModel(createModel({ id: 'anthropic.claude-opus-4-8-v1' }))).toBe(true)
+        expect(isClaudeOpus47PlusModel(createModel({ id: 'anthropic/claude-opus-4-8' }))).toBe(true)
+        expect(isClaudeOpus47PlusModel(createModel({ id: 'claude-opus-4-8-20260601' }))).toBe(true)
       })
     })
   })

--- a/src/renderer/config/models/default.ts
+++ b/src/renderer/config/models/default.ts
@@ -380,6 +380,12 @@ export const SYSTEM_MODELS: Record<SystemProviderId | 'defaultModel', Model[]> =
   ],
   anthropic: [
     {
+      id: 'claude-opus-4-8',
+      provider: 'anthropic',
+      name: 'Claude Opus 4.8',
+      group: 'Claude 4.8'
+    },
+    {
       id: 'claude-opus-4-7',
       provider: 'anthropic',
       name: 'Claude Opus 4.7',

--- a/src/renderer/config/models/reasoning.ts
+++ b/src/renderer/config/models/reasoning.ts
@@ -23,7 +23,7 @@ import {
 import {
   GEMINI_FLASH_MODEL_REGEX,
   isClaude46SeriesModel,
-  isClaude47SeriesModel,
+  isClaudeOpus47PlusModel,
   isGemini3FlashModel,
   isGemini3ProModel,
   isGemini31FlashLiteModel,
@@ -141,9 +141,9 @@ const _getThinkModelType = (model: Model): ThinkingModelType => {
   const modelId = getLowerBaseModelName(model.id)
   if (isClaudeReasoningModel(model)) {
     thinkingModelType = 'claude'
-    // 4.7 reuses the 4.6 effort list (low/medium/high/xhigh); provider-level
-    // mapping still distinguishes them (4.7 sends native 'xhigh', 4.6 sends 'max').
-    if (isClaude46SeriesModel(model) || isClaude47SeriesModel(model)) {
+    // 4.7+ reuses the 4.6 effort list (low/medium/high/xhigh); provider-level
+    // mapping still distinguishes them (4.7+ sends native 'xhigh', 4.6 sends 'max').
+    if (isClaude46SeriesModel(model) || isClaudeOpus47PlusModel(model)) {
       thinkingModelType = 'claude46'
     }
   } else if (isOpenAIDeepResearchModel(model)) {

--- a/src/renderer/config/models/utils.ts
+++ b/src/renderer/config/models/utils.ts
@@ -432,14 +432,21 @@ export function isClaude46SeriesModel(model: Model | undefined | null): boolean 
 }
 
 /**
- * Check if the model is Claude Opus 4.7.
- * 4.7 rejects temperature/top_p/top_k and natively supports xhigh reasoning effort.
+ * Check if the model is Claude Opus 4.7 or later (4.7, 4.8, ...).
+ * Starting with Opus 4.7, Anthropic switched to adaptive thinking with an output
+ * effort config: these models reject temperature/top_p/top_k, natively support the
+ * 'xhigh' reasoning effort, and reject `thinking.type: 'enabled'` (must use
+ * `thinking.type: 'adaptive'` + effort). This is treated as a long-term Anthropic
+ * direction, so the matcher covers the whole 4.7+ minor-version range rather than a
+ * single hardcoded version.
  */
-export function isClaude47SeriesModel(model: Model | undefined | null): boolean {
+export function isClaudeOpus47PlusModel(model: Model | undefined | null): boolean {
   if (!model) {
     return false
   }
   const modelId = getLowerBaseModelName(model.id, '/')
-  const regex = /(?:anthropic\.)?claude-opus-4[.-]7(?:[@\-:][\w\-:]+)?$/i
+  // Matches Opus minor version >= 7: single digit 7-9, or any two-or-more digit
+  // minor (10, 11, ...). Excludes 4.6 and below.
+  const regex = /(?:anthropic\.)?claude-opus-4[.-](?:[7-9]|\d{2,})(?:[@\-:][\w\-:]+)?$/i
   return regex.test(modelId)
 }

--- a/src/shared/utils/model.ts
+++ b/src/shared/utils/model.ts
@@ -338,10 +338,15 @@ export const isClaude46SeriesModel = (model: Model): boolean => {
   return /(?:anthropic\.)?claude-(?:opus|sonnet)-4[.-]6(?:[@\-:][\w\-:]+)?$/i.test(id)
 }
 
-/** Check if model is Claude Opus 4.7. Rejects temperature/top_p/top_k and natively supports xhigh reasoning effort. */
-export const isClaude47SeriesModel = (model: Model): boolean => {
+/**
+ * Check if model is Claude Opus 4.7 or later (4.7, 4.8, ...). These reject
+ * temperature/top_p/top_k, natively support xhigh reasoning effort, and require
+ * `thinking.type: 'adaptive'` instead of `'enabled'`. Treated as a long-term
+ * Anthropic direction, so the matcher covers the whole 4.7+ minor-version range.
+ */
+export const isClaudeOpus47PlusModel = (model: Model): boolean => {
   const id = getLowerBaseModelName(getRawModelId(model), '/')
-  return /(?:anthropic\.)?claude-opus-4[.-]7(?:[@\-:][\w\-:]+)?$/i.test(id)
+  return /(?:anthropic\.)?claude-opus-4[.-](?:[7-9]|\d{2,})(?:[@\-:][\w\-:]+)?$/i.test(id)
 }
 
 /** Check if model is a Gemma 4 model hosted on Gemini API (supports thinking mode but no hard-off). */


### PR DESCRIPTION
### What this PR does

Before this PR:

Claude Opus 4.8 fails with HTTP 400 (`"thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort"`) whenever reasoning effort is set to anything other than `default`. The detection helper `isClaude47SeriesModel` was pinned to the exact `4.7` model id, so 4.8 fell back to the legacy `thinking.type: 'enabled'` + `budgetTokens` path that the API rejects.

After this PR:

- Renamed `isClaude47SeriesModel` → `isClaudeOpus47PlusModel` and broadened the matcher to the whole Opus **4.7+** minor-version range (`4.7`, `4.8`, `4.9`, `4.10`, …). Adaptive thinking is treated as Anthropic's long-term direction, so version-pattern matching replaces per-version hardcoding.
- Opus 4.8 now routes through the adaptive thinking + `effort` path (`thinking: { type: 'adaptive', display: 'summarized' }`) and drops `temperature`/`top_p`/`top_k` as the API requires.
- Added the `claude-opus-4-8` catalog entry (default model seed).

Fixes #15412

### Why we need it and why it was done in this way

This is the **forward-port of the v1 hotfix #15474** to `main`. The same bug exists on `main`: the live request-building path (`messageThunk` → `ApiService.buildProviderOptions` → `getAnthropicReasoningParams` → `isClaude47SeriesModel`) is still driven by ID-string matching, so 4.8 hits the rejected `enabled` format here too.

The following tradeoffs were made:

- **Version-pattern matching over per-version constants.** 4.7 introduced adaptive thinking and 4.8 keeps it, so the matcher covers `4.7+` rather than enumerating each version. Future minor bumps need no code change.

The following alternatives were considered:

- Hardcoding a `claude-opus-4-8` branch alongside `4.7` — rejected as it would need a new edit per release.

### Breaking changes

None.

### Special notes for your reviewer

**Two copies of the matcher are updated in lockstep — this is intentional:**

- `src/renderer/config/models/utils.ts` — the **live runtime** matcher. This is what actually fixes the bug; it drives the Anthropic param-building path on every request.
- `src/shared/utils/model.ts` — a **duplicate** that currently has **no runtime consumers**. It is the future canonical "vendor-pattern" home (per `packages/provider-registry`), intended to populate model schema fields (`parameterSupport`) at model-creation time, replacing the runtime ID-matching above once that migration lands.

The shared copy was still pinned to `4.7`. It does not affect the bug today (nothing calls it), but if the runtime path is later migrated onto it, the stale `4.7` regex would **silently reintroduce this exact bug** for 4.8+. Updating it now closes that trap. I have intentionally not touched the rest of the shared module's migration scope.

**Out of scope (pre-existing):** the OpenAI-compatible aggregator path (`getReasoningEffort`) sends `thinking.type: 'enabled'` for all Claude versions regardless of 4.7+; that gap predates this change and is not addressed here.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix Claude Opus 4.8 failing with an HTTP 400 error when a reasoning effort other than "default" is selected.
```
