### PR TITLE
fix(data): normalize backslash paths from cross-platform backup restores

### DIFF
--- a/src/main/data/services/AgentService.ts
+++ b/src/main/data/services/AgentService.ts
@@ -5,7 +5,7 @@ import { userModelTable } from '@data/db/schemas/userModel'
 import { defaultHandlersFor, withSqliteErrors } from '@data/db/sqliteErrors'
 import type { DbOrTx } from '@data/db/types'
 import { pinService } from '@data/services/PinService'
-import { nullsToUndefined, timestampToISO } from '@data/services/utils/rowMappers'
+import { normalizePaths, nullsToUndefined, timestampToISO } from '@data/services/utils/rowMappers'
 import { loggerService } from '@logger'
 import { DataApiErrorFactory } from '@shared/data/api'
 import {
@@ -35,7 +35,7 @@ function rowToAgent(row: AgentRow, modelName: string | null = null): AgentEntity
   return {
     ...clean,
     type: (row.type === 'cherry-claw' ? 'claude-code' : row.type) as AgentType,
-    accessiblePaths: row.accessiblePaths,
+    accessiblePaths: normalizePaths(row.accessiblePaths),
     configuration: parseConfiguration(row.configuration),
     createdAt: timestampToISO(row.createdAt),
     updatedAt: timestampToISO(row.updatedAt),

--- a/src/main/data/services/AgentSessionService.ts
+++ b/src/main/data/services/AgentSessionService.ts
@@ -6,7 +6,7 @@ import {
   type InsertAgentSessionRow as InsertSessionRow
 } from '@data/db/schemas/agentSession'
 import { defaultHandlersFor, withSqliteErrors } from '@data/db/sqliteErrors'
-import { nullsToUndefined, timestampToISO } from '@data/services/utils/rowMappers'
+import { normalizePaths, nullsToUndefined, timestampToISO } from '@data/services/utils/rowMappers'
 import { loggerService } from '@logger'
 import { DataApiErrorFactory } from '@shared/data/api'
 import {
@@ -50,7 +50,7 @@ function agentRowToSessionDefaults(row: Record<string, unknown>): {
     type: (row.type === 'cherry-claw' ? 'claude-code' : row.type) as AgentType,
     name: (row.name as string) || '',
     model: row.model as string,
-    accessiblePaths: row.accessiblePaths as string[],
+    accessiblePaths: normalizePaths(row.accessiblePaths as string[]),
     configuration: parseConfiguration(row.configuration)
   }
 }
@@ -60,7 +60,7 @@ function rowToSession(row: SessionRow): AgentSessionEntity {
   return {
     ...clean,
     agentType: (row.agentType === 'cherry-claw' ? 'claude-code' : row.agentType) as AgentType,
-    accessiblePaths: row.accessiblePaths,
+    accessiblePaths: normalizePaths(row.accessiblePaths),
     configuration: parseConfiguration(row.configuration),
     createdAt: timestampToISO(row.createdAt),
     updatedAt: timestampToISO(row.updatedAt)

--- a/src/main/data/services/utils/rowMappers.ts
+++ b/src/main/data/services/utils/rowMappers.ts
@@ -58,3 +58,13 @@ export function timestampToISO(value: number | Date): string {
 export function timestampToISOOrUndefined(value: number | Date | null | undefined): string | undefined {
   return value ? new Date(value).toISOString() : undefined
 }
+
+/**
+ * Normalize backslash paths from cross-platform backup restores.
+ * On non-Windows platforms, Windows-style `\` separators in stored paths
+ * are converted to `/` so the paths resolve correctly.
+ */
+export function normalizePaths(paths: string[]): string[] {
+  if (process.platform === 'win32') return paths
+  return paths.map((p) => p.replace(/\\/g, '/'))
+}

--- a/src/main/services/agents/skills/SkillService.ts
+++ b/src/main/services/agents/skills/SkillService.ts
@@ -9,7 +9,7 @@ import {
   type InsertAgentGlobalSkillRow
 } from '@data/db/schemas/agentGlobalSkill'
 import { agentSkillTable } from '@data/db/schemas/agentSkill'
-import { timestampToISO } from '@data/services/utils/rowMappers'
+import { normalizePaths, timestampToISO } from '@data/services/utils/rowMappers'
 import { loggerService } from '@logger'
 import { directoryExists } from '@main/utils/file'
 import { deleteDirectoryRecursive } from '@main/utils/fileOperations'
@@ -841,7 +841,8 @@ export class SkillService {
 
   private parseFirstAccessiblePath(paths: string[] | null | undefined): string | undefined {
     if (!paths || paths.length === 0) return undefined
-    return typeof paths[0] === 'string' ? paths[0] : undefined
+    const normalized = normalizePaths(paths)
+    return typeof normalized[0] === 'string' ? normalized[0] : undefined
   }
 
   private async getSkillById(id: string): Promise<InstalledSkill | null> {


### PR DESCRIPTION
## What
When a Windows backup is restored on Linux, `accessiblePaths` retains backslash separators (e.g. `\home\bubu12\.config\...`). On POSIX, these resolve to literal directory names rather than path separators, breaking agent session cwd resolution and creating garbage directories under the process CWD.

## Why
- **AgentService / AgentSessionService**: path resolution fails silently, leading to "No conversation found with session ID" errors
- **SkillService** (new in this update): `parseFirstAccessiblePath()` creates directory trees with literal backslashes in `~/Downloads/` when syncing builtin skills (reported in #15692)

## Changes
1. Extract `normalizePaths()` to `rowMappers.ts` — replaces `\` with `/` on non-Windows platforms
2. Call `normalizePaths()` in `AgentService` and `AgentSessionService` when reading `accessiblePaths` from DB
3. Call `normalizePaths()` in `SkillService.parseFirstAccessiblePath()` to prevent garbage directory creation

## Fixes
Fixes #15692