### PR TITLE
Extend Claude Opus 4.7 adaptive thinking handling to newer 4.x models

### DIFF
--- a/.changeset/claude-opus-future-thinking.md
+++ b/.changeset/claude-opus-future-thinking.md
@@ -1,0 +1,5 @@
+---
+'@cherrystudio/ai-core': patch
+---
+
+Apply the Claude Opus 4.7 adaptive-thinking parameter handling to newer Opus 4.x model ids such as `claude-opus-4-8`.

--- a/src/main/ai/utils/__tests__/modelParameters.test.ts
+++ b/src/main/ai/utils/__tests__/modelParameters.test.ts
@@ -70,11 +70,14 @@ describe('getTemperature', () => {
     expect(getTemperature(a, model)).toBeUndefined()
   })
 
-  it('disables temperature for Claude Opus 4.7 models', () => {
-    const a = makeAssistant({ temperature: 0.8 })
-    const model = makeModel({ id: 'anthropic::claude-opus-4-7-20260101', providerId: 'anthropic' })
-    expect(getTemperature(a, model)).toBeUndefined()
-  })
+  it.each(['claude-opus-4-7-20260101', 'claude-opus-4-8-20260201'])(
+    'disables temperature for Claude Opus 4.7+ model %s',
+    (modelId) => {
+      const a = makeAssistant({ temperature: 0.8 })
+      const model = makeModel({ id: `anthropic::${modelId}`, providerId: 'anthropic' })
+      expect(getTemperature(a, model)).toBeUndefined()
+    }
+  )
 })
 
 describe('getTopP', () => {
@@ -108,11 +111,14 @@ describe('getTopP', () => {
     expect(getTopP(a, model)).toBeUndefined()
   })
 
-  it('disables topP for Claude Opus 4.7 models', () => {
-    const a = makeAssistant({ enableTopP: true, topP: 0.8 })
-    const model = makeModel({ id: 'anthropic::claude-opus-4-7-20260101', providerId: 'anthropic' })
-    expect(getTopP(a, model)).toBeUndefined()
-  })
+  it.each(['claude-opus-4-7-20260101', 'claude-opus-4-8-20260201'])(
+    'disables topP for Claude Opus 4.7+ model %s',
+    (modelId) => {
+      const a = makeAssistant({ enableTopP: true, topP: 0.8 })
+      const model = makeModel({ id: `anthropic::${modelId}`, providerId: 'anthropic' })
+      expect(getTopP(a, model)).toBeUndefined()
+    }
+  )
 })
 
 describe('filterStandardParams', () => {
@@ -121,10 +127,13 @@ describe('filterStandardParams', () => {
     expect(filterStandardParams({ topK: 40, frequencyPenalty: 0.1 }, model)).toEqual({ frequencyPenalty: 0.1 })
   })
 
-  it('drops topK for Claude Opus 4.7 models', () => {
-    const model = makeModel({ id: 'anthropic::claude-opus-4-7-20260101', providerId: 'anthropic' })
-    expect(filterStandardParams({ topK: 40, frequencyPenalty: 0.1 }, model)).toEqual({ frequencyPenalty: 0.1 })
-  })
+  it.each(['claude-opus-4-7-20260101', 'claude-opus-4-8-20260201'])(
+    'drops topK for Claude Opus 4.7+ model %s',
+    (modelId) => {
+      const model = makeModel({ id: `anthropic::${modelId}`, providerId: 'anthropic' })
+      expect(filterStandardParams({ topK: 40, frequencyPenalty: 0.1 }, model)).toEqual({ frequencyPenalty: 0.1 })
+    }
+  )
 
   it('keeps topK for other models', () => {
     const input = { topK: 40 }
@@ -150,10 +159,13 @@ describe('getMaxTokens', () => {
     expect(getMaxTokens(a, model, provider)).toBe(8000)
   })
 
-  it('skips budget subtraction on Claude Opus 4.7 series (adaptive thinking)', () => {
-    const a = makeAssistant({ enableMaxTokens: true, maxTokens: 8000, reasoning_effort: 'high' })
-    const model = makeModel({ id: 'anthropic::claude-opus-4-7-20260101', providerId: 'anthropic' })
-    const provider = makeProvider({ id: 'anthropic', presetProviderId: 'anthropic' })
-    expect(getMaxTokens(a, model, provider)).toBe(8000)
-  })
+  it.each(['claude-opus-4-7-20260101', 'claude-opus-4-8-20260201'])(
+    'skips budget subtraction on Claude Opus 4.7+ model %s',
+    (modelId) => {
+      const a = makeAssistant({ enableMaxTokens: true, maxTokens: 8000, reasoning_effort: 'high' })
+      const model = makeModel({ id: `anthropic::${modelId}`, providerId: 'anthropic' })
+      const provider = makeProvider({ id: 'anthropic', presetProviderId: 'anthropic' })
+      expect(getMaxTokens(a, model, provider)).toBe(8000)
+    }
+  )
 })

--- a/src/main/ai/utils/reasoning.ts
+++ b/src/main/ai/utils/reasoning.ts
@@ -722,7 +722,7 @@ export function getAnthropicReasoningParams(
 
   // Claude reasoning parameters
   if (isSupportedThinkingTokenClaudeModel(model)) {
-    // Claude 4.7: adaptive thinking + native 'xhigh' effort.
+    // Claude 4.7+: adaptive thinking + native 'xhigh' effort.
     // Also requires thinking.display: 'summarized' — API defaults to 'omitted'
     // (no reasoning text in response), which would break Cherry's thinking UI.
     if (isClaude47SeriesModel(model)) {
@@ -1005,8 +1005,8 @@ export function getBedrockReasoningParams(
     return {}
   }
 
-  // Claude 4.6 / 4.7 use adaptive thinking + maxReasoningEffort.
-  // Bedrock's maxReasoningEffort enum doesn't yet include 'xhigh', so 4.7 xhigh
+  // Claude 4.6 / 4.7+ use adaptive thinking + maxReasoningEffort.
+  // Bedrock's maxReasoningEffort enum doesn't yet include 'xhigh', so 4.7+ xhigh
   // falls back to 'max' here (matches the 4.6 mapping).
   if (isClaude46SeriesModel(model) || isClaude47SeriesModel(model)) {
     const effortMap = {

--- a/src/shared/utils/__tests__/model.test.ts
+++ b/src/shared/utils/__tests__/model.test.ts
@@ -1,5 +1,6 @@
 import { type Model, MODEL_CAPABILITY } from '@shared/data/types/model'
 import {
+  findTokenLimit,
   inferEmbeddingFromModelId,
   inferFunctionCallingFromModelId,
   inferImageGenerationFromModelId,
@@ -8,6 +9,7 @@ import {
   inferVisionFromModelId,
   inferWebSearchFromModelId,
   isAudioModel,
+  isClaude47SeriesModel,
   isEmbeddingModel,
   isFunctionCallingModel,
   isGenerateImageModel,
@@ -215,6 +217,27 @@ describe('shared model capability helpers', () => {
     'infers image-generation capability for %s',
     (modelId) => {
       expect(inferImageGenerationFromModelId(modelId)).toBe(true)
+    }
+  )
+
+  it.each(['claude-opus-4-7', 'claude-opus-4.8', 'claude-opus-4-10', 'anthropic.claude-opus-4-8-v1'])(
+    'detects Claude Opus 4.7+ sampling-restricted models for %s',
+    (modelId) => {
+      expect(isClaude47SeriesModel({ ...createModel(), apiModelId: modelId, id: `anthropic::${modelId}` })).toBe(true)
+    }
+  )
+
+  it.each(['claude-opus-4-6', 'claude-opus-4-5', 'claude-opus-4-20250514', 'claude-sonnet-4-8'])(
+    'does not treat %s as Claude Opus 4.7+',
+    (modelId) => {
+      expect(isClaude47SeriesModel({ ...createModel(), apiModelId: modelId, id: `anthropic::${modelId}` })).toBe(false)
+    }
+  )
+
+  it.each(['claude-opus-4-7', 'claude-opus-4.8', 'anthropic.claude-opus-4-8-v1', 'claude-opus-4-10@20261201'])(
+    'uses 128K thinking-token limits for Claude Opus 4.7+ id %s',
+    (modelId) => {
+      expect(findTokenLimit(modelId)).toEqual({ min: 1024, max: 128_000 })
     }
   )
 })

--- a/src/shared/utils/model.ts
+++ b/src/shared/utils/model.ts
@@ -362,10 +362,10 @@ export const isClaude46SeriesModel = (model: Model): boolean => {
   return /(?:anthropic\.)?claude-(?:opus|sonnet)-4[.-]6(?:[@\-:][\w\-:]+)?$/i.test(id)
 }
 
-/** Check if model is Claude Opus 4.7. Rejects temperature/top_p/top_k and natively supports xhigh reasoning effort. */
+/** Check if model is Claude Opus 4.7 or newer. Rejects temperature/top_p/top_k and natively supports xhigh reasoning effort. */
 export const isClaude47SeriesModel = (model: Model): boolean => {
   const id = getLowerBaseModelName(getRawModelId(model), '/')
-  return /(?:anthropic\.)?claude-opus-4[.-]7(?:[@\-:][\w\-:]+)?$/i.test(id)
+  return /(?:anthropic\.)?claude-opus-4[.-](?:[7-9]|[1-9]\d)(?:[@\-:][\w\-:]+)?$/i.test(id)
 }
 
 /** Check if model is a Gemma 4 model hosted on Gemini API (supports thinking mode but no hard-off). */
@@ -841,7 +841,7 @@ const THINKING_TOKEN_MAP: Record<string, { min: number; max: number }> = {
   'qwen-max-latest$': { min: 0, max: 81_920 },
   '^qwen3\\.[5-9]': { min: 0, max: 81_920 },
   'qwen3-(?!max).*$': { min: 1024, max: 38_912 },
-  '(?:anthropic\\.)?claude-opus-4[.-]7(?:[@\\-:][\\w\\-:]+)?$': { min: 1024, max: 128_000 },
+  '(?:anthropic\\.)?claude-opus-4[.-](?:[7-9]|[1-9]\\d)(?:[@\\-:][\\w\\-:]+)?$': { min: 1024, max: 128_000 },
   '(?:anthropic\\.)?claude-opus-4[.-]6(?:[@\\-:][\\w\\-:]+)?$': { min: 1024, max: 128_000 },
   '(?:anthropic\\.)?claude-(:?sonnet|haiku)-4[.-]6.*(?:-v\\d+:\\d+)?$': { min: 1024, max: 64_000 },
   '(?:anthropic\\.)?claude-(:?haiku|sonnet|opus)-4[.-]5.*(?:-v\\d+:\\d+)?$': { min: 1024, max: 64_000 },


### PR DESCRIPTION
### Description

Extends the existing Claude Opus 4.7 handling to newer Opus 4.x model IDs such as `claude-opus-4-8`.

Opus 4.8 reports the same adaptive-thinking requirement as Opus 4.7: it rejects `thinking.type.enabled` and expects adaptive thinking with an effort setting. This patch generalizes the existing 4.7 path without applying it to 4.6, non-Opus Claude models, or date-only Opus 4 IDs such as `claude-opus-4-20250514`.

Fixes #15412.

### Changes

- Detect Claude Opus 4.7 and newer Opus 4.x subversions.
- Reuse the existing adaptive-thinking path and native `xhigh` effort handling for newer Opus 4.x IDs.
- Keep sampling parameters disabled for these Opus 4.x models.
- Preserve 128K output token limits for newer Opus 4.x models.
- Add regression coverage for 4.8, 4.10, AWS-style IDs, and date-only Opus 4 IDs that must stay on the older 4.0 path.
- Add a patch changeset.

### Verification

```powershell
corepack pnpm install --frozen-lockfile --ignore-scripts --prefer-offline
corepack pnpm exec vitest --version
corepack pnpm exec vitest run --project renderer src/renderer/config/models/__tests__/utils.test.ts src/renderer/config/models/__tests__/reasoning.test.ts
corepack pnpm exec vitest run --project renderer src/renderer/aiCore/prepareParams/__tests__/modelParameters.test.ts src/renderer/aiCore/utils/__tests__/reasoning.test.ts
corepack pnpm exec biome format --write src/renderer/aiCore/prepareParams/__tests__/modelParameters.test.ts src/renderer/aiCore/prepareParams/modelParameters.ts src/renderer/aiCore/utils/__tests__/reasoning.test.ts src/renderer/aiCore/utils/reasoning.ts src/renderer/config/models/__tests__/reasoning.test.ts src/renderer/config/models/__tests__/utils.test.ts src/renderer/config/models/reasoning.ts src/renderer/config/models/utils.ts
corepack pnpm exec biome lint src/renderer/aiCore/prepareParams/__tests__/modelParameters.test.ts src/renderer/aiCore/prepareParams/modelParameters.ts src/renderer/aiCore/utils/__tests__/reasoning.test.ts src/renderer/aiCore/utils/reasoning.ts src/renderer/config/models/__tests__/reasoning.test.ts src/renderer/config/models/__tests__/utils.test.ts src/renderer/config/models/reasoning.ts src/renderer/config/models/utils.ts
corepack pnpm exec oxlint src/renderer/aiCore/prepareParams/__tests__/modelParameters.test.ts src/renderer/aiCore/prepareParams/modelParameters.ts src/renderer/aiCore/utils/__tests__/reasoning.test.ts src/renderer/aiCore/utils/reasoning.ts src/renderer/config/models/__tests__/reasoning.test.ts src/renderer/config/models/__tests__/utils.test.ts src/renderer/config/models/reasoning.ts src/renderer/config/models/utils.ts
git diff --check
```

Results:

- Renderer model tests passed: 2 files, 519 tests.
- Renderer aiCore tests passed: 2 files, 131 tests.
- Biome format/lint passed for the changed TS files.
- Oxlint passed with 0 warnings and 0 errors for the changed TS files.
- `git diff --check` passed.

Note: the aiCore Vitest run still writes an existing renderer store startup warning about `window.api.getAppInfo` to stderr, but exits 0 after the local test stub.
