### PR TITLE
fix(types): replace any types with proper TypeScript types in main services

### DIFF
--- a/src/main/services/ExportService.ts
+++ b/src/main/services/ExportService.ts
@@ -21,6 +21,7 @@ import {
 } from 'docx'
 import { dialog } from 'electron'
 import MarkdownIt from 'markdown-it'
+import type Token from 'markdown-it/lib/token'
 
 import { fileStorage } from './FileStorage'
 
@@ -34,7 +35,7 @@ export class ExportService {
 
   private convertMarkdownToDocxElements(markdown: string) {
     const tokens = this.md.parse(markdown, {})
-    const elements: any[] = []
+    const elements: (Paragraph | Table)[] = []
     let listLevel = 0
     let currentTable: Table | null = null
     let currentRowCells: TableCell[] = []
@@ -42,7 +43,7 @@ export class ExportService {
     let tableColumnCount = 0
     let tableRows: TableRow[] = [] // Store rows temporarily
 
-    const processInlineTokens = (tokens: any[], isHeaderRow: boolean): (TextRun | ExternalHyperlink)[] => {
+    const processInlineTokens = (tokens: Token[], isHeaderRow: boolean): (TextRun | ExternalHyperlink)[] => {
       const runs: (TextRun | ExternalHyperlink)[] = []
       let linkText = ''
       let linkUrl = ''

--- a/src/main/services/KnowledgeService.ts
+++ b/src/main/services/KnowledgeService.ts
@@ -331,11 +331,11 @@ class KnowledgeService {
                   loaderTask.loaderDoneReturn = errorResult
                   return errorResult
                 })
-            } catch (e: any) {
+            } catch (e: unknown) {
               logger.error(`Preprocessing failed for ${file.name}: ${e}`)
               const errorResult: LoaderReturn = {
                 ...KnowledgeService.ERROR_LOADER_RETURN,
-                message: e.message,
+                message: e instanceof Error ? e.message : String(e),
                 messageSource: 'preprocess'
               }
               loaderTask.loaderDoneReturn = errorResult
@@ -503,7 +503,7 @@ class KnowledgeService {
   ): LoaderTask {
     const { base, item, forceReload } = options
     const content = item.content as string
-    const sourceUrl = (item as any).sourceUrl
+    const sourceUrl = item.sourceUrl
 
     const encoder = new TextEncoder()
     const contentBytes = encoder.encode(content)

--- a/src/main/services/MCPService.ts
+++ b/src/main/services/MCPService.ts
@@ -67,7 +67,7 @@ import { windowService } from './WindowService'
 // Generic type for caching wrapped functions
 type CachedFunction<T extends unknown[], R> = (...args: T) => Promise<R>
 
-type CallToolArgs = { server: MCPServer; name: string; args: any; callId?: string }
+type CallToolArgs = { server: MCPServer; name: string; args: Record<string, unknown>; callId?: string }
 
 const logger = loggerService.withContext('MCPService')
 
@@ -77,19 +77,19 @@ const logger = loggerService.withContext('MCPService')
 const MCP_CONNECT_TIMEOUT_FLOOR_MS = 180_000
 
 // Redact potentially sensitive fields in objects (headers, tokens, api keys)
-function redactSensitive(input: any): any {
+function redactSensitive(input: unknown): unknown {
   const SENSITIVE_KEYS = ['authorization', 'Authorization', 'apiKey', 'api_key', 'apikey', 'token', 'access_token']
   const MAX_STRING = 300
 
-  const redact = (val: any): any => {
+  const redact = (val: unknown): unknown => {
     if (val == null) return val
     if (typeof val === 'string') {
       return val.length > MAX_STRING ? `${val.slice(0, MAX_STRING)}…<${val.length - MAX_STRING} more>` : val
     }
     if (Array.isArray(val)) return val.map((v) => redact(v))
     if (typeof val === 'object') {
-      const out: Record<string, any> = {}
-      for (const [k, v] of Object.entries(val)) {
+      const out: Record<string, unknown> = {}
+      for (const [k, v] of Object.entries(val as Record<string, unknown>)) {
         if (SENSITIVE_KEYS.includes(k)) {
           out[k] = '<redacted>'
         } else {
@@ -105,7 +105,7 @@ function redactSensitive(input: any): any {
 }
 
 // Create a context-aware logger for a server
-function getServerLogger(server: MCPServer, extra?: Record<string, any>) {
+function getServerLogger(server: MCPServer, extra?: Record<string, unknown>) {
   const base = {
     serverName: server?.name,
     serverId: server?.id,
@@ -286,7 +286,7 @@ class McpService {
         } else {
           return existingClient
         }
-      } catch (error: any) {
+      } catch (error: unknown) {
         getServerLogger(server).error(`Error pinging server ${server.name}`, error as Error)
         this.clients.delete(serverKey)
       }
@@ -354,7 +354,7 @@ class McpService {
             try {
               await inMemoryServer.connect(serverTransport)
               getServerLogger(server).debug(`In-memory server started`)
-            } catch (error: any) {
+            } catch (error: unknown) {
               getServerLogger(server).error(`Error starting in-memory server`, error as Error)
               throw new Error(`Failed to start in-memory server: ${error.message}`)
             }
@@ -612,7 +612,7 @@ class McpService {
           }
           try {
             await client.connect(transport, connectOptions)
-          } catch (error: any) {
+          } catch (error: unknown) {
             if (
               error instanceof Error &&
               (error.name === 'UnauthorizedError' || error.message.includes('Unauthorized'))
@@ -840,7 +840,7 @@ class McpService {
     for (const [key] of this.clients) {
       try {
         await this.closeClient(key)
-      } catch (error: any) {
+      } catch (error: unknown) {
         logger.error(`Failed to close client`, error as Error)
       }
     }
@@ -1007,7 +1007,7 @@ class McpService {
     getServerLogger(server).debug(`Listing prompts`)
     try {
       const { prompts } = await client.listPrompts()
-      return prompts.map((prompt: any) => ({
+      return prompts.map((prompt) => ({
         ...prompt,
         id: `p${nanoid()}`,
         serverId: server.id,
@@ -1041,7 +1041,7 @@ class McpService {
   /**
    * Get a specific prompt from an MCP server (implementation)
    */
-  private async getPromptImpl(server: MCPServer, name: string, args?: Record<string, any>): Promise<GetPromptResult> {
+  private async getPromptImpl(server: MCPServer, name: string, args?: Record<string, unknown>): Promise<GetPromptResult> {
     logger.debug(`Getting prompt ${name} from server: ${server.name}`)
     const client = await this.initClient(server)
     return await client.getPrompt({ name, arguments: args })
@@ -1053,9 +1053,9 @@ class McpService {
   @TraceMethod({ spanName: 'getPrompt', tag: 'mcp' })
   public async getPrompt(
     _: Electron.IpcMainInvokeEvent,
-    { server, name, args }: { server: MCPServer; name: string; args?: Record<string, any> }
+    { server, name, args }: { server: MCPServer; name: string; args?: Record<string, unknown> }
   ): Promise<GetPromptResult> {
-    const cachedGetPrompt = withCache<[MCPServer, string, Record<string, any> | undefined], GetPromptResult>(
+    const cachedGetPrompt = withCache<[MCPServer, string, Record<string, unknown> | undefined], GetPromptResult>(
       this.getPromptImpl.bind(this),
       (server, name, args) => {
         const serverKey = this.getServerKey(server)
@@ -1077,12 +1077,12 @@ class McpService {
     try {
       const result = await client.listResources()
       const resources = result.resources || []
-      return (Array.isArray(resources) ? resources : []).map((resource: any) => ({
+      return (Array.isArray(resources) ? resources : []).map((resource) => ({
         ...resource,
         serverId: server.id,
         serverName: server.name
       }))
-    } catch (error: any) {
+    } catch (error: unknown) {
       // -32601 is the code for the method not found
       if (error?.code !== -32601) {
         getServerLogger(server).error(`Failed to list resources`, error as Error)
@@ -1117,7 +1117,7 @@ class McpService {
       const result = await client.readResource({ uri: uri })
       const contents: MCPResource[] = []
       if (result.contents && result.contents.length > 0) {
-        result.contents.forEach((content: any) => {
+        result.contents.forEach((content) => {
           contents.push({
             ...content,
             serverId: server.id,
@@ -1128,7 +1128,7 @@ class McpService {
       return {
         contents: contents
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       getServerLogger(server, { uri }).error(`Failed to get resource`, error as Error)
       throw new Error(`Failed to get resource ${uri} from server: ${server.name}: ${error.message}`)
     }
@@ -1187,7 +1187,7 @@ class McpService {
 
       getServerLogger(server).warn(`No version information available`)
       return null
-    } catch (error: any) {
+    } catch (error: unknown) {
       getServerLogger(server).error(`Failed to get server version`, error as Error)
       return null
     }

--- a/src/renderer/src/types/knowledge.ts
+++ b/src/renderer/src/types/knowledge.ts
@@ -19,6 +19,7 @@ export type KnowledgeItem = {
   processingError?: string
   retryCount?: number
   isPreprocessed?: boolean
+  sourceUrl?: string
 }
 
 export type KnowledgeFileItem = KnowledgeItem & {


### PR DESCRIPTION
## Summary
Replace pervasive 'any' types with proper TypeScript types across main process services.

## Changes

### MCPService.ts
- CallToolArgs.args: any -> Record<string, unknown>
- redactSensitive: any -> unknown
- getServerLogger extra param: Record<string, any> -> Record<string, unknown>
- error catches: error: any -> error: unknown
- prompt/resource mappings: remove explicit any annotations

### KnowledgeService.ts
- error catch: e: any -> e: unknown with proper Error handling
- sourceUrl access: remove as any cast, add sourceUrl to KnowledgeItem type

### ExportService.ts
- elements array: any[] -> (Paragraph | Table)[]
- processInlineTokens: any[] -> Token[]

### knowledge.ts
- Add optional sourceUrl property to KnowledgeItem type

## Benefits
- Improves type safety across main process services
- Catches potential runtime errors at compile time
- Follows TypeScript best practices (unknown over any)