### PR TITLE
feat(errors): add ErrorBoundary to critical page components

### DIFF
--- a/src/renderer/src/pages/notes/NotesPage.tsx
+++ b/src/renderer/src/pages/notes/NotesPage.tsx
@@ -1,5 +1,6 @@
 import { loggerService } from '@logger'
 import { Navbar, NavbarCenter } from '@renderer/components/app/Navbar'
+import { ErrorBoundary } from '@renderer/components/ErrorBoundary'
 import type { CodeEditorHandles } from '@renderer/components/CodeEditor'
 import type { RichEditorRef } from '@renderer/components/RichEditor/types'
 import { useActiveNode, useFileContent, useFileContentSync } from '@renderer/hooks/useNotesQuery'
@@ -907,10 +908,11 @@ const NotesPage: FC = () => {
   }, [activeNode?.id, activeFilePath, notesTree, dispatch, invalidateFileContent])
 
   return (
-    <Container id="notes-page">
-      <Navbar>
-        <NavbarCenter style={{ borderRight: 'none' }}>{t('notes.title')}</NavbarCenter>
-      </Navbar>
+    <ErrorBoundary>
+      <Container id="notes-page">
+        <Navbar>
+          <NavbarCenter style={{ borderRight: 'none' }}>{t('notes.title')}</NavbarCenter>
+        </Navbar>
       <ContentContainer id="content-container">
         <AnimatePresence initial={false}>
           {showWorkspace && (
@@ -955,7 +957,8 @@ const NotesPage: FC = () => {
           />
         </EditorWrapper>
       </ContentContainer>
-    </Container>
+      </Container>
+    </ErrorBoundary>
   )
 }
 

--- a/src/renderer/src/pages/paintings/PaintingsRoutePage.tsx
+++ b/src/renderer/src/pages/paintings/PaintingsRoutePage.tsx
@@ -1,4 +1,5 @@
 import { loggerService } from '@logger'
+import { ErrorBoundary } from '@renderer/components/ErrorBoundary'
 import { useAllProviders } from '@renderer/hooks/useProvider'
 import { useAppDispatch } from '@renderer/store'
 import { setDefaultPaintingProvider } from '@renderer/store/settings'
@@ -51,21 +52,23 @@ const PaintingsRoutePage: FC = () => {
   }, [provider, dispatch, validOptions])
 
   return (
-    <Routes>
-      <Route path="*" element={<NewApiPage Options={validOptions} />} />
-      <Route path="/zhipu" element={<ZhipuPage Options={validOptions} />} />
-      <Route path="/aihubmix" element={<AihubmixPage Options={validOptions} />} />
-      <Route path="/silicon" element={<SiliconPage Options={validOptions} />} />
-      <Route path="/dmxapi" element={<DmxapiPage Options={validOptions} />} />
-      <Route path="/tokenflux" element={<TokenFluxPage Options={validOptions} />} />
-      <Route path="/ovms" element={<OvmsPage Options={validOptions} />} />
-      <Route path="/ppio" element={<PpioPage Options={validOptions} />} />
-      <Route path="/new-api" element={<NewApiPage Options={validOptions} />} />
-      {/* new-api family providers are mounted dynamically below */}
-      {newApiProviders.map((p) => (
-        <Route key={p.id} path={`/${p.id}`} element={<NewApiPage Options={validOptions} />} />
-      ))}
-    </Routes>
+    <ErrorBoundary>
+      <Routes>
+        <Route path="*" element={<NewApiPage Options={validOptions} />} />
+        <Route path="/zhipu" element={<ZhipuPage Options={validOptions} />} />
+        <Route path="/aihubmix" element={<AihubmixPage Options={validOptions} />} />
+        <Route path="/silicon" element={<SiliconPage Options={validOptions} />} />
+        <Route path="/dmxapi" element={<DmxapiPage Options={validOptions} />} />
+        <Route path="/tokenflux" element={<TokenFluxPage Options={validOptions} />} />
+        <Route path="/ovms" element={<OvmsPage Options={validOptions} />} />
+        <Route path="/ppio" element={<PpioPage Options={validOptions} />} />
+        <Route path="/new-api" element={<NewApiPage Options={validOptions} />} />
+        {/* new-api family providers are mounted dynamically below */}
+        {newApiProviders.map((p) => (
+          <Route key={p.id} path={`/${p.id}`} element={<NewApiPage Options={validOptions} />} />
+        ))}
+      </Routes>
+    </ErrorBoundary>
   )
 }
 

--- a/src/renderer/src/pages/translate/TranslatePage.tsx
+++ b/src/renderer/src/pages/translate/TranslatePage.tsx
@@ -1,6 +1,7 @@
 import { PlusOutlined, SendOutlined, SwapOutlined } from '@ant-design/icons'
 import { loggerService } from '@logger'
 import { Navbar, NavbarCenter } from '@renderer/components/app/Navbar'
+import { ErrorBoundary } from '@renderer/components/ErrorBoundary'
 import { CopyIcon } from '@renderer/components/Icons'
 import LanguageSelect from '@renderer/components/LanguageSelect'
 import ModelSelectButton from '@renderer/components/ModelSelectButton'
@@ -702,15 +703,16 @@ const TranslatePage: FC = () => {
     [getSingleFile, isProcessing, processFile, t]
   )
   return (
-    <Container
-      id="translate-page"
-      onDragEnter={handleDragEnter}
-      onDragLeave={handleDragLeave}
-      onDragOver={handleDragOver}
-      onDrop={preventDrop}>
-      <Navbar>
-        <NavbarCenter style={{ borderRight: 'none', gap: 10 }}>{t('translate.title')}</NavbarCenter>
-      </Navbar>
+    <ErrorBoundary>
+      <Container
+        id="translate-page"
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDragOver={handleDragOver}
+        onDrop={preventDrop}>
+        <Navbar>
+          <NavbarCenter style={{ borderRight: 'none', gap: 10 }}>{t('translate.title')}</NavbarCenter>
+        </Navbar>
       <ContentContainer id="content-container" ref={contentContainerRef} $historyDrawerVisible={historyDrawerVisible}>
         <TranslateHistoryList
           onHistoryItemClick={onHistoryItemClick}
@@ -856,7 +858,8 @@ const TranslatePage: FC = () => {
         autoDetectionMethod={autoDetectionMethod}
         setAutoDetectionMethod={updateAutoDetectionMethod}
       />
-    </Container>
+      </Container>
+    </ErrorBoundary>
   )
 }
 


### PR DESCRIPTION
## Summary
Add ErrorBoundary wrappers to key page components to prevent entire page crashes from component-level errors.

## Changes
- PaintingsRoutePage: wrap Routes with ErrorBoundary
- TranslatePage: wrap Container with ErrorBoundary
- NotesPage: wrap Container with ErrorBoundary

## Benefits
- Catches rendering errors at the page level
- Displays fallback UI instead of crashing the entire application
- Improves user experience when errors occur
- Follows React error boundary best practices