### PR TITLE
feat(api): add Zod validation schemas for messages and MCP routes

### DIFF
--- a/src/main/apiServer/routes/mcp/validators.ts
+++ b/src/main/apiServer/routes/mcp/validators.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod'
+
+// Schema for MCP server ID parameter
+export const MCPServerIdSchema = z.object({
+  serverId: z.string().min(1, 'Server ID is required')
+})
+
+// Schema for calling an MCP tool
+export const CallMCPToolSchema = z.object({
+  serverId: z.string().min(1, 'Server ID is required'),
+  toolName: z.string().min(1, 'Tool name is required'),
+  arguments: z.record(z.unknown()).optional()
+})
+
+// Schema for getting an MCP resource
+export const GetMCPResourceSchema = z.object({
+  serverId: z.string().min(1, 'Server ID is required'),
+  resourceUri: z.string().min(1, 'Resource URI is required')
+})
+
+// Schema for getting an MCP prompt
+export const GetMCPPromptSchema = z.object({
+  serverId: z.string().min(1, 'Server ID is required'),
+  promptName: z.string().min(1, 'Prompt name is required'),
+  arguments: z.record(z.string()).optional()
+})
+
+// Schema for creating/updating an MCP server
+export const CreateMCPServerSchema = z.object({
+  name: z.string().min(1, 'Server name is required'),
+  type: z.enum(['stdio', 'http', 'sse']),
+  command: z.string().optional(),
+  args: z.array(z.string()).optional(),
+  env: z.record(z.string()).optional(),
+  url: z.string().url().optional(),
+  isActive: z.boolean().optional()
+})
+
+// Schema for updating an MCP server
+export const UpdateMCPServerSchema = z.object({
+  name: z.string().optional(),
+  type: z.enum(['stdio', 'http', 'sse']).optional(),
+  command: z.string().optional(),
+  args: z.array(z.string()).optional(),
+  env: z.record(z.string()).optional(),
+  url: z.string().url().optional(),
+  isActive: z.boolean().optional()
+})

--- a/src/main/apiServer/routes/messages/validators.ts
+++ b/src/main/apiServer/routes/messages/validators.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod'
+
+// Schema for message content blocks
+const ContentBlockSchema = z.object({
+  type: z.enum(['text', 'image', 'image_url']),
+  text: z.string().optional(),
+  image_url: z
+    .object({
+      url: z.string()
+    })
+    .optional()
+})
+
+// Schema for creating a message
+export const CreateMessageSchema = z.object({
+  model: z.string().min(1, 'Model is required'),
+  messages: z
+    .array(
+      z.object({
+        role: z.enum(['system', 'user', 'assistant']),
+        content: z.union([z.string(), z.array(ContentBlockSchema)])
+      })
+    )
+    .min(1, 'At least one message is required'),
+  temperature: z.number().min(0).max(2).optional(),
+  max_tokens: z.number().positive().optional(),
+  stream: z.boolean().optional(),
+  tools: z
+    .array(
+      z.object({
+        type: z.literal('function'),
+        function: z.object({
+          name: z.string(),
+          description: z.string().optional(),
+          parameters: z.record(z.unknown()).optional()
+        })
+      })
+    )
+    .optional()
+})
+
+// Schema for listing messages
+export const ListMessagesSchema = z.object({
+  topicId: z.string().min(1, 'Topic ID is required'),
+  limit: z.number().positive().optional(),
+  offset: z.number().nonnegative().optional()
+})
+
+// Schema for getting a single message
+export const GetMessageSchema = z.object({
+  messageId: z.string().min(1, 'Message ID is required')
+})
+
+// Schema for updating a message
+export const UpdateMessageSchema = z.object({
+  messageId: z.string().min(1, 'Message ID is required'),
+  content: z.string().optional(),
+  model: z.string().optional()
+})
+
+// Schema for deleting a message
+export const DeleteMessageSchema = z.object({
+  messageId: z.string().min(1, 'Message ID is required')
+})
+
+// Schema for searching messages
+export const SearchMessagesSchema = z.object({
+  query: z.string().min(1, 'Search query is required'),
+  topicId: z.string().optional(),
+  limit: z.number().positive().optional(),
+  offset: z.number().nonnegative().optional()
+})

--- a/src/main/apiServer/routes/messages/validators.ts
+++ b/src/main/apiServer/routes/messages/validators.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import * as z from 'zod'
 
 // Schema for message content blocks
 const ContentBlockSchema = z.object({


### PR DESCRIPTION
## Summary
Add Zod validation schemas for API server routes.

## New Schemas

### messages/validators.ts
- CreateMessageSchema for message creation
- ListMessagesSchema for listing messages
- GetMessageSchema for getting a single message
- UpdateMessageSchema for updating messages
- DeleteMessageSchema for deleting messages
- SearchMessagesSchema for searching messages

### mcp/validators.ts
- MCPServerIdSchema for server ID parameter
- CallMCPToolSchema for calling MCP tools
- GetMCPResourceSchema for getting MCP resources
- GetMCPPromptSchema for getting MCP prompts
- CreateMCPServerSchema for creating MCP servers
- UpdateMCPServerSchema for updating MCP servers

## Benefits
- Input validation at the API layer
- Consistent error messages
- Type safety for request bodies
- Prevents invalid data from reaching services