### PR TITLE
fix(backup): include .claude/projects in backup to preserve agent sessions (v1 port)

### DIFF
--- a/src/main/services/BackupManager.ts
+++ b/src/main/services/BackupManager.ts
@@ -125,6 +125,15 @@ class BackupManager {
         await fs.rename(dataRestore, dataDest)
       }
 
+      // Restore Claude Code SDK session data
+      const claudeProjRestore = path.join(userDataPath, '.claude', 'projects.restore')
+      const claudeProjDest = path.join(userDataPath, '.claude', 'projects')
+      if (await fs.pathExists(claudeProjRestore)) {
+        logger.info('[handleStartupRestore] Found .claude/projects.restore, completing restoration...')
+        await fs.remove(claudeProjDest).catch(() => {})
+        await fs.rename(claudeProjRestore, claudeProjDest)
+      }
+
       logger.info('[handleStartupRestore] Restoration completed successfully')
     } catch (error) {
       logger.error('[handleStartupRestore] Failed to complete restoration:', error as Error)
@@ -132,6 +141,8 @@ class BackupManager {
       await fs.remove(indexedDBRestore).catch(() => {})
       await fs.remove(localStorageRestore).catch(() => {})
       await fs.remove(dataRestore).catch(() => {})
+      const claudeProjRestore = path.join(userDataPath, '.claude', 'projects.restore')
+      await fs.remove(claudeProjRestore).catch(() => {})
     }
   }
 
@@ -227,6 +238,16 @@ class BackupManager {
         logger.debug('[backupDirect] Skip the backup of the file')
         await fs.promises.mkdir(path.join(this.tempDir, 'Data'))
       }
+
+      // Copy Claude Code SDK session data so agent sessions survive restore
+      const claudeProjectsSource = path.join(userDataPath, '.claude', 'projects')
+      if (await fs.pathExists(claudeProjectsSource)) {
+        const claudeProjDir = path.join(this.tempDir, '.claude', 'projects')
+        await fs.ensureDir(path.dirname(claudeProjDir))
+        await fs.copy(claudeProjectsSource, claudeProjDir)
+        logger.debug('[backupDirect] Copied .claude/projects/ for SDK session preservation')
+      }
+
       onProgress({ stage: 'compressing', progress: 80, total: 100 })
 
       // Step 5: Create ZIP archive
@@ -574,6 +595,7 @@ class BackupManager {
     const indexedDBDest = path.join(userDataPath, 'IndexedDB.restore')
     const localStorageDest = path.join(userDataPath, 'Local Storage.restore')
     const dataDest = path.join(userDataPath, 'Data.restore')
+    const claudeProjDest = path.join(userDataPath, '.claude', 'projects.restore')
 
     try {
       // Read and validate metadata
@@ -636,6 +658,14 @@ class BackupManager {
         logger.debug('[restoreDirect] No Data directory to restore')
       }
 
+      // Restore Claude Code SDK session data
+      const claudeProjSource = path.join(this.tempDir, '.claude', 'projects')
+      if (await fs.pathExists(claudeProjSource)) {
+        await fs.remove(claudeProjDest).catch(() => {})
+        await fs.copy(claudeProjSource, claudeProjDest)
+        logger.debug('[restoreDirect] Staged .claude/projects.restore')
+      }
+
       // Clean up
       await fs.remove(this.tempDir)
       onProgress({ stage: 'completed', progress: 100, total: 100 })
@@ -651,7 +681,8 @@ class BackupManager {
         fs.remove(this.tempDir).catch(() => {}),
         fs.remove(indexedDBDest).catch(() => {}),
         fs.remove(localStorageDest).catch(() => {}),
-        fs.remove(dataDest).catch(() => {})
+        fs.remove(dataDest).catch(() => {}),
+        fs.remove(claudeProjDest).catch(() => {})
       ])
       throw error
     }


### PR DESCRIPTION
Port of #15477 to v1. Same fix, adapted to v1 codebase.

Before: backup zip only had IndexedDB, Local Storage, Data/ — Claude Code
SDK session jsonls (.claude/projects/) were left out. After restore, every
agent session throws "No conversation found with session ID".

After: .claude/projects/ included in zip and restored via the same .restore
staging pattern used by other directories.

Fixes #15476 for v1 users.