### PR TITLE
feat(i18n): add i18n keys for hardcoded strings

### DIFF
--- a/src/renderer/src/components/CodeBlockView/view.tsx
+++ b/src/renderer/src/components/CodeBlockView/view.tsx
@@ -333,7 +333,7 @@ export const CodeBlockView: React.FC<Props> = memo(({ children, language, onSave
         <StatusBar>
           {executionResult.text}
           {executionResult.image && (
-            <ImageViewer src={executionResult.image} alt="Matplotlib plot" style={{ cursor: 'pointer' }} />
+            <ImageViewer src={executionResult.image} alt={t('code_block.matplotlib_plot', 'Matplotlib plot')} style={{ cursor: 'pointer' }} />
           )}
         </StatusBar>
       )}

--- a/src/renderer/src/components/TooltipIcons/HelpTooltip.tsx
+++ b/src/renderer/src/components/TooltipIcons/HelpTooltip.tsx
@@ -1,6 +1,7 @@
 import type { TooltipProps } from 'antd'
 import { Tooltip } from 'antd'
 import { HelpCircle } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 
 type InheritedTooltipProps = Omit<TooltipProps, 'children'>
 
@@ -11,9 +12,10 @@ interface HelpTooltipProps extends InheritedTooltipProps {
 }
 
 const HelpTooltip = ({ iconColor = 'var(--color-text-2)', iconSize = 14, iconStyle, ...rest }: HelpTooltipProps) => {
+  const { t } = useTranslation()
   return (
     <Tooltip {...rest}>
-      <HelpCircle size={iconSize} color={iconColor} style={{ ...iconStyle }} role="img" aria-label="Help" />
+      <HelpCircle size={iconSize} color={iconColor} style={{ ...iconStyle }} role="img" aria-label={t('common.help', 'Help')} />
     </Tooltip>
   )
 }

--- a/src/renderer/src/components/TooltipIcons/InfoTooltip.tsx
+++ b/src/renderer/src/components/TooltipIcons/InfoTooltip.tsx
@@ -1,6 +1,7 @@
 import type { TooltipProps } from 'antd'
 import { Tooltip } from 'antd'
 import { Info } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 
 type InheritedTooltipProps = Omit<TooltipProps, 'children'>
 
@@ -11,9 +12,10 @@ interface InfoTooltipProps extends InheritedTooltipProps {
 }
 
 const InfoTooltip = ({ iconColor = 'var(--color-text-2)', iconSize = 14, iconStyle, ...rest }: InfoTooltipProps) => {
+  const { t } = useTranslation()
   return (
     <Tooltip {...rest}>
-      <Info size={iconSize} color={iconColor} style={{ ...iconStyle }} role="img" aria-label="Information" />
+      <Info size={iconSize} color={iconColor} style={{ ...iconStyle }} role="img" aria-label={t('common.information', 'Information')} />
     </Tooltip>
   )
 }

--- a/src/renderer/src/components/TooltipIcons/WarnTooltip.tsx
+++ b/src/renderer/src/components/TooltipIcons/WarnTooltip.tsx
@@ -1,6 +1,7 @@
 import type { TooltipProps } from 'antd'
 import { Tooltip } from 'antd'
 import { AlertTriangle } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 
 type InheritedTooltipProps = Omit<TooltipProps, 'children'>
 
@@ -16,9 +17,10 @@ const WarnTooltip = ({
   iconStyle,
   ...rest
 }: WarnTooltipProps) => {
+  const { t } = useTranslation()
   return (
     <Tooltip {...rest}>
-      <AlertTriangle size={iconSize} color={iconColor} style={{ ...iconStyle }} role="img" aria-label="Information" />
+      <AlertTriangle size={iconSize} color={iconColor} style={{ ...iconStyle }} role="img" aria-label={t('common.warning', 'Warning')} />
     </Tooltip>
   )
 }

--- a/src/renderer/src/pages/paintings/AihubmixPage.tsx
+++ b/src/renderer/src/pages/paintings/AihubmixPage.tsx
@@ -824,7 +824,7 @@ const AihubmixPage: FC<{ Options: string[] }> = ({ Options }) => {
             }}>
             {painting[item.key!] ? (
               <ImagePreview>
-                <img src={painting[item.key!]} alt="预览图" />
+                <img src={painting[item.key!]} alt={t('paintings.preview_image', 'Preview image')} />
               </ImagePreview>
             ) : (
               <ImageSizeImage src={IcImageUp} theme={theme} />

--- a/src/renderer/src/pages/paintings/components/DynamicFormRender.tsx
+++ b/src/renderer/src/pages/paintings/components/DynamicFormRender.tsx
@@ -101,7 +101,7 @@ export const DynamicFormRender: React.FC<DynamicFormRenderProps> = ({
             }}>
             <img
               src={value}
-              alt="Image preview"
+              alt={t('paintings.image_preview', 'Image preview')}
               style={{
                 width: '48px',
                 height: '48px',


### PR DESCRIPTION
## Summary
Replace hardcoded strings with i18n translation keys.

## Changes

### TooltipIcons
- HelpTooltip: aria-label 'Help' -> t('common.help')
- InfoTooltip: aria-label 'Information' -> t('common.information')
- WarnTooltip: aria-label 'Information' -> t('common.warning')

### Paintings
- DynamicFormRender: alt 'Image preview' -> t('paintings.image_preview')
- AihubmixPage: alt '预览图' -> t('paintings.preview_image')

### CodeBlockView
- view.tsx: alt 'Matplotlib plot' -> t('code_block.matplotlib_plot')

## Benefits
- Consistent i18n usage across the application
- Support for multiple languages
- Better accessibility for international users