### PR TITLE
test(store): add unit tests for settings and llm slices

### DIFF
--- a/src/renderer/src/store/__tests__/llm.test.ts
+++ b/src/renderer/src/store/__tests__/llm.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+
+import { llmSlice, initialState } from '../llm'
+
+describe('llmSlice', () => {
+  it('should return the initial state', () => {
+    expect(llmSlice.getInitialState()).toEqual(initialState)
+  })
+
+  it('should handle setDefaultModel', () => {
+    const model = { id: 'test-model', name: 'Test Model', provider: 'test' }
+    const state = llmSlice.reducer(initialState, llmSlice.actions.setDefaultModel(model))
+    expect(state.defaultModel).toEqual(model)
+  })
+
+  it('should handle setTopicNamingModel', () => {
+    const model = { id: 'test-model', name: 'Test Model', provider: 'test' }
+    const state = llmSlice.reducer(initialState, llmSlice.actions.setTopicNamingModel(model))
+    expect(state.topicNamingModel).toEqual(model)
+  })
+
+  it('should handle setQuickModel', () => {
+    const model = { id: 'test-model', name: 'Test Model', provider: 'test' }
+    const state = llmSlice.reducer(initialState, llmSlice.actions.setQuickModel(model))
+    expect(state.quickModel).toEqual(model)
+  })
+
+  it('should handle setTranslateModel', () => {
+    const model = { id: 'test-model', name: 'Test Model', provider: 'test' }
+    const state = llmSlice.reducer(initialState, llmSlice.actions.setTranslateModel(model))
+    expect(state.translateModel).toEqual(model)
+  })
+
+  it('should handle setQuickAssistantId', () => {
+    const state = llmSlice.reducer(initialState, llmSlice.actions.setQuickAssistantId('test-id'))
+    expect(state.quickAssistantId).toBe('test-id')
+  })
+
+  it('should handle updateProvider', () => {
+    const provider = {
+      id: 'test-provider',
+      name: 'Test Provider',
+      type: 'openai' as const,
+      apiKey: 'test-key',
+      apiHost: 'https://test.com',
+      models: [],
+      isSystem: false,
+      enabled: true
+    }
+    const state = llmSlice.reducer(initialState, llmSlice.actions.updateProvider(provider))
+    expect(state.providers.find((p) => p.id === 'test-provider')).toEqual(provider)
+  })
+
+  it('should handle addProvider', () => {
+    const provider = {
+      id: 'new-provider',
+      name: 'New Provider',
+      type: 'openai' as const,
+      apiKey: 'test-key',
+      apiHost: 'https://test.com',
+      models: [],
+      isSystem: false,
+      enabled: true
+    }
+    const state = llmSlice.reducer(initialState, llmSlice.actions.addProvider(provider))
+    expect(state.providers.find((p) => p.id === 'new-provider')).toEqual(provider)
+  })
+
+  it('should handle removeProvider', () => {
+    const state = llmSlice.reducer(initialState, llmSlice.actions.removeProvider('openai'))
+    expect(state.providers.find((p) => p.id === 'openai')).toBeUndefined()
+  })
+
+  it('should handle setOllamaKeepAliveTime', () => {
+    const state = llmSlice.reducer(initialState, llmSlice.actions.setOllamaKeepAliveTime(5))
+    expect(state.settings.ollama.keepAliveTime).toBe(5)
+  })
+
+  it('should handle setLmstudioKeepAliveTime', () => {
+    const state = llmSlice.reducer(initialState, llmSlice.actions.setLmstudioKeepAliveTime(5))
+    expect(state.settings.lmstudio.keepAliveTime).toBe(5)
+  })
+
+  it('should handle setGpustackKeepAliveTime', () => {
+    const state = llmSlice.reducer(initialState, llmSlice.actions.setGpustackKeepAliveTime(5))
+    expect(state.settings.gpustack.keepAliveTime).toBe(5)
+  })
+
+  it('should handle setVertexAIServiceAccount', () => {
+    const serviceAccount = { privateKey: 'test-key', clientEmail: 'test@test.com' }
+    const state = llmSlice.reducer(
+      initialState,
+      llmSlice.actions.setVertexAIServiceAccount(serviceAccount)
+    )
+    expect(state.settings.vertexai.serviceAccount).toEqual(serviceAccount)
+  })
+
+  it('should handle setVertexAIProjectId', () => {
+    const state = llmSlice.reducer(initialState, llmSlice.actions.setVertexAIProjectId('test-project'))
+    expect(state.settings.vertexai.projectId).toBe('test-project')
+  })
+
+  it('should handle setVertexAILocation', () => {
+    const state = llmSlice.reducer(initialState, llmSlice.actions.setVertexAILocation('us-central1'))
+    expect(state.settings.vertexai.location).toBe('us-central1')
+  })
+})

--- a/src/renderer/src/store/__tests__/settings.test.ts
+++ b/src/renderer/src/store/__tests__/settings.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+
+import { settingsSlice, initialState } from '../settings'
+
+describe('settingsSlice', () => {
+  it('should return the initial state', () => {
+    expect(settingsSlice.getInitialState()).toEqual(initialState)
+  })
+
+  it('should handle setShowAssistants', () => {
+    const state = settingsSlice.reducer(initialState, settingsSlice.actions.setShowAssistants(false))
+    expect(state.showAssistants).toBe(false)
+  })
+
+  it('should handle setShowTopics', () => {
+    const state = settingsSlice.reducer(initialState, settingsSlice.actions.setShowTopics(false))
+    expect(state.showTopics).toBe(false)
+  })
+
+  it('should handle setSendMessageShortcut', () => {
+    const state = settingsSlice.reducer(
+      initialState,
+      settingsSlice.actions.setSendMessageShortcut('Shift+Enter')
+    )
+    expect(state.sendMessageShortcut).toBe('Shift+Enter')
+  })
+
+  it('should handle setLanguage', () => {
+    const state = settingsSlice.reducer(initialState, settingsSlice.actions.setLanguage('zh-CN'))
+    expect(state.language).toBe('zh-CN')
+  })
+
+  it('should handle setTargetLanguage', () => {
+    const state = settingsSlice.reducer(initialState, settingsSlice.actions.setTargetLanguage('en-US'))
+    expect(state.targetLanguage).toBe('en-US')
+  })
+
+  it('should handle setProxyMode', () => {
+    const state = settingsSlice.reducer(initialState, settingsSlice.actions.setProxyMode('custom'))
+    expect(state.proxyMode).toBe('custom')
+  })
+
+  it('should handle setProxyUrl', () => {
+    const state = settingsSlice.reducer(
+      initialState,
+      settingsSlice.actions.setProxyUrl('http://localhost:8080')
+    )
+    expect(state.proxyUrl).toBe('http://localhost:8080')
+  })
+
+  it('should handle setUserName', () => {
+    const state = settingsSlice.reducer(initialState, settingsSlice.actions.setUserName('Test User'))
+    expect(state.userName).toBe('Test User')
+  })
+
+  it('should handle setShowPrompt', () => {
+    const state = settingsSlice.reducer(initialState, settingsSlice.actions.setShowPrompt(true))
+    expect(state.showPrompt).toBe(true)
+  })
+
+  it('should handle setShowMessageDivider', () => {
+    const state = settingsSlice.reducer(initialState, settingsSlice.actions.setShowMessageDivider(false))
+    expect(state.showMessageDivider).toBe(false)
+  })
+
+  it('should handle setMessageFont', () => {
+    const state = settingsSlice.reducer(initialState, settingsSlice.actions.setMessageFont('serif'))
+    expect(state.messageFont).toBe('serif')
+  })
+
+  it('should handle setShowInputEstimatedTokens', () => {
+    const state = settingsSlice.reducer(
+      initialState,
+      settingsSlice.actions.setShowInputEstimatedTokens(true)
+    )
+    expect(state.showInputEstimatedTokens).toBe(true)
+  })
+
+  it('should handle setLaunchOnBoot', () => {
+    const state = settingsSlice.reducer(initialState, settingsSlice.actions.setLaunchOnBoot(true))
+    expect(state.launchOnBoot).toBe(true)
+  })
+
+  it('should handle setLaunchToTray', () => {
+    const state = settingsSlice.reducer(initialState, settingsSlice.actions.setLaunchToTray(true))
+    expect(state.launchToTray).toBe(true)
+  })
+
+  it('should handle setTrayOnClose', () => {
+    const state = settingsSlice.reducer(initialState, settingsSlice.actions.setTrayOnClose(true))
+    expect(state.trayOnClose).toBe(true)
+  })
+
+  it('should handle setTray', () => {
+    const state = settingsSlice.reducer(initialState, settingsSlice.actions.setTray(true))
+    expect(state.tray).toBe(true)
+  })
+
+  it('should handle setDefaultModel', () => {
+    const model = { id: 'test-model', name: 'Test Model', provider: 'test' }
+    const state = settingsSlice.reducer(initialState, settingsSlice.actions.setDefaultModel(model))
+    expect(state.defaultModel).toEqual(model)
+  })
+
+  it('should handle setTheme', () => {
+    const state = settingsSlice.reducer(initialState, settingsSlice.actions.setTheme('dark'))
+    expect(state.theme).toBe('dark')
+  })
+
+  it('should handle setFontSize', () => {
+    const state = settingsSlice.reducer(initialState, settingsSlice.actions.setFontSize(16))
+    expect(state.fontSize).toBe(16)
+  })
+
+  it('should handle setCodeShowLineNumbers', () => {
+    const state = settingsSlice.reducer(
+      initialState,
+      settingsSlice.actions.setCodeShowLineNumbers(true)
+    )
+    expect(state.codeShowLineNumbers).toBe(true)
+  })
+
+  it('should handle setCodeCollapsible', () => {
+    const state = settingsSlice.reducer(initialState, settingsSlice.actions.setCodeCollapsible(true))
+    expect(state.codeCollapsible).toBe(true)
+  })
+
+  it('should handle setCodeWrappable', () => {
+    const state = settingsSlice.reducer(initialState, settingsSlice.actions.setCodeWrappable(true))
+    expect(state.codeWrappable).toBe(true)
+  })
+
+  it('should handle setAutoCheckUpdate', () => {
+    const state = settingsSlice.reducer(initialState, settingsSlice.actions.setAutoCheckUpdate(false))
+    expect(state.autoCheckUpdate).toBe(false)
+  })
+
+  it('should handle setShowBetaVersion', () => {
+    const state = settingsSlice.reducer(initialState, settingsSlice.actions.setShowBetaVersion(true))
+    expect(state.showBetaVersion).toBe(true)
+  })
+
+  it('should handle setDefaultPaintingProvider', () => {
+    const state = settingsSlice.reducer(
+      initialState,
+      settingsSlice.actions.setDefaultPaintingProvider('silicon')
+    )
+    expect(state.defaultPaintingProvider).toBe('silicon')
+  })
+})


### PR DESCRIPTION
## Summary
Add comprehensive unit tests for the settings and llm store slices.

## New Test Files

### settings.test.ts (150 lines)
- Test initial state
- Test setShowAssistants, setShowTopics
- Test setSendMessageShortcut, setLanguage, setTargetLanguage
- Test setProxyMode, setProxyUrl
- Test setUserName, setShowPrompt, setShowMessageDivider
- Test setMessageFont, setShowInputEstimatedTokens
- Test setLaunchOnBoot, setLaunchToTray, setTrayOnClose, setTray
- Test setDefaultModel, setTheme, setFontSize
- Test code editor settings (line numbers, collapsible, wrappable)
- Test update settings, painting provider

### llm.test.ts (107 lines)
- Test initial state
- Test setDefaultModel, setTopicNamingModel, setQuickModel, setTranslateModel
- Test setQuickAssistantId
- Test updateProvider, addProvider, removeProvider
- Test Ollama, LMStudio, GPUStack keep alive settings
- Test VertexAI settings (service account, project ID, location)

## Benefits
- Improves test coverage for critical store slices
- Catches regressions in state management
- Documents expected behavior