### PR TITLE
fix(data): cascade-delete session messages when deleting a session

### DIFF
--- a/src/main/data/services/AgentSessionService.ts
+++ b/src/main/data/services/AgentSessionService.ts
@@ -5,6 +5,7 @@ import {
   agentSessionTable as sessionsTable,
   type InsertAgentSessionRow as InsertSessionRow
 } from '@data/db/schemas/agentSession'
+import { agentSessionMessageTable as sessionMessagesTable } from '@data/db/schemas/agentSessionMessage'
 import { defaultHandlersFor, withSqliteErrors } from '@data/db/sqliteErrors'
 import { nullsToUndefined, timestampToISO } from '@data/services/utils/rowMappers'
 import { loggerService } from '@logger'
@@ -223,11 +224,15 @@ export class AgentSessionService {
 
   async deleteSession(agentId: string, id: string): Promise<boolean> {
     const database = application.get('DbService').getDb()
-    const result = await withSqliteErrors(
-      () => database.delete(sessionsTable).where(and(eq(sessionsTable.id, id), eq(sessionsTable.agentId, agentId))),
-      defaultHandlersFor('Session', id)
-    )
-    return result.rowsAffected > 0
+    let deleted = false
+    await database.transaction(async (tx) => {
+      await tx.delete(sessionMessagesTable).where(eq(sessionMessagesTable.sessionId, id))
+      const result = await tx
+        .delete(sessionsTable)
+        .where(and(eq(sessionsTable.id, id), eq(sessionsTable.agentId, agentId)))
+      deleted = result.rowsAffected > 0
+    })
+    return deleted
   }
 
   async reorderSessions(agentId: string, orderedIds: string[]): Promise<void> {

--- a/src/main/data/services/__tests__/AgentSessionService.test.ts
+++ b/src/main/data/services/__tests__/AgentSessionService.test.ts
@@ -1,6 +1,8 @@
 import { agentTable } from '@data/db/schemas/agent'
+import { agentSessionMessageTable } from '@data/db/schemas/agentSessionMessage'
 import { agentSessionService, buildSessionUpdateData } from '@data/services/AgentSessionService'
 import { setupTestDatabase } from '@test-helpers/db'
+import { eq } from 'drizzle-orm'
 import { describe, expect, it } from 'vitest'
 
 // ─────────────────────────────────────────────────────────
@@ -184,6 +186,40 @@ describe('AgentSessionService', () => {
       const agentId = await insertAgent(`agent_${Date.now()}_delmiss`)
       const result = await agentSessionService.deleteSession(agentId, 'nonexistent')
       expect(result).toBe(false)
+    })
+
+    it('cascade-deletes session messages when session is deleted', async () => {
+      const agentId = await insertAgent(`agent_${Date.now()}_cascade`)
+      const session = await agentSessionService.createSession(agentId, { name: 'Cascade test' })
+
+      // Insert test messages (content is AgentPersistedMessage, cast for test brevity)
+      const row = (role: string) => ({
+        id: crypto.randomUUID(),
+        sessionId: session!.id,
+        role,
+        content: { message: { id: 't', role }, blocks: [] } as any,
+        agentSessionId: null as any,
+        metadata: null as any
+      })
+      await dbh.db.insert(agentSessionMessageTable).values([row('user'), row('assistant')] as any)
+
+      // Verify messages exist before delete
+      const before = await dbh.db
+        .select()
+        .from(agentSessionMessageTable)
+        .where(eq(agentSessionMessageTable.sessionId, session!.id))
+      expect(before).toHaveLength(2)
+
+      // Delete the session
+      const deleted = await agentSessionService.deleteSession(agentId, session!.id)
+      expect(deleted).toBe(true)
+
+      // Verify messages are gone
+      const after = await dbh.db
+        .select()
+        .from(agentSessionMessageTable)
+        .where(eq(agentSessionMessageTable.sessionId, session!.id))
+      expect(after).toHaveLength(0)
     })
   })
 })


### PR DESCRIPTION
Fixes #15503

Before: deleteSession() only removed the agent_session row. Messages in
agent_session_message became orphans. On a real database, 110/224 messages
(49%) were unreferenced — deleted from the UI but still in SQLite.

After: deletion wraps in a transaction, removing messages first then the
session. The schema has ON DELETE CASCADE but it doesn't fire when SQLite
foreign_keys are OFF (the default) or on databases migrated from older
versions that lack the FK constraint.

2 files, +41/-5 with a cascade-deletion unit test.