### PR TITLE
fix(agent): validate Claude Code session jsonl before resume (v1 port)

### DIFF
--- a/src/main/services/agents/services/claudecode/__tests__/utils.test.ts
+++ b/src/main/services/agents/services/claudecode/__tests__/utils.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-import { isCherryInOfficialHost, isDeepSeekOfficialHost, isMiMoOfficialHost, with1mContextSuffix } from '../utils'
+import {
+  encodeCwdForClaudeProjects,
+  isCherryInOfficialHost,
+  isDeepSeekOfficialHost,
+  isMiMoOfficialHost,
+  with1mContextSuffix
+} from '../utils'
 
 describe('isDeepSeekOfficialHost', () => {
   it('matches the canonical DeepSeek Anthropic endpoint', () => {
@@ -150,5 +156,34 @@ describe('with1mContextSuffix', () => {
   it('returns empty string when modelId is missing', () => {
     expect(with1mContextSuffix(undefined, deepSeekHost)).toBe('')
     expect(with1mContextSuffix('', deepSeekHost)).toBe('')
+  })
+})
+
+describe('encodeCwdForClaudeProjects', () => {
+  it('matches SDK project-dir naming for POSIX cwds', () => {
+    expect(encodeCwdForClaudeProjects('/home/alice/.config/CherryStudio/Data/Agents/t-default'))
+      .toBe('-home-alice--config-CherryStudio-Data-Agents-t-default')
+  })
+
+  it('matches SDK convention for Windows-style cwds', () => {
+    expect(
+      encodeCwdForClaudeProjects(
+        'C:\\Users\\Administrator\\AppData\\Roaming\\CherryStudio\\Data\\Agents\\t-default'
+      )
+    ).toBe('C--Users-Administrator-AppData-Roaming-CherryStudio-Data-Agents-t-default')
+  })
+
+  it('encodes nested Windows-in-POSIX residue', () => {
+    expect(
+      encodeCwdForClaudeProjects(
+        '/home/bubu/Downloads/C:/Users/Administrator/AppData/Roaming/CherryStudio/Data/Agents/t-default'
+      )
+    ).toBe(
+      '-home-bubu-Downloads-C--Users-Administrator-AppData-Roaming-CherryStudio-Data-Agents-t-default'
+    )
+  })
+
+  it('preserves alphanumerics, underscores, and existing dashes', () => {
+    expect(encodeCwdForClaudeProjects('plain_dir-name_42')).toBe('plain_dir-name_42')
   })
 })

--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -35,6 +35,7 @@ import {
 import { toAsarUnpackedPath } from '@main/utils'
 import { autoDiscoverGitBash, getBinaryPath } from '@main/utils/process'
 import { rtkRewrite } from '@main/utils/rtk'
+import { encodeCwdForClaudeProjects } from './utils'
 import getLoginShellEnvironment from '@main/utils/shell-env'
 import {
   CHANNEL_SECURITY_PROMPT,
@@ -671,9 +672,21 @@ class ClaudeCodeService implements AgentServiceInterface {
     }
 
     if (lastAgentSessionId && !NO_RESUME_COMMANDS.some((cmd) => prompt.includes(cmd))) {
-      options.resume = lastAgentSessionId
-      // TODO: use fork session when we support branching sessions
-      // options.forkSession = true
+      const claudeRoot = path.join(app.getPath('userData'), '.claude')
+      const projectDir = path.join(claudeRoot, 'projects', encodeCwdForClaudeProjects(cwd))
+      const sessionFile = path.join(projectDir, `${lastAgentSessionId}.jsonl`)
+      const resumable = await fs.promises
+        .access(sessionFile, fs.constants.R_OK)
+        .then(() => true)
+        .catch(() => false)
+      if (resumable) {
+        options.resume = lastAgentSessionId
+      } else {
+        logger.warn(
+          'Skipping resume — Claude Code session jsonl missing on disk (orphaned agent_session_id). Starting a fresh SDK session.',
+          { sessionId: lastAgentSessionId, cwd, expectedFile: sessionFile }
+        )
+      }
     }
 
     logger.info('Starting Claude Code SDK query', {

--- a/src/main/services/agents/services/claudecode/utils.ts
+++ b/src/main/services/agents/services/claudecode/utils.ts
@@ -183,3 +183,12 @@ export function with1mContextSuffix(modelId: string | undefined, anthropicHost: 
 
   return modelId
 }
+
+/**
+ * Encode a cwd path the way Claude Code SDK does for project directories
+ * (`<CLAUDE_CONFIG_DIR>/projects/<encoded-cwd>/<session-id>.jsonl`).
+ * The SDK replaces `/`, `\`, `:`, `.` with `-`.
+ */
+export function encodeCwdForClaudeProjects(cwd: string): string {
+  return cwd.replace(/[/\\:.]/g, '-')
+}


### PR DESCRIPTION
Port of #15450 to v1.

Fixes #15505 for v1 users.

Before: passing --resume with an orphan agent_session_id throws
"No conversation found with session ID", permanently breaking the session.

After: fs.access the expected jsonl before resuming. If it's missing,
skip resume and start a fresh SDK session.