### PR TITLE
fix: respect topic naming setting for agent sessions

### DIFF
--- a/src/renderer/src/pages/agents/components/SessionItem.tsx
+++ b/src/renderer/src/pages/agents/components/SessionItem.tsx
@@ -145,7 +145,7 @@ const SessionItem = ({ session, agentId, channelType, onDelete, onPress }: Sessi
           void dispatch(loadTopicMessagesThunk(sessionTopicId))
           try {
             startTopicRenaming(sessionTopicId)
-            await renameAgentSessionIfNeeded(agentSession, sessionTopicId, store.getState)
+            await renameAgentSessionIfNeeded(agentSession, sessionTopicId, store.getState, { force: true })
           } finally {
             finishTopicRenaming(sessionTopicId)
           }

--- a/src/renderer/src/store/thunk/messageThunk.ts
+++ b/src/renderer/src/store/thunk/messageThunk.ts
@@ -154,7 +154,8 @@ const buildAgentBaseURL = (apiServer: ApiServerConfig) => {
 export const renameAgentSessionIfNeeded = async (
   agentSession: AgentSessionContext,
   topicId: string,
-  getState: () => RootState
+  getState: () => RootState,
+  options: { force?: boolean } = {}
 ): Promise<void> => {
   const lockId = `${agentSession.agentId}:${agentSession.sessionId}`
   if (agentSessionRenameLocks.has(lockId)) {
@@ -165,6 +166,10 @@ export const renameAgentSessionIfNeeded = async (
     const state = getState()
     const apiServer = state.settings.apiServer
     if (!apiServer?.apiKey) {
+      return
+    }
+
+    if (!options.force && !state.settings.enableTopicNaming) {
       return
     }
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR:

Agent sessions always ran AI-generated session renaming after a response completed, even when topic auto-renaming was disabled in quick model settings.

After this PR:

Automatic agent session renaming now respects the global topic naming setting. Manual agent session "Auto Rename" still works because explicit user actions pass a forced rename option.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #15457

### Why we need it and why it was done in this way

The following tradeoffs were made:

This keeps the fix minimal for v1 by gating only the agent session rename helper and preserving existing normal chat topic naming behavior.

The following alternatives were considered:

Disabling all automatic topic name fallback behavior was considered, but that would change existing normal chat behavior beyond the reported agents bug.

Links to places where the discussion took place: #15457

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

`pnpm test` currently fails in `src/renderer/src/utils/__tests__/analytics.test.ts` because token usage tracking still runs when data collection is disabled. That failure is unrelated to this PR and was intentionally left unchanged.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix agent sessions automatically renaming after topic auto-renaming is disabled.
```
