### PR TITLE
feat(models): add MiniMax M3 to the system model registry

### DIFF
--- a/src/renderer/config/models/__tests__/reasoning.test.ts
+++ b/src/renderer/config/models/__tests__/reasoning.test.ts
@@ -352,6 +352,7 @@ describe('Claude & regional providers', () => {
     expect(isMiniMaxReasoningModel(createModel({ id: 'minimax-m2-pro' }))).toBe(true)
     expect(isMiniMaxReasoningModel(createModel({ id: 'minimax-m2.7' }))).toBe(true)
     expect(isMiniMaxReasoningModel(createModel({ id: 'minimax-m2.7-highspeed' }))).toBe(true)
+    expect(isMiniMaxReasoningModel(createModel({ id: 'minimax-m3' }))).toBe(true)
   })
 })
 

--- a/src/renderer/config/models/__tests__/tooluse.test.ts
+++ b/src/renderer/config/models/__tests__/tooluse.test.ts
@@ -185,6 +185,11 @@ describe('isFunctionCallingModel', () => {
       expect(isFunctionCallingModel(createModel({ id: 'MiniMax-M2.7', provider: 'minimax' }))).toBe(true)
       expect(isFunctionCallingModel(createModel({ id: 'MiniMax-M2.7-highspeed', provider: 'minimax' }))).toBe(true)
     })
+
+    it('supports minimax-m3 model', () => {
+      expect(isFunctionCallingModel(createModel({ id: 'minimax-m3', provider: 'minimax' }))).toBe(true)
+      expect(isFunctionCallingModel(createModel({ id: 'MiniMax-M3', provider: 'minimax' }))).toBe(true)
+    })
   })
 
   describe('MiMo V2.5 Models', () => {

--- a/src/renderer/config/models/__tests__/vision.test.ts
+++ b/src/renderer/config/models/__tests__/vision.test.ts
@@ -167,6 +167,11 @@ describe('isVisionModel', () => {
     expect(isVisionModel(createModel({ id: 'gpt-4o-mini' }))).toBe(true)
   })
 
+  it('matches MiniMax M3 as vision but not text-only M2.x', () => {
+    expect(isVisionModel(createModel({ id: 'MiniMax-M3', provider: 'minimax' }))).toBe(true)
+    expect(isVisionModel(createModel({ id: 'MiniMax-M2.7', provider: 'minimax' }))).toBe(false)
+  })
+
   it('leverages image enhancement regex when standard vision regex does not match', () => {
     expect(isVisionModel(createModel({ id: 'qwen-image-edit' }))).toBe(true)
   })

--- a/src/renderer/config/models/default.ts
+++ b/src/renderer/config/models/default.ts
@@ -1056,6 +1056,12 @@ export const SYSTEM_MODELS: Record<SystemProviderId | 'defaultModel', Model[]> =
   ],
   minimax: [
     {
+      id: 'MiniMax-M3',
+      provider: 'minimax',
+      name: 'MiniMax-M3',
+      group: 'M3'
+    },
+    {
       id: 'MiniMax-M2.7',
       provider: 'minimax',
       name: 'MiniMax-M2.7',
@@ -1111,6 +1117,12 @@ export const SYSTEM_MODELS: Record<SystemProviderId | 'defaultModel', Model[]> =
     }
   ],
   'minimax-global': [
+    {
+      id: 'MiniMax-M3',
+      provider: 'minimax-global',
+      name: 'MiniMax-M3',
+      group: 'M3'
+    },
     {
       id: 'MiniMax-M2.7',
       provider: 'minimax-global',

--- a/src/renderer/config/models/reasoning.ts
+++ b/src/renderer/config/models/reasoning.ts
@@ -762,7 +762,7 @@ export const isMiniMaxReasoningModel = (model?: Model): boolean => {
     return false
   }
   const modelId = getLowerBaseModelName(model.id, '/')
-  return (['minimax-m1', 'minimax-m2', 'minimax-m2.1'] as const).some((id) => modelId.includes(id))
+  return (['minimax-m1', 'minimax-m2', 'minimax-m2.1', 'minimax-m3'] as const).some((id) => modelId.includes(id))
 }
 
 export const isBaichuanReasoningModel = (model?: Model): boolean => {

--- a/src/renderer/config/models/tooluse.ts
+++ b/src/renderer/config/models/tooluse.ts
@@ -36,7 +36,7 @@ export const FUNCTION_CALLING_MODELS = [
   'kimi-k2(?:-[\\w-]+)?',
   'ling-\\w+(?:-[\\w-]+)?',
   'ring-\\w+(?:-[\\w-]+)?',
-  'minimax-m2(?:\\.\\d+)?(?:-[\\w-]+)?',
+  'minimax-m[23](?:\\.\\d+)?(?:-[\\w-]+)?',
   'mimo-v2\\.5(?:-pro)?(?!-)',
   'mimo-v2-flash',
   'mimo-v2-pro',

--- a/src/renderer/config/models/vision.ts
+++ b/src/renderer/config/models/vision.ts
@@ -51,6 +51,7 @@ const visionAllowedModels = [
   'doubao-seed-1[.-][68](?:-[\\w-]+)?',
   'doubao-seed-2[.-]0(?:-[\\w-]+)?',
   'doubao-seed-code(?:-[\\w-]+)?',
+  'minimax-m3(?:-[\\w-]+)?',
   'kimi-thinking-preview',
   `gemma3(?:[-:\\w]+)?`,
   'kimi-vl-a3b-thinking(?:-[\\w-]+)?',

--- a/src/shared/utils/model.ts
+++ b/src/shared/utils/model.ts
@@ -643,7 +643,7 @@ export function inferReasoningFromModelId(rawModelId: string): boolean {
     id.includes('gemma4') ||
     id.includes('step-3') ||
     id.includes('step-r1-v-mini') ||
-    ['minimax-m1', 'minimax-m2', 'minimax-m2.1'].some((m) => id.includes(m)) ||
+    ['minimax-m1', 'minimax-m2', 'minimax-m2.1', 'minimax-m3'].some((m) => id.includes(m)) ||
     id === 'baichuan-m2' ||
     id === 'baichuan-m3' ||
     ['ring-1t', 'ring-mini', 'ring-flash'].some((m) => id.includes(m)) ||
@@ -749,7 +749,7 @@ const FUNCTION_CALLING_ALLOWED_MODELS = [
   'kimi-k2(?:-[\\w-]+)?',
   'ling-\\w+(?:-[\\w-]+)?',
   'ring-\\w+(?:-[\\w-]+)?',
-  'minimax-m2(?:\\.\\d+)?(?:-[\\w-]+)?',
+  'minimax-m[23](?:\\.\\d+)?(?:-[\\w-]+)?',
   'mimo-v2-flash',
   'mimo-v2-pro',
   'mimo-v2-omni',
@@ -999,6 +999,7 @@ const visionAllowedModels = [
   'doubao-seed-1[.-][68](?:-[\\w-]+)?',
   'doubao-seed-2[.-]0(?:-[\\w-]+)?',
   'doubao-seed-code(?:-[\\w-]+)?',
+  'minimax-m3(?:-[\\w-]+)?',
   'kimi-thinking-preview',
   'gemma3(?:[-:\\w]+)?',
   'kimi-vl-a3b-thinking(?:-[\\w-]+)?',


### PR DESCRIPTION
## What

Adds MiniMax's new flagship **MiniMax-M3** to the built-in model registry and wires it through the capability checks.

- **default.ts**: add `MiniMax-M3` (group `M3`) to the `minimax` and `minimax-global` providers in `SYSTEM_MODELS`
- **tooluse.ts**: extend the `minimax-m2` function-calling pattern to `minimax-m[23]` so M3 is recognized for tool use
- **vision.ts**: add `minimax-m3` to the vision allow-list (M3 is natively multimodal — image input)
- **reasoning.ts**: add `minimax-m3` to `isMiniMaxReasoningModel` (M3 supports thinking)

Older M2.x entries are kept, matching this provider's existing convention (e.g. PR adding M2.7 kept M2/M2.1/M2.5).

## Why

M3 is MiniMax's current flagship; the provider registry currently tops out at M2.7. Without this, M3 is missing from the model list and isn't recognized as vision/reasoning/tool-capable.

## Test

Added unit assertions for M3 in `tooluse.test.ts`, `vision.test.ts`, `reasoning.test.ts`. Full `config/models` suite passes (8 files, 703 tests). M3 verified working end-to-end against the MiniMax OpenAI-compatible endpoint (text + image).

> Note: M3 reasoning *registry* recognition here is complementary to #15513, which focuses on M3 thinking-process parsing. This PR also corrects the file path (`src/renderer/config/...`, matching current main).