### PR TITLE
fix: guard OV OCR availability CPU detection

### DIFF
--- a/src/main/services/ocr/builtin/OvOcrService.ts
+++ b/src/main/services/ocr/builtin/OvOcrService.ts
@@ -22,12 +22,16 @@ export class OvOcrService extends OcrBaseService {
   }
 
   public isAvailable(): boolean {
-    return (
-      isWin &&
-      os.cpus()[0].model.toLowerCase().includes('intel') &&
-      os.cpus()[0].model.toLowerCase().includes('ultra') &&
-      fs.existsSync(PATH_BAT_FILE)
-    )
+    if (!isWin) {
+      return false
+    }
+
+    const cpuModel = os.cpus()[0]?.model.toLowerCase()
+    if (!cpuModel) {
+      return false
+    }
+
+    return cpuModel.includes('intel') && cpuModel.includes('ultra') && fs.existsSync(PATH_BAT_FILE)
   }
 
   private getOvOcrPath(): string {


### PR DESCRIPTION
### What this PR does

Before this PR:

Cherry Studio could crash during main process startup on Windows when OV OCR availability detection received no CPU information from `os.cpus()`, because it directly read `os.cpus()[0].model`.

After this PR:

OV OCR availability detection safely returns `false` when CPU information is unavailable, so the app can continue startup.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #15315

### Why we need it and why it was done in this way

The following tradeoffs were made:

This keeps the fix minimal for the v1 branch: OV OCR is only registered when the same Windows + Intel Ultra + installed batch file checks pass, but missing CPU metadata no longer crashes the app.

The following alternatives were considered:

Registering OV OCR unconditionally or changing OCR provider defaults was avoided because the crash is isolated to availability detection.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/15315

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

This is a minimal v1 bug fix for a Windows startup crash.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed a Windows startup crash that could occur while detecting Intel OV OCR availability.
```
