### PR TITLE
fix(mcp-servers): strip readonly fields before mutations

### DIFF
--- a/src/renderer/hooks/__tests__/useMcpServers.test.tsx
+++ b/src/renderer/hooks/__tests__/useMcpServers.test.tsx
@@ -1,0 +1,59 @@
+import { MockUseDataApiUtils } from '@test-mocks/renderer/useDataApi'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useMcpServerMutations, useMcpServers } from '../useMcpServers'
+
+describe('useMcpServers', () => {
+  beforeEach(() => {
+    MockUseDataApiUtils.resetMocks()
+  })
+
+  it('strips read-only fields before creating a server', async () => {
+    const trigger = vi.fn().mockResolvedValue({ id: 'server-id', name: '@cherry/fetch' })
+    MockUseDataApiUtils.mockQueryData('/mcp-servers', { items: [], total: 0, page: 1 })
+    MockUseDataApiUtils.mockMutationWithTrigger('POST', '/mcp-servers', trigger)
+
+    const { result } = renderHook(() => useMcpServers())
+
+    await act(async () => {
+      await result.current.addMcpServer({
+        id: '00000000-0000-4000-8000-000000000000',
+        name: '@cherry/fetch',
+        isActive: true,
+        createdAt: '2026-06-01T00:00:00.000Z',
+        updatedAt: '2026-06-01T00:00:00.000Z'
+      })
+    })
+
+    expect(trigger).toHaveBeenCalledWith({
+      body: {
+        name: '@cherry/fetch',
+        isActive: true
+      }
+    })
+  })
+
+  it('strips read-only fields before updating a server', async () => {
+    const trigger = vi.fn().mockResolvedValue({ id: 'server-id', name: '@cherry/fetch' })
+    MockUseDataApiUtils.mockMutationWithTrigger('PATCH', '/mcp-servers/server-id', trigger)
+
+    const { result } = renderHook(() => useMcpServerMutations('server-id'))
+
+    await act(async () => {
+      await result.current.updateMcpServer({
+        body: {
+          id: 'server-id',
+          name: '@cherry/fetch',
+          updatedAt: '2026-06-01T00:00:00.000Z'
+        }
+      })
+    })
+
+    expect(trigger).toHaveBeenCalledWith({
+      body: {
+        name: '@cherry/fetch'
+      }
+    })
+  })
+})

--- a/src/renderer/hooks/useMcpServers.ts
+++ b/src/renderer/hooks/useMcpServers.ts
@@ -1,7 +1,12 @@
 import { useMutation, useQuery } from '@data/hooks/useDataApi'
 import { loggerService } from '@logger'
 import NavigationService from '@renderer/services/NavigationService'
-import type { CreateMCPServerDto, ListMCPServersQuery } from '@shared/data/api/schemas/mcpServers'
+import {
+  type CreateMCPServerDto,
+  type ListMCPServersQuery,
+  stripReadOnlyMCPServerFields,
+  type UpdateMCPServerDto
+} from '@shared/data/api/schemas/mcpServers'
 import type { MCPServer } from '@shared/data/types/mcpServer'
 import { IpcChannel } from '@shared/IpcChannel'
 import { useCallback, useMemo } from 'react'
@@ -11,6 +16,10 @@ window.electron.ipcRenderer.on(IpcChannel.Mcp_AddServer, (_event, server: { id: 
   void NavigationService.navigate?.({ to: '/settings/mcp' })
   void NavigationService.navigate?.({ to: `/settings/mcp/settings/${server.id}` })
 })
+
+type ReadOnlyMcpServerFields = Pick<MCPServer, 'id' | 'createdAt' | 'updatedAt'>
+type CreateMcpServerInput = CreateMCPServerDto & Partial<ReadOnlyMcpServerFields>
+type UpdateMcpServerInput = UpdateMCPServerDto & Partial<ReadOnlyMcpServerFields>
 
 /**
  * MCP servers list hook — data fetching with optional filters and create mutation.
@@ -24,7 +33,10 @@ export const useMcpServers = (query?: ListMCPServersQuery) => {
     refresh: ['/mcp-servers']
   })
 
-  const addMcpServer = useCallback((dto: CreateMCPServerDto) => createMcpServer({ body: dto }), [createMcpServer])
+  const addMcpServer = useCallback(
+    (dto: CreateMcpServerInput) => createMcpServer({ body: stripReadOnlyMCPServerFields(dto) }),
+    [createMcpServer]
+  )
 
   const { trigger: reorderTrigger } = useMutation('PATCH', '/mcp-servers', {
     refresh: ['/mcp-servers']
@@ -76,9 +88,21 @@ export const useMcpServer = (id: string) => {
 export const useMcpServerMutations = (id: string) => {
   const path = `/mcp-servers/${id}` as const
 
-  const { trigger: updateMcpServer } = useMutation('PATCH', path, {
+  const { trigger: updateMcpServerTrigger } = useMutation('PATCH', path, {
     refresh: ['/mcp-servers']
   })
+
+  type UpdateMcpServerArgs = Omit<NonNullable<Parameters<typeof updateMcpServerTrigger>[0]>, 'body'> & {
+    body?: UpdateMcpServerInput
+  }
+
+  const updateMcpServer = useCallback(
+    (data?: UpdateMcpServerArgs) => {
+      if (!data?.body) return updateMcpServerTrigger(data)
+      return updateMcpServerTrigger({ ...data, body: stripReadOnlyMCPServerFields(data.body) })
+    },
+    [updateMcpServerTrigger]
+  )
 
   const { trigger: deleteMcpServer } = useMutation('DELETE', path, {
     refresh: ['/mcp-servers']

--- a/src/renderer/pages/settings/McpSettings/McpProviderSettings.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpProviderSettings.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { getMCPProviderLogo, getProviderDisplayName, type ProviderConfig } from './providers/config'
+import { isSameMcpServerInstall } from './providers/identity'
 
 const logger = loggerService.withContext('McpProviderSettings')
 
@@ -201,7 +202,7 @@ const McpProviderSettings: React.FC<Props> = ({ provider, existingServers }) => 
                   </div>
                 </div>
                 {(() => {
-                  const isAlreadyAdded = existingServers.some((existing) => existing.id === server.id)
+                  const isAlreadyAdded = existingServers.some((existing) => isSameMcpServerInstall(existing, server))
                   return (
                     <Button
                       disabled={isAlreadyAdded}

--- a/src/renderer/pages/settings/McpSettings/providers/302ai.ts
+++ b/src/renderer/pages/settings/McpSettings/providers/302ai.ts
@@ -3,6 +3,8 @@ import { nanoid } from '@reduxjs/toolkit'
 import type { MCPServer } from '@renderer/types'
 import i18next from 'i18next'
 
+import { isSameMcpServerInstall } from './identity'
+
 const logger = loggerService.withContext('302ai')
 
 // Token storage constants and utilities
@@ -93,9 +95,6 @@ export const syncAi302Servers = async (token: string, existingServers: MCPServer
 
     for (const server of servers) {
       try {
-        // Check if server already exists
-        const existingServer = existingServers.find((s) => s.id === `@302ai/${server.name}`)
-
         const mcpServer: MCPServer = {
           id: `@302ai/${server.name}`,
           name: server.name || `302ai Server ${nanoid()}`,
@@ -108,6 +107,7 @@ export const syncAi302Servers = async (token: string, existingServers: MCPServer
           tags: server.tags,
           logoUrl: server.logoUrl
         }
+        const existingServer = existingServers.find((s) => isSameMcpServerInstall(s, mcpServer))
 
         if (existingServer) {
           // Update existing server with latest info

--- a/src/renderer/pages/settings/McpSettings/providers/__tests__/identity.test.ts
+++ b/src/renderer/pages/settings/McpSettings/providers/__tests__/identity.test.ts
@@ -1,0 +1,60 @@
+import type { MCPServer } from '@shared/data/types/mcpServer'
+import { describe, expect, it } from 'vitest'
+
+import { isSameMcpServerInstall } from '../identity'
+
+function server(overrides: Partial<MCPServer>): MCPServer {
+  return {
+    id: '00000000-0000-4000-8000-000000000000',
+    name: 'server',
+    isActive: true,
+    ...overrides
+  }
+}
+
+describe('isSameMcpServerInstall', () => {
+  it('matches provider servers by providerUrl after create replaces the synthetic id', () => {
+    const installed = server({
+      id: '11111111-1111-4111-8111-111111111111',
+      provider: 'ModelScope',
+      providerUrl: 'https://modelscope.cn/mcp/servers/demo'
+    })
+    const marketplace = server({
+      id: '@modelscope/demo',
+      provider: 'ModelScope',
+      providerUrl: 'https://modelscope.cn/mcp/servers/demo'
+    })
+
+    expect(isSameMcpServerInstall(installed, marketplace)).toBe(true)
+  })
+
+  it('matches provider servers by baseUrl when providerUrl is absent', () => {
+    const installed = server({
+      id: '11111111-1111-4111-8111-111111111111',
+      provider: 'LanYun',
+      baseUrl: 'https://mcp.lanyun.net/demo'
+    })
+    const marketplace = server({
+      id: '@lanyun/demo',
+      provider: 'LanYun',
+      baseUrl: 'https://mcp.lanyun.net/demo'
+    })
+
+    expect(isSameMcpServerInstall(installed, marketplace)).toBe(true)
+  })
+
+  it('does not match provider servers with different stable urls', () => {
+    const installed = server({
+      id: '11111111-1111-4111-8111-111111111111',
+      provider: 'TokenFlux',
+      providerUrl: 'https://tokenflux.ai/mcps/installed'
+    })
+    const marketplace = server({
+      id: '@tokenflux/other',
+      provider: 'TokenFlux',
+      providerUrl: 'https://tokenflux.ai/mcps/other'
+    })
+
+    expect(isSameMcpServerInstall(installed, marketplace)).toBe(false)
+  })
+})

--- a/src/renderer/pages/settings/McpSettings/providers/bailian.ts
+++ b/src/renderer/pages/settings/McpSettings/providers/bailian.ts
@@ -3,6 +3,8 @@ import { nanoid } from '@reduxjs/toolkit'
 import type { MCPServer } from '@renderer/types'
 import i18next from 'i18next'
 
+import { isSameMcpServerInstall } from './identity'
+
 const logger = loggerService.withContext('BailianSyncUtils')
 
 // 常量定义
@@ -127,7 +129,6 @@ export const syncBailianServers = async (token: string, existingServers: MCPServ
         }
 
         const id = `@bailian/${server.id}`
-        const existingServer = existingServers.find((s) => s.id === id)
 
         const mcpServer: MCPServer = {
           id,
@@ -147,6 +148,7 @@ export const syncBailianServers = async (token: string, existingServers: MCPServ
             Authorization: `Bearer ${token}`
           }
         }
+        const existingServer = existingServers.find((s) => isSameMcpServerInstall(s, mcpServer))
 
         if (existingServer) {
           updatedServers.push(mcpServer)

--- a/src/renderer/pages/settings/McpSettings/providers/identity.ts
+++ b/src/renderer/pages/settings/McpSettings/providers/identity.ts
@@ -1,0 +1,28 @@
+import type { MCPServer } from '@shared/data/types/mcpServer'
+
+function normalize(value: string | undefined): string | undefined {
+  const trimmed = value?.trim().toLowerCase()
+  return trimmed || undefined
+}
+
+function sameStableValue(left: string | undefined, right: string | undefined): boolean {
+  const normalizedLeft = normalize(left)
+  return normalizedLeft !== undefined && normalizedLeft === normalize(right)
+}
+
+function hasCompatibleProvider(left: MCPServer, right: MCPServer): boolean {
+  const leftProvider = normalize(left.provider)
+  const rightProvider = normalize(right.provider)
+  return leftProvider === undefined || rightProvider === undefined || leftProvider === rightProvider
+}
+
+export function isSameMcpServerInstall(left: MCPServer, right: MCPServer): boolean {
+  if (sameStableValue(left.id, right.id)) return true
+  if (!hasCompatibleProvider(left, right)) return false
+
+  return (
+    sameStableValue(left.providerUrl, right.providerUrl) ||
+    sameStableValue(left.baseUrl, right.baseUrl) ||
+    sameStableValue(left.searchKey, right.searchKey)
+  )
+}

--- a/src/renderer/pages/settings/McpSettings/providers/lanyun.ts
+++ b/src/renderer/pages/settings/McpSettings/providers/lanyun.ts
@@ -3,6 +3,8 @@ import { getProviderLabel } from '@renderer/i18n/label'
 import type { MCPServer } from '@renderer/types'
 import i18next from 'i18next'
 
+import { isSameMcpServerInstall } from './identity'
+
 const logger = loggerService.withContext('TokenLanYunSyncUtils')
 
 // Token storage constants and utilities
@@ -146,9 +148,6 @@ export const syncTokenLanYunServers = async (
       try {
         if (!server.operationalUrls?.[0]?.url) continue
 
-        // Check if server already exists
-        const existingServer = existingServers.find((s) => s.id === `@lanyun/${server.id}`)
-
         const mcpServer: MCPServer = {
           id: `@lanyun/${server.id}`,
           name:
@@ -165,6 +164,7 @@ export const syncTokenLanYunServers = async (
           logoUrl: server.logoUrl || '',
           tags: server.tags ?? (server.chineseName ? [server.chineseName] : [])
         }
+        const existingServer = existingServers.find((s) => isSameMcpServerInstall(s, mcpServer))
 
         if (existingServer) {
           // Update existing server with latest info

--- a/src/renderer/pages/settings/McpSettings/providers/mcprouter.ts
+++ b/src/renderer/pages/settings/McpSettings/providers/mcprouter.ts
@@ -3,6 +3,8 @@ import { nanoid } from '@reduxjs/toolkit'
 import type { MCPServer } from '@renderer/types'
 import i18next from 'i18next'
 
+import { isSameMcpServerInstall } from './identity'
+
 const logger = loggerService.withContext('MCPRouterSyncUtils')
 
 // Token storage constants and utilities
@@ -110,9 +112,6 @@ export const syncMCPRouterServers = async (
     const allServers: MCPServer[] = []
     for (const server of servers) {
       try {
-        // Check if server already exists using server_key
-        const existingServer = existingServers.find((s) => s.id === `@mcprouter/${server.server_key}`)
-
         const mcpServer: MCPServer = {
           id: `@mcprouter/${server.server_key}`,
           name: server.title || server.name || `MCPRouter Server ${nanoid()}`,
@@ -128,6 +127,7 @@ export const syncMCPRouterServers = async (
             Authorization: `Bearer ${token}`
           }
         }
+        const existingServer = existingServers.find((s) => isSameMcpServerInstall(s, mcpServer))
 
         if (existingServer) {
           // Update existing server with corrected URL and latest info

--- a/src/renderer/pages/settings/McpSettings/providers/modelscope.ts
+++ b/src/renderer/pages/settings/McpSettings/providers/modelscope.ts
@@ -3,6 +3,8 @@ import { nanoid } from '@reduxjs/toolkit'
 import { getMcpServerType, type MCPServer } from '@renderer/types'
 import i18next from 'i18next'
 
+import { isSameMcpServerInstall } from './identity'
+
 const logger = loggerService.withContext('ModelScopeSyncUtils')
 
 // Token storage constants and utilities
@@ -107,8 +109,6 @@ export const syncModelScopeServers = async (
       try {
         if (!server.operational_urls?.[0]?.url) continue
 
-        // Check if server already exists
-        const existingServer = existingServers.find((s) => s.id === `@modelscope/${server.id}`)
         const url = server.operational_urls[0].url
         const mcpServer: MCPServer = {
           id: `@modelscope/${server.id}`,
@@ -125,6 +125,7 @@ export const syncModelScopeServers = async (
           logoUrl: server.logo_url || '',
           tags: server.tags || []
         }
+        const existingServer = existingServers.find((s) => isSameMcpServerInstall(s, mcpServer))
 
         if (existingServer) {
           // Update existing server with latest info

--- a/src/renderer/pages/settings/McpSettings/providers/tokenflux.ts
+++ b/src/renderer/pages/settings/McpSettings/providers/tokenflux.ts
@@ -3,6 +3,8 @@ import { nanoid } from '@reduxjs/toolkit'
 import type { MCPServer } from '@renderer/types'
 import i18next from 'i18next'
 
+import { isSameMcpServerInstall } from './identity'
+
 const logger = loggerService.withContext('TokenFluxSyncUtils')
 
 // Token storage constants and utilities
@@ -111,9 +113,6 @@ export const syncTokenFluxServers = async (
     logger.debug('TokenFlux servers:', servers)
     for (const server of servers) {
       try {
-        // Check if server already exists
-        const existingServer = existingServers.find((s) => s.id === `@tokenflux/${server.name}`)
-
         const authHeaders = {}
         if (server.security_schemes && server.security_schemes.api_key) {
           const keyAuth = server.security_schemes.api_key as TokenFluxServerAuthSchemaApiKey
@@ -135,6 +134,7 @@ export const syncTokenFluxServers = async (
           tags: server.categories || [],
           headers: authHeaders
         }
+        const existingServer = existingServers.find((s) => isSameMcpServerInstall(s, mcpServer))
 
         if (existingServer) {
           // Update existing server with corrected URL and latest info

--- a/src/shared/data/api/schemas/__tests__/mcpServers.test.ts
+++ b/src/shared/data/api/schemas/__tests__/mcpServers.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import { CreateMCPServerSchema, stripReadOnlyMCPServerFields, UpdateMCPServerSchema } from '../mcpServers'
+
+const SERVER_ID = '00000000-0000-4000-8000-000000000000'
+
+describe('MCP server schemas', () => {
+  it.each([CreateMCPServerSchema, UpdateMCPServerSchema])('rejects read-only fields at the API boundary', (schema) => {
+    expect(() => schema.parse({ id: SERVER_ID, name: '@cherry/fetch' })).toThrow(/unrecognized/i)
+  })
+
+  it('strips read-only fields before renderer mutations send DTO bodies', () => {
+    const stripped = stripReadOnlyMCPServerFields({
+      id: SERVER_ID,
+      name: '@cherry/fetch',
+      isActive: true,
+      createdAt: '2026-06-01T00:00:00.000Z',
+      updatedAt: '2026-06-01T00:00:00.000Z'
+    })
+
+    expect(stripped).toEqual({
+      name: '@cherry/fetch',
+      isActive: true
+    })
+    expect(CreateMCPServerSchema.parse(stripped)).toEqual(stripped)
+  })
+})

--- a/src/shared/data/api/schemas/mcpServers.ts
+++ b/src/shared/data/api/schemas/mcpServers.ts
@@ -62,6 +62,18 @@ export type CreateMCPServerDto = z.infer<typeof CreateMCPServerSchema>
 export const UpdateMCPServerSchema = CreateMCPServerSchema.partial()
 export type UpdateMCPServerDto = z.infer<typeof UpdateMCPServerSchema>
 
+type MCPServerReadOnlyFields = Pick<MCPServer, 'id' | 'createdAt' | 'updatedAt'>
+
+export function stripReadOnlyMCPServerFields<T extends CreateMCPServerDto | UpdateMCPServerDto>(
+  dto: T & Partial<MCPServerReadOnlyFields>
+): T {
+  const body = { ...dto }
+  delete body.id
+  delete body.createdAt
+  delete body.updatedAt
+  return body as T
+}
+
 /**
  * Query parameters for listing MCP servers
  */


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

POST /mcp-servers could fail when the renderer sent read-only fields such as `id`, `createdAt`, or `updatedAt` to strict Data API schemas. Built-in MCP provider install state also relied on synthetic provider IDs, so installed providers could be missed after the database generated a real UUID.

After this PR:

Renderer MCP server create/update mutations strip read-only fields before calling Data API. Built-in MCP providers now compare install state using stable provider identity fields instead of only the server ID.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

Keep the backend schemas strict and normalize renderer mutation payloads at the MCP server hook boundary, so validation still catches unexpected API input while UI callers can safely pass full server objects.

The following alternatives were considered:

Allowing `id` in the create schema was rejected because create payloads should not accept database-owned fields. Keeping provider matching by synthetic IDs was rejected because created MCP servers receive generated IDs.

Links to places where the discussion took place: N/A

### Breaking changes

N/A

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Validation:

- `pnpm format` passed.
- Targeted MCP tests passed: `pnpm vitest run --silent=true src/renderer/hooks/__tests__/useMcpServers.test.tsx src/renderer/pages/settings/McpSettings/providers/__tests__/identity.test.ts src/shared/data/api/schemas/__tests__/mcpServers.test.ts`.
- `pnpm build:check` was run in a non-sandbox environment after a sandbox-only IPC failure. It passed lint, typecheck, i18n, format, OpenAPI check, and docs link check, then failed in an unrelated file watcher test: `src/main/services/file/tree/__tests__/builder.test.ts` (`dispose() stops the chokidar watcher so post-dispose FS changes emit nothing`). Re-running that file alone also fails, indicating a current baseline/test-environment blocker unrelated to this MCP change.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix built-in MCP server installation failures caused by read-only fields being sent to strict Data API validation.
```
