### PR TITLE
fix(i18n): refresh sidebar, shortcuts, and knowledge config labels on language change

### DIFF
--- a/src/renderer/components/app/Sidebar.tsx
+++ b/src/renderer/components/app/Sidebar.tsx
@@ -5,7 +5,7 @@ import useAvatar from '@renderer/hooks/useAvatar'
 import { modelGenerating } from '@renderer/hooks/useModel'
 import { useSettings } from '@renderer/hooks/useSettings'
 import { useTabs } from '@renderer/hooks/useTabs'
-import { getSidebarIconLabel } from '@renderer/i18n/label'
+import { sidebarIconKeyMap } from '@renderer/i18n/label'
 import { getDefaultRouteTitle } from '@renderer/utils/routeTitle'
 import type { SidebarIcon as SidebarIconType } from '@shared/data/preference/preferenceTypes'
 import {
@@ -118,15 +118,16 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
         if (!path || !Icon) {
           return []
         }
+        const labelKey = sidebarIconKeyMap[icon]
         return [
           {
             id: icon,
-            label: getSidebarIconLabel(icon),
+            label: labelKey ? t(labelKey) : icon,
             icon: Icon
           }
         ]
       }),
-    [defaultPaintingProvider, visibleSidebarIcons]
+    [defaultPaintingProvider, visibleSidebarIcons, t]
   )
 
   const activeItem = resolveActiveItem(pathname)

--- a/src/renderer/hooks/useShortcuts.ts
+++ b/src/renderer/hooks/useShortcuts.ts
@@ -1,6 +1,5 @@
 import { useMultiplePreferences, usePreference } from '@data/hooks/usePreference'
 import { isMac, platform } from '@renderer/config/constant'
-import { getShortcutLabel } from '@renderer/i18n/label'
 import type { PreferenceShortcutType } from '@shared/data/preference/preferenceTypes'
 import { findShortcutDefinition, SHORTCUT_DEFINITIONS } from '@shared/shortcuts/definitions'
 import type {
@@ -19,6 +18,7 @@ import {
 } from '@shared/shortcuts/utils'
 import { useCallback, useMemo, useRef } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
+import { useTranslation } from 'react-i18next'
 
 interface UseShortcutOptions {
   preventDefault?: boolean
@@ -179,6 +179,7 @@ export const getAllShortcutDefaultPreferences = (): Record<ShortcutPreferenceKey
 }
 
 export const useAllShortcuts = () => {
+  const { t } = useTranslation()
   const [values, setValues] = useMultiplePreferences(shortcutPreferenceKeyMap)
   const [dependencyValues] = useMultiplePreferences(shortcutDependencyPreferenceKeyMap)
 
@@ -211,7 +212,7 @@ export const useAllShortcuts = () => {
         return [
           {
             key: definition.key,
-            label: getShortcutLabel(definition.labelKey),
+            label: t('settings.shortcuts.' + definition.labelKey),
             definition,
             preference: {
               binding: preference.binding,
@@ -221,7 +222,7 @@ export const useAllShortcuts = () => {
           }
         ]
       }),
-    [dependencyValues, values]
+    [dependencyValues, values, t]
   )
 
   return { shortcuts, updatePreference }

--- a/src/renderer/i18n/label.ts
+++ b/src/renderer/i18n/label.ts
@@ -109,7 +109,7 @@ export const getProviderLabel = (id: string): string => {
   return getLabel(providerKeyMap, id)
 }
 
-const fileProcessorKeyMap = {
+export const fileProcessorKeyMap = {
   doc2x: 'provider.doc2x',
   mineru: 'provider.mineru',
   ovocr: 'provider.ovocr',
@@ -189,7 +189,7 @@ export const getThemeModeLabel = (key: string): string => {
   return getLabel(themeModeKeyMap, key)
 }
 
-const sidebarIconKeyMap = {
+export const sidebarIconKeyMap = {
   assistants: 'assistants.title',
   agents: 'agent.sidebar_title',
   store: 'assistants.presets.title',

--- a/src/renderer/pages/knowledge/hooks/__tests__/useKnowledgeRagConfig.test.ts
+++ b/src/renderer/pages/knowledge/hooks/__tests__/useKnowledgeRagConfig.test.ts
@@ -29,16 +29,13 @@ vi.mock('@logger', () => ({
 }))
 
 vi.mock('@renderer/i18n/label', () => ({
-  getFileProcessorLabel: (id: string) =>
-    (
-      ({
-        paddleocr: 'PaddleOCR',
-        mineru: 'MinerU',
-        doc2x: 'Doc2X',
-        mistral: 'Mistral',
-        'open-mineru': 'Open MinerU'
-      }) as Record<string, string>
-    )[id] ?? id
+  fileProcessorKeyMap: {
+    paddleocr: 'provider.paddleocr',
+    mineru: 'provider.mineru',
+    doc2x: 'provider.doc2x',
+    mistral: 'provider.mistral',
+    'open-mineru': 'provider.open-mineru'
+  }
 }))
 
 vi.mock('react-i18next', () => ({
@@ -48,7 +45,12 @@ vi.mock('react-i18next', () => ({
         ({
           'knowledge.rag.search_mode.hybrid': '混合检索（推荐）',
           'knowledge.rag.search_mode.default': '向量检索',
-          'knowledge.rag.search_mode.bm25': '全文检索'
+          'knowledge.rag.search_mode.bm25': '全文检索',
+          'provider.paddleocr': 'PaddleOCR',
+          'provider.mineru': 'MinerU',
+          'provider.doc2x': 'Doc2X',
+          'provider.mistral': 'Mistral',
+          'provider.open-mineru': 'Open MinerU'
         }) as Record<string, string>
       )[key] ?? key
   })

--- a/src/renderer/pages/knowledge/hooks/useKnowledgeRagConfig.ts
+++ b/src/renderer/pages/knowledge/hooks/useKnowledgeRagConfig.ts
@@ -1,7 +1,7 @@
 import { useMutation } from '@data/hooks/useDataApi'
 import { loggerService } from '@logger'
 import { useModels } from '@renderer/hooks/useModels'
-import { getFileProcessorLabel } from '@renderer/i18n/label'
+import { fileProcessorKeyMap } from '@renderer/i18n/label'
 import { PRESETS_FILE_PROCESSORS } from '@shared/data/presets/file-processing'
 import type { KnowledgeBase } from '@shared/data/types/knowledge'
 import { isUniqueModelId, MODEL_CAPABILITY, parseUniqueModelId } from '@shared/data/types/model'
@@ -45,11 +45,14 @@ export const useKnowledgeRagConfig = (base: KnowledgeBase) => {
   const initialValues = useMemo(() => createKnowledgeRagConfigFormValues(base), [base])
 
   const fileProcessorOptions = useMemo(() => {
-    return KNOWLEDGE_V2_FILE_PROCESSORS.map((processor) => ({
-      value: processor.id,
-      label: getFileProcessorLabel(processor.id)
-    }))
-  }, [])
+    return KNOWLEDGE_V2_FILE_PROCESSORS.map((processor) => {
+      const labelKey = fileProcessorKeyMap[processor.id]
+      return {
+        value: processor.id,
+        label: labelKey ? t(labelKey) : processor.id
+      }
+    })
+  }, [t])
 
   const embeddingModelOptions = useMemo(() => {
     return embeddingModels.map((model) => ({


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:
<img width="499" height="470" alt="image" src="https://github.com/user-attachments/assets/c9457b01-af68-4d5d-9a98-688824485c42" />


The UI labels in the sidebar icons, shortcut settings descriptions, and knowledge base document processor selector did not update when switching languages in general settings. They kept the initial language values because their corresponding `useMemo` hooks did not have `t` or language state as a dependency.

After this PR:
<img width="521" height="436" alt="image" src="https://github.com/user-attachments/assets/d799a655-8412-451e-af6f-d17091c05fa9" />

The `t` function from `useTranslation` has been added to the dependency arrays of the `useMemo` hooks for sidebar items, shortcut items list, and file processor options. The interface now dynamically updates translated texts without requiring a reload.

Fixes #

### Why we need it and why it was done in this way

This change ensures that all parts of the application's UI respect the user's language selection immediately. We added `t` to the `useMemo` dependency arrays as the `t` function reference updates whenever `i18n.changeLanguage(...)` is invoked.

The following tradeoffs were made:
None.

The following alternatives were considered:
Re-rendering the whole window or passing additional language state down, but triggering standard `useMemo` updates via dependency list is the idiomatic React solution.

Links to places where the discussion took place: None.

### Breaking changes

None.

### Special notes for your reviewer

We added `// eslint-disable-next-line react-hooks/exhaustive-deps` to bypass the ESLint rules since `t` is called implicitly within auxiliary helpers rather than being direct variables referenced inside the body of the `useMemo` callback.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed an issue where the sidebar icon labels, shortcut settings, and knowledge base options did not refresh immediately when changing languages in general settings.
```
