### PR TITLE
fix(mini-apps): hide global MiniMax Agent in China (CN) region

### DIFF
--- a/src/renderer/hooks/__tests__/useMiniApps.test.ts
+++ b/src/renderer/hooks/__tests__/useMiniApps.test.ts
@@ -74,13 +74,14 @@ describe('useMiniApps', () => {
   // === Region Filtering ===
 
   describe('region filtering', () => {
-    it('should show all apps when region is CN (default)', () => {
+    it('should show only CN-compatible and region-free apps when region is CN (default)', () => {
       const { mixedRegion } = appFixtures
       const apps = Object.values(mixedRegion).map((a) => ({ ...a, status: 'enabled' as const }))
       MockUseDataApiUtils.mockQueryData('/mini-apps', paginated(apps))
       MockUsePreferenceUtils.setPreferenceValue('feature.mini_app.region', 'CN')
       const { result } = renderHook(() => useMiniApps())
-      expect(result.current.miniApps).toHaveLength(3)
+      expect(result.current.miniApps).toHaveLength(2)
+      expect(result.current.miniApps.find((a) => a.appId === 'global-app')).toBeUndefined()
     })
 
     it('should only show Global apps when region is Global', () => {
@@ -139,7 +140,8 @@ describe('useMiniApps', () => {
       const apps = [createGlobalApp('g', { status: 'enabled' }), createCnOnlyApp('c', { status: 'enabled' })]
       MockUseDataApiUtils.mockQueryData('/mini-apps', paginated(apps))
       const { result } = renderHook(() => useMiniApps())
-      expect(result.current.miniApps).toHaveLength(2)
+      expect(result.current.miniApps).toHaveLength(1)
+      expect(result.current.miniApps[0].appId).toBe('c')
     })
 
     it('should use preference Global when explicitly set', () => {
@@ -166,7 +168,8 @@ describe('useMiniApps', () => {
       const apps = [createGlobalApp('g', { status: 'enabled' }), createCnOnlyApp('c', { status: 'enabled' })]
       MockUseDataApiUtils.mockQueryData('/mini-apps', paginated(apps))
       const { result } = renderHook(() => useMiniApps())
-      expect(result.current.miniApps).toHaveLength(2)
+      expect(result.current.miniApps).toHaveLength(1)
+      expect(result.current.miniApps[0].appId).toBe('c')
     })
   })
 

--- a/src/renderer/hooks/useMiniApps.ts
+++ b/src/renderer/hooks/useMiniApps.ts
@@ -38,12 +38,13 @@ import { useCallback, useEffect, useMemo } from 'react'
  *      own app under Global.
  */
 const isVisibleForRegion = (app: MiniApp, region: MiniAppRegion): boolean => {
+  if (app.supportedRegions && app.supportedRegions.length > 0) {
+    return app.supportedRegions.includes(region)
+  }
+
   if (region === 'CN') return true
 
-  if (!app.supportedRegions || app.supportedRegions.length === 0) {
-    return app.presetMiniAppId === null
-  }
-  return app.supportedRegions.includes('Global')
+  return app.presetMiniAppId === null
 }
 
 // Filter apps by region

--- a/src/shared/data/presets/mini-apps.ts
+++ b/src/shared/data/presets/mini-apps.ts
@@ -138,7 +138,7 @@ export const PRESETS_MINI_APPS: MiniAppPreset[] = [
     url: 'https://agent.minimax.io/',
     logo: 'minimax',
     bordered: true,
-    supportedRegions: ['CN', 'Global']
+    supportedRegions: ['Global']
   },
   {
     id: 'ima',


### PR DESCRIPTION
﻿<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:
In mainland China (CN) region, both the domestic MiniMax Agent and the global MiniMax Agent were displayed in the Mini Apps panel. This happened because the global MiniMax Agent (`minimax-agent-global`) was incorrectly configured to support `['CN', 'Global']`, and the region filtering helper `isVisibleForRegion` unconditionally returned `true` for `CN` region users, bypassing any restriction on built-in preset apps.

After this PR:
- Updated the `supportedRegions` of the global MiniMax Agent (`minimax-agent-global`) in `mini-apps.ts` to `['Global']`.
- Improved the `isVisibleForRegion` filtering logic in `useMiniApps.ts` to strictly verify that `supportedRegions` contains the active region (if specifically defined) even when the active region is `CN`.
- Updated unit tests in `useMiniApps.test.ts` to reflect the updated filtering behavior under CN region, ensuring that global-only apps are properly hidden.

Fixes #

### Why we need it and why it was done in this way

Mainland China users should only see the domestic version of the MiniMax Agent (`https://agent.minimaxi.com/`) to prevent duplicate items and confusion with the global version (`https://agent.minimax.io/`). 
The filtering logic change ensures that preset apps with explicit region limitations (such as global-only apps) are correctly hidden from CN users, while preserving the behavior of showing all non-restricted or custom mini apps.

The following tradeoffs were made:
None.

The following alternatives were considered:
None.

Links to places where the discussion took place: None.

### Breaking changes

None.

### Special notes for your reviewer

None.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix(mini-apps): hide global MiniMax Agent in China (CN) region.
```
