### PR TITLE
fix: encode gemini model list api key

### DIFF
--- a/src/renderer/src/aiCore/services/__tests__/listModels.test.ts
+++ b/src/renderer/src/aiCore/services/__tests__/listModels.test.ts
@@ -464,6 +464,26 @@ describe('listModels', () => {
       expect(models[0].id).toBe('gemini-2.5-flash')
       expect(models).toMatchSnapshot()
     })
+
+    it('should encode special characters in API key query parameter', async () => {
+      mockGetFromApi.mockResolvedValue({ value: REAL_GEMINI })
+
+      await listModels(
+        makeProvider({
+          id: 'gemini',
+          type: 'gemini',
+          apiHost: 'https://generativelanguage.googleapis.com/v1beta',
+          apiKey: 'AIzaSyABC&DEF=xyz+123'
+        })
+      )
+
+      const [request] = mockGetFromApi.mock.calls[0]
+      expect(request.url).toBe(
+        'https://generativelanguage.googleapis.com/v1beta/models?key=AIzaSyABC%26DEF%3Dxyz%2B123'
+      )
+      expect(new URL(request.url).searchParams.get('key')).toBe('AIzaSyABC&DEF=xyz+123')
+      expect(Array.from(new URL(request.url).searchParams.keys())).toEqual(['key'])
+    })
   })
 
   describe('Vertex AI', () => {

--- a/src/renderer/src/aiCore/services/listModels.ts
+++ b/src/renderer/src/aiCore/services/listModels.ts
@@ -180,8 +180,9 @@ const geminiFetcher: ModelFetcher = {
   fetch: async (provider, signal) => {
     let baseUrl = withoutTrailingSlash(provider.apiHost)
     baseUrl = baseUrl.replace(/\/v1(beta)?$/, '')
+    const searchParams = new URLSearchParams({ key: getApiKey(provider) })
     const response = await getFromApi({
-      url: `${baseUrl}/v1beta/models?key=${getApiKey(provider)}`,
+      url: `${baseUrl}/v1beta/models?${searchParams.toString()}`,
       headers: { ...defaultAppHeaders(), ...provider.extra_headers },
       responseSchema: GeminiModelsResponseSchema,
       abortSignal: signal


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR:

Gemini model list requests appended the API key directly in the query string. API keys containing URL special characters such as `&`, `=`, or `+` could be parsed incorrectly, causing model list fetches to fail.

After this PR:

Gemini model list requests build the `key` query parameter with `URLSearchParams`, preserving special characters in API keys.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #15568

### Why we need it and why it was done in this way

The following tradeoffs were made:

This keeps the change scoped to Gemini model listing, which is the path that passes the API key through the URL query string. OpenAI-compatible model listing already sends API keys through headers.

The following alternatives were considered:

Encoding only the API key with `encodeURIComponent` was considered, but `URLSearchParams` is the standard API for query parameter construction and avoids manual query encoding mistakes.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Added a regression test covering `&`, `=`, and `+` in Gemini API keys.

Validation completed:
- `pnpm vitest run --silent=true src/renderer/src/aiCore/services/__tests__/listModels.test.ts`
- `pnpm lint`
- `pnpm test`
- `pnpm format`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Gemini model list fetching when API keys contain URL special characters.
```
