### PR TITLE
fix: infer custom provider model groups

### DIFF
--- a/src/renderer/src/aiCore/services/__tests__/listModels.test.ts
+++ b/src/renderer/src/aiCore/services/__tests__/listModels.test.ts
@@ -42,6 +42,10 @@ vi.mock('@renderer/i18n', () => ({
 
 vi.mock('@renderer/utils', () => ({
   formatApiHost: (host: string) => host?.replace(/\/$/, ''),
+  getDefaultGroupName: (id: string, provider?: string) => {
+    const parts = id.toLowerCase().split(/[-_]/)
+    return provider && parts.length > 1 ? `${parts[0]}-${parts[1]}` : id.toLowerCase()
+  },
   withoutTrailingSlash: (s: string) => s?.replace(/\/$/, ''),
   getLowerBaseModelName: (id: string) => id.toLowerCase()
 }))
@@ -422,6 +426,24 @@ describe('listModels', () => {
       const models = await listModels(makeProvider({ id: 'deepseek' }))
       assertValidModels(models)
       expect(models).toMatchSnapshot()
+    })
+
+    it('should infer model groups from ids for custom UUID providers', async () => {
+      const providerId = '9d08892b-3023-4b98-8c69-8032eec3dc98'
+      mockGetFromApi.mockResolvedValue({
+        value: {
+          data: [
+            { id: 'gemini-2.5-flash', object: 'model', owned_by: 'google' },
+            { id: 'gpt-4.1-mini', object: 'model', owned_by: 'openai' }
+          ]
+        }
+      })
+
+      const models = await listModels(makeProvider({ id: providerId, isSystem: false }))
+
+      expect(models).toHaveLength(2)
+      expect(models.map((model) => model.group)).toEqual(['gemini-2.5', 'gpt-4.1'])
+      expect(models.map((model) => model.group)).not.toContain(providerId)
     })
   })
 

--- a/src/renderer/src/aiCore/services/listModels.ts
+++ b/src/renderer/src/aiCore/services/listModels.ts
@@ -14,7 +14,7 @@ import { COPILOT_DEFAULT_HEADERS } from '@renderer/aiCore/provider/constants'
 import store from '@renderer/store'
 import type { EndpointType, Model, Provider } from '@renderer/types'
 import { SystemProviderIds } from '@renderer/types'
-import { formatApiHost, withoutTrailingSlash } from '@renderer/utils'
+import { formatApiHost, getDefaultGroupName, withoutTrailingSlash } from '@renderer/utils'
 import { isGeminiProvider, isOllamaProvider, isVertexProvider } from '@renderer/utils/provider'
 import { defaultAppHeaders } from '@shared/utils'
 import * as z from 'zod'
@@ -120,9 +120,13 @@ function defaultHeaders(provider: Provider): Record<string, string> {
   }
 }
 
-function defaultGroup(modelId: string, providerId: string): string {
+function defaultGroup(modelId: string, provider: Provider): string {
+  if (provider.isSystem === false) {
+    return getDefaultGroupName(modelId, provider.id)
+  }
+
   const parts = modelId.split('/')
-  return parts.length > 1 ? parts[0] : providerId
+  return parts.length > 1 ? parts[0] : provider.id
 }
 
 function toModel(id: string, provider: Provider, extra?: Partial<Model>): Model {
@@ -130,7 +134,7 @@ function toModel(id: string, provider: Provider, extra?: Partial<Model>): Model 
     id,
     name: extra?.name || id,
     provider: provider.id,
-    group: extra?.group || defaultGroup(id, provider.id),
+    group: extra?.group || defaultGroup(id, provider),
     ...extra
   }
 }


### PR DESCRIPTION
### What this PR does

Before this PR:

Custom providers could show fetched models under a group named after the provider UUID or provider ID when the remote model ID did not include a slash.

<img width="1394" height="906" alt="image" src="https://github.com/user-attachments/assets/6894ba19-a600-45ba-95c1-cdd241bdcb8c" />

After this PR:

Fetched models for custom providers infer their default group from the model ID, so model lists group by model series instead of provider UUID.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #15569

### Why we need it and why it was done in this way

The following tradeoffs were made:

The fix is limited to custom providers (`isSystem === false`) to avoid changing existing grouping behavior for built-in providers.

The following alternatives were considered:

Changing the model list UI was considered, but normalizing the default group during model list conversion keeps saved model data correct and avoids UI-only masking.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

The branch intentionally preserves existing system-provider grouping behavior and only changes the custom-provider fallback path.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed fetched models for custom providers being grouped under the provider UUID or provider ID instead of the model series.
```
