### PR TITLE
chore(models): prune legacy MiniMax models, keep M2.7 and M3

### DIFF
--- a/src/renderer/src/config/models/default.ts
+++ b/src/renderer/src/config/models/default.ts
@@ -1072,48 +1072,6 @@ export const SYSTEM_MODELS: Record<SystemProviderId | 'defaultModel', Model[]> =
       provider: 'minimax',
       name: 'MiniMax-M2.7-highspeed',
       group: 'M2.7'
-    },
-    {
-      id: 'MiniMax-M2.5',
-      provider: 'minimax',
-      name: 'MiniMax-M2.5',
-      group: 'M2.5'
-    },
-    {
-      id: 'MiniMax-M2.5-highspeed',
-      provider: 'minimax',
-      name: 'MiniMax-M2.5-highspeed',
-      group: 'M2.5'
-    },
-    {
-      id: 'MiniMax-M2.5-lightning',
-      provider: 'minimax',
-      name: 'MiniMax-M2.5-lightning',
-      group: 'M2.5'
-    },
-    {
-      id: 'MiniMax-M2.1',
-      provider: 'minimax',
-      name: 'MiniMax-M2.1',
-      group: 'M2.1'
-    },
-    {
-      id: 'MiniMax-M2.1-lightning',
-      provider: 'minimax',
-      name: 'MiniMax-M2.1-lightning',
-      group: 'M2.1'
-    },
-    {
-      id: 'MiniMax-M2',
-      provider: 'minimax',
-      name: 'MiniMax-M2',
-      group: 'M2'
-    },
-    {
-      id: 'M2-her',
-      provider: 'minimax',
-      name: 'M2-her',
-      group: 'M2'
     }
   ],
   'minimax-global': [
@@ -1134,48 +1092,6 @@ export const SYSTEM_MODELS: Record<SystemProviderId | 'defaultModel', Model[]> =
       provider: 'minimax-global',
       name: 'MiniMax-M2.7-highspeed',
       group: 'M2.7'
-    },
-    {
-      id: 'MiniMax-M2.5',
-      provider: 'minimax-global',
-      name: 'MiniMax-M2.5',
-      group: 'M2.5'
-    },
-    {
-      id: 'MiniMax-M2.5-highspeed',
-      provider: 'minimax-global',
-      name: 'MiniMax-M2.5-highspeed',
-      group: 'M2.5'
-    },
-    {
-      id: 'MiniMax-M2.5-lightning',
-      provider: 'minimax-global',
-      name: 'MiniMax-M2.5-lightning',
-      group: 'M2.5'
-    },
-    {
-      id: 'MiniMax-M2.1',
-      provider: 'minimax-global',
-      name: 'MiniMax-M2.1',
-      group: 'M2.1'
-    },
-    {
-      id: 'MiniMax-M2.1-lightning',
-      provider: 'minimax-global',
-      name: 'MiniMax-M2.1-lightning',
-      group: 'M2.1'
-    },
-    {
-      id: 'MiniMax-M2',
-      provider: 'minimax-global',
-      name: 'MiniMax-M2',
-      group: 'M2'
-    },
-    {
-      id: 'M2-her',
-      provider: 'minimax-global',
-      name: 'M2-her',
-      group: 'M2'
     }
   ],
   hyperbolic: [


### PR DESCRIPTION
## What

Removes the deprecated MiniMax **M2.5 / M2.1 / M2 / M2-her** entries from the `minimax` and `minimax-global` system model lists in `default.ts`, keeping only the current generation:

- `MiniMax-M3` (flagship)
- `MiniMax-M2.7`
- `MiniMax-M2.7-highspeed`

## Why

These older models are no longer generally available on MiniMax's platform — M2.7 and M3 are the current text models. The built-in list currently shows 10 MiniMax entries per provider, most of which point to retired models, which is confusing for users picking a model.

This only trims the built-in suggestion list; users with existing custom model configs are unaffected.

> Follow-up to #15543 (which added M3). Targets `v1`.

## Test

`config/models` suite passes (8 files, 703 tests). Pure deletion, no other files touched.