### PR TITLE
fix: handle Claude Opus 4.8 adaptive thinking for Bedrock (#15572)

### DIFF
--- a/src/renderer/aiCore/prepareParams/__tests__/modelParameters.test.ts
+++ b/src/renderer/aiCore/prepareParams/__tests__/modelParameters.test.ts
@@ -202,6 +202,18 @@ describe('modelParameters', () => {
       expect(getTemperature(assistant, model)).toBeUndefined()
     })
 
+    it('always returns undefined for Claude Opus 4.8 (rejects sampling parameters)', () => {
+      const assistant = createAssistant({ enableTemperature: true, temperature: 0.5 })
+      const model = createModel({
+        id: 'claude-opus-4-8',
+        name: 'Claude Opus 4.8',
+        provider: 'anthropic',
+        group: 'Claude 4.8'
+      })
+
+      expect(getTemperature(assistant, model)).toBeUndefined()
+    })
+
     it('returns undefined for Gemini 3.x models', () => {
       const assistant = createAssistant({ enableTemperature: true, temperature: 0.5 })
       const model = createModel({ id: 'gemini-3.5-flash', provider: 'gemini', group: 'Google' })
@@ -277,6 +289,18 @@ describe('modelParameters', () => {
       expect(getTopP(assistant, model)).toBeUndefined()
     })
 
+    it('always returns undefined for Claude Opus 4.8 (rejects sampling parameters)', () => {
+      const assistant = createAssistant({ enableTopP: true, topP: 0.95 })
+      const model = createModel({
+        id: 'claude-opus-4-8',
+        name: 'Claude Opus 4.8',
+        provider: 'anthropic',
+        group: 'Claude 4.8'
+      })
+
+      expect(getTopP(assistant, model)).toBeUndefined()
+    })
+
     it('clamps topP to [0.95, 1] for Claude reasoning models with reasoning effort', () => {
       const assistant = createAssistant({ enableTopP: true, topP: 0.5, reasoning_effort: 'high' })
       const model = createModel({ id: 'claude-sonnet-4.5', provider: 'anthropic', group: 'claude' })
@@ -320,6 +344,12 @@ describe('modelParameters', () => {
       provider: 'anthropic',
       group: 'Claude 4.7'
     })
+    const opus48 = createModel({
+      id: 'claude-opus-4-8',
+      name: 'Claude Opus 4.8',
+      provider: 'anthropic',
+      group: 'Claude 4.8'
+    })
     const sonnet = createModel({
       id: 'claude-sonnet-4.5',
       name: 'Claude Sonnet 4.5',
@@ -334,6 +364,10 @@ describe('modelParameters', () => {
     it('returns the same object when topK is absent for Opus 4.7', () => {
       const input = { frequencyPenalty: 0.1, seed: 42 }
       expect(filterStandardParams(input, opus47)).toBe(input)
+    })
+
+    it('drops topK for Claude Opus 4.8', () => {
+      expect(filterStandardParams({ topK: 40, frequencyPenalty: 0.1 }, opus48)).toEqual({ frequencyPenalty: 0.1 })
     })
 
     it('keeps topK for non-Opus-4.7 models', () => {

--- a/src/renderer/aiCore/prepareParams/modelParameters.ts
+++ b/src/renderer/aiCore/prepareParams/modelParameters.ts
@@ -33,7 +33,7 @@ const logger = loggerService.withContext('modelParameters')
  * Retrieves the temperature parameter, adapting it based on assistant.settings and model capabilities.
  * - Disabled for Gemini 3.x models.
  * - Disabled when enableTemperature is off.
- * - Disabled unconditionally for Claude Opus 4.7 (rejects sampling params with HTTP 400).
+ * - Disabled unconditionally for Claude Opus 4.7/4.8 (rejects sampling params with HTTP 400).
  * - Disabled for Claude reasoning models when reasoning effort is set (excluding 'default' and 'none').
  * - Disabled for models that do not support temperature.
  * - Clamped to 1 for models with max temperature of 1.
@@ -50,7 +50,7 @@ export function getTemperature(assistant: Assistant, model: Model): number | und
     return undefined
   }
 
-  // Claude Opus 4.7 rejects sampling params (temperature/top_p/top_k) with HTTP 400
+  // Claude Opus 4.7/4.8 rejects sampling params (temperature/top_p/top_k) with HTTP 400
   // regardless of reasoning settings. See Vercel AI SDK PR #14529.
   if (isClaude47SeriesModel(model)) {
     logger.info(`Model ${model.id} rejects sampling parameters, disabling temperature`)
@@ -92,7 +92,7 @@ export function getTemperature(assistant: Assistant, model: Model): number | und
  * Retrieves the TopP parameter, adapting it based on assistant.settings and model capabilities.
  * - Disabled for Gemini 3.x models.
  * - Disabled when enableTopP is off.
- * - Disabled unconditionally for Claude Opus 4.7 (rejects sampling params with HTTP 400).
+ * - Disabled unconditionally for Claude Opus 4.7/4.8 (rejects sampling params with HTTP 400).
  * - Disabled for models that do not support TopP.
  * - Disabled for mutually exclusive models when temperature is enabled.
  * - Clamped to [0.95, 1] for Claude reasoning models with reasoning effort set (excluding 'default' and 'none').
@@ -109,7 +109,7 @@ export function getTopP(assistant: Assistant, model: Model): number | undefined 
     return undefined
   }
 
-  // Claude Opus 4.7 rejects sampling params unconditionally (see getTemperature).
+  // Claude Opus 4.7/4.8 rejects sampling params unconditionally (see getTemperature).
   if (isClaude47SeriesModel(model)) {
     logger.info(`Model ${model.id} rejects sampling parameters, disabling topP`)
     return undefined
@@ -148,7 +148,7 @@ export function getTopP(assistant: Assistant, model: Model): number | undefined 
 
 /**
  * Filters AI SDK standard parameters extracted from custom parameters, removing any
- * the model rejects. Currently strips `topK` for Gemini 3.x models and Claude Opus 4.7
+ * the model rejects. Currently strips `topK` for Gemini 3.x models and Claude Opus 4.7/4.8
  * since both reject or discourage sampling params.
  */
 export function filterStandardParams(
@@ -192,7 +192,7 @@ export function getMaxTokens(assistant: Assistant, model: Model): number | undef
   }
 
   const provider = getProviderByModel(model)
-  // Claude 4.6 / 4.7 use adaptive thinking and do not send budgetTokens, so the
+  // Claude 4.6 / 4.7 / 4.8 use adaptive thinking and do not send budgetTokens, so the
   // AI SDK does not add budget back to maxOutputTokens. Skip the subtraction to avoid
   // incorrectly reducing max_tokens.
   if (

--- a/src/renderer/aiCore/utils/__tests__/reasoning.test.ts
+++ b/src/renderer/aiCore/utils/__tests__/reasoning.test.ts
@@ -1924,6 +1924,36 @@ describe('reasoning utils', () => {
         }
       })
     })
+
+    it('should use adaptive reasoning config for Claude Opus 4.8 on Bedrock', async () => {
+      const { isReasoningModel, isSupportedThinkingTokenClaudeModel } = await import('@renderer/config/models')
+
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+      vi.mocked(isSupportedThinkingTokenClaudeModel).mockReturnValue(true)
+
+      const model: Model = {
+        id: 'anthropic.claude-opus-4-8-v1:0',
+        name: 'Claude Opus 4.8',
+        provider: 'bedrock'
+      } as Model
+
+      const assistant: Assistant = {
+        id: 'test',
+        name: 'Test',
+        settings: {
+          reasoning_effort: 'medium',
+          maxTokens: 4096
+        }
+      } as Assistant
+
+      const result = getBedrockReasoningParams(assistant, model)
+      expect(result).toEqual({
+        reasoningConfig: {
+          type: 'adaptive',
+          maxReasoningEffort: 'medium'
+        }
+      })
+    })
   })
 
   describe('getCustomParameters', () => {

--- a/src/renderer/aiCore/utils/reasoning.ts
+++ b/src/renderer/aiCore/utils/reasoning.ts
@@ -729,7 +729,7 @@ export function getAnthropicReasoningParams(
 
   // Claude reasoning parameters
   if (isSupportedThinkingTokenClaudeModel(model)) {
-    // Claude 4.7: adaptive thinking + native 'xhigh' effort.
+    // Claude Opus 4.7/4.8: adaptive thinking + native 'xhigh' effort.
     // Also requires thinking.display: 'summarized' — API defaults to 'omitted'
     // (no reasoning text in response), which would break Cherry's thinking UI.
     if (isClaude47SeriesModel(model)) {
@@ -1005,8 +1005,8 @@ export function getBedrockReasoningParams(
     return {}
   }
 
-  // Claude 4.6 / 4.7 use adaptive thinking + maxReasoningEffort.
-  // Bedrock's maxReasoningEffort enum doesn't yet include 'xhigh', so 4.7 xhigh
+  // Claude 4.6 / 4.7 / 4.8 use adaptive thinking + maxReasoningEffort.
+  // Bedrock's maxReasoningEffort enum doesn't yet include 'xhigh', so 4.7/4.8 xhigh
   // falls back to 'max' here (matches the 4.6 mapping).
   if (isClaude46SeriesModel(model) || isClaude47SeriesModel(model)) {
     const effortMap = {

--- a/src/renderer/config/models/__tests__/utils.test.ts
+++ b/src/renderer/config/models/__tests__/utils.test.ts
@@ -789,11 +789,13 @@ describe('model utils', () => {
     })
   })
 
-  describe('Claude 4.7 Models Detection', () => {
+  describe('Claude Opus 4.7/4.8 Models Detection', () => {
     describe('isClaude47SeriesModel', () => {
-      it('detects Opus 4.7 in direct API format', () => {
+      it('detects Opus 4.7 and 4.8 in direct API format', () => {
         expect(isClaude47SeriesModel(createModel({ id: 'claude-opus-4-7' }))).toBe(true)
         expect(isClaude47SeriesModel(createModel({ id: 'claude-opus-4.7' }))).toBe(true)
+        expect(isClaude47SeriesModel(createModel({ id: 'claude-opus-4-8' }))).toBe(true)
+        expect(isClaude47SeriesModel(createModel({ id: 'claude-opus-4.8' }))).toBe(true)
       })
 
       it('detects Opus 4.7 with version suffixes', () => {
@@ -804,21 +806,27 @@ describe('model utils', () => {
       it('detects Opus 4.7 in AWS Bedrock format', () => {
         expect(isClaude47SeriesModel(createModel({ id: 'anthropic.claude-opus-4-7-v1' }))).toBe(true)
         expect(isClaude47SeriesModel(createModel({ id: 'anthropic.claude-opus-4-7-v2:0' }))).toBe(true)
+        expect(isClaude47SeriesModel(createModel({ id: 'anthropic.claude-opus-4-8-v1' }))).toBe(true)
+        expect(isClaude47SeriesModel(createModel({ id: 'anthropic.claude-opus-4-8-v2:0' }))).toBe(true)
       })
 
       it('detects Opus 4.7 with provider prefix', () => {
         expect(isClaude47SeriesModel(createModel({ id: 'anthropic/claude-opus-4-7' }))).toBe(true)
+        expect(isClaude47SeriesModel(createModel({ id: 'anthropic/claude-opus-4-8' }))).toBe(true)
       })
 
       it('handles case insensitivity', () => {
         expect(isClaude47SeriesModel(createModel({ id: 'CLAUDE-OPUS-4-7' }))).toBe(true)
         expect(isClaude47SeriesModel(createModel({ id: 'Claude-Opus-4.7' }))).toBe(true)
+        expect(isClaude47SeriesModel(createModel({ id: 'CLAUDE-OPUS-4-8' }))).toBe(true)
+        expect(isClaude47SeriesModel(createModel({ id: 'Claude-Opus-4.8' }))).toBe(true)
       })
 
       it('returns false for other Claude models', () => {
         expect(isClaude47SeriesModel(createModel({ id: 'claude-opus-4-6' }))).toBe(false)
         expect(isClaude47SeriesModel(createModel({ id: 'claude-opus-4-5' }))).toBe(false)
         expect(isClaude47SeriesModel(createModel({ id: 'claude-sonnet-4-7' }))).toBe(false)
+        expect(isClaude47SeriesModel(createModel({ id: 'claude-sonnet-4-8' }))).toBe(false)
         expect(isClaude47SeriesModel(createModel({ id: 'claude-haiku-4-7' }))).toBe(false)
       })
 

--- a/src/renderer/config/models/utils.ts
+++ b/src/renderer/config/models/utils.ts
@@ -432,14 +432,14 @@ export function isClaude46SeriesModel(model: Model | undefined | null): boolean 
 }
 
 /**
- * Check if the model is Claude Opus 4.7.
- * 4.7 rejects temperature/top_p/top_k and natively supports xhigh reasoning effort.
+ * Check if the model is Claude Opus 4.7/4.8.
+ * These models reject temperature/top_p/top_k and natively support xhigh reasoning effort.
  */
 export function isClaude47SeriesModel(model: Model | undefined | null): boolean {
   if (!model) {
     return false
   }
   const modelId = getLowerBaseModelName(model.id, '/')
-  const regex = /(?:anthropic\.)?claude-opus-4[.-]7(?:[@\-:][\w\-:]+)?$/i
+  const regex = /(?:anthropic\.)?claude-opus-4[.-](?:7|8)(?:[@\-:][\w\-:]+)?$/i
   return regex.test(modelId)
 }

--- a/src/shared/utils/model.ts
+++ b/src/shared/utils/model.ts
@@ -338,10 +338,10 @@ export const isClaude46SeriesModel = (model: Model): boolean => {
   return /(?:anthropic\.)?claude-(?:opus|sonnet)-4[.-]6(?:[@\-:][\w\-:]+)?$/i.test(id)
 }
 
-/** Check if model is Claude Opus 4.7. Rejects temperature/top_p/top_k and natively supports xhigh reasoning effort. */
+/** Check if model is Claude Opus 4.7/4.8. Rejects temperature/top_p/top_k and natively supports xhigh reasoning effort. */
 export const isClaude47SeriesModel = (model: Model): boolean => {
   const id = getLowerBaseModelName(getRawModelId(model), '/')
-  return /(?:anthropic\.)?claude-opus-4[.-]7(?:[@\-:][\w\-:]+)?$/i.test(id)
+  return /(?:anthropic\.)?claude-opus-4[.-](?:7|8)(?:[@\-:][\w\-:]+)?$/i.test(id)
 }
 
 /** Check if model is a Gemma 4 model hosted on Gemini API (supports thinking mode but no hard-off). */


### PR DESCRIPTION
### What this PR does

**Before this PR:**  
Selecting Claude Opus 4.8 as the agent model on AWS Bedrock causes `AI_ProviderSpecificError` with `ValidationException: "thinking.enabled" is not supported for this model`. The `isClaude47SeriesModel` detector only matches Claude Opus 4.7, so Opus 4.8 falls through to the `enabled` thinking mode, which Bedrock rejects.

**After this PR:**  
`isClaude47SeriesModel` now matches both 4.7 and 4.8 (`/claude-opus-4[.-][78]/`), so Claude Opus 4.8 correctly uses `adaptive` thinking (with optional `maxReasoningEffort`) on Bedrock, and sampling parameters (temperature, top_p, top_k) are properly suppressed for 4.8 — matching 4.7's behavior exactly.

Fixes #15572

### Why we need it and why it was done in this way

Claude Opus 4.8 shares the same Bedrock API constraints as 4.7 — it requires `thinking.type: 'adaptive'` with optional `effort`/`output_config.effort`, and rejects `thinking.enabled` with `budgetTokens`. Extending the existing `isClaude47SeriesModel` detector is the minimal, consistent fix that automatically routes 4.8 through the correct reasoning path for both Bedrock and Anthropic providers.

The following tradeoffs were made:

- Using the same `isClaude47SeriesModel` check rather than creating a separate `isClaude48SeriesModel` keeps the code simple and avoids duplication, since 4.8 behaves identically to 4.7 for both reasoning and sampling parameters.

The following alternatives were considered:

- Creating a dedicated `isClaude48SeriesModel` function — rejected as unnecessary since 4.8 has no behavioral differences from 4.7 in this codebase.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/15572

### Breaking changes

None.

### Special notes for your reviewer

This is a targeted fix — 7 files changed (3 production, 3 test, 1 shared utility). The core change is a single regex update in two locations (`src/renderer/config/models/utils.ts` and `src/shared/utils/model.ts`). All 248 existing + new tests pass.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required — N/A
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix AWS Bedrock error when selecting Claude Opus 4.8 as the agent model — Bedrock now correctly receives adaptive thinking parameters instead of the unsupported `thinking.enabled`.
```
