### PR TITLE
fix(translate-history): prevent scroll update loop

### DIFF
--- a/src/main/data/api/handlers/__tests__/translate.test.ts
+++ b/src/main/data/api/handlers/__tests__/translate.test.ts
@@ -14,21 +14,26 @@ describe('Translate handler validation (Zod schemas)', () => {
     })
 
     it('should accept valid query', () => {
-      const result = TranslateHistoryQuerySchema.parse({ page: 1, limit: 20, star: true, search: 'hello' })
-      expect(result.page).toBe(1)
+      const result = TranslateHistoryQuerySchema.parse({
+        cursor: '1000:history-1',
+        limit: 20,
+        star: true,
+        search: 'hello'
+      })
+      expect(result.cursor).toBe('1000:history-1')
       expect(result.star).toBe(true)
     })
 
-    it('should reject negative page', () => {
-      expect(() => TranslateHistoryQuerySchema.parse({ page: -1 })).toThrow()
+    it('should reject offset pagination params', () => {
+      expect(() => TranslateHistoryQuerySchema.parse({ page: 1 })).toThrow()
     })
 
     it('should reject limit over 100', () => {
       expect(() => TranslateHistoryQuerySchema.parse({ limit: 101 })).toThrow()
     })
 
-    it('should reject non-integer page', () => {
-      expect(() => TranslateHistoryQuerySchema.parse({ page: 1.5 })).toThrow()
+    it('should reject non-integer limit', () => {
+      expect(() => TranslateHistoryQuerySchema.parse({ limit: 1.5 })).toThrow()
     })
   })
 

--- a/src/main/data/db/schemas/translateHistory.ts
+++ b/src/main/data/db/schemas/translateHistory.ts
@@ -7,7 +7,7 @@ import { translateLanguageTable } from './translateLanguage'
  * Translate history table - stores translation records
  *
  * Design notes:
- * - Data grows unbounded, renderer should use paginated queries (offset/limit)
+ * - Data grows unbounded, renderer should use cursor paginated queries
  *   with infinite scroll instead of loading all records at once.
  * - Text search (sourceText/targetText) uses SQL LIKE at DB layer,
  *   not client-side filtering.

--- a/src/main/data/services/TranslateHistoryService.ts
+++ b/src/main/data/services/TranslateHistoryService.ts
@@ -6,20 +6,47 @@ import { application } from '@application'
 import { translateHistoryTable } from '@data/db/schemas/translateHistory'
 import { loggerService } from '@logger'
 import { DataApiErrorFactory } from '@shared/data/api'
-import type { OffsetPaginationResponse } from '@shared/data/api/apiTypes'
 import type {
   CreateTranslateHistoryDto,
+  TranslateHistoryListResponse,
   TranslateHistoryQuery,
   UpdateTranslateHistoryDto
 } from '@shared/data/api/schemas/translate'
 import { parsePersistedLangCode } from '@shared/data/preference/preferenceTypes'
 import type { TranslateHistory } from '@shared/data/types/translate'
 import type { SQL } from 'drizzle-orm'
-import { and, desc, eq, or, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, gt, lt, or, sql } from 'drizzle-orm'
 
 import { timestampToISO } from './utils/rowMappers'
 
 const logger = loggerService.withContext('DataApi:TranslateHistoryService')
+
+type TranslateHistoryRow = typeof translateHistoryTable.$inferSelect
+type TranslateHistoryCursor = { createdAt: number; id: string } | null
+
+function decodeCursor(raw: string | undefined): TranslateHistoryCursor {
+  if (!raw) return null
+
+  const separator = raw.indexOf(':')
+  if (separator < 0) return warnAndFallback(raw, 'missing separator')
+
+  const createdAt = Number(raw.slice(0, separator))
+  const id = raw.slice(separator + 1)
+  if (!Number.isFinite(createdAt) || !id) {
+    return warnAndFallback(raw, 'malformed createdAt or id')
+  }
+
+  return { createdAt, id }
+}
+
+function warnAndFallback(raw: string, reason: string): TranslateHistoryCursor {
+  logger.warn('decodeCursor: cursor unparseable, falling back to first page', { cursor: raw, reason })
+  return null
+}
+
+function encodeCursor(row: TranslateHistoryRow): string {
+  return `${row.createdAt}:${row.id}`
+}
 
 function rowToTranslateHistory(row: typeof translateHistoryTable.$inferSelect): TranslateHistory {
   return {
@@ -35,15 +62,14 @@ function rowToTranslateHistory(row: typeof translateHistoryTable.$inferSelect): 
 }
 
 export class TranslateHistoryService {
-  async list(query: TranslateHistoryQuery): Promise<OffsetPaginationResponse<TranslateHistory>> {
+  async list(query: TranslateHistoryQuery): Promise<TranslateHistoryListResponse> {
     const db = application.get('DbService').getDb()
-    const { page, limit } = query
-    const offset = (page - 1) * limit
+    const { limit } = query
 
-    const conditions: SQL[] = []
+    const filterConditions: SQL[] = []
 
     if (query?.star !== undefined) {
-      conditions.push(eq(translateHistoryTable.star, query.star))
+      filterConditions.push(eq(translateHistoryTable.star, query.star))
     }
 
     if (query?.search) {
@@ -54,27 +80,41 @@ export class TranslateHistoryService {
         sql`${translateHistoryTable.targetText} LIKE ${pattern} ESCAPE '\\'`
       )
       if (searchCondition) {
-        conditions.push(searchCondition)
+        filterConditions.push(searchCondition)
       }
+    }
+
+    const conditions = [...filterConditions]
+    const cursor = decodeCursor(query.cursor)
+    if (cursor) {
+      conditions.push(
+        or(
+          lt(translateHistoryTable.createdAt, cursor.createdAt),
+          and(eq(translateHistoryTable.createdAt, cursor.createdAt), gt(translateHistoryTable.id, cursor.id))
+        )!
+      )
     }
 
     const where = conditions.length > 0 ? and(...conditions) : undefined
 
-    const [items, [{ count }]] = await Promise.all([
+    const [rows, [{ count }]] = await Promise.all([
       db
         .select()
         .from(translateHistoryTable)
         .where(where)
-        .orderBy(desc(translateHistoryTable.createdAt))
-        .limit(limit)
-        .offset(offset),
-      db.select({ count: sql<number>`count(*)` }).from(translateHistoryTable).where(where)
+        .orderBy(desc(translateHistoryTable.createdAt), asc(translateHistoryTable.id))
+        .limit(limit + 1),
+      db
+        .select({ count: sql<number>`count(*)` })
+        .from(translateHistoryTable)
+        .where(filterConditions.length > 0 ? and(...filterConditions) : undefined)
     ])
+    const pageRows = rows.slice(0, limit)
 
     return {
-      items: items.map(rowToTranslateHistory),
+      items: pageRows.map(rowToTranslateHistory),
       total: count,
-      page
+      nextCursor: rows.length > limit ? encodeCursor(pageRows[pageRows.length - 1]) : undefined
     }
   }
 

--- a/src/main/data/services/__tests__/TranslateHistoryService.test.ts
+++ b/src/main/data/services/__tests__/TranslateHistoryService.test.ts
@@ -22,46 +22,66 @@ describe('TranslateHistoryService', () => {
   }
 
   describe('list', () => {
-    it('should return paginated results with defaults', async () => {
+    it('should return cursor paginated results with defaults', async () => {
       await seedHistory()
 
-      const result = await translateHistoryService.list({ page: 1, limit: 20 })
+      const result = await translateHistoryService.list({ limit: 20 })
       expect(result.items).toHaveLength(1)
       expect(result.total).toBe(1)
-      expect(result.page).toBe(1)
+      expect(result.nextCursor).toBeUndefined()
     })
 
     it('should return empty results', async () => {
-      const result = await translateHistoryService.list({ page: 1, limit: 20 })
+      const result = await translateHistoryService.list({ limit: 20 })
       expect(result.items).toHaveLength(0)
       expect(result.total).toBe(0)
+      expect(result.nextCursor).toBeUndefined()
     })
 
-    it('should pass custom page and limit', async () => {
-      const result = await translateHistoryService.list({ page: 2, limit: 10 })
-      expect(result.page).toBe(2)
+    it('should page by createdAt and id cursor', async () => {
+      const newest = await seedHistory({
+        id: '550e8400-e29b-41d4-a716-446655440010',
+        createdAt: 3000,
+        updatedAt: 3000
+      })
+      const middle = await seedHistory({
+        id: '550e8400-e29b-41d4-a716-446655440011',
+        createdAt: 2000,
+        updatedAt: 2000
+      })
+      const oldest = await seedHistory({
+        id: '550e8400-e29b-41d4-a716-446655440012',
+        createdAt: 1000,
+        updatedAt: 1000
+      })
+
+      const firstPage = await translateHistoryService.list({ limit: 2 })
+      expect(firstPage.items.map((item) => item.id)).toEqual([newest.id, middle.id])
+      expect(firstPage.nextCursor).toBe(`${middle.createdAt}:${middle.id}`)
+
+      const secondPage = await translateHistoryService.list({ cursor: firstPage.nextCursor, limit: 2 })
+      expect(secondPage.items.map((item) => item.id)).toEqual([oldest.id])
+      expect(secondPage.nextCursor).toBeUndefined()
     })
 
     it('should search by text', async () => {
       await seedHistory({ sourceText: 'Hello world' })
       await seedHistory({ id: '550e8400-e29b-41d4-a716-446655440001', sourceText: 'Goodbye' })
 
-      const result = await translateHistoryService.list({ page: 1, limit: 20, search: 'Hello' })
+      const result = await translateHistoryService.list({ limit: 20, search: 'Hello' })
       expect(result.items.length).toBeGreaterThanOrEqual(1)
       expect(result.items.some((i) => i.sourceText.includes('Hello'))).toBe(true)
     })
 
     it('should escape LIKE wildcards in search', async () => {
-      await expect(
-        translateHistoryService.list({ page: 1, limit: 20, search: '100% off_sale\\test' })
-      ).resolves.toBeDefined()
+      await expect(translateHistoryService.list({ limit: 20, search: '100% off_sale\\test' })).resolves.toBeDefined()
     })
 
     it('should filter by star', async () => {
       await seedHistory({ star: true })
       await seedHistory({ id: '550e8400-e29b-41d4-a716-446655440002', star: false })
 
-      const result = await translateHistoryService.list({ page: 1, limit: 20, star: true })
+      const result = await translateHistoryService.list({ limit: 20, star: true })
       expect(result.items.every((i) => i.star === true)).toBe(true)
     })
   })

--- a/src/renderer/hooks/translate/__tests__/useTranslateHistories.test.ts
+++ b/src/renderer/hooks/translate/__tests__/useTranslateHistories.test.ts
@@ -52,6 +52,36 @@ describe('useTranslateHistories', () => {
     expect(result.current.hasMore).toBe(true)
   })
 
+  it('keeps loaded items stable when a page re-emits equivalent history data', async () => {
+    mockUsePaginatedQuery.mockReturnValue(buildPaginatedState({ items: [{ id: 'a' }], total: 1, page: 1 }))
+
+    const { result, rerender } = renderHook(() => useTranslateHistories())
+    await act(async () => {})
+    const firstItems = result.current.items
+
+    mockUsePaginatedQuery.mockReturnValue(buildPaginatedState({ items: [{ id: 'a' }], total: 1, page: 1 }))
+    rerender()
+    await act(async () => {})
+
+    expect(result.current.items).toBe(firstItems)
+  })
+
+  it('does not replace loaded items while the next page has no new rows yet', async () => {
+    mockUsePaginatedQuery.mockReturnValue(buildPaginatedState({ items: [{ id: 'a' }], total: 2, page: 1 }))
+
+    const { result, rerender } = renderHook(() => useTranslateHistories())
+    await act(async () => {})
+    const firstItems = result.current.items
+
+    mockUsePaginatedQuery.mockReturnValue(
+      buildPaginatedState({ items: [], total: 2, page: 2, isRefreshing: true, hasNext: false })
+    )
+    rerender()
+    await act(async () => {})
+
+    expect(result.current.items).toBe(firstItems)
+  })
+
   it('reports hasMore=false once loaded items reach the total', () => {
     mockUsePaginatedQuery.mockReturnValue(
       buildPaginatedState({ items: [{ id: 'a' }, { id: 'b' }], total: 2, hasNext: false })

--- a/src/renderer/hooks/translate/__tests__/useTranslateHistories.test.ts
+++ b/src/renderer/hooks/translate/__tests__/useTranslateHistories.test.ts
@@ -1,4 +1,4 @@
-import { mockUsePaginatedQuery } from '@test-mocks/renderer/useDataApi'
+import { mockUseInfiniteQuery } from '@test-mocks/renderer/useDataApi'
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -6,21 +6,17 @@ import { useTranslateHistories } from '../useTranslateHistories'
 
 type HistoryItem = { id: string }
 
-function buildPaginatedState(overrides: Record<string, unknown> = {}) {
+function buildInfiniteState(overrides: Record<string, unknown> = {}) {
   return {
-    items: [],
-    total: 0,
-    page: 1,
+    pages: [],
     isLoading: false,
     isRefreshing: false,
-    isValidating: false,
     error: undefined,
     hasNext: false,
-    hasPrev: false,
-    prevPage: vi.fn(),
-    nextPage: vi.fn(),
+    loadNext: vi.fn(),
     refresh: vi.fn(),
     reset: vi.fn(),
+    mutate: vi.fn(),
     ...overrides
   }
 }
@@ -35,56 +31,29 @@ describe('useTranslateHistories', () => {
     Object.defineProperty(window, 'toast', { value: toast, writable: true, configurable: true })
   })
 
-  it('accumulates items across paginated pages and exposes total from usePaginatedQuery', async () => {
+  it('flattens infinite query pages and exposes total from the first page', () => {
     const page1: HistoryItem[] = [{ id: 'a' }, { id: 'b' }]
     const page2: HistoryItem[] = [{ id: 'c' }, { id: 'd' }]
-    mockUsePaginatedQuery.mockReturnValue(buildPaginatedState({ items: page1, total: 5, page: 1, hasNext: true }))
+    mockUseInfiniteQuery.mockReturnValue(
+      buildInfiniteState({
+        pages: [
+          { items: page1, total: 5, nextCursor: 'cursor-2' },
+          { items: page2, total: 5 }
+        ],
+        hasNext: true
+      })
+    )
 
-    const { result, rerender } = renderHook(() => useTranslateHistories({ pageSize: 2 }))
-    await act(async () => {})
-
-    mockUsePaginatedQuery.mockReturnValue(buildPaginatedState({ items: page2, total: 5, page: 2, hasNext: true }))
-    rerender()
-    await act(async () => {})
+    const { result } = renderHook(() => useTranslateHistories({ pageSize: 2 }))
 
     expect(result.current.items.map((i) => i.id)).toEqual(['a', 'b', 'c', 'd'])
     expect(result.current.total).toBe(5)
     expect(result.current.hasMore).toBe(true)
   })
 
-  it('keeps loaded items stable when a page re-emits equivalent history data', async () => {
-    mockUsePaginatedQuery.mockReturnValue(buildPaginatedState({ items: [{ id: 'a' }], total: 1, page: 1 }))
-
-    const { result, rerender } = renderHook(() => useTranslateHistories())
-    await act(async () => {})
-    const firstItems = result.current.items
-
-    mockUsePaginatedQuery.mockReturnValue(buildPaginatedState({ items: [{ id: 'a' }], total: 1, page: 1 }))
-    rerender()
-    await act(async () => {})
-
-    expect(result.current.items).toBe(firstItems)
-  })
-
-  it('does not replace loaded items while the next page has no new rows yet', async () => {
-    mockUsePaginatedQuery.mockReturnValue(buildPaginatedState({ items: [{ id: 'a' }], total: 2, page: 1 }))
-
-    const { result, rerender } = renderHook(() => useTranslateHistories())
-    await act(async () => {})
-    const firstItems = result.current.items
-
-    mockUsePaginatedQuery.mockReturnValue(
-      buildPaginatedState({ items: [], total: 2, page: 2, isRefreshing: true, hasNext: false })
-    )
-    rerender()
-    await act(async () => {})
-
-    expect(result.current.items).toBe(firstItems)
-  })
-
-  it('reports hasMore=false once loaded items reach the total', () => {
-    mockUsePaginatedQuery.mockReturnValue(
-      buildPaginatedState({ items: [{ id: 'a' }, { id: 'b' }], total: 2, hasNext: false })
+  it('reports hasMore=false when the infinite query has no next cursor', () => {
+    mockUseInfiniteQuery.mockReturnValue(
+      buildInfiniteState({ pages: [{ items: [{ id: 'a' }, { id: 'b' }], total: 2 }], hasNext: false })
     )
 
     const { result } = renderHook(() => useTranslateHistories())
@@ -92,10 +61,10 @@ describe('useTranslateHistories', () => {
     expect(result.current.hasMore).toBe(false)
   })
 
-  it('loadMore increments setSize when there are more pages to fetch', () => {
-    const nextPage = vi.fn()
-    mockUsePaginatedQuery.mockReturnValue(
-      buildPaginatedState({ items: [{ id: 'a' }, { id: 'b' }], total: 10, hasNext: true, nextPage })
+  it('loadMore loads the next infinite page when there are more pages to fetch', () => {
+    const loadNext = vi.fn()
+    mockUseInfiniteQuery.mockReturnValue(
+      buildInfiniteState({ pages: [{ items: [{ id: 'a' }, { id: 'b' }], total: 10 }], hasNext: true, loadNext })
     )
 
     const { result } = renderHook(() => useTranslateHistories({ pageSize: 2 }))
@@ -104,13 +73,13 @@ describe('useTranslateHistories', () => {
       result.current.loadMore()
     })
 
-    expect(nextPage).toHaveBeenCalledTimes(1)
+    expect(loadNext).toHaveBeenCalledTimes(1)
   })
 
   it('loadMore is a no-op when hasMore is false', () => {
-    const nextPage = vi.fn()
-    mockUsePaginatedQuery.mockReturnValue(
-      buildPaginatedState({ items: [{ id: 'a' }, { id: 'b' }], total: 2, hasNext: false, nextPage })
+    const loadNext = vi.fn()
+    mockUseInfiniteQuery.mockReturnValue(
+      buildInfiniteState({ pages: [{ items: [{ id: 'a' }, { id: 'b' }], total: 2 }], hasNext: false, loadNext })
     )
 
     const { result } = renderHook(() => useTranslateHistories())
@@ -119,15 +88,15 @@ describe('useTranslateHistories', () => {
       result.current.loadMore()
     })
 
-    expect(nextPage).not.toHaveBeenCalled()
+    expect(loadNext).not.toHaveBeenCalled()
   })
 
-  it('uses usePaginatedQuery with search, star, and pageSize query options', () => {
-    mockUsePaginatedQuery.mockReturnValue(buildPaginatedState())
+  it('uses useInfiniteQuery with search, star, and pageSize query options', () => {
+    mockUseInfiniteQuery.mockReturnValue(buildInfiniteState())
 
     renderHook(() => useTranslateHistories({ search: 'hello', star: true, pageSize: 5 }))
 
-    expect(mockUsePaginatedQuery).toHaveBeenCalledWith('/translate/histories', {
+    expect(mockUseInfiniteQuery).toHaveBeenCalledWith('/translate/histories', {
       query: { search: 'hello', star: true },
       limit: 5,
       swrOptions: { keepPreviousData: false }
@@ -135,8 +104,8 @@ describe('useTranslateHistories', () => {
   })
 
   it('exposes SWR errors so consumers can distinguish loading from failure', () => {
-    const failure = new Error('paginated fetch failed')
-    mockUsePaginatedQuery.mockReturnValue(buildPaginatedState({ error: failure }))
+    const failure = new Error('infinite fetch failed')
+    mockUseInfiniteQuery.mockReturnValue(buildInfiniteState({ error: failure }))
 
     const { result } = renderHook(() => useTranslateHistories())
 
@@ -151,7 +120,7 @@ describe('useTranslateHistories', () => {
 
   describe('status discriminator', () => {
     it("returns 'loading' while SWR has neither data nor error", () => {
-      mockUsePaginatedQuery.mockReturnValue(buildPaginatedState({ isLoading: true }))
+      mockUseInfiniteQuery.mockReturnValue(buildInfiniteState({ isLoading: true }))
 
       const { result } = renderHook(() => useTranslateHistories())
 
@@ -159,7 +128,7 @@ describe('useTranslateHistories', () => {
     })
 
     it("returns 'error' when the request failed without cached data", () => {
-      mockUsePaginatedQuery.mockReturnValue(buildPaginatedState({ error: new Error('boom') }))
+      mockUseInfiniteQuery.mockReturnValue(buildInfiniteState({ error: new Error('boom') }))
 
       const { result } = renderHook(() => useTranslateHistories())
 
@@ -167,7 +136,7 @@ describe('useTranslateHistories', () => {
     })
 
     it("returns 'ready' once data is resolved, even when the list is empty", () => {
-      mockUsePaginatedQuery.mockReturnValue(buildPaginatedState({ items: [], total: 0 }))
+      mockUseInfiniteQuery.mockReturnValue(buildInfiniteState({ pages: [{ items: [], total: 0 }] }))
 
       const { result } = renderHook(() => useTranslateHistories())
 

--- a/src/renderer/hooks/translate/useTranslateHistories.ts
+++ b/src/renderer/hooks/translate/useTranslateHistories.ts
@@ -7,6 +7,27 @@ import { useTranslation } from 'react-i18next'
 
 const logger = loggerService.withContext('translate/useTranslateHistories')
 
+const isSameHistoryList = (left: TranslateHistory[], right: TranslateHistory[]) => {
+  if (left.length !== right.length) return false
+
+  return left.every((item, index) => {
+    const next = right[index]
+    if (!next) return false
+
+    return (
+      item === next ||
+      (item.id === next.id &&
+        item.sourceText === next.sourceText &&
+        item.targetText === next.targetText &&
+        item.sourceLanguage === next.sourceLanguage &&
+        item.targetLanguage === next.targetLanguage &&
+        item.star === next.star &&
+        item.createdAt === next.createdAt &&
+        item.updatedAt === next.updatedAt)
+    )
+  })
+}
+
 interface UseTranslateHistoriesOptions {
   /** Full-text search on sourceText/targetText (server-side LIKE). */
   search?: string
@@ -52,10 +73,11 @@ export const useTranslateHistories = ({
 
   useEffect(() => {
     setLoadedItems((prev) => {
-      if (page <= 1) return items
+      if (page <= 1) return isSameHistoryList(prev, items) ? prev : items
 
       const itemIds = new Set(items.map((item) => item.id))
-      return [...prev.filter((item) => !itemIds.has(item.id)), ...items]
+      const nextItems = [...prev.filter((item) => !itemIds.has(item.id)), ...items]
+      return isSameHistoryList(prev, nextItems) ? prev : nextItems
     })
   }, [items, page])
 

--- a/src/renderer/hooks/translate/useTranslateHistories.ts
+++ b/src/renderer/hooks/translate/useTranslateHistories.ts
@@ -1,32 +1,10 @@
-import { usePaginatedQuery } from '@data/hooks/useDataApi'
+import { useInfiniteFlatItems, useInfiniteQuery } from '@data/hooks/useDataApi'
 import { loggerService } from '@logger'
 import { TRANSLATE_HISTORY_DEFAULT_LIMIT } from '@shared/data/api/schemas/translate'
-import type { TranslateHistory } from '@shared/data/types/translate'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
 const logger = loggerService.withContext('translate/useTranslateHistories')
-
-const isSameHistoryList = (left: TranslateHistory[], right: TranslateHistory[]) => {
-  if (left.length !== right.length) return false
-
-  return left.every((item, index) => {
-    const next = right[index]
-    if (!next) return false
-
-    return (
-      item === next ||
-      (item.id === next.id &&
-        item.sourceText === next.sourceText &&
-        item.targetText === next.targetText &&
-        item.sourceLanguage === next.sourceLanguage &&
-        item.targetLanguage === next.targetLanguage &&
-        item.star === next.star &&
-        item.createdAt === next.createdAt &&
-        item.updatedAt === next.updatedAt)
-    )
-  })
-}
 
 interface UseTranslateHistoriesOptions {
   /** Full-text search on sourceText/targetText (server-side LIKE). */
@@ -44,42 +22,31 @@ export const useTranslateHistories = ({
 }: UseTranslateHistoriesOptions = {}) => {
   const searchKey = search?.trim() || undefined
   const starKey = star || undefined
-  const [loadedItems, setLoadedItems] = useState<TranslateHistory[]>([])
+  const query = useMemo(() => ({ search: searchKey, star: starKey }), [searchKey, starKey])
 
   const {
-    items,
-    total,
-    page,
+    pages,
     error,
     isLoading,
     isRefreshing,
     hasNext,
-    nextPage,
+    loadNext,
     refresh: pageRefresh,
     reset
-  } = usePaginatedQuery('/translate/histories', {
-    query: { search: searchKey, star: starKey },
+  } = useInfiniteQuery('/translate/histories', {
+    query,
     limit: pageSize,
     swrOptions: { keepPreviousData: false }
   })
+  const histories = useInfiniteFlatItems(pages)
+  const total = pages[0]?.total ?? 0
 
   const resetRef = useRef(reset)
   resetRef.current = reset
 
   useEffect(() => {
-    setLoadedItems([])
     resetRef.current()
   }, [pageSize, searchKey, starKey])
-
-  useEffect(() => {
-    setLoadedItems((prev) => {
-      if (page <= 1) return isSameHistoryList(prev, items) ? prev : items
-
-      const itemIds = new Set(items.map((item) => item.id))
-      const nextItems = [...prev.filter((item) => !itemIds.has(item.id)), ...items]
-      return isSameHistoryList(prev, nextItems) ? prev : nextItems
-    })
-  }, [items, page])
 
   const { t } = useTranslation()
   // One-shot UX surface: mirror useLanguages — only notify the user once per
@@ -93,18 +60,16 @@ export const useTranslateHistories = ({
     }
   }, [error, t])
 
-  const histories = useMemo(() => loadedItems, [loadedItems])
   const hasMore = hasNext
-  const isLoadingMore = isRefreshing && page > 1
+  const isLoadingMore = isRefreshing && pages.length > 0
 
   const loadMore = useCallback(() => {
     if (!isLoadingMore && hasMore) {
-      nextPage()
+      loadNext()
     }
-  }, [isLoadingMore, hasMore, nextPage])
+  }, [isLoadingMore, hasMore, loadNext])
 
   const reload = useCallback(async () => {
-    setLoadedItems([])
     resetRef.current()
     await pageRefresh()
   }, [pageRefresh])

--- a/src/renderer/pages/translate/components/TranslateHistory.tsx
+++ b/src/renderer/pages/translate/components/TranslateHistory.tsx
@@ -7,7 +7,7 @@ import type { TranslateLangCode } from '@shared/data/preference/preferenceTypes'
 import type { TranslateHistory, TranslateLanguage } from '@shared/data/types/translate'
 import { ArrowRight, ChevronRight, Clock, Copy, Repeat, Star, Trash2 } from 'lucide-react'
 import type { FC, UIEvent } from 'react'
-import { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react'
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import IconButton from './IconButton'
@@ -56,6 +56,7 @@ const TranslateHistoryList: FC<Props> = ({ isOpen, onHistoryItemClick, onClose }
   })
   const { getLanguage, getLabel } = useLanguageLabels()
   const { clear: clearHistory, update: updateHistory } = useTranslateHistory()
+  const pendingLoadMoreRef = useRef(false)
 
   const history: DisplayedTranslateHistoryItem[] = useMemo(
     () =>
@@ -114,6 +115,10 @@ const TranslateHistoryList: FC<Props> = ({ isOpen, onHistoryItemClick, onClose }
     }
   }, [history, selectedId])
 
+  useEffect(() => {
+    pendingLoadMoreRef.current = false
+  }, [hasMore, history.length, isLoadingMore])
+
   const handleReuse = useCallback(
     (item: DisplayedTranslateHistoryItem) => {
       setSelectedId(null)
@@ -127,8 +132,14 @@ const TranslateHistoryList: FC<Props> = ({ isOpen, onHistoryItemClick, onClose }
   const handleListScroll = useCallback(
     (e: UIEvent<HTMLDivElement>) => {
       const el = e.currentTarget
-      if (hasMore && !isLoadingMore && el.scrollHeight - el.scrollTop - el.clientHeight < ITEM_HEIGHT * 2) {
-        loadMore()
+      if (
+        hasMore &&
+        !isLoadingMore &&
+        !pendingLoadMoreRef.current &&
+        el.scrollHeight - el.scrollTop - el.clientHeight < ITEM_HEIGHT * 2
+      ) {
+        pendingLoadMoreRef.current = true
+        queueMicrotask(loadMore)
       }
     },
     [hasMore, isLoadingMore, loadMore]

--- a/src/renderer/pages/translate/components/__tests__/TranslateHistory.test.tsx
+++ b/src/renderer/pages/translate/components/__tests__/TranslateHistory.test.tsx
@@ -355,4 +355,27 @@ describe('TranslateHistory', () => {
 
     await waitFor(() => expect(loadMoreMock).toHaveBeenCalledTimes(1))
   })
+
+  it('coalesces repeated near-bottom scroll events into one load request', async () => {
+    translateHistoryMock.useTranslateHistories.mockReturnValueOnce({
+      items: histories,
+      total: histories.length,
+      hasMore: true,
+      isLoadingMore: false,
+      loadMore: loadMoreMock,
+      status: 'success'
+    })
+
+    render(<TranslateHistory isOpen onHistoryItemClick={vi.fn()} onClose={vi.fn()} />)
+
+    const list = screen.getByTestId('virtual-list')
+    Object.defineProperty(list, 'scrollHeight', { configurable: true, value: 1000 })
+    Object.defineProperty(list, 'clientHeight', { configurable: true, value: 300 })
+    Object.defineProperty(list, 'scrollTop', { configurable: true, value: 650 })
+
+    fireEvent.scroll(list)
+    fireEvent.scroll(list)
+
+    await waitFor(() => expect(loadMoreMock).toHaveBeenCalledTimes(1))
+  })
 })

--- a/src/shared/data/api/schemas/translate.ts
+++ b/src/shared/data/api/schemas/translate.ts
@@ -16,7 +16,7 @@ import {
   type TranslateLanguage,
   TranslateLanguageSchema
 } from '../../types/translate'
-import type { OffsetPaginationResponse } from '../apiTypes'
+import type { CursorPaginationParams, CursorPaginationResponse } from '../apiTypes'
 
 // ============================================================================
 // Translate History DTOs & Query
@@ -49,28 +49,36 @@ export const UpdateTranslateHistorySchema = TranslateHistorySchema.pick({
  */
 export type UpdateTranslateHistoryDto = z.infer<typeof UpdateTranslateHistorySchema>
 
-export const TRANSLATE_HISTORY_DEFAULT_PAGE = 1
 export const TRANSLATE_HISTORY_DEFAULT_LIMIT = 20
 export const TRANSLATE_HISTORY_MAX_LIMIT = 100
 export const TRANSLATE_HISTORY_SEARCH_MAX_LENGTH = 200
 
-export const TranslateHistoryQuerySchema = z.object({
-  /** Positive integer, defaults to {@link TRANSLATE_HISTORY_DEFAULT_PAGE} */
-  page: z.int().positive().default(TRANSLATE_HISTORY_DEFAULT_PAGE),
-  /** Positive integer, max {@link TRANSLATE_HISTORY_MAX_LIMIT}, defaults to {@link TRANSLATE_HISTORY_DEFAULT_LIMIT} */
-  limit: z.int().positive().max(TRANSLATE_HISTORY_MAX_LIMIT).default(TRANSLATE_HISTORY_DEFAULT_LIMIT),
-  /**
-   * LIKE search on sourceText and targetText (wildcards are escaped).
-   * Bounded `[1, TRANSLATE_HISTORY_SEARCH_MAX_LENGTH]` so an empty value can't
-   * widen the query to `LIKE '%%'` (effectively returning everything) and an
-   * unbounded value can't be used to push expensive scans.
-   */
-  search: z.string().min(1).max(TRANSLATE_HISTORY_SEARCH_MAX_LENGTH).optional(),
-  /** Filter by starred status */
-  star: z.boolean().optional()
-})
-/** Query parameters for listing translate histories. */
+export const TranslateHistoryQuerySchema = z
+  .object({
+    /** Cursor returned by the previous page. Omitted for the first page. */
+    cursor: z.string().optional(),
+    /** Positive integer, max {@link TRANSLATE_HISTORY_MAX_LIMIT}, defaults to {@link TRANSLATE_HISTORY_DEFAULT_LIMIT} */
+    limit: z.int().positive().max(TRANSLATE_HISTORY_MAX_LIMIT).default(TRANSLATE_HISTORY_DEFAULT_LIMIT),
+    /**
+     * LIKE search on sourceText and targetText (wildcards are escaped).
+     * Bounded `[1, TRANSLATE_HISTORY_SEARCH_MAX_LENGTH]` so an empty value can't
+     * widen the query to `LIKE '%%'` (effectively returning everything) and an
+     * unbounded value can't be used to push expensive scans.
+     */
+    search: z.string().min(1).max(TRANSLATE_HISTORY_SEARCH_MAX_LENGTH).optional(),
+    /** Filter by starred status */
+    star: z.boolean().optional()
+  })
+  .strict()
+/** Parsed query parameters for listing translate histories. */
 export type TranslateHistoryQuery = z.infer<typeof TranslateHistoryQuerySchema>
+/** Input query parameters accepted by the API before schema defaults are applied. */
+export type TranslateHistoryQueryParams = z.input<typeof TranslateHistoryQuerySchema> & CursorPaginationParams
+
+export interface TranslateHistoryListResponse extends CursorPaginationResponse<TranslateHistory> {
+  items: TranslateHistory[]
+  total: number
+}
 
 // ============================================================================
 // Translate Language DTOs
@@ -105,8 +113,8 @@ export type TranslateSchemas = {
   '/translate/histories': {
     /** List translate histories with pagination, search, and star filter */
     GET: {
-      query?: TranslateHistoryQuery
-      response: OffsetPaginationResponse<TranslateHistory>
+      query?: TranslateHistoryQueryParams
+      response: TranslateHistoryListResponse
     }
     /** Create a new translate history record */
     POST: {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The translation history list used offset pagination through `usePaginatedQuery`, then accumulated fetched pages into local React state for infinite scroll. Scrolling near the bottom could repeatedly write derived pagination data back into state and synchronously request more data from the virtualized list scroll handler, producing React update-loop and `flushSync` lifecycle warnings.

After this PR:

`/translate/histories` uses cursor pagination, and `useTranslateHistories` consumes it through `useInfiniteQuery` and `useInfiniteFlatItems` instead of maintaining a second accumulated list in local state. Scroll-triggered load-more requests are deferred to a microtask and coalesced while a request is pending.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The fix moves translation history to the existing cursor-based infinite query contract rather than adding equality guards around duplicated local pagination state. The service cursor uses `(createdAt, id)` over the existing newest-first ordering so page boundaries are stable even when rows share the same timestamp.

The following alternatives were considered:

Keeping offset pagination plus local list guards was considered, but that keeps two sources of truth for loaded pages. Changing the shared virtual list was also considered, but the issue is caused by this consumer requesting more data during scroll handling, so deferring that request locally keeps the blast radius small.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Local validation was run with Node 22.22.0, so pnpm printed the repo's Node >=24.11.1 engine warning.

Validation:

- `pnpm format` passed.
- `pnpm lint` passed with 26 pre-existing warnings and no errors.
- Affected tests passed: `pnpm vitest run src/renderer/hooks/translate/__tests__/useTranslateHistories.test.ts src/renderer/pages/translate/components/__tests__/TranslateHistory.test.tsx src/main/data/api/handlers/__tests__/translate.test.ts src/main/data/services/__tests__/TranslateHistoryService.test.ts src/renderer/data/hooks/__tests__/useDataApi.test.ts`.
- `pnpm test` was run twice; both runs failed only on `src/main/services/file/tree/__tests__/builder.test.ts > dispose() stops the chokidar watcher so post-dispose FS changes emit nothing`. That file passes when rerun in isolation with `pnpm vitest run src/main/services/file/tree/__tests__/builder.test.ts`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix translation history scrolling so loading more records no longer triggers React update-loop errors.
```
