### PR TITLE
fix: consolidate small fixes (typo + console.log)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build:linux:x64": "dotenv npm run build && electron-builder --linux --x64",
     "release": "node scripts/version.js",
     "publish": "pnpm build:check && pnpm release patch push",
-    "pulish:artifacts": "cd packages/artifacts && npm publish && cd -",
+    "publish:artifacts": "cd packages/artifacts && npm publish && cd -",
     "analyze:renderer": "VISUALIZER_RENDERER=true pnpm build",
     "analyze:main": "VISUALIZER_MAIN=true pnpm build",
     "typecheck": "pnpm --filter @cherrystudio/ai-sdk-provider build && concurrently -n \"node,web,aicore\" -c \"cyan,magenta,yellow\" \"npm run typecheck:node\" \"npm run typecheck:web\" \"pnpm --filter @cherrystudio/ai-core typecheck\"",

--- a/src/main/mcpServers/browser/controller.ts
+++ b/src/main/mcpServers/browser/controller.ts
@@ -247,7 +247,7 @@ export class CdpBrowserController {
       (function() {
         window.addEventListener('message', function(e) {
           if (e.data && e.data.channel === 'tabbar-action') {
-            console.log(JSON.stringify(e.data));
+            // Tab bar action received
           }
         });
       })();


### PR DESCRIPTION
## Summary

This PR consolidates two small fixes into one, as suggested by @kangfenmao:

### Changes

1. Fix script name typo in package.json: pulish:artifacts -> publish:artifacts
2. Remove console.log from production code in browser controller

### Related PRs (can be closed)
- #15463 (pulish:artifacts typo)
- #15462 (console.log in browser controller)