### PR TITLE
fix(paintings): preserve NewAPI image generation state

### DIFF
--- a/src/renderer/src/pages/paintings/NewApiPage.tsx
+++ b/src/renderer/src/pages/paintings/NewApiPage.tsx
@@ -20,7 +20,11 @@ import {
   getPaintingsQualityOptionsLabel
 } from '@renderer/i18n/label'
 import PaintingsList from '@renderer/pages/paintings/components/PaintingsList'
-import { DEFAULT_PAINTING, MODELS, SUPPORTED_MODELS } from '@renderer/pages/paintings/config/NewApiConfig'
+import {
+  DEFAULT_PAINTING,
+  getNewApiModelConfig,
+  isSupportedNewApiModel
+} from '@renderer/pages/paintings/config/NewApiConfig'
 import FileManager from '@renderer/services/FileManager'
 import { translateText } from '@renderer/services/TranslateService'
 import { useAppDispatch } from '@renderer/store'
@@ -44,7 +48,7 @@ import SendMessageButton from '../home/Inputbar/SendMessageButton'
 import { SettingHelpLink, SettingTitle } from '../settings'
 import Artboard from './components/Artboard'
 import ProviderSelect from './components/ProviderSelect'
-import { checkProviderEnabled, findPaintingByFiles } from './utils'
+import { checkProviderEnabled, findPaintingByFiles, getNewApiSeedPainting } from './utils'
 
 const logger = loggerService.withContext('NewApiPage')
 
@@ -160,7 +164,7 @@ const NewApiPage: FC<{ Options: string[] }> = ({ Options }) => {
       .map((m) => ({
         label: m.name,
         value: m.id,
-        custom: !SUPPORTED_MODELS.includes(m.id),
+        custom: !isSupportedNewApiModel(m.id),
         group: m.group
       }))
     return [...customModels]
@@ -178,22 +182,23 @@ const NewApiPage: FC<{ Options: string[] }> = ({ Options }) => {
     }, {})
   }, [modelOptions])
 
-  const getNewPainting = useCallback(() => {
-    return {
-      ...DEFAULT_PAINTING,
-      model: painting.model || modelOptions[0]?.value || '',
-      id: uuid(),
-      providerId: newApiProvider.id
-    }
-  }, [modelOptions, painting.model, newApiProvider.id])
-
-  const selectedModelConfig = useMemo(
-    () => MODELS.find((m) => m.name === painting.model) || MODELS[0],
-    [painting.model]
+  const getNewPainting = useCallback(
+    (basePainting?: PaintingAction) => {
+      return {
+        ...DEFAULT_PAINTING,
+        ...basePainting,
+        model: basePainting?.model || painting.model || modelOptions[0]?.value || '',
+        id: basePainting?.id || uuid(),
+        providerId: newApiProvider.id
+      }
+    },
+    [modelOptions, painting.model, newApiProvider.id]
   )
 
+  const selectedModelConfig = useMemo(() => getNewApiModelConfig(painting.model), [painting.model])
+
   const handleModelChange = (value: string) => {
-    const modelConfig = MODELS.find((m) => m.name === value)
+    const modelConfig = getNewApiModelConfig(value)
     const updates: Partial<PaintingAction> = { model: value }
 
     // 设置默认值
@@ -544,7 +549,7 @@ const NewApiPage: FC<{ Options: string[] }> = ({ Options }) => {
 
   useEffect(() => {
     if (filteredPaintings.length === 0) {
-      const newPainting = getNewPainting()
+      const newPainting = getNewApiSeedPainting(painting, newApiProvider.id, getNewPainting)
       addPainting(mode, newPainting)
       setPainting(newPainting)
     } else {
@@ -556,7 +561,7 @@ const NewApiPage: FC<{ Options: string[] }> = ({ Options }) => {
         setPainting(filteredPaintings[0])
       }
     }
-  }, [filteredPaintings, mode, addPainting, getNewPainting, painting.id])
+  }, [filteredPaintings, mode, addPainting, getNewPainting, newApiProvider.id, painting])
 
   useEffect(() => {
     const timer = spaceClickTimer.current

--- a/src/renderer/src/pages/paintings/config/NewApiConfig.ts
+++ b/src/renderer/src/pages/paintings/config/NewApiConfig.ts
@@ -1,7 +1,7 @@
 import type { GeneratePainting } from '@renderer/types'
 import { uuid } from '@renderer/utils'
 
-export const SUPPORTED_MODELS = ['gpt-image-1']
+export const SUPPORTED_MODELS = ['gpt-image-1', 'gpt-image-2']
 
 export const MODELS = [
   {
@@ -14,8 +14,40 @@ export const MODELS = [
     output_compression_format: [{ value: 'jpeg' }, { value: 'webp' }],
     output_format: [{ value: 'image/png' }, { value: 'image/jpeg' }, { value: 'image/webp' }],
     background: [{ value: 'auto' }, { value: 'transparent' }, { value: 'opaque' }]
+  },
+  {
+    name: 'gpt-image-2',
+    group: 'OpenAI',
+    imageSizes: [
+      { value: 'auto' },
+      { value: '1024x1024' },
+      { value: '1536x1024' },
+      { value: '1024x1536' },
+      { value: '2048x2048' },
+      { value: '2560x1440' },
+      { value: '1440x2560' }
+    ],
+    max_images: 10,
+    quality: [{ value: 'auto' }, { value: 'high' }, { value: 'medium' }, { value: 'low' }],
+    moderation: [{ value: 'auto' }, { value: 'low' }],
+    output_compression_format: [{ value: 'jpeg' }, { value: 'webp' }],
+    output_format: [{ value: 'image/png' }, { value: 'image/jpeg' }, { value: 'image/webp' }],
+    background: [{ value: 'auto' }, { value: 'opaque' }]
   }
 ]
+
+const isGptImage2FamilyModel = (modelName: string): boolean =>
+  modelName === 'gpt-image-2' || modelName.startsWith('gpt-image-2-')
+
+export const isSupportedNewApiModel = (modelName: string): boolean => {
+  return SUPPORTED_MODELS.includes(modelName) || isGptImage2FamilyModel(modelName)
+}
+
+export const getNewApiModelConfig = (modelName?: string) => {
+  const normalizedModelName = modelName && isGptImage2FamilyModel(modelName) ? 'gpt-image-2' : modelName
+
+  return MODELS.find((m) => m.name === normalizedModelName) || MODELS[0]
+}
 
 export const DEFAULT_PAINTING: GeneratePainting = {
   id: uuid(),

--- a/src/renderer/src/pages/paintings/config/__tests__/NewApiConfig.test.ts
+++ b/src/renderer/src/pages/paintings/config/__tests__/NewApiConfig.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { getNewApiModelConfig, isSupportedNewApiModel } from '../NewApiConfig'
+
+describe('NewApiConfig', () => {
+  it('treats gpt-image-2 aliases as supported NewAPI image models', () => {
+    expect(isSupportedNewApiModel('gpt-image-2')).toBe(true)
+    expect(isSupportedNewApiModel('gpt-image-2-c')).toBe(true)
+  })
+
+  it('exposes 2560x1440 for gpt-image-2 family aliases', () => {
+    const imageSizes = getNewApiModelConfig('gpt-image-2-c').imageSizes.map((option) => option.value)
+
+    expect(imageSizes).toContain('2560x1440')
+  })
+
+  it('keeps gpt-image-1 on its documented fixed-size set', () => {
+    const imageSizes = getNewApiModelConfig('gpt-image-1').imageSizes.map((option) => option.value)
+
+    expect(imageSizes).not.toContain('2560x1440')
+  })
+})

--- a/src/renderer/src/pages/paintings/utils/__tests__/index.test.ts
+++ b/src/renderer/src/pages/paintings/utils/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { findPaintingByFiles } from '../index'
+import { findPaintingByFiles, getNewApiSeedPainting } from '../index'
 
 describe('findPaintingByFiles', () => {
   const createPainting = (id: string, providerId: string, fileIds: string[]) => ({
@@ -27,5 +27,47 @@ describe('findPaintingByFiles', () => {
     ]
 
     expect(findPaintingByFiles(paintings, 'provider-a', [{ id: 'file-1' }, { id: 'file-2' }])).toBeUndefined()
+  })
+})
+
+describe('getNewApiSeedPainting', () => {
+  const createPainting = (id: string, providerId: string) => ({
+    id,
+    providerId,
+    urls: [],
+    files: [],
+    model: '',
+    prompt: ''
+  })
+
+  it('keeps the current provider draft so first updates target the seeded painting', () => {
+    const currentPainting = createPainting('draft-id', 'provider-a')
+
+    const seedPainting = getNewApiSeedPainting(currentPainting, 'provider-a', (basePainting) => ({
+      ...createPainting('new-id', 'provider-a'),
+      ...basePainting,
+      model: basePainting?.model || 'gpt-image-1'
+    }))
+
+    expect(seedPainting).toMatchObject({
+      id: 'draft-id',
+      model: 'gpt-image-1',
+      providerId: 'provider-a'
+    })
+  })
+
+  it('creates a fresh seed when the current draft belongs to another provider', () => {
+    const currentPainting = createPainting('other-provider-draft-id', 'provider-b')
+
+    const seedPainting = getNewApiSeedPainting(currentPainting, 'provider-a', (basePainting) => ({
+      ...createPainting('new-id', 'provider-a'),
+      ...basePainting,
+      model: basePainting?.model || 'gpt-image-1'
+    }))
+
+    expect(seedPainting).toMatchObject({
+      id: 'new-id',
+      providerId: 'provider-a'
+    })
   })
 })

--- a/src/renderer/src/pages/paintings/utils/index.ts
+++ b/src/renderer/src/pages/paintings/utils/index.ts
@@ -35,3 +35,11 @@ export function findPaintingByFiles<T extends { providerId?: string; files: Read
       painting.files.every((file, index) => file.id === files[index]?.id)
   )
 }
+
+export function getNewApiSeedPainting<T extends { providerId?: string }>(
+  currentPainting: T,
+  providerId: string,
+  createPainting: (basePainting?: T) => T
+): T {
+  return createPainting(currentPainting.providerId === providerId ? currentPainting : undefined)
+}


### PR DESCRIPTION
## What?
Fixes the v1 Paintings NewAPI flow so the initial local draft is the same painting record seeded into Redux, and adds GPT-image-2 family configuration for NewAPI image models.

## Why?
The installed v1 app could log `Painting with id ... not found in openai_image_generate` because the page created one local draft ID, then seeded Redux with a different painting ID. When a slow generation response later tried to update the local draft, the reducer could not find it, making successful image results look like they timed out or disappeared.

The NewAPI page also treated `gpt-image-2` aliases such as `gpt-image-2-c` as custom models and fell back to GPT-image-1 size controls, hiding the requested 16:9 `2560x1440` option even when the selected model family supports it.

## How?
- Added a small NewAPI seeding helper that preserves the current provider draft when the page needs to initialize an empty provider/mode list.
- Updated `NewApiPage` to seed Redux from that helper, so prompt/result updates target the seeded record.
- Added GPT-image-2 model config and alias detection for `gpt-image-2-*` model IDs.
- Kept GPT-image-1 on its fixed-size set while exposing `2560x1440` for GPT-image-2 family models.
- Added renderer regression tests for both the state seeding path and GPT-image-2 alias/size config.

## Testing?
- PASS: `pnpm format`
- PASS: `pnpm lint`
- PASS: `pnpm vitest run --project renderer src/renderer/src/pages/paintings/utils/__tests__/index.test.ts --silent`
- PASS: `pnpm vitest run --project renderer src/renderer/src/pages/paintings/config/__tests__/NewApiConfig.test.ts --silent`
- PASS: `pnpm test:renderer -- --silent` (161 files, 2929 tests)
- FAIL: `pnpm test` still fails in unrelated main-process suites: CherryClaw prompt memory expectations plus Windows path-separator expectations in built-in skills/workspace memory tests.

## Screenshots (optional)
No screenshot. This is a state/config fix; no paid external image generation call was made during local validation.

## Anything Else?
Targets `v1`. The GPT-image-2 size support is intentionally scoped to GPT-image-2 family IDs and does not add unsupported high-resolution sizes to GPT-image-1.