### PR TITLE
fix(mcp): port stale MCP reference cleanup to v1

### DIFF
--- a/packages/shared/IpcChannel.ts
+++ b/packages/shared/IpcChannel.ts
@@ -98,6 +98,7 @@ export enum IpcChannel {
   Mcp_Progress = 'mcp:progress',
   Mcp_GetServerLogs = 'mcp:get-server-logs',
   Mcp_ServerLog = 'mcp:server-log',
+  Mcp_CleanupAgentReferences = 'mcp:cleanup-agent-references',
   // Python
   Python_Execute = 'python:execute',
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -815,6 +815,64 @@ export async function registerIpc(mainWindow: BrowserWindow, app: Electron.App) 
   })
   ipcMain.handle(IpcChannel.Mcp_GetServerVersion, mcpService.getServerVersion)
   ipcMain.handle(IpcChannel.Mcp_GetServerLogs, mcpService.getServerLogs)
+  ipcMain.handle(IpcChannel.Mcp_CleanupAgentReferences, async (_event, serverId: string) => {
+    try {
+      const { agentsTable } = await import('./services/agents/database/schema/agents.schema')
+      const { sessionsTable } = await import('./services/agents/database/schema/sessions.schema')
+      const { DatabaseManager } = await import('./services/agents/database/DatabaseManager')
+      const { eq, sql } = await import('drizzle-orm')
+      const logger = loggerService.withContext('IpcHandler:McpCleanup')
+
+      const dbManager = await DatabaseManager.getInstance()
+      const db = dbManager.getDatabase()
+
+      const rawLike = `%"${serverId.replace(/[\\%_]/g, '\\$&')}"%`
+
+      // Clean up agent mcps arrays
+      const agentsToFix = await db
+        .select({ id: agentsTable.id, mcps: agentsTable.mcps })
+        .from(agentsTable)
+        .where(sql`${agentsTable.mcps} LIKE ${rawLike} ESCAPE '\\'`)
+
+      for (const a of agentsToFix) {
+        if (!a.mcps) continue
+        const mcps = JSON.parse(a.mcps)
+        if (Array.isArray(mcps)) {
+          await db
+            .update(agentsTable)
+            .set({ mcps: JSON.stringify(mcps.filter((id: string) => id !== serverId)) })
+            .where(eq(agentsTable.id, a.id))
+        }
+      }
+
+      // Clean up session mcps arrays
+      const sessionsToFix = await db
+        .select({ id: sessionsTable.id, mcps: sessionsTable.mcps })
+        .from(sessionsTable)
+        .where(sql`${sessionsTable.mcps} LIKE ${rawLike} ESCAPE '\\'`)
+
+      for (const s of sessionsToFix) {
+        if (!s.mcps) continue
+        const mcps = JSON.parse(s.mcps)
+        if (Array.isArray(mcps)) {
+          await db
+            .update(sessionsTable)
+            .set({ mcps: JSON.stringify(mcps.filter((id: string) => id !== serverId)) })
+            .where(eq(sessionsTable.id, s.id))
+        }
+      }
+
+      if (agentsToFix.length > 0 || sessionsToFix.length > 0) {
+        logger.info('Cleaned up stale MCP references from agents/sessions', {
+          serverId,
+          affectedAgents: agentsToFix.length,
+          affectedSessions: sessionsToFix.length
+        })
+      }
+    } catch (error) {
+      loggerService.withContext('IpcHandler:McpCleanup').error('Failed to clean up MCP references', error as Error)
+    }
+  })
 
   // Channel logs & status
   ipcMain.handle(IpcChannel.Channel_GetLogs, async (_event, channelId: string) => {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -39,6 +39,7 @@ import { BrowserWindow, dialog, ipcMain, session, shell, systemPreferences, webC
 import fontList from 'font-list'
 
 import { agentMessageRepository } from './services/agents/database'
+import { agentService } from './services/agents/services'
 import { skillService } from './services/agents/skills/SkillService'
 import { analyticsService } from './services/AnalyticsService'
 import { apiServerService } from './services/ApiServerService'
@@ -816,62 +817,7 @@ export async function registerIpc(mainWindow: BrowserWindow, app: Electron.App) 
   ipcMain.handle(IpcChannel.Mcp_GetServerVersion, mcpService.getServerVersion)
   ipcMain.handle(IpcChannel.Mcp_GetServerLogs, mcpService.getServerLogs)
   ipcMain.handle(IpcChannel.Mcp_CleanupAgentReferences, async (_event, serverId: string) => {
-    try {
-      const { agentsTable } = await import('./services/agents/database/schema/agents.schema')
-      const { sessionsTable } = await import('./services/agents/database/schema/sessions.schema')
-      const { DatabaseManager } = await import('./services/agents/database/DatabaseManager')
-      const { eq, sql } = await import('drizzle-orm')
-      const logger = loggerService.withContext('IpcHandler:McpCleanup')
-
-      const dbManager = await DatabaseManager.getInstance()
-      const db = dbManager.getDatabase()
-
-      const rawLike = `%"${serverId.replace(/[\\%_]/g, '\\$&')}"%`
-
-      // Clean up agent mcps arrays
-      const agentsToFix = await db
-        .select({ id: agentsTable.id, mcps: agentsTable.mcps })
-        .from(agentsTable)
-        .where(sql`${agentsTable.mcps} LIKE ${rawLike} ESCAPE '\\'`)
-
-      for (const a of agentsToFix) {
-        if (!a.mcps) continue
-        const mcps = JSON.parse(a.mcps)
-        if (Array.isArray(mcps)) {
-          await db
-            .update(agentsTable)
-            .set({ mcps: JSON.stringify(mcps.filter((id: string) => id !== serverId)) })
-            .where(eq(agentsTable.id, a.id))
-        }
-      }
-
-      // Clean up session mcps arrays
-      const sessionsToFix = await db
-        .select({ id: sessionsTable.id, mcps: sessionsTable.mcps })
-        .from(sessionsTable)
-        .where(sql`${sessionsTable.mcps} LIKE ${rawLike} ESCAPE '\\'`)
-
-      for (const s of sessionsToFix) {
-        if (!s.mcps) continue
-        const mcps = JSON.parse(s.mcps)
-        if (Array.isArray(mcps)) {
-          await db
-            .update(sessionsTable)
-            .set({ mcps: JSON.stringify(mcps.filter((id: string) => id !== serverId)) })
-            .where(eq(sessionsTable.id, s.id))
-        }
-      }
-
-      if (agentsToFix.length > 0 || sessionsToFix.length > 0) {
-        logger.info('Cleaned up stale MCP references from agents/sessions', {
-          serverId,
-          affectedAgents: agentsToFix.length,
-          affectedSessions: sessionsToFix.length
-        })
-      }
-    } catch (error) {
-      loggerService.withContext('IpcHandler:McpCleanup').error('Failed to clean up MCP references', error as Error)
-    }
+    return agentService.cleanupMcpReferences(serverId)
   })
 
   // Channel logs & status

--- a/src/main/services/agents/BaseService.ts
+++ b/src/main/services/agents/BaseService.ts
@@ -2,7 +2,6 @@ import { loggerService } from '@logger'
 import { mcpApiService } from '@main/apiServer/services/mcp'
 import type { ModelValidationError } from '@main/apiServer/utils'
 import { validateModelId } from '@main/apiServer/utils'
-import { getMCPServersFromRedux } from '@main/apiServer/utils/mcp'
 import { getDataPath } from '@main/utils'
 import { buildFunctionCallToolName } from '@shared/mcp'
 import type { AgentType, MCPTool, SlashCommand, SystemProviderId, Tool } from '@types'
@@ -62,6 +61,7 @@ export abstract class BaseService {
       // Pre-filter: only connect to servers that still exist and are active.
       // This avoids log noise, wasted DB lookups, and connection timeouts from
       // stale references in agent/session mcps arrays.
+      const { getMCPServersFromRedux } = await import('@main/apiServer/utils/mcp')
       const activeServers = await getMCPServersFromRedux()
       const activeServerIds = new Set(activeServers.filter((s) => s.isActive).map((s) => s.id))
       const validIds = ids.filter((id) => activeServerIds.has(id))

--- a/src/main/services/agents/BaseService.ts
+++ b/src/main/services/agents/BaseService.ts
@@ -2,6 +2,7 @@ import { loggerService } from '@logger'
 import { mcpApiService } from '@main/apiServer/services/mcp'
 import type { ModelValidationError } from '@main/apiServer/utils'
 import { validateModelId } from '@main/apiServer/utils'
+import { getMCPServersFromRedux } from '@main/apiServer/utils/mcp'
 import { getDataPath } from '@main/utils'
 import { buildFunctionCallToolName } from '@shared/mcp'
 import type { AgentType, MCPTool, SlashCommand, SystemProviderId, Tool } from '@types'
@@ -58,7 +59,19 @@ export abstract class BaseService {
       tools.push(...builtinTools)
     }
     if (ids && ids.length > 0) {
-      for (const id of ids) {
+      // Pre-filter: only connect to servers that still exist and are active.
+      // This avoids log noise, wasted DB lookups, and connection timeouts from
+      // stale references in agent/session mcps arrays.
+      const activeServers = await getMCPServersFromRedux()
+      const activeServerIds = new Set(activeServers.filter((s) => s.isActive).map((s) => s.id))
+      const validIds = ids.filter((id) => activeServerIds.has(id))
+
+      if (validIds.length < ids.length) {
+        const dropped = ids.filter((id) => !activeServerIds.has(id))
+        logger.warn('Skipping inactive/deleted MCP servers when listing tools', { dropped })
+      }
+
+      for (const id of validIds) {
         try {
           const server = await mcpApiService.getServerInfo(id)
           if (server) {

--- a/src/main/services/agents/services/AgentService.ts
+++ b/src/main/services/agents/services/AgentService.ts
@@ -554,6 +554,90 @@ export class AgentService extends BaseService {
     logger.info('Agents reordered', { count: orderedIds.length })
   }
 
+  async cleanupMcpReferences(serverId: string): Promise<{ affectedAgents: number; affectedSessions: number }> {
+    const database = await this.getDatabase()
+    const rawLike = `%"${serverId.replace(/[\\%_]/g, '\\$&')}"%`
+
+    let affectedAgents = 0
+    let affectedSessions = 0
+
+    await database.transaction(async (tx) => {
+      const agentsToFix = await tx
+        .select({ id: agentsTable.id, mcps: agentsTable.mcps })
+        .from(agentsTable)
+        .where(sql`${agentsTable.mcps} LIKE ${rawLike} ESCAPE '\\'`)
+
+      for (const agent of agentsToFix) {
+        if (!agent.mcps) continue
+
+        let parsedMcps: unknown
+        try {
+          parsedMcps = JSON.parse(agent.mcps)
+        } catch (error) {
+          logger.warn('Failed to parse agent mcps during MCP cleanup', {
+            serverId,
+            agentId: agent.id,
+            error: error instanceof Error ? error.message : String(error)
+          })
+          continue
+        }
+
+        if (!Array.isArray(parsedMcps)) continue
+
+        const filteredMcps = parsedMcps.filter((id: string) => id !== serverId)
+        if (filteredMcps.length === parsedMcps.length) continue
+
+        await tx
+          .update(agentsTable)
+          .set({ mcps: JSON.stringify(filteredMcps) })
+          .where(eq(agentsTable.id, agent.id))
+        affectedAgents++
+      }
+
+      const sessionsToFix = await tx
+        .select({ id: sessionsTable.id, mcps: sessionsTable.mcps })
+        .from(sessionsTable)
+        .where(sql`${sessionsTable.mcps} LIKE ${rawLike} ESCAPE '\\'`)
+
+      for (const session of sessionsToFix) {
+        if (!session.mcps) continue
+
+        let parsedMcps: unknown
+        try {
+          parsedMcps = JSON.parse(session.mcps)
+        } catch (error) {
+          logger.warn('Failed to parse session mcps during MCP cleanup', {
+            serverId,
+            sessionId: session.id,
+            error: error instanceof Error ? error.message : String(error)
+          })
+          continue
+        }
+
+        if (!Array.isArray(parsedMcps)) continue
+
+        const filteredMcps = parsedMcps.filter((id: string) => id !== serverId)
+        if (filteredMcps.length === parsedMcps.length) continue
+
+        await tx
+          .update(sessionsTable)
+          .set({ mcps: JSON.stringify(filteredMcps) })
+          .where(eq(sessionsTable.id, session.id))
+        affectedSessions++
+      }
+    })
+
+    if (affectedAgents > 0 || affectedSessions > 0) {
+      logger.info('Cleaned up stale MCP references from agents/sessions', {
+        serverId,
+        affectedAgents,
+        affectedSessions
+      })
+    }
+
+    return { affectedAgents, affectedSessions }
+  }
+
   private async deleteAgentRelations(tx: AgentTransaction, id: string): Promise<void> {
     // Agent DB migrations did not always create FK constraints, so clean child rows explicitly.
     await tx.delete(agentSkillsTable).where(eq(agentSkillsTable.agent_id, id))

--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -21,7 +21,6 @@ import type { Base64ImageSource, ContentBlockParam } from '@anthropic-ai/sdk/res
 import { loggerService } from '@logger'
 import { config as apiConfigService } from '@main/apiServer/config'
 import { validateModelId } from '@main/apiServer/utils'
-import { getMCPServersFromRedux } from '@main/apiServer/utils/mcp'
 import { isWin } from '@main/constant'
 import AssistantServer from '@main/mcpServers/assistant'
 import ClawServer from '@main/mcpServers/claw'
@@ -568,6 +567,7 @@ class ClaudeCodeService implements AgentServiceInterface {
       // This avoids log noise, wasted DB lookups, and connection timeouts from
       // stale references in session mcps arrays (e.g. after an MCP server
       // was deleted without cleaning up the session's mcps list).
+      const { getMCPServersFromRedux } = await import('@main/apiServer/utils/mcp')
       const activeServers = await getMCPServersFromRedux()
       const activeServerIds = new Set(activeServers.filter((s) => s.isActive).map((s) => s.id))
       const validIds = session.mcps.filter((id: string) => activeServerIds.has(id))

--- a/src/main/services/agents/services/claudecode/index.ts
+++ b/src/main/services/agents/services/claudecode/index.ts
@@ -21,6 +21,7 @@ import type { Base64ImageSource, ContentBlockParam } from '@anthropic-ai/sdk/res
 import { loggerService } from '@logger'
 import { config as apiConfigService } from '@main/apiServer/config'
 import { validateModelId } from '@main/apiServer/utils'
+import { getMCPServersFromRedux } from '@main/apiServer/utils/mcp'
 import { isWin } from '@main/constant'
 import AssistantServer from '@main/mcpServers/assistant'
 import ClawServer from '@main/mcpServers/claw'
@@ -563,9 +564,22 @@ class ClaudeCodeService implements AgentServiceInterface {
     }
 
     if (session.mcps && session.mcps.length > 0) {
+      // Pre-filter: only connect to servers that still exist and are active.
+      // This avoids log noise, wasted DB lookups, and connection timeouts from
+      // stale references in session mcps arrays (e.g. after an MCP server
+      // was deleted without cleaning up the session's mcps list).
+      const activeServers = await getMCPServersFromRedux()
+      const activeServerIds = new Set(activeServers.filter((s) => s.isActive).map((s) => s.id))
+      const validIds = session.mcps.filter((id: string) => activeServerIds.has(id))
+
+      if (validIds.length < session.mcps.length) {
+        const dropped = session.mcps.filter((id: string) => !activeServerIds.has(id))
+        logger.warn('Skipping inactive/deleted MCP servers when creating session', { dropped })
+      }
+
       // mcp configs
       const mcpList: Record<string, McpHttpServerConfig> = {}
-      for (const mcpId of session.mcps) {
+      for (const mcpId of validIds) {
         mcpList[mcpId] = {
           type: 'http',
           url: `http://${apiConfig.host}:${apiConfig.port}/v1/mcps/${mcpId}/mcp`,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -393,6 +393,7 @@ const api = {
   },
   mcp: {
     removeServer: (server: MCPServer) => ipcRenderer.invoke(IpcChannel.Mcp_RemoveServer, server),
+    cleanupAgentReferences: (serverId: string) => ipcRenderer.invoke(IpcChannel.Mcp_CleanupAgentReferences, serverId),
     restartServer: (server: MCPServer) => ipcRenderer.invoke(IpcChannel.Mcp_RestartServer, server),
     stopServer: (server: MCPServer) => ipcRenderer.invoke(IpcChannel.Mcp_StopServer, server),
     listTools: (server: MCPServer, context?: SpanContext) => tracedInvoke(IpcChannel.Mcp_ListTools, context, server),

--- a/src/renderer/src/pages/settings/MCPSettings/McpServersList.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/McpServersList.tsx
@@ -128,6 +128,7 @@ const McpServersList: FC = () => {
           centered: true,
           onOk: async () => {
             await window.api.mcp.removeServer(server)
+            await window.api.mcp.cleanupAgentReferences(server.id)
             deleteMCPServer(server.id)
             window.toast.success(t('settings.mcp.deleteSuccess'))
           }

--- a/src/renderer/src/pages/settings/MCPSettings/McpSettings.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/McpSettings.tsx
@@ -407,6 +407,7 @@ const McpSettings: React.FC = () => {
           centered: true,
           onOk: async () => {
             await window.api.mcp.removeServer(server)
+            await window.api.mcp.cleanupAgentReferences(server.id)
             deleteMCPServer(server.id)
             window.toast.success(t('settings.mcp.deleteSuccess'))
             navigate('/settings/mcp')


### PR DESCRIPTION
## What this PR does

Three-layer fix ported from #15597 to the v1 branch. When an MCP server is deleted from global settings, stale UUID references in agents' and sessions' `mcps` arrays are now cleaned up automatically.

### Fix 1: Cleanup on delete
New `Mcp_CleanupAgentReferences` IPC handler that removes the deleted MCP server ID from agent and session `mcps` arrays in the agents SQLite DB. Wired into both `McpSettings` and `McpServersList` delete flows.

### Fix 2: Defensive pre-filter in BaseService.listMcpTools()
Prefilters MCP IDs against active servers (from Redux) before attempting connections, skipping stale/inactive entries. Logs dropped IDs at warn level for diagnostics.

### Fix 3: Session guard in claudecode/index.ts
Session MCP handling now pre-filters `session.mcps` against active servers before creating HTTP proxy transports.

## Adaptations from main branch

- MCP server configs live in Redux (not a DB table), so the pre-filter uses `getMCPServersFromRedux()` instead of `mcpServerService.list()$
- `mcps` column is `text` (not `text({mode:'json'})`) — uses manual JSON.parse/JSON.stringify
- Uses HTTP proxy transport (no SDK bridge) — no `createSdkMcpServerInstance` equivalent
- Renderer settings changes from #15597 don't apply (different component structure on v1)

## Checklist

- [x] Port: This PR ports the fix from #15597 to the v1 maintenance branch
- [x] Branch: This PR targets `v1`
- [x] Breaking changes: None

```release-note
Fix Agent module lag caused by stale MCP server references accumulating in agent configurations when MCP servers are deleted from global settings (v1 port of #15597).
```