### PR TITLE
fix(stream): stabilize reasoning thinking time

### DIFF
--- a/src/main/ai/streamManager/AiStreamManager.ts
+++ b/src/main/ai/streamManager/AiStreamManager.ts
@@ -28,6 +28,7 @@ import { KeyedMutex } from './KeyedMutex'
 import { createChatStreamLifecycle, promptStreamLifecycle, type StreamLifecycle } from './lifecycle'
 import { WebContentsListener } from './listeners/WebContentsListener'
 import { pipeStreamLoop } from './pipeStreamLoop'
+import { withReasoningTimingMetadata } from './reasoningTimingTransform'
 import type {
   ActiveStream,
   AiStreamManagerConfig,
@@ -797,7 +798,7 @@ export class AiStreamManager extends BaseService {
     // upstream AI SDK request is already wired to. Caller override via
     // `requestOptions.timeout`; otherwise `DEFAULT_TIMEOUT`.
     const timeoutMs = request.requestOptions?.timeout ?? DEFAULT_TIMEOUT
-    const stream = withIdleTimeout(rawStream, exec.abortController, timeoutMs)
+    const stream = withReasoningTimingMetadata(withIdleTimeout(rawStream, exec.abortController, timeoutMs))
 
     // `continue-conversation` chunks reference toolCallIds on the anchor
     // assistant message; without seeding, `readUIMessageStream`'s

--- a/src/main/ai/streamManager/AiStreamManager.ts
+++ b/src/main/ai/streamManager/AiStreamManager.ts
@@ -798,6 +798,8 @@ export class AiStreamManager extends BaseService {
     // upstream AI SDK request is already wired to. Caller override via
     // `requestOptions.timeout`; otherwise `DEFAULT_TIMEOUT`.
     const timeoutMs = request.requestOptions?.timeout ?? DEFAULT_TIMEOUT
+    // Wrap before pipeStreamLoop's tee() so broadcast + accumulator share one
+    // thinkingMs measurement (see reasoningTimingTransform).
     const stream = withReasoningTimingMetadata(withIdleTimeout(rawStream, exec.abortController, timeoutMs))
 
     // `continue-conversation` chunks reference toolCallIds on the anchor

--- a/src/main/ai/streamManager/__tests__/reasoningTimingTransform.test.ts
+++ b/src/main/ai/streamManager/__tests__/reasoningTimingTransform.test.ts
@@ -1,0 +1,217 @@
+import type { UIMessageChunk } from 'ai'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { pipeStreamLoop } from '../pipeStreamLoop'
+import { withReasoningTimingMetadata } from '../reasoningTimingTransform'
+
+function streamFrom(chunks: UIMessageChunk[]): ReadableStream<UIMessageChunk> {
+  return new ReadableStream<UIMessageChunk>({
+    start(controller) {
+      chunks.forEach((chunk) => controller.enqueue(chunk))
+      controller.close()
+    }
+  })
+}
+
+async function collect(stream: ReadableStream<UIMessageChunk>): Promise<UIMessageChunk[]> {
+  const reader = stream.getReader()
+  const chunks: UIMessageChunk[] = []
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      chunks.push(value)
+    }
+  } finally {
+    reader.releaseLock()
+  }
+  return chunks
+}
+
+function cherryMeta(chunk: UIMessageChunk): Record<string, unknown> | undefined {
+  const metadata =
+    'providerMetadata' in chunk ? (chunk.providerMetadata as Record<string, unknown> | undefined) : undefined
+  return metadata?.cherry as Record<string, unknown> | undefined
+}
+
+describe('withReasoningTimingMetadata', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('adds thinkingMs to reasoning-end chunks', async () => {
+    vi.spyOn(performance, 'now').mockReturnValueOnce(100).mockReturnValueOnce(432)
+
+    const chunks = await collect(
+      withReasoningTimingMetadata(
+        streamFrom([
+          { type: 'reasoning-start', id: 'r1' } as UIMessageChunk,
+          { type: 'reasoning-delta', id: 'r1', delta: 'thinking' } as UIMessageChunk,
+          { type: 'reasoning-end', id: 'r1' } as UIMessageChunk,
+          { type: 'text-start', id: 't1' } as UIMessageChunk,
+          { type: 'text-delta', id: 't1', delta: 'answer' } as UIMessageChunk
+        ])
+      )
+    )
+
+    expect(cherryMeta(chunks[2])?.thinkingMs).toBe(332)
+  })
+
+  it('preserves existing provider metadata and cherry fields', async () => {
+    vi.spyOn(performance, 'now').mockReturnValueOnce(10).mockReturnValueOnce(35)
+
+    const chunks = await collect(
+      withReasoningTimingMetadata(
+        streamFrom([
+          { type: 'reasoning-start', id: 'r1' } as UIMessageChunk,
+          {
+            type: 'reasoning-end',
+            id: 'r1',
+            providerMetadata: {
+              openai: { itemId: 'provider-item' },
+              cherry: { existing: true }
+            }
+          } as UIMessageChunk
+        ])
+      )
+    )
+
+    const reasoningEnd = chunks[1] as UIMessageChunk & {
+      providerMetadata: { openai: Record<string, unknown>; cherry: Record<string, unknown> }
+    }
+    expect(reasoningEnd.providerMetadata.openai).toEqual({ itemId: 'provider-item' })
+    expect(reasoningEnd.providerMetadata.cherry).toEqual({ existing: true, thinkingMs: 25 })
+  })
+
+  it('merges reasoning-start provider metadata into the reasoning-end chunk', async () => {
+    vi.spyOn(performance, 'now').mockReturnValueOnce(10).mockReturnValueOnce(35)
+
+    const chunks = await collect(
+      withReasoningTimingMetadata(
+        streamFrom([
+          {
+            type: 'reasoning-start',
+            id: 'r1',
+            providerMetadata: {
+              'claude-code': { parentToolCallId: 'parent-tool' },
+              cherry: { transport: 'claude-agent' }
+            }
+          } as UIMessageChunk,
+          {
+            type: 'reasoning-end',
+            id: 'r1',
+            providerMetadata: {
+              openai: { itemId: 'provider-item' },
+              cherry: { existing: true }
+            }
+          } as UIMessageChunk
+        ])
+      )
+    )
+
+    const reasoningEnd = chunks[1] as UIMessageChunk & {
+      providerMetadata: {
+        'claude-code': Record<string, unknown>
+        openai: Record<string, unknown>
+        cherry: Record<string, unknown>
+      }
+    }
+    expect(reasoningEnd.providerMetadata['claude-code']).toEqual({ parentToolCallId: 'parent-tool' })
+    expect(reasoningEnd.providerMetadata.openai).toEqual({ itemId: 'provider-item' })
+    expect(reasoningEnd.providerMetadata.cherry).toEqual({
+      transport: 'claude-agent',
+      existing: true,
+      thinkingMs: 25
+    })
+  })
+
+  it('tracks multiple reasoning ids independently', async () => {
+    vi.spyOn(performance, 'now')
+      .mockReturnValueOnce(100)
+      .mockReturnValueOnce(200)
+      .mockReturnValueOnce(350)
+      .mockReturnValueOnce(550)
+
+    const chunks = await collect(
+      withReasoningTimingMetadata(
+        streamFrom([
+          { type: 'reasoning-start', id: 'a' } as UIMessageChunk,
+          { type: 'reasoning-start', id: 'b' } as UIMessageChunk,
+          { type: 'reasoning-end', id: 'a' } as UIMessageChunk,
+          { type: 'reasoning-end', id: 'b' } as UIMessageChunk
+        ])
+      )
+    )
+
+    expect(cherryMeta(chunks[2])?.thinkingMs).toBe(250)
+    expect(cherryMeta(chunks[3])?.thinkingMs).toBe(350)
+  })
+
+  it('feeds the same thinkingMs into broadcast chunks and the accumulated final message', async () => {
+    vi.spyOn(performance, 'now').mockReturnValueOnce(100).mockReturnValueOnce(450).mockReturnValueOnce(1000)
+
+    const broadcastChunks: UIMessageChunk[] = []
+    const result = await pipeStreamLoop(
+      withReasoningTimingMetadata(
+        streamFrom([
+          { type: 'start' } as UIMessageChunk,
+          { type: 'reasoning-start', id: 'r1' } as UIMessageChunk,
+          { type: 'reasoning-delta', id: 'r1', delta: 'steady thought' } as UIMessageChunk,
+          { type: 'reasoning-end', id: 'r1' } as UIMessageChunk,
+          { type: 'text-start', id: 't1' } as UIMessageChunk,
+          { type: 'text-delta', id: 't1', delta: 'answer' } as UIMessageChunk,
+          { type: 'text-end', id: 't1' } as UIMessageChunk,
+          { type: 'finish' } as UIMessageChunk
+        ])
+      ),
+      new AbortController().signal,
+      {
+        onChunk: (chunk) => broadcastChunks.push(chunk)
+      }
+    )
+
+    const broadcastReasoningEnd = broadcastChunks.find((chunk) => chunk.type === 'reasoning-end')
+    const finalReasoningPart = result.finalMessage?.parts.find((part) => part.type === 'reasoning') as
+      | { providerMetadata?: { cherry?: { thinkingMs?: number } } }
+      | undefined
+
+    expect(cherryMeta(broadcastReasoningEnd!)?.thinkingMs).toBe(350)
+    expect(finalReasoningPart?.providerMetadata?.cherry?.thinkingMs).toBe(350)
+    expect(result.finalMessage?.parts.find((part) => part.type === 'text')).toMatchObject({ text: 'answer' })
+  })
+
+  it('preserves reasoning-start provider metadata in the accumulated final message', async () => {
+    vi.spyOn(performance, 'now').mockReturnValueOnce(100).mockReturnValueOnce(450).mockReturnValueOnce(1000)
+
+    const result = await pipeStreamLoop(
+      withReasoningTimingMetadata(
+        streamFrom([
+          { type: 'start' } as UIMessageChunk,
+          {
+            type: 'reasoning-start',
+            id: 'r1',
+            providerMetadata: {
+              'claude-code': { parentToolCallId: 'parent-tool' },
+              cherry: { transport: 'claude-agent' }
+            }
+          } as UIMessageChunk,
+          { type: 'reasoning-delta', id: 'r1', delta: 'steady thought' } as UIMessageChunk,
+          { type: 'reasoning-end', id: 'r1' } as UIMessageChunk,
+          { type: 'finish' } as UIMessageChunk
+        ])
+      ),
+      new AbortController().signal,
+      { onChunk: () => {} }
+    )
+
+    const finalReasoningPart = result.finalMessage?.parts.find((part) => part.type === 'reasoning') as
+      | { providerMetadata?: Record<string, unknown> }
+      | undefined
+
+    expect(finalReasoningPart?.providerMetadata?.['claude-code']).toEqual({ parentToolCallId: 'parent-tool' })
+    expect(finalReasoningPart?.providerMetadata?.cherry).toEqual({
+      transport: 'claude-agent',
+      thinkingMs: 350
+    })
+  })
+})

--- a/src/main/ai/streamManager/__tests__/reasoningTimingTransform.test.ts
+++ b/src/main/ai/streamManager/__tests__/reasoningTimingTransform.test.ts
@@ -1,3 +1,4 @@
+import { mockMainLoggerService } from '@test-mocks/MainLoggerService'
 import type { UIMessageChunk } from 'ai'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -35,6 +36,10 @@ function cherryMeta(chunk: UIMessageChunk): Record<string, unknown> | undefined 
 }
 
 describe('withReasoningTimingMetadata', () => {
+  beforeEach(() => {
+    mockMainLoggerService.debug.mockClear()
+  })
+
   afterEach(() => {
     vi.restoreAllMocks()
   })
@@ -213,5 +218,42 @@ describe('withReasoningTimingMetadata', () => {
       transport: 'claude-agent',
       thinkingMs: 350
     })
+  })
+
+  it('passes through reasoning-end chunks untouched if no matching reasoning-start was seen', async () => {
+    const chunks = await collect(
+      withReasoningTimingMetadata(streamFrom([{ type: 'reasoning-end', id: 'unmatched-id' } as UIMessageChunk]))
+    )
+
+    expect(chunks[0]).toEqual({ type: 'reasoning-end', id: 'unmatched-id' })
+    expect(cherryMeta(chunks[0])).toBeUndefined()
+    expect(mockMainLoggerService.debug).toHaveBeenCalledWith(
+      expect.stringContaining('reasoning-end received with no matching reasoning-start'),
+      expect.objectContaining({ id: 'unmatched-id' })
+    )
+  })
+
+  it('warns when a reasoning-start arrives for an id whose previous start was never ended', async () => {
+    // Three performance.now() calls in order: first start (100),
+    // second start (200, overwrites the first), end (300).
+    vi.spyOn(performance, 'now').mockReturnValueOnce(100).mockReturnValueOnce(200).mockReturnValueOnce(300)
+
+    const chunks = await collect(
+      withReasoningTimingMetadata(
+        streamFrom([
+          { type: 'reasoning-start', id: 'r1' } as UIMessageChunk,
+          { type: 'reasoning-start', id: 'r1' } as UIMessageChunk,
+          { type: 'reasoning-end', id: 'r1' } as UIMessageChunk
+        ])
+      )
+    )
+
+    // The second start overwrote the first, so the end's thinkingMs is the
+    // delta from the second start (200 -> 300 = 100), not the first.
+    expect(cherryMeta(chunks[2])?.thinkingMs).toBe(100)
+    expect(mockMainLoggerService.debug).toHaveBeenCalledWith(
+      expect.stringContaining('reasoning-start received for an id that was never ended'),
+      expect.objectContaining({ id: 'r1' })
+    )
   })
 })

--- a/src/main/ai/streamManager/reasoningTimingTransform.ts
+++ b/src/main/ai/streamManager/reasoningTimingTransform.ts
@@ -1,7 +1,26 @@
-import type { UIMessageChunk } from 'ai'
+/**
+ * reasoningTimingTransform.ts
+ *
+ * This module stabilizes the reasoning thinking time by calculating it before the stream
+ * is split into broadcast (live renderer) and accumulated branches.
+ *
+ * Load-bearing Invariants:
+ * 1. Must run before pipeStreamLoop's tee() so both broadcast chunks and the AI SDK accumulator
+ *    receive the same performance.now() delta (preventing post-refresh value mismatch).
+ * 2. The transform preserves provider metadata from reasoning-start when writing metadata onto
+ *    reasoning-end. The AI SDK accumulator overwrites (not merges) the reasoning part's metadata
+ *    on end:
+ *      reasoningPart.providerMetadata = chunk.providerMetadata ?? reasoningPart.providerMetadata
+ *    Without this re-merge, start-only metadata (e.g. claude-code.parentToolCallId) is dropped
+ *    from the final persisted message.
+ */
+
+import { loggerService } from '@logger'
+import type { ProviderMetadata, UIMessageChunk } from 'ai'
+
+const logger = loggerService.withContext('reasoningTimingTransform')
 
 type ReasoningEndChunk = Extract<UIMessageChunk, { type: 'reasoning-end' }>
-type ProviderMetadata = Record<string, unknown>
 
 export function withReasoningTimingMetadata(stream: ReadableStream<UIMessageChunk>): ReadableStream<UIMessageChunk> {
   const reasoningById = new Map<string, { startedAt: number; providerMetadata?: ProviderMetadata }>()
@@ -10,6 +29,11 @@ export function withReasoningTimingMetadata(stream: ReadableStream<UIMessageChun
     new TransformStream<UIMessageChunk, UIMessageChunk>({
       transform(chunk, controller) {
         if (chunk.type === 'reasoning-start') {
+          if (reasoningById.has(chunk.id)) {
+            logger.debug('reasoning-start received for an id that was never ended; overwriting timing', {
+              id: chunk.id
+            })
+          }
           reasoningById.set(chunk.id, {
             startedAt: performance.now(),
             providerMetadata: toProviderMetadata(chunk.providerMetadata)
@@ -27,6 +51,7 @@ export function withReasoningTimingMetadata(stream: ReadableStream<UIMessageChun
             )
             return
           }
+          logger.debug('reasoning-end received with no matching reasoning-start; passing through', { id: chunk.id })
         }
 
         controller.enqueue(chunk)
@@ -59,7 +84,7 @@ function withThinkingMs(
 }
 
 function toProviderMetadata(value: unknown): ProviderMetadata | undefined {
-  return isRecord(value) ? value : undefined
+  return isRecord(value) ? (value as ProviderMetadata) : undefined
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/main/ai/streamManager/reasoningTimingTransform.ts
+++ b/src/main/ai/streamManager/reasoningTimingTransform.ts
@@ -1,0 +1,67 @@
+import type { UIMessageChunk } from 'ai'
+
+type ReasoningEndChunk = Extract<UIMessageChunk, { type: 'reasoning-end' }>
+type ProviderMetadata = Record<string, unknown>
+
+export function withReasoningTimingMetadata(stream: ReadableStream<UIMessageChunk>): ReadableStream<UIMessageChunk> {
+  const reasoningById = new Map<string, { startedAt: number; providerMetadata?: ProviderMetadata }>()
+
+  return stream.pipeThrough(
+    new TransformStream<UIMessageChunk, UIMessageChunk>({
+      transform(chunk, controller) {
+        if (chunk.type === 'reasoning-start') {
+          reasoningById.set(chunk.id, {
+            startedAt: performance.now(),
+            providerMetadata: toProviderMetadata(chunk.providerMetadata)
+          })
+          controller.enqueue(chunk)
+          return
+        }
+
+        if (chunk.type === 'reasoning-end') {
+          const reasoning = reasoningById.get(chunk.id)
+          if (reasoning) {
+            reasoningById.delete(chunk.id)
+            controller.enqueue(
+              withThinkingMs(chunk, Math.round(performance.now() - reasoning.startedAt), reasoning.providerMetadata)
+            )
+            return
+          }
+        }
+
+        controller.enqueue(chunk)
+      }
+    })
+  )
+}
+
+function withThinkingMs(
+  chunk: ReasoningEndChunk,
+  thinkingMs: number,
+  startProviderMetadata: ProviderMetadata | undefined
+): ReasoningEndChunk {
+  const endProviderMetadata = toProviderMetadata(chunk.providerMetadata)
+  const startCherry = isRecord(startProviderMetadata?.cherry) ? startProviderMetadata.cherry : {}
+  const endCherry = isRecord(endProviderMetadata?.cherry) ? endProviderMetadata.cherry : {}
+
+  return {
+    ...chunk,
+    providerMetadata: {
+      ...startProviderMetadata,
+      ...endProviderMetadata,
+      cherry: {
+        ...startCherry,
+        ...endCherry,
+        thinkingMs
+      }
+    }
+  }
+}
+
+function toProviderMetadata(value: unknown): ProviderMetadata | undefined {
+  return isRecord(value) ? value : undefined
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
@@ -83,15 +83,20 @@ const AnimatedBlockWrapper: React.FC<{
   animation?: 'slide' | 'fade'
 }> = ({ className, children, enableAnimation, animation = 'slide' }) => {
   const wrapperClassName = ['block-wrapper', className].filter(Boolean).join(' ')
-  const [hasAnimated, setHasAnimated] = React.useState(enableAnimation)
+
+  // Latch: Once a block has entered the motion.div branch during streaming (enableAnimation === true),
+  // we keep it there forever (hasEverAnimated === true). Returning to a plain <div> when streaming
+  // ends changes the React element type, triggering a full subtree remount which would destroy
+  // child components' internal state (e.g. ThinkingBlock's timer and fold/unfold state) and cause flicker.
+  const [hasEverAnimated, setHasEverAnimated] = React.useState(enableAnimation)
 
   React.useEffect(() => {
     if (enableAnimation) {
-      setHasAnimated(true)
+      setHasEverAnimated(true)
     }
   }, [enableAnimation])
 
-  if (!hasAnimated) {
+  if (!hasEverAnimated) {
     return (
       <div className={wrapperClassName}>
         <ErrorBoundary fallbackComponent={BlockErrorFallback}>{children}</ErrorBoundary>

--- a/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
@@ -83,8 +83,15 @@ const AnimatedBlockWrapper: React.FC<{
   animation?: 'slide' | 'fade'
 }> = ({ className, children, enableAnimation, animation = 'slide' }) => {
   const wrapperClassName = ['block-wrapper', className].filter(Boolean).join(' ')
+  const [hasAnimated, setHasAnimated] = React.useState(enableAnimation)
 
-  if (!enableAnimation) {
+  React.useEffect(() => {
+    if (enableAnimation) {
+      setHasAnimated(true)
+    }
+  }, [enableAnimation])
+
+  if (!hasAnimated) {
     return (
       <div className={wrapperClassName}>
         <ErrorBoundary fallbackComponent={BlockErrorFallback}>{children}</ErrorBoundary>
@@ -93,7 +100,11 @@ const AnimatedBlockWrapper: React.FC<{
   }
   const variants = animation === 'fade' ? blockWrapperFadeVariants : blockWrapperVariants
   return (
-    <motion.div className={wrapperClassName} variants={variants} initial="hidden" animate="visible">
+    <motion.div
+      className={wrapperClassName}
+      variants={enableAnimation ? variants : undefined}
+      initial={enableAnimation ? 'hidden' : undefined}
+      animate={enableAnimation ? 'visible' : undefined}>
       <ErrorBoundary fallbackComponent={BlockErrorFallback}>{children}</ErrorBoundary>
     </motion.div>
   )

--- a/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
@@ -16,8 +16,20 @@ vi.mock('@logger', () => ({
 }))
 vi.mock('@data/hooks/usePreference', () => ({ usePreference: vi.fn(() => [false, vi.fn()]) }))
 const mockIsActiveTurnTarget = vi.hoisted(() => vi.fn(() => false))
+const mockTopicStreamState = vi.hoisted(() => ({ isPending: false }))
+const mockThinkingBlockMounted = vi.hoisted(() => vi.fn())
 vi.mock('@renderer/hooks/useIsActiveTurnTarget', () => ({
   useIsActiveTurnTarget: () => mockIsActiveTurnTarget()
+}))
+vi.mock('@renderer/hooks/useTopicStreamStatus', () => ({
+  useTopicStreamStatus: () => ({
+    status: undefined,
+    activeExecutions: [],
+    awaitingApprovalAnchors: [],
+    isPending: mockTopicStreamState.isPending,
+    isFulfilled: false,
+    markSeen: vi.fn()
+  })
 }))
 vi.mock('@renderer/types/file', () => ({
   FILE_TYPE: { IMAGE: 'image', VIDEO: 'video', AUDIO: 'audio', TEXT: 'text', DOCUMENT: 'document', OTHER: 'other' }
@@ -129,7 +141,16 @@ vi.mock('../ErrorBlock', () => ({
 
 vi.mock('../ThinkingBlock', () => ({
   __esModule: true,
-  default: ({ content }: any) => <div data-testid="mock-thinking-block">{content}</div>
+  default: function ThinkingBlockMock({ content, thinkingMs }: any) {
+    React.useEffect(() => {
+      mockThinkingBlockMounted()
+    }, [])
+    return (
+      <div data-testid="mock-thinking-block" data-thinking-ms={String(thinkingMs)}>
+        {content}
+      </div>
+    )
+  }
 }))
 
 vi.mock('../../frame/MessageAttachments', () => ({
@@ -223,6 +244,8 @@ const renderParts = (parts: CherryMessagePart[], message?: MessageListItem) => {
 describe('MessagePartsRenderer', () => {
   beforeEach(() => {
     mockIsActiveTurnTarget.mockReturnValue(false)
+    mockTopicStreamState.isPending = false
+    mockThinkingBlockMounted.mockClear()
   })
 
   // -- empty --
@@ -495,6 +518,59 @@ describe('MessagePartsRenderer', () => {
     const wrappers = thinkingBlocks.map((block) => block.closest('.block-wrapper'))
     expect(wrappers[0]).toHaveClass('message-thought-wrapper')
     expect(wrappers[1]).toHaveClass('message-thought-wrapper')
+  })
+
+  it('keeps reasoning blocks mounted when a pending message settles', () => {
+    mockTopicStreamState.isPending = true
+
+    const parts = [
+      {
+        type: 'reasoning',
+        text: 'steady thought',
+        state: 'done',
+        providerMetadata: { cherry: { thinkingMs: 3100 } }
+      },
+      { type: 'text', text: 'answer still streaming' }
+    ] as unknown as CherryMessagePart[]
+    const pendingMessage = msg({ status: 'pending' })
+    const { rerender } = renderParts(parts, pendingMessage)
+
+    const initialNode = screen.getByTestId('mock-thinking-block')
+    expect(initialNode).toHaveAttribute('data-thinking-ms', '3100')
+    expect(mockThinkingBlockMounted).toHaveBeenCalledTimes(1)
+
+    mockTopicStreamState.isPending = false
+    rerender(
+      <MessageListProvider
+        value={{
+          state: {
+            topic: { id: pendingMessage.topicId, name: 'Topic' } as MessageListProviderValue['state']['topic'],
+            messages: [msg({ status: 'success' })],
+            partsByMessageId: { [pendingMessage.id]: parts },
+            messageNavigation: 'none',
+            estimateSize: 400,
+            overscan: 0,
+            loadOlderDelayMs: 0,
+            loadingResetDelayMs: 0,
+            renderConfig: defaultMessageRenderConfig,
+            getMessageActivityState: () => ({
+              isProcessing: false,
+              isStreamTarget: false,
+              isApprovalAnchor: false
+            })
+          },
+          actions: {},
+          meta: { selectionLayer: false }
+        }}>
+        <PartsProvider value={{ [pendingMessage.id]: parts }}>
+          <MessagePartsRenderer message={msg({ status: 'success' })} />
+        </PartsProvider>
+      </MessageListProvider>
+    )
+
+    expect(screen.getByTestId('mock-thinking-block')).toBe(initialNode)
+    expect(screen.getByTestId('mock-thinking-block')).toHaveAttribute('data-thinking-ms', '3100')
+    expect(mockThinkingBlockMounted).toHaveBeenCalledTimes(1)
   })
 
   it('does not render an empty wrapper for tool responses hidden by the tool renderer', () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Reasoning duration could change after the answer text finished streaming because the live renderer and final persisted message used different timing sources. Reasoning blocks could also remount when a pending message settled, causing a brief visual flicker.

After this PR:

`reasoning-end` chunks carry the final `providerMetadata.cherry.thinkingMs` before the stream is split for broadcast and accumulation, so the live UI and final message share the same value. Reasoning block wrappers also keep a stable element type after pending messages settle to avoid remount flicker.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The timing transform is added before `pipeStreamLoop` so both broadcast chunks and the AI SDK accumulator receive the same `thinkingMs`. The transform also preserves provider metadata from `reasoning-start` when writing metadata onto `reasoning-end`, because the accumulator treats end metadata as authoritative for the final reasoning part.

The following alternatives were considered:

Persisting or recomputing `thinkingMs` in the terminal persistence listener was avoided because it creates a second timing source and can still cause a post-refresh value change. A renderer-only timer fix was also avoided because it would not align the final accumulated message.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

This branch was created from `preview/v2.0.0-alpha.2`; targeting `main` may include unrelated preview branch changes.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed reasoning duration flicker and post-refresh timing changes after an assistant response finishes streaming.
```

