### PR TITLE
fix: use openPath instead of openExternal for HTML artifacts external browser

### DIFF
--- a/src/renderer/src/components/CodeBlockView/HtmlArtifactsCard.tsx
+++ b/src/renderer/src/components/CodeBlockView/HtmlArtifactsCard.tsx
@@ -37,15 +37,11 @@ const HtmlArtifactsCard: FC<Props> = ({ html, onSave, isStreaming = false }) => 
   const hasContent = htmlContent.trim().length > 0
 
   const handleOpenExternal = async () => {
-    const path = await window.api.file.createTempFile('artifacts-preview.html')
-    await window.api.file.write(path, htmlContent)
-    const filePath = `file://${path}`
-
-    if (window.api.shell?.openExternal) {
-      void window.api.shell.openExternal(filePath)
-    } else {
+    const tempPath = await window.api.file.createTempFile('artifacts-preview.html')
+    await window.api.file.write(tempPath, htmlContent)
+    window.api.openPath(tempPath).catch(() => {
       logger.error(t('chat.artifacts.preview.openExternal.error.content'))
-    }
+    })
   }
 
   const handleDownload = async () => {


### PR DESCRIPTION
### What this PR does

Before this PR:
Clicking "Open in external browser" on HTML artifacts card had no response. The `handleOpenExternal` function constructed a `file://` URL and passed it to `shell.openExternal()`, but the preload bridge blocks `file:` protocol (only `http:`, `https:`, `mailto:`, `obsidian:` are allowed), causing a silent rejection.

After this PR:
Uses the existing `window.api.openPath()` (which calls `shell.openPath()` via IPC) to open the temp HTML file with the system's default browser. This is the same pattern used elsewhere in the codebase for opening local files.

Fixes #15585

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Reused existing `window.api.openPath` IPC channel instead of adding `file:` to the `openExternal` allowlist, avoiding security surface expansion.
- `shell.openPath` is the correct Electron API for opening local files — it uses the OS default handler (browser for `.html`), works cross-platform, and avoids the `file://` URI format issues on Windows.

The following alternatives were considered:
- Adding `file:` to the `openExternal` allowlist: rejected because `file://` URLs on Windows (`file://C:\Users\...`) are invalid URIs, and widening the allowlist increases attack surface.

### Breaking changes

None.

### Special notes for your reviewer

Single file change, 4 lines added, 8 lines removed. The same bug exists on the `main` (v2) branch at `src/renderer/components/CodeBlockView/HtmlArtifactsCard.tsx` and needs a separate fix there.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [ ] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code

### Release note

```release-note
Fix "Open in external browser" not working for HTML artifacts
```
