### PR TITLE
fix(link-converter): isolate streaming state per request...

### DIFF
--- a/src/renderer/aiCore/chunk/AiSdkToChunkAdapter.ts
+++ b/src/renderer/aiCore/chunk/AiSdkToChunkAdapter.ts
@@ -11,7 +11,7 @@ import { ChunkType } from '@renderer/types/chunk'
 import { ProviderSpecificError } from '@renderer/types/providerSpecificError'
 import { formatErrorMessage, isAbortError } from '@renderer/utils/error'
 import type { IdleTimeoutHandle } from '@renderer/utils/IdleTimeoutController'
-import { convertLinks, flushLinkConverterBuffer } from '@renderer/utils/linkConverter'
+import { LinkConverter } from '@renderer/utils/linkConverter'
 import type { ClaudeCodeRawValue } from '@shared/agents/claudecode/types'
 import { AISDKError, type TextStreamPart, type ToolSet } from 'ai'
 
@@ -35,6 +35,7 @@ export class AiSdkToChunkAdapter {
   private getSessionWasCleared?: () => boolean
   private providerId?: string
   private idleTimeout?: IdleTimeoutHandle
+  private linkConverter = new LinkConverter()
 
   constructor(
     private onChunk: (chunk: Chunk) => void,
@@ -121,7 +122,7 @@ export class AiSdkToChunkAdapter {
         if (done) {
           // Flush any remaining content from link converter buffer if web search is enabled
           if (this.enableWebSearch) {
-            const remainingText = flushLinkConverterBuffer()
+            const remainingText = this.linkConverter.flush()
             if (remainingText) {
               this.markFirstTokenIfNeeded()
               this.onChunk({
@@ -204,7 +205,7 @@ export class AiSdkToChunkAdapter {
 
         // Only apply link conversion if web search is enabled
         if (this.enableWebSearch) {
-          const result = convertLinks(processedText, this.isFirstChunk)
+          const result = this.linkConverter.convert(processedText, this.isFirstChunk)
 
           if (this.isFirstChunk) {
             this.isFirstChunk = false

--- a/src/renderer/utils/__tests__/linkConverter.test.ts
+++ b/src/renderer/utils/__tests__/linkConverter.test.ts
@@ -1,47 +1,46 @@
 import { describe, expect, it } from 'vitest'
 
-import {
-  cleanLinkCommas,
-  completeLinks,
-  convertLinks,
-  extractUrlsFromMarkdown,
-  flushLinkConverterBuffer
-} from '../linkConverter'
+import { cleanLinkCommas, completeLinks, extractUrlsFromMarkdown, LinkConverter } from '../linkConverter'
 
 describe('linkConverter', () => {
-  describe('convertLinks', () => {
+  describe('LinkConverter.convert', () => {
     it('should convert number links to numbered links', () => {
+      const lc = new LinkConverter()
       const input = '参考 [1](https://example.com/1) 和 [2](https://example.com/2)'
-      const result = convertLinks(input, true)
+      const result = lc.convert(input, true)
       expect(result.text).toBe('参考 [<sup>1</sup>](https://example.com/1) 和 [<sup>2</sup>](https://example.com/2)')
       expect(result.hasBufferedContent).toBe(false)
     })
 
     it('should convert links with domain-like text to numbered links', () => {
+      const lc = new LinkConverter()
       const input = '查看这个网站 [example.com](https://example.com)'
-      const result = convertLinks(input, true)
+      const result = lc.convert(input, true)
       expect(result.text).toBe('查看这个网站 [<sup>1</sup>](https://example.com)')
       expect(result.hasBufferedContent).toBe(false)
     })
 
     it('should handle parenthesized link format ([host](url))', () => {
+      const lc = new LinkConverter()
       const input = '这里有链接 ([example.com](https://example.com))'
-      const result = convertLinks(input, true)
+      const result = lc.convert(input, true)
       expect(result.text).toBe('这里有链接 [<sup>1</sup>](https://example.com)')
       expect(result.hasBufferedContent).toBe(false)
     })
 
     it('should not handle impossible parenthesized grounding link', () => {
+      const lc = new LinkConverter()
       const input = 'await sendBatch([1], topicData.topicID, topicData.csrfToken);'
-      const result = convertLinks(input, true)
+      const result = lc.convert(input, true)
       expect(result.text).toBe(input)
       expect(result.hasBufferedContent).toBe(false)
     })
 
     it('should use the same counter for duplicate URLs', () => {
+      const lc = new LinkConverter()
       const input =
         '第一个链接 [example.com](https://example.com) 和第二个相同链接 [subdomain.example.com](https://example.com)'
-      const result = convertLinks(input, true)
+      const result = lc.convert(input, true)
       expect(result.text).toBe(
         '第一个链接 [<sup>1</sup>](https://example.com) 和第二个相同链接 [<sup>1</sup>](https://example.com)'
       )
@@ -49,9 +48,10 @@ describe('linkConverter', () => {
     })
 
     it('should not misinterpret code placeholders as incomplete links', () => {
+      const lc = new LinkConverter()
       const input =
         'The most common reason for a `404` error is that the repository specified in the `owner` and `repo`'
-      const result = convertLinks(input, true)
+      const result = lc.convert(input, true)
       expect(result.text).toBe(
         'The most common reason for a `404` error is that the repository specified in the `owner` and `repo`'
       )
@@ -59,64 +59,72 @@ describe('linkConverter', () => {
     })
 
     it('should handle text with square brackets that are not links', () => {
+      const lc = new LinkConverter()
       const input = 'Use [owner] and [repo] placeholders in your configuration [file]'
-      const result = convertLinks(input, true)
+      const result = lc.convert(input, true)
       expect(result.text).toBe('Use [owner] and [repo] placeholders in your configuration [file]')
       expect(result.hasBufferedContent).toBe(false)
     })
 
     it('should handle markdown code blocks with square brackets', () => {
+      const lc = new LinkConverter()
       const input = 'In the code: `const config = { [key]: value }` you can see [brackets]'
-      const result = convertLinks(input, true)
+      const result = lc.convert(input, true)
       expect(result.text).toBe('In the code: `const config = { [key]: value }` you can see [brackets]')
       expect(result.hasBufferedContent).toBe(false)
     })
 
     it('should properly handle partial markdown link patterns', () => {
+      const lc = new LinkConverter()
       // 这种情况下，[text] 后面没有紧跟 (，所以不应该被当作潜在链接
       const input = 'Check the [documentation] for more details'
-      const result = convertLinks(input, true)
+      const result = lc.convert(input, true)
       expect(result.text).toBe('Check the [documentation] for more details')
       expect(result.hasBufferedContent).toBe(false)
     })
 
     it('should correctly identify and handle real incomplete links', () => {
+      const lc = new LinkConverter()
       // 第一个块包含真正的不完整链接模式
       const chunk1 = 'Visit [example.com]('
-      const result1 = convertLinks(chunk1, true)
+      const result1 = lc.convert(chunk1, true)
       expect(result1.text).toBe('Visit ')
       expect(result1.hasBufferedContent).toBe(true)
 
       // 第二个块完成该链接
       const chunk2 = 'https://example.com) for more info'
-      const result2 = convertLinks(chunk2, false)
+      const result2 = lc.convert(chunk2, false)
       expect(result2.text).toBe('[<sup>1</sup>](https://example.com) for more info')
       expect(result2.hasBufferedContent).toBe(false)
     })
 
     it('should handle mixed content with real links and placeholders', () => {
+      const lc = new LinkConverter()
       const input = 'Configure [owner] and [repo] in [GitHub](https://github.com) settings'
-      const result = convertLinks(input, true)
+      const result = lc.convert(input, true)
       expect(result.text).toBe('Configure [owner] and [repo] in GitHub [<sup>1</sup>](https://github.com) settings')
       expect(result.hasBufferedContent).toBe(false)
     })
 
     it('should handle empty text', () => {
+      const lc = new LinkConverter()
       const input = ''
-      const result = convertLinks(input, true)
+      const result = lc.convert(input, true)
       expect(result.text).toBe('')
       expect(result.hasBufferedContent).toBe(false)
     })
 
     it('should handle text with only square brackets', () => {
+      const lc = new LinkConverter()
       const input = '[][][]'
-      const result = convertLinks(input, true)
+      const result = lc.convert(input, true)
       expect(result.text).toBe('[][][]')
       expect(result.hasBufferedContent).toBe(false)
     })
 
     describe('streaming small chunks simulation', () => {
       it('should handle non-link placeholders in small chunks without buffering', () => {
+        const lc = new LinkConverter()
         // 模拟用户遇到的问题：包含方括号占位符的文本被分成小chunks
         const chunks = [
           'The most common reason for a `404` error is that the repository specified in the `',
@@ -127,19 +135,19 @@ describe('linkConverter', () => {
         let accumulatedText = ''
 
         // 第一个chunk
-        const result1 = convertLinks(chunks[0], true)
+        const result1 = lc.convert(chunks[0], true)
         expect(result1.text).toBe(chunks[0]) // 应该立即返回，不缓冲
         expect(result1.hasBufferedContent).toBe(false)
         accumulatedText += result1.text
 
         // 第二个chunk
-        const result2 = convertLinks(chunks[1], false)
+        const result2 = lc.convert(chunks[1], false)
         expect(result2.text).toBe(chunks[1]) // 应该立即返回，不缓冲
         expect(result2.hasBufferedContent).toBe(false)
         accumulatedText += result2.text
 
         // 第三个chunk
-        const result3 = convertLinks(chunks[2], false)
+        const result3 = lc.convert(chunks[2], false)
         expect(result3.text).toBe(chunks[2]) // 应该立即返回，不缓冲
         expect(result3.hasBufferedContent).toBe(false)
         accumulatedText += result3.text
@@ -152,6 +160,7 @@ describe('linkConverter', () => {
       })
 
       it('should handle real links split across small chunks with proper buffering', () => {
+        const lc = new LinkConverter()
         // 模拟真实链接被分割成小chunks的情况 - 更现实的分割方式
         const chunks = [
           'Please visit [example.',
@@ -163,23 +172,23 @@ describe('linkConverter', () => {
         let accumulatedText = ''
 
         // 第一个chunk：包含不完整链接 [text](
-        const result1 = convertLinks(chunks[0], true)
+        const result1 = lc.convert(chunks[0], true)
         expect(result1.text).toBe('Please visit ') // 只返回安全部分
         expect(result1.hasBufferedContent).toBe(true) //
         accumulatedText += result1.text
 
         // 第二个chunk
-        const result2 = convertLinks(chunks[1], false)
+        const result2 = lc.convert(chunks[1], false)
         expect(result2.text).toBe('')
         expect(result2.hasBufferedContent).toBe(true)
         // 第三个chunk
-        const result3 = convertLinks(chunks[2], false)
+        const result3 = lc.convert(chunks[2], false)
         expect(result3.text).toBe('')
         expect(result3.hasBufferedContent).toBe(true)
         accumulatedText += result3.text
 
         // 第四个chunk
-        const result4 = convertLinks(chunks[3], false)
+        const result4 = lc.convert(chunks[3], false)
         expect(result4.text).toBe('[<sup>1</sup>](https://example.com) for details')
         expect(result4.hasBufferedContent).toBe(false)
         accumulatedText += result4.text
@@ -189,6 +198,7 @@ describe('linkConverter', () => {
       })
 
       it('should handle mixed content with placeholders and real links in small chunks', () => {
+        const lc = new LinkConverter()
         // 混合内容：既有占位符又有真实链接 - 更现实的分割方式
         const chunks = [
           'Configure [owner] and [repo] in [GitHub](', // 占位符 + 不完整链接
@@ -198,13 +208,13 @@ describe('linkConverter', () => {
         let accumulatedText = ''
 
         // 第一个chunk：包含占位符和不完整链接
-        const result1 = convertLinks(chunks[0], true)
+        const result1 = lc.convert(chunks[0], true)
         expect(result1.text).toBe('Configure [owner] and [repo] in ') // 占位符保留，链接部分被缓冲
         expect(result1.hasBufferedContent).toBe(true) // [GitHub]( 被缓冲
         accumulatedText += result1.text
 
         // 第二个chunk：完成链接
-        const result2 = convertLinks(chunks[1], false)
+        const result2 = lc.convert(chunks[1], false)
         expect(result2.text).toBe('GitHub [<sup>1</sup>](https://github.com) settings page.') // 完整链接 + 剩余文本
         expect(result2.hasBufferedContent).toBe(false)
         accumulatedText += result2.text
@@ -218,17 +228,66 @@ describe('linkConverter', () => {
       })
 
       it('should properly handle buffer flush at stream end', () => {
+        const lc = new LinkConverter()
         // 测试流结束时的buffer清理
         const incompleteChunk = 'Check the documentation at [GitHub]('
-        const result = convertLinks(incompleteChunk, true)
+        const result = lc.convert(incompleteChunk, true)
 
         // 应该有内容被缓冲
         expect(result.hasBufferedContent).toBe(true)
         expect(result.text).toBe('Check the documentation at ') // 只返回安全部分
 
         // 模拟流结束，强制清空buffer
-        const remainingText = flushLinkConverterBuffer()
+        const remainingText = lc.flush()
         expect(remainingText).toBe('[GitHub](') // buffer中的剩余内容
+      })
+    })
+
+    describe('concurrent stream isolation', () => {
+      it('should not leak buffered text between two interleaved converters', () => {
+        // Regression test for cross-conversation streaming bleed: two streams run
+        // concurrently, each with its own LinkConverter. Stream A buffers an
+        // incomplete link while stream B emits unrelated text in between. With the
+        // old module-level buffer, A's buffered tail leaked into B's output (and
+        // B's reset wiped A's buffer). With per-instance state, each stays isolated.
+        const lcA = new LinkConverter()
+        const lcB = new LinkConverter()
+
+        let textA = ''
+        let textB = ''
+
+        // A: starts an incomplete link → buffers the tail
+        const a1 = lcA.convert('Visit [example.com](', true)
+        expect(a1.hasBufferedContent).toBe(true)
+        textA += a1.text
+
+        // B: a fresh stream resets ITS OWN state; must not touch A's buffer
+        const b1 = lcB.convert('Plain text from B with [docs] placeholder', true)
+        expect(b1.hasBufferedContent).toBe(false)
+        textB += b1.text
+
+        // A: completes its link → uses A's own buffer, not contaminated by B
+        const a2 = lcA.convert('https://example.com) done', false)
+        expect(a2.hasBufferedContent).toBe(false)
+        textA += a2.text
+
+        // B: continues with its own incomplete link
+        const b2 = lcB.convert(' and a link [GitHub](', false)
+        expect(b2.hasBufferedContent).toBe(true)
+        textB += b2.text
+        const b3 = lcB.convert('https://github.com) end', false)
+        textB += b3.text
+
+        // Each stream produced exactly its own content, with independent counters
+        expect(textA).toBe('Visit [<sup>1</sup>](https://example.com) done')
+        expect(textB).toBe(
+          'Plain text from B with [docs] placeholder and a link GitHub [<sup>1</sup>](https://github.com) end'
+        )
+
+        // No fragment of one stream appears in the other
+        expect(textA).not.toContain('GitHub')
+        expect(textA).not.toContain('docs')
+        expect(textB).not.toContain('example.com')
       })
     })
   })

--- a/src/renderer/utils/linkConverter.ts
+++ b/src/renderer/utils/linkConverter.ts
@@ -1,10 +1,3 @@
-// Counter for numbering links
-let linkCounter = 1
-// Buffer to hold incomplete link fragments across chunks
-let buffer = ''
-// Map to track URLs that have already been assigned numbers
-let urlToCounterMap: Map<string, number> = new Map()
-
 /**
  * Determines if a string looks like a host/URL
  * @param {string} text The text to check
@@ -16,158 +9,182 @@ function isHost(text: string): boolean {
 }
 
 /**
- * Converts Markdown links in the text to numbered links based on the rules:
- * 1. ([host](url)) -> [cnt](url)
- * 2. [host](url) -> [cnt](url)
- * 3. [any text except url](url)-> any text [cnt](url)
+ * Converts Markdown links in a single stream's text to numbered links.
  *
- * @param {string} text The current chunk of text to process
- * @param {boolean} resetCounter Whether to reset the counter and buffer
- * @returns {{text: string, hasBufferedContent: boolean}} Processed text and whether content was buffered
+ * State (the cross-chunk buffer, link counter and URL→number map) is held per
+ * instance, so each concurrent stream MUST own its own `LinkConverter`. Sharing
+ * a single instance (or module-level state) across streams interleaves their
+ * buffers and leaks text between conversations.
  */
-export function convertLinks(
-  text: string,
-  resetCounter: boolean = false
-): { text: string; hasBufferedContent: boolean } {
-  if (resetCounter) {
-    linkCounter = 1
-    buffer = ''
-    urlToCounterMap = new Map<string, number>()
-  }
+export class LinkConverter {
+  // Counter for numbering links
+  private linkCounter = 1
+  // Buffer to hold incomplete link fragments across chunks
+  private buffer = ''
+  // Map to track URLs that have already been assigned numbers
+  private urlToCounterMap = new Map<string, number>()
 
-  // Append the new text to the buffer
-  buffer += text
+  /**
+   * Converts Markdown links in the text to numbered links based on the rules:
+   * 1. ([host](url)) -> [cnt](url)
+   * 2. [host](url) -> [cnt](url)
+   * 3. [any text except url](url)-> any text [cnt](url)
+   *
+   * @param {string} text The current chunk of text to process
+   * @param {boolean} resetCounter Whether to reset the counter and buffer
+   * @returns {{text: string, hasBufferedContent: boolean}} Processed text and whether content was buffered
+   */
+  convert(text: string, resetCounter: boolean = false): { text: string; hasBufferedContent: boolean } {
+    if (resetCounter) {
+      this.linkCounter = 1
+      this.buffer = ''
+      this.urlToCounterMap = new Map<string, number>()
+    }
 
-  // Find the safe point - the position after which we might have incomplete patterns
-  let safePoint = buffer.length
+    // Append the new text to the buffer
+    this.buffer += text
 
-  // Check for potentially incomplete patterns from the end
-  for (let i = buffer.length - 1; i >= 0; i--) {
-    if (buffer[i] === '(') {
-      // Check if this could be the start of a parenthesized link
-      if (i + 1 < buffer.length && buffer[i + 1] === '[') {
-        // Verify if we have a complete parenthesized link
-        const substring = buffer.substring(i)
+    // Find the safe point - the position after which we might have incomplete patterns
+    let safePoint = this.buffer.length
+
+    // Check for potentially incomplete patterns from the end
+    for (let i = this.buffer.length - 1; i >= 0; i--) {
+      if (this.buffer[i] === '(') {
+        // Check if this could be the start of a parenthesized link
+        if (i + 1 < this.buffer.length && this.buffer[i + 1] === '[') {
+          // Verify if we have a complete parenthesized link
+          const substring = this.buffer.substring(i)
+          const match = /^\(\[([^\]]+)\]\(([^)]+)\)\)/.exec(substring)
+
+          if (!match) {
+            // [text] 已完整但后面没跟 (，永远无法形成合法的 ([text](url)) 格式
+            const definitelyNotLink = /^\(\[[^\]]+\][^(]/.test(substring)
+            if (!definitelyNotLink) {
+              safePoint = i
+              break
+            }
+            // fall through，按普通字符处理
+          }
+        }
+      } else if (this.buffer[i] === '[') {
+        // Check if this could be the start of a regular link
+        const substring = this.buffer.substring(i)
+
+        // 检查是否是真正的不完整链接：[text]( 但没有完整的 url)
+        const incompleteLink = /^\[([^\]]+)\]\s*\([^)]*$/.test(substring)
+        if (incompleteLink) {
+          safePoint = i
+          break
+        }
+
+        // 检查是否是完整的链接
+        const completeLink = /^\[([^\]]+)\]\(([^)]+)\)/.test(substring)
+        if (completeLink) {
+          // 如果是完整链接，继续处理，不设置safePoint
+          continue
+        }
+
+        // 检查是否是不完整的 [ 开始但还没有闭合的 ]
+        // 例如 [example. 这种情况
+        const incompleteBracket = /^\[[^\]]*$/.test(substring)
+        if (incompleteBracket) {
+          safePoint = i
+          break
+        }
+
+        // 如果不是潜在的链接格式，继续检查
+      }
+    }
+
+    // Extract the part of the buffer that we can safely process
+    const safeBuffer = this.buffer.substring(0, safePoint)
+    this.buffer = this.buffer.substring(safePoint)
+
+    // 检查是否有内容被保留在buffer中
+    const hasBufferedContent = this.buffer.length > 0
+
+    // Process the safe buffer to handle complete links
+    let result = ''
+    let position = 0
+
+    while (position < safeBuffer.length) {
+      // Check for parenthesized link pattern: ([text](url))
+      if (position + 1 < safeBuffer.length && safeBuffer[position] === '(' && safeBuffer[position + 1] === '[') {
+        const substring = safeBuffer.substring(position)
         const match = /^\(\[([^\]]+)\]\(([^)]+)\)\)/.exec(substring)
 
-        if (!match) {
-          // [text] 已完整但后面没跟 (，永远无法形成合法的 ([text](url)) 格式
-          const definitelyNotLink = /^\(\[[^\]]+\][^(]/.test(substring)
-          if (!definitelyNotLink) {
-            safePoint = i
-            break
+        if (match) {
+          // Found complete parenthesized link
+          const url = match[2]
+
+          // Check if this URL has been seen before
+          let counter: number
+          if (this.urlToCounterMap.has(url)) {
+            counter = this.urlToCounterMap.get(url)!
+          } else {
+            counter = this.linkCounter++
+            this.urlToCounterMap.set(url, counter)
           }
-          // fall through，按普通字符处理
-        }
-      }
-    } else if (buffer[i] === '[') {
-      // Check if this could be the start of a regular link
-      const substring = buffer.substring(i)
 
-      // 检查是否是真正的不完整链接：[text]( 但没有完整的 url)
-      const incompleteLink = /^\[([^\]]+)\]\s*\([^)]*$/.test(substring)
-      if (incompleteLink) {
-        safePoint = i
-        break
-      }
-
-      // 检查是否是完整的链接
-      const completeLink = /^\[([^\]]+)\]\(([^)]+)\)/.test(substring)
-      if (completeLink) {
-        // 如果是完整链接，继续处理，不设置safePoint
-        continue
-      }
-
-      // 检查是否是不完整的 [ 开始但还没有闭合的 ]
-      // 例如 [example. 这种情况
-      const incompleteBracket = /^\[[^\]]*$/.test(substring)
-      if (incompleteBracket) {
-        safePoint = i
-        break
-      }
-
-      // 如果不是潜在的链接格式，继续检查
-    }
-  }
-
-  // Extract the part of the buffer that we can safely process
-  const safeBuffer = buffer.substring(0, safePoint)
-  buffer = buffer.substring(safePoint)
-
-  // 检查是否有内容被保留在buffer中
-  const hasBufferedContent = buffer.length > 0
-
-  // Process the safe buffer to handle complete links
-  let result = ''
-  let position = 0
-
-  while (position < safeBuffer.length) {
-    // Check for parenthesized link pattern: ([text](url))
-    if (position + 1 < safeBuffer.length && safeBuffer[position] === '(' && safeBuffer[position + 1] === '[') {
-      const substring = safeBuffer.substring(position)
-      const match = /^\(\[([^\]]+)\]\(([^)]+)\)\)/.exec(substring)
-
-      if (match) {
-        // Found complete parenthesized link
-        const url = match[2]
-
-        // Check if this URL has been seen before
-        let counter: number
-        if (urlToCounterMap.has(url)) {
-          counter = urlToCounterMap.get(url)!
-        } else {
-          counter = linkCounter++
-          urlToCounterMap.set(url, counter)
-        }
-
-        result += `[<sup>${counter}</sup>](${url})`
-        position += match[0].length
-        continue
-      }
-    }
-
-    // Check for regular link pattern: [text](url)
-    if (safeBuffer[position] === '[') {
-      const substring = safeBuffer.substring(position)
-      const match = /^\[([^\]]+)\]\(([^)]+)\)/.exec(substring)
-
-      if (match) {
-        // Found complete regular link
-        const linkText = match[1]
-        const url = match[2]
-
-        // Check if this URL has been seen before
-        let counter: number
-        if (urlToCounterMap.has(url)) {
-          counter = urlToCounterMap.get(url)!
-        } else {
-          counter = linkCounter++
-          urlToCounterMap.set(url, counter)
-        }
-
-        // Rule 3: If the link text is not a URL/host, keep the text and add the numbered link
-        // 增加一个条件：如果 linkText 是纯数字，也直接替换
-        if (isHost(linkText) || /^\d+$/.test(linkText)) {
-          // Rule 2: If the link text is a URL/host or purely digits, replace with numbered link
           result += `[<sup>${counter}</sup>](${url})`
-        } else {
-          // If the link text is neither a URL/host nor purely digits, keep the text and add the numbered link
-          result += `${linkText} [<sup>${counter}</sup>](${url})`
+          position += match[0].length
+          continue
         }
-
-        position += match[0].length
-        continue
       }
+
+      // Check for regular link pattern: [text](url)
+      if (safeBuffer[position] === '[') {
+        const substring = safeBuffer.substring(position)
+        const match = /^\[([^\]]+)\]\(([^)]+)\)/.exec(substring)
+
+        if (match) {
+          // Found complete regular link
+          const linkText = match[1]
+          const url = match[2]
+
+          // Check if this URL has been seen before
+          let counter: number
+          if (this.urlToCounterMap.has(url)) {
+            counter = this.urlToCounterMap.get(url)!
+          } else {
+            counter = this.linkCounter++
+            this.urlToCounterMap.set(url, counter)
+          }
+
+          // Rule 3: If the link text is not a URL/host, keep the text and add the numbered link
+          // 增加一个条件：如果 linkText 是纯数字，也直接替换
+          if (isHost(linkText) || /^\d+$/.test(linkText)) {
+            // Rule 2: If the link text is a URL/host or purely digits, replace with numbered link
+            result += `[<sup>${counter}</sup>](${url})`
+          } else {
+            // If the link text is neither a URL/host nor purely digits, keep the text and add the numbered link
+            result += `${linkText} [<sup>${counter}</sup>](${url})`
+          }
+
+          position += match[0].length
+          continue
+        }
+      }
+
+      // If no pattern matches at this position, add the character and move on
+      result += safeBuffer[position]
+      position++
     }
 
-    // If no pattern matches at this position, add the character and move on
-    result += safeBuffer[position]
-    position++
+    return {
+      text: result,
+      hasBufferedContent
+    }
   }
 
-  return {
-    text: result,
-    hasBufferedContent
+  /**
+   * 强制返回buffer中的所有内容，用于流结束时清空缓冲区
+   * @returns {string} buffer中剩余的所有内容
+   */
+  flush(): string {
+    const remainingBuffer = this.buffer
+    this.buffer = ''
+    return remainingBuffer
   }
 }
 
@@ -240,14 +257,4 @@ function isValidUrl(url: string): boolean {
 export function cleanLinkCommas(text: string): string {
   // 匹配两个 Markdown 链接之间的英文逗号（可能包含空格）
   return text.replace(/\]\(([^)]+)\)\s*,\s*\[/g, ']($1)[')
-}
-
-/**
- * 强制返回buffer中的所有内容，用于流结束时清空缓冲区
- * @returns {string} buffer中剩余的所有内容
- */
-export function flushLinkConverterBuffer(): string {
-  const remainingBuffer = buffer
-  buffer = ''
-  return remainingBuffer
 }


### PR DESCRIPTION
… to stop cross-conversation bleed

### What this PR does

Fixes a long-standing bug where **streaming output from two simultaneous conversations gets mixed** — text snippets from one response appear in the other (and some text is silently dropped).

Before this PR: `src/renderer/utils/linkConverter.ts` held its streaming state (the cross-chunk `buffer`, `linkCounter`, and `urlToCounterMap`) in **module-level globals**. The converter is stateful by design — it retains an incomplete-link tail (e.g. a half-streamed `[text](url)`) across chunks. With a single shared buffer, two concurrent streams interleaved into it: one stream's buffered tail leaked into the other's output, a new stream's reset wiped the other's in-flight buffer, and the shared counter/map corrupted citation numbering. This only triggers when web search is enabled (the sole caller invokes the converter under `enableWebSearch`), i.e. two concurrent chats both using native/built-in web search.

After this PR: the stateful functions become a `LinkConverter` **class** with per-instance `buffer` / `linkCounter` / `urlToCounterMap` (`convert(text, resetCounter?)` + `flush()`). Each `AiSdkToChunkAdapter` (created fresh per stream) owns one instance, so concurrent streams no longer share a buffer. Single-stream behavior is unchanged; the stateless helpers (`completeLinks`, `extractUrlsFromMarkdown`, `cleanLinkCommas`) are untouched.

### Why we need it and why it was done in this way

Concurrent conversations are normal usage, and cross-conversation text bleed corrupts responses in a way that looks like a provider error but is a client-side state bug.

The following tradeoffs were made:

- **Class over factory-closure**, to match the sibling stream helpers in this area (`ToolCallChunkHandler` in `src/renderer/aiCore/chunk/`, `TagExtractor` in `src/renderer/utils/`).
- **Kept the `resetCounter` parameter** so a single adapter that processes multiple sequential streams (agent multi-step loops) still re-initializes correctly — zero behavior change.

The following alternatives were considered: a fresh converter per `readFullStream()` (equivalent, but the adapter field is simpler); a backward-compat `convertLinks` wrapper (rejected — it would reintroduce the global).

### Breaking changes

<!-- optional -->

None. Internal refactor of a utility plus its single caller; user-visible behavior is unchanged except that concurrent streams no longer corrupt each other.

### Special notes for your reviewer

<!-- optional -->

- The `linkConverter.ts` diff: the function bodies moved verbatim into the class with `buffer`/`linkCounter`/`urlToCounterMap` → `this.*`; the parsing logic is unchanged. Existing tests were migrated to `new LinkConverter()` with assertions preserved.
- The new isolation test was verified to catch the bug: its exact assertions fail against a single shared converter (`Received: "Visit https://example.com) done"` vs `Expected: "Visit [<sup>1</sup>](https://example.com) done"`).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required (none — no persisted data or schema is touched)
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior. — not required (bug fix, no new/changed feature)
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix streaming responses from two simultaneous conversations getting mixed together (text fragments from one response appearing in the other) when web search is enabled.
```
