### PR TITLE
fix(models): normalize model group display names to prevent garbled text

### DIFF
--- a/src/renderer/i18n/label.ts
+++ b/src/renderer/i18n/label.ts
@@ -109,6 +109,10 @@ export const getProviderLabel = (id: string): string => {
   return getLabel(providerKeyMap, id)
 }
 
+export const hasProviderLabel = (id: string): boolean => {
+  return Object.prototype.hasOwnProperty.call(providerKeyMap, id)
+}
+
 const fileProcessorKeyMap = {
   doc2x: 'provider.doc2x',
   mineru: 'provider.mineru',

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelListGroup.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelListGroup.tsx
@@ -32,7 +32,7 @@ const ModelListGroup: React.FC<ModelListGroupProps> = ({
   const { t } = useTranslation()
   const [open, setOpen] = useState(defaultOpen)
   const scrollerRef = useRef<HTMLDivElement>(null)
-  const groupLabel = getModelGroupDisplayName(getModelGroupLabel(groupName, t))
+  const groupLabel = getModelGroupLabel(groupName, getModelGroupDisplayName, t)
   const shouldVirtualize = items.length > 80
   const previewItems = useMemo(() => items.slice(0, 80), [items])
   const virtualizer = useVirtualizer({

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelListGroup.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelListGroup.tsx
@@ -6,7 +6,7 @@ import React, { memo, useCallback, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { modelListClasses } from '../primitives/ProviderSettingsPrimitives'
-import { getModelGroupLabel } from './grouping'
+import { getModelGroupDisplayName, getModelGroupLabel } from './grouping'
 import ModelListItem from './ModelListItem'
 import type { ModelListGroupItem } from './useProviderModelList'
 
@@ -32,7 +32,7 @@ const ModelListGroup: React.FC<ModelListGroupProps> = ({
   const { t } = useTranslation()
   const [open, setOpen] = useState(defaultOpen)
   const scrollerRef = useRef<HTMLDivElement>(null)
-  const groupLabel = getModelGroupLabel(groupName, t)
+  const groupLabel = getModelGroupDisplayName(getModelGroupLabel(groupName, t))
   const shouldVirtualize = items.length > 80
   const previewItems = useMemo(() => items.slice(0, 80), [items])
   const virtualizer = useVirtualizer({

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/grouping.test.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/grouping.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@renderer/i18n/label', () => ({
+  hasProviderLabel: (id: string) => id === 'openai' || id === 'minimax-global',
+  getProviderLabel: (id: string) => {
+    if (id === 'openai') return 'OpenAI'
+    if (id === 'minimax-global') return 'MiniMax Global'
+    return id
+  }
+}))
+
+import {
+  getModelGroupDisplayName,
+  getModelGroupLabel,
+  normalizeModelGroupName,
+  UNGROUPED_MODEL_GROUP_KEY
+} from '../grouping'
+
+describe('getModelGroupDisplayName', () => {
+  it('uses localised provider labels for known provider IDs', () => {
+    expect(getModelGroupDisplayName('openai')).toBe('OpenAI')
+    expect(getModelGroupDisplayName('minimax-global')).toBe('MiniMax Global')
+  })
+
+  it('humanises known provider-style aliases', () => {
+    expect(getModelGroupDisplayName('black-forest-labs')).toBe('Black Forest Labs')
+    expect(getModelGroupDisplayName('deepseek-ai')).toBe('DeepSeek')
+    expect(getModelGroupDisplayName('DeepSeek-AI')).toBe('DeepSeek')
+    expect(getModelGroupDisplayName('mistralai')).toBe('Mistral AI')
+    expect(getModelGroupDisplayName('MISTRALAI')).toBe('Mistral AI')
+    expect(getModelGroupDisplayName('x-ai')).toBe('xAI')
+    expect(getModelGroupDisplayName('X-AI')).toBe('xAI')
+    expect(getModelGroupDisplayName('xai')).toBe('xAI')
+    expect(getModelGroupDisplayName('qwen')).toBe('Qwen')
+    expect(getModelGroupDisplayName('google')).toBe('Google')
+    expect(getModelGroupDisplayName('cartesia')).toBe('Cartesia')
+    expect(getModelGroupDisplayName('hexgrad')).toBe('Hexgrad')
+    expect(getModelGroupDisplayName('meta')).toBe('Meta')
+    expect(getModelGroupDisplayName('nvidia')).toBe('NVIDIA')
+  })
+
+  it('preserves canonical model family identifiers', () => {
+    expect(getModelGroupDisplayName('Pro')).toBe('Pro')
+    expect(getModelGroupDisplayName('gpt-5')).toBe('gpt-5')
+    expect(getModelGroupDisplayName('gpt-image')).toBe('gpt-image')
+    expect(getModelGroupDisplayName('gpt-4.1-mini')).toBe('gpt-4.1-mini')
+    expect(getModelGroupDisplayName('GPT4')).toBe('GPT4')
+    expect(getModelGroupDisplayName('APIKey')).toBe('APIKey')
+    expect(getModelGroupDisplayName('MyModel')).toBe('MyModel')
+    expect(getModelGroupDisplayName('moonshot-v1')).toBe('moonshot-v1')
+    expect(getModelGroupDisplayName('GLM-4.5')).toBe('GLM-4.5')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(getModelGroupDisplayName('')).toBe('')
+    expect(getModelGroupDisplayName('   ')).toBe('')
+  })
+
+  it('trims whitespace', () => {
+    expect(getModelGroupDisplayName('  openai  ')).toBe('OpenAI')
+    expect(getModelGroupDisplayName('  deepseek-ai  ')).toBe('DeepSeek')
+  })
+})
+
+describe('normalizeModelGroupName', () => {
+  it('returns trimmed group when valid', () => {
+    expect(normalizeModelGroupName('deepseek')).toBe('deepseek')
+    expect(normalizeModelGroupName('  gpt-5  ')).toBe('gpt-5')
+  })
+
+  it('falls back when group is empty or undefined', () => {
+    expect(normalizeModelGroupName(null, 'fallback')).toBe('fallback')
+    expect(normalizeModelGroupName(undefined, 'fallback')).toBe('fallback')
+    expect(normalizeModelGroupName('', 'fallback')).toBe('fallback')
+  })
+
+  it('returns UNGROUPED_MODEL_GROUP_KEY when no group or fallback', () => {
+    expect(normalizeModelGroupName(null)).toBe(UNGROUPED_MODEL_GROUP_KEY)
+    expect(normalizeModelGroupName(undefined)).toBe(UNGROUPED_MODEL_GROUP_KEY)
+  })
+
+  it('treats literal "undefined" string as empty', () => {
+    expect(normalizeModelGroupName('undefined', 'fallback')).toBe('fallback')
+    expect(normalizeModelGroupName('UNDEFINED', 'fallback')).toBe('fallback')
+  })
+})
+
+describe('getModelGroupLabel', () => {
+  const t = (key: string) => {
+    if (key === 'assistants.tags.untagged') return 'Untagged'
+    return key
+  }
+
+  it('returns translation for ungrouped key', () => {
+    expect(getModelGroupLabel(UNGROUPED_MODEL_GROUP_KEY, t as any)).toBe('Untagged')
+  })
+
+  it('returns raw group name for non-ungrouped', () => {
+    expect(getModelGroupLabel('deepseek', t as any)).toBe('deepseek')
+    expect(getModelGroupLabel('gpt-5', t as any)).toBe('gpt-5')
+  })
+})

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/grouping.test.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/grouping.test.ts
@@ -92,11 +92,17 @@ describe('getModelGroupLabel', () => {
   }
 
   it('returns translation for ungrouped key', () => {
-    expect(getModelGroupLabel(UNGROUPED_MODEL_GROUP_KEY, t as any)).toBe('Untagged')
+    expect(getModelGroupLabel(UNGROUPED_MODEL_GROUP_KEY, undefined, t as any)).toBe('Untagged')
   })
 
-  it('returns raw group name for non-ungrouped', () => {
-    expect(getModelGroupLabel('deepseek', t as any)).toBe('deepseek')
-    expect(getModelGroupLabel('gpt-5', t as any)).toBe('gpt-5')
+  it('returns display name via displayName fn for non-ungrouped', () => {
+    const displayName = (group: string) => `Display:${group}`
+    expect(getModelGroupLabel('deepseek', displayName)).toBe('Display:deepseek')
+    expect(getModelGroupLabel('gpt-5', displayName)).toBe('Display:gpt-5')
+  })
+
+  it('returns raw group name when no displayName fn is provided', () => {
+    expect(getModelGroupLabel('deepseek')).toBe('deepseek')
+    expect(getModelGroupLabel('gpt-5')).toBe('gpt-5')
   })
 })

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/grouping.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/grouping.ts
@@ -1,6 +1,53 @@
+import { getProviderLabel, hasProviderLabel } from '@renderer/i18n/label'
 import type { TFunction } from 'i18next'
 
 export const UNGROUPED_MODEL_GROUP_KEY = '__ungrouped__'
+
+/**
+ * Known provider-style aliases that appear as model ID prefixes on multi-tenant
+ * platforms (e.g. OpenRouter).  Lower-case keys for case-insensitive lookup.
+ */
+const MODEL_GROUP_DISPLAY_ALIASES: Record<string, string> = {
+  'black-forest-labs': 'Black Forest Labs',
+  'deepseek-ai': 'DeepSeek',
+  cartesia: 'Cartesia',
+  google: 'Google',
+  hexgrad: 'Hexgrad',
+  mistralai: 'Mistral AI',
+  qwen: 'Qwen',
+  'x-ai': 'xAI',
+  xai: 'xAI',
+  meta: 'Meta',
+  nvidia: 'NVIDIA'
+}
+
+/**
+ * Return a human-friendly display label for a model group name.
+ *
+ * 1. If the group is a known provider ID → localised provider label.
+ * 2. If the group matches a known provider-style alias → the alias.
+ * 3. Otherwise → the original group name unchanged.
+ */
+export function getModelGroupDisplayName(group: string): string {
+  const trimmedGroup = group.trim()
+
+  if (!trimmedGroup) {
+    return ''
+  }
+
+  // Prefer the i18n provider label when the group happens to be a provider ID.
+  if (hasProviderLabel(trimmedGroup)) {
+    return getProviderLabel(trimmedGroup)
+  }
+
+  // Fallback to known provider-style aliases (e.g. "deepseek-ai" → "DeepSeek").
+  const alias = MODEL_GROUP_DISPLAY_ALIASES[trimmedGroup.toLowerCase()]
+  if (alias) {
+    return alias
+  }
+
+  return trimmedGroup
+}
 
 export function normalizeModelGroupName(group: string | null | undefined, fallback?: string): string {
   const normalizedGroup = group?.trim()

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/grouping.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/grouping.ts
@@ -6,6 +6,12 @@ export const UNGROUPED_MODEL_GROUP_KEY = '__ungrouped__'
 /**
  * Known provider-style aliases that appear as model ID prefixes on multi-tenant
  * platforms (e.g. OpenRouter).  Lower-case keys for case-insensitive lookup.
+ *
+ * NOTE: These are intentionally separate from `providerKeyMap` in the i18n layer.
+ * `providerKeyMap` maps *app-registered* provider IDs (e.g. "openai", "anthropic")
+ * to i18n keys, while these aliases cover *sub-tenant prefixes* on external
+ * platforms that don't correspond to app provider IDs.  Keep this map colocated
+ * with the lookup logic here to avoid divergent label sources.
  */
 const MODEL_GROUP_DISPLAY_ALIASES: Record<string, string> = {
   'black-forest-labs': 'Black Forest Labs',
@@ -63,6 +69,9 @@ export function normalizeModelGroupName(group: string | null | undefined, fallba
   return UNGROUPED_MODEL_GROUP_KEY
 }
 
-export function getModelGroupLabel(groupName: string, t: TFunction): string {
-  return groupName === UNGROUPED_MODEL_GROUP_KEY ? t('assistants.tags.untagged') : groupName
+export function getModelGroupLabel(groupName: string, displayName?: (group: string) => string, t?: TFunction): string {
+  if (groupName === UNGROUPED_MODEL_GROUP_KEY) {
+    return t ? t('assistants.tags.untagged') : groupName
+  }
+  return displayName ? displayName(groupName) : groupName
 }


### PR DESCRIPTION
### What this PR does

Before this PR:
Model list group headers displayed raw provider-style slugs (e.g. `deepseek-ai`, `mistralai`, `x-ai`) instead of human-friendly names. This was caused by `defaultGroup()` deriving group names from model ID prefixes without any display name mapping.

After this PR:
Model list group labels are normalized conservatively: known provider slugs are rendered with friendly names, while canonical family IDs (e.g. `gpt-5`, `GLM-4.5`) remain unchanged. The mapping uses the existing i18n `providerKeyMap` for recognized provider IDs, plus a static alias map for common provider-style prefixes that appear on multi-tenant platforms like OpenRouter.

Fixes #14362

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Only explicit provider-style aliases are humanized, so valid model family IDs are preserved.
- The shared `getModelGroupDisplayName` helper is applied at the display layer (in `ModelListGroup.tsx`) so the raw group value is preserved for internal use (e.g. model invocation, DB storage).

The following alternatives were considered:
- Title-casing every slug-like group — would fix some raw provider names but break valid family labels like `gpt-5`.
- Leaving the raw group string everywhere — would preserve correctness but keep the original garbled labels.

Links to places where the discussion took place:
- https://github.com/CherryHQ/cherry-studio/issues/14362

### Breaking changes

None.

### Special notes for your reviewer

Verified with `pnpm vitest run src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/grouping.test.ts`.

### Checklist

- [x] Branch: This PR targets `main` for active development
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Documentation: A user-guide update was considered and is not required.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Normalize model group labels so known provider slugs render cleanly while preserving canonical model family IDs like gpt-5 and gpt-image.
```

## Summary by Sourcery

Normalize model group display labels to use human-friendly provider names while preserving canonical model family IDs.

Bug Fixes:
- Fix garbled model list group headers that previously showed raw provider-style slugs instead of readable names.

Enhancements:
- Introduce a shared helper to derive localized, human-friendly model group display names using provider label mappings and alias prefixes.
- Expose a helper to detect available provider labels in the i18n layer and apply it in model list grouping logic.

Tests:
- Add tests covering model group name normalization and display label behavior in provider settings.