### PR TITLE
feat(skills): add demand-first-review skill

### DIFF
--- a/.agents/skills/.gitignore
+++ b/.agents/skills/.gitignore
@@ -8,6 +8,8 @@
 !cherry-pr-test/**
 !create-skill/
 !create-skill/**
+!demand-first-review/
+!demand-first-review/**
 !gh-create-issue/
 !gh-create-issue/**
 !gh-create-pr/

--- a/.agents/skills/demand-first-review/SKILL.md
+++ b/.agents/skills/demand-first-review/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: demand-first-review
+description: Use when reviewing a PR, API, IPC channel, endpoint, parameter, type, or config that adds new surface area — BEFORE commenting on implementation quality. Also use immediately when a review surfaces signals like "no consumers yet", "unused export", "speculative", "additive", "forward-compatible", or "for future use".
+---
+
+# Demand-First Review
+
+## Overview
+
+In engineering, the first-principles starting point is the **demand** (the requirement). The biggest waste in review is providing high-quality polish suggestions for something that should not exist. First audit whether the demand is real (**consumer archaeology**); only review the implementation of what survives.
+
+**Iron ordering** (the first three steps of Musk's five-step algorithm): question the requirements → delete → only then simplify/optimize. Reversing the order = optimizing something that should not exist.
+
+## Consumer Archaeology (core workflow)
+
+For every newly added API / channel / parameter / type / field:
+
+1. **List consumers**: trace ALL real call sites across branches and repos (`git grep` including feature branches). Do not trust the PR description.
+2. **Measure consumption**: for each consumer, check **which part of the return value / capability it actually reads**. Consumer count ≠ consumption; a consumer that only reads one boolean consumes zero of an error taxonomy. Real consumption = the real size of the demand.
+3. **Judge pseudo-demand** — two checks, both required:
+   - **Zero consumption** → pseudo-demand;
+   - **Non-zero consumption but policy**: does this dimension move a judgment the consumer could compute in one line into the contract (e.g. an `expectedKind` param vs. "read `kind` and compare")? Contracts carry facts; policy inlines back into consumers — **delete even when it has real readers**.
+
+   Either hit → **challenge the whole dimension instead of polishing it**.
+4. **Check same-source capability**: does an existing API already cover this, including "strict projection" relations (e.g. `getFileSize ≡ getMetadata().size`)? Never open a second entry point for the same capability.
+5. **Check responsibility**: is the demand leaked from another layer (e.g. renderer interpreting fs errors, UI doing business validation)? Check-then-act queries usually should become try-the-operation.
+
+After each question eliminates a layer, apply normal implementation review (validation, tests, types, docs) **only to the survivors**.
+
+## Rationalization Table
+
+| Excuse | Reality |
+|---|---|
+| "The API is clean / the types are elegant" | A clean thing that shouldn't exist still shouldn't exist. Question existence first. |
+| "It has consumers" | Counting isn't enough. Check which fields each consumer reads — a zero-consumption dimension is still pseudo-demand. |
+| "This parameter/field IS consumed" | Consumed ≠ should exist. Second check: fact or policy? A dimension that moves a one-line consumer-side judgment into the contract gets inlined back, readers or not. |
+| "Found an unused export — add a test for safety" | Zero-consumption signals should trigger demand questioning, not test backfill. |
+| "A technical constraint makes it necessary" | Ask whether the demand served by that constraint is itself real. Constraints are not axioms. |
+| "The PR is additive, it breaks nothing" | Additive is exactly how pseudo-demands sneak in. New surface needs MORE existence scrutiny than modified surface. |
+| "We may need it later / forward-compatible" | Zero consumption now means pseudo-demand now. Add it when a real consumer appears. |
+| "Existence is the author's / architect's call" | Questioning demand is part of review. Downgrading existence questions to nits equals not asking. |
+
+## Red Flags — stop, return to step 1
+
+- You have written five implementation-level comments without listing consumers
+- Your report says "speculative" / "no consumers yet" / "unused" but concludes keep / note / add test
+- You are finding reasons for an API to exist instead of finding its consumers
+- You are about to suggest "add a comment explaining why this is needed" — first confirm it is needed
+
+## Real-World Impact
+
+PR #15695 (2 new IPC channels): six implementation-level review agents produced 30+ polish comments, zero questioning existence. Three consumer-archaeology questions later: one channel rejected as a duplicate entry point, one parameter deleted, one channel classified as debt-to-remove — invalidating most of the polish comments.

--- a/.agents/skills/public-skills.txt
+++ b/.agents/skills/public-skills.txt
@@ -3,6 +3,7 @@
 gh-create-pr
 prepare-release
 create-skill
+demand-first-review
 gh-create-issue
 gh-pr-review
 vercel-react-best-practices

--- a/.claude/skills/.gitignore
+++ b/.claude/skills/.gitignore
@@ -5,6 +5,7 @@
 !README*.md
 !cherry-pr-test
 !create-skill
+!demand-first-review
 !gh-create-issue
 !gh-create-pr
 !gh-pr-review

--- a/.claude/skills/demand-first-review
+++ b/.claude/skills/demand-first-review
@@ -1,0 +1,1 @@
+../../.agents/skills/demand-first-review


### PR DESCRIPTION
### What this PR does

Before this PR:

Repository review skills cover implementation-level checks (code quality, tests, conventions), but nothing front-loads the existence-level question: *should this new surface exist at all?* Reviews routinely polish APIs/parameters whose demand is never audited.

After this PR:

A new public skill `demand-first-review` is available (synced to `.claude/skills/`). It enforces a demand-first ordering for reviews of new surface area (APIs, IPC channels, endpoints, parameters, types, configs): consumer archaeology (list real consumers across branches → measure per-consumer field consumption) → pseudo-demand judgment (zero consumption, or policy moved into the contract) → same-source capability check (no second entry point for a strict projection) → layer-responsibility check — then normal implementation review applies **only to the survivors**. Includes a rationalization table and red-flags list to resist common "keep it anyway" excuses.

Fixes #

### Why we need it and why it was done in this way

Distilled from the PR #15695 review: six implementation-level review passes produced 30+ polish comments with zero existence questions, while three consumer-archaeology questions ended up rejecting one channel as a duplicate entry point, deleting one parameter, and classifying one channel as debt-to-remove — invalidating most of the polish comments. The biggest review waste is high-quality polish on something that should not exist (cf. the ordering of Musk's five-step algorithm: question requirements → delete → only then optimize).

The following tradeoffs were made:

- The skill was validated with a RED-GREEN-REFACTOR loop using subagent scenarios: baseline failure modes were collected from the real #15695 review, the skill was tested against the same review task plus two transfer scenarios (policy-in-contract parameters with real consumers, run on a smaller model), and one loophole ("the parameter IS consumed") was explicitly countered after a failed first pass.
- Body kept compact (<500 words) per skill-authoring guidance, with one real-world impact example instead of exhaustive case studies.

The following alternatives were considered:

- Keeping it as a personal (user-level) skill only — rejected since the failure mode it counters was observed in this repository's own multi-agent review workflows and applies to any reviewer.
- Folding the guidance into `gh-pr-review` — rejected: that skill is implementation-review tooling; this one governs what to review first and applies beyond PRs (API/design reviews).

Links to places where the discussion took place: CherryHQ/cherry-studio#15695

### Breaking changes

None.

### Special notes for your reviewer

- `.claude/skills/demand-first-review` is a symlink created by `pnpm skills:sync`; `.gitignore` updates under `.agents/skills/` and `.claude/skills/` are generated by the same script. `pnpm skills:check` passes (8 public skills).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
