### PR TITLE
feat(library): add assistant tag management

### DIFF
--- a/src/renderer/hooks/useTags.ts
+++ b/src/renderer/hooks/useTags.ts
@@ -36,6 +36,39 @@ export function useTagList(): TagListResult {
   }
 }
 
+export function useRenameTag() {
+  const { trigger } = useMutation('PATCH', '/tags/:id', {
+    refresh: ['/tags', '/assistants']
+  })
+
+  const renameTag = useCallback(
+    (id: string, name: string): Promise<Tag> =>
+      trigger({
+        params: { id },
+        body: { name: name.trim() }
+      }),
+    [trigger]
+  )
+
+  return { renameTag }
+}
+
+export function useDeleteTag() {
+  const { trigger } = useMutation('DELETE', '/tags/:id', {
+    refresh: ['/tags', '/assistants']
+  })
+
+  const deleteTag = useCallback(
+    (id: string): Promise<void> =>
+      trigger({
+        params: { id }
+      }).then(() => undefined),
+    [trigger]
+  )
+
+  return { deleteTag }
+}
+
 /**
  * Resolve a list of tag names to Tag records, creating any that don't exist yet.
  *

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -3246,6 +3246,7 @@
     "title": "Library",
     "toolbar": {
       "add_tag_placeholder": "Tag name...",
+      "all_tags": "All tags",
       "new_resource": "New resource",
       "search_placeholder": "Search by name or description...",
       "tag_button": "Tag"

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -3246,6 +3246,7 @@
     "title": "资源",
     "toolbar": {
       "add_tag_placeholder": "标签名...",
+      "all_tags": "全部标签",
       "new_resource": "新建资源",
       "search_placeholder": "搜索资源名称、描述...",
       "tag_button": "标签"

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -3246,6 +3246,7 @@
     "title": "資源庫",
     "toolbar": {
       "add_tag_placeholder": "標籤名稱...",
+      "all_tags": "全部標籤",
       "new_resource": "新資源",
       "search_placeholder": "搜尋資源...",
       "tag_button": "標籤"

--- a/src/renderer/i18n/translate/de-de.json
+++ b/src/renderer/i18n/translate/de-de.json
@@ -3245,10 +3245,11 @@
     },
     "title": "Bibliothek",
     "toolbar": {
-      "add_tag_placeholder": "Tag-Name...",
-      "new_resource": "Neue Ressource",
-      "search_placeholder": "Ressourcen durchsuchen...",
-      "tag_button": "Tag"
+"add_tag_placeholder": "Tag-Name...",
+"all_tags": "[to be translated]:All tags",
+"new_resource": "Neue Ressource",
+"search_placeholder": "Ressourcen durchsuchen...",
+"tag_button": "Tag"
     },
     "type": {
       "agent": "Agent",

--- a/src/renderer/i18n/translate/el-gr.json
+++ b/src/renderer/i18n/translate/el-gr.json
@@ -3245,10 +3245,11 @@
     },
     "title": "Βιβλιοθήκη",
     "toolbar": {
-      "add_tag_placeholder": "Όνομα ετικέτας...",
-      "new_resource": "Νέος πόρος",
-      "search_placeholder": "Αναζήτηση πόρων...",
-      "tag_button": "Ετικέτα"
+"add_tag_placeholder": "Όνομα ετικέτας...",
+"all_tags": "[to be translated]:All tags",
+"new_resource": "Νέος πόρος",
+"search_placeholder": "Αναζήτηση πόρων...",
+"tag_button": "Ετικέτα"
     },
     "type": {
       "agent": "Πράκτορας",

--- a/src/renderer/i18n/translate/es-es.json
+++ b/src/renderer/i18n/translate/es-es.json
@@ -3245,10 +3245,11 @@
     },
     "title": "Biblioteca",
     "toolbar": {
-      "add_tag_placeholder": "Nombre de la etiqueta...",
-      "new_resource": "Nuevo recurso",
-      "search_placeholder": "Buscar recursos...",
-      "tag_button": "Etiqueta"
+"add_tag_placeholder": "Nombre de la etiqueta...",
+"all_tags": "[to be translated]:All tags",
+"new_resource": "Nuevo recurso",
+"search_placeholder": "Buscar recursos...",
+"tag_button": "Etiqueta"
     },
     "type": {
       "agent": "Agente",

--- a/src/renderer/i18n/translate/fr-fr.json
+++ b/src/renderer/i18n/translate/fr-fr.json
@@ -3245,10 +3245,11 @@
     },
     "title": "Bibliothèque",
     "toolbar": {
-      "add_tag_placeholder": "Nom de l'étiquette...",
-      "new_resource": "Nouvelle ressource",
-      "search_placeholder": "Rechercher des ressources...",
-      "tag_button": "Étiquette"
+"add_tag_placeholder": "Nom de l'étiquette...",
+"all_tags": "[to be translated]:All tags",
+"new_resource": "Nouvelle ressource",
+"search_placeholder": "Rechercher des ressources...",
+"tag_button": "Étiquette"
     },
     "type": {
       "agent": "Agent",

--- a/src/renderer/i18n/translate/ja-jp.json
+++ b/src/renderer/i18n/translate/ja-jp.json
@@ -3245,10 +3245,11 @@
     },
     "title": "図書館",
     "toolbar": {
-      "add_tag_placeholder": "タグ名...",
-      "new_resource": "新しいリソース",
-      "search_placeholder": "リソースを検索...",
-      "tag_button": "タグ"
+"add_tag_placeholder": "タグ名...",
+"all_tags": "[to be translated]:All tags",
+"new_resource": "新しいリソース",
+"search_placeholder": "リソースを検索...",
+"tag_button": "タグ"
     },
     "type": {
       "agent": "エージェント",

--- a/src/renderer/i18n/translate/pt-pt.json
+++ b/src/renderer/i18n/translate/pt-pt.json
@@ -3245,10 +3245,11 @@
     },
     "title": "Biblioteca",
     "toolbar": {
-      "add_tag_placeholder": "Nome da etiqueta...",
-      "new_resource": "Novo recurso",
-      "search_placeholder": "Pesquisar recursos...",
-      "tag_button": "Etiqueta"
+"add_tag_placeholder": "Nome da etiqueta...",
+"all_tags": "[to be translated]:All tags",
+"new_resource": "Novo recurso",
+"search_placeholder": "Pesquisar recursos...",
+"tag_button": "Etiqueta"
     },
     "type": {
       "agent": "Agente",

--- a/src/renderer/i18n/translate/ro-ro.json
+++ b/src/renderer/i18n/translate/ro-ro.json
@@ -3245,10 +3245,11 @@
     },
     "title": "Bibliotecă",
     "toolbar": {
-      "add_tag_placeholder": "Nume etichetă...",
-      "new_resource": "Resursă nouă",
-      "search_placeholder": "Caută resurse...",
-      "tag_button": "Etichetă"
+"add_tag_placeholder": "Nume etichetă...",
+"all_tags": "[to be translated]:All tags",
+"new_resource": "Resursă nouă",
+"search_placeholder": "Caută resurse...",
+"tag_button": "Etichetă"
     },
     "type": {
       "agent": "Agent",

--- a/src/renderer/i18n/translate/ru-ru.json
+++ b/src/renderer/i18n/translate/ru-ru.json
@@ -3245,10 +3245,11 @@
     },
     "title": "Библиотека",
     "toolbar": {
-      "add_tag_placeholder": "Имя тега...",
-      "new_resource": "Новый ресурс",
-      "search_placeholder": "Поиск ресурсов...",
-      "tag_button": "Тег"
+"add_tag_placeholder": "Имя тега...",
+"all_tags": "[to be translated]:All tags",
+"new_resource": "Новый ресурс",
+"search_placeholder": "Поиск ресурсов...",
+"tag_button": "Тег"
     },
     "type": {
       "agent": "Агент",

--- a/src/renderer/i18n/translate/vi-vn.json
+++ b/src/renderer/i18n/translate/vi-vn.json
@@ -3245,10 +3245,11 @@
     },
     "title": "Thư viện",
     "toolbar": {
-      "add_tag_placeholder": "Tên thẻ...",
-      "new_resource": "Tài nguyên mới",
-      "search_placeholder": "Tìm kiếm tài nguyên...",
-      "tag_button": "Thẻ"
+"add_tag_placeholder": "Tên thẻ...",
+"all_tags": "[to be translated]:All tags",
+"new_resource": "Tài nguyên mới",
+"search_placeholder": "Tìm kiếm tài nguyên...",
+"tag_button": "Thẻ"
     },
     "type": {
       "agent": "Đặc vụ",

--- a/src/renderer/pages/library/LibraryPage.tsx
+++ b/src/renderer/pages/library/LibraryPage.tsx
@@ -51,21 +51,28 @@ const DEFAULT_RESOURCE_TYPE = RESOURCE_TYPE_ORDER[0]
  * Build the top-bar chip list.
  *
  * Source: `resources` (so count reflects real bindings — unbound tags stay hidden,
- * matching the spec). Color is resolved against the backend `/tags` list; only
- * if the tag isn't in the list yet (SWR cache race) do we fall back to
- * `DEFAULT_TAG_COLOR`.
+ * matching the default collapsed state). Tag id/color are resolved from the
+ * backend `/tags` list and embedded assistant tag refs; only if neither has the
+ * tag yet (SWR cache race) do we fall back to `DEFAULT_TAG_COLOR`.
  */
 function buildTags(resources: ResourceItem[], backendTags: Tag[], filterType?: ResourceType): TagItem[] {
-  const colorByName = new Map(backendTags.map((t) => [t.name, t.color] as const))
+  const backendTagByName = new Map(backendTags.map((t) => [t.name, t] as const))
   const tagMap = new Map<string, number>()
   const list = filterType ? resources.filter((r) => r.type === filterType) : resources
-  list.forEach((r) => r.tags.forEach((t) => tagMap.set(t, (tagMap.get(t) || 0) + 1)))
+  list.forEach((r) => {
+    if (r.type === 'assistant') {
+      for (const tag of r.raw.tags ?? []) {
+        if (!backendTagByName.has(tag.name)) backendTagByName.set(tag.name, tag)
+      }
+    }
+    r.tags.forEach((t) => tagMap.set(t, (tagMap.get(t) || 0) + 1))
+  })
   return Array.from(tagMap.entries())
     .sort((a, b) => b[1] - a[1])
-    .map(([name, count], i) => ({
-      id: `tag-${i}`,
+    .map(([name, count], index) => ({
+      id: backendTagByName.get(name)?.id ?? `tag-${index}`,
       name,
-      color: colorByName.get(name) ?? DEFAULT_TAG_COLOR,
+      color: backendTagByName.get(name)?.color ?? DEFAULT_TAG_COLOR,
       count
     }))
 }
@@ -458,6 +465,7 @@ export default function LibraryPage() {
             }}
             onUpdateResourceTags={noop /* binding is executed inside FixedCardMenu via the tag hooks */}
             allTagNames={allTagNames}
+            allTags={tagList.tags}
             assistantCatalog={assistantCatalogProp}
           />
         )}

--- a/src/renderer/pages/library/__tests__/LibraryPage.test.tsx
+++ b/src/renderer/pages/library/__tests__/LibraryPage.test.tsx
@@ -554,6 +554,26 @@ describe('LibraryPage create flow', () => {
     expect(screen.getByTestId('assistant-edit-dialog')).toBeInTheDocument()
   })
 
+  it('keeps rendering assistant resources when stale raw data has no tags field', async () => {
+    const user = userEvent.setup()
+    allResourcesMock.push({
+      id: 'assistant-stale-tags',
+      type: 'assistant',
+      name: 'Stale Assistant',
+      description: '',
+      avatar: '💬',
+      tags: [],
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      raw: { id: 'assistant-stale-tags', name: 'Stale Assistant' }
+    })
+
+    render(<LibraryPage />)
+    await user.click(screen.getByRole('button', { name: 'select assistant type' }))
+
+    expect(screen.getByTestId('resource-grid')).toBeInTheDocument()
+  })
+
   it('updates a prompt in a dialog while keeping the list visible', async () => {
     const user = userEvent.setup()
     allResourcesMock.push({

--- a/src/renderer/pages/library/dialogs/__tests__/EditDialogs.test.tsx
+++ b/src/renderer/pages/library/dialogs/__tests__/EditDialogs.test.tsx
@@ -571,13 +571,39 @@ describe('edit dialogs', () => {
     })
   })
 
-  it('does not render search or offer free-text tag creation in assistant editing', async () => {
+  it('creates and binds a new tag typed in assistant editing', async () => {
+    ensureTagsMock.mockResolvedValueOnce([
+      { id: 'tag-work', name: 'work', color: '#8b5cf6' },
+      { id: 'tag-new', name: 'new-tag', color: '#10b981' }
+    ])
     render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'work' }))
+    fireEvent.change(screen.getByPlaceholderText('Search tags'), { target: { value: 'new-tag' } })
+    fireEvent.click(await screen.findByText('new-tag'))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
 
-    expect(screen.queryByPlaceholderText('Search tags')).not.toBeInTheDocument()
-    expect(screen.queryByText('new-tag')).not.toBeInTheDocument()
+    await waitFor(() => expect(ensureTagsMock).toHaveBeenCalledWith(['work', 'new-tag']))
+    expect(updateAssistantMock).toHaveBeenCalledWith({
+      body: expect.objectContaining({
+        tagIds: ['tag-work', 'tag-new']
+      })
+    })
+  })
+
+  it('does not expose typed tag names beyond the server-side max length', async () => {
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+    // Open the combobox popover (CommandInput only mounts once the trigger is active)
+    fireEvent.click(screen.getByRole('button', { name: 'work' }))
+    const atLimit = 'y'.repeat(64) // TagNameSchema.max(64)
+    const tooLong = 'x'.repeat(65) // one over the limit — server would reject
+    const searchInput = screen.getByPlaceholderText('Search tags')
+
+    fireEvent.change(searchInput, { target: { value: tooLong } })
+    expect(screen.queryByText(tooLong)).not.toBeInTheDocument()
+
+    fireEvent.change(searchInput, { target: { value: atLimit } })
+    expect(await screen.findByText(atLimit)).toBeInTheDocument()
   })
 
   it('submits agent instructions and model changes as a PATCH', async () => {

--- a/src/renderer/pages/library/dialogs/components/TagSelector.tsx
+++ b/src/renderer/pages/library/dialogs/components/TagSelector.tsx
@@ -1,6 +1,7 @@
 import { Combobox, type ComboboxOption } from '@cherrystudio/ui'
+import { TagNameSchema } from '@shared/data/types/tag'
 import type { FC } from 'react'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 interface Props {
@@ -13,28 +14,38 @@ interface Props {
 
 export const TagSelector: FC<Props> = ({ value, onChange, allTagNames, disabled, portalContainer }) => {
   const { t } = useTranslation()
+  const [search, setSearch] = useState('')
 
   // `value` may contain names not present in `/tags` yet, for example while a
   // caller waits for SWR refresh. Keep selected names visible in the options.
   const tagOptions = useMemo<ComboboxOption[]>(() => {
-    const names = Array.from(new Set([...allTagNames, ...value]))
-    names.sort((a, b) => a.localeCompare(b, 'zh'))
-    return names.map((name) => ({
+    const trimmedSearch = search.trim()
+    const names = new Set([...allTagNames, ...value])
+    // Mirror the server-side TagNameSchema (z.string().trim().min(1).max(64))
+    // so a user cannot select a name the create endpoint would reject.
+    if (trimmedSearch && TagNameSchema.safeParse(trimmedSearch).success) {
+      names.add(trimmedSearch)
+    }
+
+    const sortedNames = Array.from(names)
+    sortedNames.sort((a, b) => a.localeCompare(b, 'zh'))
+    return sortedNames.map((name) => ({
       value: name,
       label: name
     }))
-  }, [allTagNames, value])
+  }, [allTagNames, search, value])
 
   return (
     <Combobox
       multiple
-      searchable={false}
       size="sm"
       disabled={disabled}
       options={tagOptions}
       value={value}
       onChange={(v) => onChange(Array.isArray(v) ? v : v ? [v] : [])}
+      onSearch={setSearch}
       placeholder={t('library.config.basic.tag_placeholder')}
+      searchPlaceholder={t('library.config.basic.tag_search')}
       emptyText={t('library.config.basic.tag_empty')}
       portalContainer={portalContainer ?? undefined}
     />

--- a/src/renderer/pages/library/list/ResourceGrid.tsx
+++ b/src/renderer/pages/library/list/ResourceGrid.tsx
@@ -1,8 +1,26 @@
-import { Button, EmptyState, Input, Skeleton } from '@cherrystudio/ui'
+import {
+  Button,
+  ConfirmDialog,
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuItemContent,
+  ContextMenuTrigger,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  EmptyState,
+  Input,
+  Skeleton
+} from '@cherrystudio/ui'
 import { loggerService } from '@logger'
+import { useDeleteTag, useRenameTag } from '@renderer/hooks/useTags'
 import type { Assistant } from '@shared/data/types/assistant'
+import type { Tag as BackendTag } from '@shared/data/types/tag'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { Plus, Search, Tag, Upload, X } from 'lucide-react'
+import { Pencil, Plus, Search, Tag, Trash2, Upload, X } from 'lucide-react'
 import type { FC, RefObject } from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -55,6 +73,8 @@ interface Props {
   /** Replace the tag-name set for a single resource. Caller handles ensure-tag + bind. */
   onUpdateResourceTags: (resourceId: string, tags: string[]) => Promise<void> | void
   allTagNames: string[]
+  /** Full backend tag records (id + name + color). Distinct from `allTagNames` (names only). */
+  allTags: BackendTag[]
   assistantCatalog?: AssistantCatalogGridState
 }
 
@@ -111,15 +131,23 @@ export const ResourceGrid: FC<Props> = ({
   onAddTag,
   onUpdateResourceTags,
   allTagNames,
+  allTags,
   assistantCatalog
 }) => {
   const { t } = useTranslation()
+  const { renameTag } = useRenameTag()
+  const { deleteTag } = useDeleteTag()
   const scrollRef = useRef<HTMLDivElement>(null)
   const columnCount = useGridColumnCount(scrollRef)
   const [showAddTag, setShowAddTag] = useState(false)
   const [newTagName, setNewTagName] = useState('')
   const [addingTag, setAddingTag] = useState(false)
   const [addingPresetKeys, setAddingPresetKeys] = useState<Set<string>>(new Set())
+  const [renamingTag, setRenamingTag] = useState<TagItem | null>(null)
+  const [renameValue, setRenameValue] = useState('')
+  const [renaming, setRenaming] = useState(false)
+  const [deletingTag, setDeletingTag] = useState<TagItem | null>(null)
+  const [deleting, setDeleting] = useState(false)
   const showingAssistantCatalogPresets =
     Boolean(assistantCatalog) && assistantCatalog?.activeTab !== ASSISTANT_CATALOG_MY_TAB
   const showTagToolbar =
@@ -143,6 +171,60 @@ export const ResourceGrid: FC<Props> = ({
       setAddingTag(false)
     }
   }
+
+  const handleOpenRenameTag = useCallback((tag: TagItem) => {
+    setRenamingTag(tag)
+    setRenameValue(tag.name)
+  }, [])
+
+  const handleRenameTag = useCallback(async () => {
+    const tag = renamingTag
+    const nextName = renameValue.trim()
+    if (!tag || renaming || !nextName) return
+
+    if (nextName === tag.name) {
+      setRenamingTag(null)
+      return
+    }
+
+    setRenaming(true)
+    try {
+      const updated = await renameTag(tag.id, nextName)
+      if (activeTag === tag.name) onTagFilter(updated.name)
+      setRenamingTag(null)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : t('library.tag_sync_failed')
+      window.toast.error(message)
+      logger.error('Failed to rename tag', error instanceof Error ? error : new Error(String(error)), {
+        id: tag.id,
+        name: tag.name,
+        nextName
+      })
+    } finally {
+      setRenaming(false)
+    }
+  }, [activeTag, onTagFilter, renameTag, renameValue, renaming, renamingTag, t])
+
+  const handleConfirmDeleteTag = useCallback(async () => {
+    const tag = deletingTag
+    if (!tag || deleting) return
+
+    setDeleting(true)
+    try {
+      await deleteTag(tag.id)
+      if (activeTag === tag.name) onTagFilter(null)
+      setDeletingTag(null)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : t('library.tag_sync_failed')
+      window.toast.error(message)
+      logger.error('Failed to delete tag', error instanceof Error ? error : new Error(String(error)), {
+        id: tag.id,
+        name: tag.name
+      })
+    } finally {
+      setDeleting(false)
+    }
+  }, [activeTag, deleteTag, deleting, deletingTag, onTagFilter, t])
 
   const handleAddPreset = useCallback(
     async (preset: AssistantCatalogPreset) => {
@@ -229,25 +311,39 @@ export const ResourceGrid: FC<Props> = ({
           <div className="flex items-center gap-1.5 overflow-x-auto px-5 pb-3 [&::-webkit-scrollbar]:h-0">
             <Tag size={12} className="mr-0.5 shrink-0 text-foreground-muted" />
             {tags.map((tag) => (
-              <Button
-                variant="ghost"
-                key={tag.id}
-                onClick={() => onTagFilter(activeTag === tag.name ? null : tag.name)}
-                className={`flex h-6 min-h-0 shrink-0 items-center gap-1.5 rounded-full border px-2.5 text-xs shadow-none ${
-                  activeTag === tag.name
-                    ? 'border-border-active bg-secondary text-foreground hover:bg-secondary-hover hover:text-foreground'
-                    : 'border-border-subtle text-foreground-muted hover:border-border-hover hover:bg-accent hover:text-foreground'
-                }`}>
-                <span className="h-1.5 w-1.5 shrink-0 rounded-full" style={{ backgroundColor: tag.color }} />
-                <span>{tag.name}</span>
-                <span className="text-foreground-muted text-xs tabular-nums">{tag.count}</span>
-              </Button>
+              <ContextMenu key={tag.id}>
+                <ContextMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    onClick={() => onTagFilter(activeTag === tag.name ? null : tag.name)}
+                    className={`flex h-6 min-h-0 shrink-0 items-center gap-1.5 rounded-full border px-2.5 text-xs shadow-none ${
+                      activeTag === tag.name
+                        ? 'border-border-active bg-secondary text-foreground hover:bg-secondary-hover hover:text-foreground'
+                        : 'border-border-subtle text-foreground-muted hover:border-border-hover hover:bg-accent hover:text-foreground'
+                    }`}>
+                    <span className="h-1.5 w-1.5 shrink-0 rounded-full" style={{ backgroundColor: tag.color }} />
+                    <span>{tag.name}</span>
+                    <span className="text-foreground-muted text-xs tabular-nums">{tag.count}</span>
+                  </Button>
+                </ContextMenuTrigger>
+                <ContextMenuContent className="min-w-32">
+                  <ContextMenuItem onSelect={() => handleOpenRenameTag(tag)}>
+                    <ContextMenuItemContent icon={<Pencil size={12} />}>{t('common.rename')}</ContextMenuItemContent>
+                  </ContextMenuItem>
+                  <ContextMenuItem variant="destructive" onSelect={() => setDeletingTag(tag)}>
+                    <ContextMenuItemContent icon={<Trash2 size={12} />}>
+                      {t('assistants.tags.delete')}
+                    </ContextMenuItemContent>
+                  </ContextMenuItem>
+                </ContextMenuContent>
+              </ContextMenu>
             ))}
 
             {showAddTag ? (
               <div className="flex shrink-0 items-center gap-1">
                 <Input
                   autoFocus
+                  maxLength={64}
                   value={newTagName}
                   onChange={(e) => setNewTagName(e.target.value)}
                   onKeyDown={(e) => {
@@ -283,6 +379,56 @@ export const ResourceGrid: FC<Props> = ({
             )}
           </div>
         )}
+        <Dialog
+          open={Boolean(renamingTag)}
+          onOpenChange={(open) => {
+            if (!open && !renaming) setRenamingTag(null)
+          }}>
+          <DialogContent className="max-w-sm rounded-xl">
+            <DialogHeader>
+              <DialogTitle>{t('common.rename')}</DialogTitle>
+            </DialogHeader>
+            <Input
+              autoFocus
+              maxLength={64}
+              aria-label={t('common.rename')}
+              value={renameValue}
+              onChange={(event) => setRenameValue(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') void handleRenameTag()
+                if (event.key === 'Escape' && !renaming) setRenamingTag(null)
+              }}
+              disabled={renaming}
+              className="h-9 rounded-md border-input bg-background"
+            />
+            <DialogFooter>
+              <Button variant="outline" size="sm" disabled={renaming} onClick={() => setRenamingTag(null)}>
+                {t('common.cancel')}
+              </Button>
+              <Button
+                size="sm"
+                loading={renaming}
+                disabled={!renameValue.trim()}
+                onClick={() => void handleRenameTag()}>
+                {t('common.save')}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        <ConfirmDialog
+          open={Boolean(deletingTag)}
+          onOpenChange={(open) => {
+            if (!open && !deleting) setDeletingTag(null)
+          }}
+          title={t('assistants.tags.delete')}
+          description={t('assistants.tags.deleteConfirm')}
+          confirmText={t('common.delete')}
+          cancelText={t('common.cancel')}
+          destructive
+          confirmLoading={deleting}
+          onConfirm={handleConfirmDeleteTag}
+        />
       </div>
 
       <div

--- a/src/renderer/pages/library/list/ResourceGrid.tsx
+++ b/src/renderer/pages/library/list/ResourceGrid.tsx
@@ -20,12 +20,12 @@ import { useDeleteTag, useRenameTag } from '@renderer/hooks/useTags'
 import type { Assistant } from '@shared/data/types/assistant'
 import type { Tag as BackendTag } from '@shared/data/types/tag'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { Pencil, Plus, Search, Tag, Trash2, Upload, X } from 'lucide-react'
+import { ChevronLeft, ChevronRight, Pencil, Plus, Search, Tag, Trash2, Upload, X } from 'lucide-react'
 import type { FC, RefObject } from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { RESOURCE_TYPE_META } from '../constants'
+import { DEFAULT_TAG_COLOR, RESOURCE_TYPE_META } from '../constants'
 import type { ResourceItem, ResourceType, TagItem } from '../types'
 import { AssistantCatalogTabRail } from './AssistantCatalogTabRail'
 import { AssistantCatalogPresetContent, ResourceCard } from './ResourceCards'
@@ -140,6 +140,7 @@ export const ResourceGrid: FC<Props> = ({
   const scrollRef = useRef<HTMLDivElement>(null)
   const columnCount = useGridColumnCount(scrollRef)
   const [showAddTag, setShowAddTag] = useState(false)
+  const [showAllTags, setShowAllTags] = useState(false)
   const [newTagName, setNewTagName] = useState('')
   const [addingTag, setAddingTag] = useState(false)
   const [addingPresetKeys, setAddingPresetKeys] = useState<Set<string>>(new Set())
@@ -152,6 +153,23 @@ export const ResourceGrid: FC<Props> = ({
     Boolean(assistantCatalog) && assistantCatalog?.activeTab !== ASSISTANT_CATALOG_MY_TAB
   const showTagToolbar =
     activeResourceType === 'assistant' && (!assistantCatalog || assistantCatalog.activeTab === ASSISTANT_CATALOG_MY_TAB)
+  // This "unused" set is scoped to the assistant library: today user-managed
+  // resource tags are only bound to assistants. If other entity types start
+  // sharing `/tags`, replace this client-side difference with server-provided
+  // global usage/unused data before exposing destructive actions.
+  const unusedTags = useMemo(() => {
+    const usedNames = new Set(tags.map((tag) => tag.name))
+    return allTags
+      .filter((tag) => !usedNames.has(tag.name))
+      .map((tag) => ({
+        id: tag.id,
+        name: tag.name,
+        color: tag.color ?? DEFAULT_TAG_COLOR,
+        count: 0
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name, 'zh'))
+  }, [allTags, tags])
+  const visibleTags = showAllTags ? [...tags, ...unusedTags] : tags
 
   const handleAddTag = async () => {
     const trimmed = newTagName.trim()
@@ -310,7 +328,7 @@ export const ResourceGrid: FC<Props> = ({
         {showTagToolbar && (
           <div className="flex items-center gap-1.5 overflow-x-auto px-5 pb-3 [&::-webkit-scrollbar]:h-0">
             <Tag size={12} className="mr-0.5 shrink-0 text-foreground-muted" />
-            {tags.map((tag) => (
+            {visibleTags.map((tag) => (
               <ContextMenu key={tag.id}>
                 <ContextMenuTrigger asChild>
                   <Button
@@ -338,6 +356,18 @@ export const ResourceGrid: FC<Props> = ({
                 </ContextMenuContent>
               </ContextMenu>
             ))}
+
+            {unusedTags.length > 0 && (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label={t('library.toolbar.all_tags')}
+                title={t('library.toolbar.all_tags')}
+                onClick={() => setShowAllTags((value) => !value)}
+                className="size-6 shrink-0 rounded-full text-foreground-muted hover:bg-accent hover:text-foreground">
+                {showAllTags ? <ChevronLeft size={13} /> : <ChevronRight size={13} />}
+              </Button>
+            )}
 
             {showAddTag ? (
               <div className="flex shrink-0 items-center gap-1">

--- a/src/renderer/pages/library/list/__tests__/ResourceGrid.test.tsx
+++ b/src/renderer/pages/library/list/__tests__/ResourceGrid.test.tsx
@@ -27,6 +27,7 @@ vi.mock('react-i18next', () => ({
           'common.delete': '删除',
           'common.rename': '重命名',
           'common.save': '保存',
+          'library.toolbar.all_tags': '全部标签',
           'library.toolbar.tag_button': '标签'
         }) satisfies Record<string, string>
       )[key] ?? key
@@ -391,6 +392,45 @@ describe('ResourceGrid tag toolbar management', () => {
   beforeEach(() => {
     deleteTagMock.mockReset()
     renameTagMock.mockReset()
+  })
+
+  it('keeps unused tags collapsed behind the arrow before the add-tag button', async () => {
+    const user = userEvent.setup()
+
+    renderResourceGrid({
+      tags: [{ id: 'tag-alpha', name: 'alpha', color: '#111111', count: 1 }],
+      allTags: [
+        {
+          id: 'tag-alpha',
+          name: 'alpha',
+          color: '#111111',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z'
+        },
+        {
+          id: 'tag-beta',
+          name: 'beta',
+          color: '#222222',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z'
+        }
+      ]
+    })
+
+    const alphaTag = screen.getByRole('button', { name: /alpha/ })
+    const expandButton = screen.getByRole('button', { name: '全部标签' })
+    const addTagButton = screen.getByRole('button', { name: '标签' })
+
+    expect(screen.queryByRole('button', { name: /beta/ })).not.toBeInTheDocument()
+    expect(alphaTag.compareDocumentPosition(expandButton)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(expandButton.compareDocumentPosition(addTagButton)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+
+    await user.click(expandButton)
+
+    const betaTag = screen.getByRole('button', { name: /beta/ })
+    expect(betaTag.compareDocumentPosition(screen.getByRole('button', { name: '全部标签' }))).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    )
   })
 
   it('renames a tag from the right-click menu', async () => {

--- a/src/renderer/pages/library/list/__tests__/ResourceGrid.test.tsx
+++ b/src/renderer/pages/library/list/__tests__/ResourceGrid.test.tsx
@@ -1,5 +1,5 @@
 import type { ResourceItem } from '@renderer/pages/library/types'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type * as ReactModule from 'react'
 import type { ComponentProps, ReactNode } from 'react'
@@ -10,14 +10,26 @@ import { ResourceCardMenu } from '../ResourceCardMenu'
 import { AssistantCatalogPresetContent, ResourceCard } from '../ResourceCards'
 import { ResourceGrid } from '../ResourceGrid'
 
-const { ensureTagsMock, updateAssistantMock } = vi.hoisted(() => ({
+const { deleteTagMock, ensureTagsMock, renameTagMock, updateAssistantMock } = vi.hoisted(() => ({
+  deleteTagMock: vi.fn(),
   ensureTagsMock: vi.fn(),
+  renameTagMock: vi.fn(),
   updateAssistantMock: vi.fn()
 }))
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => key
+    t: (key: string) =>
+      (
+        ({
+          'assistants.tags.delete': '删除标签',
+          'assistants.tags.deleteConfirm': '确定要删除这个标签吗？',
+          'common.delete': '删除',
+          'common.rename': '重命名',
+          'common.save': '保存',
+          'library.toolbar.tag_button': '标签'
+        }) satisfies Record<string, string>
+      )[key] ?? key
   })
 }))
 
@@ -28,6 +40,13 @@ vi.mock('@renderer/pages/library/list/AssistantPresetGroupIcon', () => ({
 vi.mock('@cherrystudio/ui', async () => {
   const React = await vi.importActual<typeof ReactModule>('react')
   const PopoverContext = React.createContext<{
+    open: boolean
+    setOpen: (open: boolean) => void
+  }>({
+    open: false,
+    setOpen: () => {}
+  })
+  const ContextMenuContext = React.createContext<{
     open: boolean
     setOpen: (open: boolean) => void
   }>({
@@ -72,6 +91,76 @@ vi.mock('@cherrystudio/ui', async () => {
           onClick={() => onCheckedChange?.(!checked)}
           {...props}
         />
+      )
+    },
+    ConfirmDialog: ({
+      cancelText,
+      confirmText,
+      description,
+      onConfirm,
+      open,
+      title
+    }: {
+      cancelText?: string
+      confirmText?: string
+      description?: ReactNode
+      onConfirm?: () => void | Promise<void>
+      open?: boolean
+      title?: ReactNode
+    }) =>
+      open ? (
+        <div role="dialog">
+          {title && <h2>{title}</h2>}
+          {description && <div>{description}</div>}
+          {cancelText && <button type="button">{cancelText}</button>}
+          {confirmText && (
+            <button type="button" onClick={() => void onConfirm?.()}>
+              {confirmText}
+            </button>
+          )}
+        </div>
+      ) : null,
+    ContextMenu: ({ children }: { children?: ReactNode }) => {
+      const [open, setOpen] = React.useState(false)
+      return <ContextMenuContext value={{ open, setOpen }}>{children}</ContextMenuContext>
+    },
+    ContextMenuContent: ({ children }: { children?: ReactNode }) => {
+      const { open } = React.use(ContextMenuContext)
+      return open ? <div role="menu">{children}</div> : null
+    },
+    ContextMenuItem: ({
+      children,
+      onSelect,
+      variant,
+      ...props
+    }: ComponentProps<'button'> & {
+      onSelect?: (event: React.MouseEvent<HTMLButtonElement>) => void
+      variant?: string
+    }) => {
+      void variant
+      return (
+        <button type="button" onClick={(event) => onSelect?.(event)} {...props}>
+          {children}
+        </button>
+      )
+    },
+    ContextMenuItemContent: ({ children, icon }: { children?: ReactNode; icon?: ReactNode }) => (
+      <>
+        {icon}
+        <span>{children}</span>
+      </>
+    ),
+    ContextMenuTrigger: ({ asChild, children }: { asChild?: boolean; children?: ReactNode }) => {
+      const { setOpen } = React.use(ContextMenuContext)
+      void asChild
+      return (
+        <span
+          onContextMenu={(event) => {
+            event.preventDefault()
+            setOpen(true)
+          }}>
+          {children}
+        </span>
       )
     },
     EmptyState: ({ description, title }: { description?: string; title?: string }) => (
@@ -150,8 +239,14 @@ vi.mock('../../adapters/assistantAdapter', () => ({
 }))
 
 vi.mock('@renderer/hooks/useTags', () => ({
+  useDeleteTag: () => ({
+    deleteTag: deleteTagMock
+  }),
   useEnsureTags: () => ({
     ensureTags: ensureTagsMock
+  }),
+  useRenameTag: () => ({
+    renameTag: renameTagMock
   }),
   useTagList: () => ({
     tags: [
@@ -248,6 +343,7 @@ function renderResourceGrid(props: Partial<ComponentProps<typeof ResourceGrid>> 
       onAddTag={vi.fn()}
       onUpdateResourceTags={vi.fn()}
       allTagNames={[]}
+      allTags={[]}
       {...props}
     />
   )
@@ -291,12 +387,67 @@ describe('ResourceGrid empty state copy', () => {
   })
 })
 
+describe('ResourceGrid tag toolbar management', () => {
+  beforeEach(() => {
+    deleteTagMock.mockReset()
+    renameTagMock.mockReset()
+  })
+
+  it('renames a tag from the right-click menu', async () => {
+    const user = userEvent.setup()
+    const onTagFilter = vi.fn()
+    renameTagMock.mockResolvedValueOnce({
+      id: 'tag-alpha',
+      name: 'renamed',
+      color: '#111111',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z'
+    })
+
+    renderResourceGrid({
+      activeTag: 'alpha',
+      onTagFilter,
+      tags: [{ id: 'tag-alpha', name: 'alpha', color: '#111111', count: 1 }]
+    })
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: /alpha/ }), { clientX: 20, clientY: 30 })
+    await user.click(screen.getByRole('button', { name: '重命名' }))
+    fireEvent.change(screen.getByLabelText('重命名'), { target: { value: 'renamed' } })
+    await user.click(screen.getByRole('button', { name: '保存' }))
+
+    await waitFor(() => expect(renameTagMock).toHaveBeenCalledWith('tag-alpha', 'renamed'))
+    expect(onTagFilter).toHaveBeenCalledWith('renamed')
+  })
+
+  it('confirms before deleting a tag from the right-click menu', async () => {
+    const user = userEvent.setup()
+    const onTagFilter = vi.fn()
+
+    renderResourceGrid({
+      activeTag: 'alpha',
+      onTagFilter,
+      tags: [{ id: 'tag-alpha', name: 'alpha', color: '#111111', count: 1 }]
+    })
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: /alpha/ }), { clientX: 20, clientY: 30 })
+    await user.click(screen.getByRole('button', { name: '删除标签' }))
+
+    expect(screen.getByRole('dialog')).toHaveTextContent('确定要删除这个标签吗？')
+    expect(deleteTagMock).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: '删除' }))
+
+    await waitFor(() => expect(deleteTagMock).toHaveBeenCalledWith('tag-alpha'))
+    expect(onTagFilter).toHaveBeenCalledWith(null)
+  })
+})
+
 describe('ResourceGrid card actions', () => {
   it('shows the overflow menu only for assistant cards', () => {
     render(<ResourceCard resource={createAssistantResource()} {...getResourceCardProps()} />)
 
     expect(screen.getByRole('button', { name: /common.more/ })).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /common.delete/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '删除' })).not.toBeInTheDocument()
   })
 
   it('shows a direct delete action when delete is the only card action', async () => {
@@ -307,7 +458,7 @@ describe('ResourceGrid card actions', () => {
     render(<ResourceCard resource={resource} {...getResourceCardProps({ onDelete })} />)
 
     expect(screen.queryByRole('button', { name: /common.more/ })).not.toBeInTheDocument()
-    await user.click(screen.getByRole('button', { name: /common.delete/ }))
+    await user.click(screen.getByRole('button', { name: '删除' }))
 
     expect(onDelete).toHaveBeenCalledWith(resource)
   })
@@ -517,6 +668,6 @@ describe('ResourceCardMenu tag binding', () => {
 
     expect(screen.queryByRole('button', { name: /common.edit/ })).not.toBeInTheDocument()
     expect(screen.getByTestId('menu-divider')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /common.delete/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '删除' })).toBeInTheDocument()
   })
 })

--- a/src/renderer/routeTree.gen.ts
+++ b/src/renderer/routeTree.gen.ts
@@ -138,8 +138,8 @@ const SettingsComponentLabRoute = SettingsComponentLabRouteImport.update({
   getParentRoute: () => SettingsRoute,
 } as any)
 const SettingsChannelsRoute = SettingsChannelsRouteImport.update({
-  id: '/agent-channels',
-  path: '/agent-channels',
+  id: '/channels',
+  path: '/channels',
   getParentRoute: () => SettingsRoute,
 } as any)
 const SettingsApiServerRoute = SettingsApiServerRouteImport.update({
@@ -645,7 +645,7 @@ declare module '@tanstack/react-router' {
     }
     '/settings/channels': {
       id: '/settings/channels'
-      path: '/agent-channels'
+      path: '/channels'
       fullPath: '/settings/channels'
       preLoaderRoute: typeof SettingsChannelsRouteImport
       parentRoute: typeof SettingsRoute


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:
Assistant tag creation and management were not a complete user workflow. Users could assign tags to assistants, but the surrounding UI had several gaps:
- The assistant tag selector did not expose a smooth path for creating a new tag while editing tags.
- Newly created tags that were not yet bound to an assistant were hidden from the resource-library toolbar by default, so users could create a tag and immediately lose sight of it.
- Existing toolbar tags could be used for filtering, but they could not be renamed or deleted from the toolbar.
- Deleting a tag had no toolbar-level management entry point or confirmation flow.
- Long typed tag names were only rejected after reaching the backend, which produced a generic save failure instead of preventing the invalid option from being selected.

After this PR:
<img width="317" height="236" alt="image" src="https://github.com/user-attachments/assets/830beb33-c8d9-4a42-a69a-c0c91f3fd4a0" />

<img width="728" height="68" alt="image" src="https://github.com/user-attachments/assets/04747924-7fbb-4735-ae06-776e77aa3c50" />


Assistant tags have a complete create, discover, rename, and delete workflow in the resource library:
- The assistant tag selector can expose a typed tag name as a selectable option when it passes the shared tag-name schema.
- Typed tag names longer than the server-side max length are not exposed as selectable chips.
- The assistant resource toolbar keeps bound tags visible by default and keeps unbound assistant tags collapsed behind an all-tags chevron.
- The chevron is placed after all currently visible tag chips and before the `+ Tag` control.
- Expanding the chevron shows all assistant-library tags, including tags with a current assistant usage count of `0`.
- Each toolbar tag chip supports a right-click menu with rename and delete actions.
- Rename updates the backend tag and keeps the active filter in sync when the renamed tag was selected.
- Delete shows a confirmation dialog before calling the backend delete endpoint.
- New visible strings for tag management are covered by i18n entries.
- The tag toolbar is more robust against stale assistant data where `raw.tags` can be missing while the normalized resource item already has a safe empty tag list.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #N/A

### Why we need it and why it was done in this way

The original user-facing problem was that assistant tag usage and assistant tag management did not form a closed loop. A user could create or assign tags, but the UI did not reliably let them find, rename, or delete those tags afterwards. This made tag creation feel fragile: an unbound tag could be created and then disappear from the default toolbar view, while existing tags had no direct management affordance.

The following tradeoffs were made:
- The all-tags chevron restores discoverability for unbound assistant tags without making the default toolbar noisy.
- Unbound tags are collapsed by default because the most common toolbar action is filtering by currently used assistant tags.
- Rename and delete are exposed through a right-click menu to keep the toolbar compact while still making management available on each chip.
- Delete uses a confirmation dialog because `/tags/:id` is a destructive operation.
- The unused-tag calculation is intentionally scoped to the assistant library. Today, user-managed resource tags in this UI are only bound to assistants, so `allTags - assistant-bound tags` is a valid assistant-library view of currently unbound assistant tags.
- A code comment was added next to this calculation to document the future risk: if other entity types start sharing the same `/tags` pool in user-facing tag management, this client-side difference must be replaced with server-provided global usage or unused-tag data before exposing destructive actions.

The following alternatives were considered:
- Adding a backend tag usage endpoint, such as `GET /tags/usage` or `GET /tags/unused`, was considered. That would be the more general solution if tags become shared across multiple user-managed entity types. It was not added here because the current resource-library tag UI is assistant-only, and adding a new backend usage API would broaden this PR beyond the current assistant tag management workflow.
- Keeping unbound tags always visible was considered, but it would make the default toolbar noisier and reduce scanability for users who mostly filter by actively used tags.
- Leaving tag deletion out of this PR was considered, but that would keep the management loop incomplete: users would still have no way to remove tags they created by mistake.
- Allowing invalid typed tag names and relying on the backend error was rejected because it creates a generic save failure and does not clearly tell users which tag caused the problem.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

This PR adds assistant tag management UI and uses existing tag APIs. It does not change the tag schema, assistant schema, or existing assistant tag bindings.

### Special notes for your reviewer

<!-- optional -->

Please pay special attention to the assistant-only tag assumption around the all-tags chevron:
- The resource library currently exposes user-managed tags only for assistants.
- `unusedTags` in the toolbar means "not currently bound to assistants in this assistant-library view", not a backend-proven global unused state.
- This is documented inline near the `unusedTags` calculation.
- If future work exposes the same `/tags` pool for other entity types, the toolbar should switch to backend-provided usage data before allowing destructive actions on expanded unbound tags.

Validation performed:
- `pnpm exec vitest run --project renderer src/renderer/pages/library/__tests__/LibraryPage.test.tsx src/renderer/pages/library/list/__tests__/useResourceLibrary.test.ts src/renderer/pages/library/list/__tests__/ResourceGrid.test.tsx src/renderer/pages/library/dialogs/__tests__/EditDialogs.test.tsx --silent`
- `pnpm exec eslint src/renderer/hooks/useTags.ts src/renderer/pages/library/LibraryPage.tsx src/renderer/pages/library/__tests__/LibraryPage.test.tsx src/renderer/pages/library/dialogs/__tests__/EditDialogs.test.tsx src/renderer/pages/library/dialogs/components/TagSelector.tsx src/renderer/pages/library/list/ResourceGrid.tsx src/renderer/pages/library/list/__tests__/ResourceGrid.test.tsx`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Added assistant tag management in the resource library, including typed tag creation, collapsed unbound tags, toolbar rename/delete actions, and delete confirmation.
```

## Summary by Sourcery

Enhance assistant tag management in the library resource toolbar and edit dialogs, adding full create, discover, rename, and delete workflows backed by tag APIs.

New Features:
- Allow creating and binding new assistant tags directly from the assistant edit dialog via a searchable tag selector.
- Expose unused assistant tags in the library toolbar behind an expandable control so all assistant tags are discoverable without cluttering the default view.
- Add context-menu actions on toolbar tag chips to rename or delete assistant tags, with a confirmation step for deletions.

Bug Fixes:
- Prevent invalid overlong tag names from being selectable by mirroring server-side tag name validation in the client tag selector.
- Ensure the assistant library still renders when stale assistant raw data is missing the tags field by safely deriving tag metadata.

Enhancements:
- Derive toolbar tag IDs, colors, and usage counts from both backend tags and embedded assistant tag references to keep tag visuals consistent.
- Introduce hooks for renaming and deleting tags that reuse existing tag APIs and keep tag and assistant lists refreshed after mutations.

Tests:
- Extend resource grid, library page, and edit dialog tests to cover the new tag toolbar behaviors, tag creation limits, and stale data handling.