### PR TITLE
fix: avoid embedding dimensions request parameter

### DIFF
--- a/src/main/knowledge/embedjs/embeddings/Embeddings.ts
+++ b/src/main/knowledge/embedjs/embeddings/Embeddings.ts
@@ -6,10 +6,12 @@ import EmbeddingsFactory from './EmbeddingsFactory'
 
 export default class Embeddings {
   private sdk: BaseEmbeddings
+  private readonly dimensions?: number
+
   constructor({ embedApiClient, dimensions }: { embedApiClient: ApiClient; dimensions?: number }) {
+    this.dimensions = dimensions
     this.sdk = EmbeddingsFactory.create({
-      embedApiClient,
-      dimensions
+      embedApiClient
     })
   }
   public async init(): Promise<void> {
@@ -18,7 +20,7 @@ export default class Embeddings {
 
   @TraceMethod({ spanName: 'dimensions', tag: 'Embeddings' })
   public async getDimensions(): Promise<number> {
-    return this.sdk.getDimensions()
+    return this.dimensions ?? this.sdk.getDimensions()
   }
 
   @TraceMethod({ spanName: 'embedDocuments', tag: 'Embeddings' })

--- a/src/main/knowledge/embedjs/embeddings/EmbeddingsFactory.ts
+++ b/src/main/knowledge/embedjs/embeddings/EmbeddingsFactory.ts
@@ -7,29 +7,26 @@ import { net } from 'electron'
 import { VoyageEmbeddings } from './VoyageEmbeddings'
 
 export default class EmbeddingsFactory {
-  static create({ embedApiClient, dimensions }: { embedApiClient: ApiClient; dimensions?: number }): BaseEmbeddings {
+  static create({ embedApiClient }: { embedApiClient: ApiClient }): BaseEmbeddings {
     const batchSize = 10
     const { model, provider, apiKey, baseURL } = embedApiClient
     if (provider === 'voyageai') {
       return new VoyageEmbeddings({
         modelName: model,
         apiKey,
-        outputDimension: dimensions,
         batchSize: 8
       })
     }
     if (provider === 'ollama') {
       return new OllamaEmbeddings({
         model,
-        baseUrl: baseURL.replace(/\/api$/, ''),
-        dimensions
+        baseUrl: baseURL.replace(/\/api$/, '')
       })
     }
     // NOTE: Azure OpenAI 也走 OpenAIEmbeddings, baseURL是https://xxxx.openai.azure.com/openai/v1
     return new OpenAiEmbeddings({
       model,
       apiKey,
-      dimensions,
       batchSize,
       configuration: { baseURL, fetch: net.fetch as typeof fetch }
     })

--- a/src/main/knowledge/embedjs/embeddings/__tests__/EmbeddingsFactory.test.ts
+++ b/src/main/knowledge/embedjs/embeddings/__tests__/EmbeddingsFactory.test.ts
@@ -1,0 +1,102 @@
+import type { ApiClient } from '@types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { ollamaEmbeddingsMock, openAiEmbeddingsMock, voyageEmbeddingsMock } = vi.hoisted(() => ({
+  ollamaEmbeddingsMock: vi.fn(),
+  openAiEmbeddingsMock: vi.fn(),
+  voyageEmbeddingsMock: vi.fn()
+}))
+
+vi.mock('@cherrystudio/embedjs-ollama', () => ({
+  OllamaEmbeddings: ollamaEmbeddingsMock
+}))
+
+vi.mock('@cherrystudio/embedjs-openai', () => ({
+  OpenAiEmbeddings: openAiEmbeddingsMock
+}))
+
+vi.mock('../VoyageEmbeddings', () => ({
+  VoyageEmbeddings: voyageEmbeddingsMock
+}))
+
+const createEmbedApiClient = (overrides: Partial<ApiClient>): ApiClient => ({
+  apiKey: 'test-key',
+  apiVersion: '',
+  baseURL: 'https://example.com/v1',
+  model: 'text-embedding-3-small',
+  provider: 'openai',
+  ...overrides
+})
+
+describe('EmbeddingsFactory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('passes CherryIN model names through without passing dimensions to OpenAI-compatible embeddings', async () => {
+    const { default: EmbeddingsFactory } = await import('../EmbeddingsFactory')
+
+    EmbeddingsFactory.create({
+      embedApiClient: createEmbedApiClient({
+        provider: 'cherryin',
+        baseURL: 'https://open.cherryin.ai/v1',
+        model: 'baai/bge-m3(free)'
+      })
+    })
+
+    expect(openAiEmbeddingsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'baai/bge-m3(free)',
+        apiKey: 'test-key',
+        batchSize: 10,
+        configuration: expect.objectContaining({
+          baseURL: 'https://open.cherryin.ai/v1'
+        })
+      })
+    )
+    expect(openAiEmbeddingsMock.mock.calls[0][0]).not.toHaveProperty('dimensions')
+  })
+
+  it('keeps configured dimensions local without passing them to official OpenAI embeddings', async () => {
+    const { default: Embeddings } = await import('../Embeddings')
+
+    const embeddings = new Embeddings({
+      embedApiClient: createEmbedApiClient({
+        provider: 'openai',
+        model: 'text-embedding-3-small'
+      }),
+      dimensions: 768
+    })
+
+    expect(openAiEmbeddingsMock.mock.calls[0][0]).not.toHaveProperty('dimensions')
+    await expect(embeddings.getDimensions()).resolves.toBe(768)
+  })
+
+  it('does not pass dimensions to Ollama or Voyage SDK constructors', async () => {
+    const { default: EmbeddingsFactory } = await import('../EmbeddingsFactory')
+
+    EmbeddingsFactory.create({
+      embedApiClient: createEmbedApiClient({
+        provider: 'ollama',
+        baseURL: 'http://localhost:11434/api',
+        model: 'nomic-embed-text'
+      })
+    })
+    EmbeddingsFactory.create({
+      embedApiClient: createEmbedApiClient({
+        provider: 'voyageai',
+        model: 'voyage-3'
+      })
+    })
+
+    expect(ollamaEmbeddingsMock.mock.calls[0][0]).toEqual({
+      model: 'nomic-embed-text',
+      baseUrl: 'http://localhost:11434'
+    })
+    expect(voyageEmbeddingsMock.mock.calls[0][0]).toEqual({
+      modelName: 'voyage-3',
+      apiKey: 'test-key',
+      batchSize: 8
+    })
+  })
+})


### PR DESCRIPTION
### What this PR does

Before this PR:

Knowledge base embedding setup passed the configured `dimensions` value into embedding SDK constructors. OpenAI-compatible providers could forward that value as a request parameter, which caused some providers to reject embedding requests with `400 The parameter is invalid`.

After this PR:

Knowledge base dimensions are kept local for vector database initialization, while embedding SDK constructors no longer receive `dimensions` or `outputDimension` request options.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

Keep the existing knowledge base dimension flow intact for LibSQL vector column initialization, but avoid provider-specific request options that are not accepted by every OpenAI-compatible embedding API.

The following alternatives were considered:

Provider-specific allowlists for `dimensions` were considered, but omitting the parameter is safer for the current v1 hotfix because the configured dimension is only required locally for vector database setup.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Added focused unit coverage for the embedding factory to ensure dimensions are not passed to OpenAI, Ollama, or Voyage constructors while still being returned locally by `Embeddings.getDimensions()`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix knowledge base embedding failures with OpenAI-compatible providers that reject the dimensions request parameter.
```
