### PR TITLE
fix(file-migrator): cross-platform v1 recovery and row-level read fault isolation

### DIFF
--- a/src/main/data/migration/v2/migrators/FileMigrator.ts
+++ b/src/main/data/migration/v2/migrators/FileMigrator.ts
@@ -51,35 +51,22 @@ function parseTimestamp(dateStr: string | undefined | null, onInvalid?: (raw: st
   return ms
 }
 
-interface PreparedEntryBase {
+/**
+ * v1 semantically has no external entries — rows were only persisted after
+ * upload, so every migratable row is internal. Mirrors the DB CHECKs
+ * (`fe_origin_consistency`, `fe_size_internal_only`) in TS.
+ */
+interface PreparedFileEntry {
   id: string
+  origin: 'internal'
   name: string
   ext: string | null
+  size: number
+  externalPath: null
   deletedAt: null
   createdAt: number
   updatedAt: number
 }
-
-/**
- * Discriminated by `origin` so the DB CHECK constraints
- * (`fe_origin_consistency`, `fe_size_internal_only`) are mirrored in TS: a
- * `{origin: 'internal', size: null, externalPath: '/foo'}` literal is rejected
- * at compile time, and `validate()`'s `filter(e => e.origin === 'internal')`
- * narrows to `PreparedInternalEntry` naturally — no `as` casts.
- */
-interface PreparedInternalEntry extends PreparedEntryBase {
-  origin: 'internal'
-  size: number
-  externalPath: null
-}
-
-interface PreparedExternalEntry extends PreparedEntryBase {
-  origin: 'external'
-  size: null
-  externalPath: string
-}
-
-type PreparedFileEntry = PreparedInternalEntry | PreparedExternalEntry
 
 /**
  * Determine origin and derive v2 fields from a v1 FileMetadata row.
@@ -117,43 +104,45 @@ function toFileEntry(
     onWarning(`Invalid created_at for file id=${row.id}; falling back to migration time. raw=${JSON.stringify(raw)}`)
   })
 
-  // Origin discrimination: internal files live under userData/Data/Files/
+  // Origin discrimination. v1 has no external entries (rows persisted only
+  // after upload), and v1 runtime locates physical files by storage name
+  // (`row.name` = `{id}{ext}`), never via the `path` column — so a backup
+  // restored across platforms carries foreign-separator paths that fail the
+  // prefix check even though the file sits right here (#15733). Trust the
+  // filesystem over the stale path string before declaring a row orphaned.
   const internalPrefix = path.join(userData, 'Data', 'Files')
-  const isInternal = row.path.startsWith(internalPrefix)
+  const isInternal = row.path.startsWith(internalPrefix) || fs.existsSync(path.join(internalPrefix, row.name))
 
-  if (isInternal) {
-    const validSize = typeof row.size === 'number' && row.size >= 0
-    if (!validSize) {
-      // size column has a DB CHECK but accepts 0 (legitimate empty files),
-      // so a garbage v1 size would land indistinguishably as a 0-byte file in
-      // the v2 UI. Treat as malformed row instead — the caller skips it with
-      // a warning. Physical orphans are reclaimed by the startup FS sweep.
-      onWarning(`Invalid size for file id=${row.id}; treating row as malformed. raw=${JSON.stringify(row.size)}`)
-      return null
-    }
-    return {
-      id: row.id,
-      origin: 'internal',
-      name: row.origin_name
-        ? path.basename(row.origin_name, row.origin_name.includes('.') ? path.extname(row.origin_name) : '')
-        : row.name,
-      ext,
-      size: row.size,
-      externalPath: null,
-      deletedAt: null,
-      createdAt,
-      updatedAt: createdAt
-    }
+  if (!isInternal) {
+    // Neither under the internal dir nor physically present: dead metadata
+    // left by incomplete v1 deletes. Do not fabricate an external entry —
+    // downstream migrators (Chat/Painting) already resolve file_ref against
+    // file_entry, so skipping cannot create dangling FKs.
+    onWarning(
+      `Orphan file row id=${row.id}: no physical file and path is not internal; skipping. path=${JSON.stringify(row.path)}`
+    )
+    return null
   }
 
-  // External file
+  const validSize = typeof row.size === 'number' && row.size >= 0
+  if (!validSize) {
+    // size column has a DB CHECK but accepts 0 (legitimate empty files),
+    // so a garbage v1 size would land indistinguishably as a 0-byte file in
+    // the v2 UI. Treat as malformed row instead — the caller skips it with
+    // a warning. Physical orphans are reclaimed by the startup FS sweep.
+    onWarning(`Invalid size for file id=${row.id}; treating row as malformed. raw=${JSON.stringify(row.size)}`)
+    return null
+  }
+
   return {
     id: row.id,
-    origin: 'external',
-    name: path.basename(row.path, path.extname(row.path)) || row.name,
+    origin: 'internal',
+    name: row.origin_name
+      ? path.basename(row.origin_name, row.origin_name.includes('.') ? path.extname(row.origin_name) : '')
+      : row.name,
     ext,
-    size: null,
-    externalPath: row.path,
+    size: row.size,
+    externalPath: null,
     deletedAt: null,
     createdAt,
     updatedAt: createdAt
@@ -202,7 +191,7 @@ export class FileMigrator extends BaseMigrator {
           if (!entry) {
             this.skippedCount += 1
             const label = row?.id ?? '(unknown)'
-            this.recordWarning(`Skipped malformed file row (id=${label}): missing required fields`)
+            this.recordWarning(`Skipped unmigratable file row (id=${label})`)
             continue
           }
 
@@ -300,9 +289,7 @@ export class FileMigrator extends BaseMigrator {
       // runtime FS orphan sweep already cleans up. Record as a non-fatal
       // warning so the migration log carries the diagnostic trail but the
       // engine still proceeds to downstream migrators.
-      const internalEntries = this.preparedEntries
-        .filter((e): e is PreparedInternalEntry => e.origin === 'internal')
-        .slice(0, VALIDATE_SAMPLE_LIMIT)
+      const internalEntries = this.preparedEntries.slice(0, VALIDATE_SAMPLE_LIMIT)
 
       let missingPhysical = 0
       for (const entry of internalEntries) {

--- a/src/main/data/migration/v2/migrators/FileMigrator.ts
+++ b/src/main/data/migration/v2/migrators/FileMigrator.ts
@@ -71,10 +71,11 @@ function stripExt(base: string): string {
  * Derive a SafeNameSchema-conformant display name from the v1 name source.
  *
  * Degradation chain: raw → sanitized (last segment, trimmed) → row id.
- * Never asks the caller to skip the row: a skipped internal row
- * strands its physical file, which the startup FS sweep then reclaims —
- * real data loss. `name` does not participate in physical paths
- * (`{id}.{ext}`), so degrading it is always safe.
+ * Never asks the caller to skip the row: a skipped internal row strands
+ * its physical file, which the user-triggered FS orphan sweep
+ * (`File_RunSweep`; no startup auto-run) then reclaims — real data loss.
+ * `name` does not participate in physical paths (`{id}.{ext}`), so
+ * degrading it is always safe.
  */
 function deriveSafeName(nameSource: string, rowId: string, onWarning: (message: string) => void): string {
   const raw = stripExt(nameSource)
@@ -360,9 +361,10 @@ export class FileMigrator extends BaseMigrator {
       // a real condition on v1 installs — users delete `~/.../Data/Files/*`
       // outside Cherry, leaving dangling metadata. Surfacing it as a fatal
       // validation error aborts the whole migration over data that the
-      // runtime FS orphan sweep already cleans up. Record as a non-fatal
-      // warning so the migration log carries the diagnostic trail but the
-      // engine still proceeds to downstream migrators.
+      // user-triggered FS orphan sweep (`File_RunSweep`) can clean up later.
+      // Record as a non-fatal warning so the migration log carries the
+      // diagnostic trail but the engine still proceeds to downstream
+      // migrators.
       const internalEntries = this.preparedEntries.slice(0, VALIDATE_SAMPLE_LIMIT)
 
       let missingPhysical = 0

--- a/src/main/data/migration/v2/migrators/FileMigrator.ts
+++ b/src/main/data/migration/v2/migrators/FileMigrator.ts
@@ -150,7 +150,8 @@ function toFileEntry(
   // prefix check even though the file sits right here (#15733). Trust the
   // filesystem over the stale path string before declaring a row orphaned.
   const internalPrefix = path.join(userData, 'Data', 'Files')
-  const isInternal = row.path.startsWith(internalPrefix) || fs.existsSync(path.join(internalPrefix, row.name))
+  const physicalPath = path.join(internalPrefix, row.name)
+  const isInternal = row.path.startsWith(internalPrefix) || fs.existsSync(physicalPath)
 
   if (!isInternal) {
     // Neither under the internal dir nor physically present: dead metadata
@@ -163,14 +164,27 @@ function toFileEntry(
     return null
   }
 
-  const validSize = typeof row.size === 'number' && row.size >= 0
-  if (!validSize) {
-    // size column has a DB CHECK but accepts 0 (legitimate empty files),
-    // so a garbage v1 size would land indistinguishably as a 0-byte file in
-    // the v2 UI. Treat as malformed row instead — the caller skips it with
-    // a warning. Physical orphans are reclaimed by the startup FS sweep.
-    onWarning(`Invalid size for file id=${row.id}; treating row as malformed. raw=${JSON.stringify(row.size)}`)
-    return null
+  // size column has a DB CHECK but accepts 0 (legitimate empty files), so a
+  // garbage v1 size cannot simply be coerced to 0 — it would land
+  // indistinguishably as an empty file in the v2 UI. Skipping outright is
+  // worse: every row reaching this point is internal, so a physically
+  // present file would be stranded and become eligible for the
+  // user-triggered FS orphan sweep (`File_RunSweep`) — real data loss for
+  // recoverable content. Recover the true size from disk instead; skip only
+  // when the disk holds nothing recoverable.
+  let size: number
+  if (typeof row.size === 'number' && row.size >= 0) {
+    size = row.size
+  } else {
+    try {
+      size = fs.statSync(physicalPath).size
+      onWarning(`Invalid size for file id=${row.id}; recovered size=${size} from disk. raw=${JSON.stringify(row.size)}`)
+    } catch {
+      onWarning(
+        `Invalid size for file id=${row.id} and physical file is unreadable; skipping row. raw=${JSON.stringify(row.size)}`
+      )
+      return null
+    }
   }
 
   const entry: PreparedFileEntry = {
@@ -178,7 +192,7 @@ function toFileEntry(
     origin: 'internal',
     name: deriveSafeName(row.origin_name || row.name, row.id, onWarning),
     ext,
-    size: row.size,
+    size,
     externalPath: null,
     deletedAt: null,
     createdAt,

--- a/src/main/data/migration/v2/migrators/FileMigrator.ts
+++ b/src/main/data/migration/v2/migrators/FileMigrator.ts
@@ -6,7 +6,7 @@ import path from 'node:path'
 import { fileEntryTable } from '@data/db/schemas/file'
 import { loggerService } from '@logger'
 import type { ExecuteResult, PrepareResult, ValidateResult, ValidationError } from '@shared/data/migration/v2/types'
-import { SafeExtSchema } from '@shared/data/types/file/essential'
+import { SafeExtSchema, SafeNameSchema } from '@shared/data/types/file/essential'
 import type { FileMetadata } from '@shared/data/types/file/legacyFileMetadata'
 import { sql } from 'drizzle-orm'
 
@@ -49,6 +49,44 @@ function parseTimestamp(dateStr: string | undefined | null, onInvalid?: (raw: st
     return Date.now()
   }
   return ms
+}
+
+/**
+ * Last path segment, treating both '/' and '\' as separators. v1 rows can
+ * carry foreign-platform paths (#15733), so platform-default `path.basename`
+ * must never be applied to v1-persisted strings.
+ */
+function basenameAnySep(p: string): string {
+  return p.split(/[\\/]/).pop() || p
+}
+
+/** Strip a trailing `.ext`; leading-dot names (`.gitignore`) stay intact. */
+function stripExt(base: string): string {
+  const dot = base.lastIndexOf('.')
+  return dot > 0 ? base.slice(0, dot) : base
+}
+
+/**
+ * Derive a SafeNameSchema-conformant display name from the v1 name source.
+ *
+ * Degradation chain (spec R4): raw → sanitized (last segment, trimmed) →
+ * row id. Never asks the caller to skip the row: a skipped internal row
+ * strands its physical file, which the startup FS sweep then reclaims —
+ * real data loss. `name` does not participate in physical paths
+ * (`{id}.{ext}`), so degrading it is always safe.
+ */
+function deriveSafeName(nameSource: string, rowId: string, onWarning: (message: string) => void): string {
+  const raw = stripExt(nameSource)
+  if (SafeNameSchema.safeParse(raw).success) return raw
+
+  const sanitized = stripExt(basenameAnySep(nameSource)).trim()
+  if (SafeNameSchema.safeParse(sanitized).success) {
+    onWarning(`Sanitized name for file id=${rowId}: ${JSON.stringify(nameSource)} -> ${JSON.stringify(sanitized)}`)
+    return sanitized
+  }
+
+  onWarning(`Name for file id=${rowId} cannot be sanitized; falling back to row id. raw=${JSON.stringify(nameSource)}`)
+  return rowId
 }
 
 /**
@@ -137,9 +175,7 @@ function toFileEntry(
   return {
     id: row.id,
     origin: 'internal',
-    name: row.origin_name
-      ? path.basename(row.origin_name, row.origin_name.includes('.') ? path.extname(row.origin_name) : '')
-      : row.name,
+    name: deriveSafeName(row.origin_name || row.name, row.id, onWarning),
     ext,
     size: row.size,
     externalPath: null,

--- a/src/main/data/migration/v2/migrators/FileMigrator.ts
+++ b/src/main/data/migration/v2/migrators/FileMigrator.ts
@@ -6,6 +6,7 @@ import path from 'node:path'
 import { fileEntryTable } from '@data/db/schemas/file'
 import { loggerService } from '@logger'
 import type { ExecuteResult, PrepareResult, ValidateResult, ValidationError } from '@shared/data/migration/v2/types'
+import { FileEntrySchema } from '@shared/data/types/file'
 import { SafeExtSchema, SafeNameSchema } from '@shared/data/types/file/essential'
 import type { FileMetadata } from '@shared/data/types/file/legacyFileMetadata'
 import { sql } from 'drizzle-orm'
@@ -172,7 +173,7 @@ function toFileEntry(
     return null
   }
 
-  return {
+  const entry: PreparedFileEntry = {
     id: row.id,
     origin: 'internal',
     name: deriveSafeName(row.origin_name || row.name, row.id, onWarning),
@@ -183,6 +184,29 @@ function toFileEntry(
     createdAt,
     updatedAt: createdAt
   }
+
+  // Spec R5: write-side validation must be >= read-side validation. Probe
+  // through the same schema the runtime read path applies (rowToFileEntry →
+  // FileEntrySchema.parse) so a malformed row can never reach SQLite and
+  // detonate at read time (#15733). Unreachable by construction today —
+  // this guards future field/schema drift.
+  const probe = FileEntrySchema.safeParse({
+    id: entry.id,
+    origin: 'internal',
+    name: entry.name,
+    ext: entry.ext,
+    size: entry.size,
+    createdAt: entry.createdAt,
+    updatedAt: entry.updatedAt
+  })
+  if (!probe.success) {
+    onWarning(
+      `Prepared entry for file id=${row.id} failed read-schema validation; skipping. issues=${JSON.stringify(probe.error.issues)}`
+    )
+    return null
+  }
+
+  return entry
 }
 
 export class FileMigrator extends BaseMigrator {

--- a/src/main/data/migration/v2/migrators/FileMigrator.ts
+++ b/src/main/data/migration/v2/migrators/FileMigrator.ts
@@ -70,8 +70,8 @@ function stripExt(base: string): string {
 /**
  * Derive a SafeNameSchema-conformant display name from the v1 name source.
  *
- * Degradation chain (spec R4): raw → sanitized (last segment, trimmed) →
- * row id. Never asks the caller to skip the row: a skipped internal row
+ * Degradation chain: raw → sanitized (last segment, trimmed) → row id.
+ * Never asks the caller to skip the row: a skipped internal row
  * strands its physical file, which the startup FS sweep then reclaims —
  * real data loss. `name` does not participate in physical paths
  * (`{id}.{ext}`), so degrading it is always safe.
@@ -185,7 +185,7 @@ function toFileEntry(
     updatedAt: createdAt
   }
 
-  // Spec R5: write-side validation must be >= read-side validation. Probe
+  // Write-side validation must be >= read-side validation. Probe
   // through the same schema the runtime read path applies (rowToFileEntry →
   // FileEntrySchema.parse) so a malformed row can never reach SQLite and
   // detonate at read time (#15733). Unreachable by construction today —

--- a/src/main/data/migration/v2/migrators/KnowledgeMigrator.ts
+++ b/src/main/data/migration/v2/migrators/KnowledgeMigrator.ts
@@ -525,7 +525,9 @@ export class KnowledgeMigrator extends BaseMigrator {
           continue
         }
 
-        const baseResult = transformKnowledgeBase(validBase, resolvedDimensions.dimensions)
+        const baseResult = transformKnowledgeBase(validBase, resolvedDimensions.dimensions, (msg) =>
+          this.recordWarning(msg)
+        )
         const preparedBase = { ...baseResult.value }
 
         if (embeddingResolution.kind === 'resolved') {

--- a/src/main/data/migration/v2/migrators/KnowledgeMigrator.ts
+++ b/src/main/data/migration/v2/migrators/KnowledgeMigrator.ts
@@ -353,6 +353,10 @@ export class KnowledgeMigrator extends BaseMigrator {
       return `Skipped directory item with invalid content (itemId=${item.id})`
     }
 
+    if (reason === 'invalid_note') {
+      return `Skipped note item with neither sourceUrl nor content (itemId=${item.id})`
+    }
+
     return `Skipped invalid knowledge item in base ${baseId} (itemId=${item.id})`
   }
 

--- a/src/main/data/migration/v2/migrators/__tests__/FileMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/FileMigrator.test.ts
@@ -651,3 +651,69 @@ describe('FileMigrator cross-platform recovery (#15733)', () => {
     expect(joined).toContain(FIXTURE_WINDOWS_ROW.id)
   })
 })
+
+// ─── Name degradation chain (spec R3/R4) ────────────────────────────────────
+
+describe('FileMigrator name degradation chain', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('derives name from origin_name with extension stripped (normal path, no warning)', async () => {
+    const row = makeInternalRow({ origin_name: 'My Report.v2.pdf' })
+    const { ctx, insertValues } = createMockContext([row])
+    const m = new FileMigrator()
+    const result = await m.prepare(ctx as never)
+    await m.execute(ctx as never)
+
+    const inserted = insertValues.mock.calls[0][0]
+    const firstRow = Array.isArray(inserted) ? inserted[0] : inserted
+    expect(firstRow.name).toBe('My Report.v2')
+    const joined = (result.warnings ?? []).join('\n')
+    expect(joined).not.toContain('Sanitized name')
+  })
+
+  it('sanitizes an origin_name containing separators instead of skipping the row (AC4)', async () => {
+    const row = makeInternalRow({ origin_name: 'evil\\dir/report.pdf' })
+    const { ctx, insertValues } = createMockContext([row])
+    const m = new FileMigrator()
+    const result = await m.prepare(ctx as never)
+    await m.execute(ctx as never)
+
+    expect(insertValues).toHaveBeenCalled()
+    const inserted = insertValues.mock.calls[0][0]
+    const firstRow = Array.isArray(inserted) ? inserted[0] : inserted
+    expect(firstRow.name).toBe('report')
+    const joined = (result.warnings ?? []).join('\n')
+    expect(joined).toContain('Sanitized name')
+    expect(joined).toContain(row.id)
+  })
+
+  it('falls back to the row id when sanitization cannot produce a safe name (AC4)', async () => {
+    const row = makeInternalRow({ origin_name: '..' })
+    const { ctx, insertValues } = createMockContext([row])
+    const m = new FileMigrator()
+    const result = await m.prepare(ctx as never)
+    await m.execute(ctx as never)
+
+    expect(insertValues).toHaveBeenCalled()
+    const inserted = insertValues.mock.calls[0][0]
+    const firstRow = Array.isArray(inserted) ? inserted[0] : inserted
+    expect(firstRow.name).toBe(row.id)
+    const joined = (result.warnings ?? []).join('\n')
+    expect(joined).toContain('falling back to row id')
+  })
+
+  it('falls back to v1 storage name when origin_name is empty', async () => {
+    const row = makeInternalRow({ origin_name: '' })
+    const { ctx, insertValues } = createMockContext([row])
+    const m = new FileMigrator()
+    await m.prepare(ctx as never)
+    await m.execute(ctx as never)
+
+    const inserted = insertValues.mock.calls[0][0]
+    const firstRow = Array.isArray(inserted) ? inserted[0] : inserted
+    // makeInternalRow: name='report' (no dot) → stays as-is
+    expect(firstRow.name).toBe('report')
+  })
+})

--- a/src/main/data/migration/v2/migrators/__tests__/FileMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/FileMigrator.test.ts
@@ -61,9 +61,10 @@ function makeExternalRow(overrides: Partial<FileMetadata> = {}): FileMetadata {
   }
 }
 
-// 脱敏自 #15733 报告者的真实数据:Windows 上创建的 internal 文件,数据同步到
-// POSIX 机器后迁移。前缀匹配必然失败(分隔符不同),唯一可靠的判别是物理文件
-// 是否存在于本机 Files 目录。
+// Desensitized from the reporter's actual DB row in #15733: an internal file
+// created on Windows whose data was then synced to a POSIX machine before
+// migrating. The prefix check is guaranteed to miss (different separators),
+// so physical presence in the local Files dir is the only reliable signal.
 const FIXTURE_WINDOWS_ROW: FileMetadata = {
   id: '11111111-1111-4111-8111-111111111111',
   name: '11111111-1111-4111-8111-111111111111.png',
@@ -626,7 +627,7 @@ describe('FileMigrator cross-platform recovery (#15733)', () => {
     vi.clearAllMocks()
   })
 
-  it('recovers a Windows-origin internal row on POSIX when the physical file is present (AC1)', async () => {
+  it('recovers a Windows-origin internal row on POSIX when the physical file is present', async () => {
     vi.mocked(fs.existsSync).mockImplementation((p) => p === `${MOCK_USER_DATA}/Data/Files/${FIXTURE_WINDOWS_ROW.name}`)
     const { ctx, insertValues } = createMockContext([FIXTURE_WINDOWS_ROW])
     const m = new FileMigrator()
@@ -642,7 +643,7 @@ describe('FileMigrator cross-platform recovery (#15733)', () => {
     expect(firstRow.externalPath).toBeNull()
   })
 
-  it('skips the same row as orphan when the physical file is absent (AC2)', async () => {
+  it('skips the same row as orphan when the physical file is absent', async () => {
     vi.mocked(fs.existsSync).mockReturnValue(false)
     const { ctx, insertValues } = createMockContext([FIXTURE_WINDOWS_ROW])
     const m = new FileMigrator()
@@ -656,7 +657,7 @@ describe('FileMigrator cross-platform recovery (#15733)', () => {
   })
 })
 
-// ─── Name degradation chain (spec R3/R4) ────────────────────────────────────
+// ─── Name degradation chain ──────────────────────────────────────────────
 
 describe('FileMigrator name degradation chain', () => {
   beforeEach(() => {
@@ -677,7 +678,7 @@ describe('FileMigrator name degradation chain', () => {
     expect(joined).not.toContain('Sanitized name')
   })
 
-  it('sanitizes an origin_name containing separators instead of skipping the row (AC4)', async () => {
+  it('sanitizes an origin_name containing separators instead of skipping the row', async () => {
     const row = makeInternalRow({ origin_name: 'evil\\dir/report.pdf' })
     const { ctx, insertValues } = createMockContext([row])
     const m = new FileMigrator()
@@ -693,7 +694,7 @@ describe('FileMigrator name degradation chain', () => {
     expect(joined).toContain(row.id)
   })
 
-  it('falls back to the row id when sanitization cannot produce a safe name (AC4)', async () => {
+  it('falls back to the row id when sanitization cannot produce a safe name', async () => {
     const row = makeInternalRow({ origin_name: '..' })
     const { ctx, insertValues } = createMockContext([row])
     const m = new FileMigrator()
@@ -722,14 +723,14 @@ describe('FileMigrator name degradation chain', () => {
   })
 })
 
-// ─── Write-side ≥ read-side validation invariant (spec R5) ──────────────────
+// ─── Write-side ≥ read-side validation invariant ────────────────────────────
 
 describe('FileMigrator write/read validation invariant', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('every prepared entry passes the runtime read schema (AC5)', async () => {
+  it('every prepared entry passes the runtime read schema', async () => {
     const rows = [
       makeInternalRow(),
       makeInternalRow({

--- a/src/main/data/migration/v2/migrators/__tests__/FileMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/FileMigrator.test.ts
@@ -693,6 +693,23 @@ describe('FileMigrator name degradation chain', () => {
     expect(joined).toContain(row.id)
   })
 
+  it('falls back to the row id when the name exceeds the 255-char SafeNameSchema limit', async () => {
+    // Sanitization (last segment + trim) cannot shorten a separator-free
+    // over-long name, so the chain must terminate at the row id.
+    const row = makeInternalRow({ origin_name: `${'x'.repeat(300)}.pdf` })
+    const { ctx, insertValues } = createMockContext([row])
+    const m = new FileMigrator()
+    const result = await m.prepare(ctx as never)
+    await m.execute(ctx as never)
+
+    expect(insertValues).toHaveBeenCalled()
+    const inserted = insertValues.mock.calls[0][0]
+    const firstRow = Array.isArray(inserted) ? inserted[0] : inserted
+    expect(firstRow.name).toBe(row.id)
+    const joined = (result.warnings ?? []).join('\n')
+    expect(joined).toContain('falling back to row id')
+  })
+
   it('falls back to the row id when sanitization cannot produce a safe name', async () => {
     const row = makeInternalRow({ origin_name: '..' })
     const { ctx, insertValues } = createMockContext([row])

--- a/src/main/data/migration/v2/migrators/__tests__/FileMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/FileMigrator.test.ts
@@ -307,12 +307,37 @@ describe('FileMigrator ext normalization', () => {
 describe('FileMigrator size handling', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(fs.existsSync).mockReset()
+    vi.mocked(fs.statSync).mockReset()
   })
 
-  it('non-numeric size: row treated as malformed and skipped, warning carries row id and raw value', async () => {
+  it('invalid size with a present physical file: size recovered from disk instead of skipping', async () => {
+    const row = makeInternalRow({
+      id: '550e8400-e29b-41d4-a716-446655440012',
+      size: 'big' as unknown as number
+    })
+    vi.mocked(fs.statSync).mockReturnValue({ size: 2048 } as fs.Stats)
+    const { ctx, insertValues } = createMockContext([row])
+    const m = new FileMigrator()
+    const result = await m.prepare(ctx as never)
+    await m.execute(ctx as never)
+
+    expect(insertValues).toHaveBeenCalled()
+    const inserted = insertValues.mock.calls[0][0]
+    const firstRow = Array.isArray(inserted) ? inserted[0] : inserted
+    expect(firstRow.size).toBe(2048)
+    const joined = (result.warnings ?? []).join('\n')
+    expect(joined).toContain('Invalid size')
+    expect(joined).toContain('recovered size=2048')
+  })
+
+  it('non-numeric size with no recoverable physical file: row skipped, warning carries row id and raw value', async () => {
     const row = makeInternalRow({
       id: '550e8400-e29b-41d4-a716-446655440010',
       size: 'big' as unknown as number
+    })
+    vi.mocked(fs.statSync).mockImplementation(() => {
+      throw new Error('ENOENT')
     })
     const { ctx, insertValues } = createMockContext([row])
     const m = new FileMigrator()
@@ -324,14 +349,17 @@ describe('FileMigrator size handling', () => {
     expect(joined).toContain('Invalid size')
     expect(joined).toContain(row.id)
     expect(joined).toContain('"big"')
-    expect(joined).toContain('treating row as malformed')
+    expect(joined).toContain('skipping row')
 
     // Row was skipped — no insert happened (single-row fixture).
     expect(insertValues).not.toHaveBeenCalled()
   })
 
-  it('negative size: row treated as malformed and skipped, warning carries raw value', async () => {
+  it('negative size with no recoverable physical file: row skipped, warning carries raw value', async () => {
     const row = makeInternalRow({ id: '550e8400-e29b-41d4-a716-446655440011', size: -1 })
+    vi.mocked(fs.statSync).mockImplementation(() => {
+      throw new Error('ENOENT')
+    })
     const { ctx, insertValues } = createMockContext([row])
     const m = new FileMigrator()
     const result = await m.prepare(ctx as never)
@@ -340,7 +368,7 @@ describe('FileMigrator size handling', () => {
     const joined = (result.warnings ?? []).join('\n')
     expect(joined).toContain('Invalid size')
     expect(joined).toContain('-1')
-    expect(joined).toContain('treating row as malformed')
+    expect(joined).toContain('skipping row')
 
     expect(insertValues).not.toHaveBeenCalled()
   })

--- a/src/main/data/migration/v2/migrators/__tests__/FileMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/FileMigrator.test.ts
@@ -47,7 +47,7 @@ function makeInternalRow(overrides: Partial<FileMetadata> = {}): FileMetadata {
 
 function makeExternalRow(overrides: Partial<FileMetadata> = {}): FileMetadata {
   return {
-    id: 'ext-file-v4-id-001',
+    id: '6f9619ff-8b86-4d01-b42d-00cf4fc964ff',
     name: 'notes.txt',
     origin_name: 'notes.txt',
     path: '/Users/alice/Documents/notes.txt',
@@ -58,6 +58,21 @@ function makeExternalRow(overrides: Partial<FileMetadata> = {}): FileMetadata {
     count: 1,
     ...overrides
   }
+}
+
+// 脱敏自 #15733 报告者的真实数据:Windows 上创建的 internal 文件,数据同步到
+// POSIX 机器后迁移。前缀匹配必然失败(分隔符不同),唯一可靠的判别是物理文件
+// 是否存在于本机 Files 目录。
+const FIXTURE_WINDOWS_ROW: FileMetadata = {
+  id: '11111111-1111-4111-8111-111111111111',
+  name: '11111111-1111-4111-8111-111111111111.png',
+  origin_name: 'Screenshot_2025-03-13_21-25-45.png',
+  path: 'C:\\Users\\testuser\\AppData\\Roaming\\CherryStudio\\Data\\Files\\11111111-1111-4111-8111-111111111111.png',
+  size: 442074,
+  ext: '.png',
+  type: 'image',
+  created_at: '2025-03-13T13:34:04.480Z',
+  count: 1
 }
 
 function createMockContext(rows: FileMetadata[], overrides: Record<string, unknown> = {}) {
@@ -232,19 +247,18 @@ describe('FileMigrator origin discrimination', () => {
     expect(typeof firstRow.size).toBe('number')
   })
 
-  it('absolute path outside userData → origin=external, externalPath = row.path', async () => {
+  it('row outside internal dir with no physical file → orphan, skipped with warning', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false)
     const row = makeExternalRow()
     const { ctx, insertValues } = createMockContext([row])
     const m = new FileMigrator()
-    await m.prepare(ctx as never)
+    const result = await m.prepare(ctx as never)
     await m.execute(ctx as never)
 
-    expect(insertValues).toHaveBeenCalled()
-    const inserted = insertValues.mock.calls[0][0]
-    const firstRow = Array.isArray(inserted) ? inserted[0] : inserted
-    expect(firstRow.origin).toBe('external')
-    expect(firstRow.externalPath).toBe('/Users/alice/Documents/notes.txt')
-    expect(firstRow.size).toBeNull()
+    expect(insertValues).not.toHaveBeenCalled()
+    const joined = (result.warnings ?? []).join('\n')
+    expect(joined).toContain('Orphan file row')
+    expect(joined).toContain(row.id)
   })
 })
 
@@ -598,5 +612,42 @@ describe('FileMigrator malformed row handling', () => {
 
     expect(result.success).toBe(true)
     expect(result.processedCount).toBe(1)
+  })
+})
+
+// ─── Cross-platform recovery (#15733) ────────────────────────────────────────
+
+describe('FileMigrator cross-platform recovery (#15733)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('recovers a Windows-origin internal row on POSIX when the physical file is present (AC1)', async () => {
+    vi.mocked(fs.existsSync).mockImplementation((p) => p === `${MOCK_USER_DATA}/Data/Files/${FIXTURE_WINDOWS_ROW.name}`)
+    const { ctx, insertValues } = createMockContext([FIXTURE_WINDOWS_ROW])
+    const m = new FileMigrator()
+    await m.prepare(ctx as never)
+    await m.execute(ctx as never)
+
+    const inserted = insertValues.mock.calls[0][0]
+    const firstRow = Array.isArray(inserted) ? inserted[0] : inserted
+    expect(firstRow.origin).toBe('internal')
+    expect(firstRow.name).toBe('Screenshot_2025-03-13_21-25-45')
+    expect(firstRow.ext).toBe('png')
+    expect(firstRow.size).toBe(442074)
+    expect(firstRow.externalPath).toBeNull()
+  })
+
+  it('skips the same row as orphan when the physical file is absent (AC2)', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false)
+    const { ctx, insertValues } = createMockContext([FIXTURE_WINDOWS_ROW])
+    const m = new FileMigrator()
+    const result = await m.prepare(ctx as never)
+    await m.execute(ctx as never)
+
+    expect(insertValues).not.toHaveBeenCalled()
+    const joined = (result.warnings ?? []).join('\n')
+    expect(joined).toContain('Orphan file row')
+    expect(joined).toContain(FIXTURE_WINDOWS_ROW.id)
   })
 })

--- a/src/main/data/migration/v2/migrators/__tests__/FileMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/FileMigrator.test.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 
+import { FileEntrySchema } from '@shared/data/types/file'
 import type { FileMetadata } from '@shared/data/types/file/legacyFileMetadata'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -603,7 +604,10 @@ describe('FileMigrator malformed row handling', () => {
 
   it('execute still succeeds after skipping malformed rows', async () => {
     const badRow = { ...makeInternalRow(), id: '' } as any
-    const goodRow = makeInternalRow({ id: 'ccccdddd-cccc-4ccc-cccc-cccccccccccc' })
+    // Note the RFC 4122 variant nibble must be [89ab] — the write-side
+    // read-schema probe rejects ids the runtime FileEntryIdSchema would
+    // reject anyway.
+    const goodRow = makeInternalRow({ id: 'ccccdddd-cccc-4ccc-8ccc-cccccccccccc' })
     const { ctx } = createMockContext([badRow, goodRow])
 
     const m = new FileMigrator()
@@ -715,5 +719,48 @@ describe('FileMigrator name degradation chain', () => {
     const firstRow = Array.isArray(inserted) ? inserted[0] : inserted
     // makeInternalRow: name='report' (no dot) → stays as-is
     expect(firstRow.name).toBe('report')
+  })
+})
+
+// ─── Write-side ≥ read-side validation invariant (spec R5) ──────────────────
+
+describe('FileMigrator write/read validation invariant', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('every prepared entry passes the runtime read schema (AC5)', async () => {
+    const rows = [
+      makeInternalRow(),
+      makeInternalRow({
+        id: 'aaaabbbb-aaaa-4aaa-aaaa-aaaaaaaaaaaa',
+        path: `${MOCK_USER_DATA}/Data/Files/aaaabbbb-aaaa-4aaa-aaaa-aaaaaaaaaaaa.pdf`,
+        origin_name: 'evil\\dir/report.pdf'
+      }),
+      makeInternalRow({
+        id: 'bbbbcccc-bbbb-4bbb-bbbb-bbbbbbbbbbbb',
+        path: `${MOCK_USER_DATA}/Data/Files/bbbbcccc-bbbb-4bbb-bbbb-bbbbbbbbbbbb.txt`,
+        origin_name: '..',
+        ext: '.txt'
+      })
+    ]
+    const { ctx } = createMockContext(rows)
+    const m = new FileMigrator()
+    await m.prepare(ctx as never)
+
+    const prepared = (m as any).preparedEntries as Array<Record<string, unknown>>
+    expect(prepared).toHaveLength(3)
+    for (const e of prepared) {
+      const probe = FileEntrySchema.safeParse({
+        id: e.id,
+        origin: 'internal',
+        name: e.name,
+        ext: e.ext,
+        size: e.size,
+        createdAt: e.createdAt,
+        updatedAt: e.updatedAt
+      })
+      expect(probe.success).toBe(true)
+    }
   })
 })

--- a/src/main/data/migration/v2/migrators/__tests__/FileMigrator.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/FileMigrator.test.ts
@@ -46,21 +46,6 @@ function makeInternalRow(overrides: Partial<FileMetadata> = {}): FileMetadata {
   }
 }
 
-function makeExternalRow(overrides: Partial<FileMetadata> = {}): FileMetadata {
-  return {
-    id: '6f9619ff-8b86-4d01-b42d-00cf4fc964ff',
-    name: 'notes.txt',
-    origin_name: 'notes.txt',
-    path: '/Users/alice/Documents/notes.txt',
-    size: 512,
-    ext: '.txt',
-    type: 'document',
-    created_at: '2024-03-01T00:00:00.000Z',
-    count: 1,
-    ...overrides
-  }
-}
-
 // Desensitized from the reporter's actual DB row in #15733: an internal file
 // created on Windows whose data was then synced to a POSIX machine before
 // migrating. The prefix check is guaranteed to miss (different separators),
@@ -247,20 +232,6 @@ describe('FileMigrator origin discrimination', () => {
     const firstRow = Array.isArray(inserted) ? inserted[0] : inserted
     expect(firstRow.externalPath).toBeNull()
     expect(typeof firstRow.size).toBe('number')
-  })
-
-  it('row outside internal dir with no physical file → orphan, skipped with warning', async () => {
-    vi.mocked(fs.existsSync).mockReturnValue(false)
-    const row = makeExternalRow()
-    const { ctx, insertValues } = createMockContext([row])
-    const m = new FileMigrator()
-    const result = await m.prepare(ctx as never)
-    await m.execute(ctx as never)
-
-    expect(insertValues).not.toHaveBeenCalled()
-    const joined = (result.warnings ?? []).join('\n')
-    expect(joined).toContain('Orphan file row')
-    expect(joined).toContain(row.id)
   })
 })
 

--- a/src/main/data/migration/v2/migrators/mappings/KnowledgeMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/KnowledgeMappings.ts
@@ -339,7 +339,10 @@ export const transformKnowledgeItem = (
   } else if (item.type === 'note') {
     const note = deps.noteById.get(item.id)
     const content = note?.content ?? (typeof item.content === 'string' ? item.content : '')
-    const source = note?.sourceUrl ?? item.sourceUrl ?? content
+    // `||`, not `??`: an empty-string sourceUrl must fall through to a
+    // recoverable non-empty content instead of short-circuiting the chain
+    // and getting the note dropped as invalid below.
+    const source = note?.sourceUrl || item.sourceUrl || content
 
     // Sibling branches all guard their source against blank values because
     // the read path requires `source: trim().min(1)`; a note with neither

--- a/src/main/data/migration/v2/migrators/mappings/KnowledgeMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/KnowledgeMappings.ts
@@ -237,7 +237,12 @@ export const transformKnowledgeBase = (
 
   const transformedBase: NewKnowledgeBase = {
     id: uuidv4(),
-    name: base.name,
+    // The identity guard only checks `name !== ''`, so an all-whitespace v1
+    // name reaches here — but the read path (KnowledgeBaseSchema) requires
+    // `trim().min(1)` and one such row poisons the whole list query.
+    // Write-side validation must be >= read-side: trim, and fall back to
+    // the v1 base id (locatable in migration logs) when nothing remains.
+    name: base.name.trim() || base.id,
     groupId: null,
     dimensions,
     embeddingModelId,

--- a/src/main/data/migration/v2/migrators/mappings/KnowledgeMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/KnowledgeMappings.ts
@@ -231,19 +231,25 @@ export const resolveLegacyFileEntryId = (
 
 export const transformKnowledgeBase = (
   base: LegacyKnowledgeBaseWithIdentity,
-  dimensions: number | null
+  dimensions: number | null,
+  onWarning?: (message: string) => void
 ): KnowledgeBaseTransformResult => {
   const embeddingModelId = legacyModelToUniqueId(base.model ?? null)
   const rerankModelId = legacyModelToUniqueId(base.rerankModel ?? null)
 
+  // The identity guard only checks `name !== ''`, so an all-whitespace v1
+  // name reaches here — but the read path (KnowledgeBaseSchema) requires
+  // `trim().min(1)` and one such row poisons the whole list query.
+  // Write-side validation must be >= read-side: trim, and fall back to
+  // the v1 base id when nothing remains.
+  const trimmedName = base.name.trim()
+  if (trimmedName === '') {
+    onWarning?.(`Knowledge base ${base.id} has a blank v1 name; falling back to the base id`)
+  }
+
   const transformedBase: NewKnowledgeBase = {
     id: uuidv4(),
-    // The identity guard only checks `name !== ''`, so an all-whitespace v1
-    // name reaches here — but the read path (KnowledgeBaseSchema) requires
-    // `trim().min(1)` and one such row poisons the whole list query.
-    // Write-side validation must be >= read-side: trim, and fall back to
-    // the v1 base id (locatable in migration logs) when nothing remains.
-    name: base.name.trim() || base.id,
+    name: trimmedName || base.id,
     groupId: null,
     dimensions,
     embeddingModelId,

--- a/src/main/data/migration/v2/migrators/mappings/KnowledgeMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/KnowledgeMappings.ts
@@ -92,6 +92,7 @@ export type KnowledgeItemTransformResult =
         | 'invalid_url'
         | 'invalid_sitemap'
         | 'invalid_directory'
+        | 'invalid_note'
     }
 
 const hasCompleteFileMetadata = (value: LegacyKnowledgeItem['content'] | FileMetadata): value is FileMetadata =>
@@ -338,10 +339,21 @@ export const transformKnowledgeItem = (
   } else if (item.type === 'note') {
     const note = deps.noteById.get(item.id)
     const content = note?.content ?? (typeof item.content === 'string' ? item.content : '')
+    const source = note?.sourceUrl ?? item.sourceUrl ?? content
+
+    // Sibling branches all guard their source against blank values because
+    // the read path requires `source: trim().min(1)`; a note with neither
+    // sourceUrl nor content has nothing to recover — skip it.
+    if (source.trim() === '') {
+      return {
+        ok: false,
+        reason: 'invalid_note'
+      }
+    }
 
     type = 'note'
     data = {
-      source: note?.sourceUrl ?? item.sourceUrl ?? content,
+      source,
       content,
       sourceUrl: note?.sourceUrl ?? item.sourceUrl
     }

--- a/src/main/data/migration/v2/migrators/mappings/__tests__/KnowledgeMappings.test.ts
+++ b/src/main/data/migration/v2/migrators/mappings/__tests__/KnowledgeMappings.test.ts
@@ -270,6 +270,71 @@ describe('KnowledgeMappings', () => {
     })
   })
 
+  it('transformKnowledgeItem skips a note with neither sourceUrl nor content', () => {
+    // Sibling branches (file/url/directory) all guard their source, but the
+    // note branch let `source: ''` through — the read path requires
+    // `source: trim().min(1)` and one such row breaks the item list query.
+    const result = transformKnowledgeItem(
+      'kb-1',
+      {
+        id: 'note-empty',
+        type: 'note',
+        content: ''
+      },
+      {
+        noteById: new Map(),
+        filesById: new Map()
+      }
+    )
+
+    expect(result).toStrictEqual({ ok: false, reason: 'invalid_note' })
+  })
+
+  it('transformKnowledgeItem skips a note whose content is whitespace-only', () => {
+    const result = transformKnowledgeItem(
+      'kb-1',
+      {
+        id: 'note-blank',
+        type: 'note',
+        content: '  \n  '
+      },
+      {
+        noteById: new Map(),
+        filesById: new Map()
+      }
+    )
+
+    expect(result).toStrictEqual({ ok: false, reason: 'invalid_note' })
+  })
+
+  it('transformKnowledgeItem keeps a note that has a sourceUrl but empty content', () => {
+    const result = transformKnowledgeItem(
+      'kb-1',
+      {
+        id: 'note-url-only',
+        type: 'note',
+        content: '',
+        sourceUrl: 'https://example.com/origin'
+      },
+      {
+        noteById: new Map(),
+        filesById: new Map()
+      }
+    )
+
+    expect(result).toStrictEqual({
+      ok: true,
+      value: expect.objectContaining({
+        type: 'note',
+        data: {
+          source: 'https://example.com/origin',
+          content: '',
+          sourceUrl: 'https://example.com/origin'
+        }
+      })
+    })
+  })
+
   it('transformKnowledgeItem resolves file metadata by file id fallback', () => {
     const result = transformKnowledgeItem(
       'kb-1',

--- a/src/main/data/migration/v2/migrators/mappings/__tests__/KnowledgeMappings.test.ts
+++ b/src/main/data/migration/v2/migrators/mappings/__tests__/KnowledgeMappings.test.ts
@@ -335,6 +335,37 @@ describe('KnowledgeMappings', () => {
     })
   })
 
+  it('transformKnowledgeItem keeps a note with an empty-string sourceUrl but non-empty content', () => {
+    // The source chain must use `||`, not `??`: an empty-string sourceUrl
+    // would short-circuit a nullish chain and get a recoverable note
+    // dropped as invalid_note despite its non-empty content.
+    const result = transformKnowledgeItem(
+      'kb-1',
+      {
+        id: 'note-blank-url',
+        type: 'note',
+        content: 'recoverable body',
+        sourceUrl: ''
+      },
+      {
+        noteById: new Map(),
+        filesById: new Map()
+      }
+    )
+
+    expect(result).toStrictEqual({
+      ok: true,
+      value: expect.objectContaining({
+        type: 'note',
+        data: {
+          source: 'recoverable body',
+          content: 'recoverable body',
+          sourceUrl: ''
+        }
+      })
+    })
+  })
+
   it('transformKnowledgeItem resolves file metadata by file id fallback', () => {
     const result = transformKnowledgeItem(
       'kb-1',

--- a/src/main/data/migration/v2/migrators/mappings/__tests__/KnowledgeMappings.test.ts
+++ b/src/main/data/migration/v2/migrators/mappings/__tests__/KnowledgeMappings.test.ts
@@ -57,6 +57,43 @@ describe('KnowledgeMappings', () => {
     })
   })
 
+  it('transformKnowledgeBase falls back to the v1 base id for an all-whitespace name', () => {
+    // Write-side guard only checked `name !== ''`, but the read path
+    // (KnowledgeBaseSchema `name: trim().min(1)`) rejects whitespace-only
+    // names — one such row used to poison the whole list query.
+    expect(
+      transformKnowledgeBase(
+        {
+          id: 'kb-blank-name',
+          name: '   '
+        },
+        1024
+      )
+    ).toStrictEqual({
+      ok: true,
+      value: expect.objectContaining({
+        name: 'kb-blank-name'
+      })
+    })
+  })
+
+  it('transformKnowledgeBase trims surrounding whitespace from a valid name', () => {
+    expect(
+      transformKnowledgeBase(
+        {
+          id: 'kb-padded-name',
+          name: '  My KB  '
+        },
+        1024
+      )
+    ).toStrictEqual({
+      ok: true,
+      value: expect.objectContaining({
+        name: 'My KB'
+      })
+    })
+  })
+
   it('transformKnowledgeBase fills default chunk config when legacy values are missing', () => {
     expect(
       transformKnowledgeBase(

--- a/src/main/data/migration/v2/migrators/mappings/__tests__/KnowledgeMappings.test.ts
+++ b/src/main/data/migration/v2/migrators/mappings/__tests__/KnowledgeMappings.test.ts
@@ -61,13 +61,15 @@ describe('KnowledgeMappings', () => {
     // Write-side guard only checked `name !== ''`, but the read path
     // (KnowledgeBaseSchema `name: trim().min(1)`) rejects whitespace-only
     // names — one such row used to poison the whole list query.
+    const warnings: string[] = []
     expect(
       transformKnowledgeBase(
         {
           id: 'kb-blank-name',
           name: '   '
         },
-        1024
+        1024,
+        (msg) => warnings.push(msg)
       )
     ).toStrictEqual({
       ok: true,
@@ -75,6 +77,10 @@ describe('KnowledgeMappings', () => {
         name: 'kb-blank-name'
       })
     })
+    // The fallback leaves a diagnostic trail in the migration log.
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('kb-blank-name')
+    expect(warnings[0]).toContain('blank v1 name')
   })
 
   it('transformKnowledgeBase trims surrounding whitespace from a valid name', () => {

--- a/src/main/data/services/FileEntryService.ts
+++ b/src/main/data/services/FileEntryService.ts
@@ -248,14 +248,19 @@ function rowToFileEntry(row: FileEntryRow): FileEntry {
  *
  * Contract change for bulk reads: they return every PARSEABLE row, not
  * every physically existing row. Excluded rows are warned with their id.
+ *
+ * Only validation failures (`ZodError`) are isolated — anything else
+ * rethrows, so a programming error inside `rowToFileEntry` cannot
+ * masquerade as a corrupt row and vanish from bulk reads.
  */
 function rowToFileEntrySafe(row: FileEntryRow): FileEntry | null {
   try {
     return rowToFileEntry(row)
   } catch (error) {
+    if (!(error instanceof ZodError)) throw error
     logger.warn('Skipping un-parseable file_entry row in bulk read', {
       id: row.id,
-      issues: error instanceof ZodError ? error.issues : String(error)
+      issues: error.issues
     })
     return null
   }

--- a/src/main/data/services/FileEntryService.ts
+++ b/src/main/data/services/FileEntryService.ts
@@ -20,11 +20,15 @@
 
 import { application } from '@application'
 import { fileEntryTable, fileRefTable } from '@data/db/schemas/file'
+import { loggerService } from '@logger'
 import { DataApiErrorFactory } from '@shared/data/api'
 import type { CanonicalExternalPath, FileEntry, FileEntryId, FileEntryOrigin } from '@shared/data/types/file'
 import { AbsolutePathSchema, FileEntrySchema, SafeNameSchema } from '@shared/data/types/file'
 import { and, asc, count, desc, eq, isNotNull, isNull, type SQL, sql } from 'drizzle-orm'
 import { v7 as uuidv7 } from 'uuid'
+import { ZodError } from 'zod'
+
+const logger = loggerService.withContext('FileEntryService')
 
 /** Columns a caller may provide on insert (id defaults to a fresh UUID v7 when omitted). */
 export interface CreateFileEntryRow {
@@ -116,10 +120,15 @@ export interface FileEntryService {
    * lives in `ensureExternalEntry` (`fs.realpath` resolves whether the two
    * case-different paths are the same FS entity); see
    * `file-manager-architecture.md §1.2 Duplicate-entry detection on insert`.
+   *
+   * Un-parseable rows are skipped with a warning (see `rowToFileEntrySafe`).
    */
   findCaseInsensitivePeers(canonicalPath: CanonicalExternalPath): Promise<FileEntry[]>
 
-  /** Flat listing. Trashed filter defaults to "active only" when `inTrash` is omitted. */
+  /**
+   * Flat listing. Trashed filter defaults to "active only" when `inTrash` is omitted.
+   * Un-parseable rows are skipped with a warning (see `rowToFileEntrySafe`).
+   */
   findMany(query?: FindEntriesQuery): Promise<FileEntry[]>
 
   /**
@@ -134,6 +143,10 @@ export interface FileEntryService {
    * `sortBy: 'size'` is only meaningful within an `origin='internal'` filter
    * (external rows have `size IS NULL`); see the schema-level JSDoc for the
    * mixed-origin caveat.
+   *
+   * Un-parseable rows are skipped with a warning (see `rowToFileEntrySafe`).
+   * `total` is a SQL count and may exceed `items.length` when corrupted
+   * rows were skipped.
    */
   listPaged(query?: ListPagedQuery): Promise<ListPagedResult>
 
@@ -141,6 +154,8 @@ export interface FileEntryService {
    * Active (non-trashed) entries with zero `file_ref` rows pointing at them.
    * Used by Phase 1b.4 OrphanRefScanner's report-only entry pass — see
    * file-manager-architecture §7.1 (default policy is "preserve").
+   *
+   * Un-parseable rows are skipped with a warning (see `rowToFileEntrySafe`).
    */
   findUnreferenced(query?: { origin?: FileEntryOrigin }): Promise<FileEntry[]>
 
@@ -220,6 +235,32 @@ function rowToFileEntry(row: FileEntryRow): FileEntry {
   })
 }
 
+/**
+ * Fault-isolating variant of `rowToFileEntry` for BULK reads only.
+ *
+ * One legacy-corrupted row must not take down a whole collection query —
+ * and with it `danglingCache.initFromDb` → `FileManager.onInit` → the
+ * entire File IPC surface for the session (#15733). Point reads
+ * (`findById` / `getById` / `findByExternalPath`) and write-read-backs
+ * (`create` / `update` / `setExternalPathAndName`) deliberately keep
+ * throwing: there the caller named a specific row or just validated the
+ * payload pre-write, so a silent null would mask a real bug.
+ *
+ * Contract change for bulk reads: they return every PARSEABLE row, not
+ * every physically existing row. Excluded rows are warned with their id.
+ */
+function rowToFileEntrySafe(row: FileEntryRow): FileEntry | null {
+  try {
+    return rowToFileEntry(row)
+  } catch (error) {
+    logger.warn('Skipping un-parseable file_entry row in bulk read', {
+      id: row.id,
+      issues: error instanceof ZodError ? error.issues : String(error)
+    })
+    return null
+  }
+}
+
 class FileEntryServiceImpl implements FileEntryService {
   private getDb() {
     return application.get('DbService').getDb()
@@ -262,7 +303,7 @@ class FileEntryServiceImpl implements FileEntryService {
       // tests and for the surviving-row selection in any future FileMigrator
       // dedupe pass).
       .orderBy(asc(fileEntryTable.createdAt), asc(fileEntryTable.id))
-    return rows.map(rowToFileEntry)
+    return rows.map(rowToFileEntrySafe).filter((e): e is FileEntry => e !== null)
   }
 
   async findMany(query: FindEntriesQuery = {}): Promise<FileEntry[]> {
@@ -291,7 +332,7 @@ class FileEntryServiceImpl implements FileEntryService {
     }
 
     const rows = await queryBuilder
-    return rows.map(rowToFileEntry)
+    return rows.map(rowToFileEntrySafe).filter((e): e is FileEntry => e !== null)
   }
 
   async listPaged(query: ListPagedQuery = {}): Promise<ListPagedResult> {
@@ -336,7 +377,7 @@ class FileEntryServiceImpl implements FileEntryService {
     ])
 
     return {
-      items: rows.map(rowToFileEntry),
+      items: rows.map(rowToFileEntrySafe).filter((e): e is FileEntry => e !== null),
       total: totalRow[0]?.value ?? 0,
       page
     }
@@ -351,7 +392,7 @@ class FileEntryServiceImpl implements FileEntryService {
       .leftJoin(fileRefTable, eq(fileRefTable.fileEntryId, fileEntryTable.id))
       .where(and(...conditions))
       .orderBy(asc(fileEntryTable.createdAt))
-    return rows.map((r) => rowToFileEntry(r.entry))
+    return rows.map((r) => rowToFileEntrySafe(r.entry)).filter((e): e is FileEntry => e !== null)
   }
 
   async listAllIds(): Promise<Set<FileEntryId>> {

--- a/src/main/data/services/__tests__/FileEntryService.test.ts
+++ b/src/main/data/services/__tests__/FileEntryService.test.ts
@@ -6,6 +6,21 @@ import { MockMainDbServiceUtils } from '@test-mocks/main/DbService'
 import { eq } from 'drizzle-orm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const { loggerWarnMock } = vi.hoisted(() => ({
+  loggerWarnMock: vi.fn()
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: vi.fn(() => ({
+      info: vi.fn(),
+      warn: loggerWarnMock,
+      error: vi.fn(),
+      debug: vi.fn()
+    }))
+  }
+}))
+
 vi.mock('@application', async () => {
   const { mockApplicationFactory } = await import('@test-mocks/main/application')
   return mockApplicationFactory()
@@ -949,6 +964,74 @@ describe('FileEntryService', () => {
 
       const result = await fileEntryService.findUnreferenced()
       expect(result.find((e) => e.id === id)).toBeUndefined()
+    })
+  })
+
+  describe('bulk-read fault isolation (#15733)', () => {
+    const goodId = '019606a0-0000-7000-8000-00000000aa01' as FileEntryId
+    const badId = '019606a0-0000-7000-8000-00000000aa02' as FileEntryId
+
+    async function seedOneGoodOneBad() {
+      const now = Date.now()
+      await dbh.db.insert(fileEntryTable).values([
+        {
+          id: goodId,
+          origin: 'internal',
+          name: 'good',
+          ext: 'txt',
+          size: 1,
+          externalPath: null,
+          deletedAt: null,
+          createdAt: now,
+          updatedAt: now
+        },
+        {
+          // Simulates pre-fix FileMigrator output: a name carrying path
+          // separators. No DB CHECK guards `name`, so it inserts cleanly
+          // and only SafeNameSchema rejects it at read time.
+          id: badId,
+          origin: 'internal',
+          name: 'C:\\Users\\x\\bad',
+          ext: 'png',
+          size: 1,
+          externalPath: null,
+          deletedAt: null,
+          createdAt: now + 1,
+          updatedAt: now + 1
+        }
+      ])
+    }
+
+    it('findMany returns parseable rows and warns once per bad row', async () => {
+      await seedOneGoodOneBad()
+      loggerWarnMock.mockClear()
+
+      const entries = await fileEntryService.findMany()
+      expect(entries.map((e) => e.id)).toEqual([goodId])
+      expect(loggerWarnMock).toHaveBeenCalledTimes(1)
+      expect(loggerWarnMock).toHaveBeenCalledWith(
+        expect.stringContaining('un-parseable'),
+        expect.objectContaining({ id: badId })
+      )
+    })
+
+    it('findById still throws for the bad row; good rows unaffected', async () => {
+      await seedOneGoodOneBad()
+      await expect(fileEntryService.findById(badId)).rejects.toThrow()
+      await expect(fileEntryService.findById(goodId)).resolves.toMatchObject({ id: goodId })
+    })
+
+    it('listPaged excludes bad rows from items while total still counts them', async () => {
+      await seedOneGoodOneBad()
+      const page = await fileEntryService.listPaged()
+      expect(page.items.map((e) => e.id)).toEqual([goodId])
+      expect(page.total).toBe(2)
+    })
+
+    it('findUnreferenced skips bad rows', async () => {
+      await seedOneGoodOneBad()
+      const entries = await fileEntryService.findUnreferenced()
+      expect(entries.map((e) => e.id)).toEqual([goodId])
     })
   })
 })

--- a/src/main/data/services/__tests__/FileEntryService.test.ts
+++ b/src/main/data/services/__tests__/FileEntryService.test.ts
@@ -1022,5 +1022,58 @@ describe('FileEntryService', () => {
       const entries = await fileEntryService.findUnreferenced()
       expect(entries.map((e) => e.id)).toEqual([goodId])
     })
+
+    it('findCaseInsensitivePeers isolates a corrupt external row instead of throwing', async () => {
+      // The functional unique index `fe_external_path_lower_unique_idx`
+      // makes "a good and a bad row sharing a case-insensitive
+      // externalPath" unrepresentable, so the corrupt row IS the only
+      // possible match for its path: fault isolation must turn the
+      // would-be throw into an empty result plus one warning.
+      const badExternalId = '019606a0-0000-7000-8000-00000000aa03' as FileEntryId
+      const goodExternalId = '019606a0-0000-7000-8000-00000000aa04' as FileEntryId
+      const now = Date.now()
+      await dbh.db.insert(fileEntryTable).values([
+        {
+          id: badExternalId,
+          origin: 'external',
+          name: 'C:\\Users\\x\\bad-peer',
+          ext: 'txt',
+          size: null,
+          externalPath: '/Users/me/BAD-PEER.TXT',
+          deletedAt: null,
+          createdAt: now,
+          updatedAt: now
+        },
+        {
+          id: goodExternalId,
+          origin: 'external',
+          name: 'good-peer',
+          ext: 'txt',
+          size: null,
+          externalPath: '/Users/me/GOOD-PEER.TXT',
+          deletedAt: null,
+          createdAt: now + 1,
+          updatedAt: now + 1
+        }
+      ])
+      mockMainLoggerService.warn.mockClear()
+
+      // Corrupt match → excluded with one warning, not a throw.
+      const badPeers = await fileEntryService.findCaseInsensitivePeers(
+        '/users/me/bad-peer.txt' as CanonicalExternalPath
+      )
+      expect(badPeers).toEqual([])
+      expect(mockMainLoggerService.warn).toHaveBeenCalledTimes(1)
+      expect(mockMainLoggerService.warn).toHaveBeenCalledWith(
+        expect.stringContaining('un-parseable'),
+        expect.objectContaining({ id: badExternalId })
+      )
+
+      // Good rows still surface through the same method.
+      const goodPeers = await fileEntryService.findCaseInsensitivePeers(
+        '/users/me/good-peer.txt' as CanonicalExternalPath
+      )
+      expect(goodPeers.map((e) => e.id)).toEqual([goodExternalId])
+    })
   })
 })

--- a/src/main/data/services/__tests__/FileEntryService.test.ts
+++ b/src/main/data/services/__tests__/FileEntryService.test.ts
@@ -3,23 +3,12 @@ import { DataApiError, ErrorCode } from '@shared/data/api'
 import type { CanonicalExternalPath, FileEntryId } from '@shared/data/types/file'
 import { setupTestDatabase } from '@test-helpers/db'
 import { MockMainDbServiceUtils } from '@test-mocks/main/DbService'
+import { mockMainLoggerService } from '@test-mocks/MainLoggerService'
 import { eq } from 'drizzle-orm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { loggerWarnMock } = vi.hoisted(() => ({
-  loggerWarnMock: vi.fn()
-}))
-
-vi.mock('@logger', () => ({
-  loggerService: {
-    withContext: vi.fn(() => ({
-      info: vi.fn(),
-      warn: loggerWarnMock,
-      error: vi.fn(),
-      debug: vi.fn()
-    }))
-  }
-}))
+// `@logger` is mocked globally by tests/main.setup.ts with the unified
+// MockMainLoggerService singleton — assert on `mockMainLoggerService.warn`.
 
 vi.mock('@application', async () => {
   const { mockApplicationFactory } = await import('@test-mocks/main/application')
@@ -1004,12 +993,12 @@ describe('FileEntryService', () => {
 
     it('findMany returns parseable rows and warns once per bad row', async () => {
       await seedOneGoodOneBad()
-      loggerWarnMock.mockClear()
+      mockMainLoggerService.warn.mockClear()
 
       const entries = await fileEntryService.findMany()
       expect(entries.map((e) => e.id)).toEqual([goodId])
-      expect(loggerWarnMock).toHaveBeenCalledTimes(1)
-      expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect(mockMainLoggerService.warn).toHaveBeenCalledTimes(1)
+      expect(mockMainLoggerService.warn).toHaveBeenCalledWith(
         expect.stringContaining('un-parseable'),
         expect.objectContaining({ id: badId })
       )


### PR DESCRIPTION
### What this PR does

Before this PR:

- `FileMigrator` derived v2 fields from the v1 `path` column with platform-default `node:path`. A Windows-created internal file restored/synced onto macOS failed the prefix check, was fabricated into an `external` entry, and its `name` kept the whole foreign path (`C:\Users\...`) — which `SafeNameSchema` rejects at read time.
- One such row made `FileEntryService.findMany` throw for the whole result set, killing `danglingCache.initFromDb` → `FileManager.onInit`: every `File_*` IPC handler stayed unregistered for the entire session.
- The migration bulk insert validated only `ext`, never `name` — write-side validation was weaker than read-side validation.
- Same pathology in knowledge migration: a whitespace-only v1 base name and a note item with blank `source` both passed the write guards but fail `trim().min(1)` on read, poisoning the respective list queries.

After this PR:

- **FileMigrator** classifies a row as internal when its path matches the local prefix **or** the physical file exists at `Files/{row.name}` (how v1 runtime itself locates files — the `path` column was never its source of truth). Rows matching neither are dead metadata and are skipped with a warning. The `external` branch is removed entirely: v1 semantically has no external entries (rows were only persisted after upload), so fabricated externals can no longer appear.
- `name` is derived separator-agnostically from `origin_name` with a degradation chain (raw → sanitized last segment → row id) that never drops a row over its display name — a skipped internal row would strand its physical file for the FS sweep to reclaim.
- Every prepared row is probed through `FileEntrySchema` (the exact schema the read path applies) before the bulk insert, enforcing write-side ≥ read-side validation.
- **FileEntryService** bulk reads (`findMany` / `listPaged` / `findCaseInsensitivePeers` / `findUnreferenced`) skip un-parseable rows with a warning carrying the row id; point reads and write-read-backs keep throwing by design. A single corrupted row can no longer take down FileManager — this also rescues users whose DB already contains pre-fix rows.
- **KnowledgeMappings**: migrated base names are trimmed with a v1-base-id fallback; note items with neither `sourceUrl` nor content are skipped (`invalid_note`), matching the sibling branches.

Fixes #15733

### Why we need it and why it was done in this way

The following tradeoffs were made:

- **Sanitize-and-keep instead of skip for bad names** (differs from the issue's suggestion): skipping an internal row strands its physical file, which the startup FS sweep then deletes — real data loss. `name` never participates in physical paths (`{id}.{ext}`), so degrading it is always safe.
- **Delete the external branch instead of fixing its derivation** (differs from the issue's framing): v1's Dexie `files` table only ever receives rows after upload (`FileManager.addFile` has no remaining callers), so "external" rows can only be orphans. Downstream migrators (Chat/Painting) already resolve `file_ref` against `file_entry` before inserting, so skipping cannot create dangling FKs.
- **Row-level fault isolation only for bulk reads**: point reads name a specific row (returning null would conflate with "not found") and write-read-backs just validated their payload (a failure there is a code bug) — both keep failing fast.
- `listPaged.total` stays a SQL count and may exceed `items.length` when corrupted rows are skipped; documented in the interface JSDoc.

The following alternatives were considered:

- Catching errors at the `danglingCache.initFromDb` call site: keeps the service alive but degrades a whole query (and any business query would still explode); row-level isolation bounds the blast radius to the actual bad row.
- Path-pattern matching (`...\Data\Files\...`) for origin discrimination: zero IO, but "looks like an internal path" ≠ "the file is actually here"; physical presence is the same ground truth v1 used.

Links to places where the discussion took place: #15733

### Breaking changes

None user-facing. Contract change for `FileEntryService` bulk reads: they now return every *parseable* row instead of throwing on the first corrupted one (documented in JSDoc). Migration no longer produces `origin='external'` file entries — v1 data never legitimately contained them.

### Special notes for your reviewer

- The regression fixture in `FileMigrator.test.ts` (`FIXTURE_WINDOWS_ROW`) is desensitized from the reporter's actual DB row in #15733 and exercises the full decision chain: prefix miss → physical presence check → separator-agnostic name derivation.
- One pre-existing test id (`ccccdddd-cccc-4ccc-cccc-...`) had an invalid RFC 4122 variant nibble and was caught by the new write-side probe — exactly the class of row the runtime `FileEntryIdSchema` would reject at read time. Fixed to `8ccc`.
- The two knowledge-migration commits (B1/B2) fix the same write-loose/read-strict pathology found by a horizontal scan of all migrators; the scan found no other startup-path single-row crash besides FileManager.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed a startup crash (FileManager initialization failure) when v1 data created on one OS was migrated on another, and made file/knowledge data migration and reads resilient to corrupted legacy rows.
```
