### PR TITLE
fix(release-workflows): align v1 release automation

### DIFF
--- a/.agents/skills/prepare-release/SKILL.md
+++ b/.agents/skills/prepare-release/SKILL.md
@@ -20,6 +20,15 @@ Defaults to `patch` if no version is specified. Always echo the resolved target 
 
 ## Workflow
 
+### Step 0: Start From v1
+
+All v1 releases must be prepared from `origin/v1`, not from the current working branch:
+
+```bash
+git fetch origin v1:refs/remotes/origin/v1 --tags
+git switch --detach origin/v1
+```
+
 ### Step 1: Determine Version
 
 1. Get the latest tag:
@@ -143,14 +152,14 @@ Otherwise, ask the user to confirm before proceeding to Step 6.
 
 1. Create and push the release branch:
    ```bash
-   git checkout -b release/v{version}
+   git switch -c release/v{version}
    git add package.json electron-builder.yml
    git commit -m "chore: release v{version}"
    git push -u origin release/v{version}
    ```
 2. Create the PR using the `gh-create-pr` skill. If the skill tool is unavailable, read `.agents/skills/gh-create-pr/SKILL.md` and follow it manually. In CI (non-interactive) mode, skip interactive confirmation steps and create the PR directly after filling the template.
    - Use title: `chore: release v{version}`
-   - Use base branch: `main`
+   - Use base branch: `v1`
    - When filling the PR template, incorporate:
      - The generated release notes (English section only, for readability).
      - A list of included commits.
@@ -163,7 +172,7 @@ Otherwise, ask the user to confirm before proceeding to Step 6.
 
 ## CI Trigger Chain
 
-Creating a PR from `release/v*` to `main` automatically triggers:
+Creating a PR from `release/v*` to `v1` automatically triggers:
 - **`release.yml`**: Builds on macOS, Windows, Linux and creates a draft GitHub Release.
 - **`ci.yml`**: Runs lint, typecheck, and tests.
 
@@ -171,5 +180,5 @@ Creating a PR from `release/v*` to `main` automatically triggers:
 
 - Always read `electron-builder.yml` before modifying it to understand the current format.
 - Never modify files other than `package.json` and `electron-builder.yml`.
-- Never push directly to `main`.
+- Never push directly to `v1`.
 - Always show the generated release notes to the user before creating the branch/PR (unless running in CI with no interactive user).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,11 @@ on:
   push:
     branches:
       - main
-      - v2
+      - v1
   pull_request:
     branches:
       - main
-      - develop
-      - v2
+      - v1
     types: [ready_for_review, synchronize, opened]
 
 jobs:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -11,7 +11,7 @@ on:
 
   # Ensure this workflow only runs from the default branch
   # (workflow_dispatch already restricts to branches with write access,
-  # but we guard the job to main to prevent accidental runs from feature branches)
+  # but we guard the job to main or v1 to prevent accidental runs from feature branches)
 
 permissions:
   contents: write
@@ -20,12 +20,13 @@ permissions:
 
 jobs:
   prepare:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v1'
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v6
         with:
+          ref: v1
           fetch-depth: 0
 
       - name: Prepare Release via Claude

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ on:
   pull_request_target:
     branches:
       - main
+      - v1
     types:
       - closed
 

--- a/.github/workflows/sync-to-gitcode.yml
+++ b/.github/workflows/sync-to-gitcode.yml
@@ -21,7 +21,47 @@ permissions:
   contents: read
 
 jobs:
+  check-release-target:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.get-tag.outputs.tag }}
+      should_run: ${{ steps.check-main.outputs.should_run }}
+    steps:
+      - name: Get tag name
+        id: get-tag
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check out Git repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.get-tag.outputs.tag }}
+
+      - name: Skip tags from main
+        id: check-main
+        shell: bash
+        run: |
+          TAG="${{ steps.get-tag.outputs.tag }}"
+          git fetch origin main:refs/remotes/origin/main --tags --force
+
+          TAG_COMMIT="$(git rev-list -n 1 "$TAG")"
+          if git merge-base --is-ancestor "$TAG_COMMIT" origin/main; then
+            echo "Tag $TAG points to a commit on main. Skipping GitCode sync."
+            echo "should_run=false" >> $GITHUB_OUTPUT
+          else
+            echo "Tag $TAG is not on main. Continuing GitCode sync."
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          fi
+
   build-windows-signed:
+    needs: check-release-target
+    if: needs.check-release-target.outputs.should_run == 'true'
     runs-on: [self-hosted, windows-signing]
     outputs:
       tag: ${{ steps.get-tag.outputs.tag }}
@@ -105,7 +145,8 @@ jobs:
 
   sync-to-gitcode:
     runs-on: [self-hosted, windows-signing]
-    needs: build-windows-signed
+    needs: [check-release-target, build-windows-signed]
+    if: needs.check-release-target.outputs.should_run == 'true'
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v6
@@ -212,7 +253,7 @@ jobs:
               tag_name: $tag,
               name: $name,
               body: $body,
-              target_commitish: "main"
+              target_commitish: "v1"
             }'
           echo
           echo "Files that would be uploaded:"
@@ -261,7 +302,7 @@ jobs:
               tag_name: $tag,
               name: $name,
               body: $body,
-              target_commitish: "main"
+              target_commitish: "v1"
             }' > /tmp/release_payload.json
 
           RELEASE_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
@@ -381,9 +422,10 @@ jobs:
 
   notify:
     runs-on: ubuntu-latest
-    needs: [build-windows-signed, sync-to-gitcode]
+    needs: [check-release-target, build-windows-signed, sync-to-gitcode]
     if: >-
       always() &&
+      needs.check-release-target.outputs.should_run == 'true' &&
       (github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != 'true') &&
       (
         needs.build-windows-signed.result == 'failure' ||
@@ -397,7 +439,7 @@ jobs:
         env:
           FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_WEBHOOK_URL }}
           FEISHU_WEBHOOK_SECRET: ${{ secrets.FEISHU_WEBHOOK_SECRET }}
-          TAG_NAME: ${{ needs.build-windows-signed.outputs.tag }}
+          TAG_NAME: ${{ needs.check-release-target.outputs.tag }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           BUILD_RESULT: ${{ needs.build-windows-signed.result }}
           SYNC_RESULT: ${{ needs.sync-to-gitcode.result }}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:
v1 release preparation and follow-up release workflows still assumed `main` as the release base in several places.

After this PR:
v1 release preparation starts from `origin/v1`, creates release PRs against `v1`, allows release workflows to run for `v1`, and skips GitCode sync for tags that belong to `main`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:
The workflow changes are limited to release automation and the release skill instructions so the branch strategy is updated without touching unrelated release behavior.

The following alternatives were considered:
Keeping release preparation on `main` was rejected because v1 release branches must target `v1`.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

This is release automation only. No application runtime behavior is changed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
