### PR TITLE
feat(data-services): enforce write/read symmetry with structural CHECKs, contract tests, and DO guards

### DIFF
--- a/migrations/sqlite-drizzle/0005_amazing_meltdown.sql
+++ b/migrations/sqlite-drizzle/0005_amazing_meltdown.sql
@@ -1,0 +1,76 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_file_entry` (
+	`id` text PRIMARY KEY NOT NULL,
+	`origin` text NOT NULL,
+	`name` text NOT NULL,
+	`ext` text,
+	`size` integer,
+	`external_path` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	`deleted_at` integer,
+	CONSTRAINT "fe_origin_check" CHECK("__new_file_entry"."origin" IN ('internal', 'external')),
+	CONSTRAINT "fe_origin_consistency" CHECK(("__new_file_entry"."origin" = 'internal' AND "__new_file_entry"."external_path" IS NULL) OR ("__new_file_entry"."origin" = 'external' AND "__new_file_entry"."external_path" IS NOT NULL)),
+	CONSTRAINT "fe_external_no_delete" CHECK("__new_file_entry"."origin" != 'external' OR "__new_file_entry"."deleted_at" IS NULL),
+	CONSTRAINT "fe_size_internal_only" CHECK(("__new_file_entry"."origin" = 'internal' AND "__new_file_entry"."size" IS NOT NULL AND "__new_file_entry"."size" >= 0) OR ("__new_file_entry"."origin" = 'external' AND "__new_file_entry"."size" IS NULL)),
+	CONSTRAINT "fe_name_no_separators" CHECK(instr("__new_file_entry"."name", '/') = 0 AND instr("__new_file_entry"."name", char(92)) = 0),
+	CONSTRAINT "fe_name_not_blank" CHECK(length(trim("__new_file_entry"."name")) > 0),
+	CONSTRAINT "fe_ext_no_separators" CHECK("__new_file_entry"."ext" IS NULL OR (instr("__new_file_entry"."ext", '/') = 0 AND instr("__new_file_entry"."ext", char(92)) = 0))
+);
+--> statement-breakpoint
+INSERT INTO `__new_file_entry`("id", "origin", "name", "ext", "size", "external_path", "created_at", "updated_at", "deleted_at") SELECT "id", "origin", "name", "ext", "size", "external_path", "created_at", "updated_at", "deleted_at" FROM `file_entry`;--> statement-breakpoint
+DROP TABLE `file_entry`;--> statement-breakpoint
+ALTER TABLE `__new_file_entry` RENAME TO `file_entry`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `fe_deleted_at_idx` ON `file_entry` (`deleted_at`);--> statement-breakpoint
+CREATE INDEX `fe_created_at_idx` ON `file_entry` (`created_at`);--> statement-breakpoint
+-- drizzle-kit's table-recreate path wrongly emits the functional index expression as a
+-- backtick-quoted identifier (`lower("external_path")`), which fails with "no such column".
+-- Hand-fixed to the bare expression form (matching 0000). Snapshot is untouched, so
+-- `db:migrations:generate` stays a no-op and CI's drift check passes. Recurs on any future
+-- file_entry recreate until the pre-release migration wipe-and-regenerate.
+CREATE UNIQUE INDEX `fe_external_path_lower_unique_idx` ON `file_entry` (lower("external_path"));--> statement-breakpoint
+CREATE INDEX `fe_external_path_idx` ON `file_entry` (`external_path`);--> statement-breakpoint
+CREATE TABLE `__new_knowledge_base` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`group_id` text,
+	`dimensions` integer,
+	`embedding_model_id` text,
+	`status` text NOT NULL,
+	`error` text,
+	`rerank_model_id` text,
+	`file_processor_id` text,
+	`chunk_size` integer NOT NULL,
+	`chunk_overlap` integer NOT NULL,
+	`threshold` real,
+	`document_count` integer,
+	`search_mode` text NOT NULL,
+	`hybrid_alpha` real,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`group_id`) REFERENCES `group`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`embedding_model_id`) REFERENCES `user_model`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`rerank_model_id`) REFERENCES `user_model`(`id`) ON UPDATE no action ON DELETE set null,
+	CONSTRAINT "knowledge_base_search_mode_check" CHECK("__new_knowledge_base"."search_mode" IN ('default', 'bm25', 'hybrid')),
+	CONSTRAINT "knowledge_base_status_check" CHECK("__new_knowledge_base"."status" IN ('completed', 'failed')),
+	CONSTRAINT "knowledge_base_status_error_check" CHECK(
+        (
+          "__new_knowledge_base"."status" = 'completed'
+          AND "__new_knowledge_base"."embedding_model_id" IS NOT NULL
+          AND "__new_knowledge_base"."dimensions" IS NOT NULL
+          AND "__new_knowledge_base"."dimensions" > 0
+          AND "__new_knowledge_base"."error" IS NULL
+        )
+        OR (
+          "__new_knowledge_base"."status" = 'failed'
+          AND "__new_knowledge_base"."error" IS NOT NULL
+          AND length(trim("__new_knowledge_base"."error")) > 0
+        )
+      ),
+	CONSTRAINT "knowledge_base_name_not_blank" CHECK(length(trim("__new_knowledge_base"."name")) > 0)
+);
+--> statement-breakpoint
+INSERT INTO `__new_knowledge_base`("id", "name", "group_id", "dimensions", "embedding_model_id", "status", "error", "rerank_model_id", "file_processor_id", "chunk_size", "chunk_overlap", "threshold", "document_count", "search_mode", "hybrid_alpha", "created_at", "updated_at") SELECT "id", "name", "group_id", "dimensions", "embedding_model_id", "status", "error", "rerank_model_id", "file_processor_id", "chunk_size", "chunk_overlap", "threshold", "document_count", "search_mode", "hybrid_alpha", "created_at", "updated_at" FROM `knowledge_base`;--> statement-breakpoint
+DROP TABLE `knowledge_base`;--> statement-breakpoint
+ALTER TABLE `__new_knowledge_base` RENAME TO `knowledge_base`;

--- a/migrations/sqlite-drizzle/meta/0005_snapshot.json
+++ b/migrations/sqlite-drizzle/meta/0005_snapshot.json
@@ -1,0 +1,3652 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "09c1453a-5f56-4750-a82d-aeb4e5a4da17",
+  "prevId": "42474ea0-ee52-400c-830d-844399281ff1",
+  "tables": {
+    "agent": {
+      "name": "agent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plan_model": {
+          "name": "plan_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "small_model": {
+          "name": "small_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcps": {
+          "name": "mcps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_name_idx": {
+          "name": "agent_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "agent_type_idx": {
+          "name": "agent_type_idx",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "agent_order_key_idx": {
+          "name": "agent_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_model_user_model_id_fk": {
+          "name": "agent_model_user_model_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user_model",
+          "columnsFrom": ["model"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_plan_model_user_model_id_fk": {
+          "name": "agent_plan_model_user_model_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user_model",
+          "columnsFrom": ["plan_model"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_small_model_user_model_id_fk": {
+          "name": "agent_small_model_user_model_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user_model",
+          "columnsFrom": ["small_model"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_channel": {
+      "name": "agent_channel",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "active_chat_ids": {
+          "name": "active_chat_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_channel_agent_id_idx": {
+          "name": "agent_channel_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agent_channel_type_idx": {
+          "name": "agent_channel_type_idx",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "agent_channel_session_id_idx": {
+          "name": "agent_channel_session_id_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_channel_agent_id_agent_id_fk": {
+          "name": "agent_channel_agent_id_agent_id_fk",
+          "tableFrom": "agent_channel",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_channel_session_id_agent_session_id_fk": {
+          "name": "agent_channel_session_id_agent_session_id_fk",
+          "tableFrom": "agent_channel",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agent_channel_type_check": {
+          "name": "agent_channel_type_check",
+          "value": "\"agent_channel\".\"type\" IN ('telegram', 'feishu', 'qq', 'wechat', 'discord', 'slack')"
+        },
+        "agent_channel_permission_mode_check": {
+          "name": "agent_channel_permission_mode_check",
+          "value": "\"agent_channel\".\"permission_mode\" IS NULL OR \"agent_channel\".\"permission_mode\" IN ('default', 'acceptEdits', 'bypassPermissions', 'plan')"
+        }
+      }
+    },
+    "agent_channel_task": {
+      "name": "agent_channel_task",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_channel_task_channel_id_idx": {
+          "name": "agent_channel_task_channel_id_idx",
+          "columns": ["channel_id"],
+          "isUnique": false
+        },
+        "agent_channel_task_task_id_idx": {
+          "name": "agent_channel_task_task_id_idx",
+          "columns": ["task_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_channel_task_channel_id_agent_channel_id_fk": {
+          "name": "agent_channel_task_channel_id_agent_channel_id_fk",
+          "tableFrom": "agent_channel_task",
+          "tableTo": "agent_channel",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_channel_task_task_id_job_schedule_id_fk": {
+          "name": "agent_channel_task_task_id_job_schedule_id_fk",
+          "tableFrom": "agent_channel_task",
+          "tableTo": "job_schedule",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_channel_task_channel_id_task_id_pk": {
+          "columns": ["channel_id", "task_id"],
+          "name": "agent_channel_task_channel_id_task_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_global_skill": {
+      "name": "agent_global_skill",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folder_name": {
+          "name": "folder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_global_skill_folder_name_unique": {
+          "name": "agent_global_skill_folder_name_unique",
+          "columns": ["folder_name"],
+          "isUnique": true
+        },
+        "agent_global_skill_source_idx": {
+          "name": "agent_global_skill_source_idx",
+          "columns": ["source"],
+          "isUnique": false
+        },
+        "agent_global_skill_is_enabled_idx": {
+          "name": "agent_global_skill_is_enabled_idx",
+          "columns": ["is_enabled"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_session": {
+      "name": "agent_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_session_order_key_idx": {
+          "name": "agent_session_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_session_agent_id_agent_id_fk": {
+          "name": "agent_session_agent_id_agent_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_session_workspace_id_agent_workspace_id_fk": {
+          "name": "agent_session_workspace_id_agent_workspace_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "agent_workspace",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_session_message": {
+      "name": "agent_session_message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "searchable_text": {
+          "name": "searchable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_snapshot": {
+          "name": "model_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runtime_resume_token": {
+          "name": "runtime_resume_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_session_message_session_created_id_idx": {
+          "name": "agent_session_message_session_created_id_idx",
+          "columns": ["session_id", "created_at", "id"],
+          "isUnique": false
+        },
+        "agent_session_message_status_idx": {
+          "name": "agent_session_message_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_session_message_session_id_agent_session_id_fk": {
+          "name": "agent_session_message_session_id_agent_session_id_fk",
+          "tableFrom": "agent_session_message",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_session_message_model_id_user_model_id_fk": {
+          "name": "agent_session_message_model_id_user_model_id_fk",
+          "tableFrom": "agent_session_message",
+          "tableTo": "user_model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agent_session_message_role_check": {
+          "name": "agent_session_message_role_check",
+          "value": "\"agent_session_message\".\"role\" IN ('user', 'assistant', 'system')"
+        },
+        "agent_session_message_status_check": {
+          "name": "agent_session_message_status_check",
+          "value": "\"agent_session_message\".\"status\" IN ('pending', 'success', 'error', 'paused')"
+        }
+      }
+    },
+    "agent_skill": {
+      "name": "agent_skill",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_skill_agent_id_idx": {
+          "name": "agent_skill_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agent_skill_skill_id_idx": {
+          "name": "agent_skill_skill_id_idx",
+          "columns": ["skill_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_agent_id_agent_id_fk": {
+          "name": "agent_skill_agent_id_agent_id_fk",
+          "tableFrom": "agent_skill",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_skill_skill_id_agent_global_skill_id_fk": {
+          "name": "agent_skill_skill_id_agent_global_skill_id_fk",
+          "tableFrom": "agent_skill",
+          "tableTo": "agent_global_skill",
+          "columnsFrom": ["skill_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_skill_agent_id_skill_id_pk": {
+          "columns": ["agent_id", "skill_id"],
+          "name": "agent_skill_agent_id_skill_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_workspace": {
+      "name": "agent_workspace",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_workspace_path_unique_idx": {
+          "name": "agent_workspace_path_unique_idx",
+          "columns": ["path"],
+          "isUnique": true
+        },
+        "agent_workspace_order_key_idx": {
+          "name": "agent_workspace_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_state": {
+      "name": "app_state",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assistant": {
+      "name": "assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "assistant_created_at_idx": {
+          "name": "assistant_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "assistant_order_key_idx": {
+          "name": "assistant_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "assistant_model_id_user_model_id_fk": {
+          "name": "assistant_model_id_user_model_id_fk",
+          "tableFrom": "assistant",
+          "tableTo": "user_model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assistant_knowledge_base": {
+      "name": "assistant_knowledge_base",
+      "columns": {
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "knowledge_base_id": {
+          "name": "knowledge_base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "assistant_knowledge_base_assistant_id_assistant_id_fk": {
+          "name": "assistant_knowledge_base_assistant_id_assistant_id_fk",
+          "tableFrom": "assistant_knowledge_base",
+          "tableTo": "assistant",
+          "columnsFrom": ["assistant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assistant_knowledge_base_knowledge_base_id_knowledge_base_id_fk": {
+          "name": "assistant_knowledge_base_knowledge_base_id_knowledge_base_id_fk",
+          "tableFrom": "assistant_knowledge_base",
+          "tableTo": "knowledge_base",
+          "columnsFrom": ["knowledge_base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "assistant_knowledge_base_assistant_id_knowledge_base_id_pk": {
+          "columns": ["assistant_id", "knowledge_base_id"],
+          "name": "assistant_knowledge_base_assistant_id_knowledge_base_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assistant_mcp_server": {
+      "name": "assistant_mcp_server",
+      "columns": {
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "assistant_mcp_server_assistant_id_assistant_id_fk": {
+          "name": "assistant_mcp_server_assistant_id_assistant_id_fk",
+          "tableFrom": "assistant_mcp_server",
+          "tableTo": "assistant",
+          "columnsFrom": ["assistant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assistant_mcp_server_mcp_server_id_mcp_server_id_fk": {
+          "name": "assistant_mcp_server_mcp_server_id_mcp_server_id_fk",
+          "tableFrom": "assistant_mcp_server",
+          "tableTo": "mcp_server",
+          "columnsFrom": ["mcp_server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "assistant_mcp_server_assistant_id_mcp_server_id_pk": {
+          "columns": ["assistant_id", "mcp_server_id"],
+          "name": "assistant_mcp_server_assistant_id_mcp_server_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_entry": {
+      "name": "file_entry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_path": {
+          "name": "external_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "fe_deleted_at_idx": {
+          "name": "fe_deleted_at_idx",
+          "columns": ["deleted_at"],
+          "isUnique": false
+        },
+        "fe_created_at_idx": {
+          "name": "fe_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "fe_external_path_lower_unique_idx": {
+          "name": "fe_external_path_lower_unique_idx",
+          "columns": ["lower(\"external_path\")"],
+          "isUnique": true
+        },
+        "fe_external_path_idx": {
+          "name": "fe_external_path_idx",
+          "columns": ["external_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "fe_origin_check": {
+          "name": "fe_origin_check",
+          "value": "\"file_entry\".\"origin\" IN ('internal', 'external')"
+        },
+        "fe_origin_consistency": {
+          "name": "fe_origin_consistency",
+          "value": "(\"file_entry\".\"origin\" = 'internal' AND \"file_entry\".\"external_path\" IS NULL) OR (\"file_entry\".\"origin\" = 'external' AND \"file_entry\".\"external_path\" IS NOT NULL)"
+        },
+        "fe_external_no_delete": {
+          "name": "fe_external_no_delete",
+          "value": "\"file_entry\".\"origin\" != 'external' OR \"file_entry\".\"deleted_at\" IS NULL"
+        },
+        "fe_size_internal_only": {
+          "name": "fe_size_internal_only",
+          "value": "(\"file_entry\".\"origin\" = 'internal' AND \"file_entry\".\"size\" IS NOT NULL AND \"file_entry\".\"size\" >= 0) OR (\"file_entry\".\"origin\" = 'external' AND \"file_entry\".\"size\" IS NULL)"
+        },
+        "fe_name_no_separators": {
+          "name": "fe_name_no_separators",
+          "value": "instr(\"file_entry\".\"name\", '/') = 0 AND instr(\"file_entry\".\"name\", char(92)) = 0"
+        },
+        "fe_name_not_blank": {
+          "name": "fe_name_not_blank",
+          "value": "length(trim(\"file_entry\".\"name\")) > 0"
+        },
+        "fe_ext_no_separators": {
+          "name": "fe_ext_no_separators",
+          "value": "\"file_entry\".\"ext\" IS NULL OR (instr(\"file_entry\".\"ext\", '/') = 0 AND instr(\"file_entry\".\"ext\", char(92)) = 0)"
+        }
+      }
+    },
+    "file_ref": {
+      "name": "file_ref",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_entry_id": {
+          "name": "file_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "file_ref_entry_id_idx": {
+          "name": "file_ref_entry_id_idx",
+          "columns": ["file_entry_id"],
+          "isUnique": false
+        },
+        "file_ref_source_idx": {
+          "name": "file_ref_source_idx",
+          "columns": ["source_type", "source_id"],
+          "isUnique": false
+        },
+        "file_ref_unique_idx": {
+          "name": "file_ref_unique_idx",
+          "columns": ["file_entry_id", "source_type", "source_id", "role"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "file_ref_file_entry_id_file_entry_id_fk": {
+          "name": "file_ref_file_entry_id_file_entry_id_fk",
+          "tableFrom": "file_ref",
+          "tableTo": "file_entry",
+          "columnsFrom": ["file_entry_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group": {
+      "name": "group",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_entity_type_order_key_idx": {
+          "name": "group_entity_type_order_key_idx",
+          "columns": ["entity_type", "order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "job_schedule": {
+      "name": "job_schedule",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_input_template": {
+          "name": "job_input_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "next_run": {
+          "name": "next_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "catch_up_policy": {
+          "name": "catch_up_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "job_schedule_type_name_uq": {
+          "name": "job_schedule_type_name_uq",
+          "columns": ["type", "name"],
+          "isUnique": true
+        },
+        "job_schedule_enabled_next_run_idx": {
+          "name": "job_schedule_enabled_next_run_idx",
+          "columns": ["enabled", "next_run"],
+          "isUnique": false
+        },
+        "job_schedule_type_idx": {
+          "name": "job_schedule_type_idx",
+          "columns": ["type"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "job": {
+      "name": "job",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "queue": {
+          "name": "queue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_requested": {
+          "name": "cancel_requested",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "job_queue_status_scheduled_at_idx": {
+          "name": "job_queue_status_scheduled_at_idx",
+          "columns": ["queue", "status", "scheduled_at"],
+          "isUnique": false
+        },
+        "job_status_idx": {
+          "name": "job_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "job_schedule_id_finished_at_idx": {
+          "name": "job_schedule_id_finished_at_idx",
+          "columns": ["schedule_id", "finished_at"],
+          "isUnique": false
+        },
+        "job_parent_id_idx": {
+          "name": "job_parent_id_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "job_idempotency_key_partial_uq": {
+          "name": "job_idempotency_key_partial_uq",
+          "columns": ["idempotency_key"],
+          "isUnique": true,
+          "where": "\"job\".\"idempotency_key\" IS NOT NULL AND \"job\".\"status\" NOT IN ('completed','failed','cancelled')"
+        }
+      },
+      "foreignKeys": {
+        "job_schedule_id_job_schedule_id_fk": {
+          "name": "job_schedule_id_job_schedule_id_fk",
+          "tableFrom": "job",
+          "tableTo": "job_schedule",
+          "columnsFrom": ["schedule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "job_parent_id_job_id_fk": {
+          "name": "job_parent_id_job_id_fk",
+          "tableFrom": "job",
+          "tableTo": "job",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "job_status_check": {
+          "name": "job_status_check",
+          "value": "\"job\".\"status\" IN ('pending','delayed','running','completed','failed','cancelled')"
+        }
+      }
+    },
+    "knowledge_base": {
+      "name": "knowledge_base",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_model_id": {
+          "name": "embedding_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rerank_model_id": {
+          "name": "rerank_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_processor_id": {
+          "name": "file_processor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chunk_size": {
+          "name": "chunk_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chunk_overlap": {
+          "name": "chunk_overlap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_mode": {
+          "name": "search_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hybrid_alpha": {
+          "name": "hybrid_alpha",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "knowledge_base_group_id_group_id_fk": {
+          "name": "knowledge_base_group_id_group_id_fk",
+          "tableFrom": "knowledge_base",
+          "tableTo": "group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "knowledge_base_embedding_model_id_user_model_id_fk": {
+          "name": "knowledge_base_embedding_model_id_user_model_id_fk",
+          "tableFrom": "knowledge_base",
+          "tableTo": "user_model",
+          "columnsFrom": ["embedding_model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "knowledge_base_rerank_model_id_user_model_id_fk": {
+          "name": "knowledge_base_rerank_model_id_user_model_id_fk",
+          "tableFrom": "knowledge_base",
+          "tableTo": "user_model",
+          "columnsFrom": ["rerank_model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "knowledge_base_search_mode_check": {
+          "name": "knowledge_base_search_mode_check",
+          "value": "\"knowledge_base\".\"search_mode\" IN ('default', 'bm25', 'hybrid')"
+        },
+        "knowledge_base_status_check": {
+          "name": "knowledge_base_status_check",
+          "value": "\"knowledge_base\".\"status\" IN ('completed', 'failed')"
+        },
+        "knowledge_base_status_error_check": {
+          "name": "knowledge_base_status_error_check",
+          "value": "\n        (\n          \"knowledge_base\".\"status\" = 'completed'\n          AND \"knowledge_base\".\"embedding_model_id\" IS NOT NULL\n          AND \"knowledge_base\".\"dimensions\" IS NOT NULL\n          AND \"knowledge_base\".\"dimensions\" > 0\n          AND \"knowledge_base\".\"error\" IS NULL\n        )\n        OR (\n          \"knowledge_base\".\"status\" = 'failed'\n          AND \"knowledge_base\".\"error\" IS NOT NULL\n          AND length(trim(\"knowledge_base\".\"error\")) > 0\n        )\n      "
+        },
+        "knowledge_base_name_not_blank": {
+          "name": "knowledge_base_name_not_blank",
+          "value": "length(trim(\"knowledge_base\".\"name\")) > 0"
+        }
+      }
+    },
+    "knowledge_item": {
+      "name": "knowledge_item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "knowledge_item_base_type_created_idx": {
+          "name": "knowledge_item_base_type_created_idx",
+          "columns": ["base_id", "type", "created_at"],
+          "isUnique": false
+        },
+        "knowledge_item_base_group_created_idx": {
+          "name": "knowledge_item_base_group_created_idx",
+          "columns": ["base_id", "group_id", "created_at"],
+          "isUnique": false
+        },
+        "knowledge_item_baseId_id_unique": {
+          "name": "knowledge_item_baseId_id_unique",
+          "columns": ["base_id", "id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "knowledge_item_base_id_knowledge_base_id_fk": {
+          "name": "knowledge_item_base_id_knowledge_base_id_fk",
+          "tableFrom": "knowledge_item",
+          "tableTo": "knowledge_base",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_item_base_id_group_id_knowledge_item_base_id_id_fk": {
+          "name": "knowledge_item_base_id_group_id_knowledge_item_base_id_id_fk",
+          "tableFrom": "knowledge_item",
+          "tableTo": "knowledge_item",
+          "columnsFrom": ["base_id", "group_id"],
+          "columnsTo": ["base_id", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "knowledge_item_type_check": {
+          "name": "knowledge_item_type_check",
+          "value": "\"knowledge_item\".\"type\" IN ('file', 'url', 'note', 'directory')"
+        },
+        "knowledge_item_status_check": {
+          "name": "knowledge_item_status_check",
+          "value": "\"knowledge_item\".\"status\" IN ('idle', 'preparing', 'processing', 'reading', 'embedding', 'completed', 'failed', 'deleting')"
+        },
+        "knowledge_item_type_status_check": {
+          "name": "knowledge_item_type_status_check",
+          "value": "\n        (\"knowledge_item\".\"type\" IN ('file', 'url', 'note') AND \"knowledge_item\".\"status\" IN ('idle', 'processing', 'reading', 'embedding', 'completed', 'failed', 'deleting'))\n        OR (\"knowledge_item\".\"type\" = 'directory' AND \"knowledge_item\".\"status\" IN ('idle', 'preparing', 'processing', 'completed', 'failed', 'deleting'))\n      "
+        },
+        "knowledge_item_status_error_check": {
+          "name": "knowledge_item_status_error_check",
+          "value": "\n        (\n          \"knowledge_item\".\"status\" IN ('idle', 'preparing', 'processing', 'reading', 'embedding', 'completed', 'deleting')\n          AND \"knowledge_item\".\"error\" IS NULL\n        )\n        OR (\n          \"knowledge_item\".\"status\" = 'failed'\n          AND \"knowledge_item\".\"error\" IS NOT NULL\n          AND length(trim(\"knowledge_item\".\"error\")) > 0\n        )\n      "
+        }
+      }
+    },
+    "mcp_server": {
+      "name": "mcp_server",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_url": {
+          "name": "provider_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "long_running": {
+          "name": "long_running",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dxt_version": {
+          "name": "dxt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dxt_path": {
+          "name": "dxt_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_key": {
+          "name": "search_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config_sample": {
+          "name": "config_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_tools": {
+          "name": "disabled_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_auto_approve_tools": {
+          "name": "disabled_auto_approve_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "should_config": {
+          "name": "should_config",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "install_source": {
+          "name": "install_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_trusted": {
+          "name": "is_trusted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trusted_at": {
+          "name": "trusted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_server_name_idx": {
+          "name": "mcp_server_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "mcp_server_is_active_idx": {
+          "name": "mcp_server_is_active_idx",
+          "columns": ["is_active"],
+          "isUnique": false
+        },
+        "mcp_server_sort_order_idx": {
+          "name": "mcp_server_sort_order_idx",
+          "columns": ["sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "mcp_server_type_check": {
+          "name": "mcp_server_type_check",
+          "value": "\"mcp_server\".\"type\" IS NULL OR \"mcp_server\".\"type\" IN ('stdio', 'sse', 'streamableHttp', 'inMemory')"
+        },
+        "mcp_server_install_source_check": {
+          "name": "mcp_server_install_source_check",
+          "value": "\"mcp_server\".\"install_source\" IS NULL OR \"mcp_server\".\"install_source\" IN ('builtin', 'manual', 'protocol', 'unknown')"
+        }
+      }
+    },
+    "message": {
+      "name": "message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "searchable_text": {
+          "name": "searchable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "siblings_group_id": {
+          "name": "siblings_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_snapshot": {
+          "name": "model_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "message_parent_id_idx": {
+          "name": "message_parent_id_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "message_topic_created_idx": {
+          "name": "message_topic_created_idx",
+          "columns": ["topic_id", "created_at"],
+          "isUnique": false
+        },
+        "message_trace_id_idx": {
+          "name": "message_trace_id_idx",
+          "columns": ["trace_id"],
+          "isUnique": false
+        },
+        "message_status_idx": {
+          "name": "message_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "message_topic_id_topic_id_fk": {
+          "name": "message_topic_id_topic_id_fk",
+          "tableFrom": "message",
+          "tableTo": "topic",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_model_id_user_model_id_fk": {
+          "name": "message_model_id_user_model_id_fk",
+          "tableFrom": "message",
+          "tableTo": "user_model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "message_parent_id_message_id_fk": {
+          "name": "message_parent_id_message_id_fk",
+          "tableFrom": "message",
+          "tableTo": "message",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "message_role_check": {
+          "name": "message_role_check",
+          "value": "\"message\".\"role\" IN ('user', 'assistant', 'system')"
+        },
+        "message_status_check": {
+          "name": "message_status_check",
+          "value": "\"message\".\"status\" IN ('pending', 'success', 'error', 'paused')"
+        }
+      }
+    },
+    "mini_app": {
+      "name": "mini_app",
+      "columns": {
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_mini_app_id": {
+          "name": "preset_mini_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'enabled'"
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bordered": {
+          "name": "bordered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "background": {
+          "name": "background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supported_regions": {
+          "name": "supported_regions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_key": {
+          "name": "name_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mini_app_status_order_key_idx": {
+          "name": "mini_app_status_order_key_idx",
+          "columns": ["status", "order_key"],
+          "isUnique": false
+        },
+        "mini_app_preset_mini_app_id_idx": {
+          "name": "mini_app_preset_mini_app_id_idx",
+          "columns": ["preset_mini_app_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "mini_app_status_check": {
+          "name": "mini_app_status_check",
+          "value": "\"mini_app\".\"status\" IN ('enabled', 'disabled', 'pinned')"
+        }
+      }
+    },
+    "note": {
+      "name": "note",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "root_path": {
+          "name": "root_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_starred": {
+          "name": "is_starred",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_expanded": {
+          "name": "is_expanded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "note_root_path_path_unique_idx": {
+          "name": "note_root_path_path_unique_idx",
+          "columns": ["root_path", "path"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "note_has_state_check": {
+          "name": "note_has_state_check",
+          "value": "\"note\".\"is_starred\" = 1 OR \"note\".\"is_expanded\" = 1"
+        }
+      }
+    },
+    "painting": {
+      "name": "painting",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "painting_order_key_idx": {
+          "name": "painting_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pin": {
+      "name": "pin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pin_entity_type_entity_id_unique_idx": {
+          "name": "pin_entity_type_entity_id_unique_idx",
+          "columns": ["entity_type", "entity_id"],
+          "isUnique": true
+        },
+        "pin_entity_type_order_key_idx": {
+          "name": "pin_entity_type_order_key_idx",
+          "columns": ["entity_type", "order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "preference": {
+      "name": "preference",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "preference_scope_key_pk": {
+          "columns": ["scope", "key"],
+          "name": "preference_scope_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt": {
+      "name": "prompt",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prompt_order_key_idx": {
+          "name": "prompt_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "entity_tag": {
+      "name": "entity_tag",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "entity_tag_tag_id_idx": {
+          "name": "entity_tag_tag_id_idx",
+          "columns": ["tag_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "entity_tag_tag_id_tag_id_fk": {
+          "name": "entity_tag_tag_id_tag_id_fk",
+          "tableFrom": "entity_tag",
+          "tableTo": "tag",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "entity_tag_entity_type_entity_id_tag_id_pk": {
+          "columns": ["entity_type", "entity_id", "tag_id"],
+          "name": "entity_tag_entity_type_entity_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag": {
+      "name": "tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tag_name_unique": {
+          "name": "tag_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "topic": {
+      "name": "topic",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "is_name_manually_edited": {
+          "name": "is_name_manually_edited",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_node_id": {
+          "name": "active_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "topic_group_updated_idx": {
+          "name": "topic_group_updated_idx",
+          "columns": ["group_id", "updated_at"],
+          "isUnique": false
+        },
+        "topic_updated_at_idx": {
+          "name": "topic_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "topic_group_id_order_key_idx": {
+          "name": "topic_group_id_order_key_idx",
+          "columns": ["group_id", "order_key"],
+          "isUnique": false
+        },
+        "topic_assistant_id_idx": {
+          "name": "topic_assistant_id_idx",
+          "columns": ["assistant_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "topic_assistant_id_assistant_id_fk": {
+          "name": "topic_assistant_id_assistant_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "assistant",
+          "columnsFrom": ["assistant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "topic_group_id_group_id_fk": {
+          "name": "topic_group_id_group_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translate_history": {
+      "name": "translate_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_text": {
+          "name": "target_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_language": {
+          "name": "source_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "star": {
+          "name": "star",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "translate_history_created_at_idx": {
+          "name": "translate_history_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "translate_history_star_created_at_idx": {
+          "name": "translate_history_star_created_at_idx",
+          "columns": ["star", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "translate_history_source_language_translate_language_lang_code_fk": {
+          "name": "translate_history_source_language_translate_language_lang_code_fk",
+          "tableFrom": "translate_history",
+          "tableTo": "translate_language",
+          "columnsFrom": ["source_language"],
+          "columnsTo": ["lang_code"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translate_history_target_language_translate_language_lang_code_fk": {
+          "name": "translate_history_target_language_translate_language_lang_code_fk",
+          "tableFrom": "translate_history",
+          "tableTo": "translate_language",
+          "columnsFrom": ["target_language"],
+          "columnsTo": ["lang_code"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translate_language": {
+      "name": "translate_language",
+      "columns": {
+        "lang_code": {
+          "name": "lang_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_model": {
+      "name": "user_model",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_model_id": {
+          "name": "preset_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_modalities": {
+          "name": "output_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endpoint_types": {
+          "name": "endpoint_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_endpoint_url": {
+          "name": "custom_endpoint_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_input_tokens": {
+          "name": "max_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supports_streaming": {
+          "name": "supports_streaming",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_deprecated": {
+          "name": "is_deprecated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_overrides": {
+          "name": "user_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_model_preset_idx": {
+          "name": "user_model_preset_idx",
+          "columns": ["preset_model_id"],
+          "isUnique": false
+        },
+        "user_model_provider_enabled_idx": {
+          "name": "user_model_provider_enabled_idx",
+          "columns": ["provider_id", "is_enabled"],
+          "isUnique": false
+        },
+        "user_model_provider_id_order_key_idx": {
+          "name": "user_model_provider_id_order_key_idx",
+          "columns": ["provider_id", "order_key"],
+          "isUnique": false
+        },
+        "user_model_provider_model_unique": {
+          "name": "user_model_provider_model_unique",
+          "columns": ["provider_id", "model_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_model_provider_id_user_provider_provider_id_fk": {
+          "name": "user_model_provider_id_user_provider_provider_id_fk",
+          "tableFrom": "user_model",
+          "tableTo": "user_provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["provider_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_provider": {
+      "name": "user_provider",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_provider_id": {
+          "name": "preset_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint_configs": {
+          "name": "endpoint_configs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_chat_endpoint": {
+          "name": "default_chat_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_keys": {
+          "name": "api_keys",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_features": {
+          "name": "api_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_settings": {
+          "name": "provider_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_provider_preset_idx": {
+          "name": "user_provider_preset_idx",
+          "columns": ["preset_provider_id"],
+          "isUnique": false
+        },
+        "user_provider_enabled_idx": {
+          "name": "user_provider_enabled_idx",
+          "columns": ["is_enabled"],
+          "isUnique": false
+        },
+        "user_provider_order_key_idx": {
+          "name": "user_provider_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "fe_external_path_lower_unique_idx": {
+        "columns": {
+          "lower(\"external_path\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/migrations/sqlite-drizzle/meta/_journal.json
+++ b/migrations/sqlite-drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1780732250477,
       "tag": "0004_tough_mephisto",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1780796212083,
+      "tag": "0005_amazing_meltdown",
+      "breakpoints": true
     }
   ]
 }

--- a/src/main/data/db/schemas/__tests__/file.test.ts
+++ b/src/main/data/db/schemas/__tests__/file.test.ts
@@ -147,6 +147,48 @@ describe('fileEntryTable — fe_size_internal_only check', () => {
   })
 })
 
+describe('fileEntryTable — fe_name_no_separators check', () => {
+  const dbh = setupTestDatabase()
+
+  it('rejects a name containing a forward slash', async () => {
+    await expect(dbh.db.insert(fileEntryTable).values(baseInternal({ name: 'dir/doc' }))).rejects.toThrow()
+  })
+
+  it('rejects a name containing a backslash (the #15733 corruption shape: a full Windows path stored as name)', async () => {
+    await expect(
+      dbh.db.insert(fileEntryTable).values(baseExternal('/Users/me/from-windows.pdf', { name: 'C:\\Users\\x\\doc' }))
+    ).rejects.toThrow()
+  })
+})
+
+describe('fileEntryTable — fe_name_not_blank check', () => {
+  const dbh = setupTestDatabase()
+
+  it('rejects an empty name', async () => {
+    await expect(dbh.db.insert(fileEntryTable).values(baseInternal({ name: '' }))).rejects.toThrow()
+  })
+
+  it('rejects an all-whitespace name', async () => {
+    await expect(dbh.db.insert(fileEntryTable).values(baseInternal({ name: '   ' }))).rejects.toThrow()
+  })
+})
+
+describe('fileEntryTable — fe_ext_no_separators check', () => {
+  const dbh = setupTestDatabase()
+
+  it('rejects an ext containing a forward slash (ext composes the physical storage path `{id}.{ext}`)', async () => {
+    await expect(dbh.db.insert(fileEntryTable).values(baseInternal({ ext: 'pdf/../evil' }))).rejects.toThrow()
+  })
+
+  it('rejects an ext containing a backslash', async () => {
+    await expect(dbh.db.insert(fileEntryTable).values(baseInternal({ ext: 'pdf\\evil' }))).rejects.toThrow()
+  })
+
+  it('accepts a null ext (extensionless file)', async () => {
+    await expect(dbh.db.insert(fileEntryTable).values(baseInternal({ ext: null }))).resolves.not.toThrow()
+  })
+})
+
 describe('fileRefTable — CASCADE FK', () => {
   const dbh = setupTestDatabase()
 

--- a/src/main/data/db/schemas/__tests__/knowledge.test.ts
+++ b/src/main/data/db/schemas/__tests__/knowledge.test.ts
@@ -1,0 +1,60 @@
+/**
+ * DB-level integrity tests for the `knowledge_base` schema.
+ *
+ * These exercise the SQLite CHECK constraints — runtime guards we rely on
+ * beyond the Zod layer. Kept separate from Zod-level shape tests (see
+ * `src/shared/__tests__/knowledge-schemas.test.ts`).
+ */
+
+import { randomUUID } from 'node:crypto'
+
+import { knowledgeBaseTable } from '@data/db/schemas/knowledge'
+import { setupTestDatabase } from '@test-helpers/db'
+import { describe, expect, it } from 'vitest'
+
+const TS = 1700000000000
+
+/**
+ * Baseline row in `failed` state: `knowledge_base_status_error_check` is
+ * satisfied without a `user_model` FK target (embeddingModelId stays null).
+ */
+type KnowledgeBaseInsert = typeof knowledgeBaseTable.$inferInsert
+
+function baseKb(overrides: Partial<KnowledgeBaseInsert> = {}): KnowledgeBaseInsert {
+  return {
+    id: randomUUID(),
+    name: 'My KB',
+    groupId: null,
+    dimensions: null,
+    embeddingModelId: null,
+    status: 'failed',
+    error: 'missing_embedding_model',
+    rerankModelId: null,
+    fileProcessorId: null,
+    chunkSize: 1024,
+    chunkOverlap: 200,
+    threshold: null,
+    documentCount: null,
+    searchMode: 'hybrid',
+    hybridAlpha: null,
+    createdAt: TS,
+    updatedAt: TS,
+    ...overrides
+  }
+}
+
+describe('knowledgeBaseTable — knowledge_base_name_not_blank check', () => {
+  const dbh = setupTestDatabase()
+
+  it('accepts a base with a non-blank name', async () => {
+    await expect(dbh.db.insert(knowledgeBaseTable).values(baseKb())).resolves.not.toThrow()
+  })
+
+  it('rejects an empty name', async () => {
+    await expect(dbh.db.insert(knowledgeBaseTable).values(baseKb({ name: '' }))).rejects.toThrow()
+  })
+
+  it('rejects an all-whitespace name (the corruption shape that poisons the strict-parsing list query)', async () => {
+    await expect(dbh.db.insert(knowledgeBaseTable).values(baseKb({ name: '   ' }))).rejects.toThrow()
+  })
+})

--- a/src/main/data/db/schemas/file.ts
+++ b/src/main/data/db/schemas/file.ts
@@ -109,7 +109,22 @@ export const fileEntryTable = sqliteTable(
     check(
       'fe_size_internal_only',
       sql`(${t.origin} = 'internal' AND ${t.size} IS NOT NULL AND ${t.size} >= 0) OR (${t.origin} = 'external' AND ${t.size} IS NULL)`
-    )
+    ),
+    // `name` is a single path segment by architecture: external names are
+    // basename(externalPath) projections, and names flow into FS path
+    // composition (external rename, temp copies). A separator in `name` is
+    // the #15733 corruption shape (a full Windows path stored as name).
+    // Coarse net only — the finer rules (`..`, null bytes, length cap) live
+    // in `SafeNameSchema` and are enforced at the service layer.
+    check('fe_name_no_separators', sql`instr(${t.name}, '/') = 0 AND instr(${t.name}, char(92)) = 0`),
+    // Blank names produce invisible entries and are rejected by the strict
+    // read path. SQLite trim() only strips ASCII spaces — Unicode whitespace
+    // remains the Zod layer's job (coarse net, same as trim() checks on
+    // other tables).
+    check('fe_name_not_blank', sql`length(trim(${t.name})) > 0`),
+    // `ext` composes the physical storage path `{id}.{ext}` for internal
+    // entries — a separator here would escape the managed directory.
+    check('fe_ext_no_separators', sql`${t.ext} IS NULL OR (instr(${t.ext}, '/') = 0 AND instr(${t.ext}, char(92)) = 0)`)
   ]
 )
 

--- a/src/main/data/db/schemas/knowledge.ts
+++ b/src/main/data/db/schemas/knowledge.ts
@@ -60,7 +60,12 @@ export const knowledgeBaseTable = sqliteTable(
           AND length(trim(${t.error})) > 0
         )
       `
-    )
+    ),
+    // `name` is the base's only identity field; a blank name poisons the
+    // strict-parsing list query (read path requires trim().min(1)). SQLite
+    // trim() only strips ASCII spaces — Unicode whitespace remains the Zod
+    // layer's job (coarse net).
+    check('knowledge_base_name_not_blank', sql`length(trim(${t.name})) > 0`)
   ]
 )
 

--- a/src/main/data/migration/v2/migrators/mappings/KnowledgeMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/KnowledgeMappings.ts
@@ -6,8 +6,13 @@ import {
   DEFAULT_KNOWLEDGE_BASE_STATUS,
   DEFAULT_KNOWLEDGE_SEARCH_MODE,
   KNOWLEDGE_BASE_ERROR_MISSING_EMBEDDING_MODEL,
+  KnowledgeBaseNameSchema,
+  KnowledgeDirectoryPathSchema,
   type KnowledgeItemData,
-  type KnowledgeItemStatus
+  KnowledgeItemErrorSchema,
+  KnowledgeItemSourceSchema,
+  type KnowledgeItemStatus,
+  KnowledgeItemUrlSchema
 } from '@shared/data/types/knowledge'
 import { v4 as uuidv4, v7 as uuidv7 } from 'uuid'
 
@@ -140,9 +145,12 @@ const normalizeKnowledgeItemError = (
     return null
   }
 
-  const normalizedError = processingError?.trim()
-  if (normalizedError) {
-    return normalizedError
+  // The read path requires a non-blank error for failed items — validate
+  // with the same field atom (`KnowledgeItemErrorSchema`) instead of a
+  // hand-copied trim check.
+  const parsedError = KnowledgeItemErrorSchema.safeParse(processingError)
+  if (parsedError.success) {
+    return parsedError.data
   }
 
   if (processingStatus === 'pending' || processingStatus === 'processing') {
@@ -238,18 +246,18 @@ export const transformKnowledgeBase = (
   const rerankModelId = legacyModelToUniqueId(base.rerankModel ?? null)
 
   // The identity guard only checks `name !== ''`, so an all-whitespace v1
-  // name reaches here — but the read path (KnowledgeBaseSchema) requires
-  // `trim().min(1)` and one such row poisons the whole list query.
-  // Write-side validation must be >= read-side: trim, and fall back to
-  // the v1 base id when nothing remains.
-  const trimmedName = base.name.trim()
-  if (trimmedName === '') {
+  // name reaches here — but the read path (KnowledgeBaseSchema) rejects it
+  // and one such row poisons the whole list query. Guard with the SAME
+  // field atom the read path is assembled from (no hand-copied rule to
+  // drift), falling back to the v1 base id when the name is unusable.
+  const parsedName = KnowledgeBaseNameSchema.safeParse(base.name)
+  if (!parsedName.success) {
     onWarning?.(`Knowledge base ${base.id} has a blank v1 name; falling back to the base id`)
   }
 
   const transformedBase: NewKnowledgeBase = {
     id: uuidv4(),
-    name: trimmedName || base.id,
+    name: parsedName.success ? parsedName.data : base.id,
     groupId: null,
     dimensions,
     embeddingModelId,
@@ -303,7 +311,9 @@ export const transformKnowledgeItem = (
     type = 'file'
     data = { source: file.path, fileEntryId }
   } else if (item.type === 'url') {
-    if (typeof item.content !== 'string' || item.content.trim() === '') {
+    // `typeof` narrows the legacy content union for TS; the field atom
+    // carries the actual read-path rule (here and in the branches below).
+    if (typeof item.content !== 'string' || !KnowledgeItemUrlSchema.safeParse(item.content).success) {
       return {
         ok: false,
         reason: 'invalid_url'
@@ -316,8 +326,8 @@ export const transformKnowledgeItem = (
       url: item.content
     }
   } else if (item.type === 'sitemap') {
-    const content = typeof item.content === 'string' ? item.content.trim() : ''
-    if (content === '') {
+    const parsedSitemap = KnowledgeItemUrlSchema.safeParse(item.content)
+    if (!parsedSitemap.success) {
       return {
         ok: false,
         reason: 'invalid_sitemap'
@@ -326,11 +336,11 @@ export const transformKnowledgeItem = (
 
     type = 'url'
     data = {
-      source: content,
-      url: content
+      source: parsedSitemap.data,
+      url: parsedSitemap.data
     }
   } else if (item.type === 'directory') {
-    if (typeof item.content !== 'string' || item.content.trim() === '') {
+    if (typeof item.content !== 'string' || !KnowledgeDirectoryPathSchema.safeParse(item.content).success) {
       return {
         ok: false,
         reason: 'invalid_directory'
@@ -351,9 +361,9 @@ export const transformKnowledgeItem = (
     const source = note?.sourceUrl || item.sourceUrl || content
 
     // Sibling branches all guard their source against blank values because
-    // the read path requires `source: trim().min(1)`; a note with neither
-    // sourceUrl nor content has nothing to recover — skip it.
-    if (source.trim() === '') {
+    // the read path rejects them (`KnowledgeItemSourceSchema`); a note with
+    // neither sourceUrl nor content has nothing to recover — skip it.
+    if (!KnowledgeItemSourceSchema.safeParse(source).success) {
       return {
         ok: false,
         reason: 'invalid_note'

--- a/src/main/data/migration/v2/migrators/mappings/__tests__/KnowledgeMappings.test.ts
+++ b/src/main/data/migration/v2/migrators/mappings/__tests__/KnowledgeMappings.test.ts
@@ -313,6 +313,84 @@ describe('KnowledgeMappings', () => {
     expect(result).toStrictEqual({ ok: false, reason: 'invalid_note' })
   })
 
+  it('transformKnowledgeItem skips a url item with whitespace-only content', () => {
+    // Pins the atom-based guard boundary (`KnowledgeItemUrlSchema`): a
+    // future tightening of the atom must surface here as a deliberate
+    // migrator behavior change, not a silent one.
+    const result = transformKnowledgeItem(
+      'kb-1',
+      {
+        id: 'url-blank',
+        type: 'url',
+        content: '   '
+      },
+      {
+        noteById: new Map(),
+        filesById: new Map()
+      }
+    )
+
+    expect(result).toStrictEqual({ ok: false, reason: 'invalid_url' })
+  })
+
+  it('transformKnowledgeItem skips a sitemap item with non-string content', () => {
+    const result = transformKnowledgeItem(
+      'kb-1',
+      {
+        id: 'sitemap-bad',
+        type: 'sitemap',
+        content: { id: 'not-a-string' }
+      },
+      {
+        noteById: new Map(),
+        filesById: new Map()
+      }
+    )
+
+    expect(result).toStrictEqual({ ok: false, reason: 'invalid_sitemap' })
+  })
+
+  it('transformKnowledgeItem maps a sitemap item to a url item with trimmed content', () => {
+    const result = transformKnowledgeItem(
+      'kb-1',
+      {
+        id: 'sitemap-ok',
+        type: 'sitemap',
+        content: '  https://example.com/sitemap.xml  '
+      },
+      {
+        noteById: new Map(),
+        filesById: new Map()
+      }
+    )
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.type).toBe('url')
+      expect(result.value.data).toStrictEqual({
+        source: 'https://example.com/sitemap.xml',
+        url: 'https://example.com/sitemap.xml'
+      })
+    }
+  })
+
+  it('transformKnowledgeItem skips a directory item with whitespace-only content', () => {
+    const result = transformKnowledgeItem(
+      'kb-1',
+      {
+        id: 'dir-blank',
+        type: 'directory',
+        content: '   '
+      },
+      {
+        noteById: new Map(),
+        filesById: new Map()
+      }
+    )
+
+    expect(result).toStrictEqual({ ok: false, reason: 'invalid_directory' })
+  })
+
   it('transformKnowledgeItem keeps a note that has a sourceUrl but empty content', () => {
     const result = transformKnowledgeItem(
       'kb-1',

--- a/src/main/data/services/FileEntryService.ts
+++ b/src/main/data/services/FileEntryService.ts
@@ -23,7 +23,13 @@ import { fileEntryTable, fileRefTable } from '@data/db/schemas/file'
 import { loggerService } from '@logger'
 import { DataApiErrorFactory } from '@shared/data/api'
 import type { CanonicalExternalPath, FileEntry, FileEntryId, FileEntryOrigin } from '@shared/data/types/file'
-import { AbsolutePathSchema, FileEntrySchema, SafeExtSchema, SafeNameSchema } from '@shared/data/types/file'
+import {
+  AbsolutePathSchema,
+  FileEntrySchema,
+  SafeExtSchema,
+  SafeNameSchema,
+  TimestampSchema
+} from '@shared/data/types/file'
 import { and, asc, count, desc, eq, isNotNull, isNull, type SQL, sql } from 'drizzle-orm'
 import { v7 as uuidv7 } from 'uuid'
 import { ZodError } from 'zod'
@@ -431,13 +437,20 @@ class FileEntryServiceImpl implements FileEntryService {
   }
 
   async update(id: FileEntryId, values: UpdateFileEntryRow): Promise<FileEntry> {
-    // Validate user-controlled string columns BEFORE the SQL UPDATE so a
-    // rejected value never persists. Without this, a name failing
-    // `SafeNameSchema` (path separators, `..`, null bytes, > 255 chars)
-    // commits to SQLite first and only fails at `rowToFileEntry`'s
-    // schema parse — leaving the row permanently un-parseable.
+    // Validate caller-controlled columns against their field atoms BEFORE
+    // the SQL UPDATE so a rejected value never persists. Without this, a
+    // value the strict read path rejects — a name with separators / `..` /
+    // null bytes / > 255 chars (`SafeNameSchema`), an ext with a leading dot
+    // or separators (`SafeExtSchema`), a negative or non-integer deletedAt
+    // (`TimestampSchema`) — commits to SQLite first and only fails at
+    // `rowToFileEntry`'s parse, leaving the row permanently un-parseable.
+    // `size` needs no guard here: `fe_size_internal_only` rejects bad values
+    // at the SQL layer. deletedAt is optional on the BO — undefined leaves
+    // it untouched and null restores from trash; only a concrete timestamp
+    // is validated.
     if (values.name !== undefined) SafeNameSchema.parse(values.name)
     if (values.ext !== undefined && values.ext !== null) SafeExtSchema.parse(values.ext)
+    if (values.deletedAt !== undefined && values.deletedAt !== null) TimestampSchema.parse(values.deletedAt)
     const updates: Partial<typeof fileEntryTable.$inferInsert> = {
       updatedAt: Date.now()
     }

--- a/src/main/data/services/FileEntryService.ts
+++ b/src/main/data/services/FileEntryService.ts
@@ -23,7 +23,7 @@ import { fileEntryTable, fileRefTable } from '@data/db/schemas/file'
 import { loggerService } from '@logger'
 import { DataApiErrorFactory } from '@shared/data/api'
 import type { CanonicalExternalPath, FileEntry, FileEntryId, FileEntryOrigin } from '@shared/data/types/file'
-import { AbsolutePathSchema, FileEntrySchema, SafeNameSchema } from '@shared/data/types/file'
+import { AbsolutePathSchema, FileEntrySchema, SafeExtSchema, SafeNameSchema } from '@shared/data/types/file'
 import { and, asc, count, desc, eq, isNotNull, isNull, type SQL, sql } from 'drizzle-orm'
 import { v7 as uuidv7 } from 'uuid'
 import { ZodError } from 'zod'
@@ -408,20 +408,25 @@ class FileEntryServiceImpl implements FileEntryService {
   async create(values: CreateFileEntryRow): Promise<FileEntry> {
     const now = Date.now()
     const id = values.id ?? uuidv7()
-    const rows = await this.getDb()
-      .insert(fileEntryTable)
-      .values({
-        id,
-        origin: values.origin,
-        name: values.name,
-        ext: values.ext,
-        size: values.size,
-        externalPath: values.externalPath,
-        deletedAt: values.deletedAt ?? null,
-        createdAt: now,
-        updatedAt: now
-      })
-      .returning()
+    const row: FileEntryRow = {
+      id,
+      origin: values.origin,
+      name: values.name,
+      ext: values.ext,
+      size: values.size,
+      externalPath: values.externalPath,
+      deletedAt: values.deletedAt ?? null,
+      createdAt: now,
+      updatedAt: now
+    }
+    // Probe the BO projection BEFORE the INSERT so a rejected value never
+    // persists (write/read symmetry, #15740). Same rationale as `update`'s
+    // pre-SQL validation: without this, garbage that passes the coarse DB
+    // CHECKs (e.g. name '..', ext '.pdf', a relative externalPath) commits
+    // first and only fails at the read-back parse — leaving the row
+    // permanently un-parseable for strict point reads.
+    rowToFileEntry(row)
+    const rows = await this.getDb().insert(fileEntryTable).values(row).returning()
     return rowToFileEntry(rows[0])
   }
 
@@ -432,6 +437,7 @@ class FileEntryServiceImpl implements FileEntryService {
     // commits to SQLite first and only fails at `rowToFileEntry`'s
     // schema parse — leaving the row permanently un-parseable.
     if (values.name !== undefined) SafeNameSchema.parse(values.name)
+    if (values.ext !== undefined && values.ext !== null) SafeExtSchema.parse(values.ext)
     const updates: Partial<typeof fileEntryTable.$inferInsert> = {
       updatedAt: Date.now()
     }

--- a/src/main/data/services/FileRefService.ts
+++ b/src/main/data/services/FileRefService.ts
@@ -132,39 +132,40 @@ class FileRefServiceImpl implements FileRefService {
 
   async create(values: CreateFileRefRow): Promise<FileRef> {
     const now = Date.now()
-    const rows = await this.getDb()
-      .insert(fileRefTable)
-      .values({
-        id: uuidv4(),
-        fileEntryId: values.fileEntryId,
-        sourceType: values.sourceType,
-        sourceId: values.sourceId,
-        role: values.role,
-        createdAt: now,
-        updatedAt: now
-      })
-      .returning()
+    const row: FileRefRow = {
+      id: uuidv4(),
+      fileEntryId: values.fileEntryId,
+      sourceType: values.sourceType,
+      sourceId: values.sourceId,
+      role: values.role,
+      createdAt: now,
+      updatedAt: now
+    }
+    // Probe the BO projection BEFORE the INSERT so a rejected value never
+    // persists (write/read symmetry, #15740). The discriminated-union parse
+    // rejects unregistered sourceTypes and per-variant illegal roles that
+    // the free-form DB columns deliberately do not constrain.
+    rowToFileRef(row)
+    const rows = await this.getDb().insert(fileRefTable).values(row).returning()
     return rowToFileRef(rows[0])
   }
 
   async createMany(values: readonly CreateFileRefRow[]): Promise<FileRef[]> {
     if (values.length === 0) return []
     const now = Date.now()
-    const rows = await this.getDb()
-      .insert(fileRefTable)
-      .values(
-        values.map((v) => ({
-          id: uuidv4(),
-          fileEntryId: v.fileEntryId,
-          sourceType: v.sourceType,
-          sourceId: v.sourceId,
-          role: v.role,
-          createdAt: now,
-          updatedAt: now
-        }))
-      )
-      .onConflictDoNothing()
-      .returning()
+    const candidateRows: FileRefRow[] = values.map((v) => ({
+      id: uuidv4(),
+      fileEntryId: v.fileEntryId,
+      sourceType: v.sourceType,
+      sourceId: v.sourceId,
+      role: v.role,
+      createdAt: now,
+      updatedAt: now
+    }))
+    // Same pre-INSERT probe as `create` — one bad row must not poison the
+    // whole batch into the table.
+    candidateRows.forEach(rowToFileRef)
+    const rows = await this.getDb().insert(fileRefTable).values(candidateRows).onConflictDoNothing().returning()
     return rows.map(rowToFileRef)
   }
 

--- a/src/main/data/services/KnowledgeBaseService.ts
+++ b/src/main/data/services/KnowledgeBaseService.ts
@@ -23,9 +23,15 @@ import {
   DEFAULT_KNOWLEDGE_BASE_STATUS,
   DEFAULT_KNOWLEDGE_SEARCH_MODE,
   type KnowledgeBase,
-  KnowledgeBaseSchema
+  KnowledgeBaseSchema,
+  KnowledgeChunkOverlapSchema,
+  KnowledgeChunkSizeSchema,
+  KnowledgeDocumentCountSchema,
+  KnowledgeHybridAlphaSchema,
+  KnowledgeThresholdSchema
 } from '@shared/data/types/knowledge'
 import { and, count as sqlCount, desc, eq, ne, sql } from 'drizzle-orm'
+import { v4 as uuidv4 } from 'uuid'
 
 import { nullsToUndefined, timestampToISO } from './utils/rowMappers'
 
@@ -126,7 +132,9 @@ export class KnowledgeBaseService {
       throw DataApiErrorFactory.validation(createFieldErrors)
     }
 
-    const createValues: Omit<typeof knowledgeBaseTable.$inferInsert, 'id' | 'createdAt' | 'updatedAt'> = {
+    const now = Date.now()
+    const createValues: KnowledgeBaseRow = {
+      id: uuidv4(),
       name: dto.name.trim(),
       groupId: dto.groupId ?? null,
       dimensions: dto.dimensions,
@@ -140,8 +148,17 @@ export class KnowledgeBaseService {
       threshold: dto.threshold ?? null,
       documentCount: dto.documentCount ?? null,
       searchMode: createConfig.searchMode,
-      hybridAlpha: createConfig.hybridAlpha ?? null
+      hybridAlpha: createConfig.hybridAlpha ?? null,
+      createdAt: now,
+      updatedAt: now
     }
+
+    // Probe the BO projection BEFORE the INSERT so a rejected value never
+    // persists (write/read symmetry, #15740). Direct main-process callers
+    // bypass the handler's DTO parse, and business-tunable rules (threshold,
+    // documentCount, chunk bounds, hybridAlpha range) deliberately have no
+    // DB CHECK — this probe is their only non-bypassable write-side guard.
+    rowToKnowledgeBase(createValues)
 
     const dbService = application.get('DbService')
     const row = await dbService.withWriteTx(async (tx) => {
@@ -154,6 +171,16 @@ export class KnowledgeBaseService {
   }
 
   async update(id: string, dto: UpdateKnowledgeBaseDto): Promise<KnowledgeBase> {
+    // Validate the delta against the shared field atoms BEFORE any SQL so a
+    // rejected value never persists (write/read symmetry, #15740). Partial
+    // updates can't be whole-object probed cheaply; the atoms carry the same
+    // truth the strict read path enforces.
+    if (dto.chunkSize !== undefined) KnowledgeChunkSizeSchema.parse(dto.chunkSize)
+    if (dto.chunkOverlap !== undefined) KnowledgeChunkOverlapSchema.parse(dto.chunkOverlap)
+    if (dto.threshold !== undefined) KnowledgeThresholdSchema.parse(dto.threshold)
+    if (dto.documentCount !== undefined) KnowledgeDocumentCountSchema.parse(dto.documentCount)
+    if (dto.hybridAlpha !== undefined) KnowledgeHybridAlphaSchema.parse(dto.hybridAlpha)
+
     const existing = await this.getById(id)
 
     const nextConfig: {

--- a/src/main/data/services/KnowledgeItemService.ts
+++ b/src/main/data/services/KnowledgeItemService.ts
@@ -15,22 +15,41 @@ import { DataApiErrorFactory } from '@shared/data/api'
 import type { ListKnowledgeItemsQuery } from '@shared/data/api/schemas/knowledges'
 import type { FileEntryId } from '@shared/data/types/file'
 import type { KnowledgeItemFileRefRole } from '@shared/data/types/file/ref'
-import { knowledgeItemSourceType } from '@shared/data/types/file/ref'
+import { knowledgeItemRoleSchema, knowledgeItemSourceType } from '@shared/data/types/file/ref'
 import {
   type CreateKnowledgeItemDto,
+  DirectoryItemDataSchema,
+  FileItemDataSchema,
   type KnowledgeItem,
   type KnowledgeItemData,
   KnowledgeItemSchema,
-  type KnowledgeItemStatus
+  type KnowledgeItemStatus,
+  type KnowledgeItemType,
+  KnowledgeItemTypeSchema,
+  NoteItemDataSchema,
+  UrlItemDataSchema
 } from '@shared/data/types/knowledge'
 import { and, desc, eq, inArray, isNull, ne, sql } from 'drizzle-orm'
 import { v4 as uuidv4 } from 'uuid'
+import type * as z from 'zod'
 
 import { knowledgeBaseService } from './KnowledgeBaseService'
 import { timestampToISO } from './utils/rowMappers'
 
 const logger = loggerService.withContext('DataApi:KnowledgeItemService')
 const CONTAINER_CHILD_FAILURE_ERROR = 'One or more child items failed'
+
+/**
+ * Persisted `data` payload truth per item type — the same domain atoms
+ * `KnowledgeItemSchema`'s read-path variants are assembled from. Used by
+ * `create` as the DO-level write guard for the free-form JSON column.
+ */
+const knowledgeItemDataSchemaByType: Record<KnowledgeItemType, z.ZodType<KnowledgeItemData>> = {
+  file: FileItemDataSchema,
+  url: UrlItemDataSchema,
+  note: NoteItemDataSchema,
+  directory: DirectoryItemDataSchema
+}
 
 type KnowledgeItemRow = typeof knowledgeItemTable.$inferSelect
 type KnowledgeItemRowLike = Omit<KnowledgeItemRow, 'data'> & {
@@ -184,6 +203,15 @@ export class KnowledgeItemService {
   }
 
   async create(baseId: string, item: CreateKnowledgeItemDto): Promise<KnowledgeItem> {
+    // DO-level guard BEFORE any SQL (write/read symmetry, #15740): whatever
+    // goes into the free-form `data` JSON column must satisfy the persisted
+    // payload truth for its item type — the same domain data schemas the
+    // strict read path (`KnowledgeItemSchema`) is assembled from, so there
+    // is no second source of truth. DTO-shape validation stays at the API
+    // boundary (handlers); `groupId` is owned by `validateGroupOwnerTx`'s
+    // referential pre-check below. The parsed result is used for the INSERT
+    // so schema normalizations (e.g. trimmed source) persist.
+    const data = knowledgeItemDataSchemaByType[KnowledgeItemTypeSchema.parse(item.type)].parse(item.data)
     const dbService = application.get('DbService')
     const row = await dbService.withWriteTx(async (tx) => {
       await this.validateGroupOwnerTx(tx, baseId, item.groupId)
@@ -208,7 +236,7 @@ export class KnowledgeItemService {
               baseId,
               groupId: item.groupId ?? null,
               type: item.type,
-              data: item.data,
+              data,
               status: 'idle',
               error: null
             })
@@ -434,6 +462,10 @@ export class KnowledgeItemService {
   }
 
   async replaceFileRef(itemId: string, fileEntryId: FileEntryId, role: KnowledgeItemFileRefRole): Promise<void> {
+    // The role brand is TS-only; validate at runtime BEFORE any SQL so an
+    // illegal role never persists into the free-form file_ref columns
+    // (write/read symmetry, #15740).
+    knowledgeItemRoleSchema.parse(role)
     const dbService = application.get('DbService')
     await dbService.withWriteTx(async (tx) => {
       const [item] = await tx

--- a/src/main/data/services/__tests__/FileEntryService.test.ts
+++ b/src/main/data/services/__tests__/FileEntryService.test.ts
@@ -4,7 +4,7 @@ import type { CanonicalExternalPath, FileEntryId } from '@shared/data/types/file
 import { setupTestDatabase } from '@test-helpers/db'
 import { MockMainDbServiceUtils } from '@test-mocks/main/DbService'
 import { mockMainLoggerService } from '@test-mocks/MainLoggerService'
-import { eq } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // `@logger` is mocked globally by tests/main.setup.ts with the unified
@@ -960,9 +960,25 @@ describe('FileEntryService', () => {
     const goodId = '019606a0-0000-7000-8000-00000000aa01' as FileEntryId
     const badId = '019606a0-0000-7000-8000-00000000aa02' as FileEntryId
 
+    /**
+     * Seed rows that violate the schema CHECK constraints — simulating legacy
+     * corrupt data written before the CHECKs existed, or writes that bypassed
+     * them. The read-path isolation under test is the defense-in-depth layer
+     * for exactly those rows. `ignore_check_constraints` is connection-scoped
+     * and restored before any assertion runs.
+     */
+    async function insertBypassingChecks(values: (typeof fileEntryTable.$inferInsert)[]) {
+      await dbh.db.run(sql`PRAGMA ignore_check_constraints = ON`)
+      try {
+        await dbh.db.insert(fileEntryTable).values(values)
+      } finally {
+        await dbh.db.run(sql`PRAGMA ignore_check_constraints = OFF`)
+      }
+    }
+
     async function seedOneGoodOneBad() {
       const now = Date.now()
-      await dbh.db.insert(fileEntryTable).values([
+      await insertBypassingChecks([
         {
           id: goodId,
           origin: 'internal',
@@ -976,8 +992,9 @@ describe('FileEntryService', () => {
         },
         {
           // Simulates pre-fix FileMigrator output: a name carrying path
-          // separators. No DB CHECK guards `name`, so it inserts cleanly
-          // and only SafeNameSchema rejects it at read time.
+          // separators. `fe_name_no_separators` now rejects this at write
+          // time, so the seed bypasses CHECKs to model rows that predate
+          // the constraint; SafeNameSchema still rejects it at read time.
           id: badId,
           origin: 'internal',
           name: 'C:\\Users\\x\\bad',
@@ -1032,7 +1049,7 @@ describe('FileEntryService', () => {
       const badExternalId = '019606a0-0000-7000-8000-00000000aa03' as FileEntryId
       const goodExternalId = '019606a0-0000-7000-8000-00000000aa04' as FileEntryId
       const now = Date.now()
-      await dbh.db.insert(fileEntryTable).values([
+      await insertBypassingChecks([
         {
           id: badExternalId,
           origin: 'external',

--- a/src/main/data/services/__tests__/writeReadSymmetry.test.ts
+++ b/src/main/data/services/__tests__/writeReadSymmetry.test.ts
@@ -1,0 +1,490 @@
+/**
+ * Write/read symmetry contract tests (#15740).
+ *
+ * Contract: after ANY write attempt through a data service write method —
+ * accepted or rejected — every row present in the table must parse through
+ * the service's strict read path. Two failure shapes violate it:
+ *
+ * - the write accepts garbage silently (the bad row persists and strict
+ *   point reads now throw), or
+ * - the write throws only on its post-insert read-back (the bad row is
+ *   already committed — rejected-but-persisted).
+ *
+ * The corpus is a curated adversarial set, not a property search: each case
+ * is either a valid baseline (must be accepted) or a single-invariant
+ * violation (must be cleanly rejected). Structural invariants are expected
+ * to be stopped by the DB CHECK layer; business invariants by the service's
+ * own DO-level guards — services must hold the contract for direct
+ * main-process callers that never pass through DataApi handler DTO parsing.
+ *
+ * Scope: the 4 strict-parse services (the release-gate set agreed in
+ * #15740) — FileEntryService, FileRefService, KnowledgeBaseService,
+ * KnowledgeItemService.
+ */
+
+import { fileEntryTable, fileRefTable } from '@data/db/schemas/file'
+import { knowledgeBaseTable, knowledgeItemTable } from '@data/db/schemas/knowledge'
+import { userModelTable } from '@data/db/schemas/userModel'
+import { userProviderTable } from '@data/db/schemas/userProvider'
+import type { CreateFileEntryRow } from '@data/services/FileEntryService'
+import { fileEntryService } from '@data/services/FileEntryService'
+import type { CreateFileRefRow } from '@data/services/FileRefService'
+import { fileRefService } from '@data/services/FileRefService'
+import { knowledgeBaseService } from '@data/services/KnowledgeBaseService'
+import { knowledgeItemService } from '@data/services/KnowledgeItemService'
+import { generateOrderKeySequence } from '@data/services/utils/orderKey'
+import type { CanonicalExternalPath, FileEntryId } from '@shared/data/types/file'
+import type { KnowledgeItemFileRefRole } from '@shared/data/types/file/ref'
+import { KNOWLEDGE_NOTE_CONTENT_MAX } from '@shared/data/types/knowledge'
+import { createUniqueModelId } from '@shared/data/types/model'
+import { setupTestDatabase } from '@test-helpers/db'
+import { describe, expect, it } from 'vitest'
+
+/** True iff the write attempt threw (no judgement on error type — the
+ *  contract only distinguishes accepted from rejected). */
+async function rejected(write: () => Promise<unknown>): Promise<boolean> {
+  try {
+    await write()
+    return false
+  } catch {
+    return true
+  }
+}
+
+type ContractCase = {
+  label: string
+  accepted: boolean
+  write: () => Promise<unknown>
+}
+
+describe('write/read symmetry contract (#15740)', () => {
+  const dbh = setupTestDatabase()
+
+  // ─── Strict full-table scans (the contract's postcondition) ───
+  // Bulk reads are fault-isolating by design (#15737), so each scan walks
+  // ids raw and replays them through the service's STRICT point-read path.
+
+  async function expectAllFileEntriesParse() {
+    const rows = await dbh.db.select({ id: fileEntryTable.id }).from(fileEntryTable)
+    for (const { id } of rows) {
+      await fileEntryService.findById(id)
+    }
+  }
+
+  async function expectAllFileRefsParse() {
+    const rows = await dbh.db.select({ entryId: fileRefTable.fileEntryId }).from(fileRefTable)
+    for (const { entryId } of rows) {
+      await fileRefService.findByEntryId(entryId)
+    }
+  }
+
+  async function expectAllKnowledgeBasesParse() {
+    const rows = await dbh.db.select({ id: knowledgeBaseTable.id }).from(knowledgeBaseTable)
+    for (const { id } of rows) {
+      await knowledgeBaseService.getById(id)
+    }
+  }
+
+  async function expectAllKnowledgeItemsParse() {
+    const rows = await dbh.db.select({ id: knowledgeItemTable.id }).from(knowledgeItemTable)
+    for (const { id } of rows) {
+      await knowledgeItemService.getById(id)
+    }
+  }
+
+  // ─── Shared seeds ───
+
+  function internalEntry(overrides: Partial<CreateFileEntryRow> = {}): CreateFileEntryRow {
+    return { origin: 'internal', name: 'doc', ext: 'md', size: 10, externalPath: null, ...overrides }
+  }
+
+  function externalEntry(path: string, overrides: Partial<CreateFileEntryRow> = {}): CreateFileEntryRow {
+    return { origin: 'external', name: 'report', ext: 'pdf', size: null, externalPath: path, ...overrides }
+  }
+
+  const EMBED_MODEL_ID = createUniqueModelId('openai', 'embed-model')
+
+  /** FK target for knowledge_base.embedding_model_id → user_model.id */
+  async function seedEmbeddingModel() {
+    const [providerKey, modelKey] = generateOrderKeySequence(2)
+    await dbh.db.insert(userProviderTable).values([{ providerId: 'openai', name: 'OpenAI', orderKey: providerKey }])
+    await dbh.db.insert(userModelTable).values([
+      {
+        id: EMBED_MODEL_ID,
+        providerId: 'openai',
+        modelId: 'embed-model',
+        presetModelId: 'embed-model',
+        name: 'embed-model',
+        isEnabled: true,
+        isHidden: false,
+        orderKey: modelKey
+      }
+    ])
+  }
+
+  async function seedKnowledgeBase(): Promise<string> {
+    await seedEmbeddingModel()
+    const base = await knowledgeBaseService.create({
+      name: 'Contract Base',
+      dimensions: 1536,
+      embeddingModelId: EMBED_MODEL_ID
+    })
+    return base.id
+  }
+
+  // ─── FileEntryService ───
+
+  describe('FileEntryService', () => {
+    const cases: ContractCase[] = [
+      {
+        label: 'create: valid internal baseline is accepted',
+        accepted: true,
+        write: () => fileEntryService.create(internalEntry())
+      },
+      {
+        label: 'create: valid external baseline is accepted',
+        accepted: true,
+        write: () => fileEntryService.create(externalEntry('/Users/me/sym-base.pdf'))
+      },
+      {
+        label: 'create: name with forward slash is rejected (CHECK)',
+        accepted: false,
+        write: () => fileEntryService.create(internalEntry({ name: 'dir/doc' }))
+      },
+      {
+        label: 'create: name as full Windows path is rejected (CHECK, the #15733 shape)',
+        accepted: false,
+        write: () => fileEntryService.create(externalEntry('/Users/me/sym-win.pdf', { name: 'C:\\Users\\x\\doc' }))
+      },
+      {
+        label: 'create: all-whitespace name is rejected (CHECK)',
+        accepted: false,
+        write: () => fileEntryService.create(internalEntry({ name: '   ' }))
+      },
+      {
+        label: 'create: name ".." must not persist',
+        accepted: false,
+        write: () => fileEntryService.create(internalEntry({ name: '..' }))
+      },
+      {
+        label: 'create: name longer than 255 chars must not persist',
+        accepted: false,
+        write: () => fileEntryService.create(internalEntry({ name: 'x'.repeat(300) }))
+      },
+      {
+        label: 'create: name with a null byte must not persist',
+        accepted: false,
+        write: () => fileEntryService.create(internalEntry({ name: 'evil\0doc' }))
+      },
+      {
+        label: 'create: ext with a leading dot must not persist',
+        accepted: false,
+        write: () => fileEntryService.create(internalEntry({ ext: '.pdf' }))
+      },
+      {
+        label: 'create: all-whitespace ext must not persist',
+        accepted: false,
+        write: () => fileEntryService.create(internalEntry({ ext: '   ' }))
+      },
+      {
+        label: 'create: relative externalPath must not persist',
+        accepted: false,
+        write: () => fileEntryService.create(externalEntry('relative/path.txt'))
+      },
+      {
+        label: 'create: negative internal size is rejected (CHECK)',
+        accepted: false,
+        write: () => fileEntryService.create(internalEntry({ size: -1 }))
+      },
+      {
+        label: 'update: name with separators is rejected pre-SQL (existing guard)',
+        accepted: false,
+        write: async () => {
+          const entry = await fileEntryService.create(internalEntry())
+          return fileEntryService.update(entry.id, { name: 'a/b' })
+        }
+      },
+      {
+        label: 'update: ext with a leading dot must not persist',
+        accepted: false,
+        write: async () => {
+          const entry = await fileEntryService.create(internalEntry())
+          return fileEntryService.update(entry.id, { ext: '.png' })
+        }
+      },
+      {
+        label: 'update: clearing ext to null is accepted',
+        accepted: true,
+        write: async () => {
+          const entry = await fileEntryService.create(internalEntry())
+          return fileEntryService.update(entry.id, { ext: null })
+        }
+      },
+      {
+        label: 'setExternalPathAndName: relative path is rejected pre-SQL (existing guard)',
+        accepted: false,
+        write: async () => {
+          const entry = await fileEntryService.create(externalEntry('/Users/me/sym-move.pdf'))
+          return fileEntryService.setExternalPathAndName(entry.id, 'rel/p.pdf' as CanonicalExternalPath, 'p')
+        }
+      }
+    ]
+
+    it.each(cases)('$label', async ({ accepted, write }) => {
+      expect(await rejected(write)).toBe(!accepted)
+      await expectAllFileEntriesParse()
+    })
+  })
+
+  // ─── FileRefService ───
+
+  describe('FileRefService', () => {
+    async function seedEntryId(): Promise<FileEntryId> {
+      const entry = await fileEntryService.create(internalEntry())
+      return entry.id
+    }
+
+    const cases: ContractCase[] = [
+      {
+        label: 'create: valid temp_session ref is accepted',
+        accepted: true,
+        write: async () => {
+          const fileEntryId = await seedEntryId()
+          return fileRefService.create({ fileEntryId, sourceType: 'temp_session', sourceId: 'sess-1', role: 'pending' })
+        }
+      },
+      {
+        label: 'create: unregistered sourceType must not persist',
+        accepted: false,
+        write: async () => {
+          const fileEntryId = await seedEntryId()
+          const values = { fileEntryId, sourceType: 'note_legacy', sourceId: 's-1', role: 'pending' }
+          return fileRefService.create(values as unknown as CreateFileRefRow)
+        }
+      },
+      {
+        label: 'create: role outside the variant enum must not persist',
+        accepted: false,
+        write: async () => {
+          const fileEntryId = await seedEntryId()
+          return fileRefService.create({ fileEntryId, sourceType: 'temp_session', sourceId: 's-1', role: 'attachment' })
+        }
+      },
+      {
+        label: 'create: empty sourceId must not persist',
+        accepted: false,
+        write: async () => {
+          const fileEntryId = await seedEntryId()
+          return fileRefService.create({ fileEntryId, sourceType: 'temp_session', sourceId: '', role: 'pending' })
+        }
+      },
+      {
+        label: 'createMany: a bad row in the batch must not persist',
+        accepted: false,
+        write: async () => {
+          const fileEntryId = await seedEntryId()
+          return fileRefService.createMany([
+            { fileEntryId, sourceType: 'temp_session', sourceId: 'good', role: 'pending' },
+            { fileEntryId, sourceType: 'temp_session', sourceId: 'bad', role: 'attachment' }
+          ])
+        }
+      }
+    ]
+
+    it.each(cases)('$label', async ({ accepted, write }) => {
+      expect(await rejected(write)).toBe(!accepted)
+      await expectAllFileRefsParse()
+    })
+  })
+
+  // ─── KnowledgeBaseService ───
+
+  describe('KnowledgeBaseService', () => {
+    const validDto = () => ({
+      name: 'Contract Base',
+      dimensions: 1536,
+      embeddingModelId: EMBED_MODEL_ID
+    })
+
+    const cases: ContractCase[] = [
+      {
+        label: 'create: valid baseline is accepted',
+        accepted: true,
+        write: async () => {
+          await seedEmbeddingModel()
+          return knowledgeBaseService.create(validDto())
+        }
+      },
+      {
+        label: 'create: empty name is rejected (CHECK)',
+        accepted: false,
+        write: async () => {
+          await seedEmbeddingModel()
+          return knowledgeBaseService.create({ ...validDto(), name: '' })
+        }
+      },
+      {
+        label: 'create: ideographic-space name is rejected (JS trim + CHECK)',
+        accepted: false,
+        write: async () => {
+          await seedEmbeddingModel()
+          return knowledgeBaseService.create({ ...validDto(), name: '　' })
+        }
+      },
+      {
+        label: 'create: threshold outside [0,1] must not persist',
+        accepted: false,
+        write: async () => {
+          await seedEmbeddingModel()
+          return knowledgeBaseService.create({ ...validDto(), threshold: 5 })
+        }
+      },
+      {
+        label: 'create: non-positive documentCount must not persist',
+        accepted: false,
+        write: async () => {
+          await seedEmbeddingModel()
+          return knowledgeBaseService.create({ ...validDto(), documentCount: 0 })
+        }
+      },
+      {
+        label: 'create: negative chunk config must not persist',
+        accepted: false,
+        write: async () => {
+          await seedEmbeddingModel()
+          return knowledgeBaseService.create({ ...validDto(), chunkSize: -5, chunkOverlap: -10 })
+        }
+      },
+      {
+        label: 'create: hybridAlpha outside [0,1] must not persist',
+        accepted: false,
+        write: async () => {
+          await seedEmbeddingModel()
+          return knowledgeBaseService.create({ ...validDto(), searchMode: 'hybrid', hybridAlpha: 2 })
+        }
+      },
+      {
+        label: 'create: non-positive dimensions is rejected (CHECK)',
+        accepted: false,
+        write: async () => {
+          await seedEmbeddingModel()
+          return knowledgeBaseService.create({ ...validDto(), dimensions: 0 })
+        }
+      },
+      {
+        label: 'update: empty name is rejected (CHECK)',
+        accepted: false,
+        write: async () => {
+          const baseId = await seedKnowledgeBase()
+          return knowledgeBaseService.update(baseId, { name: '' })
+        }
+      },
+      {
+        label: 'update: threshold outside [0,1] must not persist',
+        accepted: false,
+        write: async () => {
+          const baseId = await seedKnowledgeBase()
+          return knowledgeBaseService.update(baseId, { threshold: 5 })
+        }
+      },
+      {
+        label: 'update: negative chunk config must not persist',
+        accepted: false,
+        write: async () => {
+          const baseId = await seedKnowledgeBase()
+          return knowledgeBaseService.update(baseId, { chunkSize: -5, chunkOverlap: -10 })
+        }
+      }
+    ]
+
+    it.each(cases)('$label', async ({ accepted, write }) => {
+      expect(await rejected(write)).toBe(!accepted)
+      await expectAllKnowledgeBasesParse()
+    })
+  })
+
+  // ─── KnowledgeItemService ───
+
+  describe('KnowledgeItemService', () => {
+    const cases: ContractCase[] = [
+      {
+        label: 'create: valid note item is accepted',
+        accepted: true,
+        write: async () => {
+          const baseId = await seedKnowledgeBase()
+          return knowledgeItemService.create(baseId, { type: 'note', data: { source: 'note', content: 'hello' } })
+        }
+      },
+      {
+        label: 'create: note with empty source must not persist',
+        accepted: false,
+        write: async () => {
+          const baseId = await seedKnowledgeBase()
+          return knowledgeItemService.create(baseId, { type: 'note', data: { source: '', content: 'hello' } })
+        }
+      },
+      {
+        label: 'create: url item with empty url must not persist',
+        accepted: false,
+        write: async () => {
+          const baseId = await seedKnowledgeBase()
+          return knowledgeItemService.create(baseId, { type: 'url', data: { source: 'site', url: '' } })
+        }
+      },
+      {
+        label: 'create: note content above the size cap must not persist',
+        accepted: false,
+        write: async () => {
+          const baseId = await seedKnowledgeBase()
+          return knowledgeItemService.create(baseId, {
+            type: 'note',
+            data: { source: 'big', content: 'x'.repeat(KNOWLEDGE_NOTE_CONTENT_MAX + 1) }
+          })
+        }
+      },
+      {
+        label: 'create: file item with missing fileEntryId is rejected (existing pre-check)',
+        accepted: false,
+        write: async () => {
+          const baseId = await seedKnowledgeBase()
+          return knowledgeItemService.create(baseId, {
+            type: 'file',
+            data: { source: 'f', fileEntryId: '019606a0-0000-7000-8000-00000000ffff' as FileEntryId }
+          })
+        }
+      },
+      {
+        label: 'updateStatus: failed with blank error is rejected (existing guard)',
+        accepted: false,
+        write: async () => {
+          const baseId = await seedKnowledgeBase()
+          const item = await knowledgeItemService.create(baseId, {
+            type: 'note',
+            data: { source: 'note', content: 'hello' }
+          })
+          return knowledgeItemService.updateStatus(item.id, 'failed', { error: '   ' })
+        }
+      }
+    ]
+
+    it.each(cases)('$label', async ({ accepted, write }) => {
+      expect(await rejected(write)).toBe(!accepted)
+      await expectAllKnowledgeItemsParse()
+    })
+
+    it('replaceFileRef: role outside the variant enum must not persist', async () => {
+      const baseId = await seedKnowledgeBase()
+      const entry = await fileEntryService.create(internalEntry())
+      const item = await knowledgeItemService.create(baseId, {
+        type: 'note',
+        data: { source: 'note', content: 'hello' }
+      })
+      expect(
+        await rejected(() =>
+          knowledgeItemService.replaceFileRef(item.id, entry.id, 'garbage' as KnowledgeItemFileRefRole)
+        )
+      ).toBe(true)
+      await expectAllFileRefsParse()
+    })
+  })
+})

--- a/src/main/data/services/__tests__/writeReadSymmetry.test.ts
+++ b/src/main/data/services/__tests__/writeReadSymmetry.test.ts
@@ -147,17 +147,17 @@ describe('write/read symmetry contract (#15740)', () => {
         write: () => fileEntryService.create(externalEntry('/Users/me/sym-base.pdf'))
       },
       {
-        label: 'create: name with forward slash is rejected (CHECK)',
+        label: 'create: name with forward slash is rejected (probe; CHECK backstop)',
         accepted: false,
         write: () => fileEntryService.create(internalEntry({ name: 'dir/doc' }))
       },
       {
-        label: 'create: name as full Windows path is rejected (CHECK, the #15733 shape)',
+        label: 'create: name as full Windows path is rejected (probe; CHECK backstop — the #15733 shape)',
         accepted: false,
         write: () => fileEntryService.create(externalEntry('/Users/me/sym-win.pdf', { name: 'C:\\Users\\x\\doc' }))
       },
       {
-        label: 'create: all-whitespace name is rejected (CHECK)',
+        label: 'create: all-whitespace name is rejected (probe; CHECK backstop)',
         accepted: false,
         write: () => fileEntryService.create(internalEntry({ name: '   ' }))
       },
@@ -192,7 +192,7 @@ describe('write/read symmetry contract (#15740)', () => {
         write: () => fileEntryService.create(externalEntry('relative/path.txt'))
       },
       {
-        label: 'create: negative internal size is rejected (CHECK)',
+        label: 'create: negative internal size is rejected (probe; CHECK backstop)',
         accepted: false,
         write: () => fileEntryService.create(internalEntry({ size: -1 }))
       },
@@ -218,6 +218,30 @@ describe('write/read symmetry contract (#15740)', () => {
         write: async () => {
           const entry = await fileEntryService.create(internalEntry())
           return fileEntryService.update(entry.id, { ext: null })
+        }
+      },
+      {
+        label: 'update: negative deletedAt must not persist',
+        accepted: false,
+        write: async () => {
+          const entry = await fileEntryService.create(internalEntry())
+          return fileEntryService.update(entry.id, { deletedAt: -1 })
+        }
+      },
+      {
+        label: 'update: non-integer deletedAt must not persist',
+        accepted: false,
+        write: async () => {
+          const entry = await fileEntryService.create(internalEntry())
+          return fileEntryService.update(entry.id, { deletedAt: 1.5 })
+        }
+      },
+      {
+        label: 'update: restoring from trash (deletedAt: null) is accepted — deletedAt is optional on the BO',
+        accepted: true,
+        write: async () => {
+          const entry = await fileEntryService.create(internalEntry({ deletedAt: 1700000000000 }))
+          return fileEntryService.update(entry.id, { deletedAt: null })
         }
       },
       {
@@ -316,7 +340,7 @@ describe('write/read symmetry contract (#15740)', () => {
         }
       },
       {
-        label: 'create: empty name is rejected (CHECK)',
+        label: 'create: empty name is rejected (probe; CHECK backstop)',
         accepted: false,
         write: async () => {
           await seedEmbeddingModel()
@@ -324,7 +348,7 @@ describe('write/read symmetry contract (#15740)', () => {
         }
       },
       {
-        label: 'create: ideographic-space name is rejected (JS trim + CHECK)',
+        label: 'create: ideographic-space name is rejected (service trim + probe; CHECK backstop)',
         accepted: false,
         write: async () => {
           await seedEmbeddingModel()
@@ -364,7 +388,7 @@ describe('write/read symmetry contract (#15740)', () => {
         }
       },
       {
-        label: 'create: non-positive dimensions is rejected (CHECK)',
+        label: 'create: non-positive dimensions is rejected (probe; CHECK backstop)',
         accepted: false,
         write: async () => {
           await seedEmbeddingModel()
@@ -463,6 +487,20 @@ describe('write/read symmetry contract (#15740)', () => {
             data: { source: 'note', content: 'hello' }
           })
           return knowledgeItemService.updateStatus(item.id, 'failed', { error: '   ' })
+        }
+      },
+      {
+        // `setSubtreeStatus` has its own hand-written blank-error guard,
+        // independent from `updateStatus`'s — pin both parallel paths.
+        label: 'setSubtreeStatus: failed with blank error is rejected (existing guard)',
+        accepted: false,
+        write: async () => {
+          const baseId = await seedKnowledgeBase()
+          const item = await knowledgeItemService.create(baseId, {
+            type: 'note',
+            data: { source: 'note', content: 'hello' }
+          })
+          return knowledgeItemService.setSubtreeStatus(baseId, [item.id], 'failed', { error: '   ' })
         }
       }
     ]

--- a/src/shared/data/types/knowledge.ts
+++ b/src/shared/data/types/knowledge.ts
@@ -91,6 +91,22 @@ export const DEFAULT_KNOWLEDGE_BASE_CHUNK_OVERLAP = 200
 export const KNOWLEDGE_RUNTIME_ITEMS_MAX = 100
 export const KNOWLEDGE_NOTE_CONTENT_MAX = 1_000_000
 
+// ─── Field atoms ───
+// Single shared truth for field rules consumed from multiple layers: the BO
+// object schemas below, service DO write guards, and migrator probes all
+// reference these atoms instead of restating the rule. Inlining a rule in an
+// object schema leaves guards nothing to reference, so they hand-copy it —
+// which is how the migrator's `name !== ''` drifted from the read path's
+// `trim().min(1)` and let a blank-name base poison the list query (#15737).
+export const KnowledgeBaseNameSchema = z.string().trim().min(1)
+export const KnowledgeBaseDimensionsSchema = z.number().int().positive()
+export const KnowledgeEmbeddingModelIdSchema = z.string().trim().min(1)
+export const KnowledgeItemSourceSchema = z.string().trim().min(1)
+export const KnowledgeItemUrlSchema = z.string().trim().min(1)
+export const KnowledgeNoteContentSchema = z.string().max(KNOWLEDGE_NOTE_CONTENT_MAX)
+export const KnowledgeDirectoryPathSchema = z.string().trim().min(1)
+export const KnowledgeItemErrorSchema = z.string().trim().min(1)
+
 // ============================================================================
 // Knowledge Base Entity
 // ============================================================================
@@ -100,10 +116,10 @@ export const KNOWLEDGE_NOTE_CONTENT_MAX = 1_000_000
  */
 export const KnowledgeBaseEntitySchema = z.strictObject({
   id: KnowledgeBaseIdSchema,
-  name: z.string().trim().min(1),
+  name: KnowledgeBaseNameSchema,
   groupId: GroupIdSchema.nullable(),
-  dimensions: z.number().int().positive().nullable(),
-  embeddingModelId: z.string().trim().min(1).nullable(),
+  dimensions: KnowledgeBaseDimensionsSchema.nullable(),
+  embeddingModelId: KnowledgeEmbeddingModelIdSchema.nullable(),
   status: KnowledgeBaseStatusSchema,
   error: KnowledgeBaseErrorCodeSchema.nullable(),
   rerankModelId: z.string().nullable().optional(),
@@ -176,7 +192,7 @@ export type KnowledgeBase = z.infer<typeof KnowledgeBaseSchema>
 // ============================================================================
 
 const KnowledgeItemSharedSchema = z.strictObject({
-  source: z.string().trim().min(1).describe('Original user-facing source identifier for the knowledge item.')
+  source: KnowledgeItemSourceSchema.describe('Original user-facing source identifier for the knowledge item.')
 })
 
 /**
@@ -190,14 +206,14 @@ export const FileItemDataSchema = KnowledgeItemSharedSchema.extend({
  * URL item data.
  */
 export const UrlItemDataSchema = KnowledgeItemSharedSchema.extend({
-  url: z.string().trim().min(1).describe('URL to read and index.')
+  url: KnowledgeItemUrlSchema.describe('URL to read and index.')
 })
 
 /**
  * Note item data.
  */
 export const NoteItemDataSchema = KnowledgeItemSharedSchema.extend({
-  content: z.string().max(KNOWLEDGE_NOTE_CONTENT_MAX).describe('Plain text note content to index.'),
+  content: KnowledgeNoteContentSchema.describe('Plain text note content to index.'),
   sourceUrl: z.string().optional().describe('Optional external URL associated with the note.')
 })
 
@@ -205,7 +221,7 @@ export const NoteItemDataSchema = KnowledgeItemSharedSchema.extend({
  * Directory item data.
  */
 export const DirectoryItemDataSchema = KnowledgeItemSharedSchema.extend({
-  path: z.string().trim().min(1).describe('Directory path to expand into child file or directory items.')
+  path: KnowledgeDirectoryPathSchema.describe('Directory path to expand into child file or directory items.')
 })
 
 /**
@@ -272,7 +288,7 @@ const DeletingKnowledgeItemLifecycleSchema = {
 
 const FailedKnowledgeItemLifecycleSchema = {
   status: z.literal('failed').describe('Workflow failed.'),
-  error: z.string().trim().min(1).describe('Non-empty failure message for failed items.')
+  error: KnowledgeItemErrorSchema.describe('Non-empty failure message for failed items.')
 } as const
 
 const createLeafKnowledgeItemEntitySchemas = <TType extends KnowledgeItemType, TData extends z.ZodType>(
@@ -390,7 +406,7 @@ export type KnowledgeItemOf<T extends KnowledgeItemType> = Extract<KnowledgeItem
 export const KnowledgeChunkMetadataSchema = z.strictObject({
   itemId: KnowledgeItemIdSchema,
   itemType: KnowledgeItemTypeSchema,
-  source: z.string().trim().min(1),
+  source: KnowledgeItemSourceSchema,
   chunkIndex: z.number().int().min(0),
   tokenCount: z.number().int().min(0)
 })
@@ -424,8 +440,8 @@ export type KnowledgeItemChunk = z.infer<typeof KnowledgeItemChunkSchema>
 // ============================================================================
 
 const KnowledgeBaseRuntimeConfigSchema = z.strictObject({
-  dimensions: z.number().int().positive(),
-  embeddingModelId: z.string().trim().min(1),
+  dimensions: KnowledgeBaseDimensionsSchema,
+  embeddingModelId: KnowledgeEmbeddingModelIdSchema,
   rerankModelId: z.string().nullable().optional(),
   fileProcessorId: z.string().nullable().optional(),
   chunkSize: KnowledgeChunkSizeSchema.optional(),
@@ -459,20 +475,20 @@ const refineRuntimeConfig = (value: z.infer<typeof KnowledgeBaseRuntimeConfigSch
  * orchestration creates the SQLite row and initializes the vector store.
  */
 export const CreateKnowledgeBaseSchema = KnowledgeBaseRuntimeConfigSchema.extend({
-  name: z.string().trim().min(1),
+  name: KnowledgeBaseNameSchema,
   groupId: KnowledgeBaseGroupIdInputSchema.optional()
 }).superRefine(refineRuntimeConfig)
 export type CreateKnowledgeBaseDto = z.input<typeof CreateKnowledgeBaseSchema>
 
 export const RestoreKnowledgeBaseSchema = z.strictObject({
   sourceBaseId: z.string().trim().pipe(KnowledgeBaseIdSchema),
-  name: z.string().trim().min(1),
+  name: KnowledgeBaseNameSchema,
   // Dimensions must be the resolved embedding vector size for embeddingModelId.
   // Automatic callers should fill this from AI Core dimension detection; manual
   // callers are responsible for confirming the value matches the selected model.
   // Restore validates shape only and does not probe the model again server-side.
-  dimensions: z.number().int().positive(),
-  embeddingModelId: z.string().trim().min(1)
+  dimensions: KnowledgeBaseDimensionsSchema,
+  embeddingModelId: KnowledgeEmbeddingModelIdSchema
 })
 export type RestoreKnowledgeBaseDto = z.input<typeof RestoreKnowledgeBaseSchema>
 


### PR DESCRIPTION
### What this PR does

Before this PR:

The write side of the 4 strict-parse data services (`FileEntryService`, `FileRefService`, `KnowledgeBaseService`, `KnowledgeItemService`) could persist rows that their own strict read path rejects — either by accepting garbage silently or by throwing only on the post-insert read-back with the row already committed. This is the write-side half of the #15733 incident class; #15737 only added read-side fault isolation.

After this PR, three layers close the write side:

1. **Structural DB CHECKs** (coarse net, `4f8174b9`): `fe_name_no_separators` (the #15733 corruption shape), `fe_name_not_blank`, `fe_ext_no_separators` (ext composes the physical storage path `{id}.{ext}`), `knowledge_base_name_not_blank` (the blank-name shape that poisoned list queries). Deliberately minimal — only stable structural invariants; business-tunable rules stay in Zod where changes need no migration.
2. **Write/read symmetry contract tests** (`4c83fb5a`): `writeReadSymmetry.test.ts` asserts that after ANY write attempt — accepted or rejected — every persisted row parses through the strict read path. 21 of 39 adversarial corpus cases failed before the guards.
3. **Pre-SQL DO guards in the services** (`4c83fb5a`) + **field-atom extraction** (`e01cab7d`): `create()` paths probe the BO projection before the INSERT (reusing the existing strict row mappers — no second source of truth); `update()` paths validate deltas with shared field atoms; `knowledge.ts`'s 14 inlined field rules are extracted into 8 named atoms (`KnowledgeBaseNameSchema`, …) and the KnowledgeMappings migrator guards now reference those atoms instead of hand-copying trim checks — the exact drift shape that caused the blank-name incident.

Part of #15740 (intentionally does **not** close it — remaining follow-ups are tracked there).

### Why we need it and why it was done in this way

Main-process modules may call data services directly, bypassing DataApi handler DTO parsing — so correctness validation must live in the service methods themselves (#15740 decision). All guards are DO-level: they reference the domain truth (strict row mappers / domain field atoms), never API-boundary DTO schemas.

The following tradeoffs were made:

- DB CHECKs only encode invariants that survive any plausible business evolution (path-segment-ness, non-blank identity fields). SQLite `trim()` only strips ASCII spaces — the CHECK layer is intentionally weaker than Zod; the service guards carry the full truth.
- `KnowledgeItemService.create()` validates the `data` JSON payload per type but leaves `groupId` to `validateGroupOwnerTx`, whose referential pre-check already keeps garbage out of the INSERT and produces curated diagnostics.

The following alternatives were considered:

- Layer 1 (branded `Validated<T>` type) and Layer 2 (write gateway + schema registry) from the issue's structural-guarantee spectrum — deferred until the CHECK + contract-test core is shown insufficient (per review discussion in #15740).

Links to places where the discussion took place: #15740 (design addendum + review by @0xfullex)

### Breaking changes

None user-facing. Dev-only note: migration 0005 rebuilds `file_entry` / `knowledge_base` to add the CHECKs, so a dev DB containing rows that violate them will fail to migrate — acceptable mid-development drift per the v2 migration policy (`migrations/sqlite-drizzle` is wiped and regenerated before release).

### Special notes for your reviewer

- **Hand-fix inside `0005_amazing_meltdown.sql`**: drizzle-kit's table-recreate path emits the functional index expression `lower("external_path")` as a backtick-quoted identifier, which fails to apply ("no such column"). The SQL is hand-corrected to the bare expression form (matching 0000); the snapshot is untouched, so `db:migrations:generate` stays a no-op and CI's drift check passes. This recurs on any future `file_entry` recreate until the pre-release migration regeneration.
- Read-path fault-isolation tests now seed their corrupt rows via `PRAGMA ignore_check_constraints` — they model legacy rows that predate the CHECKs, which is exactly what read-side isolation defends against.
- Follow-ups deliberately out of scope (tracked in #15740): service signature refactor (DTO types out of service signatures; `UpdateKnowledgeBaseDto` & `List*Query` currently import from `api/schemas` into services), `BaseMigrator.insertWithProbe()` affordance, bulk-read isolation for the remaining 3 strict-parse services.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
