### PR TITLE
feat(reasoning): add MiniMax M3 thinking control support

### DIFF
--- a/patches/@ai-sdk__anthropic.patch
+++ b/patches/@ai-sdk__anthropic.patch
@@ -27,11 +27,61 @@ index 468e7518923b5bfaffa3a5a601e233b5271889ae..8a20d03b8186bb35c2ddce6a50997a44
        ...((anthropicOptions == null ? void 0 : anthropicOptions.effort) || (anthropicOptions == null ? void 0 : anthropicOptions.taskBudget) || useStructuredOutput && (responseFormat == null ? void 0 : responseFormat.type) === "json" && responseFormat.schema != null) && {
          output_config: {
            ...(anthropicOptions == null ? void 0 : anthropicOptions.effort) && {
-@@ -3217,7 +3220,9 @@ var AnthropicMessagesLanguageModel = class {
-           details: "topP is not supported when thinking is enabled"
-         });
+@@ -3196,31 +3199,35 @@ var AnthropicMessagesLanguageModel = class {
+         };
+         thinkingBudget = 1024;
        }
+-      if (baseArgs.temperature != null) {
+-        baseArgs.temperature = void 0;
+-        warnings.push({
+-          type: "unsupported",
+-          feature: "temperature",
+-          details: "temperature is not supported when thinking is enabled"
+-        });
+-      }
+-      if (topK != null) {
+-        baseArgs.top_k = void 0;
+-        warnings.push({
+-          type: "unsupported",
+-          feature: "topK",
+-          details: "topK is not supported when thinking is enabled"
+-        });
+-      }
+-      if (topP != null) {
+-        baseArgs.top_p = void 0;
+-        warnings.push({
+-          type: "unsupported",
+-          feature: "topP",
+-          details: "topP is not supported when thinking is enabled"
+-        });
+-      }
 -      baseArgs.max_tokens = maxTokens + (thinkingBudget != null ? thinkingBudget : 0);
++      if (isAnthropicModel) {
++        if (baseArgs.temperature != null) {
++          baseArgs.temperature = void 0;
++          warnings.push({
++            type: "unsupported",
++            feature: "temperature",
++            details: "temperature is not supported when thinking is enabled"
++          });
++        }
++        if (topK != null) {
++          baseArgs.top_k = void 0;
++          warnings.push({
++            type: "unsupported",
++            feature: "topK",
++            details: "topK is not supported when thinking is enabled"
++          });
++        }
++        if (topP != null) {
++          baseArgs.top_p = void 0;
++          warnings.push({
++            type: "unsupported",
++            feature: "topP",
++            details: "topP is not supported when thinking is enabled"
++          });
++        }
++      }
 +      if (maxTokens != null) {
 +        baseArgs.max_tokens = maxTokens + (thinkingBudget != null ? thinkingBudget : 0);
 +      }
@@ -67,11 +117,61 @@ index 6e9ff51dd8ccc4785ecd423ec34a84eba8a7d42d..a601f20a3d15672f55b35ee78980de3a
        ...((anthropicOptions == null ? void 0 : anthropicOptions.effort) || (anthropicOptions == null ? void 0 : anthropicOptions.taskBudget) || useStructuredOutput && (responseFormat == null ? void 0 : responseFormat.type) === "json" && responseFormat.schema != null) && {
          output_config: {
            ...(anthropicOptions == null ? void 0 : anthropicOptions.effort) && {
-@@ -3246,7 +3249,9 @@ var AnthropicMessagesLanguageModel = class {
-           details: "topP is not supported when thinking is enabled"
-         });
+@@ -3228,31 +3231,35 @@ var AnthropicMessagesLanguageModel = class {
+         };
+         thinkingBudget = 1024;
        }
+-      if (baseArgs.temperature != null) {
+-        baseArgs.temperature = void 0;
+-        warnings.push({
+-          type: "unsupported",
+-          feature: "temperature",
+-          details: "temperature is not supported when thinking is enabled"
+-        });
+-      }
+-      if (topK != null) {
+-        baseArgs.top_k = void 0;
+-        warnings.push({
+-          type: "unsupported",
+-          feature: "topK",
+-          details: "topK is not supported when thinking is enabled"
+-        });
+-      }
+-      if (topP != null) {
+-        baseArgs.top_p = void 0;
+-        warnings.push({
+-          type: "unsupported",
+-          feature: "topP",
+-          details: "topP is not supported when thinking is enabled"
+-        });
+-      }
 -      baseArgs.max_tokens = maxTokens + (thinkingBudget != null ? thinkingBudget : 0);
++      if (isAnthropicModel) {
++        if (baseArgs.temperature != null) {
++          baseArgs.temperature = void 0;
++          warnings.push({
++            type: "unsupported",
++            feature: "temperature",
++            details: "temperature is not supported when thinking is enabled"
++          });
++        }
++        if (topK != null) {
++          baseArgs.top_k = void 0;
++          warnings.push({
++            type: "unsupported",
++            feature: "topK",
++            details: "topK is not supported when thinking is enabled"
++          });
++        }
++        if (topP != null) {
++          baseArgs.top_p = void 0;
++          warnings.push({
++            type: "unsupported",
++            feature: "topP",
++            details: "topP is not supported when thinking is enabled"
++          });
++        }
++      }
 +      if (maxTokens != null) {
 +        baseArgs.max_tokens = maxTokens + (thinkingBudget != null ? thinkingBudget : 0);
 +      }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ overrides:
 
 patchedDependencies:
   '@ai-sdk/anthropic':
-    hash: 9e459da7b108668e23131b383077b3c254fe1cc93a51768da3615f4489299af9
+    hash: 64d9ea96c222d27c248c5414b4a9b130451e0b2c3552e94edbbd05a52951e627
     path: patches/@ai-sdk__anthropic.patch
   '@ai-sdk/deepseek@2.0.30':
     hash: db4c4c1e60c18e61952ec4432de7a401adf44420bdbfe4bb6f726a8958642790
@@ -189,7 +189,7 @@ importers:
         version: 4.0.96(zod@4.3.4)
       '@ai-sdk/anthropic':
         specifier: ^3.0.71
-        version: 3.0.71(patch_hash=9e459da7b108668e23131b383077b3c254fe1cc93a51768da3615f4489299af9)(zod@4.3.4)
+        version: 3.0.71(patch_hash=64d9ea96c222d27c248c5414b4a9b130451e0b2c3552e94edbbd05a52951e627)(zod@4.3.4)
       '@ai-sdk/azure':
         specifier: ^3.0.54
         version: 3.0.54(zod@4.3.4)
@@ -1303,7 +1303,7 @@ importers:
     dependencies:
       '@ai-sdk/anthropic':
         specifier: ^3.0.71
-        version: 3.0.71(patch_hash=9e459da7b108668e23131b383077b3c254fe1cc93a51768da3615f4489299af9)(zod@4.3.6)
+        version: 3.0.71(patch_hash=64d9ea96c222d27c248c5414b4a9b130451e0b2c3552e94edbbd05a52951e627)(zod@4.3.6)
       '@ai-sdk/google':
         specifier: ^3.0.64
         version: 3.0.64(patch_hash=3dbdd2fbbe5a44bc23a04b1195329dd8d78043447e925342ad5ed53c8c3b96ec)(zod@4.3.6)
@@ -1334,7 +1334,7 @@ importers:
     dependencies:
       '@ai-sdk/anthropic':
         specifier: ^3.0.71
-        version: 3.0.71(patch_hash=9e459da7b108668e23131b383077b3c254fe1cc93a51768da3615f4489299af9)(zod@4.3.4)
+        version: 3.0.71(patch_hash=64d9ea96c222d27c248c5414b4a9b130451e0b2c3552e94edbbd05a52951e627)(zod@4.3.4)
       '@ai-sdk/azure':
         specifier: ^3.0.54
         version: 3.0.54(zod@4.3.4)
@@ -12933,7 +12933,7 @@ snapshots:
 
   '@ai-sdk/amazon-bedrock@4.0.96(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/anthropic': 3.0.71(patch_hash=9e459da7b108668e23131b383077b3c254fe1cc93a51768da3615f4489299af9)(zod@4.3.4)
+      '@ai-sdk/anthropic': 3.0.71(patch_hash=64d9ea96c222d27c248c5414b4a9b130451e0b2c3552e94edbbd05a52951e627)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.4)
       '@smithy/eventstream-codec': 4.2.14
@@ -12941,13 +12941,13 @@ snapshots:
       aws4fetch: 1.0.20
       zod: 4.3.4
 
-  '@ai-sdk/anthropic@3.0.71(patch_hash=9e459da7b108668e23131b383077b3c254fe1cc93a51768da3615f4489299af9)(zod@4.3.4)':
+  '@ai-sdk/anthropic@3.0.71(patch_hash=64d9ea96c222d27c248c5414b4a9b130451e0b2c3552e94edbbd05a52951e627)(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/anthropic@3.0.71(patch_hash=9e459da7b108668e23131b383077b3c254fe1cc93a51768da3615f4489299af9)(zod@4.3.6)':
+  '@ai-sdk/anthropic@3.0.71(patch_hash=64d9ea96c222d27c248c5414b4a9b130451e0b2c3552e94edbbd05a52951e627)(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
@@ -12995,7 +12995,7 @@ snapshots:
 
   '@ai-sdk/google-vertex@4.0.112(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/anthropic': 3.0.71(patch_hash=9e459da7b108668e23131b383077b3c254fe1cc93a51768da3615f4489299af9)(zod@4.3.4)
+      '@ai-sdk/anthropic': 3.0.71(patch_hash=64d9ea96c222d27c248c5414b4a9b130451e0b2c3552e94edbbd05a52951e627)(zod@4.3.4)
       '@ai-sdk/google': 3.0.64(patch_hash=3dbdd2fbbe5a44bc23a04b1195329dd8d78043447e925342ad5ed53c8c3b96ec)(zod@4.3.4)
       '@ai-sdk/openai-compatible': 2.0.41(zod@4.3.4)
       '@ai-sdk/provider': 3.0.8

--- a/scripts/__tests__/anthropic-compatible-thinking.test.ts
+++ b/scripts/__tests__/anthropic-compatible-thinking.test.ts
@@ -1,0 +1,85 @@
+import { AnthropicMessagesLanguageModel } from '@ai-sdk/anthropic/internal'
+import { describe, expect, it } from 'vitest'
+
+type CapturedRequest = {
+  body?: Record<string, unknown>
+}
+
+const createModel = (modelId: string, captured: CapturedRequest) =>
+  new AnthropicMessagesLanguageModel(modelId as any, {
+    provider: 'test.anthropic',
+    baseURL: 'https://example.com',
+    headers: () => ({ 'x-api-key': 'test-key' }),
+    supportedUrls: () => ({}),
+    fetch: async (_url, init) => {
+      captured.body = JSON.parse(String(init?.body))
+
+      return new Response(
+        JSON.stringify({
+          id: 'msg_test',
+          type: 'message',
+          role: 'assistant',
+          model: modelId,
+          content: [{ type: 'text', text: 'ok' }],
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: {
+            input_tokens: 1,
+            output_tokens: 1
+          }
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' }
+        }
+      )
+    }
+  })
+
+const generateWithThinkingAndSampling = async (modelId: string) => {
+  const captured: CapturedRequest = {}
+  const model = createModel(modelId, captured)
+
+  await model.doGenerate({
+    prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+    maxOutputTokens: 128,
+    temperature: 0.3,
+    topK: 40,
+    topP: 0.9,
+    providerOptions: {
+      anthropic: {
+        thinking: { type: 'adaptive' }
+      }
+    }
+  })
+
+  return captured.body
+}
+
+describe('@ai-sdk/anthropic compatible thinking patch', () => {
+  it('keeps sampling parameters for Anthropic-compatible non-Claude models', async () => {
+    const body = await generateWithThinkingAndSampling('MiniMax-M3')
+
+    expect(body).toMatchObject({
+      model: 'MiniMax-M3',
+      max_tokens: 128,
+      temperature: 0.3,
+      top_k: 40,
+      top_p: 0.9,
+      thinking: { type: 'adaptive' }
+    })
+  })
+
+  it('keeps Claude native sampling guard when thinking is enabled', async () => {
+    const body = await generateWithThinkingAndSampling('claude-3-7-sonnet-latest')
+
+    expect(body).toMatchObject({
+      model: 'claude-3-7-sonnet-latest',
+      max_tokens: 128,
+      thinking: { type: 'adaptive' }
+    })
+    expect(body).not.toHaveProperty('temperature')
+    expect(body).not.toHaveProperty('top_k')
+    expect(body).not.toHaveProperty('top_p')
+  })
+})

--- a/scripts/__tests__/anthropic-compatible-thinking.test.ts
+++ b/scripts/__tests__/anthropic-compatible-thinking.test.ts
@@ -1,11 +1,19 @@
 import { AnthropicMessagesLanguageModel } from '@ai-sdk/anthropic/internal'
 import { describe, expect, it } from 'vitest'
 
-type CapturedRequest = {
+interface CapturedRequest {
   body?: Record<string, unknown>
 }
 
-const createModel = (modelId: string, captured: CapturedRequest) =>
+type ThinkingType = 'adaptive' | 'disabled'
+
+interface GenerateOptions {
+  thinkingType?: ThinkingType
+  maxOutputTokens?: number
+  omitMaxOutputTokens?: boolean
+}
+
+const createModel = (modelId: string, captured: CapturedRequest): AnthropicMessagesLanguageModel =>
   new AnthropicMessagesLanguageModel(modelId as any, {
     provider: 'test.anthropic',
     baseURL: 'https://example.com',
@@ -36,19 +44,22 @@ const createModel = (modelId: string, captured: CapturedRequest) =>
     }
   })
 
-const generateWithThinkingAndSampling = async (modelId: string) => {
+const generateWithThinkingAndSampling = async (
+  modelId: string,
+  { thinkingType = 'adaptive', maxOutputTokens = 128, omitMaxOutputTokens = false }: GenerateOptions = {}
+): Promise<CapturedRequest['body']> => {
   const captured: CapturedRequest = {}
   const model = createModel(modelId, captured)
 
   await model.doGenerate({
     prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
-    maxOutputTokens: 128,
+    maxOutputTokens: omitMaxOutputTokens ? undefined : maxOutputTokens,
     temperature: 0.3,
     topK: 40,
     topP: 0.9,
     providerOptions: {
       anthropic: {
-        thinking: { type: 'adaptive' }
+        thinking: { type: thinkingType }
       }
     }
   })
@@ -81,5 +92,29 @@ describe('@ai-sdk/anthropic compatible thinking patch', () => {
     expect(body).not.toHaveProperty('temperature')
     expect(body).not.toHaveProperty('top_k')
     expect(body).not.toHaveProperty('top_p')
+  })
+
+  it('passes disabled thinking through for Claude and Anthropic-compatible models', async () => {
+    const minimaxBody = await generateWithThinkingAndSampling('MiniMax-M3', { thinkingType: 'disabled' })
+    const claudeBody = await generateWithThinkingAndSampling('claude-3-7-sonnet-latest', { thinkingType: 'disabled' })
+
+    expect(minimaxBody).toMatchObject({
+      model: 'MiniMax-M3',
+      thinking: { type: 'disabled' }
+    })
+    expect(claudeBody).toMatchObject({
+      model: 'claude-3-7-sonnet-latest',
+      thinking: { type: 'disabled' }
+    })
+  })
+
+  it('omits max_tokens for Anthropic-compatible non-Claude models when no limit is provided', async () => {
+    const body = await generateWithThinkingAndSampling('MiniMax-M3', { omitMaxOutputTokens: true })
+
+    expect(body).toMatchObject({
+      model: 'MiniMax-M3',
+      thinking: { type: 'adaptive' }
+    })
+    expect(body).not.toHaveProperty('max_tokens')
   })
 })

--- a/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
+++ b/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
@@ -69,6 +69,8 @@ vi.mock('@renderer/config/models', async (importOriginal) => {
   return {
     ...actual,
     isReasoningModel: vi.fn(() => false),
+    isMiniMaxReasoningModel: vi.fn(() => false),
+    isMiniMaxM3SeriesModel: vi.fn(() => false),
     isOpenAIDeepResearchModel: vi.fn(() => false),
     isOpenAIModel: vi.fn(() => false),
     isSupportedReasoningEffortOpenAIModel: vi.fn(() => false),
@@ -704,6 +706,49 @@ describe('reasoning utils', () => {
         })
       })
 
+      describe('minimax models', () => {
+        const createMiniMaxModel = (id: string): Model =>
+          ({
+            id,
+            name: id,
+            provider: 'minimax'
+          }) as Model
+
+        const createAssistantWithReasoning = (effort: string | undefined): Assistant =>
+          ({
+            id: 'test',
+            name: 'Test',
+            settings: {
+              reasoning_effort: effort as any
+            }
+          }) as Assistant
+
+        describe.each([
+          {
+            name: 'M3 / default',
+            isM3: true,
+            effort: 'default',
+            expected: { thinking: { type: 'adaptive' as const } }
+          },
+          { name: 'M3 / none', isM3: true, effort: 'none', expected: { thinking: { type: 'disabled' as const } } },
+          { name: 'M2.x / default', isM3: false, effort: 'default', expected: {} },
+          { name: 'M2.x / none', isM3: false, effort: 'none', expected: {} }
+        ])('$name', ({ isM3, effort, expected }) => {
+          it(`returns ${JSON.stringify(expected)}`, async () => {
+            const { isReasoningModel, isMiniMaxReasoningModel, isMiniMaxM3SeriesModel } = await import(
+              '@renderer/config/models'
+            )
+            vi.mocked(isReasoningModel).mockReturnValue(true)
+            vi.mocked(isMiniMaxReasoningModel).mockReturnValue(true)
+            vi.mocked(isMiniMaxM3SeriesModel).mockReturnValue(isM3)
+
+            const model = createMiniMaxModel(isM3 ? 'minimax-m3' : 'minimax-m2.7')
+            const assistant = createAssistantWithReasoning(effort)
+            expect(getReasoningEffort(assistant, model)).toEqual(expected)
+          })
+        })
+      })
+
       describe('edge cases', () => {
         it('should return {} for non-reasoning Mistral models', async () => {
           // isReasoningModel returns false by default in the top-level mock
@@ -1271,6 +1316,65 @@ describe('reasoning utils', () => {
         sendReasoning: true
       })
       expect(result).not.toHaveProperty('effort')
+    })
+
+    describe.each([
+      {
+        name: 'M3 / none',
+        isM3: true,
+        modelId: 'minimax-m3',
+        effort: 'none',
+        expected: { thinking: { type: 'disabled' as const }, sendReasoning: true }
+      },
+      {
+        name: 'M3 / default',
+        isM3: true,
+        modelId: 'minimax-m3',
+        effort: 'default',
+        expected: { thinking: { type: 'adaptive' as const }, sendReasoning: true }
+      },
+      {
+        name: 'M2.x / none',
+        isM3: false,
+        modelId: 'minimax-m2.7',
+        effort: 'none',
+        expected: {}
+      },
+      {
+        name: 'M2.x / default',
+        isM3: false,
+        modelId: 'minimax-m2.7',
+        effort: 'default',
+        expected: {}
+      }
+    ])('MiniMax on Anthropic endpoint — $name', ({ isM3, modelId, effort, expected }) => {
+      it(`returns ${JSON.stringify(expected)}`, async () => {
+        const {
+          isReasoningModel,
+          isSupportedThinkingTokenClaudeModel,
+          isMiniMaxReasoningModel,
+          isMiniMaxM3SeriesModel
+        } = await import('@renderer/config/models')
+
+        vi.mocked(isReasoningModel).mockReturnValue(true)
+        vi.mocked(isSupportedThinkingTokenClaudeModel).mockReturnValue(false)
+        vi.mocked(isMiniMaxReasoningModel).mockReturnValue(true)
+        vi.mocked(isMiniMaxM3SeriesModel).mockReturnValue(isM3)
+
+        const model: Model = {
+          id: modelId,
+          name: modelId,
+          provider: 'custom-provider'
+        } as Model
+
+        const assistant: Assistant = {
+          id: 'test',
+          name: 'Test',
+          settings: { reasoning_effort: effort }
+        } as Assistant
+
+        expect(getAnthropicReasoningParams(assistant, model)).toEqual(expected)
+      })
     })
   })
 

--- a/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
+++ b/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
@@ -724,10 +724,12 @@ describe('reasoning utils', () => {
           }) as Assistant
 
         describe.each([
+          { name: 'M3 / unset', isM3: true, effort: undefined, expected: {} },
+          { name: 'M3 / default', isM3: true, effort: 'default', expected: {} },
           {
-            name: 'M3 / default',
+            name: 'M3 / auto',
             isM3: true,
-            effort: 'default',
+            effort: 'auto',
             expected: { thinking: { type: 'adaptive' as const } }
           },
           { name: 'M3 / none', isM3: true, effort: 'none', expected: { thinking: { type: 'disabled' as const } } },
@@ -1327,10 +1329,24 @@ describe('reasoning utils', () => {
         expected: { thinking: { type: 'disabled' as const }, sendReasoning: true }
       },
       {
+        name: 'M3 / unset',
+        isM3: true,
+        modelId: 'minimax-m3',
+        effort: undefined,
+        expected: {}
+      },
+      {
         name: 'M3 / default',
         isM3: true,
         modelId: 'minimax-m3',
         effort: 'default',
+        expected: {}
+      },
+      {
+        name: 'M3 / auto',
+        isM3: true,
+        modelId: 'minimax-m3',
+        effort: 'auto',
         expected: { thinking: { type: 'adaptive' as const }, sendReasoning: true }
       },
       {

--- a/src/renderer/src/aiCore/utils/reasoning.ts
+++ b/src/renderer/src/aiCore/utils/reasoning.ts
@@ -19,6 +19,7 @@ import {
   isGemini3ThinkingTokenModel,
   isGrok4FastReasoningModel,
   isHostedGemma4ThinkingModel,
+  isMiniMaxM3SeriesModel,
   isMiniMaxReasoningModel,
   isOpenAIDeepResearchModel,
   isOpenAIModel,
@@ -56,7 +57,7 @@ import type { OllamaProviderOptions } from 'ollama-ai-provider-v2'
 const logger = loggerService.withContext('reasoning')
 
 type ReasoningEffortOptionalParams = {
-  thinking?: { type: 'disabled' | 'enabled' | 'auto'; budget_tokens?: number }
+  thinking?: { type: 'disabled' | 'enabled' | 'auto' | 'adaptive'; budget_tokens?: number }
   reasoning?: { max_tokens?: number; exclude?: boolean; effort?: string; enabled?: boolean } | OpenAI.Reasoning
   reasoningEffort?: OpenAIReasoningEffort
   // WARN: This field will be overwrite to undefined by aisdk if the provider is openai-compatible. Use reasoningEffort instead.
@@ -88,6 +89,21 @@ type ReasoningEffortOptionalParams = {
   // Add any other potential reasoning-related keys here if they exist
 }
 
+/**
+ * Resolve the MiniMax M3 thinking directive from the assistant's reasoning_effort.
+ * Returns 'adaptive' / 'disabled' for M3 only; undefined for M2.x and non-MiniMax
+ * models so callers can leave the M2.x path to the generic Claude-endpoint branch.
+ *
+ * MiniMax docs (https://platform.minimaxi.com/docs/api-reference/text-anthropic-api):
+ *   - thinking.type: 'adaptive'   → keep thinking on
+ *   - thinking.type: 'disabled'   → turn thinking off (M3 only; ignored on M2.x)
+ *   - omitted                      → on by default
+ */
+function getMiniMaxThinkingType(assistant: Assistant, model: Model): 'adaptive' | 'disabled' | undefined {
+  if (!isMiniMaxM3SeriesModel(model)) return undefined
+  return assistant?.settings?.reasoning_effort === 'none' ? 'disabled' : 'adaptive'
+}
+
 // The function is only for generic provider. May extract some logics to independent provider
 export function getReasoningEffort(assistant: Assistant, model: Model): ReasoningEffortOptionalParams {
   const provider = getProviderByModel(model)
@@ -100,15 +116,24 @@ export function getReasoningEffort(assistant: Assistant, model: Model): Reasonin
     return {}
   }
 
-  // MiniMax models: always enable thinking to ensure <think> tags in response
-  // This must be before the reasoningEffort check because MiniMax needs thinking
-  // to be explicitly enabled regardless of the user's reasoning effort setting
+  // MiniMax M3 only accepts the Anthropic-protocol thinking shape
+  // (type: 'adaptive' | 'disabled'). M2.x cannot be controlled at all
+  // and falls through to the generic Anthropic-endpoint branch below,
+  // which emits sendReasoning: true to stream reasoning back to the UI.
+  const m3ThinkingType = getMiniMaxThinkingType(assistant, model)
+  if (m3ThinkingType) {
+    return { thinking: { type: m3ThinkingType } }
+  }
   if (isMiniMaxReasoningModel(model)) {
-    const reasoningEffort = assistant?.settings?.reasoning_effort
-    if (reasoningEffort === 'none') {
-      return { thinking: { type: 'disabled' } }
-    }
-    return { thinking: { type: 'enabled' } }
+    // M2.x: API has no controllable thinking directive.
+    // Per https://platform.minimaxi.com/docs/api-reference/text-anthropic-api
+    // M2.x thinking "cannot be turned off" — the API defaults to thinking-on
+    // and silently ignores type: 'enabled' | 'disabled'. We rely on that
+    // default rather than emitting a dead 'enabled' byte. If MiniMax ever
+    // changes the default, M2.x users would silently lose thinking output;
+    // revisit by switching to a sentinelled return (e.g. { thinking: { type: 'enabled' } })
+    // once the upstream documents a stable on-by-default contract.
+    return {}
   }
 
   if (isOpenAIDeepResearchModel(model)) {
@@ -724,6 +749,27 @@ export function getAnthropicReasoningParams(
   sendReasoning?: AnthropicProviderOptions['sendReasoning']
 } {
   if (!isReasoningModel(model)) {
+    return {}
+  }
+
+  // MiniMax M3 only accepts the Anthropic-protocol thinking shape
+  // (type: 'adaptive' | 'disabled'). M2.x is intercepted here because its
+  // API rejects every controllable directive: thinking cannot be turned
+  // off and the model does not understand 'enabled' + budgetTokens. The
+  // only safe answer is {} — let the API default to thinking-on.
+  const m3ThinkingType = getMiniMaxThinkingType(assistant, model)
+  if (m3ThinkingType) {
+    return { thinking: { type: m3ThinkingType }, sendReasoning: true }
+  }
+  if (isMiniMaxReasoningModel(model)) {
+    // M2.x on the Anthropic endpoint: API has no controllable thinking
+    // directive. Per https://platform.minimaxi.com/docs/api-reference/text-anthropic-api
+    // M2.x thinking "cannot be turned off" — the API defaults to thinking-on
+    // and silently ignores every directive we could send. Returning {} here
+    // also means sendReasoning is NOT set, but the upstream's reasoning
+    // content is still surfaced via the default thinking-on path (the
+    // reasoning block is part of the response, not gated by sendReasoning).
+    // See the matching comment in getReasoningEffort for the trade-off.
     return {}
   }
 

--- a/src/renderer/src/aiCore/utils/reasoning.ts
+++ b/src/renderer/src/aiCore/utils/reasoning.ts
@@ -91,17 +91,21 @@ type ReasoningEffortOptionalParams = {
 
 /**
  * Resolve the MiniMax M3 thinking directive from the assistant's reasoning_effort.
- * Returns 'adaptive' / 'disabled' for M3 only; undefined for M2.x and non-MiniMax
- * models so callers can leave the M2.x path to the generic Claude-endpoint branch.
+ * Returns 'adaptive' / 'disabled' for M3 only; undefined for M2.x, non-MiniMax
+ * models, or when reasoning_effort is unset/default (API defaults to thinking-off).
  *
  * MiniMax docs (https://platform.minimaxi.com/docs/api-reference/text-anthropic-api):
- *   - thinking.type: 'adaptive'   → keep thinking on
+ *   - thinking.type: 'adaptive'   → keep thinking on (only when user picks 'auto')
  *   - thinking.type: 'disabled'   → turn thinking off (M3 only; ignored on M2.x)
- *   - omitted                      → on by default
+ *   - omitted (undefined/default) → thinking OFF by default
  */
 function getMiniMaxThinkingType(assistant: Assistant, model: Model): 'adaptive' | 'disabled' | undefined {
   if (!isMiniMaxM3SeriesModel(model)) return undefined
-  return assistant?.settings?.reasoning_effort === 'none' ? 'disabled' : 'adaptive'
+  const effort = assistant?.settings?.reasoning_effort
+  if (effort === 'none') return 'disabled'
+  if (effort === 'auto') return 'adaptive'
+  // undefined / 'default': don't send thinking param — API default is thinking-off
+  return undefined
 }
 
 // The function is only for generic provider. May extract some logics to independent provider

--- a/src/renderer/src/config/models/__tests__/reasoning.test.ts
+++ b/src/renderer/src/config/models/__tests__/reasoning.test.ts
@@ -21,6 +21,7 @@ import {
   isInterleavedThinkingModel,
   isKimiReasoningModel,
   isLingReasoningModel,
+  isMiniMaxM3SeriesModel,
   isMiniMaxReasoningModel,
   isPerplexityReasoningModel,
   isQwenAlwaysThinkModel,
@@ -353,6 +354,19 @@ describe('Claude & regional providers', () => {
     expect(isMiniMaxReasoningModel(createModel({ id: 'minimax-m2.7' }))).toBe(true)
     expect(isMiniMaxReasoningModel(createModel({ id: 'minimax-m2.7-highspeed' }))).toBe(true)
     expect(isMiniMaxReasoningModel(createModel({ id: 'minimax-m3' }))).toBe(true)
+    expect(isMiniMaxM3SeriesModel(createModel({ id: 'minimax-m3' }))).toBe(true)
+    expect(isMiniMaxM3SeriesModel(createModel({ id: 'minimax-m3.1' }))).toBe(true)
+    expect(isMiniMaxM3SeriesModel(createModel({ id: 'minimax-m3.5' }))).toBe(true)
+    expect(isMiniMaxM3SeriesModel(createModel({ id: 'minimax-m3-highspeed' }))).toBe(true)
+    // All -xxx / .xxx suffixes are accepted as M3 series variants
+    expect(isMiniMaxM3SeriesModel(createModel({ id: 'minimax-m3-ultra' }))).toBe(true)
+    expect(isMiniMaxM3SeriesModel(createModel({ id: 'minimax-m3-preview' }))).toBe(true)
+    expect(isMiniMaxM3SeriesModel(createModel({ id: 'minimax-m3-turbo' }))).toBe(true)
+    expect(isMiniMaxM3SeriesModel(createModel({ id: 'minimax-m3-ultra.1' }))).toBe(true)
+    // Separate model lines remain excluded
+    expect(isMiniMaxM3SeriesModel(createModel({ id: 'minimax-m2.7' }))).toBe(false)
+    expect(isMiniMaxM3SeriesModel(createModel({ id: 'minimax-m30' }))).toBe(false)
+    expect(isMiniMaxM3SeriesModel(createModel({ id: 'minimax-m300' }))).toBe(false)
   })
 })
 

--- a/src/renderer/src/config/models/reasoning.ts
+++ b/src/renderer/src/config/models/reasoning.ts
@@ -91,7 +91,13 @@ export const MODEL_SUPPORTED_REASONING_EFFORT = {
   claude: ['low', 'medium', 'high'] as const,
   // Claude 4.6 supports low, medium, high, xhigh (xhigh is mapped to max in API)
   claude46: ['low', 'medium', 'high', 'xhigh'] as const,
-  mistral: ['high'] as const
+  mistral: ['high'] as const,
+  // MiniMax M3 supports on/off thinking only — no graded effort levels.
+  // 'auto' = on (M3 emits { thinking: { type: 'adaptive' } }); the 'none'
+  // off-mode is already provided by the uniform 'default' + 'none' prefix
+  // in MODEL_SUPPORTED_OPTIONS. Mirrors the pattern used by grok4_fast,
+  // hunyuan, mimo, and zhipu for binary on/off models.
+  minimax_m3: ['auto'] as const
 } as const satisfies ReasoningEffortConfig
 
 // Model type to supported options mapping
@@ -132,7 +138,8 @@ export const MODEL_SUPPORTED_OPTIONS: ThinkingOptionConfig = {
   kimi_k2_5: ['default', ...MODEL_SUPPORTED_REASONING_EFFORT.kimi_k2_5] as const,
   claude: ['default', 'none', ...MODEL_SUPPORTED_REASONING_EFFORT.claude] as const,
   claude46: ['default', 'none', ...MODEL_SUPPORTED_REASONING_EFFORT.claude46] as const,
-  mistral: ['default', 'none', ...MODEL_SUPPORTED_REASONING_EFFORT.mistral] as const
+  mistral: ['default', 'none', ...MODEL_SUPPORTED_REASONING_EFFORT.mistral] as const,
+  minimax_m3: ['default', 'none', ...MODEL_SUPPORTED_REASONING_EFFORT.minimax_m3] as const
 } as const
 
 // TODO: add ut
@@ -230,6 +237,8 @@ const _getThinkModelType = (model: Model): ThinkingModelType => {
     thinkingModelType = 'kimi_k2_5'
   } else if (isMistralReasoningModel(model)) {
     thinkingModelType = 'mistral'
+  } else if (isMiniMaxM3SeriesModel(model)) {
+    thinkingModelType = 'minimax_m3'
   }
   return thinkingModelType
 }
@@ -319,7 +328,14 @@ function _isSupportedThinkingTokenModel(model: Model): boolean {
     isSupportedThinkingTokenZhipuModel(model) ||
     isSupportedThinkingTokenMiMoModel(model) ||
     isSupportedThinkingTokenKimiModel(model) ||
-    isSupportedThinkingTokenDeepSeekModel(model)
+    isSupportedThinkingTokenDeepSeekModel(model) ||
+    // MiniMax M3 has no budgetTokens control, but we still route it through
+    // this chain so useAssistant.ts (isSupportedThinkingTokenModel ||
+    // isSupportedReasoningEffortModel) picks up the ['default', 'none', 'auto']
+    // options and getThinkModelType resolves to 'minimax_m3'. The actual
+    // thinking shape (type: 'adaptive' | 'disabled') is emitted by
+    // getReasoningEffort / getAnthropicReasoningParams — not via budgetTokens.
+    isMiniMaxM3SeriesModel(model)
   )
 }
 
@@ -765,6 +781,25 @@ export const isMiniMaxReasoningModel = (model?: Model): boolean => {
   return (['minimax-m1', 'minimax-m2', 'minimax-m2.1', 'minimax-m2.5', 'minimax-m2.7', 'minimax-m3'] as const).some(
     (id) => modelId.includes(id)
   )
+}
+
+const _isMiniMaxM3SeriesModel = (model: Model): boolean => {
+  const modelId = getLowerBaseModelName(model.id, '/')
+  // Matches the M3 series and its variants: `minimax-m3`, `minimax-m3.1`,
+  // `minimax-m3.5`, `minimax-m3-highspeed`, `minimax-m3-ultra`,
+  // `minimax-m3-preview`, and any future `-xxx` suffix. Excludes
+  // `m30` / `m300` (the sub-version group requires a leading `.`,
+  // and suffix groups require a leading `.` or `-`, neither of which
+  // `m30` provides).
+  return /(\b|[.-])minimax-m3(\.\d+)?([.-][\w-]+)*$/.test(modelId)
+}
+
+export function isMiniMaxM3SeriesModel(model?: Model): boolean {
+  if (!model) {
+    return false
+  }
+  const { idResult, nameResult } = withModelIdAndNameAsId(model, _isMiniMaxM3SeriesModel)
+  return idResult || nameResult
 }
 
 export const isBaichuanReasoningModel = (model?: Model): boolean => {

--- a/src/renderer/src/hooks/useAssistant.ts
+++ b/src/renderer/src/hooks/useAssistant.ts
@@ -123,6 +123,8 @@ export function useAssistant(id: string) {
           } else {
             // 灵活回退到支持的值
             // 注意：这里假设可用的options不会为空
+            // 有 reasoning_effort 时优先用分级 effort（M3 等 'auto' 模型落这里），
+            // 没有 reasoning_effort 时落回 'default'，保留与 git HEAD 一致的"未设置→default"语义。
             const enableThinking = currentReasoningEffort !== undefined
             fallbackOption = enableThinking
               ? MODEL_SUPPORTED_REASONING_EFFORT[modelType][0]

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -132,7 +132,8 @@ const ThinkModelTypes = [
   'kimi_k2_5',
   'claude',
   'claude46',
-  'mistral'
+  'mistral',
+  'minimax_m3'
 ] as const
 
 /** If the model's reasoning effort could be controlled, or its reasoning behavior could be turned on/off.


### PR DESCRIPTION
<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR:
- Cherry Studio had no first-class support for the MiniMax M3 model family. Models matching `minimax-m3*` were either routed through generic (Kimi / DeepSeek) code paths or misclassified, leaving the M3-specific `thinking: { type: 'adaptive' | 'disabled' }` shape unsupported.
- The `useAssistant` fallback silently simplified the 3-state `enableThinking` branch down to a single `??` chain, changing the persisted `reasoning_effort` from `'default'` to `'auto'` whenever a user first switched to a binary on/off model.

After this PR:
- M3 (and its variants — `minimax-m3`, `minimax-m3.1`, `minimax-m3.5`, `minimax-m3-highspeed`, `minimax-m3-ultra`, `minimax-m3-preview`, etc.) is recognized as a reasoning model via a new `isMiniMaxM3SeriesModel` predicate, exposed in the reasoning-effort UI as `['default', 'none', 'auto']`.
- `getReasoningEffort` and `getAnthropicReasoningParams` route M3 through a shared `getMiniMaxThinkingType` helper, emitting `{ thinking: { type: 'adaptive' } }` (or `'disabled'` when the user picks `none`).
- M2.x continues to fall through to `{}` — relies on the documented MiniMax default that M2.x thinking "cannot be turned off"; the trade-off is documented inline so future maintainers know the upstream contract they depend on.
- The `useAssistant` fallback is restored to the original 3-state `enableThinking` branch, preserving the historical "unset → `default`" semantics.

Fix #15789 

### Why we need it and why it was done in this way

The MiniMax M3 family exposes thinking control through a non-standard shape that no existing Cherry Studio branch handled. Per the [MiniMax Anthropic API reference](https://platform.minimaxi.com/docs/api-reference/text-anthropic-api) and the [MiniMax OpenAI-compatible API reference](https://platform.minimaxi.com/docs/api-reference/text-openai-api), M3 accepts only the following `thinking` directive:

- `{"type": "adaptive"}` — keep thinking on (M3-specific, identical to "enabled" for older models)
- `{"type": "disabled"}` — turn thinking off (M3 only; M2.x silently ignores this)
- omitted — on by default

`budget_tokens` is **not** supported, and M2.x's API "cannot be turned off" — every controllable directive is silently ignored. Both endpoints (Anthropic-compatible at `/anthropic` and OpenAI-compatible at `/v1/`) accept the same `thinking` shape, so a single code path covers both.

The following tradeoffs were made:

- **M2.x → `{}` vs explicit `enabled`:** We rely on the documented M2.x "always-on" default rather than emitting `{ thinking: { type: 'enabled' } }` (which M2.x silently ignores anyway). The trade-off is documented in the code: if MiniMax ever changes the M2.x default, M2.x users would silently lose thinking output. Revisit by switching to a sentinelled return once the upstream documents a stable on-by-default contract.
- **New `isMiniMaxM3SeriesModel` predicate vs. extending `isMiniMaxReasoningModel`'s id array:** M3 has its own controllable protocol (vs. M2.x's "fixed" behavior), so it warrants a separate predicate. The regex covers M3 and all its `-xxx` / `.x` variants (e.g. `m3.1`, `m3-highspeed`, `m3-ultra`) while explicitly excluding `m30` / `m300` (separate model lines).
- **M3 added to `_isSupportedThinkingTokenModel` chain:** M3 doesn't support `budgetTokens`, but the chain is also the entry point for `useAssistant` to pick up model-type options. Adding it there routes M3 into the `['default', 'none', 'auto']` UI options. Inline comment explains the routing.
- **`useAssistant` 3-state branch restored:** A previous simplification to a `??` chain silently dropped the "user has no `reasoning_effort` set" case, persisting `'auto'` instead of `'default'`. Restored the original 3-state branch.

The following alternatives were considered:

- A per-model-type `THINKING_SHAPE_RESOLVER` registry to data-drive the per-family mapping (Claude 4.6, Opus 4.7+, DeepSeek V4+, M3). Deferred to the v2 refactor — out of scope for a v1.9.x bug-fix-shaped PR.
- Using the existing `isFixedReasoningModel` predicate for the M2.x early-return. Functionally equivalent, but the current code is more explicit about *why* M2.x is being intercepted (M2.x-specific doc comment). Left for a follow-up.

Links to places where the discussion took place: N/A

### Breaking changes

None. New behavior is opt-in via the new `isMiniMaxM3SeriesModel` predicate. M2.x users see no change in emitted parameters.

### Special notes for your reviewer

- The `isMiniMaxM3SeriesModel` regex is `/(\b|[.-])minimax-m3(\.\d+)?([.-][\w-]+)*$/`. Boundary cases (`m3.1`, `m3.5`, `m3-highspeed`, `m3-ultra`, `m3-preview`, `m3-turbo`, `m3-ultra.1`, `m2.7`, `m30`, `m300`) are covered by tests in `config/models/__tests__/reasoning.test.ts`.
- The M3 path emits `sendReasoning: true` only in `getAnthropicReasoningParams` (Anthropic SDK's internal provider-options key for streaming reasoning back to the UI). The OpenAI-compatible path does not — that's intentional, since `sendReasoning` is a `@ai-sdk/anthropic`-specific field.
- The M2.x early-return is now backed by an inline comment citing the MiniMax docs. Please push back if you prefer a more defensive `{ thinking: { type: 'enabled' } }` byte — both behaviors are equivalent today, but the current choice saves bytes and avoids sending a directive the API silently ignores.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule) — `useAssistant` 3-state branch restored, helper extracted for M3 thinking-type resolution
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via `/gh-pr-review`, `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
feat(reasoning): add MiniMax M3 thinking control support

M3 is now recognized as a reasoning model and routed through the new
thinking-control path. Users picking M3 from the model list will see
[default, none, auto] reasoning-effort options in the UI; selecting
"none" emits { thinking: { type: 'disabled' } }, while default/auto
emit { thinking: { type: 'adaptive' } } per the MiniMax API contract.
```
