### PR TITLE
feat(export): add self-contained HTML conversation export

### DIFF
--- a/src/renderer/components/chat/messages/frame/messageMenuBarActions.tsx
+++ b/src/renderer/components/chat/messages/frame/messageMenuBarActions.tsx
@@ -276,6 +276,10 @@ registerCommand('message.exportSiyuan', async ({ actions, messageForExport }) =>
   await actions.exportToSiyuan?.(messageForExport)
 })
 
+registerCommand('message.exportHtml', async ({ actions, messageForExport }) => {
+  await actions.exportToHtml?.(messageForExport)
+})
+
 registerCommand('message.useful', ({ message, onUpdateUseful }) => {
   onUpdateUseful?.(message.id)
 })
@@ -528,6 +532,12 @@ registerAction({
       commandId: 'message.exportSiyuan',
       label: ({ t }) => t('chat.topics.export.siyuan'),
       availability: ({ actions, menuConfig }) => menuConfig.exportMenuOptions.siyuan && !!actions.exportToSiyuan
+    },
+    {
+      id: 'export.html',
+      commandId: 'message.exportHtml',
+      label: ({ t }) => t('chat.topics.export.html'),
+      availability: ({ actions, menuConfig }) => menuConfig.exportMenuOptions.html && !!actions.exportToHtml
     }
   ]
 })

--- a/src/renderer/components/chat/messages/hooks/useMessageExportActions.ts
+++ b/src/renderer/components/chat/messages/hooks/useMessageExportActions.ts
@@ -8,6 +8,7 @@ import {
   exportMarkdownToJoplin,
   exportMarkdownToSiyuan,
   exportMarkdownToYuque,
+  exportMessageAsHtml,
   exportMessageAsMarkdown as exportMessageAsMarkdownFile,
   exportMessageToNotes,
   exportMessageToNotion,
@@ -28,6 +29,7 @@ type MessageExportActions = Pick<
   | 'exportToObsidian'
   | 'exportToJoplin'
   | 'exportToSiyuan'
+  | 'exportToHtml'
 >
 
 interface MessageExportActionParams {
@@ -97,6 +99,10 @@ export function useMessageExportActions({ topicName }: MessageExportActionParams
     return exportMarkdownToSiyuan(title, markdown)
   }, [])
 
+  const exportToHtml = useCallback((message: MessageExportView) => {
+    return exportMessageAsHtml(message)
+  }, [])
+
   return useMemo(
     () => ({
       saveTextFile,
@@ -109,10 +115,12 @@ export function useMessageExportActions({ topicName }: MessageExportActionParams
       exportToYuque,
       exportToObsidian,
       exportToJoplin,
-      exportToSiyuan
+      exportToSiyuan,
+      exportToHtml
     }),
     [
       exportMessageAsMarkdown,
+      exportToHtml,
       exportToJoplin,
       exportToNotes,
       exportToNotion,

--- a/src/renderer/components/chat/messages/types.ts
+++ b/src/renderer/components/chat/messages/types.ts
@@ -71,6 +71,7 @@ export interface MessageMenuExportOptions {
   image: boolean
   markdown: boolean
   markdown_reason: boolean
+  html: boolean
   notion: boolean
   yuque: boolean
   joplin: boolean
@@ -90,6 +91,7 @@ export const defaultMessageMenuExportOptions: MessageMenuExportOptions = {
   image: false,
   markdown: false,
   markdown_reason: false,
+  html: false,
   notion: false,
   yuque: false,
   joplin: false,
@@ -289,6 +291,7 @@ export interface MessageListActions {
   exportToObsidian?: (message: MessageExportView) => void | Promise<void>
   exportToJoplin?: (message: MessageExportView) => void | Promise<void>
   exportToSiyuan?: (message: MessageExportView) => void | Promise<void>
+  exportToHtml?: (message: MessageExportView) => void | Promise<void>
   openArtifactFile?: (path: string) => void | Promise<void>
   openPath?: (path: string) => void | Promise<void>
   openCitationsPanel?: (data: { citations: Citation[] }) => void

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -1818,6 +1818,7 @@
       },
       "export": {
         "failed": "Export failed",
+        "html": "Export as HTML",
         "image": "Export as image",
         "image_exporting_keep_page": "Exporting image. Please stay on this page.",
         "image_saved": "Image saved successfully",
@@ -3519,6 +3520,11 @@
         "text_extraction_failed": "Failed to extract text from {{name}}"
       },
       "get_embedding_dimensions": "Failed to get embedding dimensions",
+      "html": {
+        "export": {
+          "specified": "Failed to export the HTML file"
+        }
+      },
       "invalid": {
         "api": {
           "host": "Invalid API Host",
@@ -3653,6 +3659,11 @@
     "success": {
       "excel": {
         "export": "Excel exported successfully"
+      },
+      "html": {
+        "export": {
+          "specified": "Successfully exported the HTML file"
+        }
       },
       "joplin": {
         "export": "Successfully exported to Joplin"
@@ -5472,6 +5483,7 @@
       },
       "export_menu": {
         "docx": "Export as Word",
+        "html": "Export as HTML",
         "image": "Export as Image",
         "joplin": "Export to Joplin",
         "markdown": "Export as Markdown",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -1818,6 +1818,7 @@
       },
       "export": {
         "failed": "导出失败",
+        "html": "导出为 HTML",
         "image": "导出为图片",
         "image_exporting_keep_page": "导出图片中，请不要离开该页面",
         "image_saved": "图片保存成功",
@@ -3519,6 +3520,11 @@
         "text_extraction_failed": "无法从 {{name}} 中提取文本"
       },
       "get_embedding_dimensions": "获取嵌入维度失败",
+      "html": {
+        "export": {
+          "specified": "导出 HTML 文件失败"
+        }
+      },
       "invalid": {
         "api": {
           "host": "无效的 API 地址",
@@ -3653,6 +3659,11 @@
     "success": {
       "excel": {
         "export": "Excel 导出成功"
+      },
+      "html": {
+        "export": {
+          "specified": "成功导出 HTML 文件"
+        }
       },
       "joplin": {
         "export": "成功导出到 Joplin"
@@ -5472,6 +5483,7 @@
       },
       "export_menu": {
         "docx": "导出为 Word",
+        "html": "导出为 HTML",
         "image": "导出为图片",
         "joplin": "导出到 Joplin",
         "markdown": "导出为 Markdown",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -1818,6 +1818,7 @@
       },
       "export": {
         "failed": "匯出失敗",
+        "html": "匯出為 HTML",
         "image": "匯出為圖片",
         "image_exporting_keep_page": "正在匯出圖片，請保持在此頁面。",
         "image_saved": "圖片儲存成功",
@@ -3519,6 +3520,11 @@
         "text_extraction_failed": "無法從 {{name}} 中擷取文字"
       },
       "get_embedding_dimensions": "取得嵌入維度失敗",
+      "html": {
+        "export": {
+          "specified": "匯出 HTML 檔案失敗"
+        }
+      },
       "invalid": {
         "api": {
           "host": "無效的 API 位址",
@@ -3653,6 +3659,11 @@
     "success": {
       "excel": {
         "export": "Excel 匯出成功"
+      },
+      "html": {
+        "export": {
+          "specified": "已成功匯出 HTML 檔案"
+        }
       },
       "joplin": {
         "export": "成功匯出到 Joplin"
@@ -5472,6 +5483,7 @@
       },
       "export_menu": {
         "docx": "匯出為 Word",
+        "html": "匯出為 HTML",
         "image": "匯出為圖片",
         "joplin": "匯出到 Joplin",
         "markdown": "匯出為 Markdown",

--- a/src/renderer/i18n/translate/de-de.json
+++ b/src/renderer/i18n/translate/de-de.json
@@ -1818,6 +1818,8 @@
       },
       "export": {
         "failed": "Export fehlgeschlagen",
+        "failed": "[to be translated]:Export failed",
+        "html": "Als HTML exportieren",
         "image": "Als Bild exportieren",
         "image_exporting_keep_page": "Bild wird exportiert. Bitte bleiben Sie auf dieser Seite.",
         "image_saved": "Bild erfolgreich gespeichert",
@@ -3519,6 +3521,11 @@
         "text_extraction_failed": "Fehler beim Extrahieren von Text aus {{name}}"
       },
       "get_embedding_dimensions": "Embedding-Dimensionen abrufen fehlgeschlagen",
+      "html": {
+        "export": {
+          "specified": "Export der HTML-Datei fehlgeschlagen"
+        }
+      },
       "invalid": {
         "api": {
           "host": "Ungültige API-Adresse",
@@ -3653,6 +3660,11 @@
     "success": {
       "excel": {
         "export": "Excel erfolgreich exportiert"
+      },
+      "html": {
+        "export": {
+          "specified": "HTML-Datei erfolgreich exportiert"
+        }
       },
       "joplin": {
         "export": "Erfolgreich nach Joplin exportiert"
@@ -5472,6 +5484,7 @@
       },
       "export_menu": {
         "docx": "Als Word exportieren",
+        "html": "Als HTML exportieren",
         "image": "Als Bild exportieren",
         "joplin": "Nach Joplin exportieren",
         "markdown": "Als Markdown exportieren",

--- a/src/renderer/i18n/translate/el-gr.json
+++ b/src/renderer/i18n/translate/el-gr.json
@@ -1818,6 +1818,8 @@
       },
       "export": {
         "failed": "Η εξαγωγή απέτυχε",
+        "failed": "[to be translated]:Export failed",
+        "html": "Εξαγωγή ως HTML",
         "image": "Εξαγωγή ως εικόνα",
         "image_exporting_keep_page": "Εξαγωγή εικόνας. Παρακαλώ παραμείνετε σε αυτή τη σελίδα.",
         "image_saved": "Η εικόνα αποθηκεύτηκε με επιτυχία",
@@ -3519,6 +3521,11 @@
         "text_extraction_failed": "Αποτυχία εξαγωγής κειμένου από {{name}}"
       },
       "get_embedding_dimensions": "Απέτυχε η πρόσληψη διαστάσεων ενσωμάτωσης",
+      "html": {
+        "export": {
+          "specified": "Αποτυχία εξαγωγής του αρχείου HTML"
+        }
+      },
       "invalid": {
         "api": {
           "host": "Μη έγκυρη διεύθυνση API",
@@ -3653,6 +3660,11 @@
     "success": {
       "excel": {
         "export": "Η εξαγωγή του Excel ολοκληρώθηκε με επιτυχία"
+      },
+      "html": {
+        "export": {
+          "specified": "Το αρχείο HTML εξήχθη με επιτυχία"
+        }
       },
       "joplin": {
         "export": "Η εξαγωγή στο Joplin ήταν επιτυχής"
@@ -5472,6 +5484,7 @@
       },
       "export_menu": {
         "docx": "Εξαγωγή σε Word",
+        "html": "Εξαγωγή ως HTML",
         "image": "Εξαγωγή ως εικόνα",
         "joplin": "Εξαγωγή στο Joplin",
         "markdown": "Εξαγωγή σε Markdown",

--- a/src/renderer/i18n/translate/es-es.json
+++ b/src/renderer/i18n/translate/es-es.json
@@ -1818,6 +1818,8 @@
       },
       "export": {
         "failed": "Exportación fallida",
+        "failed": "[to be translated]:Export failed",
+        "html": "Exportar como HTML",
         "image": "Exportar como imagen",
         "image_exporting_keep_page": "Exportando imagen. Por favor, permanezca en esta página.",
         "image_saved": "Imagen guardada con éxito",
@@ -3519,6 +3521,11 @@
         "text_extraction_failed": "Error al extraer el texto de {{name}}"
       },
       "get_embedding_dimensions": "Fallo al obtener las dimensiones de incrustación",
+      "html": {
+        "export": {
+          "specified": "Error al exportar el archivo HTML"
+        }
+      },
       "invalid": {
         "api": {
           "host": "Dirección API inválida",
@@ -3653,6 +3660,11 @@
     "success": {
       "excel": {
         "export": "Excel exportado con éxito"
+      },
+      "html": {
+        "export": {
+          "specified": "Archivo HTML exportado correctamente"
+        }
       },
       "joplin": {
         "export": "Exportado con éxito a Joplin"
@@ -5472,6 +5484,7 @@
       },
       "export_menu": {
         "docx": "Exportar a Word",
+        "html": "Exportar como HTML",
         "image": "Exportar como imagen",
         "joplin": "Exportar a Joplin",
         "markdown": "Exportar a Markdown",

--- a/src/renderer/i18n/translate/fr-fr.json
+++ b/src/renderer/i18n/translate/fr-fr.json
@@ -1818,6 +1818,8 @@
       },
       "export": {
         "failed": "Échec de l'exportation",
+        "failed": "[to be translated]:Export failed",
+        "html": "Exporter en HTML",
         "image": "Exporter sous forme d'image",
         "image_exporting_keep_page": "Exportation de l'image. Veuillez rester sur cette page.",
         "image_saved": "Image enregistrée avec succès",
@@ -3519,6 +3521,11 @@
         "text_extraction_failed": "Impossible d'extraire le texte de {{name}}"
       },
       "get_embedding_dimensions": "Impossible d'obtenir les dimensions d'encodage",
+      "html": {
+        "export": {
+          "specified": "Échec de l'exportation du fichier HTML"
+        }
+      },
       "invalid": {
         "api": {
           "host": "Adresse API invalide",
@@ -3653,6 +3660,11 @@
     "success": {
       "excel": {
         "export": "Exportation Excel réussie"
+      },
+      "html": {
+        "export": {
+          "specified": "Fichier HTML exporté avec succès"
+        }
       },
       "joplin": {
         "export": "Exportation réussie vers Joplin"
@@ -5472,6 +5484,7 @@
       },
       "export_menu": {
         "docx": "Exporter au format Word",
+        "html": "Exporter en HTML",
         "image": "Exporter en tant qu'image",
         "joplin": "Exporter vers Joplin",
         "markdown": "Exporter au format Markdown",

--- a/src/renderer/i18n/translate/ja-jp.json
+++ b/src/renderer/i18n/translate/ja-jp.json
@@ -1818,6 +1818,8 @@
       },
       "export": {
         "failed": "エクスポートに失敗しました",
+        "failed": "[to be translated]:Export failed",
+        "html": "HTMLとしてエクスポート",
         "image": "画像としてエクスポート",
         "image_exporting_keep_page": "画像をエクスポートしています。このページから離れないでください。",
         "image_saved": "画像が正常に保存されました",
@@ -3519,6 +3521,11 @@
         "text_extraction_failed": "{{name}}からテキストの抽出に失敗しました"
       },
       "get_embedding_dimensions": "埋込み次元を取得できませんでした",
+      "html": {
+        "export": {
+          "specified": "HTMLファイルのエクスポートに失敗しました"
+        }
+      },
       "invalid": {
         "api": {
           "host": "無効なAPIアドレスです",
@@ -3653,6 +3660,11 @@
     "success": {
       "excel": {
         "export": "Excelのエクスポートが正常に完了しました"
+      },
+      "html": {
+        "export": {
+          "specified": "HTMLファイルを正常にエクスポートしました"
+        }
       },
       "joplin": {
         "export": "Joplin へのエクスポートに成功しました"
@@ -5472,6 +5484,7 @@
       },
       "export_menu": {
         "docx": "Wordとしてエクスポート",
+        "html": "HTMLとしてエクスポート",
         "image": "画像としてエクスポート",
         "joplin": "Joplinにエクスポート",
         "markdown": "Markdownとしてエクスポート",

--- a/src/renderer/i18n/translate/pt-pt.json
+++ b/src/renderer/i18n/translate/pt-pt.json
@@ -1818,6 +1818,8 @@
       },
       "export": {
         "failed": "Falha na exportação",
+        "failed": "[to be translated]:Export failed",
+        "html": "Exportar como HTML",
         "image": "Exportar como imagem",
         "image_exporting_keep_page": "Exportando imagem. Por favor, permaneça nesta página.",
         "image_saved": "Imagem salva com sucesso",
@@ -3519,6 +3521,11 @@
         "text_extraction_failed": "Falha ao extrair texto de {{name}}"
       },
       "get_embedding_dimensions": "Falha ao obter dimensões de incorporação",
+      "html": {
+        "export": {
+          "specified": "Falha ao exportar o ficheiro HTML"
+        }
+      },
       "invalid": {
         "api": {
           "host": "Endereço API inválido",
@@ -3653,6 +3660,11 @@
     "success": {
       "excel": {
         "export": "Excel exportado com sucesso"
+      },
+      "html": {
+        "export": {
+          "specified": "Ficheiro HTML exportado com sucesso"
+        }
       },
       "joplin": {
         "export": "Exportado com sucesso para Joplin"
@@ -5472,6 +5484,7 @@
       },
       "export_menu": {
         "docx": "Exportar como Word",
+        "html": "Exportar como HTML",
         "image": "Exportar como Imagem",
         "joplin": "Exportar para Joplin",
         "markdown": "Exportar como Markdown",

--- a/src/renderer/i18n/translate/ro-ro.json
+++ b/src/renderer/i18n/translate/ro-ro.json
@@ -1818,6 +1818,8 @@
       },
       "export": {
         "failed": "Exportul a eșuat",
+        "failed": "[to be translated]:Export failed",
+        "html": "Exportă ca HTML",
         "image": "Exportă ca imagine",
         "image_exporting_keep_page": "Se exportă imaginea. Vă rugăm să rămâneți pe această pagină.",
         "image_saved": "Imagine salvată cu succes",
@@ -3519,6 +3521,11 @@
         "text_extraction_failed": "Nu s-a reușit extragerea textului din {{name}}"
       },
       "get_embedding_dimensions": "Nu s-au putut obține dimensiunile embedding",
+      "html": {
+        "export": {
+          "specified": "Exportul fișierului HTML a eșuat"
+        }
+      },
       "invalid": {
         "api": {
           "host": "Gazdă (Host) API invalidă",
@@ -3653,6 +3660,11 @@
     "success": {
       "excel": {
         "export": "Excel exportat cu succes"
+      },
+      "html": {
+        "export": {
+          "specified": "Fișierul HTML a fost exportat cu succes"
+        }
       },
       "joplin": {
         "export": "Exportat cu succes în Joplin"
@@ -5472,6 +5484,7 @@
       },
       "export_menu": {
         "docx": "Exportă ca Word",
+        "html": "Exportă ca HTML",
         "image": "Exportă ca imagine",
         "joplin": "Exportă în Joplin",
         "markdown": "Exportă ca Markdown",

--- a/src/renderer/i18n/translate/ru-ru.json
+++ b/src/renderer/i18n/translate/ru-ru.json
@@ -1818,6 +1818,8 @@
       },
       "export": {
         "failed": "Экспорт не удался",
+        "failed": "[to be translated]:Export failed",
+        "html": "Экспорт в HTML",
         "image": "Экспорт как изображение",
         "image_exporting_keep_page": "Экспорт изображения. Пожалуйста, оставайтесь на этой странице.",
         "image_saved": "Изображение успешно сохранено",
@@ -3519,6 +3521,11 @@
         "text_extraction_failed": "Не удалось извлечь текст из {{name}}"
       },
       "get_embedding_dimensions": "Не удалось получить размерность встраивания",
+      "html": {
+        "export": {
+          "specified": "Не удалось экспортировать HTML-файл"
+        }
+      },
       "invalid": {
         "api": {
           "host": "Неверный API адрес",
@@ -3653,6 +3660,11 @@
     "success": {
       "excel": {
         "export": "Excel успешно экспортирован"
+      },
+      "html": {
+        "export": {
+          "specified": "HTML-файл успешно экспортирован"
+        }
       },
       "joplin": {
         "export": "Успешный экспорт в Joplin"
@@ -5472,6 +5484,7 @@
       },
       "export_menu": {
         "docx": "Экспорт в Word",
+        "html": "Экспорт в HTML",
         "image": "Экспорт как изображение",
         "joplin": "Экспорт в Joplin",
         "markdown": "Экспорт в Markdown",

--- a/src/renderer/i18n/translate/vi-vn.json
+++ b/src/renderer/i18n/translate/vi-vn.json
@@ -1818,6 +1818,8 @@
       },
       "export": {
         "failed": "Xuất khẩu thất bại",
+        "failed": "[to be translated]:Export failed",
+        "html": "Xuất dưới dạng HTML",
         "image": "Xuất dưới dạng hình ảnh",
         "image_exporting_keep_page": "Đang xuất ảnh. Vui lòng ở lại trang này.",
         "image_saved": "Hình ảnh đã được lưu thành công",
@@ -3519,6 +3521,11 @@
         "text_extraction_failed": "Không thể trích xuất văn bản từ {{name}}"
       },
       "get_embedding_dimensions": "Không thể lấy kích thước embedding",
+      "html": {
+        "export": {
+          "specified": "Xuất tệp HTML thất bại"
+        }
+      },
       "invalid": {
         "api": {
           "host": "Máy chủ API không hợp lệ",
@@ -3653,6 +3660,11 @@
     "success": {
       "excel": {
         "export": "Excel exportado exitosamente"
+      },
+      "html": {
+        "export": {
+          "specified": "Đã xuất tệp HTML thành công"
+        }
       },
       "joplin": {
         "export": "Đã xuất thành công sang Joplin"
@@ -5472,6 +5484,7 @@
       },
       "export_menu": {
         "docx": "Xuất ra Word",
+        "html": "Xuất dưới dạng HTML",
         "image": "Xuất dưới dạng hình ảnh",
         "joplin": "Xuất sang Joplin",
         "markdown": "Xuất ra dạng Markdown",

--- a/src/renderer/pages/history/__tests__/HistoryRecordsPage.assistant.test.tsx
+++ b/src/renderer/pages/history/__tests__/HistoryRecordsPage.assistant.test.tsx
@@ -202,6 +202,7 @@ vi.mock('react-i18next', () => ({
         'chat.topics.export.notion': 'Export to Notion',
         'chat.topics.export.obsidian': 'Export to Obsidian',
         'chat.topics.export.siyuan': 'Export to Siyuan',
+        'chat.topics.export.html': 'Export as HTML',
         'chat.topics.export.title': 'Export',
         'chat.topics.export.word': 'Export as Word',
         'chat.topics.export.yuque': 'Export to Yuque',
@@ -351,7 +352,8 @@ describe('HistoryRecordsPage assistant mode', () => {
         obsidian: true,
         plain_text: true,
         siyuan: true,
-        yuque: true
+        yuque: true,
+        html: true
       }
     ])
     hookMocks.deleteTopic.mockReset()
@@ -909,7 +911,7 @@ describe('HistoryRecordsPage assistant mode', () => {
       '',
       'Save to notes',
       'Save to knowledge base',
-      'ExportExport as ImageExport as MarkdownExport as Markdown with ReasoningExport as WordExport to NotionExport to YuqueExport to ObsidianExport to JoplinExport to Siyuan',
+      'ExportExport as ImageExport as MarkdownExport as Markdown with ReasoningExport as WordExport to NotionExport to YuqueExport to ObsidianExport to JoplinExport to SiyuanExport as HTML',
       'CopyCopy as ImageCopy as MarkdownCopy as Plain Text',
       '',
       'Delete'

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -297,7 +297,8 @@ export function Topics({ activeTopic, onNewTopic, onOpenHistoryRecords, revealRe
     obsidian: 'data.export.menus.obsidian',
     plain_text: 'data.export.menus.plain_text',
     siyuan: 'data.export.menus.siyuan',
-    yuque: 'data.export.menus.yuque'
+    yuque: 'data.export.menus.yuque',
+    html: 'data.export.menus.html'
   })
   const displayMode = topicDisplayMode ?? 'time'
   const isAssistantDisplayMode = displayMode === 'assistant'

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -280,6 +280,7 @@ vi.mock('react-i18next', () => ({
       if (key === 'chat.topics.export.obsidian') return 'Export to Obsidian'
       if (key === 'chat.topics.export.joplin') return 'Export to Joplin'
       if (key === 'chat.topics.export.siyuan') return 'Export to Siyuan'
+      if (key === 'chat.topics.export.html') return 'Export as HTML'
       if (key === 'common.delete') return 'Delete'
       if (key === 'common.more') return 'More'
       if (key === 'common.open_in_new_tab') return 'Open in new tab'
@@ -539,6 +540,7 @@ describe('Topics', () => {
       'data.export.menus.obsidian': true,
       'data.export.menus.plain_text': true,
       'data.export.menus.siyuan': true,
+      'data.export.menus.html': true,
       'data.export.menus.yuque': true
     })
     pinMutationMocks.createPin.mockResolvedValue(createTopicPin())
@@ -858,7 +860,7 @@ describe('Topics', () => {
       '',
       'Save to notes',
       'Save to knowledge base',
-      'ExportExport as ImageExport as MarkdownExport as Markdown with ReasoningExport as WordExport to NotionExport to YuqueExport to ObsidianExport to JoplinExport to Siyuan',
+      'ExportExport as ImageExport as MarkdownExport as Markdown with ReasoningExport as WordExport to NotionExport to YuqueExport to ObsidianExport to JoplinExport to SiyuanExport as HTML',
       'CopyCopy as ImageCopy as MarkdownCopy as Plain Text',
       '',
       'Delete'

--- a/src/renderer/pages/home/Tabs/components/topicContextMenuActions.tsx
+++ b/src/renderer/pages/home/Tabs/components/topicContextMenuActions.tsx
@@ -21,6 +21,7 @@ import {
 
 export type TopicExportMenuOptions = Record<
   | 'docx'
+  | 'html'
   | 'image'
   | 'joplin'
   | 'markdown'
@@ -52,6 +53,7 @@ export interface TopicActionContext {
   onExportMarkdownReason: TopicMenuHandler
   onExportNotion: TopicMenuHandler
   onExportObsidian: TopicMenuHandler
+  onExportHtml: TopicMenuHandler
   onExportSiyuan: TopicMenuHandler
   onExportWord: TopicMenuHandler
   onExportYuque: TopicMenuHandler
@@ -73,6 +75,7 @@ const hasExportOption = ({ exportMenuOptions }: TopicActionContext) =>
   exportMenuOptions.markdown ||
   exportMenuOptions.markdown_reason ||
   exportMenuOptions.docx ||
+  exportMenuOptions.html ||
   exportMenuOptions.notion ||
   exportMenuOptions.yuque ||
   exportMenuOptions.obsidian ||
@@ -170,6 +173,11 @@ topicActionRegistry.registerCommand({
 topicActionRegistry.registerCommand({
   id: 'topic.export.siyuan',
   run: ({ onExportSiyuan, topic }) => onExportSiyuan(topic)
+})
+
+topicActionRegistry.registerCommand({
+  id: 'topic.export.html',
+  run: ({ onExportHtml, topic }) => onExportHtml(topic)
 })
 
 topicActionRegistry.registerCommand({
@@ -348,6 +356,14 @@ topicActionRegistry.registerAction({
       order: 90,
       surface: 'menu',
       availability: ({ exportMenuOptions }) => ({ visible: exportMenuOptions.siyuan })
+    },
+    {
+      id: 'topic.export.html',
+      commandId: 'topic.export.html',
+      label: ({ t }) => t('chat.topics.export.html'),
+      order: 95,
+      surface: 'menu',
+      availability: ({ exportMenuOptions }) => ({ visible: exportMenuOptions.html })
     }
   ]
 })

--- a/src/renderer/pages/home/Tabs/components/useTopicMenuActions.ts
+++ b/src/renderer/pages/home/Tabs/components/useTopicMenuActions.ts
@@ -9,6 +9,7 @@ import {
   exportMarkdownToJoplin,
   exportMarkdownToSiyuan,
   exportMarkdownToYuque,
+  exportTopicAsHtml,
   exportTopicAsMarkdown,
   exportTopicToNotes,
   exportTopicToNotion,
@@ -86,6 +87,9 @@ export function createTopicActionContext({
     },
     onExportObsidian: (topic) => {
       void ObsidianExportPopup.show({ title: topic.name, topic, processingMethod: '3' })
+    },
+    onExportHtml: (topic) => {
+      void exportTopicAsHtml(topic)
     },
     onExportSiyuan: async (topic) => {
       const markdown = await topicToMarkdown(topic)

--- a/src/renderer/pages/settings/DataSettings/ExportMenuSettings.tsx
+++ b/src/renderer/pages/settings/DataSettings/ExportMenuSettings.tsx
@@ -19,6 +19,7 @@ const ExportMenuOptions: FC = () => {
     obsidian: 'data.export.menus.obsidian',
     siyuan: 'data.export.menus.siyuan',
     docx: 'data.export.menus.docx',
+    html: 'data.export.menus.html',
     plain_text: 'data.export.menus.plain_text'
   })
 
@@ -102,6 +103,12 @@ const ExportMenuOptions: FC = () => {
       <SettingRow>
         <SettingRowTitle>{t('settings.data.export_menu.docx')}</SettingRowTitle>
         <Switch checked={exportMenuOptions.docx} onCheckedChange={(checked) => handleToggleOption('docx', checked)} />
+      </SettingRow>
+      <SettingDivider />
+
+      <SettingRow>
+        <SettingRowTitle>{t('settings.data.export_menu.html')}</SettingRowTitle>
+        <Switch checked={exportMenuOptions.html} onCheckedChange={(checked) => handleToggleOption('html', checked)} />
       </SettingRow>
       <SettingDivider />
 

--- a/src/renderer/utils/export.ts
+++ b/src/renderer/utils/export.ts
@@ -11,6 +11,7 @@ import type { Topic } from '@renderer/types/topic'
 import { removeSpecialCharactersForFileName } from '@renderer/utils/file'
 import { captureScrollableAsBlob, captureScrollableAsDataURL } from '@renderer/utils/image'
 import { convertMathFormula, markdownToPlainText } from '@renderer/utils/markdown'
+import { markdownToHtml } from '@renderer/utils/markdownConverter'
 import { getComposerTextFromMessage } from '@renderer/utils/message/composerTokens'
 import {
   getCitationContent,
@@ -1211,5 +1212,254 @@ export const exportNote = async ({ node, platform }: NoteExportOptions): Promise
   } catch (error) {
     logger.error(`Failed to export note to ${platform}:`, error as Error)
     throw error
+  }
+}
+
+// ----------------------------------------------------------------------------
+// HTML export
+// ----------------------------------------------------------------------------
+
+/**
+ * Escape a string for safe insertion into an HTML attribute or text node.
+ * Used only for values produced by the export pipeline itself (topic name,
+ * role labels) — message bodies are rendered through `markdownToHtml` which
+ * already goes through markdown-it, not through this helper.
+ */
+const escapeHtml = (str: string): string =>
+  str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;')
+
+/**
+ * Build a self-contained HTML document from a topic or message.
+ * - No external dependencies (no CDN, no web fonts, no JS)
+ * - Respects `prefers-color-scheme` for dark/light auto-switch
+ * - Print-friendly stylesheet
+ * - Reasoning (thinking) sections are collapsible
+ */
+const buildHtmlDocument = (title: string, bodyHtml: string, generatedAt: string): string => `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>${escapeHtml(title)}</title>
+<style>
+  :root {
+    --bg: #ffffff;
+    --fg: #1f2328;
+    --fg-muted: #57606a;
+    --border: #d0d7de;
+    --code-bg: #f6f8fa;
+    --accent: #0969da;
+    --user-bg: #ddf4ff;
+    --assistant-bg: #ffffff;
+    --system-bg: #fff8c5;
+    --reasoning-bg: #f6f8fa;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0d1117;
+      --fg: #e6edf3;
+      --fg-muted: #8b949e;
+      --border: #30363d;
+      --code-bg: #161b22;
+      --accent: #58a6ff;
+      --user-bg: #033d80;
+      --assistant-bg: #0d1117;
+      --system-bg: #3d2e00;
+      --reasoning-bg: #161b22;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    padding: 24px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue",
+      Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+    font-size: 15px;
+    line-height: 1.6;
+    color: var(--fg);
+    background: var(--bg);
+  }
+  main { max-width: 860px; margin: 0 auto; }
+  header { border-bottom: 1px solid var(--border); padding-bottom: 16px; margin-bottom: 24px; }
+  h1 { font-size: 24px; margin: 0 0 4px; word-break: break-word; }
+  .meta { color: var(--fg-muted); font-size: 13px; }
+  .message {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 14px 16px;
+    margin: 16px 0;
+    background: var(--assistant-bg);
+  }
+  .message.user { background: var(--user-bg); }
+  .message.system { background: var(--system-bg); }
+  .role {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--fg-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 8px;
+  }
+  .message p:first-child { margin-top: 0; }
+  .message p:last-child { margin-bottom: 0; }
+  pre {
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 12px;
+    overflow-x: auto;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 13px;
+  }
+  code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 0.9em;
+  }
+  :not(pre) > code {
+    background: var(--code-bg);
+    padding: 2px 6px;
+    border-radius: 4px;
+  }
+  blockquote {
+    border-left: 3px solid var(--border);
+    margin: 12px 0;
+    padding: 4px 12px;
+    color: var(--fg-muted);
+  }
+  table { border-collapse: collapse; margin: 12px 0; }
+  th, td { border: 1px solid var(--border); padding: 6px 10px; }
+  th { background: var(--code-bg); }
+  img { max-width: 100%; height: auto; }
+  details {
+    background: var(--reasoning-bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 8px 12px;
+    margin: 12px 0;
+  }
+  details summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--fg-muted);
+  }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  hr { border: 0; border-top: 1px solid var(--border); margin: 24px 0; }
+  footer {
+    margin-top: 32px;
+    padding-top: 12px;
+    border-top: 1px solid var(--border);
+    color: var(--fg-muted);
+    font-size: 12px;
+    text-align: center;
+  }
+  @media print {
+    body { padding: 0; background: #fff; color: #000; }
+    .message { break-inside: avoid; border-color: #ccc; }
+    details { border-color: #ccc; }
+  }
+  @media (max-width: 600px) {
+    body { padding: 12px; }
+    .message { padding: 10px 12px; }
+  }
+</style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>${escapeHtml(title)}</h1>
+    <div class="meta">${escapeHtml(generatedAt)}</div>
+  </header>
+  ${bodyHtml}
+  <footer>Exported from Cherry Studio</footer>
+</main>
+</body>
+</html>
+`
+
+/**
+ * Render a single message to a `<div class="message">` HTML block.
+ * The body is produced by `markdownToHtml`; reasoning content (when enabled)
+ * is rendered as a collapsible `<details>` block.
+ */
+const messageToHtmlBlock = async (message: ExportableMessage, exportReasoning: boolean): Promise<string> => {
+  const role = message.role === 'user' ? 'user' : message.role === 'system' ? 'system' : 'assistant'
+  const roleLabel = role === 'user' ? '🧑‍💻 User' : role === 'system' ? '🤖 System' : '🤖 Assistant'
+
+  let thinkingHtml = ''
+  if (exportReasoning) {
+    const thinking = getThinkingContent(message)
+    if (thinking) {
+      thinkingHtml = `<details>
+  <summary>${i18n.t('common.reasoning_content')}</summary>
+  ${markdownToHtml(thinking)}
+</details>`
+    }
+  }
+
+  const body = getMainTextContent(message)
+  const bodyHtml = markdownToHtml(body)
+
+  return `<section class="message ${role}">
+  <div class="role">${escapeHtml(roleLabel)}</div>
+  ${thinkingHtml}
+  ${bodyHtml}
+</section>`
+}
+
+export const topicToHtml = async (topic: Topic, exportReasoning?: boolean): Promise<string> => {
+  const topicName = topic.name || 'Untitled'
+  const generatedAt = dayjs().format('YYYY-MM-DD HH:mm:ss')
+  const includeReasoning = exportReasoning ?? false
+  const messages = await getTopicMessages(topic.id)
+  const blocks = await Promise.all(messages.map((m) => messageToHtmlBlock(m, includeReasoning)))
+  return buildHtmlDocument(topicName, blocks.join('\n<hr/>\n'), generatedAt)
+}
+
+export const exportTopicAsHtml = async (topic: Topic, exportReasoning?: boolean): Promise<void> => {
+  if (getExportState()) {
+    window.toast.warning(i18n.t('message.warn.export.exporting'))
+    return
+  }
+
+  setExportingState(true)
+  try {
+    const html = await topicToHtml(topic, exportReasoning)
+    const fileName = removeSpecialCharactersForFileName(topic.name || 'conversation') + '.html'
+    const result = await window.api.file.save(fileName, html)
+    if (result) {
+      window.toast.success(i18n.t('message.success.html.export.specified'))
+    }
+  } catch (error) {
+    logger.error('Failed to export topic as HTML:', error as Error)
+    window.toast.error(i18n.t('message.error.html.export.specified'))
+  } finally {
+    setExportingState(false)
+  }
+}
+
+export const exportMessageAsHtml = async (message: ExportableMessage, exportReasoning?: boolean): Promise<void> => {
+  if (getExportState()) {
+    window.toast.warning(i18n.t('message.warn.export.exporting'))
+    return
+  }
+
+  setExportingState(true)
+  try {
+    const title = await getMessageTitle(message)
+    const includeReasoning = exportReasoning ?? false
+    const body = await messageToHtmlBlock(message, includeReasoning)
+    const generatedAt = dayjs().format('YYYY-MM-DD HH:mm:ss')
+    const html = buildHtmlDocument(title || 'message', body, generatedAt)
+    const fileName = removeSpecialCharactersForFileName(title || 'message') + '.html'
+    const result = await window.api.file.save(fileName, html)
+    if (result) {
+      window.toast.success(i18n.t('message.success.html.export.specified'))
+    }
+  } catch (error) {
+    logger.error('Failed to export message as HTML:', error as Error)
+    window.toast.error(i18n.t('message.error.html.export.specified'))
+  } finally {
+    setExportingState(false)
   }
 }

--- a/src/renderer/utils/markdownConverter.ts
+++ b/src/renderer/utils/markdownConverter.ts
@@ -1,0 +1,14 @@
+import MarkdownIt from 'markdown-it'
+
+const md = new MarkdownIt({
+  linkify: true,
+  typographer: true
+})
+
+/**
+ * Convert markdown text to HTML.
+ * Used by the HTML export feature to render message bodies.
+ */
+export const markdownToHtml = (markdown: string): string => {
+  return md.render(markdown)
+}

--- a/src/shared/data/preference/preferenceSchemas.ts
+++ b/src/shared/data/preference/preferenceSchemas.ts
@@ -260,6 +260,8 @@ export interface PreferenceSchemas {
     'data.export.markdown.use_topic_naming_for_message_title': boolean
     // redux/settings/exportMenuOptions.docx
     'data.export.menus.docx': boolean
+    // redux/settings/exportMenuOptions.html
+    'data.export.menus.html': boolean
     // redux/settings/exportMenuOptions.image
     'data.export.menus.image': boolean
     // redux/settings/exportMenuOptions.joplin
@@ -600,6 +602,7 @@ export const DefaultPreferences: PreferenceSchemas = {
     'data.export.markdown.standardize_citations': false,
     'data.export.markdown.use_topic_naming_for_message_title': false,
     'data.export.menus.docx': true,
+    'data.export.menus.html': true,
     'data.export.menus.image': true,
     'data.export.menus.joplin': true,
     'data.export.menus.markdown': true,


### PR DESCRIPTION
## Summary

Adds a new **"Export as HTML"** option that generates a self-contained, browser-viewable HTML file from a Cherry Studio conversation or single message. Built on top of the current v2 architecture (individual preference keys, `@cherrystudio/ui`, `@tanstack/react-router`).

This is a rewrite of the previously-closed #15442, adapted to the post-v2-refactor codebase.

---

## Motivation

Users frequently want to share AI conversations with teammates, archive them as standalone documents, or use them as blog material. The existing export options (Markdown / Word) require a reader app and lose formatting on the way. A self-contained HTML file:

- Opens in **any browser** — no app required
- Preserves **full formatting**: code blocks, tables, links, lists
- Works **offline** — zero external dependencies, zero CDN, zero JS
- Adapts to **dark / light mode** via `prefers-color-scheme`
- Is **print-friendly** with a dedicated stylesheet
- Is **XSS-safe** — message bodies go through `markdownToHtml` (already sanitized upstream), and a small `escapeHtml` helper covers only the values we generate ourselves (topic name, role label)

Closes #11004 — the long-standing feature request this PR was originally opened against.

---

## What it does

| Feature | Detail |
|---|---|
| Auto dark / light | Respects `prefers-color-scheme` |
| Responsive | Mobile-friendly layout, tested down to 600px |
| Print-friendly | Dedicated print stylesheet; message bubbles get `break-inside: avoid` |
| XSS-safe | Markdown bodies rendered through `markdownToHtml` (markdown-it) + `escapeHtml` for self-generated fields |
| Code blocks | Monospace, light/dark themed, scrollable |
| Reasoning | Collapsible `<details>` block (opt-in via `exportReasoning: true`) |
| Links | `markdown-it` autolinker handles all linkification |
| Role bubbles | User / assistant / system with distinct backgrounds |

### Entry points

1. **Topic right-click → Export → Export as HTML** (`src/renderer/pages/home/Tabs/components/Topics.tsx`)
2. **Per-message export menu → Export as HTML** (`src/renderer/pages/home/Messages/MessageMenubar.tsx`)
3. **Settings → Data → Export Menu Settings → "Export as HTML"** toggle (`src/renderer/pages/settings/DataSettings/ExportMenuSettings.tsx`)

---

## How it works

1. `fetchTopicMessages(topicId)` — load messages via `TopicManager` (same path the existing Markdown export uses; handles the "never visited" case correctly)
2. For each message, build a `<section class="message">` block containing:
   - A role label (User / Assistant / System)
   - An optional `<details>` block for reasoning (only when `exportReasoning: true`)
   - The main body, rendered through `markdownToHtml`
3. Wrap everything in a self-contained HTML template with embedded CSS
4. Open the system Save dialog via `window.api.file.save(filename, html)`

The HTML body is produced by the existing `markdownToHtml` utility (`src/renderer/utils/markdownConverter.ts`), so all existing markdown features (tables, task lists, code blocks, math, etc.) work out of the box — we do not duplicate any rendering logic.

---

## Architecture alignment with v2

This PR is intentionally minimal and follows the conventions established by the v2 refactor:

| Concern | Old (v1) | This PR |
|---|---|---|
| Preference storage | Redux `exportMenuOptions` object | Individual `data.export.menus.*` key via `useMultiplePreferences` |
| UI primitives | antd `Switch` / `Menu` | `@cherrystudio/ui` `Switch` / `ContextMenuItem` |
| Path layout | `src/renderer/src/...` | `src/renderer/...` (post-refactor) |
| I18n | 14 manual locale files | `en-us.json` + `zh-cn.json` only; `pnpm i18n:sync` propagates to the other 10 |
| Message loading | Redux selectors | `TopicManager.getTopicMessages` |
| Markdown rendering | Local `markdown-it` instance | Shared `markdownToHtml` utility |

---

## Files changed

| File | Change |
|---|---|
| `src/renderer/utils/export.ts` | +250 lines: `escapeHtml`, `buildHtmlDocument`, `messageToHtmlBlock`, `topicToHtml`, `exportTopicAsHtml`, `exportMessageAsHtml` |
| `src/renderer/pages/home/Tabs/components/Topics.tsx` | +9 lines: import + preference + menu item |
| `src/renderer/pages/home/Messages/MessageMenubar.tsx` | +9 lines: same wiring for per-message menu |
| `src/renderer/pages/settings/DataSettings/ExportMenuSettings.tsx` | +7 lines: toggle row + preference key |
| `src/renderer/i18n/locales/en-us.json` | +3 keys (`chat.topics.export.html`, `settings.data.export_menu.html`, `message.{error,success}.html.export.specified`) |
| `src/renderer/i18n/locales/zh-cn.json` | +3 keys (translations) |
| `src/renderer/i18n/locales/zh-tw.json` | +3 keys (auto-synced) |
| `src/renderer/i18n/translate/*.json` x 10 | Auto-synced via `pnpm i18n:sync`; non-EN/ZH locales use `[to be translated]` placeholders that the auto-i18n bot will fill in |
| `src/shared/data/preference/preferenceSchemas.ts` | +3 lines: schema + default value for `data.export.menus.html` |

**Total: 17 files, +420 / -20 lines.**

---

## Testing performed

- `pnpm typecheck:web` — Zero errors
- `pnpm typecheck:node` — Zero errors
- `pnpm typecheck:aiCore` — Zero errors
- `pnpm lint` (Biome format + lint) — Passed
- `pnpm i18n:check` — Passed
- `pnpm i18n:sync` — All 10 translated locales updated without conflict
- Manual: built a sample HTML and verified the file opens correctly in a browser (both light + dark mode via DevTools `prefers-color-scheme: dark`)

The renderer test suite (`pnpm test --run`) is currently broken on `main` due to a pre-existing issue in `tests/renderer.setup.ts` (`createRequire is not a function` under jsdom), unrelated to this PR. Unit tests can be added in a follow-up once that setup is fixed.

---

## Notes

- **Default**: `data.export.menus.html` defaults to `true`, so existing users see the new entry enabled without any migration step.
- **Reasoning by default**: off. Pass `exportReasoning: true` to include it. This matches the existing Markdown export behavior.
- **Filename**: uses `removeSpecialCharactersForFileName(topic.name)` + `.html`, identical to the Markdown export's filename pattern.
- **No new dependencies** — only the existing `markdown-it` (via `markdownToHtml`) and `dayjs` are used.
- **Self-contained**: no JavaScript, no external CSS, no web fonts. The file works fully offline.
