### PR TITLE
feat(stats): add conversation usage statistics dashboard

### DIFF
--- a/src/renderer/components/Popups/TopicStatsPopup.tsx
+++ b/src/renderer/components/Popups/TopicStatsPopup.tsx
@@ -5,6 +5,8 @@ import { loadTopicStats, type ResolvedModelUsage } from '@renderer/utils/topicSt
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+type TFunc = ReturnType<typeof useTranslation>['t']
+
 const logger = loggerService.withContext('Popups:TopicStatsPopup')
 const CLOSE_ANIMATION_MS = 200
 
@@ -115,13 +117,14 @@ const Body: React.FC<{ data: TopicStatsData }> = ({ data }) => {
           <StatBox label={t('stats.total_tokens')} value={stats.totalTokens.toLocaleString()} />
           <StatBox label={t('stats.total_characters')} value={stats.totalCharacters.toLocaleString()} />
           <StatBox label={t('stats.total_words')} value={stats.totalWords.toLocaleString()} />
-          {stats.durationMs > 0 && <StatBox label={t('stats.duration')} value={formatDuration(stats.durationMs)} />}
+          {stats.durationMs > 0 && <StatBox label={t('stats.duration')} value={formatDuration(stats.durationMs, t)} />}
         </div>
       </Section>
 
       {/* Token Breakdown */}
       <Section title={t('stats.token_breakdown')}>
         <TokenBar
+          t={t}
           input={stats.inputTokens}
           output={stats.outputTokens}
           thinking={stats.thinkingTokens}
@@ -138,7 +141,7 @@ const Body: React.FC<{ data: TopicStatsData }> = ({ data }) => {
             label={t('stats.avg_speed')}
             value={
               stats.performance.avgTokensPerSecond != null
-                ? `${stats.performance.avgTokensPerSecond.toFixed(1)} tok/s`
+                ? t('stats.units.tok_per_sec', { value: stats.performance.avgTokensPerSecond.toFixed(1) })
                 : '—'
             }
           />
@@ -159,7 +162,8 @@ const Body: React.FC<{ data: TopicStatsData }> = ({ data }) => {
                     <div className="truncate text-(--color-foreground-muted) text-xs">{u.providerName}</div>
                   </div>
                   <div className="text-right text-(--color-foreground) text-xs tabular-nums">
-                    {u.totalTokens.toLocaleString()} <span className="text-(--color-foreground-muted)">tok</span>
+                    {u.totalTokens.toLocaleString()}{' '}
+                    <span className="text-(--color-foreground-muted)">{t('stats.units.tok')}</span>
                   </div>
                 </div>
                 <div className="mt-1.5 flex flex-wrap gap-x-3 text-(--color-foreground-muted) text-xs">
@@ -167,7 +171,7 @@ const Body: React.FC<{ data: TopicStatsData }> = ({ data }) => {
                     {t('stats.messages')}: {u.messageCount}
                   </span>
                   {u.performance.avgFirstTokenMs != null && (
-                    <span>TTFT {Math.round(u.performance.avgFirstTokenMs)}ms</span>
+                    <span>{t('stats.units.ttft', { ms: Math.round(u.performance.avgFirstTokenMs) })}</span>
                   )}
                 </div>
               </div>
@@ -194,12 +198,13 @@ const StatBox: React.FC<{ label: string; value: string; sub?: string }> = ({ lab
   </div>
 )
 
-const TokenBar: React.FC<{ input: number; output: number; thinking: number; total: number }> = ({
-  input,
-  output,
-  thinking,
-  total
-}) => {
+const TokenBar: React.FC<{
+  input: number
+  output: number
+  thinking: number
+  total: number
+  t: TFunc
+}> = ({ input, output, thinking, total, t }) => {
   if (total === 0) return <div className="text-(--color-foreground-muted) text-xs">—</div>
   const i = (input / total) * 100
   const o = (output / total) * 100
@@ -207,23 +212,25 @@ const TokenBar: React.FC<{ input: number; output: number; thinking: number; tota
   return (
     <div className="space-y-1.5">
       <div className="flex h-2 w-full overflow-hidden rounded-full bg-(--color-background-soft)">
-        {i > 0 && <div className="bg-[#6366f1]" style={{ width: `${i}%` }} title={`Input ${input}`} />}
-        {o > 0 && <div className="bg-[#10b981]" style={{ width: `${o}%` }} title={`Output ${output}`} />}
-        {th > 0 && <div className="bg-[#a855f7]" style={{ width: `${th}%` }} title={`Thinking ${thinking}`} />}
+        {i > 0 && <div className="bg-[#6366f1]" style={{ width: `${i}%` }} title={tokenLabel('input', input, t)} />}
+        {o > 0 && <div className="bg-[#10b981]" style={{ width: `${o}%` }} title={tokenLabel('output', output, t)} />}
+        {th > 0 && (
+          <div className="bg-[#a855f7]" style={{ width: `${th}%` }} title={tokenLabel('thinking', thinking, t)} />
+        )}
       </div>
       <div className="flex flex-wrap gap-x-3 text-(--color-foreground-muted) text-xs">
         <span>
           <span className="mr-1 inline-block size-2 rounded-full bg-[#6366f1]" />
-          Input {input.toLocaleString()}
+          {tokenLabel('input', input, t)}
         </span>
         <span>
           <span className="mr-1 inline-block size-2 rounded-full bg-[#10b981]" />
-          Output {output.toLocaleString()}
+          {tokenLabel('output', output, t)}
         </span>
         {thinking > 0 && (
           <span>
             <span className="mr-1 inline-block size-2 rounded-full bg-[#a855f7]" />
-            Thinking {thinking.toLocaleString()}
+            {tokenLabel('thinking', thinking, t)}
           </span>
         )}
       </div>
@@ -237,13 +244,25 @@ const formatMs = (ms: number | null): string => {
   return `${(ms / 1000).toFixed(2)}s`
 }
 
-const formatDuration = (ms: number): string => {
+const formatDuration = (ms: number, t: TFunc): string => {
   if (ms <= 0) return '—'
   const totalMin = Math.floor(ms / 60_000)
   const d = Math.floor(totalMin / (60 * 24))
   const h = Math.floor((totalMin - d * 60 * 24) / 60)
   const m = totalMin - d * 60 * 24 - h * 60
-  return `${d}d ${h}h ${m}m`
+  return t('stats.units.d_h_m', { d, h, m })
+}
+
+/**
+ * Localised token-segment label. Kept as a tiny wrapper so the
+ * `t(key, { count })` calls (which i18next's strict typegen can't
+ * infer for new keys) live in one place.
+ */
+const tokenLabel = (kind: 'input' | 'output' | 'thinking', count: number, t: TFunc): string => {
+  const key = kind === 'input' ? 'stats.token_input' : kind === 'output' ? 'stats.token_output' : 'stats.token_thinking'
+  // The plural-aware t() signature expects a count; cast through unknown
+  // because our typegen doesn't yet model the interpolation slot.
+  return (t as unknown as (k: string, opts: { count: string }) => string)(key, { count: count.toLocaleString() })
 }
 
 const TopViewKey = 'TopicStatsPopup'

--- a/src/renderer/components/Popups/TopicStatsPopup.tsx
+++ b/src/renderer/components/Popups/TopicStatsPopup.tsx
@@ -1,0 +1,270 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@cherrystudio/ui'
+import { loggerService } from '@logger'
+import { TopView } from '@renderer/components/TopView'
+import { loadTopicStats, type ResolvedModelUsage } from '@renderer/utils/topicStatsLoader'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+const logger = loggerService.withContext('Popups:TopicStatsPopup')
+const CLOSE_ANIMATION_MS = 200
+
+interface ShowParams {
+  topicId: string
+}
+
+interface Props extends ShowParams {
+  resolve: (data: any) => void
+}
+
+interface TopicStatsData {
+  topicId: string
+  topicName: string
+  stats: {
+    messageCount: number
+    userMessageCount: number
+    assistantMessageCount: number
+    totalTokens: number
+    inputTokens: number
+    outputTokens: number
+    thinkingTokens: number
+    totalCharacters: number
+    totalWords: number
+    durationMs: number
+    createdAt: string
+    firstMessageAt: string | null
+    lastMessageAt: string | null
+    performance: {
+      avgFirstTokenMs: number | null
+      avgCompletionMs: number | null
+      avgTokensPerSecond: number | null
+      measuredMessages: number
+    }
+  }
+  modelUsage: ResolvedModelUsage[]
+  dailyUsage: { date: string; messageCount: number; totalTokens: number }[]
+}
+
+const PopupContainer: React.FC<Props> = ({ topicId, resolve }) => {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(true)
+  const [data, setData] = useState<TopicStatsData | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    loadTopicStats(topicId)
+      .then((result) => {
+        if (cancelled) return
+        if (!result) {
+          setError(t('stats.popup.topic_not_found'))
+          return
+        }
+        setData(result as TopicStatsData)
+      })
+      .catch((e) => {
+        logger.error('Failed to load topic stats', e as Error)
+        if (!cancelled) setError(t('stats.popup.load_failed'))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [topicId, t])
+
+  const closePopup = () => {
+    setOpen(false)
+    window.setTimeout(() => resolve({}), CLOSE_ANIMATION_MS)
+  }
+
+  TopicStatsPopup.hide = closePopup
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) closePopup()
+      }}>
+      <DialogContent className="max-h-[85vh] sm:max-w-[640px]">
+        <DialogHeader className="pr-8">
+          <DialogTitle>{t('stats.popup.title')}</DialogTitle>
+          {data && <p className="text-(--color-foreground-muted) text-xs">{data.topicName}</p>}
+        </DialogHeader>
+        <div className="max-h-[60vh] overflow-y-auto pr-2">
+          {error && <div className="text-(--color-foreground-muted) text-sm">{error}</div>}
+          {!error && !data && <div className="text-(--color-foreground-muted) text-sm">{t('stats.loading')}</div>}
+          {data && <Body data={data} />}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+const Body: React.FC<{ data: TopicStatsData }> = ({ data }) => {
+  const { t } = useTranslation()
+  const { stats } = data
+
+  return (
+    <div className="space-y-5 py-2 text-sm">
+      {/* Conversation Info */}
+      <Section title={t('stats.conversation_info')}>
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+          <StatBox
+            label={t('stats.total_messages')}
+            value={String(stats.messageCount)}
+            sub={`${stats.userMessageCount} / ${stats.assistantMessageCount}`}
+          />
+          <StatBox label={t('stats.total_tokens')} value={stats.totalTokens.toLocaleString()} />
+          <StatBox label={t('stats.total_characters')} value={stats.totalCharacters.toLocaleString()} />
+          <StatBox label={t('stats.total_words')} value={stats.totalWords.toLocaleString()} />
+          {stats.durationMs > 0 && <StatBox label={t('stats.duration')} value={formatDuration(stats.durationMs)} />}
+        </div>
+      </Section>
+
+      {/* Token Breakdown */}
+      <Section title={t('stats.token_breakdown')}>
+        <TokenBar
+          input={stats.inputTokens}
+          output={stats.outputTokens}
+          thinking={stats.thinkingTokens}
+          total={stats.totalTokens}
+        />
+      </Section>
+
+      {/* Performance */}
+      <Section title={t('stats.performance')}>
+        <div className="grid grid-cols-3 gap-2">
+          <StatBox label={t('stats.avg_first_token')} value={formatMs(stats.performance.avgFirstTokenMs)} />
+          <StatBox label={t('stats.avg_completion')} value={formatMs(stats.performance.avgCompletionMs)} />
+          <StatBox
+            label={t('stats.avg_speed')}
+            value={
+              stats.performance.avgTokensPerSecond != null
+                ? `${stats.performance.avgTokensPerSecond.toFixed(1)} tok/s`
+                : '—'
+            }
+          />
+        </div>
+      </Section>
+
+      {/* Model Usage */}
+      {data.modelUsage.length > 0 && (
+        <Section title={t('stats.model_usage')}>
+          <div className="space-y-2">
+            {data.modelUsage.map((u) => (
+              <div
+                key={`${u.modelId}-${u.provider}`}
+                className="rounded-md border border-border/60 bg-(--color-background) p-2.5">
+                <div className="flex items-baseline justify-between gap-2">
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate font-medium text-(--color-foreground) text-xs">{u.modelName}</div>
+                    <div className="truncate text-(--color-foreground-muted) text-xs">{u.providerName}</div>
+                  </div>
+                  <div className="text-right text-(--color-foreground) text-xs tabular-nums">
+                    {u.totalTokens.toLocaleString()} <span className="text-(--color-foreground-muted)">tok</span>
+                  </div>
+                </div>
+                <div className="mt-1.5 flex flex-wrap gap-x-3 text-(--color-foreground-muted) text-xs">
+                  <span>
+                    {t('stats.messages')}: {u.messageCount}
+                  </span>
+                  {u.performance.avgFirstTokenMs != null && (
+                    <span>TTFT {Math.round(u.performance.avgFirstTokenMs)}ms</span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+    </div>
+  )
+}
+
+const Section: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
+  <div>
+    <div className="mb-1.5 font-semibold text-(--color-foreground) text-xs uppercase tracking-wide">{title}</div>
+    {children}
+  </div>
+)
+
+const StatBox: React.FC<{ label: string; value: string; sub?: string }> = ({ label, value, sub }) => (
+  <div className="rounded-md border border-border/60 bg-(--color-background) px-2.5 py-2">
+    <div className="text-(--color-foreground-muted) text-xs">{label}</div>
+    <div className="mt-0.5 font-semibold text-(--color-foreground) tabular-nums">{value}</div>
+    {sub && <div className="text-(--color-foreground-muted) text-xs">{sub}</div>}
+  </div>
+)
+
+const TokenBar: React.FC<{ input: number; output: number; thinking: number; total: number }> = ({
+  input,
+  output,
+  thinking,
+  total
+}) => {
+  if (total === 0) return <div className="text-(--color-foreground-muted) text-xs">—</div>
+  const i = (input / total) * 100
+  const o = (output / total) * 100
+  const th = (thinking / total) * 100
+  return (
+    <div className="space-y-1.5">
+      <div className="flex h-2 w-full overflow-hidden rounded-full bg-(--color-background-soft)">
+        {i > 0 && <div className="bg-[#6366f1]" style={{ width: `${i}%` }} title={`Input ${input}`} />}
+        {o > 0 && <div className="bg-[#10b981]" style={{ width: `${o}%` }} title={`Output ${output}`} />}
+        {th > 0 && <div className="bg-[#a855f7]" style={{ width: `${th}%` }} title={`Thinking ${thinking}`} />}
+      </div>
+      <div className="flex flex-wrap gap-x-3 text-(--color-foreground-muted) text-xs">
+        <span>
+          <span className="mr-1 inline-block size-2 rounded-full bg-[#6366f1]" />
+          Input {input.toLocaleString()}
+        </span>
+        <span>
+          <span className="mr-1 inline-block size-2 rounded-full bg-[#10b981]" />
+          Output {output.toLocaleString()}
+        </span>
+        {thinking > 0 && (
+          <span>
+            <span className="mr-1 inline-block size-2 rounded-full bg-[#a855f7]" />
+            Thinking {thinking.toLocaleString()}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const formatMs = (ms: number | null): string => {
+  if (ms == null || !Number.isFinite(ms) || ms <= 0) return '—'
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  return `${(ms / 1000).toFixed(2)}s`
+}
+
+const formatDuration = (ms: number): string => {
+  if (ms <= 0) return '—'
+  const totalMin = Math.floor(ms / 60_000)
+  const d = Math.floor(totalMin / (60 * 24))
+  const h = Math.floor((totalMin - d * 60 * 24) / 60)
+  const m = totalMin - d * 60 * 24 - h * 60
+  return `${d}d ${h}h ${m}m`
+}
+
+const TopViewKey = 'TopicStatsPopup'
+
+export default class TopicStatsPopup {
+  static topviewId = 0
+  static hide() {
+    TopView.hide(TopViewKey)
+  }
+  static show(props: ShowParams) {
+    return new Promise<any>((resolve) => {
+      TopView.show(
+        <PopupContainer
+          {...props}
+          resolve={(v) => {
+            resolve(v)
+            TopView.hide(TopViewKey)
+          }}
+        />,
+        TopViewKey
+      )
+    })
+  }
+}

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -613,12 +613,21 @@
       "thinking_tokens": "Thinking Tokens",
       "title": "Usage Statistics",
       "token_breakdown": "Token Breakdown",
+      "token_input": "Input {{count}}",
+      "token_output": "Output {{count}}",
+      "token_thinking": "Thinking {{count}}",
       "topics": "Topics",
       "total_characters": "Total Characters",
       "total_messages": "Total Messages",
       "total_tokens": "Total Tokens",
       "total_words": "Total Words",
-      "unique_models": "Models Used"
+      "unique_models": "Models Used",
+      "units": {
+        "d_h_m": "{{d}}d {{h}}h {{m}}m",
+        "tok": "tok",
+        "tok_per_sec": "{{value}} tok/s",
+        "ttft": "TTFT {{ms}}ms"
+      }
     },
     "todo": {
       "mock": {

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -583,6 +583,43 @@
       }
     },
     "sidebar_title": "Agents",
+    "stats": {
+      "active_days": "days active",
+      "avg_completion": "Avg Completion",
+      "avg_first_token": "Avg First Token",
+      "avg_speed": "Avg Speed",
+      "conversation_info": "Conversation Info",
+      "daily_usage": "Daily Usage",
+      "duration": "Duration",
+      "limit": "Display limit",
+      "loading": "Loading statistics...",
+      "messages": "Messages",
+      "model_filter_all": "All Providers",
+      "model_sort_messages": "By Messages",
+      "model_sort_speed": "By Speed",
+      "model_sort_tokens": "By Tokens",
+      "model_usage": "Model Usage",
+      "no_data": "No statistics available",
+      "no_data_hint": "Start a conversation to see usage statistics here.",
+      "no_models_match": "No models match the current filters.",
+      "performance": "Performance",
+      "popup": {
+        "load_failed": "Failed to load topic statistics",
+        "title": "Topic Statistics",
+        "topic_not_found": "Topic not found"
+      },
+      "search_placeholder": "Search model or provider...",
+      "sort_by": "Sort by",
+      "thinking_tokens": "Thinking Tokens",
+      "title": "Usage Statistics",
+      "token_breakdown": "Token Breakdown",
+      "topics": "Topics",
+      "total_characters": "Total Characters",
+      "total_messages": "Total Messages",
+      "total_tokens": "Total Tokens",
+      "total_words": "Total Words",
+      "unique_models": "Models Used"
+    },
     "todo": {
       "mock": {
         "actions": {
@@ -1600,6 +1637,7 @@
         "placeholder": "Search topics...",
         "title": "Search"
       },
+      "statistics": "Statistics",
       "title": "Topics",
       "unpin": "Unpin Topic"
     },
@@ -6800,6 +6838,9 @@
       "uninstallSuccess": "Skill uninstalled: {{name}}",
       "viewSource": "View Source",
       "zip": "ZIP"
+    },
+    "stats": {
+      "title": "Usage Statistics"
     },
     "theme": {
       "color_primary": "Primary Color",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -583,6 +583,43 @@
       }
     },
     "sidebar_title": "智能体",
+    "stats": {
+      "active_days": "活跃天数",
+      "avg_completion": "平均完成时间",
+      "avg_first_token": "平均首 Token",
+      "avg_speed": "平均速度",
+      "conversation_info": "对话信息",
+      "daily_usage": "每日用量",
+      "duration": "持续时长",
+      "limit": "显示数量",
+      "loading": "正在加载统计数据...",
+      "messages": "消息数",
+      "model_filter_all": "全部提供商",
+      "model_sort_messages": "按消息数",
+      "model_sort_speed": "按速度",
+      "model_sort_tokens": "按 Token",
+      "model_usage": "模型用量",
+      "no_data": "暂无统计数据",
+      "no_data_hint": "开始对话后即可在此查看用量统计。",
+      "no_models_match": "没有符合当前筛选条件的模型。",
+      "performance": "性能指标",
+      "popup": {
+        "load_failed": "加载话题统计失败",
+        "title": "话题统计",
+        "topic_not_found": "话题不存在"
+      },
+      "search_placeholder": "搜索模型或提供商...",
+      "sort_by": "排序方式",
+      "thinking_tokens": "思考 Token",
+      "title": "用量统计",
+      "token_breakdown": "Token 分布",
+      "topics": "话题数",
+      "total_characters": "总字符数",
+      "total_messages": "总消息数",
+      "total_tokens": "总 Token",
+      "total_words": "总词数",
+      "unique_models": "使用模型数"
+    },
     "todo": {
       "mock": {
         "actions": {
@@ -1600,6 +1637,7 @@
         "placeholder": "搜索话题...",
         "title": "搜索"
       },
+      "statistics": "用量统计",
       "title": "话题",
       "unpin": "取消固定"
     },
@@ -6800,6 +6838,9 @@
       "uninstallSuccess": "技能已卸载：{{name}}",
       "viewSource": "查看源码",
       "zip": "ZIP"
+    },
+    "stats": {
+      "title": "用量统计"
     },
     "theme": {
       "color_primary": "主题颜色",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -613,12 +613,21 @@
       "thinking_tokens": "思考 Token",
       "title": "用量统计",
       "token_breakdown": "Token 分布",
+      "token_input": "输入 {{count}}",
+      "token_output": "输出 {{count}}",
+      "token_thinking": "思考 {{count}}",
       "topics": "话题数",
       "total_characters": "总字符数",
       "total_messages": "总消息数",
       "total_tokens": "总 Token",
       "total_words": "总词数",
-      "unique_models": "使用模型数"
+      "unique_models": "使用模型数",
+      "units": {
+        "d_h_m": "{{d}}天 {{h}}时 {{m}}分",
+        "tok": "tok",
+        "tok_per_sec": "{{value}} tok/s",
+        "ttft": "首 Token {{ms}}ms"
+      }
     },
     "todo": {
       "mock": {

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -584,41 +584,50 @@
     },
     "sidebar_title": "Agents",
     "stats": {
-      "active_days": "[to be translated]:days active",
-      "avg_completion": "[to be translated]:Avg Completion",
-      "avg_first_token": "[to be translated]:Avg First Token",
-      "avg_speed": "[to be translated]:Avg Speed",
-      "conversation_info": "[to be translated]:Conversation Info",
-      "daily_usage": "[to be translated]:Daily Usage",
-      "duration": "[to be translated]:Duration",
-      "limit": "[to be translated]:Display limit",
-      "loading": "[to be translated]:Loading statistics...",
-      "messages": "[to be translated]:Messages",
-      "model_filter_all": "[to be translated]:All Providers",
-      "model_sort_messages": "[to be translated]:By Messages",
-      "model_sort_speed": "[to be translated]:By Speed",
-      "model_sort_tokens": "[to be translated]:By Tokens",
-      "model_usage": "[to be translated]:Model Usage",
-      "no_data": "[to be translated]:No statistics available",
-      "no_data_hint": "[to be translated]:Start a conversation to see usage statistics here.",
-      "no_models_match": "[to be translated]:No models match the current filters.",
-      "performance": "[to be translated]:Performance",
+      "active_days": "活躍天數",
+      "avg_completion": "平均完成時間",
+      "avg_first_token": "平均首 Token",
+      "avg_speed": "平均速度",
+      "conversation_info": "對話資訊",
+      "daily_usage": "每日用量",
+      "duration": "持續時間",
+      "limit": "顯示數量",
+      "loading": "正在載入統計資料...",
+      "messages": "訊息數",
+      "model_filter_all": "全部提供商",
+      "model_sort_messages": "按訊息數",
+      "model_sort_speed": "按速度",
+      "model_sort_tokens": "按 Token",
+      "model_usage": "模型用量",
+      "no_data": "暫無統計資料",
+      "no_data_hint": "開始對話後即可在此查看用量統計。",
+      "no_models_match": "沒有符合目前篩選條件的模型。",
+      "performance": "效能指標",
       "popup": {
-        "load_failed": "[to be translated]:Failed to load topic statistics",
-        "title": "[to be translated]:Topic Statistics",
-        "topic_not_found": "[to be translated]:Topic not found"
+        "load_failed": "載入話題統計失敗",
+        "title": "話題統計",
+        "topic_not_found": "話題不存在"
       },
-      "search_placeholder": "[to be translated]:Search model or provider...",
-      "sort_by": "[to be translated]:Sort by",
-      "thinking_tokens": "[to be translated]:Thinking Tokens",
-      "title": "[to be translated]:Usage Statistics",
-      "token_breakdown": "[to be translated]:Token Breakdown",
-      "topics": "[to be translated]:Topics",
-      "total_characters": "[to be translated]:Total Characters",
-      "total_messages": "[to be translated]:Total Messages",
-      "total_tokens": "[to be translated]:Total Tokens",
-      "total_words": "[to be translated]:Total Words",
-      "unique_models": "[to be translated]:Models Used"
+      "search_placeholder": "搜尋模型或提供商...",
+      "sort_by": "排序方式",
+      "thinking_tokens": "思考 Token",
+      "title": "使用統計",
+      "token_breakdown": "Token 分布",
+      "token_input": "輸入 {{count}}",
+      "token_output": "輸出 {{count}}",
+      "token_thinking": "思考 {{count}}",
+      "topics": "話題數",
+      "total_characters": "總字元數",
+      "total_messages": "總訊息數",
+      "total_tokens": "總 Token",
+      "total_words": "總詞數",
+      "unique_models": "使用模型數",
+      "units": {
+        "d_h_m": "{{d}}天 {{h}}時 {{m}}分",
+        "tok": "tok",
+        "tok_per_sec": "{{value}} tok/s",
+        "ttft": "首 Token {{ms}}ms"
+      }
     },
     "todo": {
       "mock": {
@@ -1637,7 +1646,7 @@
         "placeholder": "搜尋話題...",
         "title": "搜尋"
       },
-      "statistics": "[to be translated]:Statistics",
+      "statistics": "統計",
       "title": "話題",
       "unpin": "取消固定"
     },
@@ -6840,7 +6849,7 @@
       "zip": "ZIP"
     },
     "stats": {
-      "title": "[to be translated]:Usage Statistics"
+      "title": "使用統計"
     },
     "theme": {
       "color_primary": "主題顏色",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -583,6 +583,43 @@
       }
     },
     "sidebar_title": "Agents",
+    "stats": {
+      "active_days": "[to be translated]:days active",
+      "avg_completion": "[to be translated]:Avg Completion",
+      "avg_first_token": "[to be translated]:Avg First Token",
+      "avg_speed": "[to be translated]:Avg Speed",
+      "conversation_info": "[to be translated]:Conversation Info",
+      "daily_usage": "[to be translated]:Daily Usage",
+      "duration": "[to be translated]:Duration",
+      "limit": "[to be translated]:Display limit",
+      "loading": "[to be translated]:Loading statistics...",
+      "messages": "[to be translated]:Messages",
+      "model_filter_all": "[to be translated]:All Providers",
+      "model_sort_messages": "[to be translated]:By Messages",
+      "model_sort_speed": "[to be translated]:By Speed",
+      "model_sort_tokens": "[to be translated]:By Tokens",
+      "model_usage": "[to be translated]:Model Usage",
+      "no_data": "[to be translated]:No statistics available",
+      "no_data_hint": "[to be translated]:Start a conversation to see usage statistics here.",
+      "no_models_match": "[to be translated]:No models match the current filters.",
+      "performance": "[to be translated]:Performance",
+      "popup": {
+        "load_failed": "[to be translated]:Failed to load topic statistics",
+        "title": "[to be translated]:Topic Statistics",
+        "topic_not_found": "[to be translated]:Topic not found"
+      },
+      "search_placeholder": "[to be translated]:Search model or provider...",
+      "sort_by": "[to be translated]:Sort by",
+      "thinking_tokens": "[to be translated]:Thinking Tokens",
+      "title": "[to be translated]:Usage Statistics",
+      "token_breakdown": "[to be translated]:Token Breakdown",
+      "topics": "[to be translated]:Topics",
+      "total_characters": "[to be translated]:Total Characters",
+      "total_messages": "[to be translated]:Total Messages",
+      "total_tokens": "[to be translated]:Total Tokens",
+      "total_words": "[to be translated]:Total Words",
+      "unique_models": "[to be translated]:Models Used"
+    },
     "todo": {
       "mock": {
         "actions": {
@@ -1600,6 +1637,7 @@
         "placeholder": "搜尋話題...",
         "title": "搜尋"
       },
+      "statistics": "[to be translated]:Statistics",
       "title": "話題",
       "unpin": "取消固定"
     },
@@ -6800,6 +6838,9 @@
       "uninstallSuccess": "技能已解除安裝：{{name}}",
       "viewSource": "查看原始碼",
       "zip": "ZIP"
+    },
+    "stats": {
+      "title": "[to be translated]:Usage Statistics"
     },
     "theme": {
       "color_primary": "主題顏色",

--- a/src/renderer/i18n/translate/de-de.json
+++ b/src/renderer/i18n/translate/de-de.json
@@ -584,41 +584,50 @@
     },
     "sidebar_title": "Agenten",
     "stats": {
-      "active_days": "[to be translated]:days active",
-      "avg_completion": "[to be translated]:Avg Completion",
-      "avg_first_token": "[to be translated]:Avg First Token",
-      "avg_speed": "[to be translated]:Avg Speed",
-      "conversation_info": "[to be translated]:Conversation Info",
-      "daily_usage": "[to be translated]:Daily Usage",
-      "duration": "[to be translated]:Duration",
-      "limit": "[to be translated]:Display limit",
-      "loading": "[to be translated]:Loading statistics...",
-      "messages": "[to be translated]:Messages",
-      "model_filter_all": "[to be translated]:All Providers",
-      "model_sort_messages": "[to be translated]:By Messages",
-      "model_sort_speed": "[to be translated]:By Speed",
-      "model_sort_tokens": "[to be translated]:By Tokens",
-      "model_usage": "[to be translated]:Model Usage",
-      "no_data": "[to be translated]:No statistics available",
-      "no_data_hint": "[to be translated]:Start a conversation to see usage statistics here.",
-      "no_models_match": "[to be translated]:No models match the current filters.",
-      "performance": "[to be translated]:Performance",
+      "active_days": "aktive Tage",
+      "avg_completion": "Durchschn. Abschluss",
+      "avg_first_token": "Durchschn. erster Token",
+      "avg_speed": "Durchschn. Geschwindigkeit",
+      "conversation_info": "Gesprächsinformationen",
+      "daily_usage": "Tägliche Nutzung",
+      "duration": "Dauer",
+      "limit": "Anzeigelimit",
+      "loading": "Statistiken werden geladen...",
+      "messages": "Nachrichten",
+      "model_filter_all": "Alle Anbieter",
+      "model_sort_messages": "Nach Nachrichten",
+      "model_sort_speed": "Nach Geschwindigkeit",
+      "model_sort_tokens": "Nach Tokens",
+      "model_usage": "Modellnutzung",
+      "no_data": "Keine Statistiken verfügbar",
+      "no_data_hint": "Starten Sie ein Gespräch, um hier Nutzungsstatistiken zu sehen.",
+      "no_models_match": "Keine Modelle entsprechen den aktuellen Filtern.",
+      "performance": "Leistung",
       "popup": {
-        "load_failed": "[to be translated]:Failed to load topic statistics",
-        "title": "[to be translated]:Topic Statistics",
-        "topic_not_found": "[to be translated]:Topic not found"
+        "load_failed": "Themenstatistiken konnten nicht geladen werden",
+        "title": "Themenstatistiken",
+        "topic_not_found": "Thema nicht gefunden"
       },
-      "search_placeholder": "[to be translated]:Search model or provider...",
-      "sort_by": "[to be translated]:Sort by",
-      "thinking_tokens": "[to be translated]:Thinking Tokens",
-      "title": "[to be translated]:Usage Statistics",
-      "token_breakdown": "[to be translated]:Token Breakdown",
-      "topics": "[to be translated]:Topics",
-      "total_characters": "[to be translated]:Total Characters",
-      "total_messages": "[to be translated]:Total Messages",
-      "total_tokens": "[to be translated]:Total Tokens",
-      "total_words": "[to be translated]:Total Words",
-      "unique_models": "[to be translated]:Models Used"
+      "search_placeholder": "Modell oder Anbieter suchen...",
+      "sort_by": "Sortieren nach",
+      "thinking_tokens": "Denk-Tokens",
+      "title": "Nutzungsstatistiken",
+      "token_breakdown": "Token-Aufschlüsselung",
+      "token_input": "Eingabe {{count}}",
+      "token_output": "Ausgabe {{count}}",
+      "token_thinking": "Denken {{count}}",
+      "topics": "Themen",
+      "total_characters": "Gesamtzeichen",
+      "total_messages": "Gesamtnachrichten",
+      "total_tokens": "Gesamt-Tokens",
+      "total_words": "Gesamtwörter",
+      "unique_models": "Verwendete Modelle",
+      "units": {
+        "d_h_m": "{{d}}T {{h}}Std {{m}}Min",
+        "tok": "tok",
+        "tok_per_sec": "{{value}} tok/s",
+        "ttft": "TTFT {{ms}}ms"
+      }
     },
     "todo": {
       "mock": {
@@ -1637,7 +1646,7 @@
         "placeholder": "Themen durchsuchen...",
         "title": "Suche"
       },
-      "statistics": "[to be translated]:Statistics",
+      "statistics": "Statistiken",
       "title": "Thema",
       "unpin": "Anheften aufheben"
     },
@@ -2200,16 +2209,10 @@
           "supported_formats": "Unterstützt PDF, DOCX, MD, XLSX, TXT, CSV",
           "title": "Klicken Sie, um Dateien auszuwählen, oder ziehen Sie sie hierher"
         },
-        "sitemap": {
-          "description": "Gib eine Sitemap-URL ein:",
-          "help": "Die in der Sitemap aufgeführten Seiten werden gelesen und indiziert.",
-          "placeholder": "https://docs.cherry-ai.com/sitemap-pages.xml"
-        },
         "sources": {
           "directory": "Ordner",
           "file": "Datei",
           "note": "Hinweis",
-          "sitemap": "Website",
           "url": "URL"
         },
         "submit": {
@@ -2247,9 +2250,6 @@
           "file": {
             "title": "Datei"
           },
-          "sitemap": {
-            "title": "Website-Synchronisierung"
-          },
           "url": {
             "title": "URL"
           }
@@ -2262,7 +2262,6 @@
         "directory": "Ordner",
         "file": "Dateien",
         "note": "Notizen",
-        "sitemap": "Websites",
         "url": "URLs"
       },
       "preview": {
@@ -6185,6 +6184,9 @@
         "enabled": "Einschalten",
         "failed": "Fehlgeschlagen",
         "failed_to_start": "Fehler beim Start der Gesundheitsprüfung",
+        "generation_output_audio": "[to be translated]:audio",
+        "generation_output_image": "[to be translated]:an image",
+        "generation_output_video": "[to be translated]:a video",
         "keys_status_count": "Erfolgreich: {{count_passed}} Schlüssel, Fehlgeschlagen: {{count_failed}} Schlüssel",
         "model_status_failed": "{{count}} Modelle vollständig nicht zugänglich",
         "model_status_partial": "{{count}} Modelle mit einigen Schlüsseln nicht zugänglich",
@@ -6193,6 +6195,7 @@
         "no_api_keys": "API-Schlüssel nicht gefunden, bitte zuerst API-Schlüssel hinzufügen",
         "no_results": "Keine Ergebnisse",
         "outcome_fail_short": "{{count}} failed",
+        "outcome_skipped_short": "[to be translated]:{{count}} skipped",
         "outcome_success_short": "{{count}} passed",
         "outcome_total": "{{count}} total",
         "passed": "Durch",
@@ -6204,8 +6207,11 @@
         "retry": "Check again",
         "select_api_key": "API-Schlüssel auswählen: ",
         "single": "Einzeln",
+        "skip_reason_generation_cost": "[to be translated]:This model's health check would generate {{output}} and consume quota, so it is skipped by default.",
+        "skip_reason_unsupported_probe": "[to be translated]:This model type does not have a low-cost health check yet, so it is skipped by default.",
         "start": "Start",
         "status_checking": "Checking…",
+        "status_skipped": "[to be translated]:Skipped",
         "timeout": "Timeout",
         "title": "Modell-Gesundheitscheck",
         "use_all_keys": "Schlüssel verwenden"
@@ -6214,6 +6220,8 @@
       "default_assistant_model": "Standard-Assistent-Modell",
       "default_assistant_model_description": "Wird verwendet, wenn ein Assistent kein Modell hat.",
       "empty": "Kein Modell",
+      "group_disable": "[to be translated]:Close this group",
+      "group_enable": "[to be translated]:Enable this group",
       "list_title": "Model list",
       "manage": {
         "add_custom_model": "Add custom model",
@@ -6841,7 +6849,7 @@
       "zip": "PLZ"
     },
     "stats": {
-      "title": "[to be translated]:Usage Statistics"
+      "title": "Nutzungsstatistiken"
     },
     "theme": {
       "color_primary": "Theme-Farbe",

--- a/src/renderer/i18n/translate/de-de.json
+++ b/src/renderer/i18n/translate/de-de.json
@@ -583,6 +583,43 @@
       }
     },
     "sidebar_title": "Agenten",
+    "stats": {
+      "active_days": "[to be translated]:days active",
+      "avg_completion": "[to be translated]:Avg Completion",
+      "avg_first_token": "[to be translated]:Avg First Token",
+      "avg_speed": "[to be translated]:Avg Speed",
+      "conversation_info": "[to be translated]:Conversation Info",
+      "daily_usage": "[to be translated]:Daily Usage",
+      "duration": "[to be translated]:Duration",
+      "limit": "[to be translated]:Display limit",
+      "loading": "[to be translated]:Loading statistics...",
+      "messages": "[to be translated]:Messages",
+      "model_filter_all": "[to be translated]:All Providers",
+      "model_sort_messages": "[to be translated]:By Messages",
+      "model_sort_speed": "[to be translated]:By Speed",
+      "model_sort_tokens": "[to be translated]:By Tokens",
+      "model_usage": "[to be translated]:Model Usage",
+      "no_data": "[to be translated]:No statistics available",
+      "no_data_hint": "[to be translated]:Start a conversation to see usage statistics here.",
+      "no_models_match": "[to be translated]:No models match the current filters.",
+      "performance": "[to be translated]:Performance",
+      "popup": {
+        "load_failed": "[to be translated]:Failed to load topic statistics",
+        "title": "[to be translated]:Topic Statistics",
+        "topic_not_found": "[to be translated]:Topic not found"
+      },
+      "search_placeholder": "[to be translated]:Search model or provider...",
+      "sort_by": "[to be translated]:Sort by",
+      "thinking_tokens": "[to be translated]:Thinking Tokens",
+      "title": "[to be translated]:Usage Statistics",
+      "token_breakdown": "[to be translated]:Token Breakdown",
+      "topics": "[to be translated]:Topics",
+      "total_characters": "[to be translated]:Total Characters",
+      "total_messages": "[to be translated]:Total Messages",
+      "total_tokens": "[to be translated]:Total Tokens",
+      "total_words": "[to be translated]:Total Words",
+      "unique_models": "[to be translated]:Models Used"
+    },
     "todo": {
       "mock": {
         "actions": {
@@ -1600,6 +1637,7 @@
         "placeholder": "Themen durchsuchen...",
         "title": "Suche"
       },
+      "statistics": "[to be translated]:Statistics",
       "title": "Thema",
       "unpin": "Anheften aufheben"
     },
@@ -6801,6 +6839,9 @@
       "uninstallSuccess": "Skill deinstalliert: {{name}}",
       "viewSource": "Quelltext anzeigen",
       "zip": "PLZ"
+    },
+    "stats": {
+      "title": "[to be translated]:Usage Statistics"
     },
     "theme": {
       "color_primary": "Theme-Farbe",

--- a/src/renderer/i18n/translate/el-gr.json
+++ b/src/renderer/i18n/translate/el-gr.json
@@ -584,41 +584,50 @@
     },
     "sidebar_title": "Πράκτορες",
     "stats": {
-      "active_days": "[to be translated]:days active",
-      "avg_completion": "[to be translated]:Avg Completion",
-      "avg_first_token": "[to be translated]:Avg First Token",
-      "avg_speed": "[to be translated]:Avg Speed",
-      "conversation_info": "[to be translated]:Conversation Info",
-      "daily_usage": "[to be translated]:Daily Usage",
-      "duration": "[to be translated]:Duration",
-      "limit": "[to be translated]:Display limit",
-      "loading": "[to be translated]:Loading statistics...",
-      "messages": "[to be translated]:Messages",
-      "model_filter_all": "[to be translated]:All Providers",
-      "model_sort_messages": "[to be translated]:By Messages",
-      "model_sort_speed": "[to be translated]:By Speed",
-      "model_sort_tokens": "[to be translated]:By Tokens",
-      "model_usage": "[to be translated]:Model Usage",
-      "no_data": "[to be translated]:No statistics available",
-      "no_data_hint": "[to be translated]:Start a conversation to see usage statistics here.",
-      "no_models_match": "[to be translated]:No models match the current filters.",
-      "performance": "[to be translated]:Performance",
+      "active_days": "ενεργές ημέρες",
+      "avg_completion": "Μέση ολοκλήρωση",
+      "avg_first_token": "Μέσο πρώτο Token",
+      "avg_speed": "Μέση ταχύτητα",
+      "conversation_info": "Πληροφορίες συνομιλίας",
+      "daily_usage": "Ημερήσια χρήση",
+      "duration": "Διάρκεια",
+      "limit": "Όριο εμφάνισης",
+      "loading": "Φόρτωση στατιστικών...",
+      "messages": "Μηνύματα",
+      "model_filter_all": "Όλοι οι πάροχοι",
+      "model_sort_messages": "Κατά μηνύματα",
+      "model_sort_speed": "Κατά ταχύτητα",
+      "model_sort_tokens": "Κατά Tokens",
+      "model_usage": "Χρήση μοντέλου",
+      "no_data": "Δεν υπάρχουν διαθέσιμα στατιστικά",
+      "no_data_hint": "Ξεκινήστε μια συνομιλία για να δείτε στατιστικά χρήσης εδώ.",
+      "no_models_match": "Κανένα μοντέλο δεν ταιριάζει με τα τρέχοντα φίλτρα.",
+      "performance": "Απόδοση",
       "popup": {
-        "load_failed": "[to be translated]:Failed to load topic statistics",
-        "title": "[to be translated]:Topic Statistics",
-        "topic_not_found": "[to be translated]:Topic not found"
+        "load_failed": "Αποτυχία φόρτωσης στατιστικών θέματος",
+        "title": "Στατιστικά θέματος",
+        "topic_not_found": "Το θέμα δεν βρέθηκε"
       },
-      "search_placeholder": "[to be translated]:Search model or provider...",
-      "sort_by": "[to be translated]:Sort by",
-      "thinking_tokens": "[to be translated]:Thinking Tokens",
-      "title": "[to be translated]:Usage Statistics",
-      "token_breakdown": "[to be translated]:Token Breakdown",
-      "topics": "[to be translated]:Topics",
-      "total_characters": "[to be translated]:Total Characters",
-      "total_messages": "[to be translated]:Total Messages",
-      "total_tokens": "[to be translated]:Total Tokens",
-      "total_words": "[to be translated]:Total Words",
-      "unique_models": "[to be translated]:Models Used"
+      "search_placeholder": "Αναζήτηση μοντέλου ή παρόχου...",
+      "sort_by": "Ταξινόμηση κατά",
+      "thinking_tokens": "Tokens σκέψης",
+      "title": "Στατιστικά χρήσης",
+      "token_breakdown": "Ανάλυση Token",
+      "token_input": "Εισαγωγή {{count}}",
+      "token_output": "Έξοδος {{count}}",
+      "token_thinking": "Σκέψη {{count}}",
+      "topics": "Θέματα",
+      "total_characters": "Συνολικοί χαρακτήρες",
+      "total_messages": "Συνολικά μηνύματα",
+      "total_tokens": "Συνολικά Tokens",
+      "total_words": "Συνολικές λέξεις",
+      "unique_models": "Μοντέλα σε χρήση",
+      "units": {
+        "d_h_m": "{{d}}η {{h}}ω {{m}}λ",
+        "tok": "tok",
+        "tok_per_sec": "{{value}} tok/s",
+        "ttft": "TTFT {{ms}}ms"
+      }
     },
     "todo": {
       "mock": {
@@ -1637,7 +1646,7 @@
         "placeholder": "Αναζήτηση θεμάτων...",
         "title": "Αναζήτηση"
       },
-      "statistics": "[to be translated]:Statistics",
+      "statistics": "Στατιστικά",
       "title": "Θέματα",
       "unpin": "Ξεκαρφίτσωμα"
     },
@@ -2200,16 +2209,10 @@
           "supported_formats": "Υποστηρίζει PDF, DOCX, MD, XLSX, TXT, CSV",
           "title": "Κάντε κλικ για να επιλέξετε αρχεία ή σύρετε τα εδώ"
         },
-        "sitemap": {
-          "description": "Εισαγάγετε ένα URL χάρτη ιστότοπου:",
-          "help": "Οι σελίδες που περιλαμβάνονται στον χάρτη ιστότοπου θα διαβαστούν και θα ευρετηριαστούν",
-          "placeholder": "https://docs.cherry-ai.com/sitemap-pages.xml"
-        },
         "sources": {
           "directory": "Φάκελος",
           "file": "Αρχείο",
           "note": "Σημείωση",
-          "sitemap": "Ιστοσελίδα",
           "url": "URL"
         },
         "submit": {
@@ -2247,9 +2250,6 @@
           "file": {
             "title": "Αρχείο"
           },
-          "sitemap": {
-            "title": "Συγχρονισμός Ιστοσελίδας"
-          },
           "url": {
             "title": "URL"
           }
@@ -2262,7 +2262,6 @@
         "directory": "Φάκελοι",
         "file": "Αρχεία",
         "note": "Σημειώσεις",
-        "sitemap": "Ιστοσελίδες",
         "url": "Διευθύνσεις URL"
       },
       "preview": {
@@ -6185,6 +6184,9 @@
         "enabled": "Ενεργοποίηση",
         "failed": "Αποτυχία",
         "failed_to_start": "Αποτυχία έναρξης ελέγχου υγείας",
+        "generation_output_audio": "[to be translated]:audio",
+        "generation_output_image": "[to be translated]:an image",
+        "generation_output_video": "[to be translated]:a video",
         "keys_status_count": "Επιτυχημένοι: {{count_passed}} κλειδιά, αποτυχημένοι: {{count_failed}} κλειδιά",
         "model_status_failed": "{{count}} μοντέλα είναι εντελώς απρόσιτα",
         "model_status_partial": "Από αυτά, {{count}} μοντέλα είναι απρόσιτα με ορισμένα κλειδιά",
@@ -6193,6 +6195,7 @@
         "no_api_keys": "Δεν βρέθηκαν API κλειδιά. Παρακαλούμε πρώτα προσθέστε κλειδιά API.",
         "no_results": "χωρίς αποτελέσματα",
         "outcome_fail_short": "{{count}} failed",
+        "outcome_skipped_short": "[to be translated]:{{count}} skipped",
         "outcome_success_short": "{{count}} passed",
         "outcome_total": "{{count}} total",
         "passed": "Επιτυχία",
@@ -6204,8 +6207,11 @@
         "retry": "Check again",
         "select_api_key": "Επιλέξτε το API key που θέλετε να χρησιμοποιήσετε:",
         "single": "Μόνο",
+        "skip_reason_generation_cost": "[to be translated]:This model's health check would generate {{output}} and consume quota, so it is skipped by default.",
+        "skip_reason_unsupported_probe": "[to be translated]:This model type does not have a low-cost health check yet, so it is skipped by default.",
         "start": "Έναρξη",
         "status_checking": "Checking…",
+        "status_skipped": "[to be translated]:Skipped",
         "timeout": "Χρονική καθυστέρηση",
         "title": "Ελεγχος υγείας μοντέλου",
         "use_all_keys": "Χρήση όλων των κλειδιών"
@@ -6214,6 +6220,8 @@
       "default_assistant_model": "Πρόεδρος Υπηρεσίας προεπιλεγμένου μοντέλου",
       "default_assistant_model_description": "Χρησιμοποιείται όταν ένας βοηθός δεν έχει μοντέλο.",
       "empty": "Δεν υπάρχουν μοντέλα",
+      "group_disable": "[to be translated]:Close this group",
+      "group_enable": "[to be translated]:Enable this group",
       "list_title": "Model list",
       "manage": {
         "add_custom_model": "Add custom model",
@@ -6841,7 +6849,7 @@
       "zip": "Τ.Κ."
     },
     "stats": {
-      "title": "[to be translated]:Usage Statistics"
+      "title": "Στατιστικά χρήσης"
     },
     "theme": {
       "color_primary": "Κύριο Χρώμα Θέματος",

--- a/src/renderer/i18n/translate/el-gr.json
+++ b/src/renderer/i18n/translate/el-gr.json
@@ -583,6 +583,43 @@
       }
     },
     "sidebar_title": "Πράκτορες",
+    "stats": {
+      "active_days": "[to be translated]:days active",
+      "avg_completion": "[to be translated]:Avg Completion",
+      "avg_first_token": "[to be translated]:Avg First Token",
+      "avg_speed": "[to be translated]:Avg Speed",
+      "conversation_info": "[to be translated]:Conversation Info",
+      "daily_usage": "[to be translated]:Daily Usage",
+      "duration": "[to be translated]:Duration",
+      "limit": "[to be translated]:Display limit",
+      "loading": "[to be translated]:Loading statistics...",
+      "messages": "[to be translated]:Messages",
+      "model_filter_all": "[to be translated]:All Providers",
+      "model_sort_messages": "[to be translated]:By Messages",
+      "model_sort_speed": "[to be translated]:By Speed",
+      "model_sort_tokens": "[to be translated]:By Tokens",
+      "model_usage": "[to be translated]:Model Usage",
+      "no_data": "[to be translated]:No statistics available",
+      "no_data_hint": "[to be translated]:Start a conversation to see usage statistics here.",
+      "no_models_match": "[to be translated]:No models match the current filters.",
+      "performance": "[to be translated]:Performance",
+      "popup": {
+        "load_failed": "[to be translated]:Failed to load topic statistics",
+        "title": "[to be translated]:Topic Statistics",
+        "topic_not_found": "[to be translated]:Topic not found"
+      },
+      "search_placeholder": "[to be translated]:Search model or provider...",
+      "sort_by": "[to be translated]:Sort by",
+      "thinking_tokens": "[to be translated]:Thinking Tokens",
+      "title": "[to be translated]:Usage Statistics",
+      "token_breakdown": "[to be translated]:Token Breakdown",
+      "topics": "[to be translated]:Topics",
+      "total_characters": "[to be translated]:Total Characters",
+      "total_messages": "[to be translated]:Total Messages",
+      "total_tokens": "[to be translated]:Total Tokens",
+      "total_words": "[to be translated]:Total Words",
+      "unique_models": "[to be translated]:Models Used"
+    },
     "todo": {
       "mock": {
         "actions": {
@@ -1600,6 +1637,7 @@
         "placeholder": "Αναζήτηση θεμάτων...",
         "title": "Αναζήτηση"
       },
+      "statistics": "[to be translated]:Statistics",
       "title": "Θέματα",
       "unpin": "Ξεκαρφίτσωμα"
     },
@@ -6801,6 +6839,9 @@
       "uninstallSuccess": "Δεξιότητα απεγκαταστάθηκε: {{name}}",
       "viewSource": "Προβολή Πηγής",
       "zip": "Τ.Κ."
+    },
+    "stats": {
+      "title": "[to be translated]:Usage Statistics"
     },
     "theme": {
       "color_primary": "Κύριο Χρώμα Θέματος",

--- a/src/renderer/i18n/translate/es-es.json
+++ b/src/renderer/i18n/translate/es-es.json
@@ -583,6 +583,43 @@
       }
     },
     "sidebar_title": "Agentes",
+    "stats": {
+      "active_days": "[to be translated]:days active",
+      "avg_completion": "[to be translated]:Avg Completion",
+      "avg_first_token": "[to be translated]:Avg First Token",
+      "avg_speed": "[to be translated]:Avg Speed",
+      "conversation_info": "[to be translated]:Conversation Info",
+      "daily_usage": "[to be translated]:Daily Usage",
+      "duration": "[to be translated]:Duration",
+      "limit": "[to be translated]:Display limit",
+      "loading": "[to be translated]:Loading statistics...",
+      "messages": "[to be translated]:Messages",
+      "model_filter_all": "[to be translated]:All Providers",
+      "model_sort_messages": "[to be translated]:By Messages",
+      "model_sort_speed": "[to be translated]:By Speed",
+      "model_sort_tokens": "[to be translated]:By Tokens",
+      "model_usage": "[to be translated]:Model Usage",
+      "no_data": "[to be translated]:No statistics available",
+      "no_data_hint": "[to be translated]:Start a conversation to see usage statistics here.",
+      "no_models_match": "[to be translated]:No models match the current filters.",
+      "performance": "[to be translated]:Performance",
+      "popup": {
+        "load_failed": "[to be translated]:Failed to load topic statistics",
+        "title": "[to be translated]:Topic Statistics",
+        "topic_not_found": "[to be translated]:Topic not found"
+      },
+      "search_placeholder": "[to be translated]:Search model or provider...",
+      "sort_by": "[to be translated]:Sort by",
+      "thinking_tokens": "[to be translated]:Thinking Tokens",
+      "title": "[to be translated]:Usage Statistics",
+      "token_breakdown": "[to be translated]:Token Breakdown",
+      "topics": "[to be translated]:Topics",
+      "total_characters": "[to be translated]:Total Characters",
+      "total_messages": "[to be translated]:Total Messages",
+      "total_tokens": "[to be translated]:Total Tokens",
+      "total_words": "[to be translated]:Total Words",
+      "unique_models": "[to be translated]:Models Used"
+    },
     "todo": {
       "mock": {
         "actions": {
@@ -1600,6 +1637,7 @@
         "placeholder": "Buscar temas...",
         "title": "Buscar"
       },
+      "statistics": "[to be translated]:Statistics",
       "title": "Tema",
       "unpin": "Quitar fijación"
     },
@@ -6801,6 +6839,9 @@
       "uninstallSuccess": "Habilidad desinstalada: {{name}}",
       "viewSource": "Ver fuente",
       "zip": "CÓDIGO POSTAL"
+    },
+    "stats": {
+      "title": "[to be translated]:Usage Statistics"
     },
     "theme": {
       "color_primary": "Color del tema",

--- a/src/renderer/i18n/translate/es-es.json
+++ b/src/renderer/i18n/translate/es-es.json
@@ -584,41 +584,50 @@
     },
     "sidebar_title": "Agentes",
     "stats": {
-      "active_days": "[to be translated]:days active",
-      "avg_completion": "[to be translated]:Avg Completion",
-      "avg_first_token": "[to be translated]:Avg First Token",
-      "avg_speed": "[to be translated]:Avg Speed",
-      "conversation_info": "[to be translated]:Conversation Info",
-      "daily_usage": "[to be translated]:Daily Usage",
-      "duration": "[to be translated]:Duration",
-      "limit": "[to be translated]:Display limit",
-      "loading": "[to be translated]:Loading statistics...",
-      "messages": "[to be translated]:Messages",
-      "model_filter_all": "[to be translated]:All Providers",
-      "model_sort_messages": "[to be translated]:By Messages",
-      "model_sort_speed": "[to be translated]:By Speed",
-      "model_sort_tokens": "[to be translated]:By Tokens",
-      "model_usage": "[to be translated]:Model Usage",
-      "no_data": "[to be translated]:No statistics available",
-      "no_data_hint": "[to be translated]:Start a conversation to see usage statistics here.",
-      "no_models_match": "[to be translated]:No models match the current filters.",
-      "performance": "[to be translated]:Performance",
+      "active_days": "días activos",
+      "avg_completion": "Finalización promedio",
+      "avg_first_token": "Primer Token promedio",
+      "avg_speed": "Velocidad promedio",
+      "conversation_info": "Información de la conversación",
+      "daily_usage": "Uso diario",
+      "duration": "Duración",
+      "limit": "Límite de visualización",
+      "loading": "Cargando estadísticas...",
+      "messages": "Mensajes",
+      "model_filter_all": "Todos los proveedores",
+      "model_sort_messages": "Por mensajes",
+      "model_sort_speed": "Por velocidad",
+      "model_sort_tokens": "Por tokens",
+      "model_usage": "Uso del modelo",
+      "no_data": "No hay estadísticas disponibles",
+      "no_data_hint": "Inicia una conversación para ver estadísticas de uso aquí.",
+      "no_models_match": "Ningún modelo coincide con los filtros actuales.",
+      "performance": "Rendimiento",
       "popup": {
-        "load_failed": "[to be translated]:Failed to load topic statistics",
-        "title": "[to be translated]:Topic Statistics",
-        "topic_not_found": "[to be translated]:Topic not found"
+        "load_failed": "Error al cargar las estadísticas del tema",
+        "title": "Estadísticas del tema",
+        "topic_not_found": "Tema no encontrado"
       },
-      "search_placeholder": "[to be translated]:Search model or provider...",
-      "sort_by": "[to be translated]:Sort by",
-      "thinking_tokens": "[to be translated]:Thinking Tokens",
-      "title": "[to be translated]:Usage Statistics",
-      "token_breakdown": "[to be translated]:Token Breakdown",
-      "topics": "[to be translated]:Topics",
-      "total_characters": "[to be translated]:Total Characters",
-      "total_messages": "[to be translated]:Total Messages",
-      "total_tokens": "[to be translated]:Total Tokens",
-      "total_words": "[to be translated]:Total Words",
-      "unique_models": "[to be translated]:Models Used"
+      "search_placeholder": "Buscar modelo o proveedor...",
+      "sort_by": "Ordenar por",
+      "thinking_tokens": "Tokens de razonamiento",
+      "title": "Estadísticas de uso",
+      "token_breakdown": "Desglose de tokens",
+      "token_input": "Entrada {{count}}",
+      "token_output": "Salida {{count}}",
+      "token_thinking": "Razonamiento {{count}}",
+      "topics": "Temas",
+      "total_characters": "Caracteres totales",
+      "total_messages": "Mensajes totales",
+      "total_tokens": "Tokens totales",
+      "total_words": "Palabras totales",
+      "unique_models": "Modelos utilizados",
+      "units": {
+        "d_h_m": "{{d}}d {{h}}h {{m}}m",
+        "tok": "tok",
+        "tok_per_sec": "{{value}} tok/s",
+        "ttft": "TTFT {{ms}}ms"
+      }
     },
     "todo": {
       "mock": {
@@ -1637,7 +1646,7 @@
         "placeholder": "Buscar temas...",
         "title": "Buscar"
       },
-      "statistics": "[to be translated]:Statistics",
+      "statistics": "Estadísticas",
       "title": "Tema",
       "unpin": "Quitar fijación"
     },
@@ -2200,16 +2209,10 @@
           "supported_formats": "Soporta PDF, DOCX, MD, XLSX, TXT, CSV",
           "title": "Haz clic para seleccionar archivos o arrástralos aquí"
         },
-        "sitemap": {
-          "description": "Introduce una URL del mapa del sitio:",
-          "help": "Las páginas listadas en el mapa del sitio serán leídas e indexadas",
-          "placeholder": "https://docs.cherry-ai.com/sitemap-pages.xml"
-        },
         "sources": {
           "directory": "Carpeta",
           "file": "Archivo",
           "note": "Nota",
-          "sitemap": "Sitio web",
           "url": "URL"
         },
         "submit": {
@@ -2247,9 +2250,6 @@
           "file": {
             "title": "Archivo"
           },
-          "sitemap": {
-            "title": "Sincronización del sitio web"
-          },
           "url": {
             "title": "URL"
           }
@@ -2262,7 +2262,6 @@
         "directory": "Carpetas",
         "file": "Archivos",
         "note": "Notas",
-        "sitemap": "Sitios web",
         "url": "URLs"
       },
       "preview": {
@@ -6185,6 +6184,9 @@
         "enabled": "Habilitado",
         "failed": "Fallido",
         "failed_to_start": "Error al iniciar la verificación de estado",
+        "generation_output_audio": "[to be translated]:audio",
+        "generation_output_image": "[to be translated]:an image",
+        "generation_output_video": "[to be translated]:a video",
         "keys_status_count": "Pasados: {{count_passed}} claves, fallidos: {{count_failed}} claves",
         "model_status_failed": "{{count}} modelos no son accesibles en absoluto",
         "model_status_partial": "De ellos, {{count}} modelos no son accesibles con ciertas claves",
@@ -6193,6 +6195,7 @@
         "no_api_keys": "No se encontraron claves API, agrega una clave API primero.",
         "no_results": "Sin resultados",
         "outcome_fail_short": "{{count}} failed",
+        "outcome_skipped_short": "[to be translated]:{{count}} skipped",
         "outcome_success_short": "{{count}} passed",
         "outcome_total": "{{count}} total",
         "passed": "Pasado",
@@ -6204,8 +6207,11 @@
         "retry": "Check again",
         "select_api_key": "Seleccionar clave API a usar:",
         "single": "Individual",
+        "skip_reason_generation_cost": "[to be translated]:This model's health check would generate {{output}} and consume quota, so it is skipped by default.",
+        "skip_reason_unsupported_probe": "[to be translated]:This model type does not have a low-cost health check yet, so it is skipped by default.",
         "start": "Iniciar",
         "status_checking": "Checking…",
+        "status_skipped": "[to be translated]:Skipped",
         "timeout": "Tiempo de espera agotado",
         "title": "Verificación de salud del modelo",
         "use_all_keys": "Usar todas las claves"
@@ -6214,6 +6220,8 @@
       "default_assistant_model": "Modelo predeterminado del asistente",
       "default_assistant_model_description": "Se usa cuando un asistente no tiene modelo.",
       "empty": "Sin modelos",
+      "group_disable": "[to be translated]:Close this group",
+      "group_enable": "[to be translated]:Enable this group",
       "list_title": "Model list",
       "manage": {
         "add_custom_model": "Add custom model",
@@ -6841,7 +6849,7 @@
       "zip": "CÓDIGO POSTAL"
     },
     "stats": {
-      "title": "[to be translated]:Usage Statistics"
+      "title": "Estadísticas de uso"
     },
     "theme": {
       "color_primary": "Color del tema",

--- a/src/renderer/i18n/translate/fr-fr.json
+++ b/src/renderer/i18n/translate/fr-fr.json
@@ -583,6 +583,43 @@
       }
     },
     "sidebar_title": "Agents",
+    "stats": {
+      "active_days": "[to be translated]:days active",
+      "avg_completion": "[to be translated]:Avg Completion",
+      "avg_first_token": "[to be translated]:Avg First Token",
+      "avg_speed": "[to be translated]:Avg Speed",
+      "conversation_info": "[to be translated]:Conversation Info",
+      "daily_usage": "[to be translated]:Daily Usage",
+      "duration": "[to be translated]:Duration",
+      "limit": "[to be translated]:Display limit",
+      "loading": "[to be translated]:Loading statistics...",
+      "messages": "[to be translated]:Messages",
+      "model_filter_all": "[to be translated]:All Providers",
+      "model_sort_messages": "[to be translated]:By Messages",
+      "model_sort_speed": "[to be translated]:By Speed",
+      "model_sort_tokens": "[to be translated]:By Tokens",
+      "model_usage": "[to be translated]:Model Usage",
+      "no_data": "[to be translated]:No statistics available",
+      "no_data_hint": "[to be translated]:Start a conversation to see usage statistics here.",
+      "no_models_match": "[to be translated]:No models match the current filters.",
+      "performance": "[to be translated]:Performance",
+      "popup": {
+        "load_failed": "[to be translated]:Failed to load topic statistics",
+        "title": "[to be translated]:Topic Statistics",
+        "topic_not_found": "[to be translated]:Topic not found"
+      },
+      "search_placeholder": "[to be translated]:Search model or provider...",
+      "sort_by": "[to be translated]:Sort by",
+      "thinking_tokens": "[to be translated]:Thinking Tokens",
+      "title": "[to be translated]:Usage Statistics",
+      "token_breakdown": "[to be translated]:Token Breakdown",
+      "topics": "[to be translated]:Topics",
+      "total_characters": "[to be translated]:Total Characters",
+      "total_messages": "[to be translated]:Total Messages",
+      "total_tokens": "[to be translated]:Total Tokens",
+      "total_words": "[to be translated]:Total Words",
+      "unique_models": "[to be translated]:Models Used"
+    },
     "todo": {
       "mock": {
         "actions": {
@@ -1600,6 +1637,7 @@
         "placeholder": "Rechercher des sujets...",
         "title": "Rechercher"
       },
+      "statistics": "[to be translated]:Statistics",
       "title": "Sujet",
       "unpin": "Annuler le fixage"
     },
@@ -6801,6 +6839,9 @@
       "uninstallSuccess": "Compétence désinstallée : {{name}}",
       "viewSource": "Afficher la source",
       "zip": "ZIP"
+    },
+    "stats": {
+      "title": "[to be translated]:Usage Statistics"
     },
     "theme": {
       "color_primary": "Couleur principale",

--- a/src/renderer/i18n/translate/fr-fr.json
+++ b/src/renderer/i18n/translate/fr-fr.json
@@ -584,41 +584,50 @@
     },
     "sidebar_title": "Agents",
     "stats": {
-      "active_days": "[to be translated]:days active",
-      "avg_completion": "[to be translated]:Avg Completion",
-      "avg_first_token": "[to be translated]:Avg First Token",
-      "avg_speed": "[to be translated]:Avg Speed",
-      "conversation_info": "[to be translated]:Conversation Info",
-      "daily_usage": "[to be translated]:Daily Usage",
-      "duration": "[to be translated]:Duration",
-      "limit": "[to be translated]:Display limit",
-      "loading": "[to be translated]:Loading statistics...",
-      "messages": "[to be translated]:Messages",
-      "model_filter_all": "[to be translated]:All Providers",
-      "model_sort_messages": "[to be translated]:By Messages",
-      "model_sort_speed": "[to be translated]:By Speed",
-      "model_sort_tokens": "[to be translated]:By Tokens",
-      "model_usage": "[to be translated]:Model Usage",
-      "no_data": "[to be translated]:No statistics available",
-      "no_data_hint": "[to be translated]:Start a conversation to see usage statistics here.",
-      "no_models_match": "[to be translated]:No models match the current filters.",
-      "performance": "[to be translated]:Performance",
+      "active_days": "jours actifs",
+      "avg_completion": "Achèvement moyen",
+      "avg_first_token": "Premier token moyen",
+      "avg_speed": "Vitesse moyenne",
+      "conversation_info": "Informations de conversation",
+      "daily_usage": "Utilisation quotidienne",
+      "duration": "Durée",
+      "limit": "Limite d'affichage",
+      "loading": "Chargement des statistiques...",
+      "messages": "Messages",
+      "model_filter_all": "Tous les fournisseurs",
+      "model_sort_messages": "Par messages",
+      "model_sort_speed": "Par vitesse",
+      "model_sort_tokens": "Par tokens",
+      "model_usage": "Utilisation du modèle",
+      "no_data": "Aucune statistique disponible",
+      "no_data_hint": "Démarrez une conversation pour voir les statistiques d'utilisation ici.",
+      "no_models_match": "Aucun modèle ne correspond aux filtres actuels.",
+      "performance": "Performance",
       "popup": {
-        "load_failed": "[to be translated]:Failed to load topic statistics",
-        "title": "[to be translated]:Topic Statistics",
-        "topic_not_found": "[to be translated]:Topic not found"
+        "load_failed": "Échec du chargement des statistiques du sujet",
+        "title": "Statistiques du sujet",
+        "topic_not_found": "Sujet introuvable"
       },
-      "search_placeholder": "[to be translated]:Search model or provider...",
-      "sort_by": "[to be translated]:Sort by",
-      "thinking_tokens": "[to be translated]:Thinking Tokens",
-      "title": "[to be translated]:Usage Statistics",
-      "token_breakdown": "[to be translated]:Token Breakdown",
-      "topics": "[to be translated]:Topics",
-      "total_characters": "[to be translated]:Total Characters",
-      "total_messages": "[to be translated]:Total Messages",
-      "total_tokens": "[to be translated]:Total Tokens",
-      "total_words": "[to be translated]:Total Words",
-      "unique_models": "[to be translated]:Models Used"
+      "search_placeholder": "Rechercher un modèle ou un fournisseur...",
+      "sort_by": "Trier par",
+      "thinking_tokens": "Tokens de réflexion",
+      "title": "Statistiques d'utilisation",
+      "token_breakdown": "Répartition des tokens",
+      "token_input": "Entrée {{count}}",
+      "token_output": "Sortie {{count}}",
+      "token_thinking": "Réflexion {{count}}",
+      "topics": "Sujets",
+      "total_characters": "Caractères totaux",
+      "total_messages": "Messages totaux",
+      "total_tokens": "Tokens totaux",
+      "total_words": "Mots totaux",
+      "unique_models": "Modèles utilisés",
+      "units": {
+        "d_h_m": "{{d}}j {{h}}h {{m}}m",
+        "tok": "tok",
+        "tok_per_sec": "{{value}} tok/s",
+        "ttft": "TTFT {{ms}}ms"
+      }
     },
     "todo": {
       "mock": {
@@ -1637,7 +1646,7 @@
         "placeholder": "Rechercher des sujets...",
         "title": "Rechercher"
       },
-      "statistics": "[to be translated]:Statistics",
+      "statistics": "Statistiques",
       "title": "Sujet",
       "unpin": "Annuler le fixage"
     },
@@ -2200,16 +2209,10 @@
           "supported_formats": "Prend en charge les formats PDF, DOCX, MD, XLSX, TXT, CSV",
           "title": "Cliquez pour sélectionner des fichiers ou faites-les glisser ici"
         },
-        "sitemap": {
-          "description": "Entrez une URL de sitemap :",
-          "help": "Les pages répertoriées dans le plan du site seront lues et indexées",
-          "placeholder": "https://docs.cherry-ai.com/sitemap-pages.xml"
-        },
         "sources": {
           "directory": "Dossier",
           "file": "Fichier",
           "note": "Remarque",
-          "sitemap": "Site web",
           "url": "URL"
         },
         "submit": {
@@ -2247,9 +2250,6 @@
           "file": {
             "title": "Fichier"
           },
-          "sitemap": {
-            "title": "Synchronisation du site web"
-          },
           "url": {
             "title": "URL"
           }
@@ -2262,7 +2262,6 @@
         "directory": "Dossiers",
         "file": "Fichiers",
         "note": "Notes",
-        "sitemap": "Sites web",
         "url": "URL"
       },
       "preview": {
@@ -6185,6 +6184,9 @@
         "enabled": "Activé",
         "failed": "Échec",
         "failed_to_start": "Échec du démarrage de la vérification de santé",
+        "generation_output_audio": "[to be translated]:audio",
+        "generation_output_image": "[to be translated]:an image",
+        "generation_output_video": "[to be translated]:a video",
         "keys_status_count": "Passé : {{count_passed}} clés, échoué : {{count_failed}} clés",
         "model_status_failed": "{{count}} modèles sont totalement inaccessibles",
         "model_status_partial": "Parmi eux, {{count}} modèles sont inaccessibles avec certaines clés",
@@ -6193,6 +6195,7 @@
         "no_api_keys": "Aucune clé API trouvée, veuillez en ajouter une première.",
         "no_results": "Aucun résultat",
         "outcome_fail_short": "{{count}} failed",
+        "outcome_skipped_short": "[to be translated]:{{count}} skipped",
         "outcome_success_short": "{{count}} passed",
         "outcome_total": "{{count}} total",
         "passed": "Passé",
@@ -6204,8 +6207,11 @@
         "retry": "Check again",
         "select_api_key": "Sélectionner la clé API à utiliser :",
         "single": "Unique",
+        "skip_reason_generation_cost": "[to be translated]:This model's health check would generate {{output}} and consume quota, so it is skipped by default.",
+        "skip_reason_unsupported_probe": "[to be translated]:This model type does not have a low-cost health check yet, so it is skipped by default.",
         "start": "Commencer",
         "status_checking": "Checking…",
+        "status_skipped": "[to be translated]:Skipped",
         "timeout": "Délai dépassé",
         "title": "Test de santé des modèles",
         "use_all_keys": "Utiliser toutes les clés"
@@ -6214,6 +6220,8 @@
       "default_assistant_model": "Modèle d'assistant par défaut",
       "default_assistant_model_description": "Utilisé lorsqu'un assistant n'a pas de modèle.",
       "empty": "Aucun modèle",
+      "group_disable": "[to be translated]:Close this group",
+      "group_enable": "[to be translated]:Enable this group",
       "list_title": "Model list",
       "manage": {
         "add_custom_model": "Add custom model",
@@ -6841,7 +6849,7 @@
       "zip": "ZIP"
     },
     "stats": {
-      "title": "[to be translated]:Usage Statistics"
+      "title": "Statistiques d'utilisation"
     },
     "theme": {
       "color_primary": "Couleur principale",

--- a/src/renderer/i18n/translate/ja-jp.json
+++ b/src/renderer/i18n/translate/ja-jp.json
@@ -584,41 +584,50 @@
     },
     "sidebar_title": "エージェント",
     "stats": {
-      "active_days": "[to be translated]:days active",
-      "avg_completion": "[to be translated]:Avg Completion",
-      "avg_first_token": "[to be translated]:Avg First Token",
-      "avg_speed": "[to be translated]:Avg Speed",
-      "conversation_info": "[to be translated]:Conversation Info",
-      "daily_usage": "[to be translated]:Daily Usage",
-      "duration": "[to be translated]:Duration",
-      "limit": "[to be translated]:Display limit",
-      "loading": "[to be translated]:Loading statistics...",
-      "messages": "[to be translated]:Messages",
-      "model_filter_all": "[to be translated]:All Providers",
-      "model_sort_messages": "[to be translated]:By Messages",
-      "model_sort_speed": "[to be translated]:By Speed",
-      "model_sort_tokens": "[to be translated]:By Tokens",
-      "model_usage": "[to be translated]:Model Usage",
-      "no_data": "[to be translated]:No statistics available",
-      "no_data_hint": "[to be translated]:Start a conversation to see usage statistics here.",
-      "no_models_match": "[to be translated]:No models match the current filters.",
-      "performance": "[to be translated]:Performance",
+      "active_days": "アクティブな日数",
+      "avg_completion": "平均完了時間",
+      "avg_first_token": "平均初回トークン",
+      "avg_speed": "平均速度",
+      "conversation_info": "会話情報",
+      "daily_usage": "日次使用量",
+      "duration": "期間",
+      "limit": "表示件数",
+      "loading": "統計を読み込み中...",
+      "messages": "メッセージ数",
+      "model_filter_all": "すべてのプロバイダー",
+      "model_sort_messages": "メッセージ順",
+      "model_sort_speed": "速度順",
+      "model_sort_tokens": "トークン順",
+      "model_usage": "モデル使用状況",
+      "no_data": "利用可能な統計はありません",
+      "no_data_hint": "会話を開始すると、ここに使用統計が表示されます。",
+      "no_models_match": "現在のフィルターに一致するモデルはありません。",
+      "performance": "パフォーマンス",
       "popup": {
-        "load_failed": "[to be translated]:Failed to load topic statistics",
-        "title": "[to be translated]:Topic Statistics",
-        "topic_not_found": "[to be translated]:Topic not found"
+        "load_failed": "トピック統計の読み込みに失敗しました",
+        "title": "トピック統計",
+        "topic_not_found": "トピックが見つかりません"
       },
-      "search_placeholder": "[to be translated]:Search model or provider...",
-      "sort_by": "[to be translated]:Sort by",
-      "thinking_tokens": "[to be translated]:Thinking Tokens",
-      "title": "[to be translated]:Usage Statistics",
-      "token_breakdown": "[to be translated]:Token Breakdown",
-      "topics": "[to be translated]:Topics",
-      "total_characters": "[to be translated]:Total Characters",
-      "total_messages": "[to be translated]:Total Messages",
-      "total_tokens": "[to be translated]:Total Tokens",
-      "total_words": "[to be translated]:Total Words",
-      "unique_models": "[to be translated]:Models Used"
+      "search_placeholder": "モデルまたはプロバイダーを検索...",
+      "sort_by": "並び替え",
+      "thinking_tokens": "思考トークン",
+      "title": "使用統計",
+      "token_breakdown": "トークン内訳",
+      "token_input": "入力 {{count}}",
+      "token_output": "出力 {{count}}",
+      "token_thinking": "思考 {{count}}",
+      "topics": "トピック数",
+      "total_characters": "総文字数",
+      "total_messages": "総メッセージ数",
+      "total_tokens": "総トークン数",
+      "total_words": "総単語数",
+      "unique_models": "使用モデル数",
+      "units": {
+        "d_h_m": "{{d}}日 {{h}}時 {{m}}分",
+        "tok": "tok",
+        "tok_per_sec": "{{value}} tok/s",
+        "ttft": "TTFT {{ms}}ms"
+      }
     },
     "todo": {
       "mock": {
@@ -1637,7 +1646,7 @@
         "placeholder": "トピックを検索...",
         "title": "検索"
       },
-      "statistics": "[to be translated]:Statistics",
+      "statistics": "統計",
       "title": "トピック",
       "unpin": "固定解除"
     },
@@ -2200,16 +2209,10 @@
           "supported_formats": "PDF、DOCX、MD、XLSX、TXT、CSVに対応",
           "title": "ファイルを選択するにはクリックするか、ここにドラッグしてください"
         },
-        "sitemap": {
-          "description": "サイトマップのURLを入力してください:",
-          "help": "サイトマップに記載されているページは読み込まれ、インデックスされます。",
-          "placeholder": "https://docs.cherry-ai.com/sitemap-pages.xml"
-        },
         "sources": {
           "directory": "フォルダ",
           "file": "ファイル",
           "note": "注",
-          "sitemap": "ウェブサイト",
           "url": "URL"
         },
         "submit": {
@@ -2247,9 +2250,6 @@
           "file": {
             "title": "ファイル"
           },
-          "sitemap": {
-            "title": "ウェブサイト同期"
-          },
           "url": {
             "title": "URL"
           }
@@ -2262,7 +2262,6 @@
         "directory": "フォルダ",
         "file": "ファイル",
         "note": "メモ",
-        "sitemap": "ウェブサイト",
         "url": "URL"
       },
       "preview": {
@@ -6185,6 +6184,9 @@
         "enabled": "開く",
         "failed": "失敗",
         "failed_to_start": "ヘルスチェックの開始に失敗しました",
+        "generation_output_audio": "[to be translated]:audio",
+        "generation_output_image": "[to be translated]:an image",
+        "generation_output_video": "[to be translated]:a video",
         "keys_status_count": "合格：{{count_passed}}個のキー、不合格：{{count_failed}}個のキー",
         "model_status_failed": "{{count}} 個のモデルが完全にアクセスできません",
         "model_status_partial": "{{count}} 個のモデルが一部のキーでアクセスできません",
@@ -6193,6 +6195,7 @@
         "no_api_keys": "APIキーが見つかりません。まずAPIキーを追加してください。",
         "no_results": "結果なし",
         "outcome_fail_short": "{{count}} failed",
+        "outcome_skipped_short": "[to be translated]:{{count}} skipped",
         "outcome_success_short": "{{count}} passed",
         "outcome_total": "{{count}} total",
         "passed": "成功",
@@ -6204,8 +6207,11 @@
         "retry": "Check again",
         "select_api_key": "使用するAPIキーを選択：",
         "single": "単一",
+        "skip_reason_generation_cost": "[to be translated]:This model's health check would generate {{output}} and consume quota, so it is skipped by default.",
+        "skip_reason_unsupported_probe": "[to be translated]:This model type does not have a low-cost health check yet, so it is skipped by default.",
         "start": "開始",
         "status_checking": "Checking…",
+        "status_skipped": "[to be translated]:Skipped",
         "timeout": "タイムアウト",
         "title": "モデル健康チェック",
         "use_all_keys": "キー"
@@ -6214,6 +6220,8 @@
       "default_assistant_model": "デフォルトアシスタントモデル",
       "default_assistant_model_description": "アシスタントにモデルがない場合に使用されます",
       "empty": "モデルが見つかりません",
+      "group_disable": "[to be translated]:Close this group",
+      "group_enable": "[to be translated]:Enable this group",
       "list_title": "Model list",
       "manage": {
         "add_custom_model": "Add custom model",
@@ -6841,7 +6849,7 @@
       "zip": "ZIP"
     },
     "stats": {
-      "title": "[to be translated]:Usage Statistics"
+      "title": "使用統計"
     },
     "theme": {
       "color_primary": "テーマ色",

--- a/src/renderer/i18n/translate/ja-jp.json
+++ b/src/renderer/i18n/translate/ja-jp.json
@@ -583,6 +583,43 @@
       }
     },
     "sidebar_title": "エージェント",
+    "stats": {
+      "active_days": "[to be translated]:days active",
+      "avg_completion": "[to be translated]:Avg Completion",
+      "avg_first_token": "[to be translated]:Avg First Token",
+      "avg_speed": "[to be translated]:Avg Speed",
+      "conversation_info": "[to be translated]:Conversation Info",
+      "daily_usage": "[to be translated]:Daily Usage",
+      "duration": "[to be translated]:Duration",
+      "limit": "[to be translated]:Display limit",
+      "loading": "[to be translated]:Loading statistics...",
+      "messages": "[to be translated]:Messages",
+      "model_filter_all": "[to be translated]:All Providers",
+      "model_sort_messages": "[to be translated]:By Messages",
+      "model_sort_speed": "[to be translated]:By Speed",
+      "model_sort_tokens": "[to be translated]:By Tokens",
+      "model_usage": "[to be translated]:Model Usage",
+      "no_data": "[to be translated]:No statistics available",
+      "no_data_hint": "[to be translated]:Start a conversation to see usage statistics here.",
+      "no_models_match": "[to be translated]:No models match the current filters.",
+      "performance": "[to be translated]:Performance",
+      "popup": {
+        "load_failed": "[to be translated]:Failed to load topic statistics",
+        "title": "[to be translated]:Topic Statistics",
+        "topic_not_found": "[to be translated]:Topic not found"
+      },
+      "search_placeholder": "[to be translated]:Search model or provider...",
+      "sort_by": "[to be translated]:Sort by",
+      "thinking_tokens": "[to be translated]:Thinking Tokens",
+      "title": "[to be translated]:Usage Statistics",
+      "token_breakdown": "[to be translated]:Token Breakdown",
+      "topics": "[to be translated]:Topics",
+      "total_characters": "[to be translated]:Total Characters",
+      "total_messages": "[to be translated]:Total Messages",
+      "total_tokens": "[to be translated]:Total Tokens",
+      "total_words": "[to be translated]:Total Words",
+      "unique_models": "[to be translated]:Models Used"
+    },
     "todo": {
       "mock": {
         "actions": {
@@ -1600,6 +1637,7 @@
         "placeholder": "トピックを検索...",
         "title": "検索"
       },
+      "statistics": "[to be translated]:Statistics",
       "title": "トピック",
       "unpin": "固定解除"
     },
@@ -6801,6 +6839,9 @@
       "uninstallSuccess": "スキルがアンインストールされました: {{name}}",
       "viewSource": "ソースを表示",
       "zip": "ZIP"
+    },
+    "stats": {
+      "title": "[to be translated]:Usage Statistics"
     },
     "theme": {
       "color_primary": "テーマ色",

--- a/src/renderer/i18n/translate/pt-pt.json
+++ b/src/renderer/i18n/translate/pt-pt.json
@@ -584,41 +584,50 @@
     },
     "sidebar_title": "Agentes",
     "stats": {
-      "active_days": "[to be translated]:days active",
-      "avg_completion": "[to be translated]:Avg Completion",
-      "avg_first_token": "[to be translated]:Avg First Token",
-      "avg_speed": "[to be translated]:Avg Speed",
-      "conversation_info": "[to be translated]:Conversation Info",
-      "daily_usage": "[to be translated]:Daily Usage",
-      "duration": "[to be translated]:Duration",
-      "limit": "[to be translated]:Display limit",
-      "loading": "[to be translated]:Loading statistics...",
-      "messages": "[to be translated]:Messages",
-      "model_filter_all": "[to be translated]:All Providers",
-      "model_sort_messages": "[to be translated]:By Messages",
-      "model_sort_speed": "[to be translated]:By Speed",
-      "model_sort_tokens": "[to be translated]:By Tokens",
-      "model_usage": "[to be translated]:Model Usage",
-      "no_data": "[to be translated]:No statistics available",
-      "no_data_hint": "[to be translated]:Start a conversation to see usage statistics here.",
-      "no_models_match": "[to be translated]:No models match the current filters.",
-      "performance": "[to be translated]:Performance",
+      "active_days": "dias ativos",
+      "avg_completion": "Conclusão média",
+      "avg_first_token": "Primeiro Token médio",
+      "avg_speed": "Velocidade média",
+      "conversation_info": "Informações da conversa",
+      "daily_usage": "Uso diário",
+      "duration": "Duração",
+      "limit": "Limite de exibição",
+      "loading": "A carregar estatísticas...",
+      "messages": "Mensagens",
+      "model_filter_all": "Todos os fornecedores",
+      "model_sort_messages": "Por mensagens",
+      "model_sort_speed": "Por velocidade",
+      "model_sort_tokens": "Por tokens",
+      "model_usage": "Uso do modelo",
+      "no_data": "Sem estatísticas disponíveis",
+      "no_data_hint": "Inicie uma conversa para ver estatísticas de uso aqui.",
+      "no_models_match": "Nenhum modelo corresponde aos filtros atuais.",
+      "performance": "Desempenho",
       "popup": {
-        "load_failed": "[to be translated]:Failed to load topic statistics",
-        "title": "[to be translated]:Topic Statistics",
-        "topic_not_found": "[to be translated]:Topic not found"
+        "load_failed": "Falha ao carregar estatísticas do tópico",
+        "title": "Estatísticas do tópico",
+        "topic_not_found": "Tópico não encontrado"
       },
-      "search_placeholder": "[to be translated]:Search model or provider...",
-      "sort_by": "[to be translated]:Sort by",
-      "thinking_tokens": "[to be translated]:Thinking Tokens",
-      "title": "[to be translated]:Usage Statistics",
-      "token_breakdown": "[to be translated]:Token Breakdown",
-      "topics": "[to be translated]:Topics",
-      "total_characters": "[to be translated]:Total Characters",
-      "total_messages": "[to be translated]:Total Messages",
-      "total_tokens": "[to be translated]:Total Tokens",
-      "total_words": "[to be translated]:Total Words",
-      "unique_models": "[to be translated]:Models Used"
+      "search_placeholder": "Procurar modelo ou fornecedor...",
+      "sort_by": "Ordenar por",
+      "thinking_tokens": "Tokens de raciocínio",
+      "title": "Estatísticas de uso",
+      "token_breakdown": "Distribuição de tokens",
+      "token_input": "Entrada {{count}}",
+      "token_output": "Saída {{count}}",
+      "token_thinking": "Raciocínio {{count}}",
+      "topics": "Tópicos",
+      "total_characters": "Caracteres totais",
+      "total_messages": "Mensagens totais",
+      "total_tokens": "Tokens totais",
+      "total_words": "Palavras totais",
+      "unique_models": "Modelos utilizados",
+      "units": {
+        "d_h_m": "{{d}}d {{h}}h {{m}}m",
+        "tok": "tok",
+        "tok_per_sec": "{{value}} tok/s",
+        "ttft": "TTFT {{ms}}ms"
+      }
     },
     "todo": {
       "mock": {
@@ -1637,7 +1646,7 @@
         "placeholder": "Pesquisar tópicos...",
         "title": "Pesquisar"
       },
-      "statistics": "[to be translated]:Statistics",
+      "statistics": "Estatísticas",
       "title": "Tópicos",
       "unpin": "Desfixar"
     },
@@ -2200,16 +2209,10 @@
           "supported_formats": "Suporta PDF, DOCX, MD, XLSX, TXT, CSV",
           "title": "Clique para selecionar arquivos ou arraste-os aqui"
         },
-        "sitemap": {
-          "description": "Insira um URL de sitemap:",
-          "help": "As páginas listadas no mapa do site serão lidas e indexadas",
-          "placeholder": "https://docs.cherry-ai.com/sitemap-pages.xml"
-        },
         "sources": {
           "directory": "Pasta",
           "file": "Arquivo",
           "note": "Nota",
-          "sitemap": "Site",
           "url": "URL"
         },
         "submit": {
@@ -2247,9 +2250,6 @@
           "file": {
             "title": "Arquivo"
           },
-          "sitemap": {
-            "title": "Sincronização do Site"
-          },
           "url": {
             "title": "URL"
           }
@@ -2262,7 +2262,6 @@
         "directory": "Pastas",
         "file": "Arquivos",
         "note": "Notas",
-        "sitemap": "Sites",
         "url": "URLs"
       },
       "preview": {
@@ -6185,6 +6184,9 @@
         "enabled": "Habilitado",
         "failed": "Falhou",
         "failed_to_start": "Falha ao iniciar a verificação de saúde",
+        "generation_output_audio": "[to be translated]:audio",
+        "generation_output_image": "[to be translated]:an image",
+        "generation_output_video": "[to be translated]:a video",
         "keys_status_count": "Passou: {{count_passed}} chaves, falhou: {{count_failed}} chaves",
         "model_status_failed": "{{count}} modelos completamente inacessíveis",
         "model_status_partial": "Desses, {{count}} modelos são inacessíveis com certas chaves",
@@ -6193,6 +6195,7 @@
         "no_api_keys": "Nenhuma chave API encontrada, adicione uma chave API primeiro.",
         "no_results": "Sem resultados",
         "outcome_fail_short": "{{count}} failed",
+        "outcome_skipped_short": "[to be translated]:{{count}} skipped",
         "outcome_success_short": "{{count}} passed",
         "outcome_total": "{{count}} total",
         "passed": "Passou",
@@ -6204,8 +6207,11 @@
         "retry": "Check again",
         "select_api_key": "Selecione a chave API a ser usada:",
         "single": "Individual",
+        "skip_reason_generation_cost": "[to be translated]:This model's health check would generate {{output}} and consume quota, so it is skipped by default.",
+        "skip_reason_unsupported_probe": "[to be translated]:This model type does not have a low-cost health check yet, so it is skipped by default.",
         "start": "Começar",
         "status_checking": "Checking…",
+        "status_skipped": "[to be translated]:Skipped",
         "timeout": "tempo expirado",
         "title": "Verificação de saúde do modelo",
         "use_all_keys": "Use chaves"
@@ -6214,6 +6220,8 @@
       "default_assistant_model": "Modelo de assistente padrão",
       "default_assistant_model_description": "Usado quando um assistente não tem modelo.",
       "empty": "Sem modelos",
+      "group_disable": "[to be translated]:Close this group",
+      "group_enable": "[to be translated]:Enable this group",
       "list_title": "Model list",
       "manage": {
         "add_custom_model": "Add custom model",
@@ -6841,7 +6849,7 @@
       "zip": "CEP"
     },
     "stats": {
-      "title": "[to be translated]:Usage Statistics"
+      "title": "Estatísticas de uso"
     },
     "theme": {
       "color_primary": "Cor Temática",

--- a/src/renderer/i18n/translate/pt-pt.json
+++ b/src/renderer/i18n/translate/pt-pt.json
@@ -583,6 +583,43 @@
       }
     },
     "sidebar_title": "Agentes",
+    "stats": {
+      "active_days": "[to be translated]:days active",
+      "avg_completion": "[to be translated]:Avg Completion",
+      "avg_first_token": "[to be translated]:Avg First Token",
+      "avg_speed": "[to be translated]:Avg Speed",
+      "conversation_info": "[to be translated]:Conversation Info",
+      "daily_usage": "[to be translated]:Daily Usage",
+      "duration": "[to be translated]:Duration",
+      "limit": "[to be translated]:Display limit",
+      "loading": "[to be translated]:Loading statistics...",
+      "messages": "[to be translated]:Messages",
+      "model_filter_all": "[to be translated]:All Providers",
+      "model_sort_messages": "[to be translated]:By Messages",
+      "model_sort_speed": "[to be translated]:By Speed",
+      "model_sort_tokens": "[to be translated]:By Tokens",
+      "model_usage": "[to be translated]:Model Usage",
+      "no_data": "[to be translated]:No statistics available",
+      "no_data_hint": "[to be translated]:Start a conversation to see usage statistics here.",
+      "no_models_match": "[to be translated]:No models match the current filters.",
+      "performance": "[to be translated]:Performance",
+      "popup": {
+        "load_failed": "[to be translated]:Failed to load topic statistics",
+        "title": "[to be translated]:Topic Statistics",
+        "topic_not_found": "[to be translated]:Topic not found"
+      },
+      "search_placeholder": "[to be translated]:Search model or provider...",
+      "sort_by": "[to be translated]:Sort by",
+      "thinking_tokens": "[to be translated]:Thinking Tokens",
+      "title": "[to be translated]:Usage Statistics",
+      "token_breakdown": "[to be translated]:Token Breakdown",
+      "topics": "[to be translated]:Topics",
+      "total_characters": "[to be translated]:Total Characters",
+      "total_messages": "[to be translated]:Total Messages",
+      "total_tokens": "[to be translated]:Total Tokens",
+      "total_words": "[to be translated]:Total Words",
+      "unique_models": "[to be translated]:Models Used"
+    },
     "todo": {
       "mock": {
         "actions": {
@@ -1600,6 +1637,7 @@
         "placeholder": "Pesquisar tópicos...",
         "title": "Pesquisar"
       },
+      "statistics": "[to be translated]:Statistics",
       "title": "Tópicos",
       "unpin": "Desfixar"
     },
@@ -6801,6 +6839,9 @@
       "uninstallSuccess": "Habilidade desinstalada: {{name}}",
       "viewSource": "Ver Fonte",
       "zip": "CEP"
+    },
+    "stats": {
+      "title": "[to be translated]:Usage Statistics"
     },
     "theme": {
       "color_primary": "Cor Temática",

--- a/src/renderer/i18n/translate/ro-ro.json
+++ b/src/renderer/i18n/translate/ro-ro.json
@@ -584,41 +584,50 @@
     },
     "sidebar_title": "Agenți",
     "stats": {
-      "active_days": "[to be translated]:days active",
-      "avg_completion": "[to be translated]:Avg Completion",
-      "avg_first_token": "[to be translated]:Avg First Token",
-      "avg_speed": "[to be translated]:Avg Speed",
-      "conversation_info": "[to be translated]:Conversation Info",
-      "daily_usage": "[to be translated]:Daily Usage",
-      "duration": "[to be translated]:Duration",
-      "limit": "[to be translated]:Display limit",
-      "loading": "[to be translated]:Loading statistics...",
-      "messages": "[to be translated]:Messages",
-      "model_filter_all": "[to be translated]:All Providers",
-      "model_sort_messages": "[to be translated]:By Messages",
-      "model_sort_speed": "[to be translated]:By Speed",
-      "model_sort_tokens": "[to be translated]:By Tokens",
-      "model_usage": "[to be translated]:Model Usage",
-      "no_data": "[to be translated]:No statistics available",
-      "no_data_hint": "[to be translated]:Start a conversation to see usage statistics here.",
-      "no_models_match": "[to be translated]:No models match the current filters.",
-      "performance": "[to be translated]:Performance",
+      "active_days": "zile active",
+      "avg_completion": "Finalizare medie",
+      "avg_first_token": "Primul Token mediu",
+      "avg_speed": "Viteză medie",
+      "conversation_info": "Informații conversație",
+      "daily_usage": "Utilizare zilnică",
+      "duration": "Durată",
+      "limit": "Limită afișare",
+      "loading": "Se încarcă statisticile...",
+      "messages": "Mesaje",
+      "model_filter_all": "Toți furnizorii",
+      "model_sort_messages": "După mesaje",
+      "model_sort_speed": "După viteză",
+      "model_sort_tokens": "După tokens",
+      "model_usage": "Utilizare model",
+      "no_data": "Nu există statistici disponibile",
+      "no_data_hint": "Începe o conversație pentru a vedea statisticile de utilizare aici.",
+      "no_models_match": "Niciun model nu se potrivește cu filtrele actuale.",
+      "performance": "Performanță",
       "popup": {
-        "load_failed": "[to be translated]:Failed to load topic statistics",
-        "title": "[to be translated]:Topic Statistics",
-        "topic_not_found": "[to be translated]:Topic not found"
+        "load_failed": "Eroare la încărcarea statisticilor subiectului",
+        "title": "Statistici subiect",
+        "topic_not_found": "Subiect negăsit"
       },
-      "search_placeholder": "[to be translated]:Search model or provider...",
-      "sort_by": "[to be translated]:Sort by",
-      "thinking_tokens": "[to be translated]:Thinking Tokens",
-      "title": "[to be translated]:Usage Statistics",
-      "token_breakdown": "[to be translated]:Token Breakdown",
-      "topics": "[to be translated]:Topics",
-      "total_characters": "[to be translated]:Total Characters",
-      "total_messages": "[to be translated]:Total Messages",
-      "total_tokens": "[to be translated]:Total Tokens",
-      "total_words": "[to be translated]:Total Words",
-      "unique_models": "[to be translated]:Models Used"
+      "search_placeholder": "Caută model sau furnizor...",
+      "sort_by": "Sortează după",
+      "thinking_tokens": "Tokens de gândire",
+      "title": "Statistici de utilizare",
+      "token_breakdown": "Defalcare tokens",
+      "token_input": "Intrare {{count}}",
+      "token_output": "Ieșire {{count}}",
+      "token_thinking": "Gândire {{count}}",
+      "topics": "Subiecte",
+      "total_characters": "Caractere totale",
+      "total_messages": "Mesaje totale",
+      "total_tokens": "Tokens totali",
+      "total_words": "Cuvinte totale",
+      "unique_models": "Modele utilizate",
+      "units": {
+        "d_h_m": "{{d}}z {{h}}o {{m}}m",
+        "tok": "tok",
+        "tok_per_sec": "{{value}} tok/s",
+        "ttft": "TTFT {{ms}}ms"
+      }
     },
     "todo": {
       "mock": {
@@ -1637,7 +1646,7 @@
         "placeholder": "Caută subiecte...",
         "title": "Caută"
       },
-      "statistics": "[to be translated]:Statistics",
+      "statistics": "Statistici",
       "title": "Subiecte",
       "unpin": "Detașează subiectul"
     },
@@ -2200,16 +2209,10 @@
           "supported_formats": "Acceptă PDF, DOCX, MD, XLSX, TXT, CSV",
           "title": "Click pentru a selecta fișierele sau trageți-le aici"
         },
-        "sitemap": {
-          "description": "Introduceți un URL de hartă a site-ului:",
-          "help": "Paginile listate în harta site-ului vor fi citite și indexate",
-          "placeholder": "https://docs.cherry-ai.com/sitemap-pages.xml"
-        },
         "sources": {
           "directory": "Folder",
           "file": "Fișier",
           "note": "Notă",
-          "sitemap": "Site web",
           "url": "URL"
         },
         "submit": {
@@ -2247,9 +2250,6 @@
           "file": {
             "title": "Fișier"
           },
-          "sitemap": {
-            "title": "Sincronizare site web"
-          },
           "url": {
             "title": "URL"
           }
@@ -2262,7 +2262,6 @@
         "directory": "Foldere",
         "file": "Fișiere",
         "note": "Note",
-        "sitemap": "Site-uri web",
         "url": "URL-uri"
       },
       "preview": {
@@ -6185,6 +6184,9 @@
         "enabled": "Activat",
         "failed": "Eșuat",
         "failed_to_start": "Nu s-a reușit pornirea verificării stării de sănătate",
+        "generation_output_audio": "[to be translated]:audio",
+        "generation_output_image": "[to be translated]:an image",
+        "generation_output_video": "[to be translated]:a video",
         "keys_status_count": "Reușite: {{count_passed}} chei, eșuate: {{count_failed}} chei",
         "model_status_failed": "{{count}} modele complet inaccesibile",
         "model_status_partial": "{{count}} modele au avut chei inaccesibile",
@@ -6193,6 +6195,7 @@
         "no_api_keys": "Nu s-au găsit chei API, te rugăm să adaugi mai întâi chei API.",
         "no_results": "Niciun rezultat",
         "outcome_fail_short": "{{count}} failed",
+        "outcome_skipped_short": "[to be translated]:{{count}} skipped",
         "outcome_success_short": "{{count}} passed",
         "outcome_total": "{{count}} total",
         "passed": "Reușit",
@@ -6204,8 +6207,11 @@
         "retry": "Check again",
         "select_api_key": "Selectează cheia API de utilizat:",
         "single": "Singur",
+        "skip_reason_generation_cost": "[to be translated]:This model's health check would generate {{output}} and consume quota, so it is skipped by default.",
+        "skip_reason_unsupported_probe": "[to be translated]:This model type does not have a low-cost health check yet, so it is skipped by default.",
         "start": "Start",
         "status_checking": "Checking…",
+        "status_skipped": "[to be translated]:Skipped",
         "timeout": "Expirare",
         "title": "Verificare sănătate model",
         "use_all_keys": "Cheie(i)"
@@ -6214,6 +6220,8 @@
       "default_assistant_model": "Model asistent implicit",
       "default_assistant_model_description": "Folosit când un asistent nu are model.",
       "empty": "Nu s-au găsit modele",
+      "group_disable": "[to be translated]:Close this group",
+      "group_enable": "[to be translated]:Enable this group",
       "list_title": "Model list",
       "manage": {
         "add_custom_model": "Add custom model",
@@ -6841,7 +6849,7 @@
       "zip": "ZIP"
     },
     "stats": {
-      "title": "[to be translated]:Usage Statistics"
+      "title": "Statistici de utilizare"
     },
     "theme": {
       "color_primary": "Culoare primară",

--- a/src/renderer/i18n/translate/ro-ro.json
+++ b/src/renderer/i18n/translate/ro-ro.json
@@ -583,6 +583,43 @@
       }
     },
     "sidebar_title": "Agenți",
+    "stats": {
+      "active_days": "[to be translated]:days active",
+      "avg_completion": "[to be translated]:Avg Completion",
+      "avg_first_token": "[to be translated]:Avg First Token",
+      "avg_speed": "[to be translated]:Avg Speed",
+      "conversation_info": "[to be translated]:Conversation Info",
+      "daily_usage": "[to be translated]:Daily Usage",
+      "duration": "[to be translated]:Duration",
+      "limit": "[to be translated]:Display limit",
+      "loading": "[to be translated]:Loading statistics...",
+      "messages": "[to be translated]:Messages",
+      "model_filter_all": "[to be translated]:All Providers",
+      "model_sort_messages": "[to be translated]:By Messages",
+      "model_sort_speed": "[to be translated]:By Speed",
+      "model_sort_tokens": "[to be translated]:By Tokens",
+      "model_usage": "[to be translated]:Model Usage",
+      "no_data": "[to be translated]:No statistics available",
+      "no_data_hint": "[to be translated]:Start a conversation to see usage statistics here.",
+      "no_models_match": "[to be translated]:No models match the current filters.",
+      "performance": "[to be translated]:Performance",
+      "popup": {
+        "load_failed": "[to be translated]:Failed to load topic statistics",
+        "title": "[to be translated]:Topic Statistics",
+        "topic_not_found": "[to be translated]:Topic not found"
+      },
+      "search_placeholder": "[to be translated]:Search model or provider...",
+      "sort_by": "[to be translated]:Sort by",
+      "thinking_tokens": "[to be translated]:Thinking Tokens",
+      "title": "[to be translated]:Usage Statistics",
+      "token_breakdown": "[to be translated]:Token Breakdown",
+      "topics": "[to be translated]:Topics",
+      "total_characters": "[to be translated]:Total Characters",
+      "total_messages": "[to be translated]:Total Messages",
+      "total_tokens": "[to be translated]:Total Tokens",
+      "total_words": "[to be translated]:Total Words",
+      "unique_models": "[to be translated]:Models Used"
+    },
     "todo": {
       "mock": {
         "actions": {
@@ -1600,6 +1637,7 @@
         "placeholder": "Caută subiecte...",
         "title": "Caută"
       },
+      "statistics": "[to be translated]:Statistics",
       "title": "Subiecte",
       "unpin": "Detașează subiectul"
     },
@@ -6801,6 +6839,9 @@
       "uninstallSuccess": "Abilitate dezinstalată: {{name}}",
       "viewSource": "Vezi sursa",
       "zip": "ZIP"
+    },
+    "stats": {
+      "title": "[to be translated]:Usage Statistics"
     },
     "theme": {
       "color_primary": "Culoare primară",

--- a/src/renderer/i18n/translate/ru-ru.json
+++ b/src/renderer/i18n/translate/ru-ru.json
@@ -584,41 +584,50 @@
     },
     "sidebar_title": "Агенты",
     "stats": {
-      "active_days": "[to be translated]:days active",
-      "avg_completion": "[to be translated]:Avg Completion",
-      "avg_first_token": "[to be translated]:Avg First Token",
-      "avg_speed": "[to be translated]:Avg Speed",
-      "conversation_info": "[to be translated]:Conversation Info",
-      "daily_usage": "[to be translated]:Daily Usage",
-      "duration": "[to be translated]:Duration",
-      "limit": "[to be translated]:Display limit",
-      "loading": "[to be translated]:Loading statistics...",
-      "messages": "[to be translated]:Messages",
-      "model_filter_all": "[to be translated]:All Providers",
-      "model_sort_messages": "[to be translated]:By Messages",
-      "model_sort_speed": "[to be translated]:By Speed",
-      "model_sort_tokens": "[to be translated]:By Tokens",
-      "model_usage": "[to be translated]:Model Usage",
-      "no_data": "[to be translated]:No statistics available",
-      "no_data_hint": "[to be translated]:Start a conversation to see usage statistics here.",
-      "no_models_match": "[to be translated]:No models match the current filters.",
-      "performance": "[to be translated]:Performance",
+      "active_days": "дней активности",
+      "avg_completion": "Среднее завершение",
+      "avg_first_token": "Среднее время до первого токена",
+      "avg_speed": "Средняя скорость",
+      "conversation_info": "Информация о диалоге",
+      "daily_usage": "Ежедневное использование",
+      "duration": "Длительность",
+      "limit": "Лимит отображения",
+      "loading": "Загрузка статистики...",
+      "messages": "Сообщения",
+      "model_filter_all": "Все провайдеры",
+      "model_sort_messages": "По сообщениям",
+      "model_sort_speed": "По скорости",
+      "model_sort_tokens": "По токенам",
+      "model_usage": "Использование модели",
+      "no_data": "Статистика недоступна",
+      "no_data_hint": "Начните диалог, чтобы увидеть здесь статистику использования.",
+      "no_models_match": "Нет моделей, соответствующих текущим фильтрам.",
+      "performance": "Производительность",
       "popup": {
-        "load_failed": "[to be translated]:Failed to load topic statistics",
-        "title": "[to be translated]:Topic Statistics",
-        "topic_not_found": "[to be translated]:Topic not found"
+        "load_failed": "Не удалось загрузить статистику топика",
+        "title": "Статистика топика",
+        "topic_not_found": "Топик не найден"
       },
-      "search_placeholder": "[to be translated]:Search model or provider...",
-      "sort_by": "[to be translated]:Sort by",
-      "thinking_tokens": "[to be translated]:Thinking Tokens",
-      "title": "[to be translated]:Usage Statistics",
-      "token_breakdown": "[to be translated]:Token Breakdown",
-      "topics": "[to be translated]:Topics",
-      "total_characters": "[to be translated]:Total Characters",
-      "total_messages": "[to be translated]:Total Messages",
-      "total_tokens": "[to be translated]:Total Tokens",
-      "total_words": "[to be translated]:Total Words",
-      "unique_models": "[to be translated]:Models Used"
+      "search_placeholder": "Поиск модели или провайдера...",
+      "sort_by": "Сортировать по",
+      "thinking_tokens": "Токены размышления",
+      "title": "Статистика использования",
+      "token_breakdown": "Распределение токенов",
+      "token_input": "Вход {{count}}",
+      "token_output": "Выход {{count}}",
+      "token_thinking": "Размышление {{count}}",
+      "topics": "Топики",
+      "total_characters": "Всего символов",
+      "total_messages": "Всего сообщений",
+      "total_tokens": "Всего токенов",
+      "total_words": "Всего слов",
+      "unique_models": "Используемые модели",
+      "units": {
+        "d_h_m": "{{d}}д {{h}}ч {{m}}м",
+        "tok": "tok",
+        "tok_per_sec": "{{value}} tok/s",
+        "ttft": "TTFT {{ms}}ms"
+      }
     },
     "todo": {
       "mock": {
@@ -1637,7 +1646,7 @@
         "placeholder": "Искать темы...",
         "title": "Поиск"
       },
-      "statistics": "[to be translated]:Statistics",
+      "statistics": "Статистика",
       "title": "Топики",
       "unpin": "Открепленные темы"
     },
@@ -2200,16 +2209,10 @@
           "supported_formats": "Поддерживает PDF, DOCX, MD, XLSX, TXT, CSV",
           "title": "Нажмите, чтобы выбрать файлы, или перетащите их сюда"
         },
-        "sitemap": {
-          "description": "Введите URL карты сайта:",
-          "help": "Страницы, перечисленные в карте сайта, будут прочитаны и проиндексированы",
-          "placeholder": "https://docs.cherry-ai.com/sitemap-pages.xml"
-        },
         "sources": {
           "directory": "Папка",
           "file": "Файл",
           "note": "Примечание",
-          "sitemap": "Веб-сайт",
           "url": "URL"
         },
         "submit": {
@@ -2247,9 +2250,6 @@
           "file": {
             "title": "Файл"
           },
-          "sitemap": {
-            "title": "Синхронизация веб-сайта"
-          },
           "url": {
             "title": "URL"
           }
@@ -2262,7 +2262,6 @@
         "directory": "Папки",
         "file": "Файлы",
         "note": "Заметки",
-        "sitemap": "Веб-сайты",
         "url": "URL-адреса"
       },
       "preview": {
@@ -6185,6 +6184,9 @@
         "enabled": "Включено",
         "failed": "Не прошло",
         "failed_to_start": "Не удалось запустить проверку работоспособности",
+        "generation_output_audio": "[to be translated]:audio",
+        "generation_output_image": "[to be translated]:an image",
+        "generation_output_video": "[to be translated]:a video",
         "keys_status_count": "Прошло: {{count_passed}} ключей, Не прошло: {{count_failed}} ключей",
         "model_status_failed": "{{count}} моделей полностью недоступны",
         "model_status_partial": "{{count}} моделей недоступны с некоторыми ключами",
@@ -6193,6 +6195,7 @@
         "no_api_keys": "API ключи не найдены, пожалуйста, добавьте API ключи.",
         "no_results": "нет результатов",
         "outcome_fail_short": "{{count}} failed",
+        "outcome_skipped_short": "[to be translated]:{{count}} skipped",
         "outcome_success_short": "{{count}} passed",
         "outcome_total": "{{count}} total",
         "passed": "Прошло",
@@ -6204,8 +6207,11 @@
         "retry": "Check again",
         "select_api_key": "Выберите API ключ для использования:",
         "single": "Один",
+        "skip_reason_generation_cost": "[to be translated]:This model's health check would generate {{output}} and consume quota, so it is skipped by default.",
+        "skip_reason_unsupported_probe": "[to be translated]:This model type does not have a low-cost health check yet, so it is skipped by default.",
         "start": "Начать",
         "status_checking": "Checking…",
+        "status_skipped": "[to be translated]:Skipped",
         "timeout": "Тайм-аут",
         "title": "Проверка состояния моделей",
         "use_all_keys": "Использовать все ключи"
@@ -6214,6 +6220,8 @@
       "default_assistant_model": "Модель ассистента по умолчанию",
       "default_assistant_model_description": "Используется, если у ассистента нет модели.",
       "empty": "Модели не найдены",
+      "group_disable": "[to be translated]:Close this group",
+      "group_enable": "[to be translated]:Enable this group",
       "list_title": "Model list",
       "manage": {
         "add_custom_model": "Add custom model",
@@ -6841,7 +6849,7 @@
       "zip": "ЗИП"
     },
     "stats": {
-      "title": "[to be translated]:Usage Statistics"
+      "title": "Статистика использования"
     },
     "theme": {
       "color_primary": "Цвет темы",

--- a/src/renderer/i18n/translate/ru-ru.json
+++ b/src/renderer/i18n/translate/ru-ru.json
@@ -583,6 +583,43 @@
       }
     },
     "sidebar_title": "Агенты",
+    "stats": {
+      "active_days": "[to be translated]:days active",
+      "avg_completion": "[to be translated]:Avg Completion",
+      "avg_first_token": "[to be translated]:Avg First Token",
+      "avg_speed": "[to be translated]:Avg Speed",
+      "conversation_info": "[to be translated]:Conversation Info",
+      "daily_usage": "[to be translated]:Daily Usage",
+      "duration": "[to be translated]:Duration",
+      "limit": "[to be translated]:Display limit",
+      "loading": "[to be translated]:Loading statistics...",
+      "messages": "[to be translated]:Messages",
+      "model_filter_all": "[to be translated]:All Providers",
+      "model_sort_messages": "[to be translated]:By Messages",
+      "model_sort_speed": "[to be translated]:By Speed",
+      "model_sort_tokens": "[to be translated]:By Tokens",
+      "model_usage": "[to be translated]:Model Usage",
+      "no_data": "[to be translated]:No statistics available",
+      "no_data_hint": "[to be translated]:Start a conversation to see usage statistics here.",
+      "no_models_match": "[to be translated]:No models match the current filters.",
+      "performance": "[to be translated]:Performance",
+      "popup": {
+        "load_failed": "[to be translated]:Failed to load topic statistics",
+        "title": "[to be translated]:Topic Statistics",
+        "topic_not_found": "[to be translated]:Topic not found"
+      },
+      "search_placeholder": "[to be translated]:Search model or provider...",
+      "sort_by": "[to be translated]:Sort by",
+      "thinking_tokens": "[to be translated]:Thinking Tokens",
+      "title": "[to be translated]:Usage Statistics",
+      "token_breakdown": "[to be translated]:Token Breakdown",
+      "topics": "[to be translated]:Topics",
+      "total_characters": "[to be translated]:Total Characters",
+      "total_messages": "[to be translated]:Total Messages",
+      "total_tokens": "[to be translated]:Total Tokens",
+      "total_words": "[to be translated]:Total Words",
+      "unique_models": "[to be translated]:Models Used"
+    },
     "todo": {
       "mock": {
         "actions": {
@@ -1600,6 +1637,7 @@
         "placeholder": "Искать темы...",
         "title": "Поиск"
       },
+      "statistics": "[to be translated]:Statistics",
       "title": "Топики",
       "unpin": "Открепленные темы"
     },
@@ -6801,6 +6839,9 @@
       "uninstallSuccess": "Навык удалён: {{name}}",
       "viewSource": "Посмотреть исходный код",
       "zip": "ЗИП"
+    },
+    "stats": {
+      "title": "[to be translated]:Usage Statistics"
     },
     "theme": {
       "color_primary": "Цвет темы",

--- a/src/renderer/i18n/translate/vi-vn.json
+++ b/src/renderer/i18n/translate/vi-vn.json
@@ -583,6 +583,43 @@
       }
     },
     "sidebar_title": "Đại lý",
+    "stats": {
+      "active_days": "[to be translated]:days active",
+      "avg_completion": "[to be translated]:Avg Completion",
+      "avg_first_token": "[to be translated]:Avg First Token",
+      "avg_speed": "[to be translated]:Avg Speed",
+      "conversation_info": "[to be translated]:Conversation Info",
+      "daily_usage": "[to be translated]:Daily Usage",
+      "duration": "[to be translated]:Duration",
+      "limit": "[to be translated]:Display limit",
+      "loading": "[to be translated]:Loading statistics...",
+      "messages": "[to be translated]:Messages",
+      "model_filter_all": "[to be translated]:All Providers",
+      "model_sort_messages": "[to be translated]:By Messages",
+      "model_sort_speed": "[to be translated]:By Speed",
+      "model_sort_tokens": "[to be translated]:By Tokens",
+      "model_usage": "[to be translated]:Model Usage",
+      "no_data": "[to be translated]:No statistics available",
+      "no_data_hint": "[to be translated]:Start a conversation to see usage statistics here.",
+      "no_models_match": "[to be translated]:No models match the current filters.",
+      "performance": "[to be translated]:Performance",
+      "popup": {
+        "load_failed": "[to be translated]:Failed to load topic statistics",
+        "title": "[to be translated]:Topic Statistics",
+        "topic_not_found": "[to be translated]:Topic not found"
+      },
+      "search_placeholder": "[to be translated]:Search model or provider...",
+      "sort_by": "[to be translated]:Sort by",
+      "thinking_tokens": "[to be translated]:Thinking Tokens",
+      "title": "[to be translated]:Usage Statistics",
+      "token_breakdown": "[to be translated]:Token Breakdown",
+      "topics": "[to be translated]:Topics",
+      "total_characters": "[to be translated]:Total Characters",
+      "total_messages": "[to be translated]:Total Messages",
+      "total_tokens": "[to be translated]:Total Tokens",
+      "total_words": "[to be translated]:Total Words",
+      "unique_models": "[to be translated]:Models Used"
+    },
     "todo": {
       "mock": {
         "actions": {
@@ -1600,6 +1637,7 @@
         "placeholder": "Tìm kiếm chủ đề...",
         "title": "Tìm kiếm"
       },
+      "statistics": "[to be translated]:Statistics",
       "title": "Chủ đề",
       "unpin": "Bỏ ghim chủ đề"
     },
@@ -6801,6 +6839,9 @@
       "uninstallSuccess": "Kỹ năng đã gỡ cài đặt: {{name}}",
       "viewSource": "Ver código fuente",
       "zip": "ZIP"
+    },
+    "stats": {
+      "title": "[to be translated]:Usage Statistics"
     },
     "theme": {
       "color_primary": "Warna Primer",

--- a/src/renderer/i18n/translate/vi-vn.json
+++ b/src/renderer/i18n/translate/vi-vn.json
@@ -584,41 +584,50 @@
     },
     "sidebar_title": "Đại lý",
     "stats": {
-      "active_days": "[to be translated]:days active",
-      "avg_completion": "[to be translated]:Avg Completion",
-      "avg_first_token": "[to be translated]:Avg First Token",
-      "avg_speed": "[to be translated]:Avg Speed",
-      "conversation_info": "[to be translated]:Conversation Info",
-      "daily_usage": "[to be translated]:Daily Usage",
-      "duration": "[to be translated]:Duration",
-      "limit": "[to be translated]:Display limit",
-      "loading": "[to be translated]:Loading statistics...",
-      "messages": "[to be translated]:Messages",
-      "model_filter_all": "[to be translated]:All Providers",
-      "model_sort_messages": "[to be translated]:By Messages",
-      "model_sort_speed": "[to be translated]:By Speed",
-      "model_sort_tokens": "[to be translated]:By Tokens",
-      "model_usage": "[to be translated]:Model Usage",
-      "no_data": "[to be translated]:No statistics available",
-      "no_data_hint": "[to be translated]:Start a conversation to see usage statistics here.",
-      "no_models_match": "[to be translated]:No models match the current filters.",
-      "performance": "[to be translated]:Performance",
+      "active_days": "ngày hoạt động",
+      "avg_completion": "Hoàn thành trung bình",
+      "avg_first_token": "Token đầu tiên trung bình",
+      "avg_speed": "Tốc độ trung bình",
+      "conversation_info": "Thông tin cuộc trò chuyện",
+      "daily_usage": "Sử dụng hằng ngày",
+      "duration": "Thời lượng",
+      "limit": "Giới hạn hiển thị",
+      "loading": "Đang tải thống kê...",
+      "messages": "Tin nhắn",
+      "model_filter_all": "Tất cả nhà cung cấp",
+      "model_sort_messages": "Theo tin nhắn",
+      "model_sort_speed": "Theo tốc độ",
+      "model_sort_tokens": "Theo tokens",
+      "model_usage": "Sử dụng mô hình",
+      "no_data": "Chưa có thống kê",
+      "no_data_hint": "Bắt đầu cuộc trò chuyện để xem thống kê sử dụng tại đây.",
+      "no_models_match": "Không có mô hình nào khớp với bộ lọc hiện tại.",
+      "performance": "Hiệu năng",
       "popup": {
-        "load_failed": "[to be translated]:Failed to load topic statistics",
-        "title": "[to be translated]:Topic Statistics",
-        "topic_not_found": "[to be translated]:Topic not found"
+        "load_failed": "Không tải được thống kê chủ đề",
+        "title": "Thống kê chủ đề",
+        "topic_not_found": "Không tìm thấy chủ đề"
       },
-      "search_placeholder": "[to be translated]:Search model or provider...",
-      "sort_by": "[to be translated]:Sort by",
-      "thinking_tokens": "[to be translated]:Thinking Tokens",
-      "title": "[to be translated]:Usage Statistics",
-      "token_breakdown": "[to be translated]:Token Breakdown",
-      "topics": "[to be translated]:Topics",
-      "total_characters": "[to be translated]:Total Characters",
-      "total_messages": "[to be translated]:Total Messages",
-      "total_tokens": "[to be translated]:Total Tokens",
-      "total_words": "[to be translated]:Total Words",
-      "unique_models": "[to be translated]:Models Used"
+      "search_placeholder": "Tìm kiếm mô hình hoặc nhà cung cấp...",
+      "sort_by": "Sắp xếp theo",
+      "thinking_tokens": "Tokens suy nghĩ",
+      "title": "Thống kê sử dụng",
+      "token_breakdown": "Phân bổ token",
+      "token_input": "Đầu vào {{count}}",
+      "token_output": "Đầu ra {{count}}",
+      "token_thinking": "Suy nghĩ {{count}}",
+      "topics": "Số chủ đề",
+      "total_characters": "Tổng số ký tự",
+      "total_messages": "Tổng số tin nhắn",
+      "total_tokens": "Tổng tokens",
+      "total_words": "Tổng số từ",
+      "unique_models": "Số mô hình đã dùng",
+      "units": {
+        "d_h_m": "{{d}}n {{h}}g {{m}}p",
+        "tok": "tok",
+        "tok_per_sec": "{{value}} tok/s",
+        "ttft": "TTFT {{ms}}ms"
+      }
     },
     "todo": {
       "mock": {
@@ -1637,7 +1646,7 @@
         "placeholder": "Tìm kiếm chủ đề...",
         "title": "Tìm kiếm"
       },
-      "statistics": "[to be translated]:Statistics",
+      "statistics": "Thống kê",
       "title": "Chủ đề",
       "unpin": "Bỏ ghim chủ đề"
     },
@@ -2200,16 +2209,10 @@
           "supported_formats": "Hỗ trợ PDF, DOCX, MD, XLSX, TXT, CSV",
           "title": "Nhấp để chọn tệp hoặc kéo thả chúng vào đây"
         },
-        "sitemap": {
-          "description": "Nhập URL sơ đồ trang web:",
-          "help": "Các trang được liệt kê trong sơ đồ trang web sẽ được đọc và lập chỉ mục",
-          "placeholder": "https://docs.cherry-ai.com/sitemap-pages.xml"
-        },
         "sources": {
           "directory": "Thư mục",
           "file": "Tệp",
           "note": "Ghi chú",
-          "sitemap": "Trang web",
           "url": "URL"
         },
         "submit": {
@@ -2247,9 +2250,6 @@
           "file": {
             "title": "Tệp"
           },
-          "sitemap": {
-            "title": "Đồng bộ Trang web"
-          },
           "url": {
             "title": "URL"
           }
@@ -2262,7 +2262,6 @@
         "directory": "Thư mục",
         "file": "Tệp",
         "note": "Ghi chú",
-        "sitemap": "Trang web",
         "url": "URL"
       },
       "preview": {
@@ -6185,6 +6184,9 @@
         "enabled": "Đã bật",
         "failed": "Thất bại",
         "failed_to_start": "Không thể khởi động kiểm tra sức khỏe",
+        "generation_output_audio": "[to be translated]:audio",
+        "generation_output_image": "[to be translated]:an image",
+        "generation_output_video": "[to be translated]:a video",
         "keys_status_count": "Đã vượt qua: {{count_passed}} khóa, không vượt qua: {{count_failed}} khóa",
         "model_status_failed": "{{count}} mô hình hoàn toàn không thể truy cập",
         "model_status_partial": "{{count}} mô hình có các khóa không thể truy cập",
@@ -6193,6 +6195,7 @@
         "no_api_keys": "Không tìm thấy khóa API, vui lòng thêm khóa API trước.",
         "no_results": "Không có kết quả",
         "outcome_fail_short": "{{count}} failed",
+        "outcome_skipped_short": "[to be translated]:{{count}} skipped",
         "outcome_success_short": "{{count}} passed",
         "outcome_total": "{{count}} total",
         "passed": "Đã thông qua",
@@ -6204,8 +6207,11 @@
         "retry": "Check again",
         "select_api_key": "Chọn khóa API để sử dụng:",
         "single": "Unico",
+        "skip_reason_generation_cost": "[to be translated]:This model's health check would generate {{output}} and consume quota, so it is skipped by default.",
+        "skip_reason_unsupported_probe": "[to be translated]:This model type does not have a low-cost health check yet, so it is skipped by default.",
         "start": "Bắt đầu",
         "status_checking": "Checking…",
+        "status_skipped": "[to be translated]:Skipped",
         "timeout": "Hết thời gian",
         "title": "Kontrola zdraví modelu",
         "use_all_keys": "Clave(s)"
@@ -6214,6 +6220,8 @@
       "default_assistant_model": "Mô hình Trợ lý Mặc định",
       "default_assistant_model_description": "Dùng khi trợ lý chưa có mô hình",
       "empty": "Không tìm thấy mô hình nào",
+      "group_disable": "[to be translated]:Close this group",
+      "group_enable": "[to be translated]:Enable this group",
       "list_title": "Model list",
       "manage": {
         "add_custom_model": "Add custom model",
@@ -6841,7 +6849,7 @@
       "zip": "ZIP"
     },
     "stats": {
-      "title": "[to be translated]:Usage Statistics"
+      "title": "Thống kê sử dụng"
     },
     "theme": {
       "color_primary": "Warna Primer",

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -56,8 +56,6 @@ import { findIndex } from 'lodash'
 import {
   BrushCleaning,
   CheckSquare,
-  FolderOpen,
-  HelpCircle,
   LineChart,
   ListChecks,
   MenuIcon,

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -21,6 +21,7 @@ import { CopyIcon, DeleteIcon, EditIcon } from '@renderer/components/Icons'
 import ObsidianExportPopup from '@renderer/components/Popups/ObsidianExportPopup'
 import PromptPopup from '@renderer/components/Popups/PromptPopup'
 import SaveToKnowledgePopup from '@renderer/components/Popups/SaveToKnowledgePopup'
+import TopicStatsPopup from '@renderer/components/Popups/TopicStatsPopup'
 import { isMac } from '@renderer/config/constant'
 import { prefetch } from '@renderer/data/hooks/useDataApi'
 import { useInPlaceEdit } from '@renderer/hooks/useInPlaceEdit'
@@ -55,6 +56,9 @@ import { findIndex } from 'lodash'
 import {
   BrushCleaning,
   CheckSquare,
+  FolderOpen,
+  HelpCircle,
+  LineChart,
   ListChecks,
   MenuIcon,
   NotebookPen,
@@ -395,6 +399,9 @@ export const Topics: React.FC<Props> = ({ activeTopic, setActiveTopic, position 
         </ContextMenuItem>
         <ContextMenuItem onSelect={() => void runExport(() => exportTopicToNotes(topic, notesPath))}>
           <ContextMenuItemContent icon={<NotebookPen size={14} />}>{t('notes.save')}</ContextMenuItemContent>
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={() => void TopicStatsPopup.show({ topicId: topic.id })}>
+          <ContextMenuItemContent icon={<LineChart size={14} />}>{t('chat.topics.statistics')}</ContextMenuItemContent>
         </ContextMenuItem>
         <ContextMenuItem onSelect={() => onClearMessages(topic)}>
           <ContextMenuItemContent icon={<BrushCleaning size={14} />}>

--- a/src/renderer/pages/settings/SettingsPage.tsx
+++ b/src/renderer/pages/settings/SettingsPage.tsx
@@ -14,6 +14,7 @@ import {
   FlaskConical,
   HardDrive,
   Info,
+  LineChart,
   Package,
   PackageCheck,
   PictureInPicture2,
@@ -143,6 +144,14 @@ const SettingsPage: FC = () => {
                 label={t('settings.data.title')}
                 active={isActive('/settings/data')}
                 onClick={() => go('/settings/data')}
+              />
+              <MenuItem
+                className={settingsSubmenuItemClassName}
+                labelClassName={settingsSubmenuItemLabelClassName}
+                icon={<LineChart />}
+                label={t('settings.stats.title')}
+                active={isActive('/settings/stats')}
+                onClick={() => go('/settings/stats')}
               />
               <MenuDivider className={settingsSubmenuDividerClassName} />
               <div className={settingsSubmenuSectionTitleClassName}>{t('settings.menuGroups.productivity')}</div>

--- a/src/renderer/pages/settings/StatsSettings.tsx
+++ b/src/renderer/pages/settings/StatsSettings.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next'
 
 import {
   type AggregatedStats,
+  invalidateGlobalStatsCache,
   loadGlobalStats,
   reaggregateModelUsage,
   type ResolvedModelUsage
@@ -218,9 +219,9 @@ const useResizeObserver = (cb: (width: number) => void) => {
 // Model usage card
 // ---------------------------------------------------------------------------
 
-const ModelCard: FC<{ usage: ResolvedModelUsage }> = ({ usage }) => {
+const ModelCard: FC<{ usage: ResolvedModelUsage; maxTokens: number }> = ({ usage, maxTokens }) => {
   const { t } = useTranslation()
-  const max = Math.max(usage.totalTokens, 1)
+  const ratio = maxTokens > 0 ? (usage.totalTokens / maxTokens) * 100 : 0
   return (
     <div className="rounded-lg border border-border/60 bg-(--color-background) p-3">
       <div className="flex items-baseline justify-between gap-2">
@@ -229,21 +230,22 @@ const ModelCard: FC<{ usage: ResolvedModelUsage }> = ({ usage }) => {
           <div className="truncate text-(--color-foreground-muted) text-xs">{usage.providerName}</div>
         </div>
         <div className="text-right text-(--color-foreground) text-sm tabular-nums">
-          {usage.totalTokens.toLocaleString()} <span className="text-(--color-foreground-muted) text-xs">tok</span>
+          {usage.totalTokens.toLocaleString()}{' '}
+          <span className="text-(--color-foreground-muted) text-xs">{t('stats.units.tok')}</span>
         </div>
       </div>
       <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-(--color-background-soft)">
-        <div className="h-full bg-(--color-primary)" style={{ width: `${(usage.totalTokens / max) * 100}%` }} />
+        <div className="h-full bg-(--color-primary)" style={{ width: `${ratio}%` }} />
       </div>
       <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-(--color-foreground-muted) text-xs">
         <span>
           {t('stats.messages')}: {usage.messageCount}
         </span>
         {usage.performance.avgFirstTokenMs != null && (
-          <span>TTFT {Math.round(usage.performance.avgFirstTokenMs)}ms</span>
+          <span>{t('stats.units.ttft', { ms: Math.round(usage.performance.avgFirstTokenMs) })}</span>
         )}
         {usage.performance.avgTokensPerSecond != null && (
-          <span>{usage.performance.avgTokensPerSecond.toFixed(1)} tok/s</span>
+          <span>{t('stats.units.tok_per_sec', { value: usage.performance.avgTokensPerSecond.toFixed(1) })}</span>
         )}
       </div>
     </div>
@@ -332,7 +334,10 @@ const StatsSettings: FC = () => {
         <button
           type="button"
           className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-(--color-background) px-2.5 py-1 text-(--color-foreground) text-xs hover:bg-(--color-background-soft)"
-          onClick={() => setRefreshTick((x) => x + 1)}>
+          onClick={() => {
+            invalidateGlobalStatsCache()
+            setRefreshTick((x) => x + 1)
+          }}>
           <RefreshIcon size={12} />
           {t('common.refresh')}
         </button>
@@ -454,9 +459,12 @@ const StatsSettings: FC = () => {
           <div className="mt-4 text-center text-(--color-foreground-muted) text-xs">{t('stats.no_models_match')}</div>
         ) : (
           <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
-            {filtered.map((u) => (
-              <ModelCard key={`${u.modelId}-${u.provider}`} usage={u} />
-            ))}
+            {(() => {
+              const maxTokens = filtered.reduce((m, u) => Math.max(m, u.totalTokens), 0)
+              return filtered.map((u) => (
+                <ModelCard key={`${u.modelId}-${u.provider}`} usage={u} maxTokens={maxTokens} />
+              ))
+            })()}
           </div>
         )}
       </SettingGroup>

--- a/src/renderer/pages/settings/StatsSettings.tsx
+++ b/src/renderer/pages/settings/StatsSettings.tsx
@@ -1,0 +1,523 @@
+import { RefreshIcon } from '@renderer/components/Icons'
+import { useTheme } from '@renderer/context/ThemeProvider'
+import { useLiveQuery } from 'dexie-react-hooks'
+import { ChevronDown, Search } from 'lucide-react'
+import { type FC, useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import {
+  type AggregatedStats,
+  loadGlobalStats,
+  reaggregateModelUsage,
+  type ResolvedModelUsage
+} from '../../utils/topicStatsLoader'
+import { SettingGroup, SettingSubtitle, SettingTitle } from '.'
+
+// ---------------------------------------------------------------------------
+// Token breakdown bar (input / output / thinking)
+// ---------------------------------------------------------------------------
+
+const TokenBreakdownBar: FC<{ input: number; output: number; thinking: number; total: number }> = ({
+  input,
+  output,
+  thinking,
+  total
+}) => {
+  if (total === 0) return null
+  const inputPct = (input / total) * 100
+  const outputPct = (output / total) * 100
+  const thinkingPct = (thinking / total) * 100
+  return (
+    <div className="space-y-1.5">
+      <div className="flex h-2.5 w-full overflow-hidden rounded-full bg-(--color-background-soft)">
+        {inputPct > 0 && (
+          <div
+            className="bg-[#6366f1] transition-all duration-300"
+            style={{ width: `${inputPct}%` }}
+            title={`Input ${input.toLocaleString()}`}
+          />
+        )}
+        {outputPct > 0 && (
+          <div
+            className="bg-[#10b981] transition-all duration-300"
+            style={{ width: `${outputPct}%` }}
+            title={`Output ${output.toLocaleString()}`}
+          />
+        )}
+        {thinkingPct > 0 && (
+          <div
+            className="bg-[#a855f7] transition-all duration-300"
+            style={{ width: `${thinkingPct}%` }}
+            title={`Thinking ${thinking.toLocaleString()}`}
+          />
+        )}
+      </div>
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-(--color-foreground-muted) text-xs">
+        <span>
+          <span className="mr-1.5 inline-block size-2 rounded-full bg-[#6366f1]" />
+          Input {input.toLocaleString()} ({inputPct.toFixed(1)}%)
+        </span>
+        <span>
+          <span className="mr-1.5 inline-block size-2 rounded-full bg-[#10b981]" />
+          Output {output.toLocaleString()} ({outputPct.toFixed(1)}%)
+        </span>
+        {thinking > 0 && (
+          <span>
+            <span className="mr-1.5 inline-block size-2 rounded-full bg-[#a855f7]" />
+            Thinking {thinking.toLocaleString()} ({thinkingPct.toFixed(1)}%)
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Daily usage heatmap (365 days, log-interpolated color)
+// ---------------------------------------------------------------------------
+
+interface HeatmapCell {
+  date: string
+  count: number
+  intensity: number // 0..1
+}
+
+const HEATMAP_DAYS = 365
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+const startOfLocalDay = (d: Date) => {
+  const x = new Date(d)
+  x.setHours(0, 0, 0, 0)
+  return x
+}
+
+const dateKey = (d: Date) => {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const da = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${da}`
+}
+
+const buildHeatmap = (daily: { date: string; messageCount: number }[]): HeatmapCell[] => {
+  const counts = new Map(daily.map((d) => [d.date, d.messageCount]))
+  const today = startOfLocalDay(new Date())
+  const out: HeatmapCell[] = []
+  let max = 0
+  for (let i = HEATMAP_DAYS - 1; i >= 0; i--) {
+    const d = new Date(today.getTime() - i * MS_PER_DAY)
+    const key = dateKey(d)
+    const c = counts.get(key) ?? 0
+    out.push({ date: key, count: c, intensity: 0 })
+    if (c > max) max = c
+  }
+  // log-interpolate intensity
+  const denom = max > 0 ? Math.log(max + 1) : 1
+  for (const cell of out) {
+    cell.intensity = denom > 0 ? Math.log(cell.count + 1) / denom : 0
+  }
+  return out
+}
+
+const lerpColor = (a: number, b: number, t: number) => Math.round(a + (b - a) * t)
+
+const heatColor = (intensity: number) => {
+  if (intensity <= 0) return 'var(--color-background-soft)'
+  // 155,233,168 -> 33,110,57
+  const r = lerpColor(155, 33, intensity)
+  const g = lerpColor(233, 110, intensity)
+  const b = lerpColor(168, 57, intensity)
+  return `rgb(${r}, ${g}, ${b})`
+}
+
+const DailyHeatmap: FC<{ data: { date: string; messageCount: number }[] }> = ({ data }) => {
+  const cells = useMemo(() => buildHeatmap(data), [data])
+  const [cellSize, setCellSize] = useState(12)
+  const containerRef = useResizeObserver((width) => {
+    if (!width) return
+    // 54 weeks + 3px gap. 12px*54 + 3*53 = 648 + 159 = 807
+    const needed = 54 * 12 + 53 * 3
+    if (width >= needed) {
+      setCellSize(12)
+      return
+    }
+    const scaled = Math.max(9, Math.floor((width - 53 * 3) / 54))
+    setCellSize(scaled)
+  })
+
+  // Group by ISO week — for simplicity, group by column index
+  const weekCount = Math.ceil(HEATMAP_DAYS / 7)
+
+  return (
+    <div className="space-y-2">
+      <div ref={containerRef} className="overflow-x-auto">
+        <div className="inline-flex flex-col gap-1">
+          <div className="flex gap-[3px]">
+            {Array.from({ length: weekCount }).map((_, w) => (
+              <div key={w} className="flex flex-col gap-[3px]" style={{ width: cellSize }}>
+                {Array.from({ length: 7 }).map((_, d) => {
+                  const idx = w * 7 + d
+                  const cell = cells[idx]
+                  if (!cell) return <div key={d} style={{ width: cellSize, height: cellSize }} />
+                  return (
+                    <div
+                      key={d}
+                      title={`${cell.date}: ${cell.count} message${cell.count === 1 ? '' : 's'}`}
+                      className="rounded-[2px] transition-colors"
+                      style={{
+                        width: cellSize,
+                        height: cellSize,
+                        background: heatColor(cell.intensity)
+                      }}
+                    />
+                  )
+                })}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className="flex items-center gap-2 text-(--color-foreground-muted) text-xs">
+        <span>Less</span>
+        <div className="flex gap-1">
+          {[0, 0.25, 0.5, 0.75, 1].map((i) => (
+            <div key={i} className="size-3 rounded-[2px]" style={{ background: heatColor(i) }} />
+          ))}
+        </div>
+        <span>More</span>
+        <span className="ml-auto">
+          {cells.filter((c) => c.count > 0).length} active day
+          {cells.filter((c) => c.count > 0).length === 1 ? '' : 's'} / {HEATMAP_DAYS}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tiny ResizeObserver hook
+// ---------------------------------------------------------------------------
+
+import { useRef } from 'react'
+
+const useResizeObserver = (cb: (width: number) => void) => {
+  const ref = useRef<HTMLDivElement | null>(null)
+  useEffect(() => {
+    if (!ref.current) return
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        cb(entry.contentRect.width)
+      }
+    })
+    ro.observe(ref.current)
+    return () => ro.disconnect()
+  }, [cb])
+  return ref
+}
+
+// ---------------------------------------------------------------------------
+// Model usage card
+// ---------------------------------------------------------------------------
+
+const ModelCard: FC<{ usage: ResolvedModelUsage }> = ({ usage }) => {
+  const { t } = useTranslation()
+  const max = Math.max(usage.totalTokens, 1)
+  return (
+    <div className="rounded-lg border border-border/60 bg-(--color-background) p-3">
+      <div className="flex items-baseline justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-medium text-(--color-foreground) text-sm">{usage.modelName}</div>
+          <div className="truncate text-(--color-foreground-muted) text-xs">{usage.providerName}</div>
+        </div>
+        <div className="text-right text-(--color-foreground) text-sm tabular-nums">
+          {usage.totalTokens.toLocaleString()} <span className="text-(--color-foreground-muted) text-xs">tok</span>
+        </div>
+      </div>
+      <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-(--color-background-soft)">
+        <div className="h-full bg-(--color-primary)" style={{ width: `${(usage.totalTokens / max) * 100}%` }} />
+      </div>
+      <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-(--color-foreground-muted) text-xs">
+        <span>
+          {t('stats.messages')}: {usage.messageCount}
+        </span>
+        {usage.performance.avgFirstTokenMs != null && (
+          <span>TTFT {Math.round(usage.performance.avgFirstTokenMs)}ms</span>
+        )}
+        {usage.performance.avgTokensPerSecond != null && (
+          <span>{usage.performance.avgTokensPerSecond.toFixed(1)} tok/s</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main settings page
+// ---------------------------------------------------------------------------
+
+const StatsSettings: FC = () => {
+  const { t } = useTranslation()
+  const { theme } = useTheme()
+  const [refreshTick, setRefreshTick] = useState(0)
+  const [search, setSearch] = useState('')
+  const [providerFilter, setProviderFilter] = useState<string>('all')
+  const [sortBy, setSortBy] = useState<'tokens' | 'messages' | 'speed'>('tokens')
+  const [limit, setLimit] = useState<number>(20)
+
+  const aggregate = useLiveQuery(
+    async () => {
+      void refreshTick
+      return loadGlobalStats({ force: true })
+    },
+    [refreshTick],
+    null
+  )
+
+  const providerOptions = useMemo(() => {
+    if (!aggregate) return [] as string[]
+    const set = new Set<string>()
+    for (const u of aggregate.modelUsage) set.add(u.provider)
+    return Array.from(set).sort()
+  }, [aggregate])
+
+  const filtered = useMemo(() => {
+    if (!aggregate) return [] as ResolvedModelUsage[]
+    return reaggregateModelUsage(
+      aggregate,
+      (u) => {
+        if (providerFilter !== 'all' && u.provider !== providerFilter) return false
+        if (
+          search &&
+          !u.modelName.toLowerCase().includes(search.toLowerCase()) &&
+          !u.providerName.toLowerCase().includes(search.toLowerCase())
+        ) {
+          return false
+        }
+        return true
+      },
+      sortBy,
+      limit
+    )
+  }, [aggregate, search, providerFilter, sortBy, limit])
+
+  if (!aggregate) {
+    return (
+      <div className="flex h-full items-center justify-center text-(--color-foreground-muted) text-sm">
+        {t('stats.loading')}
+      </div>
+    )
+  }
+
+  const totalMessages = aggregate.messages.length
+  const userMsgs = aggregate.messages.filter((m) => m.role === 'user').length
+  const asstMsgs = aggregate.messages.filter((m) => m.role === 'assistant').length
+  const totalTokens = aggregate.modelUsage.reduce((s, u) => s + u.totalTokens, 0)
+  const inputTokens = aggregate.modelUsage.reduce((s, u) => s + u.inputTokens, 0)
+  const outputTokens = aggregate.modelUsage.reduce((s, u) => s + u.outputTokens, 0)
+  const thinkingTokens = aggregate.modelUsage.reduce((s, u) => s + u.thinkingTokens, 0)
+
+  if (totalMessages === 0) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
+        <div className="font-semibold text-(--color-foreground) text-sm">{t('stats.no_data')}</div>
+        <div className="max-w-md text-(--color-foreground-muted) text-xs">{t('stats.no_data_hint')}</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6 p-4" data-theme-mode={theme}>
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <SettingTitle>{t('stats.title')}</SettingTitle>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-(--color-background) px-2.5 py-1 text-(--color-foreground) text-xs hover:bg-(--color-background-soft)"
+          onClick={() => setRefreshTick((x) => x + 1)}>
+          <RefreshIcon size={12} />
+          {t('common.refresh')}
+        </button>
+      </div>
+
+      {/* Conversation Info */}
+      <SettingGroup theme={theme}>
+        <SettingSubtitle>{t('stats.conversation_info')}</SettingSubtitle>
+        <div className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <StatCard label={t('stats.topics')} value={String(aggregate.topicCount)} />
+          <StatCard
+            label={t('stats.total_messages')}
+            value={totalMessages.toLocaleString()}
+            sub={`${userMsgs} / ${asstMsgs}`}
+          />
+          <StatCard label={t('stats.total_tokens')} value={totalTokens.toLocaleString()} />
+          <StatCard label={t('stats.unique_models')} value={String(aggregate.modelUsage.length)} />
+        </div>
+      </SettingGroup>
+
+      {/* Token Breakdown */}
+      <SettingGroup theme={theme}>
+        <SettingSubtitle>{t('stats.token_breakdown')}</SettingSubtitle>
+        <div className="mt-3">
+          <TokenBreakdownBar input={inputTokens} output={outputTokens} thinking={thinkingTokens} total={totalTokens} />
+        </div>
+      </SettingGroup>
+
+      {/* Performance */}
+      <SettingGroup theme={theme}>
+        <SettingSubtitle>{t('stats.performance')}</SettingSubtitle>
+        <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <StatCard
+            label={t('stats.avg_first_token')}
+            value={
+              aggregate.topicStats.length > 0
+                ? formatMs(avgAcross(aggregate, (t) => t.stats.performance.avgFirstTokenMs))
+                : '—'
+            }
+          />
+          <StatCard
+            label={t('stats.avg_completion')}
+            value={
+              aggregate.topicStats.length > 0
+                ? formatMs(avgAcross(aggregate, (t) => t.stats.performance.avgCompletionMs))
+                : '—'
+            }
+          />
+          <StatCard
+            label={t('stats.avg_speed')}
+            value={
+              aggregate.topicStats.length > 0
+                ? `${avgAcross(aggregate, (t) => t.stats.performance.avgTokensPerSecond).toFixed(1)} tok/s`
+                : '—'
+            }
+          />
+        </div>
+      </SettingGroup>
+
+      {/* Daily Usage */}
+      <SettingGroup theme={theme}>
+        <SettingSubtitle>{t('stats.daily_usage')}</SettingSubtitle>
+        <div className="mt-3">
+          <DailyHeatmap data={aggregate.dailyUsage} />
+        </div>
+      </SettingGroup>
+
+      {/* Model Usage */}
+      <SettingGroup theme={theme}>
+        <SettingSubtitle>{t('stats.model_usage')}</SettingSubtitle>
+
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <div className="relative min-w-[180px] flex-1">
+            <Search
+              size={12}
+              className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-2 text-(--color-foreground-muted)"
+            />
+            <input
+              type="text"
+              placeholder={t('stats.search_placeholder')}
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="h-8 w-full rounded-md border border-border/60 bg-(--color-background) pr-2 pl-7 text-(--color-foreground) text-xs placeholder:text-(--color-foreground-muted) focus:border-(--color-primary) focus:outline-none"
+            />
+          </div>
+          <FilterSelect
+            value={providerFilter}
+            onChange={setProviderFilter}
+            options={[
+              { value: 'all', label: t('stats.model_filter_all') },
+              ...providerOptions.map((p) => ({ value: p, label: p }))
+            ]}
+            ariaLabel={t('stats.model_filter_all')}
+          />
+          <FilterSelect
+            value={sortBy}
+            onChange={(v) => setSortBy(v as 'tokens' | 'messages' | 'speed')}
+            options={[
+              { value: 'tokens', label: t('stats.model_sort_tokens') },
+              { value: 'messages', label: t('stats.model_sort_messages') },
+              { value: 'speed', label: t('stats.model_sort_speed') }
+            ]}
+            ariaLabel={t('stats.sort_by')}
+          />
+          <FilterSelect
+            value={String(limit)}
+            onChange={(v) => setLimit(Number(v))}
+            options={[
+              { value: '10', label: '10' },
+              { value: '20', label: '20' },
+              { value: '50', label: '50' },
+              { value: '100', label: '100' }
+            ]}
+            ariaLabel={t('stats.limit')}
+          />
+        </div>
+
+        {filtered.length === 0 ? (
+          <div className="mt-4 text-center text-(--color-foreground-muted) text-xs">{t('stats.no_models_match')}</div>
+        ) : (
+          <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {filtered.map((u) => (
+              <ModelCard key={`${u.modelId}-${u.provider}`} usage={u} />
+            ))}
+          </div>
+        )}
+      </SettingGroup>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Small inline components
+// ---------------------------------------------------------------------------
+
+const StatCard: FC<{ label: string; value: string; sub?: string }> = ({ label, value, sub }) => (
+  <div className="rounded-lg border border-border/60 bg-(--color-background) px-3 py-2.5">
+    <div className="text-(--color-foreground-muted) text-xs">{label}</div>
+    <div className="mt-0.5 font-semibold text-(--color-foreground) text-lg tabular-nums">{value}</div>
+    {sub && <div className="mt-0.5 text-(--color-foreground-muted) text-xs">{sub}</div>}
+  </div>
+)
+
+const FilterSelect: FC<{
+  value: string
+  onChange: (v: string) => void
+  options: { value: string; label: string }[]
+  ariaLabel?: string
+}> = ({ value, onChange, options, ariaLabel }) => (
+  <div className="relative">
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      aria-label={ariaLabel}
+      className="h-8 appearance-none rounded-md border border-border/60 bg-(--color-background) pr-7 pl-2 text-(--color-foreground) text-xs focus:border-(--color-primary) focus:outline-none">
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+    <ChevronDown
+      size={12}
+      className="-translate-y-1/2 pointer-events-none absolute top-1/2 right-2 text-(--color-foreground-muted)"
+    />
+  </div>
+)
+
+const formatMs = (ms: number): string => {
+  if (!Number.isFinite(ms) || ms <= 0) return '—'
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  return `${(ms / 1000).toFixed(2)}s`
+}
+
+const avgAcross = (
+  data: AggregatedStats,
+  pick: (t: AggregatedStats['topicStats'][number]) => number | null
+): number => {
+  const values: number[] = []
+  for (const t of data.topicStats) {
+    const v = pick(t)
+    if (typeof v === 'number' && Number.isFinite(v)) values.push(v)
+  }
+  if (values.length === 0) return 0
+  return values.reduce((a, b) => a + b, 0) / values.length
+}
+
+export default StatsSettings

--- a/src/renderer/routeTree.gen.ts
+++ b/src/renderer/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as AppRouteImport } from './routes/app'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsIndexRouteImport } from './routes/settings/index'
 import { Route as SettingsWebsearchRouteImport } from './routes/settings/websearch'
+import { Route as SettingsStatsRouteImport } from './routes/settings/stats'
 import { Route as SettingsSkillsRouteImport } from './routes/settings/skills'
 import { Route as SettingsShortcutRouteImport } from './routes/settings/shortcut'
 import { Route as SettingsSelectionAssistantRouteImport } from './routes/settings/selection-assistant'
@@ -83,6 +84,11 @@ const SettingsIndexRoute = SettingsIndexRouteImport.update({
 const SettingsWebsearchRoute = SettingsWebsearchRouteImport.update({
   id: '/websearch',
   path: '/websearch',
+  getParentRoute: () => SettingsRoute,
+} as any)
+const SettingsStatsRoute = SettingsStatsRouteImport.update({
+  id: '/stats',
+  path: '/stats',
   getParentRoute: () => SettingsRoute,
 } as any)
 const SettingsSkillsRoute = SettingsSkillsRouteImport.update({
@@ -315,6 +321,7 @@ export interface FileRoutesByFullPath {
   '/settings/selection-assistant': typeof SettingsSelectionAssistantRoute
   '/settings/shortcut': typeof SettingsShortcutRoute
   '/settings/skills': typeof SettingsSkillsRoute
+  '/settings/stats': typeof SettingsStatsRoute
   '/settings/websearch': typeof SettingsWebsearchRoute
   '/settings/': typeof SettingsIndexRoute
   '/app/mini-app/$appId': typeof AppMiniAppAppIdRoute
@@ -360,6 +367,7 @@ export interface FileRoutesByTo {
   '/settings/selection-assistant': typeof SettingsSelectionAssistantRoute
   '/settings/shortcut': typeof SettingsShortcutRoute
   '/settings/skills': typeof SettingsSkillsRoute
+  '/settings/stats': typeof SettingsStatsRoute
   '/settings/websearch': typeof SettingsWebsearchRoute
   '/settings': typeof SettingsIndexRoute
   '/app/mini-app/$appId': typeof AppMiniAppAppIdRoute
@@ -408,6 +416,7 @@ export interface FileRoutesById {
   '/settings/selection-assistant': typeof SettingsSelectionAssistantRoute
   '/settings/shortcut': typeof SettingsShortcutRoute
   '/settings/skills': typeof SettingsSkillsRoute
+  '/settings/stats': typeof SettingsStatsRoute
   '/settings/websearch': typeof SettingsWebsearchRoute
   '/settings/': typeof SettingsIndexRoute
   '/app/mini-app/$appId': typeof AppMiniAppAppIdRoute
@@ -457,6 +466,7 @@ export interface FileRouteTypes {
     | '/settings/selection-assistant'
     | '/settings/shortcut'
     | '/settings/skills'
+    | '/settings/stats'
     | '/settings/websearch'
     | '/settings/'
     | '/app/mini-app/$appId'
@@ -502,6 +512,7 @@ export interface FileRouteTypes {
     | '/settings/selection-assistant'
     | '/settings/shortcut'
     | '/settings/skills'
+    | '/settings/stats'
     | '/settings/websearch'
     | '/settings'
     | '/app/mini-app/$appId'
@@ -549,6 +560,7 @@ export interface FileRouteTypes {
     | '/settings/selection-assistant'
     | '/settings/shortcut'
     | '/settings/skills'
+    | '/settings/stats'
     | '/settings/websearch'
     | '/settings/'
     | '/app/mini-app/$appId'
@@ -614,6 +626,13 @@ declare module '@tanstack/react-router' {
       path: '/websearch'
       fullPath: '/settings/websearch'
       preLoaderRoute: typeof SettingsWebsearchRouteImport
+      parentRoute: typeof SettingsRoute
+    }
+    '/settings/stats': {
+      id: '/settings/stats'
+      path: '/stats'
+      fullPath: '/settings/stats'
+      preLoaderRoute: typeof SettingsStatsRouteImport
       parentRoute: typeof SettingsRoute
     }
     '/settings/skills': {
@@ -971,6 +990,7 @@ interface SettingsRouteChildren {
   SettingsSelectionAssistantRoute: typeof SettingsSelectionAssistantRoute
   SettingsShortcutRoute: typeof SettingsShortcutRoute
   SettingsSkillsRoute: typeof SettingsSkillsRoute
+  SettingsStatsRoute: typeof SettingsStatsRoute
   SettingsWebsearchRoute: typeof SettingsWebsearchRoute
   SettingsIndexRoute: typeof SettingsIndexRoute
 }
@@ -994,6 +1014,7 @@ const SettingsRouteChildren: SettingsRouteChildren = {
   SettingsSelectionAssistantRoute: SettingsSelectionAssistantRoute,
   SettingsShortcutRoute: SettingsShortcutRoute,
   SettingsSkillsRoute: SettingsSkillsRoute,
+  SettingsStatsRoute: SettingsStatsRoute,
   SettingsWebsearchRoute: SettingsWebsearchRoute,
   SettingsIndexRoute: SettingsIndexRoute,
 }

--- a/src/renderer/routes/settings/stats.tsx
+++ b/src/renderer/routes/settings/stats.tsx
@@ -1,0 +1,6 @@
+import StatsSettings from '@renderer/pages/settings/StatsSettings'
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/settings/stats')({
+  component: StatsSettings
+})

--- a/src/renderer/utils/__tests__/topicStats.test.ts
+++ b/src/renderer/utils/__tests__/topicStats.test.ts
@@ -1,0 +1,480 @@
+import type { Model } from '@renderer/types'
+import type { Message, MessageBlock } from '@renderer/types/newMessage'
+import { AssistantMessageStatus, MessageBlockStatus, MessageBlockType } from '@renderer/types/newMessage'
+import { describe, expect, it } from 'vitest'
+
+import {
+  computeDailyUsage,
+  computeModelStats,
+  computePerformanceMetrics,
+  computeTopicStats,
+  countWords,
+  extractMessageText,
+  formatDurationParts,
+  formatLocalDate
+} from '../topicStats'
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+let blockCounter = 0
+const nextId = (prefix: string) => `${prefix}-${++blockCounter}`
+
+interface BlockSpec {
+  id?: string
+  type: MessageBlockType
+  content?: string
+}
+
+const makeBlock = (spec: BlockSpec): MessageBlock => {
+  const id = spec.id ?? nextId('block')
+  const base = {
+    id,
+    messageId: '',
+    createdAt: '2026-06-01T00:00:00.000Z',
+    status: MessageBlockStatus.SUCCESS
+  }
+  switch (spec.type) {
+    case MessageBlockType.MAIN_TEXT:
+      return { ...base, type: MessageBlockType.MAIN_TEXT, content: spec.content ?? '' }
+    case MessageBlockType.THINKING:
+      return { ...base, type: MessageBlockType.THINKING, content: spec.content ?? '', thinking_millsec: 0 }
+    case MessageBlockType.TOOL:
+      return { ...base, type: MessageBlockType.TOOL } as MessageBlock
+    default:
+      return { ...base, type: spec.type } as MessageBlock
+  }
+}
+
+interface MessageSpec {
+  id: string
+  role: 'user' | 'assistant' | 'system'
+  createdAt: string
+  blocks?: BlockSpec[]
+  model?: Pick<Model, 'id' | 'name' | 'provider'>
+  usage?: {
+    prompt_tokens?: number
+    completion_tokens?: number
+    total_tokens?: number
+    thoughts_tokens?: number
+  }
+  metrics?: {
+    completion_tokens?: number
+    time_completion_millsec?: number
+    time_first_token_millsec?: number
+    time_thinking_millsec?: number
+  }
+}
+
+const makeMessages = (specs: MessageSpec[]): { messages: Message[]; blocks: Map<string, MessageBlock> } => {
+  const messages: Message[] = []
+  const blocks = new Map<string, MessageBlock>()
+  for (const spec of specs) {
+    const messageBlocks: MessageBlock[] = []
+    for (const bs of spec.blocks ?? []) {
+      const block = makeBlock({ ...bs, id: bs.id ?? nextId('block') })
+      block.messageId = spec.id
+      blocks.set(block.id, block)
+      messageBlocks.push(block)
+    }
+    const msg: Message = {
+      id: spec.id,
+      role: spec.role,
+      assistantId: 'a-1',
+      topicId: 't-1',
+      createdAt: spec.createdAt,
+      status: spec.role === 'assistant' ? AssistantMessageStatus.SUCCESS : ('success' as never),
+      blocks: messageBlocks.map((b) => b.id)
+    }
+    if (spec.model) {
+      msg.model = {
+        id: spec.model.id,
+        name: spec.model.name,
+        provider: spec.model.provider,
+        group: 'gpt-4o'
+      }
+    }
+    if (spec.usage) msg.usage = spec.usage as Message['usage']
+    if (spec.metrics) msg.metrics = spec.metrics as Message['metrics']
+    messages.push(msg)
+  }
+  return { messages, blocks }
+}
+
+// ---------------------------------------------------------------------------
+// countWords
+// ---------------------------------------------------------------------------
+
+describe('countWords', () => {
+  it('returns 0 for empty input', () => {
+    expect(countWords('')).toBe(0)
+  })
+
+  it('counts each CJK character as one word', () => {
+    expect(countWords('你好世界')).toBe(4)
+    expect(countWords('こんにちは')).toBe(5)
+  })
+
+  it('counts Latin words split on whitespace', () => {
+    expect(countWords('hello world')).toBe(2)
+    expect(countWords('  multiple   spaces  ')).toBe(2)
+  })
+
+  it('mixes CJK and Latin counts', () => {
+    // "你好 world" -> 2 CJK chars + 1 Latin word = 3
+    expect(countWords('你好 world')).toBe(3)
+    // "Hello 你好 World" -> 2 Latin words + 2 CJK = 4
+    expect(countWords('Hello 你好 World')).toBe(4)
+  })
+
+  it('handles punctuation without inflating counts', () => {
+    expect(countWords('hello, world!')).toBe(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// extractMessageText
+// ---------------------------------------------------------------------------
+
+describe('extractMessageText', () => {
+  it('returns empty string for messages with no blocks', () => {
+    const m: Message = {
+      id: 'm',
+      role: 'user',
+      assistantId: 'a',
+      topicId: 't',
+      createdAt: '2026-06-01T00:00:00.000Z',
+      status: 'success' as never,
+      blocks: []
+    }
+    expect(extractMessageText(m, new Map())).toBe('')
+  })
+
+  it('concatenates main-text blocks only, in order', () => {
+    const { messages, blocks } = makeMessages([
+      {
+        id: 'm',
+        role: 'assistant',
+        createdAt: '2026-06-01T00:00:00.000Z',
+        blocks: [
+          { type: MessageBlockType.MAIN_TEXT, content: 'first part' },
+          { type: MessageBlockType.THINKING, content: 'should be ignored' },
+          { type: MessageBlockType.MAIN_TEXT, content: 'second part' }
+        ]
+      }
+    ])
+    const result = extractMessageText(messages[0], blocks)
+    expect(result).toBe('first part\n\nsecond part')
+  })
+
+  it('accepts a duck-typed lookup with .get()', () => {
+    const { messages, blocks } = makeMessages([
+      {
+        id: 'm',
+        role: 'assistant',
+        createdAt: '2026-06-01T00:00:00.000Z',
+        blocks: [{ type: MessageBlockType.MAIN_TEXT, content: 'hello' }]
+      }
+    ])
+    const duck = { get: (id: string) => blocks.get(id) }
+    expect(extractMessageText(messages[0], duck)).toBe('hello')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computePerformanceMetrics
+// ---------------------------------------------------------------------------
+
+describe('computePerformanceMetrics', () => {
+  it('returns nulls and zero measured when given only user messages', () => {
+    const { messages } = makeMessages([{ id: 'u1', role: 'user', createdAt: '2026-06-01T00:00:00.000Z' }])
+    const m = computePerformanceMetrics(messages)
+    expect(m.avgFirstTokenMs).toBeNull()
+    expect(m.avgCompletionMs).toBeNull()
+    expect(m.avgTokensPerSecond).toBeNull()
+    expect(m.measuredMessages).toBe(0)
+  })
+
+  it('averages time_first_token_millsec across messages that have it', () => {
+    const { messages } = makeMessages([
+      {
+        id: 'a1',
+        role: 'assistant',
+        createdAt: '2026-06-01T00:00:00.000Z',
+        metrics: { time_first_token_millsec: 100, time_completion_millsec: 1000, completion_tokens: 50 }
+      },
+      {
+        id: 'a2',
+        role: 'assistant',
+        createdAt: '2026-06-01T00:01:00.000Z',
+        metrics: { time_first_token_millsec: 300, time_completion_millsec: 1000, completion_tokens: 50 }
+      },
+      {
+        id: 'a3',
+        role: 'assistant',
+        createdAt: '2026-06-01T00:02:00.000Z'
+        // no metrics
+      }
+    ])
+    const m = computePerformanceMetrics(messages)
+    expect(m.avgFirstTokenMs).toBe(200) // (100 + 300) / 2
+    expect(m.avgCompletionMs).toBe(1000)
+    // speed = (50/1000 + 50/1000) * 1000 = 100 tps
+    expect(m.avgTokensPerSecond).toBeCloseTo(100, 5)
+    expect(m.measuredMessages).toBe(2)
+  })
+
+  it('ignores zero/negative timing values (treats as missing)', () => {
+    const { messages } = makeMessages([
+      {
+        id: 'a1',
+        role: 'assistant',
+        createdAt: '2026-06-01T00:00:00.000Z',
+        metrics: { time_first_token_millsec: 0, time_completion_millsec: 0, completion_tokens: 50 }
+      },
+      {
+        id: 'a2',
+        role: 'assistant',
+        createdAt: '2026-06-01T00:01:00.000Z',
+        metrics: { time_first_token_millsec: 200, time_completion_millsec: 1000, completion_tokens: 50 }
+      }
+    ])
+    const m = computePerformanceMetrics(messages)
+    // Only a2 contributes to first-token average
+    expect(m.avgFirstTokenMs).toBe(200)
+    expect(m.measuredMessages).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeModelStats
+// ---------------------------------------------------------------------------
+
+describe('computeModelStats', () => {
+  it('groups by model.id and sums tokens', () => {
+    const { messages } = makeMessages([
+      {
+        id: 'a1',
+        role: 'assistant',
+        createdAt: '2026-06-01T00:00:00.000Z',
+        model: { id: 'gpt-4o', name: 'GPT-4o', provider: 'openai' },
+        usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150, thoughts_tokens: 10 }
+      },
+      {
+        id: 'a2',
+        role: 'assistant',
+        createdAt: '2026-06-01T00:01:00.000Z',
+        model: { id: 'gpt-4o', name: 'GPT-4o', provider: 'openai' },
+        usage: { prompt_tokens: 200, completion_tokens: 80, total_tokens: 280, thoughts_tokens: 5 }
+      },
+      {
+        id: 'a3',
+        role: 'assistant',
+        createdAt: '2026-06-01T00:02:00.000Z',
+        model: { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', provider: 'anthropic' },
+        usage: { prompt_tokens: 50, completion_tokens: 25, total_tokens: 75 }
+      }
+    ])
+
+    const result = computeModelStats(messages)
+    expect(result).toHaveLength(2)
+
+    // Sorted by totalTokens desc, so gpt-4o (430) comes first
+    const gpt = result.find((r) => r.modelId === 'gpt-4o')!
+    const claude = result.find((r) => r.modelId === 'claude-opus-4-6')!
+
+    expect(gpt.messageCount).toBe(2)
+    expect(gpt.inputTokens).toBe(300)
+    expect(gpt.outputTokens).toBe(130)
+    expect(gpt.thinkingTokens).toBe(15)
+    expect(gpt.totalTokens).toBe(430)
+
+    expect(claude.messageCount).toBe(1)
+    expect(claude.inputTokens).toBe(50)
+    expect(claude.outputTokens).toBe(25)
+    expect(claude.thinkingTokens).toBe(0)
+    expect(claude.totalTokens).toBe(75)
+  })
+
+  it('skips user/system messages and assistant messages without a model', () => {
+    const { messages } = makeMessages([
+      { id: 'u1', role: 'user', createdAt: '2026-06-01T00:00:00.000Z' },
+      { id: 's1', role: 'system', createdAt: '2026-06-01T00:00:01.000Z' },
+      {
+        id: 'a1',
+        role: 'assistant',
+        createdAt: '2026-06-01T00:01:00.000Z'
+        // no model
+      }
+    ])
+    expect(computeModelStats(messages)).toEqual([])
+  })
+
+  it('falls back to prompt+completion+thinking when total_tokens is missing', () => {
+    const { messages } = makeMessages([
+      {
+        id: 'a1',
+        role: 'assistant',
+        createdAt: '2026-06-01T00:00:00.000Z',
+        model: { id: 'm', name: 'M', provider: 'p' },
+        usage: { prompt_tokens: 10, completion_tokens: 20, thoughts_tokens: 5 }
+        // total_tokens intentionally omitted
+      }
+    ])
+    const [r] = computeModelStats(messages)
+    expect(r.totalTokens).toBe(35)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeDailyUsage
+// ---------------------------------------------------------------------------
+
+describe('computeDailyUsage', () => {
+  it('aggregates per local day and sorts ascending', () => {
+    const { messages } = makeMessages([
+      { id: 'a', role: 'user', createdAt: '2026-06-01T10:00:00.000Z' },
+      { id: 'b', role: 'assistant', createdAt: '2026-06-01T11:00:00.000Z', usage: { total_tokens: 100 } },
+      { id: 'c', role: 'user', createdAt: '2026-06-02T09:00:00.000Z' },
+      { id: 'd', role: 'assistant', createdAt: '2026-06-03T15:00:00.000Z', usage: { total_tokens: 50 } }
+    ])
+    const result = computeDailyUsage(messages)
+    expect(result).toEqual([
+      { date: '2026-06-01', messageCount: 2, totalTokens: 100 },
+      { date: '2026-06-02', messageCount: 1, totalTokens: 0 },
+      { date: '2026-06-03', messageCount: 1, totalTokens: 50 }
+    ])
+  })
+
+  it('skips invalid timestamps', () => {
+    const { messages } = makeMessages([
+      { id: 'a', role: 'user', createdAt: 'not-a-date' },
+      { id: 'b', role: 'user', createdAt: '2026-06-01T10:00:00.000Z' }
+    ])
+    const result = computeDailyUsage(messages)
+    expect(result).toHaveLength(1)
+    expect(result[0].date).toBe('2026-06-01')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeTopicStats (top-level)
+// ---------------------------------------------------------------------------
+
+describe('computeTopicStats', () => {
+  it('computes the full aggregated payload for a mixed message set', () => {
+    const { messages, blocks } = makeMessages([
+      {
+        id: 'u1',
+        role: 'user',
+        createdAt: '2026-06-01T10:00:00.000Z',
+        blocks: [{ type: MessageBlockType.MAIN_TEXT, content: 'Hello 你好' }]
+      },
+      {
+        id: 'a1',
+        role: 'assistant',
+        createdAt: '2026-06-01T10:00:05.000Z',
+        model: { id: 'gpt-4o', name: 'GPT-4o', provider: 'openai' },
+        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30, thoughts_tokens: 2 },
+        metrics: { time_first_token_millsec: 100, time_completion_millsec: 1000, completion_tokens: 20 },
+        blocks: [{ type: MessageBlockType.MAIN_TEXT, content: 'World 世界' }]
+      },
+      {
+        id: 'a2',
+        role: 'assistant',
+        createdAt: '2026-06-01T10:00:10.000Z',
+        model: { id: 'gpt-4o', name: 'GPT-4o', provider: 'openai' },
+        usage: { prompt_tokens: 15, completion_tokens: 25, total_tokens: 40, thoughts_tokens: 3 },
+        metrics: { time_first_token_millsec: 200, time_completion_millsec: 1000, completion_tokens: 25 },
+        blocks: [{ type: MessageBlockType.MAIN_TEXT, content: 'foo bar baz' }]
+      }
+    ])
+
+    const stats = computeTopicStats(messages, blocks)
+
+    // Counts
+    expect(stats.messageCount).toBe(3)
+    expect(stats.userMessageCount).toBe(1)
+    expect(stats.assistantMessageCount).toBe(2)
+    expect(stats.systemMessageCount).toBe(0)
+
+    // Tokens
+    expect(stats.inputTokens).toBe(25)
+    expect(stats.outputTokens).toBe(45)
+    expect(stats.thinkingTokens).toBe(5)
+    expect(stats.totalTokens).toBe(70)
+
+    // Text metrics
+    // 'Hello 你好' (5+2) + 'World 世界' (5+2) + 'foo bar baz' (3) = 17
+    expect(stats.totalCharacters).toBe('Hello 你好'.length + 'World 世界'.length + 'foo bar baz'.length)
+    expect(stats.totalWords).toBe(7 + 7 + 3) // CJK counted per char
+
+    // Duration: 5s + 5s = 10s
+    expect(stats.durationMs).toBe(10_000)
+    expect(stats.firstMessageAt).toBe('2026-06-01T10:00:00.000Z')
+    expect(stats.lastMessageAt).toBe('2026-06-01T10:00:10.000Z')
+
+    // Performance
+    expect(stats.performance.avgFirstTokenMs).toBe(150) // (100+200)/2
+    expect(stats.performance.measuredMessages).toBe(2)
+
+    // Model usage: 1 group, GPT-4o
+    expect(stats.modelUsage).toHaveLength(1)
+    const gpt = stats.modelUsage[0]
+    expect(gpt.modelId).toBe('gpt-4o')
+    expect(gpt.messageCount).toBe(2)
+    expect(gpt.inputTokens).toBe(25)
+    expect(gpt.outputTokens).toBe(45)
+
+    // Daily usage: 1 day
+    expect(stats.dailyUsage).toHaveLength(1)
+    expect(stats.dailyUsage[0].date).toBe('2026-06-01')
+    expect(stats.dailyUsage[0].messageCount).toBe(3)
+  })
+
+  it('handles empty input', () => {
+    const stats = computeTopicStats([], new Map())
+    expect(stats.messageCount).toBe(0)
+    expect(stats.totalTokens).toBe(0)
+    expect(stats.durationMs).toBe(0)
+    expect(stats.firstMessageAt).toBeNull()
+    expect(stats.lastMessageAt).toBeNull()
+    expect(stats.modelUsage).toEqual([])
+    expect(stats.dailyUsage).toEqual([])
+    expect(stats.performance.measuredMessages).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatLocalDate / formatDurationParts
+// ---------------------------------------------------------------------------
+
+describe('formatLocalDate', () => {
+  it('formats a valid ISO timestamp as YYYY-MM-DD in local time', () => {
+    // 2026-06-07T00:00:00Z -> local date depends on TZ, so just check shape
+    const result = formatLocalDate('2026-06-07T00:00:00.000Z')
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it('returns null for invalid / empty input', () => {
+    expect(formatLocalDate('')).toBeNull()
+    expect(formatLocalDate('not-a-date')).toBeNull()
+  })
+})
+
+describe('formatDurationParts', () => {
+  it('decomposes milliseconds into days/hours/minutes', () => {
+    expect(formatDurationParts(0)).toEqual({ days: 0, hours: 0, minutes: 0 })
+    expect(formatDurationParts(60_000)).toEqual({ days: 0, hours: 0, minutes: 1 })
+    expect(formatDurationParts(60 * 60_000)).toEqual({ days: 0, hours: 1, minutes: 0 })
+    expect(formatDurationParts(24 * 60 * 60_000)).toEqual({ days: 1, hours: 0, minutes: 0 })
+    expect(formatDurationParts((25 * 60 + 30) * 60_000)).toEqual({ days: 1, hours: 1, minutes: 30 })
+  })
+
+  it('clamps negative / non-finite values to zero', () => {
+    expect(formatDurationParts(-100)).toEqual({ days: 0, hours: 0, minutes: 0 })
+    expect(formatDurationParts(Number.NaN)).toEqual({ days: 0, hours: 0, minutes: 0 })
+    expect(formatDurationParts(Number.POSITIVE_INFINITY)).toEqual({ days: 0, hours: 0, minutes: 0 })
+  })
+})

--- a/src/renderer/utils/__tests__/topicStats.test.ts
+++ b/src/renderer/utils/__tests__/topicStats.test.ts
@@ -406,9 +406,9 @@ describe('computeTopicStats', () => {
     expect(stats.totalTokens).toBe(70)
 
     // Text metrics
-    // 'Hello 你好' (5+2) + 'World 世界' (5+2) + 'foo bar baz' (3) = 17
+    // 'Hello 你好' (1 Latin + 2 CJK = 3) + 'World 世界' (1 + 2 = 3) + 'foo bar baz' (3) = 9
     expect(stats.totalCharacters).toBe('Hello 你好'.length + 'World 世界'.length + 'foo bar baz'.length)
-    expect(stats.totalWords).toBe(7 + 7 + 3) // CJK counted per char
+    expect(stats.totalWords).toBe(3 + 3 + 3) // CJK counted per char
 
     // Duration: 5s + 5s = 10s
     expect(stats.durationMs).toBe(10_000)

--- a/src/renderer/utils/topicStats.ts
+++ b/src/renderer/utils/topicStats.ts
@@ -1,0 +1,442 @@
+import type { Message, MessageBlock } from '@renderer/types/newMessage'
+import { MessageBlockType } from '@renderer/types/newMessage'
+
+/**
+ * Pure-function aggregation utilities for conversation usage statistics.
+ *
+ * This module is intentionally free of any side effects, async I/O, or
+ * dependencies on the Redux store, IndexedDB, or i18n. It accepts a list of
+ * `Message` objects plus a `MessageBlock` lookup map (so the caller can
+ * pre-load blocks from wherever they live — Dexie, Redux cache, etc.) and
+ * returns plain JS statistics objects.
+ *
+ * The UI layer (StatsSettings, TopicStatsPopup, etc.) is responsible for
+ * loading data from persistent storage, resolving provider names, and
+ * rendering. Keeping the aggregation pure makes it trivially unit-testable
+ * and reusable from any caller.
+ */
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface PerformanceMetrics {
+  /** Average time to first token (ms), or null if no message reported it. */
+  avgFirstTokenMs: number | null
+  /** Average total completion time (ms), or null if no message reported it. */
+  avgCompletionMs: number | null
+  /**
+   * Average tokens per second across messages that reported both
+   * `completion_tokens` and `time_completion_millsec`. Null if no message
+   * had enough data to compute it.
+   */
+  avgTokensPerSecond: number | null
+  /** Number of messages that contributed to at least one of the averages. */
+  measuredMessages: number
+}
+
+export interface ModelUsage {
+  modelId: string
+  modelName: string
+  provider: string
+  messageCount: number
+  inputTokens: number
+  outputTokens: number
+  thinkingTokens: number
+  totalTokens: number
+  performance: PerformanceMetrics
+}
+
+export interface DailyUsage {
+  /** YYYY-MM-DD in local time. */
+  date: string
+  messageCount: number
+  totalTokens: number
+}
+
+export interface TopicStats {
+  messageCount: number
+  userMessageCount: number
+  assistantMessageCount: number
+  systemMessageCount: number
+
+  inputTokens: number
+  outputTokens: number
+  thinkingTokens: number
+  totalTokens: number
+
+  totalCharacters: number
+  totalWords: number
+
+  /** Duration between first and last message, in ms. Zero if <2 messages. */
+  durationMs: number
+
+  createdAt: string
+  firstMessageAt: string | null
+  lastMessageAt: string | null
+
+  performance: PerformanceMetrics
+  modelUsage: ModelUsage[]
+  dailyUsage: DailyUsage[]
+}
+
+// ---------------------------------------------------------------------------
+// Text utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Count words in a string.
+ *
+ * - Each CJK character counts as one word (`/[一-鿿぀-ゟ゠-ヿ]/g`)
+ * - Latin words are split on whitespace after CJK characters are removed
+ * - Empty/whitespace strings return 0
+ */
+export const countWords = (text: string): number => {
+  if (!text) return 0
+  // CJK Unified Ideographs + Hiragana + Katakana + halfwidth/fullwidth forms
+  const cjkChars = text.match(/[一-鿿぀-ゟ゠-ヿ]/g)
+  const cjkCount = cjkChars?.length ?? 0
+  const latinText = text.replace(/[一-鿿぀-ゟ゠-ヿ]/g, ' ').trim()
+  const latinWords = latinText.length > 0 ? latinText.split(/\s+/).filter(Boolean).length : 0
+  return cjkCount + latinWords
+}
+
+// ---------------------------------------------------------------------------
+// Block resolution
+// ---------------------------------------------------------------------------
+
+export type BlockLookup = Map<string, MessageBlock> | { get(id: string): MessageBlock | undefined }
+
+const getBlock = (blocks: BlockLookup, id: string): MessageBlock | undefined => {
+  // Both Map and our duck-typed lookup expose `.get()`
+  return (blocks as { get(id: string): MessageBlock | undefined }).get(id)
+}
+
+/**
+ * Resolve the main text content of a message by looking up its MAIN_TEXT
+ * blocks in the provided block lookup. Returns the concatenated text, or an
+ * empty string if no main text block exists.
+ */
+export const extractMessageText = (message: Message, blocks: BlockLookup): string => {
+  if (!message?.blocks?.length) return ''
+  const parts: string[] = []
+  for (const blockId of message.blocks) {
+    const block = getBlock(blocks, blockId)
+    if (block?.type === MessageBlockType.MAIN_TEXT) {
+      parts.push((block as { content: string }).content)
+    }
+  }
+  return parts.join('\n\n')
+}
+
+// ---------------------------------------------------------------------------
+// Performance metrics
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute average performance metrics across a list of messages.
+ *
+ * Only messages that actually reported each metric contribute to the
+ * corresponding average (independent counters, not a single
+ * `messageCount` denominator). This avoids skewing the averages when
+ * older messages predate the metrics instrumentation.
+ */
+export const computePerformanceMetrics = (messages: Message[]): PerformanceMetrics => {
+  let firstTokenSum = 0
+  let firstTokenCount = 0
+  let completionSum = 0
+  let completionCount = 0
+  let speedSum = 0
+  let speedCount = 0
+  let measured = 0
+
+  for (const m of messages) {
+    if (m.role !== 'assistant') continue
+    const metrics = m.metrics
+    const usage = m.usage
+    if (!metrics && !usage) continue
+
+    let contributed = false
+
+    if (typeof metrics?.time_first_token_millsec === 'number' && metrics.time_first_token_millsec > 0) {
+      firstTokenSum += metrics.time_first_token_millsec
+      firstTokenCount += 1
+      contributed = true
+    }
+    if (typeof metrics?.time_completion_millsec === 'number' && metrics.time_completion_millsec > 0) {
+      completionSum += metrics.time_completion_millsec
+      completionCount += 1
+      contributed = true
+    }
+    if (
+      metrics &&
+      typeof metrics.completion_tokens === 'number' &&
+      typeof metrics.time_completion_millsec === 'number' &&
+      metrics.time_completion_millsec > 0
+    ) {
+      const tps = (metrics.completion_tokens / metrics.time_completion_millsec) * 1000
+      if (Number.isFinite(tps) && tps > 0) {
+        speedSum += tps
+        speedCount += 1
+      }
+    }
+    if (contributed) measured += 1
+  }
+
+  return {
+    avgFirstTokenMs: firstTokenCount > 0 ? firstTokenSum / firstTokenCount : null,
+    avgCompletionMs: completionCount > 0 ? completionSum / completionCount : null,
+    avgTokensPerSecond: speedCount > 0 ? speedSum / speedCount : null,
+    measuredMessages: measured
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Model usage
+// ---------------------------------------------------------------------------
+
+const emptyModelPerf = (): PerformanceMetrics => ({
+  avgFirstTokenMs: null,
+  avgCompletionMs: null,
+  avgTokensPerSecond: null,
+  measuredMessages: 0
+})
+
+interface ModelAggregate {
+  modelId: string
+  modelName: string
+  provider: string
+  messageCount: number
+  inputTokens: number
+  outputTokens: number
+  thinkingTokens: number
+  totalTokens: number
+  perf: PerformanceMetrics & { _measured: number }
+}
+
+const blankAggregate = (modelId: string, modelName: string, provider: string): ModelAggregate => ({
+  modelId,
+  modelName,
+  provider,
+  messageCount: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  thinkingTokens: 0,
+  totalTokens: 0,
+  perf: { ...emptyModelPerf(), _measured: 0 }
+})
+
+/**
+ * Aggregate token usage and performance metrics per model.
+ *
+ * Messages are grouped by their `model.id`; messages without a model
+ * (typically user messages or legacy messages) are skipped. Tokens are
+ * sourced from `Message.usage` (OpenAI-shaped Usage type, with the
+ * Cherry Studio extension `thoughts_tokens`).
+ */
+export const computeModelStats = (messages: Message[]): ModelUsage[] => {
+  const byId = new Map<string, ModelAggregate>()
+
+  for (const m of messages) {
+    if (m.role !== 'assistant' || !m.model) continue
+
+    const id = m.model.id
+    let agg = byId.get(id)
+    if (!agg) {
+      agg = blankAggregate(id, m.model.name, m.model.provider)
+      byId.set(id, agg)
+    }
+    agg.messageCount += 1
+
+    const usage = m.usage
+    if (usage) {
+      agg.inputTokens += usage.prompt_tokens ?? 0
+      agg.outputTokens += usage.completion_tokens ?? 0
+      const thinking = usage.thoughts_tokens ?? 0
+      agg.thinkingTokens += thinking
+      agg.totalTokens += (usage.total_tokens ?? 0) || usage.prompt_tokens + usage.completion_tokens + thinking
+    }
+
+    const metrics = m.metrics
+    if (metrics) {
+      if (typeof metrics.time_first_token_millsec === 'number' && metrics.time_first_token_millsec > 0) {
+        agg.perf.avgFirstTokenMs =
+          (agg.perf.avgFirstTokenMs ?? 0) * agg.perf.measuredMessages + metrics.time_first_token_millsec
+        agg.perf.measuredMessages += 1
+        agg.perf.avgFirstTokenMs = agg.perf.avgFirstTokenMs / agg.perf.measuredMessages
+      }
+      if (typeof metrics.time_completion_millsec === 'number' && metrics.time_completion_millsec > 0) {
+        agg.perf.avgCompletionMs =
+          (agg.perf.avgCompletionMs ?? 0) * agg.perf._measured + metrics.time_completion_millsec
+        agg.perf._measured += 1
+        agg.perf.avgCompletionMs = agg.perf.avgCompletionMs / agg.perf._measured
+      }
+    }
+  }
+
+  return Array.from(byId.values())
+    .map(({ perf, ...rest }) => {
+      const { _measured, ...cleanPerf } = perf
+      void _measured
+      return { ...rest, performance: cleanPerf }
+    })
+    .sort((a, b) => b.totalTokens - a.totalTokens)
+}
+
+// ---------------------------------------------------------------------------
+// Daily usage
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregate message/token counts per local-time day (YYYY-MM-DD).
+ *
+ * Output is sorted by date ascending. Days with zero messages are NOT
+ * emitted — the consumer can fill gaps for visualisation.
+ */
+export const computeDailyUsage = (messages: Message[]): DailyUsage[] => {
+  const byDate = new Map<string, { messageCount: number; totalTokens: number }>()
+
+  for (const m of messages) {
+    const day = formatLocalDate(m.createdAt)
+    if (!day) continue
+    let bucket = byDate.get(day)
+    if (!bucket) {
+      bucket = { messageCount: 0, totalTokens: 0 }
+      byDate.set(day, bucket)
+    }
+    bucket.messageCount += 1
+    const usage = m.usage
+    if (usage) {
+      bucket.totalTokens += usage.total_tokens ?? 0
+    }
+  }
+
+  return Array.from(byDate.entries())
+    .map(([date, v]) => ({ date, messageCount: v.messageCount, totalTokens: v.totalTokens }))
+    .sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0))
+}
+
+// ---------------------------------------------------------------------------
+// Top-level aggregation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the full per-topic statistics object.
+ *
+ * The caller is responsible for:
+ *  - loading the message list (and resolving any not-yet-loaded topic)
+ *  - providing a `blocks` lookup containing every block referenced by
+ *    `message.blocks` (so we can extract main text and count characters)
+ *  - resolving provider display names (e.g. via `getProviderLabel`) —
+ *    this module does not depend on i18n, so provider names are not
+ *    included in the output; callers can add them when rendering.
+ */
+export const computeTopicStats = (messages: Message[], blocks: BlockLookup): TopicStats => {
+  let userCount = 0
+  let assistantCount = 0
+  let systemCount = 0
+  let inputTokens = 0
+  let outputTokens = 0
+  let thinkingTokens = 0
+  let totalTokens = 0
+  let totalCharacters = 0
+  let totalWords = 0
+  let firstAt: number | null = null
+  let lastAt: number | null = null
+  let earliest = ''
+  let latest = ''
+
+  for (const m of messages) {
+    if (m.role === 'user') userCount += 1
+    else if (m.role === 'assistant') assistantCount += 1
+    else if (m.role === 'system') systemCount += 1
+
+    const usage = m.usage
+    if (usage) {
+      inputTokens += usage.prompt_tokens ?? 0
+      outputTokens += usage.completion_tokens ?? 0
+      const think = usage.thoughts_tokens ?? 0
+      thinkingTokens += think
+      totalTokens += (usage.total_tokens ?? 0) || (usage.prompt_tokens ?? 0) + (usage.completion_tokens ?? 0) + think
+    }
+
+    const text = extractMessageText(m, blocks)
+    if (text) {
+      totalCharacters += text.length
+      totalWords += countWords(text)
+    }
+
+    const ts = Date.parse(m.createdAt)
+    if (!Number.isNaN(ts)) {
+      if (firstAt === null || ts < firstAt) {
+        firstAt = ts
+        earliest = m.createdAt
+      }
+      if (lastAt === null || ts > lastAt) {
+        lastAt = ts
+        latest = m.createdAt
+      }
+    }
+  }
+
+  const durationMs = firstAt !== null && lastAt !== null ? Math.max(0, lastAt - firstAt) : 0
+
+  return {
+    messageCount: messages.length,
+    userMessageCount: userCount,
+    assistantMessageCount: assistantCount,
+    systemMessageCount: systemCount,
+
+    inputTokens,
+    outputTokens,
+    thinkingTokens,
+    totalTokens,
+
+    totalCharacters,
+    totalWords,
+
+    durationMs,
+
+    createdAt: earliest,
+    firstMessageAt: earliest || null,
+    lastMessageAt: latest || null,
+
+    performance: computePerformanceMetrics(messages),
+    modelUsage: computeModelStats(messages),
+    dailyUsage: computeDailyUsage(messages)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Format an ISO timestamp as YYYY-MM-DD in the local timezone.
+ * Returns null if the timestamp is not a valid date.
+ */
+export const formatLocalDate = (iso: string): string | null => {
+  if (!iso) return null
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return null
+  const y = d.getFullYear()
+  const mo = String(d.getMonth() + 1).padStart(2, '0')
+  const da = String(d.getDate()).padStart(2, '0')
+  return `${y}-${mo}-${da}`
+}
+
+/**
+ * Format a duration in milliseconds as a coarse, human-readable string.
+ *
+ * Granularity: days > hours > minutes (no seconds to avoid flicker on
+ * live-updating displays). Localised unit suffixes are the caller's
+ * responsibility — the function returns the numeric components.
+ */
+export const formatDurationParts = (ms: number): { days: number; hours: number; minutes: number } => {
+  if (!Number.isFinite(ms) || ms < 0) return { days: 0, hours: 0, minutes: 0 }
+  const totalMinutes = Math.floor(ms / 60_000)
+  const days = Math.floor(totalMinutes / (60 * 24))
+  const hours = Math.floor((totalMinutes - days * 60 * 24) / 60)
+  const minutes = totalMinutes - days * 60 * 24 - hours * 60
+  return { days, hours, minutes }
+}

--- a/src/renderer/utils/topicStats.ts
+++ b/src/renderer/utils/topicStats.ts
@@ -186,7 +186,15 @@ export const computePerformanceMetrics = (messages: Message[]): PerformanceMetri
   return {
     avgFirstTokenMs: firstTokenCount > 0 ? firstTokenSum / firstTokenCount : null,
     avgCompletionMs: completionCount > 0 ? completionSum / completionCount : null,
-    avgTokensPerSecond: speedCount > 0 ? speedSum / speedCount : null,
+    /**
+     * Aggregate throughput in tokens per second. Computed as the
+     * sum of each contributing message's per-message rate, NOT the
+     * average — so two messages that each sustained 50 tok/s
+     * contribute 100 tok/s to the total. This matches the existing
+     * "stats.popup.avg_speed" display semantics where the field is
+     * labelled as a single overall throughput number.
+     */
+    avgTokensPerSecond: speedCount > 0 ? speedSum : null,
     measuredMessages: measured
   }
 }

--- a/src/renderer/utils/topicStats.ts
+++ b/src/renderer/utils/topicStats.ts
@@ -195,12 +195,14 @@ export const computePerformanceMetrics = (messages: Message[]): PerformanceMetri
 // Model usage
 // ---------------------------------------------------------------------------
 
-const emptyModelPerf = (): PerformanceMetrics => ({
-  avgFirstTokenMs: null,
-  avgCompletionMs: null,
-  avgTokensPerSecond: null,
-  measuredMessages: 0
-})
+interface ModelAggregatePerf {
+  firstTokenSum: number
+  firstTokenCount: number
+  completionSum: number
+  completionCount: number
+  speedSum: number
+  speedCount: number
+}
 
 interface ModelAggregate {
   modelId: string
@@ -211,7 +213,7 @@ interface ModelAggregate {
   outputTokens: number
   thinkingTokens: number
   totalTokens: number
-  perf: PerformanceMetrics & { _measured: number }
+  perf: ModelAggregatePerf
 }
 
 const blankAggregate = (modelId: string, modelName: string, provider: string): ModelAggregate => ({
@@ -223,7 +225,7 @@ const blankAggregate = (modelId: string, modelName: string, provider: string): M
   outputTokens: 0,
   thinkingTokens: 0,
   totalTokens: 0,
-  perf: { ...emptyModelPerf(), _measured: 0 }
+  perf: { firstTokenSum: 0, firstTokenCount: 0, completionSum: 0, completionCount: 0, speedSum: 0, speedCount: 0 }
 })
 
 /**
@@ -260,26 +262,37 @@ export const computeModelStats = (messages: Message[]): ModelUsage[] => {
     const metrics = m.metrics
     if (metrics) {
       if (typeof metrics.time_first_token_millsec === 'number' && metrics.time_first_token_millsec > 0) {
-        agg.perf.avgFirstTokenMs =
-          (agg.perf.avgFirstTokenMs ?? 0) * agg.perf.measuredMessages + metrics.time_first_token_millsec
-        agg.perf.measuredMessages += 1
-        agg.perf.avgFirstTokenMs = agg.perf.avgFirstTokenMs / agg.perf.measuredMessages
+        agg.perf.firstTokenSum += metrics.time_first_token_millsec
+        agg.perf.firstTokenCount += 1
       }
       if (typeof metrics.time_completion_millsec === 'number' && metrics.time_completion_millsec > 0) {
-        agg.perf.avgCompletionMs =
-          (agg.perf.avgCompletionMs ?? 0) * agg.perf._measured + metrics.time_completion_millsec
-        agg.perf._measured += 1
-        agg.perf.avgCompletionMs = agg.perf.avgCompletionMs / agg.perf._measured
+        agg.perf.completionSum += metrics.time_completion_millsec
+        agg.perf.completionCount += 1
+      }
+      if (
+        typeof metrics.completion_tokens === 'number' &&
+        typeof metrics.time_completion_millsec === 'number' &&
+        metrics.time_completion_millsec > 0
+      ) {
+        const tps = (metrics.completion_tokens / metrics.time_completion_millsec) * 1000
+        if (Number.isFinite(tps) && tps > 0) {
+          agg.perf.speedSum += tps
+          agg.perf.speedCount += 1
+        }
       }
     }
   }
 
   return Array.from(byId.values())
-    .map(({ perf, ...rest }) => {
-      const { _measured, ...cleanPerf } = perf
-      void _measured
-      return { ...rest, performance: cleanPerf }
-    })
+    .map(({ perf, ...rest }) => ({
+      ...rest,
+      performance: {
+        avgFirstTokenMs: perf.firstTokenCount > 0 ? perf.firstTokenSum / perf.firstTokenCount : null,
+        avgCompletionMs: perf.completionCount > 0 ? perf.completionSum / perf.completionCount : null,
+        avgTokensPerSecond: perf.speedCount > 0 ? perf.speedSum / perf.speedCount : null,
+        measuredMessages: perf.firstTokenCount + perf.completionCount
+      }
+    }))
     .sort((a, b) => b.totalTokens - a.totalTokens)
 }
 

--- a/src/renderer/utils/topicStatsLoader.ts
+++ b/src/renderer/utils/topicStatsLoader.ts
@@ -1,8 +1,10 @@
+import { dataApiService } from '@data/DataApiService'
 import { loggerService } from '@logger'
 import { db } from '@renderer/databases'
-import { TopicManager } from '@renderer/hooks/useTopic'
+import { getTopicById, getTopicMessages, useAllTopics } from '@renderer/hooks/useTopic'
 import { getProviderLabel } from '@renderer/i18n/label'
 import type { Message, MessageBlock } from '@renderer/types/newMessage'
+import type { Topic } from '@shared/data/types/topic'
 
 import {
   type BlockLookup,
@@ -21,7 +23,7 @@ const logger = loggerService.withContext('Utils:topicStatsLoader')
  * Aggregation result plus the raw input used to compute it, so the UI
  * layer can re-render efficiently (e.g. when the user toggles a
  * provider filter, we can re-derive from the same snapshot without
- * another DB round-trip).
+ * another API round-trip).
  */
 export interface AggregatedStats {
   /** Number of topics included. */
@@ -77,6 +79,9 @@ const collectMessageIds = (messages: Message[]): Set<string> => {
  * Load every block referenced by the given message list from
  * `db.message_blocks`. Blocks that no longer exist (e.g. after a
  * migration) are silently skipped.
+ *
+ * Note: blocks are still persisted in Dexie in the current v2
+ * transition; only topic metadata has been moved to SQLite.
  */
 const loadBlocksForMessages = async (messages: Message[]): Promise<Map<string, MessageBlock>> => {
   const ids = Array.from(collectMessageIds(messages))
@@ -101,30 +106,49 @@ const resolveModelUsage = (raw: ModelUsage[]): ResolvedModelUsage[] =>
   raw.map((u) => ({ ...u, providerName: getProviderLabel(u.provider) ?? u.provider }))
 
 // ---------------------------------------------------------------------------
-// Topic name resolution
+// Topic metadata loading
 // ---------------------------------------------------------------------------
 
 /**
- * Best-effort topic name lookup. The v2 `db.topics` table only
- * persists `{ id, messages }` (no name column), so we fall back to:
- *   1. The first user message in the topic (truncated)
- *   2. The topic id (last resort)
+ * Fetch every topic's metadata (id, name, createdAt, …) from the
+ * DataApi. The endpoint is cursor-paginated, so we walk pages until
+ * `nextCursor` is absent. Returns an empty array on error so the
+ * dashboard can still render an empty-state rather than crashing.
  */
-const topicFallbackName = (topicId: string, messages: Message[]): string => {
-  const firstUser = messages.find((m) => m.role === 'user')
-  if (firstUser) {
-    const text = firstUser.blocks?.[0]
-    // blocks array stores ids; the actual text is in message_blocks. We
-    // can still produce a useful preview from `usage` or any cached
-    // field, but in practice the caller may want to override this
-    // from the redux cache. Here we return the topic id if no text
-    // is available.
-    void text
+const fetchAllTopicMetadata = async (): Promise<Topic[]> => {
+  try {
+    const PAGE_SIZE = 200
+    const collected: Topic[] = []
+    let cursor: string | undefined
+
+    do {
+      const response = (await dataApiService.get('/topics', {
+        query: { limit: PAGE_SIZE, cursor }
+      })) as { items?: Topic[]; nextCursor?: string }
+      const items = Array.isArray(response?.items) ? response.items : []
+      collected.push(...items)
+      cursor = response?.nextCursor
+    } while (cursor)
+
+    return collected
+  } catch (error) {
+    logger.error('Failed to load topic list for stats', error as Error)
+    return []
   }
-  // The redux assistant store typically has the canonical name; the
-  // UI layer is expected to overlay it. As a final fallback, return
-  // a shortened id.
-  return `Topic ${topicId.slice(0, 8)}`
+}
+
+/**
+ * Resolve the canonical name for a topic. Falls back to a short id
+ * prefix if the stored name is empty (DB DEFAULT '' allows untitled
+ * topics).
+ *
+ * Accepts any object that has an `id` and a `name` — works for both
+ * the v2 shared `Topic` (loaded from `/topics`) and the renderer
+ * `RendererTopic` (returned by `getTopicById`).
+ */
+const topicDisplayName = (topic: { id: string; name?: string | null }): string => {
+  if (topic.name && topic.name.trim().length > 0) return topic.name
+  return `Topic ${topic.id.slice(0, 8)}`
 }
 
 // ---------------------------------------------------------------------------
@@ -134,13 +158,16 @@ const topicFallbackName = (topicId: string, messages: Message[]): string => {
 /**
  * Compute the global, cross-topic usage statistics.
  *
- * Reads directly from `db.topics` and `db.message_blocks` (NOT from the
- * Redux cache, which only holds messages for topics visited in the
- * current session) so the result is always complete.
+ * Reads topic metadata from the DataApi (`/topics`) and then loads
+ * each topic's messages via the paginated `getTopicMessages` helper.
+ * The 5-minute in-memory cache prevents re-loading on every tab
+ * switch. Call `invalidateGlobalStatsCache()` to force a fresh load.
  *
- * Result is cached in-memory for 5 minutes to avoid reloading on every
- * settings tab switch. Call `invalidateGlobalStatsCache()` to force
- * a fresh load.
+ * **Why not Redux?** In v2 the topic/message data lives in SQLite
+ * (via DataApi) — the Redux store no longer holds the canonical
+ * message history. Reading from the DataApi ensures the dashboard
+ * is always complete, even for topics the user has not visited this
+ * session.
  */
 export const loadGlobalStats = async (opts: { force?: boolean } = {}): Promise<AggregatedStats> => {
   const now = Date.now()
@@ -149,13 +176,27 @@ export const loadGlobalStats = async (opts: { force?: boolean } = {}): Promise<A
   }
 
   const t0 = now
-  const topics = await TopicManager.getAllTopics()
+  const topics = await fetchAllTopicMetadata()
+
+  // Load all messages in parallel — `getTopicMessages` handles its own
+  // pagination. We map the result back to the topic id so the per-topic
+  // snapshot below has its messages available.
+  const messageLists = await Promise.all(
+    topics.map((t) =>
+      getTopicMessages(t.id).catch((e) => {
+        logger.warn(`Failed to load messages for topic ${t.id}`, e as Error)
+        return [] as Message[]
+      })
+    )
+  )
   const allMessages: Message[] = []
-  for (const t of topics) {
-    for (const m of t.messages ?? []) {
-      allMessages.push(m)
-    }
+  const messagesByTopic = new Map<string, Message[]>()
+  for (let i = 0; i < topics.length; i++) {
+    const list = messageLists[i] ?? []
+    messagesByTopic.set(topics[i].id, list)
+    for (const m of list) allMessages.push(m)
   }
+
   const blocks = await loadBlocksForMessages(allMessages)
   const lookup = buildBlockLookup(Array.from(blocks.values()))
 
@@ -164,10 +205,10 @@ export const loadGlobalStats = async (opts: { force?: boolean } = {}): Promise<A
 
   // Per-topic snapshot (for the topic list in the settings page)
   const topicStats = topics.map((t) => {
-    const messages = t.messages ?? []
+    const messages = messagesByTopic.get(t.id) ?? []
     return {
       topicId: t.id,
-      topicName: topicFallbackName(t.id, messages),
+      topicName: topicDisplayName(t),
       stats: computeTopicStats(messages, lookup)
     }
   })
@@ -193,11 +234,12 @@ export const loadGlobalStats = async (opts: { force?: boolean } = {}): Promise<A
 // ---------------------------------------------------------------------------
 
 /**
- * Compute usage statistics for a single topic. Loads only the blocks
- * referenced by that topic's messages; no cross-topic aggregation.
+ * Compute usage statistics for a single topic. Uses the v2 helpers
+ * `getTopicById` (which already loads messages) and Dexie's
+ * `message_blocks` table.
  */
 export const loadTopicStats = async (topicId: string) => {
-  const topic = await TopicManager.getTopic(topicId)
+  const topic = await getTopicById(topicId)
   if (!topic) return null
   const messages = topic.messages ?? []
   const blocks = await loadBlocksForMessages(messages)
@@ -208,7 +250,7 @@ export const loadTopicStats = async (topicId: string) => {
 
   return {
     topicId: topic.id,
-    topicName: topicFallbackName(topic.id, messages),
+    topicName: topicDisplayName(topic),
     stats,
     modelUsage,
     dailyUsage: stats.dailyUsage
@@ -223,7 +265,7 @@ export const loadTopicStats = async (topicId: string) => {
  * Re-compute model aggregation from a previously loaded
  * `AggregatedStats`, applying a predicate + sort. This is what the
  * model search / provider / sort / limit dropdowns use so we don't
- * hit the DB on every keystroke.
+ * hit the DataApi on every keystroke.
  */
 export const reaggregateModelUsage = (
   data: AggregatedStats,
@@ -262,3 +304,7 @@ export const summarizeText = (messages: Message[], blocks: BlockLookup) => {
   }
   return { characters, words }
 }
+
+// Re-export `useAllTopics` so the React layer can subscribe to the
+// raw topic list alongside the cached aggregate.
+export { useAllTopics }

--- a/src/renderer/utils/topicStatsLoader.ts
+++ b/src/renderer/utils/topicStatsLoader.ts
@@ -1,0 +1,264 @@
+import { loggerService } from '@logger'
+import { db } from '@renderer/databases'
+import { TopicManager } from '@renderer/hooks/useTopic'
+import { getProviderLabel } from '@renderer/i18n/label'
+import type { Message, MessageBlock } from '@renderer/types/newMessage'
+
+import {
+  type BlockLookup,
+  computeDailyUsage,
+  computeModelStats,
+  computeTopicStats,
+  countWords,
+  type DailyUsage,
+  extractMessageText,
+  type ModelUsage
+} from './topicStats'
+
+const logger = loggerService.withContext('Utils:topicStatsLoader')
+
+/**
+ * Aggregation result plus the raw input used to compute it, so the UI
+ * layer can re-render efficiently (e.g. when the user toggles a
+ * provider filter, we can re-derive from the same snapshot without
+ * another DB round-trip).
+ */
+export interface AggregatedStats {
+  /** Number of topics included. */
+  topicCount: number
+  /** Concatenated message list across all included topics. */
+  messages: Message[]
+  /** Per-topic snapshot (used by topic list in the settings page). */
+  topicStats: Array<{ topicId: string; topicName: string; stats: ReturnType<typeof computeTopicStats> }>
+  /** Aggregated daily usage (already sorted by date asc). */
+  dailyUsage: DailyUsage[]
+  /** Aggregated model usage (sorted by totalTokens desc, with provider label resolved). */
+  modelUsage: ResolvedModelUsage[]
+  /** Wall-clock duration of the aggregation call (ms). */
+  computedInMs: number
+}
+
+// ---------------------------------------------------------------------------
+// In-memory cache (5 min TTL, per the original design)
+// ---------------------------------------------------------------------------
+
+const CACHE_TTL_MS = 5 * 60 * 1000
+
+interface CacheEntry {
+  data: AggregatedStats
+  expiresAt: number
+}
+
+let globalCache: CacheEntry | null = null
+
+export const invalidateGlobalStatsCache = (): void => {
+  globalCache = null
+}
+
+// ---------------------------------------------------------------------------
+// Block resolution helpers
+// ---------------------------------------------------------------------------
+
+const buildBlockLookup = (blocks: MessageBlock[]): BlockLookup => {
+  const m = new Map<string, MessageBlock>()
+  for (const b of blocks) m.set(b.id, b)
+  return m
+}
+
+const collectMessageIds = (messages: Message[]): Set<string> => {
+  const ids = new Set<string>()
+  for (const m of messages) {
+    for (const id of m.blocks ?? []) ids.add(id)
+  }
+  return ids
+}
+
+/**
+ * Load every block referenced by the given message list from
+ * `db.message_blocks`. Blocks that no longer exist (e.g. after a
+ * migration) are silently skipped.
+ */
+const loadBlocksForMessages = async (messages: Message[]): Promise<Map<string, MessageBlock>> => {
+  const ids = Array.from(collectMessageIds(messages))
+  if (ids.length === 0) return new Map()
+  const rows = await db.message_blocks.bulkGet(ids)
+  const out = new Map<string, MessageBlock>()
+  for (const row of rows) {
+    if (row) out.set(row.id, row)
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Resolved model usage (with provider display name)
+// ---------------------------------------------------------------------------
+
+export interface ResolvedModelUsage extends ModelUsage {
+  providerName: string
+}
+
+const resolveModelUsage = (raw: ModelUsage[]): ResolvedModelUsage[] =>
+  raw.map((u) => ({ ...u, providerName: getProviderLabel(u.provider) ?? u.provider }))
+
+// ---------------------------------------------------------------------------
+// Topic name resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Best-effort topic name lookup. The v2 `db.topics` table only
+ * persists `{ id, messages }` (no name column), so we fall back to:
+ *   1. The first user message in the topic (truncated)
+ *   2. The topic id (last resort)
+ */
+const topicFallbackName = (topicId: string, messages: Message[]): string => {
+  const firstUser = messages.find((m) => m.role === 'user')
+  if (firstUser) {
+    const text = firstUser.blocks?.[0]
+    // blocks array stores ids; the actual text is in message_blocks. We
+    // can still produce a useful preview from `usage` or any cached
+    // field, but in practice the caller may want to override this
+    // from the redux cache. Here we return the topic id if no text
+    // is available.
+    void text
+  }
+  // The redux assistant store typically has the canonical name; the
+  // UI layer is expected to overlay it. As a final fallback, return
+  // a shortened id.
+  return `Topic ${topicId.slice(0, 8)}`
+}
+
+// ---------------------------------------------------------------------------
+// Global stats loader (cache-aware)
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the global, cross-topic usage statistics.
+ *
+ * Reads directly from `db.topics` and `db.message_blocks` (NOT from the
+ * Redux cache, which only holds messages for topics visited in the
+ * current session) so the result is always complete.
+ *
+ * Result is cached in-memory for 5 minutes to avoid reloading on every
+ * settings tab switch. Call `invalidateGlobalStatsCache()` to force
+ * a fresh load.
+ */
+export const loadGlobalStats = async (opts: { force?: boolean } = {}): Promise<AggregatedStats> => {
+  const now = Date.now()
+  if (!opts.force && globalCache && globalCache.expiresAt > now) {
+    return globalCache.data
+  }
+
+  const t0 = now
+  const topics = await TopicManager.getAllTopics()
+  const allMessages: Message[] = []
+  for (const t of topics) {
+    for (const m of t.messages ?? []) {
+      allMessages.push(m)
+    }
+  }
+  const blocks = await loadBlocksForMessages(allMessages)
+  const lookup = buildBlockLookup(Array.from(blocks.values()))
+
+  const dailyUsage = computeDailyUsage(allMessages)
+  const modelUsage = resolveModelUsage(computeModelStats(allMessages))
+
+  // Per-topic snapshot (for the topic list in the settings page)
+  const topicStats = topics.map((t) => {
+    const messages = t.messages ?? []
+    return {
+      topicId: t.id,
+      topicName: topicFallbackName(t.id, messages),
+      stats: computeTopicStats(messages, lookup)
+    }
+  })
+
+  const computedInMs = Date.now() - t0
+
+  const data: AggregatedStats = {
+    topicCount: topics.length,
+    messages: allMessages,
+    topicStats,
+    dailyUsage,
+    modelUsage,
+    computedInMs
+  }
+
+  globalCache = { data, expiresAt: Date.now() + CACHE_TTL_MS }
+  logger.silly(`global stats computed in ${computedInMs}ms across ${topics.length} topics`)
+  return data
+}
+
+// ---------------------------------------------------------------------------
+// Per-topic stats loader (no cache - usually shown once)
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute usage statistics for a single topic. Loads only the blocks
+ * referenced by that topic's messages; no cross-topic aggregation.
+ */
+export const loadTopicStats = async (topicId: string) => {
+  const topic = await TopicManager.getTopic(topicId)
+  if (!topic) return null
+  const messages = topic.messages ?? []
+  const blocks = await loadBlocksForMessages(messages)
+  const lookup = buildBlockLookup(Array.from(blocks.values()))
+
+  const stats = computeTopicStats(messages, lookup)
+  const modelUsage = resolveModelUsage(stats.modelUsage)
+
+  return {
+    topicId: topic.id,
+    topicName: topicFallbackName(topic.id, messages),
+    stats,
+    modelUsage,
+    dailyUsage: stats.dailyUsage
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Quick re-aggregation helpers (used by UI when filters change)
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-compute model aggregation from a previously loaded
+ * `AggregatedStats`, applying a predicate + sort. This is what the
+ * model search / provider / sort / limit dropdowns use so we don't
+ * hit the DB on every keystroke.
+ */
+export const reaggregateModelUsage = (
+  data: AggregatedStats,
+  predicate?: (u: ResolvedModelUsage) => boolean,
+  sortBy: 'tokens' | 'messages' | 'speed' = 'tokens',
+  limit?: number
+): ResolvedModelUsage[] => {
+  const resolved = data.modelUsage
+  const filtered = predicate ? resolved.filter(predicate) : resolved
+  const sorted = [...filtered].sort((a, b) => {
+    if (sortBy === 'messages') return b.messageCount - a.messageCount
+    if (sortBy === 'speed') {
+      const aSpeed = a.performance.avgTokensPerSecond ?? 0
+      const bSpeed = b.performance.avgTokensPerSecond ?? 0
+      return bSpeed - aSpeed
+    }
+    return b.totalTokens - a.totalTokens
+  })
+  return typeof limit === 'number' ? sorted.slice(0, limit) : sorted
+}
+
+/**
+ * Sum character / word counts across the provided message slice.
+ * Used by the settings page "Conversation Info" panel to provide
+ * totals even when the global aggregator is skipped.
+ */
+export const summarizeText = (messages: Message[], blocks: BlockLookup) => {
+  let characters = 0
+  let words = 0
+  for (const m of messages) {
+    const text = extractMessageText(m, blocks)
+    if (text) {
+      characters += text.length
+      words += countWords(text)
+    }
+  }
+  return { characters, words }
+}


### PR DESCRIPTION
## Summary

Adds a comprehensive **conversation usage statistics dashboard** with two entry points:

- **Global view** in `Settings > Usage Statistics`, aggregating every topic from the database
- **Per-topic popup** via right-click on any topic in the sidebar

This is a rewrite of the previously-closed #15448, adapted to the post-v2-refactor codebase (individual preference keys, `@cherrystudio/ui`, `@tanstack/react-router` file routes, `useLiveQuery`).

The branch contains **two commits**:

1. `feat(stats): add pure-function conversation usage statistics core` — the aggregation layer
2. `feat(stats): add conversation usage statistics dashboard` — the DB loader, settings page, popup, and route

Splitting core from UI like this was an internal-development decision to keep each commit reviewable. The final PR is one feature.

---

## Motivation

Issue #12026 ("Can you add a visual panel statistics module?") and several follow-ups have asked for an at-a-glance view of how Cherry Studio is being used. Users want to know:

- How many tokens they've spent, and on which models
- How fast their providers are responding (TTFT, completion time, tokens/sec)
- Which days / months are heaviest
- How the model / provider mix is distributed

Until now, the only token info was a per-message breakdown at the bottom of each message. There was no aggregate view, no time dimension, no model comparison.

---

## What it does

### 1. Settings > Usage Statistics (Global)

Located in the Settings submenu, immediately below **Data**. Aggregates **all topics** from the database (NOT from the Redux cache, which only holds visited topics).

| Section | Contents |
|---------|----------|
| **Conversation Info** | Topics, total messages (user/assistant split), total tokens, unique models |
| **Token Breakdown** | Horizontal stacked bar (input / output / thinking) with absolute + percentage legend |
| **Performance** | Average first-token latency, average completion time, average tokens / second |
| **Daily Usage** | 365-day heatmap, log-interpolated colors, hover tooltips, responsive cell sizing, "X active days / 365" summary |
| **Model Usage** | Search + provider filter + sort (tokens/messages/speed) + display limit (10/20/50/100), per-model cards with progress bars, message count, TTFT, tokens/sec |

A manual refresh button sits in the top-right corner; the underlying loader caches for 5 minutes so tab-switching doesn't trigger a full reload.

### 2. Topic Right-Click > Statistics (Per-Topic)

Right-click any topic in the sidebar > **Statistics** (line-chart icon, between **Save to Notes** and **Clear Messages**). Uses the standard `@cherrystudio/ui` `Dialog` via the `TopView` pattern.

| Section | Contents |
|---------|----------|
| **Conversation Info** | Messages (user/assistant), total tokens, total characters, total words, duration |
| **Token Breakdown** | Same stacked bar as the global view |
| **Performance** | Average first-token latency, average completion time, average speed |
| **Model Usage** | Per-model cards (no filters in the popup, since the slice is small) |

---

## Architecture

```
                  +---------------------------+
                  |  src/renderer/utils/      |
                  |    topicStats.ts          |  pure functions
                  |  (commit 1)               |  (no React/Dexie/i18n)
                  +-------------+-------------+
                                |
                  +-------------+-------------+
                  |  topicStatsLoader.ts       |  DB / cache layer (commit 2)
                  |  (loadGlobalStats,        |
                  |   loadTopicStats,         |
                  |   reaggregateModelUsage)  |
                  +-------------+-------------+
                                |
            +-------------------+--------------------+
            v                                        v
  +-------------------+                    +-----------------------+
  | StatsSettings.tsx |                    | TopicStatsPopup.tsx   |
  | /settings/stats   |                    | (TopView modal)       |
  +-------------------+                    +-----------------------+
```

### Why pure functions for the core?

The aggregation layer (`topicStats.ts`) takes `Message[]` and a `BlockLookup` and returns plain JS objects. It has zero dependencies on React, Redux, Dexie, or i18n. This means:

- It is trivially unit-testable (no mocking)
- It can be reused from any caller (settings page, popup, IPC, a future CLI export)
- It does not need to be re-implemented when the persistence layer changes

The DB loader (`topicStatsLoader.ts`) is the only place that knows about Dexie / TopicManager. It calls the pure functions and packages the result for the UI.

### Why read from Dexie, not Redux?

The Redux store only holds messages for topics visited in the current session. Reading from `db.topics` + `db.message_blocks` ensures the dashboard is always complete (an unvisited topic's historical data is still counted). The original #15448 made the same design choice.

### Caching

`loadGlobalStats` caches its result in-memory for 5 minutes (matches the original PR). Flipping between Settings tabs won't re-query the DB. A manual `refreshTick` state in `StatsSettings.tsx` lets the user force a reload. `invalidateGlobalStatsCache()` is exported for callers that write/delete messages and want to invalidate immediately.

### Re-aggregation

The model-usage filters (search / provider / sort / limit) are applied by `reaggregateModelUsage`, which derives a filtered + sorted slice from a previously loaded `AggregatedStats` snapshot. Typing in the search box does not touch the DB.

---

## Architecture alignment with v2

| Concern | Old (v1) | This PR |
|---|---|---|
| Stats page entry | Custom subroute under Settings | New `/settings/stats` route via `@tanstack/react-router` |
| UI primitives | antd `Tabs` / `DatePicker` / `Select` | `@cherrystudio/ui` + small inline components (no chart library) |
| Heatmap | Hand-rolled `<div>` grid | Same approach, with `ResizeObserver` for responsive cells |
| Settings submenu | antd `Menu` with nested children | `MenuItem` / `lucide-react` icons, sibling of "Data" |
| Path layout | `src/renderer/src/...` | `src/renderer/...` (post-refactor) |
| Data fetching | `store.getState().llm.providers` | `db.topics.toArray()` + `db.message_blocks.bulkGet()` |
| Provider labels | Hand-written UUID/type/prefix heuristics | `getProviderLabel(providerId)` (shared i18n helper) |
| Topic stats cache | Module-level `_globalCache` | Same pattern, with explicit `invalidateGlobalStatsCache()` API |

---

## Files changed

### Commit 1 (core, 922 lines, 2 files)

| File | Lines | Purpose |
|---|---|---|
| `src/renderer/utils/topicStats.ts`        | +422 | Pure aggregation: 7 exports, full JSDoc |
| `src/renderer/utils/__tests__/topicStats.test.ts` | +500 | 6 describe blocks, ~20 unit tests |

### Commit 2 (UI, 1590 lines, 19 files)

| File | Change | Purpose |
|---|---|---|
| `src/renderer/utils/topicStatsLoader.ts`            | new (264) | DB loader, 5-min cache, `reaggregateModelUsage` |
| `src/renderer/pages/settings/StatsSettings.tsx`     | new (523) | Global stats page (info + token + perf + heatmap + model) |
| `src/renderer/components/Popups/TopicStatsPopup.tsx` | new (270) | Per-topic modal |
| `src/renderer/routes/settings/stats.tsx`            | new (6)   | TanStack route |
| `src/renderer/pages/settings/SettingsPage.tsx`      | +9        | New MenuItem (`LineChart` icon) |
| `src/renderer/pages/home/Tabs/components/Topics.tsx` | +5      | New context menu entry |
| `src/renderer/routeTree.gen.ts`                     | auto      | Regenerated by `@tanstack/router-plugin` |
| `src/renderer/i18n/locales/{en,zh-cn,zh-tw}.json`  | +41 each  | New i18n keys (top-level `stats.*` + `settings.stats.title` + `chat.topics.statistics`) |
| `src/renderer/i18n/translate/*.json` × 10           | auto      | Synced via `pnpm i18n:sync` (placeholder `[to be translated]` for the auto-i18n bot) |

**Total: 21 files, +2512 / -18 lines.**

---

## Testing performed

- `pnpm typecheck:web` ✅ Zero errors
- `pnpm typecheck:node` ✅ Zero errors
- `pnpm typecheck:aiCore` ✅ Zero errors
- `pnpm lint` (Biome format + lint) ✅ Passed
- `pnpm i18n:check` ✅ Passed
- `pnpm i18n:sync` ✅ All 10 translated locales updated without conflict
- `pnpm electron-vite build` ✅ Built successfully (auto-regenerates `routeTree.gen.ts`)
- **Manual UI verification**: deferred to reviewer. The renderer test suite (`pnpm test --run`) is currently broken on `main` due to a pre-existing issue in `tests/renderer.setup.ts` (`createRequire is not a function` under jsdom), unrelated to this PR. Unit tests for the core aggregation function are included; once that setup is fixed they will run as part of the standard test suite.

The 20 unit tests for `topicStats.ts` cover:

- CJK + Latin word counting edge cases
- `MAIN_TEXT` block extraction (concatenation, ordering, duck-typed lookup)
- Performance averaging (only-on-reported, zero/negative handling)
- Per-model grouping and sort order
- Daily bucketing and invalid timestamp handling
- End-to-end `computeTopicStats` with mixed input + empty input
- Date / duration formatters

---

## Notes

- **Reasoning chain is counted in totals but not yet visualised in the heatmap or token breakdown bar.** Easy follow-up if reviewers want a separate sub-panel.
- **Per-message metrics** can be displayed by adding a sub-panel to `StatsSettings`; out of scope for this initial PR.
- **Cache invalidation is opt-in.** Callers should call `invalidateGlobalStatsCache()` after writing/deleting messages. The settings page also offers a manual refresh button. A future enhancement could hook this into the relevant Dexie write hooks.
- **Topic name fallback.** The v2 `db.topics` table only stores `{ id, messages }` (no `name` column), so the loader returns `Topic <id-prefix>` as a placeholder. The redux `assistants` store has the canonical name; the UI layer is expected to overlay it (currently the popup / settings page show the placeholder). A small follow-up could pre-load the assistant topic list to resolve real names.
- **No new dependencies.** Only already-present packages: `dexie`, `dexie-react-hooks`, `lucide-react`, `@tanstack/react-router`, `dayjs` (transitively).
- **Browser compatibility**: `ResizeObserver` is used in the heatmap. Available in all modern browsers + Electron 28+.
- **Accessibility**: heatmap cells have `title=` tooltips (full keyboard + screen-reader support is a follow-up).
