### PR TITLE
fix(api-server): restore GET /v1/models endpoint

### DIFF
--- a/src/main/apiServer/app.ts
+++ b/src/main/apiServer/app.ts
@@ -12,6 +12,7 @@ import { clawMcpRoutes } from './routes/claw-mcp'
 import { knowledgeRoutes } from './routes/knowledge'
 import { mcpRoutes } from './routes/mcp'
 import { messagesProviderRoutes, messagesRoutes } from './routes/messages'
+import { modelsRoutes } from './routes/models'
 
 const logger = loggerService.withContext('ApiServer')
 
@@ -129,6 +130,7 @@ export function createApp(): express.Application {
         health: 'GET /health',
         docs: 'GET /api-docs',
         docs_json: 'GET /api-docs.json',
+        models: 'GET /v1/models',
         chat_completions: 'POST /v1/chat/completions',
         messages: 'POST /v1/messages',
         messages_provider: 'POST /:provider/v1/messages',
@@ -150,6 +152,7 @@ export function createApp(): express.Application {
   const apiRouter = express.Router()
   apiRouter.use(authMiddleware)
   // Mount routes
+  apiRouter.use('/models', modelsRoutes)
   apiRouter.use('/chat', chatRoutes)
   apiRouter.use('/mcps', mcpRoutes)
   apiRouter.use('/messages', extendMessagesTimeout, messagesRoutes)

--- a/src/main/apiServer/routes/models.ts
+++ b/src/main/apiServer/routes/models.ts
@@ -1,0 +1,112 @@
+import { loggerService } from '@logger'
+import type { Request, Response } from 'express'
+import express from 'express'
+
+import { ApiModelsFilterSchema } from '../../../renderer/types/apiModels'
+import { modelsService } from '../services/models'
+
+const logger = loggerService.withContext('ApiServerModelsRoutes')
+
+const router = express.Router()
+
+/**
+ * @swagger
+ * /v1/models:
+ *   get:
+ *     summary: List available models
+ *     description: List models from all enabled providers, compatible with the OpenAI API. Model IDs are returned in "providerId::modelId" format and can be passed directly to /v1/chat/completions and /v1/messages.
+ *     tags: [Models]
+ *     parameters:
+ *       - in: query
+ *         name: providerType
+ *         required: false
+ *         schema:
+ *           type: string
+ *         description: Filter to models served by providers of this type (e.g. "anthropic")
+ *       - in: query
+ *         name: offset
+ *         required: false
+ *         schema:
+ *           type: integer
+ *           minimum: 0
+ *         description: Number of models to skip
+ *       - in: query
+ *         name: limit
+ *         required: false
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *         description: Maximum number of models to return
+ *     responses:
+ *       200:
+ *         description: List of available models
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 object:
+ *                   type: string
+ *                   example: list
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                         example: "my-provider::gpt-4o"
+ *                       object:
+ *                         type: string
+ *                         example: model
+ *                       created:
+ *                         type: integer
+ *                       owned_by:
+ *                         type: string
+ *                 total:
+ *                   type: integer
+ *                 offset:
+ *                   type: integer
+ *                 limit:
+ *                   type: integer
+ *       400:
+ *         description: Bad request
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       401:
+ *         description: Unauthorized
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+router.get('/', async (req: Request, res: Response) => {
+  const parsed = ApiModelsFilterSchema.safeParse(req.query)
+  if (!parsed.success) {
+    return res.status(400).json({
+      error: {
+        message: parsed.error.issues.map((issue) => issue.message).join('; '),
+        type: 'invalid_request_error',
+        code: 'validation_failed'
+      }
+    })
+  }
+
+  try {
+    const response = await modelsService.getModels(parsed.data)
+    return res.json(response)
+  } catch (error) {
+    logger.error('Error listing models', error as Error)
+    return res.status(500).json({
+      error: {
+        message: 'Internal server error',
+        type: 'server_error',
+        code: 'internal_error'
+      }
+    })
+  }
+})
+
+export { router as modelsRoutes }

--- a/src/main/apiServer/services/__tests__/models.test.ts
+++ b/src/main/apiServer/services/__tests__/models.test.ts
@@ -1,0 +1,165 @@
+import type { Model } from '@shared/data/types/model'
+import { ENDPOINT_TYPE } from '@shared/data/types/model'
+import type { Provider } from '@shared/data/types/provider'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { listModelsMock, listProvidersMock } = vi.hoisted(() => ({
+  listModelsMock: vi.fn(),
+  listProvidersMock: vi.fn()
+}))
+
+vi.mock('@data/services/ModelService', () => ({
+  modelService: { list: listModelsMock }
+}))
+
+vi.mock('@data/services/ProviderService', () => ({
+  providerService: { list: listProvidersMock }
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: vi.fn(() => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    }))
+  }
+}))
+
+import { modelsService } from '../models'
+
+function createProvider(overrides: Partial<Provider> = {}): Provider {
+  return {
+    id: 'openai',
+    name: 'OpenAI',
+    apiKeys: [],
+    authType: 'api-key',
+    apiFeatures: {
+      arrayContent: true,
+      streamOptions: true,
+      developerRole: false,
+      serviceTier: false,
+      verbosity: false
+    },
+    settings: {},
+    isEnabled: true,
+    endpointConfigs: {
+      [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: { baseUrl: 'https://api.openai.com/v1' }
+    },
+    ...overrides
+  } as Provider
+}
+
+function createModel(overrides: Partial<Model> = {}): Model {
+  return {
+    id: 'openai::gpt-4o',
+    providerId: 'openai',
+    apiModelId: 'gpt-4o',
+    name: 'GPT-4o',
+    capabilities: [],
+    supportsStreaming: true,
+    isEnabled: true,
+    isHidden: false,
+    ...overrides
+  } as Model
+}
+
+describe('ModelsService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns OpenAI-compatible model list with provider metadata', async () => {
+    listProvidersMock.mockResolvedValue([createProvider()])
+    listModelsMock.mockResolvedValue([createModel()])
+
+    const result = await modelsService.getModels({})
+
+    expect(result.object).toBe('list')
+    expect(result.data).toHaveLength(1)
+    expect(result.data[0]).toMatchObject({
+      // round-trips with the chat/messages parsers — keeps the "::" separator
+      id: 'openai::gpt-4o',
+      object: 'model',
+      name: 'GPT-4o',
+      owned_by: 'OpenAI',
+      provider: 'openai',
+      provider_name: 'OpenAI',
+      provider_type: 'openai',
+      provider_model_id: 'gpt-4o'
+    })
+  })
+
+  it('only requests enabled providers and models', async () => {
+    listProvidersMock.mockResolvedValue([])
+    listModelsMock.mockResolvedValue([])
+
+    await modelsService.getModels({})
+
+    expect(listProvidersMock).toHaveBeenCalledWith({ enabled: true })
+    expect(listModelsMock).toHaveBeenCalledWith({ enabled: true })
+  })
+
+  it('skips models whose provider is not enabled or missing', async () => {
+    listProvidersMock.mockResolvedValue([createProvider({ id: 'openai' })])
+    listModelsMock.mockResolvedValue([
+      createModel({ id: 'openai::gpt-4o', providerId: 'openai' }),
+      createModel({ id: 'ghost::m1', providerId: 'ghost' })
+    ])
+
+    const result = await modelsService.getModels({})
+
+    expect(result.data).toHaveLength(1)
+    expect(result.data[0].id).toBe('openai::gpt-4o')
+  })
+
+  it('filters to anthropic providers when providerType=anthropic', async () => {
+    const anthropic = createProvider({
+      id: 'my-anthropic',
+      name: 'My Anthropic',
+      endpointConfigs: {
+        [ENDPOINT_TYPE.ANTHROPIC_MESSAGES]: { baseUrl: 'https://api.anthropic.com' }
+      }
+    })
+    listProvidersMock.mockResolvedValue([createProvider(), anthropic])
+    listModelsMock.mockResolvedValue([
+      createModel({ id: 'openai::gpt-4o', providerId: 'openai' }),
+      createModel({ id: 'my-anthropic::claude', providerId: 'my-anthropic', apiModelId: 'claude' })
+    ])
+
+    const result = await modelsService.getModels({ providerType: 'anthropic' })
+
+    expect(result.data).toHaveLength(1)
+    expect(result.data[0]).toMatchObject({
+      id: 'my-anthropic::claude',
+      provider: 'my-anthropic',
+      provider_type: 'anthropic'
+    })
+  })
+
+  it('applies offset and limit with pagination metadata', async () => {
+    listProvidersMock.mockResolvedValue([createProvider()])
+    listModelsMock.mockResolvedValue([
+      createModel({ id: 'openai::a', apiModelId: 'a' }),
+      createModel({ id: 'openai::b', apiModelId: 'b' }),
+      createModel({ id: 'openai::c', apiModelId: 'c' })
+    ])
+
+    const result = await modelsService.getModels({ offset: 1, limit: 1 })
+
+    expect(result.data).toHaveLength(1)
+    expect(result.data[0].id).toBe('openai::b')
+    expect(result.total).toBe(3)
+    expect(result.offset).toBe(1)
+    expect(result.limit).toBe(1)
+  })
+
+  it('returns an empty list when the data layer throws', async () => {
+    listProvidersMock.mockRejectedValue(new Error('db down'))
+
+    const result = await modelsService.getModels({})
+
+    expect(result).toEqual({ object: 'list', data: [] })
+  })
+})

--- a/src/main/apiServer/services/models.ts
+++ b/src/main/apiServer/services/models.ts
@@ -1,0 +1,118 @@
+import { modelService } from '@data/services/ModelService'
+import { providerService } from '@data/services/ProviderService'
+import { loggerService } from '@logger'
+import type { Model } from '@shared/data/types/model'
+import { ENDPOINT_TYPE } from '@shared/data/types/model'
+import type { Provider } from '@shared/data/types/provider'
+
+import type { ApiModel, ApiModelsFilter, ApiModelsResponse } from '../../../renderer/types/apiModels'
+
+const logger = loggerService.withContext('ApiServerModelsService')
+
+export type ModelsFilter = ApiModelsFilter
+
+/**
+ * Whether a provider exposes the Anthropic Messages protocol. The v2 Provider
+ * has no single `type` field, so anthropic capability is read off the
+ * per-endpoint config — the same signal `messages.ts` uses to route requests.
+ */
+function supportsAnthropic(provider: Provider): boolean {
+  return Boolean(provider.endpointConfigs?.[ENDPOINT_TYPE.ANTHROPIC_MESSAGES]?.baseUrl)
+}
+
+function deriveProviderType(provider: Provider): ApiModel['provider_type'] {
+  if (supportsAnthropic(provider)) {
+    return 'anthropic'
+  }
+  if (provider.endpointConfigs?.[ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]?.baseUrl) {
+    return 'openai'
+  }
+  return undefined
+}
+
+function transformModelToOpenAI(model: Model, provider: Provider, created: number): ApiModel {
+  return {
+    // model.id is already a UniqueModelId ("providerId::modelId"), which is the
+    // exact shape the /v1/chat/completions and /v1/messages routes parse back.
+    id: model.id,
+    object: 'model',
+    name: model.name,
+    created,
+    owned_by: provider.name || provider.id,
+    provider: provider.id,
+    provider_name: provider.name,
+    provider_type: deriveProviderType(provider),
+    provider_model_id: model.apiModelId ?? model.id
+  }
+}
+
+export class ModelsService {
+  async getModels(filter: ModelsFilter): Promise<ApiModelsResponse> {
+    try {
+      logger.debug('Getting available models from providers', { filter })
+
+      const providers = await providerService.list({ enabled: true })
+      const providerById = new Map(providers.map((p) => [p.id, p]))
+
+      const models = await modelService.list({ enabled: true })
+      const created = Math.floor(Date.now() / 1000)
+
+      let modelData: ApiModel[] = []
+      for (const model of models) {
+        const provider = providerById.get(model.providerId)
+        if (!provider) {
+          // Model rows can outlive a disabled/removed provider; skip them rather
+          // than emit a model the chat route could never resolve.
+          logger.debug(`Skipping model ${model.id}. Reason: provider not enabled or not found.`)
+          continue
+        }
+
+        if (filter.providerType === 'anthropic' && !supportsAnthropic(provider)) {
+          continue
+        }
+
+        modelData.push(transformModelToOpenAI(model, provider, created))
+      }
+
+      const total = modelData.length
+
+      const offset = filter.offset ?? 0
+      const limit = filter.limit
+
+      if (limit !== undefined) {
+        modelData = modelData.slice(offset, offset + limit)
+      } else if (offset > 0) {
+        modelData = modelData.slice(offset)
+      }
+
+      logger.info('Models retrieved', {
+        returned: modelData.length,
+        discovered: models.length,
+        filter
+      })
+
+      const response: ApiModelsResponse = {
+        object: 'list',
+        data: modelData
+      }
+
+      if (filter.limit !== undefined || filter.offset !== undefined) {
+        response.total = total
+        response.offset = offset
+        if (filter.limit !== undefined) {
+          response.limit = filter.limit
+        }
+      }
+
+      return response
+    } catch (error) {
+      logger.error('Error getting models', error as Error, { filter })
+      return {
+        object: 'list',
+        data: []
+      }
+    }
+  }
+}
+
+export const modelsService = new ModelsService()

--- a/src/renderer/types/apiModels.ts
+++ b/src/renderer/types/apiModels.ts
@@ -1,0 +1,43 @@
+import type { Model } from '@types'
+import * as z from 'zod'
+
+import { ProviderTypeSchema } from './provider'
+
+// Request schema for /v1/models
+export const ApiModelsFilterSchema = z.object({
+  providerType: ProviderTypeSchema.optional(),
+  offset: z.coerce.number().min(0).default(0).optional(),
+  limit: z.coerce.number().min(1).optional()
+})
+
+// OpenAI compatible model schema
+export const ApiModelSchema = z.object({
+  id: z.string(),
+  object: z.literal('model'),
+  created: z.number(),
+  name: z.string(),
+  owned_by: z.string(),
+  provider: z.string().optional(),
+  provider_name: z.string().optional(),
+  provider_type: ProviderTypeSchema.optional(),
+  provider_model_id: z.string().optional()
+})
+
+// Response schema for /v1/models
+export const ApiModelsResponseSchema = z.object({
+  object: z.literal('list'),
+  data: z.array(ApiModelSchema),
+  total: z.number().optional(),
+  offset: z.number().optional(),
+  limit: z.number().optional()
+})
+
+// Inferred TypeScript types
+export type ApiModel = z.infer<typeof ApiModelSchema>
+export type ApiModelsFilter = z.infer<typeof ApiModelsFilterSchema>
+export type ApiModelsResponse = z.infer<typeof ApiModelsResponseSchema>
+
+// Adapted
+export type AdaptedApiModel = Model & {
+  origin: ApiModel
+}


### PR DESCRIPTION
## What

Restores the `GET /v1/models` endpoint on the API server.

## Why

The consolidate-AI-runtime refactor (#14911) deleted `services/models.ts` and its model-listing utils but never re-wired an HTTP route for them. As a result the API server stopped serving a model list entirely, and OpenAI-compatible clients hit a 404 on `/v1/models`. The model data access was moved into the DataApi layer (`ModelService` / `ProviderService`), which is only reachable over IPC — not as an HTTP endpoint.

## How

Reimplemented the endpoint on the v2 data layer:

- `services/models.ts` lists enabled providers + models via `providerService.list` / `modelService.list`
- Emits `model.id` verbatim (`providerId::modelId`) so IDs round-trip with the `/v1/chat/completions` and `/v1/messages` parsers (the old code emitted a single-colon `provider:id` that the v2 parsers reject)
- Derives the anthropic `provider_type` from `endpointConfigs[ANTHROPIC_MESSAGES]` — the v2 `Provider` has no `type` field — matching how `messages.ts` routes
- Skips models whose provider is disabled/missing
- Mounts `/v1/models` in `app.ts` and restores it in the root endpoint listing

Note: `src/renderer/types/apiModels.ts` (the OpenAI-compatible model schema) is included because the endpoint contract depends on it and it was not present upstream.

## Test

Adds `services/__tests__/models.test.ts` — 6 cases covering metadata mapping, enabled-only filtering, orphaned-model skipping, `providerType=anthropic` filtering, pagination, and graceful empty-list fallback on data-layer errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
