### PR TITLE
feat: add temporary @assistant invocation

### DIFF
--- a/src/main/ai/runtime/aiSdk/params/buildAgentParams.ts
+++ b/src/main/ai/runtime/aiSdk/params/buildAgentParams.ts
@@ -93,7 +93,15 @@ export async function buildAgentParams(input: BuildAgentParamsInput): Promise<Bu
   const features = extraFeatures?.length ? [...INTERNAL_FEATURES, ...extraFeatures] : INTERNAL_FEATURES
   const contributions = collectFromFeatures(scope, features)
 
-  const system = await assembleSystemPrompt({ assistant, model, tools, deferredEntries })
+  // When temporarySystemPrompt is defined (even empty string), override only the prompt field.
+  // All other assistant settings (MCP, tools, temperature, etc.) continue to use the original assistant.
+  const effectiveAssistant =
+    request.temporarySystemPrompt !== undefined && assistant
+      ? { ...assistant, prompt: request.temporarySystemPrompt }
+      : request.temporarySystemPrompt !== undefined
+        ? ({ prompt: request.temporarySystemPrompt } as typeof assistant)
+        : assistant
+  const system = await assembleSystemPrompt({ assistant: effectiveAssistant, model, tools, deferredEntries })
   const options = buildAgentOptions(scope)
 
   return {

--- a/src/main/ai/streamManager/context/PersistentChatContextProvider.ts
+++ b/src/main/ai/streamManager/context/PersistentChatContextProvider.ts
@@ -132,7 +132,12 @@ export class PersistentChatContextProvider implements ChatContextProvider {
         siblingsGroupId,
         placeholders: turnRootSpans.map(({ model, traceId }) => ({
           role: 'assistant',
-          data: { parts: [] },
+          data: {
+            parts: [],
+            ...(req.temporaryAssistantName !== undefined && {
+              temporaryAssistantName: req.temporaryAssistantName
+            })
+          },
           status: 'pending',
           modelId: model.id,
           modelSnapshot: {
@@ -143,7 +148,6 @@ export class PersistentChatContextProvider implements ChatContextProvider {
           traceId
         }))
       })
-
       const shouldAutoNameInitialTurn = !isRegenerate && !req.parentAnchorId
       if (shouldAutoNameInitialTurn) {
         void topicNamingService.maybeRenameFromFirstUserMessage(req.topicId, userMessage.id)

--- a/src/main/ai/streamManager/context/PersistentChatContextProvider.ts
+++ b/src/main/ai/streamManager/context/PersistentChatContextProvider.ts
@@ -192,9 +192,17 @@ export class PersistentChatContextProvider implements ChatContextProvider {
 
       // 7. Build per-model requests. The dispatcher runs `manager.send` itself.
       const history = await this.buildHistory(userMessage.id)
+      const temporarySystemPrompt = req.trigger === 'submit-message' ? req.temporarySystemPrompt : undefined
       const models_ = assistantPlaceholders.map(({ model, placeholder, rootSpan }) => ({
         modelId: model.id,
-        request: this.buildStreamRequest(req.topicId, assistantId, model.id, history, placeholder.id),
+        request: this.buildStreamRequest(
+          req.topicId,
+          assistantId,
+          model.id,
+          history,
+          placeholder.id,
+          temporarySystemPrompt
+        ),
         rootSpan
       }))
 
@@ -309,7 +317,8 @@ export class PersistentChatContextProvider implements ChatContextProvider {
     assistantId: string | undefined,
     uniqueModelId: UniqueModelId,
     history: CherryUIMessage[],
-    messageId: string
+    messageId: string,
+    temporarySystemPrompt?: string
   ): AiStreamRequest {
     return {
       chatId: topicId,
@@ -317,7 +326,8 @@ export class PersistentChatContextProvider implements ChatContextProvider {
       assistantId,
       uniqueModelId,
       messages: history,
-      messageId
+      messageId,
+      ...(temporarySystemPrompt !== undefined && { temporarySystemPrompt })
     }
   }
 }

--- a/src/main/ai/streamManager/context/PersistentChatContextProvider.ts
+++ b/src/main/ai/streamManager/context/PersistentChatContextProvider.ts
@@ -134,9 +134,10 @@ export class PersistentChatContextProvider implements ChatContextProvider {
           role: 'assistant',
           data: {
             parts: [],
-            ...(req.temporaryAssistantName !== undefined && {
-              temporaryAssistantName: req.temporaryAssistantName
-            })
+            ...(req.trigger === 'submit-message' &&
+              req.temporaryAssistantName !== undefined && {
+                temporaryAssistantName: req.temporaryAssistantName
+              })
           },
           status: 'pending',
           modelId: model.id,

--- a/src/main/ai/streamManager/context/__tests__/PersistentChatContextProvider.test.ts
+++ b/src/main/ai/streamManager/context/__tests__/PersistentChatContextProvider.test.ts
@@ -360,3 +360,79 @@ describe('PersistentChatContextProvider — prepareContinueDispatch (resume-afte
     expect(toolPart?.state).toBe('approval-responded')
   })
 })
+
+describe('PersistentChatContextProvider — temporarySystemPrompt', () => {
+  const dbh = setupTestDatabase()
+  const provider = new PersistentChatContextProvider()
+
+  beforeEach(async () => {
+    const [providerKey, modelKey] = generateOrderKeySequence(2)
+    await dbh.db.insert(userProviderTable).values({ providerId: 'openai', name: 'OpenAI', orderKey: providerKey })
+    await dbh.db.insert(userModelTable).values({
+      id: MODEL_ID,
+      providerId: 'openai',
+      modelId: 'gpt-4o',
+      presetModelId: 'gpt-4o',
+      name: 'GPT-4o',
+      isEnabled: true,
+      isHidden: false,
+      orderKey: modelKey
+    })
+    await dbh.db.insert(topicTable).values({ id: 'topic-tmp', activeNodeId: null, orderKey: 'b0' })
+  })
+
+  it('passes temporarySystemPrompt into the stream request when provided', async () => {
+    const prepared = await provider.prepareDispatch(makeSubscriber(), {
+      trigger: 'submit-message',
+      topicId: 'topic-tmp',
+      userMessageParts: [{ type: 'text', text: 'hello' }],
+      temporarySystemPrompt: 'You are a title strategist.'
+    } as AiStreamOpenRequest)
+
+    expect(prepared.models[0].request.temporarySystemPrompt).toBe('You are a title strategist.')
+  })
+
+  it('passes empty string temporarySystemPrompt (not coerced to undefined)', async () => {
+    const prepared = await provider.prepareDispatch(makeSubscriber(), {
+      trigger: 'submit-message',
+      topicId: 'topic-tmp',
+      userMessageParts: [{ type: 'text', text: 'hello' }],
+      temporarySystemPrompt: ''
+    } as AiStreamOpenRequest)
+
+    expect(prepared.models[0].request.temporarySystemPrompt).toBe('')
+  })
+
+  it('omits temporarySystemPrompt from stream request when not provided', async () => {
+    const prepared = await provider.prepareDispatch(makeSubscriber(), {
+      trigger: 'submit-message',
+      topicId: 'topic-tmp',
+      userMessageParts: [{ type: 'text', text: 'hello' }]
+    } as AiStreamOpenRequest)
+
+    expect(prepared.models[0].request.temporarySystemPrompt).toBeUndefined()
+  })
+
+  it('does not set temporarySystemPrompt on regenerate-message', async () => {
+    await dbh.db.insert(messageTable).values([
+      {
+        id: 'u-regen',
+        parentId: null,
+        topicId: 'topic-tmp',
+        role: 'user',
+        data: { parts: [{ type: 'text', text: 'regen me' }] },
+        status: 'success',
+        siblingsGroupId: 0,
+        createdAt: 100,
+        updatedAt: 100
+      }
+    ])
+    const prepared = await provider.prepareDispatch(makeSubscriber(), {
+      trigger: 'regenerate-message',
+      topicId: 'topic-tmp',
+      parentAnchorId: 'u-regen'
+    } as AiStreamOpenRequest)
+
+    expect(prepared.models[0].request.temporarySystemPrompt).toBeUndefined()
+  })
+})

--- a/src/main/ai/streamManager/context/__tests__/PersistentChatContextProvider.test.ts
+++ b/src/main/ai/streamManager/context/__tests__/PersistentChatContextProvider.test.ts
@@ -436,3 +436,84 @@ describe('PersistentChatContextProvider — temporarySystemPrompt', () => {
     expect(prepared.models[0].request.temporarySystemPrompt).toBeUndefined()
   })
 })
+
+describe('PersistentChatContextProvider — temporaryAssistantName', () => {
+  const dbh = setupTestDatabase()
+  const provider = new PersistentChatContextProvider()
+
+  beforeEach(async () => {
+    const [providerKey, modelKey] = generateOrderKeySequence(2)
+    await dbh.db.insert(userProviderTable).values({ providerId: 'openai', name: 'OpenAI', orderKey: providerKey })
+    await dbh.db.insert(userModelTable).values({
+      id: MODEL_ID,
+      providerId: 'openai',
+      modelId: 'gpt-4o',
+      presetModelId: 'gpt-4o',
+      name: 'GPT-4o',
+      isEnabled: true,
+      isHidden: false,
+      orderKey: modelKey
+    })
+    await dbh.db.insert(topicTable).values({ id: 'topic-asst', activeNodeId: null, orderKey: 'c0' })
+  })
+
+  it('writes temporaryAssistantName into assistant placeholder, not user message data', async () => {
+    const prepared = await provider.prepareDispatch(makeSubscriber(), {
+      trigger: 'submit-message',
+      topicId: 'topic-asst',
+      userMessageParts: [{ type: 'text', text: 'hello' }],
+      temporaryAssistantName: '审计员'
+    } as AiStreamOpenRequest)
+
+    // User message does NOT carry the field
+    const userMsg = await messageService.getById(prepared.userMessageId!)
+    expect(userMsg.data.temporaryAssistantName).toBeUndefined()
+
+    // Assistant placeholder DOES carry the field
+    const placeholders = await messageService.getChildrenByParentId(prepared.userMessageId!)
+    expect(placeholders).toHaveLength(1)
+    expect(placeholders[0].data.temporaryAssistantName).toBe('审计员')
+  })
+
+  it('does not set temporaryAssistantName on ordinary submit (no @assistant)', async () => {
+    const prepared = await provider.prepareDispatch(makeSubscriber(), {
+      trigger: 'submit-message',
+      topicId: 'topic-asst',
+      userMessageParts: [{ type: 'text', text: 'hello' }]
+    } as AiStreamOpenRequest)
+
+    const userMsg = await messageService.getById(prepared.userMessageId!)
+    expect(userMsg.data.temporaryAssistantName).toBeUndefined()
+
+    const placeholders = await messageService.getChildrenByParentId(prepared.userMessageId!)
+    expect(placeholders).toHaveLength(1)
+    expect(placeholders[0].data.temporaryAssistantName).toBeUndefined()
+  })
+
+  it('does not set temporaryAssistantName on regenerate-message', async () => {
+    await dbh.db.insert(messageTable).values([
+      {
+        id: 'u-regen2',
+        parentId: null,
+        topicId: 'topic-asst',
+        role: 'user',
+        data: { parts: [{ type: 'text', text: 'regen me' }] },
+        status: 'success',
+        siblingsGroupId: 0,
+        createdAt: 100,
+        updatedAt: 100
+      }
+    ])
+    const prepared = await provider.prepareDispatch(makeSubscriber(), {
+      trigger: 'regenerate-message',
+      topicId: 'topic-asst',
+      parentAnchorId: 'u-regen2'
+    } as AiStreamOpenRequest)
+
+    // regenerate reuses the existing user message row — userMessageId is the anchor row's id
+    expect(prepared.userMessageId).toBe('u-regen2')
+
+    const userMsg = await messageService.getById('u-regen2')
+    expect(userMsg.data.temporaryAssistantName).toBeUndefined()
+  })
+})

--- a/src/main/ai/streamManager/listeners/__tests__/PersistenceListener.test.ts
+++ b/src/main/ai/streamManager/listeners/__tests__/PersistenceListener.test.ts
@@ -15,6 +15,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const appendMessageMock = vi.fn()
 const messageUpdateMock = vi.fn()
+const messageGetByIdMock = vi.fn()
 
 vi.mock('@main/data/services/TemporaryChatService', () => ({
   temporaryChatService: {
@@ -24,6 +25,7 @@ vi.mock('@main/data/services/TemporaryChatService', () => ({
 
 vi.mock('@main/data/services/MessageService', () => ({
   messageService: {
+    getById: messageGetByIdMock,
     update: messageUpdateMock
   }
 }))
@@ -347,6 +349,8 @@ describe('PersistenceListener + TemporaryChatBackend', () => {
 
 describe('PersistenceListener + MessageServiceBackend — failed persist recovery', () => {
   beforeEach(() => {
+    messageGetByIdMock.mockReset()
+    messageGetByIdMock.mockResolvedValue({ id: 'assistant-1', data: { parts: [] } })
     messageUpdateMock.mockReset()
   })
 
@@ -392,6 +396,28 @@ describe('PersistenceListener + MessageServiceBackend — failed persist recover
     expect(onPersistFailed).toHaveBeenCalledTimes(1)
     expect(onPersistFailed).toHaveBeenCalledWith(
       expect.objectContaining({ message: expect.stringContaining('write failed') })
+    )
+  })
+
+  it('preserves assistant placeholder data when finalizing the streamed message', async () => {
+    messageGetByIdMock.mockResolvedValueOnce({
+      id: 'assistant-1',
+      data: { parts: [], temporaryAssistantName: '审计员' }
+    })
+    messageUpdateMock.mockResolvedValueOnce({ id: 'assistant-1' })
+    const listener = makeMessageServiceListener()
+
+    await listener.onDone({ finalMessage: makeFinalMessage(), status: 'success' })
+
+    expect(messageUpdateMock).toHaveBeenCalledTimes(1)
+    expect(messageUpdateMock).toHaveBeenCalledWith(
+      'assistant-1',
+      expect.objectContaining({
+        data: expect.objectContaining({
+          temporaryAssistantName: '审计员',
+          parts: [{ type: 'text', text: 'hello' }]
+        })
+      })
     )
   })
 })

--- a/src/main/ai/streamManager/persistence/backends/MessageServiceBackend.ts
+++ b/src/main/ai/streamManager/persistence/backends/MessageServiceBackend.ts
@@ -26,8 +26,9 @@ export class MessageServiceBackend implements PersistenceBackend {
   async persistAssistant(input: PersistAssistantInput): Promise<void> {
     const { finalMessage, status, stats } = input
     const parts = finalizeInterruptedParts((finalMessage?.parts ?? []) as CherryMessagePart[], status)
+    const existing = await messageService.getById(this.opts.assistantMessageId)
     await messageService.update(this.opts.assistantMessageId, {
-      data: { parts },
+      data: { ...existing.data, parts },
       status,
       stats: this.opts.stats ?? stats
     })

--- a/src/main/ai/types/requests.ts
+++ b/src/main/ai/types/requests.ts
@@ -45,6 +45,12 @@ export interface AiBaseRequest {
   requestOptions?: AiTransportOptions
   /** Per-request overrides (in-process only; assistant-less callers like the API gateway). */
   callOverrides?: CallOverrides
+  /**
+   * One-shot system prompt override from a @-mentioned assistant. When defined (including
+   * empty string), replaces the topic assistant's prompt only for assembleSystemPrompt —
+   * all other assistant settings (MCP, tools, temperature, etc.) are unchanged.
+   */
+  temporarySystemPrompt?: string
 }
 
 /**

--- a/src/renderer/components/ResourceSelector/AssistantSelector.tsx
+++ b/src/renderer/components/ResourceSelector/AssistantSelector.tsx
@@ -131,9 +131,11 @@ export function AssistantSelector(props: AssistantSelectorProps) {
     ...(openTab && {
       onEditItem: (id: string) => {
         openTab(buildLibraryRouteUrl(buildLibraryEditSearch('assistant', id)), { forceNew: true })
+        onOpenChange?.(false)
       },
       onCreateNew: () => {
         openTab(buildLibraryRouteUrl(buildLibraryCreateSearch('assistant')), { forceNew: true })
+        onOpenChange?.(false)
       }
     }),
     labels: {

--- a/src/renderer/hooks/useTopicMessagesV2.ts
+++ b/src/renderer/hooks/useTopicMessagesV2.ts
@@ -39,7 +39,7 @@ function toUIMessage(shared: SharedMessage): CherryUIMessage {
       createdAt: shared.createdAt,
       updatedAt: shared.updatedAt,
       stats: shared.stats ?? undefined,
-      ...(shared.stats?.totalTokens ? { totalTokens: shared.stats.totalTokens } : {}),
+      ...(shared.stats?.totalTokens != null ? { totalTokens: shared.stats.totalTokens } : {}),
       ...(asstName !== undefined && {
         temporaryAssistantName: asstName
       })

--- a/src/renderer/hooks/useTopicMessagesV2.ts
+++ b/src/renderer/hooks/useTopicMessagesV2.ts
@@ -24,6 +24,7 @@ const PAGE_SIZE = 50
 // ── Converters ──
 
 function toUIMessage(shared: SharedMessage): CherryUIMessage {
+  const asstName = shared.data?.temporaryAssistantName
   return {
     id: shared.id,
     role: shared.role,
@@ -38,7 +39,10 @@ function toUIMessage(shared: SharedMessage): CherryUIMessage {
       createdAt: shared.createdAt,
       updatedAt: shared.updatedAt,
       stats: shared.stats ?? undefined,
-      ...(shared.stats?.totalTokens ? { totalTokens: shared.stats.totalTokens } : {})
+      ...(shared.stats?.totalTokens ? { totalTokens: shared.stats.totalTokens } : {}),
+      ...(asstName !== undefined && {
+        temporaryAssistantName: asstName
+      })
     }
   }
 }

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -1208,6 +1208,11 @@
       "generate_image": "Generate image",
       "generate_image_not_supported": "The model does not support generating images.",
       "knowledge_base": "Knowledge Base",
+      "mention_assistant": {
+        "section_label": "Assistants",
+        "section_models_label": "Models",
+        "tag_prefix": "Assistant"
+      },
       "new": {
         "context": "Clear Context"
       },

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -1326,6 +1326,9 @@
       "regenerate": {
         "model": "Switch Model"
       },
+      "temporary_assistant": {
+        "label": "Assistant · {{name}}"
+      },
       "useful": {
         "label": "Set as context",
         "tip": "In this group of messages, this message will be selected to join the context"

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -1326,6 +1326,9 @@
       "regenerate": {
         "model": "切换模型"
       },
+      "temporary_assistant": {
+        "label": "助手 · {{name}}"
+      },
       "useful": {
         "label": "设置为上下文",
         "tip": "在这组消息中，该消息将被选择加入上下文"

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -1208,6 +1208,11 @@
       "generate_image": "生成图片",
       "generate_image_not_supported": "模型不支持生成图片",
       "knowledge_base": "知识库",
+      "mention_assistant": {
+        "section_label": "助手",
+        "section_models_label": "模型",
+        "tag_prefix": "助手"
+      },
       "new": {
         "context": "清除上下文"
       },

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -1208,6 +1208,11 @@
       "generate_image": "產生圖片",
       "generate_image_not_supported": "模型不支援產生圖片",
       "knowledge_base": "知識庫",
+      "mention_assistant": {
+        "section_label": "助手",
+        "section_models_label": "模型",
+        "tag_prefix": "助手"
+      },
       "new": {
         "context": "清除上下文"
       },
@@ -1320,6 +1325,9 @@
       "quote": "引用",
       "regenerate": {
         "model": "切換模型"
+      },
+      "temporary_assistant": {
+        "label": "助手 · {{name}}"
       },
       "useful": {
         "label": "設為上下文",

--- a/src/renderer/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/pages/home/Inputbar/Inputbar.tsx
@@ -235,6 +235,7 @@ const InputbarInner: FC<InputbarInnerProps> = ({ setActiveTopic, topic, actionsR
     // Snapshot before clearing so the request carries the right prompt even
     // if the state update races with the async send path.
     const temporarySystemPrompt = mentionedAssistant?.prompt
+    const temporaryAssistantName = mentionedAssistant?.name
     setMentionedAssistant(null)
     setTimeoutTimer('sendMessage', () => resizeTextArea(), 0)
     focusTextarea()
@@ -242,7 +243,8 @@ const InputbarInner: FC<InputbarInnerProps> = ({ setActiveTopic, topic, actionsR
       await onSendProp(text_, {
         files: files.length > 0 ? files : undefined,
         mentionedModels: mentionedModels.length > 0 ? mentionedModels.map((model) => model.id) : undefined,
-        ...(temporarySystemPrompt !== undefined && { temporarySystemPrompt })
+        ...(temporarySystemPrompt !== undefined && { temporarySystemPrompt }),
+        ...(temporaryAssistantName !== undefined && { temporaryAssistantName })
       })
     } catch (error) {
       logger.warn('send failed', { error })

--- a/src/renderer/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/pages/home/Inputbar/Inputbar.tsx
@@ -55,7 +55,12 @@ interface Props {
   topic: Topic
   onSend: (
     text: string,
-    options?: { files?: FileMetadata[]; mentionedModels?: UniqueModelId[]; temporarySystemPrompt?: string }
+    options?: {
+      files?: FileMetadata[]
+      mentionedModels?: UniqueModelId[]
+      temporarySystemPrompt?: string
+      temporaryAssistantName?: string
+    }
   ) => void | Promise<void>
 }
 
@@ -250,6 +255,7 @@ const InputbarInner: FC<InputbarInnerProps> = ({ setActiveTopic, topic, actionsR
       logger.warn('send failed', { error })
       setText(text_)
       setFiles(files)
+      setMentionedAssistant(mentionedAssistant)
       window.toast.error(t('chat.input.send_failed'))
     } finally {
       setIsSending(false)
@@ -426,7 +432,7 @@ const InputbarInner: FC<InputbarInnerProps> = ({ setActiveTopic, topic, actionsR
       leftToolbar={leftToolbar}
       primaryActionMode={loading ? 'pause' : 'send'}
       topContent={topContent}
-      forceEnableQuickPanelTriggers={true}
+      forceEnableQuickPanelTriggers={enableQuickPanelTriggers}
     />
   )
 }

--- a/src/renderer/pages/home/Inputbar/Inputbar.tsx
+++ b/src/renderer/pages/home/Inputbar/Inputbar.tsx
@@ -32,6 +32,7 @@ import { useTranslation } from 'react-i18next'
 import { InputbarCore } from './components/InputbarCore'
 import InputbarTools from './InputbarTools'
 import KnowledgeBaseInput from './KnowledgeBaseInput'
+import MentionAssistantInput from './MentionAssistantInput'
 import MentionModelsInput from './MentionModelsInput'
 import { getInputbarConfig } from './registry'
 
@@ -54,7 +55,7 @@ interface Props {
   topic: Topic
   onSend: (
     text: string,
-    options?: { files?: FileMetadata[]; mentionedModels?: UniqueModelId[] }
+    options?: { files?: FileMetadata[]; mentionedModels?: UniqueModelId[]; temporarySystemPrompt?: string }
   ) => void | Promise<void>
 }
 
@@ -117,8 +118,8 @@ const InputbarInner: FC<InputbarInnerProps> = ({ setActiveTopic, topic, actionsR
   const scope = topic.type ?? TopicType.Chat
   const config = getInputbarConfig(scope)
 
-  const { files, mentionedModels, selectedKnowledgeBases } = useInputbarToolsState()
-  const { setFiles, setMentionedModels, setSelectedKnowledgeBases } = useInputbarToolsDispatch()
+  const { files, mentionedModels, selectedKnowledgeBases, mentionedAssistant } = useInputbarToolsState()
+  const { setFiles, setMentionedModels, setSelectedKnowledgeBases, setMentionedAssistant } = useInputbarToolsDispatch()
   const { setCouldAddImageFile } = useInputbarToolsInternalDispatch()
 
   const { text, setText } = useInputText({
@@ -231,23 +232,20 @@ const InputbarInner: FC<InputbarInnerProps> = ({ setActiveTopic, topic, actionsR
     setIsSending(true)
     setText('')
     setFiles([])
+    // Snapshot before clearing so the request carries the right prompt even
+    // if the state update races with the async send path.
+    const temporarySystemPrompt = mentionedAssistant?.prompt
+    setMentionedAssistant(null)
     setTimeoutTimer('sendMessage', () => resizeTextArea(), 0)
     focusTextarea()
-    // Await `onSendProp` in a try/finally so `isSending` clears on any
-    // terminal state — success path relies on the `pending` broadcast
-    // effect above, but sync/async failures (validation, IPC reject,
-    // transport error) never reach `pending` and would otherwise
-    // strand the input bar in pause mode.
     try {
       await onSendProp(text_, {
         files: files.length > 0 ? files : undefined,
-        mentionedModels: mentionedModels.length > 0 ? mentionedModels.map((model) => model.id) : undefined
+        mentionedModels: mentionedModels.length > 0 ? mentionedModels.map((model) => model.id) : undefined,
+        ...(temporarySystemPrompt !== undefined && { temporarySystemPrompt })
       })
     } catch (error) {
       logger.warn('send failed', { error })
-      // A pre-stream failure never reaches the `pending` broadcast, so restore the
-      // optimistically-cleared input (text + files) and surface the failure rather than
-      // silently discarding what the user typed.
       setText(text_)
       setFiles(files)
       window.toast.error(t('chat.input.send_failed'))
@@ -259,9 +257,11 @@ const InputbarInner: FC<InputbarInnerProps> = ({ setActiveTopic, topic, actionsR
     onSendProp,
     text,
     mentionedModels,
+    mentionedAssistant,
     files,
     setText,
     setFiles,
+    setMentionedAssistant,
     setTimeoutTimer,
     resizeTextArea,
     focusTextarea,
@@ -304,6 +304,15 @@ const InputbarInner: FC<InputbarInnerProps> = ({ setActiveTopic, topic, actionsR
     },
     [mentionedModels, setMentionedModels]
   )
+
+  const handleRemoveAssistant = useCallback(() => {
+    setMentionedAssistant(null)
+  }, [setMentionedAssistant])
+
+  // Clear temporary assistant when switching topics
+  useEffect(() => {
+    setMentionedAssistant(null)
+  }, [topic.id, setMentionedAssistant])
 
   const handleRemoveKnowledgeBase = useCallback(
     (knowledgeBase: KnowledgeBase) => {
@@ -383,6 +392,10 @@ const InputbarInner: FC<InputbarInnerProps> = ({ setActiveTopic, topic, actionsR
         />
       )}
 
+      {mentionedAssistant && (
+        <MentionAssistantInput assistant={mentionedAssistant} onRemoveAssistant={handleRemoveAssistant} />
+      )}
+
       {mentionedModels.length > 0 && (
         <MentionModelsInput selectedModels={mentionedModels} onRemoveModel={handleRemoveModel} />
       )}
@@ -411,6 +424,7 @@ const InputbarInner: FC<InputbarInnerProps> = ({ setActiveTopic, topic, actionsR
       leftToolbar={leftToolbar}
       primaryActionMode={loading ? 'pause' : 'send'}
       topContent={topContent}
+      forceEnableQuickPanelTriggers={true}
     />
   )
 }

--- a/src/renderer/pages/home/Inputbar/MentionAssistantInput.tsx
+++ b/src/renderer/pages/home/Inputbar/MentionAssistantInput.tsx
@@ -3,7 +3,6 @@ import CustomTag from '@renderer/components/Tags/CustomTag'
 import type { Assistant } from '@renderer/types'
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import styled from 'styled-components'
 
 const MentionAssistantInput: FC<{
   assistant: Assistant
@@ -12,7 +11,7 @@ const MentionAssistantInput: FC<{
   const { t } = useTranslation()
 
   return (
-    <Container>
+    <div className="w-full px-[15px] py-[5px]">
       <HorizontalScrollContainer dependencies={[assistant]} expandable>
         <CustomTag
           icon={<span>{assistant.emoji || '🤖'}</span>}
@@ -22,13 +21,8 @@ const MentionAssistantInput: FC<{
           {t('chat.input.mention_assistant.tag_prefix')} · {assistant.name}
         </CustomTag>
       </HorizontalScrollContainer>
-    </Container>
+    </div>
   )
 }
-
-const Container = styled.div`
-  width: 100%;
-  padding: 5px 15px 5px 15px;
-`
 
 export default MentionAssistantInput

--- a/src/renderer/pages/home/Inputbar/MentionAssistantInput.tsx
+++ b/src/renderer/pages/home/Inputbar/MentionAssistantInput.tsx
@@ -1,0 +1,34 @@
+import HorizontalScrollContainer from '@renderer/components/HorizontalScrollContainer'
+import CustomTag from '@renderer/components/Tags/CustomTag'
+import type { Assistant } from '@renderer/types'
+import type { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+
+const MentionAssistantInput: FC<{
+  assistant: Assistant
+  onRemoveAssistant: () => void
+}> = ({ assistant, onRemoveAssistant }) => {
+  const { t } = useTranslation()
+
+  return (
+    <Container>
+      <HorizontalScrollContainer dependencies={[assistant]} expandable>
+        <CustomTag
+          icon={<span>{assistant.emoji || '🤖'}</span>}
+          color="var(--color-primary)"
+          closable
+          onClose={onRemoveAssistant}>
+          {t('chat.input.mention_assistant.tag_prefix')} · {assistant.name}
+        </CustomTag>
+      </HorizontalScrollContainer>
+    </Container>
+  )
+}
+
+const Container = styled.div`
+  width: 100%;
+  padding: 5px 15px 5px 15px;
+`
+
+export default MentionAssistantInput

--- a/src/renderer/pages/home/Inputbar/context/InputbarToolsProvider.tsx
+++ b/src/renderer/pages/home/Inputbar/context/InputbarToolsProvider.tsx
@@ -1,5 +1,6 @@
 import type { QuickPanelListItem, QuickPanelReservedSymbol } from '@renderer/components/QuickPanel'
 import type { FileMetadata, KnowledgeBase } from '@renderer/types'
+import type { Assistant } from '@renderer/types'
 import { FILE_TYPE } from '@renderer/types'
 import type { Model } from '@shared/data/types/model'
 import React, { createContext, use, useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -26,6 +27,9 @@ export interface InputbarToolsState {
   couldMentionNotVisionModel: boolean
   /** Supported file extensions (derived state) */
   extensions: string[]
+
+  /** Temporarily @-mentioned assistant for one-shot system prompt override */
+  mentionedAssistant: Assistant | null
 }
 
 /**
@@ -78,6 +82,7 @@ export interface InputbarToolsDispatch {
   /** State setters */
   setFiles: React.Dispatch<React.SetStateAction<FileMetadata[]>>
   setMentionedModels: React.Dispatch<React.SetStateAction<Model[]>>
+  setMentionedAssistant: React.Dispatch<React.SetStateAction<Assistant | null>>
   setSelectedKnowledgeBases: React.Dispatch<React.SetStateAction<KnowledgeBase[]>>
   setIsExpanded: React.Dispatch<React.SetStateAction<boolean>>
 
@@ -165,6 +170,7 @@ export const InputbarToolsProvider: React.FC<InputbarToolsProviderProps> = ({ ch
   // Core state
   const [files, setFiles] = useState<FileMetadata[]>(initialState?.files || [])
   const [mentionedModels, setMentionedModels] = useState<Model[]>(initialState?.mentionedModels || [])
+  const [mentionedAssistant, setMentionedAssistant] = useState<Assistant | null>(null)
   const [selectedKnowledgeBases, setSelectedKnowledgeBases] = useState<KnowledgeBase[]>(
     initialState?.selectedKnowledgeBases || []
   )
@@ -248,6 +254,7 @@ export const InputbarToolsProvider: React.FC<InputbarToolsProviderProps> = ({ ch
     () => ({
       files,
       mentionedModels,
+      mentionedAssistant,
       selectedKnowledgeBases,
       isExpanded,
       couldAddImageFile,
@@ -257,6 +264,7 @@ export const InputbarToolsProvider: React.FC<InputbarToolsProviderProps> = ({ ch
     [
       files,
       mentionedModels,
+      mentionedAssistant,
       selectedKnowledgeBases,
       isExpanded,
       couldAddImageFile,
@@ -289,6 +297,7 @@ export const InputbarToolsProvider: React.FC<InputbarToolsProviderProps> = ({ ch
       // State setters (React guarantees stable references)
       setFiles,
       setMentionedModels,
+      setMentionedAssistant,
       setSelectedKnowledgeBases,
       setIsExpanded,
 

--- a/src/renderer/pages/home/Inputbar/tools/components/MentionModelsButton.tsx
+++ b/src/renderer/pages/home/Inputbar/tools/components/MentionModelsButton.tsx
@@ -1,6 +1,6 @@
 import { ActionIconButton } from '@renderer/components/Buttons'
 import type { ToolQuickPanelApi, ToolQuickPanelController } from '@renderer/pages/home/Inputbar/types'
-import type { FileMetadata } from '@renderer/types'
+import type { Assistant, FileMetadata } from '@renderer/types'
 import type { Model } from '@shared/data/types/model'
 import { Tooltip } from 'antd'
 import { AtSign } from 'lucide-react'
@@ -16,6 +16,8 @@ interface Props {
   quickPanelController: ToolQuickPanelController
   mentionedModels: Model[]
   setMentionedModels: React.Dispatch<React.SetStateAction<Model[]>>
+  mentionedAssistant: Assistant | null
+  setMentionedAssistant: React.Dispatch<React.SetStateAction<Assistant | null>>
   couldMentionNotVisionModel: boolean
   files: FileMetadata[]
   setText: React.Dispatch<React.SetStateAction<string>>
@@ -26,6 +28,8 @@ const MentionModelsButton: FC<Props> = ({
   quickPanelController,
   mentionedModels,
   setMentionedModels,
+  mentionedAssistant,
+  setMentionedAssistant,
   couldMentionNotVisionModel,
   files,
   setText
@@ -38,6 +42,8 @@ const MentionModelsButton: FC<Props> = ({
       quickPanelController,
       mentionedModels,
       setMentionedModels,
+      mentionedAssistant,
+      setMentionedAssistant,
       couldMentionNotVisionModel,
       files,
       setText

--- a/src/renderer/pages/home/Inputbar/tools/components/MentionModelsQuickPanelManager.tsx
+++ b/src/renderer/pages/home/Inputbar/tools/components/MentionModelsQuickPanelManager.tsx
@@ -1,5 +1,4 @@
 import type { ToolActionKey, ToolRenderContext, ToolStateKey } from '@renderer/pages/home/Inputbar/types'
-import type { Assistant } from '@renderer/types'
 import type React from 'react'
 
 import { useMentionModelsPanel } from './useMentionModelsPanel'
@@ -23,7 +22,7 @@ const MentionModelsQuickPanelManager = ({ context }: ManagerProps) => {
       mentionedModels: mentionedModels,
       setMentionedModels: setMentionedModels,
       mentionedAssistant: mentionedAssistant,
-      setMentionedAssistant: setMentionedAssistant as React.Dispatch<React.SetStateAction<Assistant | null>>,
+      setMentionedAssistant: setMentionedAssistant,
       couldMentionNotVisionModel,
       files: files,
       setText: onTextChange as React.Dispatch<React.SetStateAction<string>>

--- a/src/renderer/pages/home/Inputbar/tools/components/MentionModelsQuickPanelManager.tsx
+++ b/src/renderer/pages/home/Inputbar/tools/components/MentionModelsQuickPanelManager.tsx
@@ -1,4 +1,5 @@
 import type { ToolActionKey, ToolRenderContext, ToolStateKey } from '@renderer/pages/home/Inputbar/types'
+import type { Assistant } from '@renderer/types'
 import type React from 'react'
 
 import { useMentionModelsPanel } from './useMentionModelsPanel'
@@ -11,8 +12,8 @@ const MentionModelsQuickPanelManager = ({ context }: ManagerProps) => {
   const {
     quickPanel,
     quickPanelController,
-    state: { mentionedModels, files, couldMentionNotVisionModel },
-    actions: { setMentionedModels, onTextChange }
+    state: { mentionedModels, mentionedAssistant, files, couldMentionNotVisionModel },
+    actions: { setMentionedModels, setMentionedAssistant, onTextChange }
   } = context
 
   useMentionModelsPanel(
@@ -21,6 +22,8 @@ const MentionModelsQuickPanelManager = ({ context }: ManagerProps) => {
       quickPanelController,
       mentionedModels: mentionedModels,
       setMentionedModels: setMentionedModels,
+      mentionedAssistant: mentionedAssistant,
+      setMentionedAssistant: setMentionedAssistant as React.Dispatch<React.SetStateAction<Assistant | null>>,
       couldMentionNotVisionModel,
       files: files,
       setText: onTextChange as React.Dispatch<React.SetStateAction<string>>

--- a/src/renderer/pages/home/Inputbar/tools/components/useMentionModelsPanel.tsx
+++ b/src/renderer/pages/home/Inputbar/tools/components/useMentionModelsPanel.tsx
@@ -244,7 +244,11 @@ export const useMentionModelsPanel = (params: Params, role: 'button' | 'manager'
       // Assistants section
       if (filteredAssistants.length > 0) {
         result.push({
-          label: <SectionLabel>{t('chat.input.mention_assistant.section_label')}</SectionLabel>,
+          label: (
+            <span className="pointer-events-none text-[11px] font-semibold uppercase tracking-[0.05em] opacity-50">
+              {t('chat.input.mention_assistant.section_label')}
+            </span>
+          ),
           icon: null,
           filterText: '',
           disabled: true,
@@ -285,7 +289,11 @@ export const useMentionModelsPanel = (params: Params, role: 'button' | 'manager'
       // Models section
       if (modelItems.length > 0) {
         result.push({
-          label: <SectionLabel>{t('chat.input.mention_assistant.section_models_label')}</SectionLabel>,
+          label: (
+            <span className="pointer-events-none text-[11px] font-semibold uppercase tracking-[0.05em] opacity-50">
+              {t('chat.input.mention_assistant.section_models_label')}
+            </span>
+          ),
           icon: null,
           filterText: '',
           disabled: true,
@@ -413,13 +421,4 @@ export const useMentionModelsPanel = (params: Params, role: 'button' | 'manager'
 
 const ProviderName = styled.span`
   font-weight: 500;
-`
-
-const SectionLabel = styled.span`
-  font-size: 11px;
-  font-weight: 600;
-  opacity: 0.5;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  pointer-events: none;
 `

--- a/src/renderer/pages/home/Inputbar/tools/components/useMentionModelsPanel.tsx
+++ b/src/renderer/pages/home/Inputbar/tools/components/useMentionModelsPanel.tsx
@@ -3,10 +3,11 @@ import type { QuickPanelListItem } from '@renderer/components/QuickPanel'
 import { QuickPanelReservedSymbol } from '@renderer/components/QuickPanel'
 import { getModelLogo, isEmbeddingModel, isRerankModel, isVisionModel } from '@renderer/config/models'
 import db from '@renderer/databases'
+import { useAssistantsApi } from '@renderer/hooks/useAssistant'
 import { useModels } from '@renderer/hooks/useModel'
 import { getProviderDisplayName, useProviders } from '@renderer/hooks/useProvider'
 import type { ToolQuickPanelApi, ToolQuickPanelController } from '@renderer/pages/home/Inputbar/types'
-import type { FileMetadata } from '@renderer/types'
+import type { Assistant, FileMetadata } from '@renderer/types'
 import { FILE_TYPE } from '@renderer/types'
 import type { Model } from '@shared/data/types/model'
 import { useNavigate } from '@tanstack/react-router'
@@ -26,6 +27,8 @@ interface Params {
   quickPanelController: ToolQuickPanelController
   mentionedModels: Model[]
   setMentionedModels: React.Dispatch<React.SetStateAction<Model[]>>
+  mentionedAssistant: Assistant | null
+  setMentionedAssistant: React.Dispatch<React.SetStateAction<Assistant | null>>
   couldMentionNotVisionModel: boolean
   files: FileMetadata[]
   setText: React.Dispatch<React.SetStateAction<string>>
@@ -37,6 +40,7 @@ export const useMentionModelsPanel = (params: Params, role: 'button' | 'manager'
     quickPanelController,
     mentionedModels,
     setMentionedModels,
+    setMentionedAssistant,
     couldMentionNotVisionModel,
     files,
     setText
@@ -45,6 +49,7 @@ export const useMentionModelsPanel = (params: Params, role: 'button' | 'manager'
   const { open, close, updateList, isVisible, symbol } = quickPanelController
   const { providers } = useProviders()
   const { models: v2Models } = useModels()
+  const { assistants } = useAssistantsApi()
   const modelsByProvider = useMemo(() => {
     const map = new Map<string, Model[]>()
     for (const m of v2Models) {
@@ -60,6 +65,7 @@ export const useMentionModelsPanel = (params: Params, role: 'button' | 'manager'
   const hasModelActionRef = useRef(false)
   const triggerInfoRef = useRef<MentionTriggerInfo | undefined>(undefined)
   const filesRef = useRef(files)
+  const currentSearchRef = useRef('')
 
   const removeAtSymbolAndText = useCallback(
     (currentText: string, caretPosition: number, searchText?: string, fallbackPosition?: number) => {
@@ -136,123 +142,199 @@ export const useMentionModelsPanel = (params: Params, role: 'button' | 'manager'
     []
   )
 
-  const modelItems = useMemo(() => {
-    const items: QuickPanelListItem[] = []
+  const validAssistants = useMemo(() => assistants.filter((a) => a.id && a.name && a.name.trim() !== ''), [assistants])
 
-    if (pinnedModels.length > 0) {
-      const pinnedItems = providers.flatMap((provider) =>
-        (modelsByProvider.get(provider.id) ?? [])
-          .filter((model) => !isEmbeddingModel(model) && !isRerankModel(model))
-          .filter((model) => pinnedModels.includes(model.id))
-          .filter((model) => couldMentionNotVisionModel || (!couldMentionNotVisionModel && isVisionModel(model)))
-          .map((model) => ({
+  const buildModelItems = useCallback(
+    (searchText: string): QuickPanelListItem[] => {
+      const lower = searchText.toLowerCase()
+      const items: QuickPanelListItem[] = []
+
+      if (pinnedModels.length > 0) {
+        const pinnedItems = providers.flatMap((provider) =>
+          (modelsByProvider.get(provider.id) ?? [])
+            .filter((model) => !isEmbeddingModel(model) && !isRerankModel(model))
+            .filter((model) => pinnedModels.includes(model.id))
+            .filter((model) => couldMentionNotVisionModel || isVisionModel(model))
+            .filter((model) => !lower || (getProviderDisplayName(provider) + model.name).toLowerCase().includes(lower))
+            .map((model) => ({
+              label: (
+                <>
+                  <ProviderName>{getProviderDisplayName(provider)}</ProviderName>
+                  <span style={{ opacity: 0.8 }}> | {model.name}</span>
+                </>
+              ),
+              description: <ModelTagsWithLabel model={model} showLabel={false} size={10} style={{ opacity: 0.8 }} />,
+              icon: (() => {
+                const Icon = getModelLogo(model)
+                return Icon ? <Icon.Avatar size={20} /> : <Avatar size={20}>{first(model.name)}</Avatar>
+              })(),
+              filterText: getProviderDisplayName(provider) + model.name,
+              action: () => onMentionModel(model),
+              isSelected: mentionedModels.some((selected) => selected.id === model.id)
+            }))
+        )
+        if (pinnedItems.length > 0) items.push(...sortBy(pinnedItems, ['label']))
+      }
+
+      providers.forEach((provider) => {
+        const providerModels = sortBy(
+          (modelsByProvider.get(provider.id) ?? [])
+            .filter((model) => !isEmbeddingModel(model) && !isRerankModel(model))
+            .filter((model) => !pinnedModels.includes(model.id))
+            .filter((model) => couldMentionNotVisionModel || isVisionModel(model))
+            .filter((model) => !lower || (getProviderDisplayName(provider) + model.name).toLowerCase().includes(lower)),
+          ['group', 'name']
+        )
+        const providerItems = providerModels.map((model) => ({
+          label: (
+            <>
+              <ProviderName>{getProviderDisplayName(provider)}</ProviderName>
+              <span style={{ opacity: 0.8 }}> | {model.name}</span>
+            </>
+          ),
+          description: <ModelTagsWithLabel model={model} showLabel={false} size={10} style={{ opacity: 0.8 }} />,
+          icon: (() => {
+            const Icon = getModelLogo(model)
+            return Icon ? <Icon.Avatar size={20} /> : <Avatar size={20}>{first(model.name)}</Avatar>
+          })(),
+          filterText: getProviderDisplayName(provider) + model.name,
+          action: () => onMentionModel(model),
+          isSelected: mentionedModels.some((selected) => selected.id === model.id)
+        }))
+        if (providerItems.length > 0) items.push(...providerItems)
+      })
+
+      return items
+    },
+    [couldMentionNotVisionModel, mentionedModels, onMentionModel, pinnedModels, providers, modelsByProvider]
+  )
+
+  const buildSectionedList = useCallback(
+    (searchText: string): QuickPanelListItem[] => {
+      const lower = searchText.toLowerCase()
+
+      const filteredAssistants = lower
+        ? validAssistants.filter((a) => a.name.toLowerCase().includes(lower))
+        : validAssistants
+
+      const modelItems = buildModelItems(searchText)
+
+      const result: QuickPanelListItem[] = []
+
+      // "Clear" always-visible item
+      result.push({
+        label: t('settings.input.clear.all'),
+        description: t('settings.input.clear.models'),
+        icon: <CircleX />,
+        alwaysVisible: true,
+        isSelected: false,
+        action: ({ context }) => {
+          onClearMentionModels()
+          if (triggerInfoRef.current?.type === 'input') {
+            setText((currentText) => {
+              const textArea = document.querySelector<HTMLTextAreaElement>('.inputbar textarea')
+              const caret = textArea ? (textArea.selectionStart ?? currentText.length) : currentText.length
+              return removeAtSymbolAndText(currentText, caret, undefined, triggerInfoRef.current?.position)
+            })
+          }
+          context.close()
+        }
+      })
+
+      // Assistants section
+      if (filteredAssistants.length > 0) {
+        result.push({
+          label: <SectionLabel>{t('chat.input.mention_assistant.section_label')}</SectionLabel>,
+          icon: null,
+          filterText: '',
+          disabled: true,
+          action: () => {}
+        })
+        for (const a of filteredAssistants) {
+          result.push({
             label: (
-              <>
-                <ProviderName>{getProviderDisplayName(provider)}</ProviderName>
-                <span style={{ opacity: 0.8 }}> | {model.name}</span>
-              </>
+              <span>
+                {a.emoji ? <span style={{ marginRight: 4 }}>{a.emoji}</span> : null}
+                {a.name}
+              </span>
             ),
-            description: <ModelTagsWithLabel model={model} showLabel={false} size={10} style={{ opacity: 0.8 }} />,
-            icon: (() => {
-              const Icon = getModelLogo(model)
-              return Icon ? <Icon.Avatar size={20} /> : <Avatar size={20}>{first(model.name)}</Avatar>
-            })(),
-            filterText: getProviderDisplayName(provider) + model.name,
-            action: () => onMentionModel(model),
-            isSelected: mentionedModels.some((selected) => selected.id === model.id)
-          }))
-      )
-
-      if (pinnedItems.length > 0) {
-        items.push(...sortBy(pinnedItems, ['label']))
-      }
-    }
-
-    providers.forEach((provider) => {
-      const providerModels = sortBy(
-        (modelsByProvider.get(provider.id) ?? [])
-          .filter((model) => !isEmbeddingModel(model) && !isRerankModel(model))
-          .filter((model) => !pinnedModels.includes(model.id))
-          .filter((model) => couldMentionNotVisionModel || (!couldMentionNotVisionModel && isVisionModel(model))),
-        ['group', 'name']
-      )
-
-      const providerItems = providerModels.map((model) => ({
-        label: (
-          <>
-            <ProviderName>{getProviderDisplayName(provider)}</ProviderName>
-            <span style={{ opacity: 0.8 }}> | {model.name}</span>
-          </>
-        ),
-        description: <ModelTagsWithLabel model={model} showLabel={false} size={10} style={{ opacity: 0.8 }} />,
-        icon: (() => {
-          const Icon = getModelLogo(model)
-          return Icon ? <Icon.Avatar size={20} /> : <Avatar size={20}>{first(model.name)}</Avatar>
-        })(),
-        filterText: getProviderDisplayName(provider) + model.name,
-        action: () => onMentionModel(model),
-        isSelected: mentionedModels.some((selected) => selected.id === model.id)
-      }))
-
-      if (providerItems.length > 0) {
-        items.push(...providerItems)
-      }
-    })
-
-    items.push({
-      label: t('settings.models.add.add_model') + '...',
-      icon: <Plus />,
-      action: () => navigate({ to: '/settings/provider' }),
-      isSelected: false
-    })
-
-    items.unshift({
-      label: t('settings.input.clear.all'),
-      description: t('settings.input.clear.models'),
-      icon: <CircleX />,
-      alwaysVisible: true,
-      isSelected: false,
-      action: ({ context }) => {
-        onClearMentionModels()
-
-        if (triggerInfoRef.current?.type === 'input') {
-          setText((currentText) => {
-            const textArea = document.querySelector<HTMLTextAreaElement>('.inputbar textarea')
-            const caret = textArea ? (textArea.selectionStart ?? currentText.length) : currentText.length
-            return removeAtSymbolAndText(currentText, caret, undefined, triggerInfoRef.current?.position)
+            icon: <span style={{ fontSize: 16 }}>{a.emoji || '🤖'}</span>,
+            filterText: a.name,
+            isSelected: false,
+            action: ({ context }) => {
+              setMentionedAssistant(a)
+              hasModelActionRef.current = true
+              if (triggerInfoRef.current?.type === 'input') {
+                setText((currentText) => {
+                  const textArea = document.querySelector<HTMLTextAreaElement>('.inputbar textarea')
+                  const caret = textArea ? (textArea.selectionStart ?? currentText.length) : currentText.length
+                  return removeAtSymbolAndText(
+                    currentText,
+                    caret,
+                    currentSearchRef.current || '',
+                    triggerInfoRef.current?.position
+                  )
+                })
+              }
+              context.close()
+            }
           })
         }
-
-        context.close()
       }
-    })
 
-    return items
-  }, [
-    couldMentionNotVisionModel,
-    mentionedModels,
-    navigate,
-    onClearMentionModels,
-    onMentionModel,
-    pinnedModels,
-    providers,
-    modelsByProvider,
-    removeAtSymbolAndText,
-    setText,
-    t
-  ])
+      // Models section
+      if (modelItems.length > 0) {
+        result.push({
+          label: <SectionLabel>{t('chat.input.mention_assistant.section_models_label')}</SectionLabel>,
+          icon: null,
+          filterText: '',
+          disabled: true,
+          action: () => {}
+        })
+        result.push(...modelItems)
+      }
+
+      // "Add model" footer (only show when no search or model section visible)
+      if (modelItems.length > 0 || !lower) {
+        result.push({
+          label: t('settings.models.add.add_model') + '...',
+          icon: <Plus />,
+          action: () => navigate({ to: '/settings/provider' }),
+          isSelected: false
+        })
+      }
+
+      return result
+    },
+    [
+      validAssistants,
+      buildModelItems,
+      onClearMentionModels,
+      setMentionedAssistant,
+      removeAtSymbolAndText,
+      setText,
+      navigate,
+      t
+    ]
+  )
 
   const openQuickPanel = useCallback(
     (triggerInfo?: MentionTriggerInfo) => {
       hasModelActionRef.current = false
       triggerInfoRef.current = triggerInfo
+      currentSearchRef.current = ''
 
       open({
         title: t('assistants.presets.edit.model.select.title'),
-        list: modelItems,
+        list: buildSectionedList(''),
         symbol: QuickPanelReservedSymbol.MentionModels,
         multiple: true,
+        manageListExternally: true,
         triggerInfo: triggerInfo || { type: 'button' },
+        onSearchChange: (searchText) => {
+          currentSearchRef.current = searchText
+          updateList(buildSectionedList(searchText))
+        },
         afterAction({ item }) {
           item.isSelected = !item.isSelected
         },
@@ -268,10 +350,11 @@ export const useMentionModelsPanel = (params: Params, role: 'button' | 'manager'
             }
           }
           triggerInfoRef.current = undefined
+          currentSearchRef.current = ''
         }
       })
     },
-    [modelItems, open, removeAtSymbolAndText, setText, t]
+    [buildSectionedList, open, updateList, removeAtSymbolAndText, setText, t]
   )
 
   const handleOpenQuickPanel = useCallback(() => {
@@ -295,9 +378,9 @@ export const useMentionModelsPanel = (params: Params, role: 'button' | 'manager'
   useEffect(() => {
     if (role !== 'manager') return
     if (isVisible && symbol === QuickPanelReservedSymbol.MentionModels) {
-      updateList(modelItems)
+      updateList(buildSectionedList(currentSearchRef.current))
     }
-  }, [isVisible, modelItems, role, symbol, updateList])
+  }, [isVisible, buildSectionedList, role, symbol, updateList])
 
   useEffect(() => {
     if (role !== 'manager') return
@@ -330,4 +413,13 @@ export const useMentionModelsPanel = (params: Params, role: 'button' | 'manager'
 
 const ProviderName = styled.span`
   font-weight: 500;
+`
+
+const SectionLabel = styled.span`
+  font-size: 11px;
+  font-weight: 600;
+  opacity: 0.5;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  pointer-events: none;
 `

--- a/src/renderer/pages/home/Inputbar/tools/mentionModelsTool.tsx
+++ b/src/renderer/pages/home/Inputbar/tools/mentionModelsTool.tsx
@@ -1,5 +1,4 @@
 import { defineTool, registerTool, TopicType } from '@renderer/pages/home/Inputbar/types'
-import type { Assistant } from '@renderer/types'
 import type React from 'react'
 
 import MentionModelsButton from './components/MentionModelsButton'
@@ -33,7 +32,7 @@ const mentionModelsTool = defineTool({
         mentionedModels={mentionedModels}
         setMentionedModels={setMentionedModels}
         mentionedAssistant={mentionedAssistant}
-        setMentionedAssistant={setMentionedAssistant as React.Dispatch<React.SetStateAction<Assistant | null>>}
+        setMentionedAssistant={setMentionedAssistant}
         couldMentionNotVisionModel={couldMentionNotVisionModel}
         files={files}
         setText={onTextChange as React.Dispatch<React.SetStateAction<string>>}

--- a/src/renderer/pages/home/Inputbar/tools/mentionModelsTool.tsx
+++ b/src/renderer/pages/home/Inputbar/tools/mentionModelsTool.tsx
@@ -1,4 +1,5 @@
 import { defineTool, registerTool, TopicType } from '@renderer/pages/home/Inputbar/types'
+import type { Assistant } from '@renderer/types'
 import type React from 'react'
 
 import MentionModelsButton from './components/MentionModelsButton'
@@ -16,14 +17,14 @@ const mentionModelsTool = defineTool({
 
   visibleInScopes: [TopicType.Chat, 'quick-assistant'],
   dependencies: {
-    state: ['mentionedModels', 'files', 'couldMentionNotVisionModel'] as const,
-    actions: ['setMentionedModels', 'onTextChange'] as const
+    state: ['mentionedModels', 'mentionedAssistant', 'files', 'couldMentionNotVisionModel'] as const,
+    actions: ['setMentionedModels', 'setMentionedAssistant', 'onTextChange'] as const
   },
 
   render: function MentionModelsToolRender(context) {
     const { state, actions, quickPanel, quickPanelController } = context
-    const { mentionedModels, files, couldMentionNotVisionModel } = state
-    const { setMentionedModels, onTextChange } = actions
+    const { mentionedModels, mentionedAssistant, files, couldMentionNotVisionModel } = state
+    const { setMentionedModels, setMentionedAssistant, onTextChange } = actions
 
     return (
       <MentionModelsButton
@@ -31,6 +32,8 @@ const mentionModelsTool = defineTool({
         quickPanelController={quickPanelController}
         mentionedModels={mentionedModels}
         setMentionedModels={setMentionedModels}
+        mentionedAssistant={mentionedAssistant}
+        setMentionedAssistant={setMentionedAssistant as React.Dispatch<React.SetStateAction<Assistant | null>>}
         couldMentionNotVisionModel={couldMentionNotVisionModel}
         files={files}
         setText={onTextChange as React.Dispatch<React.SetStateAction<string>>}

--- a/src/renderer/pages/home/Messages/MessageHeader.tsx
+++ b/src/renderer/pages/home/Messages/MessageHeader.tsx
@@ -46,10 +46,7 @@ const MessageHeader: FC<Props> = memo(({ assistant, model, message, topic, isGro
 
   const ModelIcon = useMemo(() => getModelLogo(message.model ?? model), [message.model, model])
 
-  const modelName = useMemo(
-    () => (model?.name || model?.id || getMessageModelId(message) || '') as string,
-    [model, message]
-  )
+  const modelName = useMemo(() => model?.name || model?.id || getMessageModelId(message) || '', [model, message])
 
   const getUserName = useCallback(() => {
     if (isAgentSessionAssistantMessage) {

--- a/src/renderer/pages/home/Messages/MessageHeader.tsx
+++ b/src/renderer/pages/home/Messages/MessageHeader.tsx
@@ -46,17 +46,24 @@ const MessageHeader: FC<Props> = memo(({ assistant, model, message, topic, isGro
 
   const ModelIcon = useMemo(() => getModelLogo(message.model ?? model), [message.model, model])
 
+  const modelName = useMemo(
+    () => (model?.name || model?.id || getMessageModelId(message) || '') as string,
+    [model, message]
+  )
+
   const getUserName = useCallback(() => {
     if (isAgentSessionAssistantMessage) {
       return agent?.name ?? t('common.unknown')
     }
 
     if (message.role === 'assistant') {
-      return model?.name || model?.id || getMessageModelId(message) || ''
+      const asstName = message.temporaryAssistantName
+      if (asstName) return t('chat.message.temporary_assistant.label', { name: asstName })
+      return modelName || t('common.unknown')
     }
 
     return userName || t('common.you')
-  }, [agent?.name, isAgentSessionAssistantMessage, message, model, t, userName])
+  }, [agent?.name, isAgentSessionAssistantMessage, message, modelName, t, userName])
 
   const isAssistantMessage = message.role === 'assistant'
   const isUserMessage = message.role === 'user'
@@ -123,6 +130,9 @@ const MessageHeader: FC<Props> = memo(({ assistant, model, message, topic, isGro
             </Tooltip>
           )}
         </RowFlex>
+        {isAssistantMessage && message.temporaryAssistantName && modelName && (
+          <div className="text-(--color-text-3) text-[10px] leading-tight">{modelName}</div>
+        )}
         <div className="message-header-info-wrap flex items-center gap-1 text-(--color-text-3) text-[10px]">
           <div>{dayjs(message?.updatedAt ?? message.createdAt).format('MM/DD HH:mm')}</div>
           {isBubbleStyle && message.usage !== undefined && (

--- a/src/renderer/pages/home/V2ChatContent.tsx
+++ b/src/renderer/pages/home/V2ChatContent.tsx
@@ -242,7 +242,12 @@ const V2ChatContentInner: FC<InnerProps> = ({
   const handleSendV2 = useCallback(
     async (
       text: string,
-      options?: { files?: FileMetadata[]; mentionedModels?: UniqueModelId[]; temporarySystemPrompt?: string }
+      options?: {
+        files?: FileMetadata[]
+        mentionedModels?: UniqueModelId[]
+        temporarySystemPrompt?: string
+        temporaryAssistantName?: string
+      }
     ) => {
       if (isFreshTemporaryTopic && onPersistTemporaryTopic) {
         try {
@@ -277,6 +282,9 @@ const V2ChatContentInner: FC<InnerProps> = ({
             mentionedModels: options?.mentionedModels,
             ...(options?.temporarySystemPrompt !== undefined && {
               temporarySystemPrompt: options.temporarySystemPrompt
+            }),
+            ...(options?.temporaryAssistantName !== undefined && {
+              temporaryAssistantName: options.temporaryAssistantName
             }),
             ...capabilityBody
           }

--- a/src/renderer/pages/home/V2ChatContent.tsx
+++ b/src/renderer/pages/home/V2ChatContent.tsx
@@ -240,7 +240,10 @@ const V2ChatContentInner: FC<InnerProps> = ({
   })
 
   const handleSendV2 = useCallback(
-    async (text: string, options?: { files?: FileMetadata[]; mentionedModels?: UniqueModelId[] }) => {
+    async (
+      text: string,
+      options?: { files?: FileMetadata[]; mentionedModels?: UniqueModelId[]; temporarySystemPrompt?: string }
+    ) => {
       if (isFreshTemporaryTopic && onPersistTemporaryTopic) {
         try {
           // Seed the new topic with the user's first message as a placeholder
@@ -272,6 +275,9 @@ const V2ChatContentInner: FC<InnerProps> = ({
           body: {
             parentAnchorId: activeNodeId ?? undefined,
             mentionedModels: options?.mentionedModels,
+            ...(options?.temporarySystemPrompt !== undefined && {
+              temporarySystemPrompt: options.temporarySystemPrompt
+            }),
             ...capabilityBody
           }
         }

--- a/src/renderer/pages/home/uiToMessage.ts
+++ b/src/renderer/pages/home/uiToMessage.ts
@@ -74,7 +74,7 @@ export function uiToMessage(uiMsg: CherryUIMessage, ctx: UiToMessageContext): Me
   const createdAt = meta.createdAt ?? ctx.createdAtFallback ?? ''
   const askId = uiMsg.role === 'assistant' ? (meta.parentId ?? ctx.askIdFallback) : undefined
 
-  return {
+  const result: Message = {
     id: uiMsg.id,
     role: uiMsg.role,
     assistantId: ctx.assistantId,
@@ -88,6 +88,8 @@ export function uiToMessage(uiMsg: CherryUIMessage, ctx: UiToMessageContext): Me
     status: projectStatus(uiMsg.role, meta.status),
     ...(meta.stats && { usage: statsToUsage(meta.stats), metrics: statsToMetrics(meta.stats) }),
     blocks: [],
-    parts: uiMsg.parts ?? []
+    parts: uiMsg.parts ?? [],
+    temporaryAssistantName: meta.temporaryAssistantName
   }
+  return result
 }

--- a/src/renderer/transport/IpcChatTransport.ts
+++ b/src/renderer/transport/IpcChatTransport.ts
@@ -51,6 +51,9 @@ export class IpcChatTransport implements ChatTransport<CherryUIMessage> {
             mentionedModelIds: mergedBody.mentionedModels,
             ...(mergedBody.temporarySystemPrompt !== undefined && {
               temporarySystemPrompt: mergedBody.temporarySystemPrompt
+            }),
+            ...(mergedBody.temporaryAssistantName !== undefined && {
+              temporaryAssistantName: mergedBody.temporaryAssistantName
             })
           }
 

--- a/src/renderer/transport/IpcChatTransport.ts
+++ b/src/renderer/transport/IpcChatTransport.ts
@@ -48,7 +48,10 @@ export class IpcChatTransport implements ChatTransport<CherryUIMessage> {
             topicId,
             parentAnchorId: mergedBody.parentAnchorId,
             userMessageParts: lastMessage?.parts ?? [],
-            mentionedModelIds: mergedBody.mentionedModels
+            mentionedModelIds: mergedBody.mentionedModels,
+            ...(mergedBody.temporarySystemPrompt !== undefined && {
+              temporarySystemPrompt: mergedBody.temporarySystemPrompt
+            })
           }
 
     streamDispatchCoordinator.dispatch(topicId, ipcRequest)

--- a/src/renderer/types/newMessage.ts
+++ b/src/renderer/types/newMessage.ts
@@ -218,6 +218,9 @@ export type Message = {
   // 跟踪Id
   traceId?: string
 
+  // @-mentioned assistant snapshot for this turn (assistant messages only)
+  temporaryAssistantName?: string
+
   // Agent session identifier used to resume Claude Code runs
   agentSessionId?: string
 

--- a/src/shared/ai/transport/index.ts
+++ b/src/shared/ai/transport/index.ts
@@ -15,6 +15,8 @@ export interface AiChatRequestBody {
    * Empty string is valid. Check with `!== undefined`, not truthiness.
    */
   temporarySystemPrompt?: string
+  /** Name snapshot of the @-mentioned assistant, for display in message history. */
+  temporaryAssistantName?: string
 }
 
 export { applyApprovalDecisions } from './applyApprovalDecisions'

--- a/src/shared/ai/transport/index.ts
+++ b/src/shared/ai/transport/index.ts
@@ -9,6 +9,12 @@ export interface AiChatRequestBody {
   mentionedModels?: UniqueModelId[]
   /** Uploaded file metadata. */
   files?: Array<{ id: string; name: string; type: string; size: number; url: string }>
+  /**
+   * One-shot system prompt from a @-mentioned assistant. Overrides only the system prompt
+   * for this request; all other assistant settings come from the topic's assistant.
+   * Empty string is valid. Check with `!== undefined`, not truthiness.
+   */
+  temporarySystemPrompt?: string
 }
 
 export { applyApprovalDecisions } from './applyApprovalDecisions'

--- a/src/shared/ai/transport/stream.ts
+++ b/src/shared/ai/transport/stream.ts
@@ -109,6 +109,12 @@ export type AiStreamOpenRequest = {
       parentAnchorId?: string
       /** Content of the new user msg. */
       userMessageParts: CherryMessagePart[]
+      /**
+       * One-shot system prompt override from a @-mentioned assistant. Applied only to this
+       * request; topic assistantId and all other assistant settings remain unchanged.
+       * Empty string is valid (overrides to blank). Check with `!== undefined`, not truthiness.
+       */
+      temporarySystemPrompt?: string
     }
   | {
       /** Re-run the assistant under an existing user msg. */
@@ -116,6 +122,7 @@ export type AiStreamOpenRequest = {
       /** Id of the existing user msg whose assistant child(ren) we're regenerating. */
       parentAnchorId: string
       userMessageParts?: never
+      temporarySystemPrompt?: never
     }
 )
 

--- a/src/shared/ai/transport/stream.ts
+++ b/src/shared/ai/transport/stream.ts
@@ -115,6 +115,8 @@ export type AiStreamOpenRequest = {
        * Empty string is valid (overrides to blank). Check with `!== undefined`, not truthiness.
        */
       temporarySystemPrompt?: string
+      /** Name snapshot of the @-mentioned assistant, persisted into assistant message data. */
+      temporaryAssistantName?: string
     }
   | {
       /** Re-run the assistant under an existing user msg. */

--- a/src/shared/ai/transport/stream.ts
+++ b/src/shared/ai/transport/stream.ts
@@ -125,6 +125,7 @@ export type AiStreamOpenRequest = {
       parentAnchorId: string
       userMessageParts?: never
       temporarySystemPrompt?: never
+      temporaryAssistantName?: never
     }
 )
 

--- a/src/shared/data/types/message.ts
+++ b/src/shared/data/types/message.ts
@@ -113,6 +113,8 @@ export type CherryMessagePart = UIMessagePart<CherryDataPartTypes, UITools>
  */
 export interface MessageData {
   parts?: CherryMessagePart[]
+  /** Name snapshot of the @-mentioned assistant at send time. Undefined for ordinary messages. */
+  temporaryAssistantName?: string
 }
 
 // ── Cherry-specific UI message types ────────────────────────────────
@@ -168,6 +170,8 @@ export interface CherryUIMessageMetadata {
   thoughtsTokens?: number
   /** Full persisted stats (tokens + durations) when available. */
   stats?: MessageStats
+  /** Name snapshot of the @-mentioned assistant at send time. Only set on assistant messages. */
+  temporaryAssistantName?: string
 }
 
 /** Cherry Studio's UIMessage with custom metadata and data part types. */

--- a/src/shared/data/types/message.ts
+++ b/src/shared/data/types/message.ts
@@ -361,6 +361,7 @@ export const MessageDataSchema = z.custom<MessageData>((value) => {
   if (typeof value !== 'object' || value === null) return false
   const v = value as MessageData
   if (v.parts !== undefined && !Array.isArray(v.parts)) return false
+  if (v.temporaryAssistantName !== undefined && typeof v.temporaryAssistantName !== 'string') return false
   return true
 })
 


### PR DESCRIPTION
## Summary
- Add temporary @assistant invocation from the input bar alongside existing @model mentions.
- Pass one-shot assistant prompt/name metadata through the chat transport and stream request path.
- Persist the temporary assistant name on assistant messages and preserve it when streamed placeholders are finalized.
- Display the temporary assistant name above the model name in message headers while ordinary replies continue to show only the model.

## Testing
- git diff --check origin/main..HEAD
- pnpm tsc --noEmit
- pnpm exec vitest run --silent=true src/main/ai/streamManager/context/__tests__/PersistentChatContextProvider.test.ts
- pnpm exec vitest run --silent=true src/main/ai/streamManager/listeners/__tests__/PersistenceListener.test.ts