### PR TITLE
fix(reasoning): use adaptive thinking for MiniMax-M3

### DIFF
--- a/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
+++ b/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
@@ -150,6 +150,63 @@ describe('reasoning utils', () => {
       expect(result).toEqual({})
     })
 
+    it('should send thinking.type adaptive for MiniMax-M3 (enabled is rejected by API)', async () => {
+      const { isReasoningModel } = await import('@renderer/config/models')
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+
+      const model: Model = {
+        id: 'MiniMax-M3',
+        name: 'MiniMax-M3',
+        provider: 'minimax'
+      } as Model
+      const assistant: Assistant = {
+        id: 'test',
+        name: 'Test',
+        settings: { reasoning_effort: 'high' }
+      } as Assistant
+
+      const result = getReasoningEffort(assistant, model)
+      expect(result).toEqual({ thinking: { type: 'adaptive' } })
+    })
+
+    it('should send thinking.type enabled for MiniMax M2.x', async () => {
+      const { isReasoningModel } = await import('@renderer/config/models')
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+
+      const model: Model = {
+        id: 'MiniMax-M2.1',
+        name: 'MiniMax-M2.1',
+        provider: 'minimax'
+      } as Model
+      const assistant: Assistant = {
+        id: 'test',
+        name: 'Test',
+        settings: { reasoning_effort: 'high' }
+      } as Assistant
+
+      const result = getReasoningEffort(assistant, model)
+      expect(result).toEqual({ thinking: { type: 'enabled' } })
+    })
+
+    it('should disable thinking for MiniMax-M3 when reasoning effort is none', async () => {
+      const { isReasoningModel } = await import('@renderer/config/models')
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+
+      const model: Model = {
+        id: 'MiniMax-M3',
+        name: 'MiniMax-M3',
+        provider: 'minimax'
+      } as Model
+      const assistant: Assistant = {
+        id: 'test',
+        name: 'Test',
+        settings: { reasoning_effort: 'none' }
+      } as Assistant
+
+      const result = getReasoningEffort(assistant, model)
+      expect(result).toEqual({ thinking: { type: 'disabled' } })
+    })
+
     it('should not override reasoning for OpenRouter when reasoning effort undefined', async () => {
       const { isReasoningModel } = await import('@renderer/config/models')
 

--- a/src/renderer/src/aiCore/utils/reasoning.ts
+++ b/src/renderer/src/aiCore/utils/reasoning.ts
@@ -19,6 +19,7 @@ import {
   isGemini3ThinkingTokenModel,
   isGrok4FastReasoningModel,
   isHostedGemma4ThinkingModel,
+  isMiniMaxM3Model,
   isMiniMaxReasoningModel,
   isOpenAIDeepResearchModel,
   isOpenAIModel,
@@ -56,7 +57,7 @@ import type { OllamaProviderOptions } from 'ollama-ai-provider-v2'
 const logger = loggerService.withContext('reasoning')
 
 type ReasoningEffortOptionalParams = {
-  thinking?: { type: 'disabled' | 'enabled' | 'auto'; budget_tokens?: number }
+  thinking?: { type: 'disabled' | 'enabled' | 'auto' | 'adaptive'; budget_tokens?: number }
   reasoning?: { max_tokens?: number; exclude?: boolean; effort?: string; enabled?: boolean } | OpenAI.Reasoning
   reasoningEffort?: OpenAIReasoningEffort
   // WARN: This field will be overwrite to undefined by aisdk if the provider is openai-compatible. Use reasoningEffort instead.
@@ -107,6 +108,10 @@ export function getReasoningEffort(assistant: Assistant, model: Model): Reasonin
     const reasoningEffort = assistant?.settings?.reasoning_effort
     if (reasoningEffort === 'none') {
       return { thinking: { type: 'disabled' } }
+    }
+    // M3 only accepts 'adaptive' | 'disabled'; M1/M2.x use 'enabled'
+    if (isMiniMaxM3Model(model)) {
+      return { thinking: { type: 'adaptive' } }
     }
     return { thinking: { type: 'enabled' } }
   }

--- a/src/renderer/src/config/models/reasoning.ts
+++ b/src/renderer/src/config/models/reasoning.ts
@@ -767,6 +767,15 @@ export const isMiniMaxReasoningModel = (model?: Model): boolean => {
   )
 }
 
+// MiniMax-M3 only accepts thinking.type 'adaptive' | 'disabled' on the OpenAI-compatible
+// endpoint, unlike M1/M2.x which use 'enabled'.
+export const isMiniMaxM3Model = (model?: Model): boolean => {
+  if (!model) {
+    return false
+  }
+  return getLowerBaseModelName(model.id, '/').includes('minimax-m3')
+}
+
 export const isBaichuanReasoningModel = (model?: Model): boolean => {
   if (!model) {
     return false


### PR DESCRIPTION
### What this PR does

Before this PR:

MiniMax-M3 requests that enable thinking (e.g. when web search is on) sent
`thinking: { "type": "enabled" }` to the OpenAI-compatible endpoint
(`/v1/chat/completions`). M3's endpoint only accepts `adaptive` or
`disabled` for `thinking.type`, so the request failed with HTTP 400:
`invalid params, invalid thinking.type: "enabled" (allowed: adaptive, disabled)`.

After this PR:

MiniMax-M3 sends `thinking: { "type": "adaptive" }` to enable thinking,
which is M3's documented "on" mode. M1/M2.x are unchanged and keep using
`enabled`. The `disabled` path (reasoning effort = none) is unchanged and
works for both.

Fixes #15782

### Why we need it and why it was done in this way

The regression was introduced in #15513, which added an explicit
`thinking: { type: 'enabled' }` branch for all MiniMax reasoning models.
That value is valid for M2.x but rejected by M3's API.

The following tradeoffs were made:
- Special-cased M3 (`isMiniMaxM3Model`) instead of switching every MiniMax
  model to `adaptive`, because M1/M2.x do not support `adaptive`.

The following alternatives were considered:
- Sending `enabled` + `budget_tokens` for M3 (valid on the Anthropic-
  compatible endpoint) — rejected because this fix targets the
  OpenAI-compatible path, which only accepts `adaptive`/`disabled`.

Links to places where the discussion took place: N/A

### Breaking changes

None

### Special notes for your reviewer

- M3 point releases (e.g. `minimax-m3.1`) are matched automatically via the
  `minimax-m3` substring; a future major (M4) would need a new entry.
- The Anthropic-compatible path (`getAnthropicReasoningParams`) is
  intentionally left unchanged.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix MiniMax-M3 returning a 400 error ("invalid thinking.type: enabled") when thinking or web search is enabled.
```
