### PR TITLE
fix(home): hide left topic sidebar and toggle icon when topic position is right

### DIFF
--- a/src/renderer/pages/home/HomePage.tsx
+++ b/src/renderer/pages/home/HomePage.tsx
@@ -147,7 +147,7 @@ const HomePage: FC = () => {
       {isLeftNavbar && <Navbar position="left" />}
       <ContentContainer id={isLeftNavbar ? 'content-container' : undefined}>
         <AnimatePresence initial={false}>
-          {showSidebar && (
+          {showSidebar && topicPosition === 'left' && (
             <ErrorBoundary>
               <motion.div
                 initial={{ width: 0, opacity: 0 }}

--- a/src/renderer/pages/home/Navbar.tsx
+++ b/src/renderer/pages/home/Navbar.tsx
@@ -34,7 +34,7 @@ const HeaderNavbar: FC<Props> = () => {
   return (
     <Navbar className="home-navbar">
       <AnimatePresence initial={false}>
-        {showSidebar && (
+        {topicPosition === 'left' && showSidebar && (
           <motion.div
             initial={{ width: 0, opacity: 0 }}
             animate={{ width: 'auto', opacity: 1 }}
@@ -51,7 +51,7 @@ const HeaderNavbar: FC<Props> = () => {
           </motion.div>
         )}
       </AnimatePresence>
-      {!showSidebar && (
+      {topicPosition === 'left' && !showSidebar && (
         <NavbarLeft
           style={{
             justifyContent: 'flex-start',

--- a/src/renderer/pages/home/components/ChatNavBar/index.tsx
+++ b/src/renderer/pages/home/components/ChatNavBar/index.tsx
@@ -21,6 +21,7 @@ const HeaderNavbar: FC<Props> = ({ assistantId, topicId }) => {
   const [showSidebar, setShowSidebar] = usePreference('topic.tab.show')
   const toggleShowSidebar = () => void setShowSidebar(!showSidebar)
   const { isTopNavbar } = useNavbarPosition()
+  const [topicPosition] = usePreference('topic.position')
 
   useCommandHandler('app.search', () => {
     void SearchPopup.show()
@@ -29,14 +30,14 @@ const HeaderNavbar: FC<Props> = ({ assistantId, topicId }) => {
   return (
     <NavbarHeader className="home-navbar" style={{ height: 'var(--navbar-height)' }}>
       <div className="flex h-full min-w-0 flex-1 shrink items-center overflow-auto">
-        {isTopNavbar && showSidebar && (
+        {isTopNavbar && topicPosition === 'left' && showSidebar && (
           <Tooltip placement="bottom" content={t('navbar.hide_sidebar')} delay={800}>
             <NavbarIcon onClick={toggleShowSidebar}>
               <PanelLeftClose size={18} />
             </NavbarIcon>
           </Tooltip>
         )}
-        {isTopNavbar && !showSidebar && (
+        {isTopNavbar && topicPosition === 'left' && !showSidebar && (
           <Tooltip placement="bottom" content={t('navbar.show_sidebar')} delay={800}>
             <NavbarIcon onClick={toggleShowSidebar} style={{ marginRight: 8 }}>
               <PanelRightClose size={18} />


### PR DESCRIPTION
### What this PR does

Before this PR:

<img width="1971" height="1351" alt="image" src="https://github.com/user-attachments/assets/39c6112b-2e73-4cfa-be47-c43462e750af" />



When the topic position was set to **right**, the left topic sidebar and its collapse/expand toggle icon were not hidden. As a result, both the left and right sidebars (and their toggle icons) showed at the same time — the left ones should have been hidden.

After this PR:

The left-side topic sidebar and its toggle icons are gated on `topicPosition === 'left'`, so only the side matching the configured position is rendered. Fixed in three places covering the content area and both navbar layouts:

- `HomePage.tsx` — content-area left topic sidebar
- `Navbar.tsx` — left-navbar layout toggle icons
- `components/ChatNavBar/index.tsx` — top-navbar layout toggle icons

Fixes #

### Why we need it and why it was done in this way

The right-side rendering was already gated on `topicPosition === 'right'`, but the left-side rendering only checked `showSidebar` (`topic.tab.show`) and ignored the position. Adding the symmetric `topicPosition === 'left'` guard is the minimal, consistent fix.

The following tradeoffs were made:

None.

The following alternatives were considered:

None.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

N/A

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required (no documented behavior, only a visual duplication bug fix)
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix duplicated topic sidebar and toggle icon showing on both sides when the topic position is set to the right.
```
