### PR TITLE
feat(settings-window): remove native title bar in favor of frameless chrome

### DIFF
--- a/src/main/core/window/__tests__/windowRegistry.test.ts
+++ b/src/main/core/window/__tests__/windowRegistry.test.ts
@@ -239,3 +239,27 @@ describe('WINDOW_TYPE_REGISTRY Main window — frame contract', () => {
     expect(result.titleBarStyle).toBe('hidden')
   })
 })
+
+// The Settings window mirrors Main's frameless contract: no native title bar on
+// macOS (hidden title bar + traffic lights) and frameless on Windows. The renderer
+// draws its own top region (SettingsPage's top bar + WindowControls). Linux frame is
+// injected at open() time from `app.use_system_title_bar` (SettingsWindowService), so
+// it is intentionally absent from the registry here.
+describe('WINDOW_TYPE_REGISTRY Settings window — frame contract', () => {
+  beforeEach(() => {
+    resetPlatform()
+  })
+
+  it('is frameless on Windows (frame:false sourced from the registry)', () => {
+    platform.isWin = true
+    expect(mergeWindowOptions(WindowType.Settings).frame).toBe(false)
+  })
+
+  it('uses a hidden native title bar with traffic lights on macOS', () => {
+    platform.isMac = true
+    const result = mergeWindowOptions(WindowType.Settings)
+    expect(result.frame).toBeUndefined()
+    expect(result.titleBarStyle).toBe('hidden')
+    expect(result.trafficLightPosition).toEqual({ x: 13, y: 16 })
+  })
+})

--- a/src/main/core/window/windowRegistry.ts
+++ b/src/main/core/window/windowRegistry.ts
@@ -101,6 +101,9 @@ export const WINDOW_TYPE_REGISTRY: Partial<Record<WindowType, WindowTypeMetadata
   // Settings window — singleton popup surface for application settings.
   // The renderer consumes initData as the target /settings/* route, so open()
   // can focus an existing settings window and navigate it in-place.
+  // Frameless on all platforms (mirrors Main/SubWindow): the renderer draws its own
+  // top region — traffic lights on macOS, WindowControls on Win/Linux — so there is no
+  // native title bar. See SettingsPage's top bar + SettingsApp's `--navbar-height`.
   [WindowType.Settings]: {
     type: WindowType.Settings,
     lifecycle: 'singleton',
@@ -118,6 +121,20 @@ export const WINDOW_TYPE_REGISTRY: Partial<Record<WindowType, WindowTypeMetadata
       transparent: false,
       vibrancy: 'sidebar',
       visualEffectState: 'active',
+      platformOverrides: {
+        mac: {
+          titleBarStyle: 'hidden',
+          trafficLightPosition: { x: 13, y: 16 },
+          // WCO height; consumed by renderer's env(titlebar-area-height). Mirrors Main.
+          titleBarOverlay: { height: 42 }
+        },
+        win: {
+          // Frameless + renderer-drawn WindowControls (mirrors Main/SubWindow).
+          frame: false
+        }
+        // linux: frame honors `app.use_system_title_bar` preference → injected via
+        //        args.options in SettingsWindowService (mirrors MainWindowService).
+      },
       webPreferences: {
         contextIsolation: true,
         nodeIntegration: false,

--- a/src/main/services/SettingsWindowService.ts
+++ b/src/main/services/SettingsWindowService.ts
@@ -1,7 +1,7 @@
 import { application } from '@application'
 import { loggerService } from '@logger'
 import { BaseService, DependsOn, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
-import { isMac } from '@main/core/platform'
+import { isLinux, isMac } from '@main/core/platform'
 import { type WindowOptions, WindowType } from '@main/core/window/types'
 import type { SettingsPath } from '@shared/data/types/settingsPath'
 import { normalizeSettingsPath } from '@shared/data/types/settingsPath'
@@ -94,6 +94,9 @@ export class SettingsWindowService extends BaseService {
   private getWindowOptions(): Partial<WindowOptions> {
     return {
       ...createSettingsWindowOptions(isMac, nativeTheme.shouldUseDarkColors),
+      // Linux frame honors the user's system-title-bar preference (mirrors MainWindowService):
+      // false → frameless with renderer-drawn WindowControls; true → native title bar.
+      ...(isLinux && { frame: application.get('PreferenceService').get('app.use_system_title_bar') }),
       ...this.getCenteredBoundsOptions()
     }
   }

--- a/src/main/services/__tests__/SettingsWindowService.test.ts
+++ b/src/main/services/__tests__/SettingsWindowService.test.ts
@@ -11,9 +11,13 @@ const { applicationMock, windowManagerMock } = vi.hoisted(() => {
     onWindowCreatedByType: vi.fn(() => ({ dispose: vi.fn() })),
     onWindowDestroyedByType: vi.fn(() => ({ dispose: vi.fn() }))
   }
+  const preferenceServiceMock = {
+    get: vi.fn<(key: string) => unknown>((key: string) => (key === 'app.use_system_title_bar' ? false : undefined))
+  }
   const applicationMock = {
     get: vi.fn((name: string) => {
       if (name === 'WindowManager') return windowManagerMock
+      if (name === 'PreferenceService') return preferenceServiceMock
       throw new Error(`unexpected service: ${name}`)
     })
   }

--- a/src/renderer/pages/settings/SettingsPage.tsx
+++ b/src/renderer/pages/settings/SettingsPage.tsx
@@ -1,7 +1,9 @@
 import { MenuDivider, MenuItem, MenuList, PageHeader } from '@cherrystudio/ui'
+import { usePreference } from '@data/hooks/usePreference'
 import { McpLogo } from '@renderer/components/Icons'
 import Scrollbar from '@renderer/components/Scrollbar'
-import { isDev } from '@renderer/config/constant'
+import WindowControls from '@renderer/components/WindowControls'
+import { isDev, isLinux, isMac } from '@renderer/config/constant'
 import useMacTransparentWindow from '@renderer/hooks/useMacTransparentWindow'
 import { cn } from '@renderer/utils/style'
 import { Outlet, useLocation, useNavigate } from '@tanstack/react-router'
@@ -40,6 +42,10 @@ const SettingsPage: FC = () => {
   const { pathname } = location
   const { t } = useTranslation()
   const isMacTransparentWindow = useMacTransparentWindow()
+  const [useSystemTitleBar] = usePreference('app.use_system_title_bar')
+  // Frameless windows host the "应用设置" title in the top region (next to the traffic lights);
+  // the Linux native-title-bar path has no top region, so it keeps the sidebar header instead.
+  const hasCustomTitleBar = !isLinux || !useSystemTitleBar
 
   const isActive = (path: string) => pathname === path || pathname.startsWith(`${path}/`)
   const go = (path: string) => navigate({ to: path })
@@ -50,14 +56,42 @@ const SettingsPage: FC = () => {
         'flex min-h-0 flex-1 flex-col',
         isMacTransparentWindow ? 'bg-transparent' : 'bg-white dark:bg-background'
       )}>
+      {/* Frameless top region (replaces the native title bar): draggable, height driven by
+          `--navbar-height` (0 when a native title bar is used). Split at `--settings-width`
+          so each segment continues its column upward — left holds the "应用设置" title past the
+          macOS traffic lights, right hosts WindowControls on Win/Linux. */}
+      <div className="flex h-(--navbar-height) shrink-0 [-webkit-app-region:drag]">
+        <div
+          className={cn(
+            'flex w-(--settings-width) min-w-(--settings-width) items-center',
+            isMacTransparentWindow ? 'bg-transparent' : 'bg-white dark:bg-background'
+          )}>
+          {hasCustomTitleBar && (
+            <h2
+              className={cn(
+                'truncate font-medium text-foreground text-sm leading-none',
+                isMac ? 'pl-[env(titlebar-area-x)]' : 'pl-5'
+              )}>
+              {t('settings.menuGroups.appSettings')}
+            </h2>
+          )}
+        </div>
+        <div
+          className={cn(
+            'flex min-w-0 flex-1 justify-end border-border/40 border-l',
+            isMacTransparentWindow ? 'bg-transparent' : 'bg-white dark:bg-background'
+          )}>
+          <WindowControls />
+        </div>
+      </div>
       <div className="flex min-h-0 flex-1 flex-row">
         <div
           className={cn(
             'flex min-h-0 w-(--settings-width) min-w-(--settings-width) flex-col',
             isMacTransparentWindow ? 'bg-transparent' : 'bg-white dark:bg-background'
           )}>
-          <PageHeader title={t('settings.menuGroups.appSettings')} />
-          <Scrollbar className="min-h-0 flex-1 select-none">
+          {!hasCustomTitleBar && <PageHeader title={t('settings.menuGroups.appSettings')} />}
+          <Scrollbar className={cn('min-h-0 flex-1 select-none', hasCustomTitleBar && 'pt-2')}>
             <MenuList className={settingsSubmenuListClassName}>
               <div className={settingsSubmenuSectionTitleClassName}>{t('settings.menuGroups.integrations')}</div>
               <MenuItem

--- a/src/renderer/windows/settings/SettingsApp.tsx
+++ b/src/renderer/windows/settings/SettingsApp.tsx
@@ -1,5 +1,7 @@
 import { Alert, Button } from '@cherrystudio/ui'
+import { usePreference } from '@data/hooks/usePreference'
 import TopViewContainer from '@renderer/components/TopView'
+import { isLinux } from '@renderer/config/constant'
 import AntdProvider from '@renderer/context/AntdProvider'
 import { CodeStyleProvider } from '@renderer/context/CodeStyleProvider'
 import { NotificationProvider } from '@renderer/context/NotificationProvider'
@@ -68,8 +70,16 @@ function SettingsWindowRouter({ initialPath }: { initialPath: string }) {
 }
 
 function SettingsApp({ initialPath }: { initialPath: string }): React.ReactElement {
-  const shellStyle = { '--navbar-height': '0px', '--settings-width': '200px' } as CSSProperties
   const isMacTransparentWindow = useMacTransparentWindow()
+  const [useSystemTitleBar] = usePreference('app.use_system_title_bar')
+  // Frameless on macOS/Windows always, and on Linux unless the user opted into the system
+  // title bar. Frameless windows reserve `--navbar-height` for the top region (traffic lights
+  // / WindowControls) drawn by SettingsPage; a native title bar reserves nothing.
+  const hasCustomTitleBar = !isLinux || !useSystemTitleBar
+  const shellStyle = {
+    '--navbar-height': hasCustomTitleBar ? '42px' : '0px',
+    '--settings-width': '200px'
+  } as CSSProperties
 
   return (
     <Provider store={store}>

--- a/src/renderer/windows/settings/entryPoint.tsx
+++ b/src/renderer/windows/settings/entryPoint.tsx
@@ -15,6 +15,7 @@ loggerService.initWindowSource('SettingsWindow')
 
 const SETTINGS_SHELL_PREFERENCE_KEYS: UnifiedPreferenceKeyType[] = [
   'app.language',
+  'app.use_system_title_bar',
   'ui.theme_mode',
   'ui.window_style',
   'ui.theme_user.color_primary',


### PR DESCRIPTION
### What this PR does

Before this PR:

- The Settings window used the default native frame, so on macOS it showed an empty native title bar (a dark strip above the content) that looked out of place.

After this PR:

- The Settings window is frameless on all platforms, mirroring the Main/SubWindow pattern:
  - **macOS**: `titleBarStyle: 'hidden'` with native traffic lights positioned over the top region.
  - **Windows**: `frame: false` + renderer-drawn `WindowControls` (min/max/close).
  - **Linux**: frame honors the `app.use_system_title_bar` preference (frameless by default, native title bar if opted in), injected at `open()` time by `SettingsWindowService` like `MainWindowService`.
- The renderer reserves a draggable top region (`--navbar-height`, `0` when a native title bar is used) split at `--settings-width`, so each segment continues its column upward. The left segment hosts the "应用设置" title next to the traffic lights; the right segment hosts `WindowControls` on Win/Linux.
- All settings pages already size content as `calc(100vh - var(--navbar-height))`, so they reflow below the new top region automatically.

Fixes #

### Why we need it and why it was done in this way

The native title bar was purely chrome and looked unpolished on macOS. Making the window frameless and drawing our own top region matches what the Main and SubWindow already do, so the approach reuses existing infrastructure (`WindowControls`, the `--navbar-height` convention, the `platformOverrides` registry layer).

The following tradeoffs were made:

- Promoted the "应用设置" title into the top region (next to the traffic lights) instead of leaving it as a sidebar header, so the otherwise-empty draggable strip reads as intentional and the menu gains vertical room.
- Kept the original sidebar header on the Linux native-title-bar path, where there is no top region to host the title.

The following alternatives were considered:

- A full-width top bar with its own background — rejected because it still reads as a title bar; the split-segment approach blends seamlessly into the two columns.
- macOS-only frameless — rejected in favor of cross-platform parity with Main/SubWindow.

Links to places where the discussion took place: N/A

### Breaking changes

None. The window is moved by dragging the top region instead of a native title bar; no data, settings, or workflows change.

### Special notes for your reviewer

- macOS uses `env(titlebar-area-x)` to indent the title past the traffic lights (same pattern as `AppShellTabBar`).
- Added frame-contract tests for the Settings window in `windowRegistry.test.ts` and extended the `SettingsWindowService` test mock with `PreferenceService` (the service now reads it on Linux).
- Verified locally: `pnpm format`, `pnpm lint` (typecheck + i18n + oxlint/eslint), and the affected Vitest suites pass. The change has not been visually verified in a running build.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
The Settings window no longer shows a native title bar — it is now frameless with custom window chrome (macOS traffic lights / Windows & Linux window controls), and the "应用设置" title sits in the top region.
```
