### PR TITLE
fix(chat): resolve thinking timer bugs, timing display truncation, and mock leaks

### DIFF
--- a/src/main/ai/streamManager/__tests__/reasoningTimingTransform.test.ts
+++ b/src/main/ai/streamManager/__tests__/reasoningTimingTransform.test.ts
@@ -85,7 +85,11 @@ describe('withReasoningTimingMetadata', () => {
       providerMetadata: { openai: Record<string, unknown>; cherry: Record<string, unknown> }
     }
     expect(reasoningEnd.providerMetadata.openai).toEqual({ itemId: 'provider-item' })
-    expect(reasoningEnd.providerMetadata.cherry).toEqual({ existing: true, thinkingMs: 25 })
+    expect(reasoningEnd.providerMetadata.cherry).toEqual({
+      existing: true,
+      thinkingMs: 25,
+      startedAt: expect.any(Number)
+    })
   })
 
   it('merges reasoning-start provider metadata into the reasoning-end chunk', async () => {
@@ -126,7 +130,8 @@ describe('withReasoningTimingMetadata', () => {
     expect(reasoningEnd.providerMetadata.cherry).toEqual({
       transport: 'claude-agent',
       existing: true,
-      thinkingMs: 25
+      thinkingMs: 25,
+      startedAt: expect.any(Number)
     })
   })
 
@@ -216,7 +221,8 @@ describe('withReasoningTimingMetadata', () => {
     expect(finalReasoningPart?.providerMetadata?.['claude-code']).toEqual({ parentToolCallId: 'parent-tool' })
     expect(finalReasoningPart?.providerMetadata?.cherry).toEqual({
       transport: 'claude-agent',
-      thinkingMs: 350
+      thinkingMs: 350,
+      startedAt: expect.any(Number)
     })
   })
 
@@ -255,5 +261,34 @@ describe('withReasoningTimingMetadata', () => {
       expect.stringContaining('reasoning-start received for an id that was never ended'),
       expect.objectContaining({ id: 'r1' })
     )
+  })
+
+  it('injects startedAt in start chunk and preserves it in reasoning-end chunk and final accumulated message', async () => {
+    const baseTime = 1780913860106
+    vi.spyOn(Date, 'now').mockReturnValue(baseTime)
+    vi.spyOn(performance, 'now').mockReturnValueOnce(100).mockReturnValueOnce(450).mockReturnValueOnce(1000)
+
+    const result = await pipeStreamLoop(
+      withReasoningTimingMetadata(
+        streamFrom([
+          { type: 'start' } as UIMessageChunk,
+          { type: 'reasoning-start', id: 'r1' } as UIMessageChunk,
+          { type: 'reasoning-delta', id: 'r1', delta: 'steady thought' } as UIMessageChunk,
+          { type: 'reasoning-end', id: 'r1' } as UIMessageChunk,
+          { type: 'finish' } as UIMessageChunk
+        ])
+      ),
+      new AbortController().signal,
+      { onChunk: () => {} }
+    )
+
+    const finalReasoningPart = result.finalMessage?.parts.find((part) => part.type === 'reasoning') as
+      | { providerMetadata?: Record<string, unknown> }
+      | undefined
+
+    expect(finalReasoningPart?.providerMetadata?.cherry).toEqual({
+      startedAt: baseTime,
+      thinkingMs: 350
+    })
   })
 })

--- a/src/main/ai/streamManager/persistence/PersistenceBackend.ts
+++ b/src/main/ai/streamManager/persistence/PersistenceBackend.ts
@@ -10,6 +10,7 @@
 
 import type { CherryMessagePart, CherryUIMessage, MessageStats } from '@shared/data/types/message'
 import type { UniqueModelId } from '@shared/data/types/model'
+import { type CherryReasoningMeta, readCherryMeta, withCherryMeta } from '@shared/data/types/uiParts'
 
 import type { SemanticTimings, TransportTimings } from '../types'
 
@@ -27,6 +28,32 @@ export function finalizeInterruptedParts(
   if (status === 'success') return parts
   const reason = status === 'paused' ? 'Interrupted by user' : 'Stream errored before tool completed'
   return parts.map((part) => {
+    if (part.type === 'reasoning') {
+      if (part.state === 'streaming') {
+        const cherry = readCherryMeta(part)
+        const startedAt = cherry?.startedAt
+        const thinkingMs = cherry?.thinkingMs
+
+        let patch: Partial<CherryReasoningMeta> = {}
+        if (typeof startedAt === 'number' && Number.isFinite(startedAt) && typeof thinkingMs !== 'number') {
+          patch = {
+            thinkingMs: Math.max(0, Date.now() - startedAt)
+          }
+        }
+
+        // TODO(stream-manager-redesign): AI SDK's ReasoningUIPart currently only supports 'streaming' | 'done'.
+        // Investigate expanding the state machine with an 'error' terminal state.
+        return withCherryMeta(
+          {
+            ...part,
+            state: 'done'
+          },
+          patch
+        )
+      }
+      return part
+    }
+
     if (!isToolPart(part)) return part
     const toolPart = part as CherryMessagePart & { state?: string; errorText?: string }
     if (toolPart.state && TERMINAL_TOOL_STATES.has(toolPart.state)) return part

--- a/src/main/ai/streamManager/persistence/__tests__/PersistenceBackend.test.ts
+++ b/src/main/ai/streamManager/persistence/__tests__/PersistenceBackend.test.ts
@@ -8,7 +8,7 @@
  */
 
 import type { CherryMessagePart } from '@shared/data/types/message'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { finalizeInterruptedParts } from '../PersistenceBackend'
 
@@ -37,6 +37,10 @@ function inProgressDynamicToolPart(): CherryMessagePart {
 const textPart = (text: string): CherryMessagePart => ({ type: 'text', text }) as unknown as CherryMessagePart
 
 describe('finalizeInterruptedParts', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('returns parts unchanged (by reference) on success', () => {
     const parts: CherryMessagePart[] = [textPart('hi'), inProgressToolPart('input-available')]
 
@@ -166,5 +170,47 @@ describe('finalizeInterruptedParts', () => {
     expect(result[1]).toBe(reasoning)
     // only the tool part is rewritten
     expect(result[2]).toMatchObject({ state: 'output-error', errorText: 'Stream errored before tool completed' })
+  })
+
+  it('rewrites a streaming reasoning part to done and calculates thinkingMs if startedAt is provided', () => {
+    const baseTime = 1780913860106
+    vi.spyOn(Date, 'now').mockReturnValue(baseTime)
+    const startedAt = baseTime - 5000 // 5 seconds ago
+    const streamingReasoning = {
+      type: 'reasoning',
+      text: 'thinking...',
+      state: 'streaming',
+      providerMetadata: {
+        cherry: {
+          startedAt
+        }
+      }
+    } as unknown as CherryMessagePart
+
+    const result = finalizeInterruptedParts([streamingReasoning], 'paused')
+
+    expect(result[0]).toMatchObject({
+      type: 'reasoning',
+      state: 'done'
+    })
+    const cherryMeta = (result[0] as any).providerMetadata?.cherry
+    expect(cherryMeta?.thinkingMs).toBe(5000)
+  })
+
+  it('rewrites a streaming reasoning part to done but leaves thinkingMs undefined if startedAt is missing', () => {
+    const streamingReasoning = {
+      type: 'reasoning',
+      text: 'thinking...',
+      state: 'streaming'
+    } as unknown as CherryMessagePart
+
+    const result = finalizeInterruptedParts([streamingReasoning], 'paused')
+
+    expect(result[0]).toMatchObject({
+      type: 'reasoning',
+      state: 'done'
+    })
+    const cherryMeta = (result[0] as any).providerMetadata?.cherry
+    expect(cherryMeta?.thinkingMs).toBeUndefined()
   })
 })

--- a/src/main/ai/streamManager/reasoningTimingTransform.ts
+++ b/src/main/ai/streamManager/reasoningTimingTransform.ts
@@ -16,14 +16,16 @@
  */
 
 import { loggerService } from '@logger'
+import { CherryReasoningMetaSchema, type CherryReasoningMeta } from '@shared/data/types/uiParts'
 import type { ProviderMetadata, UIMessageChunk } from 'ai'
 
 const logger = loggerService.withContext('reasoningTimingTransform')
 
-type ReasoningEndChunk = Extract<UIMessageChunk, { type: 'reasoning-end' }>
-
 export function withReasoningTimingMetadata(stream: ReadableStream<UIMessageChunk>): ReadableStream<UIMessageChunk> {
-  const reasoningById = new Map<string, { startedAt: number; providerMetadata?: ProviderMetadata }>()
+  const reasoningById = new Map<
+    string,
+    { startedAt: number; epochStartedAt: number; providerMetadata?: ProviderMetadata }
+  >()
 
   return stream.pipeThrough(
     new TransformStream<UIMessageChunk, UIMessageChunk>({
@@ -34,11 +36,13 @@ export function withReasoningTimingMetadata(stream: ReadableStream<UIMessageChun
               id: chunk.id
             })
           }
+          const epochNow = Date.now()
           reasoningById.set(chunk.id, {
             startedAt: performance.now(),
+            epochStartedAt: epochNow,
             providerMetadata: toProviderMetadata(chunk.providerMetadata)
           })
-          controller.enqueue(chunk)
+          controller.enqueue(withChunkCherryMeta(chunk, { startedAt: epochNow }))
           return
         }
 
@@ -46,8 +50,17 @@ export function withReasoningTimingMetadata(stream: ReadableStream<UIMessageChun
           const reasoning = reasoningById.get(chunk.id)
           if (reasoning) {
             reasoningById.delete(chunk.id)
+            const thinkingMs = Math.round(performance.now() - reasoning.startedAt)
+
             controller.enqueue(
-              withThinkingMs(chunk, Math.round(performance.now() - reasoning.startedAt), reasoning.providerMetadata)
+              withChunkCherryMeta(
+                chunk,
+                {
+                  startedAt: reasoning.epochStartedAt,
+                  thinkingMs
+                },
+                reasoning.providerMetadata
+              )
             )
             return
           }
@@ -60,24 +73,32 @@ export function withReasoningTimingMetadata(stream: ReadableStream<UIMessageChun
   )
 }
 
-function withThinkingMs(
-  chunk: ReasoningEndChunk,
-  thinkingMs: number,
-  startProviderMetadata: ProviderMetadata | undefined
-): ReasoningEndChunk {
-  const endProviderMetadata = toProviderMetadata(chunk.providerMetadata)
+function withChunkCherryMeta<C extends UIMessageChunk>(
+  chunk: C,
+  patch: CherryReasoningMeta,
+  startProviderMetadata?: ProviderMetadata
+): C {
+  const parsed = CherryReasoningMetaSchema.safeParse(patch)
+  if (!parsed.success) {
+    logger.warn('Failed to parse reasoning timing metadata chunk, falling back to empty patch', {
+      issues: parsed.error.issues.length
+    })
+  }
+  const cleanPatch = parsed.success ? parsed.data : {}
+
+  const endMeta = 'providerMetadata' in chunk ? toProviderMetadata(chunk.providerMetadata) : undefined
   const startCherry = isRecord(startProviderMetadata?.cherry) ? startProviderMetadata.cherry : {}
-  const endCherry = isRecord(endProviderMetadata?.cherry) ? endProviderMetadata.cherry : {}
+  const endCherry = isRecord(endMeta?.cherry) ? endMeta.cherry : {}
 
   return {
     ...chunk,
     providerMetadata: {
       ...startProviderMetadata,
-      ...endProviderMetadata,
+      ...endMeta,
       cherry: {
         ...startCherry,
         ...endCherry,
-        thinkingMs
+        ...cleanPatch
       }
     }
   }

--- a/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
@@ -324,6 +324,7 @@ function renderPart(
       const thinkingMs =
         cherryMeta?.thinkingMs ??
         (typeof metadataBlock?.thinking_millsec === 'number' ? metadataBlock.thinking_millsec : 0)
+      const startedAt = cherryMeta?.startedAt
       return (
         <ThinkingBlock
           key={partId}
@@ -331,6 +332,7 @@ function renderPart(
           content={reasoningPart.text || ''}
           isStreaming={reasoningPart.state === 'streaming'}
           thinkingMs={thinkingMs}
+          startedAt={startedAt}
         />
       )
     }

--- a/src/renderer/components/chat/messages/blocks/ThinkingBlock.tsx
+++ b/src/renderer/components/chat/messages/blocks/ThinkingBlock.tsx
@@ -20,9 +20,11 @@ interface Props {
   isStreaming: boolean
   /** Thinking duration in milliseconds */
   thinkingMs: number
+  /** Thinking start timestamp in epoch ms */
+  startedAt?: number
 }
 
-const ThinkingBlock: React.FC<Props> = ({ id, content, isStreaming, thinkingMs }) => {
+const ThinkingBlock: React.FC<Props> = ({ id, content, isStreaming, thinkingMs, startedAt }) => {
   const block = useMemo<MarkdownSource>(
     () => ({
       id,
@@ -82,7 +84,9 @@ const ThinkingBlock: React.FC<Props> = ({ id, content, isStreaming, thinkingMs }
         <ThinkingEffect
           expanded={isExpanded}
           isThinking={isThinking}
-          thinkingTimeText={<ThinkingTimeSeconds blockThinkingTime={thinkingMs} isThinking={isThinking} />}
+          thinkingTimeText={
+            <ThinkingTimeSeconds blockThinkingTime={thinkingMs} isThinking={isThinking} startedAt={startedAt} />
+          }
           trailing={
             copyText ? (
               <Tooltip content={t('common.copy')} delay={800}>
@@ -122,17 +126,41 @@ const ThinkingBlock: React.FC<Props> = ({ id, content, isStreaming, thinkingMs }
 const normalizeThinkingTime = (value?: number) => (typeof value === 'number' && Number.isFinite(value) ? value : 0)
 
 const ThinkingTimeSeconds = memo(
-  ({ blockThinkingTime, isThinking }: { blockThinkingTime: number; isThinking: boolean }) => {
+  ({
+    blockThinkingTime,
+    isThinking,
+    startedAt
+  }: {
+    blockThinkingTime: number
+    isThinking: boolean
+    startedAt?: number
+  }) => {
     const { t } = useTranslation()
-    const [displayTime, setDisplayTime] = useState(isThinking ? 0 : normalizeThinkingTime(blockThinkingTime))
+
+    const safeStartedAt = typeof startedAt === 'number' && Number.isFinite(startedAt) ? startedAt : undefined
+
+    const [displayTime, setDisplayTime] = useState(() => {
+      if (!isThinking) return normalizeThinkingTime(blockThinkingTime)
+      if (safeStartedAt !== undefined) {
+        return Math.max(0, Date.now() - safeStartedAt)
+      }
+      return 0
+    })
 
     const timer = useRef<NodeJS.Timeout | null>(null)
 
     useEffect(() => {
       if (isThinking) {
+        if (safeStartedAt !== undefined) {
+          setDisplayTime(Math.max(0, Date.now() - safeStartedAt))
+        }
         if (!timer.current) {
           timer.current = setInterval(() => {
-            setDisplayTime((prev) => prev + 100)
+            if (safeStartedAt !== undefined) {
+              setDisplayTime(Math.max(0, Date.now() - safeStartedAt))
+            } else {
+              setDisplayTime((prev) => prev + 100)
+            }
           }, 100)
         }
       } else {
@@ -141,9 +169,7 @@ const ThinkingTimeSeconds = memo(
           timer.current = null
         }
         const normalized = normalizeThinkingTime(blockThinkingTime)
-        if (normalized > 0) {
-          setDisplayTime(normalized)
-        }
+        setDisplayTime(normalized)
       }
 
       return () => {
@@ -152,12 +178,16 @@ const ThinkingTimeSeconds = memo(
           timer.current = null
         }
       }
-    }, [isThinking, blockThinkingTime])
+    }, [isThinking, blockThinkingTime, safeStartedAt])
 
     const thinkingTimeSeconds = useMemo(() => {
       const safeTime = normalizeThinkingTime(displayTime)
-      return ((safeTime < 1000 ? 100 : safeTime) / 1000).toFixed(1)
+      return ((safeTime < 100 ? 100 : safeTime) / 1000).toFixed(1)
     }, [displayTime])
+
+    if (!isThinking && normalizeThinkingTime(blockThinkingTime) <= 0) {
+      return t('common.reasoning_content')
+    }
 
     return isThinking
       ? t('chat.thinking', {

--- a/src/renderer/components/chat/messages/blocks/__tests__/ThinkingBlock.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/ThinkingBlock.test.tsx
@@ -22,6 +22,7 @@ type ThinkingBlockFixture = {
   content: string
   status: 'success' | 'streaming'
   thinkingMs: number
+  startedAt?: number
 }
 
 vi.mock('../../MessageListProvider', () => ({
@@ -84,6 +85,7 @@ describe('ThinkingBlock', () => {
         if (key === 'chat.deeply_thought' && params?.seconds) {
           return `Thought for ${params.seconds}s`
         }
+        if (key === 'common.reasoning_content') return 'Deep reasoning'
         if (key === 'common.copy') return 'Copy'
         if (key === 'message.copied') return 'Copied'
         if (key === 'common.copy_failed') return 'Copy failed'
@@ -107,6 +109,7 @@ describe('ThinkingBlock', () => {
     status: 'success',
     content: 'I need to think about this carefully...',
     thinkingMs: 5000,
+    startedAt: undefined,
     ...overrides
   })
 
@@ -117,6 +120,7 @@ describe('ThinkingBlock', () => {
         content={block.content}
         isStreaming={block.status === 'streaming'}
         thinkingMs={block.thinkingMs}
+        startedAt={block.startedAt}
       />
     )
   }
@@ -201,7 +205,7 @@ describe('ThinkingBlock', () => {
 
     it('should handle extreme thinking times correctly', () => {
       const testCases = [
-        { thinkingMs: 0, expectedTime: '0.1s' },
+        { thinkingMs: 0, expectedTime: 'Deep reasoning' },
         { thinkingMs: 86400000, expectedTime: '86400.0s' },
         { thinkingMs: 259200000, expectedTime: '259200.0s' }
       ]
@@ -226,9 +230,68 @@ describe('ThinkingBlock', () => {
           status: 'success'
         })
         const { unmount } = renderThinkingBlock(block)
-        expect(getThinkingTimeText()).toHaveTextContent('0.1s')
+        expect(getThinkingTimeText()).toHaveTextContent('Deep reasoning')
         unmount()
       })
+    })
+
+    it('should calculate active thinking time dynamically using startedAt if provided', () => {
+      const baseTime = 1780913860106
+      const dateSpy = vi.spyOn(Date, 'now').mockReturnValue(baseTime)
+      const startedAt = baseTime - 4500 // 4.5 seconds ago
+
+      // 1. Initial mount with isStreaming=true
+      const block = createThinkingBlock({
+        thinkingMs: 0,
+        status: 'streaming',
+        startedAt
+      })
+      const { unmount } = renderThinkingBlock(block)
+
+      // Time should be calculated as Date.now() - startedAt = 4500ms -> 4.5s
+      expect(getThinkingTimeText()).toHaveTextContent('Thinking... 4.5s')
+
+      // 2. Advance clock by 1.2 seconds, verify it updates correctly
+      dateSpy.mockReturnValue(baseTime + 1200)
+      act(() => {
+        vi.advanceTimersByTime(1200)
+      })
+      expect(getThinkingTimeText()).toHaveTextContent('Thinking... 5.7s')
+
+      // 3. Remount (simulate changing session / component remount)
+      unmount()
+      const { unmount: unmount2 } = renderThinkingBlock(block)
+      expect(getThinkingTimeText()).toHaveTextContent('Thinking... 5.7s')
+      unmount2()
+    })
+
+    it('should keep a static time when stream is finished, even if startedAt is provided', () => {
+      const baseTime = 1780913860106
+      const dateSpy = vi.spyOn(Date, 'now').mockReturnValue(baseTime)
+      const startedAt = baseTime - 5000
+
+      // 1. Mount with status: 'success' and a fixed thinkingMs: 5000 (5.0s)
+      const block = createThinkingBlock({
+        thinkingMs: 5000,
+        status: 'success',
+        startedAt
+      })
+      const { unmount } = renderThinkingBlock(block)
+
+      expect(getThinkingTimeText()).toHaveTextContent('Thought for 5.0s')
+
+      // 2. Advance clock by 10 seconds, verify it stays at 5.0s (does not tick)
+      dateSpy.mockReturnValue(baseTime + 10000)
+      act(() => {
+        vi.advanceTimersByTime(10000)
+      })
+      expect(getThinkingTimeText()).toHaveTextContent('Thought for 5.0s')
+
+      // 3. Remount (simulate switching session back), verify it still renders 5.0s
+      unmount()
+      const { unmount: unmount2 } = renderThinkingBlock(block)
+      expect(getThinkingTimeText()).toHaveTextContent('Thought for 5.0s')
+      unmount2()
     })
   })
 

--- a/src/renderer/windows/quickAssistant/home/HomeWindow.tsx
+++ b/src/renderer/windows/quickAssistant/home/HomeWindow.tsx
@@ -15,6 +15,7 @@ import { getTextFromParts } from '@renderer/utils/messageUtils/partsHelpers'
 import { defaultLanguage } from '@shared/config/constant'
 import { ThemeMode } from '@shared/data/preference/preferenceTypes'
 import type { CherryMessagePart, CherryUIMessage, ModelSnapshot } from '@shared/data/types/message'
+import { readCherryMeta, withCherryMeta, type CherryReasoningMeta } from '@shared/data/types/uiParts'
 import { IpcChannel } from '@shared/IpcChannel'
 import { Divider } from 'antd'
 import { isEmpty } from 'lodash'
@@ -37,6 +38,37 @@ const logger = loggerService.withContext('HomeWindow')
 const EMPTY_UI_MESSAGES: CherryUIMessage[] = []
 
 type MiniRoute = 'home' | 'chat' | 'translate' | 'summary' | 'explanation'
+
+/**
+ * Finalize a list of live assistant messages: turn any still-streaming
+ * reasoning part into `state: 'done'`, deriving `thinkingMs` from
+ * `startedAt` if the upstream hasn't set it yet. Called when the execution
+ * transitions from active to inactive.
+ */
+const finalizeLiveMessages = (messages: CherryUIMessage[]): CherryUIMessage[] => {
+  return messages.map((msg) => {
+    if (!msg.parts) return msg
+    let changed = false
+    const newParts = msg.parts.map((part) => {
+      if (part.type !== 'reasoning' || part.state !== 'streaming') return part
+      const cherry = readCherryMeta(part)
+      const startedAt = cherry?.startedAt
+      const thinkingMs = cherry?.thinkingMs
+
+      let patch: Partial<CherryReasoningMeta> = {}
+      if (typeof startedAt === 'number' && Number.isFinite(startedAt) && typeof thinkingMs !== 'number') {
+        patch = { thinkingMs: Math.round(Math.max(0, Date.now() - startedAt)) }
+      }
+
+      changed = true
+      return withCherryMeta(
+        { ...part, state: 'done' },
+        patch
+      )
+    })
+    return changed ? { ...msg, parts: newParts } : msg
+  })
+}
 
 const HomeWindow: FC<{ draggable?: boolean }> = ({ draggable = true }) => {
   const [readClipboardAtStartup] = usePreference('feature.quick_assistant.read_clipboard_at_startup')
@@ -127,7 +159,7 @@ const HomeWindow: FC<{ draggable?: boolean }> = ({ draggable = true }) => {
       // Snapshots are retained after a reader tears down, so the final
       // frames are still in `liveAssistants` at this →0 transition.
       if (liveAssistants.length) {
-        setCompletedAssistants((done) => [...done, ...liveAssistants])
+        setCompletedAssistants((done) => [...done, ...finalizeLiveMessages(liveAssistants)])
         resetExecutionMessages()
       }
     }

--- a/src/shared/data/types/uiParts.ts
+++ b/src/shared/data/types/uiParts.ts
@@ -18,6 +18,7 @@
  * - data-code (code blocks)
  */
 
+
 import type { FileType } from '@shared/file/types'
 import * as z from 'zod'
 
@@ -94,6 +95,8 @@ export interface CherryTextMeta {
 export interface CherryReasoningMeta {
   /** Thinking duration in ms. */
   thinkingMs?: number
+  /** Thinking start timestamp in epoch ms. */
+  startedAt?: number
 }
 
 /** Cherry metadata on a ToolUIPart / DynamicToolUIPart. */
@@ -152,7 +155,8 @@ export const CherryTextMetaSchema: z.ZodType<CherryTextMeta> = z.object({
 })
 
 export const CherryReasoningMetaSchema: z.ZodType<CherryReasoningMeta> = z.object({
-  thinkingMs: z.number().optional()
+  thinkingMs: z.number().optional(),
+  startedAt: z.number().optional()
 })
 
 export const CherryToolMetaSchema: z.ZodType<CherryToolMeta> = z.object({
@@ -285,3 +289,4 @@ export function withoutCherryMeta<P extends CherryMessagePart>(
   if (Object.keys(nextProviderMetadata).length === 0) return nextPart
   return { ...nextPart, providerMetadata: nextProviderMetadata } as P
 }
+


### PR DESCRIPTION
### What this PR does

Before this PR:
1. Switching chat sessions or remounting `ThinkingBlock` would cause the active reasoning timer to reset back to `0.1s`.
2. Stopping/interrupting a streaming reasoning run (e.g. paused by user or stream errored out) did not finalize the reasoning part status to `'done'`, and didn't compute the final elapsed duration in the database. Also, on remounting an interrupted session, the UI would re-calculate `Date.now() - startedAt`, causing the elapsed time to keep ticking and drift indefinitely.
3. All reasoning durations under 1.0s (e.g., 200ms, 800ms) were unconditionally truncated and shown as `0.1s`.
4. Unit tests in `PersistenceBackend.test.ts` lacked proper cleanup hook for `vi.spyOn(Date, 'now')`, risking mock state leakage into subsequent tests.

After this PR:
1. Passed `startedAt` (Epoch MS timestamp) as a stable data contract inside the stream reasoning chunks. This allows the component to recover and compute `Date.now() - startedAt` correctly across mounts.
2. Implemented inline finalization logic for interrupted reasoning parts in both `PersistenceBackend.ts` (database layer) and `HomeWindow.tsx` (quick assistant UI layer) to compute final duration and lock status to `done`.
3. Ensured that when a stream finishes or is interrupted (`isThinking === false`), the display clock is locked to the final persisted `thinkingMs` and ceases reacting to `Date.now()`, preventing timing drift.
4. Fixed the display truncation threshold by updating `safeTime < 1000` to `safeTime < 100`, allowing fractional durations (e.g., 0.3s) to display correctly.
5. Added `afterEach(() => { vi.restoreAllMocks() })` to `PersistenceBackend.test.ts` to prevent Vitest mock leakage.

Fixes # None

### Why we need it and why it was done in this way

The timing reset and drift issues were caused by the lack of a stable start-time contract and proper terminal state finalization on abort events.

The following tradeoffs were made:
- An inline, data-driven approach was chosen to preserve boundaries without creating global UI caches (like maps).
- Spreading and merging logic inside `withChunkCherryMeta` was refactored to protect other non-cherry provider metadata keys from being dropped when `endMeta` is undefined.

The following alternatives were considered:
None.

Links to places where the discussion took place:
None.

### Breaking changes

None.

### Special notes for your reviewer

- Staged modifications and formatting were refined to satisfy `simple-import-sort/imports` eslint rule and types correctness.
- Added comprehensive unit tests in `ThinkingBlock.test.tsx` verifying timing calculations under both streaming (dynamic clock) and completed (locked clock) states.

### Checklist

- [x] Branch: This PR targets the correct branch — `chat-page` (as requested)
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
fix(chat): fix reasoning thinking timer session reset, interruption timing drift, and sub-second duration display truncation.
```
