### PR TITLE
fix: support npx MCP command on Windows

### DIFF
--- a/src/main/ai/mcp/McpRuntimeService.ts
+++ b/src/main/ai/mcp/McpRuntimeService.ts
@@ -9,7 +9,14 @@ import { createInMemoryMcpServer } from '@main/ai/mcp/servers/factory'
 import { BaseService, DependsOn, Emitter, type Event, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
 import { WindowType } from '@main/core/window/types'
 import { makeSureDirExists, removeEnvProxy } from '@main/utils'
-import { findCommandInShellEnv, getBinaryName, getBinaryPath, isBinaryExists } from '@main/utils/process'
+import {
+  findCommandInShellEnv,
+  findExecutable,
+  getBinaryName,
+  getBinaryPath,
+  isBinaryExists,
+  normalizeCommandForStdio
+} from '@main/utils/process'
 import getLoginShellEnvironment from '@main/utils/shell-env'
 import { TraceMethod, withSpanFunc } from '@mcp-trace/trace-core'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
@@ -512,9 +519,16 @@ export class McpRuntimeService extends BaseService {
               }
             }
 
-            if (server.command === 'npx') {
+            if (cmd === 'npx') {
               // First, check if npx is available in user's shell environment
-              const npxPath = await findCommandInShellEnv('npx', loginShellEnv)
+              let npxPath = await findCommandInShellEnv('npx', loginShellEnv)
+
+              if (!npxPath) {
+                npxPath = findExecutable('npx', {
+                  extensions: ['.exe', '.cmd', '.bat'],
+                  env: loginShellEnv
+                })
+              }
 
               if (npxPath) {
                 // Use system npx
@@ -562,32 +576,33 @@ export class McpRuntimeService extends BaseService {
                   connectEnv.MCP_REGISTRY_PATH = path.join(binPath, '..', 'config', 'mcp-registry.json')
                 }
               }
-            } else if (server.command === 'uvx' || server.command === 'uv') {
+            } else if (cmd === 'uvx' || cmd === 'uv') {
+              const requestedCommand = cmd
               // First, check if uvx/uv is available in user's shell environment
-              const uvPath = await findCommandInShellEnv(server.command, loginShellEnv)
+              const uvPath = await findCommandInShellEnv(requestedCommand, loginShellEnv)
 
               if (uvPath) {
                 // Use system uvx/uv
                 cmd = uvPath
-                getServerLogger(server).debug(`Using system ${server.command}`, { command: cmd })
+                getServerLogger(server).debug(`Using system ${requestedCommand}`, { command: cmd })
               } else {
                 // System command not found, try bundled version as fallback
-                getServerLogger(server).debug(`System ${server.command} not found, checking for bundled version`)
+                getServerLogger(server).debug(`System ${requestedCommand} not found, checking for bundled version`)
 
-                if (await isBinaryExists(server.command)) {
+                if (await isBinaryExists(requestedCommand)) {
                   // Fall back to bundled version
-                  cmd = await getBinaryPath(server.command)
-                  getServerLogger(server).info(`Using bundled ${server.command} as fallback (not found in PATH)`, {
+                  cmd = await getBinaryPath(requestedCommand)
+                  getServerLogger(server).info(`Using bundled ${requestedCommand} as fallback (not found in PATH)`, {
                     command: cmd
                   })
                 } else {
                   // Neither system nor bundled available
                   throw new Error(
-                    `${server.command} not found in PATH and bundled version is not available. This may indicate an installation issue.\n` +
+                    `${requestedCommand} not found in PATH and bundled version is not available. This may indicate an installation issue.\n` +
                       'Please either:\n' +
                       '1. Install uv from https://github.com/astral-sh/uv\n' +
                       '2. Run the MCP dependencies installer from Settings\n' +
-                      `3. Restart the application if you recently installed ${server.command}`
+                      `3. Restart the application if you recently installed ${requestedCommand}`
                   )
                 }
               }
@@ -605,12 +620,17 @@ export class McpRuntimeService extends BaseService {
               removeEnvProxy(loginShellEnv)
             }
 
+            const transportEnv = {
+              ...loginShellEnv,
+              ...connectEnv
+            }
+            const stdioCommand = normalizeCommandForStdio(cmd, args, transportEnv)
+
             const transportOptions: StdioServerParameters = {
-              command: cmd,
-              args,
+              command: stdioCommand.command,
+              args: stdioCommand.args,
               env: {
-                ...loginShellEnv,
-                ...connectEnv
+                ...transportEnv
               },
               stderr: 'pipe'
             }

--- a/src/main/utils/__tests__/process.test.ts
+++ b/src/main/utils/__tests__/process.test.ts
@@ -11,6 +11,7 @@ import {
   findExecutable,
   findGitBash,
   findViaMise,
+  normalizeCommandForStdio,
   validateGitBashPath
 } from '../process'
 
@@ -356,6 +357,37 @@ describe.skipIf(process.platform !== 'win32')('process utilities', () => {
         const result = findExecutable('npm', { extensions: ['.cmd'] })
 
         expect(result).toBe('C:\\nodejs\\npm.CMD')
+      })
+    })
+  })
+
+  describe('normalizeCommandForStdio', () => {
+    it('should wrap .cmd files with cmd.exe for stdio transport', () => {
+      const result = normalizeCommandForStdio('C:\\Program Files\\nodejs\\npx.cmd', ['-y', '@foo/bar'], {
+        ComSpec: 'C:\\Windows\\System32\\cmd.exe'
+      })
+
+      expect(result).toEqual({
+        command: 'C:\\Windows\\System32\\cmd.exe',
+        args: ['/d', '/c', '"C:\\Program Files\\nodejs\\npx.cmd" -y @foo/bar']
+      })
+    })
+
+    it('should wrap .bat files and quote args containing spaces', () => {
+      const result = normalizeCommandForStdio('C:\\tools\\server.bat', ['--name', 'my server'])
+
+      expect(result).toEqual({
+        command: 'cmd.exe',
+        args: ['/d', '/c', 'C:\\tools\\server.bat --name "my server"']
+      })
+    })
+
+    it('should leave .exe commands unchanged', () => {
+      const result = normalizeCommandForStdio('C:\\nodejs\\node.exe', ['server.js'])
+
+      expect(result).toEqual({
+        command: 'C:\\nodejs\\node.exe',
+        args: ['server.js']
       })
     })
   })

--- a/src/main/utils/process.ts
+++ b/src/main/utils/process.ts
@@ -291,6 +291,41 @@ export function findExecutable(name: string, options?: FindExecutableOptions): s
   }
 }
 
+export interface StdioCommandParameters {
+  command: string
+  args: string[]
+}
+
+function quoteCmdArg(arg: string): string {
+  if (arg === '') return '""'
+  if (/^[a-zA-Z0-9_/@+=:,.;-]+$/.test(arg)) return arg
+  return `"${arg.replace(/(["^&|<>()%])/g, '^$1')}"`
+}
+
+function quoteCmdCommand(command: string): string {
+  return /\s/.test(command) ? quoteCmdArg(command) : command
+}
+
+/**
+ * Windows 的 .cmd/.bat shim 不能直接交给 spawn(shell:false) 执行。
+ * MCP SDK 的 StdioClientTransport 内部使用 spawn，所以这里提前包装为 cmd.exe。
+ */
+export function normalizeCommandForStdio(
+  command: string,
+  args: string[],
+  env?: Record<string, string>
+): StdioCommandParameters {
+  if (!isWin || !/\.(cmd|bat)$/i.test(command)) {
+    return { command, args }
+  }
+
+  const comSpec = env?.ComSpec || env?.COMSPEC || 'cmd.exe'
+  return {
+    command: comSpec,
+    args: ['/d', '/c', [quoteCmdCommand(command), ...args.map(quoteCmdArg)].join(' ')]
+  }
+}
+
 // ============================================================================
 // Unified Shell Environment Utilities
 // ============================================================================


### PR DESCRIPTION
### What this PR does

Before this PR:

On Windows, MCP servers configured with `npx` could resolve to `npx.cmd`, but the MCP stdio transport launches commands with `spawn` and `shell: false`. `.cmd` / `.bat` shim files cannot be executed directly in that mode, which could cause `npx`-based MCP servers to fail to start.

<img width="771" height="443" alt="Snipaste_2026-06-08_21-27-46" src="https://github.com/user-attachments/assets/4b1cb9b2-232a-415e-9817-acead8895e16" />

After this PR:

Windows `.cmd` / `.bat` commands are normalized before being passed to stdio transport. When `npx` resolves to a Windows shim, it is launched through `cmd.exe /d /s /c ...` with arguments quoted safely. The runtime also falls back to PATH-based executable lookup for `npx` on Windows when shell-env lookup does not find it.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

This keeps the fix localized to command normalization for stdio transport instead of changing the MCP SDK transport behavior or enabling shell execution broadly. That limits the behavior change to Windows `.cmd` / `.bat` launch compatibility while preserving the existing direct execution path for `.exe` and non-Windows commands.

The following alternatives were considered:

- Enabling shell execution for all MCP commands: rejected because it would broaden command execution semantics and quoting risk.
- Special-casing only `npx.cmd` in the MCP runtime: rejected because the same Windows shim issue also applies to other `.cmd` / `.bat` commands used with stdio transport.
- Requiring users to configure `node.exe` or absolute executable paths manually: rejected because common Node tooling on Windows naturally resolves to `.cmd` shims.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Please pay attention to the Windows command quoting path in `normalizeCommandForStdio`, especially arguments containing spaces or shell-sensitive characters.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix Windows MCP server startup when commands resolve to npx.cmd or other .cmd/.bat shims.
