### PR TITLE
refactor(stream-runtime): remove stale approval replay

### DIFF
--- a/src/main/ai/AiService.ts
+++ b/src/main/ai/AiService.ts
@@ -13,7 +13,7 @@ import { modelService } from '@main/data/services/ModelService'
 import { providerService } from '@main/data/services/ProviderService'
 import { type TranslateOpenRequest, translateService } from '@main/services/translate/translateService'
 import { downloadImageAsBase64 } from '@main/utils/downloadAsBase64'
-import { applyApprovalDecisions } from '@shared/ai/transport'
+import { type AiToolApprovalRespondResponse, applyApprovalDecisions } from '@shared/ai/transport'
 import { type Assistant } from '@shared/data/types/assistant'
 import type { FileEntry } from '@shared/data/types/file/fileEntry'
 import { type Model, parseUniqueModelId } from '@shared/data/types/model'
@@ -248,7 +248,16 @@ export class AiService extends BaseService {
       } catch {
         logger.warn('Tool-approval response anchor is missing or deleted', {
           approvalId: payload.approvalId,
-          anchorId: payload.anchorId
+          approved: payload.approved,
+          ...(payload.reason !== undefined && { reason: payload.reason }),
+          ...(payload.updatedInput !== undefined && { updatedInput: payload.updatedInput })
+        }
+
+        // Claude-Agent fast-path: live registry entry unblocks `canUseTool`.
+        const dispatched = application.get('AgentSessionRuntimeService').respondToolApproval(payload.approvalId, {
+          approved: payload.approved,
+          reason: payload.reason,
+          updatedInput: payload.updatedInput
         })
         return { ok: false }
       }
@@ -267,26 +276,68 @@ export class AiService extends BaseService {
         await messageService.update(payload.anchorId, { data: { parts: afterParts } })
       }
 
-      // Only resume once every approval on this turn is decided — a turn
-      // can request several tools at once; the not-yet-decided ones keep
-      // their cards.
-      const anyStillPending = afterParts.some((p) => isToolUIPart(p) && p.state === 'approval-requested')
-      if (anyStillPending) {
+        // MCP path: write decisions to DB, then dispatch continue-conversation when nothing is pending.
+        if (!payload.topicId || !payload.anchorId) {
+          logger.warn('Tool-approval response had no live registry entry and no anchor context', {
+            approvalId: payload.approvalId
+          })
+          return { ok: false }
+        }
+
+        // Main is the single authority for the approval mutation: the
+        // renderer no longer PATCHes (it sourced parts from a DB projection
+        // that didn't carry the overlay-only `approval-requested` part and
+        // raced/overwrote the persisted row). The decision is carried
+        // explicitly in the IPC payload; apply it here to the DB-authoritative
+        // parts (the original stream's terminal persistence wrote the
+        // `approval-requested` part onto this row) and persist.
+        // A stale click on a deleted message must resolve through the documented
+        // result shape, not throw out of the handler (getById rejects when the
+        // anchor is missing), consistent with the no-context branch above.
+        let anchor: Awaited<ReturnType<typeof messageService.getById>>
+        try {
+          anchor = await messageService.getById(payload.anchorId)
+        } catch {
+          logger.warn('Tool-approval response anchor is missing or deleted', {
+            approvalId: payload.approvalId,
+            anchorId: payload.anchorId
+          })
+          return { ok: false }
+        }
+        const beforeParts = anchor.data.parts ?? []
+        const targetPresent = beforeParts.some(
+          (p) => isToolUIPart(p) && p.state === 'approval-requested' && p.approval?.id === decision.approvalId
+        )
+        const afterParts = applyApprovalDecisions(beforeParts, [decision])
+        // Only write parts when this approval is present on the DB row.
+        // `applyApprovalDecisions` always returns a fresh array, so writing
+        // unconditionally would overwrite real (or not-yet-persisted) parts
+        // with an unchanged set. When the part is overlay-only (persist not
+        // landed yet), the continue dispatch below carries the decision and
+        // the continue provider applies it authoritatively where it reads parts.
+        if (targetPresent) {
+          await messageService.update(payload.anchorId, { data: { parts: afterParts } })
+        }
+
+        // Only resume once every approval on this turn is decided — a turn
+        // can request several tools at once; the not-yet-decided ones keep
+        // their cards.
+        const anyStillPending = afterParts.some((p) => isToolUIPart(p) && p.state === 'approval-requested')
+        if (anyStillPending) {
+          return { ok: true }
+        }
+
+        const aiStreamManager = application.get('AiStreamManager')
+        const subscriber = new WebContentsListener(event.sender, payload.topicId)
+        await aiStreamManager.dispatch(subscriber, {
+          trigger: 'continue-conversation',
+          topicId: payload.topicId,
+          parentAnchorId: payload.anchorId,
+          // Idempotent against the conditional write above; safety net when the part wasn't on the row.
+          approvalDecisions: [decision]
+        })
         return { ok: true }
       }
-
-      const aiStreamManager = application.get('AiStreamManager')
-      const subscriber = new WebContentsListener(event.sender, payload.topicId)
-      await aiStreamManager.dispatch(subscriber, {
-        trigger: 'continue-conversation',
-        topicId: payload.topicId,
-        parentAnchorId: payload.anchorId,
-        // Idempotent against the conditional write above; safety net when the part wasn't on the row.
-        approvalDecisions: [decision]
-      })
-      return { ok: true }
-    })
-  }
 
   // ── Streaming chat (agent.stream) ──
 

--- a/src/main/ai/__tests__/AiService.test.ts
+++ b/src/main/ai/__tests__/AiService.test.ts
@@ -8,6 +8,8 @@ const mockGenerateImage = vi.fn()
 const mockRerank = vi.fn()
 const mockDownloadImageAsBase64 = vi.fn()
 const mockApplicationGet = vi.fn()
+const mockMessageGetById = vi.fn()
+const mockMessageUpdate = vi.fn()
 const mockProviderGetByProviderId = vi.fn()
 const mockProviderGetRotatedApiKey = vi.fn()
 const mockModelGetByKey = vi.fn()
@@ -33,6 +35,13 @@ vi.mock('@main/data/services/ModelService', () => ({
 
 vi.mock('@main/utils/downloadAsBase64', () => ({
   downloadImageAsBase64: (...args: unknown[]) => mockDownloadImageAsBase64(...args)
+}))
+
+vi.mock('@main/data/services/MessageService', () => ({
+  messageService: {
+    getById: mockMessageGetById,
+    update: mockMessageUpdate
+  }
 }))
 
 vi.mock('@cherrystudio/ai-core', () => ({

--- a/src/main/ai/streamManager/AiStreamManager.ts
+++ b/src/main/ai/streamManager/AiStreamManager.ts
@@ -582,6 +582,15 @@ export class AiStreamManager extends BaseService {
     const exec = stream.executions.get(modelId)
     if (!exec || exec.status !== 'aborted') return
 
+    // A turn torn down while a tool is still `approval-requested` (or any
+    // in-flight tool) gets no `tool-output-*` to clear it. Clear the flag so the
+    // status resolves to plain `aborted` (not `awaiting-approval`) and the
+    // status-cache anchor drops; the dangling tool part itself is terminalized
+    // to `output-error` by `finalizeInterruptedParts` at every projection
+    // (persistence already, re-attach below). Must run before
+    // `resolveTerminalStatus`.
+    exec.awaitingApproval = false
+
     endRootSpan(exec, 'aborted')
     stream.status = this.resolveTerminalStatus(stream)
     const isTopicDone = !isLiveStatus(stream.status)
@@ -602,6 +611,10 @@ export class AiStreamManager extends BaseService {
     exec.status = 'error'
     exec.error = error
     endRootSpan(exec, 'error', error)
+
+    // Mirror of onExecutionPaused: clear the flag so the status anchor drops;
+    // the in-flight tool part is terminalized by `finalizeInterruptedParts`.
+    exec.awaitingApproval = false
 
     stream.status = this.computeTopicStatus(stream)
     const isTopicDone = !isLiveStatus(stream.status)
@@ -822,7 +835,10 @@ export class AiStreamManager extends BaseService {
     // upstream AI SDK request is already wired to. Caller override via
     // `requestOptions.timeout`; otherwise `DEFAULT_TIMEOUT`.
     const timeoutMs = request.requestOptions?.timeout ?? DEFAULT_TIMEOUT
-    const stream = withIdleTimeout(rawStream, exec.abortController, timeoutMs)
+    const { stream: idleStream, idle } = withIdleTimeout(rawStream, exec.abortController, timeoutMs)
+    // Wrap before pipeStreamLoop's tee() so broadcast + accumulator share one
+    // thinkingMs measurement (see reasoningTimingTransform).
+    const stream = withReasoningTimingMetadata(idleStream)
 
     // `continue-conversation` chunks reference toolCallIds on the anchor
     // assistant message; without seeding, `readUIMessageStream`'s
@@ -832,7 +848,10 @@ export class AiStreamManager extends BaseService {
       lastIncoming?.role === 'assistant' ? (lastIncoming as CherryUIMessage) : undefined
 
     const result = await pipeStreamLoop(stream, signal, {
-      onChunk: (chunk) => this.onChunk(topicId, modelId, chunk),
+      onChunk: (chunk) => {
+        this.onChunk(topicId, modelId, chunk)
+        if (chunk.type === 'tool-approval-request') idle.cleanup()
+      },
       accumulatorSeed,
       onAccumulatedSnapshot: (msg) => {
         exec.finalMessage = msg

--- a/src/main/utils/__tests__/withIdleTimeout.test.ts
+++ b/src/main/utils/__tests__/withIdleTimeout.test.ts
@@ -49,7 +49,7 @@ describe('withIdleTimeout', () => {
     const src = makeControllableStream<number>()
     const controller = new AbortController()
 
-    const out = withIdleTimeout(src.stream, controller, 1000)
+    const { stream: out } = withIdleTimeout(src.stream, controller, 1000)
     const reader = out.getReader()
 
     src.push(1)
@@ -68,7 +68,7 @@ describe('withIdleTimeout', () => {
     const src = makeControllableStream<number>()
     const controller = new AbortController()
 
-    const out = withIdleTimeout(src.stream, controller, 1000)
+    const { stream: out } = withIdleTimeout(src.stream, controller, 1000)
     const reader = out.getReader()
 
     // Kick the pull so the timer is running against an actually-pending read.
@@ -85,7 +85,7 @@ describe('withIdleTimeout', () => {
     const src = makeControllableStream<number>()
     const controller = new AbortController()
 
-    const out = withIdleTimeout(src.stream, controller, 1000)
+    const { stream: out } = withIdleTimeout(src.stream, controller, 1000)
     const reader = out.getReader()
 
     for (let i = 0; i < 5; i++) {
@@ -104,7 +104,7 @@ describe('withIdleTimeout', () => {
     const externalReason = new Error('user cancelled')
     controller.abort(externalReason)
 
-    const out = withIdleTimeout(src.stream, controller, 1000)
+    const { stream: out } = withIdleTimeout(src.stream, controller, 1000)
     // Idle would normally fire, but the controller is already aborted — the
     // wrapper must not overwrite the reason.
     vi.advanceTimersByTime(5000)
@@ -119,7 +119,7 @@ describe('withIdleTimeout', () => {
     const src = makeControllableStream<number>()
     const controller = new AbortController()
 
-    const out = withIdleTimeout(src.stream, controller, 1000)
+    const { stream: out } = withIdleTimeout(src.stream, controller, 1000)
     const reader = out.getReader()
 
     src.push(1)
@@ -139,7 +139,7 @@ describe('withIdleTimeout', () => {
     const src = makeControllableStream<number>()
     const controller = new AbortController()
 
-    const out = withIdleTimeout(src.stream, controller, 1000)
+    const { stream: out } = withIdleTimeout(src.stream, controller, 1000)
     const reader = out.getReader()
 
     src.push(1)
@@ -149,5 +149,45 @@ describe('withIdleTimeout', () => {
 
     vi.advanceTimersByTime(5000)
     expect(controller.signal.aborted).toBe(false)
+  })
+
+  it('exposed idle.cleanup() pauses the timer so a long no-chunk wait does not abort', async () => {
+    const src = makeControllableStream<number>()
+    const controller = new AbortController()
+
+    const { stream: out, idle } = withIdleTimeout(src.stream, controller, 1000)
+    const reader = out.getReader()
+
+    src.push(1)
+    await reader.read()
+
+    // Pause (e.g. a tool is now awaiting human approval) — no chunks for a long
+    // time must NOT trip the idle timeout.
+    idle.cleanup()
+    vi.advanceTimersByTime(5000)
+    expect(controller.signal.aborted).toBe(false)
+  })
+
+  it('rearms on the next chunk after idle.cleanup()', async () => {
+    const src = makeControllableStream<number>()
+    const controller = new AbortController()
+
+    const { stream: out, idle } = withIdleTimeout(src.stream, controller, 1000)
+    const reader = out.getReader()
+
+    src.push(1)
+    await reader.read()
+
+    idle.cleanup()
+    vi.advanceTimersByTime(5000) // paused — no abort
+    expect(controller.signal.aborted).toBe(false)
+
+    // The resolving chunk (e.g. the approval was answered) flows through `pull`,
+    // which calls `idle.reset()` and rearms the timer.
+    src.push(2)
+    await reader.read()
+    vi.advanceTimersByTime(1001)
+    expect(controller.signal.aborted).toBe(true)
+    expect((controller.signal.reason as DOMException).name).toBe('TimeoutError')
   })
 })

--- a/src/main/utils/withIdleTimeout.ts
+++ b/src/main/utils/withIdleTimeout.ts
@@ -20,13 +20,13 @@
  * isolation.
  */
 
-import { IdleTimeoutController } from './IdleTimeoutController'
+import { IdleTimeoutController, type IdleTimeoutHandle } from './IdleTimeoutController'
 
 export function withIdleTimeout<T>(
   source: ReadableStream<T>,
   controller: AbortController,
   timeoutMs: number
-): ReadableStream<T> {
+): { stream: ReadableStream<T>; idle: IdleTimeoutHandle } {
   const idle = new IdleTimeoutController(timeoutMs)
 
   // When the idle timer fires, abort the caller's controller so the abort
@@ -46,7 +46,7 @@ export function withIdleTimeout<T>(
 
   const reader = source.getReader()
 
-  return new ReadableStream<T>({
+  const stream = new ReadableStream<T>({
     async pull(dest) {
       try {
         const { done, value } = await reader.read()
@@ -67,4 +67,9 @@ export function withIdleTimeout<T>(
       return reader.cancel(reason)
     }
   })
+
+  // `idle` is exposed so a consumer can pause the timer during a legitimate
+  // no-chunk wait (e.g. a tool awaiting human approval): call `idle.cleanup()`
+  // to pause; the next pulled chunk's `idle.reset()` above rearms it.
+  return { stream, idle }
 }

--- a/src/renderer/hooks/__tests__/useToolApprovalBridge.test.ts
+++ b/src/renderer/hooks/__tests__/useToolApprovalBridge.test.ts
@@ -10,11 +10,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useToolApprovalBridge } from '../useToolApprovalBridge'
 
-vi.mock('@logger', () => ({
-  loggerService: { withContext: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() }) }
+const mocks = vi.hoisted(() => ({
+  respondToolApproval: vi.fn()
 }))
-
-const respond = vi.fn()
 
 beforeEach(() => {
   respond.mockReset()
@@ -28,8 +26,25 @@ afterEach(() => {
 const match = { messageId: 'a1', approvalId: 'ap-1', transport: 'mcp' } as ToolApprovalMatch
 
 describe('useToolApprovalBridge', () => {
-  it('resolves when main returns { ok: true }', async () => {
-    respond.mockResolvedValueOnce({ ok: true })
+  beforeEach(() => {
+    mocks.respondToolApproval.mockReset()
+    mocks.respondToolApproval.mockResolvedValue({ ok: true })
+
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        ai: {
+          toolApproval: {
+            respond: mocks.respondToolApproval
+          }
+        }
+      }
+    })
+  })
+
+  it('delivers approval decisions to main with anchor context', async () => {
+    const match = makeApprovalMatch()
+
     const { result } = renderHook(() => useToolApprovalBridge('topic-1'))
 
     await expect(result.current({ match, approved: true })).resolves.toBeUndefined()
@@ -50,14 +65,5 @@ describe('useToolApprovalBridge', () => {
     const { result } = renderHook(() => useToolApprovalBridge('topic-1'))
 
     await expect(result.current({ match, approved: false })).rejects.toThrow('ipc boom')
-  })
-
-  it('no-ops without an approvalId', async () => {
-    const { result } = renderHook(() => useToolApprovalBridge('topic-1'))
-
-    await expect(
-      result.current({ match: { messageId: 'a1' } as ToolApprovalMatch, approved: true })
-    ).resolves.toBeUndefined()
-    expect(respond).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/hooks/useToolApprovalBridge.ts
+++ b/src/renderer/hooks/useToolApprovalBridge.ts
@@ -1,8 +1,6 @@
 import { loggerService } from '@logger'
 import { useCallback } from 'react'
 
-import type { ToolApprovalRespondFn } from './ToolApprovalContext'
-
 const logger = loggerService.withContext('useToolApprovalBridge')
 
 /**

--- a/src/shared/ai/transport/index.ts
+++ b/src/shared/ai/transport/index.ts
@@ -22,6 +22,8 @@ export type {
   AiStreamDetachRequest,
   AiStreamOpenRequest,
   AiStreamOpenResponse,
+  AiToolApprovalRespondRequest,
+  AiToolApprovalRespondResponse,
   ApprovalDecision,
   StreamChunkPayload,
   StreamDonePayload,

--- a/src/shared/ai/transport/stream.ts
+++ b/src/shared/ai/transport/stream.ts
@@ -129,6 +129,16 @@ export interface ApprovalDecision {
   approvalId: string
   approved: boolean
   reason?: string
+  updatedInput?: Record<string, unknown>
+}
+
+export interface AiToolApprovalRespondRequest extends ApprovalDecision {
+  topicId?: string
+  anchorId?: string
+}
+
+export interface AiToolApprovalRespondResponse {
+  ok: boolean
 }
 
 /** Subscribe to a topic's stream state. */


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The stream runtime still carried approval replay code that no longer had an active caller in the queued stream flow.

After this PR:

The stale approval replay path is removed so the stream runtime starts from the current approval state only.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

Kept this as a narrow runtime cleanup with no queue or UI changes so later stack layers can build on a smaller surface.

The following alternatives were considered:

Leaving the replay path in place was rejected because it obscures the approval lifecycle used by the queue changes.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Stack PR 01/15 for the chat-page split. Base: `feat/chat-page`; head: `codex/chat-stack-01-stream-runtime`.

Validated at the top of this stack with `pnpm lint`, `pnpm test`, `pnpm db:migrations:check`, and `git diff --check`. Local Node 22.22.0 emitted the expected engine warning for the repo requirement `>=24.11.1`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
