### PR TITLE
feat(stream-runtime): queue steer continuations

### DIFF
--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -13,53 +13,27 @@ import { serializeError } from '@shared/types/error'
 import type { UIMessageChunk } from 'ai'
 import { v7 as uuidv7 } from 'uuid'
 
-import { startAiTurnTrace } from '../observability'
+import { applyTurnInputAttributes, deriveRootSpanId, startAiChildTurnSpan } from '../observability'
 import {
   type AgentRuntimeConnection,
   type AgentRuntimeEvent,
   type AgentRuntimePolicyUpdate,
   type AgentRuntimeTraceContext,
+  type AgentRuntimeUserInput,
   runtimeDriverRegistry
 } from '../runtime'
 import { type DispatchDecision, toolApprovalRegistry } from '../runtime/claudeCode/ToolApprovalRegistry'
 import { PersistenceListener } from '../streamManager/listeners/PersistenceListener'
 import { TraceFlushListener } from '../streamManager/listeners/TraceFlushListener'
-import type { StreamDoneResult, StreamErrorResult, StreamListener, StreamPausedResult } from '../streamManager/types'
+import type { StreamErrorResult, StreamListener, StreamPausedResult } from '../streamManager/types'
 import { AgentSessionMessageBackend } from './persistence/AgentSessionMessageBackend'
+import { extractAgentSessionId, isAgentSessionTopic } from './topic'
 
 const logger = loggerService.withContext('AgentSessionRuntimeService')
 const DEFAULT_IDLE_TTL_MS = 5 * 60 * 1000
 
 export type AgentSessionRuntimeStatus = 'active' | 'idle'
 export type AgentSessionRuntimeTerminalStatus = 'success' | 'paused' | 'error'
-
-/**
- * Why an in-flight turn is being stopped — selects how much runtime state to
- * tear down (see {@link STOP_POLICY}). Derived from the service's own typed
- * state (`turn.interruptRequested`), never from the abort signal's `reason`, so
- * a user Stop can't be misread as a steer interrupt. An abort with nothing
- * requested defaults to `user-stop` — the safe-failure direction (full teardown
- * closes the connection, killing the runtime/subagent).
- */
-type AgentTurnStopIntent = 'interrupt' | 'user-stop'
-
-interface TurnStopPolicy {
-  /** Terminal status stamped on the turn when the session survives the stop. */
-  turnStatus: AgentSessionRuntimeTerminalStatus
-  /** Tear the whole session down (connection + entry), not just the turn. */
-  closeSession: boolean
-}
-
-/**
- * `interrupt` (steer): pause this turn but keep the connection + session so the
- * queued message can open the next turn (the runtime was gracefully interrupted,
- * not closed — the warm query survives). `user-stop`: tear the session down so
- * `connection.close()` kills the runtime query and its subagent.
- */
-const STOP_POLICY: Record<AgentTurnStopIntent, TurnStopPolicy> = {
-  interrupt: { turnStatus: 'paused', closeSession: false },
-  'user-stop': { turnStatus: 'paused', closeSession: true }
-}
 
 export interface BeginAgentSessionTurnInput {
   sessionId: string
@@ -69,8 +43,8 @@ export interface BeginAgentSessionTurnInput {
   modelId: UniqueModelId
   assistantMessageId?: string
   userMessage?: AgentSessionMessageEntity
+  /** Container-level OTel trace id (one trace per session); cached on the entry. */
   traceId?: string
-  rootSpanId?: string
 }
 
 export interface AgentSessionRuntimeHandle {
@@ -93,7 +67,6 @@ export interface AgentSessionRuntimeSnapshot {
   lastTerminalStatus?: AgentSessionRuntimeTerminalStatus
   resumeToken?: string
   activeToolCount: number
-  interruptRequested: boolean
 }
 
 type AgentSessionTurn = {
@@ -105,13 +78,13 @@ type AgentSessionTurn = {
   terminalStatus?: AgentSessionRuntimeTerminalStatus
   controller?: ReadableStreamDefaultController<UIMessageChunk>
   activeToolIds: Set<string>
-  interruptRequested: boolean
-  trace?: AgentRuntimeTraceContext
 }
 
 type AgentSessionRuntimeEntry = {
   sessionId: string
   topicId: string
+  /** Container-level OTel trace id (one trace tree per session); the warm connection's traceparent. */
+  sessionTraceId?: string
   agentId: string
   agentType: string
   modelId: UniqueModelId
@@ -126,6 +99,16 @@ type AgentSessionRuntimeEntry = {
   lastTerminalStatus?: AgentSessionRuntimeTerminalStatus
   idleTimer?: ReturnType<typeof setTimeout>
   startingNextTurn?: boolean
+  /** Ids of pending messages that arrived mid-turn (steers) — drives the system-reminder wrap. */
+  steerMessageIds?: Set<string>
+  /** Roll in progress: a steer was injected mid-turn (`steer-boundary`), the current row was finalised
+   *  as A1a, and the post-steer chunks are buffered until the continuation row (A2) opens its stream. */
+  rolling?: boolean
+  /** Post-steer chunks captured between A1a closing and A2's controller being ready; flushed into A2. */
+  rollBuffer?: UIMessageChunk[]
+  /** The injected steer(s) carried to the continuation turn for its rename/seed context (U2 is already
+   *  persisted by the provider — these do NOT create a new user row). */
+  rollSteerInputs?: AgentRuntimeUserInput[]
 }
 
 class AgentSessionRuntimeTerminalListener implements StreamListener {
@@ -140,8 +123,10 @@ class AgentSessionRuntimeTerminalListener implements StreamListener {
 
   onChunk(): void {}
 
-  onDone(result: StreamDoneResult): void {
-    if (result.isTopicDone === false) return
+  onDone(): void {
+    // Always advance the runtime turn. For a single-model agent turn, `isTopicDone=false` only means
+    // the stream manager is CHAINING the next turn (keeping the stream alive so the queued follow-up
+    // can carry the renderer listeners) — which still needs markTurnTerminal to open that next turn.
     this.service.markTurnTerminal(this.sessionId, 'success')
   }
 
@@ -202,15 +187,14 @@ export class AgentSessionRuntimeService extends BaseService {
       userMessage,
       modelId: input.modelId,
       admitted: false,
-      activeToolIds: new Set(),
-      interruptRequested: false,
-      trace: this.createTraceContext(input, turnId, input.traceId, input.rootSpanId)
+      activeToolIds: new Set()
     }
 
     if (existing?.status === 'idle') {
       this.clearIdleTimer(existing)
       existing.pendingTurns = []
       existing.topicId = input.topicId
+      existing.sessionTraceId = input.traceId ?? existing.sessionTraceId
       existing.agentId = input.agentId
       existing.agentType = input.agentType
       existing.modelId = input.modelId
@@ -232,6 +216,7 @@ export class AgentSessionRuntimeService extends BaseService {
     const entry: AgentSessionRuntimeEntry = {
       sessionId: input.sessionId,
       topicId: input.topicId,
+      sessionTraceId: input.traceId,
       agentId: input.agentId,
       agentType: input.agentType,
       modelId: input.modelId,
@@ -293,7 +278,9 @@ export class AgentSessionRuntimeService extends BaseService {
           this.clearIdleTimer(entry)
           turn.controller = controller
 
-          const onAbort = () => this.stopTurn(entry, turn.interruptRequested ? 'interrupt' : 'user-stop')
+          // A user Stop is the only abort source now (steer no longer interrupts) — tear the
+          // session down so `connection.close()` kills the warm query and its subagent.
+          const onAbort = () => this.closeSession(entry.sessionId)
           if (input.signal.aborted) {
             onAbort()
             return
@@ -302,6 +289,9 @@ export class AgentSessionRuntimeService extends BaseService {
           }
 
           controller.enqueue({ type: 'start' })
+          // Roll continuation: replay the post-steer chunks captured while A2's stream was opening, as
+          // soon as the controller exists (before the connection round-trip). No-op for normal turns.
+          this.flushRollBuffer(entry, turn)
           const connected = await this.ensureConnection(entry)
           if (!connected || !this.isCurrentEntry(entry) || turn.terminalStatus) return
           await this.admitTurn(entry, turn)
@@ -319,43 +309,51 @@ export class AgentSessionRuntimeService extends BaseService {
     const entry = this.entries.get(sessionId)
     if (!entry) return
 
-    entry.pendingTurns.push(message)
     entry.status = 'active'
     this.clearIdleTimer(entry)
 
     const turn = entry.currentTurn
-    if (!turn || turn.terminalStatus) {
-      this.scheduleNextTurn(entry)
+    // Live turn + a backend that can steer → inject into the running turn (claude's PreToolUse steer
+    // hook): the steer is folded into the current turn — no new turn, no queue entry. If the turn
+    // ends before it's injected, the connection emits `steer-undelivered` and we queue it below.
+    if (turn && !turn.terminalStatus && entry.connection?.redirect?.({ message, systemReminder: true })) {
       return
     }
 
-    if (turn.activeToolIds.size > 0) return
-
-    queueMicrotask(() => {
-      const latest = this.entries.get(sessionId)
-      if (!latest?.currentTurn || latest.currentTurn.terminalStatus) {
-        if (latest) this.scheduleNextTurn(latest)
-        return
-      }
-      this.requestInterruptWhenSafe(latest)
-    })
+    // No live turn (or backend can't steer) → queue as the next turn, wrapped in a steer system-reminder.
+    entry.pendingTurns.push(message)
+    ;(entry.steerMessageIds ??= new Set()).add(message.id)
+    if (!turn || turn.terminalStatus) this.scheduleNextTurn(entry)
   }
 
   markTurnTerminal(sessionId: string, status: AgentSessionRuntimeTerminalStatus): void {
     const entry = this.entries.get(sessionId)
     if (!entry) return
 
+    // Roll: A1a closed at a steer-injection boundary. Mark A1a terminal but keep the session ACTIVE
+    // and open the continuation (A2) for the post-steer response instead of idling. `currentTurn` is
+    // still A1a here (the swap to A2 happens in the scheduled microtask), so we don't mis-mark A2.
+    if (entry.rolling) {
+      if (entry.currentTurn) entry.currentTurn.terminalStatus = status
+      if (status === 'success') {
+        entry.status = 'active'
+        entry.lastTerminalStatus = status
+        this.scheduleContinuationTurn(entry)
+        return
+      }
+      // Non-success during a roll (defensive — `onDone`/success is the only terminal kept alive across
+      // the boundary): abandon the roll and settle normally; the buffered post-steer chunks are dropped.
+      entry.rolling = false
+      entry.rollBuffer = undefined
+      entry.rollSteerInputs = undefined
+    }
+
     entry.status = 'idle'
     entry.lastTerminalStatus = status
     if (entry.currentTurn) entry.currentTurn.terminalStatus = status
 
-    if (this.shouldCloseConnectionAfterTurn(entry)) {
-      // close() may be async on some drivers; swallow rejection so it can't become unhandled.
-      void Promise.resolve(this.closeConnection(entry)?.close()).catch((error) =>
-        logger.warn('Agent runtime connection close failed', { sessionId: entry.sessionId, error })
-      )
-    }
-
+    // Connection stays warm across turns (no per-turn close) — only `closeSession`/idle TTL tears it
+    // down. A queued steer drains into the same warm subprocess via `scheduleNextTurn`.
     if (entry.pendingTurns.length > 0) {
       this.scheduleNextTurn(entry)
     } else {
@@ -383,9 +381,26 @@ export class AgentSessionRuntimeService extends BaseService {
     if (!entry) return false
     return (
       entry.startingNextTurn === true ||
+      entry.rolling === true ||
       entry.pendingTurns.length > 0 ||
       (entry.currentTurn !== undefined && entry.currentTurn.terminalStatus === undefined)
     )
+  }
+
+  /**
+   * Whether the agent runtime will open another turn for this topic once the current one ends — a
+   * queued steer/follow-up, or a next-turn drain already in progress. `AiStreamManager.onExecutionDone`
+   * uses this to KEEP the topic's stream alive across the inter-turn gap (broadcasting `isTopicDone=false`,
+   * skipping the terminal lifecycle) so the follow-up turn can carry the renderer listeners — without it
+   * the stream is evicted and the follow-up's response reaches no one.
+   */
+  willContinueTopic(topicId: string): boolean {
+    if (!isAgentSessionTopic(topicId)) return false
+    const entry = this.entries.get(extractAgentSessionId(topicId))
+    if (!entry) return false
+    // `rolling`: A1a just closed at a steer boundary and the continuation (A2) is coming — keep the
+    // stream alive so A2 carries the renderer listeners.
+    return entry.pendingTurns.length > 0 || entry.startingNextTurn === true || entry.rolling === true
   }
 
   inspect(sessionId: string): AgentSessionRuntimeSnapshot | undefined {
@@ -401,8 +416,7 @@ export class AgentSessionRuntimeService extends BaseService {
       pendingMessageCount: entry.pendingTurns.length,
       lastTerminalStatus: entry.lastTerminalStatus,
       resumeToken: entry.lastResumeToken,
-      activeToolCount: turn?.activeToolIds.size ?? 0,
-      interruptRequested: turn?.interruptRequested ?? false
+      activeToolCount: turn?.activeToolIds.size ?? 0
     }
   }
 
@@ -455,7 +469,7 @@ export class AgentSessionRuntimeService extends BaseService {
       agentId: entry.agentId,
       modelId: entry.modelId,
       resumeToken: entry.lastResumeToken,
-      trace: entry.currentTurn?.trace
+      trace: this.sessionTraceContext(entry)
     })
     if (!this.isCurrentEntry(entry)) {
       void Promise.resolve(connection.close()).catch((error) =>
@@ -494,10 +508,34 @@ export class AgentSessionRuntimeService extends BaseService {
         entry.lastResumeToken = event.token
         break
       case 'chunk': {
+        // Mid-roll: A1a is closed and A2's stream isn't open yet — buffer the post-steer chunks so
+        // `flushRollBuffer` can replay them into A2 in order (see `steer-boundary`).
+        if (entry.rolling) {
+          ;(entry.rollBuffer ??= []).push(event.chunk)
+          break
+        }
         const turn = entry.currentTurn
-        if (turn?.controller && !turn.terminalStatus) this.enqueueTurnChunk(entry, turn, event.chunk)
+        if (turn?.controller && !turn.terminalStatus) this.enqueueTurnChunk(turn, event.chunk)
         break
       }
+      case 'steer-boundary':
+        // The model is about to emit its post-steer assistant message. Finalise the pre-steer parts as
+        // A1a (`closeCurrentTurn` 'success'), then buffer the continuation until `startContinuationTurn`
+        // opens A2. `rolling` keeps the topic stream alive (willContinueTopic) across the gap.
+        entry.rolling = true
+        entry.rollBuffer = []
+        entry.rollSteerInputs = event.inputs
+        this.closeCurrentTurn(entry, 'success')
+        break
+      case 'steer-undelivered':
+        // Steers stashed via redirect() that this turn ended before injecting → queue them as the
+        // next turn (with a steer system-reminder). The following `turn-complete` → markTurnTerminal
+        // drains pendingTurns via scheduleNextTurn.
+        for (const input of event.inputs) {
+          entry.pendingTurns.push(input.message)
+          ;(entry.steerMessageIds ??= new Set()).add(input.message.id)
+        }
+        break
       case 'turn-complete':
         this.closeCurrentTurn(entry, 'success')
         break
@@ -530,13 +568,12 @@ export class AgentSessionRuntimeService extends BaseService {
     if (turn.admitted) return
     turn.admitted = true
     entry.status = 'active'
-    await entry.connection?.send({ message: turn.userMessage })
-    if (entry.pendingTurns.length > 0) {
-      queueMicrotask(() => this.requestInterruptWhenSafe(entry))
-    }
+    // `Set.delete` returns whether it was queued as a steer — consume the flag as we admit the turn.
+    const systemReminder = entry.steerMessageIds?.delete(turn.userMessage.id) ?? false
+    await entry.connection?.send({ message: turn.userMessage, systemReminder })
   }
 
-  private enqueueTurnChunk(entry: AgentSessionRuntimeEntry, turn: AgentSessionTurn, chunk: UIMessageChunk): void {
+  private enqueueTurnChunk(turn: AgentSessionTurn, chunk: UIMessageChunk): void {
     const toolChunk = chunk as { type?: string; toolCallId?: string }
     if ((toolChunk.type === 'tool-input-start' || toolChunk.type === 'tool-input-available') && toolChunk.toolCallId) {
       turn.activeToolIds.add(toolChunk.toolCallId)
@@ -550,35 +587,6 @@ export class AgentSessionRuntimeService extends BaseService {
     }
 
     turn.controller?.enqueue(chunk)
-
-    if (turn.activeToolIds.size === 0 && entry.pendingTurns.length > 0) this.requestInterruptWhenSafe(entry)
-  }
-
-  private requestInterruptWhenSafe(entry: AgentSessionRuntimeEntry): void {
-    const turn = entry.currentTurn
-    if (!turn || turn.terminalStatus || !turn.admitted || turn.interruptRequested) return
-    const canInterrupt = entry.connection?.canInterruptNow?.() ?? turn.activeToolIds.size === 0
-    if (!canInterrupt) return
-    turn.interruptRequested = true
-    this.interruptCurrentTurn(entry)
-  }
-
-  private interruptCurrentTurn(entry: AgentSessionRuntimeEntry): void {
-    const turn = entry.currentTurn
-    if (!turn || turn.terminalStatus) return
-    void entry.connection?.interrupt?.().catch((error) => {
-      logger.warn('Agent runtime interrupt failed', { sessionId: entry.sessionId, error })
-    })
-    application.get('AiStreamManager').pauseRuntimeTurn(entry.topicId, 'agent-runtime-interrupt')
-  }
-
-  private stopTurn(entry: AgentSessionRuntimeEntry, intent: AgentTurnStopIntent): void {
-    const policy = STOP_POLICY[intent]
-    if (policy.closeSession) {
-      this.closeSession(entry.sessionId)
-      return
-    }
-    this.closeCurrentTurn(entry, policy.turnStatus)
   }
 
   private closeCurrentTurn(entry: AgentSessionRuntimeEntry, status: AgentSessionRuntimeTerminalStatus): void {
@@ -619,7 +627,7 @@ export class AgentSessionRuntimeService extends BaseService {
       return
     }
 
-    const { rootSpan, traceId, rootSpanId } = this.startRuntimeRootSpan(entry)
+    const rootSpan = this.startRuntimeRootSpan(entry)
     let assistantMessage: Awaited<ReturnType<typeof agentSessionMessageService.saveMessage>>
     try {
       assistantMessage = await agentSessionMessageService.saveMessage({
@@ -628,8 +636,7 @@ export class AgentSessionRuntimeService extends BaseService {
           role: 'assistant',
           status: 'pending',
           data: { parts: [] },
-          modelId: entry.modelId,
-          traceId
+          modelId: entry.modelId
         }
       })
     } catch (error) {
@@ -637,7 +644,7 @@ export class AgentSessionRuntimeService extends BaseService {
       // point re-queuing the message — the retry would just fail the same way, and a re-queued
       // message is silently cleared by the idle TTL anyway. Instead surface the failure to the
       // live renderer and settle the turn so the session doesn't sit idle on a doomed message.
-      rootSpan.end()
+      rootSpan?.end()
       application.get('AiStreamManager').broadcastTopicError(entry.topicId, entry.modelId, serializeError(error))
       this.markTurnTerminal(entry.sessionId, 'error')
       return
@@ -648,7 +655,7 @@ export class AgentSessionRuntimeService extends BaseService {
     // mirroring every other async method here — otherwise a dead entry gets resurrected
     // into a doomed runtime turn with no backing agent connection.
     if (!this.isCurrentEntry(entry)) {
-      rootSpan.end()
+      rootSpan?.end()
       return
     }
 
@@ -661,11 +668,19 @@ export class AgentSessionRuntimeService extends BaseService {
       userMessage: nextMessage,
       modelId: entry.modelId,
       admitted: false,
-      activeToolIds: new Set(),
-      interruptRequested: false,
-      trace: this.createTraceContext(entry, turnId, traceId, rootSpanId)
+      activeToolIds: new Set()
     }
 
+    const messages = createRuntimeSeedMessages(nextMessage, assistantMessageId)
+    // Author the turn span's input/identity here (the runtime owns its continuation turns).
+    if (rootSpan) {
+      applyTurnInputAttributes(rootSpan, {
+        modelId: entry.modelId,
+        topicId: entry.topicId,
+        operation: 'invoke_agent',
+        messages
+      })
+    }
     application.get('AiStreamManager').startRuntimeTurn({
       topicId: entry.topicId,
       modelId: entry.modelId,
@@ -674,7 +689,7 @@ export class AgentSessionRuntimeService extends BaseService {
         chatId: entry.topicId,
         trigger: 'submit-message',
         messageId: assistantMessageId,
-        messages: createRuntimeSeedMessages(nextMessage, assistantMessageId),
+        messages,
         runtime: { kind: 'agent-session', sessionId: entry.sessionId, turnId }
       },
       listeners: [
@@ -685,13 +700,119 @@ export class AgentSessionRuntimeService extends BaseService {
     })
   }
 
-  private startRuntimeRootSpan(entry: AgentSessionRuntimeEntry): {
-    rootSpan: Span
-    traceId: string
-    rootSpanId: string
-  } {
-    const turnTrace = startAiTurnTrace(
-      'chat.turn',
+  /** Drain-dedup + microtask defer for the roll continuation. Mirrors `scheduleNextTurn`. */
+  private scheduleContinuationTurn(entry: AgentSessionRuntimeEntry): void {
+    if (entry.startingNextTurn) return
+    entry.startingNextTurn = true
+    queueMicrotask(() => {
+      void this.startContinuationTurn(entry)
+        .catch((error) => {
+          logger.error('Failed to start steer continuation turn', { sessionId: entry.sessionId, error })
+        })
+        .finally(() => {
+          entry.startingNextTurn = false
+        })
+    })
+  }
+
+  /**
+   * Open the post-steer continuation row (A2) after a `steer-boundary` rolled A1a closed. Unlike
+   * `startNextTurn` this sends NOTHING to the connection (the steer is already in flight via the
+   * PreToolUse hook) — the turn is pre-`admitted` so `admitTurn` no-ops, and the still-streaming SDK
+   * turn's post-steer chunks (buffered in `rollBuffer`) are replayed into A2 by `flushRollBuffer`.
+   * The steer message is reused only for rename/seed context — U2 is already a persisted row.
+   */
+  private async startContinuationTurn(entry: AgentSessionRuntimeEntry): Promise<void> {
+    const steerMessage = entry.rollSteerInputs?.[0]?.message ?? createSyntheticUserMessage(entry.sessionId)
+    entry.rollSteerInputs = undefined
+
+    const rootSpan = this.startRuntimeRootSpan(entry)
+    let assistantMessage: Awaited<ReturnType<typeof agentSessionMessageService.saveMessage>>
+    try {
+      assistantMessage = await agentSessionMessageService.saveMessage({
+        sessionId: entry.sessionId,
+        message: {
+          role: 'assistant',
+          status: 'pending',
+          data: { parts: [] },
+          modelId: entry.modelId
+        }
+      })
+    } catch (error) {
+      // The A2 placeholder save failed — abandon the roll, drop the buffered post-steer chunks, and
+      // surface the failure (mirrors `startNextTurn`'s doomed-placeholder handling).
+      rootSpan?.end()
+      entry.rolling = false
+      entry.rollBuffer = undefined
+      application.get('AiStreamManager').broadcastTopicError(entry.topicId, entry.modelId, serializeError(error))
+      this.markTurnTerminal(entry.sessionId, 'error')
+      return
+    }
+
+    if (!this.isCurrentEntry(entry)) {
+      rootSpan?.end()
+      return
+    }
+
+    const assistantMessageId = assistantMessage.id
+    const turnId = crypto.randomUUID()
+    entry.currentTurn = {
+      turnId,
+      assistantMessageId,
+      userMessage: steerMessage,
+      modelId: entry.modelId,
+      // Pre-admitted: the steer was already delivered via the hook, so `admitTurn` must NOT re-send it.
+      admitted: true,
+      activeToolIds: new Set()
+    }
+
+    const messages = createRuntimeSeedMessages(steerMessage, assistantMessageId)
+    // Author the turn span's input/identity here (the runtime owns its roll continuation turns).
+    if (rootSpan) {
+      applyTurnInputAttributes(rootSpan, {
+        modelId: entry.modelId,
+        topicId: entry.topicId,
+        operation: 'invoke_agent',
+        messages
+      })
+    }
+    application.get('AiStreamManager').startRuntimeTurn({
+      topicId: entry.topicId,
+      modelId: entry.modelId,
+      rootSpan,
+      request: {
+        chatId: entry.topicId,
+        trigger: 'submit-message',
+        messageId: assistantMessageId,
+        messages,
+        runtime: { kind: 'agent-session', sessionId: entry.sessionId, turnId }
+      },
+      listeners: [
+        this.createPersistenceListener(entry, steerMessage),
+        new AgentSessionRuntimeTerminalListener(this, entry.sessionId),
+        new TraceFlushListener(entry.topicId)
+      ]
+    })
+  }
+
+  /**
+   * Replay the post-steer chunks buffered during a roll into the continuation turn's controller, then
+   * clear the roll so subsequent chunks route live. A no-op for normal turns (`rolling` is false).
+   * Synchronous (no await between draining the buffer and clearing `rolling`) so ordering is preserved.
+   */
+  private flushRollBuffer(entry: AgentSessionRuntimeEntry, turn: AgentSessionTurn): void {
+    if (!entry.rolling || entry.currentTurn !== turn) return
+    const buffered = entry.rollBuffer ?? []
+    entry.rolling = false
+    entry.rollBuffer = undefined
+    for (const chunk of buffered) this.enqueueTurnChunk(turn, chunk)
+  }
+
+  private startRuntimeRootSpan(entry: AgentSessionRuntimeEntry): Span | undefined {
+    const traceId = entry.sessionTraceId
+    if (!traceId) return undefined
+    const turnTrace = startAiChildTurnSpan(
+      'ai.turn',
       {
         attributes: {
           'cs.topic_id': entry.topicId,
@@ -702,30 +823,24 @@ export class AgentSessionRuntimeService extends BaseService {
           'cs.session_id': entry.sessionId
         }
       },
-      { topicId: entry.topicId, modelName: parseUniqueModelId(entry.modelId).modelId }
+      { topicId: entry.topicId, modelName: parseUniqueModelId(entry.modelId).modelId },
+      { traceId, spanId: deriveRootSpanId(traceId) }
     )
-    return { rootSpan: turnTrace.rootSpan, traceId: turnTrace.traceId, rootSpanId: turnTrace.rootSpanId }
+    return turnTrace.rootSpan
   }
 
-  private createTraceContext(
-    input: Pick<BeginAgentSessionTurnInput, 'topicId' | 'sessionId' | 'modelId'>,
-    turnId: string,
-    traceId?: string,
-    rootSpanId?: string
-  ): AgentRuntimeTraceContext | undefined {
-    if (!traceId || !rootSpanId) return undefined
+  /** Container trace passed to the driver as the connection's traceparent. */
+  private sessionTraceContext(entry: AgentSessionRuntimeEntry): AgentRuntimeTraceContext | undefined {
+    const traceId = entry.sessionTraceId
+    if (!traceId) return undefined
     return {
-      topicId: input.topicId,
+      topicId: entry.topicId,
       traceId,
-      rootSpanId,
-      sessionId: input.sessionId,
-      turnId,
-      modelName: parseUniqueModelId(input.modelId).modelId
+      rootSpanId: deriveRootSpanId(traceId),
+      sessionId: entry.sessionId,
+      turnId: entry.currentTurn?.turnId ?? '',
+      modelName: parseUniqueModelId(entry.modelId).modelId
     }
-  }
-
-  private shouldCloseConnectionAfterTurn(entry: AgentSessionRuntimeEntry): boolean {
-    return entry.connection?.shouldCloseAfterTurn?.() ?? false
   }
 
   private createPersistenceListener(
@@ -778,6 +893,9 @@ export class AgentSessionRuntimeService extends BaseService {
     this.clearIdleTimer(entry)
     this.closeCurrentTurn(entry, 'paused')
     entry.pendingTurns = []
+    entry.rolling = false
+    entry.rollBuffer = undefined
+    entry.rollSteerInputs = undefined
 
     const connection = this.closeConnection(entry)
     entry.currentTurn = undefined
@@ -829,7 +947,6 @@ function createSyntheticUserMessage(sessionId: string): AgentSessionMessageEntit
     searchableText: '',
     modelId: null,
     modelSnapshot: null,
-    traceId: null,
     stats: null,
     runtimeResumeToken: null,
     createdAt: now,

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -40,7 +40,9 @@ const baseTurnInput = {
   agentId: 'agent-1',
   agentType: 'test-runtime',
   modelId: 'claude-code::claude-sonnet-4-5' as any,
-  assistantMessageId: 'assistant-1'
+  assistantMessageId: 'assistant-1',
+  // Container-level session trace id (cached on the entry, drives the connection traceparent).
+  traceId: 'a'.repeat(32)
 }
 
 function userMessage(id: string) {
@@ -248,8 +250,7 @@ describe('AgentSessionRuntimeService', () => {
       status: 'active',
       pendingMessageCount: 1,
       lastTerminalStatus: undefined,
-      activeToolCount: 0,
-      interruptRequested: false
+      activeToolCount: 0
     })
   })
 
@@ -445,7 +446,9 @@ describe('AgentSessionRuntimeService', () => {
     const reader = stream.getReader()
 
     await expect(reader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
-    await vi.waitFor(() => expect(connection.send).toHaveBeenCalledWith({ message: userMessage('user-1') }))
+    await vi.waitFor(() =>
+      expect(connection.send).toHaveBeenCalledWith({ message: userMessage('user-1'), systemReminder: false })
+    )
 
     events.push({ type: 'resume-token', token: 'resume-1' })
     await vi.waitFor(() => expect(service.inspect('session-1')).toMatchObject({ resumeToken: 'resume-1' }))
@@ -500,12 +503,11 @@ describe('AgentSessionRuntimeService', () => {
     expect(getEntry(service).currentTurn?.terminalStatus).toBe('error')
   })
 
-  it('passes trace context to the runtime driver and closes the connection after trace turns', async () => {
+  it('passes trace context to the runtime driver and keeps the connection warm across turns', async () => {
     const events = createAsyncQueue<any>()
     const connection = {
       events: events.iterable,
       send: vi.fn(),
-      shouldCloseAfterTurn: () => true,
       close: vi.fn()
     }
     const connect = vi.fn().mockResolvedValue(connection)
@@ -520,8 +522,7 @@ describe('AgentSessionRuntimeService', () => {
     const handle = service.beginTurn({
       ...baseTurnInput,
       userMessage: userMessage('user-1'),
-      traceId: '0'.repeat(32),
-      rootSpanId: '1'.repeat(16)
+      traceId: 'a'.repeat(32)
     })
     const stream = service.openTurnStream({
       sessionId: 'session-1',
@@ -539,8 +540,8 @@ describe('AgentSessionRuntimeService', () => {
         resumeToken: undefined,
         trace: {
           topicId: 'agent-session:session-1',
-          traceId: '0'.repeat(32),
-          rootSpanId: '1'.repeat(16),
+          traceId: 'a'.repeat(32),
+          rootSpanId: 'a'.repeat(16),
           sessionId: 'session-1',
           turnId: handle.turnId,
           modelName: 'claude-sonnet-4-5'
@@ -550,8 +551,10 @@ describe('AgentSessionRuntimeService', () => {
 
     void terminalListener(handle).onDone({ status: 'success', isTopicDone: true })
 
-    expect(connection.close).toHaveBeenCalledOnce()
-    expect(getEntry(service).connection).toBeUndefined()
+    // Warm: a turn ending does NOT tear the connection down — only closeSession / idle TTL does.
+    expect(connection.close).not.toHaveBeenCalled()
+    expect(getEntry(service).connection).toBe(connection)
+    service.closeSession('session-1')
     await reader.cancel().catch(() => undefined)
   })
 
@@ -587,7 +590,14 @@ describe('AgentSessionRuntimeService', () => {
         agentId: 'agent-1',
         modelId: 'claude-code::claude-sonnet-4-5',
         resumeToken: 'resume-db',
-        trace: undefined
+        trace: {
+          topicId: 'agent-session:session-1',
+          traceId: 'a'.repeat(32),
+          rootSpanId: 'a'.repeat(16),
+          sessionId: 'session-1',
+          turnId: handle.turnId,
+          modelName: 'claude-sonnet-4-5'
+        }
       })
     )
 
@@ -622,7 +632,9 @@ describe('AgentSessionRuntimeService', () => {
     const reader = stream.getReader()
 
     await expect(reader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
-    await vi.waitFor(() => expect(connection.send).toHaveBeenCalledWith({ message: userMessage('user-1') }))
+    await vi.waitFor(() =>
+      expect(connection.send).toHaveBeenCalledWith({ message: userMessage('user-1'), systemReminder: false })
+    )
 
     controller.abort('user-requested')
 
@@ -670,19 +682,19 @@ describe('AgentSessionRuntimeService', () => {
     await reader.cancel().catch(() => undefined)
   })
 
-  describe('interrupt-when-safe — live follow-up', () => {
-    it('defers the interrupt while a tool is mid-flight, then fires once the tool settles', async () => {
+  describe('steer soft-queue — live follow-up (pure streaming-input, no interrupt)', () => {
+    it('does not interrupt a live turn; soft-queues the steer and pushes it into the SAME warm connection on the next turn', async () => {
       const events = createAsyncQueue<any>()
       const connection = {
         events: events.iterable,
         send: vi.fn(),
-        interrupt: vi.fn().mockResolvedValue(undefined),
         close: vi.fn()
       }
+      const connect = vi.fn().mockResolvedValue(connection)
       runtimeDriverRegistry.register({
         type: 'test-runtime',
         capabilities: ['agent-session'],
-        connect: vi.fn().mockResolvedValue(connection),
+        connect,
         validateSession: vi.fn(),
         listAvailableTools: vi.fn().mockResolvedValue([])
       })
@@ -696,74 +708,187 @@ describe('AgentSessionRuntimeService', () => {
       const reader = stream.getReader()
 
       await expect(reader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
-      await vi.waitFor(() => expect(connection.send).toHaveBeenCalledWith({ message: userMessage('user-1') }))
+      await vi.waitFor(() =>
+        expect(connection.send).toHaveBeenCalledWith({ message: userMessage('user-1'), systemReminder: false })
+      )
 
-      // A tool is now in flight — the turn is not safe to interrupt.
+      // A tool is in flight, then a steer arrives. It must NOT interrupt — just soft-queue.
       events.push({ type: 'chunk', chunk: { type: 'tool-input-start', toolCallId: 'tool-1' } })
       await vi.waitFor(() => expect(getEntry(service).currentTurn.activeToolIds.has('tool-1')).toBe(true))
-
-      // The follow-up queues but must NOT interrupt while the tool runs.
       service.enqueueUserMessage('session-1', userMessage('user-2'))
       await new Promise((resolve) => setTimeout(resolve, 0))
-      expect(connection.interrupt).not.toHaveBeenCalled()
       expect(mocks.pauseRuntimeTurn).not.toHaveBeenCalled()
+      expect(getEntry(service).pendingTurns).toHaveLength(1)
 
-      // Tool settles → now safe → interrupt fires and the runtime turn is paused.
-      events.push({ type: 'chunk', chunk: { type: 'tool-output-available', toolCallId: 'tool-1' } })
-      await vi.waitFor(() => expect(connection.interrupt).toHaveBeenCalledOnce())
-      expect(mocks.pauseRuntimeTurn).toHaveBeenCalledWith('agent-session:session-1', 'agent-runtime-interrupt')
-
-      service.closeSession('session-1')
-      await reader.cancel().catch(() => undefined)
-    })
-
-    it('interrupts immediately on the next microtask when no tool is active', async () => {
-      const events = createAsyncQueue<any>()
-      const connection = {
-        events: events.iterable,
-        send: vi.fn(),
-        interrupt: vi.fn().mockResolvedValue(undefined),
-        close: vi.fn()
-      }
-      runtimeDriverRegistry.register({
-        type: 'test-runtime',
-        capabilities: ['agent-session'],
-        connect: vi.fn().mockResolvedValue(connection),
-        validateSession: vi.fn(),
-        listAvailableTools: vi.fn().mockResolvedValue([])
-      })
-      const service = new AgentSessionRuntimeService()
-      const handle = service.beginTurn({ ...baseTurnInput, userMessage: userMessage('user-1') })
-      const stream = service.openTurnStream({
+      // The current turn completes naturally → the steer drains into the SAME warm connection,
+      // wrapped in a system-reminder. No reconnect: connect once, close never.
+      void terminalListener(handle).onDone({ status: 'success', isTopicDone: true })
+      await vi.waitFor(() => expect(getEntry(service).currentTurn?.userMessage.id).toBe('user-2'))
+      const nextTurnId = getEntry(service).currentTurn.turnId
+      const stream2 = service.openTurnStream({
         sessionId: 'session-1',
-        turnId: handle.turnId,
+        turnId: nextTurnId,
         signal: new AbortController().signal
       })
-      const reader = stream.getReader()
+      const reader2 = stream2.getReader()
+      await reader2.read()
 
-      await expect(reader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
-      await vi.waitFor(() => expect(connection.send).toHaveBeenCalledWith({ message: userMessage('user-1') }))
-
-      // No tool in flight (activeToolIds empty) → the queued follow-up interrupts on the next microtask.
-      expect(getEntry(service).currentTurn.activeToolIds.size).toBe(0)
-      service.enqueueUserMessage('session-1', userMessage('user-2'))
-      expect(connection.interrupt).not.toHaveBeenCalled()
-
-      await vi.waitFor(() => expect(connection.interrupt).toHaveBeenCalledOnce())
-      expect(mocks.pauseRuntimeTurn).toHaveBeenCalledWith('agent-session:session-1', 'agent-runtime-interrupt')
+      await vi.waitFor(() =>
+        expect(connection.send).toHaveBeenCalledWith({ message: userMessage('user-2'), systemReminder: true })
+      )
+      expect(connect).toHaveBeenCalledOnce()
+      expect(connection.close).not.toHaveBeenCalled()
 
       service.closeSession('session-1')
       await reader.cancel().catch(() => undefined)
+      await reader2.cancel().catch(() => undefined)
     })
   })
 
-  it('keeps the runtime session alive when a steer interrupt pauses the turn', async () => {
+  describe('steer redirect — real mid-turn injection (claude PreToolUse hook)', () => {
+    it('folds a live steer into the current turn via connection.redirect (not queued, no new turn)', async () => {
+      const events = createAsyncQueue<any>()
+      const redirect = vi.fn().mockReturnValue(true)
+      const connection = { events: events.iterable, send: vi.fn(), redirect, close: vi.fn() }
+      runtimeDriverRegistry.register({
+        type: 'test-runtime',
+        capabilities: ['agent-session'],
+        connect: vi.fn().mockResolvedValue(connection),
+        validateSession: vi.fn(),
+        listAvailableTools: vi.fn().mockResolvedValue([])
+      })
+      const service = new AgentSessionRuntimeService()
+      const handle = service.beginTurn({ ...baseTurnInput, userMessage: userMessage('user-1') })
+      const stream = service.openTurnStream({
+        sessionId: 'session-1',
+        turnId: handle.turnId,
+        signal: new AbortController().signal
+      })
+      const reader = stream.getReader()
+      await expect(reader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
+      await vi.waitFor(() =>
+        expect(connection.send).toHaveBeenCalledWith({ message: userMessage('user-1'), systemReminder: false })
+      )
+
+      // Steer on a live turn → redirect injects it into the running turn: not queued, no new turn.
+      service.enqueueUserMessage('session-1', userMessage('user-2'))
+      expect(redirect).toHaveBeenCalledWith({ message: userMessage('user-2'), systemReminder: true })
+      expect(getEntry(service).pendingTurns).toHaveLength(0)
+      expect(getEntry(service).steerMessageIds?.has('user-2') ?? false).toBe(false)
+
+      service.closeSession('session-1')
+      await reader.cancel().catch(() => undefined)
+    })
+
+    it('queues a steer the turn ended before injecting (steer-undelivered → next turn, system-reminder)', async () => {
+      const events = createAsyncQueue<any>()
+      const redirect = vi.fn().mockReturnValue(true)
+      const connection = { events: events.iterable, send: vi.fn(), redirect, close: vi.fn() }
+      runtimeDriverRegistry.register({
+        type: 'test-runtime',
+        capabilities: ['agent-session'],
+        connect: vi.fn().mockResolvedValue(connection),
+        validateSession: vi.fn(),
+        listAvailableTools: vi.fn().mockResolvedValue([])
+      })
+      const service = new AgentSessionRuntimeService()
+      const handle = service.beginTurn({ ...baseTurnInput, userMessage: userMessage('user-1') })
+      const stream = service.openTurnStream({
+        sessionId: 'session-1',
+        turnId: handle.turnId,
+        signal: new AbortController().signal
+      })
+      const reader = stream.getReader()
+      await expect(reader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
+      await vi.waitFor(() => expect(connection.send).toHaveBeenCalledOnce())
+
+      // Steer redirected (stashed), but the turn calls no tool → the connection hands it back.
+      service.enqueueUserMessage('session-1', userMessage('user-2'))
+      expect(getEntry(service).pendingTurns).toHaveLength(0)
+
+      events.push({ type: 'steer-undelivered', inputs: [{ message: userMessage('user-2'), systemReminder: true }] })
+      await vi.waitFor(() => expect(getEntry(service).pendingTurns).toHaveLength(1))
+      // The undelivered steer is flagged so its next turn wraps it in a system-reminder.
+      expect(getEntry(service).steerMessageIds?.has('user-2')).toBe(true)
+
+      service.closeSession('session-1')
+      await reader.cancel().catch(() => undefined)
+    })
+
+    it('rolls the turn at a steer-boundary: finalises A1a, opens A2 without re-sending, replays buffered chunks', async () => {
+      const events = createAsyncQueue<any>()
+      const connection = {
+        events: events.iterable,
+        send: vi.fn(),
+        redirect: vi.fn().mockReturnValue(true),
+        close: vi.fn()
+      }
+      runtimeDriverRegistry.register({
+        type: 'test-runtime',
+        capabilities: ['agent-session'],
+        connect: vi.fn().mockResolvedValue(connection),
+        validateSession: vi.fn(),
+        listAvailableTools: vi.fn().mockResolvedValue([])
+      })
+      const service = new AgentSessionRuntimeService()
+      const handle = service.beginTurn({ ...baseTurnInput, userMessage: userMessage('user-1') })
+      const stream = service.openTurnStream({
+        sessionId: 'session-1',
+        turnId: handle.turnId,
+        signal: new AbortController().signal
+      })
+      const reader = stream.getReader()
+      await expect(reader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
+      await vi.waitFor(() => expect(connection.send).toHaveBeenCalledOnce())
+
+      // Pre-steer chunk → routed to A1a (the original turn's stream).
+      events.push({ type: 'chunk', chunk: { type: 'text-delta', id: 'p1', delta: 'pre' } })
+      await expect(reader.read()).resolves.toMatchObject({ value: { type: 'text-delta', delta: 'pre' }, done: false })
+
+      // The driver signals the post-steer assistant message → roll: A1a closes, the topic stays busy.
+      events.push({ type: 'steer-boundary', inputs: [{ message: userMessage('user-2'), systemReminder: true }] })
+      await vi.waitFor(() => expect(getEntry(service).rolling).toBe(true))
+      await expect(reader.read()).resolves.toMatchObject({ done: true })
+      expect(getEntry(service).currentTurn.terminalStatus).toBe('success')
+
+      // Post-steer chunk arrives before A2's stream is open → buffered, not dropped.
+      events.push({ type: 'chunk', chunk: { type: 'text-delta', id: 'p2', delta: 'post' } })
+      await vi.waitFor(() => expect(getEntry(service).rollBuffer).toHaveLength(1))
+
+      // A1a's execution settles (terminal listener) → the continuation A2 opens. `isTopicDone=false`
+      // (the stream-manager keeps the topic alive across the boundary), and onDone always advances.
+      void terminalListener(handle).onDone({ status: 'success', isTopicDone: false })
+      await vi.waitFor(() => expect(getEntry(service).currentTurn.userMessage.id).toBe('user-2'))
+      const a2 = getEntry(service).currentTurn
+      expect(a2.turnId).not.toBe(handle.turnId)
+      expect(a2.admitted).toBe(true) // continuation: the steer was already injected via the hook — never re-sent
+      expect(connection.send).toHaveBeenCalledOnce() // user-1 only; A2 sends nothing to the connection
+      expect(mocks.saveMessage).toHaveBeenLastCalledWith({
+        sessionId: 'session-1',
+        message: { role: 'assistant', status: 'pending', data: { parts: [] }, modelId: baseTurnInput.modelId }
+      })
+      expect(mocks.startRuntimeTurn).toHaveBeenCalledTimes(1)
+
+      // Opening A2's stream replays the buffered post-steer chunk in order, then routes live chunks.
+      const reader2 = service
+        .openTurnStream({ sessionId: 'session-1', turnId: a2.turnId, signal: new AbortController().signal })
+        .getReader()
+      await expect(reader2.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
+      await expect(reader2.read()).resolves.toMatchObject({ value: { type: 'text-delta', delta: 'post' }, done: false })
+      expect(getEntry(service).rolling).toBe(false)
+
+      events.push({ type: 'chunk', chunk: { type: 'text-delta', id: 'p3', delta: 'live' } })
+      await expect(reader2.read()).resolves.toMatchObject({ value: { type: 'text-delta', delta: 'live' }, done: false })
+
+      service.closeSession('session-1')
+      await reader.cancel().catch(() => undefined)
+      await reader2.cancel().catch(() => undefined)
+    })
+  })
+
+  it('admits a steer-flagged turn with a system-reminder and consumes the flag (invariant 7)', async () => {
     const events = createAsyncQueue<any>()
-    const connection = {
-      events: events.iterable,
-      send: vi.fn(),
-      close: vi.fn()
-    }
+    const connection = { events: events.iterable, send: vi.fn(), close: vi.fn() }
     runtimeDriverRegistry.register({
       type: 'test-runtime',
       capabilities: ['agent-session'],
@@ -773,31 +898,53 @@ describe('AgentSessionRuntimeService', () => {
     })
     const service = new AgentSessionRuntimeService()
     const handle = service.beginTurn({ ...baseTurnInput, userMessage: userMessage('user-1') })
-    const controller = new AbortController()
+    // Mark this turn's message as a steer, as `enqueueUserMessage` does for a mid-turn arrival.
+    getEntry(service).steerMessageIds = new Set(['user-1'])
     const stream = service.openTurnStream({
       sessionId: 'session-1',
       turnId: handle.turnId,
-      signal: controller.signal
+      signal: new AbortController().signal
     })
     const reader = stream.getReader()
 
     await expect(reader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
-    await vi.waitFor(() => expect(connection.send).toHaveBeenCalledWith({ message: userMessage('user-1') }))
-
-    // The steer path marks the turn before aborting; the abort reason is irrelevant.
-    getEntry(service).currentTurn.interruptRequested = true
-    controller.abort()
-
-    await expect(reader.read()).resolves.toMatchObject({ done: true })
-    expect(connection.close).not.toHaveBeenCalled()
-    expect(service.inspect('session-1')).toMatchObject({
-      sessionId: 'session-1',
-      status: 'active'
-    })
+    await vi.waitFor(() =>
+      expect(connection.send).toHaveBeenCalledWith({ message: userMessage('user-1'), systemReminder: true })
+    )
+    // The flag is consumed as the turn is admitted.
+    expect(getEntry(service).steerMessageIds.has('user-1')).toBe(false)
     service.closeSession('session-1')
   })
 
-  it('tears the session down on abort with an interrupt-looking reason when none was requested', async () => {
+  it('flags a mid-turn follow-up as a steer (system-reminder) while a turn is live', async () => {
+    const events = createAsyncQueue<any>()
+    const connection = { events: events.iterable, send: vi.fn(), interrupt: vi.fn(), close: vi.fn() }
+    runtimeDriverRegistry.register({
+      type: 'test-runtime',
+      capabilities: ['agent-session'],
+      connect: vi.fn().mockResolvedValue(connection),
+      validateSession: vi.fn(),
+      listAvailableTools: vi.fn().mockResolvedValue([])
+    })
+    const service = new AgentSessionRuntimeService()
+    const handle = service.beginTurn({ ...baseTurnInput, userMessage: userMessage('user-1') })
+    const stream = service.openTurnStream({
+      sessionId: 'session-1',
+      turnId: handle.turnId,
+      signal: new AbortController().signal
+    })
+    const reader = stream.getReader()
+    await expect(reader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
+    await vi.waitFor(() => expect(connection.send).toHaveBeenCalled())
+
+    // Arrives while the first turn is live → flagged as a steer.
+    service.enqueueUserMessage('session-1', userMessage('user-2'))
+    expect(getEntry(service).steerMessageIds?.has('user-2')).toBe(true)
+    service.closeSession('session-1')
+    await reader.cancel().catch(() => undefined)
+  })
+
+  it('tears the session down on any turn abort (steer no longer interrupts — abort is always a user Stop)', async () => {
     const events = createAsyncQueue<any>()
     const connection = {
       events: events.iterable,
@@ -822,10 +969,12 @@ describe('AgentSessionRuntimeService', () => {
     const reader = stream.getReader()
 
     await expect(reader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
-    await vi.waitFor(() => expect(connection.send).toHaveBeenCalledWith({ message: userMessage('user-1') }))
+    await vi.waitFor(() =>
+      expect(connection.send).toHaveBeenCalledWith({ message: userMessage('user-1'), systemReminder: false })
+    )
 
-    // Reason matches the old interrupt sentinel, but no interrupt was requested —
-    // teardown is driven by `interruptRequested`, not the signal reason.
+    // Steer no longer interrupts, so the only abort source is a user Stop — which always tears the
+    // session down (closeSession → connection.close), regardless of the signal reason.
     controller.abort('agent-runtime-interrupt')
 
     await vi.waitFor(() => expect(connection.close).toHaveBeenCalledOnce())
@@ -868,18 +1017,16 @@ describe('AgentSessionRuntimeService', () => {
 
     await (service as any).startNextTurn(entry)
 
-    const savedMessage = mocks.saveMessage.mock.calls[0][0].message
     expect(mocks.saveMessage).toHaveBeenCalledWith({
       sessionId: 'session-1',
       message: {
         role: 'assistant',
         status: 'pending',
         data: { parts: [] },
-        modelId: 'claude-code::claude-sonnet-4-5',
-        traceId: expect.any(String)
+        modelId: 'claude-code::claude-sonnet-4-5'
       }
     })
-    expect(mocks.spanCacheSetTopicId).toHaveBeenCalledWith(savedMessage.traceId, 'agent-session:session-1')
+    expect(mocks.spanCacheSetTopicId).toHaveBeenCalledWith(expect.any(String), 'agent-session:session-1')
     expect(mocks.startRuntimeTurn).toHaveBeenCalledWith({
       topicId: 'agent-session:session-1',
       modelId: 'claude-code::claude-sonnet-4-5',
@@ -902,14 +1049,8 @@ describe('AgentSessionRuntimeService', () => {
     })
     const request = mocks.startRuntimeTurn.mock.calls[0][0].request
     expect(request.messageId).toBe(request.messages[1].id)
-    expect(getEntry(service).currentTurn.trace).toMatchObject({
-      topicId: 'agent-session:session-1',
-      traceId: savedMessage.traceId,
-      rootSpanId: expect.any(String),
-      sessionId: 'session-1',
-      turnId: request.runtime.turnId,
-      modelName: 'claude-sonnet-4-5'
-    })
+    // The session trace id is cached on the entry and reused for every turn (container-scoped trace).
+    expect(getEntry(service).sessionTraceId).toBe('a'.repeat(32))
   })
 
   it('surfaces the error and settles the turn when the next-turn placeholder save rejects (R3)', async () => {

--- a/src/main/ai/runtime/aiSdk/params/__tests__/collectFromFeatures.test.ts
+++ b/src/main/ai/runtime/aiSdk/params/__tests__/collectFromFeatures.test.ts
@@ -106,7 +106,7 @@ describe('collectFromFeatures', () => {
 
   it('returns empty contributions when no features supplied', () => {
     const out = collectFromFeatures(makeScope(), [])
-    expect(out).toEqual({ modelAdapters: [], hookParts: [] })
+    expect(out).toEqual({ modelAdapters: [], hookParts: [], stopConditions: [] })
   })
 
   it('skips contribute methods that return undefined', () => {

--- a/src/main/ai/runtime/aiSdk/params/buildAgentParams.ts
+++ b/src/main/ai/runtime/aiSdk/params/buildAgentParams.ts
@@ -94,7 +94,7 @@ export async function buildAgentParams(input: BuildAgentParamsInput): Promise<Bu
   const contributions = collectFromFeatures(scope, features)
 
   const system = await assembleSystemPrompt({ assistant, model, tools, deferredEntries })
-  const options = buildAgentOptions(scope)
+  const options = buildAgentOptions(scope, contributions.stopConditions)
 
   return {
     sdkConfig,
@@ -176,7 +176,7 @@ async function resolveTools(
  * provider-scoped params), per-call headers/maxRetries, stop-after-N-tools,
  * and the tool-call repair function.
  */
-function buildAgentOptions(scope: RequestScope): AgentOptions {
+function buildAgentOptions(scope: RequestScope, featureStopConditions: StopCondition<ToolSet>[]): AgentOptions {
   const { assistant, capabilities, model, provider, sdkConfig, requestContext, request, aiSdkProviderId } = scope
 
   let providerOptions =
@@ -198,7 +198,12 @@ function buildAgentOptions(scope: RequestScope): AgentOptions {
   providerOptions = overridden.providerOptions as typeof providerOptions
 
   const { headers, maxRetries } = request.requestOptions ?? {}
-  const stopWhen = assistant ? resolveStopWhenForAssistant(assistant) : undefined
+  // Assistant step-cap OR'd with feature-contributed conditions (e.g. steer yield). An array means
+  // any condition stops the loop at that step boundary.
+  const baseStopWhen = assistant ? resolveStopWhenForAssistant(assistant) : undefined
+  const stopWhen: StopCondition<ToolSet> | StopCondition<ToolSet>[] | undefined = featureStopConditions.length
+    ? [...(baseStopWhen ? [baseStopWhen] : []), ...featureStopConditions]
+    : baseStopWhen
   const telemetry = buildTelemetry(scope)
 
   return {

--- a/src/main/ai/runtime/aiSdk/params/collectFromFeatures.ts
+++ b/src/main/ai/runtime/aiSdk/params/collectFromFeatures.ts
@@ -10,6 +10,7 @@
 
 import type { AiPlugin } from '@cherrystudio/ai-core'
 import { loggerService } from '@logger'
+import type { StopCondition, ToolSet } from 'ai'
 
 import type { AgentLoopHooks } from '../loop'
 import type { RequestFeature } from './feature'
@@ -20,12 +21,14 @@ const logger = loggerService.withContext('collectFromFeatures')
 export interface FeatureContributions {
   modelAdapters: AiPlugin[]
   hookParts: Array<Partial<AgentLoopHooks>>
+  stopConditions: StopCondition<ToolSet>[]
 }
 
 export function collectFromFeatures(scope: RequestScope, features: readonly RequestFeature[]): FeatureContributions {
   const out: FeatureContributions = {
     modelAdapters: [],
-    hookParts: []
+    hookParts: [],
+    stopConditions: []
   }
 
   for (const feature of features) {
@@ -36,6 +39,9 @@ export function collectFromFeatures(scope: RequestScope, features: readonly Requ
 
     const hooks = invokeContribution(feature, 'contributeHooks', scope)
     if (hooks) out.hookParts.push(hooks)
+
+    const stopConditions = invokeContribution(feature, 'contributeStopConditions', scope)
+    if (stopConditions) out.stopConditions.push(...stopConditions)
   }
 
   return out
@@ -51,7 +57,7 @@ function shouldRun(feature: RequestFeature, scope: RequestScope): boolean {
   }
 }
 
-type ContributionMethod = 'contributeModelAdapters' | 'contributeHooks'
+type ContributionMethod = 'contributeModelAdapters' | 'contributeHooks' | 'contributeStopConditions'
 
 function invokeContribution<M extends ContributionMethod>(
   feature: RequestFeature,

--- a/src/main/ai/runtime/aiSdk/params/feature.ts
+++ b/src/main/ai/runtime/aiSdk/params/feature.ts
@@ -1,4 +1,5 @@
 import type { AiPlugin } from '@cherrystudio/ai-core'
+import type { StopCondition, ToolSet } from 'ai'
 
 import type { AgentLoopHooks } from '../loop'
 import type { RequestScope } from './scope'
@@ -21,4 +22,8 @@ export interface RequestFeature {
   /** Pieces of `AgentLoopHooks`. Multiple features' same-named hooks are
    *  combined by `composeHooks` into a deterministic chain. */
   contributeHooks?(scope: RequestScope): Partial<AgentLoopHooks>
+
+  /** Loop-stop conditions OR'd into `AgentOptions.stopWhen` alongside the assistant's step cap.
+   *  Any condition returning true stops the agent loop at that step boundary. */
+  contributeStopConditions?(scope: RequestScope): StopCondition<ToolSet>[]
 }

--- a/src/main/ai/runtime/aiSdk/params/features/__tests__/steerYield.test.ts
+++ b/src/main/ai/runtime/aiSdk/params/features/__tests__/steerYield.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const hasPendingSteer = vi.fn()
+vi.mock('@main/core/application', () => ({
+  application: { get: vi.fn(() => ({ hasPendingSteer })) }
+}))
+vi.mock('../../../../agentSession/topic', () => ({
+  isAgentSessionTopic: (id: string) => id.startsWith('agent-session:')
+}))
+
+import { steerYieldFeature } from '../steerYield'
+
+const scope = (chatId?: string) => ({ request: { chatId } }) as any
+
+describe('steerYieldFeature', () => {
+  it('applies to chat topics, not agent sessions or topicless requests', () => {
+    expect(steerYieldFeature.applies?.(scope('topic-1'))).toBe(true)
+    expect(steerYieldFeature.applies?.(scope('agent-session:s1'))).toBe(false)
+    expect(steerYieldFeature.applies?.(scope(undefined))).toBe(false)
+  })
+
+  it('contributes a stop condition that fires only when the topic has a pending steer', () => {
+    const [condition] = steerYieldFeature.contributeStopConditions!(scope('topic-1'))
+
+    hasPendingSteer.mockReturnValue(false)
+    expect(condition({ steps: [] } as any)).toBe(false)
+
+    hasPendingSteer.mockReturnValue(true)
+    expect(condition({ steps: [] } as any)).toBe(true)
+    expect(hasPendingSteer).toHaveBeenCalledWith('topic-1')
+  })
+
+  it('contributes nothing for a topicless request', () => {
+    expect(steerYieldFeature.contributeStopConditions!(scope(undefined))).toEqual([])
+  })
+})

--- a/src/main/ai/runtime/aiSdk/params/features/index.ts
+++ b/src/main/ai/runtime/aiSdk/params/features/index.ts
@@ -22,6 +22,7 @@ import { qwenThinkingFeature } from './qwenThinking'
 import { reasoningExtractionFeature } from './reasoningExtraction'
 import { simulateStreamingFeature } from './simulateStreaming'
 import { skipGeminiThoughtSignatureFeature } from './skipGeminiThoughtSignature'
+import { steerYieldFeature } from './steerYield'
 
 export const INTERNAL_FEATURES: readonly RequestFeature[] = [
   devtoolsFeature,
@@ -39,5 +40,7 @@ export const INTERNAL_FEATURES: readonly RequestFeature[] = [
   qwenThinkingFeature,
   skipGeminiThoughtSignatureFeature,
   providerWebSearchFeature,
-  providerUrlContextFeature
+  providerUrlContextFeature,
+  // Stop condition only (no plugins/hooks) — yields a chat turn when a steer is queued.
+  steerYieldFeature
 ]

--- a/src/main/ai/runtime/aiSdk/params/features/steerYield.ts
+++ b/src/main/ai/runtime/aiSdk/params/features/steerYield.ts
@@ -1,0 +1,26 @@
+import { application } from '@main/core/application'
+import type { StopCondition, ToolSet } from 'ai'
+
+import { isAgentSessionTopic } from '../../../../agentSession/topic'
+import type { RequestFeature } from '../feature'
+
+/**
+ * Yield the running chat turn at the next safe step boundary when a steer message is queued for the
+ * topic. The step cap and this condition are OR'd into `stopWhen`; when it fires the turn stops
+ * cleanly (persisted as success) and `AiStreamManager` chains a continuation that answers the steer.
+ *
+ * Chat-only: agent sessions absorb mid-flight messages natively via the SDK streaming-input queue,
+ * so they neither run through this params path with a real topic nor need a yield condition.
+ */
+export const steerYieldFeature: RequestFeature = {
+  name: 'steer-yield',
+  applies: (scope) => {
+    const topicId = scope.request.chatId
+    return Boolean(topicId) && !isAgentSessionTopic(topicId as string)
+  },
+  contributeStopConditions: (scope): StopCondition<ToolSet>[] => {
+    const topicId = scope.request.chatId
+    if (!topicId) return []
+    return [() => application.get('AiStreamManager').hasPendingSteer(topicId)]
+  }
+}

--- a/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
+++ b/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
@@ -16,6 +16,7 @@ import {
   listClaudeAgentToolDescriptors
 } from '@main/ai/tools/adapters/claudeCode/agentTools'
 import { application } from '@main/core/application'
+import { wrapSteerReminder } from '@main/ai/steerReminder'
 import type { Tool } from '@shared/ai/tool'
 import type { AgentSessionEntity, AgentSessionMessageEntity } from '@shared/data/api/schemas/agentSessions'
 
@@ -30,7 +31,7 @@ import type {
 import { buildClaudeCodeQueryRequestForAgentSession } from './agentSessionWarmup'
 import { AgentSessionWorkspaceError, assertClaudeCodeWorkspaceDirectory } from './settingsBuilder'
 import { ClaudeCodeStreamAdapter, convertClaudeCodeUsage } from './streamAdapter'
-import type { McpToolDisplayMetadata, ToolApprovalEmitterHolder } from './types'
+import type { McpToolDisplayMetadata, SteerHolder, ToolApprovalEmitterHolder } from './types'
 
 const logger = loggerService.withContext('ClaudeCodeRuntimeDriver')
 
@@ -122,6 +123,10 @@ class ClaudeCodeRuntimeConnection implements AgentRuntimeConnection {
   private pendingInitMessage?: SDKSystemMessage
   private resumeToken?: string
   private toolPolicySnapshot?: ClaudeAgentToolPolicySnapshot
+  private steerHolder?: SteerHolder
+  /** Set when the PreToolUse hook injects a steer; the next top-level assistant `message_start`
+   *  emits a `steer-boundary` (rolls A1a + A2) and clears this. */
+  private steerBoundaryPending?: AgentRuntimeUserInput[]
 
   readonly events = this.eventQueue
 
@@ -163,6 +168,14 @@ class ClaudeCodeRuntimeConnection implements AgentRuntimeConnection {
     this.approvalEmitter = request.settings.approvalEmitter
     this.mcpToolMetadata = request.settings.mcpToolMetadata
     this.toolPolicySnapshot = request.settings.toolPolicySnapshot
+    this.steerHolder = request.settings.steerHolder
+    // Arm a `steer-boundary` when the PreToolUse hook injects a steer this turn. Bound on the live
+    // connection (not the warm prewarm) so the boundary is observed by this connection's query loop.
+    if (this.steerHolder) {
+      this.steerHolder.onInjected = (inputs) => {
+        this.steerBoundaryPending = inputs
+      }
+    }
     void this.runQueryLoop()
     return this
   }
@@ -180,16 +193,16 @@ class ClaudeCodeRuntimeConnection implements AgentRuntimeConnection {
       this.pendingInitMessage = undefined
     }
 
-    this.sdkInputQueue.push(toSdkUserMessage(input.message, this.resumeToken))
+    this.sdkInputQueue.push(toSdkUserMessage(input.message, this.resumeToken, input.systemReminder))
   }
 
-  async interrupt(): Promise<void> {
-    this.adapter?.finalizeOpenParts()
-    await this.query?.interrupt()
-  }
-
-  shouldCloseAfterTurn(): boolean {
-    return Boolean(this.input.trace) && application.get('ClaudeCodeTraceBridgeService').isTraceModeEnabled()
+  redirect(input: AgentRuntimeUserInput): boolean {
+    // No active turn (no live adapter) → can't steer; the host queues this as the next turn.
+    if (!this.adapter || !this.steerHolder) return false
+    // Stash for the PreToolUse steer hook to inject as `additionalContext` before the next tool runs.
+    // If the turn ends with no tool call, runQueryLoop emits `steer-undelivered` and the host queues it.
+    this.steerHolder.pending.push(input)
+    return true
   }
 
   async applyPolicyUpdate(update: AgentRuntimePolicyUpdate): Promise<boolean> {
@@ -207,6 +220,8 @@ class ClaudeCodeRuntimeConnection implements AgentRuntimeConnection {
     this.sdkInputQueue.close()
     this.abortController.abort('agent-runtime-closed')
     this.disposeApprovalEmitter()
+    this.steerBoundaryPending = undefined
+    this.steerHolder?.dispose()
     this.query?.close()
     this.eventQueue.close()
   }
@@ -232,9 +247,26 @@ class ClaudeCodeRuntimeConnection implements AgentRuntimeConnection {
           continue
         }
 
+        // A steer was injected this turn → the first TOP-LEVEL assistant message after it (the model's
+        // post-steer response; subagent/nested messages carry a parent_tool_use_id and are skipped) is
+        // where the host rolls A1a + A2. Emit the boundary BEFORE the adapter handles this message so it
+        // lands ahead of A2's content chunks in the event stream. (message_start is a no-op in the adapter.)
+        if (
+          this.steerBoundaryPending &&
+          message.type === 'stream_event' &&
+          message.event.type === 'message_start' &&
+          message.parent_tool_use_id == null
+        ) {
+          this.eventQueue.push({ type: 'steer-boundary', inputs: this.steerBoundaryPending })
+          this.steerBoundaryPending = undefined
+        }
+
         const result = this.adapter.handleMessage(message)
         if (result.type === 'result') {
           this.updateResumeToken(result.sessionId)
+          // The steer was injected but no post-steer top-level assistant message followed (rare; the
+          // turn ended right after the gated tool). Drop the arm — no boundary, no empty A2.
+          this.steerBoundaryPending = undefined
           // `readUIMessageStream` only reads token counts from `message-metadata`
           // chunks. The streamAdapter's V3-shaped `finish.usage` is ignored, so
           // we project the SDK BetaUsage onto a UIMessageChunk here — keeping
@@ -242,6 +274,10 @@ class ClaudeCodeRuntimeConnection implements AgentRuntimeConnection {
           this.emitUsageMetadata(result.message.usage)
           this.adapter = undefined
           this.disposeApprovalEmitter()
+          // Steers not injected by the hook this turn (the turn called no tool after they arrived) →
+          // hand them back so the host queues them as the next turn (the steer_undelivered fallback).
+          const undelivered = this.steerHolder?.pending.splice(0) ?? []
+          if (undelivered.length > 0) this.eventQueue.push({ type: 'steer-undelivered', inputs: undelivered })
           this.eventQueue.push({ type: 'turn-complete' })
         }
       }
@@ -309,10 +345,15 @@ class ClaudeCodeRuntimeConnection implements AgentRuntimeConnection {
   }
 }
 
-function toSdkUserMessage(message: AgentSessionMessageEntity, resumeToken?: string): SDKUserMessage {
+function toSdkUserMessage(
+  message: AgentSessionMessageEntity,
+  resumeToken?: string,
+  systemReminder = false
+): SDKUserMessage {
+  const text = extractMessageText(message)
   return {
     type: 'user',
-    message: { role: 'user', content: extractMessageText(message) },
+    message: { role: 'user', content: systemReminder && text.trim() ? wrapSteerReminder(text) : text },
     parent_tool_use_id: null,
     session_id: resumeToken ?? ''
   }

--- a/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeRuntimeDriver.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeRuntimeDriver.test.ts
@@ -283,24 +283,6 @@ describe('ClaudeCodeRuntimeDriver', () => {
     void connection.close()
   })
 
-  it('interrupts and finalizes the active adapter', async () => {
-    const queryQueue = createAsyncQueue<any>()
-    const query = { ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() }
-    mocks.createClaudeQuery.mockReturnValue(query)
-    const connection = await new ClaudeCodeRuntimeDriver().connect({
-      sessionId: 'session-1',
-      agentId: 'agent-1',
-      modelId: 'claude-code::sonnet' as any
-    })
-
-    void connection.send({ message: userMessage() })
-    await connection.interrupt?.()
-
-    expect(query.interrupt).toHaveBeenCalled()
-    expect(mocks.adapterInstances[0].finalizeOpenParts).toHaveBeenCalled()
-    void connection.close()
-  })
-
   it('injects Claude Code trace env and skips warm query for trace turns', async () => {
     const queryQueue = createAsyncQueue<any>()
     const query = { ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() }
@@ -345,6 +327,122 @@ describe('ClaudeCodeRuntimeDriver', () => {
         }
       })
     })
+    void connection.close()
+  })
+
+  it('redirect declines without a live turn and stashes the steer in the holder once a turn is active', async () => {
+    const queryQueue = createAsyncQueue<any>()
+    const query = { ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() }
+    mocks.createClaudeQuery.mockReturnValue(query)
+    const steerHolder = { pending: [] as unknown[], dispose: vi.fn() }
+    mocks.buildRequest.mockResolvedValueOnce({
+      key: 'warm-key',
+      options: { model: 'sonnet' },
+      settings: { steerHolder },
+      sdkModelId: 'sonnet-sdk',
+      initializeTimeoutMs: 100
+    })
+    const connection = await new ClaudeCodeRuntimeDriver().connect({
+      sessionId: 'session-1',
+      agentId: 'agent-1',
+      modelId: 'claude-code::sonnet' as any
+    })
+
+    // No active turn (no adapter yet) → redirect declines so the host queues instead of steering.
+    expect(connection.redirect?.({ message: userMessage() })).toBe(false)
+    expect(steerHolder.pending).toHaveLength(0)
+
+    // A turn is now live → redirect stashes the steer in the shared holder for the PreToolUse hook.
+    void connection.send({ message: userMessage() })
+    expect(connection.redirect?.({ message: userMessage() })).toBe(true)
+    expect(steerHolder.pending).toHaveLength(1)
+
+    void connection.close()
+    expect(steerHolder.dispose).toHaveBeenCalled()
+  })
+
+  it('emits a steer-boundary at the first top-level message_start after a steer is injected', async () => {
+    const queryQueue = createAsyncQueue<any>()
+    const query = { ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() }
+    mocks.createClaudeQuery.mockReturnValue(query)
+    const steerHolder = { pending: [] as unknown[], onInjected: undefined as any, dispose: vi.fn() }
+    mocks.buildRequest.mockResolvedValueOnce({
+      key: 'warm-key',
+      options: { model: 'sonnet' },
+      settings: { steerHolder },
+      sdkModelId: 'sonnet-sdk',
+      initializeTimeoutMs: 100
+    })
+    const connection = await new ClaudeCodeRuntimeDriver().connect({
+      sessionId: 'session-1',
+      agentId: 'agent-1',
+      modelId: 'claude-code::sonnet' as any
+    })
+    const events = connection.events[Symbol.asyncIterator]()
+
+    // The live connection binds onInjected so the PreToolUse hook can arm the boundary.
+    expect(typeof steerHolder.onInjected).toBe('function')
+
+    queryQueue.push({ type: 'system', subtype: 'init', session_id: 'resume-init' })
+    await events.next() // resume-token
+    void connection.send({ message: userMessage() })
+    await events.next() // metadata chunk (init replayed on send)
+
+    // A message_start BEFORE injection (the pre-steer assistant message) must NOT roll.
+    queryQueue.push({ type: 'stream_event', event: { type: 'message_start' }, parent_tool_use_id: null })
+    await expect(events.next()).resolves.toMatchObject({ value: { type: 'chunk', chunk: { type: 'text-delta' } } })
+
+    // PreToolUse hook injects the steer → arms the boundary.
+    const steer = { message: userMessage() }
+    steerHolder.onInjected([steer])
+
+    // A nested (subagent) message_start carries a parent_tool_use_id → must NOT roll.
+    queryQueue.push({ type: 'stream_event', event: { type: 'message_start' }, parent_tool_use_id: 'tool-x' })
+    await expect(events.next()).resolves.toMatchObject({ value: { type: 'chunk', chunk: { type: 'text-delta' } } })
+
+    // The first TOP-LEVEL message_start after injection emits the boundary, ahead of its own chunks.
+    queryQueue.push({ type: 'stream_event', event: { type: 'message_start' }, parent_tool_use_id: null })
+    await expect(events.next()).resolves.toMatchObject({ value: { type: 'steer-boundary', inputs: [steer] } })
+    await expect(events.next()).resolves.toMatchObject({ value: { type: 'chunk', chunk: { type: 'text-delta' } } })
+
+    void connection.close()
+  })
+
+  it('drops the steer-boundary arm when the turn ends before a post-steer message', async () => {
+    const queryQueue = createAsyncQueue<any>()
+    const query = { ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() }
+    mocks.createClaudeQuery.mockReturnValue(query)
+    const steerHolder = { pending: [] as unknown[], onInjected: undefined as any, dispose: vi.fn() }
+    mocks.buildRequest.mockResolvedValueOnce({
+      key: 'warm-key',
+      options: { model: 'sonnet' },
+      settings: { steerHolder },
+      sdkModelId: 'sonnet-sdk',
+      initializeTimeoutMs: 100
+    })
+    const connection = await new ClaudeCodeRuntimeDriver().connect({
+      sessionId: 'session-1',
+      agentId: 'agent-1',
+      modelId: 'claude-code::sonnet' as any
+    })
+    const events = connection.events[Symbol.asyncIterator]()
+
+    void connection.send({ message: userMessage() })
+    steerHolder.onInjected([{ message: userMessage() }])
+
+    // Turn ends (result) with no following top-level message_start → no boundary, just a clean turn end.
+    queryQueue.push({ type: 'result', subtype: 'success', session_id: 'resume-result', usage: {} })
+
+    const seen: any[] = []
+    for (;;) {
+      const { value, done } = await events.next()
+      if (done) break
+      seen.push(value)
+      if (value?.type === 'turn-complete') break
+    }
+    expect(seen.some((e) => e?.type === 'steer-boundary')).toBe(false)
+    expect(seen.some((e) => e?.type === 'turn-complete')).toBe(true)
+
     void connection.close()
   })
 

--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -59,7 +59,10 @@ import type { CherryToolMeta } from '@shared/data/types/uiParts'
 import { app } from 'electron'
 
 import { toolApprovalRegistry } from './ToolApprovalRegistry'
-import type { ClaudeCodeSettings, ToolApprovalEmitterHolder } from './types'
+import { wrapSteerReminder } from '@main/ai/steerReminder'
+
+import type { AgentRuntimeUserInput } from '../types'
+import type { ClaudeCodeSettings, McpToolDisplayMetadata, SteerHolder, ToolApprovalEmitterHolder } from './types'
 
 const logger = loggerService.withContext('ClaudeCodeSettingsBuilder')
 const require_ = createRequire(import.meta.url)
@@ -91,6 +94,36 @@ function getToolApprovalEmitterHolder(sessionId: string): ToolApprovalEmitterHol
     toolApprovalEmitters.set(sessionId, holder)
   }
   return holder
+}
+
+// Session-keyed so a warm-pooled query's PreToolUse steer hook and the live connection's
+// `redirect()` reference the SAME holder (the warm pool strips closures from its signature, so the
+// query carries prewarm-time hooks — they must resolve session state by id, not by closure).
+const steerHolders = new Map<string, SteerHolder>()
+
+function getSteerHolder(sessionId: string): SteerHolder {
+  let holder = steerHolders.get(sessionId)
+  if (!holder) {
+    const nextHolder: SteerHolder = {
+      pending: [],
+      dispose: () => {
+        nextHolder.pending = []
+        if (steerHolders.get(sessionId) === nextHolder) steerHolders.delete(sessionId)
+      }
+    }
+    holder = nextHolder
+    steerHolders.set(sessionId, holder)
+  }
+  return holder
+}
+
+function extractSteerText(input: AgentRuntimeUserInput): string {
+  return (
+    input.message.data?.parts
+      ?.filter((part): part is { type: 'text'; text: string } => part.type === 'text' && 'text' in part)
+      .map((part) => part.text)
+      .join('\n') ?? ''
+  )
 }
 
 /**
@@ -205,10 +238,12 @@ export async function buildClaudeCodeSessionSettings(
   // `dispose` drops any approval still pending for this session when the
   // stream exits abnormally.
   const approvalEmitter = getToolApprovalEmitterHolder(session.id)
+  const steerHolder = getSteerHolder(session.id)
   const { canUseTool, hooks, allowedTools, disallowedTools, toolPolicySnapshot } = await buildToolPermissions(
     session,
     agent,
-    approvalEmitter
+    approvalEmitter,
+    steerHolder
   )
 
   // 5. System prompt
@@ -239,6 +274,7 @@ export async function buildClaudeCodeSessionSettings(
     canUseTool,
     hooks,
     approvalEmitter,
+    steerHolder,
     toolPolicySnapshot,
     warmQueryKey: session.id,
     ...(mcpServers ? { mcpServers, strictMcpConfig: true } : {}),
@@ -412,7 +448,8 @@ async function discoverPlugins(cwd: string, agentId: string): Promise<SdkPluginC
 async function buildToolPermissions(
   session: AgentSessionEntity,
   agent: AgentEntity,
-  approvalEmitter: ToolApprovalEmitterHolder
+  approvalEmitter: ToolApprovalEmitterHolder,
+  steerHolder: SteerHolder
 ): Promise<{
   canUseTool: CanUseTool
   hooks: ClaudeCodeSettings['hooks']
@@ -479,9 +516,34 @@ async function buildToolPermissions(
     return { hookSpecificOutput: { hookEventName: 'PreToolUse', updatedInput: { ...toolInput, command: rewritten } } }
   }
 
+  // Real mid-turn steer (the agent SDK has no native steer API): when a steer is stashed via the
+  // connection's `redirect()`, inject it as `additionalContext` before the next tool runs so the
+  // model can change direction without aborting. If the turn ends with no tool call, the connection
+  // emits `steer-undelivered` and the host queues it as the next turn instead.
+  const steerHook: HookCallback = async (input): Promise<HookJSONOutput> => {
+    if (!input || input.hook_event_name !== 'PreToolUse') return {}
+    const taken = steerHolder.pending.splice(0)
+    if (taken.length === 0) return {}
+    const text = taken
+      .map(extractSteerText)
+      .filter((t) => t.trim())
+      .join('\n\n')
+    if (!text) return {}
+    logger.info('Injecting steer into the running turn via PreToolUse hook', {
+      sessionId: session.id,
+      count: taken.length
+    })
+    // Arm the connection's `steer-boundary` (rolls A1a + A2) — fired only when we actually inject.
+    steerHolder.onInjected?.(taken)
+    return {
+      continue: true,
+      hookSpecificOutput: { hookEventName: 'PreToolUse', additionalContext: wrapSteerReminder(text) }
+    }
+  }
+
   return {
     canUseTool,
-    hooks: { PreToolUse: [{ hooks: [rtkRewriteHook] }] },
+    hooks: { PreToolUse: [{ hooks: [rtkRewriteHook, steerHook] }] },
     allowedTools: agent.allowedTools,
     disallowedTools: [
       ...GLOBALLY_DISALLOWED_TOOLS,

--- a/src/main/ai/runtime/claudeCode/types.ts
+++ b/src/main/ai/runtime/claudeCode/types.ts
@@ -2,6 +2,8 @@ import type { LanguageModelV3ToolApprovalRequest } from '@ai-sdk/provider'
 import type { Options } from '@anthropic-ai/claude-agent-sdk'
 import type { ClaudeAgentToolPolicySnapshot } from '@main/ai/tools/adapters/claudeCode/agentTools'
 
+import type { AgentRuntimeUserInput } from '../types'
+
 export type McpToolDisplayMetadata = {
   type: 'mcp'
   serverId: string
@@ -37,6 +39,12 @@ export type ClaudeCodeSettings = Omit<Options, 'model' | 'abortController' | 'pr
    */
   approvalEmitter?: ToolApprovalEmitterHolder
   /**
+   * Session-scoped holder for mid-turn steers. The PreToolUse steer hook drains it (injecting the
+   * steer text as `additionalContext`); the connection's `redirect()` fills it. Shared by sessionId
+   * so a warm-pooled query's hook and the live connection reference the same holder.
+   */
+  steerHolder?: SteerHolder
+  /**
    * Session-scoped key used by ClaudeCodeWarmQueryManager. This is not passed
    * to the Claude Agent SDK; it only controls warm query lookup in Main.
    */
@@ -60,4 +68,16 @@ export type ToolApprovalEmitterHolder = {
   emit?: (event: LanguageModelV3ToolApprovalRequest) => void
   /** Session-scoped cleanup (e.g. `toolApprovalRegistry.abort(sessionId)`). */
   dispose?: () => void
+}
+
+export type SteerHolder = {
+  /** Mid-turn steers stashed via the connection's `redirect()`; drained in place (splice) by the
+   *  PreToolUse steer hook, or emitted as `steer-undelivered` when the turn ends before injection. */
+  pending: AgentRuntimeUserInput[]
+  /** Fired by the PreToolUse steer hook the moment it injects the drained steers as `additionalContext`.
+   *  The connection uses this to arm a `steer-boundary` at the next assistant message so the host can
+   *  roll the assistant row (A1a + A2). Bound by the live connection at start; absent ⇒ no roll. */
+  onInjected?: (inputs: AgentRuntimeUserInput[]) => void
+  /** Session-scoped cleanup — clears pending + evicts the holder. */
+  dispose: () => void
 }

--- a/src/main/ai/runtime/types.ts
+++ b/src/main/ai/runtime/types.ts
@@ -30,6 +30,9 @@ export interface AgentRuntimeConnectInput {
 
 export interface AgentRuntimeUserInput {
   message: AgentSessionMessageEntity
+  /** True when this message arrived mid-turn (a steer) — the driver wraps it in a system-reminder
+   *  so the model treats it as a redirect rather than a fresh prompt (invariant 7). */
+  systemReminder?: boolean
 }
 
 export type AgentRuntimePolicyUpdate =
@@ -40,26 +43,28 @@ export type AgentRuntimeEvent =
   | { type: 'chunk'; chunk: UIMessageChunk }
   | { type: 'resume-token'; token: string }
   | { type: 'turn-complete' }
+  /** Steers stashed via `redirect()` that the turn ended before injecting — the host queues them
+   *  as the next turn (the `steer_undelivered` fallback). */
+  | { type: 'steer-undelivered'; inputs: AgentRuntimeUserInput[] }
+  /** A steer was injected mid-turn (PreToolUse hook) and the model is about to emit its post-steer
+   *  assistant message. Marks where the host should roll the assistant message: finalise the
+   *  pre-steer parts as one row (A1a) and stream the continuation into a fresh row (A2), so the
+   *  steer user message sorts between them instead of dangling after the whole turn. */
+  | { type: 'steer-boundary'; inputs: AgentRuntimeUserInput[] }
   | { type: 'error'; error: unknown }
 
 export interface AgentRuntimeConnection {
   readonly events: AsyncIterable<AgentRuntimeEvent>
   send(input: AgentRuntimeUserInput): void | Promise<void>
+  /**
+   * Inject a mid-turn user message (steer) into the running turn without aborting it. Returns true
+   * when the message was stashed for injection (a turn is live) — the host then folds it into the
+   * current turn instead of opening a new one; if the turn ends before it is injected the connection
+   * emits `steer-undelivered`. Returns false when there is no live turn to steer, so the host queues
+   * the message as the next turn. Omitted ⇒ no native steer ⇒ host always queues.
+   */
+  redirect?(input: AgentRuntimeUserInput): boolean
   applyPolicyUpdate?(update: AgentRuntimePolicyUpdate): Promise<boolean> | boolean
-  interrupt?(): Promise<void>
-  /**
-   * Runtime-specific predicate: is it safe to interrupt the current turn right
-   * now? The host falls back to "no tool is mid-execution" when a connection
-   * omits it, so existing runtimes keep their behaviour; lets a runtime that
-   * tracks its own tool state self-manage interruptibility.
-   */
-  canInterruptNow?(): boolean
-  /**
-   * Runtime-specific policy: should the host tear this connection down once the
-   * current turn ends? Lets a driver (e.g. Claude trace mode) own the decision
-   * instead of the host reaching into driver internals. Omitted ⇒ keep open.
-   */
-  shouldCloseAfterTurn?(): boolean
   close(): void | Promise<void>
 }
 

--- a/src/main/ai/steerReminder.ts
+++ b/src/main/ai/steerReminder.ts
@@ -1,0 +1,16 @@
+/**
+ * Wrap a steer message — one the user sent while the assistant was already working — so the model
+ * treats it as a mid-task redirect rather than a fresh prompt (invariant 7). Mirrors opencode's
+ * `insertReminders`. Shared by both runtimes: chat wraps it into the rebuilt model history; the
+ * claudeCode driver wraps it as it pushes into the live streaming-input queue.
+ */
+export function wrapSteerReminder(text: string): string {
+  return [
+    '<system-reminder>',
+    'The user sent the following message:',
+    text,
+    '',
+    'Please address this message and continue with your tasks.',
+    '</system-reminder>'
+  ].join('\n')
+}

--- a/src/main/ai/streamManager/AiStreamManager.ts
+++ b/src/main/ai/streamManager/AiStreamManager.ts
@@ -22,6 +22,8 @@ import { type SerializedError, serializeError } from '@shared/types/error'
 import { type UIMessageChunk } from 'ai'
 import * as z from 'zod'
 
+import { isAgentSessionTopic } from '../agentSession/topic'
+import { applyTurnOutputAttributes } from '../observability'
 import type { AiStreamRequest, CallOverrides } from '../types/requests'
 import { buildCompactReplay } from './buildCompactReplay'
 import { dispatchStreamRequest, type MainDispatchRequest } from './context'
@@ -168,6 +170,20 @@ function ensureTerminalFinalMessage(exec: StreamExecution): CherryUIMessage {
 }
 
 /**
+ * Sentinel subscriber for a main-initiated turn with no live renderer (e.g. a steer continuation
+ * whose window closed mid-stream). `isAlive: false` so it's scrubbed on the first dispatch; the
+ * turn still runs in the background and a window re-attaches via the status cache.
+ */
+const nullStreamListener: StreamListener = {
+  id: 'null',
+  onChunk: () => {},
+  onDone: () => {},
+  onPaused: () => {},
+  onError: () => {},
+  isAlive: () => false
+}
+
+/**
  * Active-stream registry. See `docs/references/ai/stream-manager.md`.
  *
  * DO NOT add `@DependsOn(['AiService'])` here — `runExecutionLoop` does
@@ -183,6 +199,13 @@ export class AiStreamManager extends BaseService {
    *  the `hasLiveStream` snapshot and orphan a PENDING placeholder row. */
   private readonly dispatchLock = new KeyedMutex()
   private readonly config: AiStreamManagerConfig
+  private nextStreamTurnSequence = 0
+  /** Per-topic FIFO of steer user-message ids persisted while a turn was live. Chat's analogue of
+   *  the agent runtime's `pendingTurns`; drained one continuation turn at a time. */
+  private readonly pendingSteers = new Map<string, string[]>()
+  /** Topics whose steer continuation is mid-launch — dedups `scheduleNextChatTurn`, mirroring the
+   *  agent runtime's `startingNextTurn`. */
+  private readonly startingNextChat = new Set<string>()
   /** Constructed once and reused — `dispatchStreamRequest` passes it through `send()`. */
   readonly chatLifecycle: StreamLifecycle
 
@@ -320,19 +343,26 @@ export class AiStreamManager extends BaseService {
     const existing = this.activeStreams.get(input.topicId)
 
     if (existing && isLiveStatus(existing.status)) {
-      // Only agent sessions reach send() while live: the dispatcher aborts+evicts a
-      // live chat turn before re-dispatching, and an agent-session follow-up was
-      // already enqueued by its provider. Just attach the new subscriber.
+      // Live topic → inject: a chat steer (busy submit) or an agent-session follow-up was already
+      // persisted/enqueued by its provider; just attach the new subscriber to the running stream.
       for (const listener of input.listeners) this.addListener(input.topicId, listener)
       return { mode: 'injected', executionIds: [...existing.executions.keys()] }
     }
 
+    // Enqueue-only dispatch with no live stream to attach to: an agent-session follow-up landing in
+    // the inter-turn drain window (`isSessionBusy` true while the settled stream is terminal-in-grace,
+    // so `hasLiveStream` is false). The user row is already in the runtime's `pendingTurns` and the
+    // runtime will open the next turn — there's nothing to start here, so no-op instead of throwing
+    // (and leave the grace-period stream untouched for late renderer reads).
+    if (input.models.length === 0) {
+      logger.debug('send(): empty models with no live stream — enqueue-only, nothing to start', {
+        topicId: input.topicId
+      })
+      return { mode: 'injected', executionIds: [] }
+    }
+
     // Evict any grace-period stream so two streams never coexist on one topic.
     if (existing) this.evictStream(input.topicId)
-
-    if (input.models.length === 0) {
-      throw new Error(`send() requires at least one model when starting a new stream (topicId=${input.topicId})`)
-    }
 
     const isMultiModel = input.models.length > 1
     const executions = new Map<UniqueModelId, StreamExecution>()
@@ -420,21 +450,6 @@ export class AiStreamManager extends BaseService {
     })
   }
 
-  pauseRuntimeTurn(topicId: string, reason: string): boolean {
-    const stream = this.activeStreams.get(topicId)
-    if (!stream || !isLiveStatus(stream.status)) return false
-
-    logger.info('Pausing runtime stream turn', { topicId, reason })
-    for (const exec of stream.executions.values()) {
-      if (exec.status === 'streaming') {
-        exec.status = 'aborted'
-        exec.abortController.abort(reason)
-      }
-    }
-    stream.status = 'aborted'
-    return true
-  }
-
   /**
    * True iff this topic has a stream that `send()` would treat as the inject
    * path (live: pending or streaming). Providers query this in
@@ -444,6 +459,30 @@ export class AiStreamManager extends BaseService {
   hasLiveStream(topicId: string): boolean {
     const stream = this.activeStreams.get(topicId)
     return Boolean(stream && isLiveStatus(stream.status))
+  }
+
+  // ── Public: steer (mid-flight follow-up on chat topics) ───────────
+  // Chat mirrors the agent runtime's enqueue + chain-next-turn: a busy submit
+  // persists the user message and enqueues it here; the running turn yields at
+  // the next step boundary (see `hasPendingSteer`) and `onExecutionDone` chains
+  // a `steer-continuation` to answer it.
+
+  /** True iff this chat topic has a queued steer. Read by the steer-yield stop condition so the
+   *  running turn stops at the next safe step boundary. */
+  hasPendingSteer(topicId: string): boolean {
+    return (this.pendingSteers.get(topicId)?.length ?? 0) > 0
+  }
+
+  /** Enqueue a steer user message (already persisted by the provider). If the topic settled before
+   *  this landed, start the continuation immediately. Mirrors `AgentSessionRuntimeService.enqueueUserMessage`. */
+  enqueuePendingSteer(topicId: string, userMessageId: string): void {
+    const queue = this.pendingSteers.get(topicId)
+    if (queue) queue.push(userMessageId)
+    else this.pendingSteers.set(topicId, [userMessageId])
+    // Race: the turn may have reached terminal between `prepareDispatch` and here (the loop's
+    // `onExecutionDone` doesn't hold the dispatch lock). No terminal hook will fire for it, so
+    // drain now. Mirrors `enqueueUserMessage`'s no-active-turn branch.
+    if (!this.hasLiveStream(topicId)) this.scheduleNextChatTurn(topicId)
   }
 
   // ── Public: listener management ───────────────────────────────────
@@ -568,11 +607,26 @@ export class AiStreamManager extends BaseService {
 
     // Compute topic status first so listeners get isTopicDone
     stream.status = this.resolveTerminalStatus(stream)
-    const isTopicDone = !isLiveStatus(stream.status)
+    const topicDone = !isLiveStatus(stream.status)
 
-    await this.broadcastExecutionDone(stream, exec, isTopicDone)
+    // Chain the next turn instead of finishing: broadcast this exec's done with isTopicDone=false
+    // (the bubble finalises, the topic stays busy — reusing multi-model semantics), skip the terminal
+    // lifecycle (no idle flicker AND the stream stays alive so the next turn can carry the renderer
+    // listeners), and start the continuation. Chat drives the continuation here (scheduleNextChatTurn);
+    // the agent runtime drives its own (terminal listener → markTurnTerminal → startNextTurn), so for
+    // agent we just keep the stream alive — without this its follow-up turn reaches no renderer.
+    const chatChaining = topicDone && this.hasPendingSteer(topicId)
+    const agentChaining =
+      topicDone &&
+      !chatChaining &&
+      isAgentSessionTopic(topicId) &&
+      application.get('AgentSessionRuntimeService').willContinueTopic(topicId)
+    const chaining = chatChaining || agentChaining
 
-    if (isTopicDone) this.runTerminalLifecycle(stream)
+    await this.broadcastExecutionDone(stream, exec, topicDone && !chaining)
+
+    if (chatChaining) this.scheduleNextChatTurn(topicId)
+    else if (topicDone && !chaining) this.runTerminalLifecycle(stream)
   }
 
   async onExecutionPaused(topicId: string, modelId: UniqueModelId): Promise<void> {
@@ -588,7 +642,12 @@ export class AiStreamManager extends BaseService {
 
     await this.broadcastExecutionPaused(stream, exec, isTopicDone)
 
-    if (isTopicDone) this.runTerminalLifecycle(stream)
+    if (isTopicDone) {
+      // Aborted (stop button / idle timeout), not a clean steer-yield — drop any queued steer
+      // instead of chaining. Its persisted user row stays as a dangling message the user can resend.
+      this.pendingSteers.delete(topicId)
+      this.runTerminalLifecycle(stream)
+    }
   }
 
   /** Called when one execution errors. */
@@ -617,7 +676,11 @@ export class AiStreamManager extends BaseService {
     }
     await this.dispatchToListeners(stream, 'onError', (listener) => listener.onError(result))
 
-    if (isTopicDone) this.runTerminalLifecycle(stream)
+    if (isTopicDone) {
+      // Errored turn — drop any queued steer rather than chaining onto a failed turn.
+      this.pendingSteers.delete(topicId)
+      this.runTerminalLifecycle(stream)
+    }
   }
 
   /**
@@ -649,6 +712,39 @@ export class AiStreamManager extends BaseService {
         this.activeStreams.delete(stream.topicId)
       }
     })
+  }
+
+  /** Drain-dedup + microtask defer for the steer continuation. Mirrors `scheduleNextTurn`. */
+  private scheduleNextChatTurn(topicId: string): void {
+    if (this.startingNextChat.has(topicId)) return
+    this.startingNextChat.add(topicId)
+    queueMicrotask(() => {
+      void this.startNextChatTurn(topicId)
+        .catch((error) => logger.error('Failed to start chat steer continuation', { topicId, error }))
+        .finally(() => this.startingNextChat.delete(topicId))
+    })
+  }
+
+  /**
+   * Open a fresh assistant turn answering the head of the steer queue. Carries the finished turn's
+   * renderer listeners forward so the continuation streams to the same windows; persistence/trace
+   * listeners are rebuilt by `prepareDispatch`. Mirrors `AgentSessionRuntimeService.startNextTurn`.
+   */
+  private async startNextChatTurn(topicId: string): Promise<void> {
+    const queue = this.pendingSteers.get(topicId)
+    const userMessageId = queue?.shift()
+    if (!queue || queue.length === 0) this.pendingSteers.delete(topicId)
+    if (!userMessageId) return
+
+    const previous = this.activeStreams.get(topicId)
+    const carried = previous ? [...previous.listeners.values()].filter((listener) => listener.id.startsWith('wc:')) : []
+    if (previous) this.evictStream(topicId)
+
+    const req: MainDispatchRequest = { trigger: 'steer-continuation', topicId, userMessageId }
+    await this.dispatch(carried[0] ?? nullStreamListener, req)
+    // Re-attach any other windows that were on the prior turn (single subscriber goes through
+    // `dispatch`; the rest catch up via buffer replay).
+    for (const listener of carried.slice(1)) this.addListener(topicId, listener)
   }
 
   // ── Public: inspection snapshot ───────────────────────────────────

--- a/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
+++ b/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
@@ -115,6 +115,7 @@ const fakeCacheService = {
   })
 }
 const mockSaveSpans = vi.fn<(topicId: string) => Promise<void>>(async () => undefined)
+const mockWillContinueTopic = vi.fn<(topicId: string) => boolean>(() => false)
 
 vi.mock('@application', async () => {
   const { mockApplicationFactory } = await import('@test-mocks/main/application')
@@ -126,7 +127,8 @@ vi.mock('@application', async () => {
   return mockApplicationFactory({
     AiService: { streamText: mockStreamText },
     CacheService: fakeCacheService,
-    SpanCacheService: { saveSpans: mockSaveSpans }
+    SpanCacheService: { saveSpans: mockSaveSpans },
+    AgentSessionRuntimeService: { willContinueTopic: mockWillContinueTopic }
   } as Parameters<typeof mockApplicationFactory>[0])
 })
 
@@ -198,6 +200,7 @@ describe('AiStreamManager', () => {
       pendingStream((request.requestOptions as { signal?: AbortSignal } | undefined)?.signal)
     )
     mockSaveSpans.mockResolvedValue(undefined)
+    mockWillContinueTopic.mockReturnValue(false)
     sharedCacheStore.clear()
   })
 
@@ -242,6 +245,16 @@ describe('AiStreamManager', () => {
           listeners: [new FakeListener('l:a')]
         })
       ).toThrow('duplicate modelId')
+    })
+
+    it('no-ops an enqueue-only send (empty models, not live) instead of throwing', () => {
+      // An agent-session follow-up / steer landing in the inter-turn drain window reaches send with
+      // no models and no live stream: the message is already in the runtime's pendingTurns, so send
+      // must not require a model nor start a stream — just return without effect.
+      const result = mgr.send({ topicId: 'a', models: [], listeners: [new FakeListener('l:a')] })
+
+      expect(result).toEqual({ mode: 'injected', executionIds: [] })
+      expect(mgr.inspect('a')).toBeUndefined()
     })
 
     it('evicts finished stream and creates new one', async () => {
@@ -771,6 +784,113 @@ describe('AiStreamManager', () => {
     it('is a no-op when the topic has no live stream', async () => {
       await expect(mgr.abortAndAwait('missing', 'steer-restart')).resolves.toBeUndefined()
       expect(mgr.inspect('missing')).toBeUndefined()
+    })
+  })
+
+  // ── steer chaining ──────────────────────────────────────────────
+  // Chat mirrors the agent runtime: a busy submit is persisted and enqueued here; the running turn
+  // yields (`hasPendingSteer` → stop condition) and `onExecutionDone` chains a `steer-continuation`
+  // dispatch that answers it. No second loop, no idle flicker, FIFO drain.
+
+  describe('steer chaining', () => {
+    // Flush the queueMicrotask-deferred continuation (and its awaited dispatch) under fake timers.
+    const flush = async () => {
+      for (let i = 0; i < 6; i++) await Promise.resolve()
+    }
+    const steerReq = (topicId: string, userMessageId: string) => ({
+      trigger: 'steer-continuation',
+      topicId,
+      userMessageId
+    })
+
+    it('tracks the queue and starts a continuation immediately when the topic is idle', async () => {
+      const dispatchSpy = vi.spyOn(mgr, 'dispatch').mockResolvedValue({ mode: 'started', executionIds: [] } as any)
+
+      expect(mgr.hasPendingSteer('a')).toBe(false)
+      mgr.enqueuePendingSteer('a', 'u1')
+      expect(mgr.hasPendingSteer('a')).toBe(true)
+
+      await flush()
+      expect(dispatchSpy).toHaveBeenCalledTimes(1)
+      expect(dispatchSpy).toHaveBeenCalledWith(expect.anything(), steerReq('a', 'u1'))
+      expect(mgr.hasPendingSteer('a')).toBe(false)
+    })
+
+    it('a finished turn with a queued steer chains a continuation instead of finishing (no idle flicker)', async () => {
+      const dispatchSpy = vi.spyOn(mgr, 'dispatch').mockResolvedValue({ mode: 'started', executionIds: [] } as any)
+      const listener = new FakeListener('l:a')
+      startSingle(mgr, { topicId: 'a', modelId: 'provider-a::model-a', request: req('a'), listeners: [listener] })
+
+      // Steer arrives while the turn is live → queued, not started.
+      mgr.enqueuePendingSteer('a', 'u2')
+      expect(dispatchSpy).not.toHaveBeenCalled()
+
+      await mgr.onExecutionDone('a', 'provider-a::model-a')
+
+      // The assistant bubble finalises but the topic stays busy (isTopicDone=false), and no
+      // terminal `done` is broadcast to the status cache.
+      expect(listener.doneResults).toHaveLength(1)
+      expect(listener.doneResults[0].isTopicDone).toBe(false)
+      expect((sharedCacheStore.get('topic.stream.statuses.a') as any)?.status).not.toBe('done')
+
+      await flush()
+      expect(dispatchSpy).toHaveBeenCalledWith(expect.anything(), steerReq('a', 'u2'))
+    })
+
+    it('drains multiple steers FIFO — only the head starts until the next turn finishes', async () => {
+      const dispatchSpy = vi.spyOn(mgr, 'dispatch').mockResolvedValue({ mode: 'started', executionIds: [] } as any)
+      mgr.enqueuePendingSteer('a', 'u1')
+      mgr.enqueuePendingSteer('a', 'u2')
+
+      await flush()
+      expect(dispatchSpy).toHaveBeenCalledTimes(1)
+      expect(dispatchSpy).toHaveBeenCalledWith(expect.anything(), steerReq('a', 'u1'))
+      expect(mgr.hasPendingSteer('a')).toBe(true)
+    })
+
+    it('drops a queued steer when the turn is aborted instead of chaining onto it', async () => {
+      const dispatchSpy = vi.spyOn(mgr, 'dispatch').mockResolvedValue({ mode: 'started', executionIds: [] } as any)
+      const listener = new FakeListener('l:a')
+      startSingle(mgr, { topicId: 'a', modelId: 'provider-a::model-a', request: req('a'), listeners: [listener] })
+      mgr.enqueuePendingSteer('a', 'u2')
+
+      mgr.abort('a', 'user-requested')
+      await mgr.onExecutionPaused('a', 'provider-a::model-a')
+
+      await flush()
+      expect(dispatchSpy).not.toHaveBeenCalled()
+      expect(mgr.hasPendingSteer('a')).toBe(false)
+    })
+
+    // Agent sessions drive their own continuation (terminal listener → markTurnTerminal → startNextTurn),
+    // so AiStreamManager doesn't dispatch here — it only KEEPS the stream alive (isTopicDone=false, no
+    // terminal lifecycle) when `willContinueTopic` is true, so the runtime's next turn can carry the
+    // renderer listeners. Without this the stream is evicted and the follow-up reaches no renderer.
+    it('keeps an agent-session stream alive when the runtime will continue (no terminal lifecycle)', async () => {
+      mockWillContinueTopic.mockReturnValue(true)
+      const topicId = 'agent-session:s1'
+      const listener = new FakeListener(`l:${topicId}`)
+      startSingle(mgr, { topicId, modelId: 'provider-a::model-a', request: req(topicId), listeners: [listener] })
+
+      await mgr.onExecutionDone(topicId, 'provider-a::model-a')
+
+      // The bubble finalises but the topic stays busy and the terminal lifecycle is skipped (no idle
+      // flicker), so the stream object survives for the runtime's follow-up turn to carry listeners.
+      expect(listener.doneResults).toHaveLength(1)
+      expect(listener.doneResults[0].isTopicDone).toBe(false)
+      expect((sharedCacheStore.get(`topic.stream.statuses.${topicId}`) as any)?.status).not.toBe('done')
+    })
+
+    it('tears down an agent-session stream when the runtime will not continue', async () => {
+      mockWillContinueTopic.mockReturnValue(false)
+      const topicId = 'agent-session:s2'
+      const listener = new FakeListener(`l:${topicId}`)
+      startSingle(mgr, { topicId, modelId: 'provider-a::model-a', request: req(topicId), listeners: [listener] })
+
+      await mgr.onExecutionDone(topicId, 'provider-a::model-a')
+
+      expect(listener.doneResults[0].isTopicDone).toBe(true)
+      expect(mgr.hasLiveStream(topicId)).toBe(false)
     })
   })
 

--- a/src/main/ai/streamManager/context/PersistentChatContextProvider.ts
+++ b/src/main/ai/streamManager/context/PersistentChatContextProvider.ts
@@ -70,6 +70,43 @@ function endTurnRootSpansWithError(spans: Array<{ span: Span }>, error: unknown)
   }
 }
 
+/**
+ * Wrap the trailing user message's text parts in a steer system-reminder, for the model-facing
+ * history copy only — the persisted user row is untouched.
+ */
+function withSteerReminder(history: CherryUIMessage[]): CherryUIMessage[] {
+  for (let i = history.length - 1; i >= 0; i--) {
+    if (history[i].role !== 'user') continue
+    const message = history[i]
+    const parts = message.parts.map((part) =>
+      part.type === 'text' && part.text.trim() ? { ...part, text: wrapSteerReminder(part.text) } : part
+    )
+    const next = history.slice()
+    next[i] = { ...message, parts }
+    return next
+  }
+  return history
+}
+
+function toReservedUIMessage(message: SharedMessage): CherryUIMessage {
+  return {
+    id: message.id,
+    role: message.role,
+    parts: message.data.parts ?? [],
+    metadata: {
+      parentId: message.parentId,
+      siblingsGroupId: message.siblingsGroupId || undefined,
+      modelId: message.modelId ?? undefined,
+      modelSnapshot: message.modelSnapshot ?? undefined,
+      status: message.status,
+      createdAt: message.createdAt,
+      stats: message.stats ?? undefined,
+      isActiveBranch: true,
+      ...(message.stats?.totalTokens ? { totalTokens: message.stats.totalTokens } : {})
+    }
+  } as CherryUIMessage
+}
+
 export class PersistentChatContextProvider implements ChatContextProvider {
   readonly name = 'persistent'
 
@@ -86,6 +123,36 @@ export class PersistentChatContextProvider implements ChatContextProvider {
     // continue-conversation reuses the existing assistant anchor — no new placeholder, no multi-model.
     if (req.trigger === 'continue-conversation') {
       return this.prepareContinueDispatch(subscriber, req, assistantId, defaultModelId)
+    }
+
+    // steer-continuation answers a steer user message persisted while a turn was live — a fresh
+    // assistant placeholder under that user row (no new user row), single model.
+    if (req.trigger === 'steer-continuation') {
+      return this.prepareSteerContinuation(subscriber, req, assistantId, defaultModelId)
+    }
+
+    if (ctx.hasLiveStream && req.trigger === 'submit-message') {
+      const userMessage = await messageService.create(req.topicId, {
+        role: 'user',
+        parentId: req.parentAnchorId,
+        data: { parts: req.userMessageParts },
+        status: 'success',
+        modelId: defaultModelId,
+        modelSnapshot: (() => {
+          const { providerId, modelId: rawModelId } = parseUniqueModelId(defaultModelId)
+          return { id: rawModelId, name: rawModelId, provider: providerId }
+        })()
+      })
+
+      return {
+        topicId: req.topicId,
+        models: [],
+        listeners: [subscriber],
+        userMessage,
+        userMessageId: userMessage.id,
+        reservedMessages: [toReservedUIMessage(userMessage)],
+        isMultiModel: false
+      }
     }
 
     // 3. Models (single or multi)
@@ -282,6 +349,76 @@ export class PersistentChatContextProvider implements ChatContextProvider {
         ],
         listeners,
         siblingsGroupId: undefined,
+        isMultiModel: false
+      }
+    } catch (error) {
+      endTurnRootSpansWithError(turnRootSpans, error)
+      throw error
+    }
+  }
+
+  /**
+   * Answer a steer message persisted while a turn was live (`AiStreamManager.startNextChatTurn`).
+   * Creates a fresh assistant placeholder under the steer user row (no new user row) and wraps that
+   * trailing user message with a steer system-reminder in the model-facing history only.
+   */
+  private async prepareSteerContinuation(
+    subscriber: StreamListener,
+    req: MainSteerContinuationRequest,
+    assistantId: string | undefined,
+    defaultModelId: UniqueModelId
+  ): Promise<PreparedDispatch> {
+    const userMessage = await messageService.getById(req.userMessageId)
+    if (userMessage.role !== 'user') {
+      throw new Error(`'steer-continuation' anchor must be a user message (got '${userMessage.role}')`)
+    }
+    if (userMessage.topicId !== req.topicId) {
+      throw new Error(`'steer-continuation' anchor does not belong to topic ${req.topicId}`)
+    }
+
+    const steerModelId = (userMessage.modelId ?? defaultModelId) as UniqueModelId
+    const [model] = await resolveModels([steerModelId], defaultModelId)
+    const modelSnapshot = {
+      id: model.apiModelId ?? parseUniqueModelId(model.id).modelId,
+      name: model.name,
+      provider: model.providerId
+    }
+
+    const containerTraceId = await topicService.ensureTraceId(req.topicId)
+    const turnRootSpans = startTurnRootSpans(req.topicId, req.trigger, [model], containerTraceId)
+    const [{ span: rootSpan }] = turnRootSpans
+    try {
+      const { placeholders } = await messageService.createUserMessageWithPlaceholders({
+        topicId: req.topicId,
+        userMessage: { mode: 'existing', id: req.userMessageId },
+        placeholders: [{ role: 'assistant', data: { parts: [] }, status: 'pending', modelId: model.id, modelSnapshot }]
+      })
+      const placeholder = placeholders[0]
+
+      const listeners: StreamListener[] = [
+        subscriber,
+        new PersistenceListener({
+          topicId: req.topicId,
+          modelId: model.id,
+          backend: new MessageServiceBackend({ assistantMessageId: placeholder.id, modelSnapshot }),
+          onPersistFailed: (error) =>
+            void subscriber.onError({ error, status: 'error', modelId: model.id, isTopicDone: true })
+        }),
+        new TraceFlushListener(req.topicId)
+      ]
+
+      const history = withSteerReminder(await this.buildHistory(req.userMessageId))
+      return {
+        topicId: req.topicId,
+        models: [
+          {
+            modelId: model.id,
+            request: this.buildStreamRequest(req.topicId, assistantId, model.id, history, placeholder.id),
+            rootSpan
+          }
+        ],
+        listeners,
+        reservedMessages: [toReservedUIMessage(placeholder)],
         isMultiModel: false
       }
     } catch (error) {

--- a/src/main/ai/streamManager/context/TemporaryChatContextProvider.ts
+++ b/src/main/ai/streamManager/context/TemporaryChatContextProvider.ts
@@ -35,6 +35,10 @@ export class TemporaryChatContextProvider implements ChatContextProvider {
     if (req.trigger === 'continue-conversation') {
       throw new Error('continue-conversation is not supported for temporary chats (immutable append-only)')
     }
+    if (req.trigger === 'steer-continuation') {
+      // Never reached: steers are only enqueued for persistent topics (provider-gated in dispatch).
+      throw new Error('steer-continuation is not supported for temporary chats')
+    }
 
     const topic = temporaryChatService.getTopic(req.topicId)
     if (!topic) throw new Error(`Temporary topic not found: ${req.topicId}`)

--- a/src/main/ai/streamManager/context/__tests__/PersistentChatContextProvider.test.ts
+++ b/src/main/ai/streamManager/context/__tests__/PersistentChatContextProvider.test.ts
@@ -9,9 +9,10 @@ import { createUniqueModelId } from '@shared/data/types/model'
 import { setupTestDatabase } from '@test-helpers/db'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { startAiTurnTrace } from '../../../observability'
+import { startAiChildTurnSpan } from '../../../observability'
 import { PersistenceListener } from '../../listeners/PersistenceListener'
 import type { StreamListener } from '../../types'
+import type { MainSteerContinuationRequest } from '../dispatch'
 import { resolveModels, resolvePersistentSiblingsGroupId } from '../modelResolution'
 
 // Stub model resolution + tracing so the test drives the REAL DB history path
@@ -25,7 +26,9 @@ vi.mock('../modelResolution', () => ({
 }))
 
 vi.mock('../../../observability', () => ({
-  startAiTurnTrace: vi.fn(() => ({ rootSpan: { end: vi.fn() }, traceId: 'trace-1' }))
+  startAiChildTurnSpan: vi.fn(() => ({ rootSpan: { end: vi.fn() }, traceId: 'trace-1' })),
+  deriveRootSpanId: vi.fn(() => '1'.repeat(16)),
+  applyTurnInputAttributes: vi.fn()
 }))
 
 const { PersistentChatContextProvider } = await import('../PersistentChatContextProvider')
@@ -115,6 +118,48 @@ describe('PersistentChatContextProvider — steer-restart history (#B4)', () => 
     ])
   })
 
+  it('steer-continuation: opens an assistant turn under the steer user row with a reminder-wrapped prompt', async () => {
+    // u1 → a1 → u2, where u2 is the steer the user sent mid-turn (child of the assistant row).
+    await dbh.db.insert(messageTable).values({
+      id: 'u2',
+      parentId: 'a1',
+      topicId: 'topic-1',
+      role: 'user',
+      data: { parts: [{ type: 'text', text: 'actually do X instead' }] },
+      status: 'success',
+      siblingsGroupId: 0,
+      modelId: MODEL_ID,
+      createdAt: 300,
+      updatedAt: 300
+    })
+
+    const prepared = await provider.prepareDispatch(
+      makeSubscriber(),
+      { trigger: 'steer-continuation', topicId: 'topic-1', userMessageId: 'u2' } as MainSteerContinuationRequest,
+      { hasLiveStream: false }
+    )
+
+    // A fresh assistant placeholder is created under u2 — no new user row.
+    const children = await messageService.getChildrenByParentId('u2')
+    expect(children).toHaveLength(1)
+    expect(children[0]).toMatchObject({ role: 'assistant', status: 'pending' })
+
+    // The persisted steer row is untouched (only the model-facing copy is wrapped).
+    const u2 = await messageService.getById('u2')
+    expect(flatten([{ role: 'user', parts: u2.data.parts ?? [] }])[0].text).toBe('actually do X instead')
+
+    // History is the full path; only the trailing steer message is system-reminder wrapped.
+    const history = prepared.models[0].request.messages!
+    expect(history).toHaveLength(3)
+    expect(flatten([history[0]])[0]).toEqual({ role: 'user', text: 'first question' })
+    expect(flatten([history[1]])[0]).toEqual({ role: 'assistant', text: PARTIAL })
+    const lastText = flatten([history[2]])[0].text
+    expect(history[2].role).toBe('user')
+    expect(lastText).toContain('<system-reminder>')
+    expect(lastText).toContain('actually do X instead')
+    expect(lastText).toContain('Please address this message and continue with your tasks.')
+  })
+
   it('drops the paused partial when the new turn does not anchor on it (precondition is necessary)', async () => {
     // Counter-case: anchoring on the prior user message (not the paused assistant row) rebuilds
     // a prompt WITHOUT the partial — proving the efficacy hinges on `parentAnchorId` = paused row.
@@ -133,8 +178,8 @@ describe('PersistentChatContextProvider — steer-restart history (#B4)', () => 
 
   it('fans out @-mentioned siblings: shared siblingsGroupId, one placeholder per model, aligned placeholders[i]/turnRootSpans[i]', async () => {
     // Two @-mentioned models → two assistant placeholders sharing one siblings group.
-    // Each placeholder row persists ITS span's traceId; assert the per-model row, span,
-    // and traceId all line up by index so a fan-out never crosses streams.
+    // All placeholders share the container traceId now; assert the per-model row and span
+    // line up by index (keyed on modelId) so a fan-out never crosses streams.
     const MODEL_A = createUniqueModelId('openai', 'gpt-4o') // already seeded in beforeEach
     const MODEL_B = createUniqueModelId('anthropic', 'claude-sonnet-4-5')
     // Placeholder rows FK to user_model(id) — seed the second @-mentioned model.
@@ -157,12 +202,12 @@ describe('PersistentChatContextProvider — steer-restart history (#B4)', () => 
       { id: MODEL_B, name: 'Claude Sonnet 4.5', providerId: 'anthropic', apiModelId: 'claude-sonnet-4-5' }
     ] as Awaited<ReturnType<typeof resolveModels>>)
     vi.mocked(resolvePersistentSiblingsGroupId).mockResolvedValueOnce(42)
-    // Distinct span + traceId per call so index alignment is observable.
+    // Distinct span per call so index alignment is observable.
     const spanA = { end: vi.fn() }
     const spanB = { end: vi.fn() }
-    vi.mocked(startAiTurnTrace)
-      .mockReturnValueOnce({ rootSpan: spanA, traceId: 'trace-a' } as unknown as ReturnType<typeof startAiTurnTrace>)
-      .mockReturnValueOnce({ rootSpan: spanB, traceId: 'trace-b' } as unknown as ReturnType<typeof startAiTurnTrace>)
+    vi.mocked(startAiChildTurnSpan)
+      .mockReturnValueOnce({ rootSpan: spanA } as unknown as ReturnType<typeof startAiChildTurnSpan>)
+      .mockReturnValueOnce({ rootSpan: spanB } as unknown as ReturnType<typeof startAiChildTurnSpan>)
 
     const prepared = await provider.prepareDispatch(makeSubscriber(), {
       trigger: 'submit-message',
@@ -182,12 +227,12 @@ describe('PersistentChatContextProvider — steer-restart history (#B4)', () => 
     expect(prepared.models[1].rootSpan).toBe(spanB)
 
     // One persisted placeholder per model, both in the shared group, each routed to its
-    // own request — placeholders[i]/turnRootSpans[i] alignment proven via per-row traceId.
+    // own request — placeholders[i]/turnRootSpans[i] alignment proven via per-row modelId.
     const placeholders = await messageService.getChildrenByParentId(prepared.userMessageId!)
     expect(placeholders).toHaveLength(2)
-    const byTrace = new Map(placeholders.map((p) => [p.traceId, p]))
-    const phA = byTrace.get('trace-a')
-    const phB = byTrace.get('trace-b')
+    const byModel = new Map(placeholders.map((p) => [p.modelId, p]))
+    const phA = byModel.get(MODEL_A)
+    const phB = byModel.get(MODEL_B)
     expect(phA?.modelId).toBe(MODEL_A)
     expect(phB?.modelId).toBe(MODEL_B)
     expect(phA?.siblingsGroupId).toBe(42)

--- a/src/main/ai/streamManager/context/__tests__/dispatch.test.ts
+++ b/src/main/ai/streamManager/context/__tests__/dispatch.test.ts
@@ -4,7 +4,7 @@ import type { AiStreamManager } from '../../AiStreamManager'
 import type { StreamListener } from '../../types'
 import type { MainDispatchRequest } from '../dispatch'
 
-// Records the relative order of the steps we care about (abort vs prepareDispatch).
+// Records the relative order of the steps we care about (prepareDispatch / enqueue / send).
 const order: string[] = []
 // Captures the `hasLiveStream` flag the provider receives in its ctx arg.
 let preparedWithCtx: { hasLiveStream: boolean } | undefined
@@ -15,14 +15,6 @@ const mocks = vi.hoisted(() => ({
   persistentPrepare: vi.fn(),
   isWorkspaceErr: vi.fn<(error: unknown) => boolean>()
 }))
-
-const minimalPrepared = (topicId: string) => ({
-  topicId,
-  models: [] as unknown[],
-  listeners: [] as StreamListener[],
-  isMultiModel: false,
-  userMessageId: 'u1'
-})
 
 vi.mock('../AgentChatContextProvider', () => ({
   agentChatContextProvider: {
@@ -51,27 +43,30 @@ function makeSubscriber(): StreamListener {
   return { id: 'wc:1', onChunk: vi.fn(), onDone: vi.fn(), onPaused: vi.fn(), onError: vi.fn(), isAlive: () => true }
 }
 
-/** Fake manager whose `abortAndAwait` flips liveness false, mirroring evict-after-settle. */
-function makeManager(initiallyLive: boolean): AiStreamManager {
-  let live = initiallyLive
+function makeManager(live: boolean): AiStreamManager {
   return {
     hasLiveStream: vi.fn(() => live),
-    abortAndAwait: vi.fn(async () => {
-      order.push('abortAndAwait')
-      live = false
-    }),
+    enqueuePendingSteer: vi.fn(() => order.push('enqueuePendingSteer')),
     send: vi.fn(() => {
       order.push('send')
-      return { mode: 'started' as const, executionIds: [] }
+      return { mode: live ? ('injected' as const) : ('started' as const), executionIds: [] }
     })
   } as unknown as AiStreamManager
 }
 
-function wirePrepare(spy: typeof mocks.agentPrepare, topicId: string) {
+/** `inject: true` mirrors PersistentChatContextProvider's `hasLiveStream` branch — no models + a user row. */
+function wirePrepare(spy: typeof mocks.agentPrepare, topicId: string, opts: { inject: boolean }) {
   spy.mockImplementation((_subscriber: StreamListener, _req: MainDispatchRequest, ctx: { hasLiveStream: boolean }) => {
     order.push('prepareDispatch')
     preparedWithCtx = ctx
-    return Promise.resolve(minimalPrepared(topicId))
+    return Promise.resolve({
+      topicId,
+      models: opts.inject ? [] : [{ modelId: 'p::m', request: {} }],
+      listeners: [] as StreamListener[],
+      isMultiModel: false,
+      userMessage: { id: 'u1' },
+      userMessageId: 'u1'
+    })
   })
 }
 
@@ -86,41 +81,42 @@ beforeEach(() => {
   mocks.isWorkspaceErr.mockReturnValue(false)
 })
 
-describe('dispatchStreamRequest — steer-restart ordering (#B4)', () => {
-  it('aborts the live chat turn BEFORE prepareDispatch reads history, and prepares as a fresh start', async () => {
-    wirePrepare(mocks.persistentPrepare, 'topic-1')
+describe('dispatchStreamRequest — steer', () => {
+  it('persists a live chat submit as a steer and enqueues it (no abort, stream stays live)', async () => {
+    wirePrepare(mocks.persistentPrepare, 'topic-1', { inject: true })
     const manager = makeManager(true)
 
     await dispatchStreamRequest(manager, makeSubscriber(), chatReq('topic-1'))
 
-    // abortAndAwait must settle+persist the paused partial before prepareDispatch's DB read.
-    expect(order).toEqual(['abortAndAwait', 'prepareDispatch', 'send'])
-    expect(manager.abortAndAwait).toHaveBeenCalledWith('topic-1', 'steer-restart')
-    // Post-abort the stream is evicted, so the provider sees a fresh start.
-    expect(preparedWithCtx).toEqual({ hasLiveStream: false })
+    // No abort/evict — prepareDispatch observes the still-live stream and takes its inject branch,
+    // and the persisted user row is enqueued as a pending steer before send (which just attaches).
+    expect(preparedWithCtx).toEqual({ hasLiveStream: true })
+    expect(order).toEqual(['prepareDispatch', 'enqueuePendingSteer', 'send'])
+    expect(manager.enqueuePendingSteer).toHaveBeenCalledWith('topic-1', 'u1')
   })
 
-  it('does not abort a non-live chat topic', async () => {
-    wirePrepare(mocks.persistentPrepare, 'topic-2')
+  it('does not enqueue a steer for a non-live chat submit (normal turn opens models)', async () => {
+    wirePrepare(mocks.persistentPrepare, 'topic-2', { inject: false })
     const manager = makeManager(false)
 
     await dispatchStreamRequest(manager, makeSubscriber(), chatReq('topic-2'))
 
-    expect(manager.abortAndAwait).not.toHaveBeenCalled()
+    expect(manager.enqueuePendingSteer).not.toHaveBeenCalled()
     expect(order).toEqual(['prepareDispatch', 'send'])
     expect(preparedWithCtx).toEqual({ hasLiveStream: false })
   })
 
-  it('never aborts an agent-session topic and preserves its live flag for the inject path', async () => {
+  it('never enqueues a chat steer for an agent-session topic (agent runtime owns its follow-ups)', async () => {
     mocks.agentCanHandle.mockReturnValue(true)
-    wirePrepare(mocks.agentPrepare, 'agent-session:s1')
+    wirePrepare(mocks.agentPrepare, 'agent-session:s1', { inject: true })
     const manager = makeManager(true)
 
     await dispatchStreamRequest(manager, makeSubscriber(), chatReq('agent-session:s1'))
 
-    expect(manager.abortAndAwait).not.toHaveBeenCalled()
+    // Even though the agent inject shape has no models, the steer enqueue is gated to the
+    // persistent provider, so the agent path is untouched and still sees the live stream.
+    expect(manager.enqueuePendingSteer).not.toHaveBeenCalled()
     expect(order).toEqual(['prepareDispatch', 'send'])
-    // Agent session is untouched → prepareDispatch must still observe the live stream.
     expect(preparedWithCtx).toEqual({ hasLiveStream: true })
   })
 

--- a/src/main/ai/streamManager/context/dispatch.ts
+++ b/src/main/ai/streamManager/context/dispatch.ts
@@ -7,7 +7,6 @@
 import { loggerService } from '@logger'
 import type { AiStreamOpenRequest, AiStreamOpenResponse, ApprovalDecision } from '@shared/ai/transport'
 
-import { isAgentSessionTopic } from '../../agentSession/topic'
 import { isAgentSessionWorkspaceError } from '../../runtime/claudeCode/settingsBuilder'
 import type { AiStreamManager } from '../AiStreamManager'
 import type { StreamListener } from '../types'
@@ -28,7 +27,20 @@ export interface MainContinueConversationRequest {
   approvalDecisions: ApprovalDecision[]
 }
 
-export type MainDispatchRequest = AiStreamOpenRequest | MainContinueConversationRequest
+/**
+ * Answer a steer message that was persisted while a turn was live. Synthesised
+ * by `AiStreamManager.startNextChatTurn` when a finished chat turn has a pending
+ * steer queued — it opens a fresh assistant turn anchored on the steer user
+ * message (no new user row). Not on the renderer↔main IPC contract.
+ */
+export interface MainSteerContinuationRequest {
+  trigger: 'steer-continuation'
+  topicId: string
+  /** The already-persisted steer user message to answer. */
+  userMessageId: string
+}
+
+export type MainDispatchRequest = AiStreamOpenRequest | MainContinueConversationRequest | MainSteerContinuationRequest
 
 const logger = loggerService.withContext('chatContextDispatch')
 
@@ -55,17 +67,11 @@ export async function dispatchStreamRequest(
 
   logger.debug('Dispatching stream request', { topicId: req.topicId, provider: provider.name })
 
-  // Steer a live chat turn by abort+restart. This MUST run before `prepareDispatch`:
-  // `abortAndAwait` settles the running turn and persists its partial as `paused`, so the
-  // history `prepareDispatch` reads from the DB includes the text the model was mid-producing.
-  // Agent sessions are not aborted (they enqueue a follow-up onto `pendingTurns`), so their
-  // liveness must still be observed by `prepareDispatch` below.
-  if (manager.hasLiveStream(req.topicId) && !isAgentSessionTopic(req.topicId)) {
-    await manager.abortAndAwait(req.topicId, 'steer-restart')
-  }
-
-  // Re-snapshot after the abort: chat is now evicted (false → fresh start); an agent-session
-  // stream is untouched (still true → enqueue/inject path).
+  // A busy chat submit no longer aborts the live turn. Both chat and agent sessions now absorb a
+  // mid-flight user message by persisting it and enqueuing a follow-up: chat persists the steer
+  // user row (PersistentChatContextProvider's `hasLiveStream` branch) and we enqueue it below so
+  // the running turn yields at the next step boundary and the terminal hook chains a continuation;
+  // agent sessions enqueue onto `pendingTurns`. Either way `prepareDispatch` must observe liveness.
   const hasLiveStream = manager.hasLiveStream(req.topicId)
   const prepared = await provider.prepareDispatch(subscriber, req, { hasLiveStream }).catch((error: unknown) => {
     if (isAgentSessionWorkspaceError(error)) {
@@ -80,6 +86,13 @@ export async function dispatchStreamRequest(
   })
   if ('blocked' in prepared) {
     return { mode: 'blocked', ...prepared.blocked }
+  }
+
+  // Inject-steer: a live persistent-chat submit took the `hasLiveStream` branch (persisted the
+  // user row, no models → `send` will only attach the subscriber). Enqueue it so the running turn
+  // yields (`hasPendingSteer`) and `onExecutionDone` chains a `steer-continuation` to answer it.
+  if (provider.name === persistentChatContextProvider.name && prepared.models.length === 0 && prepared.userMessage) {
+    manager.enqueuePendingSteer(req.topicId, prepared.userMessage.id)
   }
 
   const result = manager.send({


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Steer/follow-up input had to race the active stream or be handled outside the stream manager lifecycle.

After this PR:

The stream runtime can enqueue continuation input and dispatch it after the current stream reaches a safe point.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The queue lives inside the stream manager boundary so callers do not duplicate stream state checks.

The following alternatives were considered:

A renderer-side queue was rejected because it would split stream ordering across process boundaries.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Stack PR 03/15 for the chat-page split. Base: `codex/chat-stack-02-observability`; head: `codex/chat-stack-03-steer-runtime`.

Validated at the top of this stack with `pnpm lint`, `pnpm test`, `pnpm db:migrations:check`, and `git diff --check`. Local Node 22.22.0 emitted the expected engine warning for the repo requirement `>=24.11.1`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
