### PR TITLE
feat(ai-tools): expose builtin web and knowledge tools

### DIFF
--- a/src/main/ai/mcp/McpCatalogService.ts
+++ b/src/main/ai/mcp/McpCatalogService.ts
@@ -7,7 +7,7 @@ import type { Tool as SDKTool } from '@modelcontextprotocol/sdk/types'
 import { isMcpToolDisabledBySource } from '@shared/ai/tools/mcpSourcePolicy'
 import type { SharedCacheKey } from '@shared/data/cache/cacheSchemas'
 import { buildFunctionCallToolName } from '@shared/mcp'
-import type { McpServer, McpTool } from '@types'
+import type { McpPrompt, McpResource, McpServer, McpTool } from '@types'
 import * as z from 'zod'
 
 const logger = loggerService.withContext('McpCatalogService')
@@ -179,6 +179,16 @@ export class McpCatalogService extends BaseService {
   public async listTools(serverId: string, options: ListToolsOptions = {}): Promise<McpTool[]> {
     const server = await this.getServerById(serverId)
     return this.listToolsForServer(server, options)
+  }
+
+  // Resources and prompts are owned by McpRuntimeService (cached under `mcp:list_*` and exposed
+  // over renderer IPC); the catalog delegates so SDK-runtime consumers keep one MCP read facade.
+  public async listResources(serverId: string): Promise<McpResource[]> {
+    return this.runtimeService().listResources(serverId)
+  }
+
+  public async listPrompts(serverId: string): Promise<McpPrompt[]> {
+    return this.runtimeService().listPrompts(serverId)
   }
 
   public async refreshTools(serverId: string): Promise<void> {

--- a/src/main/ai/mcp/__tests__/McpCatalogService.test.ts
+++ b/src/main/ai/mcp/__tests__/McpCatalogService.test.ts
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const getById = vi.fn()
 const listServers = vi.fn()
 const listTools = vi.fn()
+const runtimeListResources = vi.fn()
+const runtimeListPrompts = vi.fn()
 const cacheStore = new Map<string, unknown>()
 const cacheService = {
   has: vi.fn((key: string) => cacheStore.has(key)),
@@ -19,7 +21,9 @@ const runtimeService = {
     operation({ listTools })
   ),
   setServerStatus: vi.fn(),
-  onToolListChanged: vi.fn(() => ({ dispose: vi.fn() }))
+  onToolListChanged: vi.fn(() => ({ dispose: vi.fn() })),
+  listResources: runtimeListResources,
+  listPrompts: runtimeListPrompts
 }
 
 vi.mock('@application', async () => {
@@ -61,6 +65,8 @@ describe('McpCatalogService', () => {
     getById.mockReset()
     listServers.mockReset()
     listTools.mockReset()
+    runtimeListResources.mockReset()
+    runtimeListPrompts.mockReset()
     cacheStore.clear()
     Object.values(cacheService).forEach((mock) => mock.mockClear())
     runtimeService.getServerKey.mockClear()
@@ -134,5 +140,23 @@ describe('McpCatalogService', () => {
       'mcp.tools.server-1',
       expect.arrayContaining([expect.objectContaining({ name: 'search' })])
     )
+  })
+
+  it('delegates listResources to the runtime service', async () => {
+    const resources = [{ uri: 'file://a', name: 'a', serverId: 'server-1', serverName: 'docs' }]
+    runtimeListResources.mockResolvedValue(resources)
+
+    const service = new McpCatalogService()
+    await expect(service.listResources('server-1')).resolves.toBe(resources)
+    expect(runtimeListResources).toHaveBeenCalledWith('server-1')
+  })
+
+  it('delegates listPrompts to the runtime service', async () => {
+    const prompts = [{ id: 'p1', name: 'greet', serverId: 'server-1', serverName: 'docs' }]
+    runtimeListPrompts.mockResolvedValue(prompts)
+
+    const service = new McpCatalogService()
+    await expect(service.listPrompts('server-1')).resolves.toBe(prompts)
+    expect(runtimeListPrompts).toHaveBeenCalledWith('server-1')
   })
 })

--- a/src/main/ai/mcp/servers/__tests__/cherryBuiltinTools.test.ts
+++ b/src/main/ai/mcp/servers/__tests__/cherryBuiltinTools.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const searchKeywords = vi.fn()
+const fetchUrls = vi.fn()
+const kbSearch = vi.fn()
+const listBases = vi.fn()
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), silly: vi.fn() })
+  }
+}))
+
+vi.mock('@main/core/application', () => ({
+  application: {
+    get: (name: string) => {
+      if (name === 'WebSearchService') return { searchKeywords, fetchUrls }
+      if (name === 'KnowledgeOrchestrationService') return { search: kbSearch, listBases }
+      throw new Error(`unexpected service: ${name}`)
+    }
+  }
+}))
+
+const { callCherryBuiltinTool, listCherryBuiltinTools } = await import('../cherryBuiltinTools')
+const { WEB_LOOKUP_ERROR_NOTE } = await import('@main/ai/tools/web/webLookup')
+
+const signal = new AbortController().signal
+
+function webResponse() {
+  return {
+    providerId: 'tavily',
+    capability: 'searchKeywords',
+    inputs: ['q'],
+    results: [{ title: 'A', url: 'https://a.com', content: 'about A', sourceInput: 'q' }]
+  }
+}
+
+function textOf(result: { content: Array<{ type: string; text?: string }> }): string {
+  const part = result.content[0]
+  return part.type === 'text' ? (part.text ?? '') : ''
+}
+
+describe('cherryBuiltinTools', () => {
+  beforeEach(() => {
+    searchKeywords.mockReset()
+    fetchUrls.mockReset()
+    kbSearch.mockReset()
+    listBases.mockReset()
+  })
+
+  it('advertises the four builtin tools with object input schemas and no $schema marker', () => {
+    const tools = listCherryBuiltinTools()
+    expect(tools.map((t) => t.name).sort()).toEqual(['kb__list', 'kb__search', 'web__fetch', 'web__search'])
+    for (const tool of tools) {
+      expect(tool.inputSchema.type).toBe('object')
+      expect(tool.description).toBeTruthy()
+      expect((tool.inputSchema as Record<string, unknown>).$schema).toBeUndefined()
+    }
+  })
+
+  it('routes web__search through WebSearchService and returns mapped json content', async () => {
+    searchKeywords.mockResolvedValue(webResponse())
+
+    const result = await callCherryBuiltinTool('web__search', { query: 'hello' }, signal)
+
+    expect(searchKeywords).toHaveBeenCalledWith({ keywords: ['hello'] }, { signal })
+    expect(result.isError).toBeFalsy()
+    expect(JSON.parse(textOf(result))).toEqual([{ id: 1, title: 'A', url: 'https://a.com', content: 'about A' }])
+  })
+
+  it('routes web__fetch through WebSearchService', async () => {
+    fetchUrls.mockResolvedValue(webResponse())
+
+    const result = await callCherryBuiltinTool('web__fetch', { urls: ['https://a.com'] }, signal)
+
+    expect(fetchUrls).toHaveBeenCalledWith({ urls: ['https://a.com'] }, { signal })
+    expect(JSON.parse(textOf(result))).toHaveLength(1)
+  })
+
+  it('surfaces the retry note (not an error) when a web lookup fails', async () => {
+    searchKeywords.mockRejectedValue(new Error('upstream 503'))
+
+    const result = await callCherryBuiltinTool('web__search', { query: 'hello' }, signal)
+
+    expect(result.isError).toBeFalsy()
+    expect(textOf(result)).toBe(WEB_LOOKUP_ERROR_NOTE)
+  })
+
+  it('runs kb__search unscoped (all model-provided baseIds reach the orchestrator)', async () => {
+    kbSearch.mockResolvedValue([{ pageContent: 'doc', score: 0.9 }])
+
+    const result = await callCherryBuiltinTool('kb__search', { query: 'topic', baseIds: ['b1', 'b2'] }, signal)
+
+    expect(kbSearch).toHaveBeenCalledWith('b1', 'topic')
+    expect(kbSearch).toHaveBeenCalledWith('b2', 'topic')
+    expect(JSON.parse(textOf(result))[0]).toMatchObject({ id: 1, content: 'doc' })
+  })
+
+  it('returns an error result for an unknown tool', async () => {
+    const result = await callCherryBuiltinTool('nope', {}, signal)
+    expect(result.isError).toBe(true)
+    expect(textOf(result)).toContain('Unknown tool')
+  })
+})

--- a/src/main/ai/mcp/servers/cherryBuiltinTools.ts
+++ b/src/main/ai/mcp/servers/cherryBuiltinTools.ts
@@ -1,0 +1,144 @@
+/**
+ * In-process MCP server exposing Cherry Studio's builtin tools to Claude Code.
+ *
+ * Wraps the same `webLookup` / `kbLookup` cores the AI-SDK builtin tools use,
+ * so Claude Code's web search/fetch and knowledge-base tools run identical
+ * logic against the user's configured `WebSearchService` provider and knowledge
+ * bases. Injected by `settingsBuilder` as an `sdk`-type MCP server; Claude calls
+ * these as `mcp__cherry-tools__web__search`, `…__web__fetch`, `…__kb__search`,
+ * `…__kb__list`.
+ *
+ * KB scope is unscoped (`allowedIds: []`) because agents have no per-assistant
+ * knowledge selection — the agent sees all of the user's knowledge bases.
+ */
+
+import { loggerService } from '@logger'
+import {
+  KB_LIST_DESCRIPTION,
+  KB_SEARCH_DESCRIPTION,
+  kbListModelOutput,
+  kbSearchModelOutput,
+  listKb,
+  searchKb
+} from '@main/ai/tools/kb/kbLookup'
+import {
+  fetchWeb,
+  searchWeb,
+  WEB_FETCH_DESCRIPTION,
+  WEB_SEARCH_DESCRIPTION,
+  webLookupModelOutput
+} from '@main/ai/tools/web/webLookup'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import {
+  CallToolRequestSchema,
+  type CallToolResult,
+  ListToolsRequestSchema,
+  type Tool
+} from '@modelcontextprotocol/sdk/types.js'
+import {
+  KB_LIST_TOOL_NAME,
+  KB_SEARCH_TOOL_NAME,
+  kbListInputSchema,
+  kbSearchInputSchema,
+  WEB_FETCH_TOOL_NAME,
+  WEB_SEARCH_TOOL_NAME,
+  webFetchInputSchema,
+  webSearchInputSchema
+} from '@shared/ai/builtinTools'
+import * as z from 'zod'
+
+const logger = loggerService.withContext('McpServer:CherryBuiltinTools')
+
+type ToolModelOutput = { type: 'text'; value: string } | { type: 'json'; value: unknown }
+
+interface ToolHandler {
+  description: string
+  inputSchema: z.ZodType
+  run: (args: unknown, signal: AbortSignal) => Promise<ToolModelOutput>
+}
+
+// Agents have no per-assistant knowledge scope, so KB lookups run unscoped.
+const KB_ALLOWED_IDS: string[] = []
+
+const HANDLERS: Record<string, ToolHandler> = {
+  [WEB_SEARCH_TOOL_NAME]: {
+    description: WEB_SEARCH_DESCRIPTION,
+    inputSchema: webSearchInputSchema,
+    run: async (args, signal) => {
+      const { query } = webSearchInputSchema.parse(args)
+      return webLookupModelOutput(await searchWeb(query, signal))
+    }
+  },
+  [WEB_FETCH_TOOL_NAME]: {
+    description: WEB_FETCH_DESCRIPTION,
+    inputSchema: webFetchInputSchema,
+    run: async (args, signal) => {
+      const { urls } = webFetchInputSchema.parse(args)
+      return webLookupModelOutput(await fetchWeb(urls, signal))
+    }
+  },
+  [KB_SEARCH_TOOL_NAME]: {
+    description: KB_SEARCH_DESCRIPTION,
+    inputSchema: kbSearchInputSchema,
+    run: async (args) => {
+      const { query, baseIds } = kbSearchInputSchema.parse(args)
+      return kbSearchModelOutput(await searchKb(query, baseIds, KB_ALLOWED_IDS))
+    }
+  },
+  [KB_LIST_TOOL_NAME]: {
+    description: KB_LIST_DESCRIPTION,
+    inputSchema: kbListInputSchema,
+    run: async (args) => {
+      const input = kbListInputSchema.parse(args)
+      return kbListModelOutput(await listKb(input.query, input.groupId, KB_ALLOWED_IDS), input)
+    }
+  }
+}
+
+/** Drop the `$schema` marker so strict MCP clients don't reject the advertised input schema. */
+function toMcpInputSchema(schema: z.ZodType): Tool['inputSchema'] {
+  const json = z.toJSONSchema(schema) as Record<string, unknown>
+  delete json.$schema
+  return json as Tool['inputSchema']
+}
+
+function toMcpResult(output: ToolModelOutput): CallToolResult {
+  const text = output.type === 'text' ? output.value : JSON.stringify(output.value)
+  return { content: [{ type: 'text', text }] }
+}
+
+export function listCherryBuiltinTools(): Tool[] {
+  return Object.entries(HANDLERS).map(([name, handler]) => ({
+    name,
+    description: handler.description,
+    inputSchema: toMcpInputSchema(handler.inputSchema)
+  }))
+}
+
+export async function callCherryBuiltinTool(name: string, args: unknown, signal: AbortSignal): Promise<CallToolResult> {
+  const handler = HANDLERS[name]
+  if (!handler) {
+    return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true }
+  }
+  try {
+    return toMcpResult(await handler.run(args ?? {}, signal))
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    logger.error('cherry-tools call failed', error as Error, { tool: name })
+    return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true }
+  }
+}
+
+export class CherryBuiltinToolsServer {
+  public mcpServer: McpServer
+
+  constructor() {
+    this.mcpServer = new McpServer({ name: 'cherry-tools', version: '1.0.0' }, { capabilities: { tools: {} } })
+    this.mcpServer.server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: listCherryBuiltinTools() }))
+    this.mcpServer.server.setRequestHandler(CallToolRequestSchema, async (request, extra) =>
+      callCherryBuiltinTool(request.params.name, request.params.arguments, extra.signal)
+    )
+  }
+}
+
+export default CherryBuiltinToolsServer

--- a/src/main/ai/runtime/claudeCode/__tests__/buildMcpServers.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/buildMcpServers.test.ts
@@ -34,8 +34,12 @@ describe('adjustAllowedToolsForMcp', () => {
     expect(adjustAllowedToolsForMcp([], false, true)).toContain('mcp__assistant__*')
   })
 
-  it('leaves allowed tools untouched when neither Soul nor Assistant', () => {
-    expect(adjustAllowedToolsForMcp(['existing'], false, false)).toEqual(['existing'])
+  it('ensures cherry-tools is allowed under an explicit allowlist', () => {
+    expect(adjustAllowedToolsForMcp(['existing'], false, false)).toEqual(['existing', 'mcp__cherry-tools__*'])
+  })
+
+  it('leaves an undefined allowlist undefined for a plain agent (all tools permitted)', () => {
+    expect(adjustAllowedToolsForMcp(undefined, false, false)).toBeUndefined()
   })
 })
 
@@ -48,6 +52,12 @@ describe('buildMcpServers', () => {
   it('does not inject agent-memory when Soul Mode is off', async () => {
     const result = await buildMcpServers(session, agent, false, false)
     expect(result?.['agent-memory']).toBeUndefined()
+  })
+
+  it('injects cherry-tools for every session and no longer injects exa', async () => {
+    const result = await buildMcpServers(session, agent, false, false)
+    expect(result?.['cherry-tools']).toBeDefined()
+    expect(result?.exa).toBeUndefined()
   })
 })
 

--- a/src/main/ai/runtime/claudeCode/createSdkMcpServerInstance.ts
+++ b/src/main/ai/runtime/claudeCode/createSdkMcpServerInstance.ts
@@ -5,10 +5,16 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import {
   CallToolRequestSchema,
   type CallToolResult,
+  ListPromptsRequestSchema,
+  ListResourcesRequestSchema,
   ListToolsRequestSchema,
+  type Prompt as SdkPrompt,
+  ReadResourceRequestSchema,
+  type ReadResourceResult,
+  type Resource as SdkResource,
   type Tool as SdkTool
 } from '@modelcontextprotocol/sdk/types.js'
-import type { McpTool } from '@types'
+import type { McpPrompt, McpResource, McpTool } from '@types'
 
 const logger = loggerService.withContext('SdkMcpBridge')
 
@@ -21,10 +27,36 @@ function toSdkTool(tool: McpTool): SdkTool {
   return sdkTool
 }
 
+function toSdkResource(resource: McpResource): SdkResource {
+  const sdkResource = { ...resource } as SdkResource & Record<'serverId' | 'serverName', unknown>
+  Reflect.deleteProperty(sdkResource, 'serverId')
+  Reflect.deleteProperty(sdkResource, 'serverName')
+  return sdkResource
+}
+
+function toSdkPrompt(prompt: McpPrompt): SdkPrompt {
+  const sdkPrompt = { ...prompt } as SdkPrompt & Record<'id' | 'serverId' | 'serverName', unknown>
+  Reflect.deleteProperty(sdkPrompt, 'id')
+  Reflect.deleteProperty(sdkPrompt, 'serverId')
+  Reflect.deleteProperty(sdkPrompt, 'serverName')
+  return sdkPrompt
+}
+
+// McpResource carries both list metadata and read payload fields; a read content
+// block must collapse to the SDK's text-or-blob union, keyed on whichever is present.
+function toSdkResourceContents(content: McpResource): ReadResourceResult['contents'][number] {
+  const base: { uri: string; mimeType?: string } = { uri: content.uri }
+  if (content.mimeType) base.mimeType = content.mimeType
+  if (typeof content.text === 'string') return { ...base, text: content.text }
+  if (typeof content.blob === 'string') return { ...base, blob: content.blob }
+  // Neither text nor blob isn't representable in the protocol; surface as empty text.
+  return { ...base, text: '' }
+}
+
 /**
  * Creates an `McpServer` instance that acts as an in-process bridge,
- * proxying tool list/call requests to an existing MCP server managed
- * by `McpRuntimeService`.
+ * proxying tool/resource/prompt list and call requests to an existing MCP
+ * server managed by `McpRuntimeService`.
  *
  * The returned instance is designed for use with the Claude Agent SDK's
  * in-memory (`type: 'sdk'`) transport, keeping all communication
@@ -36,7 +68,10 @@ export async function createSdkMcpServerInstance(mcpId: string): Promise<McpServ
     throw new Error(`MCP server not found: ${mcpId}`)
   }
 
-  const sdkServer = new McpServer({ name: serverConfig.name, version: '0.1.0' }, { capabilities: { tools: {} } })
+  const sdkServer = new McpServer(
+    { name: serverConfig.name, version: '0.1.0' },
+    { capabilities: { tools: {}, resources: {}, prompts: {} } }
+  )
 
   // Use the low-level Server to set raw request handlers because this bridge
   // proxies requests to the downstream MCP server whose tool schemas are not
@@ -68,6 +103,46 @@ export async function createSdkMcpServerInstance(mcpId: string): Promise<McpServ
       return result as CallToolResult
     } catch (error) {
       logger.error('SDK bridge: failed to call tool', { mcpId, tool: request.params.name, error })
+      throw error
+    }
+  })
+
+  rawServer.setRequestHandler(ListResourcesRequestSchema, async () => {
+    try {
+      logger.debug('SDK bridge: listing resources', { mcpId })
+      const resources = await application.get('McpCatalogService').listResources(serverConfig.id)
+      return {
+        resources: resources.map(toSdkResource)
+      }
+    } catch (error) {
+      logger.error('SDK bridge: failed to list resources', { mcpId, error })
+      throw error
+    }
+  })
+
+  rawServer.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+    const { uri } = request.params
+    try {
+      logger.debug('SDK bridge: reading resource', { mcpId, uri })
+      const { contents } = await application.get('McpRuntimeService').getResource({ serverId: serverConfig.id, uri })
+      return {
+        contents: contents.map(toSdkResourceContents)
+      }
+    } catch (error) {
+      logger.error('SDK bridge: failed to read resource', { mcpId, uri, error })
+      throw error
+    }
+  })
+
+  rawServer.setRequestHandler(ListPromptsRequestSchema, async () => {
+    try {
+      logger.debug('SDK bridge: listing prompts', { mcpId })
+      const prompts = await application.get('McpCatalogService').listPrompts(serverConfig.id)
+      return {
+        prompts: prompts.map(toSdkPrompt)
+      }
+    } catch (error) {
+      logger.error('SDK bridge: failed to list prompts', { mcpId, error })
       throw error
     }
   })

--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -31,6 +31,7 @@ import { loggerService } from '@logger'
 import { isProvisioned, provisionBuiltinAgent } from '@main/ai/agents/builtin/BuiltinAgentProvisioner'
 import { PromptBuilder } from '@main/ai/agents/cherryclaw/prompt'
 import AssistantServer from '@main/ai/mcp/servers/assistant'
+import CherryBuiltinToolsServer from '@main/ai/mcp/servers/cherryBuiltinTools'
 import ClawServer from '@main/ai/mcp/servers/claw'
 import WorkspaceMemoryServer from '@main/ai/mcp/servers/workspaceMemory'
 import { createSdkMcpServerInstance } from '@main/ai/runtime/claudeCode/createSdkMcpServerInstance'
@@ -425,6 +426,8 @@ async function buildToolPermissions(
   const isAssistant = agentConfig?.builtin_role === 'assistant'
   const toolPolicySnapshot = await createClaudeAgentToolPolicySnapshot(agent, {
     autoAllowRuntimeNamePrefixes: [
+      // cherry-tools (web + knowledge) is injected for every session and is read-only.
+      'mcp__cherry-tools__',
       ...(soulEnabled ? ['mcp__claw__'] : []),
       ...(isAssistant ? ['mcp__assistant__'] : [])
     ]
@@ -570,8 +573,12 @@ export async function buildMcpServers(
     }
   }
 
-  // 3. Exa — structured web search via HTTP (free tier, no API key)
-  mcpList.exa = { type: 'http', url: 'https://mcp.exa.ai/mcp' }
+  // 3. Cherry tools
+  mcpList['cherry-tools'] = {
+    type: 'sdk',
+    name: 'cherry-tools',
+    instance: new CherryBuiltinToolsServer().mcpServer
+  }
 
   // 4. Claw — agent autonomy tools (soul mode only). Use `agent.id` instead of
   // `session.agentId` so TS can see the value is non-null after the upstream
@@ -624,20 +631,25 @@ export function adjustAllowedToolsForMcp(
   soulEnabled: boolean,
   isAssistant: boolean
 ): string[] | undefined {
-  if (!soulEnabled && !isAssistant) return allowedTools
+  // No explicit allowlist and no built-in server forcing one: leave it undefined
+  // so Claude Code permits all tools. cherry-tools is still usable because its
+  // canUseTool gate is satisfied by the auto-allow prefix in buildToolPermissions.
+  if (allowedTools === undefined && !soulEnabled && !isAssistant) return undefined
 
   const result = allowedTools ? [...allowedTools] : []
-
-  if (soulEnabled && !result.includes('mcp__claw__*')) {
-    result.push('mcp__claw__*')
+  const ensure = (name: string) => {
+    if (!result.includes(name)) result.push(name)
   }
 
-  if (soulEnabled && !result.includes('mcp__agent-memory__*')) {
-    result.push('mcp__agent-memory__*')
-  }
+  // cherry-tools is injected for every session — keep it usable under an explicit allowlist.
+  ensure('mcp__cherry-tools__*')
 
-  if (isAssistant && !result.includes('mcp__assistant__*')) {
-    result.push('mcp__assistant__*')
+  if (soulEnabled) {
+    ensure('mcp__claw__*')
+    ensure('mcp__agent-memory__*')
+  }
+  if (isAssistant) {
+    ensure('mcp__assistant__*')
   }
 
   return result.length > 0 ? result : undefined

--- a/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeListTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeListTool.ts
@@ -2,161 +2,35 @@
  * Knowledge base discovery tool — companion to `kb__search`.
  *
  * Returns metadata for the knowledge bases reachable from the current request,
- * with up to 8 sample item sources per base derived from item titles, URLs,
- * paths, or note first-lines. The model uses this to pick which `baseIds` to
- * pass to `kb__search` instead of fanning out blindly.
+ * with up to 8 sample item sources per base. The model uses this to pick which
+ * `baseIds` to pass to `kb__search` instead of fanning out blindly. The listing
+ * itself lives in the shared `kbLookup` core so the Claude Code MCP bridge runs
+ * identical logic; this file is just the AI-SDK `tool()` wrapper.
  *
  * Scope: when `assistant.knowledgeBaseIds` is non-empty, only those bases are
- * returned. When empty (future toggle path), all user bases are returned.
+ * returned; when empty, all user bases are returned.
  */
 
-import { loggerService } from '@logger'
-import { application } from '@main/core/application'
-import {
-  KB_LIST_TOOL_NAME,
-  kbListInputSchema,
-  type KbListOutput,
-  type KbListOutputItem,
-  kbListOutputSchema
-} from '@shared/ai/builtinTools'
-import type { KnowledgeBase, KnowledgeItem } from '@shared/data/types/knowledge'
+import { KB_LIST_TOOL_NAME, kbListInputSchema, kbListOutputSchema } from '@shared/ai/builtinTools'
 import { tool } from 'ai'
 
+import { KB_LIST_DESCRIPTION, kbListModelOutput, listKb } from '../../../kb/kbLookup'
 import { getToolCallContext } from '../context'
 import type { ToolEntry } from '../types'
-
-const logger = loggerService.withContext('KnowledgeListTool')
-
-const SAMPLE_LIMIT = 8
-const NOTE_SNIPPET_MAX_CHARS = 80
 
 export { KB_LIST_TOOL_NAME }
 
 const kbListTool = tool({
-  description: `Browse the user's available knowledge bases before searching.
-
-Returns each base's name, group, item count, and a few sample sources (filenames, URLs, note titles) so you can judge what topics it likely covers. Call this first when the user asks about their materials and you don't already know which base is relevant — then call kb__search with the chosen baseIds.`,
+  description: KB_LIST_DESCRIPTION,
   inputSchema: kbListInputSchema,
   outputSchema: kbListOutputSchema,
   strict: true,
-  execute: async ({ query, groupId }, options): Promise<KbListOutput> => {
+  execute: async ({ query, groupId }, options) => {
     const { request } = getToolCallContext(options)
-    const allowedIds = request.assistant?.knowledgeBaseIds ?? []
-
-    const orchestrator = application.get('KnowledgeOrchestrationService')
-    const allBases = await orchestrator.listBases()
-    const scopedBases = allowedIds.length > 0 ? allBases.filter((base) => allowedIds.includes(base.id)) : allBases
-
-    const groupFiltered = groupId !== undefined ? scopedBases.filter((base) => base.groupId === groupId) : scopedBases
-
-    // Cap concurrency: a user with 50+ KBs would otherwise fire 50 concurrent
-    // listRootItems queries against SQLite + the vector store on every kb__list
-    // call. 8 in-flight is enough to keep the agent loop responsive without
-    // overwhelming the orchestrator.
-    const items: KbListOutputItem[] = await mapWithConcurrency(groupFiltered, 8, (base) =>
-      buildOutputItem(base, orchestrator)
-    )
-
-    const lowered = query?.toLowerCase()
-    if (!lowered) return items
-    return items.filter((item) => matchesQuery(item, lowered))
+    return listKb(query, groupId, request.assistant?.knowledgeBaseIds ?? [])
   },
-  toModelOutput: ({ input, output }) => {
-    if (output.length === 0) {
-      const filtered = Boolean(input?.query) || Boolean(input?.groupId)
-      return {
-        type: 'text' as const,
-        value: filtered
-          ? 'No knowledge bases match the filter. Retry with a broader query or omit groupId to see all available bases.'
-          : 'No knowledge bases are available for this assistant. Inform the user that no knowledge base is configured rather than retrying.'
-      }
-    }
-    return { type: 'json' as const, value: output }
-  }
+  toModelOutput: ({ input, output }) => kbListModelOutput(output, input)
 })
-
-async function buildOutputItem(
-  base: KnowledgeBase,
-  orchestrator: { listRootItems: (id: string) => Promise<KnowledgeItem[]> }
-): Promise<KbListOutputItem> {
-  let rootItems: KnowledgeItem[] = []
-  if (base.status === 'completed') {
-    try {
-      rootItems = await orchestrator.listRootItems(base.id)
-    } catch (error) {
-      logger.warn('KnowledgeOrchestrationService.listRootItems failed', {
-        baseId: base.id,
-        error: error instanceof Error ? error.message : String(error)
-      })
-    }
-  }
-
-  const completedItems = rootItems.filter((item) => item.status === 'completed')
-  const sampleSources = completedItems
-    .slice(0, SAMPLE_LIMIT)
-    .map(deriveSampleSource)
-    .filter((source): source is string => source !== null)
-
-  return {
-    id: base.id,
-    name: base.name,
-    groupId: base.groupId,
-    status: base.status,
-    documentCount: base.documentCount ?? 0,
-    itemCount: rootItems.length,
-    sampleSources
-  }
-}
-
-function deriveSampleSource(item: KnowledgeItem): string | null {
-  switch (item.type) {
-    case 'file': {
-      const legacyFile = (item.data as { file?: { origin_name?: string; name?: string } }).file
-      const value =
-        legacyFile?.origin_name?.trim() ||
-        legacyFile?.name?.trim() ||
-        item.data.source.trim() ||
-        item.data.fileEntryId.trim()
-      return value ? value : null
-    }
-    case 'url':
-      return item.data.url.trim() || null
-    case 'directory':
-      return item.data.path.trim() || null
-    case 'note': {
-      const firstLine = item.data.content.split(/\r?\n/).find((line) => line.trim().length > 0)
-      if (!firstLine) return null
-      const trimmed = firstLine.trim()
-      return trimmed.length > NOTE_SNIPPET_MAX_CHARS ? `${trimmed.slice(0, NOTE_SNIPPET_MAX_CHARS - 1)}…` : trimmed
-    }
-    default:
-      return null
-  }
-}
-
-function matchesQuery(item: KbListOutputItem, lowered: string): boolean {
-  if (item.name.toLowerCase().includes(lowered)) return true
-  return item.sampleSources.some((source) => source.toLowerCase().includes(lowered))
-}
-
-/** Run `mapper` over `items` with at most `limit` in flight at once. */
-async function mapWithConcurrency<T, R>(
-  items: readonly T[],
-  limit: number,
-  mapper: (item: T) => Promise<R>
-): Promise<R[]> {
-  const results: R[] = new Array(items.length)
-  let cursor = 0
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    while (true) {
-      const i = cursor++
-      if (i >= items.length) return
-      results[i] = await mapper(items[i])
-    }
-  })
-  await Promise.all(workers)
-  return results
-}
 
 export function createKbListToolEntry(): ToolEntry {
   return {

--- a/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeSearchTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeSearchTool.ts
@@ -1,99 +1,32 @@
 /**
  * Knowledge base search tool — agentic.
  *
- * The model picks the query and the target `baseIds` (typically after calling
- * `kb__list` to discover which bases are relevant). Per-request
- * `assistant.knowledgeBaseIds` flows in via RequestContext: when non-empty it
- * scopes which base IDs the tool will accept. The tool itself is stateless;
- * registered once during AiService startup via `registerBuiltinTools(...)`.
+ * The model picks the query and target `baseIds` (typically after `kb__list`).
+ * Per-request `assistant.knowledgeBaseIds` flows in via RequestContext and
+ * scopes which base IDs are accepted. The search itself lives in the shared
+ * `kbLookup` core so the Claude Code MCP bridge runs identical logic; this
+ * file is just the AI-SDK `tool()` wrapper.
  */
 
-import { loggerService } from '@logger'
-import { application } from '@main/core/application'
-import {
-  KB_SEARCH_TOOL_NAME,
-  kbSearchInputSchema,
-  type KbSearchOutput,
-  kbSearchOutputSchema
-} from '@shared/ai/builtinTools'
-import type { KnowledgeSearchResult } from '@shared/data/types/knowledge'
+import { KB_SEARCH_TOOL_NAME, kbSearchInputSchema, kbSearchOutputSchema } from '@shared/ai/builtinTools'
 import { type InferToolInput, type InferToolOutput, tool } from 'ai'
 
+import { KB_SEARCH_DESCRIPTION, kbSearchModelOutput, searchKb } from '../../../kb/kbLookup'
 import { getToolCallContext } from '../context'
 import type { ToolEntry } from '../types'
-
-const logger = loggerService.withContext('KnowledgeSearchTool')
 
 export { KB_SEARCH_TOOL_NAME }
 
 const kbSearchTool = tool({
-  description: `Search the user's private knowledge base — local documents, notes, web clippings.
-
-Use this when:
-- The user references "my notes" / "my documents" / their own materials
-- The question references topics likely covered in stored documents
-- Specific factual lookup that isn't general knowledge
-
-Workflow: call kb__list first to discover available bases and their contents, then call this tool with the chosen baseIds. You may call this multiple times with refined queries or different baseIds if the first results are insufficient. Cite sources by [id] in your final answer.`,
+  description: KB_SEARCH_DESCRIPTION,
   inputSchema: kbSearchInputSchema,
   outputSchema: kbSearchOutputSchema,
   strict: true,
-  execute: async ({ query, baseIds }, options): Promise<KbSearchOutput> => {
+  execute: async ({ query, baseIds }, options) => {
     const { request } = getToolCallContext(options)
-    const allowedIds = request.assistant?.knowledgeBaseIds ?? []
-    const targetIds = allowedIds.length > 0 ? baseIds.filter((id) => allowedIds.includes(id)) : baseIds
-
-    if (targetIds.length === 0) return []
-
-    if (allowedIds.length > 0 && targetIds.length < baseIds.length) {
-      const rejected = baseIds.filter((id) => !allowedIds.includes(id))
-      logger.warn('Dropped baseIds outside the assistant scope', { rejected, allowedIds })
-    }
-
-    const orchestrator = application.get('KnowledgeOrchestrationService')
-    const perBaseResults = await Promise.all(
-      targetIds.map(async (baseId) => {
-        try {
-          return await orchestrator.search(baseId, query)
-        } catch (error) {
-          logger.warn('KnowledgeOrchestrationService.search failed', {
-            baseId,
-            query,
-            error: error instanceof Error ? error.message : String(error)
-          })
-          return [] as KnowledgeSearchResult[]
-        }
-      })
-    )
-
-    const merged = perBaseResults.flat()
-    const dedupedByContent = new Map<string, KnowledgeSearchResult>()
-    for (const result of merged) {
-      const existing = dedupedByContent.get(result.pageContent)
-      if (!existing || result.score > existing.score) {
-        dedupedByContent.set(result.pageContent, result)
-      }
-    }
-    const sorted = [...dedupedByContent.values()].sort((a, b) => b.score - a.score)
-
-    return sorted.map((result, index) => ({
-      id: index + 1,
-      content: result.pageContent,
-      // Clamp to the schema's [0, 1] range; AI SDK validates the final array
-      // against `outputSchema` after this returns.
-      score: Math.max(0, Math.min(1, result.score))
-    }))
+    return searchKb(query, baseIds, request.assistant?.knowledgeBaseIds ?? [])
   },
-  toModelOutput: ({ output }) => {
-    if (output.length === 0) {
-      return {
-        type: 'text' as const,
-        value:
-          'No matches in the requested knowledge bases. If you are not sure which bases to search, call kb__list first to inspect available bases and their sample sources, then retry kb__search with refined baseIds or query.'
-      }
-    }
-    return { type: 'json' as const, value: output }
-  }
+  toModelOutput: ({ output }) => kbSearchModelOutput(output)
 })
 
 export function createKbSearchToolEntry(): ToolEntry {

--- a/src/main/ai/tools/adapters/aiSdk/builtin/WebFetchTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/WebFetchTool.ts
@@ -1,0 +1,41 @@
+/**
+ * Web fetch tool — agentic.
+ *
+ * The model supplies known page URLs (often from a prior `web__search`) and
+ * gets back their readable content. The lookup itself lives in the shared
+ * `webLookup` core so the Claude Code MCP bridge runs identical logic; this
+ * file is just the AI-SDK `tool()` wrapper.
+ */
+
+import { WEB_FETCH_TOOL_NAME, webFetchInputSchema, webFetchOutputSchema } from '@shared/ai/builtinTools'
+import { type InferToolInput, type InferToolOutput, tool } from 'ai'
+import * as z from 'zod'
+
+import { fetchWeb, WEB_FETCH_DESCRIPTION, webLookupErrorSchema, webLookupModelOutput } from '../../../web/webLookup'
+import { getToolCallContext } from '../context'
+import type { ToolEntry } from '../types'
+
+const webFetchResultSchema = z.union([webFetchOutputSchema, webLookupErrorSchema])
+
+const webFetchTool = tool({
+  description: WEB_FETCH_DESCRIPTION,
+  inputSchema: webFetchInputSchema,
+  outputSchema: webFetchResultSchema,
+  strict: true,
+  execute: async ({ urls }, options) => fetchWeb(urls, getToolCallContext(options).request.abortSignal),
+  toModelOutput: ({ output }) => webLookupModelOutput(output)
+})
+
+export function createWebFetchToolEntry(): ToolEntry {
+  return {
+    name: WEB_FETCH_TOOL_NAME,
+    namespace: 'web',
+    description: 'Fetch readable content from known web page URLs',
+    defer: 'auto',
+    tool: webFetchTool,
+    applies: (scope) => Boolean(scope.assistant?.settings?.enableWebSearch)
+  }
+}
+
+export type WebFetchToolInput = InferToolInput<typeof webFetchTool>
+export type WebFetchToolOutput = InferToolOutput<typeof webFetchTool>

--- a/src/main/ai/tools/adapters/aiSdk/builtin/WebSearchTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/WebSearchTool.ts
@@ -1,161 +1,38 @@
 /**
  * Web search tool — agentic.
  *
- * The model picks search queries or URLs and may call multiple times with
- * refined terms. Provider ids are resolved inside WebSearchService from the
- * user's configured default provider for each capability.
- *
- * Replaces the deleted workflow-style `webSearchToolWithPreExtractedKeywords`
- * factory whose intent analyzer pre-baked queries into the tool itself.
+ * The model picks search queries and may call multiple times with refined
+ * terms. The actual lookup (provider resolution, mapping, error handling)
+ * lives in the shared `webLookup` core so the Claude Code MCP bridge runs the
+ * exact same logic; this file is just the AI-SDK `tool()` wrapper.
  */
 
-import { loggerService } from '@logger'
-import { application } from '@main/core/application'
 import {
   WEB_FETCH_TOOL_NAME,
   WEB_SEARCH_TOOL_NAME,
-  webFetchInputSchema,
-  type WebFetchOutput,
-  webFetchOutputSchema,
   webSearchInputSchema,
-  type WebSearchOutput,
   webSearchOutputSchema
 } from '@shared/ai/builtinTools'
-import type { WebSearchResponse } from '@shared/data/types/webSearch'
 import { type InferToolInput, type InferToolOutput, tool } from 'ai'
 import * as z from 'zod'
 
+import { searchWeb, WEB_SEARCH_DESCRIPTION, webLookupErrorSchema, webLookupModelOutput } from '../../../web/webLookup'
 import { getToolCallContext } from '../context'
 import type { ToolEntry } from '../types'
 
-const logger = loggerService.withContext('WebSearchTool')
-
 export { WEB_FETCH_TOOL_NAME, WEB_SEARCH_TOOL_NAME }
 
-/**
- * A failed lookup must be distinguishable from "ran fine, found nothing":
- * both previously returned `[]`, so the model could not tell a network/provider
- * error apart from an empty result set and would silently report "no results".
- *
- * `execute` now returns a discriminated result — the plain results array on
- * success (keeps the persisted UI output shape, validated by
- * `webSearchOutputSchema`) or `{ error }` on failure. `toModelOutput` renders a
- * retry/inform note for the error branch so the model reacts instead of giving
- * up. We never throw: throwing would abort the surrounding agentic loop.
- */
-const webSearchErrorSchema = z.object({ error: z.string() })
-const webSearchResultSchema = z.union([webSearchOutputSchema, webSearchErrorSchema])
-const webFetchResultSchema = z.union([webFetchOutputSchema, webSearchErrorSchema])
-
-type WebSearchResult = WebSearchOutput | z.infer<typeof webSearchErrorSchema>
-type WebFetchResult = WebFetchOutput | z.infer<typeof webSearchErrorSchema>
-
-const WEB_LOOKUP_ERROR_NOTE = 'Web search failed (network/provider error); retry or inform the user.'
-
-function isWebLookupError(output: unknown): output is z.infer<typeof webSearchErrorSchema> {
-  return webSearchErrorSchema.safeParse(output).success
-}
-
-function mapWebSearchOutput(response: WebSearchResponse): WebSearchOutput {
-  return response.results.map((result, index) => ({
-    id: index + 1,
-    title: result.title,
-    url: result.url,
-    content: result.content
-  }))
-}
+const webSearchResultSchema = z.union([webSearchOutputSchema, webLookupErrorSchema])
 
 const webSearchTool = tool({
-  description: `Search the web for current information, news, and real-time data.
-
-Use this when:
-- The user asks about recent events, current prices, or live data
-- You need to verify facts you're uncertain about or that may have changed
-- The user references something you don't have context on
-
-Don't use for:
-- Math, code reasoning, or things you can answer from your training
-- Well-known facts unlikely to have changed
-
-You may call this multiple times with different queries to broaden coverage:
-- If the topic likely has more authoritative sources in another language
-  (English for tech / scientific topics, the local language for regional news,
-  Japanese for anime / manga, etc.), repeat the search with the topic translated
-  into the most likely source language.
-- If the first results miss an angle, refine with synonyms or sub-aspects.
-
-Cite sources by [id] in your final answer.`,
+  description: WEB_SEARCH_DESCRIPTION,
   inputSchema: webSearchInputSchema,
   outputSchema: webSearchResultSchema,
   // Provider-level constrained decoding where supported. Repair fallback
   // (in AiService) handles providers that don't honour `strict`.
   strict: true,
-  execute: async ({ query }, options): Promise<WebSearchResult> => {
-    const { request } = getToolCallContext(options)
-
-    try {
-      const webSearchService = application.get('WebSearchService')
-      const response = await webSearchService.searchKeywords(
-        {
-          keywords: [query]
-        },
-        { signal: request.abortSignal }
-      )
-      return mapWebSearchOutput(response)
-    } catch (error) {
-      logger.error('webSearchService.searchKeywords failed', error as Error, {
-        query
-      })
-      return { error: error instanceof Error ? error.message : String(error) }
-    }
-  },
-  toModelOutput: ({ output }) => {
-    if (isWebLookupError(output)) {
-      return { type: 'text' as const, value: WEB_LOOKUP_ERROR_NOTE }
-    }
-    return { type: 'json' as const, value: output }
-  }
-})
-
-const webFetchTool = tool({
-  description: `Fetch the readable content from one or more known web page URLs.
-
-Use this when:
-- You already have specific URLs from the user, prior context, or web__search
-- You need page content from an article, documentation page, or reference URL
-- Search snippets are not enough and you need the source page text
-
-Don't use this when you only have a topic or question; call web__search first.
-
-Cite sources by [id] in your final answer.`,
-  inputSchema: webFetchInputSchema,
-  outputSchema: webFetchResultSchema,
-  strict: true,
-  execute: async ({ urls }, options): Promise<WebFetchResult> => {
-    const { request } = getToolCallContext(options)
-
-    try {
-      const webSearchService = application.get('WebSearchService')
-      const response = await webSearchService.fetchUrls(
-        {
-          urls
-        },
-        { signal: request.abortSignal }
-      )
-      return mapWebSearchOutput(response)
-    } catch (error) {
-      logger.error('webSearchService.fetchUrls failed', error as Error, {
-        urls
-      })
-      return { error: error instanceof Error ? error.message : String(error) }
-    }
-  },
-  toModelOutput: ({ output }) => {
-    if (isWebLookupError(output)) {
-      return { type: 'text' as const, value: WEB_LOOKUP_ERROR_NOTE }
-    }
-    return { type: 'json' as const, value: output }
-  }
+  execute: async ({ query }, options) => searchWeb(query, getToolCallContext(options).request.abortSignal),
+  toModelOutput: ({ output }) => webLookupModelOutput(output)
 })
 
 export function createWebSearchToolEntry(): ToolEntry {
@@ -169,18 +46,5 @@ export function createWebSearchToolEntry(): ToolEntry {
   }
 }
 
-export function createWebFetchToolEntry(): ToolEntry {
-  return {
-    name: WEB_FETCH_TOOL_NAME,
-    namespace: 'web',
-    description: 'Fetch readable content from known web page URLs',
-    defer: 'auto',
-    tool: webFetchTool,
-    applies: (scope) => Boolean(scope.assistant?.settings?.enableWebSearch)
-  }
-}
-
 export type WebSearchToolInput = InferToolInput<typeof webSearchTool>
 export type WebSearchToolOutput = InferToolOutput<typeof webSearchTool>
-export type WebFetchToolInput = InferToolInput<typeof webFetchTool>
-export type WebFetchToolOutput = InferToolOutput<typeof webFetchTool>

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/WebSearchTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/WebSearchTool.test.ts
@@ -15,12 +15,8 @@ vi.mock('@main/core/application', () => ({
   }
 }))
 
-import {
-  createWebFetchToolEntry,
-  createWebSearchToolEntry,
-  WEB_FETCH_TOOL_NAME,
-  WEB_SEARCH_TOOL_NAME
-} from '../WebSearchTool'
+import { createWebFetchToolEntry } from '../WebFetchTool'
+import { createWebSearchToolEntry, WEB_FETCH_TOOL_NAME, WEB_SEARCH_TOOL_NAME } from '../WebSearchTool'
 
 const searchEntry = createWebSearchToolEntry()
 const fetchEntry = createWebFetchToolEntry()

--- a/src/main/ai/tools/adapters/aiSdk/builtin/index.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/index.ts
@@ -12,7 +12,8 @@
 import { registry, type ToolRegistry } from '../registry'
 import { createKbListToolEntry } from './KnowledgeListTool'
 import { createKbSearchToolEntry } from './KnowledgeSearchTool'
-import { createWebFetchToolEntry, createWebSearchToolEntry } from './WebSearchTool'
+import { createWebFetchToolEntry } from './WebFetchTool'
+import { createWebSearchToolEntry } from './WebSearchTool'
 
 export function registerBuiltinTools(reg: ToolRegistry = registry): void {
   reg.register(createKbListToolEntry())

--- a/src/main/ai/tools/kb/kbLookup.ts
+++ b/src/main/ai/tools/kb/kbLookup.ts
@@ -1,0 +1,214 @@
+/**
+ * Knowledge base search / list core — runtime-agnostic.
+ *
+ * Single source of truth shared by the AI-SDK builtin tools (`kb__search` /
+ * `kb__list`) and the Claude Code in-process MCP bridge. `allowedIds` scopes
+ * which bases are reachable: in the AI-SDK path it is the assistant's
+ * `knowledgeBaseIds`; an empty array means "no scope" (all user bases),
+ * which is what the Claude Code agent path passes since agents have no
+ * per-assistant knowledge scope.
+ */
+
+import { loggerService } from '@logger'
+import { application } from '@main/core/application'
+import type { KbListOutput, KbListOutputItem, KbSearchOutput } from '@shared/ai/builtinTools'
+import type { KnowledgeBase, KnowledgeItem, KnowledgeSearchResult } from '@shared/data/types/knowledge'
+
+const logger = loggerService.withContext('KbLookup')
+
+const SAMPLE_LIMIT = 8
+const NOTE_SNIPPET_MAX_CHARS = 80
+
+export const KB_SEARCH_DESCRIPTION = `Search the user's private knowledge base — local documents, notes, web clippings.
+
+Use this when:
+- The user references "my notes" / "my documents" / their own materials
+- The question references topics likely covered in stored documents
+- Specific factual lookup that isn't general knowledge
+
+Workflow: call kb__list first to discover available bases and their contents, then call this tool with the chosen baseIds. You may call this multiple times with refined queries or different baseIds if the first results are insufficient. Cite sources by [id] in your final answer.`
+
+export const KB_LIST_DESCRIPTION = `Browse the user's available knowledge bases before searching.
+
+Returns each base's name, group, item count, and a few sample sources (filenames, URLs, note titles) so you can judge what topics it likely covers. Call this first when the user asks about their materials and you don't already know which base is relevant — then call kb__search with the chosen baseIds.`
+
+export async function searchKb(query: string, baseIds: string[], allowedIds: string[]): Promise<KbSearchOutput> {
+  const targetIds = allowedIds.length > 0 ? baseIds.filter((id) => allowedIds.includes(id)) : baseIds
+
+  if (targetIds.length === 0) return []
+
+  if (allowedIds.length > 0 && targetIds.length < baseIds.length) {
+    const rejected = baseIds.filter((id) => !allowedIds.includes(id))
+    logger.warn('Dropped baseIds outside the assistant scope', { rejected, allowedIds })
+  }
+
+  const orchestrator = application.get('KnowledgeOrchestrationService')
+  const perBaseResults = await Promise.all(
+    targetIds.map(async (baseId) => {
+      try {
+        return await orchestrator.search(baseId, query)
+      } catch (error) {
+        logger.warn('KnowledgeOrchestrationService.search failed', {
+          baseId,
+          query,
+          error: error instanceof Error ? error.message : String(error)
+        })
+        return [] as KnowledgeSearchResult[]
+      }
+    })
+  )
+
+  const merged = perBaseResults.flat()
+  const dedupedByContent = new Map<string, KnowledgeSearchResult>()
+  for (const result of merged) {
+    const existing = dedupedByContent.get(result.pageContent)
+    if (!existing || result.score > existing.score) {
+      dedupedByContent.set(result.pageContent, result)
+    }
+  }
+  const sorted = [...dedupedByContent.values()].sort((a, b) => b.score - a.score)
+
+  return sorted.map((result, index) => ({
+    id: index + 1,
+    content: result.pageContent,
+    // Clamp to the schema's [0, 1] range; the AI-SDK path validates the final
+    // array against `kbSearchOutputSchema` after this returns.
+    score: Math.max(0, Math.min(1, result.score))
+  }))
+}
+
+export function kbSearchModelOutput(
+  output: KbSearchOutput
+): { type: 'text'; value: string } | { type: 'json'; value: KbSearchOutput } {
+  if (output.length === 0) {
+    return {
+      type: 'text',
+      value:
+        'No matches in the requested knowledge bases. If you are not sure which bases to search, call kb__list first to inspect available bases and their sample sources, then retry kb__search with refined baseIds or query.'
+    }
+  }
+  return { type: 'json', value: output }
+}
+
+export async function listKb(
+  query: string | undefined,
+  groupId: string | undefined,
+  allowedIds: string[]
+): Promise<KbListOutput> {
+  const orchestrator = application.get('KnowledgeOrchestrationService')
+  const allBases = await orchestrator.listBases()
+  const scopedBases = allowedIds.length > 0 ? allBases.filter((base) => allowedIds.includes(base.id)) : allBases
+
+  const groupFiltered = groupId !== undefined ? scopedBases.filter((base) => base.groupId === groupId) : scopedBases
+
+  // Cap concurrency: a user with 50+ KBs would otherwise fire 50 concurrent
+  // listRootItems queries against SQLite + the vector store on every kb__list
+  // call. 8 in-flight is enough to keep the agent loop responsive without
+  // overwhelming the orchestrator.
+  const items: KbListOutputItem[] = await mapWithConcurrency(groupFiltered, 8, (base) =>
+    buildOutputItem(base, orchestrator)
+  )
+
+  const lowered = query?.toLowerCase()
+  if (!lowered) return items
+  return items.filter((item) => matchesQuery(item, lowered))
+}
+
+export function kbListModelOutput(
+  output: KbListOutput,
+  input: { query?: string; groupId?: string }
+): { type: 'text'; value: string } | { type: 'json'; value: KbListOutput } {
+  if (output.length === 0) {
+    const filtered = Boolean(input?.query) || Boolean(input?.groupId)
+    return {
+      type: 'text',
+      value: filtered
+        ? 'No knowledge bases match the filter. Retry with a broader query or omit groupId to see all available bases.'
+        : 'No knowledge bases are available for this assistant. Inform the user that no knowledge base is configured rather than retrying.'
+    }
+  }
+  return { type: 'json', value: output }
+}
+
+async function buildOutputItem(
+  base: KnowledgeBase,
+  orchestrator: { listRootItems: (id: string) => Promise<KnowledgeItem[]> }
+): Promise<KbListOutputItem> {
+  let rootItems: KnowledgeItem[] = []
+  if (base.status === 'completed') {
+    try {
+      rootItems = await orchestrator.listRootItems(base.id)
+    } catch (error) {
+      logger.warn('KnowledgeOrchestrationService.listRootItems failed', {
+        baseId: base.id,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+  }
+
+  const completedItems = rootItems.filter((item) => item.status === 'completed')
+  const sampleSources = completedItems
+    .slice(0, SAMPLE_LIMIT)
+    .map(deriveSampleSource)
+    .filter((source): source is string => source !== null)
+
+  return {
+    id: base.id,
+    name: base.name,
+    groupId: base.groupId,
+    status: base.status,
+    documentCount: base.documentCount ?? 0,
+    itemCount: rootItems.length,
+    sampleSources
+  }
+}
+
+function deriveSampleSource(item: KnowledgeItem): string | null {
+  switch (item.type) {
+    case 'file': {
+      const legacyFile = (item.data as { file?: { origin_name?: string; name?: string } }).file
+      const value =
+        legacyFile?.origin_name?.trim() ||
+        legacyFile?.name?.trim() ||
+        item.data.source.trim() ||
+        item.data.fileEntryId.trim()
+      return value ? value : null
+    }
+    case 'url':
+      return item.data.url.trim() || null
+    case 'directory':
+      return item.data.path.trim() || null
+    case 'note': {
+      const firstLine = item.data.content.split(/\r?\n/).find((line) => line.trim().length > 0)
+      if (!firstLine) return null
+      const trimmed = firstLine.trim()
+      return trimmed.length > NOTE_SNIPPET_MAX_CHARS ? `${trimmed.slice(0, NOTE_SNIPPET_MAX_CHARS - 1)}…` : trimmed
+    }
+    default:
+      return null
+  }
+}
+
+function matchesQuery(item: KbListOutputItem, lowered: string): boolean {
+  if (item.name.toLowerCase().includes(lowered)) return true
+  return item.sampleSources.some((source) => source.toLowerCase().includes(lowered))
+}
+
+/** Run `mapper` over `items` with at most `limit` in flight at once. */
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  mapper: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length)
+  let cursor = 0
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const i = cursor++
+      if (i >= items.length) return
+      results[i] = await mapper(items[i])
+    }
+  })
+  await Promise.all(workers)
+  return results
+}

--- a/src/main/ai/tools/web/webLookup.ts
+++ b/src/main/ai/tools/web/webLookup.ts
@@ -1,0 +1,105 @@
+/**
+ * Web search / fetch core — runtime-agnostic.
+ *
+ * Single source of truth for "look something up on the web" shared by the
+ * AI-SDK builtin tools (`web__search` / `web__fetch`) and the Claude Code
+ * in-process MCP bridge. Both runtimes are thin formatters over these
+ * functions; the provider is resolved inside `WebSearchService` from the
+ * user's configured default for each capability.
+ *
+ * Never throws: a failed lookup returns `{ error }` so the surrounding
+ * agentic loop (AI-SDK or Claude Code) keeps running instead of aborting.
+ */
+
+import { loggerService } from '@logger'
+import { application } from '@main/core/application'
+import type { WebSearchOutput } from '@shared/ai/builtinTools'
+import type { WebSearchResponse } from '@shared/data/types/webSearch'
+import * as z from 'zod'
+
+const logger = loggerService.withContext('WebLookup')
+
+export const WEB_SEARCH_DESCRIPTION = `Search the web for current information, news, and real-time data.
+
+Use this when:
+- The user asks about recent events, current prices, or live data
+- You need to verify facts you're uncertain about or that may have changed
+- The user references something you don't have context on
+
+Don't use for:
+- Math, code reasoning, or things you can answer from your training
+- Well-known facts unlikely to have changed
+
+You may call this multiple times with different queries to broaden coverage:
+- If the topic likely has more authoritative sources in another language
+  (English for tech / scientific topics, the local language for regional news,
+  Japanese for anime / manga, etc.), repeat the search with the topic translated
+  into the most likely source language.
+- If the first results miss an angle, refine with synonyms or sub-aspects.
+
+Cite sources by [id] in your final answer.`
+
+export const WEB_FETCH_DESCRIPTION = `Fetch the readable content from one or more known web page URLs.
+
+Use this when:
+- You already have specific URLs from the user, prior context, or web__search
+- You need page content from an article, documentation page, or reference URL
+- Search snippets are not enough and you need the source page text
+
+Don't use this when you only have a topic or question; call web__search first.
+
+Cite sources by [id] in your final answer.`
+
+/**
+ * A failed lookup must be distinguishable from "ran fine, found nothing": both
+ * would otherwise be `[]`. Success returns the results array (matching
+ * `webSearchOutputSchema`); failure returns `{ error }`.
+ */
+export const webLookupErrorSchema = z.object({ error: z.string() })
+export type WebLookupError = z.infer<typeof webLookupErrorSchema>
+export type WebLookupResult = WebSearchOutput | WebLookupError
+
+export const WEB_LOOKUP_ERROR_NOTE = 'Web search failed (network/provider error); retry or inform the user.'
+
+export function isWebLookupError(output: unknown): output is WebLookupError {
+  return webLookupErrorSchema.safeParse(output).success
+}
+
+/** Shared model-output projection: an error renders a retry note; results pass through as json. */
+export function webLookupModelOutput(
+  output: WebLookupResult
+): { type: 'text'; value: string } | { type: 'json'; value: WebSearchOutput } {
+  if (isWebLookupError(output)) {
+    return { type: 'text', value: WEB_LOOKUP_ERROR_NOTE }
+  }
+  return { type: 'json', value: output }
+}
+
+function mapResponse(response: WebSearchResponse): WebSearchOutput {
+  return response.results.map((result, index) => ({
+    id: index + 1,
+    title: result.title,
+    url: result.url,
+    content: result.content
+  }))
+}
+
+export async function searchWeb(query: string, signal?: AbortSignal): Promise<WebLookupResult> {
+  try {
+    const response = await application.get('WebSearchService').searchKeywords({ keywords: [query] }, { signal })
+    return mapResponse(response)
+  } catch (error) {
+    logger.error('webSearchService.searchKeywords failed', error as Error, { query })
+    return { error: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+export async function fetchWeb(urls: string[], signal?: AbortSignal): Promise<WebLookupResult> {
+  try {
+    const response = await application.get('WebSearchService').fetchUrls({ urls }, { signal })
+    return mapResponse(response)
+  } catch (error) {
+    logger.error('webSearchService.fetchUrls failed', error as Error, { urls })
+    return { error: error instanceof Error ? error.message : String(error) }
+  }
+}

--- a/src/shared/ai/claudecode/constants.ts
+++ b/src/shared/ai/claudecode/constants.ts
@@ -1,4 +1,8 @@
-/** Tools disabled for ALL agents — replaced by Exa MCP (`mcp__exa__web_search_exa`) */
+/**
+ * Tools disabled for ALL agents — replaced by the in-process `cherry-tools` MCP
+ * server (`mcp__cherry-tools__web__search` / `__web__fetch`), which routes through
+ * the user's configured WebSearchService provider.
+ */
 export const GLOBALLY_DISALLOWED_TOOLS = ['WebSearch', 'WebFetch'] as const
 
 /**


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Built-in web and knowledge actions were not available through the same runtime tool path as other AI tools.

After this PR:

The AI tool runtime exposes built-in web search and knowledge tools through typed adapters.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

Kept each built-in tool behind its adapter so registry work can compose it without coupling to implementation details.

The following alternatives were considered:

Directly invoking existing services from the runtime loop was rejected because it bypasses tool policy and metadata.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Stack PR 04/15 for the chat-page split. Base: `codex/chat-stack-03-steer-runtime`; head: `codex/chat-stack-04-builtin-tools`.

Validated at the top of this stack with `pnpm lint`, `pnpm test`, `pnpm db:migrations:check`, and `git diff --check`. Local Node 22.22.0 emitted the expected engine warning for the repo requirement `>=24.11.1`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Agent runs can use built-in web search and knowledge tools through the unified tool runtime.
```
