### PR TITLE
feat(meta-tools): harden deferred tool invocation

### DIFF
--- a/src/main/ai/runtime/aiSdk/prompts/deferredTools.ts
+++ b/src/main/ai/runtime/aiSdk/prompts/deferredTools.ts
@@ -4,9 +4,9 @@ const DEFERRED_TOOLS_HEADER = `<deferred-tools>
 Some tools are not loaded inline. Discover and call them through the meta-tools below.
 
 <usage>
-1. \`tool_search({ query?, namespace?, verbose? })\` — browse the catalog. Results are grouped by namespace (e.g. \`web\`, \`kb\`, \`mcp:<server>\`). Pass \`verbose: true\` to include full input schemas.
-2. \`tool_inspect({ name })\` — fetch a JSDoc stub for one tool when the search description isn't enough to call it confidently.
-3. \`tool_invoke({ name, params })\` — call a single tool you found.
+1. \`tool_search({ query?, namespace?, verbose? })\` — discover tools, grouped by namespace (e.g. \`web\`, \`kb\`, \`mcp:<server>\`). This is tool discovery, NOT web search. Pass \`verbose: true\` to include full input schemas.
+2. \`tool_inspect({ name })\` — fetch a tool JSDoc signature to confirm its parameter names and shapes. Optional, but inspecting first (or searching with \`verbose: true\`) saves a round-trip.
+3. \`tool_invoke({ name, params })\` — call a single tool. If you call one you haven't inspected, or pass params that don't match its signature, the call returns that tool's signature — read it and call again with corrected params.
 </usage>`
 
 /**

--- a/src/main/ai/tools/adapters/aiSdk/exposition/__tests__/applyDeferExposition.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/exposition/__tests__/applyDeferExposition.test.ts
@@ -1,5 +1,5 @@
-import type { Tool, ToolSet } from 'ai'
-import { describe, expect, it } from 'vitest'
+import { jsonSchema, type Tool, type ToolSet } from 'ai'
+import { describe, expect, it, vi } from 'vitest'
 
 import { TOOL_INSPECT_TOOL_NAME } from '../../meta/toolInspect'
 import { TOOL_INVOKE_TOOL_NAME } from '../../meta/toolInvoke'
@@ -82,6 +82,45 @@ describe('applyDeferExposition', () => {
     expect(result).toBe(tools)
     expect(result![TOOL_SEARCH_TOOL_NAME]).toBeUndefined()
     expect(deferredEntries).toEqual([])
+  })
+
+  function exposeDeferredTool() {
+    const execute = vi.fn().mockResolvedValue('ok')
+    const registry = new ToolRegistry()
+    const entry: ToolEntry = {
+      name: 'mcp__s1__t',
+      namespace: 'mcp:s1',
+      description: 'd',
+      defer: 'always',
+      tool: {
+        type: 'function',
+        description: 'inner',
+        inputSchema: jsonSchema({ type: 'object' }),
+        execute
+      } as unknown as Tool
+    }
+    registry.register(entry)
+    const { tools } = applyDeferExposition({ mcp__s1__t: entry.tool }, registry, 32_000)
+    const opts = {
+      toolCallId: 'tc-1',
+      messages: [],
+      experimental_context: { requestId: 'req-1', abortSignal: new AbortController().signal }
+    } as Parameters<NonNullable<Tool['execute']>>[1]
+    return { execute, inspect: tools![TOOL_INSPECT_TOOL_NAME], invoke: tools![TOOL_INVOKE_TOOL_NAME], opts }
+  }
+
+  it('gates the injected tool_invoke on inspection — a deferred tool never runs blind', async () => {
+    const { execute, invoke, opts } = exposeDeferredTool()
+    await expect(invoke.execute!({ name: 'mcp__s1__t', params: {} }, opts)).rejects.toThrow(/hasn't been inspected/)
+    expect(execute).not.toHaveBeenCalled()
+  })
+
+  it('shares one inspect ledger: inspecting via the injected tool_inspect unlocks tool_invoke', async () => {
+    const { execute, inspect, invoke, opts } = exposeDeferredTool()
+    await inspect.execute!({ name: 'mcp__s1__t' }, opts)
+    const result = await invoke.execute!({ name: 'mcp__s1__t', params: {} }, opts)
+    expect(result).toBe('ok')
+    expect(execute).toHaveBeenCalledTimes(1)
   })
 
   it('skips entries that have a tool but no registry entry', () => {

--- a/src/main/ai/tools/adapters/aiSdk/exposition/applyDeferExposition.ts
+++ b/src/main/ai/tools/adapters/aiSdk/exposition/applyDeferExposition.ts
@@ -50,13 +50,19 @@ export function applyDeferExposition(
   // are added below — they don't address themselves.
   const allowedNames = new Set(Object.keys(tools))
 
+  // Shared per-request inspect-before-invoke ledger: `tool_inspect` records the tools whose
+  // signature the model has seen, `tool_invoke` requires membership before running one. Scoped to
+  // this request (one streamText loop), so the model re-confirms a tool's schema each turn rather
+  // than relying on an inspect that may have been compacted out of context.
+  const inspectedNames = new Set<string>()
+
   const inlineTools: ToolSet = {}
   for (const [name, entry] of Object.entries(tools)) {
     if (!deferredNames.has(name)) inlineTools[name] = entry
   }
   inlineTools[TOOL_SEARCH_TOOL_NAME] = createToolSearchTool(registry, deferredNames)
-  inlineTools[TOOL_INSPECT_TOOL_NAME] = createToolInspectTool(registry, allowedNames)
-  inlineTools[TOOL_INVOKE_TOOL_NAME] = createToolInvokeTool(registry, allowedNames)
+  inlineTools[TOOL_INSPECT_TOOL_NAME] = createToolInspectTool(registry, allowedNames, inspectedNames)
+  inlineTools[TOOL_INVOKE_TOOL_NAME] = createToolInvokeTool(registry, allowedNames, inspectedNames)
   // `tool_exec` (worker-thread JS sandbox with full registry access) is
   // intentionally NOT injected by default — it is a meaningful privilege-
   // escalation surface vs the renderer's prior restrictions. Re-enable

--- a/src/main/ai/tools/adapters/aiSdk/meta/__tests__/toolInspect.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/__tests__/toolInspect.test.ts
@@ -1,0 +1,82 @@
+import { jsonSchema, type Tool } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import { ToolRegistry } from '../../registry'
+import type { ToolEntry } from '../../types'
+import { createToolInspectTool, TOOL_INSPECT_TOOL_NAME } from '../toolInspect'
+
+function makeRegistry(): ToolRegistry {
+  const reg = new ToolRegistry()
+  const entry: ToolEntry = {
+    name: 'mcp__s1__t',
+    namespace: 'mcp:s1',
+    description: 'inner desc',
+    defer: 'auto',
+    tool: {
+      type: 'function',
+      description: 'inner',
+      inputSchema: jsonSchema({ type: 'object', properties: { query: { type: 'string' } }, required: ['query'] })
+    } as Tool
+  }
+  reg.register(entry)
+  return reg
+}
+
+async function callInspect(tool: Tool, args: { name: string }) {
+  if (typeof tool.execute !== 'function') throw new Error('not executable')
+  return tool.execute(args, {
+    toolCallId: 'tc-1',
+    messages: [],
+    experimental_context: { requestId: 'req-1', abortSignal: new AbortController().signal }
+  } as Parameters<NonNullable<Tool['execute']>>[1])
+}
+
+describe('tool_inspect meta-tool', () => {
+  it('TOOL_INSPECT_TOOL_NAME is the agreed wire-name', () => {
+    expect(TOOL_INSPECT_TOOL_NAME).toBe('tool_inspect')
+  })
+
+  it('returns a JSDoc stub for the tool', async () => {
+    const reg = makeRegistry()
+    const tool = createToolInspectTool(reg, new Set(['mcp__s1__t']), new Set())
+    const stub = (await callInspect(tool, { name: 'mcp__s1__t' })) as string
+    expect(stub).toContain('function mcp__s1__t(params)')
+    expect(stub).toContain('@param {string} params.query')
+  })
+
+  it('records the inspected name in the shared ledger', async () => {
+    const reg = makeRegistry()
+    const ledger = new Set<string>()
+    const tool = createToolInspectTool(reg, new Set(['mcp__s1__t']), ledger)
+    await callInspect(tool, { name: 'mcp__s1__t' })
+    expect(ledger.has('mcp__s1__t')).toBe(true)
+  })
+
+  it('refuses a tool outside the per-request allowed set and does not record it', async () => {
+    const reg = makeRegistry()
+    const ledger = new Set<string>()
+    const tool = createToolInspectTool(reg, new Set(['mcp__other']), ledger)
+    await expect(callInspect(tool, { name: 'mcp__s1__t' })).rejects.toThrow(/not available in this request/)
+    expect(ledger.has('mcp__s1__t')).toBe(false)
+  })
+
+  it('throws when the tool is not registered', async () => {
+    const reg = makeRegistry()
+    const tool = createToolInspectTool(reg, new Set(['unknown']), new Set())
+    await expect(callInspect(tool, { name: 'unknown' })).rejects.toThrow(/Tool not found/)
+  })
+
+  it('toModelOutput hands the stub to the model as plain text', async () => {
+    const reg = makeRegistry()
+    const tool = createToolInspectTool(reg, new Set(['mcp__s1__t']), new Set())
+    const stub = (await callInspect(tool, { name: 'mcp__s1__t' })) as string
+    const out = tool.toModelOutput!({ toolCallId: 'tc-1', input: { name: 'mcp__s1__t' }, output: stub })
+    expect(out).toEqual({ type: 'text', value: stub })
+  })
+
+  it('advertises a callable inputExample', () => {
+    const reg = makeRegistry()
+    const tool = createToolInspectTool(reg, new Set(['mcp__s1__t']), new Set())
+    expect(tool.inputExamples?.[0]?.input).toMatchObject({ name: expect.any(String) })
+  })
+})

--- a/src/main/ai/tools/adapters/aiSdk/meta/__tests__/toolInvoke.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/__tests__/toolInvoke.test.ts
@@ -1,18 +1,20 @@
-import type { Tool } from 'ai'
+import { jsonSchema, type Tool } from 'ai'
 import { describe, expect, it, vi } from 'vitest'
+import * as z from 'zod'
 
 import { ToolRegistry } from '../../registry'
 import type { ToolEntry } from '../../types'
 import { createToolInvokeTool, TOOL_INVOKE_TOOL_NAME } from '../toolInvoke'
 
 const innerExecute = vi.fn()
+const innerToModelOutput = vi.fn()
 
 function makeRegistry(): ToolRegistry {
   const reg = new ToolRegistry()
   const innerTool: Tool = {
     type: 'function',
     description: 'inner',
-    inputSchema: { type: 'object' } as unknown as Tool['inputSchema'],
+    inputSchema: jsonSchema({ type: 'object' }),
     execute: innerExecute
   } as Tool
   const entry: ToolEntry = {
@@ -26,9 +28,33 @@ function makeRegistry(): ToolRegistry {
   return reg
 }
 
+/** Registry whose inner tool defines `toModelOutput` (e.g. MCP summarising its response to text). */
+function makeRegistryWithToModelOutput(): ToolRegistry {
+  const reg = new ToolRegistry()
+  reg.register({
+    name: 'mcp__s1__t',
+    namespace: 'mcp:s1',
+    description: 'inner desc',
+    defer: 'auto',
+    tool: {
+      type: 'function',
+      description: 'inner',
+      inputSchema: jsonSchema({ type: 'object' }),
+      execute: innerExecute,
+      toModelOutput: innerToModelOutput
+    } as Tool
+  })
+  return reg
+}
+
 /** Allow-all scope: keeps the pre-scope assertions about not-found / no-execute / approval intact. */
 function allowAll(name: string): ReadonlySet<string> {
   return new Set([name])
+}
+
+/** Already-inspected ledger so a test can exercise the happy path past the inspect gate. */
+function inspected(...names: string[]): Set<string> {
+  return new Set(names)
 }
 
 async function callInvoke(tool: Tool, args: { name: string; params?: unknown }) {
@@ -48,7 +74,7 @@ describe('tool_invoke meta-tool', () => {
   it('forwards params to the inner tool execute', async () => {
     innerExecute.mockReset().mockResolvedValue({ ok: true })
     const reg = makeRegistry()
-    const tool = createToolInvokeTool(reg, allowAll('mcp__s1__t'))
+    const tool = createToolInvokeTool(reg, allowAll('mcp__s1__t'), inspected('mcp__s1__t'))
 
     const result = await callInvoke(tool, { name: 'mcp__s1__t', params: { foo: 'bar' } })
     expect(result).toEqual({ ok: true })
@@ -59,7 +85,7 @@ describe('tool_invoke meta-tool', () => {
   it('passes empty object when params omitted', async () => {
     innerExecute.mockReset().mockResolvedValue('ok')
     const reg = makeRegistry()
-    const tool = createToolInvokeTool(reg, allowAll('mcp__s1__t'))
+    const tool = createToolInvokeTool(reg, allowAll('mcp__s1__t'), inspected('mcp__s1__t'))
     await callInvoke(tool, { name: 'mcp__s1__t' })
     expect(innerExecute.mock.calls[0][0]).toEqual({})
   })
@@ -67,7 +93,7 @@ describe('tool_invoke meta-tool', () => {
   it('nests the toolCallId so telemetry can rebuild the call tree', async () => {
     innerExecute.mockReset().mockResolvedValue('ok')
     const reg = makeRegistry()
-    const tool = createToolInvokeTool(reg, allowAll('mcp__s1__t'))
+    const tool = createToolInvokeTool(reg, allowAll('mcp__s1__t'), inspected('mcp__s1__t'))
     await callInvoke(tool, { name: 'mcp__s1__t', params: {} })
     const passedOptions = innerExecute.mock.calls[0][1]
     expect(passedOptions.toolCallId).toBe('outer-1::mcp__s1__t')
@@ -75,7 +101,7 @@ describe('tool_invoke meta-tool', () => {
 
   it('throws when target tool not registered', async () => {
     const reg = makeRegistry()
-    const tool = createToolInvokeTool(reg, allowAll('unknown'))
+    const tool = createToolInvokeTool(reg, allowAll('unknown'), inspected('unknown'))
     await expect(callInvoke(tool, { name: 'unknown' })).rejects.toThrow(/Tool not found/)
   })
 
@@ -88,7 +114,7 @@ describe('tool_invoke meta-tool', () => {
       defer: 'auto',
       tool: { type: 'function', description: 'inert', inputSchema: {} } as unknown as Tool
     })
-    const tool = createToolInvokeTool(reg, allowAll('inert'))
+    const tool = createToolInvokeTool(reg, allowAll('inert'), inspected('inert'))
     await expect(callInvoke(tool, { name: 'inert' })).rejects.toThrow(/no execute handler/)
   })
 
@@ -103,12 +129,12 @@ describe('tool_invoke meta-tool', () => {
       tool: {
         type: 'function',
         description: 'gated',
-        inputSchema: { type: 'object' } as unknown as Tool['inputSchema'],
+        inputSchema: jsonSchema({ type: 'object' }),
         needsApproval: async () => true,
         execute: innerExecute
       } as Tool
     })
-    const tool = createToolInvokeTool(reg, allowAll('mcp__s1__danger'))
+    const tool = createToolInvokeTool(reg, allowAll('mcp__s1__danger'), inspected('mcp__s1__danger'))
     await expect(callInvoke(tool, { name: 'mcp__s1__danger', params: {} })).rejects.toThrow(/requires user approval/)
     expect(innerExecute).not.toHaveBeenCalled()
   })
@@ -117,8 +143,136 @@ describe('tool_invoke meta-tool', () => {
     innerExecute.mockReset().mockResolvedValue('ok')
     const reg = makeRegistry()
     // `mcp__s1__t` IS registered process-wide, but this request did not expose it.
-    const tool = createToolInvokeTool(reg, new Set(['mcp__other__allowed']))
+    const tool = createToolInvokeTool(reg, new Set(['mcp__other__allowed']), inspected('mcp__s1__t'))
     await expect(callInvoke(tool, { name: 'mcp__s1__t', params: {} })).rejects.toThrow(/not available in this request/)
     expect(innerExecute).not.toHaveBeenCalled()
+  })
+
+  describe('Guard A: unseen-schema guard', () => {
+    it('rejects an un-inspected tool with its signature and does not run execute', async () => {
+      innerExecute.mockReset().mockResolvedValue('ok')
+      const reg = makeRegistry()
+      // Fresh ledger per call: the gate auto-records on rejection, so a second call on the same
+      // ledger would pass — each assertion must be a first-time invoke.
+      await expect(
+        callInvoke(createToolInvokeTool(reg, allowAll('mcp__s1__t'), inspected()), {
+          name: 'mcp__s1__t',
+          params: {}
+        })
+      ).rejects.toThrow(/hasn't been inspected yet/)
+      // The rejection carries the JSDoc signature so the model can retry without a separate inspect.
+      await expect(
+        callInvoke(createToolInvokeTool(reg, allowAll('mcp__s1__t'), inspected()), {
+          name: 'mcp__s1__t',
+          params: {}
+        })
+      ).rejects.toThrow(/function mcp__s1__t/)
+      expect(innerExecute).not.toHaveBeenCalled()
+    })
+
+    it('records the name on rejection so the corrected retry runs', async () => {
+      innerExecute.mockReset().mockResolvedValue('ok')
+      const reg = makeRegistry()
+      const ledger = inspected()
+      const tool = createToolInvokeTool(reg, allowAll('mcp__s1__t'), ledger)
+
+      await expect(callInvoke(tool, { name: 'mcp__s1__t', params: {} })).rejects.toThrow(/hasn't been inspected/)
+      expect(ledger.has('mcp__s1__t')).toBe(true)
+
+      const result = await callInvoke(tool, { name: 'mcp__s1__t', params: { foo: 'bar' } })
+      expect(result).toBe('ok')
+      expect(innerExecute).toHaveBeenCalledTimes(1)
+      expect(innerExecute.mock.calls[0][0]).toEqual({ foo: 'bar' })
+    })
+  })
+
+  describe('Guard B: param validation', () => {
+    function zodRegistry(): ToolRegistry {
+      const reg = new ToolRegistry()
+      reg.register({
+        name: 'web__search',
+        namespace: 'web',
+        description: 'search',
+        defer: 'auto',
+        tool: {
+          type: 'function',
+          description: 'search',
+          inputSchema: z.object({ query: z.string(), limit: z.number().default(10) }),
+          execute: innerExecute
+        } as unknown as Tool
+      })
+      return reg
+    }
+
+    it('rejects params that do not match the schema, with the signature, and skips execute', async () => {
+      innerExecute.mockReset().mockResolvedValue('ok')
+      const reg = zodRegistry()
+      const tool = createToolInvokeTool(reg, allowAll('web__search'), inspected('web__search'))
+      // `query` is required and must be a string.
+      await expect(callInvoke(tool, { name: 'web__search', params: { query: 123 } })).rejects.toThrow(
+        /Invalid params for "web__search"/
+      )
+      await expect(callInvoke(tool, { name: 'web__search', params: {} })).rejects.toThrow(/function web__search/)
+      expect(innerExecute).not.toHaveBeenCalled()
+    })
+
+    it('passes the parsed value (schema defaults applied) to execute on valid params', async () => {
+      innerExecute.mockReset().mockResolvedValue('ok')
+      const reg = zodRegistry()
+      const tool = createToolInvokeTool(reg, allowAll('web__search'), inspected('web__search'))
+      await callInvoke(tool, { name: 'web__search', params: { query: 'mcp' } })
+      expect(innerExecute).toHaveBeenCalledTimes(1)
+      expect(innerExecute.mock.calls[0][0]).toEqual({ query: 'mcp', limit: 10 })
+    })
+  })
+
+  describe('toModelOutput + inputExamples', () => {
+    it('delegates to the inner tool toModelOutput so the model sees its formatted result', () => {
+      innerToModelOutput.mockReset().mockReturnValue({ type: 'text', value: 'SUMMARY' })
+      const reg = makeRegistryWithToModelOutput()
+      const tool = createToolInvokeTool(reg, allowAll('mcp__s1__t'), inspected('mcp__s1__t'))
+      const out = tool.toModelOutput!({
+        toolCallId: 'outer-1',
+        input: { name: 'mcp__s1__t', params: { a: 1 } },
+        output: { ok: true }
+      })
+      expect(out).toEqual({ type: 'text', value: 'SUMMARY' })
+      expect(innerToModelOutput).toHaveBeenCalledTimes(1)
+      expect(innerToModelOutput.mock.calls[0][0]).toMatchObject({
+        toolCallId: 'outer-1::mcp__s1__t',
+        input: { a: 1 },
+        output: { ok: true }
+      })
+    })
+
+    it('falls back to json output when the inner tool has no toModelOutput', () => {
+      const reg = makeRegistry()
+      const tool = createToolInvokeTool(reg, allowAll('mcp__s1__t'), inspected('mcp__s1__t'))
+      const out = tool.toModelOutput!({
+        toolCallId: 'outer-1',
+        input: { name: 'mcp__s1__t', params: {} },
+        output: { ok: true }
+      })
+      expect(out).toEqual({ type: 'json', value: { ok: true } })
+    })
+
+    it('falls back to json for a name outside the allowed set', () => {
+      innerToModelOutput.mockReset()
+      const reg = makeRegistryWithToModelOutput()
+      const tool = createToolInvokeTool(reg, new Set(['mcp__other']), inspected('mcp__s1__t'))
+      const out = tool.toModelOutput!({
+        toolCallId: 'outer-1',
+        input: { name: 'mcp__s1__t', params: {} },
+        output: { ok: 1 }
+      })
+      expect(out).toEqual({ type: 'json', value: { ok: 1 } })
+      expect(innerToModelOutput).not.toHaveBeenCalled()
+    })
+
+    it('advertises a callable inputExample', () => {
+      const reg = makeRegistry()
+      const tool = createToolInvokeTool(reg, allowAll('mcp__s1__t'), inspected('mcp__s1__t'))
+      expect(tool.inputExamples?.[0]?.input).toMatchObject({ name: expect.any(String), params: expect.any(Object) })
+    })
   })
 })

--- a/src/main/ai/tools/adapters/aiSdk/meta/__tests__/toolSearch.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/__tests__/toolSearch.test.ts
@@ -85,6 +85,35 @@ describe('tool_search meta-tool', () => {
     expect(result.matchedNamespaces[0].namespace).toBe('mcp:s1')
   })
 
+  it('toModelOutput renders a compact text listing with verbatim tool names', async () => {
+    const reg = setup()
+    const deferred = new Set(['mcp__s1__a', 'mcp__s1__b', 'mcp__s2__c'])
+    const tool = createToolSearchTool(reg, deferred)
+    const output = await callExecute(tool, {})
+    const out = tool.toModelOutput!({ toolCallId: 'tc-1', input: {}, output }) as { type: string; value: string }
+    expect(out.type).toBe('text')
+    expect(out.value).toContain('mcp:s1')
+    expect(out.value).toContain('mcp__s1__a')
+    expect(out.value).toContain('mcp__s2__c')
+  })
+
+  it('toModelOutput reports no matches when nothing is deferred', () => {
+    const reg = setup()
+    const tool = createToolSearchTool(reg, new Set())
+    const out = tool.toModelOutput!({ toolCallId: 'tc-1', input: {}, output: { matchedNamespaces: [] } }) as {
+      type: string
+      value: string
+    }
+    expect(out.type).toBe('text')
+    expect(out.value).toMatch(/No tools matched/)
+  })
+
+  it('advertises inputExamples', () => {
+    const reg = setup()
+    const tool = createToolSearchTool(reg, new Set(['mcp__s1__a']))
+    expect(tool.inputExamples?.length).toBeGreaterThan(0)
+  })
+
   it('verbose mode includes inputSchema; default mode omits it', async () => {
     const reg = setup()
     const deferred = new Set(['mcp__s1__a'])

--- a/src/main/ai/tools/adapters/aiSdk/meta/schemaStub.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/schemaStub.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared JSDoc-stub builder for the meta-tools. `tool_inspect` returns it as
+ * documentation; `tool_invoke` returns it inside its rejection messages so a
+ * model that skipped inspection (or guessed wrong params) gets the exact
+ * signature back in one round-trip.
+ */
+
+import { asSchema } from 'ai'
+
+import type { ToolEntry } from '../types'
+import { schemaToJSDoc } from './formatJsDoc'
+
+/**
+ * Normalise a tool's `inputSchema` to canonical JSONSchema. Tools carry Zod,
+ * a `jsonSchema` wrapper, or raw JSONSchema; `asSchema(...).jsonSchema` is the
+ * shape the model actually sees inline. Returns undefined on any failure so
+ * the stub degrades to a description-only signature.
+ */
+export async function serializeToolSchema(schema: unknown): Promise<unknown> {
+  if (!schema) return undefined
+  try {
+    return await asSchema(schema as Parameters<typeof asSchema>[0]).jsonSchema
+  } catch {
+    return undefined
+  }
+}
+
+/** JSDoc signature for a registered tool — the text `tool_inspect` returns. */
+export async function buildToolStub(entry: ToolEntry): Promise<string> {
+  const inputSchema = await serializeToolSchema(entry.tool.inputSchema)
+  return schemaToJSDoc(entry.name, entry.description, inputSchema)
+}

--- a/src/main/ai/tools/adapters/aiSdk/meta/toolInspect.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/toolInspect.ts
@@ -1,48 +1,47 @@
 /**
  * `tool_inspect` meta-tool — emits a JSDoc stub for a single registered
- * tool, useful when the brief description from `tool_search` isn't enough
- * to call it confidently. The model can copy the stub straight into a
- * `tool_exec` body or read it as documentation before `tool_invoke`.
+ * tool: its description and parameter shapes. Optional — `tool_invoke`
+ * returns the same signature when called on an unseen tool — but inspecting
+ * first lets the model confirm parameters without a guess-and-retry round-trip.
  */
 
-import { asSchema, type Tool, tool } from 'ai'
+import { type Tool, tool } from 'ai'
 import * as z from 'zod'
 
 import type { ToolRegistry } from '../registry'
-import { schemaToJSDoc } from './formatJsDoc'
+import { buildToolStub } from './schemaStub'
 
 export const TOOL_INSPECT_TOOL_NAME = 'tool_inspect'
 
 /**
  * @param allowedNames per-request tool name set (see `createToolInvokeTool`). Scopes inspection to
  *   the tools this request exposed, so the model can't probe process-wide tools `applies()` excluded.
+ * @param inspectedNames shared per-request set of tools whose signature the model has been shown.
+ *   `tool_invoke` reads it as its unseen-schema guard; a successful inspect records the name.
  */
-export function createToolInspectTool(registry: ToolRegistry, allowedNames: ReadonlySet<string>): Tool {
+export function createToolInspectTool(
+  registry: ToolRegistry,
+  allowedNames: ReadonlySet<string>,
+  inspectedNames: Set<string>
+): Tool {
   return tool({
     description:
-      'Get a JSDoc stub for a registered tool — its description and parameter shapes, ready to consult before `tool_invoke` or `tool_exec`.',
+      'Get a single tool signature as a JSDoc stub — its description and parameter shapes. ' +
+      'Use it before `tool_invoke` to confirm parameter names and shapes and avoid a guess-and-retry.',
     inputSchema: z.object({
       name: z.string().describe('Tool name as returned by tool_search')
     }),
+    inputExamples: [{ input: { name: 'web__search' } }],
     execute: async ({ name }) => {
       if (!allowedNames.has(name)) throw new Error(`Tool not available in this request: ${name}`)
       const entry = registry.getByName(name)
       if (!entry) throw new Error(`Tool not found: ${name}`)
-      const inputSchema = await serializeSchema(entry.tool.inputSchema)
-      return schemaToJSDoc(name, entry.description, inputSchema)
-    }
+      const stub = await buildToolStub(entry)
+      inspectedNames.add(name)
+      return stub
+    },
+    // The stub is documentation, not data — hand it to the model as plain text instead of a
+    // JSON-quoted string so it reads as the signature it is.
+    toModelOutput: ({ output }) => ({ type: 'text', value: output })
   })
-}
-
-async function serializeSchema(schema: unknown): Promise<unknown> {
-  if (!schema) return undefined
-  // See toolSearch.ts: Zod / jsonSchema-wrapped / raw-JSONSchema all
-  // normalise through `asSchema(...).jsonSchema`. Stringifying a Zod
-  // object directly yields a non-JSONSchema blob.
-  try {
-    const normalised = asSchema(schema as Parameters<typeof asSchema>[0])
-    return await normalised.jsonSchema
-  } catch {
-    return undefined
-  }
 }

--- a/src/main/ai/tools/adapters/aiSdk/meta/toolInvoke.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/toolInvoke.ts
@@ -1,7 +1,19 @@
 /**
  * `tool_invoke` meta-tool — dispatches a tool by name through the registry.
- * The LLM uses this together with `tool_search`: search to discover, invoke
- * to call.
+ * The LLM uses this together with `tool_search` / `tool_inspect`: search to
+ * discover, inspect to confirm parameters, invoke to call.
+ *
+ * Two guards keep the model from guessing arguments blindly — both reject by
+ * handing back the tool signature, so the model self-corrects with "call, fix,
+ * retry" without being told up front it must inspect:
+ *   A. unseen-schema guard — the first invoke of a tool whose signature the
+ *      model hasn't seen is rejected with that signature; the name is then
+ *      recorded so the corrected retry passes (no inspect loop). This is the
+ *      only protection for raw-JSONSchema tools, where B is a no-op.
+ *   B. param validation — arguments are validated against the tool input
+ *      schema; a mismatch is rejected with the signature. (Tools backed by a
+ *      raw JSONSchema carry no validator, so B is a no-op for them — same as
+ *      the SDK's native dispatch path.)
  *
  * Forwards the AI SDK execution options (messages, abortSignal,
  * experimental_context) onto the inner tool's `execute` so the per-request
@@ -9,11 +21,13 @@
  * target name so telemetry can rebuild the call tree.
  */
 
-import { type Tool, tool } from 'ai'
+import { asSchema, type Tool, tool } from 'ai'
 import * as z from 'zod'
 
 import { isApprovalGated } from '../isApprovalGated'
 import type { ToolRegistry } from '../registry'
+import type { ToolEntry } from '../types'
+import { buildToolStub } from './schemaStub'
 
 export const TOOL_INVOKE_TOOL_NAME = 'tool_invoke'
 
@@ -22,15 +36,24 @@ export const TOOL_INVOKE_TOOL_NAME = 'tool_invoke'
  *   `tool_invoke` resolves against the process-wide registry, so without this scope a model could
  *   reach user-owned tools that `applies()` excluded for this request. Closed over here exactly as
  *   `tool_search` closes over its deferred set. The approval gate below is enforced regardless.
+ * @param inspectedNames shared per-request set of tools whose signature the model has been shown
+ *   (via `tool_inspect` or a prior rejection here). Drives Guard A, the unseen-schema guard.
  */
-export function createToolInvokeTool(registry: ToolRegistry, allowedNames: ReadonlySet<string>): Tool {
+export function createToolInvokeTool(
+  registry: ToolRegistry,
+  allowedNames: ReadonlySet<string>,
+  inspectedNames: Set<string>
+): Tool {
   return tool({
     description:
-      'Call a tool discovered via `tool_search` by name. Pass arguments under `params` matching the tool input schema.',
+      'Call a single tool discovered via `tool_search` by name, passing arguments under `params`. ' +
+      "If the tool hasn't been inspected, or the arguments don't match its schema, the call returns the " +
+      'tool signature — read it and call again with corrected params. Inspect first to skip that round-trip.',
     inputSchema: z.object({
       name: z.string().describe('Tool name as returned by tool_search'),
       params: z.record(z.string(), z.unknown()).optional().describe('Tool input arguments')
     }),
+    inputExamples: [{ input: { name: 'web__search', params: { query: 'cherry studio latest release' } } }],
     execute: async ({ name, params }, options) => {
       if (!allowedNames.has(name)) throw new Error(`Tool not available in this request: ${name}`)
       const entry = registry.getByName(name)
@@ -52,10 +75,54 @@ export function createToolInvokeTool(registry: ToolRegistry, allowedNames: Reado
       ) {
         throw new Error(`Tool "${name}" requires user approval; call it directly instead of via tool_invoke.`)
       }
-      return entry.tool.execute(params ?? {}, {
+
+      // Guard A: hand back the signature before running a tool whose schema the model hasn't seen,
+      // so it can't execute on blindly-guessed params. Record the name first so the rejection's
+      // signature is enough to retry — the schema is already in hand, re-inspecting would waste a
+      // round-trip. Not advertised as a hard rule; it's the safety net behind "call, fix, retry".
+      if (!inspectedNames.has(name)) {
+        inspectedNames.add(name)
+        const stub = await buildToolStub(entry)
+        throw new Error(
+          `Tool "${name}" hasn't been inspected yet — its signature is below. Call tool_invoke again with params matching it:\n\n${stub}`
+        )
+      }
+
+      // Guard B: validate params against the tool input schema.
+      const finalParams = await validateParams(entry, params ?? {})
+
+      return entry.tool.execute(finalParams, {
         ...options,
         toolCallId: `${options.toolCallId}::${name}`
       })
+    },
+    // Present the inner tool's result to the model exactly as a native dispatch would: delegate to
+    // the inner tool's `toModelOutput` (e.g. MCP summarises its full response to text). Without this
+    // the model sees `tool_invoke`'s raw JSON return — the inner formatter is otherwise bypassed.
+    toModelOutput: ({ toolCallId, input, output }) => {
+      const entry = allowedNames.has(input.name) ? registry.getByName(input.name) : undefined
+      const innerToModelOutput = entry?.tool.toModelOutput
+      if (innerToModelOutput) {
+        return innerToModelOutput({ toolCallId: `${toolCallId}::${input.name}`, input: input.params ?? {}, output })
+      }
+      return { type: 'json', value: output }
     }
   })
+}
+
+/**
+ * Validate `params` against the tool input schema, returning the parsed value
+ * (Zod defaults/coercions applied) on success. Throws with the tool signature
+ * on mismatch. Schemas without a validator (raw JSONSchema, e.g. MCP tools)
+ * pass through unchanged — Guard A is their protection.
+ */
+async function validateParams(entry: ToolEntry, params: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const validate = asSchema(entry.tool.inputSchema as Parameters<typeof asSchema>[0]).validate
+  if (!validate) return params
+
+  const result = await validate(params)
+  if (result.success) return result.value as Record<string, unknown>
+
+  const stub = await buildToolStub(entry)
+  throw new Error(`Invalid params for "${entry.name}": ${result.error.message}\n\nExpected signature:\n${stub}`)
 }

--- a/src/main/ai/tools/adapters/aiSdk/meta/toolSearch.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/toolSearch.ts
@@ -17,8 +17,9 @@ export const TOOL_SEARCH_TOOL_NAME = 'tool_search'
 export function createToolSearchTool(registry: ToolRegistry, deferredNames: ReadonlySet<string>): Tool {
   return tool({
     description:
-      'Discover available tools by namespace. Tools are grouped by domain (web, kb, mcp:gmail, ...). ' +
-      'Omit `query` to browse all. Use the names returned here with `tool_invoke`.',
+      'Discover available tools by namespace. This is tool discovery (NOT web search). Tools are ' +
+      'grouped by domain (web, kb, mcp:gmail, ...). Omit `query` to browse all. Inspect a name ' +
+      'returned here with `tool_inspect`, then call it with `tool_invoke`.',
     inputSchema: z.object({
       query: z
         .string()
@@ -31,6 +32,7 @@ export function createToolSearchTool(registry: ToolRegistry, deferredNames: Read
         .default(false)
         .describe('Include each tool full input schema in the result (more tokens)')
     }),
+    inputExamples: [{ input: { query: 'gmail', verbose: false } }, { input: { namespace: 'web', verbose: true } }],
     execute: async ({ query, namespace, verbose }) => {
       const grouped = registry.getByNamespace({ query, namespace })
       const matchedNamespaces: Array<{
@@ -51,8 +53,32 @@ export function createToolSearchTool(registry: ToolRegistry, deferredNames: Read
         matchedNamespaces.push({ namespace: ns, tools })
       }
       return { matchedNamespaces }
-    }
+    },
+    // Render the catalog as a compact namespace listing instead of nested JSON — fewer tokens and
+    // easier for the model to scan tool names. Names are verbatim so they can be passed to
+    // `tool_inspect` / `tool_invoke` as-is.
+    toModelOutput: ({ output }) => ({ type: 'text', value: formatSearchForModel(output) })
   })
+}
+
+function formatSearchForModel(output: {
+  matchedNamespaces: Array<{
+    namespace: string
+    tools: Array<{ name: string; description: string; inputSchema?: unknown }>
+  }>
+}): string {
+  if (output.matchedNamespaces.length === 0) {
+    return 'No tools matched. Broaden `query`, or omit it to browse all namespaces.'
+  }
+  const lines: string[] = []
+  for (const group of output.matchedNamespaces) {
+    lines.push(group.namespace)
+    for (const t of group.tools) {
+      lines.push(`  - ${t.name} — ${t.description}`)
+      if (t.inputSchema !== undefined) lines.push(`    input: ${JSON.stringify(t.inputSchema)}`)
+    }
+  }
+  return lines.join('\n')
 }
 
 async function serializeSchema(schema: unknown): Promise<unknown> {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Deferred tool invocation did not have enough validation around registry lookups and execution metadata.

After this PR:

Deferred tool invocation validates registry resolution and keeps tool execution metadata explicit.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR only hardens the meta-tool path and leaves provider-specific policy to the following registry PR.

The following alternatives were considered:

Handling missing or invalid tools at the caller was rejected because all deferred tools share the same registry boundary.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Stack PR 05/15 for the chat-page split. Base: `codex/chat-stack-04-builtin-tools`; head: `codex/chat-stack-05-tool-registry`.

Validated at the top of this stack with `pnpm lint`, `pnpm test`, `pnpm db:migrations:check`, and `git diff --check`. Local Node 22.22.0 emitted the expected engine warning for the repo requirement `>=24.11.1`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
