### PR TITLE
feat(tool-registry): add declarative claude tool policy

### DIFF
--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -273,7 +273,7 @@ export class AgentSessionRuntimeService extends BaseService {
     }
 
     if (
-      Object.prototype.hasOwnProperty.call(updates, 'allowedTools') ||
+      Object.prototype.hasOwnProperty.call(updates, 'disabledTools') ||
       Object.prototype.hasOwnProperty.call(updates, 'mcps')
     ) {
       await this.applyAgentPolicyUpdate(agentId, { type: 'tool-policy', agent })

--- a/src/main/ai/runtime/claudeCode/__tests__/buildMcpServers.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/buildMcpServers.test.ts
@@ -24,18 +24,20 @@ const agent = { id: 'agent-1', mcps: [] } as unknown as AgentEntity
 const session = { id: 'sess-1', agentId: 'agent-1' } as unknown as AgentSessionEntity
 
 describe('adjustAllowedToolsForMcp', () => {
-  it('adds the claw + agent-memory wildcards in Soul Mode', () => {
-    expect(adjustAllowedToolsForMcp([], true, false)).toEqual(
-      expect.arrayContaining(['mcp__claw__*', 'mcp__agent-memory__*'])
+  it('adds the cherry-tools + claw + agent-memory wildcards in Soul Mode', () => {
+    expect(adjustAllowedToolsForMcp(true, false)).toEqual(
+      expect.arrayContaining(['mcp__cherry-tools__*', 'mcp__claw__*', 'mcp__agent-memory__*'])
     )
   })
 
-  it('adds the assistant wildcard for the Cherry Assistant', () => {
-    expect(adjustAllowedToolsForMcp([], false, true)).toContain('mcp__assistant__*')
+  it('adds the cherry-tools + assistant wildcards for the Cherry Assistant', () => {
+    expect(adjustAllowedToolsForMcp(false, true)).toEqual(
+      expect.arrayContaining(['mcp__cherry-tools__*', 'mcp__assistant__*'])
+    )
   })
 
-  it('leaves allowed tools untouched when neither Soul nor Assistant', () => {
-    expect(adjustAllowedToolsForMcp(['existing'], false, false)).toEqual(['existing'])
+  it('leaves the allowlist undefined for a plain agent (all tools permitted)', () => {
+    expect(adjustAllowedToolsForMcp(false, false)).toBeUndefined()
   })
 })
 

--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -1,0 +1,202 @@
+import type * as NodeModule from 'node:module'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getAgent: vi.fn(),
+  reconcileAgentSkills: vi.fn(),
+  modelGetByKey: vi.fn(),
+  findBySessionId: vi.fn(),
+  createToolPolicySnapshot: vi.fn(),
+  applicationGet: vi.fn(),
+  applicationGetPath: vi.fn(),
+  getLoginShellEnvironment: vi.fn(),
+  getBinaryPath: vi.fn(),
+  getProxyEnvironment: vi.fn(),
+  getPathStatus: vi.fn(),
+  getAppLanguage: vi.fn(),
+  resolveRequire: vi.fn()
+}))
+
+vi.mock('node:module', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeModule>()
+  return {
+    ...actual,
+    createRequire: vi.fn(() => ({
+      resolve: mocks.resolveRequire
+    }))
+  }
+})
+
+vi.mock('electron', () => ({
+  app: { getVersion: vi.fn(() => '1.0.0-test') }
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }))
+  }
+}))
+
+vi.mock('@data/services/AgentService', () => ({
+  agentService: { getAgent: mocks.getAgent }
+}))
+
+vi.mock('@data/services/AgentChannelService', () => ({
+  agentChannelService: {
+    findBySessionId: mocks.findBySessionId,
+    listChannels: vi.fn(async () => [])
+  }
+}))
+
+vi.mock('@data/services/McpServerService', () => ({
+  mcpServerService: {
+    list: vi.fn(async () => ({ items: [] })),
+    findByIdOrName: vi.fn()
+  }
+}))
+
+vi.mock('@data/services/ModelService', () => ({
+  modelService: { getByKey: mocks.modelGetByKey }
+}))
+
+vi.mock('@data/services/ProviderService', () => ({
+  providerService: { list: vi.fn(async () => []) }
+}))
+
+vi.mock('@main/ai/skills/SkillService', () => ({
+  skillService: { reconcileAgentSkills: mocks.reconcileAgentSkills }
+}))
+
+vi.mock('@main/ai/agents/builtin/BuiltinAgentProvisioner', () => ({
+  isProvisioned: vi.fn(() => true),
+  provisionBuiltinAgent: vi.fn()
+}))
+
+vi.mock('@main/ai/agents/cherryclaw/prompt', () => ({
+  PromptBuilder: vi.fn(() => ({ buildSystemPrompt: vi.fn(async () => 'soul prompt') }))
+}))
+
+vi.mock('@main/ai/mcp/servers/assistant', () => ({
+  default: vi.fn(() => ({ mcpServer: {} }))
+}))
+
+vi.mock('@main/ai/mcp/servers/claw', () => ({
+  default: vi.fn(() => ({ mcpServer: {} }))
+}))
+
+vi.mock('@main/ai/runtime/claudeCode/createSdkMcpServerInstance', () => ({
+  createSdkMcpServerInstance: vi.fn()
+}))
+
+vi.mock('@main/ai/tools/adapters/claudeCode/agentTools', () => ({
+  createClaudeAgentToolPolicySnapshot: mocks.createToolPolicySnapshot
+}))
+
+vi.mock('@main/core/application', () => ({
+  application: {
+    get: mocks.applicationGet,
+    getPath: mocks.applicationGetPath
+  }
+}))
+
+vi.mock('@main/core/platform', () => ({
+  isLinux: false,
+  isWin: false
+}))
+
+vi.mock('@main/services/proxy/nodeProxy', () => ({
+  getProxyEnvironment: mocks.getProxyEnvironment
+}))
+
+vi.mock('@main/utils', () => ({
+  toAsarUnpackedPath: (input: string) => input
+}))
+
+vi.mock('@main/utils/file/pathStatus', () => ({
+  getPathStatus: mocks.getPathStatus,
+  formatPathStatusMessage: vi.fn(() => 'missing')
+}))
+
+vi.mock('@main/utils/language', () => ({
+  getAppLanguage: mocks.getAppLanguage,
+  t: (key: string, params?: Record<string, unknown>) => {
+    if (params?.path) return `${key}:${params.path}`
+    return key
+  }
+}))
+
+vi.mock('@main/utils/process', () => ({
+  autoDiscoverGitBash: vi.fn(() => null),
+  getBinaryPath: mocks.getBinaryPath
+}))
+
+vi.mock('@main/utils/rtk', () => ({
+  rtkRewrite: vi.fn()
+}))
+
+vi.mock('@main/utils/shell-env', () => ({
+  default: mocks.getLoginShellEnvironment
+}))
+
+vi.mock('../ToolApprovalRegistry', () => ({
+  toolApprovalRegistry: {
+    abort: vi.fn(),
+    register: vi.fn()
+  }
+}))
+
+const { buildClaudeCodeSessionSettings } = await import('../settingsBuilder')
+
+describe('buildClaudeCodeSessionSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.resolveRequire.mockImplementation((specifier: string) => {
+      if (specifier === '@anthropic-ai/claude-agent-sdk') return '/sdk/index.js'
+      return `/native/${specifier}/claude`
+    })
+    mocks.getAgent.mockResolvedValue({
+      id: 'agent-1',
+      type: 'claude-code',
+      instructions: 'Follow instructions.',
+      model: 'anthropic::claude-sonnet',
+      planModel: 'anthropic::claude-sonnet',
+      smallModel: 'anthropic::claude-haiku',
+      mcps: [],
+      allowedTools: [],
+      configuration: {}
+    })
+    mocks.modelGetByKey.mockResolvedValue({ apiModelId: 'claude-api' })
+    mocks.findBySessionId.mockResolvedValue(null)
+    mocks.createToolPolicySnapshot.mockResolvedValue({ resolve: vi.fn() })
+    mocks.applicationGet.mockImplementation((name: string) => {
+      if (name === 'PreferenceService') {
+        return { get: vi.fn(() => undefined) }
+      }
+      if (name === 'McpCatalogService') {
+        return { listTools: vi.fn(async () => []) }
+      }
+      throw new Error(`Unexpected application.get(${name})`)
+    })
+    mocks.applicationGetPath.mockImplementation((key: string) => `/app/${key}`)
+    mocks.getLoginShellEnvironment.mockResolvedValue({})
+    mocks.getBinaryPath.mockResolvedValue('/usr/local/bin/bun')
+    mocks.getProxyEnvironment.mockReturnValue({})
+    mocks.getPathStatus.mockResolvedValue({ ok: true, kind: 'directory' })
+    mocks.getAppLanguage.mockReturnValue('en-US')
+    mocks.reconcileAgentSkills.mockResolvedValue(undefined)
+  })
+
+  it('reconciles enabled skills into the session workspace before returning settings', async () => {
+    const session = {
+      id: 'session-1',
+      agentId: 'agent-1',
+      workspace: { path: '/workspace/project' }
+    }
+
+    const settings = await buildClaudeCodeSessionSettings(session as never, {} as never)
+
+    expect(mocks.reconcileAgentSkills).toHaveBeenCalledWith('agent-1', '/workspace/project')
+    expect(settings.cwd).toBe('/workspace/project')
+  })
+})

--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -36,6 +36,7 @@ import WorkspaceMemoryServer from '@main/ai/mcp/servers/workspaceMemory'
 import { createSdkMcpServerInstance } from '@main/ai/runtime/claudeCode/createSdkMcpServerInstance'
 import { skillService } from '@main/ai/skills/SkillService'
 import { createClaudeAgentToolPolicySnapshot } from '@main/ai/tools/adapters/claudeCode/agentTools'
+import { type ClaudeToolContext, resolveDisallowedTools } from '@main/ai/tools/adapters/claudeCode/toolConditions'
 import { application } from '@main/core/application'
 import { isLinux, isWin } from '@main/core/platform'
 import { getProxyEnvironment } from '@main/services/proxy/nodeProxy'
@@ -45,11 +46,7 @@ import { getAppLanguage, t } from '@main/utils/language'
 import { autoDiscoverGitBash, getBinaryPath } from '@main/utils/process'
 import { rtkRewrite } from '@main/utils/rtk'
 import getLoginShellEnvironment from '@main/utils/shell-env'
-import {
-  CHANNEL_SECURITY_PROMPT,
-  GLOBALLY_DISALLOWED_TOOLS,
-  SOUL_MODE_DISALLOWED_TOOLS
-} from '@shared/ai/claudecode/constants'
+import { CHANNEL_SECURITY_PROMPT, SOUL_MODE_DISALLOWED_TOOLS } from '@shared/ai/claudecode/constants'
 import { languageEnglishNameMap } from '@shared/config/languages'
 import type { AgentEntity } from '@shared/data/api/schemas/agents'
 import type { AgentSessionEntity } from '@shared/data/api/schemas/agentSessions'
@@ -205,7 +202,8 @@ export async function buildClaudeCodeSessionSettings(
   // `dispose` drops any approval still pending for this session when the
   // stream exits abnormally.
   const approvalEmitter = getToolApprovalEmitterHolder(session.id)
-  const { canUseTool, hooks, allowedTools, disallowedTools, toolPolicySnapshot } = await buildToolPermissions(
+  const steerHolder = getSteerHolder(session.id)
+  const { canUseTool, hooks, disallowedTools, toolPolicySnapshot } = await buildToolPermissions(
     session,
     agent,
     approvalEmitter
@@ -220,8 +218,8 @@ export async function buildClaudeCodeSessionSettings(
   const isAssistant = agentConfig?.builtin_role === 'assistant'
   const mcpServers = await buildMcpServers(session, agent, soulEnabled, isAssistant)
 
-  // 8. Adjust allowedTools for injected MCP servers
-  const finalAllowedTools = adjustAllowedToolsForMcp(allowedTools, soulEnabled, isAssistant)
+  // 8. Auto-approve allowlist for injected built-in MCP servers (soul/assistant only)
+  const finalAllowedTools = adjustAllowedToolsForMcp(soulEnabled, isAssistant)
 
   // 9. Build settings
   const settings: ClaudeCodeSettings = {
@@ -416,13 +414,20 @@ async function buildToolPermissions(
 ): Promise<{
   canUseTool: CanUseTool
   hooks: ClaudeCodeSettings['hooks']
-  allowedTools: string[] | undefined
   disallowedTools: string[]
   toolPolicySnapshot: Awaited<ReturnType<typeof createClaudeAgentToolPolicySnapshot>>
 }> {
   const agentConfig = agent.configuration
   const soulEnabled = agentConfig?.soul_enabled === true
   const isAssistant = agentConfig?.builtin_role === 'assistant'
+
+  // Raw session context for tool enable-predicates (worktree needs .git; claw notify/config need a
+  // connected channel). Channels are fetched once here so the predicates stay synchronous.
+  const cwd = session.workspace?.path
+  const conditionContext: ClaudeToolContext | undefined = cwd
+    ? { cwd, channels: await channelService.listChannels({ agentId: agent.id }).catch(() => []) }
+    : undefined
+
   const toolPolicySnapshot = await createClaudeAgentToolPolicySnapshot(agent, {
     autoAllowRuntimeNamePrefixes: [
       ...(soulEnabled ? ['mcp__claw__'] : []),
@@ -481,12 +486,15 @@ async function buildToolPermissions(
 
   return {
     canUseTool,
-    hooks: { PreToolUse: [{ hooks: [rtkRewriteHook] }] },
-    allowedTools: agent.allowedTools,
+    hooks: { PreToolUse: [{ hooks: [rtkRewriteHook, steerHook] }] },
+    // `disabled`-exposure tools (incl. WebSearch/WebFetch) come from the declarative
+    // registry; soul/assistant overlays stay until they migrate to per-tool exposure (PR-7).
     disallowedTools: [
-      ...GLOBALLY_DISALLOWED_TOOLS,
-      ...(soulEnabled ? SOUL_MODE_DISALLOWED_TOOLS : []),
-      ...(isAssistant ? ['AskUserQuestion'] : [])
+      ...new Set([
+        ...resolveDisallowedTools({ disabledTools: agent.disabledTools }, conditionContext),
+        ...(soulEnabled ? SOUL_MODE_DISALLOWED_TOOLS : []),
+        ...(isAssistant ? ['AskUserQuestion'] : [])
+      ])
     ],
     toolPolicySnapshot
   }
@@ -616,31 +624,17 @@ async function resolveSourceChannel(agentId: string, sessionId: string): Promise
 }
 
 /**
- * Auto-approve MCP tools for injected built-in servers.
- * Claw and assistant tools must be in allowedTools for canUseTool to pass them.
+ * Auto-approve allowlist for injected built-in MCP servers. Returns `undefined` for a plain agent
+ * (Claude Code then permits all tools; cherry-tools is auto-approved via the canUseTool prefix).
+ * Soul/assistant agents force an explicit allowlist so their claw/agent-memory/assistant tools pass.
  */
-export function adjustAllowedToolsForMcp(
-  allowedTools: string[] | undefined,
-  soulEnabled: boolean,
-  isAssistant: boolean
-): string[] | undefined {
-  if (!soulEnabled && !isAssistant) return allowedTools
+export function adjustAllowedToolsForMcp(soulEnabled: boolean, isAssistant: boolean): string[] | undefined {
+  if (!soulEnabled && !isAssistant) return undefined
 
-  const result = allowedTools ? [...allowedTools] : []
-
-  if (soulEnabled && !result.includes('mcp__claw__*')) {
-    result.push('mcp__claw__*')
-  }
-
-  if (soulEnabled && !result.includes('mcp__agent-memory__*')) {
-    result.push('mcp__agent-memory__*')
-  }
-
-  if (isAssistant && !result.includes('mcp__assistant__*')) {
-    result.push('mcp__assistant__*')
-  }
-
-  return result.length > 0 ? result : undefined
+  const result = ['mcp__cherry-tools__*']
+  if (soulEnabled) result.push('mcp__claw__*', 'mcp__agent-memory__*')
+  if (isAssistant) result.push('mcp__assistant__*')
+  return result
 }
 
 function getSettingSources(agent: AgentEntity): Array<'user' | 'project' | 'local'> {

--- a/src/main/ai/tools/adapters/claudeCode/__tests__/toolConditions.test.ts
+++ b/src/main/ai/tools/adapters/claudeCode/__tests__/toolConditions.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('node:fs', () => ({ default: { existsSync: vi.fn(() => false) } }))
+
+import fs from 'node:fs'
+
+import { resolveDisallowedTools } from '../toolConditions'
+
+const existsSync = vi.mocked(fs.existsSync)
+
+beforeEach(() => {
+  existsSync.mockReset()
+  existsSync.mockReturnValue(false)
+})
+
+describe('resolveDisallowedTools', () => {
+  it('disables every disabled-exposure tool with no overrides or ctx', () => {
+    const disallowed = new Set(resolveDisallowedTools({}))
+    // Parity with the former GLOBALLY_DISALLOWED_TOOLS set.
+    expect(disallowed.has('WebSearch')).toBe(true)
+    expect(disallowed.has('WebFetch')).toBe(true)
+    expect(disallowed.has('TodoWrite')).toBe(true)
+    // Newly disabled per the registry classification.
+    expect(disallowed.has('NotebookEdit')).toBe(true)
+    expect(disallowed.has('REPL')).toBe(true)
+    expect(disallowed.has('CronCreate')).toBe(true)
+    expect(disallowed.has('Monitor')).toBe(true)
+    // user / internal tools are not disabled by default.
+    expect(disallowed.has('Bash')).toBe(false)
+    expect(disallowed.has('Read')).toBe(false)
+    expect(disallowed.has('Workflow')).toBe(false)
+    expect(disallowed.has('Agent')).toBe(false)
+  })
+
+  it('disables a user tool and its dependents (BashOutput follows Bash)', () => {
+    const disallowed = new Set(resolveDisallowedTools({ disabledTools: ['Bash'] }))
+    expect(disallowed.has('Bash')).toBe(true)
+    expect(disallowed.has('BashOutput')).toBe(true)
+  })
+
+  it('ignores a disabledTools entry for a non-user tool', () => {
+    const base = new Set(resolveDisallowedTools({}))
+    const withAgent = new Set(resolveDisallowedTools({ disabledTools: ['Agent'] }))
+    expect(withAgent).toEqual(base)
+  })
+
+  it('treats predicate-gated tools as enabled when no ctx is supplied', () => {
+    const disallowed = new Set(resolveDisallowedTools({}))
+    expect(disallowed.has('EnterWorktree')).toBe(false)
+    expect(disallowed.has('mcp__claw__notify')).toBe(false)
+  })
+
+  it('disables worktree without .git and claw notify/config without channels', () => {
+    existsSync.mockReturnValue(false) // no .git
+    const disallowed = new Set(resolveDisallowedTools({}, { cwd: '/ws', channels: [] }))
+    expect(disallowed.has('EnterWorktree')).toBe(true)
+    expect(disallowed.has('ExitWorktree')).toBe(true)
+    expect(disallowed.has('mcp__claw__notify')).toBe(true)
+    expect(disallowed.has('mcp__claw__config')).toBe(true)
+  })
+
+  it('enables worktree with .git and claw notify/config with a channel', () => {
+    existsSync.mockReturnValue(true) // .git present
+    const disallowed = new Set(resolveDisallowedTools({}, { cwd: '/ws', channels: [{ id: 'c1' }] }))
+    expect(disallowed.has('EnterWorktree')).toBe(false)
+    expect(disallowed.has('ExitWorktree')).toBe(false)
+    expect(disallowed.has('mcp__claw__notify')).toBe(false)
+    expect(disallowed.has('mcp__claw__config')).toBe(false)
+  })
+})

--- a/src/main/ai/tools/adapters/claudeCode/agentTools.ts
+++ b/src/main/ai/tools/adapters/claudeCode/agentTools.ts
@@ -1,7 +1,7 @@
 import { mcpServerService } from '@data/services/McpServerService'
 import { loggerService } from '@logger'
 import { application } from '@main/core/application'
-import { claudeCodeBuiltinToolDescriptors } from '@shared/ai/claudecode/builtinTools'
+import { claudeRegistrySdkDescriptors } from '@shared/ai/claudecode/toolRegistry'
 import {
   buildClaudeMcpToolName,
   type ClaudeToolDecision,
@@ -34,12 +34,9 @@ function descriptorToToolWithAccess(descriptor: ClaudeToolDescriptor, access: Cl
   }
 }
 
-export function buildClaudeToolPolicy(
-  agent: Partial<Pick<AgentEntity, 'configuration' | 'allowedTools'>>
-): ClaudeToolPolicy {
+export function buildClaudeToolPolicy(agent: Partial<Pick<AgentEntity, 'configuration'>>): ClaudeToolPolicy {
   return {
-    permissionMode: agent.configuration?.permission_mode,
-    allowedTools: agent.allowedTools ?? []
+    permissionMode: agent.configuration?.permission_mode
   }
 }
 
@@ -82,7 +79,7 @@ export async function listClaudeAgentToolDescriptors(agent: Pick<AgentEntity, 'm
 }> {
   const mcpCatalog = await listMcpDescriptors(agent.mcps ?? [])
   return {
-    descriptors: [...claudeCodeBuiltinToolDescriptors(), ...mcpCatalog.descriptors]
+    descriptors: [...claudeRegistrySdkDescriptors(), ...mcpCatalog.descriptors]
   }
 }
 

--- a/src/main/ai/tools/adapters/claudeCode/toolConditions.ts
+++ b/src/main/ai/tools/adapters/claudeCode/toolConditions.ts
@@ -1,0 +1,89 @@
+/**
+ * Main-side runtime gating for Claude Code tools.
+ *
+ * The shared registry (`@shared/ai/claudecode/toolRegistry`) holds static tool data — exposure,
+ * dependencies, category, display. The per-tool *enable predicates* live here because they compute
+ * from the raw session context (file system, channels) which only main can read. The disallowed set
+ * is derived from the static data + these predicates + a runtime context.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { CLAUDE_TOOL_DEFS } from '@shared/ai/claudecode/toolRegistry'
+
+/** Raw session context the enable-predicates compute from (not pre-digested per-condition flags). */
+export interface ClaudeToolContext {
+  /** Session workspace directory. */
+  cwd: string
+  /** The agent's channels (pre-fetched — channel lookup is async; predicates read the list). */
+  channels: readonly unknown[]
+}
+
+function dirHasGit(cwd: string): boolean {
+  try {
+    return fs.existsSync(path.join(cwd, '.git'))
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Per-tool enable predicate over the raw session context. Only condition-gated tools appear here;
+ * any tool absent from this table has no runtime gate. Table-driven: the predicate function is the
+ * gate (no string condition labels / switch).
+ */
+const TOOL_ENABLE_PREDICATES: Record<string, (ctx: ClaudeToolContext) => boolean> = {
+  EnterWorktree: (ctx) => dirHasGit(ctx.cwd),
+  ExitWorktree: (ctx) => dirHasGit(ctx.cwd),
+  mcp__claw__notify: (ctx) => ctx.channels.length > 0,
+  mcp__claw__config: (ctx) => ctx.channels.length > 0
+}
+
+/**
+ * Derive the SDK `disallowedTools` set from each tool's declarations:
+ * - `exposure: 'disabled'`            → always blocked
+ * - `exposure: 'user'` + user opt-out → blocked
+ * - enable predicate returns false    → blocked (only evaluated when `ctx` is supplied)
+ * - any `dependsOn` target is blocked → blocked (propagated to a fixpoint)
+ *
+ * Blocked tools are removed from the model's context entirely (hard block). `ctx` is optional:
+ * without it, predicate-gated tools are treated as enabled (the policy layer before runtime facts
+ * are known).
+ */
+export function resolveDisallowedTools(
+  agent: { disabledTools?: readonly string[] | null },
+  ctx?: ClaudeToolContext
+): string[] {
+  const userDisabled = new Set(agent.disabledTools ?? [])
+  const blocked = new Set<string>()
+
+  for (const def of CLAUDE_TOOL_DEFS) {
+    if (def.exposure === 'disabled') {
+      blocked.add(def.name)
+      continue
+    }
+    if (def.exposure === 'user' && userDisabled.has(def.name)) {
+      blocked.add(def.name)
+      continue
+    }
+    const predicate = TOOL_ENABLE_PREDICATES[def.name]
+    if (predicate && ctx && !predicate(ctx)) blocked.add(def.name)
+  }
+
+  // Propagate dependencies: a tool whose dependency is blocked is blocked too. Loop to a fixpoint
+  // so transitive chains resolve (cheap — the dependency graph is tiny).
+  let changed = true
+  while (changed) {
+    changed = false
+    for (const def of CLAUDE_TOOL_DEFS) {
+      if (blocked.has(def.name)) continue
+      if (def.dependsOn?.some((dep) => blocked.has(dep))) {
+        blocked.add(def.name)
+        changed = true
+      }
+    }
+  }
+
+  return [...blocked]
+}

--- a/src/main/data/db/schemas/agent.ts
+++ b/src/main/data/db/schemas/agent.ts
@@ -16,7 +16,7 @@ export const agentTable = sqliteTable(
     planModel: text().references(() => userModelTable.id, { onDelete: 'set null' }),
     smallModel: text().references(() => userModelTable.id, { onDelete: 'set null' }),
     mcps: text({ mode: 'json' }).$type<string[]>().notNull().default(sql`'[]'`),
-    allowedTools: text({ mode: 'json' }).$type<string[]>().notNull().default(sql`'[]'`),
+    disabledTools: text({ mode: 'json' }).$type<string[]>().notNull().default(sql`'[]'`),
     configuration: text({ mode: 'json' }).$type<Record<string, unknown>>().notNull().default(sql`'{}'`),
     ...orderKeyColumns,
     ...createUpdateDeleteTimestamps

--- a/src/main/data/services/AgentService.ts
+++ b/src/main/data/services/AgentService.ts
@@ -98,7 +98,7 @@ export class AgentService {
       planModel: req.planModel,
       smallModel: req.smallModel,
       mcps: req.mcps,
-      allowedTools: req.allowedTools,
+      disabledTools: req.disabledTools,
       configuration: req.configuration
     }
 

--- a/src/main/data/services/__tests__/AgentService.test.ts
+++ b/src/main/data/services/__tests__/AgentService.test.ts
@@ -141,6 +141,34 @@ describe('AgentService', () => {
       // desc(createdAt), desc(id) -> 'agent_zzz' must come before 'agent_aaa'.
       expect(ids.indexOf('agent_zzz')).toBeLessThan(ids.indexOf('agent_aaa'))
     })
+
+    it('defaults disabledTools to an empty array (opt-out, backward-safe)', async () => {
+      const agent = await agentService.createAgent({
+        type: 'claude-code',
+        name: 'Disabled Tools Default',
+        model: TEST_MODEL_ID
+      })
+      const reloaded = await agentService.getAgent(agent.id)
+      expect(reloaded?.disabledTools).toEqual([])
+    })
+  })
+
+  describe('disabledTools round-trip', () => {
+    it('persists disabledTools on create and update', async () => {
+      const created = await agentService.createAgent({
+        type: 'claude-code',
+        name: 'Disabled Tools',
+        model: TEST_MODEL_ID,
+        disabledTools: ['Bash']
+      })
+      expect(created.disabledTools).toEqual(['Bash'])
+
+      const updated = await agentService.updateAgent(created.id, { disabledTools: ['Bash', 'Workflow'] })
+      expect(updated?.disabledTools).toEqual(['Bash', 'Workflow'])
+
+      const reloaded = await agentService.getAgent(created.id)
+      expect(reloaded?.disabledTools).toEqual(['Bash', 'Workflow'])
+    })
   })
 
   describe('deleteAgent', () => {

--- a/src/shared/ai/claudecode/__tests__/toolRegistry.test.ts
+++ b/src/shared/ai/claudecode/__tests__/toolRegistry.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { claudeRegistrySdkDescriptors, claudeSdkTypedToolNames } from '../toolRegistry'
+
+describe('claudeRegistrySdkDescriptors', () => {
+  const descriptors = claudeRegistrySdkDescriptors()
+  const names = new Set(descriptors.map((d) => d.name))
+
+  it('includes non-disabled SDK tools', () => {
+    expect(names.has('Bash')).toBe(true)
+    expect(names.has('Agent')).toBe(true)
+    expect(names.has('Workflow')).toBe(true)
+  })
+
+  it('excludes disabled SDK tools and all MCP tools', () => {
+    expect(names.has('WebSearch')).toBe(false)
+    expect(names.has('NotebookEdit')).toBe(false)
+    expect(names.has('mcp__cherry-tools__web_search')).toBe(false)
+  })
+
+  it('marks every descriptor as builtin origin', () => {
+    expect(descriptors.every((d) => d.origin === 'builtin')).toBe(true)
+  })
+})
+
+describe('claudeSdkTypedToolNames', () => {
+  it('includes union-typed SDK tools and excludes sdkTyped:false + mcp tools', () => {
+    const typed = new Set(claudeSdkTypedToolNames())
+    expect(typed.has('Bash')).toBe(true)
+    expect(typed.has('Workflow')).toBe(true)
+    expect(typed.has('Task')).toBe(false) // sdkTyped:false legacy alias
+    expect(typed.has('SendMessage')).toBe(false) // sdkTyped:false teams tool
+    expect(typed.has('ToolSearch')).toBe(false) // sdkTyped:false meta tool
+    expect(typed.has('mcp__cherry-tools__web_search')).toBe(false)
+  })
+})

--- a/src/shared/ai/claudecode/__tests__/toolRules.test.ts
+++ b/src/shared/ai/claudecode/__tests__/toolRules.test.ts
@@ -1,91 +1,25 @@
 import { describe, expect, it } from 'vitest'
 
-import {
-  buildClaudeMcpToolName,
-  type ClaudeToolDescriptor,
-  matchesClaudeToolRule,
-  resolveClaudeToolAccess,
-  resolveClaudeToolInvocationAccess
-} from '../toolRules'
+import { type ClaudeToolDescriptor, resolveClaudeToolAccess, resolveClaudeToolInvocationAccess } from '../toolRules'
 
 describe('Claude Code tool rules', () => {
-  const read: ClaudeToolDescriptor = {
-    id: 'Read',
-    name: 'Read',
-    origin: 'builtin'
-  }
+  const read: ClaudeToolDescriptor = { id: 'Read', name: 'Read', origin: 'builtin' }
+  const edit: ClaudeToolDescriptor = { id: 'Edit', name: 'Edit', origin: 'builtin' }
+  const webSearch: ClaudeToolDescriptor = { id: 'WebSearch', name: 'WebSearch', origin: 'builtin' }
 
-  const edit: ClaudeToolDescriptor = {
-    id: 'Edit',
-    name: 'Edit',
-    origin: 'builtin'
-  }
-
-  const webSearch: ClaudeToolDescriptor = {
-    id: 'WebSearch',
-    name: 'WebSearch',
-    origin: 'builtin'
-  }
-
-  const mcpSearch: ClaudeToolDescriptor = {
-    id: buildClaudeMcpToolName('docs', 'search_docs'),
-    name: 'search_docs',
-    origin: 'mcp',
-    sourceId: 'server-1',
-    sourceName: 'docs',
-    sourceToolName: 'search_docs'
-  }
-
-  it('matches Claude native builtin rules', () => {
-    expect(matchesClaudeToolRule('Read', read)).toBe(true)
-    expect(matchesClaudeToolRule('builtin_Read', read)).toBe(true)
+  it('lets source force-prompt override the safe default', () => {
+    expect(resolveClaudeToolAccess({ ...read, sourceApproval: 'prompt' }, {}).approval).toBe('prompt')
   })
 
-  it('matches Claude MCP runtime rules', () => {
-    expect(matchesClaudeToolRule('mcp__docs__searchDocs', mcpSearch)).toBe(true)
-    expect(matchesClaudeToolRule('mcp__docs__search_docs', mcpSearch)).toBe(true)
-    expect(matchesClaudeToolRule('mcp__docs__*', mcpSearch)).toBe(true)
-    expect(matchesClaudeToolRule('search_docs', mcpSearch)).toBe(false)
-    expect(matchesClaudeToolRule('mcp__other__searchDocs', mcpSearch)).toBe(false)
-  })
-
-  it('lets source force-prompt override explicit preapproval', () => {
-    expect(
-      resolveClaudeToolAccess({ ...webSearch, sourceApproval: 'prompt' }, { allowedTools: ['WebSearch'] }).approval
-    ).toBe('prompt')
-  })
-
-  it('applies explicit, mode, safe, and manual defaults in order', () => {
-    expect(resolveClaudeToolAccess(webSearch, { allowedTools: ['WebSearch'] }).approval).toBe('auto')
+  it('applies bypass, mode, safe, and manual defaults in order', () => {
+    expect(resolveClaudeToolAccess(webSearch, { permissionMode: 'bypassPermissions' }).approval).toBe('auto')
     expect(resolveClaudeToolAccess(edit, { permissionMode: 'acceptEdits' }).approval).toBe('auto')
     expect(resolveClaudeToolAccess(read, {}).approval).toBe('auto')
     expect(resolveClaudeToolAccess(webSearch, {}).approval).toBe('prompt')
   })
 
-  it('applies invocation-level Bash allow patterns without making the whole Bash tool auto-approved', () => {
-    const bash: ClaudeToolDescriptor = {
-      id: 'Bash',
-      name: 'Bash',
-      origin: 'builtin'
-    }
-
-    const policy = { allowedTools: ['Bash(git *)'] }
-    expect(resolveClaudeToolAccess(bash, policy).approval).toBe('prompt')
-    expect(
-      resolveClaudeToolInvocationAccess(bash, policy, { toolName: 'Bash', input: { command: 'git status' } }).approval
-    ).toBe('auto')
-    expect(
-      resolveClaudeToolInvocationAccess(bash, policy, { toolName: 'Bash', input: { command: 'curl example.com' } })
-        .approval
-    ).toBe('prompt')
-  })
-
   it('applies invocation-level acceptEdits Bash defaults', () => {
-    const bash: ClaudeToolDescriptor = {
-      id: 'Bash',
-      name: 'Bash',
-      origin: 'builtin'
-    }
+    const bash: ClaudeToolDescriptor = { id: 'Bash', name: 'Bash', origin: 'builtin' }
 
     expect(
       resolveClaudeToolInvocationAccess(

--- a/src/shared/ai/claudecode/constants.ts
+++ b/src/shared/ai/claudecode/constants.ts
@@ -1,6 +1,3 @@
-/** Tools disabled for ALL agents — replaced by Exa MCP (`mcp__exa__web_search_exa`) */
-export const GLOBALLY_DISALLOWED_TOOLS = ['WebSearch', 'WebFetch'] as const
-
 /**
  * System prompt section injected when the session receives messages from an
  * external messaging channel (Telegram, Feishu, QQ, WeChat, etc.).

--- a/src/shared/ai/claudecode/toolRegistry.ts
+++ b/src/shared/ai/claudecode/toolRegistry.ts
@@ -1,0 +1,422 @@
+/**
+ * Single declarative source of truth for Claude Code agent tools.
+ *
+ * Each tool declares its own metadata, its dependencies, and (optionally) a predicate for when it
+ * is enabled. The allowed/disallowed set for a session is *derived* from those declarations plus a
+ * runtime context — there are no side tables of tool-name relationships. This drives backend policy
+ * (which tools are blocked / the canUseTool catalog), the edit-dialog catalog UI, and chat rendering,
+ * replacing the previously hand-maintained, drifting lists in `builtinTools.ts`, the renderer's
+ * `AgentToolsType` + `toolRendererRegistry`, and the `ToolHeader` icon/label switches.
+ *
+ * See v2-refactor-temp/docs/ai/declarative-tool-registry.md.
+ */
+
+import type { ClaudeToolDescriptor } from './toolRules'
+
+export type ClaudeToolCategory = 'shell' | 'file' | 'search' | 'orchestration' | 'media' | 'context'
+
+/**
+ * Tool visibility / availability policy:
+ * - `user`     shown in the edit dialog, user toggles enable/disable
+ * - `internal` always enabled, hidden from the UI
+ * - `disabled` always blocked (added to the SDK `disallowedTools` hard-block list)
+ *
+ * Orthogonal to exposure, a tool may declare `dependsOn` (other tools it requires) here, and a
+ * runtime enable-predicate in main (`src/main/ai/tools/adapters/claudeCode/toolConditions.ts`).
+ * Both can additionally disable it — see `resolveDisallowedTools` there.
+ */
+export type ClaudeToolExposure = 'user' | 'internal' | 'disabled'
+
+export interface ClaudeToolDescriptorDef {
+  /** Runtime-native tool name == write-back id. SDK bare name (e.g. `Bash`) or `mcp__server__wire`. */
+  name: string
+  category: ClaudeToolCategory
+  exposure: ClaudeToolExposure
+  /** English copy shown in the catalog today; migrates to an i18n key in a later PR. */
+  description: string
+  /** Other tools this one requires — if any is disabled, this tool is disabled too (transitively). */
+  dependsOn?: readonly string[]
+  /**
+   * SDK tools only (`mcpServer` unset). `false` marks a runtime/experimental tool that is NOT a
+   * member of the SDK `ToolInputSchemas` union (agent-teams, ToolSearch, legacy Task/BashOutput) —
+   * the drift guard skips it. Defaults to `true` for SDK tools.
+   */
+  sdkTyped?: boolean
+  /** Set for in-process MCP tools — the server hosting this tool (drives injection). */
+  mcpServer?: 'cherry-tools' | 'claw' | 'agent-memory' | 'skills'
+  /** MCP tools only — the bare wire name within the server (e.g. `web_search`). */
+  mcpWireName?: string
+}
+
+/**
+ * The registry. Keys are stable friendly identifiers; `name` is the runtime tool name.
+ * For SDK tools key === name; for MCP tools key is friendly (e.g. `CherryWebSearch`).
+ */
+export const CLAUDE_TOOL_REGISTRY = {
+  // ── shell ────────────────────────────────────────────────────────
+  Bash: {
+    name: 'Bash',
+    category: 'shell',
+    exposure: 'user',
+    description: 'Executes shell commands in your environment'
+  },
+  // Legacy runtime tool name (the SDK union types background output as TaskOutput); render-only.
+  // Useless without Bash, so it follows Bash's enable state.
+  BashOutput: {
+    name: 'BashOutput',
+    category: 'shell',
+    exposure: 'internal',
+    description: 'Retrieves output from a running background shell',
+    dependsOn: ['Bash'],
+    sdkTyped: false
+  },
+  REPL: {
+    name: 'REPL',
+    category: 'shell',
+    exposure: 'disabled',
+    description: 'Runs code in a persistent REPL session'
+  },
+
+  // ── file ─────────────────────────────────────────────────────────
+  Read: { name: 'Read', category: 'file', exposure: 'user', description: 'Reads the contents of files' },
+  Edit: { name: 'Edit', category: 'file', exposure: 'user', description: 'Makes targeted edits to specific files' },
+  Write: { name: 'Write', category: 'file', exposure: 'user', description: 'Creates or overwrites files' },
+  NotebookEdit: {
+    name: 'NotebookEdit',
+    category: 'file',
+    exposure: 'disabled',
+    description: 'Modifies Jupyter notebook cells'
+  },
+
+  // ── search (local) ───────────────────────────────────────────────
+  Glob: { name: 'Glob', category: 'search', exposure: 'user', description: 'Finds files based on pattern matching' },
+  Grep: { name: 'Grep', category: 'search', exposure: 'user', description: 'Searches for patterns in file contents' },
+
+  // ── orchestration ────────────────────────────────────────────────
+  Agent: {
+    name: 'Agent',
+    category: 'orchestration',
+    exposure: 'internal',
+    description: 'Runs a sub-agent to handle complex, multi-step tasks'
+  },
+  // Legacy render-only alias of Agent; not a member of the SDK tool union.
+  Task: {
+    name: 'Task',
+    category: 'orchestration',
+    exposure: 'internal',
+    description: 'Runs a sub-agent to handle complex, multi-step tasks',
+    sdkTyped: false
+  },
+  TaskOutput: {
+    name: 'TaskOutput',
+    category: 'orchestration',
+    exposure: 'internal',
+    description: 'Gets output from a background task'
+  },
+  TaskStop: {
+    name: 'TaskStop',
+    category: 'orchestration',
+    exposure: 'internal',
+    description: 'Stops a running background task'
+  },
+  TaskCreate: {
+    name: 'TaskCreate',
+    category: 'orchestration',
+    exposure: 'internal',
+    description: 'Creates a structured task'
+  },
+  TaskGet: { name: 'TaskGet', category: 'orchestration', exposure: 'internal', description: 'Retrieves a task by id' },
+  TaskUpdate: { name: 'TaskUpdate', category: 'orchestration', exposure: 'internal', description: 'Updates a task' },
+  TaskList: { name: 'TaskList', category: 'orchestration', exposure: 'internal', description: 'Lists tasks' },
+  TodoWrite: {
+    name: 'TodoWrite',
+    category: 'orchestration',
+    exposure: 'disabled',
+    description: 'Creates and manages structured task lists'
+  },
+  ExitPlanMode: {
+    name: 'ExitPlanMode',
+    category: 'orchestration',
+    exposure: 'internal',
+    description: 'Exits plan mode and presents the plan'
+  },
+  EnterPlanMode: {
+    name: 'EnterPlanMode',
+    category: 'orchestration',
+    exposure: 'internal',
+    description: 'Enters plan mode'
+  },
+  // Condition-gated (workspace has .git) — see toolConditions.ts in main.
+  EnterWorktree: {
+    name: 'EnterWorktree',
+    category: 'orchestration',
+    exposure: 'internal',
+    description: 'Switches into a git worktree'
+  },
+  ExitWorktree: {
+    name: 'ExitWorktree',
+    category: 'orchestration',
+    exposure: 'internal',
+    description: 'Leaves the current git worktree'
+  },
+  AskUserQuestion: {
+    name: 'AskUserQuestion',
+    category: 'orchestration',
+    exposure: 'internal',
+    description: 'Asks the user a structured question'
+  },
+  // Meta tool surfaced via ENABLE_TOOL_SEARCH; not a member of the SDK tool union.
+  ToolSearch: {
+    name: 'ToolSearch',
+    category: 'orchestration',
+    exposure: 'internal',
+    description: 'Searches for available tools by name',
+    sdkTyped: false
+  },
+  ListMcpResources: {
+    name: 'ListMcpResources',
+    category: 'orchestration',
+    exposure: 'internal',
+    description: 'Lists resources from connected MCP servers'
+  },
+  ReadMcpResource: {
+    name: 'ReadMcpResource',
+    category: 'orchestration',
+    exposure: 'internal',
+    description: 'Reads a resource from a connected MCP server'
+  },
+  Workflow: {
+    name: 'Workflow',
+    category: 'orchestration',
+    exposure: 'user',
+    description: 'Runs a multi-step workflow that orchestrates subagents'
+  },
+  CronCreate: {
+    name: 'CronCreate',
+    category: 'orchestration',
+    exposure: 'disabled',
+    description: 'Creates a scheduled (cron) task'
+  },
+  CronDelete: {
+    name: 'CronDelete',
+    category: 'orchestration',
+    exposure: 'disabled',
+    description: 'Deletes a scheduled (cron) task'
+  },
+  CronList: {
+    name: 'CronList',
+    category: 'orchestration',
+    exposure: 'disabled',
+    description: 'Lists scheduled (cron) tasks'
+  },
+  ScheduleWakeup: {
+    name: 'ScheduleWakeup',
+    category: 'orchestration',
+    exposure: 'disabled',
+    description: 'Schedules a wakeup for the session'
+  },
+  RemoteTrigger: {
+    name: 'RemoteTrigger',
+    category: 'orchestration',
+    exposure: 'disabled',
+    description: 'Registers a remote trigger'
+  },
+  Monitor: {
+    name: 'Monitor',
+    category: 'orchestration',
+    exposure: 'disabled',
+    description: 'Monitors an external condition'
+  },
+  PushNotification: {
+    name: 'PushNotification',
+    category: 'orchestration',
+    exposure: 'disabled',
+    description: 'Sends a push notification'
+  },
+  // Agent-teams tools — runtime-injected behind CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS,
+  // NOT members of the SDK ToolInputSchemas union (drift guard skips them).
+  SendMessage: {
+    name: 'SendMessage',
+    category: 'orchestration',
+    exposure: 'internal',
+    description: 'Sends a message to another agent in the team',
+    sdkTyped: false
+  },
+  TeamCreate: {
+    name: 'TeamCreate',
+    category: 'orchestration',
+    exposure: 'internal',
+    description: 'Creates an agent team',
+    sdkTyped: false
+  },
+  TeamDelete: {
+    name: 'TeamDelete',
+    category: 'orchestration',
+    exposure: 'internal',
+    description: 'Deletes an agent team',
+    sdkTyped: false
+  },
+
+  // ── context (external / persistent context) ──────────────────────
+  // Native Web* are replaced by the cherry-tools equivalents below.
+  WebSearch: {
+    name: 'WebSearch',
+    category: 'context',
+    exposure: 'disabled',
+    description: 'Performs web searches with domain filtering'
+  },
+  WebFetch: {
+    name: 'WebFetch',
+    category: 'context',
+    exposure: 'disabled',
+    description: 'Fetches content from a specified URL'
+  },
+
+  // ── in-process MCP tools ─────────────────────────────────────────
+  // cherry-tools (always injected today)
+  CherryWebSearch: {
+    name: 'mcp__cherry-tools__web_search',
+    category: 'context',
+    exposure: 'user',
+    description: 'Searches the web via your configured provider',
+    mcpServer: 'cherry-tools',
+    mcpWireName: 'web_search'
+  },
+  CherryWebFetch: {
+    name: 'mcp__cherry-tools__web_fetch',
+    category: 'context',
+    exposure: 'user',
+    description: 'Fetches and reads a web page',
+    mcpServer: 'cherry-tools',
+    mcpWireName: 'web_fetch'
+  },
+  CherryKbSearch: {
+    name: 'mcp__cherry-tools__kb_search',
+    category: 'context',
+    exposure: 'user',
+    description: 'Searches your knowledge bases',
+    mcpServer: 'cherry-tools',
+    mcpWireName: 'kb_search'
+  },
+  CherryKbList: {
+    name: 'mcp__cherry-tools__kb_list',
+    category: 'context',
+    exposure: 'internal',
+    description: 'Lists your knowledge bases',
+    mcpServer: 'cherry-tools',
+    mcpWireName: 'kb_list'
+  },
+  // claw (agent autonomy / channels). notify/config need a connected channel to do anything.
+  ClawCron: {
+    name: 'mcp__claw__cron',
+    category: 'orchestration',
+    exposure: 'user',
+    description: 'Manages the in-app scheduler',
+    mcpServer: 'claw',
+    mcpWireName: 'cron'
+  },
+  // notify/config are condition-gated (agent has a connected channel) — see toolConditions.ts.
+  ClawNotify: {
+    name: 'mcp__claw__notify',
+    category: 'orchestration',
+    exposure: 'internal',
+    description: 'Sends a notification through a connected channel',
+    mcpServer: 'claw',
+    mcpWireName: 'notify'
+  },
+  ClawConfig: {
+    name: 'mcp__claw__config',
+    category: 'orchestration',
+    exposure: 'internal',
+    description: 'Inspects and manages this agent configuration and channels',
+    mcpServer: 'claw',
+    mcpWireName: 'config'
+  },
+  // agent-memory (cross-session memory)
+  AgentMemory: {
+    name: 'mcp__agent-memory__memory',
+    category: 'context',
+    exposure: 'user',
+    description: 'Stores and recalls cross-session memory',
+    mcpServer: 'agent-memory',
+    mcpWireName: 'memory'
+  },
+  // skills (marketplace + authoring)
+  Skills: {
+    name: 'mcp__skills__skills',
+    category: 'context',
+    exposure: 'internal',
+    description: 'Searches, installs, and authors skills',
+    mcpServer: 'skills',
+    mcpWireName: 'skills'
+  }
+} as const satisfies Record<string, ClaudeToolDescriptorDef>
+
+export type ClaudeToolKey = keyof typeof CLAUDE_TOOL_REGISTRY
+
+export const CLAUDE_TOOL_DEFS: readonly ClaudeToolDescriptorDef[] = Object.values(CLAUDE_TOOL_REGISTRY)
+
+/** A tool is an in-process MCP tool iff it declares a hosting server. */
+export const isMcpTool = (def: ClaudeToolDescriptorDef): boolean => def.mcpServer !== undefined
+
+/** SDK builtin tools that are members of the typed `ToolInputSchemas` union (drift-guard scope). */
+export const claudeSdkTypedToolNames = (): string[] =>
+  CLAUDE_TOOL_DEFS.filter((def) => !isMcpTool(def) && def.sdkTyped !== false).map((def) => def.name)
+
+/**
+ * Descriptors for the canUseTool / catalog policy layer: every non-disabled SDK tool.
+ * Disabled tools are omitted (they are hard-blocked via disallowedTools and never invoked).
+ */
+export function claudeRegistrySdkDescriptors(): ClaudeToolDescriptor[] {
+  return CLAUDE_TOOL_DEFS.filter((def) => !isMcpTool(def) && def.exposure !== 'disabled').map((def) => ({
+    id: def.name,
+    name: def.name,
+    description: def.description,
+    origin: 'builtin'
+  }))
+}
+
+/** Display order of category sections in the edit-dialog tool catalog. */
+export const CLAUDE_TOOL_CATEGORIES: readonly ClaudeToolCategory[] = [
+  'file',
+  'shell',
+  'search',
+  'context',
+  'orchestration',
+  'media'
+]
+
+export interface ClaudeUserFacingTool {
+  key: ClaudeToolKey
+  /** Runtime tool name == write-back id into `disabledTools`. */
+  name: string
+  /** Short human label for the catalog (interim English; → i18n key later). */
+  label: string
+  category: ClaudeToolCategory
+  description: string
+}
+
+/** Friendly labels for MCP wire tools whose `name` is an opaque `mcp__server__wire` id. */
+const MCP_TOOL_LABELS: Record<string, string> = {
+  'mcp__cherry-tools__web_search': 'Web Search',
+  'mcp__cherry-tools__web_fetch': 'Web Fetch',
+  'mcp__cherry-tools__kb_search': 'Knowledge Search',
+  'mcp__agent-memory__memory': 'Memory',
+  mcp__claw__cron: 'Scheduler'
+}
+
+/**
+ * The tools shown in the edit-dialog catalog (exposure `user`), across SDK + in-process MCP.
+ * `internal` / condition-gated / `disabled` tools are intentionally hidden from the UI.
+ */
+export function claudeUserFacingTools(): ClaudeUserFacingTool[] {
+  return (Object.entries(CLAUDE_TOOL_REGISTRY) as [ClaudeToolKey, ClaudeToolDescriptorDef][])
+    .filter(([, def]) => def.exposure === 'user')
+    .map(([key, def]) => ({
+      key,
+      name: def.name,
+      label: isMcpTool(def) ? (MCP_TOOL_LABELS[def.name] ?? def.name) : def.name,
+      category: def.category,
+      description: def.description
+    }))
+}

--- a/src/shared/ai/claudecode/toolRules.ts
+++ b/src/shared/ai/claudecode/toolRules.ts
@@ -1,6 +1,6 @@
 import type { AgentPermissionMode } from '../../data/api/schemas/agents'
 import type { ToolApproval, ToolOrigin } from '../tool'
-import { buildMcpWireToolId, buildMcpWireWildcard } from '../tools/mcpSourcePolicy'
+import { buildMcpWireToolId } from '../tools/mcpSourcePolicy'
 
 export interface ClaudeToolDescriptor {
   id: string
@@ -23,9 +23,9 @@ export interface ClaudeToolInvocation {
   input?: unknown
 }
 
+/** Approval is governed solely by the permission mode + the built-in safe/edit defaults. */
 export interface ClaudeToolPolicy {
   permissionMode?: AgentPermissionMode
-  allowedTools?: readonly string[]
 }
 
 const DEFAULT_SAFE_TOOLS = new Set(['Read', 'Glob', 'Grep', 'NotebookRead', 'Task', 'TodoWrite'])
@@ -38,36 +38,6 @@ export function normalizeClaudeBuiltinName(name: string): string {
 
 export function buildClaudeMcpToolName(serverName: string, toolName: string): string {
   return buildMcpWireToolId(serverName, toolName)
-}
-
-export function buildClaudeMcpWildcard(serverName: string): string {
-  return buildMcpWireWildcard(serverName)
-}
-
-function rawClaudeMcpToolName(serverName: string, toolName: string): string {
-  return `mcp__${serverName}__${toolName}`
-}
-
-export function matchesClaudeToolRule(rule: string, descriptor: ClaudeToolDescriptor): boolean {
-  if (rule === descriptor.id) return true
-
-  if (descriptor.origin === 'builtin') {
-    return normalizeClaudeBuiltinName(rule) === normalizeClaudeBuiltinName(descriptor.id)
-  }
-
-  if (descriptor.origin === 'mcp') {
-    if (descriptor.sourceName && rule === buildClaudeMcpWildcard(descriptor.sourceName)) return true
-    if (descriptor.sourceName && descriptor.sourceToolName) {
-      if (rule === rawClaudeMcpToolName(descriptor.sourceName, descriptor.sourceToolName)) return true
-      if (rule === rawClaudeMcpToolName(descriptor.sourceName, '*')) return true
-    }
-  }
-
-  return false
-}
-
-function hasRuleMatch(values: readonly string[] | undefined, descriptor: ClaudeToolDescriptor): boolean {
-  return values?.some((value) => matchesClaudeToolRule(value, descriptor)) ?? false
 }
 
 function sourceDecision(descriptor: ClaudeToolDescriptor): ClaudeToolDecision | undefined {
@@ -85,10 +55,6 @@ export function resolveClaudeToolAccess(
   if (source) return source
 
   if (policy.permissionMode === 'bypassPermissions') {
-    return { id: descriptor.id, approval: 'auto' }
-  }
-
-  if (hasRuleMatch(policy.allowedTools, descriptor)) {
     return { id: descriptor.id, approval: 'auto' }
   }
 
@@ -114,39 +80,6 @@ function matchesAcceptEditsBashInvocation(descriptor: ClaudeToolDescriptor, invo
   return ACCEPT_EDITS_BASH_COMMANDS.has(command)
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-}
-
-function matchesGlob(pattern: string, value: string): boolean {
-  const source = pattern
-    .split('*')
-    .map((part) => escapeRegExp(part))
-    .join('.*')
-  return new RegExp(`^${source}$`).test(value)
-}
-
-function matchesBashInvocationRule(
-  rule: string,
-  descriptor: ClaudeToolDescriptor,
-  invocation: ClaudeToolInvocation
-): boolean {
-  if (normalizeClaudeBuiltinName(descriptor.id) !== 'Bash') return false
-  const match = rule.match(/^Bash\((.*)\)$/)
-  if (!match) return false
-  const command = commandFromInput(invocation.input)
-  if (!command) return false
-  return matchesGlob(match[1].trim(), command)
-}
-
-function hasInvocationRuleMatch(
-  values: readonly string[] | undefined,
-  descriptor: ClaudeToolDescriptor,
-  invocation: ClaudeToolInvocation
-): boolean {
-  return values?.some((value) => matchesBashInvocationRule(value, descriptor, invocation)) ?? false
-}
-
 export function resolveClaudeToolInvocationAccess(
   descriptor: ClaudeToolDescriptor,
   policy: ClaudeToolPolicy,
@@ -156,13 +89,6 @@ export function resolveClaudeToolInvocationAccess(
   if (source) return source
 
   if (policy.permissionMode === 'bypassPermissions') {
-    return { id: descriptor.id, approval: 'auto' }
-  }
-
-  if (
-    hasRuleMatch(policy.allowedTools, descriptor) ||
-    hasInvocationRuleMatch(policy.allowedTools, descriptor, invocation)
-  ) {
     return { id: descriptor.id, approval: 'auto' }
   }
 

--- a/src/shared/data/api/schemas/agents.ts
+++ b/src/shared/data/api/schemas/agents.ts
@@ -96,7 +96,8 @@ export const AgentBaseSchema = z.strictObject({
   planModel: z.string().optional(),
   smallModel: z.string().optional(),
   mcps: z.array(z.string()).optional(),
-  allowedTools: z.array(z.string()).optional(),
+  /** Opt-out list of disabled tool names (empty = all enabled). Drives SDK disallowedTools. */
+  disabledTools: z.array(z.string()).optional(),
   configuration: AgentConfigurationSchema.optional()
 })
 export type AgentBase = z.infer<typeof AgentBaseSchema>
@@ -110,7 +111,7 @@ export const AGENT_MUTABLE_FIELDS = {
   planModel: true,
   smallModel: true,
   mcps: true,
-  allowedTools: true,
+  disabledTools: true,
   configuration: true
 } as const
 

--- a/v2-refactor-temp/docs/ai/README.md
+++ b/v2-refactor-temp/docs/ai/README.md
@@ -59,6 +59,10 @@ docs above reference them:
   model + gaps for externally-triggered (inbound IM) agent runs (review D1).
 - [`stream-ipc-validation.md`](./stream-ipc-validation.md) — scheme to validate
   the untrusted-renderer AI stream IPC payloads (review D2).
+- [`declarative-tool-registry.md`](./declarative-tool-registry.md) — one
+  declarative registry for Claude Code agent tools (policy + catalog UI +
+  chat rendering): `exposure`/`category`/`pairGroup`, opt-out `disabledTools`,
+  SDK 0.3.168 upgrade, 7-PR sequence.
 
 ## Suggested review order
 

--- a/v2-refactor-temp/docs/ai/declarative-tool-registry.md
+++ b/v2-refactor-temp/docs/ai/declarative-tool-registry.md
@@ -1,0 +1,145 @@
+# Declarative Claude Code Tool Registry
+
+> Design doc. Status: approved, implementation in progress (PR-by-PR).
+
+## Context
+
+The Claude Code agent tool set is **hand-written and duplicated across 3+ drifting places**, assembled from disconnected mechanisms:
+
+- `src/shared/ai/claudecode/builtinTools.ts` — `claudeCodeBuiltinTools` (13 tools; policy + edit-dialog catalog). Stale (lists removed `MultiEdit`/`NotebookRead`, omits `Agent`/`BashOutput`/…).
+- `src/renderer/.../tools/agent/types.ts` — `AgentToolsType` (~29 names) + per-tool input/output types (type-only import from `@anthropic-ai/claude-agent-sdk/sdk-tools`).
+- `src/renderer/.../tools/agent/toolRendererRegistry.tsx` + icon/label switches in `ToolHeader.tsx`.
+- `src/shared/ai/claudecode/constants.ts` — `GLOBALLY_DISALLOWED_TOOLS`, `SOUL_MODE_DISALLOWED_TOOLS` (mode-gated, not tool-granular).
+- **In-process MCP servers**, each gated differently in `settingsBuilder.buildMcpServers()`: `cherry-tools` (always), `claw` (cron/notify/config — **soul only**), `agent-memory` (memory — **soul only**), `assistant` (assistant only), `skills` (**defined but wired nowhere**).
+
+Goal: **one declarative registry** = single source of truth for policy (main), catalog UI (renderer), and chat rendering (renderer), covering **both SDK-native and in-process MCP tools**, classified **at tool granularity** (no all-or-nothing soul gating; some tools gated by **runtime conditions**). Plus: upgrade the SDK for the Workflow tool, make the toggle a real enable/disable, categorize + i18n the UI.
+
+## Decisions
+
+1. **Hand-authored registry + CI drift guard** (pure import from `sdk-tools.d.ts` impossible — type-only).
+2. **Upgrade SDK `0.3.145` → `0.3.168`**. **Workflow stays available** (the motivating feature).
+3. **Declarative `exposure`** per tool: `user` (shown, toggleable) · `internal` (always on, hidden) · `conditional` (on iff a runtime predicate holds, hidden) · `disabled` (always blocked). Plus `pairGroup` for atomic pair toggling.
+4. **Built-in toggle = real enable/disable** via SDK `disallowedTools` (hard block). **Per-tool approval removed** — approval governed solely by `permission_mode` cards.
+5. **App in-process tools fold into the built-in tab** by `category`.
+6. **Single opt-out `disabledTools` JSON column** (empty = all enabled). **`allowedTools` retired**.
+7. Categories: `shell | file | search | orchestration | media | context`. **`context`** = tools that feed the agent external/persistent context: web, knowledge, memory, skills, notes(future). `search` keeps only local `Glob`/`Grep`.
+8. **Drop soul-mode tool gating; classify at tool granularity.** Soul mode's non-tool effects (prompt personality) are out of scope.
+9. **Final classifications:**
+   - `NotebookEdit` → **disabled** (not needed). `TodoWrite` → **disabled** (superseded by `Task*`).
+   - `Agent` + agent-teams (`SendMessage`/`TeamCreate`/`TeamDelete`) → **internal**. `Workflow` → **user**.
+   - `ScheduleWakeup`/`RemoteTrigger`/`Monitor`/`PushNotification` → **disabled** (CLI-oriented).
+   - `EnterWorktree`/`ExitWorktree` → **conditional** (`workspace-has-git`), pair-grouped.
+   - claw `cron` → **user**; `agent-memory` `memory` → **user**; `skills` → **internal** (and newly wired); claw `notify` + `config` → **conditional** (`agent-has-channel`).
+
+## Architecture — 3 layers
+
+### Layer 1 — shared descriptor (new `src/shared/ai/claudecode/toolRegistry.ts`)
+```ts
+export type ClaudeToolCategory = 'shell' | 'file' | 'search' | 'orchestration' | 'media' | 'context'
+export type ClaudeToolExposure = 'user' | 'internal' | 'conditional' | 'disabled'
+export type ClaudeToolCondition = 'workspace-has-git' | 'agent-has-channel'
+export type ClaudeToolPairGroup = 'worktree' | 'planMode' | 'bash' | 'taskCluster' | 'mcpResource'
+
+interface ClaudeToolDescriptorDef {
+  name: string                 // runtime tool name == write-back id (SDK bare name, or mcp__server__wire)
+  category: ClaudeToolCategory
+  exposure: ClaudeToolExposure
+  condition?: ClaudeToolCondition          // required iff exposure==='conditional'
+  pairGroup?: ClaudeToolPairGroup
+  labelKey: string; descriptionKey: string // i18n keys
+  kind: 'sdk' | 'mcp'
+  sdkTyped?: boolean           // kind:'sdk'; false = runtime/experimental, absent from ToolInputSchemas (teams); guard skips
+  mcpServer?: 'cherry-tools' | 'claw' | 'agent-memory' | 'skills'  // kind:'mcp'
+  mcpWireName?: string
+}
+export const CLAUDE_TOOL_REGISTRY = { /* … */ } as const satisfies Record<string, ClaudeToolDescriptorDef>
+export type ClaudeToolKey = keyof typeof CLAUDE_TOOL_REGISTRY
+```
+Approval metadata dropped (decision #4). `AgentToolsType` derived from the registry.
+
+### Layer 2 — renderer binding (new `agent/toolBinding.tsx`)
+`TOOL_UI_BINDINGS satisfies Record<ClaudeToolKey, { icon; render? }>` — compile-time coverage guard. Replaces `toolRenderers` + `ToolHeader` switches; `UnknownToolRenderer` stays as fallback.
+
+### Layer 3 — policy & MCP injection (main)
+- `useAgentTools.ts` + `agentTools.ts` source descriptors from the registry.
+- `settingsBuilder.buildToolPermissions()` → `resolveDisallowedTools(agent, ctx)`.
+- `settingsBuilder.buildMcpServers()` injects an in-process server iff ≥1 of its tools is effectively enabled (replaces the `if (soulEnabled)` gates; wires `skills`).
+
+## Enable/disable model
+
+- New Drizzle column `disabledTools: text({mode:'json'}).$type<string[]>().notNull().default('[]')` in `agent.ts`; add to `AgentBaseSchema` + `AGENT_MUTABLE_FIELDS`.
+- `resolveDisallowedTools(agent, ctx)` in `toolRegistry.ts`, where `ctx = { workspaceHasGit: boolean; agentHasChannel: boolean }` (resolved in main: `.git` stat on cwd; `channelService.listChannels`):
+  1. `exposure:'disabled'` → always disallowed (subsumes `GLOBALLY_DISALLOWED_TOOLS`; delete that constant).
+  2. `exposure:'internal'` → never added.
+  3. `exposure:'conditional'` → disallowed iff its `condition` predicate is **false** in `ctx`.
+  4. `exposure:'user'` → disallowed iff its name or any `pairGroup` sibling is in `agent.disabledTools`.
+  5. **pairGroup atomicity** — re-expand groups (a disabled/condition-false member disables the whole group, incl. internal siblings).
+  6. `kind:'mcp'` disabled tools also drop from `adjustAllowedToolsForMcp`'s ensure-list + add `mcp__server__wire` to disallowed.
+- `SOUL_MODE_DISALLOWED_TOOLS` + `soul_enabled` server gates **removed**, replaced by per-tool exposure. Assistant-mode `AskUserQuestion` disable stays as a thin overlay.
+- `allowedTools` retired (UI stops writing; backend passes empty → SDK permits all, gated by `canUseTool` + `disallowedTools`).
+
+## Approval & ToolApprovalRegistry
+Approval = `permission_mode` cards + read-only default-safe set. **Round-trip unchanged.** A disabled/condition-false tool is in `disallowedTools` → removed from context → never reaches `canUseTool` (cover with a test).
+
+## CI drift guard
+- **Removals** → typecheck failure (named SDK-type imports + `_sdkCoverage` assertion per `kind:'sdk' && sdkTyped` key).
+- **Additions** → `scripts/check-claude-tools.ts` (mirrors `scripts/check-i18n.ts`): parse `ToolInputSchemas`/`ToolOutputSchemas` member identifiers via TS compiler API, strip `Input`/`Output`, apply SDK→name alias map, diff vs registry `kind:'sdk' && sdkTyped` keys → CI fails on any unmapped new SDK builtin.
+- `sdkTyped:false` (teams) + `kind:'mcp'` tools are hand-tracked, exempt from the union guard.
+
+## Final classification
+
+### SDK-native (`kind:'sdk'`)
+| Tool | category | exposure | pair | note |
+|---|---|---|---|---|
+| Bash | shell | user | bash | |
+| BashOutput | shell | internal | bash | |
+| Read / Edit / Write | file | user | | |
+| NotebookEdit | file | disabled | | |
+| Glob / Grep | search | user | | |
+| Agent | orchestration | internal | | subagent spawn |
+| SendMessage / TeamCreate / TeamDelete | orchestration | internal | | `sdkTyped:false` (teams, runtime flag) |
+| Task | orchestration | internal | | legacy render-only alias |
+| TaskCreate/Get/Update/List/Stop/Output | orchestration | internal | taskCluster | |
+| TodoWrite | orchestration | disabled | | |
+| ExitPlanMode / EnterPlanMode | orchestration | internal | planMode | |
+| EnterWorktree / ExitWorktree | orchestration | **conditional: workspace-has-git** | worktree | |
+| AskUserQuestion | orchestration | internal | | assistant overlay disables |
+| ToolSearch | orchestration | internal | | |
+| ListMcpResources / ReadMcpResource | orchestration | internal | mcpResource | |
+| Workflow | orchestration | **user** | | |
+| WebSearch / WebFetch (native) | context | disabled | | replaced by cherry |
+| REPL | shell | disabled | | |
+| CronCreate / CronDelete / CronList | orchestration | disabled | | |
+| ScheduleWakeup / RemoteTrigger / Monitor / PushNotification | orchestration | disabled | | |
+
+### In-process MCP (`kind:'mcp'`)
+| Tool (wire) | server | category | exposure | note |
+|---|---|---|---|---|
+| web_search / web_fetch | cherry-tools | context | user | replaces native Web* |
+| kb_search | cherry-tools | context | user | |
+| kb_list | cherry-tools | context | internal | |
+| memory | agent-memory | context | user | cross-session FACT.md/JOURNAL |
+| skills | skills | context | internal | newly wired (currently injected nowhere) |
+| cron | claw | orchestration | user | app scheduler (≠ SDK Cron*) |
+| notify | claw | orchestration | **conditional: agent-has-channel** | IM channel push |
+| config | claw | orchestration | **conditional: agent-has-channel** | agent self-config (rename/channels) |
+
+Future: media tools (image gen, audio/video) → `category:'media'`; notes → `category:'context'`.
+
+## PR sequence
+
+- **PR-1 — SDK upgrade 0.3.145 → 0.3.168.** Bump root + 8 native optional deps + verify `asarUnpack`; add new union members' type aliases to `types.ts`. *Verify*: `pnpm typecheck`, app boots, agent runs Bash+Read.
+- **PR-2 — shared registry + policy + CI guard (static exposures only).** `toolRegistry.ts`, `resolveDisallowedTools` (treats `conditional` as `internal` for now — no `ctx` yet), `scripts/check-claude-tools.ts`. Rewire `agentTools.ts`/`useAgentTools.ts`. **Snapshot-assert disallowed set == today** for non-soul agents.
+- **PR-3 — `disabledTools` column + schema + migration.** Existing agents unaffected (empty set).
+- **PR-4 — edit-dialog UI: real enable/disable + category sections + cherry fold-in.** Toggle writes `disabledTools`; group by `category`; one switch per `pairGroup`; show only `exposure==='user'`; drop per-tool approve.
+- **PR-5 — i18n.** `agent.tools.<Key>.label/.description` in en/zh-cn/zh-tw; migrate `getAgentToolLabel`.
+- **PR-6 — render-registry unification + cleanup.** `TOOL_UI_BINDINGS` + registry-driven `ToolHeader`; delete `builtinTools.ts`.
+- **PR-7 — conditional exposure + in-process MCP de-soul-gating.** Introduce the `ctx` predicates (`workspace-has-git` via `.git` stat; `agent-has-channel` via `channelService`); enforce `conditional`. De-soul-gate claw/agent-memory; wire `skills`; inject servers per-tool-enabled; remove `SOUL_MODE_DISALLOWED_TOOLS` + soul server gates. **Behavior change** — explicit before/after, tested.
+
+## Risks
+
+- **`exposure:'disabled'` correctness (high):** WebSearch/WebFetch hard-disabled today; mis-encoding re-grants them. PR-2 snapshot assertion is the safety net.
+- **De-soul-gating + conditional (high):** PR-7 changes which agents see claw/memory/skills/worktree. Must be explicit + tested; existing soul agents keep their tools; conditional predicates must be cheap (cache `.git` stat / channel count per session build).
+- **`skills` newly wired:** confirm marketplace install/authoring is safe to expose (internal = on for every agent).
+- **Teams outside typed union:** `SendMessage`/`Team*` can't be union-guarded; need explicit `internal` entries + bindings or they fall to `UnknownToolRenderer`.
+- **Warm-query staleness (low):** `disabledTools`/`ctx` re-key the warm signature; applies next session, not mid-session.


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Claude Code tool availability was derived from scattered conditions instead of a declarative registry policy.

After this PR:

Claude Code tool policy is declared through registry metadata so tools can be filtered and explained consistently.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

Policy stays in shared registry definitions to support both runtime enforcement and later settings UI.

The following alternatives were considered:

Duplicating the allow/deny logic in the Claude runtime was rejected because it would drift from settings and inspection flows.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Stack PR 06/15 for the chat-page split. Base: `codex/chat-stack-05-tool-registry`; head: `codex/chat-stack-06-claude-tool-registry`.

Validated at the top of this stack with `pnpm lint`, `pnpm test`, `pnpm db:migrations:check`, and `git diff --check`. Local Node 22.22.0 emitted the expected engine warning for the repo requirement `>=24.11.1`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
