### PR TITLE
test(stream-runtime): cover approval teardown semantics

### DIFF
--- a/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
+++ b/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
@@ -1,4 +1,5 @@
 import { BaseService } from '@main/core/lifecycle/BaseService'
+import type { UniqueModelId } from '@shared/data/types/model'
 import type { SerializedError } from '@shared/types/error'
 import type { UIMessageChunk } from 'ai'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -809,6 +810,33 @@ describe('AiStreamManager', () => {
       expect(listener.pausedResults[0].status).toBe('paused')
       expect(mgr.inspect('a')!.status).toBe('aborted')
     })
+
+    it('pauses the idle timer while a tool is awaiting approval — a long deliberation is not killed', async () => {
+      vi.useRealTimers()
+
+      const controlled = controlledStream()
+      mockStreamText.mockImplementationOnce(async () => controlled.stream)
+
+      const listener = new FakeListener('l:a')
+      startSingle(mgr, {
+        topicId: 'a',
+        modelId: 'provider-a::model-a',
+        request: { ...req('a'), requestOptions: { timeout: 30 } },
+        listeners: [listener]
+      })
+
+      // The approval-request chunk flows through the loop's onChunk callback,
+      // which calls `idle.cleanup()`. The stream then stays open with no further
+      // chunks (the human is deliberating).
+      controlled.enqueue({ type: 'start' } as UIMessageChunk)
+      controlled.enqueue({ type: 'tool-approval-request', toolCallId: 'tc-1', approvalId: 'a-1' } as UIMessageChunk)
+
+      // Wait well past the 30ms idle timeout — with the timer paused, no abort.
+      await new Promise((resolve) => setTimeout(resolve, 90))
+
+      expect(listener.pausedResults).toHaveLength(0)
+      expect(mgr.inspect('a')!.status).not.toBe('aborted')
+    })
   })
 
   // ── live finalMessage accumulation ──────────────────────────────
@@ -1182,6 +1210,62 @@ describe('AiStreamManager', () => {
       expect(statusSequence('t')).toEqual(['pending', 'streaming', 'done'])
       expect(mgr.inspect('t')!.status).toBe('done')
       expect(mgr.inspect('t')!.status).not.toBe('awaiting-approval')
+    })
+
+    // ── Teardown clears the awaiting-approval flag (no manager-side settle) ──
+    //
+    // A turn torn down (paused/errored) while a tool is `approval-requested`
+    // gets no `tool-output-*` to clear it. The manager only clears the flag so
+    // the status resolves to plain aborted/error and the `awaitingApprovalAnchors`
+    // anchor drops; the dangling tool part is terminalized to `output-error` by
+    // `finalizeInterruptedParts` (persistence already, re-attach below) — NOT by
+    // the manager minting a chunk or rewriting `finalMessage`.
+
+    /** Drive a `tool-approval-request` so the exec is awaiting approval; return the private exec. */
+    const startAwaitingApproval = (topicId: string, modelId: UniqueModelId) => {
+      mgr.onChunk(topicId, modelId, { type: 'tool-approval-request' } as UIMessageChunk)
+      // biome-ignore lint/suspicious/noExplicitAny: reach the private exec to drive the abort path
+      return (mgr as any).activeStreams.get(topicId).executions.get(modelId)
+    }
+
+    const anchorsOf = (topicId: string) =>
+      (sharedCacheStore.get(`topic.stream.statuses.${topicId}`) as { awaitingApprovalAnchors?: unknown[] } | undefined)
+        ?.awaitingApprovalAnchors ?? []
+
+    it('onExecutionPaused while awaiting approval clears the flag → status aborted, anchor dropped, no minted chunk', async () => {
+      const listener = new FakeListener('l:t')
+      startSingle(mgr, { topicId: 't', modelId: 'p::m', request: req('t'), listeners: [listener] })
+
+      const exec = startAwaitingApproval('t', 'p::m')
+      exec.status = 'aborted'
+      await mgr.onExecutionPaused('t', 'p::m')
+
+      expect(mgr.inspect('t')!.status).toBe('aborted')
+      expect(anchorsOf('t')).toEqual([])
+      // The manager does not fabricate a settle chunk — finalize owns that.
+      expect(listener.chunks.some((c) => c.type === 'tool-output-denied' || c.type === 'tool-output-error')).toBe(false)
+    })
+
+    it('onExecutionError while awaiting approval clears the flag → status error, anchor dropped', async () => {
+      const listener = new FakeListener('l:t')
+      startSingle(mgr, { topicId: 't', modelId: 'p::m', request: req('t'), listeners: [listener] })
+
+      startAwaitingApproval('t', 'p::m')
+      await mgr.onExecutionError('t', 'p::m', error('boom'))
+
+      expect(mgr.inspect('t')!.status).toBe('error')
+      expect(anchorsOf('t')).toEqual([])
+    })
+
+    it('onExecutionDone while awaiting approval keeps awaiting-approval (MCP continue)', async () => {
+      const listener = new FakeListener('l:t')
+      startSingle(mgr, { topicId: 't', modelId: 'p::m', request: req('t'), listeners: [listener] })
+
+      startAwaitingApproval('t', 'p::m')
+      await mgr.onExecutionDone('t', 'p::m')
+
+      expect(mgr.inspect('t')!.status).toBe('awaiting-approval')
+      expect(anchorsOf('t')).toHaveLength(1)
     })
 
     it('multi-model: flips on first chunk from any execution and stays pending if an execution errors before any chunks', async () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Approval teardown behavior in the stream runtime was not directly covered by tests.

After this PR:

Stream approval teardown semantics are covered so queue and context changes have a regression guard.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

Kept this as a test-only layer so behavior assertions are reviewable independently from runtime feature changes.

The following alternatives were considered:

Folding the tests into runtime feature PRs was avoided because this behavior spans multiple later changes.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Stack PR 08/15 for the chat-page split. Base: `codex/chat-stack-07-agent-context`; head: `codex/chat-stack-08-stream-approval`.

Validated at the top of this stack with `pnpm lint`, `pnpm test`, `pnpm db:migrations:check`, and `git diff --check`. Local Node 22.22.0 emitted the expected engine warning for the repo requirement `>=24.11.1`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
