### PR TITLE
feat(home-chat): queue streaming followups

### DIFF
--- a/src/renderer/components/chat/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/chat/composer/variants/ChatComposer.tsx
@@ -1,0 +1,971 @@
+import { Button } from '@cherrystudio/ui'
+import { cacheService } from '@data/CacheService'
+import { loggerService } from '@logger'
+import ModelAvatar from '@renderer/components/Avatar/ModelAvatar'
+import ComposerSurface, { type ComposerSurfaceActions } from '@renderer/components/chat/composer/ComposerSurface'
+import {
+  ComposerToolDerivedStateProvider,
+  ComposerToolRuntimeHost,
+  ComposerToolRuntimeProvider,
+  useComposerTokenReconcile,
+  useComposerToolDispatch,
+  useComposerToolLauncherActions,
+  useComposerToolState
+} from '@renderer/components/chat/composer/ComposerToolRuntime'
+import { getComposerToolConfig } from '@renderer/components/chat/composer/tools/registry'
+import EmojiIcon from '@renderer/components/EmojiIcon'
+import { AssistantSelector, ModelSelector } from '@renderer/components/Selector'
+import { MessageEditingProvider, useMessageEditing } from '@renderer/context/MessageEditingContext'
+import { useIsActiveTab } from '@renderer/context/TabIdContext'
+import { useCache } from '@renderer/data/hooks/useCache'
+import { usePreference } from '@renderer/data/hooks/usePreference'
+import { useCommandHandler } from '@renderer/features/command'
+import { useChatWrite } from '@renderer/hooks/ChatWriteContext'
+import { useAssistant } from '@renderer/hooks/useAssistant'
+import { useKnowledgeBases } from '@renderer/hooks/useKnowledgeBase'
+import { useProviderDisplayName, useProviders } from '@renderer/hooks/useProvider'
+import { useTopicMutations } from '@renderer/hooks/useTopic'
+import { useTopicAwaitingApproval, useTopicStreamStatus } from '@renderer/hooks/useTopicStreamStatus'
+import type { AddNewTopicPayload } from '@renderer/pages/home/types'
+import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
+import type { FileMetadata, Topic } from '@renderer/types'
+import { TopicType } from '@renderer/types'
+import { cn, getLeadingEmoji } from '@renderer/utils'
+import { getSendMessageShortcutLabel } from '@renderer/utils/input'
+import { canModelUseAssistantWebSearch } from '@renderer/utils/modelReconcile'
+import type { ComposerQueuedMessagePayload } from '@shared/ai/transport'
+import type { KnowledgeBase } from '@shared/data/types/knowledge'
+import type { CherryMessagePart } from '@shared/data/types/message'
+import type { Model, UniqueModelId } from '@shared/data/types/model'
+import type { Provider } from '@shared/data/types/provider'
+import { isNonChatModel } from '@shared/utils/model'
+import { Bot } from 'lucide-react'
+import React, { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { createComposerUserMessageParts } from '../composerDraft'
+import { QueuedFollowupsDock } from '../QueuedFollowupsDock'
+import { type ComposerDraftToken, type ComposerSerializedDraft, type ComposerSerializedToken } from '../tokens'
+import { type FollowupQueueItem, useFollowupQueue } from '../useFollowupQueue'
+import { createEditableMessageDraft, getEditableKnowledgeBases } from './chat/messageEditingDraft'
+import { useChatKnowledgeBaseScope } from './chat/useChatKnowledgeBaseScope'
+import { useChatMentionedModels } from './chat/useChatMentionedModels'
+import {
+  chatComposerTokenId,
+  fileToComposerToken,
+  getComposerTokenIds,
+  knowledgeBaseToComposerToken
+} from './chatComposerTokens'
+import { SelectedModelsTrigger } from './SelectedModelsTrigger'
+import {
+  COMPOSER_ICON_ONLY_LABEL_CLASS,
+  COMPOSER_ICON_ONLY_SELECTOR_BUTTON_CLASS,
+  COMPOSER_SELECTOR_BUTTON_CLASS,
+  COMPOSER_TOOLBAR_CLASS,
+  ComposerBelowControls,
+  ComposerToolbarControls,
+  ComposerToolMenuControls
+} from './shared/ComposerControlScaffolding'
+import { buildComposerQueuedPayload } from './shared/composerQueuedPayload'
+import { useComposerQuoteInsertion } from './shared/composerQuote'
+import { useComposerFileCapabilities } from './shared/useComposerFileCapabilities'
+import { useLatest } from './shared/useLatest'
+
+const INPUTBAR_DRAFT_CACHE_KEY = 'inputbar-draft'
+const DRAFT_CACHE_TTL = 24 * 60 * 60 * 1000
+const logger = loggerService.withContext('ChatComposer')
+const CHAT_MANAGED_TOKEN_KINDS = ['file', 'knowledge'] as const satisfies readonly ComposerDraftToken['kind'][]
+const CHAT_MODEL_FILTER = (model: Model) => !isNonChatModel(model)
+const COMPOSER_BELOW_SELECTOR_BUTTON_CLASS =
+  'h-8 shrink-0 gap-1.5 rounded-lg border border-transparent bg-transparent px-2.5 text-xs font-medium text-muted-foreground/75 shadow-none hover:bg-accent hover:text-accent-foreground active:bg-accent disabled:bg-transparent disabled:text-muted-foreground/50 [&_svg]:text-muted-foreground/60 hover:[&_svg]:text-accent-foreground'
+
+interface ChatComposerProps {
+  topic: Topic
+  onSend: (
+    text: string,
+    options?: {
+      files?: FileMetadata[]
+      mentionedModels?: UniqueModelId[]
+      knowledgeBaseIds?: KnowledgeBase['id'][]
+      userMessageParts?: CherryMessagePart[]
+    }
+  ) => void | Promise<void>
+  sendDisabled?: boolean
+  useMentionedModelSelector?: boolean
+  onTemporaryAssistantChange?: (assistantId: string | null) => void | Promise<void>
+  onNewTopic?: (payload?: AddNewTopicPayload) => void | Promise<void>
+}
+
+type ProviderActionHandlers = ComposerSurfaceActions & {
+  addNewTopic: (payload?: AddNewTopicPayload) => void
+}
+
+const emptyActions: ProviderActionHandlers = {
+  addNewTopic: () => undefined,
+  focus: () => undefined,
+  onTextChange: () => undefined,
+  toggleExpanded: () => undefined,
+  removeToken: () => undefined,
+  insertToken: () => undefined,
+  getDraft: () => ({ text: '', tokens: [] })
+}
+
+interface SavedComposerDraft {
+  text: string
+  draftTokens: ComposerSerializedToken[]
+  files: FileMetadata[]
+  selectedKnowledgeBases: KnowledgeBase[]
+}
+
+interface ChatComposerContextControlsProps {
+  assistantId: string | null
+  assistantName: string
+  assistantEmoji?: string
+  model?: Model
+  modelProviderName?: string
+  modelPending?: boolean
+  providers: Provider[]
+  mentionedModels: Model[]
+  mentionedModelSelectorValue: Model[]
+  mentionedModelMultiSelectMode: boolean
+  selectModelLabel: string
+  useMentionedModelSelector?: boolean
+  shouldAutoSelectCreatedAssistant: boolean
+  side: 'top' | 'bottom'
+  iconOnly?: boolean
+  onAssistantChange: (assistantId: string | null) => void | Promise<void>
+  onModelSelect: (model: Model | undefined) => void
+  onMentionedModelsSelect: (models: Model[]) => void
+  onMentionedModelMultiSelectModeChange: (enabled: boolean) => void
+  onMentionedModelSelectorRestore: () => void
+}
+
+const ChatComposerContextControls = ({
+  assistantId,
+  assistantName,
+  assistantEmoji,
+  model,
+  modelProviderName,
+  modelPending,
+  providers,
+  mentionedModels,
+  mentionedModelSelectorValue,
+  mentionedModelMultiSelectMode,
+  selectModelLabel,
+  useMentionedModelSelector,
+  shouldAutoSelectCreatedAssistant,
+  side,
+  iconOnly = false,
+  onAssistantChange,
+  onModelSelect,
+  onMentionedModelsSelect,
+  onMentionedModelMultiSelectModeChange,
+  onMentionedModelSelectorRestore
+}: ChatComposerContextControlsProps) => {
+  const assistantIcon = assistantEmoji || getLeadingEmoji(assistantName)
+  const triggerClassName = side === 'bottom' ? COMPOSER_BELOW_SELECTOR_BUTTON_CLASS : COMPOSER_SELECTOR_BUTTON_CLASS
+  const compactTriggerClassName = cn(triggerClassName, iconOnly && COMPOSER_ICON_ONLY_SELECTOR_BUTTON_CLASS)
+  const labelClassName = cn('truncate', iconOnly && COMPOSER_ICON_ONLY_LABEL_CLASS)
+  const modelTriggerClassName = cn(triggerClassName, iconOnly && model && COMPOSER_ICON_ONLY_SELECTOR_BUTTON_CLASS)
+  const modelLabelClassName = cn('truncate', iconOnly && model && COMPOSER_ICON_ONLY_LABEL_CLASS)
+  const selectedMentionedModels = useMentionedModelSelector ? mentionedModelSelectorValue : mentionedModels
+  const mentionedModelTriggerClassName = cn(
+    triggerClassName,
+    iconOnly && selectedMentionedModels.length > 0 && COMPOSER_ICON_ONLY_SELECTOR_BUTTON_CLASS
+  )
+  const assistantModelLabel = model
+    ? `${model.name}${modelProviderName ? ` | ${modelProviderName}` : ''}`
+    : selectModelLabel
+  const modelLabel = assistantModelLabel
+  const [mentionedModelSelectorOpen, setMentionedModelSelectorOpen] = useState(false)
+  const handleMentionedModelSelect = useCallback(
+    (nextModels: Model[]) => {
+      onMentionedModelsSelect(nextModels)
+    },
+    [onMentionedModelsSelect]
+  )
+
+  const handleMentionedModelMultiSelectModeChange = useCallback(
+    (nextEnabled: boolean) => {
+      onMentionedModelMultiSelectModeChange(nextEnabled)
+    },
+    [onMentionedModelMultiSelectModeChange]
+  )
+
+  return (
+    <>
+      <AssistantSelector
+        multi={false}
+        value={assistantId}
+        onChange={onAssistantChange}
+        autoSelectOnCreate={shouldAutoSelectCreatedAssistant}
+        side={side}
+        align="start"
+        mountStrategy="lazy-keep"
+        trigger={
+          <Button variant="ghost" size="sm" className={compactTriggerClassName}>
+            {assistantIcon ? (
+              <EmojiIcon emoji={assistantIcon} size={20} />
+            ) : iconOnly ? (
+              <Bot size={16} aria-hidden />
+            ) : null}
+            <span className={cn('max-w-40', labelClassName)}>{assistantName}</span>
+          </Button>
+        }
+      />
+      {useMentionedModelSelector ? (
+        <ModelSelector
+          multiple
+          value={mentionedModelSelectorValue}
+          onSelect={handleMentionedModelSelect}
+          open={mentionedModelSelectorOpen}
+          onOpenChange={setMentionedModelSelectorOpen}
+          multiSelectMode={mentionedModelMultiSelectMode}
+          onMultiSelectModeChange={handleMentionedModelMultiSelectModeChange}
+          filter={CHAT_MODEL_FILTER}
+          shortcut="chat.model.select"
+          side={side}
+          align="start"
+          mountStrategy="lazy-keep"
+          trigger={
+            <SelectedModelsTrigger
+              className={mentionedModelTriggerClassName}
+              disabled={modelPending}
+              iconOnly={iconOnly}
+              models={selectedMentionedModels}
+              assistantModel={model}
+              providers={providers}
+              fallbackLabel={selectModelLabel}
+              suppressSelectionPopover={mentionedModelSelectorOpen}
+              onModelsChange={handleMentionedModelSelect}
+              onRestore={onMentionedModelSelectorRestore}
+            />
+          }
+        />
+      ) : (
+        <ModelSelector
+          multiple={false}
+          value={model}
+          onSelect={onModelSelect}
+          filter={CHAT_MODEL_FILTER}
+          shortcut="chat.model.select"
+          side={side}
+          align="start"
+          mountStrategy="lazy-keep"
+          trigger={
+            <Button variant="ghost" size="sm" className={modelTriggerClassName} disabled={modelPending}>
+              {model ? <ModelAvatar model={model} size={20} /> : null}
+              <span className={cn('max-w-52', modelLabelClassName)}>{modelLabel}</span>
+            </Button>
+          }
+        />
+      )}
+    </>
+  )
+}
+
+type ChatComposerControlProps = Omit<ChatComposerContextControlsProps, 'side'>
+
+type ComposerSurfaceProps = React.ComponentProps<typeof ComposerSurface>
+type ChatComposerControlSlots = Pick<ComposerSurfaceProps, 'renderLeftControls' | 'renderBelowControls'>
+type ChatComposerControlsRenderer = (props: ChatComposerControlProps) => ChatComposerControlSlots
+
+const renderChatToolbarControls: ChatComposerControlsRenderer = (props) => ({
+  renderLeftControls: (inputAdapter) => (
+    <ComposerToolbarControls
+      inputAdapter={inputAdapter}
+      renderContextControls={({ side, iconOnly }) => (
+        <ChatComposerContextControls {...props} side={side} iconOnly={iconOnly} />
+      )}
+    />
+  )
+})
+
+const renderChatHomeControls: ChatComposerControlsRenderer = (props) => ({
+  renderLeftControls: (inputAdapter) => (
+    <div className={COMPOSER_TOOLBAR_CLASS}>
+      <ComposerToolMenuControls inputAdapter={inputAdapter} />
+    </div>
+  ),
+  renderBelowControls: () => (
+    <ComposerBelowControls
+      renderContextControls={({ side, iconOnly }) => (
+        <ChatComposerContextControls {...props} side={side} useMentionedModelSelector iconOnly={iconOnly} />
+      )}
+    />
+  )
+})
+
+type ChatComposerRootProps = ChatComposerProps & {
+  renderControls: ChatComposerControlsRenderer
+}
+
+const ChatComposerRoot = ({
+  topic,
+  onSend,
+  sendDisabled,
+  useMentionedModelSelector,
+  onTemporaryAssistantChange,
+  onNewTopic,
+  renderControls
+}: ChatComposerRootProps) => {
+  const actionsRef = useRef<ProviderActionHandlers>({ ...emptyActions })
+  const initialState = useMemo(
+    () => ({
+      files: [] as FileMetadata[],
+      mentionedModels: [] as Model[],
+      selectedKnowledgeBases: [] as KnowledgeBase[],
+      isExpanded: false,
+      couldAddImageFile: false,
+      extensions: [] as string[]
+    }),
+    []
+  )
+
+  return (
+    <MessageEditingProvider>
+      <ComposerToolRuntimeProvider
+        initialState={initialState}
+        actions={{
+          addNewTopic: () => actionsRef.current.addNewTopic(),
+          onTextChange: (updater) => actionsRef.current.onTextChange(updater)
+        }}>
+        <ChatComposerInner
+          topic={topic}
+          actionsRef={actionsRef}
+          onSend={onSend}
+          sendDisabled={sendDisabled}
+          useMentionedModelSelector={useMentionedModelSelector}
+          onTemporaryAssistantChange={onTemporaryAssistantChange}
+          onNewTopic={onNewTopic}
+          renderControls={renderControls}
+        />
+      </ComposerToolRuntimeProvider>
+    </MessageEditingProvider>
+  )
+}
+
+interface ChatComposerInnerProps extends Omit<ChatComposerProps, 'setActiveTopic'> {
+  actionsRef: React.RefObject<ProviderActionHandlers>
+  renderControls: ChatComposerControlsRenderer
+}
+
+const ChatComposerInner = ({
+  topic,
+  actionsRef,
+  onSend,
+  sendDisabled = false,
+  useMentionedModelSelector,
+  onTemporaryAssistantChange,
+  onNewTopic,
+  renderControls
+}: ChatComposerInnerProps) => {
+  const awaitingApproval = useTopicAwaitingApproval(topic.id)
+  const scope = topic.type ?? TopicType.Chat
+  const config = getComposerToolConfig(scope)
+  const { files, mentionedModels, selectedKnowledgeBases, isExpanded } = useComposerToolState()
+  const { setFiles, setMentionedModels, setSelectedKnowledgeBases, setIsExpanded } = useComposerToolDispatch()
+  const { getLaunchers, dispatchLauncher } = useComposerToolLauncherActions()
+  const {
+    assistant,
+    isLoading: isAssistantLoading,
+    model,
+    isModelPending,
+    isModelMissing,
+    setModel
+  } = useAssistant(topic.assistantId)
+  const { updateTopic } = useTopicMutations()
+  const { bases: allKnowledgeBases, isLoading: isKnowledgeBasesLoading } = useKnowledgeBases()
+  const { providers } = useProviders()
+  const [sendMessageShortcut] = usePreference('chat.input.send_message_shortcut')
+  const [enableSpellCheck] = usePreference('app.spell_check.enabled')
+  const [fontSize] = usePreference('chat.message.font_size')
+  const [narrowMode] = usePreference('chat.narrow_mode')
+  const [searching, setSearching] = useCache('chat.web_search.searching')
+  const [isMultiSelectMode] = useCache('chat.multi_select_mode')
+  const { t } = useTranslation()
+  const chatWrite = useChatWrite()
+  const { editingMessage, cancelEditing, stopEditing } = useMessageEditing()
+  const editingMessageForCurrentTopic = editingMessage?.message.topicId === topic.id ? editingMessage : null
+  const staleEditingMessage = editingMessage && !editingMessageForCurrentTopic
+  const { isPending, isFulfilled, markSeen } = useTopicStreamStatus(topic.id)
+  const [isSending, setIsSending] = useState(false)
+  const [text, setTextState] = useState(() => cacheService.getCasual<string>(INPUTBAR_DRAFT_CACHE_KEY) ?? '')
+  const [draftTokens, setDraftTokens] = useState<ComposerSerializedToken[] | undefined>(undefined)
+  const filesRef = useLatest(files)
+  const selectedKnowledgeBasesRef = useLatest(selectedKnowledgeBases)
+  const savedDraftBeforeEditingRef = useRef<SavedComposerDraft | null>(null)
+  const restoredEditingSessionIdRef = useRef<number | null>(null)
+  const selectAssistantMessage = t('button.select_assistant')
+  const displayAssistant = assistant
+  const hasMissingPersistedAssistant = !!topic.assistantId && !isAssistantLoading && !assistant
+  const runtimeModel = assistant || !topic.assistantId ? model : undefined
+  const runtimeModelPending = isAssistantLoading || isModelPending
+  const selectedAssistantId = assistant?.id ?? null
+
+  const handleModelSelect = useCallback(
+    (nextModel: Model | undefined) => {
+      if (!nextModel) return
+      if (!assistant) return
+
+      const enabledWebSearch = canModelUseAssistantWebSearch(nextModel)
+      return setModel(nextModel, { enableWebSearch: enabledWebSearch && assistant.settings.enableWebSearch })
+    },
+    [assistant, setModel]
+  )
+
+  const {
+    mentionedModelSelectorValue,
+    mentionedModelMultiSelectMode,
+    handleMentionedModelsSelect,
+    handleMentionedModelMultiSelectModeChange,
+    handleMentionedModelSelectorRestore
+  } = useChatMentionedModels({
+    enabled: useMentionedModelSelector,
+    runtimeModel,
+    runtimeModelPending,
+    selectedAssistantId,
+    topicId: topic.id,
+    mentionedModels,
+    setMentionedModels,
+    onModelSelect: handleModelSelect
+  })
+
+  const selectedModelForMissingAssistantDefault =
+    assistant && !assistant.modelId ? mentionedModelSelectorValue[0] : undefined
+  const missingAssistantMessage = hasMissingPersistedAssistant ? selectAssistantMessage : undefined
+  const missingModelMessage =
+    assistant && isModelMissing && !selectedModelForMissingAssistantDefault ? t('code.model_required') : undefined
+  const missingSelectedModelMessage =
+    useMentionedModelSelector && mentionedModelSelectorValue.length === 0 ? t('code.model_required') : undefined
+
+  useEffect(() => {
+    if (isPending) setIsSending(false)
+  }, [isPending])
+
+  useEffect(() => {
+    setIsSending(false)
+  }, [topic.id])
+
+  const loading = isPending || isSending || awaitingApproval
+  // Steer: while a turn is streaming (but not paused for tool approval) a new message is sent as a
+  // follow-up rather than blocked — the main process persists it and yields/chains a continuation.
+  const canSteer = isPending && !awaitingApproval
+  const selectedKnowledgeBasesScopeKey = `${topic.id}:${selectedAssistantId ?? 'no-assistant'}`
+  const assistantName = displayAssistant?.name ?? (isAssistantLoading ? t('common.loading') : selectAssistantMessage)
+  const providerName = useProviderDisplayName(runtimeModel?.providerId)
+
+  const { canAddImageFile, supportedExts } = useComposerFileCapabilities({
+    models: mentionedModels,
+    fallbackModel: runtimeModel
+  })
+
+  const { selectableKnowledgeBases, selectedKnowledgeBasesInScope, resolveKnowledgeBaseMarker } =
+    useChatKnowledgeBaseScope({
+      assistantKnowledgeBaseIds: assistant?.knowledgeBaseIds,
+      allKnowledgeBases,
+      isKnowledgeBasesLoading,
+      topicId: topic.id,
+      selectedAssistantId,
+      selectedKnowledgeBases,
+      setSelectedKnowledgeBases
+    })
+
+  const setText = useCallback(
+    (nextText: string) => {
+      setTextState(nextText)
+      if (!editingMessageForCurrentTopic) {
+        cacheService.setCasual(INPUTBAR_DRAFT_CACHE_KEY, nextText, DRAFT_CACHE_TTL)
+      }
+    },
+    [editingMessageForCurrentTopic]
+  )
+
+  const restoreSavedDraft = useCallback(() => {
+    const savedDraft = savedDraftBeforeEditingRef.current
+    savedDraftBeforeEditingRef.current = null
+
+    if (!savedDraft) return
+
+    setTextState(savedDraft.text)
+    cacheService.setCasual(INPUTBAR_DRAFT_CACHE_KEY, savedDraft.text, DRAFT_CACHE_TTL)
+    setDraftTokens(savedDraft.draftTokens)
+    setFiles(savedDraft.files)
+    setSelectedKnowledgeBases(savedDraft.selectedKnowledgeBases)
+  }, [setFiles, setSelectedKnowledgeBases])
+
+  const handleCancelEditing = useCallback(() => {
+    restoreSavedDraft()
+    cancelEditing()
+  }, [cancelEditing, restoreSavedDraft])
+  const editingMessageId = editingMessageForCurrentTopic?.message.id
+  const handleLocateEditingMessage = useCallback(() => {
+    if (!editingMessageId) return
+    void EventEmitter.emit(EVENT_NAMES.LOCATE_MESSAGE + ':' + editingMessageId, true)
+  }, [editingMessageId])
+
+  const restoreEditableMessageDraft = useEffectEvent((nextEditingMessage: NonNullable<typeof editingMessage>) => {
+    const editableDraft = createEditableMessageDraft(nextEditingMessage.parts)
+    setTextState(editableDraft.text)
+    setDraftTokens(editableDraft.draftTokens)
+    setFiles(editableDraft.files)
+    setSelectedKnowledgeBases(getEditableKnowledgeBases(editableDraft.draftTokens, selectableKnowledgeBases))
+  })
+
+  useEffect(() => {
+    if (!editingMessageForCurrentTopic) {
+      restoredEditingSessionIdRef.current = null
+      return
+    }
+    if (restoredEditingSessionIdRef.current === editingMessageForCurrentTopic.editingSessionId) return
+    restoredEditingSessionIdRef.current = editingMessageForCurrentTopic.editingSessionId
+
+    if (savedDraftBeforeEditingRef.current?.text === undefined) {
+      const currentDraft = actionsRef.current.getDraft()
+      savedDraftBeforeEditingRef.current = {
+        text: currentDraft.text,
+        draftTokens: currentDraft.tokens,
+        files: filesRef.current,
+        selectedKnowledgeBases: selectedKnowledgeBasesRef.current
+      }
+    }
+
+    restoreEditableMessageDraft(editingMessageForCurrentTopic)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `useEffectEvent` reads latest selectable knowledge bases; this effect is keyed by editingSessionId.
+  }, [actionsRef, editingMessageForCurrentTopic, filesRef, selectedKnowledgeBasesRef])
+
+  useEffect(() => {
+    if (!staleEditingMessage) return
+    restoreSavedDraft()
+    stopEditing()
+  }, [restoreSavedDraft, staleEditingMessage, stopEditing])
+
+  const placeholderText = t('chat.input.placeholder', { key: getSendMessageShortcutLabel(sendMessageShortcut) })
+
+  const tokens = useMemo(
+    () => [...files.map(fileToComposerToken), ...selectedKnowledgeBasesInScope.map(knowledgeBaseToComposerToken)],
+    [files, selectedKnowledgeBasesInScope]
+  )
+
+  // Editor→state reconciliation owned by the tools: attachmentTool prunes+dedupes files,
+  // knowledgeBaseTool prunes+re-adds knowledge bases (against the injected selectableKnowledgeBases).
+  const handleTokensChange = useComposerTokenReconcile({ scope, assistant: displayAssistant, model: runtimeModel })
+
+  const onPause = useCallback(() => {
+    chatWrite?.pause()
+  }, [chatWrite])
+
+  const handleAssistantChange = useCallback(
+    async (nextId: string | null) => {
+      if (!nextId || nextId === selectedAssistantId) return
+      if (onTemporaryAssistantChange) {
+        await onTemporaryAssistantChange(nextId)
+        return
+      }
+      await updateTopic(topic.id, { assistantId: nextId })
+    },
+    [onTemporaryAssistantChange, selectedAssistantId, topic.id, updateTopic]
+  )
+
+  const addNewTopic = useCallback(
+    (payload?: AddNewTopicPayload) => {
+      void onNewTopic?.(payload)
+    },
+    [onNewTopic]
+  )
+
+  const handleSurfaceActionsChange = useCallback(
+    (actions: ComposerSurfaceActions) => {
+      Object.assign(actionsRef.current, actions)
+    },
+    [actionsRef]
+  )
+
+  useEffect(() => {
+    return EventEmitter.on(EVENT_NAMES.FOCUS_CHAT_COMPOSER, (payload) => {
+      const topicId = typeof payload === 'object' && payload ? (payload as { topicId?: string }).topicId : undefined
+      if (topicId !== topic.id) return
+      actionsRef.current.focus()
+    })
+  }, [actionsRef, topic.id])
+
+  useEffect(() => {
+    Object.assign(actionsRef.current, { addNewTopic })
+  }, [actionsRef, addNewTopic])
+
+  useComposerQuoteInsertion(actionsRef, isExpanded)
+
+  const isActiveTab = useIsActiveTab()
+  useCommandHandler(
+    'topic.create',
+    () => {
+      addNewTopic()
+    },
+    { enabled: isActiveTab }
+  )
+
+  const buildQueuedPayload = useCallback(
+    (draft: ComposerSerializedDraft): ComposerQueuedMessagePayload | null =>
+      buildComposerQueuedPayload(draft, {
+        files,
+        fileTokenId: chatComposerTokenId.file,
+        requireText: true,
+        extra: (tokenIds) => {
+          const knowledgeBaseIds = selectedKnowledgeBasesInScope
+            .filter((base) => tokenIds.has(chatComposerTokenId.knowledge(base)))
+            .map((base) => base.id)
+          return {
+            mentionedModels: mentionedModels.length
+              ? mentionedModels.map((currentModel) => currentModel.id)
+              : undefined,
+            knowledgeBaseIds: knowledgeBaseIds.length ? knowledgeBaseIds : undefined
+          }
+        }
+      }),
+    [files, mentionedModels, selectedKnowledgeBasesInScope]
+  )
+
+  const sendQueuedPayload = useCallback(
+    async (payload: ComposerQueuedMessagePayload) => {
+      setIsSending(true)
+
+      try {
+        await onSend(payload.text, {
+          files: payload.files as FileMetadata[] | undefined,
+          mentionedModels: payload.mentionedModels,
+          knowledgeBaseIds: payload.knowledgeBaseIds,
+          userMessageParts: payload.userMessageParts
+        })
+        return true
+      } catch (error) {
+        logger.warn('send failed', { error })
+        return false
+      } finally {
+        setIsSending(false)
+      }
+    },
+    [onSend]
+  )
+
+  const clearCurrentDraft = useCallback(() => {
+    setText('')
+    setDraftTokens(undefined)
+    setFiles([])
+    setSelectedKnowledgeBases([])
+  }, [setFiles, setSelectedKnowledgeBases, setText])
+
+  // Queue mode: while a turn streams, follow-ups go here instead of sending; the head auto-drains
+  // (normal send) when the topic goes idle, and the dock steers/edits/removes individual items.
+  const {
+    items: queuedFollowups,
+    enqueue: enqueueFollowup,
+    removeId: removeFollowup,
+    reorder: reorderFollowups,
+    paused: followupPaused,
+    setPaused: setFollowupPaused
+  } = useFollowupQueue({
+    scopeKey: selectedKnowledgeBasesScopeKey,
+    isFulfilled,
+    markSeen,
+    onDrain: sendQueuedPayload
+  })
+
+  // Edit a queued item = restore the whole draft (text + tokens + files + knowledge bases) into the
+  // live composer, then drop it from the queue. Mirrors `restoreEditableMessageDraft`.
+  const restoreFollowupDraft = useCallback(
+    (item: FollowupQueueItem) => {
+      setText(item.draft.text)
+      setDraftTokens(item.draft.tokens.length ? [...item.draft.tokens] : undefined)
+      setFiles((item.payload.files as FileMetadata[] | undefined) ?? [])
+      setSelectedKnowledgeBases(allKnowledgeBases.filter((base) => item.payload.knowledgeBaseIds?.includes(base.id)))
+    },
+    [allKnowledgeBases, setFiles, setSelectedKnowledgeBases, setText]
+  )
+
+  const buildEditedMessageParts = useCallback(
+    (draft: ComposerSerializedDraft) => {
+      const tokenIds = getComposerTokenIds(draft.tokens)
+      const payloadFiles = files.filter((file) => tokenIds.has(chatComposerTokenId.file(file)))
+      const originalFilePartsByTokenId = new Map<string, Extract<CherryMessagePart, { type: 'file' }>>()
+
+      if (editingMessageForCurrentTopic) {
+        const editableDraft = createEditableMessageDraft(editingMessageForCurrentTopic.parts)
+        // Keep this filter aligned with editableDraft.files: createEditableFileMetadata only drops
+        // parts without a url, so excluding url-less file parts keeps the two arrays index-aligned.
+        const originalFileParts = editingMessageForCurrentTopic.parts.filter(
+          (part): part is Extract<CherryMessagePart, { type: 'file' }> => part.type === 'file' && !!part.url
+        )
+
+        originalFileParts.forEach((part, index) => {
+          const file = editableDraft.files[index]
+          if (file) originalFilePartsByTokenId.set(chatComposerTokenId.file(file), part)
+        })
+      }
+
+      const newFiles = payloadFiles.filter((file) => !originalFilePartsByTokenId.has(chatComposerTokenId.file(file)))
+      const rebuiltParts = createComposerUserMessageParts(draft, { files: newFiles })
+      const textPart = rebuiltParts[0]
+      const rebuiltFileParts = new Map<string, CherryMessagePart>()
+
+      rebuiltParts.slice(1).forEach((part, index) => {
+        const file = newFiles[index]
+        if (file) rebuiltFileParts.set(chatComposerTokenId.file(file), part)
+      })
+
+      return [
+        textPart,
+        ...payloadFiles.flatMap((file) => {
+          const tokenId = chatComposerTokenId.file(file)
+          const filePart = originalFilePartsByTokenId.get(tokenId) ?? rebuiltFileParts.get(tokenId)
+          return filePart ? [filePart] : []
+        })
+      ]
+    },
+    [editingMessageForCurrentTopic, files]
+  )
+
+  const handleSendDraft = useCallback(
+    async (draft: ComposerSerializedDraft) => {
+      if (staleEditingMessage) {
+        restoreSavedDraft()
+        stopEditing()
+        return
+      }
+
+      if (editingMessageForCurrentTopic) {
+        if (!chatWrite?.forkAndResend) {
+          window.toast?.error(t('message.error.operation_unavailable'))
+          return
+        }
+
+        const editedParts = buildEditedMessageParts(draft)
+        try {
+          await chatWrite.forkAndResend(editingMessageForCurrentTopic.message.id, editedParts)
+          restoreSavedDraft()
+          stopEditing()
+        } catch (error) {
+          logger.warn('edited message fork and resend failed', { error })
+          window.toast?.error(t('message.error.operation_unavailable'))
+        }
+        return
+      }
+
+      if (missingAssistantMessage) {
+        window.toast?.error(selectAssistantMessage)
+        return
+      }
+
+      if (!runtimeModel && !selectedModelForMissingAssistantDefault) {
+        window.toast?.error(t('code.model_required'))
+        return
+      }
+
+      if (missingSelectedModelMessage) {
+        window.toast?.error(missingSelectedModelMessage)
+        return
+      }
+
+      if (sendDisabled) return
+      if (runtimeModelPending) return
+      // While streaming, only block if we can't steer (e.g. paused for tool approval).
+      if (loading && !canSteer) return
+
+      const payload = buildQueuedPayload(draft)
+      if (!payload) return
+
+      // Busy (streaming, not awaiting approval) → queue the follow-up instead of sending now. The
+      // dock lets the user steer/edit/remove it; the head auto-drains when the turn goes idle.
+      if (canSteer) {
+        enqueueFollowup(draft, payload)
+        clearCurrentDraft()
+        return
+      }
+
+      if (selectedModelForMissingAssistantDefault) {
+        await handleModelSelect(selectedModelForMissingAssistantDefault)
+      }
+
+      // Optimistically clear the draft so the cleared input doubles as the re-entry
+      // guard, but snapshot it first: a pre-stream failure never reaches the streaming
+      // UI, so restore the draft (text + files + knowledge bases; tokens re-derive) and
+      // surface the failure instead of silently discarding what the user typed.
+      const previousText = text
+      const previousFiles = files
+      const previousKnowledgeBases = selectedKnowledgeBases
+
+      clearCurrentDraft()
+      const sent = await sendQueuedPayload(payload)
+      if (!sent) {
+        setText(previousText)
+        setFiles(previousFiles)
+        setSelectedKnowledgeBases(previousKnowledgeBases)
+        window.toast?.error(t('chat.input.send_failed'))
+      }
+    },
+    [
+      buildQueuedPayload,
+      buildEditedMessageParts,
+      canSteer,
+      chatWrite,
+      clearCurrentDraft,
+      editingMessageForCurrentTopic,
+      enqueueFollowup,
+      files,
+      handleModelSelect,
+      loading,
+      missingAssistantMessage,
+      missingSelectedModelMessage,
+      runtimeModel,
+      runtimeModelPending,
+      selectedKnowledgeBases,
+      selectedModelForMissingAssistantDefault,
+      sendDisabled,
+      selectAssistantMessage,
+      sendQueuedPayload,
+      setFiles,
+      setSelectedKnowledgeBases,
+      setText,
+      staleEditingMessage,
+      stopEditing,
+      restoreSavedDraft,
+      t,
+      text
+    ]
+  )
+
+  if (isMultiSelectMode) return null
+
+  const controlSlots = renderControls({
+    assistantId: selectedAssistantId,
+    assistantName,
+    assistantEmoji: displayAssistant?.emoji,
+    model: runtimeModel,
+    modelProviderName: providerName,
+    modelPending: runtimeModelPending,
+    providers,
+    mentionedModels,
+    mentionedModelSelectorValue,
+    mentionedModelMultiSelectMode,
+    useMentionedModelSelector,
+    shouldAutoSelectCreatedAssistant: Boolean(onTemporaryAssistantChange),
+    selectModelLabel: runtimeModelPending ? t('common.loading') : t('button.select_model'),
+    onAssistantChange: handleAssistantChange,
+    onModelSelect: handleModelSelect,
+    onMentionedModelsSelect: handleMentionedModelsSelect,
+    onMentionedModelMultiSelectModeChange: handleMentionedModelMultiSelectModeChange,
+    onMentionedModelSelectorRestore: handleMentionedModelSelectorRestore
+  })
+
+  return (
+    <ComposerToolDerivedStateProvider
+      couldAddImageFile={canAddImageFile}
+      extensions={supportedExts}
+      selectableKnowledgeBases={selectableKnowledgeBases}>
+      {displayAssistant && runtimeModel && (
+        <ComposerToolRuntimeHost scope={scope} assistant={displayAssistant} model={runtimeModel} />
+      )}
+      <ComposerSurface
+        text={text}
+        onTextChange={setText}
+        tokens={tokens}
+        draftTokens={draftTokens}
+        managedTokenKinds={CHAT_MANAGED_TOKEN_KINDS}
+        onTokensChange={handleTokensChange}
+        resolveKnowledgeBaseMarker={resolveKnowledgeBaseMarker}
+        placeholder={searching ? t('chat.input.translating') : placeholderText}
+        sendDisabled={
+          text.trim().length === 0 ||
+          (loading && !canSteer) ||
+          sendDisabled ||
+          searching ||
+          runtimeModelPending ||
+          !!missingAssistantMessage ||
+          !!missingModelMessage ||
+          !!missingSelectedModelMessage
+        }
+        sendBlockedReason={
+          sendDisabled
+            ? t('common.loading')
+            : (missingAssistantMessage ?? missingModelMessage ?? missingSelectedModelMessage)
+        }
+        isLoading={loading}
+        onSendDraft={handleSendDraft}
+        editingState={
+          editingMessageForCurrentTopic
+            ? {
+                messageId: editingMessageForCurrentTopic.message.id,
+                highlightKey: editingMessageForCurrentTopic.editingSessionId,
+                onLocate: handleLocateEditingMessage,
+                onCancel: handleCancelEditing
+              }
+            : undefined
+        }
+        onPause={onPause}
+        queueContent={
+          queuedFollowups.length > 0 ? (
+            <QueuedFollowupsDock
+              items={queuedFollowups}
+              paused={followupPaused}
+              onTogglePause={() => setFollowupPaused(!followupPaused)}
+              onSteer={(id) => {
+                const item = queuedFollowups.find((entry) => entry.id === id)
+                if (!item) return
+                void sendQueuedPayload(item.payload)
+                removeFollowup(id)
+              }}
+              onEdit={(id) => {
+                const item = queuedFollowups.find((entry) => entry.id === id)
+                if (!item) return
+                restoreFollowupDraft(item)
+                removeFollowup(id)
+              }}
+              onRemove={removeFollowup}
+              onReorder={reorderFollowups}
+            />
+          ) : undefined
+        }
+        supportedExts={supportedExts}
+        setFiles={setFiles}
+        filesCount={files.length}
+        isExpanded={isExpanded}
+        onExpandedChange={setIsExpanded}
+        quickPanelEnabled={config.enableQuickPanel ?? true}
+        enableDragDrop={config.enableDragDrop ?? true}
+        enableSpellCheck={enableSpellCheck}
+        editable={!searching}
+        fontSize={fontSize}
+        narrowMode={narrowMode}
+        onFocus={() => setSearching(false)}
+        onActionsChange={handleSurfaceActionsChange}
+        getToolLaunchers={() => getLaunchers()}
+        onToolLauncherSelect={(launcher, options) => dispatchLauncher(launcher, options)}
+        {...controlSlots}
+      />
+    </ComposerToolDerivedStateProvider>
+  )
+}
+
+const ChatComposer = (props: ChatComposerProps) => {
+  return <ChatComposerRoot {...props} renderControls={renderChatToolbarControls} />
+}
+
+export const ChatHomeComposer = (props: ChatComposerProps) => {
+  return <ChatComposerRoot {...props} useMentionedModelSelector renderControls={renderChatHomeControls} />
+}
+
+export const ChatPlacementComposer = ({
+  isHome,
+  onTemporaryAssistantChange,
+  ...props
+}: ChatComposerProps & { isHome: boolean }) => {
+  return (
+    <ChatComposerRoot
+      {...props}
+      onTemporaryAssistantChange={isHome ? onTemporaryAssistantChange : undefined}
+      useMentionedModelSelector
+      renderControls={isHome ? renderChatHomeControls : renderChatToolbarControls}
+    />
+  )
+}
+
+export default ChatComposer

--- a/src/renderer/components/chat/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/chat/composer/variants/__tests__/ChatComposer.test.tsx
@@ -1,0 +1,2081 @@
+import { cacheService } from '@data/CacheService'
+import { MessageEditingProvider, useMessageEditing } from '@renderer/context/MessageEditingContext'
+import type { KnowledgeBase } from '@shared/data/types/knowledge'
+import { type Model, MODEL_CAPABILITY } from '@shared/data/types/model'
+import { IpcChannel } from '@shared/IpcChannel'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { type ReactNode, useEffect } from 'react'
+import type * as ReactI18nextModule from 'react-i18next'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ComposerSurfaceProps } from '../../ComposerSurface'
+import type { ComposerSerializedToken } from '../../tokens'
+import ChatComposer, { ChatHomeComposer, ChatPlacementComposer } from '../ChatComposer'
+
+const mocks = vi.hoisted(() => ({
+  createTopic: vi.fn(),
+  updateTopic: vi.fn(),
+  setModel: vi.fn(),
+  setDefaultModel: vi.fn(),
+  setFiles: vi.fn(),
+  setMentionedModels: vi.fn(),
+  setSelectedKnowledgeBases: vi.fn(),
+  setIsExpanded: vi.fn(),
+  updateAssistant: vi.fn(),
+  toastError: vi.fn(),
+  focusComposer: vi.fn(),
+  insertToken: vi.fn(),
+  getDraft: vi.fn(),
+  reconcileTokens: vi.fn(),
+  commandHandlers: new Map<string, () => void>(),
+  eventListeners: new Map<string, (payload: unknown) => void>(),
+  eventEmit: vi.fn(),
+  eventOn: vi.fn(),
+  mentionedModels: undefined as Model[] | undefined,
+  selectedKnowledgeBases: undefined as KnowledgeBase[] | undefined,
+  knowledgeBases: [] as KnowledgeBase[],
+  assistant: undefined as any,
+  model: undefined as Model | undefined,
+  assistantLoading: false,
+  modelPending: false,
+  modelMissing: undefined as boolean | undefined,
+  selectedModel: undefined as Model | undefined,
+  topicPending: false,
+  surfaceProps: undefined as ComposerSurfaceProps | undefined,
+  derivedToolState: undefined as { couldAddImageFile: boolean; extensions: string[] } | undefined,
+  ipcListeners: new Map<string, (_event: unknown, payload: unknown) => void>(),
+  ipcOn: vi.fn(),
+  chatWrite: undefined as any,
+  files: undefined as any[] | undefined
+}))
+
+const originalResizeObserver = globalThis.ResizeObserver
+
+const serializeComposerToken = (token: ComposerSurfaceProps['tokens'][number]) => ({
+  ...token,
+  index: 0,
+  textOffset: 0
+})
+
+interface ResizeObserverMockInstance {
+  callback: ResizeObserverCallback
+  target?: Element
+  observe: ReturnType<typeof vi.fn>
+  disconnect: ReturnType<typeof vi.fn>
+}
+
+const resizeObserverMockInstances: ResizeObserverMockInstance[] = []
+
+const model = {
+  id: 'provider::model-a',
+  providerId: 'provider',
+  apiModelId: 'model-a',
+  name: 'Model A',
+  capabilities: [],
+  supportsStreaming: true,
+  isEnabled: true,
+  isHidden: false
+} satisfies Model
+
+const modelB = {
+  id: 'provider::model-b',
+  providerId: 'provider',
+  apiModelId: 'model-b',
+  name: 'Model B',
+  capabilities: [],
+  supportsStreaming: true,
+  isEnabled: true,
+  isHidden: false
+} satisfies Model
+
+const modelBWithFunctionCall = {
+  ...modelB,
+  capabilities: [MODEL_CAPABILITY.FUNCTION_CALL]
+} satisfies Model
+
+vi.mock('@data/CacheService', () => ({
+  cacheService: {
+    getCasual: vi.fn(() => ''),
+    setCasual: vi.fn()
+  }
+}))
+
+vi.mock('@renderer/components/chat/composer/ComposerSurface', () => {
+  function MockComposerSurface(props: ComposerSurfaceProps) {
+    useEffect(() => {
+      props.onActionsChange?.({
+        focus: mocks.focusComposer,
+        onTextChange: (updater) => {
+          const nextText = typeof updater === 'function' ? updater(props.text) : updater
+          props.onTextChange(nextText)
+        },
+        toggleExpanded: vi.fn(),
+        removeToken: vi.fn(),
+        insertToken: mocks.insertToken,
+        getDraft: mocks.getDraft
+      })
+    }, [props])
+
+    mocks.surfaceProps = props
+    return (
+      <div>
+        <div data-testid="composer-left-controls">{props.renderLeftControls?.(undefined)}</div>
+        <div data-testid="composer-below-controls">{props.renderBelowControls?.(undefined)}</div>
+      </div>
+    )
+  }
+
+  return {
+    default: MockComposerSurface
+  }
+})
+
+vi.mock('@renderer/services/EventService', () => ({
+  EVENT_NAMES: {
+    FOCUS_CHAT_COMPOSER: 'FOCUS_CHAT_COMPOSER',
+    LOCATE_MESSAGE: 'LOCATE_MESSAGE',
+    SEND_MESSAGE: 'SEND_MESSAGE'
+  },
+  EventEmitter: {
+    emit: mocks.eventEmit,
+    on: mocks.eventOn
+  }
+}))
+
+vi.mock('@renderer/components/chat/composer/ComposerToolRuntime', () => ({
+  ComposerToolRuntimeProvider: ({
+    children,
+    initialState
+  }: {
+    children: ReactNode
+    initialState?: { mentionedModels?: Model[]; selectedKnowledgeBases?: KnowledgeBase[] }
+  }) => {
+    if (mocks.mentionedModels === undefined) {
+      mocks.mentionedModels = initialState?.mentionedModels ?? []
+    }
+    if (mocks.selectedKnowledgeBases === undefined) {
+      mocks.selectedKnowledgeBases = initialState?.selectedKnowledgeBases ?? []
+    }
+    return <>{children}</>
+  },
+  ComposerToolDerivedStateProvider: ({
+    children,
+    couldAddImageFile,
+    extensions
+  }: {
+    children: ReactNode
+    couldAddImageFile: boolean
+    extensions: string[]
+  }) => {
+    mocks.derivedToolState = { couldAddImageFile, extensions }
+    return <>{children}</>
+  },
+  ComposerToolRuntimeHost: () => null,
+  ComposerToolMenu: () => <button type="button">tool menu</button>,
+  ComposerActiveToolControls: () => null,
+  useComposerTokenReconcile: () => mocks.reconcileTokens,
+  useComposerToolState: () => ({
+    files: mocks.files ?? [],
+    mentionedModels: mocks.mentionedModels ?? [],
+    selectedKnowledgeBases: mocks.selectedKnowledgeBases ?? [],
+    isExpanded: false,
+    couldAddImageFile: false,
+    extensions: []
+  }),
+  useComposerToolDispatch: () => ({
+    setFiles: mocks.setFiles,
+    setMentionedModels: mocks.setMentionedModels,
+    setSelectedKnowledgeBases: mocks.setSelectedKnowledgeBases,
+    setIsExpanded: mocks.setIsExpanded,
+    addNewTopic: vi.fn(),
+    onTextChange: vi.fn(),
+    toolsRegistry: {
+      registerLaunchers: vi.fn(() => vi.fn())
+    },
+    triggers: {
+      getLaunchers: vi.fn(() => []),
+      version: 0
+    }
+  }),
+  useComposerToolLauncherController: () => ({
+    getLaunchers: vi.fn(() => []),
+    dispatchLauncher: vi.fn()
+  }),
+  useComposerToolLauncherActions: () => ({
+    getLaunchers: vi.fn(() => []),
+    dispatchLauncher: vi.fn()
+  })
+}))
+
+vi.mock('@renderer/components/Avatar/ModelAvatar', () => ({
+  default: () => <span data-testid="model-avatar" />
+}))
+
+vi.mock('../SelectedModelsTrigger', () => ({
+  SelectedModelsTrigger: ({
+    models,
+    assistantModel,
+    fallbackLabel,
+    iconOnly,
+    className,
+    suppressSelectionPopover,
+    onModelsChange,
+    onRestore
+  }: any) => (
+    <div
+      data-testid="selected-models-trigger"
+      className={className}
+      data-assistant-model-id={assistantModel?.id ?? ''}
+      data-model-count={String(models.length)}
+      data-suppress-selection-popover={String(Boolean(suppressSelectionPopover))}>
+      <span className={iconOnly ? 'sr-only' : undefined}>
+        {models.length === 0 ? fallbackLabel : `${models[0].name} | Provider`}
+      </span>
+      <button
+        type="button"
+        onClick={() => onModelsChange(models.filter((currentModel: Model) => currentModel.id !== modelB.id))}>
+        trigger remove model 2
+      </button>
+      <button type="button" onClick={() => onModelsChange([])}>
+        trigger clear models
+      </button>
+      <button type="button" onClick={onRestore}>
+        trigger restore model
+      </button>
+    </div>
+  )
+}))
+
+vi.mock('@renderer/components/EmojiIcon', () => ({
+  default: ({ emoji }: { emoji: string }) => <span>{emoji}</span>
+}))
+
+vi.mock('@renderer/components/Selector', () => ({
+  AssistantSelector: ({ autoSelectOnCreate, onChange, trigger, value }: any) => (
+    <div
+      data-testid="assistant-selector"
+      data-value={value ?? ''}
+      data-auto-select-on-create={String(Boolean(autoSelectOnCreate))}>
+      {trigger}
+      <button type="button" onClick={() => onChange('assistant-2')}>
+        select assistant 2
+      </button>
+    </div>
+  ),
+  ModelSelector: ({
+    onSelect,
+    trigger,
+    multiple,
+    open,
+    onOpenChange,
+    value,
+    defaultMultiSelectMode,
+    multiSelectMode,
+    onMultiSelectModeChange
+  }: any) => (
+    <div
+      data-testid="model-selector"
+      data-multiple={String(multiple)}
+      data-open={String(Boolean(open))}
+      data-default-multi-select={String(Boolean(defaultMultiSelectMode))}
+      data-multi-select-mode={String(Boolean(multiSelectMode))}
+      data-value-count={Array.isArray(value) ? String(value.length) : ''}>
+      {trigger}
+      {onOpenChange ? (
+        <>
+          <button type="button" onClick={() => onOpenChange(true)}>
+            open model selector popup
+          </button>
+          <button type="button" onClick={() => onOpenChange(false)}>
+            close model selector popup
+          </button>
+        </>
+      ) : null}
+      <button
+        type="button"
+        onClick={() => {
+          const selectedModel = mocks.selectedModel ?? modelB
+          onSelect(multiple ? [selectedModel] : selectedModel)
+        }}>
+        select model 2
+      </button>
+      {multiple ? (
+        <>
+          <button type="button" onClick={() => onMultiSelectModeChange?.(!multiSelectMode)}>
+            toggle model multi select
+          </button>
+          <button type="button" onClick={() => onSelect([model, modelB])}>
+            select models 1 and 2
+          </button>
+          <button type="button" onClick={() => onSelect([])}>
+            clear model selection
+          </button>
+        </>
+      ) : null}
+    </div>
+  )
+}))
+
+vi.mock('@renderer/config/models', () => ({
+  getThinkModelType: () => 'default',
+  isEmbeddingModel: () => false,
+  isFunctionCallingModel: (currentModel?: Model) =>
+    currentModel?.capabilities.includes(MODEL_CAPABILITY.FUNCTION_CALL) ?? false,
+  isGenerateImageModel: () => false,
+  isGenerateImageModels: () => false,
+  isOpenRouterBuiltInWebSearchModel: () => false,
+  isRerankModel: () => false,
+  isSupportedReasoningEffortModel: () => false,
+  isSupportedThinkingTokenModel: () => false,
+  isVisionModel: () => false,
+  isVisionModels: () => false,
+  isWebSearchModel: () => false,
+  MODEL_SUPPORTED_OPTIONS: { default: ['none'] },
+  MODEL_SUPPORTED_REASONING_EFFORT: { default: ['none'] }
+}))
+
+vi.mock('@renderer/data/hooks/useCache', () => ({
+  useCache: (key: string) => (key === 'chat.multi_select_mode' ? [false] : [false, vi.fn()])
+}))
+
+vi.mock('@renderer/data/hooks/usePreference', () => ({
+  usePreference: (key: string) => {
+    const values: Record<string, unknown> = {
+      'app.spell_check.enabled': true,
+      'chat.message.font_size': 14,
+      'chat.narrow_mode': false,
+      'chat.input.send_message_shortcut': 'Enter'
+    }
+    return [values[key]]
+  }
+}))
+
+vi.mock('@renderer/hooks/ChatWriteContext', () => ({
+  useChatWrite: () => mocks.chatWrite ?? { pause: vi.fn() }
+}))
+
+vi.mock('@renderer/hooks/useAssistant', () => ({
+  useAssistant: () => ({
+    assistant: mocks.assistant,
+    isLoading: mocks.assistantLoading,
+    model: mocks.model,
+    isModelPending: mocks.modelPending,
+    isModelMissing: mocks.modelMissing ?? (!mocks.assistantLoading && !mocks.modelPending && !mocks.model),
+    setModel: mocks.setModel,
+    updateAssistant: mocks.updateAssistant
+  })
+}))
+
+vi.mock('@renderer/hooks/useKnowledgeBase', () => ({
+  useKnowledgeBases: () => ({ bases: mocks.knowledgeBases, isLoading: false })
+}))
+
+vi.mock('@renderer/hooks/useModel', () => ({
+  useDefaultModel: () => ({ setDefaultModel: mocks.setDefaultModel }),
+  useModels: () => ({ models: [model, modelB] })
+}))
+
+vi.mock('@renderer/hooks/useProvider', () => ({
+  getProviderDisplayName: () => 'Provider',
+  useProviderDisplayName: (providerId?: string) => (providerId ? 'Provider' : undefined),
+  useProviders: () => ({ providers: [{ id: 'provider', name: 'Provider' }] })
+}))
+
+vi.mock('@renderer/features/command', () => ({
+  useCommandHandler: (command: string, handler: () => void) => {
+    mocks.commandHandlers.set(command, handler)
+  }
+}))
+
+vi.mock('@renderer/hooks/useTopic', () => ({
+  useTopicMutations: () => ({
+    createTopic: mocks.createTopic,
+    updateTopic: mocks.updateTopic
+  })
+}))
+
+vi.mock('@renderer/hooks/useTopicAwaitingApproval', () => ({
+  useTopicAwaitingApproval: () => false
+}))
+
+vi.mock('@renderer/hooks/useTopicStreamStatus', () => ({
+  useTopicAwaitingApproval: () => false,
+  useTopicStreamStatus: () => ({ isPending: mocks.topicPending, isFulfilled: false, markSeen: () => {} })
+}))
+
+vi.mock('@shared/utils/model', () => ({
+  isFunctionCallingModel: (currentModel?: Model) =>
+    currentModel?.capabilities.includes(MODEL_CAPABILITY.FUNCTION_CALL) ?? false,
+  isNonChatModel: () => false,
+  isWebSearchModel: () => false
+}))
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactI18nextModule>()
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, options?: Record<string, unknown>) => {
+        if (key === 'common.selectedItems') return `${options?.count ?? 0} selected`
+        return String(options?.defaultValue ?? key)
+      }
+    })
+  }
+})
+
+const topic = {
+  id: 'topic-1',
+  assistantId: 'assistant-1',
+  type: 'chat'
+} as any
+
+const unlinkedTopic = {
+  id: 'topic-unlinked',
+  assistantId: undefined,
+  type: 'chat'
+} as any
+
+const missingAssistantTopic = {
+  id: 'topic-missing',
+  assistantId: 'missing-assistant',
+  type: 'chat'
+} as any
+
+const StartEditingOnMount = ({ enabled = true, message, parts }: { enabled?: boolean; message: any; parts: any }) => {
+  const { startEditing } = useMessageEditing()
+
+  useEffect(() => {
+    if (!enabled) return
+    startEditing(message, parts)
+  }, [enabled, message, parts, startEditing])
+
+  return null
+}
+
+const StartEditingButton = ({ message, parts }: { message: any; parts: any }) => {
+  const { startEditing } = useMessageEditing()
+
+  return (
+    <button type="button" onClick={() => startEditing(message, parts)}>
+      start editing
+    </button>
+  )
+}
+
+describe('ChatComposer', () => {
+  beforeEach(() => {
+    resizeObserverMockInstances.length = 0
+    globalThis.ResizeObserver = vi.fn((callback: ResizeObserverCallback) => {
+      const instance: ResizeObserverMockInstance = {
+        callback,
+        observe: vi.fn((target: Element) => {
+          instance.target = target
+        }),
+        disconnect: vi.fn()
+      }
+      resizeObserverMockInstances.push(instance)
+
+      return {
+        observe: instance.observe,
+        disconnect: instance.disconnect
+      } as unknown as ResizeObserver
+    }) as unknown as typeof ResizeObserver
+
+    vi.mocked(cacheService.getCasual).mockReset()
+    vi.mocked(cacheService.getCasual).mockReturnValue('')
+    vi.mocked(cacheService.setCasual).mockReset()
+    mocks.createTopic.mockReset()
+    mocks.updateTopic.mockReset()
+    mocks.setModel.mockReset()
+    mocks.setDefaultModel.mockReset()
+    mocks.setFiles.mockReset()
+    mocks.setFiles.mockImplementation((value) => {
+      mocks.files = typeof value === 'function' ? value(mocks.files ?? []) : value
+    })
+    mocks.setMentionedModels.mockReset()
+    mocks.setMentionedModels.mockImplementation((nextModels: Model[] | ((previous: Model[]) => Model[])) => {
+      mocks.mentionedModels = typeof nextModels === 'function' ? nextModels(mocks.mentionedModels ?? []) : nextModels
+    })
+    mocks.setSelectedKnowledgeBases.mockReset()
+    mocks.setSelectedKnowledgeBases.mockImplementation(
+      (nextBases: KnowledgeBase[] | ((previousBases: KnowledgeBase[]) => KnowledgeBase[])) => {
+        const previousBases = mocks.selectedKnowledgeBases ?? []
+        mocks.selectedKnowledgeBases = typeof nextBases === 'function' ? nextBases(previousBases) : nextBases
+      }
+    )
+    mocks.setIsExpanded.mockReset()
+    mocks.updateAssistant.mockReset()
+    mocks.toastError.mockReset()
+    mocks.focusComposer.mockReset()
+    mocks.insertToken.mockReset()
+    mocks.getDraft.mockReset()
+    mocks.getDraft.mockReturnValue({ text: 'original draft', tokens: [] })
+    mocks.reconcileTokens.mockReset()
+    mocks.reconcileTokens.mockImplementation((draftTokens: readonly ComposerSerializedToken[]) => {
+      const knowledgeTokenIds = new Set(
+        draftTokens.filter((token) => token.kind === 'knowledge').map((token) => token.id)
+      )
+      const configuredKnowledgeBaseIds = new Set(mocks.assistant?.knowledgeBaseIds ?? [])
+      const selectableKnowledgeBases = mocks.knowledgeBases.filter((base) => configuredKnowledgeBaseIds.has(base.id))
+      mocks.setSelectedKnowledgeBases((previousBases: KnowledgeBase[]) => {
+        const nextBases = previousBases.filter((base) => knowledgeTokenIds.has(`knowledge:${base.id}`))
+        const nextBaseIds = new Set(nextBases.map((base) => `knowledge:${base.id}`))
+        let changed = nextBases.length !== previousBases.length
+
+        for (const base of selectableKnowledgeBases) {
+          const tokenId = `knowledge:${base.id}`
+          if (!knowledgeTokenIds.has(tokenId) || nextBaseIds.has(tokenId)) continue
+          nextBases.push(base)
+          nextBaseIds.add(tokenId)
+          changed = true
+        }
+
+        return changed ? nextBases : previousBases
+      })
+    })
+    mocks.commandHandlers.clear()
+    mocks.eventListeners.clear()
+    mocks.eventEmit.mockReset()
+    mocks.eventOn.mockReset()
+    mocks.eventOn.mockImplementation((eventName: string, listener: (payload: unknown) => void) => {
+      mocks.eventListeners.set(eventName, listener)
+      return () => mocks.eventListeners.delete(eventName)
+    })
+    mocks.mentionedModels = undefined
+    mocks.selectedKnowledgeBases = undefined
+    mocks.files = undefined
+    mocks.knowledgeBases = []
+    mocks.assistant = {
+      id: 'assistant-1',
+      name: 'Assistant 1',
+      emoji: 'A',
+      modelId: model.id,
+      settings: { enableWebSearch: true },
+      knowledgeBaseIds: []
+    }
+    mocks.model = model
+    mocks.assistantLoading = false
+    mocks.modelPending = false
+    mocks.modelMissing = undefined
+    mocks.selectedModel = undefined
+    mocks.topicPending = false
+    mocks.surfaceProps = undefined
+    mocks.derivedToolState = undefined
+    mocks.ipcListeners.clear()
+    mocks.ipcOn.mockReset()
+    mocks.chatWrite = undefined
+    mocks.ipcOn.mockImplementation((channel: string, listener: (_event: unknown, payload: unknown) => void) => {
+      mocks.ipcListeners.set(channel, listener)
+      return () => mocks.ipcListeners.delete(channel)
+    })
+    Object.defineProperty(window, 'electron', {
+      configurable: true,
+      value: {
+        ipcRenderer: {
+          on: mocks.ipcOn
+        }
+      }
+    })
+    Object.defineProperty(window, 'toast', {
+      configurable: true,
+      value: { error: mocks.toastError }
+    })
+  })
+
+  afterEach(() => {
+    globalThis.ResizeObserver = originalResizeObserver
+  })
+
+  it('renders the tool menu before assistant and model selectors', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(screen.getByText('tool menu')).toBeInTheDocument()
+    expect(screen.getByText('Assistant 1')).toBeInTheDocument()
+    expect(screen.getByText('Model A | Provider')).toBeInTheDocument()
+  })
+
+  it('does not enable skill marker paste handling', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(mocks.surfaceProps?.resolveSkillMarker).toBeUndefined()
+  })
+
+  it('focuses only the current topic composer from the focus event', async () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(mocks.eventOn).toHaveBeenCalledWith('FOCUS_CHAT_COMPOSER', expect.any(Function))
+    })
+
+    act(() => {
+      mocks.eventListeners.get('FOCUS_CHAT_COMPOSER')?.({ topicId: 'other-topic' })
+    })
+    expect(mocks.focusComposer).not.toHaveBeenCalled()
+
+    act(() => {
+      mocks.eventListeners.get('FOCUS_CHAT_COMPOSER')?.({ topicId: 'topic-1' })
+    })
+    expect(mocks.focusComposer).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows only icons in the input bottom toolbar when it is narrow', async () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(screen.getByText('Assistant 1')).not.toHaveClass('sr-only')
+    expect(screen.getByText('Model A | Provider')).not.toHaveClass('sr-only')
+
+    await notifyComposerBottomToolbarWidth(420)
+
+    await waitFor(() => {
+      expect(screen.getByText('Assistant 1')).toHaveClass('sr-only')
+      expect(screen.getByText('Model A | Provider')).toHaveClass('sr-only')
+    })
+  })
+
+  it('keeps input bottom toolbar labels visible when the toolbar fits', async () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    await notifyComposerBottomToolbarWidth(420, 420)
+
+    expect(screen.getByText('Assistant 1')).not.toHaveClass('sr-only')
+    expect(screen.getByText('Model A | Provider')).not.toHaveClass('sr-only')
+  })
+
+  it('passes attachment capabilities through the provider without effect mirroring', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(mocks.derivedToolState).toEqual({
+      couldAddImageFile: false,
+      extensions: mocks.surfaceProps?.supportedExts
+    })
+  })
+
+  it('inserts quoted selected text as a quote token from the main-window quote IPC', async () => {
+    vi.mocked(cacheService.getCasual).mockReturnValue('Existing draft')
+
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(mocks.ipcOn).toHaveBeenCalledWith(IpcChannel.App_QuoteToMain, expect.any(Function))
+    })
+
+    act(() => {
+      mocks.ipcListeners.get(IpcChannel.App_QuoteToMain)?.({}, 'Selected message text')
+    })
+
+    expect(mocks.insertToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'quote',
+        label: 'selection.action.builtin.quote',
+        description: 'Selected message text',
+        promptText: '<blockquote>\n\nSelected message text\n</blockquote>'
+      })
+    )
+    expect(mocks.surfaceProps?.text).toBe('Existing draft')
+  })
+
+  it('updates the topic assistant from the composer toolbar', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('select assistant 2'))
+
+    expect(mocks.updateTopic).toHaveBeenCalledWith('topic-1', { assistantId: 'assistant-2' })
+  })
+
+  it('updates the assistant model from the composer toolbar', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('select model 2'))
+
+    expect(mocks.setModel).toHaveBeenCalledWith(modelB, { enableWebSearch: false })
+  })
+
+  it('keeps web search enabled when switching to a function-calling model', () => {
+    mocks.selectedModel = modelBWithFunctionCall
+
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('select model 2'))
+
+    expect(mocks.setModel).toHaveBeenCalledWith(modelBWithFunctionCall, { enableWebSearch: true })
+  })
+
+  it('uses mentioned-model multi-select when requested by the composer toolbar', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} useMentionedModelSelector />)
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-multiple', 'true')
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+
+    fireEvent.click(screen.getByText('toggle model multi select'))
+    fireEvent.click(screen.getByText('select models 1 and 2'))
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-multi-select-mode', 'true')
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '2')
+    expect(mocks.setMentionedModels).toHaveBeenCalledWith([model, modelB])
+    expect(mocks.setModel).not.toHaveBeenCalled()
+  })
+
+  it('sets the assistant model from the first mentioned model before sending when multi-selecting without a configured model', async () => {
+    mocks.assistant = {
+      ...mocks.assistant,
+      modelId: null
+    }
+    mocks.model = undefined
+    const onSend = vi.fn()
+
+    render(<ChatComposer topic={topic} onSend={onSend} useMentionedModelSelector />)
+
+    fireEvent.click(screen.getByText('toggle model multi select'))
+    fireEvent.click(screen.getByText('select models 1 and 2'))
+
+    expect(mocks.setMentionedModels).toHaveBeenCalledWith([model, modelB])
+    expect(mocks.setModel).not.toHaveBeenCalled()
+
+    await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [] })
+
+    expect(mocks.setModel).toHaveBeenCalledWith(model, { enableWebSearch: false })
+    expect(onSend).toHaveBeenCalledWith(
+      'hello',
+      expect.objectContaining({
+        mentionedModels: [model.id, modelB.id]
+      })
+    )
+  })
+
+  it('suppresses the selected-model trigger popover while the mentioned-model selector is open', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} useMentionedModelSelector />)
+
+    expect(screen.getByTestId('selected-models-trigger')).toHaveAttribute('data-suppress-selection-popover', 'false')
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-open', 'false')
+
+    fireEvent.click(screen.getByText('open model selector popup'))
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-open', 'true')
+    expect(screen.getByTestId('selected-models-trigger')).toHaveAttribute('data-suppress-selection-popover', 'true')
+
+    fireEvent.click(screen.getByText('close model selector popup'))
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-open', 'false')
+    expect(screen.getByTestId('selected-models-trigger')).toHaveAttribute('data-suppress-selection-popover', 'false')
+  })
+
+  it('updates the assistant model from the home model selector in single-select mode', () => {
+    render(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('select model 2'))
+
+    expect(mocks.setModel).toHaveBeenCalledWith(modelB, { enableWebSearch: false })
+    expect(mocks.setMentionedModels).toHaveBeenCalledWith([])
+  })
+
+  it('does not expose selected models as editor tokens', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} useMentionedModelSelector />)
+
+    fireEvent.click(screen.getByText('toggle model multi select'))
+    fireEvent.click(screen.getByText('select models 1 and 2'))
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '2')
+
+    expect(mocks.surfaceProps?.tokens.map((token) => token.kind)).not.toContain('model')
+    expect(screen.queryByTestId('remove-token-model:provider::model-a')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('remove-token-model:provider::model-b')).not.toBeInTheDocument()
+  })
+
+  it('updates mentioned models when the selected-model trigger removes one model', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} useMentionedModelSelector />)
+
+    fireEvent.click(screen.getByText('toggle model multi select'))
+    fireEvent.click(screen.getByText('select models 1 and 2'))
+    expect(screen.getByTestId('selected-models-trigger')).toHaveAttribute('data-model-count', '2')
+
+    fireEvent.click(screen.getByText('trigger remove model 2'))
+
+    expect(mocks.setMentionedModels).toHaveBeenLastCalledWith([model])
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+    expect(mocks.setModel).not.toHaveBeenCalled()
+  })
+
+  it('keeps an empty mentioned-model selection when the selected-model trigger removes the last model', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} useMentionedModelSelector />)
+
+    fireEvent.click(screen.getByText('toggle model multi select'))
+    fireEvent.click(screen.getByText('select models 1 and 2'))
+
+    fireEvent.click(screen.getByText('trigger clear models'))
+
+    expect(mocks.setMentionedModels).toHaveBeenLastCalledWith([])
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '0')
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-multi-select-mode', 'true')
+    expect(mocks.surfaceProps?.sendDisabled).toBe(true)
+    expect(mocks.surfaceProps?.sendBlockedReason).toBe('code.model_required')
+    expect(mocks.setModel).not.toHaveBeenCalled()
+  })
+
+  it('restores the selected-model trigger to the current assistant model', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} useMentionedModelSelector />)
+
+    fireEvent.click(screen.getByText('toggle model multi select'))
+    fireEvent.click(screen.getByText('select models 1 and 2'))
+
+    fireEvent.click(screen.getByText('trigger restore model'))
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-multi-select-mode', 'false')
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+    expect(screen.getByTestId('selected-models-trigger')).toHaveAttribute('data-assistant-model-id', model.id)
+    expect(mocks.setMentionedModels).toHaveBeenLastCalledWith([])
+    expect(mocks.setModel).not.toHaveBeenCalled()
+  })
+
+  it('does not update the default model while a persisted assistant is loading', () => {
+    mocks.assistant = undefined
+    mocks.model = undefined
+
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('select model 2'))
+
+    expect(mocks.setDefaultModel).not.toHaveBeenCalled()
+    expect(mocks.setModel).not.toHaveBeenCalled()
+  })
+
+  it('shows model selection instead of a fallback model when the assistant has no configured model', () => {
+    mocks.assistant = {
+      ...mocks.assistant,
+      modelId: null
+    }
+    mocks.model = undefined
+
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(screen.getByText('button.select_model')).toBeInTheDocument()
+    expect(mocks.surfaceProps?.sendDisabled).toBe(true)
+    expect(mocks.surfaceProps?.sendBlockedReason).toBe('code.model_required')
+  })
+
+  it('shows assistant selection with the default model for unlinked home topics', () => {
+    mocks.assistant = undefined
+
+    render(<ChatHomeComposer topic={unlinkedTopic} onSend={vi.fn()} />)
+
+    expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('button.select_assistant')
+    expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Model A | Provider')
+    expect(screen.getByTestId('composer-below-controls')).not.toHaveTextContent('Default Assistant')
+    expect(screen.getByTestId('assistant-selector')).toHaveAttribute('data-value', '')
+    expect(mocks.surfaceProps?.sendBlockedReason).toBeUndefined()
+  })
+
+  it('sends unlinked home topics through the default model fallback', async () => {
+    mocks.assistant = undefined
+    const onSend = vi.fn()
+
+    render(<ChatHomeComposer topic={unlinkedTopic} onSend={onSend} />)
+
+    await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [] })
+
+    expect(onSend).toHaveBeenCalledWith(
+      'hello',
+      expect.objectContaining({
+        mentionedModels: undefined
+      })
+    )
+    expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+
+  it('blocks sends for missing-assistant topics until a new assistant is selected', async () => {
+    mocks.assistant = undefined
+    const onSend = vi.fn()
+
+    render(<ChatComposer topic={missingAssistantTopic} onSend={onSend} />)
+
+    await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [] })
+    fireEvent.click(screen.getByText('select assistant 2'))
+
+    expect(onSend).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledWith('button.select_assistant')
+    expect(mocks.updateTopic).toHaveBeenCalledWith('topic-missing', { assistantId: 'assistant-2' })
+    expect(mocks.setDefaultModel).not.toHaveBeenCalled()
+  })
+
+  it('does not auto-select assistants created from a persisted topic', () => {
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(screen.getByTestId('assistant-selector')).toHaveAttribute('data-auto-select-on-create', 'false')
+  })
+
+  it('shows a loading model state while the assistant model is resolving', () => {
+    mocks.assistant = undefined
+    mocks.model = undefined
+    mocks.assistantLoading = true
+    mocks.modelPending = true
+
+    render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(screen.getAllByText('common.loading').length).toBeGreaterThan(0)
+    expect(screen.queryByText('button.select_model')).not.toBeInTheDocument()
+    expect(mocks.surfaceProps?.sendDisabled).toBe(true)
+    expect(mocks.surfaceProps?.sendBlockedReason).toBeUndefined()
+  })
+
+  it('blocks send with a model-required toast when the assistant has no configured model', async () => {
+    mocks.assistant = {
+      ...mocks.assistant,
+      modelId: null
+    }
+    mocks.model = undefined
+    const onSend = vi.fn()
+
+    render(<ChatComposer topic={topic} onSend={onSend} />)
+
+    await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [] })
+
+    expect(onSend).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledWith('code.model_required')
+  })
+
+  it('queues a follow-up while the topic is streaming (does not send directly)', async () => {
+    mocks.topicPending = true
+    const onSend = vi.fn().mockResolvedValue(undefined)
+
+    render(<ChatComposer topic={topic} onSend={onSend} />)
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [] })
+    })
+
+    // Busy → the message is queued, not sent; the dock surfaces through `queueContent`.
+    expect(onSend).not.toHaveBeenCalled()
+    expect(mocks.surfaceProps?.queueContent).toBeTruthy()
+  })
+
+  it('keeps the current draft when sending a new message fails', async () => {
+    const onSend = vi.fn().mockRejectedValue(new Error('open failed'))
+
+    render(<ChatComposer topic={topic} onSend={onSend} />)
+
+    act(() => {
+      mocks.surfaceProps?.onTextChange('draft message')
+    })
+    await waitFor(() => expect(mocks.surfaceProps?.text).toBe('draft message'))
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({ text: 'draft message', tokens: [] })
+    })
+
+    expect(onSend).toHaveBeenCalledWith(
+      'draft message',
+      expect.objectContaining({
+        userMessageParts: [expect.objectContaining({ type: 'text', text: 'draft message' })]
+      })
+    )
+    expect(mocks.surfaceProps?.text).toBe('draft message')
+  })
+
+  it('routes new topic shortcuts through the explicit parent action', () => {
+    const onNewTopic = vi.fn()
+    render(<ChatComposer topic={topic} onSend={vi.fn()} onNewTopic={onNewTopic} />)
+
+    mocks.commandHandlers.get('topic.create')?.()
+
+    expect(onNewTopic).toHaveBeenCalledWith(undefined)
+    expect(mocks.createTopic).not.toHaveBeenCalled()
+  })
+
+  it('renders selectors below the surface in temporary home mode', () => {
+    render(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(screen.getByTestId('composer-left-controls')).toHaveTextContent('tool menu')
+    expect(screen.getByTestId('composer-left-controls')).not.toHaveTextContent('Assistant 1')
+    expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Assistant 1')
+    expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Model A | Provider')
+  })
+
+  it('shows only icons in the temporary home bottom toolbar when it is narrow', async () => {
+    render(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(screen.getByText('Assistant 1')).not.toHaveClass('sr-only')
+    expect(screen.getByText('Model A | Provider')).not.toHaveClass('sr-only')
+
+    await notifyComposerBottomToolbarWidth(420)
+
+    await waitFor(() => {
+      expect(screen.getByText('Assistant 1')).toHaveClass('sr-only')
+      expect(screen.getByText('Model A | Provider')).toHaveClass('sr-only')
+      expect(screen.getByTestId('selected-models-trigger')).toHaveClass('w-8')
+    })
+  })
+
+  it('routes temporary home assistant changes to the temporary handler', async () => {
+    const onTemporaryAssistantChange = vi.fn()
+    const view = render(
+      <ChatHomeComposer topic={topic} onSend={vi.fn()} onTemporaryAssistantChange={onTemporaryAssistantChange} />
+    )
+
+    expect(screen.getByTestId('assistant-selector')).toHaveAttribute('data-auto-select-on-create', 'true')
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+    expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Model A | Provider')
+    expect(mocks.setMentionedModels).not.toHaveBeenCalledWith([model])
+    mocks.setMentionedModels.mockClear()
+
+    fireEvent.click(screen.getByText('select assistant 2'))
+
+    mocks.assistant = { ...mocks.assistant, id: 'assistant-2' }
+    mocks.model = modelB
+    mocks.mentionedModels = []
+    view.rerender(
+      <ChatHomeComposer
+        topic={{ ...topic, assistantId: 'assistant-2' }}
+        onSend={vi.fn()}
+        onTemporaryAssistantChange={onTemporaryAssistantChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+      expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Model B | Provider')
+    })
+    expect(mocks.setMentionedModels).not.toHaveBeenCalledWith([modelB])
+    expect(onTemporaryAssistantChange).toHaveBeenCalledWith('assistant-2')
+    expect(mocks.updateTopic).not.toHaveBeenCalled()
+  })
+
+  it('uses the temporary home model selector as single-select until multi-select is enabled', async () => {
+    const view = render(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
+
+    const selector = screen.getByTestId('model-selector')
+    expect(selector).toHaveAttribute('data-multiple', 'true')
+    expect(selector).toHaveAttribute('data-default-multi-select', 'false')
+    expect(selector).toHaveAttribute('data-multi-select-mode', 'false')
+    expect(selector).toHaveAttribute('data-value-count', '1')
+
+    fireEvent.click(screen.getByText('select model 2'))
+
+    expect(mocks.setMentionedModels).toHaveBeenCalledWith([])
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+    expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Model B')
+    expect(mocks.setModel).toHaveBeenCalledWith(modelB, { enableWebSearch: false })
+
+    mocks.model = undefined
+    mocks.modelPending = true
+    view.rerender(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+      expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Model B')
+    })
+  })
+
+  it('does not hydrate temporary home model selection from mentioned-model cache', () => {
+    vi.mocked(cacheService.getCasual).mockImplementation((key: string) =>
+      key.startsWith('inputbar-mentioned-models-') ? [model, modelB] : ''
+    )
+
+    render(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+    expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Model A | Provider')
+  })
+
+  it('does not hydrate the docked model selector from mentioned-model cache', () => {
+    vi.mocked(cacheService.getCasual).mockImplementation((key: string) =>
+      key.startsWith('inputbar-mentioned-models-') ? [model, modelB] : ''
+    )
+
+    render(<ChatComposer topic={topic} onSend={vi.fn()} useMentionedModelSelector />)
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+    expect(screen.getByText('Model A | Provider')).toBeInTheDocument()
+  })
+
+  it('does not read or write mentioned-model rich-text cache', () => {
+    const { unmount } = render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    unmount()
+
+    expect(cacheService.getCasual).not.toHaveBeenCalledWith(expect.stringMatching(/^inputbar-mentioned-models-/))
+    expect(cacheService.setCasual).not.toHaveBeenCalledWith(
+      expect.stringMatching(/^inputbar-mentioned-models-/),
+      expect.anything(),
+      expect.anything()
+    )
+  })
+
+  it('sends selected model ids from the model selector without editor model tokens', async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined)
+    render(<ChatHomeComposer topic={topic} onSend={onSend} />)
+
+    fireEvent.click(screen.getByText('toggle model multi select'))
+    fireEvent.click(screen.getByText('select models 1 and 2'))
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-multi-select-mode', 'true')
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '2')
+    expect(mocks.setMentionedModels).toHaveBeenCalledWith([model, modelB])
+    expect(mocks.surfaceProps?.tokens.map((token) => token.kind)).not.toContain('model')
+
+    await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [] })
+
+    expect(onSend).toHaveBeenCalledWith(
+      'hello',
+      expect.objectContaining({
+        mentionedModels: [model.id, modelB.id],
+        userMessageParts: [{ type: 'text', text: 'hello' }]
+      })
+    )
+  })
+
+  it('hydrates Composer from an edited message and restores the previous draft on cancel', async () => {
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+    const parts = [
+      {
+        type: 'text',
+        text: '<blockquote>\n\nSelected text\n</blockquote>\n\nFollow up',
+        providerMetadata: {
+          cherry: {
+            composer: {
+              version: 1,
+              tokens: [
+                {
+                  id: 'quote-1',
+                  kind: 'quote',
+                  label: 'Quote',
+                  description: 'Selected text',
+                  index: 0,
+                  textOffset: 0,
+                  promptText: '<blockquote>\n\nSelected text\n</blockquote>'
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        type: 'file',
+        url: 'file:///tmp/default-topic.png',
+        mediaType: '.png',
+        filename: 'default-topic.png'
+      },
+      {
+        type: 'file',
+        url: 'file:///tmp/report.pdf',
+        mediaType: '.pdf',
+        filename: 'report.pdf'
+      }
+    ] as any[]
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingOnMount message={message as any} parts={parts as any} />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+    expect(mocks.surfaceProps?.text).toBe('<blockquote>\n\nSelected text\n</blockquote>\n\nFollow up')
+    expect(mocks.surfaceProps?.draftTokens).toEqual([
+      expect.objectContaining({
+        id: 'quote-1',
+        kind: 'quote',
+        label: 'Quote',
+        textOffset: 0
+      })
+    ])
+    expect(mocks.surfaceProps?.tokens).toEqual([
+      expect.objectContaining({
+        kind: 'file',
+        label: 'default-topic.png',
+        payload: expect.objectContaining({
+          type: 'image',
+          ext: '.png',
+          name: 'default-topic.png',
+          origin_name: 'default-topic.png'
+        })
+      }),
+      expect.objectContaining({
+        kind: 'file',
+        label: 'report.pdf',
+        payload: expect.objectContaining({
+          type: 'document',
+          ext: '.pdf',
+          name: 'report.pdf',
+          origin_name: 'report.pdf'
+        })
+      })
+    ])
+    expect(mocks.surfaceProps?.tokens).not.toEqual([
+      expect.objectContaining({
+        kind: 'file',
+        label: 'default-topic.png',
+        payload: expect.objectContaining({
+          type: 'document'
+        })
+      }),
+      expect.objectContaining({
+        kind: 'file',
+        label: 'report.pdf'
+      })
+    ])
+
+    act(() => {
+      mocks.surfaceProps?.editingState?.onCancel()
+    })
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState).toBeUndefined())
+    expect(mocks.surfaceProps?.text).toBe('original draft')
+  })
+
+  it('restores the edited message draft only once per editing session', async () => {
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+    const parts = [{ type: 'text', text: 'old' }] as any
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingButton message={message as any} parts={parts} />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps).toBeDefined())
+    mocks.setFiles.mockClear()
+    mocks.setSelectedKnowledgeBases.mockClear()
+    mocks.getDraft.mockClear()
+
+    fireEvent.click(screen.getByRole('button', { name: 'start editing' }))
+
+    await waitFor(() => expect(mocks.surfaceProps?.text).toBe('old'))
+
+    expect(mocks.setFiles).toHaveBeenCalledTimes(1)
+    expect(mocks.setSelectedKnowledgeBases).toHaveBeenCalledTimes(1)
+    expect(mocks.getDraft).toHaveBeenCalledTimes(1)
+  })
+
+  it('locates the edited message from the Composer editing state', async () => {
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingOnMount message={message as any} parts={[{ type: 'text', text: 'old' }] as any} />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+
+    act(() => {
+      mocks.surfaceProps?.editingState?.onLocate?.()
+    })
+
+    expect(mocks.eventEmit).toHaveBeenCalledWith('LOCATE_MESSAGE:message-1', true)
+  })
+
+  it('passes a new composer highlight key for each edit trigger', async () => {
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+    const parts = [{ type: 'text', text: 'old' }] as any
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingButton message={message as any} parts={parts} />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'start editing' }))
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+    const firstHighlightKey = mocks.surfaceProps?.editingState?.highlightKey
+    expect(firstHighlightKey).toEqual(expect.any(Number))
+    if (typeof firstHighlightKey !== 'number') throw new Error('Expected first highlight key')
+
+    fireEvent.click(screen.getByRole('button', { name: 'start editing' }))
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.highlightKey).toBeGreaterThan(firstHighlightKey))
+  })
+
+  it('exits edit mode and restores the saved draft when the topic changes', async () => {
+    const forkAndResend = vi.fn().mockResolvedValue(undefined)
+    mocks.chatWrite = { pause: vi.fn(), editMessage: vi.fn(), resend: vi.fn(), forkAndResend }
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+    const nextTopic = { ...topic, id: 'topic-2' }
+    const onSend = vi.fn().mockResolvedValue(undefined)
+    const view = render(
+      <MessageEditingProvider>
+        <StartEditingOnMount message={message as any} parts={[{ type: 'text', text: 'old' }] as any} />
+        <ChatComposer topic={topic} onSend={onSend} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+    expect(mocks.surfaceProps?.text).toBe('old')
+
+    view.rerender(
+      <MessageEditingProvider>
+        <StartEditingOnMount enabled={false} message={message as any} parts={[{ type: 'text', text: 'old' }] as any} />
+        <ChatComposer topic={nextTopic} onSend={onSend} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState).toBeUndefined())
+    expect(mocks.surfaceProps?.text).toBe('original draft')
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({ text: 'topic 2 draft', tokens: [] })
+    })
+
+    expect(forkAndResend).not.toHaveBeenCalled()
+    expect(onSend).toHaveBeenCalledWith(
+      'topic 2 draft',
+      expect.objectContaining({
+        userMessageParts: [{ type: 'text', text: 'topic 2 draft' }]
+      })
+    )
+  })
+
+  it('preserves Cherry file metadata when resending an edited message with an existing attachment', async () => {
+    const editMessage = vi.fn().mockResolvedValue(undefined)
+    const resend = vi.fn().mockResolvedValue(undefined)
+    const forkAndResend = vi.fn().mockResolvedValue(undefined)
+    mocks.chatWrite = { pause: vi.fn(), editMessage, resend, forkAndResend }
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+    const filePart = {
+      type: 'file',
+      url: 'file:///tmp/report.pdf',
+      mediaType: 'application/pdf',
+      filename: 'report.pdf',
+      providerMetadata: {
+        cherry: {
+          fileEntryId: 'file-entry-1'
+        }
+      }
+    }
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingOnMount message={message as any} parts={[{ type: 'text', text: 'old text' }, filePart] as any} />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+    const fileToken = mocks.surfaceProps?.tokens.find((token) => token.kind === 'file')
+    expect(fileToken).toBeDefined()
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({
+        text: 'new text',
+        tokens: [serializeComposerToken(fileToken!)]
+      })
+    })
+
+    const editedParts = forkAndResend.mock.calls[0]?.[1] as Array<Record<string, unknown>>
+    expect(editedParts.find((part) => part.type === 'file')).toEqual(filePart)
+    expect(forkAndResend).toHaveBeenCalledWith('message-1', expect.any(Array))
+    expect(editMessage).not.toHaveBeenCalled()
+    expect(resend).not.toHaveBeenCalled()
+  })
+
+  it('keeps edited message file tokens at their persisted text offsets', async () => {
+    const editMessage = vi.fn().mockResolvedValue(undefined)
+    const resend = vi.fn().mockResolvedValue(undefined)
+    const forkAndResend = vi.fn().mockResolvedValue(undefined)
+    mocks.chatWrite = { pause: vi.fn(), editMessage, resend, forkAndResend }
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+    const filePart = {
+      type: 'file',
+      url: 'file:///tmp/test.pdf',
+      mediaType: 'application/pdf',
+      filename: 'test.pdf',
+      providerMetadata: {
+        cherry: {
+          fileEntryId: 'file-entry-1'
+        }
+      }
+    }
+    const fileToken: ComposerSerializedToken = {
+      id: 'file:file-entry-1',
+      kind: 'file',
+      label: 'test.pdf',
+      index: 0,
+      textOffset: 0,
+      promptText: 'test.pdf',
+      payload: {
+        type: 'document',
+        ext: '.pdf',
+        name: 'test.pdf',
+        origin_name: 'test.pdf'
+      }
+    }
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingOnMount
+          message={message as any}
+          parts={
+            [
+              {
+                type: 'text',
+                text: 'test.pdf 你好',
+                providerMetadata: {
+                  cherry: {
+                    composer: {
+                      version: 1,
+                      tokens: [fileToken]
+                    }
+                  }
+                }
+              },
+              filePart
+            ] as any
+          }
+        />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+    expect(mocks.surfaceProps?.draftTokens).toEqual([expect.objectContaining(fileToken)])
+    expect(mocks.surfaceProps?.tokens).toEqual([expect.objectContaining({ id: fileToken.id, kind: 'file' })])
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({
+        text: 'test.pdf 你好',
+        tokens: [fileToken]
+      })
+    })
+
+    const editedParts = forkAndResend.mock.calls[0]?.[1] as Array<Record<string, any>>
+    expect(editedParts[0]).toMatchObject({
+      type: 'text',
+      text: 'test.pdf 你好',
+      providerMetadata: {
+        cherry: {
+          composer: {
+            tokens: [expect.objectContaining({ id: fileToken.id, kind: 'file', textOffset: 0 })]
+          }
+        }
+      }
+    })
+    expect(editedParts.find((part) => part.type === 'file')).toEqual(filePart)
+    expect(editMessage).not.toHaveBeenCalled()
+    expect(resend).not.toHaveBeenCalled()
+  })
+
+  it('re-links multiple edited file tokens to their original parts by source id regardless of order', async () => {
+    const editMessage = vi.fn().mockResolvedValue(undefined)
+    const resend = vi.fn().mockResolvedValue(undefined)
+    const forkAndResend = vi.fn().mockResolvedValue(undefined)
+    mocks.chatWrite = { pause: vi.fn(), editMessage, resend, forkAndResend }
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+    const pdfPart = {
+      type: 'file',
+      url: 'file:///tmp/a.pdf',
+      mediaType: 'application/pdf',
+      filename: 'a.pdf',
+      providerMetadata: { cherry: { fileEntryId: 'entry-pdf' } }
+    }
+    const pngPart = {
+      type: 'file',
+      url: 'file:///tmp/b.png',
+      mediaType: '.png',
+      filename: 'b.png',
+      providerMetadata: { cherry: { fileEntryId: 'entry-png' } }
+    }
+    const pdfToken: ComposerSerializedToken = {
+      id: 'file:entry-pdf',
+      kind: 'file',
+      label: 'a.pdf',
+      index: 1,
+      textOffset: 0,
+      promptText: 'a.pdf',
+      payload: { type: 'document', ext: '.pdf', name: 'a.pdf', origin_name: 'a.pdf' }
+    }
+    const pngToken: ComposerSerializedToken = {
+      id: 'file:entry-png',
+      kind: 'file',
+      label: 'b.png',
+      index: 0,
+      textOffset: 6,
+      promptText: 'b.png',
+      payload: { type: 'image', ext: '.png', name: 'b.png', origin_name: 'b.png' }
+    }
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingOnMount
+          message={message as any}
+          parts={
+            [
+              {
+                type: 'text',
+                text: 'a.pdf b.png',
+                // Stored token order is intentionally reversed relative to text offset to prove
+                // matching is by source id, not document position.
+                providerMetadata: { cherry: { composer: { version: 1, tokens: [pngToken, pdfToken] } } }
+              },
+              pngPart,
+              pdfPart
+            ] as any
+          }
+        />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({ text: 'a.pdf b.png', tokens: [pdfToken, pngToken] })
+    })
+
+    const editedParts = forkAndResend.mock.calls[0]?.[1] as Array<Record<string, any>>
+    const fileParts = editedParts.filter((part) => part.type === 'file')
+    // Both originals are reused verbatim (no re-attachment as new files), each linked to the
+    // correct part by fileEntryId despite the reversed token order.
+    expect(fileParts).toEqual([pngPart, pdfPart])
+    expect(editMessage).not.toHaveBeenCalled()
+    expect(resend).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the sole remaining file token when no source id matches', async () => {
+    const editMessage = vi.fn().mockResolvedValue(undefined)
+    const resend = vi.fn().mockResolvedValue(undefined)
+    const forkAndResend = vi.fn().mockResolvedValue(undefined)
+    mocks.chatWrite = { pause: vi.fn(), editMessage, resend, forkAndResend }
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+    // Neither the part's fileEntryId nor its url equals the token source id, so only the
+    // single-unused-token fallback can keep the attachment linked.
+    const filePart = {
+      type: 'file',
+      url: 'file:///tmp/x.pdf',
+      mediaType: 'application/pdf',
+      filename: 'x.pdf',
+      providerMetadata: { cherry: { fileEntryId: 'real-1' } }
+    }
+    const ghostToken: ComposerSerializedToken = {
+      id: 'file:ghost',
+      kind: 'file',
+      label: 'x.pdf',
+      index: 0,
+      textOffset: 0,
+      promptText: 'x.pdf',
+      payload: { type: 'document', ext: '.pdf', name: 'x.pdf', origin_name: 'x.pdf' }
+    }
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingOnMount
+          message={message as any}
+          parts={
+            [
+              {
+                type: 'text',
+                text: 'x.pdf 你好',
+                providerMetadata: { cherry: { composer: { version: 1, tokens: [ghostToken] } } }
+              },
+              filePart
+            ] as any
+          }
+        />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({ text: 'x.pdf 你好', tokens: [ghostToken] })
+    })
+
+    const editedParts = forkAndResend.mock.calls[0]?.[1] as Array<Record<string, any>>
+    // The attachment is preserved (reused verbatim), not dropped, via the unambiguous fallback.
+    expect(editedParts.find((part) => part.type === 'file')).toEqual(filePart)
+    expect(editMessage).not.toHaveBeenCalled()
+    expect(resend).not.toHaveBeenCalled()
+  })
+
+  it('keeps editable knowledge tokens when forking and resending an edited message', async () => {
+    const editMessage = vi.fn().mockResolvedValue(undefined)
+    const resend = vi.fn().mockResolvedValue(undefined)
+    const forkAndResend = vi.fn().mockResolvedValue(undefined)
+    const knowledgeBase = {
+      id: 'kb-1',
+      name: 'Knowledge One',
+      documentCount: 1
+    } as KnowledgeBase
+    mocks.chatWrite = { pause: vi.fn(), editMessage, resend, forkAndResend }
+    mocks.assistant = {
+      ...mocks.assistant,
+      knowledgeBaseIds: ['kb-1']
+    }
+    mocks.knowledgeBases = [knowledgeBase]
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingOnMount
+          message={message as any}
+          parts={
+            [
+              {
+                type: 'text',
+                text: 'question with knowledge',
+                providerMetadata: {
+                  cherry: {
+                    composer: {
+                      version: 1,
+                      tokens: [
+                        {
+                          id: 'knowledge:kb-1',
+                          kind: 'knowledge',
+                          label: 'Knowledge One',
+                          index: 0,
+                          textOffset: 0
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ] as any
+          }
+        />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+    await waitFor(() =>
+      expect(mocks.surfaceProps?.tokens).toEqual([
+        expect.objectContaining({
+          id: 'knowledge:kb-1',
+          kind: 'knowledge',
+          label: 'Knowledge One'
+        })
+      ])
+    )
+
+    const [knowledgeToken] = mocks.surfaceProps?.tokens ?? []
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({
+        text: 'edited question with knowledge',
+        tokens: [serializeComposerToken(knowledgeToken)]
+      })
+    })
+
+    const editedParts = forkAndResend.mock.calls[0]?.[1] as Array<Record<string, any>>
+    expect(forkAndResend).toHaveBeenCalledWith('message-1', expect.any(Array))
+    expect(editedParts[0]).toMatchObject({
+      type: 'text',
+      text: 'edited question with knowledge',
+      providerMetadata: {
+        cherry: {
+          composer: {
+            tokens: [
+              expect.objectContaining({
+                id: 'knowledge:kb-1',
+                kind: 'knowledge',
+                label: 'Knowledge One'
+              })
+            ]
+          }
+        }
+      }
+    })
+    expect(editMessage).not.toHaveBeenCalled()
+    expect(resend).not.toHaveBeenCalled()
+  })
+
+  it('forks and resends the edited message when Composer sends in edit mode', async () => {
+    const editMessage = vi.fn().mockResolvedValue(undefined)
+    const resend = vi.fn().mockResolvedValue(undefined)
+    const forkAndResend = vi.fn().mockResolvedValue(undefined)
+    mocks.chatWrite = { pause: vi.fn(), editMessage, resend, forkAndResend }
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingOnMount message={message as any} parts={[{ type: 'text', text: 'old' }] as any} />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+    await mocks.surfaceProps?.onSendDraft({ text: 'new text', tokens: [] })
+
+    expect(forkAndResend).toHaveBeenCalledWith('message-1', [{ type: 'text', text: 'new text' }])
+    expect(editMessage).not.toHaveBeenCalled()
+    expect(resend).not.toHaveBeenCalled()
+    await waitFor(() => expect(mocks.surfaceProps?.editingState).toBeUndefined())
+  })
+
+  it('keeps editing when the edited message fork and resend fails', async () => {
+    const editMessage = vi.fn().mockResolvedValue(undefined)
+    const resend = vi.fn().mockResolvedValue(undefined)
+    const forkAndResend = vi.fn().mockRejectedValue(new Error('stream open failed'))
+    mocks.chatWrite = { pause: vi.fn(), editMessage, resend, forkAndResend }
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingOnMount message={message as any} parts={[{ type: 'text', text: 'old' }] as any} />
+        <ChatComposer topic={topic} onSend={vi.fn()} />
+      </MessageEditingProvider>
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+    await expect(mocks.surfaceProps?.onSendDraft({ text: 'new text', tokens: [] })).resolves.toBeUndefined()
+
+    expect(forkAndResend).toHaveBeenCalledWith('message-1', [{ type: 'text', text: 'new text' }])
+    expect(editMessage).not.toHaveBeenCalled()
+    expect(resend).not.toHaveBeenCalled()
+    expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1')
+    expect(mocks.toastError).toHaveBeenCalledWith('message.error.operation_unavailable')
+  })
+
+  it('does not auto-enable assistant knowledge bases and keeps manual deletion', async () => {
+    const knowledgeBase = {
+      id: 'kb-1',
+      name: 'Knowledge One',
+      documentCount: 1
+    } as KnowledgeBase
+    mocks.assistant = {
+      ...mocks.assistant,
+      knowledgeBaseIds: ['kb-1']
+    }
+    mocks.knowledgeBases = [knowledgeBase]
+    const view = render(<ChatComposer topic={topic} onSend={vi.fn()} />)
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(mocks.selectedKnowledgeBases).toEqual([])
+    expect(mocks.setSelectedKnowledgeBases).not.toHaveBeenCalledWith([knowledgeBase])
+    expect(mocks.surfaceProps?.tokens).toEqual([])
+
+    mocks.selectedKnowledgeBases = [knowledgeBase]
+    view.rerender(<ChatComposer topic={topic} onSend={vi.fn()} />)
+    expect(mocks.surfaceProps?.tokens).toEqual([
+      expect.objectContaining({
+        id: 'knowledge:kb-1',
+        kind: 'knowledge'
+      })
+    ])
+
+    act(() => {
+      mocks.surfaceProps?.onTokensChange([])
+    })
+
+    expect(mocks.selectedKnowledgeBases).toEqual([])
+    mocks.setSelectedKnowledgeBases.mockClear()
+    mocks.knowledgeBases = [{ ...knowledgeBase }]
+
+    view.rerender(<ChatComposer topic={topic} onSend={vi.fn()} />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(mocks.setSelectedKnowledgeBases).not.toHaveBeenCalled()
+    expect(mocks.surfaceProps?.tokens).toEqual([])
+  })
+
+  it('clears selected knowledge bases after sending a draft', async () => {
+    const knowledgeBase = {
+      id: 'kb-1',
+      name: 'Knowledge One',
+      documentCount: 1
+    } as KnowledgeBase
+    mocks.assistant = {
+      ...mocks.assistant,
+      knowledgeBaseIds: ['kb-1']
+    }
+    mocks.knowledgeBases = [knowledgeBase]
+    const onSend = vi.fn().mockResolvedValue(undefined)
+    const view = render(<ChatComposer topic={topic} onSend={onSend} />)
+
+    mocks.selectedKnowledgeBases = [knowledgeBase]
+    view.rerender(<ChatComposer topic={topic} onSend={onSend} />)
+
+    const [knowledgeToken] = mocks.surfaceProps?.tokens ?? []
+    expect(knowledgeToken).toMatchObject({
+      id: 'knowledge:kb-1',
+      kind: 'knowledge'
+    })
+
+    await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [serializeComposerToken(knowledgeToken)] })
+
+    expect(onSend).toHaveBeenCalledWith(
+      'hello',
+      expect.objectContaining({
+        knowledgeBaseIds: ['kb-1'],
+        userMessageParts: [expect.objectContaining({ type: 'text', text: 'hello' })]
+      })
+    )
+    expect(mocks.selectedKnowledgeBases).toEqual([])
+  })
+
+  it('does not render stale knowledge tokens during same-topic assistant switches', () => {
+    const knowledgeBase = {
+      id: 'kb-1',
+      name: 'Knowledge One',
+      documentCount: 1
+    } as KnowledgeBase
+    mocks.assistant = {
+      ...mocks.assistant,
+      knowledgeBaseIds: ['kb-1']
+    }
+    mocks.knowledgeBases = [knowledgeBase]
+    const onSend = vi.fn()
+    const view = render(<ChatComposer topic={topic} onSend={onSend} />)
+
+    mocks.selectedKnowledgeBases = [knowledgeBase]
+    view.rerender(<ChatComposer topic={topic} onSend={onSend} />)
+    expect(mocks.surfaceProps?.tokens).toEqual([
+      expect.objectContaining({
+        id: 'knowledge:kb-1',
+        kind: 'knowledge'
+      })
+    ])
+
+    mocks.assistant = {
+      ...mocks.assistant,
+      id: 'assistant-2',
+      knowledgeBaseIds: []
+    }
+    view.rerender(<ChatComposer topic={{ ...topic, assistantId: 'assistant-2' }} onSend={onSend} />)
+
+    expect(mocks.surfaceProps?.tokens).toEqual([])
+  })
+
+  it('drops selected knowledge bases that are no longer configured before sending', async () => {
+    const knowledgeBase = {
+      id: 'kb-1',
+      name: 'Knowledge One',
+      documentCount: 1
+    } as KnowledgeBase
+    mocks.assistant = {
+      ...mocks.assistant,
+      knowledgeBaseIds: ['kb-1']
+    }
+    mocks.knowledgeBases = [knowledgeBase]
+    const onSend = vi.fn().mockResolvedValue(undefined)
+    const view = render(<ChatComposer topic={topic} onSend={onSend} />)
+
+    mocks.selectedKnowledgeBases = [knowledgeBase]
+    view.rerender(<ChatComposer topic={topic} onSend={onSend} />)
+    const [staleKnowledgeToken] = mocks.surfaceProps?.tokens ?? []
+    expect(staleKnowledgeToken).toMatchObject({
+      id: 'knowledge:kb-1',
+      kind: 'knowledge'
+    })
+
+    mocks.assistant = {
+      ...mocks.assistant,
+      knowledgeBaseIds: []
+    }
+    view.rerender(<ChatComposer topic={topic} onSend={onSend} />)
+
+    expect(mocks.surfaceProps?.tokens).toEqual([])
+
+    await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [serializeComposerToken(staleKnowledgeToken)] })
+
+    expect(onSend).toHaveBeenCalledWith('hello', expect.any(Object))
+    expect(onSend.mock.calls[0]?.[1]?.knowledgeBaseIds).toBeUndefined()
+  })
+
+  it('restores pasted knowledge tokens into selected knowledge base state before sending', async () => {
+    const knowledgeBase = {
+      id: 'kb-1',
+      name: 'Knowledge One',
+      documentCount: 1
+    } as KnowledgeBase
+    mocks.assistant = {
+      ...mocks.assistant,
+      knowledgeBaseIds: ['kb-1']
+    }
+    mocks.knowledgeBases = [knowledgeBase]
+    const onSend = vi.fn().mockResolvedValue(undefined)
+    const view = render(<ChatComposer topic={topic} onSend={onSend} />)
+
+    act(() => {
+      mocks.surfaceProps?.onTokensChange([
+        {
+          id: 'knowledge:kb-1',
+          kind: 'knowledge',
+          label: 'Knowledge One',
+          index: 0,
+          textOffset: 0
+        }
+      ])
+    })
+
+    expect(mocks.selectedKnowledgeBases).toEqual([knowledgeBase])
+
+    view.rerender(<ChatComposer topic={topic} onSend={onSend} />)
+    const [knowledgeToken] = mocks.surfaceProps?.tokens ?? []
+    await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [serializeComposerToken(knowledgeToken)] })
+
+    expect(onSend).toHaveBeenCalledWith(
+      'hello',
+      expect.objectContaining({
+        knowledgeBaseIds: ['kb-1']
+      })
+    )
+  })
+
+  it('keeps the temporary home model selector empty after manual clear', () => {
+    const view = render(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+
+    fireEvent.click(screen.getByText('clear model selection'))
+
+    expect(mocks.setMentionedModels).toHaveBeenCalledWith([])
+
+    mocks.mentionedModels = []
+    view.rerender(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '0')
+    expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('button.select_model')
+    expect(mocks.surfaceProps?.sendDisabled).toBe(true)
+    expect(mocks.surfaceProps?.sendBlockedReason).toBe('code.model_required')
+  })
+
+  it('reinitializes the temporary home selector when a new topic is created', async () => {
+    const view = render(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('clear model selection'))
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '0')
+
+    view.rerender(<ChatHomeComposer topic={{ ...topic, id: 'topic-2' }} onSend={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+      expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Model A | Provider')
+    })
+  })
+
+  it('renders multiple temporary home model selections through the selected-model trigger', () => {
+    render(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('toggle model multi select'))
+    fireEvent.click(screen.getByText('select models 1 and 2'))
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-multi-select-mode', 'true')
+
+    expect(screen.getByTestId('selected-models-trigger')).toHaveAttribute('data-model-count', '2')
+  })
+
+  it('keeps temporary multi-model selection when the composer placement docks', () => {
+    const view = render(<ChatPlacementComposer isHome topic={topic} onSend={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('toggle model multi select'))
+    fireEvent.click(screen.getByText('select models 1 and 2'))
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-multi-select-mode', 'true')
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '2')
+    expect(screen.getByTestId('selected-models-trigger')).toHaveAttribute('data-model-count', '2')
+
+    view.rerender(<ChatPlacementComposer isHome={false} topic={topic} onSend={vi.fn()} />)
+
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-multi-select-mode', 'true')
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '2')
+    expect(screen.getByTestId('selected-models-trigger')).toHaveAttribute('data-model-count', '2')
+  })
+})
+
+async function notifyComposerBottomToolbarWidth(width: number, scrollWidth = width + 240) {
+  await waitFor(() => {
+    expect(
+      resizeObserverMockInstances.some((instance) =>
+        String(instance.target?.getAttribute('class') ?? '').includes('max-w-full')
+      )
+    ).toBe(true)
+  })
+
+  const toolbarInstances = resizeObserverMockInstances.filter((instance) =>
+    String(instance.target?.getAttribute('class') ?? '').includes('max-w-full')
+  )
+  if (toolbarInstances.length === 0) {
+    throw new Error('Expected composer bottom toolbar to create a ResizeObserver')
+  }
+
+  act(() => {
+    for (const instance of toolbarInstances) {
+      Object.defineProperty(instance.target, 'clientWidth', { configurable: true, value: width })
+      Object.defineProperty(instance.target, 'scrollWidth', { configurable: true, value: scrollWidth })
+      instance.callback(
+        [
+          {
+            contentRect: { width }
+          } as ResizeObserverEntry
+        ],
+        {} as ResizeObserver
+      )
+    }
+  })
+}

--- a/src/renderer/hooks/__tests__/useExecutionOverlay.test.ts
+++ b/src/renderer/hooks/__tests__/useExecutionOverlay.test.ts
@@ -203,4 +203,27 @@ describe('useExecutionOverlay', () => {
     act(() => result.current.disposeOverlay('anchor-a'))
     await waitFor(() => expect(result.current.overlay['anchor-a']).toBeUndefined())
   })
+
+  it('does NOT fire onFinish when an execution leaves activeExecutions (why the status-driven handoff exists)', async () => {
+    // When the topic goes terminal, the execution drops out of `activeExecutions`
+    // and the teardown loop `cancel()`s the reader, which SUPPRESSES `onFinish`.
+    // So overlay disposal cannot ride `onFinish` — it must be driven off the
+    // terminal status (see `useTopicOverlayHandoffOnTerminal`). This locks that
+    // assumption: if someone "fixes" onFinish to fire here, the handoff design
+    // must be revisited.
+    const onFinish = vi.fn()
+    const ui = [asst('anchor-a')]
+    const { rerender } = renderHook(
+      ({ execs }: { execs: ActiveExecution[] }) => useExecutionOverlay(TOPIC, execs, ui, { onFinish }),
+      { initialProps: { execs: [exec(A, 'anchor-a')] } }
+    )
+
+    // Execution leaves activeExecutions WITHOUT the overlay's own terminal signal.
+    await act(async () => {
+      rerender({ execs: [] })
+      await Promise.resolve()
+    })
+
+    expect(onFinish).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/hooks/__tests__/useTopicOverlayHandoffOnTerminal.test.ts
+++ b/src/renderer/hooks/__tests__/useTopicOverlayHandoffOnTerminal.test.ts
@@ -1,0 +1,98 @@
+import type { TopicStreamStatus } from '@shared/ai/transport'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockEntry = vi.fn<() => { status: TopicStreamStatus | undefined } | undefined>()
+
+// Mock at the cache layer (intra-module calls can't be intercepted at the hook).
+vi.mock('@renderer/data/hooks/useCache', () => ({
+  useSharedCache: () => [mockEntry()]
+}))
+
+import { useTopicOverlayHandoffOnTerminal } from '../useTopicStreamStatus'
+
+const setStatus = (status: TopicStreamStatus | undefined) => mockEntry.mockReturnValue({ status })
+
+describe('useTopicOverlayHandoffOnTerminal', () => {
+  beforeEach(() => mockEntry.mockReset())
+
+  it.each<TopicStreamStatus>(['done', 'error', 'aborted'])('fires once on streaming → %s', async (terminal) => {
+    const handoff = vi.fn(async () => {})
+    setStatus('streaming')
+    const { rerender } = renderHook(() => useTopicOverlayHandoffOnTerminal('t', handoff))
+    expect(handoff).not.toHaveBeenCalled()
+
+    setStatus(terminal)
+    await act(async () => {
+      rerender()
+    })
+    expect(handoff).toHaveBeenCalledTimes(1)
+
+    // No double-fire while it stays terminal.
+    await act(async () => {
+      rerender()
+    })
+    expect(handoff).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT fire on streaming → awaiting-approval (the MCP card must stay)', async () => {
+    const handoff = vi.fn(async () => {})
+    setStatus('streaming')
+    const { rerender } = renderHook(() => useTopicOverlayHandoffOnTerminal('t', handoff))
+
+    setStatus('awaiting-approval')
+    await act(async () => {
+      rerender()
+    })
+    expect(handoff).not.toHaveBeenCalled()
+  })
+
+  it('fires on the later live → done edge after a continue stream resumes an approval', async () => {
+    const handoff = vi.fn(async () => {})
+    setStatus('streaming')
+    const { rerender } = renderHook(() => useTopicOverlayHandoffOnTerminal('t', handoff))
+
+    setStatus('awaiting-approval')
+    await act(async () => {
+      rerender()
+    })
+    expect(handoff).not.toHaveBeenCalled()
+
+    // Continue stream: awaiting-approval → streaming → done.
+    setStatus('streaming')
+    await act(async () => {
+      rerender()
+    })
+    setStatus('done')
+    await act(async () => {
+      rerender()
+    })
+    expect(handoff).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs refresh before dispose (no stale-base flicker)', async () => {
+    const order: string[] = []
+    const refresh = vi.fn(async () => {
+      order.push('refresh')
+    })
+    const dispose = vi.fn(() => {
+      order.push('dispose')
+    })
+    const handoff = async () => {
+      try {
+        await refresh()
+      } finally {
+        dispose()
+      }
+    }
+
+    setStatus('streaming')
+    const { rerender } = renderHook(() => useTopicOverlayHandoffOnTerminal('t', handoff))
+    setStatus('done')
+    await act(async () => {
+      rerender()
+      await Promise.resolve()
+    })
+    expect(order).toEqual(['refresh', 'dispose'])
+  })
+})

--- a/src/renderer/hooks/useTopicStreamStatus.ts
+++ b/src/renderer/hooks/useTopicStreamStatus.ts
@@ -72,3 +72,37 @@ export function useTopicDbRefreshOnTerminal(topicId: string, refresh: () => Prom
     }
   }, [status])
 }
+
+/**
+ * Deterministic overlay→DB handoff at terminal. On the live→terminal edge the
+ * live chunk overlay must yield to the DB row (which persistence already
+ * finalized — e.g. an interrupted tool becomes `output-error`). The overlay's
+ * own `onFinish` is suppressed when an execution leaves `activeExecutions`, so
+ * disposal can't ride it; this fires `onHandoff` (refresh-then-dispose) off the
+ * status edge instead.
+ *
+ * Excludes `awaiting-approval` (which is `isTerminal` but must KEEP the live
+ * card — a continue stream will resume it). That distinction lives only here in
+ * `classifyTurn`, not inside the status-agnostic overlay hook — hence the
+ * handoff is decided at the consumer layer, separate from
+ * `useTopicDbRefreshOnTerminal` (whose refresh-on-awaiting-approval is wanted).
+ */
+export function useTopicOverlayHandoffOnTerminal(topicId: string, onHandoff: () => Promise<void> | void): void {
+  const [entry] = useSharedCache(`topic.stream.statuses.${topicId}` as const)
+  const status = entry?.status
+  const onHandoffRef = useRef(onHandoff)
+  onHandoffRef.current = onHandoff
+  const prevRef = useRef<typeof status>(undefined)
+  useEffect(() => {
+    const prev = prevRef.current
+    prevRef.current = status
+    const next = classifyTurn(status)
+    if (classifyTurn(prev).isStreamLive && next.isTerminal && !next.isAwaitingApproval) {
+      void (async () => {
+        await onHandoffRef.current()
+      })().catch(() => {
+        // Caller logs; the handoff must not throw out of the effect.
+      })
+    }
+  }, [status])
+}

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -1205,6 +1205,14 @@
       "file_error": "Error processing file",
       "file_not_supported": "Model does not support this file type",
       "file_not_supported_count": "{{count}} files are not supported",
+      "followup_queue": {
+        "edit": "Edit",
+        "pause": "Pause auto-send",
+        "remove": "Remove",
+        "resume": "Resume auto-send",
+        "steer": "Send into current turn",
+        "title": "Queued ({{count}})"
+      },
       "generate_image": "Generate image",
       "generate_image_not_supported": "The model does not support generating images.",
       "knowledge_base": "Knowledge Base",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -1205,6 +1205,14 @@
       "file_error": "文件处理出错",
       "file_not_supported": "模型不支持此文件类型",
       "file_not_supported_count": "{{count}} 个文件不被支持",
+      "followup_queue": {
+        "edit": "编辑",
+        "pause": "暂停自动发送",
+        "remove": "移除",
+        "resume": "恢复自动发送",
+        "steer": "插入当前回合",
+        "title": "排队中 ({{count}})"
+      },
       "generate_image": "生成图片",
       "generate_image_not_supported": "模型不支持生成图片",
       "knowledge_base": "知识库",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -1205,6 +1205,14 @@
       "file_error": "檔案處理錯誤",
       "file_not_supported": "模型不支援此檔案類型",
       "file_not_supported_count": "{{count}} 個檔案不被支援",
+      "followup_queue": {
+        "edit": "編輯",
+        "pause": "暫停自動傳送",
+        "remove": "移除",
+        "resume": "恢復自動傳送",
+        "steer": "插入目前回合",
+        "title": "排隊中 ({{count}})"
+      },
       "generate_image": "產生圖片",
       "generate_image_not_supported": "模型不支援產生圖片",
       "knowledge_base": "知識庫",

--- a/src/renderer/pages/home/ChatComposerSlot.tsx
+++ b/src/renderer/pages/home/ChatComposerSlot.tsx
@@ -1,0 +1,49 @@
+import type { ComposerContextValue } from '@renderer/components/chat/composer/ComposerContext'
+import ConversationComposerSlot from '@renderer/components/chat/composer/ConversationComposerSlot'
+import { ChatPlacementComposer } from '@renderer/components/chat/composer/variants/ChatComposer'
+import type { FileMetadata, Topic } from '@renderer/types'
+import type { CherryMessagePart } from '@shared/data/types/message'
+import type { UniqueModelId } from '@shared/data/types/model'
+
+import type { AddNewTopicPayload } from './types'
+
+interface ChatComposerSlotProps {
+  isHome: boolean
+  topic: Topic
+  onSend: (
+    text: string,
+    options?: {
+      files?: FileMetadata[]
+      mentionedModels?: UniqueModelId[]
+      knowledgeBaseIds?: string[]
+      userMessageParts?: CherryMessagePart[]
+    }
+  ) => Promise<void>
+  onTemporaryAssistantChange?: (assistantId: string | null) => void | Promise<void>
+  onNewTopic?: (payload?: AddNewTopicPayload) => void | Promise<void>
+  sendDisabled?: boolean
+  composerContext?: ComposerContextValue
+}
+
+export default function ChatComposerSlot({
+  isHome,
+  topic,
+  onSend,
+  onTemporaryAssistantChange,
+  onNewTopic,
+  sendDisabled,
+  composerContext
+}: ChatComposerSlotProps) {
+  const fallback = (
+    <ChatPlacementComposer
+      isHome={isHome}
+      topic={topic}
+      onSend={onSend}
+      onTemporaryAssistantChange={onTemporaryAssistantChange}
+      onNewTopic={onNewTopic}
+      sendDisabled={isHome ? undefined : sendDisabled}
+    />
+  )
+
+  return <ConversationComposerSlot composerContext={composerContext} fallback={fallback} />
+}

--- a/src/renderer/pages/home/ChatContent.tsx
+++ b/src/renderer/pages/home/ChatContent.tsx
@@ -1,0 +1,260 @@
+import { ChatLayoutModeProvider } from '@renderer/components/chat/layout/ChatLayoutModeContext'
+import {
+  RefreshProvider,
+  TranslationOverlayProvider,
+  TranslationOverlaySetterProvider
+} from '@renderer/components/chat/messages/blocks'
+import type { TopicMessageFlowLiveState } from '@renderer/components/chat/messages/flow/topicMessageFlowLiveTree'
+import type { MessageListActions } from '@renderer/components/chat/messages/types'
+import ConversationStageCenter from '@renderer/components/chat/shell/ConversationStageCenter'
+import { MessageEditingProvider } from '@renderer/context/MessageEditingContext'
+import { ChatWriteProvider } from '@renderer/hooks/ChatWriteContext'
+import { SiblingsProvider } from '@renderer/hooks/SiblingsContext'
+import type { TemporaryConversation } from '@renderer/hooks/useTemporaryConversation'
+import { useTopicMessages } from '@renderer/hooks/useTopicMessages'
+import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
+import type { Topic } from '@renderer/types'
+import type { CherryUIMessage } from '@shared/data/types/message'
+import type { FC } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import ChatComposerSlot from './ChatComposerSlot'
+import ChatMain from './ChatMain'
+import type { AddNewTopicPayload } from './types'
+import { useChatRuntimeState } from './useChatRuntimeState'
+
+interface Props {
+  topic: Topic
+  onOpenCitationsPanel?: MessageListActions['openCitationsPanel']
+  onOpenTrace?: MessageListActions['openTrace']
+  onTemporaryAssistantChange?: (assistantId: string | null) => void | Promise<void>
+  onNewTopic?: (payload?: AddNewTopicPayload) => void | Promise<void>
+  locateMessageId?: string
+  onLocateMessageHandled?: () => void
+  onBranchLiveStateChange?: (state: TopicMessageFlowLiveState | null) => void
+  clearBranchDraft?: () => void
+  getBranchDraftAnchorId?: () => string | null
+  /**
+   * If the active topic is a freshly-leased temporary one, this callback
+   * migrates it into SQLite (with the same id) before the first message
+   * is sent. Owned by HomePage so the lease and the persist trigger live
+   * on the same hook instance. `initialName` seeds a placeholder topic
+   * title so the sidebar isn't blank pre-auto-name.
+   */
+  onPersistTemporaryTopic?: (initialName?: string) => Promise<TemporaryConversation | null>
+}
+
+/**
+ * Home chat content.
+ *
+ * Outer shell — mounts the frame immediately; the shared message list owns the
+ * initial-loading view so the composer doesn't disappear during topic switches.
+ *
+ * `useChatRuntimeState` owns message runtime concerns — stream handoff,
+ * execution overlays, and write actions. This page keeps the provider/frame
+ * composition visible.
+ */
+const ChatContent: FC<Props> = ({
+  topic,
+  onOpenCitationsPanel,
+  onOpenTrace,
+  onTemporaryAssistantChange,
+  onNewTopic,
+  locateMessageId,
+  onLocateMessageHandled,
+  onBranchLiveStateChange,
+  clearBranchDraft,
+  getBranchDraftAnchorId,
+  onPersistTemporaryTopic
+}) => {
+  const [hasPersistedTemporaryTopic, setHasPersistedTemporaryTopic] = useState(false)
+  useEffect(() => setHasPersistedTemporaryTopic(false), [topic.id])
+  const isFreshTemporaryTopic = !!onPersistTemporaryTopic && !hasPersistedTemporaryTopic
+  const {
+    uiMessages,
+    siblingsMap,
+    isLoading: isHistoryLoading,
+    refresh,
+    activeNodeId,
+    loadOlder,
+    hasOlder,
+    mutate: messagesCacheMutate
+  } = useTopicMessages(topic.id, { fetchOnMount: !isFreshTemporaryTopic })
+
+  return (
+    <ChatContentInner
+      topic={topic}
+      onOpenCitationsPanel={onOpenCitationsPanel}
+      onOpenTrace={onOpenTrace}
+      onTemporaryAssistantChange={onTemporaryAssistantChange}
+      onNewTopic={onNewTopic}
+      locateMessageId={locateMessageId}
+      onLocateMessageHandled={onLocateMessageHandled}
+      onBranchLiveStateChange={onBranchLiveStateChange}
+      clearBranchDraft={clearBranchDraft}
+      getBranchDraftAnchorId={getBranchDraftAnchorId}
+      onPersistTemporaryTopic={onPersistTemporaryTopic}
+      isHistoryLoading={isHistoryLoading}
+      isFreshTemporaryTopic={isFreshTemporaryTopic}
+      onTemporaryTopicPersisted={() => setHasPersistedTemporaryTopic(true)}
+      initialMessages={uiMessages}
+      uiMessages={uiMessages}
+      siblingsMap={siblingsMap}
+      refresh={refresh}
+      activeNodeId={activeNodeId}
+      loadOlder={loadOlder}
+      hasOlder={hasOlder}
+      messagesCacheMutate={messagesCacheMutate}
+    />
+  )
+}
+
+// ============================================================================
+// Inner — keeps composer mounted while history loads
+// ============================================================================
+
+interface InnerProps extends Props {
+  isHistoryLoading: boolean
+  isFreshTemporaryTopic: boolean
+  onTemporaryTopicPersisted: () => void
+  onBranchLiveStateChange?: (state: TopicMessageFlowLiveState | null) => void
+  /** One-time seed for `useChat(messages:)` — consumed on mount only. */
+  initialMessages: CherryUIMessage[]
+  /** Live DB-backed message list; reactive to SWR refreshes. */
+  uiMessages: CherryUIMessage[]
+  siblingsMap: ReturnType<typeof useTopicMessages>['siblingsMap']
+  refresh: () => Promise<CherryUIMessage[]>
+  activeNodeId: string | null
+  loadOlder: () => void
+  hasOlder: boolean
+  messagesCacheMutate: ReturnType<typeof useTopicMessages>['mutate']
+}
+
+const ChatContentInner: FC<InnerProps> = ({
+  topic,
+  onOpenCitationsPanel,
+  onOpenTrace,
+  onTemporaryAssistantChange,
+  onNewTopic,
+  locateMessageId,
+  onLocateMessageHandled,
+  onBranchLiveStateChange,
+  clearBranchDraft,
+  getBranchDraftAnchorId,
+  onPersistTemporaryTopic,
+  isHistoryLoading,
+  isFreshTemporaryTopic,
+  onTemporaryTopicPersisted,
+  initialMessages,
+  uiMessages,
+  siblingsMap,
+  refresh,
+  activeNodeId,
+  loadOlder,
+  hasOlder,
+  messagesCacheMutate
+}) => {
+  const { t } = useTranslation()
+  const locateLoadRequestRef = useRef<string | undefined>(undefined)
+  const runtime = useChatRuntimeState({
+    topic,
+    isHistoryLoading,
+    isFreshTemporaryTopic,
+    onPersistTemporaryTopic,
+    onTemporaryTopicPersisted,
+    initialMessages,
+    uiMessages,
+    refresh,
+    activeNodeId,
+    messagesCacheMutate,
+    onBranchLiveStateChange,
+    clearBranchDraft,
+    getBranchDraftAnchorId
+  })
+  const siblingsContextValue = useMemo(() => ({ siblingsMap, activeNodeId }), [siblingsMap, activeNodeId])
+
+  useEffect(() => {
+    if (!locateMessageId) {
+      locateLoadRequestRef.current = undefined
+      return
+    }
+
+    if (uiMessages.some((message) => message.id === locateMessageId)) {
+      locateLoadRequestRef.current = undefined
+      window.requestAnimationFrame(() => {
+        void EventEmitter.emit(EVENT_NAMES.LOCATE_MESSAGE + ':' + locateMessageId, true)
+      })
+      onLocateMessageHandled?.()
+      return
+    }
+
+    if (hasOlder && !isHistoryLoading) {
+      const requestKey = `${locateMessageId}:${uiMessages.length}`
+      if (locateLoadRequestRef.current !== requestKey) {
+        locateLoadRequestRef.current = requestKey
+        loadOlder()
+      }
+      return
+    }
+
+    if (!hasOlder && !isHistoryLoading) {
+      locateLoadRequestRef.current = undefined
+      onLocateMessageHandled?.()
+    }
+  }, [hasOlder, isHistoryLoading, loadOlder, locateMessageId, onLocateMessageHandled, uiMessages])
+
+  return (
+    <ChatWriteProvider value={runtime.chatWriteActions}>
+      <SiblingsProvider value={siblingsContextValue}>
+        <RefreshProvider value={refresh}>
+          <TranslationOverlaySetterProvider value={runtime.setTranslationOverlay}>
+            <TranslationOverlayProvider value={runtime.translationOverlay}>
+              <MessageEditingProvider>
+                <ChatLayoutModeProvider>
+                  {(() => {
+                    const main = (
+                      <ChatMain
+                        key={topic.id}
+                        topic={topic}
+                        messages={runtime.messages}
+                        partsByMessageId={runtime.partsByMessageId}
+                        isInitialLoading={isHistoryLoading}
+                        loadOlder={loadOlder}
+                        hasOlder={hasOlder}
+                        openCitationsPanel={onOpenCitationsPanel}
+                        openTrace={onOpenTrace}
+                      />
+                    )
+                    const composer = (
+                      <ChatComposerSlot
+                        isHome={runtime.shouldRenderHomeComposer}
+                        topic={topic}
+                        onSend={runtime.sendMessage}
+                        onTemporaryAssistantChange={onTemporaryAssistantChange}
+                        onNewTopic={onNewTopic}
+                        sendDisabled={isHistoryLoading}
+                        composerContext={runtime.composerContext}
+                      />
+                    )
+                    const placement = runtime.shouldRenderHomeComposer ? 'home' : 'docked'
+                    return (
+                      <ConversationStageCenter
+                        placement={placement}
+                        main={main}
+                        composer={composer}
+                        homeWelcomeText={t('chat.home.welcome_title')}
+                      />
+                    )
+                  })()}
+                </ChatLayoutModeProvider>
+              </MessageEditingProvider>
+            </TranslationOverlayProvider>
+          </TranslationOverlaySetterProvider>
+        </RefreshProvider>
+      </SiblingsProvider>
+    </ChatWriteProvider>
+  )
+}
+
+export default ChatContent

--- a/src/renderer/pages/home/Inputbar/QueuedFollowupsDock.tsx
+++ b/src/renderer/pages/home/Inputbar/QueuedFollowupsDock.tsx
@@ -1,0 +1,146 @@
+import { Button, ReorderableList } from '@cherrystudio/ui'
+import { ComposerToken } from '@renderer/components/chat/tokens/ComposerToken'
+import {
+  CHAT_INPUT_TOKEN_KINDS,
+  type ChatInputTokenKind,
+  type ChatTokenView
+} from '@renderer/components/chat/tokens/tokenView'
+import { Pause, Pencil, Play, X, Zap } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import type { FollowupQueueItem } from './useFollowupQueue'
+
+interface QueuedFollowupsDockProps {
+  items: FollowupQueueItem[]
+  paused: boolean
+  onTogglePause: () => void
+  onSteer: (id: string) => void
+  onEdit: (id: string) => void
+  onRemove: (id: string) => void
+  onReorder: (nextItems: FollowupQueueItem[]) => void
+}
+
+const DISPLAY_TOKEN_KINDS = new Set<string>(CHAT_INPUT_TOKEN_KINDS)
+
+/** Read-only chips for a queued draft's composer tokens (file / skill / knowledge / quote …). */
+function DraftTokenChips({ item }: { item: FollowupQueueItem }) {
+  const tokens = (item.draft?.tokens ?? []).filter((token) => DISPLAY_TOKEN_KINDS.has(token.kind))
+  if (tokens.length === 0) return null
+  return (
+    <div className="mt-1 flex flex-wrap gap-1">
+      {tokens.map((token) => (
+        <ComposerToken
+          key={token.id}
+          token={
+            {
+              id: token.id,
+              kind: token.kind as ChatInputTokenKind,
+              label: token.label,
+              description: token.description,
+              promptText: token.promptText,
+              payload: token.payload
+            } satisfies ChatTokenView
+          }
+        />
+      ))}
+    </div>
+  )
+}
+
+function QueuedFollowupRow({
+  item,
+  onSteer,
+  onEdit,
+  onRemove
+}: {
+  item: FollowupQueueItem
+  onSteer: (id: string) => void
+  onEdit: (id: string) => void
+  onRemove: (id: string) => void
+}) {
+  const { t } = useTranslation()
+  return (
+    <div className="group flex items-start gap-1.5 rounded-[12px] bg-muted/40 px-2 py-1.5">
+      <div className="min-w-0 flex-1">
+        <span className="line-clamp-2 text-foreground text-sm">{item.draft?.text ?? item.payload.text}</span>
+        <DraftTokenChips item={item} />
+      </div>
+      <div className="flex shrink-0 items-center gap-0.5 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="size-7 shadow-none"
+          aria-label={t('chat.input.followup_queue.steer')}
+          onClick={() => onSteer(item.id)}>
+          <Zap className="size-4" />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="size-7 shadow-none"
+          aria-label={t('chat.input.followup_queue.edit')}
+          onClick={() => onEdit(item.id)}>
+          <Pencil className="size-4" />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="size-7 shadow-none"
+          aria-label={t('chat.input.followup_queue.remove')}
+          onClick={() => onRemove(item.id)}>
+          <X className="size-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Dock above the input listing queued follow-up drafts (queue mode). Items are drag-reorderable;
+ * each can be steered into the running turn, edited back into the composer, or removed; auto-drain
+ * can be paused. Renders via `ComposerSurface.queueContent`.
+ */
+export function QueuedFollowupsDock({
+  items,
+  paused,
+  onTogglePause,
+  onSteer,
+  onEdit,
+  onRemove,
+  onReorder
+}: QueuedFollowupsDockProps) {
+  const { t } = useTranslation()
+  if (items.length === 0) return null
+
+  return (
+    <div className="mx-2 mb-1.5 rounded-[16px] border-[0.5px] border-border bg-(--color-background-opacity) p-1.5 backdrop-blur">
+      <div className="flex items-center justify-between px-1.5 pb-1">
+        <span className="text-muted-foreground text-xs">
+          {t('chat.input.followup_queue.title', { count: items.length })}
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="size-6 shadow-none"
+          aria-label={paused ? t('chat.input.followup_queue.resume') : t('chat.input.followup_queue.pause')}
+          onClick={onTogglePause}>
+          {paused ? <Play className="size-3.5" /> : <Pause className="size-3.5" />}
+        </Button>
+      </div>
+      <div className="max-h-40 overflow-y-auto">
+        <ReorderableList
+          items={items}
+          getId={(item) => item.id}
+          onReorder={onReorder}
+          direction="vertical"
+          gap={4}
+          renderItem={(item) => <QueuedFollowupRow item={item} onSteer={onSteer} onEdit={onEdit} onRemove={onRemove} />}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/pages/home/Inputbar/__tests__/QueuedFollowupsDock.test.tsx
+++ b/src/renderer/pages/home/Inputbar/__tests__/QueuedFollowupsDock.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import type * as ReactI18next from 'react-i18next'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('react-i18next', async (importOriginal) => ({
+  ...(await importOriginal<typeof ReactI18next>()),
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+import { QueuedFollowupsDock } from '../QueuedFollowupsDock'
+
+const items = [
+  {
+    id: '1',
+    draft: { text: 'first', tokens: [{ id: 'sk1', kind: 'skill', label: 'mySkill', index: 0, textOffset: 0 }] },
+    payload: { text: 'first', userMessageParts: [] }
+  },
+  { id: '2', draft: { text: 'second', tokens: [] }, payload: { text: 'second', userMessageParts: [] } }
+] as any
+
+describe('QueuedFollowupsDock', () => {
+  it('renders queued items with token chips and fires the per-item + pause callbacks', () => {
+    const onSteer = vi.fn()
+    const onEdit = vi.fn()
+    const onRemove = vi.fn()
+    const onTogglePause = vi.fn()
+    const onReorder = vi.fn()
+
+    render(
+      <QueuedFollowupsDock
+        items={items}
+        paused={false}
+        onTogglePause={onTogglePause}
+        onSteer={onSteer}
+        onEdit={onEdit}
+        onRemove={onRemove}
+        onReorder={onReorder}
+      />
+    )
+
+    expect(screen.getByText('first')).toBeInTheDocument()
+    expect(screen.getByText('second')).toBeInTheDocument()
+    // Composer token chip is rendered read-only from the stored draft tokens.
+    expect(screen.getByText('mySkill')).toBeInTheDocument()
+
+    fireEvent.click(screen.getAllByLabelText('chat.input.followup_queue.steer')[0])
+    expect(onSteer).toHaveBeenCalledWith('1')
+
+    fireEvent.click(screen.getAllByLabelText('chat.input.followup_queue.edit')[1])
+    expect(onEdit).toHaveBeenCalledWith('2')
+
+    fireEvent.click(screen.getAllByLabelText('chat.input.followup_queue.remove')[0])
+    expect(onRemove).toHaveBeenCalledWith('1')
+
+    fireEvent.click(screen.getByLabelText('chat.input.followup_queue.pause'))
+    expect(onTogglePause).toHaveBeenCalled()
+  })
+
+  it('renders nothing when the queue is empty', () => {
+    const { container } = render(
+      <QueuedFollowupsDock
+        items={[]}
+        paused={false}
+        onTogglePause={vi.fn()}
+        onSteer={vi.fn()}
+        onEdit={vi.fn()}
+        onRemove={vi.fn()}
+        onReorder={vi.fn()}
+      />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/src/renderer/pages/home/Inputbar/__tests__/useFollowupQueue.test.ts
+++ b/src/renderer/pages/home/Inputbar/__tests__/useFollowupQueue.test.ts
@@ -1,0 +1,107 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const store = new Map<string, unknown>()
+vi.mock('@data/CacheService', () => ({
+  cacheService: {
+    getCasual: vi.fn((key: string) => store.get(key)),
+    setCasual: vi.fn((key: string, value: unknown) => {
+      store.set(key, value)
+    })
+  }
+}))
+
+const { useFollowupQueue } = await import('../useFollowupQueue')
+
+const draft = (text: string) => ({ text, tokens: [] }) as any
+const payload = (text: string) => ({ text, userMessageParts: [{ type: 'text', text }] }) as any
+const item = (id: string, text: string) => ({ id, draft: draft(text), payload: payload(text) })
+
+const persistedTexts = (key: string) => (store.get(key) as Array<{ draft: { text: string } }>).map((i) => i.draft.text)
+
+describe('useFollowupQueue', () => {
+  beforeEach(() => store.clear())
+
+  it('enqueues (storing draft + payload, persisting) and removeId dequeues', () => {
+    const { result } = renderHook(() =>
+      useFollowupQueue({ scopeKey: 's1', isFulfilled: false, markSeen: vi.fn(), onDrain: vi.fn() })
+    )
+
+    act(() => result.current.enqueue(draft('a'), payload('a')))
+    act(() => result.current.enqueue(draft('b'), payload('b')))
+
+    expect(result.current.items.map((i) => i.draft.text)).toEqual(['a', 'b'])
+    expect(result.current.items.map((i) => i.payload.text)).toEqual(['a', 'b'])
+    expect(persistedTexts('followup-queue.s1')).toEqual(['a', 'b'])
+
+    act(() => result.current.removeId(result.current.items[0].id))
+    expect(result.current.items.map((i) => i.draft.text)).toEqual(['b'])
+  })
+
+  it('reorders the queue and persists the new order', () => {
+    const { result } = renderHook(() =>
+      useFollowupQueue({ scopeKey: 's1', isFulfilled: false, markSeen: vi.fn(), onDrain: vi.fn() })
+    )
+
+    act(() => result.current.enqueue(draft('a'), payload('a')))
+    act(() => result.current.enqueue(draft('b'), payload('b')))
+    const [first, second] = result.current.items
+
+    act(() => result.current.reorder([second, first]))
+
+    expect(result.current.items.map((i) => i.draft.text)).toEqual(['b', 'a'])
+    expect(persistedTexts('followup-queue.s1')).toEqual(['b', 'a'])
+  })
+
+  it('reloads the queue from the cache when the scopeKey changes', () => {
+    store.set('followup-queue.s2', [item('x', 'queued')])
+    const { result, rerender } = renderHook(
+      ({ scopeKey }) => useFollowupQueue({ scopeKey, isFulfilled: false, markSeen: vi.fn(), onDrain: vi.fn() }),
+      { initialProps: { scopeKey: 's1' } }
+    )
+
+    expect(result.current.items).toEqual([])
+    rerender({ scopeKey: 's2' })
+    expect(result.current.items.map((i) => i.draft.text)).toEqual(['queued'])
+  })
+
+  it('drains the head on the live→idle edge, then dequeues on success', async () => {
+    const onDrain = vi.fn().mockResolvedValue(true)
+    const markSeen = vi.fn()
+    const headPayload = payload('head')
+    store.set('followup-queue.s1', [{ id: 'h', draft: draft('head'), payload: headPayload }])
+
+    const { result, rerender } = renderHook(
+      ({ isFulfilled }) => useFollowupQueue({ scopeKey: 's1', isFulfilled, markSeen, onDrain }),
+      { initialProps: { isFulfilled: false } }
+    )
+
+    expect(onDrain).not.toHaveBeenCalled()
+
+    await act(async () => {
+      rerender({ isFulfilled: true })
+    })
+
+    expect(markSeen).toHaveBeenCalled()
+    expect(onDrain).toHaveBeenCalledWith(headPayload)
+    expect(result.current.items).toEqual([])
+  })
+
+  it('does not drain while paused', async () => {
+    const onDrain = vi.fn().mockResolvedValue(true)
+    store.set('followup-queue.s1', [item('h', 'head')])
+
+    const { result, rerender } = renderHook(
+      ({ isFulfilled }) => useFollowupQueue({ scopeKey: 's1', isFulfilled, markSeen: vi.fn(), onDrain }),
+      { initialProps: { isFulfilled: false } }
+    )
+
+    act(() => result.current.setPaused(true))
+    await act(async () => {
+      rerender({ isFulfilled: true })
+    })
+
+    expect(onDrain).not.toHaveBeenCalled()
+    expect(result.current.items).toHaveLength(1)
+  })
+})

--- a/src/renderer/pages/home/Inputbar/useFollowupQueue.ts
+++ b/src/renderer/pages/home/Inputbar/useFollowupQueue.ts
@@ -1,0 +1,122 @@
+import { cacheService } from '@data/CacheService'
+import type { ComposerQueuedMessagePayload } from '@shared/ai/transport'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import type { ComposerSerializedDraft } from './tokens'
+
+export interface FollowupQueueItem {
+  id: string
+  /** Serialized draft (text + tokens) — drives the dock preview and edit-restore. */
+  draft: ComposerSerializedDraft
+  /** Send-ready payload (text + parts + files/models) captured at enqueue time. */
+  payload: ComposerQueuedMessagePayload
+}
+
+/** Same per-window memory tier + TTL as the inputbar draft cache (`composerDraft` / ChatComposer). */
+const QUEUE_TTL = 24 * 60 * 60 * 1000
+const keyFor = (scopeKey: string) => `followup-queue.${scopeKey}`
+
+/** Load + validate a persisted queue (the cache holds arbitrary JSON; guard non-array entries). */
+function loadQueue(scopeKey: string): FollowupQueueItem[] {
+  const cached = cacheService.getCasual<FollowupQueueItem[]>(keyFor(scopeKey))
+  return Array.isArray(cached) ? cached : []
+}
+
+interface UseFollowupQueueParams {
+  /** Per-conversation key — same `${topicId}:${assistantId}` scope as the draft cache. */
+  scopeKey: string
+  /** `done`-and-unacknowledged edge from `useTopicStreamStatus` — the live→idle drain trigger. */
+  isFulfilled: boolean
+  /** Acknowledge the completion so the drain fires once per turn. */
+  markSeen: () => void
+  /** Send a payload (busy → backend steer; idle → normal send). Resolves to whether it was sent. */
+  onDrain: (payload: ComposerQueuedMessagePayload) => Promise<boolean>
+}
+
+export interface FollowupQueueController {
+  items: FollowupQueueItem[]
+  enqueue: (draft: ComposerSerializedDraft, payload: ComposerQueuedMessagePayload) => void
+  removeId: (id: string) => void
+  reorder: (nextItems: FollowupQueueItem[]) => void
+  paused: boolean
+  setPaused: (paused: boolean) => void
+}
+
+/**
+ * Per-conversation FIFO queue of follow-up drafts. While a turn streams the composer enqueues here
+ * instead of sending; on the live→idle edge the head auto-drains (one per completion), and the dock
+ * lets the user steer/edit/remove individual items or pause auto-drain. Persistence mirrors the
+ * draft cache (`cacheService.setCasual`, per-window memory + TTL).
+ */
+export function useFollowupQueue({
+  scopeKey,
+  isFulfilled,
+  markSeen,
+  onDrain
+}: UseFollowupQueueParams): FollowupQueueController {
+  const [items, setItems] = useState<FollowupQueueItem[]>(() => loadQueue(scopeKey))
+  const [paused, setPaused] = useState(false)
+
+  // Latest values for the persistence + drain closures (kept off the effect deps to avoid re-running).
+  const scopeKeyRef = useRef(scopeKey)
+  const itemsRef = useRef(items)
+  itemsRef.current = items
+  const onDrainRef = useRef(onDrain)
+  onDrainRef.current = onDrain
+
+  const persist = useCallback((next: FollowupQueueItem[]) => {
+    cacheService.setCasual(keyFor(scopeKeyRef.current), next, QUEUE_TTL)
+  }, [])
+
+  // Reload when switching conversations; the previous queue stays in its own scoped cache entry.
+  useEffect(() => {
+    if (scopeKeyRef.current === scopeKey) return
+    scopeKeyRef.current = scopeKey
+    setItems(loadQueue(scopeKey))
+    setPaused(false)
+  }, [scopeKey])
+
+  const enqueue = useCallback(
+    (draft: ComposerSerializedDraft, payload: ComposerQueuedMessagePayload) => {
+      setItems((prev) => {
+        const next = [...prev, { id: crypto.randomUUID(), draft, payload }]
+        persist(next)
+        return next
+      })
+    },
+    [persist]
+  )
+
+  const removeId = useCallback(
+    (id: string) => {
+      setItems((prev) => {
+        const next = prev.filter((item) => item.id !== id)
+        persist(next)
+        return next
+      })
+    },
+    [persist]
+  )
+
+  const reorder = useCallback(
+    (nextItems: FollowupQueueItem[]) => {
+      setItems(nextItems)
+      persist(nextItems)
+    },
+    [persist]
+  )
+
+  // Drain one message per completion: on the live→idle edge, acknowledge it (so it fires once) and
+  // send the head; on success dequeue. The next send goes busy→idle again and drains the next item.
+  useEffect(() => {
+    if (!isFulfilled || paused) return
+    const head = itemsRef.current[0]
+    if (!head) return
+    markSeen()
+    void onDrainRef.current(head.payload).then((sent) => {
+      if (sent) removeId(head.id)
+    })
+  }, [isFulfilled, paused, markSeen, removeId])
+
+  return { items, enqueue, removeId, reorder, paused, setPaused }
+}

--- a/src/renderer/pages/home/__tests__/ChatComposerSlot.test.tsx
+++ b/src/renderer/pages/home/__tests__/ChatComposerSlot.test.tsx
@@ -1,0 +1,45 @@
+import type { ComposerContextValue } from '@renderer/components/chat/composer/ComposerContext'
+import type { Topic } from '@renderer/types'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import ChatComposerSlot from '../ChatComposerSlot'
+
+// The real fallback composer pulls in the whole input toolbar; swap it for a
+// sentinel so the test exercises only the override-forwarding wire.
+vi.mock('@renderer/components/chat/composer/variants/ChatComposer', () => ({
+  ChatPlacementComposer: () => <div data-testid="chat-fallback-composer">fallback</div>
+}))
+
+const topic = { id: 'topic-1' } as Topic
+
+const baseProps = {
+  isHome: false,
+  topic,
+  onSend: vi.fn()
+}
+
+describe('ChatComposerSlot', () => {
+  it('renders the normal composer when no approval override is active', () => {
+    render(<ChatComposerSlot {...baseProps} composerContext={{ overrides: [] }} />)
+
+    expect(screen.getByTestId('chat-fallback-composer')).toBeInTheDocument()
+  })
+
+  it('surfaces an active composer override (tool-approval card) in place of the input', () => {
+    const composerContext: ComposerContextValue = {
+      overrides: [
+        {
+          id: 'tool-permission:approval-1',
+          priority: 90,
+          render: () => <div data-testid="permission-card">approve?</div>
+        }
+      ]
+    }
+
+    render(<ChatComposerSlot {...baseProps} composerContext={composerContext} />)
+
+    expect(screen.getByTestId('permission-card')).toBeInTheDocument()
+    expect(screen.queryByTestId('chat-fallback-composer')).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/pages/home/useChatRuntimeState.ts
+++ b/src/renderer/pages/home/useChatRuntimeState.ts
@@ -1,0 +1,412 @@
+import { useInvalidateCache } from '@data/hooks/useDataApi'
+import { loggerService } from '@logger'
+import type { ComposerContextValue } from '@renderer/components/chat/composer/ComposerContext'
+import { useToolApprovalComposerOverrides } from '@renderer/components/chat/composer/useToolApprovalComposerOverrides'
+import { type TranslationOverlayEntry, type TranslationOverlaySetter } from '@renderer/components/chat/messages/blocks'
+import {
+  buildTopicMessageFlowLiveState,
+  type TopicMessageFlowLiveState
+} from '@renderer/components/chat/messages/flow/topicMessageFlowLiveTree'
+import { useChatWithHistory } from '@renderer/hooks/useChatWithHistory'
+import {
+  type ConversationHistoryAdapter,
+  useConversationTurnController
+} from '@renderer/hooks/useConversationTurnController'
+import { type ExecutionFinishEvent, useExecutionOverlay } from '@renderer/hooks/useExecutionOverlay'
+import type { TemporaryConversation } from '@renderer/hooks/useTemporaryConversation'
+import { useToolApprovalBridge } from '@renderer/hooks/useToolApprovalBridge'
+import { useTopicOverlayHandoffOnTerminal } from '@renderer/hooks/useTopicStreamStatus'
+import type { FileMetadata, Topic } from '@renderer/types'
+import type { ActiveExecution } from '@shared/ai/transport'
+import type { CherryMessagePart, CherryUIMessage } from '@shared/data/types/message'
+import type { UniqueModelId } from '@shared/data/types/model'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { useChatWriteActions } from './hooks/useChatWriteActions'
+import { useStablePartsByMessageId } from './hooks/useStablePartsByMessageId'
+import { useTopicMessagesCache, type UseTopicMessagesCacheParams } from './hooks/useTopicMessagesCache'
+
+const logger = loggerService.withContext('useChatRuntimeState')
+
+export interface ChatTurnInput {
+  text: string
+  options?: {
+    files?: FileMetadata[]
+    mentionedModels?: UniqueModelId[]
+    knowledgeBaseIds?: string[]
+    userMessageParts?: CherryMessagePart[]
+  }
+}
+
+interface UseChatRuntimeStateParams {
+  topic: Topic
+  isHistoryLoading: boolean
+  isFreshTemporaryTopic: boolean
+  onPersistTemporaryTopic?: (initialName?: string) => Promise<TemporaryConversation | null>
+  onTemporaryTopicPersisted: () => void
+  initialMessages: CherryUIMessage[]
+  uiMessages: CherryUIMessage[]
+  refresh: () => Promise<CherryUIMessage[]>
+  activeNodeId: string | null
+  messagesCacheMutate: UseTopicMessagesCacheParams['mutate']
+  onBranchLiveStateChange?: (state: TopicMessageFlowLiveState | null) => void
+  clearBranchDraft?: () => void
+  getBranchDraftAnchorId?: () => string | null
+}
+
+function mergeBranchLiveMessages(...sources: CherryUIMessage[][]): CherryUIMessage[] {
+  const order: string[] = []
+  const byId = new Map<string, CherryUIMessage>()
+
+  for (const messages of sources) {
+    for (const message of messages) {
+      const existing = byId.get(message.id)
+      if (!existing) {
+        order.push(message.id)
+        byId.set(message.id, message)
+        continue
+      }
+
+      const metadata = existing.metadata || message.metadata ? { ...existing.metadata, ...message.metadata } : undefined
+      byId.set(message.id, {
+        ...existing,
+        ...message,
+        ...(metadata && { metadata })
+      })
+    }
+  }
+
+  return order.flatMap((id) => {
+    const message = byId.get(id)
+    return message ? [message] : []
+  })
+}
+
+function mergeActiveExecutions(...sources: ActiveExecution[][]): ActiveExecution[] {
+  const order: string[] = []
+  const byId = new Map<string, ActiveExecution>()
+
+  for (const executions of sources) {
+    for (const execution of executions) {
+      const existing = byId.get(execution.executionId)
+      if (!existing) order.push(execution.executionId)
+      byId.set(execution.executionId, {
+        ...existing,
+        ...execution,
+        anchorMessageId: execution.anchorMessageId ?? existing?.anchorMessageId
+      })
+    }
+  }
+
+  return order.flatMap((executionId) => {
+    const execution = byId.get(executionId)
+    return execution ? [execution] : []
+  })
+}
+
+function getReservedActiveExecutions(messages: CherryUIMessage[]): ActiveExecution[] {
+  const executions: ActiveExecution[] = []
+  const seen = new Set<string>()
+
+  for (const message of messages) {
+    const executionId = message.role === 'assistant' ? message.metadata?.modelId : undefined
+    if (!executionId || seen.has(executionId)) continue
+    seen.add(executionId)
+    executions.push({ executionId: executionId as ActiveExecution['executionId'], anchorMessageId: message.id })
+  }
+
+  return executions
+}
+
+export function useChatRuntimeState({
+  topic,
+  isHistoryLoading,
+  isFreshTemporaryTopic,
+  onPersistTemporaryTopic,
+  onTemporaryTopicPersisted,
+  initialMessages,
+  uiMessages,
+  refresh,
+  activeNodeId,
+  messagesCacheMutate,
+  onBranchLiveStateChange,
+  clearBranchDraft,
+  getBranchDraftAnchorId
+}: UseChatRuntimeStateParams) {
+  const { regenerate, stop, setMessages, activeExecutions } = useChatWithHistory(topic.id, initialMessages, refresh)
+  const messages = uiMessages
+  const invalidateCache = useInvalidateCache()
+
+  // PR 3: the effect that pushed `uiMessages` into `useChat.setMessages` after
+  // every terminal render was the user's banned anti-pattern (effect-driven
+  // mutation of SWR-read data into another store). The only consumer that
+  // needs `useChat.state.messages` hydrated is `regenerate({ messageId })` for
+  // anchor resolution — that snapshot now happens synchronously at the call
+  // site inside `chatWriteActions.regenerateWithCapabilities`.
+
+  const [translationOverlay, setTranslationOverlayMap] = useState<Record<string, TranslationOverlayEntry>>({})
+  const [branchLiveMessages, setBranchLiveMessages] = useState<CherryUIMessage[]>([])
+  const [branchLiveExecutions, setBranchLiveExecutions] = useState<ActiveExecution[]>([])
+  const finishedBranchExecutionIdsRef = useRef<Set<string>>(new Set())
+  const runtimeBranchLiveStatePublishedRef = useRef(false)
+  useEffect(() => {
+    finishedBranchExecutionIdsRef.current.clear()
+    runtimeBranchLiveStatePublishedRef.current = false
+    setBranchLiveMessages([])
+    setBranchLiveExecutions([])
+  }, [topic.id])
+  const setTranslationOverlay = useCallback<TranslationOverlaySetter>((messageId, entry) => {
+    setTranslationOverlayMap((prev) => {
+      if (entry == null) {
+        if (!(messageId in prev)) return prev
+        const next = { ...prev }
+        delete next[messageId]
+        return next
+      }
+      const existing = prev[messageId]
+      if (
+        existing &&
+        existing.content === entry.content &&
+        existing.targetLanguage === entry.targetLanguage &&
+        existing.sourceLanguage === entry.sourceLanguage
+      ) {
+        return prev
+      }
+      return { ...prev, [messageId]: entry }
+    })
+  }, [])
+
+  const branchActiveExecutions = useMemo(
+    () => mergeActiveExecutions(branchLiveExecutions, [...activeExecutions]),
+    [activeExecutions, branchLiveExecutions]
+  )
+
+  const finishRef = useRef<((executionId: string, event: ExecutionFinishEvent) => void) | undefined>(undefined)
+  const {
+    overlay,
+    liveAssistants,
+    disposeOverlay,
+    reset: resetOverlay
+  } = useExecutionOverlay(topic.id, branchActiveExecutions, messages, {
+    onFinish: (executionId, event) => finishRef.current?.(executionId, event)
+  })
+
+  // Deterministic overlay→DB handoff at terminal (see hook docs). The overlay's
+  // `onFinish` is suppressed when an execution leaves `activeExecutions`, so a
+  // torn-down turn's live card would otherwise override the finalized DB row.
+  // Refresh-then-dispose off the status edge; branch-rollback/bookkeeping stays
+  // in `handleExecutionFinish`. Excludes awaiting-approval (card must remain).
+  useTopicOverlayHandoffOnTerminal(topic.id, async () => {
+    try {
+      await refresh()
+    } finally {
+      resetOverlay()
+    }
+  })
+
+  const partsByMessageId = useStablePartsByMessageId(messages, overlay, translationOverlay)
+
+  // Tool-approval card surface. Awaiting-approval tools render `null` inline
+  // (see MessageMcpTool / AgentExecutionTimeline), so the composer override is
+  // the only approve/deny UI. The bridge just delivers the decision to main;
+  // the card hides optimistically and the live stream pushes the continuation.
+  const respondToolApproval = useToolApprovalBridge(topic.id)
+  const toolApprovalComposerOverrides = useToolApprovalComposerOverrides({
+    partsByMessageId,
+    onRespond: respondToolApproval
+  })
+  const composerContext = useMemo<ComposerContextValue>(
+    () => ({ overrides: toolApprovalComposerOverrides }),
+    [toolApprovalComposerOverrides]
+  )
+
+  const cache = useTopicMessagesCache({ topicId: topic.id, mutate: messagesCacheMutate })
+  const seedReservedMessages = useCallback(
+    async (reservedMessages: CherryUIMessage[]) => {
+      if (reservedMessages.length > 0) {
+        const reservedExecutions = getReservedActiveExecutions(reservedMessages)
+        if (reservedExecutions.length > 0) {
+          for (const execution of reservedExecutions) {
+            finishedBranchExecutionIdsRef.current.delete(execution.executionId)
+          }
+          setBranchLiveExecutions((current) => mergeActiveExecutions(current, reservedExecutions))
+        }
+        setBranchLiveMessages((current) => mergeBranchLiveMessages(current, reservedMessages))
+      }
+      await cache.seedReservedMessages(reservedMessages)
+    },
+    [cache.seedReservedMessages]
+  )
+  const historyAdapter = useMemo<ConversationHistoryAdapter>(
+    () => ({
+      seedReservedMessages,
+      refresh,
+      rollback: isFreshTemporaryTopic ? cache.clearBranchCache : cache.rollbackBranch
+    }),
+    [cache.clearBranchCache, cache.rollbackBranch, isFreshTemporaryTopic, refresh, seedReservedMessages]
+  )
+  const turnController = useConversationTurnController<
+    ChatTurnInput,
+    { topicId: string; parentAnchorId: string | null }
+  >({
+    scopeKey: topic.id,
+    historyAdapter,
+    ensureConversation: async ({ text }) => {
+      if (isHistoryLoading) return null
+      const parentAnchorId = getBranchDraftAnchorId?.() ?? activeNodeId ?? null
+      if (isFreshTemporaryTopic && onPersistTemporaryTopic) {
+        const persisted = await onPersistTemporaryTopic(text)
+        if (persisted?.type !== 'assistant') {
+          throw new Error('Temporary topic handoff failed before stream open')
+        }
+        onTemporaryTopicPersisted()
+        return { topicId: persisted.topicId, parentAnchorId }
+      }
+      return { topicId: topic.id, parentAnchorId }
+    },
+    buildStreamRequest: ({ text, options }, conversation) => ({
+      trigger: 'submit-message',
+      topicId: conversation.topicId,
+      parentAnchorId: conversation.parentAnchorId ?? undefined,
+      userMessageParts: options?.userMessageParts ?? [{ type: 'text', text }],
+      mentionedModelIds: options?.mentionedModels
+    }),
+    refreshMetadata: ({ topicId }) => invalidateCache(['/topics', `/topics/${topicId}`])
+  })
+
+  const activeStreamingMessageIds = useMemo(
+    () =>
+      new Set([
+        ...branchActiveExecutions.flatMap((execution) =>
+          execution.anchorMessageId ? [execution.anchorMessageId] : []
+        ),
+        ...liveAssistants.map((message) => message.id)
+      ]),
+    [branchActiveExecutions, liveAssistants]
+  )
+  const activeAnchorMessages = useMemo(
+    () => messages.filter((message) => activeStreamingMessageIds.has(message.id)),
+    [activeStreamingMessageIds, messages]
+  )
+  const branchFlowLiveMessages = useMemo(
+    () => mergeBranchLiveMessages(branchLiveMessages, activeAnchorMessages, liveAssistants),
+    [activeAnchorMessages, branchLiveMessages, liveAssistants]
+  )
+
+  useEffect(() => {
+    if (!onBranchLiveStateChange) return
+
+    if (branchActiveExecutions.length === 0 && branchFlowLiveMessages.length === 0) {
+      if (runtimeBranchLiveStatePublishedRef.current) {
+        runtimeBranchLiveStatePublishedRef.current = false
+        onBranchLiveStateChange(null)
+      }
+      return
+    }
+
+    const liveState = buildTopicMessageFlowLiveState({
+      topicId: topic.id,
+      messages: branchFlowLiveMessages,
+      partsByMessageId,
+      activeNodeId: branchFlowLiveMessages.at(-1)?.id ?? activeNodeId,
+      streamingMessageIds: activeStreamingMessageIds
+    })
+
+    if (!liveState) {
+      if (runtimeBranchLiveStatePublishedRef.current) {
+        runtimeBranchLiveStatePublishedRef.current = false
+        onBranchLiveStateChange(null)
+      }
+      return
+    }
+
+    runtimeBranchLiveStatePublishedRef.current = true
+    onBranchLiveStateChange(liveState)
+  }, [
+    activeNodeId,
+    branchActiveExecutions.length,
+    activeStreamingMessageIds,
+    branchFlowLiveMessages,
+    onBranchLiveStateChange,
+    partsByMessageId,
+    topic.id
+  ])
+
+  const handleExecutionFinish = useCallback(
+    (executionId: string, { message, isError }: ExecutionFinishEvent) => {
+      const treeCachePath = `/topics/${topic.id}/tree`
+      void (async () => {
+        try {
+          if (isError || !message.parts?.length) {
+            await cache.rollbackBranch()
+          } else {
+            await refresh()
+          }
+          await invalidateCache(treeCachePath)
+        } catch (err) {
+          logger.warn('failed to reconcile topic branch flow after execution finish', err as Error)
+        } finally {
+          finishedBranchExecutionIdsRef.current.add(executionId)
+          disposeOverlay(message.id)
+          setBranchLiveExecutions((current) => current.filter((execution) => execution.executionId !== executionId))
+          const hasRemainingExecutions = branchActiveExecutions.some(
+            (execution) => !finishedBranchExecutionIdsRef.current.has(execution.executionId)
+          )
+          if (hasRemainingExecutions) {
+            setBranchLiveMessages((current) => current.filter((item) => item.id !== message.id))
+          } else {
+            setBranchLiveMessages([])
+            runtimeBranchLiveStatePublishedRef.current = false
+            onBranchLiveStateChange?.(null)
+          }
+        }
+      })()
+    },
+    [branchActiveExecutions, cache, disposeOverlay, invalidateCache, onBranchLiveStateChange, refresh, topic.id]
+  )
+  finishRef.current = handleExecutionFinish
+
+  const shouldRenderHomeComposer =
+    !isHistoryLoading &&
+    isFreshTemporaryTopic &&
+    turnController.layout === 'draft' &&
+    uiMessages.length === 0 &&
+    branchActiveExecutions.length === 0
+
+  const { actions: chatWriteActions } = useChatWriteActions({
+    topic,
+    uiMessages: messages,
+    regenerate,
+    setMessages,
+    stop,
+    refresh,
+    cache,
+    seedReservedMessages
+  })
+
+  const sendMessage = useCallback(
+    async (text: string, options?: ChatTurnInput['options']) => {
+      try {
+        const ack = await turnController.send({ text, options })
+        if (ack?.mode === 'started') {
+          clearBranchDraft?.()
+        }
+      } catch (err) {
+        logger.warn('failed to open conversation turn', err as Error)
+        throw err
+      }
+    },
+    [clearBranchDraft, turnController]
+  )
+
+  return {
+    messages,
+    partsByMessageId,
+    shouldRenderHomeComposer,
+    chatWriteActions,
+    sendMessage,
+    composerContext,
+    translationOverlay,
+    setTranslationOverlay
+  }
+}

--- a/tests/renderer.setup.ts
+++ b/tests/renderer.setup.ts
@@ -153,8 +153,17 @@ vi.mock('@cherrystudio/ui', () => {
   const SelectContext = React.createContext({ value: undefined, onValueChange: undefined })
   const PopoverContext = React.createContext({ open: false, onOpenChange: undefined })
   return {
-    Button: ({ children, onPress, disabled, isDisabled, startContent, asChild, ...props }) => {
-      const buttonProps = { ...props, onClick: onPress ?? props.onClick, disabled: disabled || isDisabled }
+    ReorderableList: ({ items, renderItem, getId }) =>
+      React.createElement(
+        React.Fragment,
+        null,
+        items.map((item, index) =>
+          React.createElement('div', { key: getId(item) }, renderItem(item, index, { dragging: false }))
+        )
+      ),
+    NormalTooltip: ({ children }) => children,
+    Button: ({ children, onPress, disabled, isDisabled, loading, startContent, asChild, ...props }) => {
+      const buttonProps = { ...props, onClick: onPress ?? props.onClick, disabled: disabled || isDisabled || loading }
       if (asChild && React.isValidElement(children)) {
         const childProps = children.props || {}
         return React.cloneElement(children, {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Home chat follow-up sends during an active stream did not have a dedicated queued-send path.

After this PR:

Home chat queues follow-up input while a stream is active and submits it when the runtime can continue.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR keeps the feature scoped to the home page and copies only the required page-level wiring.

The following alternatives were considered:

A shared frontend abstraction was deferred because the stack needs page-isolated PRs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Stack PR 11/15 for the chat-page split. Base: `codex/chat-stack-10-builtin-tool-names`; head: `codex/chat-stack-11-home-followups`.

Validated at the top of this stack with `pnpm lint`, `pnpm test`, `pnpm db:migrations:check`, and `git diff --check`. Local Node 22.22.0 emitted the expected engine warning for the repo requirement `>=24.11.1`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Home chat now queues follow-up messages while a response is still streaming.
```
