### PR TITLE
feat(message-tools): render agent deliverables

### DIFF
--- a/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
@@ -1,0 +1,783 @@
+/**
+ * MessagePartsRenderer — message parts renderer.
+ *
+ * Routes CherryMessagePart[] directly to leaf components. No intermediate
+ * block conversion — each part type is rendered from its raw data.
+ *
+ * Grouping logic:
+ * - Consecutive file parts with image mediaType → image block row
+ * - Consecutive tool-* / dynamic-tool parts → ToolBlockGroup
+ * - data-video parts with same filePath → video block row
+ */
+
+import { loggerService } from '@logger'
+import { ErrorBoundary } from '@renderer/components/ErrorBoundary'
+import { useIsActiveTurnTarget } from '@renderer/hooks/useIsActiveTurnTarget'
+import { useTopicStreamStatus } from '@renderer/hooks/useTopicStreamStatus'
+import { FILE_TYPE } from '@renderer/types/file'
+import { convertReferencesToCitationReferences, convertReferencesToCitations } from '@renderer/utils/partsToBlocks'
+import type { CherryMessagePart, ContentReference, ReasoningUIPart } from '@shared/data/types/message'
+import type { CherryProviderMetadata, ErrorPartData, VideoPartData } from '@shared/data/types/uiParts'
+import { getToolName, isDataUIPart, isFileUIPart, isToolUIPart } from 'ai'
+import { ChevronDown } from 'lucide-react'
+import { AnimatePresence, motion, type Variants } from 'motion/react'
+import React, { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import MessageAttachments from '../frame/MessageAttachments'
+import MessageVideo from '../frame/MessageVideo'
+import { useMessageRenderConfig } from '../MessageListProvider'
+import { isReportArtifactsToolResponse, MessageReportArtifacts } from '../tools/agent/ReportArtifacts'
+import { AgentToolsType } from '../tools/agent/types'
+import MessageTools, { canRenderMessageTool } from '../tools/MessageTools'
+import { hasPartParentToolCallId } from '../tools/toolParentMetadata'
+import { buildToolResponseFromPart, type ToolRenderItem } from '../tools/toolResponse'
+import type { MessageListItem } from '../types'
+import BlockErrorFallback from './BlockErrorFallback'
+import CompactBlock from './CompactBlock'
+import CompactionAnchorBlock from './CompactionAnchorBlock'
+import ErrorBlock from './ErrorBlock'
+import ImageBlock from './ImageBlock'
+import MainTextBlock from './MainTextBlock'
+import { useMessageParts, useTranslationOverlayEntry } from './MessagePartsContext'
+import PlaceholderBlock, { type PlaceholderStatus } from './PlaceholderBlock'
+import ThinkingBlock from './ThinkingBlock'
+import ToolBlockGroup, { ToolBlockGroupContent, ToolBlockGroupHeaderContent } from './ToolBlockGroup'
+import TranslationBlock from './TranslationBlock'
+
+const logger = loggerService.withContext('MessagePartsRenderer')
+
+// ============================================================================
+// Animation shared by message block renderers.
+// ============================================================================
+
+const blockWrapperVariants: Variants = {
+  visible: {
+    opacity: 1,
+    x: 0,
+    transition: { duration: 0.3, type: 'spring', bounce: 0 }
+  },
+  hidden: {
+    opacity: 0,
+    x: 10
+  },
+  static: {
+    opacity: 1,
+    x: 0,
+    transition: { duration: 0 }
+  }
+}
+
+const blockWrapperFadeVariants: Variants = {
+  visible: {
+    opacity: 1,
+    transition: { duration: 0.2 }
+  },
+  hidden: {
+    opacity: 0
+  }
+}
+
+const AnimatedBlockWrapper: React.FC<{
+  children: React.ReactNode
+  enableAnimation: boolean
+  className?: string
+  animation?: 'slide' | 'fade'
+}> = ({ className, children, enableAnimation, animation = 'slide' }) => {
+  const wrapperClassName = ['block-wrapper', className].filter(Boolean).join(' ')
+
+  // Latch: Once a block has entered the motion.div branch during streaming (enableAnimation === true),
+  // we keep it there forever (hasEverAnimated === true). Returning to a plain <div> when streaming
+  // ends changes the React element type, triggering a full subtree remount which would destroy
+  // child components' internal state (e.g. ThinkingBlock's timer and fold/unfold state) and cause flicker.
+  const [hasEverAnimated, setHasEverAnimated] = React.useState(enableAnimation)
+
+  React.useEffect(() => {
+    if (enableAnimation) {
+      setHasEverAnimated(true)
+    }
+  }, [enableAnimation])
+
+  if (!hasEverAnimated) {
+    return (
+      <div className={wrapperClassName}>
+        <ErrorBoundary fallbackComponent={BlockErrorFallback}>{children}</ErrorBoundary>
+      </div>
+    )
+  }
+  const variants = animation === 'fade' ? blockWrapperFadeVariants : blockWrapperVariants
+  return (
+    <motion.div
+      className={wrapperClassName}
+      variants={enableAnimation ? variants : undefined}
+      initial={enableAnimation ? 'hidden' : undefined}
+      animate={enableAnimation ? 'visible' : undefined}>
+      <ErrorBoundary fallbackComponent={BlockErrorFallback}>{children}</ErrorBoundary>
+    </motion.div>
+  )
+}
+
+// ============================================================================
+// Props
+// ============================================================================
+
+interface Props {
+  message: MessageListItem
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Check if a part is an image file part. */
+function isImageFilePart(part: CherryMessagePart): boolean {
+  return isFileUIPart(part) && part.mediaType.startsWith('image/')
+}
+
+/** Extract image URL from a file part. */
+function extractImageUrl(part: CherryMessagePart): string | undefined {
+  if (part.type !== 'file' || !('url' in part)) return undefined
+  const filePart = part as { url?: string; mediaType?: string }
+  return filePart.url || undefined
+}
+
+/** Get video filePath from a data-video part. */
+function getVideoFilePath(part: CherryMessagePart): string | undefined {
+  if (isDataUIPart(part) && part.type === 'data-video') {
+    return part.data.filePath
+  }
+  return undefined
+}
+
+// ============================================================================
+// Part grouping
+// ============================================================================
+
+type PartEntry = { part: CherryMessagePart; index: number }
+type GroupedEntry = PartEntry | PartEntry[]
+
+function groupPartEntries(entries: readonly PartEntry[]): GroupedEntry[] {
+  return entries.reduce<GroupedEntry[]>((acc, entry) => {
+    const { part } = entry
+
+    if (isImageFilePart(part)) {
+      const prev = acc[acc.length - 1]
+      if (Array.isArray(prev) && isImageFilePart(prev[0].part)) {
+        prev.push(entry)
+      } else {
+        acc.push([entry])
+      }
+    } else if (isToolUIPart(part)) {
+      const prev = acc[acc.length - 1]
+      if (Array.isArray(prev) && isToolUIPart(prev[0].part)) {
+        prev.push(entry)
+      } else {
+        acc.push([entry])
+      }
+    } else if (isDataUIPart(part) && part.type === 'data-video') {
+      const filePath = getVideoFilePath(part)
+      const existingGroup = acc.find(
+        (g) =>
+          Array.isArray(g) &&
+          isDataUIPart(g[0].part) &&
+          g[0].part.type === 'data-video' &&
+          getVideoFilePath(g[0].part) === filePath
+      ) as PartEntry[] | undefined
+      if (existingGroup) {
+        existingGroup.push(entry)
+      } else {
+        acc.push([entry])
+      }
+    } else {
+      acc.push(entry)
+    }
+
+    return acc
+  }, [])
+}
+
+function isSummaryMessagePart(part: CherryMessagePart): boolean {
+  const partType = part.type as string
+  if (partType === 'text') {
+    return !!(part as { text?: string }).text?.trim()
+  }
+  if (partType === 'data-code') {
+    return !!(part as { data?: { content?: string } }).data?.content?.trim()
+  }
+  if (partType === 'data-compact' || partType === 'data-translation') {
+    return !!(part as { data?: { content?: string } }).data?.content?.trim()
+  }
+  if (partType === 'data-compaction-anchor') {
+    return true
+  }
+  return false
+}
+
+function isReasoningMessagePart(part: CherryMessagePart): boolean {
+  return (part.type as string) === 'reasoning' && !!(part as ReasoningUIPart).text?.trim()
+}
+
+function isStreamingReasoningMessagePart(part: CherryMessagePart): boolean {
+  return isReasoningMessagePart(part) && (part as ReasoningUIPart).state === 'streaming'
+}
+
+function isResultPart(part: CherryMessagePart): boolean {
+  const partType = part.type as string
+  return isSummaryMessagePart(part) || partType === 'data-error' || partType === 'file' || partType === 'data-video'
+}
+
+function isTopLevelSubagentToolPart(part: CherryMessagePart): boolean {
+  if (!isToolUIPart(part) || hasPartParentToolCallId(part)) return false
+  const toolName = getToolName(part)
+  return toolName === AgentToolsType.Agent || toolName === AgentToolsType.Task
+}
+
+function shouldCollapseAfterLastTool(part: CherryMessagePart): boolean {
+  const partType = part.type as string
+  return (
+    isReasoningMessagePart(part) ||
+    partType === 'step-start' ||
+    partType === 'source-url' ||
+    partType === 'data-citation'
+  )
+}
+
+function getLatestToolHistoryActivity(entries: readonly PartEntry[]): 'thinking' | undefined {
+  for (let index = entries.length - 1; index >= 0; index--) {
+    const { part } = entries[index]
+    if (isStreamingReasoningMessagePart(part)) return 'thinking'
+    if (isToolUIPart(part)) return undefined
+  }
+  return undefined
+}
+
+function getProcessingPlaceholderStatus(entries: readonly PartEntry[]): PlaceholderStatus {
+  for (let index = entries.length - 1; index >= 0; index--) {
+    const { part } = entries[index]
+    if (isToolUIPart(part)) return 'usingTools'
+    if (isReasoningMessagePart(part)) return 'thinking'
+    if (isResultPart(part)) return 'generating'
+  }
+
+  return 'preparing'
+}
+
+// ============================================================================
+// Render helpers — Batch 1 stable components
+// ============================================================================
+
+/** Extract CherryProviderMetadata from a part. */
+function getCherryMeta(part: CherryMessagePart): CherryProviderMetadata | undefined {
+  if ('providerMetadata' in part && part.providerMetadata) {
+    return part.providerMetadata.cherry as CherryProviderMetadata | undefined
+  }
+  return undefined
+}
+
+/**
+ * Memoized adapter from `ErrorPartData` (with optional name/message/stack) to
+ * the normalized `SerializedError` shape `ErrorBlock` consumes. Lives here —
+ * not inline in the switch — so the normalized object's identity is tied to
+ * `rawData`, not to whichever render of the parent triggered it. Keeping
+ * identity stable lets `React.memo(ErrorBlock)` and the downstream `useMemo`s
+ * actually do their job; an inline spread would mint a fresh object every
+ * render and silently break memoization.
+ */
+const ErrorPartView = React.memo(function ErrorPartView({
+  partId,
+  rawData,
+  message
+}: {
+  partId: string
+  rawData: ErrorPartData
+  message: MessageListItem
+}) {
+  const error = useMemo(
+    () => ({
+      ...rawData,
+      name: rawData.name ?? null,
+      message: rawData.message ?? null,
+      stack: rawData.stack ?? null
+    }),
+    [rawData]
+  )
+  return <ErrorBlock partId={partId} error={error} message={message} />
+})
+
+/**
+ * Render a single part directly from CherryMessagePart — no MessageBlock conversion.
+ *
+ * Data extraction happens HERE — leaf components receive pure view props only.
+ */
+function renderPart(
+  part: CherryMessagePart,
+  partId: string,
+  message: MessageListItem,
+  isStreaming: boolean,
+  isTranslationOverlayActive: boolean
+): React.ReactNode {
+  const partType = part.type as string
+
+  switch (partType) {
+    case 'reasoning': {
+      const reasoningPart = part as ReasoningUIPart
+      const cherryMeta = getCherryMeta(part)
+      const metadataBlock =
+        'providerMetadata' in part && part.providerMetadata
+          ? ((part.providerMetadata as Record<string, unknown>).metadata as Record<string, unknown> | undefined)
+          : undefined
+      const thinkingMs =
+        cherryMeta?.thinkingMs ??
+        (typeof metadataBlock?.thinking_millsec === 'number' ? metadataBlock.thinking_millsec : 0)
+      return (
+        <ThinkingBlock
+          key={partId}
+          id={partId}
+          content={reasoningPart.text || ''}
+          isStreaming={reasoningPart.state === 'streaming'}
+          thinkingMs={thinkingMs}
+        />
+      )
+    }
+
+    case 'data-compact': {
+      const compactData = (part as { data: { content: string; compactedContent: string } }).data
+      return (
+        <CompactBlock
+          key={partId}
+          id={partId}
+          content={compactData.content}
+          compactedContent={compactData.compactedContent}
+        />
+      )
+    }
+
+    case 'data-compaction-anchor':
+      return <CompactionAnchorBlock key={partId} />
+
+    case 'data-translation': {
+      const translationData = (part as { data: { content: string } }).data
+      return (
+        <TranslationBlock
+          key={partId}
+          id={partId}
+          content={translationData.content}
+          isStreaming={isStreaming || isTranslationOverlayActive}
+        />
+      )
+    }
+
+    case 'text': {
+      const textPart = part as { text?: string }
+      const cherryMeta = getCherryMeta(part)
+      const citations = cherryMeta?.references
+        ? convertReferencesToCitations(cherryMeta.references as ContentReference[])
+        : []
+      const citationReferences = cherryMeta?.references
+        ? convertReferencesToCitationReferences(cherryMeta.references as ContentReference[], partId)
+        : undefined
+      return (
+        <MainTextBlock
+          key={partId}
+          id={partId}
+          content={textPart.text || ''}
+          isStreaming={isStreaming}
+          citations={citations}
+          citationReferences={citationReferences}
+          role={message.role}
+          composer={cherryMeta?.composer}
+        />
+      )
+    }
+
+    case 'data-code': {
+      const codeData = (part as { data: { content: string; language?: string } }).data
+      const codeContent = `\`\`\`${codeData.language ?? ''}\n${codeData.content}\n\`\`\``
+      return (
+        <MainTextBlock key={partId} id={partId} content={codeContent} isStreaming={isStreaming} role={message.role} />
+      )
+    }
+
+    case 'data-error': {
+      const rawData = 'data' in part ? (part.data as ErrorPartData) : undefined
+      if (!rawData) return null
+      return <ErrorPartView key={partId} partId={partId} rawData={rawData} message={message} />
+    }
+
+    case 'data-video': {
+      const rawData = 'data' in part ? (part.data as VideoPartData) : undefined
+      if (!rawData) return null
+      return <MessageVideo key={partId} url={rawData.url} filePath={rawData.filePath} />
+    }
+
+    case 'data-citation':
+      // Citation data is embedded in MainTextBlock.citationReferences; no standalone render is needed.
+      return null
+
+    case 'file': {
+      const filePart = part as { url?: string; mediaType?: string; filename?: string }
+      if (filePart.mediaType?.startsWith('image/')) {
+        const url = filePart.url
+        if (!url) return null
+        return <ImageBlock key={partId} images={[url]} isSingle={true} />
+      }
+      if (!filePart.url) {
+        logger.warn('File part has no url, skipping', { filename: filePart.filename })
+        return null
+      }
+      return (
+        <MessageAttachments
+          key={partId}
+          file={{
+            id: partId,
+            name: filePart.filename || '',
+            origin_name: filePart.filename || '',
+            path: filePart.url.replace('file://', ''),
+            size: 0,
+            ext: '',
+            type: FILE_TYPE.OTHER,
+            created_at: message.createdAt,
+            count: 0
+          }}
+        />
+      )
+    }
+
+    case 'source-url':
+    case 'step-start':
+      return null
+
+    default: {
+      if (isToolUIPart(part)) {
+        return renderToolPart(part, partId)
+      }
+
+      logger.warn('Unknown part type in MessagePartsRenderer', { type: partType })
+      return null
+    }
+  }
+}
+
+const ToolPartView = React.memo(function ToolPartView({ part, partId }: { part: CherryMessagePart; partId: string }) {
+  const toolResponse = useMemo(() => buildToolResponseFromPart(part, partId), [part, partId])
+  if (!toolResponse) return null
+  return <MessageTools toolResponse={toolResponse} />
+})
+
+function renderToolPart(part: CherryMessagePart, partId: string): React.ReactNode {
+  return <ToolPartView key={partId} part={part} partId={partId} />
+}
+
+interface ToolGroupEntryShape {
+  part: CherryMessagePart
+  index: number
+}
+
+function buildToolRenderItems(entries: readonly ToolGroupEntryShape[], messageId: string): ToolRenderItem[] {
+  return entries.flatMap((e): ToolRenderItem[] => {
+    const id = `${messageId}-part-${e.index}`
+    const toolResponse = buildToolResponseFromPart(e.part, id)
+    return toolResponse && canRenderMessageTool(toolResponse) ? [{ id, toolResponse }] : []
+  })
+}
+
+function getReportArtifactToolResponses(entries: readonly PartEntry[], messageId: string) {
+  return entries.flatMap((entry) => {
+    const toolResponse = buildToolResponseFromPart(entry.part, `${messageId}-part-${entry.index}`)
+    return toolResponse && isReportArtifactsToolResponse(toolResponse) ? [toolResponse] : []
+  })
+}
+
+const ToolGroupView = React.memo(
+  function ToolGroupView({ entries, messageId }: { entries: readonly ToolGroupEntryShape[]; messageId: string }) {
+    const toolItems = buildToolRenderItems(entries, messageId)
+    if (toolItems.length === 0) return null
+    if (toolItems.length === 1) return <MessageTools toolResponse={toolItems[0].toolResponse} />
+    return <ToolBlockGroup items={toolItems} />
+  },
+  (prev, next) => {
+    if (prev.messageId !== next.messageId) return false
+    if (prev.entries.length !== next.entries.length) return false
+    for (let i = 0; i < prev.entries.length; i++) {
+      if (prev.entries[i].part !== next.entries[i].part) return false
+      if (prev.entries[i].index !== next.entries[i].index) return false
+    }
+    return true
+  }
+)
+
+const ToolHistoryGroup = React.memo(function ToolHistoryGroup({
+  entries,
+  message,
+  toolCount,
+  hasResult,
+  isProcessing
+}: {
+  entries: readonly PartEntry[]
+  message: MessageListItem
+  toolCount: number
+  hasResult: boolean
+  isProcessing: boolean
+}) {
+  const { t } = useTranslation()
+  const [isExpanded, setIsExpanded] = React.useState(false)
+  const contentId = React.useId()
+
+  const groupedEntries = useMemo(() => groupPartEntries(entries), [entries])
+  const toolItems = useMemo(() => buildToolRenderItems(entries, message.id), [entries, message.id])
+  const summary = t('message.tools.groupHeader', { count: toolCount })
+  const showLiveProgress = (isProcessing || message.status !== 'success') && !hasResult
+  const activityLabel =
+    showLiveProgress && getLatestToolHistoryActivity(entries) === 'thinking'
+      ? t('message.tools.thinkingHeader')
+      : undefined
+  const headerContent = (
+    <ToolBlockGroupHeaderContent
+      items={toolItems}
+      activityLabel={activityLabel}
+      summary={summary}
+      isLiveProgress={showLiveProgress}
+      showLatestWhenComplete={showLiveProgress}
+    />
+  )
+
+  return (
+    <div className={`group/completed-tool-history max-w-full ${isExpanded ? 'w-full' : 'w-fit'}`}>
+      {showLiveProgress ? (
+        <button
+          type="button"
+          aria-expanded={isExpanded}
+          aria-controls={contentId}
+          className="flex min-h-7 w-full items-center justify-start gap-1 rounded border-0 bg-transparent px-0 py-0.5 text-left focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2"
+          onClick={() => setIsExpanded((expanded) => !expanded)}>
+          {headerContent}
+        </button>
+      ) : (
+        <button
+          type="button"
+          aria-expanded={isExpanded}
+          aria-controls={contentId}
+          className={`-ml-0.5 flex min-h-7 ${isExpanded ? 'w-full' : 'w-fit'} items-center justify-start gap-1.5 rounded border-0 bg-transparent px-0 py-0.5 text-left focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2`}
+          onClick={() => setIsExpanded((expanded) => !expanded)}>
+          <ChevronDown
+            size={16}
+            className={`shrink-0 text-foreground-muted transition-transform duration-150 ${isExpanded ? 'rotate-180' : '-rotate-90'}`}
+          />
+          {headerContent}
+        </button>
+      )}
+      {isExpanded && (
+        <div
+          id={contentId}
+          className="mt-1.5 flex w-full flex-col gap-2 [&>.block-wrapper+.block-wrapper]:mt-0! [&>.block-wrapper:empty]:hidden [&>.block-wrapper]:mt-0! [&_.message-thought-container]:mt-0! [&_.message-thought-container]:mb-0!">
+          {groupedEntries.map((entry) =>
+            renderGroupedEntry(entry, message, false, false, { renderToolGroupsInline: true })
+          )}
+        </div>
+      )}
+    </div>
+  )
+})
+
+function getToolHistoryGroup(
+  entries: readonly PartEntry[],
+  message: MessageListItem,
+  isProcessing: boolean
+): { collapsedEntries: PartEntry[]; resultEntries: PartEntry[]; toolCount: number; hasResult: boolean } | null {
+  if (message.role !== 'assistant') return null
+
+  let lastToolIndex = -1
+  for (let index = entries.length - 1; index >= 0; index--) {
+    if (isToolUIPart(entries[index].part)) {
+      lastToolIndex = index
+      break
+    }
+  }
+
+  if (lastToolIndex < 0) return null
+
+  let collapsedEndIndex = lastToolIndex
+  for (let index = lastToolIndex + 1; index < entries.length; index++) {
+    if (!shouldCollapseAfterLastTool(entries[index].part)) break
+    collapsedEndIndex = index
+  }
+
+  const collapsedEntries = entries.slice(0, collapsedEndIndex + 1)
+  const resultEntries = entries.slice(collapsedEndIndex + 1)
+  const hasResult = resultEntries.some((entry) => isResultPart(entry.part))
+  if (message.status === 'success' && !isProcessing && !hasResult) return null
+  if (collapsedEntries.some((entry) => isTopLevelSubagentToolPart(entry.part))) return null
+
+  const toolCount = collapsedEntries.filter((entry) => isToolUIPart(entry.part)).length
+  if (toolCount === 0) return null
+
+  return {
+    collapsedEntries,
+    resultEntries,
+    toolCount,
+    hasResult
+  }
+}
+
+function renderGroupedEntry(
+  entry: GroupedEntry,
+  message: MessageListItem,
+  isStreaming: boolean,
+  isTranslationOverlayActive: boolean,
+  options?: { renderToolGroupsInline?: boolean }
+): React.ReactNode {
+  if (Array.isArray(entry)) {
+    const groupKey = entry.map((e) => `${message.id}-part-${e.index}`).join('-')
+    const firstPart = entry[0].part
+
+    if (isImageFilePart(firstPart)) {
+      const images = entry.map((e) => extractImageUrl(e.part)).filter(Boolean) as string[]
+      if (images.length === 0) return null
+
+      if (images.length === 1) {
+        return (
+          <AnimatedBlockWrapper key={groupKey} enableAnimation={isStreaming}>
+            <ImageBlock images={images} isSingle={true} />
+          </AnimatedBlockWrapper>
+        )
+      }
+      return (
+        <AnimatedBlockWrapper key={groupKey} enableAnimation={isStreaming}>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10, maxWidth: '100%' }}>
+            {images.map((src, i) => (
+              <ImageBlock key={`${groupKey}-img-${i}`} images={[src]} isSingle={false} />
+            ))}
+          </div>
+        </AnimatedBlockWrapper>
+      )
+    }
+
+    if (isToolUIPart(firstPart)) {
+      const toolItems = buildToolRenderItems(entry, message.id)
+      if (toolItems.length === 0) return null
+
+      const stableGroupKey = `tool-group-${message.id}-part-${entry[0].index}`
+      if (options?.renderToolGroupsInline) {
+        return (
+          <AnimatedBlockWrapper key={stableGroupKey} enableAnimation={isStreaming} animation="fade">
+            <ToolBlockGroupContent items={toolItems} />
+          </AnimatedBlockWrapper>
+        )
+      }
+
+      return (
+        <AnimatedBlockWrapper key={stableGroupKey} enableAnimation={isStreaming} animation="fade">
+          <ToolGroupView entries={entry} messageId={message.id} />
+        </AnimatedBlockWrapper>
+      )
+    }
+
+    if (isDataUIPart(firstPart) && firstPart.type === 'data-video') {
+      const firstEntry = entry[0]
+      const partId = `${message.id}-part-${firstEntry.index}`
+      return (
+        <AnimatedBlockWrapper key={groupKey} enableAnimation={isStreaming}>
+          {renderPart(firstEntry.part, partId, message, isStreaming, isTranslationOverlayActive)}
+        </AnimatedBlockWrapper>
+      )
+    }
+
+    return null
+  }
+
+  const partId = `${message.id}-part-${entry.index}`
+  const rendered = renderPart(entry.part, partId, message, isStreaming, isTranslationOverlayActive)
+  if (!rendered) return null
+
+  return (
+    <AnimatedBlockWrapper
+      key={partId}
+      enableAnimation={isStreaming}
+      className={isReasoningMessagePart(entry.part) ? 'message-thought-wrapper' : undefined}>
+      {rendered}
+    </AnimatedBlockWrapper>
+  )
+}
+
+// ============================================================================
+// Main component
+// ============================================================================
+
+const MessagePartsRenderer: React.FC<Props> = ({ message }) => {
+  const messageParts = useMessageParts(message.id)
+  const { isPending: isTopicStreaming } = useTopicStreamStatus(message.topicId)
+  const isStreaming = isTopicStreaming && message.status === 'pending'
+  const isTranslationOverlayActive = useTranslationOverlayEntry(message.id) !== undefined
+  const renderConfig = useMessageRenderConfig()
+
+  // Beat loader visible only when THIS specific message is the active turn
+  // target. The identity predicate lives in `useIsActiveTurnTarget` so
+  // consumers do not over-scope topic-level stream status to user messages.
+  const isProcessing = useIsActiveTurnTarget(message)
+
+  const partEntries = useMemo(
+    () => messageParts.flatMap((part, index) => (hasPartParentToolCallId(part) ? [] : [{ part, index }])),
+    [messageParts]
+  )
+  const placeholderStatus = useMemo(() => getProcessingPlaceholderStatus(partEntries), [partEntries])
+  const toolHistoryGroup = useMemo(
+    () => (renderConfig.collapseCompletedToolHistory ? getToolHistoryGroup(partEntries, message, isProcessing) : null),
+    [partEntries, message, isProcessing, renderConfig.collapseCompletedToolHistory]
+  )
+  const reportArtifactToolResponses = useMemo(
+    () => getReportArtifactToolResponses(partEntries, message.id),
+    [partEntries, message.id]
+  )
+  const visibleEntries = toolHistoryGroup?.resultEntries ?? partEntries
+
+  const grouped = useMemo(() => {
+    if (visibleEntries.length === 0) return []
+    return groupPartEntries(visibleEntries)
+  }, [visibleEntries])
+
+  // No parts to render — normal for user messages (content is in message text, not parts)
+  // But if the message is processing (pending/streaming), show the loading placeholder
+  if (partEntries.length === 0) {
+    if (isProcessing) {
+      return (
+        <AnimatePresence mode="sync">
+          <AnimatedBlockWrapper key="message-loading-placeholder" enableAnimation={true}>
+            <PlaceholderBlock isProcessing={true} createdAt={message.createdAt} status={placeholderStatus} />
+          </AnimatedBlockWrapper>
+        </AnimatePresence>
+      )
+    }
+    return null
+  }
+
+  return (
+    <AnimatePresence mode="sync">
+      {isProcessing && (
+        <AnimatedBlockWrapper key="message-loading-placeholder" enableAnimation={true}>
+          <PlaceholderBlock isProcessing={true} createdAt={message.createdAt} status={placeholderStatus} />
+        </AnimatedBlockWrapper>
+      )}
+      {toolHistoryGroup && (
+        <AnimatedBlockWrapper key={`tool-history-${message.id}`} enableAnimation={false}>
+          <ToolHistoryGroup
+            entries={toolHistoryGroup.collapsedEntries}
+            message={message}
+            toolCount={toolHistoryGroup.toolCount}
+            hasResult={toolHistoryGroup.hasResult}
+            isProcessing={isProcessing}
+          />
+        </AnimatedBlockWrapper>
+      )}
+      {grouped.map((entry) => {
+        return renderGroupedEntry(entry, message, isStreaming, isTranslationOverlayActive)
+      })}
+      {reportArtifactToolResponses.length > 0 && (
+        <AnimatedBlockWrapper key={`report-artifacts-${message.id}`} enableAnimation={isStreaming} animation="fade">
+          <MessageReportArtifacts toolResponses={reportArtifactToolResponses} />
+        </AnimatedBlockWrapper>
+      )}
+    </AnimatePresence>
+  )
+}
+
+export default React.memo(MessagePartsRenderer)

--- a/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
@@ -1,0 +1,842 @@
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import type * as ReactI18next from 'react-i18next'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { MessageListProvider } from '../../MessageListProvider'
+import { defaultMessageRenderConfig, type MessageListItem, type MessageListProviderValue } from '../../types'
+import { PartsProvider } from '../MessagePartsContext'
+
+// ============================================================================
+// Mocks — keep minimal, only mock what prevents module loading
+// ============================================================================
+
+vi.mock('@logger', () => ({
+  loggerService: { withContext: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() }) }
+}))
+vi.mock('@data/hooks/usePreference', () => ({ usePreference: vi.fn(() => [false, vi.fn()]) }))
+const mockIsActiveTurnTarget = vi.hoisted(() => vi.fn(() => false))
+const mockTopicStreamState = vi.hoisted(() => ({ isPending: false }))
+const mockThinkingBlockMounted = vi.hoisted(() => vi.fn())
+vi.mock('@renderer/hooks/useIsActiveTurnTarget', () => ({
+  useIsActiveTurnTarget: () => mockIsActiveTurnTarget()
+}))
+vi.mock('@renderer/hooks/useTopicStreamStatus', () => ({
+  useTopicStreamStatus: () => ({
+    status: undefined,
+    activeExecutions: [],
+    awaitingApprovalAnchors: [],
+    isPending: mockTopicStreamState.isPending,
+    isFulfilled: false,
+    markSeen: vi.fn()
+  })
+}))
+vi.mock('@renderer/types/file', () => ({
+  FILE_TYPE: { IMAGE: 'image', VIDEO: 'video', AUDIO: 'audio', TEXT: 'text', DOCUMENT: 'document', OTHER: 'other' }
+}))
+
+// motion/react — provide motion.create so Spinner.tsx module loads
+vi.mock('motion/react', () => {
+  const Div = ({ ref, children, ...p }: any) => (
+    <div ref={ref} {...p}>
+      {children}
+    </div>
+  )
+  const proxy = new Proxy({ div: Div, create: (C: any) => C }, { get: (t, k) => (t as any)[k] ?? Div })
+  return { AnimatePresence: ({ children }: any) => <>{children}</>, motion: proxy }
+})
+
+vi.mock('@renderer/components/ErrorBoundary', () => ({
+  ErrorBoundary: ({ children }: any) => <>{children}</>
+}))
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactI18next>()
+
+  return {
+    ...actual,
+    initReactI18next: {
+      type: '3rdParty',
+      init: vi.fn()
+    },
+    useTranslation: () => ({
+      t: (key: string, params?: Record<string, number>) => {
+        if (key === 'message.tools.groupHeader') return `${params?.count} tool calls`
+        if (key === 'message.tools.thinkingHeader') return 'Thinking...'
+        if (key === 'common.preview') return 'Preview'
+        if (key === 'chat.input.tools.open_file') return 'Open File'
+        if (key === 'chat.input.tools.open_file_error') return 'Failed to open file'
+        return key
+      }
+    })
+  }
+})
+
+vi.mock('@iconify/react', () => ({
+  Icon: ({ icon }: { icon: string }) => <span data-icon={icon} />
+}))
+
+// Leaf component mocks — render data-testid with key props for assertions
+vi.mock('@renderer/components/chat/messages/markdown/ChatMarkdown', () => ({
+  __esModule: true,
+  default: ({ block, postProcess }: any) => (
+    <div data-testid="mock-markdown">{postProcess ? postProcess(block.content) : block.content}</div>
+  ),
+  MarkdownBlockContext: React.createContext(null)
+}))
+
+vi.mock('../ImageBlock', () => ({
+  __esModule: true,
+  default: ({ images, isSingle }: any) => (
+    <div data-testid="mock-image-block" data-images={JSON.stringify(images)} data-single={String(isSingle)} />
+  )
+}))
+
+vi.mock('../../tools/MessageTools', () => ({
+  __esModule: true,
+  canRenderMessageTool: (toolResponse: any) =>
+    toolResponse?.tool?.name !== 'report_artifacts' &&
+    !(toolResponse?.tool?.type === 'provider' && toolResponse?.tool?.name === 'web_search'),
+  default: ({ toolResponse }: any) => (
+    <div
+      data-testid="mock-message-tools"
+      data-status={toolResponse?.status}
+      data-tool-type={toolResponse?.tool?.type}
+      data-tool-name={toolResponse?.tool?.name}
+      data-server-name={toolResponse?.tool?.serverName ?? ''}
+    />
+  )
+}))
+
+vi.mock('../../tools/toolResponse', () => ({
+  buildToolResponseFromPart: (part: any, fallbackId?: string) => {
+    const t = part.type as string
+    if (!t.startsWith('tool-') && t !== 'dynamic-tool') return null
+    const id = part.toolCallId ?? fallbackId
+    if (!id) return null
+    const name = part.toolName || t.replace(/^tool-/, '') || 'unknown'
+    const out = part.output
+    const meta = out && typeof out === 'object' && out.metadata ? out.metadata : undefined
+    const isMcp = meta?.type === 'mcp' || t === 'dynamic-tool'
+    const status =
+      part.state === 'output-available'
+        ? 'done'
+        : part.state === 'output-error'
+          ? 'error'
+          : part.state === 'input-available'
+            ? 'invoking'
+            : 'pending'
+    return {
+      id,
+      toolCallId: id,
+      tool: {
+        id,
+        name,
+        type: part.toolType ?? (isMcp ? 'mcp' : 'builtin'),
+        ...(isMcp ? { serverId: meta?.serverId ?? 'unknown', serverName: meta?.serverName ?? 'MCP' } : {})
+      },
+      arguments: part.input,
+      status,
+      response: part.state === 'output-error' ? { isError: true } : (out?.content ?? out)
+    }
+  }
+}))
+
+vi.mock('../../frame/MessageVideo', () => ({
+  __esModule: true,
+  default: ({ url, filePath }: any) => (
+    <div data-testid="mock-message-video" data-url={url ?? ''} data-file-path={filePath ?? ''} />
+  )
+}))
+
+vi.mock('../ErrorBlock', () => ({
+  __esModule: true,
+  default: ({ error }: any) => <div data-testid="mock-error-block" data-error-message={error?.message ?? ''} />
+}))
+
+vi.mock('../ThinkingBlock', () => ({
+  __esModule: true,
+  default: function ThinkingBlockMock({ content, thinkingMs }: any) {
+    React.useEffect(() => {
+      mockThinkingBlockMounted()
+    }, [])
+    return (
+      <div data-testid="mock-thinking-block" data-thinking-ms={String(thinkingMs)}>
+        {content}
+      </div>
+    )
+  }
+}))
+
+vi.mock('../../frame/MessageAttachments', () => ({
+  __esModule: true,
+  default: ({ file }: any) => <div data-testid="mock-attachments" data-file-name={file?.name ?? ''} />
+}))
+
+vi.mock('../ToolBlockGroup', () => ({
+  __esModule: true,
+  ToolBlockGroupContent: ({ items }: any) => (
+    <div data-testid="mock-tool-group-content" data-count={items?.length ?? 0}>
+      {items?.map((item: any) => (
+        <div
+          key={item.id}
+          data-testid="mock-message-tools"
+          data-status={item.toolResponse?.status}
+          data-tool-type={item.toolResponse?.tool?.type}
+          data-tool-name={item.toolResponse?.tool?.name}
+          data-server-name={item.toolResponse?.tool?.serverName ?? ''}
+        />
+      ))}
+    </div>
+  ),
+  ToolBlockGroupHeaderContent: ({ activityLabel, summary, items }: any) => (
+    <span>{activityLabel ?? summary ?? `${items?.length ?? 0} tool calls`}</span>
+  ),
+  default: ({ items }: any) => <div data-testid="mock-tool-group" data-count={items?.length ?? 0} />
+}))
+
+vi.mock('../BlockErrorFallback', () => ({ __esModule: true, default: () => null }))
+vi.mock('../PlaceholderBlock', () => ({
+  __esModule: true,
+  default: ({ createdAt, status }: any) => (
+    <div data-testid="mock-placeholder" data-created-at={createdAt} data-status={status} />
+  )
+}))
+
+// ============================================================================
+// Setup
+// ============================================================================
+
+import MessagePartsRenderer from '../MessagePartsRenderer'
+
+const msg = (overrides: Partial<MessageListItem> = {}): MessageListItem =>
+  ({
+    id: 'msg-1',
+    role: 'assistant',
+    assistantId: 'a',
+    topicId: 't',
+    createdAt: '2026-01-01T00:00:00Z',
+    status: 'success',
+    ...overrides
+  }) as MessageListItem
+
+const renderParts = (
+  parts: CherryMessagePart[],
+  message?: MessageListItem,
+  actions: MessageListProviderValue['actions'] = {}
+) => {
+  const m = message ?? msg()
+  const value: MessageListProviderValue = {
+    state: {
+      topic: { id: m.topicId, name: 'Topic' } as MessageListProviderValue['state']['topic'],
+      messages: [m],
+      partsByMessageId: { [m.id]: parts },
+      messageNavigation: 'none',
+      estimateSize: 400,
+      overscan: 0,
+      loadOlderDelayMs: 0,
+      loadingResetDelayMs: 0,
+      renderConfig: defaultMessageRenderConfig,
+      getMessageActivityState: () => ({
+        isProcessing: false,
+        isStreamTarget: false,
+        isApprovalAnchor: false
+      })
+    },
+    actions,
+    meta: { selectionLayer: false }
+  }
+
+  return render(
+    <MessageListProvider value={value}>
+      <PartsProvider value={{ [m.id]: parts }}>
+        <MessagePartsRenderer message={m} />
+      </PartsProvider>
+    </MessageListProvider>
+  )
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('MessagePartsRenderer', () => {
+  beforeEach(() => {
+    mockIsActiveTurnTarget.mockReturnValue(false)
+    mockTopicStreamState.isPending = false
+    mockThinkingBlockMounted.mockClear()
+  })
+
+  // -- empty --
+  it('renders nothing for empty parts', () => {
+    const { container } = renderParts([])
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('shows the preparing placeholder before any parts arrive', () => {
+    mockIsActiveTurnTarget.mockReturnValue(true)
+
+    renderParts([], msg({ status: 'pending' }))
+
+    expect(screen.getByTestId('mock-placeholder')).toHaveAttribute('data-status', 'preparing')
+    expect(screen.getByTestId('mock-placeholder')).toHaveAttribute('data-created-at', '2026-01-01T00:00:00Z')
+  })
+
+  it('shows the thinking placeholder while reasoning is the latest activity', () => {
+    mockIsActiveTurnTarget.mockReturnValue(true)
+
+    const { container } = renderParts([
+      { type: 'reasoning', text: 'thinking', state: 'streaming' } as unknown as CherryMessagePart
+    ])
+
+    expect(screen.getByTestId('mock-placeholder')).toHaveAttribute('data-status', 'thinking')
+    expect(
+      Array.from(
+        container.querySelectorAll('[data-testid="mock-placeholder"], [data-testid="mock-thinking-block"]')
+      ).map((node) => node.getAttribute('data-testid'))
+    ).toEqual(['mock-placeholder', 'mock-thinking-block'])
+  })
+
+  it('shows the tool placeholder before existing content while a tool call is the latest activity', () => {
+    mockIsActiveTurnTarget.mockReturnValue(true)
+
+    const { container } = renderParts([
+      {
+        type: 'dynamic-tool',
+        toolCallId: 'a',
+        toolName: 'Read',
+        state: 'output-available',
+        input: {},
+        output: { content: 'ok', metadata: { serverName: 'S', serverId: 's1', type: 'mcp' } }
+      }
+    ] as unknown as CherryMessagePart[])
+
+    expect(screen.getByTestId('mock-placeholder')).toHaveAttribute('data-status', 'usingTools')
+    expect(
+      Array.from(container.querySelectorAll('button, [data-testid="mock-placeholder"]')).map(
+        (node) => node.getAttribute('data-testid') ?? node.tagName.toLowerCase()
+      )
+    ).toEqual(['mock-placeholder', 'button'])
+  })
+
+  it('shows the generating placeholder before answer text starts streaming', () => {
+    mockIsActiveTurnTarget.mockReturnValue(true)
+
+    const { container } = renderParts([{ type: 'text', text: 'partial answer' } as unknown as CherryMessagePart])
+
+    expect(screen.getByTestId('mock-placeholder')).toHaveAttribute('data-status', 'generating')
+    expect(
+      Array.from(container.querySelectorAll('[data-testid="mock-markdown"], [data-testid="mock-placeholder"]')).map(
+        (node) => node.getAttribute('data-testid')
+      )
+    ).toEqual(['mock-placeholder', 'mock-markdown'])
+  })
+
+  // -- text --
+  it('renders text part via Markdown', () => {
+    renderParts([{ type: 'text', text: 'hello world' } as unknown as CherryMessagePart])
+    expect(screen.getByTestId('mock-markdown').textContent).toContain('hello world')
+  })
+
+  it('renders a compaction anchor as a separator without a placeholder', () => {
+    renderParts([
+      {
+        type: 'data-compaction-anchor',
+        data: { trigger: 'auto', completedAt: '2026-06-09T12:00:00.000Z' }
+      } as unknown as CherryMessagePart
+    ])
+
+    expect(screen.getByRole('separator')).toBeInTheDocument()
+    expect(screen.queryByTestId('mock-placeholder')).toBeNull()
+  })
+
+  // -- data-code --
+  it('renders data-code as markdown code fence', () => {
+    renderParts([
+      { type: 'data-code', data: { content: 'console.log(1)', language: 'js' } } as unknown as CherryMessagePart
+    ])
+    const md = screen.getByTestId('mock-markdown')
+    expect(md.textContent).toContain('```js')
+    expect(md.textContent).toContain('console.log(1)')
+  })
+
+  // -- images --
+  it('renders single image with isSingle=true', () => {
+    renderParts([
+      { type: 'file', url: 'https://img.test/a.png', mediaType: 'image/png' } as unknown as CherryMessagePart
+    ])
+    const el = screen.getByTestId('mock-image-block')
+    expect(el.getAttribute('data-single')).toBe('true')
+    expect(el.getAttribute('data-images')).toBe('["https://img.test/a.png"]')
+  })
+
+  it('renders multiple images as group with isSingle=false', () => {
+    renderParts([
+      { type: 'file', url: 'https://img.test/a.png', mediaType: 'image/png' },
+      { type: 'file', url: 'https://img.test/b.jpg', mediaType: 'image/jpeg' }
+    ] as unknown as CherryMessagePart[])
+    const blocks = screen.getAllByTestId('mock-image-block')
+    expect(blocks).toHaveLength(2)
+    blocks.forEach((b) => expect(b.getAttribute('data-single')).toBe('false'))
+  })
+
+  it('skips image parts without url', () => {
+    renderParts([{ type: 'file', mediaType: 'image/png' } as unknown as CherryMessagePart])
+    expect(screen.queryByTestId('mock-image-block')).toBeNull()
+  })
+
+  // -- non-image file --
+  it('renders non-image file as attachment', () => {
+    renderParts([
+      {
+        type: 'file',
+        url: 'file:///doc.pdf',
+        mediaType: 'application/pdf',
+        filename: 'doc.pdf'
+      } as unknown as CherryMessagePart
+    ])
+    expect(screen.queryByTestId('mock-image-block')).toBeNull()
+    expect(screen.getByTestId('mock-attachments').getAttribute('data-file-name')).toBe('doc.pdf')
+  })
+
+  // -- tool (single) --
+  it('renders single dynamic-tool via MessageTools', () => {
+    renderParts([
+      {
+        type: 'dynamic-tool',
+        toolCallId: 'tc-1',
+        toolName: 'search',
+        state: 'output-available',
+        input: { q: 'hi' },
+        output: { content: 'ok', metadata: { serverName: 'S', serverId: 's1', type: 'mcp' } }
+      } as unknown as CherryMessagePart
+    ])
+    const el = screen.getByTestId('mock-message-tools')
+    expect(el.getAttribute('data-status')).toBe('done')
+    expect(el.getAttribute('data-tool-name')).toBe('search')
+    expect(el.getAttribute('data-server-name')).toBe('S')
+  })
+
+  it('hides tool parts that belong to a parent agent flow', () => {
+    renderParts([
+      {
+        type: 'dynamic-tool',
+        toolCallId: 'parent',
+        toolName: 'Agent',
+        state: 'output-available',
+        input: { description: 'Explore project' },
+        output: {}
+      },
+      {
+        type: 'dynamic-tool',
+        toolCallId: 'child',
+        toolName: 'Read',
+        state: 'output-available',
+        output: {},
+        callProviderMetadata: {
+          'claude-code': {
+            parentToolCallId: 'parent'
+          }
+        }
+      },
+      {
+        type: 'text',
+        text: 'child text',
+        providerMetadata: {
+          'claude-code': {
+            parentToolCallId: 'parent'
+          }
+        }
+      }
+    ] as unknown as CherryMessagePart[])
+
+    const tools = screen.getAllByTestId('mock-message-tools')
+    expect(tools).toHaveLength(1)
+    expect(tools[0].getAttribute('data-tool-name')).toBe('Agent')
+    expect(screen.queryByText('child text')).toBeNull()
+  })
+
+  // -- tool group --
+  it('renders multiple tool parts as ToolBlockGroup', () => {
+    renderParts([
+      { type: 'dynamic-tool', toolCallId: 'a', toolName: 't1', state: 'output-available', output: {} },
+      { type: 'dynamic-tool', toolCallId: 'b', toolName: 't2', state: 'output-available', output: {} }
+    ] as unknown as CherryMessagePart[])
+    expect(screen.getByTestId('mock-tool-group').getAttribute('data-count')).toBe('2')
+  })
+
+  it('renders grouped dynamic-tool parts without persisted toolCallId using fallback ids', () => {
+    renderParts([
+      { type: 'dynamic-tool', toolName: 'TodoWrite', state: 'output-available', output: {} },
+      { type: 'dynamic-tool', toolName: 'WebSearch', state: 'output-available', output: {} }
+    ] as unknown as CherryMessagePart[])
+    expect(screen.getByTestId('mock-tool-group').getAttribute('data-count')).toBe('2')
+  })
+
+  it('filters hidden tool responses inside ToolBlockGroup', () => {
+    renderParts([
+      { type: 'dynamic-tool', toolCallId: 'a', toolName: 'visible-tool', state: 'output-available', output: {} },
+      {
+        type: 'dynamic-tool',
+        toolCallId: 'hidden-web-search',
+        toolName: 'web_search',
+        toolType: 'provider',
+        state: 'output-available',
+        output: {}
+      },
+      { type: 'dynamic-tool', toolCallId: 'b', toolName: 'another-visible-tool', state: 'output-available', output: {} }
+    ] as unknown as CherryMessagePart[])
+
+    expect(screen.getByTestId('mock-tool-group').getAttribute('data-count')).toBe('2')
+  })
+
+  it('renders report_artifacts at the end of the full message instead of inline', () => {
+    const openArtifactFile = vi.fn()
+    const openPath = vi.fn()
+    const { container } = renderParts(
+      [
+        { type: 'text', text: 'before tool' },
+        {
+          type: 'dynamic-tool',
+          toolCallId: 'report',
+          toolName: 'report_artifacts',
+          state: 'output-available',
+          input: {
+            summary: 'Created final outputs',
+            artifacts: [{ path: 'dist/report.md', description: 'Report' }]
+          },
+          output: {}
+        },
+        { type: 'text', text: 'final answer' }
+      ] as unknown as CherryMessagePart[],
+      undefined,
+      { openArtifactFile, openPath }
+    )
+
+    expect(screen.queryByTestId('mock-message-tools')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Preview report.md' })).toBeInTheDocument()
+    expect(screen.getByText('report.md')).toBeInTheDocument()
+
+    const text = container.textContent ?? ''
+    expect(text.indexOf('final answer')).toBeGreaterThan(-1)
+    expect(text.indexOf('report.md')).toBeGreaterThan(text.indexOf('final answer'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview report.md' }))
+    expect(openArtifactFile).toHaveBeenCalledWith('dist/report.md')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open File report.md' }))
+    expect(openPath).toHaveBeenCalledWith('dist/report.md')
+  })
+
+  it('collapses completed tool history before final result', () => {
+    renderParts([
+      { type: 'text', text: 'checking project files' },
+      { type: 'dynamic-tool', toolCallId: 'a', toolName: 'list', state: 'output-available', output: {} },
+      { type: 'text', text: 'reading package metadata' },
+      { type: 'dynamic-tool', toolCallId: 'b', toolName: 'read', state: 'output-available', output: {} },
+      { type: 'text', text: 'final answer' }
+    ] as unknown as CherryMessagePart[])
+
+    const historyButton = screen.getByRole('button', { name: '2 tool calls' })
+    expect(screen.getByTestId('mock-markdown').textContent).toContain('final answer')
+    expect(screen.queryByText(/checking project files/)).toBeNull()
+    expect(screen.queryByText(/reading package metadata/)).toBeNull()
+
+    fireEvent.click(historyButton)
+
+    expect(document.getElementById(historyButton.getAttribute('aria-controls') ?? '')).toHaveClass(
+      'mt-1.5 flex w-full flex-col gap-2 [&_.message-thought-container]:mb-0! [&_.message-thought-container]:mt-0! [&>.block-wrapper:empty]:hidden'
+    )
+    expect(screen.getAllByTestId('mock-message-tools')).toHaveLength(2)
+    expect(screen.getAllByTestId('mock-markdown').map((node) => node.textContent)).toEqual([
+      'checking project files',
+      'reading package metadata',
+      'final answer'
+    ])
+  })
+
+  it('expands completed history tool runs without nesting another ToolBlockGroup', () => {
+    renderParts([
+      { type: 'text', text: 'checking project files' },
+      { type: 'dynamic-tool', toolCallId: 'a', toolName: 'list', state: 'output-available', output: {} },
+      { type: 'dynamic-tool', toolCallId: 'b', toolName: 'read', state: 'output-available', output: {} },
+      { type: 'text', text: 'final answer' }
+    ] as unknown as CherryMessagePart[])
+
+    const historyButton = screen.getByRole('button', { name: '2 tool calls' })
+    expect(screen.getByTestId('mock-markdown')).toHaveTextContent('final answer')
+    expect(screen.queryByTestId('mock-tool-group')).toBeNull()
+
+    fireEvent.click(historyButton)
+
+    expect(screen.queryByTestId('mock-tool-group')).toBeNull()
+    expect(screen.getByTestId('mock-tool-group-content').getAttribute('data-count')).toBe('2')
+    expect(screen.getAllByTestId('mock-message-tools').map((node) => node.getAttribute('data-tool-name'))).toEqual([
+      'list',
+      'read'
+    ])
+  })
+
+  it('collapses reasoning after the final tool before final result', () => {
+    renderParts([
+      { type: 'text', text: 'checking project files' },
+      { type: 'dynamic-tool', toolCallId: 'a', toolName: 'list', state: 'output-available', output: {} },
+      { type: 'reasoning', text: 'deep thought after tool', state: 'done' },
+      { type: 'text', text: 'final answer' }
+    ] as unknown as CherryMessagePart[])
+
+    const historyButton = screen.getByRole('button', { name: '1 tool calls' })
+    expect(screen.getByTestId('mock-markdown').textContent).toContain('final answer')
+    expect(screen.queryByText(/checking project files/)).toBeNull()
+    expect(screen.queryByTestId('mock-thinking-block')).toBeNull()
+
+    fireEvent.click(historyButton)
+
+    expect(screen.getByTestId('mock-thinking-block')).toHaveTextContent('deep thought after tool')
+    expect(screen.getAllByTestId('mock-markdown').map((node) => node.textContent)).toEqual([
+      'checking project files',
+      'final answer'
+    ])
+  })
+
+  it('marks consecutive reasoning blocks for consistent spacing', () => {
+    renderParts([
+      { type: 'reasoning', text: 'first thought', state: 'done' },
+      { type: 'reasoning', text: 'second thought', state: 'done' }
+    ] as unknown as CherryMessagePart[])
+
+    const thinkingBlocks = screen.getAllByTestId('mock-thinking-block')
+    expect(thinkingBlocks).toHaveLength(2)
+
+    const wrappers = thinkingBlocks.map((block) => block.closest('.block-wrapper'))
+    expect(wrappers[0]).toHaveClass('message-thought-wrapper')
+    expect(wrappers[1]).toHaveClass('message-thought-wrapper')
+  })
+
+  it('keeps reasoning blocks mounted when a pending message settles', () => {
+    mockTopicStreamState.isPending = true
+
+    const parts = [
+      {
+        type: 'reasoning',
+        text: 'steady thought',
+        state: 'done',
+        providerMetadata: { cherry: { thinkingMs: 3100 } }
+      },
+      { type: 'text', text: 'answer still streaming' }
+    ] as unknown as CherryMessagePart[]
+    const pendingMessage = msg({ status: 'pending' })
+    const { rerender } = renderParts(parts, pendingMessage)
+
+    const initialNode = screen.getByTestId('mock-thinking-block')
+    expect(initialNode).toHaveAttribute('data-thinking-ms', '3100')
+    expect(mockThinkingBlockMounted).toHaveBeenCalledTimes(1)
+
+    mockTopicStreamState.isPending = false
+    rerender(
+      <MessageListProvider
+        value={{
+          state: {
+            topic: { id: pendingMessage.topicId, name: 'Topic' } as MessageListProviderValue['state']['topic'],
+            messages: [msg({ status: 'success' })],
+            partsByMessageId: { [pendingMessage.id]: parts },
+            messageNavigation: 'none',
+            estimateSize: 400,
+            overscan: 0,
+            loadOlderDelayMs: 0,
+            loadingResetDelayMs: 0,
+            renderConfig: defaultMessageRenderConfig,
+            getMessageActivityState: () => ({
+              isProcessing: false,
+              isStreamTarget: false,
+              isApprovalAnchor: false
+            })
+          },
+          actions: {},
+          meta: { selectionLayer: false }
+        }}>
+        <PartsProvider value={{ [pendingMessage.id]: parts }}>
+          <MessagePartsRenderer message={msg({ status: 'success' })} />
+        </PartsProvider>
+      </MessageListProvider>
+    )
+
+    expect(screen.getByTestId('mock-thinking-block')).toBe(initialNode)
+    expect(screen.getByTestId('mock-thinking-block')).toHaveAttribute('data-thinking-ms', '3100')
+    expect(mockThinkingBlockMounted).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not render an empty wrapper for tool responses hidden by the tool renderer', () => {
+    const { container } = renderParts([
+      { type: 'reasoning', text: 'first thought', state: 'done' },
+      {
+        type: 'dynamic-tool',
+        toolCallId: 'hidden-web-search',
+        toolName: 'web_search',
+        toolType: 'provider',
+        state: 'output-available',
+        output: {}
+      },
+      { type: 'reasoning', text: 'second thought', state: 'done' }
+    ] as unknown as CherryMessagePart[])
+
+    expect(screen.getAllByTestId('mock-thinking-block')).toHaveLength(2)
+    expect(screen.queryByTestId('mock-message-tools')).toBeNull()
+    expect(container.querySelectorAll('.block-wrapper')).toHaveLength(2)
+  })
+
+  it('collapses tool history while message is pending and keeps the final answer visible', () => {
+    renderParts(
+      [
+        { type: 'text', text: 'checking project files' },
+        { type: 'dynamic-tool', toolCallId: 'a', toolName: 'list', state: 'output-available', output: {} },
+        { type: 'text', text: 'final answer' }
+      ] as unknown as CherryMessagePart[],
+      msg({ status: 'pending' })
+    )
+
+    const historyButton = screen.getByRole('button', { name: '1 tool calls' })
+    expect(historyButton).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.getByTestId('mock-markdown')).toHaveTextContent('final answer')
+    expect(screen.queryByText(/checking project files/)).toBeNull()
+
+    fireEvent.click(historyButton)
+
+    expect(historyButton).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getAllByTestId('mock-markdown').map((node) => node.textContent)).toEqual([
+      'checking project files',
+      'final answer'
+    ])
+  })
+
+  it('collapses thinking content with active tool history before the final result exists', () => {
+    renderParts(
+      [
+        { type: 'reasoning', text: 'thinking before tool', state: 'streaming' },
+        { type: 'dynamic-tool', toolCallId: 'a', toolName: 'list', state: 'input-available', input: {} }
+      ] as unknown as CherryMessagePart[],
+      msg({ status: 'pending' })
+    )
+
+    const historyButton = screen.getByRole('button', { name: '1 tool calls' })
+    expect(historyButton).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByText('thinking before tool')).toBeNull()
+    expect(screen.queryByTestId('mock-message-tools')).toBeNull()
+
+    fireEvent.click(historyButton)
+
+    expect(historyButton).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByTestId('mock-thinking-block')).toHaveTextContent('thinking before tool')
+    expect(screen.getByTestId('mock-message-tools').getAttribute('data-tool-name')).toBe('list')
+  })
+
+  it('shows thinking as the top-level history title while reasoning is streaming after a tool', () => {
+    mockIsActiveTurnTarget.mockReturnValue(true)
+
+    const { container } = renderParts(
+      [
+        { type: 'dynamic-tool', toolCallId: 'a', toolName: 'list', state: 'output-available', output: {} },
+        { type: 'reasoning', text: 'thinking after tool', state: 'streaming' }
+      ] as unknown as CherryMessagePart[],
+      msg({ status: 'pending' })
+    )
+
+    const historyButton = screen.getByRole('button', { name: 'Thinking...' })
+    expect(historyButton).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByTestId('mock-thinking-block')).toBeNull()
+    expect(screen.getByTestId('mock-placeholder')).toHaveAttribute('data-status', 'thinking')
+    expect(
+      Array.from(container.querySelectorAll('[data-testid="mock-placeholder"], button')).map(
+        (node) => node.getAttribute('data-testid') ?? node.tagName.toLowerCase()
+      )
+    ).toEqual(['mock-placeholder', 'button'])
+
+    fireEvent.click(historyButton)
+
+    expect(historyButton).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByTestId('mock-thinking-block')).toHaveTextContent('thinking after tool')
+    expect(screen.getByTestId('mock-message-tools').getAttribute('data-tool-name')).toBe('list')
+  })
+
+  // -- data-video --
+  it('renders data-video with filePath', () => {
+    renderParts([{ type: 'data-video', data: { filePath: '/tmp/v.mp4' } } as unknown as CherryMessagePart])
+    const el = screen.getByTestId('mock-message-video')
+    expect(el.getAttribute('data-file-path')).toBe('/tmp/v.mp4')
+  })
+
+  it('renders data-video with url', () => {
+    renderParts([{ type: 'data-video', data: { url: 'https://v.test/v.mp4' } } as unknown as CherryMessagePart])
+    expect(screen.getByTestId('mock-message-video').getAttribute('data-url')).toBe('https://v.test/v.mp4')
+  })
+
+  // -- data-error --
+  it('renders data-error as ErrorBlock', () => {
+    renderParts([{ type: 'data-error', data: { name: 'Err', message: 'boom' } } as unknown as CherryMessagePart])
+    expect(screen.getByTestId('mock-error-block').getAttribute('data-error-message')).toBe('boom')
+  })
+
+  // -- data-citation --
+  it('returns nothing for data-citation (embedded in text)', () => {
+    const { container } = renderParts([{ type: 'data-citation', data: {} } as unknown as CherryMessagePart])
+    // Should render the AnimatePresence wrapper but no visible content
+    expect(container.querySelector('[data-testid]')).toBeNull()
+  })
+
+  // -- source-url / step-start --
+  it('skips source-url and step-start parts', () => {
+    const { container } = renderParts([
+      { type: 'source-url' } as unknown as CherryMessagePart,
+      { type: 'step-start' } as unknown as CherryMessagePart
+    ])
+    expect(container.querySelector('[data-testid]')).toBeNull()
+  })
+
+  // -- text with citations --
+  it('passes citation references through to MainTextBlock', () => {
+    renderParts([
+      {
+        type: 'text',
+        text: 'cited [1]',
+        providerMetadata: {
+          cherry: {
+            references: [
+              {
+                category: 'citation',
+                citationType: 'web',
+                content: { source: 'websearch', results: [{ url: 'https://ex.com', title: 'Ex' }] }
+              }
+            ]
+          }
+        }
+      } as unknown as CherryMessagePart
+    ])
+    const md = screen.getByTestId('mock-markdown')
+    expect(md.textContent).toContain('data-citation')
+    expect(md.textContent).toContain('https://ex.com')
+  })
+
+  it('renders user text composer metadata as inline token chips', () => {
+    renderParts(
+      [
+        {
+          type: 'text',
+          text: 'Open ',
+          providerMetadata: {
+            cherry: {
+              composer: {
+                version: 1,
+                tokens: [{ id: 'kb-1', kind: 'knowledge', label: 'Docs', index: 0, textOffset: 5 }]
+              }
+            }
+          }
+        } as unknown as CherryMessagePart
+      ],
+      msg({ role: 'user' })
+    )
+
+    expect(screen.getByText('Docs')).toBeInTheDocument()
+    expect(document.querySelector('[data-composer-token-kind="knowledge"]')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/chat/messages/markdown/CodeBlock.tsx
+++ b/src/renderer/components/chat/messages/markdown/CodeBlock.tsx
@@ -1,0 +1,99 @@
+import { ClickableFilePath } from '@renderer/components/chat/messages/tools/agent/ClickableFilePath'
+import { CodeBlockView, HtmlArtifactsCard } from '@renderer/components/CodeBlockView'
+import { isWin } from '@renderer/config/constant'
+import { getCodeBlockId } from '@renderer/utils/markdown'
+import type { Node } from 'mdast'
+import React, { memo, useCallback, useMemo } from 'react'
+import { useIsCodeFenceIncomplete } from 'streamdown'
+
+import { useMessageRenderConfig, useOptionalMessageListActions, useOptionalMessageListUi } from '../MessageListProvider'
+import { isInlineFilePath, normalizeInlineFilePath } from '../utils/filePath'
+
+interface Props {
+  children: string
+  className?: string
+  node?: Omit<Node, 'type'>
+  blockId: string // Message block id
+  [key: string]: any
+}
+
+const INLINE_CODE_CLASS =
+  'inline-flex items-center whitespace-pre-wrap! break-words! rounded-[5px] px-1! py-0.5! text-[0.95em]! leading-normal'
+const INLINE_FILE_PATH_CODE_CLASS = `${INLINE_CODE_CLASS} max-w-full align-middle break-all! [&>span]:translate-y-px`
+
+const mergeClassNames = (...classNames: Array<string | undefined>) => classNames.filter(Boolean).join(' ')
+
+const CodeBlock: React.FC<Props> = ({ children, className, node, blockId }) => {
+  const languageMatch = /language-([\w-+]+)/.exec(className || '')
+  const isMultiline = children?.includes('\n')
+  const detectedLanguage = languageMatch?.[1] ?? (isMultiline ? 'text' : null)
+  const language = useMemo(() => {
+    return detectedLanguage !== 'xml'
+      ? detectedLanguage
+      : /^\s*(?:<\?xml[\s\S]*?\?>\s*)?<svg[\s>]/i.test(children)
+        ? 'svg'
+        : detectedLanguage
+  }, [children, detectedLanguage])
+  const { codeFancyBlock } = useMessageRenderConfig()
+  const isIncomplete = useIsCodeFenceIncomplete()
+
+  // 代码块 id
+  const id = useMemo(() => getCodeBlockId(node?.position?.start), [node?.position?.start])
+
+  const actions = useOptionalMessageListActions()
+  const ui = useOptionalMessageListUi()
+  const canSaveCodeBlock = !!id && !!actions?.saveCodeBlock && ui?.readonly !== true
+
+  const handleSave = useCallback(
+    (newContent: string) => {
+      if (id != null) {
+        void actions?.saveCodeBlock?.({
+          msgBlockId: blockId,
+          codeBlockId: id,
+          newContent
+        })
+      }
+    },
+    [actions, blockId, id]
+  )
+
+  // A plain text fence may be the model's way to present a single generated file or directory path.
+  if (
+    !isWin &&
+    (language === null || language === 'text') &&
+    typeof children === 'string' &&
+    isInlineFilePath(children)
+  ) {
+    return (
+      <code className={mergeClassNames(className, INLINE_FILE_PATH_CODE_CLASS)}>
+        <ClickableFilePath path={normalizeInlineFilePath(children)} />
+      </code>
+    )
+  }
+
+  if (language !== null) {
+    // Fancy code block
+    if (codeFancyBlock) {
+      if (language === 'html') {
+        return (
+          <HtmlArtifactsCard
+            html={children}
+            onSave={handleSave}
+            editable={canSaveCodeBlock}
+            isStreaming={isIncomplete}
+          />
+        )
+      }
+    }
+
+    return (
+      <CodeBlockView language={language} onSave={handleSave} editable={canSaveCodeBlock}>
+        {children}
+      </CodeBlockView>
+    )
+  }
+
+  return <code className={mergeClassNames(className, INLINE_CODE_CLASS)}>{children}</code>
+}
+
+export default memo(CodeBlock)

--- a/src/renderer/components/chat/messages/markdown/__tests__/CodeBlock.test.tsx
+++ b/src/renderer/components/chat/messages/markdown/__tests__/CodeBlock.test.tsx
@@ -1,0 +1,317 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import CodeBlock from '../CodeBlock'
+
+// Hoisted mocks
+const mocks = vi.hoisted(() => {
+  const saveCodeBlock = vi.fn()
+
+  return {
+    saveCodeBlock,
+    messageListActions: { saveCodeBlock } as any,
+    getCodeBlockId: vi.fn(),
+    isCodeFenceIncomplete: false,
+    renderConfig: { codeFancyBlock: true },
+    messageListUi: { readonly: false },
+    isWin: false,
+    CodeBlockView: vi.fn(({ onSave, children }) => (
+      <div>
+        <code>{children}</code>
+        <button type="button" onClick={() => onSave('new code content')}>
+          Save
+        </button>
+      </div>
+    )),
+    HtmlArtifactsCard: vi.fn(({ onSave, html, isStreaming }) => (
+      <div>
+        <div>{html}</div>
+        <div data-testid="html-streaming-state">{String(isStreaming)}</div>
+        <button type="button" onClick={() => onSave('new html content')}>
+          Save HTML
+        </button>
+      </div>
+    ))
+  }
+})
+
+vi.mock('../../MessageListProvider', () => ({
+  useMessageRenderConfig: () => mocks.renderConfig,
+  useOptionalMessageListActions: () => mocks.messageListActions,
+  useOptionalMessageListUi: () => mocks.messageListUi
+}))
+
+vi.mock('@renderer/config/constant', () => ({
+  get isWin() {
+    return mocks.isWin
+  }
+}))
+
+vi.mock('@renderer/utils/markdown', () => ({
+  getCodeBlockId: mocks.getCodeBlockId
+}))
+
+vi.mock('streamdown', () => ({
+  useIsCodeFenceIncomplete: () => mocks.isCodeFenceIncomplete
+}))
+
+vi.mock('@renderer/components/CodeBlockView', () => ({
+  CodeBlockView: mocks.CodeBlockView,
+  HtmlArtifactsCard: mocks.HtmlArtifactsCard
+}))
+
+// Mock message parts context — returns null by default
+vi.mock('@renderer/components/chat/messages/blocks', () => ({
+  useResolveBlock: vi.fn(() => null)
+}))
+
+// Mock ClickableFilePath
+vi.mock('@renderer/components/chat/messages/tools/agent/ClickableFilePath', () => ({
+  ClickableFilePath: ({ path }: { path: string }) => <span data-testid="clickable-file-path">{path}</span>
+}))
+
+describe('CodeBlock', () => {
+  const defaultProps = {
+    blockId: 'test-msg-block-id',
+    node: {
+      position: {
+        start: { line: 1, column: 1, offset: 0 },
+        end: { line: 2, column: 1, offset: 2 },
+        value: 'console.log("hello world")'
+      }
+    },
+    children: 'console.log("hello world")',
+    className: 'language-javascript'
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.isWin = false
+    mocks.messageListActions = { saveCodeBlock: mocks.saveCodeBlock }
+    mocks.messageListUi = { readonly: false }
+    // Default mock return values
+    mocks.getCodeBlockId.mockReturnValue('test-code-block-id')
+    mocks.isCodeFenceIncomplete = false
+  })
+
+  describe('rendering', () => {
+    it('should render a snapshot', () => {
+      const { container } = render(<CodeBlock {...defaultProps} />)
+      expect(container).toMatchSnapshot()
+    })
+
+    it('should render inline code when no language match is found', () => {
+      const inlineProps = {
+        ...defaultProps,
+        className: undefined,
+        children: 'inline code'
+      }
+      render(<CodeBlock {...inlineProps} />)
+
+      const codeElement = screen.getByText('inline code')
+      expect(codeElement.tagName).toBe('CODE')
+      expect(codeElement).not.toHaveAttribute('style')
+      expect(codeElement).toHaveClass('whitespace-pre-wrap!')
+      expect(mocks.CodeBlockView).not.toHaveBeenCalled()
+    })
+
+    it('should render without a message list provider', () => {
+      mocks.messageListActions = undefined
+
+      expect(() => render(<CodeBlock {...defaultProps} />)).not.toThrow()
+      fireEvent.click(screen.getByText('Save'))
+      expect(mocks.saveCodeBlock).not.toHaveBeenCalled()
+    })
+
+    it('should render ClickableFilePath for absolute file paths', () => {
+      const pathProps = {
+        ...defaultProps,
+        className: undefined,
+        children: '/Users/foo/bar.tsx'
+      }
+      render(<CodeBlock {...pathProps} />)
+
+      expect(screen.getByTestId('clickable-file-path')).toBeInTheDocument()
+      expect(screen.getByText('/Users/foo/bar.tsx')).toBeInTheDocument()
+      expect(screen.getByTestId('clickable-file-path').closest('code')).not.toHaveAttribute('style')
+      expect(screen.getByTestId('clickable-file-path').closest('code')).toHaveClass('break-all!')
+    })
+
+    it('should render ClickableFilePath for workspace-relative file paths', () => {
+      render(<CodeBlock {...defaultProps} className={undefined} children="src/renderer/src/index.tsx" />)
+
+      expect(screen.getByTestId('clickable-file-path')).toBeInTheDocument()
+      expect(screen.getByText('src/renderer/src/index.tsx')).toBeInTheDocument()
+    })
+
+    it('should render ClickableFilePath for file paths with a line suffix', () => {
+      render(<CodeBlock {...defaultProps} className={undefined} children="src/renderer/src/index.tsx:42:5" />)
+
+      expect(screen.getByTestId('clickable-file-path')).toBeInTheDocument()
+      expect(screen.getByText('src/renderer/src/index.tsx')).toBeInTheDocument()
+    })
+
+    it('should render ClickableFilePath for absolute file paths wrapped in backticks', () => {
+      render(<CodeBlock {...defaultProps} className={undefined} children="`/Users/foo/bar.tsx`" />)
+
+      expect(screen.getByTestId('clickable-file-path')).toBeInTheDocument()
+      expect(screen.getByText('/Users/foo/bar.tsx')).toBeInTheDocument()
+    })
+
+    it.each([
+      '/home/user/project/src/index.ts',
+      '/tmp/test.log',
+      '/var/log/app.log',
+      '/etc/nginx/nginx.conf',
+      '/path with spaces/file.ts',
+      '/Users/suyao/Library/Application Support/CherryStudioDev/.claude/skills/guizang-ppt-skill/',
+      './src/index.ts',
+      '../packages/ui/src/button.tsx',
+      '../packages/ui/src/'
+    ])('should detect %s as a file path', (path) => {
+      render(<CodeBlock {...defaultProps} className={undefined} children={path} />)
+      expect(screen.getByTestId('clickable-file-path')).toBeInTheDocument()
+    })
+
+    it('should render ClickableFilePath for text code fences containing a single path', () => {
+      const path = '/Users/suyao/Library/Application Support/CherryStudioDev/.claude/skills/guizang-ppt-skill/'
+      render(<CodeBlock {...defaultProps} className="language-text" children={path} />)
+
+      expect(screen.getByTestId('clickable-file-path')).toBeInTheDocument()
+      expect(screen.getByText(path)).toBeInTheDocument()
+      expect(mocks.CodeBlockView).not.toHaveBeenCalled()
+    })
+
+    it.each(['inline code', '/single-segment', '//comment style', 'not/absolute/path'])(
+      'should NOT detect %s as a file path',
+      (text) => {
+        render(<CodeBlock {...defaultProps} className={undefined} children={text} />)
+        expect(screen.queryByTestId('clickable-file-path')).not.toBeInTheDocument()
+      }
+    )
+
+    it.each(['/home/user/project/src/index.ts', '/tmp/test.log', '/var/log/app.log', '/etc/nginx/nginx.conf'])(
+      'should NOT detect %s as a file path on Windows',
+      (path) => {
+        mocks.isWin = true
+        render(<CodeBlock {...defaultProps} className={undefined} children={path} />)
+        expect(screen.queryByTestId('clickable-file-path')).not.toBeInTheDocument()
+      }
+    )
+
+    it('should render mermaid code fences with the app code block view', () => {
+      render(<CodeBlock {...defaultProps} className="language-mermaid" children="graph TD; A-->B;" />)
+
+      expect(screen.getByText('graph TD; A-->B;')).toBeInTheDocument()
+      expect(mocks.CodeBlockView).toHaveBeenCalled()
+      expect(mocks.CodeBlockView.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          language: 'mermaid',
+          children: 'graph TD; A-->B;',
+          editable: true
+        })
+      )
+      expect(mocks.HtmlArtifactsCard).not.toHaveBeenCalled()
+    })
+
+    it('should pass editable=false for standard code blocks in readonly surfaces', () => {
+      mocks.messageListUi = { readonly: true }
+
+      render(<CodeBlock {...defaultProps} />)
+
+      expect(mocks.CodeBlockView).toHaveBeenCalledWith(
+        expect.objectContaining({
+          editable: false
+        }),
+        undefined
+      )
+    })
+
+    it('should pass editable=false for standard code blocks when saving is unavailable', () => {
+      mocks.messageListActions = {}
+
+      render(<CodeBlock {...defaultProps} />)
+
+      expect(mocks.CodeBlockView).toHaveBeenCalledWith(
+        expect.objectContaining({
+          editable: false
+        }),
+        undefined
+      )
+    })
+
+    it('should pass editable=false for HTML artifacts in readonly surfaces', () => {
+      mocks.messageListUi = { readonly: true }
+      const htmlProps = {
+        ...defaultProps,
+        className: 'language-html',
+        children: '<h1>Hello</h1>'
+      }
+
+      render(<CodeBlock {...htmlProps} />)
+
+      expect(mocks.HtmlArtifactsCard).toHaveBeenCalledWith(
+        expect.objectContaining({
+          editable: false
+        }),
+        undefined
+      )
+    })
+  })
+
+  describe('save', () => {
+    it('should call saveCodeBlock with correct payload when saving a standard code block', () => {
+      render(<CodeBlock {...defaultProps} />)
+
+      // Simulate clicking the save button inside the mocked CodeBlockView
+      const saveButton = screen.getByText('Save')
+      fireEvent.click(saveButton)
+
+      // Verify getCodeBlockId was called
+      expect(mocks.getCodeBlockId).toHaveBeenCalledWith(defaultProps.node.position.start)
+
+      expect(mocks.saveCodeBlock).toHaveBeenCalledOnce()
+      expect(mocks.saveCodeBlock).toHaveBeenCalledWith({
+        msgBlockId: 'test-msg-block-id',
+        codeBlockId: 'test-code-block-id',
+        newContent: 'new code content'
+      })
+    })
+
+    it('should call saveCodeBlock with correct payload when saving an HTML block', () => {
+      const htmlProps = {
+        ...defaultProps,
+        className: 'language-html',
+        children: '<h1>Hello</h1>'
+      }
+      render(<CodeBlock {...htmlProps} />)
+
+      // Simulate clicking the save button inside the mocked HtmlArtifactsCard
+      const saveButton = screen.getByText('Save HTML')
+      fireEvent.click(saveButton)
+
+      // Verify getCodeBlockId was called
+      expect(mocks.getCodeBlockId).toHaveBeenCalledWith(htmlProps.node.position.start)
+
+      expect(mocks.saveCodeBlock).toHaveBeenCalledOnce()
+      expect(mocks.saveCodeBlock).toHaveBeenCalledWith({
+        msgBlockId: 'test-msg-block-id',
+        codeBlockId: 'test-code-block-id',
+        newContent: 'new html content'
+      })
+    })
+
+    it('should pass Streamdown incomplete fence state to HTML artifact cards', () => {
+      mocks.isCodeFenceIncomplete = true
+      const htmlProps = {
+        ...defaultProps,
+        className: 'language-html',
+        children: '<h1>Hello</h1>'
+      }
+
+      render(<CodeBlock {...htmlProps} />)
+
+      expect(screen.getByTestId('html-streaming-state')).toHaveTextContent('true')
+    })
+  })
+})

--- a/src/renderer/components/chat/messages/tools/ToolHeader.tsx
+++ b/src/renderer/components/chat/messages/tools/ToolHeader.tsx
@@ -1,0 +1,626 @@
+import { Flex, Tooltip } from '@cherrystudio/ui'
+import type { McpTool, McpToolResponse, NormalToolResponse } from '@renderer/types'
+import {
+  Bot,
+  DoorOpen,
+  FileEdit,
+  FileSearch,
+  FileText,
+  FolderSearch,
+  Globe,
+  ListTodo,
+  NotebookPen,
+  PencilRuler,
+  Search,
+  Send,
+  ShieldCheck,
+  Terminal,
+  Wrench
+} from 'lucide-react'
+import type { ComponentPropsWithoutRef, FC, ReactNode } from 'react'
+import { memo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { useOptionalMessageListUi } from '../MessageListProvider'
+import { type ToolStatus, ToolStatusIndicator, useIsStreaming } from './agent/GenericTools'
+import { AgentToolsType } from './agent/types'
+
+type Translate = (key: string, options?: Record<string, string>) => string
+export interface ToolActivity {
+  label: string
+  description?: string
+}
+
+export interface ToolHeaderProps {
+  toolResponse?: McpToolResponse | NormalToolResponse
+
+  label?: string
+  toolName?: string
+  args?: unknown
+  icon?: ReactNode
+  params?: ReactNode
+  stats?: ReactNode
+
+  // Common config
+  status?: ToolStatus
+  hasError?: boolean
+  showStatus?: boolean // default true
+
+  // Style variant
+  variant?: 'standalone' | 'collapse-label'
+}
+
+/**
+ * Per-tool chat-header display: icon + (optional) i18n label key. Table-driven (replaces the
+ * former icon/label switches). Tools absent here fall back to a generic wrench icon + the raw
+ * tool name.
+ */
+export const TOOL_HEADER_UI: Record<string, { icon: ReactNode; labelKey?: string }> = {
+  [AgentToolsType.Agent]: { icon: <Bot size={14} /> },
+  [AgentToolsType.Read]: { icon: <FileText size={14} />, labelKey: 'message.tools.labels.readFile' },
+  [AgentToolsType.Task]: { icon: <Bot size={14} />, labelKey: 'message.tools.labels.task' },
+  [AgentToolsType.TaskCreate]: { icon: <Bot size={14} /> },
+  [AgentToolsType.TaskGet]: { icon: <Bot size={14} /> },
+  [AgentToolsType.TaskUpdate]: { icon: <Bot size={14} /> },
+  [AgentToolsType.TaskList]: { icon: <Bot size={14} /> },
+  [AgentToolsType.TaskOutput]: { icon: <Bot size={14} /> },
+  [AgentToolsType.TaskStop]: { icon: <Bot size={14} /> },
+  [AgentToolsType.Bash]: { icon: <Terminal size={14} />, labelKey: 'message.tools.labels.bash' },
+  [AgentToolsType.BashOutput]: { icon: <Terminal size={14} />, labelKey: 'message.tools.labels.bashOutput' },
+  [AgentToolsType.Search]: { icon: <Search size={14} />, labelKey: 'message.tools.labels.search' },
+  [AgentToolsType.Glob]: { icon: <FolderSearch size={14} />, labelKey: 'message.tools.labels.glob' },
+  [AgentToolsType.Grep]: { icon: <FileSearch size={14} />, labelKey: 'message.tools.labels.grep' },
+  [AgentToolsType.Write]: { icon: <FileText size={14} />, labelKey: 'message.tools.labels.write' },
+  [AgentToolsType.Edit]: { icon: <FileEdit size={14} />, labelKey: 'message.tools.labels.edit' },
+  [AgentToolsType.MultiEdit]: { icon: <FileText size={14} />, labelKey: 'message.tools.labels.multiEdit' },
+  [AgentToolsType.WebSearch]: { icon: <Globe size={14} />, labelKey: 'message.tools.labels.webSearch' },
+  [AgentToolsType.WebFetch]: { icon: <Globe size={14} />, labelKey: 'message.tools.labels.webFetch' },
+  [AgentToolsType.NotebookEdit]: { icon: <NotebookPen size={14} />, labelKey: 'message.tools.labels.notebookEdit' },
+  [AgentToolsType.TodoWrite]: { icon: <ListTodo size={14} />, labelKey: 'message.tools.labels.todoWrite' },
+  [AgentToolsType.ExitPlanMode]: { icon: <DoorOpen size={14} />, labelKey: 'message.tools.labels.exitPlanMode' },
+  [AgentToolsType.SendMessage]: { icon: <Send size={14} /> },
+  [AgentToolsType.TeamCreate]: { icon: <Bot size={14} /> },
+  [AgentToolsType.TeamDelete]: { icon: <Bot size={14} /> },
+  [AgentToolsType.EnterWorktree]: { icon: <DoorOpen size={14} /> },
+  [AgentToolsType.ExitWorktree]: { icon: <DoorOpen size={14} /> },
+  [AgentToolsType.Skill]: { icon: <PencilRuler size={14} />, labelKey: 'message.tools.labels.skill' }
+}
+
+const getAgentToolIcon = (toolName: string): ReactNode => TOOL_HEADER_UI[toolName]?.icon ?? <Wrench size={14} />
+
+const getAgentToolLabel = (toolName: string, t: Translate): string => {
+  const labelKey = TOOL_HEADER_UI[toolName]?.labelKey
+  return labelKey ? t(labelKey) : toolName
+}
+
+function getStringArg(args: unknown, key: string): string | undefined {
+  if (!args || typeof args !== 'object' || Array.isArray(args)) return undefined
+  const value = (args as Record<string, unknown>)[key]
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function getStringInput(args: unknown): string | undefined {
+  return typeof args === 'string' && args.trim() ? args.trim() : undefined
+}
+
+function getFileName(filePath: string | undefined): string | undefined {
+  if (!filePath) return undefined
+  return filePath.split('/').filter(Boolean).pop() ?? filePath
+}
+
+function getReadableUrlTarget(url: string | undefined, t: Translate): string | undefined {
+  if (!url) return undefined
+  try {
+    const parsed = new URL(url)
+    return parsed.hostname || t('message.tools.activity.webPage')
+  } catch {
+    return t('message.tools.activity.webPage')
+  }
+}
+
+function getReadableFileGroup(text: string | undefined, t: Translate): string | undefined {
+  if (!text) return undefined
+  const value = text.toLowerCase()
+  if (
+    value.includes('readme') ||
+    value.includes('package.json') ||
+    value.includes('go.mod') ||
+    value.includes('cargo.toml') ||
+    value.includes('tsconfig') ||
+    value.includes('.config.')
+  ) {
+    return t('message.tools.activity.configFiles')
+  }
+  if (value.includes('*.md') || value.includes('.md') || value.includes('markdown') || value.includes('md files')) {
+    return t('message.tools.activity.documentFiles')
+  }
+  if (/\.(png|jpe?g|gif|webp|svg|ico)\b/.test(value)) {
+    return t('message.tools.activity.imageFiles')
+  }
+  if (value.includes('locales') || value.includes('i18n')) {
+    return t('message.tools.activity.translationFiles')
+  }
+  if (/\.(ts|tsx|js|jsx|json|css|go|rs|py|java|kt|swift|cpp|c|h)\b/.test(value)) {
+    return t('message.tools.activity.codeFiles')
+  }
+  return undefined
+}
+
+function getReadablePathTarget(filePath: string | undefined, t: Translate): string | undefined {
+  return getFileName(filePath) ?? getReadableFileGroup(filePath, t)
+}
+
+const SEARCH_PATTERN_META_RE = /[\\^$.*+?()[\]{}|]/
+
+function getReadableSearchTarget(value: string | undefined, t: Translate): string {
+  const text = value?.trim()
+  if (!text) return t('message.tools.activity.relatedContent')
+  const fileGroup = getReadableFileGroup(text, t)
+  if (fileGroup) return fileGroup
+  if (SEARCH_PATTERN_META_RE.test(text) || text.length > 48) return t('message.tools.activity.relatedContent')
+  return text
+}
+
+function getFirstShellWord(command: string | undefined): string | undefined {
+  const firstWord = command?.trim().match(/^[\w./-]+/)?.[0]
+  if (!firstWord) return undefined
+  return firstWord.split('/').pop()
+}
+
+function getShellWords(command: string | undefined): string[] {
+  return (
+    command
+      ?.match(/"[^"]+"|'[^']+'|\S+/g)
+      ?.map((word) => word.replace(/^['"]|['"]$/g, ''))
+      .filter((word) => word && !word.startsWith('-') && word !== '&&' && word !== '||') ?? []
+  )
+}
+
+function getCommandPathTarget(command: string | undefined, t: Translate): string {
+  const words = getShellWords(command)
+  const firstPath = words.slice(1).find((word) => /[/.]/.test(word) && !/^https?:\/\//i.test(word))
+  return getReadablePathTarget(firstPath, t) ?? t('message.tools.activity.file')
+}
+
+function getPackageTarget(command: string | undefined, t: Translate): string {
+  if (!command) return t('message.tools.activity.projectDependencies')
+  const match = command.match(
+    /\b(?:npm|pnpm|yarn|bun|pip3?|poetry|uv|cargo|go|brew)\s+(?:install|add|get)\s+([^;&|]+)/i
+  )
+  if (!match?.[1]) return t('message.tools.activity.projectDependencies')
+  const packages = match[1]
+    .split(/\s+/)
+    .filter((value) => value && !value.startsWith('-'))
+    .slice(0, 3)
+    .join(' ')
+  return packages || t('message.tools.activity.projectDependencies')
+}
+
+function getDownloadedTarget(command: string | undefined, t: Translate): string {
+  const url = command?.match(/https?:\/\/[^\s'")]+/i)?.[0]
+  if (!url) return t('message.tools.activity.file')
+  try {
+    const parsed = new URL(url)
+    return parsed.pathname.split('/').filter(Boolean).pop() || parsed.hostname
+  } catch {
+    return t('message.tools.activity.file')
+  }
+}
+
+function getActivityLabels(active: boolean, t: Translate) {
+  return active
+    ? {
+        build: t('message.tools.activity.building'),
+        check: t('message.tools.activity.checking'),
+        copy: t('message.tools.activity.copying'),
+        create: t('message.tools.activity.creating'),
+        delete: t('message.tools.activity.deleting'),
+        download: t('message.tools.activity.downloading'),
+        execute: t('message.tools.activity.executingCommand'),
+        extract: t('message.tools.activity.extracting'),
+        handle: t('message.tools.activity.handling'),
+        install: t('message.tools.activity.installing'),
+        modify: t('message.tools.activity.modifying'),
+        move: t('message.tools.activity.moving'),
+        open: t('message.tools.activity.opening'),
+        search: t('message.tools.activity.searching'),
+        switch: t('message.tools.activity.switching'),
+        sync: t('message.tools.activity.syncing'),
+        upload: t('message.tools.activity.uploading'),
+        view: t('message.tools.activity.viewing'),
+        write: t('message.tools.activity.writing')
+      }
+    : {
+        build: t('message.tools.activity.build'),
+        check: t('message.tools.activity.check'),
+        copy: t('message.tools.activity.copy'),
+        create: t('message.tools.activity.create'),
+        delete: t('message.tools.activity.delete'),
+        download: t('message.tools.activity.download'),
+        execute: t('message.tools.activity.executeCommand'),
+        extract: t('message.tools.activity.extract'),
+        handle: t('message.tools.activity.handle'),
+        install: t('message.tools.activity.install'),
+        modify: t('message.tools.activity.modify'),
+        move: t('message.tools.activity.move'),
+        open: t('message.tools.activity.open'),
+        search: t('message.tools.activity.search'),
+        switch: t('message.tools.activity.switch'),
+        sync: t('message.tools.activity.sync'),
+        upload: t('message.tools.activity.upload'),
+        view: t('message.tools.activity.view'),
+        write: t('message.tools.activity.write')
+      }
+}
+
+function getCommandActivity(args: unknown, active: boolean, t: Translate): ToolActivity {
+  const description = getStringArg(args, 'description')
+  const command = getStringArg(args, 'command')
+  const text = `${description ?? ''} ${command ?? ''}`.toLowerCase()
+  const labels = getActivityLabels(active, t)
+
+  if (/\b(?:npm|pnpm|yarn|bun|pip3?|poetry|uv|cargo|go|brew)\s+(?:install|add|get)\b/.test(text)) {
+    return { label: labels.install, description: getPackageTarget(command, t) }
+  }
+  if (/\b(?:npm|pnpm|yarn|bun|pip3?|poetry|uv|cargo|brew)\s+(?:remove|uninstall|rm)\b/.test(text)) {
+    return { label: labels.delete, description: t('message.tools.activity.projectDependencies') }
+  }
+  if (/\b(?:curl|wget)\b/.test(text)) {
+    return { label: labels.download, description: getDownloadedTarget(command, t) }
+  }
+  if (/\bgit\s+clone\b/.test(text))
+    return { label: labels.download, description: t('message.tools.activity.repository') }
+  if (/\bgit\s+(?:pull|fetch|rebase|merge)\b/.test(text)) {
+    return { label: labels.sync, description: t('message.tools.activity.repository') }
+  }
+  if (/\bgit\s+(?:checkout|switch|branch)\b/.test(text)) {
+    return { label: labels.switch, description: t('message.tools.activity.branch') }
+  }
+  if (/\bgit\s+(?:status|diff|log|show|blame)\b/.test(text)) {
+    return { label: labels.view, description: t('message.tools.activity.projectChanges') }
+  }
+  if (/\bgit\s+commit\b/.test(text))
+    return { label: labels.write, description: t('message.tools.activity.projectChanges') }
+  if (/\bgit\s+push\b/.test(text))
+    return { label: labels.upload, description: t('message.tools.activity.projectChanges') }
+  if (/\bgh\s+(?:pr|issue|run|workflow|repo)\b/.test(text)) {
+    return { label: labels.view, description: t('message.tools.activity.codeHostInfo') }
+  }
+  if (/\b(?:cp|rsync)\b/.test(text)) return { label: labels.copy, description: getCommandPathTarget(command, t) }
+  if (/\bmv\b/.test(text)) return { label: labels.move, description: getCommandPathTarget(command, t) }
+  if (/\b(?:rm|rmdir)\b/.test(text)) return { label: labels.delete, description: getCommandPathTarget(command, t) }
+  if (/\bmkdir\b/.test(text)) return { label: labels.create, description: t('message.tools.activity.folder') }
+  if (/\btouch\b/.test(text)) return { label: labels.create, description: getCommandPathTarget(command, t) }
+  if (/\b(?:unzip|tar)\b/.test(text)) return { label: labels.extract, description: t('message.tools.activity.archive') }
+  if (/\b(?:open|xdg-open|start)\b/.test(text))
+    return { label: labels.open, description: getCommandPathTarget(command, t) }
+  if (
+    /\b(?:npm|pnpm|yarn|bun)\s+(?:run\s+)?(?:build|compile|package)\b|\b(?:vite|tsup|rollup|webpack|electron-builder)\b/.test(
+      text
+    )
+  ) {
+    return { label: labels.build, description: t('message.tools.activity.projectFiles') }
+  }
+  if (
+    /(\btest\b|\blint\b|\btypecheck\b|\bcheck\b|\bvitest\b|\bjest\b|\bplaywright\b|\btsc\b|\beslint\b|\bbiome\b)/.test(
+      text
+    )
+  ) {
+    return { label: labels.check, description: t('message.tools.activity.projectChecks') }
+  }
+  if (/(\brg\b|\bgrep\b|\bag\b|\bfd\b|\bfind\b|\blocate\b)/.test(text)) {
+    return { label: labels.search, description: getReadableSearchTarget(description ?? command, t) }
+  }
+  if (/\bpwd\b/.test(text)) return { label: labels.view, description: t('message.tools.activity.currentFolder') }
+  if (/(\bcat\b|\bhead\b|\btail\b|\bless\b|\bmore\b|\bsed\s+-n\b|\bawk\b|\bwc\b|\bstat\b|\bdu\b)/.test(text)) {
+    return { label: labels.view, description: getCommandPathTarget(command, t) }
+  }
+  const fileGroup = getReadableFileGroup(text, t)
+  if (fileGroup) return { label: labels.search, description: fileGroup }
+  if (text.includes('root directory'))
+    return { label: labels.view, description: t('message.tools.activity.projectRootFiles') }
+  if (text.includes('project directory'))
+    return { label: labels.view, description: t('message.tools.activity.projectFiles') }
+  if (/(\bls\b|\btree\b|\blist\b)/.test(text))
+    return { label: labels.view, description: t('message.tools.activity.fileList') }
+
+  const shellWord = getFirstShellWord(command)
+  return {
+    label: labels.execute,
+    description: shellWord
+      ? t('message.tools.activity.commandName', { name: shellWord })
+      : t('message.tools.activity.projectTask')
+  }
+}
+
+export function getReadableToolActivity(
+  toolName: string,
+  args: unknown,
+  active: boolean,
+  t: Translate
+): ToolActivity | undefined {
+  const labels = getActivityLabels(active, t)
+  const searchText = getStringInput(args) ?? getStringArg(args, 'pattern') ?? getStringArg(args, 'query')
+
+  switch (toolName) {
+    case AgentToolsType.Agent:
+    case AgentToolsType.Task:
+      return {
+        label: labels.handle,
+        description:
+          getStringArg(args, 'description') ?? getStringArg(args, 'prompt') ?? t('message.tools.activity.assistantTask')
+      }
+    case AgentToolsType.TaskCreate:
+      return {
+        label: labels.create,
+        description:
+          getStringArg(args, 'subject') ?? getStringArg(args, 'description') ?? t('message.tools.activity.taskList')
+      }
+    case AgentToolsType.TaskGet:
+    case AgentToolsType.TaskList:
+    case AgentToolsType.TaskOutput:
+      return { label: labels.view, description: t('message.tools.activity.taskList') }
+    case AgentToolsType.TaskUpdate:
+    case AgentToolsType.TaskStop:
+      return { label: labels.modify, description: t('message.tools.activity.taskList') }
+    case AgentToolsType.Bash:
+    case AgentToolsType.BashOutput:
+      return getCommandActivity(args, active, t)
+    case AgentToolsType.Glob:
+      return {
+        label: labels.search,
+        description: getReadableFileGroup(getStringArg(args, 'pattern'), t) ?? t('message.tools.activity.matchingFiles')
+      }
+    case AgentToolsType.Grep:
+    case AgentToolsType.Search:
+      return { label: labels.search, description: getReadableSearchTarget(searchText, t) }
+    case AgentToolsType.Read:
+      return { label: labels.view, description: getReadablePathTarget(getStringArg(args, 'file_path'), t) }
+    case AgentToolsType.Write:
+      return { label: labels.write, description: getReadablePathTarget(getStringArg(args, 'file_path'), t) }
+    case AgentToolsType.Edit:
+    case AgentToolsType.MultiEdit:
+    case AgentToolsType.NotebookEdit:
+      return {
+        label: labels.modify,
+        description: getReadablePathTarget(getStringArg(args, 'file_path') ?? getStringArg(args, 'notebook_path'), t)
+      }
+    case AgentToolsType.WebSearch:
+      return { label: labels.search, description: getStringArg(args, 'query') ?? t('message.tools.activity.webSearch') }
+    case AgentToolsType.WebFetch:
+      return {
+        label: labels.view,
+        description: getReadableUrlTarget(getStringArg(args, 'url'), t) ?? t('message.tools.activity.webPage')
+      }
+    case AgentToolsType.TodoWrite:
+      return { label: labels.modify, description: t('message.tools.activity.taskList') }
+    case AgentToolsType.Skill:
+      return {
+        label: labels.handle,
+        description: getStringArg(args, 'skill') ?? t('message.tools.activity.assistantTask')
+      }
+    case AgentToolsType.ToolSearch:
+      return {
+        label: labels.search,
+        description: getStringArg(args, 'query') ?? t('message.tools.activity.availableFeatures')
+      }
+    case AgentToolsType.ListMcpResources:
+    case AgentToolsType.ReadMcpResource:
+      return { label: labels.view, description: t('message.tools.activity.availableResources') }
+    case AgentToolsType.EnterWorktree:
+    case AgentToolsType.ExitWorktree:
+      return { label: labels.switch, description: t('message.tools.activity.workspace') }
+    case AgentToolsType.ExitPlanMode:
+      return { label: labels.write, description: t('message.tools.activity.plan') }
+    default:
+      return undefined
+  }
+}
+
+export function getReadableToolDescription(toolName: string, args: unknown, t: Translate): string | undefined {
+  return getReadableToolActivity(toolName, args, false, t)?.description
+}
+
+function isActiveStatus(status: ToolStatus | undefined): boolean {
+  return status === 'pending' || status === 'invoking' || status === 'streaming' || status === 'waiting'
+}
+
+const getToolDescription = (toolName: string, args: unknown, t: Translate): string | undefined => {
+  if (!args || typeof args !== 'object' || Array.isArray(args)) return undefined
+
+  const readableDescription = getReadableToolDescription(toolName, args, t)
+  if (readableDescription) return readableDescription
+
+  // Common description fields
+  const argsRecord = args as Record<string, unknown>
+  return (
+    argsRecord.description ||
+    argsRecord.file_path ||
+    argsRecord.pattern ||
+    argsRecord.query ||
+    argsRecord.command ||
+    argsRecord.url
+  )?.toString()
+}
+
+const HeaderContainer = ({ className, ...props }: ComponentPropsWithoutRef<'div'>) => (
+  <div
+    className={[
+      'flex min-w-0 items-center gap-2 rounded-xl border border-border bg-background px-3 py-2 text-[13px]',
+      className
+    ]
+      .filter(Boolean)
+      .join(' ')}
+    {...props}
+  />
+)
+
+// Label variant: no border/padding, for use inside Collapse header
+const LabelContainer = ({ className, ...props }: ComponentPropsWithoutRef<'div'>) => (
+  <div
+    className={['flex min-w-0 items-center gap-1 text-[13px] leading-5', className].filter(Boolean).join(' ')}
+    {...props}
+  />
+)
+
+const ToolName = ({ className, ...props }: ComponentPropsWithoutRef<typeof Flex>) => (
+  <Flex className={['shrink-0 [&_.name]:whitespace-nowrap', className].filter(Boolean).join(' ')} {...props} />
+)
+
+const Description = ({ className, ...props }: ComponentPropsWithoutRef<'span'>) => (
+  <span
+    className={[
+      'inline-flex min-w-0 max-w-[300px] shrink items-center overflow-hidden text-ellipsis whitespace-nowrap font-normal text-[13px] text-foreground-secondary',
+      className
+    ]
+      .filter(Boolean)
+      .join(' ')}
+    {...props}
+  />
+)
+
+const Stats = ({ className, ...props }: ComponentPropsWithoutRef<'span'>) => (
+  <span
+    className={['shrink-0 whitespace-nowrap font-normal text-[13px] text-foreground-secondary', className]
+      .filter(Boolean)
+      .join(' ')}
+    {...props}
+  />
+)
+
+const StatusWrapper = ({ className, ...props }: ComponentPropsWithoutRef<'div'>) => (
+  <div className={['ml-auto flex shrink-0 items-center', className].filter(Boolean).join(' ')} {...props} />
+)
+
+function getToolNameClassName(variant: ToolHeaderProps['variant']): string {
+  return [
+    'items-center gap-1.5',
+    variant === 'collapse-label' && 'font-normal text-foreground-secondary [&_.tool-icon]:text-foreground-muted',
+    variant === 'standalone' && 'font-medium text-foreground [&_.tool-icon]:text-(--color-primary)'
+  ]
+    .filter(Boolean)
+    .join(' ')
+}
+
+function getToolIconClassName(isIconBreathing: boolean): string {
+  return ['tool-icon inline-flex shrink-0 items-center', isIconBreathing && 'animate-pulse'].filter(Boolean).join(' ')
+}
+
+// ============ MCP Tool sub-renderer ============
+
+interface McpToolHeaderProps {
+  tool: McpTool
+  description?: ReactNode
+  stats?: ReactNode
+  showStatus: boolean
+  status?: ToolStatus
+  hasError: boolean
+  Container: typeof HeaderContainer
+  variant: ToolHeaderProps['variant']
+}
+
+const McpToolHeader: FC<McpToolHeaderProps> = ({
+  tool,
+  description,
+  stats,
+  showStatus,
+  status,
+  hasError,
+  Container,
+  variant
+}) => {
+  const { t } = useTranslation()
+  const { isToolAutoApproved } = useOptionalMessageListUi() ?? {}
+  const autoApproved = isToolAutoApproved?.(tool) ?? false
+  const isIconBreathing = variant === 'collapse-label' && isActiveStatus(status)
+  return (
+    <Container>
+      <ToolName className={getToolNameClassName(variant)}>
+        <span className={getToolIconClassName(isIconBreathing)}>
+          <Wrench size={14} />
+        </span>
+        <span className="name">
+          {tool.serverName} : {tool.name}
+        </span>
+        {autoApproved && (
+          <Tooltip content={t('message.tools.autoApproveEnabled')}>
+            <ShieldCheck size={14} color="var(--color-primary)" />
+          </Tooltip>
+        )}
+      </ToolName>
+      {description && <Description>{description}</Description>}
+      {stats && <Stats>{stats}</Stats>}
+      {showStatus && status && (
+        <StatusWrapper>
+          <ToolStatusIndicator status={status} hasError={hasError} />
+        </StatusWrapper>
+      )}
+    </Container>
+  )
+}
+
+// ============ Main Component ============
+
+const ToolHeader: FC<ToolHeaderProps> = ({
+  toolResponse,
+  label: propLabel,
+  toolName: propToolName,
+  args: propArgs,
+  icon: propIcon,
+  params,
+  stats,
+  status: propStatus,
+  hasError: propHasError,
+  showStatus = true,
+  variant = 'standalone'
+}) => {
+  const { t } = useTranslation()
+  const isStreaming = useIsStreaming()
+
+  const tool = toolResponse?.tool
+
+  const toolName = propToolName || tool?.name || 'Tool'
+
+  const status = propStatus || (toolResponse?.status as ToolStatus)
+  const hasError = propHasError ?? toolResponse?.response?.isError === true
+  const args = toolResponse?.arguments ?? propArgs
+  const activity = getReadableToolActivity(toolName, args, isStreaming || isActiveStatus(status), t)
+  const displayLabel = propLabel ?? activity?.label ?? getAgentToolLabel(toolName, t)
+  const description = params ?? activity?.description ?? getToolDescription(toolName, args, t)
+  const isIconBreathing = variant === 'collapse-label' && isActiveStatus(status)
+
+  const Container = variant === 'standalone' ? HeaderContainer : LabelContainer
+
+  if (tool?.type === 'mcp') {
+    return (
+      <McpToolHeader
+        tool={tool as McpTool}
+        description={description}
+        stats={stats}
+        showStatus={showStatus}
+        status={status}
+        hasError={hasError}
+        Container={Container}
+        variant={variant}
+      />
+    )
+  }
+
+  return (
+    <Container>
+      <ToolName className={getToolNameClassName(variant)}>
+        <span className={getToolIconClassName(isIconBreathing)}>{propIcon || getAgentToolIcon(toolName)}</span>
+        <span className="name">{displayLabel}</span>
+      </ToolName>
+      {description && <Description>{description}</Description>}
+      {stats && <Stats>{stats}</Stats>}
+      {showStatus && status && (
+        <StatusWrapper>
+          <ToolStatusIndicator status={status} hasError={hasError} />
+        </StatusWrapper>
+      )}
+    </Container>
+  )
+}
+
+export default memo(ToolHeader)

--- a/src/renderer/components/chat/messages/tools/__tests__/AgentToolRenderer.test.tsx
+++ b/src/renderer/components/chat/messages/tools/__tests__/AgentToolRenderer.test.tsx
@@ -1,0 +1,702 @@
+import type { NormalToolResponse } from '@renderer/types'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { parse as parsePartialJson } from 'partial-json'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AgentToolRenderer, isValidAgentToolsType } from '../agent'
+import { AskUserQuestionOptimisticInputProvider } from '../agent/AskUserQuestionOptimisticContext'
+import MessageTool from '../MessageTool'
+
+vi.mock('@renderer/services/AssistantService', () => ({
+  getDefaultAssistant: vi.fn(() => ({
+    id: 'test-assistant',
+    name: 'Test Assistant',
+    settings: {}
+  })),
+  getDefaultTopic: vi.fn(() => ({
+    id: 'test-topic',
+    assistantId: 'test-assistant',
+    createdAt: new Date().toISOString()
+  }))
+}))
+
+// Mock dependencies
+const mockUseTranslation = vi.fn()
+
+// Parts map drives approval state post-migration. Default: no pending approvals.
+const mockPartsMap = vi.hoisted(() => vi.fn((): Record<string, unknown[]> | null => null))
+const mockMessageListActions = vi.hoisted(() => vi.fn(() => ({})))
+
+vi.mock('@renderer/components/chat/messages/blocks', () => ({
+  usePartsMap: () => mockPartsMap()
+}))
+
+vi.mock('@renderer/components/chat/messages/MessageListProvider', () => ({
+  useOptionalMessageListActions: () => mockMessageListActions(),
+  useOptionalMessageListUi: () => ({ externalCodeEditors: [] })
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => mockUseTranslation(),
+  initReactI18next: {
+    type: '3rdParty',
+    init: vi.fn()
+  }
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    })
+  }
+}))
+
+// Mock lucide-react icons
+vi.mock('lucide-react', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    Loader2: ({ className }: any) => <span data-testid="loader-icon" className={className} />,
+    FileText: () => <span data-testid="file-icon" />,
+    Terminal: () => <span data-testid="terminal-icon" />,
+    ListTodo: () => <span data-testid="list-icon" />,
+    Circle: () => <span data-testid="circle-icon" />,
+    CheckCircle: () => <span data-testid="check-circle-icon" />,
+    Clock: () => <span data-testid="clock-icon" />,
+    Check: () => <span data-testid="check-icon" />,
+    TriangleAlert: () => <span data-testid="triangle-alert-icon" />,
+    X: () => <span data-testid="x-icon" />,
+    Wrench: () => <span data-testid="wrench-icon" />,
+    ImageIcon: () => <span data-testid="image-icon" />
+  }
+})
+
+// Mock CodeViewer (used by ReadTool/WriteTool, depends on useSettings and useCodeStyle)
+vi.mock('@renderer/components/CodeViewer', () => ({
+  default: ({ value }: any) => <pre data-testid="code-viewer">{value}</pre>
+}))
+
+// Mock LoadingIcon
+vi.mock('@renderer/components/Icons', () => ({
+  LoadingIcon: () => <span data-testid="loading-icon" />
+}))
+
+describe('AgentToolRenderer', () => {
+  // Mock translations for tools
+  const mockTranslations: Record<string, string> = {
+    'message.tools.labels.bash': 'Bash',
+    'message.tools.labels.readFile': 'Read File',
+    'message.tools.labels.todoWrite': 'Todo Write',
+    'message.tools.labels.edit': 'Edit',
+    'message.tools.labels.write': 'Write',
+    'message.tools.labels.grep': 'Grep',
+    'message.tools.labels.glob': 'Glob',
+    'message.tools.labels.webSearch': 'Web Search',
+    'message.tools.labels.webFetch': 'Web Fetch',
+    'message.tools.labels.skill': 'Skill',
+    'message.tools.labels.task': 'Task',
+    'message.tools.labels.search': 'Search',
+    'message.tools.labels.exitPlanMode': 'ExitPlanMode',
+    'message.tools.labels.multiEdit': 'MultiEdit',
+    'message.tools.labels.notebookEdit': 'NotebookEdit',
+    'message.tools.labels.mcpServerTool': 'MCP Server Tool',
+    'message.tools.labels.tool': 'Tool',
+    'message.tools.invoking': 'Invoking',
+    'message.tools.activity.assistantTask': 'task',
+    'message.tools.activity.availableFeatures': 'available features',
+    'message.tools.activity.availableResources': 'available resources',
+    'message.tools.activity.commandName': '{{name}} command',
+    'message.tools.activity.create': 'Create',
+    'message.tools.activity.currentFolder': 'current folder',
+    'message.tools.activity.executeCommand': 'Run command',
+    'message.tools.activity.executingCommand': 'Running command',
+    'message.tools.activity.file': 'file',
+    'message.tools.activity.handle': 'Handle',
+    'message.tools.activity.handling': 'Handling',
+    'message.tools.activity.installing': 'Installing',
+    'message.tools.activity.projectDependencies': 'project dependencies',
+    'message.tools.activity.searching': 'Finding',
+    'message.tools.activity.taskList': 'task list',
+    'message.tools.activity.view': 'View',
+    'message.tools.activity.viewing': 'Viewing',
+    'message.tools.error': 'Error',
+    'message.tools.sections.command': 'Command',
+    'message.tools.sections.output': 'Output',
+    'message.tools.sections.prompt': 'Prompt',
+    'message.tools.sections.input': 'Input',
+    'agent.askUserQuestion.title': 'Questions from Agent',
+    'agent.askUserQuestion.answered': 'answered',
+    'message.tools.status.done': 'Done',
+    'message.tools.units.item_one': '{{count}} item',
+    'message.tools.units.item_other': '{{count}} items',
+    'message.tools.units.line_one': '{{count}} line',
+    'message.tools.units.line_other': '{{count}} lines',
+    'message.tools.units.file_one': '{{count}} file',
+    'message.tools.units.file_other': '{{count}} files',
+    'message.tools.units.result_one': '{{count}} result',
+    'message.tools.units.result_other': '{{count}} results'
+  }
+
+  beforeEach(() => {
+    mockPartsMap.mockReturnValue(null) // no parts context: no pending approval
+    mockMessageListActions.mockReturnValue({})
+    mockUseTranslation.mockReturnValue({
+      t: (key: string, options?: string | { count?: number }) => {
+        // Handle plural keys with count option
+        if (typeof options === 'object' && options.count !== undefined) {
+          const pluralKey = options.count === 1 ? `${key}_one` : `${key}_other`
+          const template = mockTranslations[pluralKey] ?? mockTranslations[key] ?? key
+          return template.replace('{{count}}', String(options.count))
+        }
+        return mockTranslations[key] ?? (typeof options === 'string' ? options : key)
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // Helper to create tool response
+  const createToolResponse = (overrides: Partial<NormalToolResponse> = {}): NormalToolResponse => ({
+    id: 'test-tool-1',
+    tool: {
+      id: 'Read',
+      name: 'Read',
+      description: 'Read a file',
+      type: 'provider'
+    },
+    arguments: undefined,
+    status: 'pending',
+    toolCallId: 'call-123',
+    ...overrides
+  })
+
+  describe('isValidAgentToolsType', () => {
+    it('should return true for valid tool types', () => {
+      expect(isValidAgentToolsType('Read')).toBe(true)
+      expect(isValidAgentToolsType('Bash')).toBe(true)
+      expect(isValidAgentToolsType('Agent')).toBe(true)
+      expect(isValidAgentToolsType('TaskCreate')).toBe(true)
+    })
+
+    it('should return false for invalid tool types', () => {
+      expect(isValidAgentToolsType('InvalidTool')).toBe(false)
+      expect(isValidAgentToolsType('')).toBe(false)
+      expect(isValidAgentToolsType(null)).toBe(false)
+      expect(isValidAgentToolsType(undefined)).toBe(false)
+    })
+  })
+
+  describe('partial-json parsing', () => {
+    it('should parse partial JSON correctly', () => {
+      // Test partial-json library behavior
+      const partialJson = '{"file_path": "/test.ts"'
+      const parsed = parsePartialJson(partialJson)
+      expect(parsed).toEqual({ file_path: '/test.ts' })
+    })
+
+    it('should parse nested partial JSON', () => {
+      const partialJson = '{"todos": [{"content": "Task 1", "status": "pending"'
+      const parsed = parsePartialJson(partialJson)
+      expect(parsed).toEqual({
+        todos: [{ content: 'Task 1', status: 'pending' }]
+      })
+    })
+
+    it('should handle empty partial JSON', () => {
+      const partialJson = '{'
+      const parsed = parsePartialJson(partialJson)
+      expect(parsed).toEqual({})
+    })
+  })
+
+  describe('streaming tool rendering', () => {
+    it('should render dedicated tool renderer with partial arguments during streaming', () => {
+      const toolResponse = createToolResponse({
+        tool: { id: 'Read', name: 'Read', description: 'Read a file', type: 'provider' },
+        status: 'streaming',
+        partialArguments: '{"file_path": "/test.ts"'
+      })
+
+      render(<AgentToolRenderer toolResponse={toolResponse} />)
+
+      // Should render the DEDICATED ReadTool component, not StreamingToolContent
+      // ReadTool uses a friendly activity label, not just the raw tool name
+      expect(screen.getByText('Viewing')).toBeInTheDocument()
+      // Should show the filename from partial args
+      expect(screen.getByText('test.ts')).toBeInTheDocument()
+    })
+
+    it('should pass parsed partial arguments to dedicated tool renderer', () => {
+      const toolResponse = createToolResponse({
+        tool: { id: 'Read', name: 'Read', description: 'Read a file', type: 'provider' },
+        status: 'streaming',
+        partialArguments: '{"file_path": "/path/to/myfile.ts", "offset": 10'
+      })
+
+      render(<AgentToolRenderer toolResponse={toolResponse} />)
+
+      // Should use dedicated ReadTool renderer
+      expect(screen.getByText('Viewing')).toBeInTheDocument()
+      // Should show the filename extracted by ReadTool
+      expect(screen.getByText('myfile.ts')).toBeInTheDocument()
+    })
+
+    it('should update dedicated renderer as more arguments stream in', () => {
+      const initialResponse = createToolResponse({
+        tool: { id: 'Read', name: 'Read', description: 'Read a file', type: 'provider' },
+        status: 'streaming',
+        partialArguments: '{"file_path": "/test/partial'
+      })
+
+      const { rerender } = render(<AgentToolRenderer toolResponse={initialResponse} />)
+
+      // Should use dedicated renderer even with partial path
+      expect(screen.getByText('Viewing')).toBeInTheDocument()
+
+      // Update with status changed to pending when arguments complete
+      const updatedResponse = createToolResponse({
+        tool: { id: 'Read', name: 'Read', description: 'Read a file', type: 'provider' },
+        status: 'pending',
+        partialArguments: '{"file_path": "/test/complete.ts", "limit": 100}'
+      })
+
+      rerender(<AgentToolRenderer toolResponse={updatedResponse} />)
+
+      expect(screen.getByText('Invoking')).toBeInTheDocument()
+      expect(screen.queryByTestId('loading-icon')).toBeNull()
+    })
+  })
+
+  describe('completed tool rendering', () => {
+    it('should render newly supported structured agent tools', () => {
+      const toolResponse = createToolResponse({
+        tool: { id: 'TaskCreate', name: 'TaskCreate', description: 'Create task', type: 'provider' },
+        status: 'done',
+        arguments: {
+          subject: 'Wire tool registry',
+          description: 'Register the new SDK task tools'
+        },
+        response: {
+          task: {
+            id: 'task-1',
+            subject: 'Wire tool registry'
+          }
+        }
+      })
+
+      const { container } = render(<AgentToolRenderer toolResponse={toolResponse} />)
+
+      expect(screen.getByText('Create')).toBeInTheDocument()
+      expect(screen.getByText('Register the new SDK task tools')).toBeInTheDocument()
+      expect(container.textContent).not.toContain('task-1')
+      expect(screen.queryByTestId('collapse-content-TaskCreate')).toBeNull()
+    })
+
+    it('should route Agent through the task renderer', () => {
+      const toolResponse = createToolResponse({
+        tool: { id: 'Agent', name: 'Agent', description: 'Run subagent', type: 'provider' },
+        status: 'done',
+        arguments: {
+          description: 'Inspect renderer',
+          prompt: 'Check the message renderer'
+        },
+        response: {
+          agentId: 'agent-1',
+          content: [{ type: 'text', text: 'Inspection complete' }],
+          totalToolUseCount: 0,
+          totalDurationMs: 1,
+          totalTokens: 1,
+          usage: {
+            input_tokens: 1,
+            output_tokens: 1,
+            cache_creation_input_tokens: null,
+            cache_read_input_tokens: null,
+            server_tool_use: null,
+            service_tier: null,
+            cache_creation: null
+          },
+          status: 'completed',
+          prompt: 'Check the message renderer'
+        }
+      })
+
+      render(<AgentToolRenderer toolResponse={toolResponse} />)
+
+      expect(screen.getByText('Handle')).toBeInTheDocument()
+      expect(screen.getByText('Inspect renderer')).toBeInTheDocument()
+      expect(screen.queryByText('Inspection complete')).toBeNull()
+      expect(screen.queryByTestId('collapse-content-Agent')).toBeNull()
+    })
+
+    it('should render tool with full arguments when done', () => {
+      const toolResponse = createToolResponse({
+        tool: { id: 'Read', name: 'Read', description: 'Read a file', type: 'provider' },
+        status: 'done',
+        arguments: { file_path: '/test.ts', limit: 100 },
+        response: 'file content here'
+      })
+
+      render(<AgentToolRenderer toolResponse={toolResponse} />)
+
+      // Should render the complete tool with output
+      expect(screen.getByText('View')).toBeInTheDocument()
+    })
+
+    it('should render error state correctly', () => {
+      const toolResponse = createToolResponse({
+        tool: { id: 'Read', name: 'Read', description: 'Read a file', type: 'provider' },
+        status: 'error',
+        arguments: { file_path: '/nonexistent.ts' },
+        response: 'File not found'
+      })
+
+      render(<AgentToolRenderer toolResponse={toolResponse} />)
+
+      // Should still render the tool component
+      expect(screen.getByText('View')).toBeInTheDocument()
+      expect(screen.getByText('Error')).toHaveStyle('color: var(--color-foreground-secondary)')
+    })
+  })
+
+  describe('pending without streaming', () => {
+    it('hides the message card while the composer handles pending permission', () => {
+      const toolResponse = createToolResponse({
+        status: 'pending',
+        partialArguments: undefined
+      })
+
+      // Simulate an AI-SDK-v6 `approval-requested` ToolUIPart in the
+      // current message's parts.
+      mockPartsMap.mockReturnValue({
+        msg1: [
+          {
+            type: 'tool-Read',
+            toolCallId: toolResponse.toolCallId,
+            state: 'approval-requested',
+            approval: { id: 'approval-1' },
+            input: toolResponse.arguments
+          }
+        ]
+      })
+
+      const { container } = render(<AgentToolRenderer toolResponse={toolResponse} />)
+
+      expect(container).toBeEmptyDOMElement()
+    })
+
+    it('should show pending indicator when no streaming and no permission', () => {
+      const toolResponse = createToolResponse({
+        status: 'pending',
+        partialArguments: undefined
+      })
+
+      render(<AgentToolRenderer toolResponse={toolResponse} />)
+
+      expect(screen.getByText('Invoking')).toBeInTheDocument()
+      expect(screen.queryByTestId('loading-icon')).toBeNull()
+    })
+
+    it('hides AskUserQuestion message card while the composer handles the pending question', () => {
+      const toolResponse = createToolResponse({
+        tool: { id: 'AskUserQuestion', name: 'AskUserQuestion', description: 'Ask user', type: 'provider' },
+        status: 'pending',
+        toolCallId: 'call-ask',
+        arguments: {
+          questions: [
+            {
+              question: 'Choose logger',
+              header: 'Logger',
+              options: [{ label: 'Winston' }, { label: 'Pino' }],
+              multiSelect: false
+            }
+          ]
+        }
+      })
+
+      mockPartsMap.mockReturnValue({
+        msg1: [
+          {
+            type: 'tool-AskUserQuestion',
+            toolName: 'AskUserQuestion',
+            toolCallId: toolResponse.toolCallId,
+            state: 'approval-requested',
+            approval: { id: 'approval-ask' },
+            input: toolResponse.arguments
+          }
+        ]
+      })
+
+      const { container } = render(<AgentToolRenderer toolResponse={toolResponse} />)
+
+      expect(container).toBeEmptyDOMElement()
+    })
+
+    it('shows AskUserQuestion answers from tool output when input only has questions', () => {
+      const questions = [
+        {
+          question: 'Choose logger',
+          header: 'Logger',
+          options: [{ label: 'Winston' }, { label: 'Pino' }],
+          multiSelect: false
+        }
+      ]
+      const toolResponse = createToolResponse({
+        tool: { id: 'AskUserQuestion', name: 'AskUserQuestion', description: 'Ask user', type: 'provider' },
+        status: 'done',
+        toolCallId: 'call-ask',
+        arguments: { questions },
+        response: {
+          questions,
+          answers: { 'Choose logger': 'Winston' }
+        }
+      })
+
+      render(<AgentToolRenderer toolResponse={toolResponse} />)
+
+      expect(screen.getByText('Winston')).not.toBeVisible()
+      fireEvent.click(screen.getAllByRole('button')[0])
+      expect(screen.getByText('Winston')).toBeInTheDocument()
+      expect(screen.getByText('Winston')).toBeVisible()
+    })
+
+    it('shows optimistic AskUserQuestion answers before persisted tool data arrives', () => {
+      const questions = [
+        {
+          question: 'Choose logger',
+          header: 'Logger',
+          options: [{ label: 'Winston' }, { label: 'Pino' }],
+          multiSelect: false
+        }
+      ]
+      const toolResponse = createToolResponse({
+        tool: { id: 'AskUserQuestion', name: 'AskUserQuestion', description: 'Ask user', type: 'provider' },
+        status: 'pending',
+        toolCallId: 'call-ask',
+        arguments: { questions }
+      })
+
+      mockPartsMap.mockReturnValue({
+        msg1: [
+          {
+            type: 'tool-AskUserQuestion',
+            toolName: 'AskUserQuestion',
+            toolCallId: toolResponse.toolCallId,
+            state: 'approval-responded',
+            approval: { id: 'approval-ask', approved: true },
+            input: toolResponse.arguments
+          }
+        ]
+      })
+
+      render(
+        <AskUserQuestionOptimisticInputProvider
+          value={{
+            'call-ask': {
+              questions,
+              answers: { 'Choose logger': 'Winston' }
+            }
+          }}>
+          <AgentToolRenderer toolResponse={toolResponse} />
+        </AskUserQuestionOptimisticInputProvider>
+      )
+
+      expect(screen.getByText('Questions from Agent')).toBeInTheDocument()
+      expect(screen.getByText('Winston')).not.toBeVisible()
+      fireEvent.click(screen.getAllByRole('button')[0])
+      expect(screen.getByText('Winston')).toBeVisible()
+    })
+
+    it('renders builtin AskUserQuestion tool names through MessageTool', () => {
+      const questions = [
+        {
+          question: 'Choose logger',
+          header: 'Logger',
+          options: [{ label: 'Winston' }, { label: 'Pino' }],
+          multiSelect: false
+        }
+      ]
+      const toolResponse = createToolResponse({
+        tool: {
+          id: 'call-ask',
+          name: 'builtin_AskUserQuestion',
+          description: 'Ask user',
+          type: 'builtin'
+        },
+        status: 'done',
+        toolCallId: 'call-ask',
+        arguments: { questions, answers: { 'Choose logger': 'Winston' } }
+      })
+
+      render(<MessageTool toolResponse={toolResponse} />)
+
+      expect(screen.getByText('Questions from Agent')).toBeInTheDocument()
+      fireEvent.click(screen.getAllByRole('button')[0])
+      expect(screen.getByText('Winston')).toBeVisible()
+    })
+  })
+
+  describe('navigate tool rendering', () => {
+    it('routes navigate tool clicks through message list action', () => {
+      const navigateToRoute = vi.fn()
+      mockMessageListActions.mockReturnValue({ navigateToRoute })
+      const toolResponse = createToolResponse({
+        tool: {
+          id: 'mcp__assistant__navigate',
+          name: 'mcp__assistant__navigate',
+          description: 'Navigate',
+          type: 'provider'
+        },
+        status: 'done',
+        arguments: {
+          path: '/settings/provider',
+          query: { id: 'openai' }
+        },
+        response: 'Navigated to /settings/provider'
+      })
+
+      render(<AgentToolRenderer toolResponse={toolResponse} />)
+      fireEvent.click(screen.getByRole('button'))
+
+      expect(navigateToRoute).toHaveBeenCalledWith({
+        path: '/settings/provider',
+        query: { id: 'openai' }
+      })
+    })
+  })
+
+  describe('meta tool rendering', () => {
+    it('renders tool_search with the light tool-row styling', async () => {
+      const toolResponse = createToolResponse({
+        id: 'meta-tool-search',
+        tool: {
+          id: 'tool_search',
+          name: 'tool_search',
+          description: 'Search deferred tools',
+          type: 'provider'
+        },
+        status: 'done',
+        arguments: { namespace: 'mcp:tavily' },
+        response: {
+          matchedNamespaces: [
+            {
+              namespace: 'mcp:tavily',
+              tools: [{ name: 'tavily_search' }]
+            }
+          ]
+        }
+      })
+
+      const { container } = render(<MessageTool toolResponse={toolResponse} />)
+
+      const disclosure = container.querySelector('.message-tools-container')
+      expect(disclosure).toHaveClass('border-none')
+      expect(disclosure).toHaveClass('bg-transparent')
+      expect(disclosure).not.toHaveClass('rounded-[7px]')
+      expect(screen.getByTestId('wrench-icon')).toBeInTheDocument()
+
+      const title = screen.getByText('tool_search · ns=mcp:tavily')
+      expect(title).toHaveClass('font-normal')
+      expect(title).toHaveClass('text-foreground-secondary')
+
+      fireEvent.click(screen.getByRole('button'))
+      expect(await screen.findByText('tavily_search')).toBeInTheDocument()
+    })
+
+    it('shows tool_invoke input params flat without nesting a second tool card', async () => {
+      const toolResponse = createToolResponse({
+        id: 'meta-tool-invoke',
+        tool: { id: 'tool_invoke', name: 'tool_invoke', description: 'Invoke a tool', type: 'provider' },
+        status: 'error',
+        arguments: { name: 'mcp__CherryPython__pythonExecute', params: { code: 'print(1)' } },
+        response: { isError: true, content: [{ type: 'text', text: 'boom' }] }
+      })
+
+      render(<MessageTool toolResponse={toolResponse} />)
+
+      // Outer header names the inner tool (raw mcp__ form).
+      expect(screen.getByText('tool_invoke · mcp__CherryPython__pythonExecute')).toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button'))
+
+      // Input params are visible flat — no second expand needed.
+      expect(await screen.findByText('code')).toBeInTheDocument()
+      expect(screen.getByText('print(1)')).toBeInTheDocument()
+      // No nested inner tool card (its header would format the name as `Server:tool`).
+      expect(screen.queryByText(/CherryPython:pythonExecute/)).toBeNull()
+    })
+  })
+
+  describe('agent tool flow action', () => {
+    it('opens the right-pane flow only from subagent rows', () => {
+      const openAgentToolFlow = vi.fn()
+      mockMessageListActions.mockReturnValue({ openAgentToolFlow })
+      const toolResponse = createToolResponse({
+        tool: { id: 'Agent', name: 'Agent', description: 'Run subagent', type: 'provider' },
+        status: 'done',
+        arguments: { description: 'Inspect renderer', prompt: 'Check the message renderer' },
+        response: 'ok'
+      })
+
+      render(<AgentToolRenderer toolResponse={toolResponse} />)
+
+      fireEvent.click(screen.getByText('Handle').closest('[role="button"]')!)
+      expect(openAgentToolFlow).toHaveBeenCalledWith({
+        toolCallId: 'call-123',
+        toolName: 'Agent',
+        sourceMessageId: undefined,
+        title: 'Inspect renderer'
+      })
+      expect(screen.queryByRole('button', { name: 'code_block.expand' })).toBeNull()
+    })
+
+    it('keeps ordinary tool row clicks local even when the flow action exists', () => {
+      const openAgentToolFlow = vi.fn()
+      mockMessageListActions.mockReturnValue({ openAgentToolFlow })
+      const toolResponse = createToolResponse({
+        tool: { id: 'Bash', name: 'Bash', description: 'Execute command', type: 'provider' },
+        status: 'done',
+        arguments: { command: 'pwd' },
+        response: 'ok'
+      })
+
+      render(<AgentToolRenderer toolResponse={toolResponse} />)
+
+      fireEvent.click(screen.getByText('View').closest('[role="button"]')!)
+      expect(openAgentToolFlow).not.toHaveBeenCalled()
+      expect(screen.getByTestId('collapse-content-Bash')).toBeVisible()
+      expect(screen.getByTestId('collapse-content-Bash')).toHaveClass('rounded-xl', 'bg-muted', 'px-4', 'py-3')
+
+      fireEvent.click(screen.getByText('View').closest('[role="button"]')!)
+      expect(screen.getByTestId('collapse-content-Bash')).not.toBeVisible()
+      expect(screen.queryByRole('button', { name: 'button.collapse' })).toBeNull()
+      expect(screen.queryByRole('button', { name: 'code_block.expand' })).toBeNull()
+    })
+  })
+
+  describe('Bash streaming', () => {
+    it('should render Bash dedicated renderer with partial command during streaming', () => {
+      const toolResponse = createToolResponse({
+        tool: { id: 'Bash', name: 'Bash', description: 'Execute command', type: 'provider' },
+        status: 'streaming',
+        partialArguments: '{"command": "npm install",'
+      })
+
+      render(<AgentToolRenderer toolResponse={toolResponse} />)
+
+      // Should render the DEDICATED BashTool component
+      const bashLabel = screen.getByText('Installing')
+      expect(bashLabel.parentElement?.parentElement).toHaveClass('text-[13px]')
+      expect(bashLabel.parentElement?.parentElement).not.toHaveClass('text-sm')
+      expect(bashLabel.parentElement).toHaveClass('font-normal text-foreground-secondary')
+      // Command should be visible in the dedicated renderer (ANSI colorizer splits tokens across spans)
+      const container = screen.getByTestId('collapse-content-Bash')
+      expect(container.textContent).toContain('npm install')
+    })
+  })
+})

--- a/src/renderer/components/chat/messages/tools/__tests__/MessageMcpTool.test.tsx
+++ b/src/renderer/components/chat/messages/tools/__tests__/MessageMcpTool.test.tsx
@@ -1,0 +1,101 @@
+import type { McpToolResponse } from '@renderer/types'
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import MessageMcpTool from '../mcp/MessageMcpTool'
+
+const mockApproval = vi.hoisted(() => vi.fn())
+const mockActions = vi.hoisted(() => vi.fn(() => ({}) as Record<string, unknown>))
+
+// Control approval state directly so the test doesn't need the MCP-server data hooks.
+vi.mock('../hooks/useToolApproval', () => ({
+  useToolApproval: () => mockApproval()
+}))
+
+vi.mock('@renderer/components/chat/messages/MessageListProvider', () => ({
+  useOptionalMessageListActions: () => mockActions(),
+  useOptionalMessageListUi: () => ({ isToolAutoApproved: () => false }),
+  useMessageRenderConfig: () => ({ messageFont: 'sans-serif', fontSize: 14 })
+}))
+
+vi.mock('@renderer/hooks/useTimer', () => ({
+  useTimer: () => ({ setTimeoutTimer: vi.fn() })
+}))
+
+vi.mock('@renderer/context/CodeStyleProvider', () => ({
+  useCodeStyle: () => ({ highlightCode: vi.fn(async () => '') })
+}))
+
+vi.mock('@renderer/components/Icons', () => ({
+  CopyIcon: () => <span data-testid="copy-icon" />
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string, fallback?: string) => (typeof fallback === 'string' ? fallback : key) }),
+  initReactI18next: { type: '3rdParty', init: vi.fn() }
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+  }
+}))
+
+const createMcpToolResponse = (overrides: Partial<McpToolResponse> = {}): McpToolResponse => ({
+  id: 'call-1',
+  tool: {
+    id: 'CherryBrowser__execute',
+    name: 'execute',
+    type: 'mcp',
+    serverId: 'CherryBrowser',
+    serverName: 'CherryBrowser',
+    inputSchema: { type: 'object', properties: {}, required: [] }
+  },
+  arguments: { url: 'https://example.com' },
+  status: 'pending',
+  response: undefined,
+  toolCallId: 'call-1',
+  ...overrides
+})
+
+describe('MessageMcpTool', () => {
+  beforeEach(() => {
+    // An abort handler is available, so the removed v1 ActionsBar *would* have
+    // rendered its destructive abort button — making the absence assertion meaningful.
+    mockActions.mockReturnValue({ abortTool: vi.fn() })
+    mockApproval.mockReturnValue({
+      isWaiting: false,
+      isExecuting: true,
+      isSubmitting: false,
+      confirm: vi.fn(),
+      cancel: vi.fn()
+    })
+  })
+
+  afterEach(() => vi.clearAllMocks())
+
+  it('renders nothing while awaiting approval (the composer owns that surface)', () => {
+    mockApproval.mockReturnValue({
+      isWaiting: true,
+      isExecuting: false,
+      isSubmitting: false,
+      confirm: vi.fn(),
+      cancel: vi.fn()
+    })
+
+    const { container } = render(<MessageMcpTool toolResponse={createMcpToolResponse()} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows only the disclosure header while executing — no abort bar (v2 style)', () => {
+    const { container } = render(<MessageMcpTool toolResponse={createMcpToolResponse({ status: 'pending' })} />)
+
+    // Header still identifies the tool.
+    expect(container.textContent).toContain('CherryBrowser : execute')
+    // The v1 destructive abort button is gone.
+    expect(container.textContent).not.toContain('chat.input.pause')
+    // Only the collapse header is interactive — no separate actions-bar controls.
+    expect(screen.getAllByRole('button')).toHaveLength(1)
+  })
+})

--- a/src/renderer/components/chat/messages/tools/__tests__/toolResponse.test.ts
+++ b/src/renderer/components/chat/messages/tools/__tests__/toolResponse.test.ts
@@ -1,0 +1,236 @@
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { describe, expect, it } from 'vitest'
+
+import { buildToolResponseFromPart } from '../toolResponse'
+
+describe('toolResponse adapter', () => {
+  it('maps structured dynamic-tool output metadata to MCP tool fields', () => {
+    const part = {
+      type: 'dynamic-tool',
+      toolCallId: 'call-1',
+      toolName: 'search_docs',
+      state: 'output-available',
+      input: { q: 'hello' },
+      output: {
+        content: 'ok',
+        metadata: {
+          description: 'Search project documentation',
+          name: 'search_docs',
+          serverName: 'Docs',
+          serverId: 'docs-server',
+          type: 'mcp'
+        }
+      }
+    } as unknown as CherryMessagePart
+
+    const response = buildToolResponseFromPart(part)
+    expect(response).toBeTruthy()
+    if (!response) throw new Error('Expected tool response')
+    expect(response.status).toBe('done')
+    expect(response.tool.type).toBe('mcp')
+    expect(response.tool.name).toBe('search_docs')
+    expect((response.tool as any).description).toBe('Search project documentation')
+    expect((response.tool as any).serverId).toBe('docs-server')
+    expect((response.tool as any).serverName).toBe('Docs')
+    expect(response.response).toBe('ok')
+  })
+
+  it('parses the cherry-tools wire name into server + tool (no metadata path)', () => {
+    // Real production shape (from the agent_session_message table): a dynamic-tool part whose
+    // toolName is the full `mcp__cherry-tools__web_search`, with NO output metadata. The single-
+    // underscore wire name splits cleanly on the last `__` into server `cherry-tools` / tool
+    // `web_search`.
+    const part = {
+      type: 'dynamic-tool',
+      toolCallId: 'call-cherry',
+      toolName: 'mcp__cherry-tools__web_search',
+      state: 'output-available',
+      input: { query: 'latest news' },
+      output: { content: '[]' }
+    } as unknown as CherryMessagePart
+
+    const response = buildToolResponseFromPart(part)
+    expect(response).toBeTruthy()
+    if (!response) throw new Error('Expected tool response')
+    expect(response.tool.type).toBe('mcp')
+    expect(response.tool.name).toBe('web_search')
+    expect((response.tool as any).serverId).toBe('cherry-tools')
+  })
+
+  it('keeps a successful tool_invoke as a meta (non-mcp) tool despite leaked inner result metadata', () => {
+    // A completed tool_invoke carries the inner tool's result metadata (`type: 'mcp'`,
+    // `serverName`). The outer meta-tool must NOT be reshaped into an MCP response.
+    const part = {
+      type: 'tool-tool_invoke',
+      toolCallId: 'call-meta',
+      state: 'output-available',
+      input: { name: 'mcp__duckduckgo__search', params: { query: 'latest tech news' } },
+      output: {
+        content: 'ok',
+        metadata: { serverName: 'duckduckgo', serverId: 'dd-server', type: 'mcp' }
+      }
+    } as unknown as CherryMessagePart
+
+    const response = buildToolResponseFromPart(part)
+    expect(response).toBeTruthy()
+    if (!response) throw new Error('Expected tool response')
+    expect(response.tool.type).not.toBe('mcp')
+    expect(response.tool.name).toBe('tool_invoke')
+    // Inner arguments stay intact for the meta renderer to unwrap.
+    expect(response.arguments).toEqual({ name: 'mcp__duckduckgo__search', params: { query: 'latest tech news' } })
+  })
+
+  it('maps output-error to error status and error-shaped response', () => {
+    const part = {
+      type: 'dynamic-tool',
+      toolCallId: 'call-2',
+      toolName: 'search_docs',
+      state: 'output-error',
+      errorText: 'failed'
+    } as unknown as CherryMessagePart
+
+    const response = buildToolResponseFromPart(part)
+    expect(response?.status).toBe('error')
+    expect(response?.response).toMatchObject({
+      isError: true
+    })
+  })
+
+  it('maps tool-* streaming MCP part to invoking and displays the tool segment', () => {
+    const part = {
+      type: 'tool-mcp__assistant__read',
+      toolCallId: 'call-3',
+      state: 'input-available',
+      input: { file_path: '/tmp/a.ts' }
+    } as unknown as CherryMessagePart
+
+    const response = buildToolResponseFromPart(part)
+    expect(response?.status).toBe('invoking')
+    expect(response?.toolCallId).toBe('call-3')
+    expect(response?.tool.name).toBe('read')
+  })
+
+  it('keeps real Claude Code dynamic tool calls on the provider renderer path', () => {
+    const part = {
+      type: 'dynamic-tool',
+      toolName: 'CustomTool',
+      toolCallId: 'call-4',
+      state: 'approval-requested',
+      input: { command: 'pnpm test' },
+      approval: { id: 'approval-4' },
+      callProviderMetadata: {
+        'claude-code': {
+          rawInput: { command: 'pnpm test' },
+          parentToolCallId: null
+        }
+      }
+    } as unknown as CherryMessagePart
+
+    const response = buildToolResponseFromPart(part)
+    expect(response?.status).toBe('pending')
+    expect(response?.tool.type).toBe('provider')
+    expect(response?.tool.name).toBe('CustomTool')
+  })
+
+  it('keeps migrated agent dynamic-tool calls without metadata on the provider renderer path', () => {
+    const part = {
+      type: 'dynamic-tool',
+      toolName: 'WebSearch',
+      toolCallId: 'legacy-call',
+      state: 'output-available',
+      input: { query: 'desktop clients' },
+      output: 'ok'
+    } as unknown as CherryMessagePart
+
+    const response = buildToolResponseFromPart(part)
+    expect(response?.status).toBe('done')
+    expect(response?.tool.type).toBe('provider')
+    expect(response?.tool.name).toBe('WebSearch')
+  })
+
+  it('parses Claude Code MCP tool ids as MCP tools without display metadata', () => {
+    const part = {
+      type: 'dynamic-tool',
+      toolName: 'mcp__8171b5f3-c666-4ead-b2ab-bb9ac244af57__resolve-library-id',
+      toolCallId: 'mcp-call',
+      state: 'approval-requested',
+      input: { libraryName: 'React' },
+      approval: { id: 'approval-mcp' },
+      callProviderMetadata: {
+        'claude-code': {
+          parentToolCallId: null
+        }
+      }
+    } as unknown as CherryMessagePart
+
+    const response = buildToolResponseFromPart(part)
+    expect(response).toBeTruthy()
+    if (!response) throw new Error('Expected tool response')
+    expect(response.tool.type).toBe('mcp')
+    expect(response.tool.name).toBe('resolve-library-id')
+    expect((response.tool as any).serverId).toBe('8171b5f3-c666-4ead-b2ab-bb9ac244af57')
+    expect((response.tool as any).serverName).toBe('8171b5f3-c666-4ead-b2ab-bb9ac244af57')
+  })
+
+  it('uses migrated cherry tool metadata from callProviderMetadata before name fallbacks', () => {
+    const part = {
+      type: 'dynamic-tool',
+      toolName: 'WebSearch',
+      toolCallId: 'legacy-mcp-call',
+      state: 'output-available',
+      input: { query: 'desktop clients' },
+      output: 'ok',
+      callProviderMetadata: {
+        cherry: {
+          tool: {
+            type: 'mcp',
+            name: 'search_docs',
+            description: 'Search desktop docs',
+            serverId: 'search-server',
+            serverName: 'Search'
+          }
+        }
+      }
+    } as unknown as CherryMessagePart
+
+    const response = buildToolResponseFromPart(part)
+    expect(response).toBeTruthy()
+    if (!response) throw new Error('Expected tool response')
+    expect(response.tool.type).toBe('mcp')
+    expect(response.tool.name).toBe('search_docs')
+    expect((response.tool as any).description).toBe('Search desktop docs')
+    expect((response.tool as any).serverId).toBe('search-server')
+    expect((response.tool as any).serverName).toBe('Search')
+  })
+
+  it('extracts parent tool id from Claude Code provider metadata', () => {
+    const part = {
+      type: 'dynamic-tool',
+      toolName: 'Read',
+      toolCallId: 'child-call',
+      state: 'output-available',
+      input: { file_path: '/tmp/a.ts' },
+      output: 'ok',
+      callProviderMetadata: {
+        'claude-code': {
+          parentToolCallId: 'parent-call'
+        }
+      }
+    } as unknown as CherryMessagePart
+
+    const response = buildToolResponseFromPart(part)
+    expect(response?.parentToolUseId).toBe('parent-call')
+  })
+
+  it('does not synthesize a tool response without an AI SDK toolCallId', () => {
+    const part = {
+      type: 'dynamic-tool',
+      toolName: 'CustomTool',
+      state: 'approval-requested',
+      input: { command: 'pnpm test' },
+      approval: { id: 'approval-missing-call' }
+    } as unknown as CherryMessagePart
+
+    expect(buildToolResponseFromPart(part)).toBeNull()
+  })
+})

--- a/src/renderer/components/chat/messages/tools/agent/AgentExecutionTimeline.tsx
+++ b/src/renderer/components/chat/messages/tools/agent/AgentExecutionTimeline.tsx
@@ -1,0 +1,74 @@
+import { usePartsMap } from '@renderer/components/chat/messages/blocks'
+import type { NormalToolResponse } from '@renderer/types'
+import { parse as parsePartialJson } from 'partial-json'
+import { useDeferredValue, useMemo } from 'react'
+
+import { isToolPartAwaitingApproval } from '../toolResponse'
+import { AgentToolCallCard } from './AgentToolCallCard'
+import { AskUserQuestionCard } from './AskUserQuestionCard'
+import { getEffectiveStatus, StreamingContext } from './GenericTools'
+import { NavigateToolInline } from './NavigateTool'
+import { AgentToolsType, isAskUserQuestionToolName } from './types'
+
+export function AgentExecutionTimeline({ toolResponse }: { toolResponse: NormalToolResponse }) {
+  const { arguments: args, response, tool, status, partialArguments } = toolResponse
+
+  const partsMap = usePartsMap()
+  const awaitingApproval = isToolPartAwaitingApproval(partsMap, toolResponse.toolCallId)
+
+  const deferredPartialArguments = useDeferredValue(partialArguments)
+  const parsedPartialArgs = useMemo(() => {
+    if (!deferredPartialArguments) return undefined
+    try {
+      return parsePartialJson(deferredPartialArguments)
+    } catch {
+      return undefined
+    }
+  }, [deferredPartialArguments])
+
+  if (tool?.name === 'mcp__assistant__navigate') {
+    return <NavigateToolInline input={args ?? parsedPartialArgs} output={response} />
+  }
+
+  if (isAskUserQuestionToolName(tool?.name)) {
+    if (awaitingApproval) return null
+
+    const isLoading = status === 'streaming' || status === 'invoking'
+    return (
+      <StreamingContext value={isLoading}>
+        <AskUserQuestionCard toolResponse={toolResponse} />
+      </StreamingContext>
+    )
+  }
+
+  // TodoWrite is globally disabled; old DB messages may still carry it — keep hiding them.
+  if (tool?.name === 'TodoWrite') {
+    return null
+  }
+
+  const effectiveStatus = getEffectiveStatus(status, awaitingApproval)
+
+  if (effectiveStatus === 'waiting') {
+    return null
+  }
+
+  const isLoading = effectiveStatus === 'streaming' || effectiveStatus === 'invoking'
+  const isSubagentTool = tool?.name === AgentToolsType.Agent || tool?.name === AgentToolsType.Task
+  return (
+    <AgentToolCallCard
+      toolCallId={toolResponse.toolCallId}
+      toolName={tool?.name}
+      input={args ?? parsedPartialArgs}
+      output={isLoading || isSubagentTool ? undefined : response}
+      isStreaming={isLoading}
+      status={effectiveStatus}
+      hasError={status === 'error'}
+      openFlowOnClick={isSubagentTool}
+      showInlineDetails={!isSubagentTool}
+    />
+  )
+}
+
+export function AgentToolRenderer(props: { toolResponse: NormalToolResponse }) {
+  return <AgentExecutionTimeline {...props} />
+}

--- a/src/renderer/components/chat/messages/tools/agent/toolRendererRegistry.tsx
+++ b/src/renderer/components/chat/messages/tools/agent/toolRendererRegistry.tsx
@@ -1,0 +1,70 @@
+import type { ToolDisclosureItem } from '../shared/ToolDisclosure'
+import { BashOutputTool } from './BashOutputTool'
+import { BashTool } from './BashTool'
+import { EditTool } from './EditTool'
+import { ExitPlanModeTool } from './ExitPlanModeTool'
+import { GlobTool } from './GlobTool'
+import { GrepTool } from './GrepTool'
+import { MultiEditTool } from './MultiEditTool'
+import { NotebookEditTool } from './NotebookEditTool'
+import { ReadTool } from './ReadTool'
+import { SearchTool } from './SearchTool'
+import { SkillTool } from './SkillTool'
+import { createStructuredAgentTool } from './StructuredAgentTool'
+import { TaskTool } from './TaskTool'
+import { ToolSearchTool } from './ToolSearchTool'
+import { AgentToolsType, type TaskToolInput, type TaskToolOutput, type ToolInput, type ToolOutput } from './types'
+import { WebFetchTool } from './WebFetchTool'
+import { WebSearchTool } from './WebSearchTool'
+import { WriteTool } from './WriteTool'
+
+export const toolRenderers = {
+  [AgentToolsType.Agent]: ({ input, output }: { input?: unknown; output?: unknown }) =>
+    TaskTool({
+      input: input as TaskToolInput,
+      output: output as TaskToolOutput,
+      toolName: AgentToolsType.Agent
+    }),
+  [AgentToolsType.Read]: ReadTool,
+  [AgentToolsType.Task]: TaskTool,
+  [AgentToolsType.TaskOutput]: createStructuredAgentTool(AgentToolsType.TaskOutput),
+  [AgentToolsType.TaskStop]: createStructuredAgentTool(AgentToolsType.TaskStop),
+  [AgentToolsType.Bash]: BashTool,
+  [AgentToolsType.Search]: SearchTool,
+  [AgentToolsType.Glob]: GlobTool,
+  [AgentToolsType.WebSearch]: WebSearchTool,
+  [AgentToolsType.Grep]: GrepTool,
+  [AgentToolsType.Write]: WriteTool,
+  [AgentToolsType.WebFetch]: WebFetchTool,
+  [AgentToolsType.Edit]: EditTool,
+  [AgentToolsType.MultiEdit]: MultiEditTool,
+  [AgentToolsType.BashOutput]: BashOutputTool,
+  [AgentToolsType.NotebookEdit]: NotebookEditTool,
+  [AgentToolsType.ExitPlanMode]: ExitPlanModeTool,
+  [AgentToolsType.Skill]: SkillTool,
+  [AgentToolsType.ToolSearch]: ToolSearchTool,
+  [AgentToolsType.ListMcpResources]: createStructuredAgentTool(AgentToolsType.ListMcpResources),
+  [AgentToolsType.ReadMcpResource]: createStructuredAgentTool(AgentToolsType.ReadMcpResource),
+  [AgentToolsType.TaskCreate]: createStructuredAgentTool(AgentToolsType.TaskCreate),
+  [AgentToolsType.TaskGet]: createStructuredAgentTool(AgentToolsType.TaskGet),
+  [AgentToolsType.TaskUpdate]: createStructuredAgentTool(AgentToolsType.TaskUpdate),
+  [AgentToolsType.TaskList]: createStructuredAgentTool(AgentToolsType.TaskList),
+  [AgentToolsType.SendMessage]: createStructuredAgentTool(AgentToolsType.SendMessage),
+  [AgentToolsType.TeamCreate]: createStructuredAgentTool(AgentToolsType.TeamCreate),
+  [AgentToolsType.TeamDelete]: createStructuredAgentTool(AgentToolsType.TeamDelete),
+  [AgentToolsType.EnterWorktree]: createStructuredAgentTool(AgentToolsType.EnterWorktree),
+  [AgentToolsType.ExitWorktree]: createStructuredAgentTool(AgentToolsType.ExitWorktree)
+}
+
+export function renderTool(
+  toolName: AgentToolsType,
+  input: ToolInput | Record<string, unknown> | string | undefined,
+  output?: ToolOutput | unknown
+): ToolDisclosureItem {
+  const renderer = toolRenderers[toolName] as (props: { input?: unknown; output?: unknown }) => ToolDisclosureItem
+  return renderer({ input, output })
+}
+
+export function isValidAgentToolsType(toolName: unknown): toolName is AgentToolsType {
+  return typeof toolName === 'string' && Object.values(AgentToolsType).includes(toolName as AgentToolsType)
+}

--- a/src/renderer/components/chat/messages/tools/agent/types.ts
+++ b/src/renderer/components/chat/messages/tools/agent/types.ts
@@ -1,0 +1,404 @@
+import type {
+  AgentInput,
+  AgentOutput,
+  AskUserQuestionInput,
+  AskUserQuestionOutput,
+  BashInput,
+  BashOutput,
+  EnterWorktreeInput,
+  EnterWorktreeOutput,
+  ExitPlanModeInput,
+  ExitPlanModeOutput,
+  ExitWorktreeInput,
+  ExitWorktreeOutput,
+  FileEditInput,
+  FileEditOutput,
+  FileReadInput,
+  FileReadOutput,
+  FileWriteInput,
+  FileWriteOutput,
+  GlobInput,
+  GlobOutput,
+  GrepInput,
+  GrepOutput,
+  ListMcpResourcesInput,
+  ListMcpResourcesOutput,
+  NotebookEditInput,
+  NotebookEditOutput,
+  ReadMcpResourceInput,
+  ReadMcpResourceOutput,
+  TaskCreateInput,
+  TaskCreateOutput,
+  TaskGetInput,
+  TaskGetOutput,
+  TaskListInput,
+  TaskListOutput,
+  TaskOutputInput,
+  TaskStopInput,
+  TaskStopOutput,
+  TaskUpdateInput,
+  TaskUpdateOutput,
+  TodoWriteInput,
+  TodoWriteOutput,
+  WebFetchInput,
+  WebFetchOutput,
+  WebSearchInput,
+  WebSearchOutput
+} from '@anthropic-ai/claude-agent-sdk/sdk-tools'
+import * as z from 'zod'
+
+import type { ToolDisclosureItem } from '../shared/ToolDisclosure'
+
+export const AgentToolsType = {
+  Skill: 'Skill',
+  Agent: 'Agent',
+  Read: 'Read',
+  Task: 'Task',
+  TaskOutput: 'TaskOutput',
+  TaskStop: 'TaskStop',
+  Bash: 'Bash',
+  Search: 'Search',
+  Glob: 'Glob',
+  TodoWrite: 'TodoWrite',
+  WebSearch: 'WebSearch',
+  Grep: 'Grep',
+  Write: 'Write',
+  WebFetch: 'WebFetch',
+  Edit: 'Edit',
+  MultiEdit: 'MultiEdit',
+  BashOutput: 'BashOutput',
+  NotebookEdit: 'NotebookEdit',
+  ExitPlanMode: 'ExitPlanMode',
+  AskUserQuestion: 'AskUserQuestion',
+  ToolSearch: 'ToolSearch',
+  ListMcpResources: 'ListMcpResources',
+  ReadMcpResource: 'ReadMcpResource',
+  TaskCreate: 'TaskCreate',
+  TaskGet: 'TaskGet',
+  TaskUpdate: 'TaskUpdate',
+  TaskList: 'TaskList',
+  SendMessage: 'SendMessage',
+  TeamCreate: 'TeamCreate',
+  TeamDelete: 'TeamDelete',
+  EnterWorktree: 'EnterWorktree',
+  ExitWorktree: 'ExitWorktree'
+} as const
+
+export type AgentToolsType = (typeof AgentToolsType)[keyof typeof AgentToolsType]
+
+export type TextOutput = {
+  type: 'text'
+  text: string
+}
+
+export interface SkillToolInput {
+  skill: string
+  args?: string
+}
+export type SkillToolOutput = string
+
+export type ReadToolInput = FileReadInput
+export type ReadToolOutput = FileReadOutput | string | TextOutput[]
+
+export type TaskToolInput = AgentInput
+export type TaskToolOutput = AgentOutput | TextOutput[]
+
+export type AgentToolInput = AgentInput
+export type AgentToolOutput = AgentOutput | TextOutput[]
+
+export type TaskOutputToolInput = TaskOutputInput
+export type TaskOutputToolOutput = Record<string, unknown> | unknown[] | string
+
+export type TaskStopToolInput = TaskStopInput
+export type TaskStopToolOutput = TaskStopOutput | string
+
+export type BashToolInput = BashInput
+export type BashToolOutput = BashOutput | string
+
+export type SearchToolInput = string
+export type SearchToolOutput = string
+
+export type GlobToolInput = GlobInput
+export type GlobToolOutput = GlobOutput | string
+
+export type TodoItem = TodoWriteInput['todos'][number]
+export type TodoWriteToolInput = TodoWriteInput
+export type TodoWriteToolOutput = TodoWriteOutput | string
+
+export type WebSearchToolInput = WebSearchInput
+export type WebSearchToolOutput = WebSearchOutput | string
+
+export type WebFetchToolInput = WebFetchInput
+export type WebFetchToolOutput = WebFetchOutput | string
+
+export type GrepToolInput = GrepInput
+export type GrepToolOutput = GrepOutput | string
+
+export type WriteToolInput = FileWriteInput
+export type WriteToolOutput = FileWriteOutput | string
+
+export type EditToolInput = FileEditInput
+export type EditToolOutput = FileEditOutput | string
+
+export type MultiEditToolInput = {
+  file_path: string
+  edits: Array<{
+    old_string: string
+    new_string: string
+    replace_all?: boolean
+  }>
+}
+export type MultiEditToolOutput = string
+
+export type BashOutputToolInput = Partial<TaskOutputInput> & {
+  bash_id?: string
+  filter?: string
+}
+export type BashOutputToolOutput = string
+
+export type NotebookEditToolInput = NotebookEditInput
+export type NotebookEditToolOutput = NotebookEditOutput | string
+
+export type ExitPlanModeToolInput = ExitPlanModeInput & {
+  plan?: string
+}
+export type ExitPlanModeToolOutput = ExitPlanModeOutput | string
+
+export interface ToolSearchToolInput {
+  query: string
+  max_results?: number
+}
+
+export const ToolSearchToolOutputSchema = z.union([
+  z.array(z.object({ type: z.literal('tool_reference'), tool_name: z.string() })),
+  z.string()
+])
+export type ToolSearchToolOutput = z.infer<typeof ToolSearchToolOutputSchema>
+
+export const AskUserQuestionOptionSchema = z.object({
+  label: z.string(),
+  description: z.string().optional(),
+  preview: z.string().optional()
+})
+
+export const AskUserQuestionItemSchema = z.object({
+  question: z.string(),
+  header: z.string(),
+  options: z.array(AskUserQuestionOptionSchema).min(2).max(4),
+  multiSelect: z.boolean().default(false)
+})
+
+export const AskUserQuestionAnswerSchema = z.record(z.string(), z.string())
+
+export const AskUserQuestionToolInputSchema = z.object({
+  questions: z.array(AskUserQuestionItemSchema).min(1).max(4),
+  answers: AskUserQuestionAnswerSchema.optional(),
+  annotations: z.record(z.string(), z.record(z.string(), z.unknown())).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional()
+})
+
+type SDKAskUserQuestionItem = AskUserQuestionInput['questions'][number]
+type SDKAskUserQuestionOption = SDKAskUserQuestionItem['options'][number]
+
+export type AskUserQuestionOption = Omit<SDKAskUserQuestionOption, 'description'> & {
+  description?: string
+}
+export type AskUserQuestionItem = Omit<SDKAskUserQuestionItem, 'options'> & {
+  options: AskUserQuestionOption[]
+}
+export type AskUserQuestionToolInput = Omit<AskUserQuestionInput, 'questions'> & {
+  questions: AskUserQuestionItem[]
+}
+export type AskUserQuestionToolOutput = AskUserQuestionOutput
+export type AskUserQuestionAnswer = NonNullable<AskUserQuestionInput['answers']>
+
+export function isAskUserQuestionToolName(toolName: unknown): boolean {
+  return toolName === AgentToolsType.AskUserQuestion || toolName === 'builtin_AskUserQuestion'
+}
+
+/**
+ * Safely parse AskUserQuestionToolInput from unknown data.
+ * Returns undefined if the data doesn't match the expected structure.
+ */
+export function parseAskUserQuestionToolInput(value: unknown): AskUserQuestionToolInput | undefined {
+  const result = AskUserQuestionToolInputSchema.safeParse(value)
+  return result.success ? (result.data as AskUserQuestionToolInput) : undefined
+}
+
+export type ListMcpResourcesToolInput = ListMcpResourcesInput
+export type ListMcpResourcesToolOutput = ListMcpResourcesOutput | string
+
+export type ReadMcpResourceToolInput = ReadMcpResourceInput
+export type ReadMcpResourceToolOutput = ReadMcpResourceOutput | string
+
+export type KillBashToolInput = TaskStopInput
+export type KillBashToolOutput = TaskStopOutput | string
+
+export type TaskCreateToolInput = TaskCreateInput
+export type TaskCreateToolOutput = TaskCreateOutput | string
+
+export type TaskGetToolInput = TaskGetInput
+export type TaskGetToolOutput = TaskGetOutput | string
+
+export type TaskUpdateToolInput = TaskUpdateInput
+export type TaskUpdateToolOutput = TaskUpdateOutput | string
+
+export type TaskListToolInput = TaskListInput
+export type TaskListToolOutput = TaskListOutput | string
+
+export type EnterWorktreeToolInput = EnterWorktreeInput
+export type EnterWorktreeToolOutput = EnterWorktreeOutput | string
+
+export type ExitWorktreeToolInput = ExitWorktreeInput
+export type ExitWorktreeToolOutput = ExitWorktreeOutput | string
+
+// Agent-teams tools are runtime/experimental (not in the SDK typed union) — loosely typed.
+export type SendMessageToolInput = { to?: string; message?: string } & Record<string, unknown>
+export type SendMessageToolOutput = string
+export type TeamCreateToolInput = Record<string, unknown>
+export type TeamCreateToolOutput = string
+export type TeamDeleteToolInput = Record<string, unknown>
+export type TeamDeleteToolOutput = string
+
+export type ToolInput =
+  | SkillToolInput
+  | AgentToolInput
+  | ReadToolInput
+  | TaskOutputToolInput
+  | TaskStopToolInput
+  | BashToolInput
+  | BashOutputToolInput
+  | SearchToolInput
+  | GlobToolInput
+  | TodoWriteToolInput
+  | WebSearchToolInput
+  | GrepToolInput
+  | WriteToolInput
+  | WebFetchToolInput
+  | EditToolInput
+  | MultiEditToolInput
+  | NotebookEditToolInput
+  | ExitPlanModeToolInput
+  | ListMcpResourcesToolInput
+  | ReadMcpResourceToolInput
+  | AskUserQuestionToolInput
+  | ToolSearchToolInput
+  | TaskCreateToolInput
+  | TaskGetToolInput
+  | TaskUpdateToolInput
+  | TaskListToolInput
+  | SendMessageToolInput
+  | TeamCreateToolInput
+  | TeamDeleteToolInput
+  | EnterWorktreeToolInput
+  | ExitWorktreeToolInput
+
+export type ToolOutput =
+  | SkillToolOutput
+  | AgentToolOutput
+  | ReadToolOutput
+  | TaskToolOutput
+  | TaskOutputToolOutput
+  | TaskStopToolOutput
+  | BashToolOutput
+  | GlobToolOutput
+  | TodoWriteToolOutput
+  | WebSearchToolOutput
+  | GrepToolOutput
+  | WriteToolOutput
+  | WebFetchToolOutput
+  | EditToolOutput
+  | NotebookEditToolOutput
+  | ExitPlanModeToolOutput
+  | ListMcpResourcesToolOutput
+  | ReadMcpResourceToolOutput
+  | KillBashToolOutput
+  | AskUserQuestionToolOutput
+  | ToolSearchToolOutput
+  | TaskCreateToolOutput
+  | TaskGetToolOutput
+  | TaskUpdateToolOutput
+  | TaskListToolOutput
+  | EnterWorktreeToolOutput
+  | ExitWorktreeToolOutput
+
+export interface ToolRenderer {
+  render: (props: { input: ToolInput; output?: ToolOutput }) => React.ReactElement
+}
+
+export interface ToolInputMap {
+  [AgentToolsType.Skill]: SkillToolInput
+  [AgentToolsType.Agent]: AgentToolInput
+  [AgentToolsType.Read]: ReadToolInput
+  [AgentToolsType.Task]: TaskToolInput
+  [AgentToolsType.TaskOutput]: TaskOutputToolInput
+  [AgentToolsType.TaskStop]: TaskStopToolInput
+  [AgentToolsType.Bash]: BashToolInput
+  [AgentToolsType.Search]: SearchToolInput
+  [AgentToolsType.Glob]: GlobToolInput
+  [AgentToolsType.TodoWrite]: TodoWriteToolInput
+  [AgentToolsType.WebSearch]: WebSearchToolInput
+  [AgentToolsType.Grep]: GrepToolInput
+  [AgentToolsType.Write]: WriteToolInput
+  [AgentToolsType.WebFetch]: WebFetchToolInput
+  [AgentToolsType.Edit]: EditToolInput
+  [AgentToolsType.MultiEdit]: MultiEditToolInput
+  [AgentToolsType.BashOutput]: BashOutputToolInput
+  [AgentToolsType.NotebookEdit]: NotebookEditToolInput
+  [AgentToolsType.ExitPlanMode]: ExitPlanModeToolInput
+  [AgentToolsType.AskUserQuestion]: AskUserQuestionToolInput
+  [AgentToolsType.ToolSearch]: ToolSearchToolInput
+  [AgentToolsType.ListMcpResources]: ListMcpResourcesToolInput
+  [AgentToolsType.ReadMcpResource]: ReadMcpResourceToolInput
+  [AgentToolsType.TaskCreate]: TaskCreateToolInput
+  [AgentToolsType.TaskGet]: TaskGetToolInput
+  [AgentToolsType.TaskUpdate]: TaskUpdateToolInput
+  [AgentToolsType.TaskList]: TaskListToolInput
+  [AgentToolsType.SendMessage]: SendMessageToolInput
+  [AgentToolsType.TeamCreate]: TeamCreateToolInput
+  [AgentToolsType.TeamDelete]: TeamDeleteToolInput
+  [AgentToolsType.EnterWorktree]: EnterWorktreeToolInput
+  [AgentToolsType.ExitWorktree]: ExitWorktreeToolInput
+}
+
+export interface ToolOutputMap {
+  [AgentToolsType.Skill]: SkillToolOutput
+  [AgentToolsType.Agent]: AgentToolOutput
+  [AgentToolsType.Read]: ReadToolOutput
+  [AgentToolsType.Task]: TaskToolOutput
+  [AgentToolsType.TaskOutput]: TaskOutputToolOutput
+  [AgentToolsType.TaskStop]: TaskStopToolOutput
+  [AgentToolsType.Bash]: BashToolOutput
+  [AgentToolsType.Search]: SearchToolOutput
+  [AgentToolsType.Glob]: GlobToolOutput
+  [AgentToolsType.TodoWrite]: TodoWriteToolOutput
+  [AgentToolsType.WebSearch]: WebSearchToolOutput
+  [AgentToolsType.Grep]: GrepToolOutput
+  [AgentToolsType.Write]: WriteToolOutput
+  [AgentToolsType.WebFetch]: WebFetchToolOutput
+  [AgentToolsType.Edit]: EditToolOutput
+  [AgentToolsType.MultiEdit]: MultiEditToolOutput
+  [AgentToolsType.BashOutput]: BashOutputToolOutput
+  [AgentToolsType.NotebookEdit]: NotebookEditToolOutput
+  [AgentToolsType.ExitPlanMode]: ExitPlanModeToolOutput
+  [AgentToolsType.AskUserQuestion]: AskUserQuestionToolOutput
+  [AgentToolsType.ToolSearch]: ToolSearchToolOutput
+  [AgentToolsType.ListMcpResources]: ListMcpResourcesToolOutput
+  [AgentToolsType.ReadMcpResource]: ReadMcpResourceToolOutput
+  [AgentToolsType.TaskCreate]: TaskCreateToolOutput
+  [AgentToolsType.TaskGet]: TaskGetToolOutput
+  [AgentToolsType.TaskUpdate]: TaskUpdateToolOutput
+  [AgentToolsType.TaskList]: TaskListToolOutput
+  [AgentToolsType.SendMessage]: SendMessageToolOutput
+  [AgentToolsType.TeamCreate]: TeamCreateToolOutput
+  [AgentToolsType.TeamDelete]: TeamDeleteToolOutput
+  [AgentToolsType.EnterWorktree]: EnterWorktreeToolOutput
+  [AgentToolsType.ExitWorktree]: ExitWorktreeToolOutput
+}
+
+export type ToolRendererFn = (props: {
+  input?: ToolInput | Record<string, unknown> | string
+  output?: ToolOutput | unknown
+}) => ToolDisclosureItem
+
+export type ToolRenderersMap = Partial<Record<AgentToolsType, ToolRendererFn>>

--- a/src/renderer/components/chat/messages/tools/knowledge/__tests__/MessageKnowledgeSearch.test.tsx
+++ b/src/renderer/components/chat/messages/tools/knowledge/__tests__/MessageKnowledgeSearch.test.tsx
@@ -1,0 +1,76 @@
+import type { NormalToolResponse } from '@renderer/types'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { MessageKnowledgeSearchToolTitle } from '../MessageKnowledgeSearch'
+
+vi.mock('@renderer/i18n', () => ({
+  default: {
+    t: (key: string, params?: Record<string, number>) => {
+      if (key === 'message.searching') return 'Searching'
+      if (key === 'message.websearch.fetch_complete') return `${params?.count} search results`
+      return key
+    }
+  }
+}))
+
+vi.mock('lucide-react', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    FileSearch: ({ className, size }: { className?: string; size?: number | string }) => (
+      <span data-testid="file-search-icon" data-size={size} className={className} />
+    )
+  }
+})
+
+describe('MessageKnowledgeSearchToolTitle', () => {
+  it('wraps result details in the shared disclosure container', async () => {
+    render(
+      <MessageKnowledgeSearchToolTitle
+        toolResponse={
+          {
+            id: 'tool-call-1',
+            toolCallId: 'tool-call-1',
+            tool: { id: 'knowledge-search', name: 'kb_search', type: 'builtin' },
+            status: 'done',
+            arguments: { query: 'Cherry Studio', baseIds: ['base-1'] },
+            response: [{ id: 1, content: 'Cherry Studio', score: 0.9 }]
+          } as NormalToolResponse
+        }
+      />
+    )
+
+    const title = screen.getByText('1 search results').closest('span')
+    expect(title).toHaveClass('flex items-center gap-1.5 py-0.5 text-[13px] leading-5 text-foreground-secondary')
+    expect(title).not.toHaveClass('text-sm')
+    expect(screen.getByTestId('file-search-icon')).toHaveAttribute('data-size', '14')
+    expect(screen.getByTestId('file-search-icon')).toHaveClass('shrink-0 text-foreground-muted')
+
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByTestId('collapse-content-tool-call-1')).toHaveClass('rounded-xl bg-muted px-4 py-3')
+    expect(await screen.findByText('Cherry Studio')).toBeInTheDocument()
+  })
+
+  it('uses compact text while searching', () => {
+    render(
+      <MessageKnowledgeSearchToolTitle
+        toolResponse={
+          {
+            id: 'tool-call-1',
+            toolCallId: 'tool-call-1',
+            tool: { id: 'knowledge-search', name: 'kb_search', type: 'builtin' },
+            status: 'invoking',
+            arguments: { query: 'Cherry Studio', baseIds: ['base-1'] },
+            response: []
+          } as NormalToolResponse
+        }
+      />
+    )
+
+    const searchingText = screen.getByText('Searching').closest('span')
+    expect(searchingText).toHaveClass('py-0.5 text-[13px] leading-5')
+    expect(searchingText).not.toHaveClass('text-sm')
+    expect(screen.getByText('Cherry Studio')).toHaveClass('truncate')
+  })
+})

--- a/src/renderer/components/chat/messages/tools/mcp/MessageMcpTool.tsx
+++ b/src/renderer/components/chat/messages/tools/mcp/MessageMcpTool.tsx
@@ -1,0 +1,522 @@
+import { CircularProgress, Flex, Tooltip } from '@cherrystudio/ui'
+import { loggerService } from '@logger'
+import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import { CopyIcon } from '@renderer/components/Icons'
+import { useCodeStyle } from '@renderer/context/CodeStyleProvider'
+import { useTimer } from '@renderer/hooks/useTimer'
+import type { McpToolResponse } from '@renderer/types'
+import { Check, ShieldCheck, Wrench } from 'lucide-react'
+import { parse as parsePartialJson } from 'partial-json'
+import type { ComponentPropsWithoutRef, FC } from 'react'
+import { memo, useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import {
+  useMessageRenderConfig,
+  useOptionalMessageListActions,
+  useOptionalMessageListUi
+} from '../../MessageListProvider'
+import { getEffectiveStatus, SkeletonSpan, ToolStatusIndicator, TruncatedIndicator } from '../agent/GenericTools'
+import { useToolApproval } from '../hooks/useToolApproval'
+import { ArgKey, ArgsSection, ArgsSectionTitle, ArgsTable, ArgValue, ResponseSection } from '../shared/ArgsTable'
+import { ToolDisclosure, type ToolDisclosureItem } from '../shared/ToolDisclosure'
+import { truncateOutput } from '../shared/truncateOutput'
+
+interface Props {
+  toolResponse: McpToolResponse
+}
+
+const logger = loggerService.withContext('MessageTools')
+const TOOL_RESPONSE_RENDER_DELAY_MS = 40
+const TOOL_ARGS_RENDER_DELAY_MS = 120
+const TOOL_RESPONSE_HIGHLIGHT_DELAY_MS = 220
+const MAX_ARG_STRING_PARSE_LENGTH = 20000
+const MAX_ARG_VALUE_LENGTH = 4000
+const MAX_ARG_OBJECT_KEYS = 24
+const MAX_ARG_ARRAY_ITEMS = 24
+
+const MessageMcpTool: FC<Props> = ({ toolResponse }) => {
+  const [activeKeys, setActiveKeys] = useState<string[]>([])
+  const [copiedMap, setCopiedMap] = useState<Record<string, boolean>>({})
+  const { t } = useTranslation()
+  const { messageFont, fontSize } = useMessageRenderConfig()
+  const [progress, setProgress] = useState<number>(0)
+  const { setTimeoutTimer } = useTimer()
+  const actions = useOptionalMessageListActions()
+  const copyText = actions?.copyText
+  const notifyError = actions?.notifyError
+  const subscribeToolProgress = actions?.subscribeToolProgress
+  const { isToolAutoApproved } = useOptionalMessageListUi() ?? {}
+
+  // Use the unified approval hook
+  const { id, tool, status, response, partialArguments } = toolResponse
+  const approval = useToolApproval(toolResponse, tool)
+  const autoApproved = isToolAutoApproved?.(tool) ?? false
+  const isPending = status === 'pending'
+  const isDone = status === 'done'
+  const isError = status === 'error'
+  const isStreaming = status === 'streaming'
+  const willAwaitApproval = approval.isWaiting || (!autoApproved && status === 'invoking')
+
+  useEffect(() => {
+    const unsubscribe = subscribeToolProgress?.(id, setProgress)
+    return () => {
+      setProgress(0)
+      unsubscribe?.()
+    }
+  }, [id, subscribeToolProgress])
+
+  // Auto-expand when streaming, auto-collapse when done
+  useEffect(() => {
+    if (isStreaming) {
+      // Expand when streaming starts
+      setActiveKeys((prev) => (prev.includes(id) ? prev : [...prev, id]))
+    } else if (isDone || isError) {
+      // Collapse when streaming ends
+      setActiveKeys((prev) => prev.filter((key) => key !== id))
+    }
+  }, [isStreaming, isDone, isError, id])
+
+  if (approval.isWaiting) {
+    return null
+  }
+
+  const copyContent = (content: string, toolId: string) => {
+    if (!copyText) return
+    Promise.resolve(copyText(content, { successMessage: t('message.copied') }))
+      .then(() => {
+        setCopiedMap((prev) => ({ ...prev, [toolId]: true }))
+        setTimeoutTimer('copyContent', () => setCopiedMap((prev) => ({ ...prev, [toolId]: false })), 2000)
+      })
+      .catch((error) => {
+        logger.error('Failed to copy tool response:', error as Error)
+        notifyError?.(t('message.copy.failed'))
+      })
+  }
+
+  const handleCollapseChange = (keys: string | string[]) => {
+    setActiveKeys(Array.isArray(keys) ? keys : [keys])
+  }
+
+  // Format tool responses for collapse items
+  const getDisclosureItems = (): ToolDisclosureItem[] => {
+    const items: ToolDisclosureItem[] = []
+    const hasError = response?.isError === true
+    const result = {
+      params: toolResponse.arguments,
+      response: toolResponse.response
+    }
+    items.push({
+      key: id,
+      label: (
+        <MessageTitleLabel>
+          <StatusIconColumn>
+            <Wrench size={15} />
+          </StatusIconColumn>
+          <TitleContent>
+            <ToolName className="min-w-0 items-center gap-1">
+              <span className="truncate">
+                {tool.serverName} : {tool.name}
+              </span>
+            </ToolName>
+            <TitleActions>
+              {progress > 0 ? (
+                <CircularProgress value={Number((progress * 100)?.toFixed(0))} size={13} strokeWidth={2} />
+              ) : (
+                <ToolStatusIndicator status={getEffectiveStatus(status, willAwaitApproval)} hasError={hasError} />
+              )}
+              {autoApproved && (
+                <Tooltip content={t('message.tools.autoApproveEnabled')}>
+                  <ShieldCheck size={13} color="var(--status-color-success)" />
+                </Tooltip>
+              )}
+              {!isPending && copyText && (
+                <Tooltip content={t('common.copy')} delay={500}>
+                  <ActionButton
+                    className="message-action-button invisible opacity-0 transition-opacity duration-150 focus-visible:visible focus-visible:opacity-100 group-hover/tool:visible group-hover/tool:opacity-100"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      copyContent(JSON.stringify(result, null, 2), id)
+                    }}
+                    aria-label={t('common.copy')}>
+                    {!copiedMap[id] && <CopyIcon size={13} />}
+                    {copiedMap[id] && <Check size={13} color="var(--status-color-success)" />}
+                  </ActionButton>
+                </Tooltip>
+              )}
+            </TitleActions>
+          </TitleContent>
+        </MessageTitleLabel>
+      ),
+      children: (
+        <ToolResponseContainer
+          style={{
+            fontFamily: messageFont === 'serif' ? 'var(--font-family-serif)' : 'var(--font-family)',
+            fontSize
+          }}>
+          <ToolResponseContent
+            isExpanded={activeKeys.includes(id)}
+            args={isStreaming ? partialArguments : toolResponse.arguments}
+            isStreaming={!!isStreaming}
+            response={isDone || isError ? toolResponse.response : undefined}
+          />
+        </ToolResponseContainer>
+      )
+    })
+
+    return items
+  }
+
+  return (
+    <ToolContainer>
+      <CollapseContainer
+        variant="light"
+        activeKey={activeKeys}
+        onActiveKeyChange={handleCollapseChange}
+        className="message-tools-container"
+        items={getDisclosureItems()}
+      />
+    </ToolContainer>
+  )
+}
+
+type ExtractedContent = {
+  text: string
+  images: Array<{ data: string; mimeType: string }>
+}
+
+/**
+ * Extract preview content from MCP tool response using SDK schema
+ */
+const extractPreviewContent = (response: unknown): ExtractedContent => {
+  if (!response) return { text: '', images: [] }
+
+  const result = CallToolResultSchema.safeParse(response)
+  if (result.success) {
+    const contents = result.data.content
+    if (contents.length === 0) return { text: '', images: [] }
+
+    const textParts: string[] = []
+    const images: Array<{ data: string; mimeType: string }> = []
+    for (const content of contents) {
+      switch (content.type) {
+        case 'text':
+          if (content.text) {
+            try {
+              const parsed = JSON.parse(content.text)
+              textParts.push(JSON.stringify(parsed, null, 2))
+            } catch {
+              textParts.push(content.text)
+            }
+          }
+          break
+        case 'image':
+          if (content.data) {
+            images.push({ data: content.data, mimeType: content.mimeType ?? 'image/png' })
+          }
+          break
+        case 'resource':
+          textParts.push(`[Resource: ${content.resource?.uri ?? 'unknown'}]`)
+          break
+      }
+    }
+    return { text: textParts.join('\n\n'), images }
+  }
+
+  // Fallback: return JSON string for unknown format
+  return { text: JSON.stringify(response, null, 2), images: [] }
+}
+
+const truncateArgText = (text: string): string => {
+  const result = truncateOutput(text, MAX_ARG_VALUE_LENGTH)
+  return result.isTruncated ? `${result.data}\n... truncated (${result.originalLength} chars)` : result.data
+}
+
+const formatArgPreviewValue = (value: unknown, depth = 0): string => {
+  if (value === null) return 'null'
+  if (value === undefined) return ''
+  if (typeof value === 'string') return truncateArgText(value)
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  if (typeof value === 'bigint') return value.toString()
+
+  if (depth >= 2) {
+    if (Array.isArray(value)) return `[${value.length} items]`
+    return '{...}'
+  }
+
+  if (Array.isArray(value)) {
+    const visibleItems = value.slice(0, MAX_ARG_ARRAY_ITEMS).map((item) => formatArgPreviewValue(item, depth + 1))
+    const suffix = value.length > MAX_ARG_ARRAY_ITEMS ? `, ... ${value.length - MAX_ARG_ARRAY_ITEMS} more items` : ''
+    return `[${visibleItems.join(', ')}${suffix}]`
+  }
+
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+    const visibleEntries = entries.slice(0, MAX_ARG_OBJECT_KEYS).map(([key, item]) => {
+      return `${JSON.stringify(key)}: ${formatArgPreviewValue(item, depth + 1)}`
+    })
+    const suffix = entries.length > MAX_ARG_OBJECT_KEYS ? `, ... ${entries.length - MAX_ARG_OBJECT_KEYS} more keys` : ''
+    return `{${visibleEntries.join(', ')}${suffix}}`
+  }
+
+  return truncateArgText(String(value))
+}
+
+const ToolResponseContent: FC<{
+  isExpanded: boolean
+  args: string | Record<string, unknown> | Record<string, unknown>[] | undefined
+  isStreaming: boolean
+  response?: unknown
+}> = ({ isExpanded, args, isStreaming, response }) => {
+  const [shouldRender, setShouldRender] = useState(false)
+
+  useEffect(() => {
+    if (!isExpanded) {
+      setShouldRender(false)
+      return
+    }
+
+    const timer = window.setTimeout(() => setShouldRender(true), TOOL_RESPONSE_RENDER_DELAY_MS)
+    return () => window.clearTimeout(timer)
+  }, [isExpanded])
+
+  if (!isExpanded || !shouldRender) return null
+
+  return <ExpandedToolResponseContent args={args} isStreaming={isStreaming} response={response} />
+}
+
+// Unified tool response content component
+const ExpandedToolResponseContent: FC<{
+  args: string | Record<string, unknown> | Record<string, unknown>[] | undefined
+  isStreaming: boolean
+  response?: unknown
+}> = ({ args, isStreaming, response }) => {
+  const { highlightCode } = useCodeStyle()
+  const [showArgs, setShowArgs] = useState(false)
+  const [showResponse, setShowResponse] = useState(false)
+  const [highlightedResponse, setHighlightedResponse] = useState<string>('')
+  const [responseImages, setResponseImages] = useState<Array<{ data: string; mimeType: string }>>([])
+  const [isTruncated, setIsTruncated] = useState(false)
+  const [originalLength, setOriginalLength] = useState(0)
+
+  useEffect(() => {
+    const argsTimer = window.setTimeout(() => setShowArgs(true), TOOL_ARGS_RENDER_DELAY_MS)
+    const responseTimer = window.setTimeout(() => setShowResponse(true), TOOL_RESPONSE_HIGHLIGHT_DELAY_MS)
+
+    return () => {
+      window.clearTimeout(argsTimer)
+      window.clearTimeout(responseTimer)
+    }
+  }, [])
+
+  // Parse args if it's a string (streaming partial JSON)
+  const parsedArgs = useMemo(() => {
+    if (!showArgs) return null
+    if (!args) return null
+    if (typeof args === 'string') {
+      if (args.length > MAX_ARG_STRING_PARSE_LENGTH) {
+        return { arguments: truncateArgText(args) }
+      }
+      try {
+        return parsePartialJson(args)
+      } catch {
+        return { arguments: truncateArgText(args) }
+      }
+    }
+    return args
+  }, [args, showArgs])
+
+  // Extract and highlight response when available
+  useEffect(() => {
+    if (!showResponse || !response) return
+
+    let cancelled = false
+
+    const highlight = async () => {
+      setHighlightedResponse('')
+      setResponseImages([])
+      setIsTruncated(false)
+      setOriginalLength(0)
+      const { text: previewContent, images } = extractPreviewContent(response)
+      if (cancelled) return
+      setResponseImages(images)
+      const {
+        data: truncatedContent,
+        isTruncated: wasTruncated,
+        originalLength: origLen
+      } = truncateOutput(previewContent)
+      if (cancelled) return
+      setIsTruncated(wasTruncated)
+      setOriginalLength(origLen)
+      const result = await highlightCode(truncatedContent, 'json')
+      if (cancelled) return
+      setHighlightedResponse(result)
+    }
+
+    if (window.requestIdleCallback) {
+      const idleId = window.requestIdleCallback(() => void highlight(), { timeout: 500 })
+      return () => {
+        cancelled = true
+        window.cancelIdleCallback(idleId)
+      }
+    }
+
+    const timer = window.setTimeout(() => void highlight(), 80)
+    return () => {
+      cancelled = true
+      window.clearTimeout(timer)
+    }
+  }, [showResponse, response, highlightCode])
+
+  // Handle both object and array args - for arrays, show as single entry
+  const getEntries = (): Array<[string, unknown]> => {
+    if (!parsedArgs || typeof parsedArgs !== 'object') return []
+    if (Array.isArray(parsedArgs)) {
+      return [['arguments', parsedArgs]]
+    }
+    return Object.entries(parsedArgs)
+  }
+  const entries = getEntries()
+
+  const renderArgsTable = (): React.ReactNode => {
+    if (entries.length === 0) return null
+    return (
+      <ArgsSection>
+        <ArgsSectionTitle>Arguments</ArgsSectionTitle>
+        <ArgsTable>
+          <tbody>
+            {entries.map(([key, value]) => (
+              <tr key={key}>
+                <ArgKey>{key}</ArgKey>
+                <ArgValue>{formatArgPreviewValue(value)}</ArgValue>
+              </tr>
+            ))}
+            {isStreaming && (
+              <tr>
+                <ArgKey>
+                  <SkeletonSpan width="60px" />
+                </ArgKey>
+                <ArgValue>
+                  <SkeletonSpan width="120px" />
+                </ArgValue>
+              </tr>
+            )}
+          </tbody>
+        </ArgsTable>
+      </ArgsSection>
+    )
+  }
+
+  return (
+    <div>
+      {/* Arguments Table */}
+      {renderArgsTable()}
+
+      {/* Response */}
+      {response !== undefined && response !== null && (highlightedResponse || responseImages.length > 0) && (
+        <ResponseSection>
+          <ArgsSectionTitle>Response</ArgsSectionTitle>
+          {highlightedResponse && (
+            <MarkdownContainer className="markdown" dangerouslySetInnerHTML={{ __html: highlightedResponse }} />
+          )}
+          {isTruncated && <TruncatedIndicator originalLength={originalLength} />}
+          {responseImages.map((img, idx) => (
+            <img
+              key={idx}
+              src={`data:${img.mimeType};base64,${img.data}`}
+              alt="Tool output"
+              style={{ maxWidth: 300, borderRadius: 4, marginTop: 8 }}
+            />
+          ))}
+        </ResponseSection>
+      )}
+    </div>
+  )
+}
+
+const CollapseContainer = ({ className, ...props }: ComponentPropsWithoutRef<typeof ToolDisclosure>) => (
+  <ToolDisclosure
+    className={[
+      'border-none [--status-color-error:var(--color-foreground-secondary)] [--status-color-invoking:var(--color-primary)] [--status-color-success:var(--color-primary,green)] [--status-color-warning:var(--color-warning,#faad14)]',
+      className
+    ]
+      .filter(Boolean)
+      .join(' ')}
+    {...props}
+  />
+)
+
+const ToolContainer = ({ className, ...props }: ComponentPropsWithoutRef<'div'>) => (
+  <div className={['group/tool my-px first:mt-0 first:pt-0', className].filter(Boolean).join(' ')} {...props} />
+)
+
+const MarkdownContainer = ({ className, ...props }: ComponentPropsWithoutRef<'div'>) => (
+  <div
+    className={['[&_pre]:bg-transparent! [&_pre_span]:whitespace-pre-wrap', className].filter(Boolean).join(' ')}
+    {...props}
+  />
+)
+
+const MessageTitleLabel = ({ className, ...props }: ComponentPropsWithoutRef<'div'>) => (
+  <div
+    className={['flex w-full flex-row items-center justify-between gap-2 p-0', className].filter(Boolean).join(' ')}
+    {...props}
+  />
+)
+
+const TitleContent = ({ className, ...props }: ComponentPropsWithoutRef<'div'>) => (
+  <div
+    className={['flex min-w-0 flex-1 flex-row items-center gap-1.5 leading-5', className].filter(Boolean).join(' ')}
+    {...props}
+  />
+)
+
+const StatusIconColumn = ({ className, ...props }: ComponentPropsWithoutRef<'div'>) => (
+  <div
+    className={[
+      'items-left justify-left flex h-5 w-4 shrink-0 items-center text-foreground-muted transition-colors duration-150 group-hover/tool:text-foreground-secondary',
+      className
+    ]
+      .filter(Boolean)
+      .join(' ')}
+    {...props}
+  />
+)
+
+const ToolName = ({ className, ...props }: ComponentPropsWithoutRef<typeof Flex>) => (
+  <Flex
+    className={[
+      'font-normal text-[13px] text-foreground-secondary transition-colors duration-150 group-hover/tool:text-foreground',
+      className
+    ]
+      .filter(Boolean)
+      .join(' ')}
+    {...props}
+  />
+)
+
+const TitleActions = ({ className, ...props }: ComponentPropsWithoutRef<'div'>) => (
+  <div className={['flex shrink-0 items-center gap-1.5', className].filter(Boolean).join(' ')} {...props} />
+)
+
+const ActionButton = ({ className, ...props }: ComponentPropsWithoutRef<'button'>) => (
+  <button
+    type="button"
+    className={[
+      'flex size-5 cursor-pointer items-center justify-center gap-1 rounded border-none bg-transparent p-0 text-foreground-secondary opacity-70 transition-all duration-200 hover:bg-(--color-accent) hover:text-foreground hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-(--color-primary) focus-visible:outline-2 focus-visible:outline-offset-2 [&.confirm-button:hover]:bg-(--color-primary-soft) [&.confirm-button:hover]:text-(--color-primary) [&.confirm-button]:text-(--color-primary) [&_.iconfont]:text-[13px]',
+      className
+    ]
+      .filter(Boolean)
+      .join(' ')}
+    {...props}
+  />
+)
+
+const ToolResponseContainer = ({ className, ...props }: ComponentPropsWithoutRef<'div'>) => (
+  <div
+    className={['relative max-h-[300px] overflow-auto rounded-none border-t-0', className].filter(Boolean).join(' ')}
+    {...props}
+  />
+)
+
+export default memo(MessageMcpTool)

--- a/src/renderer/components/chat/messages/tools/web-search/MessageWebSearch.tsx
+++ b/src/renderer/components/chat/messages/tools/web-search/MessageWebSearch.tsx
@@ -1,0 +1,99 @@
+import Favicon from '@renderer/components/Icons/FallbackFavicon'
+import Spinner from '@renderer/components/Spinner'
+import type { NormalToolResponse } from '@renderer/types'
+import { webSearchInputSchema, type WebSearchOutputItem, webSearchOutputSchema } from '@shared/ai/builtinTools'
+import { useTranslation } from 'react-i18next'
+
+import Link from '../../markdown/Link'
+import { ToolDisclosure } from '../shared/ToolDisclosure'
+
+/** Split a result URL into the favicon hostname (keeps `www.`) and the display domain (drops it). */
+function parseResultUrl(url: string): { hostname: string; domain: string } {
+  try {
+    const hostname = new URL(url).hostname
+    return { hostname, domain: hostname.replace(/^www\./, '') }
+  } catch {
+    return { hostname: '', domain: url }
+  }
+}
+
+const MessageWebSearchToolLabel = ({ toolResponse }: { toolResponse: NormalToolResponse }) => {
+  const { t } = useTranslation()
+  const inputParse = webSearchInputSchema.safeParse(toolResponse.arguments)
+  const outputParse = webSearchOutputSchema.safeParse(toolResponse.response)
+  const query = inputParse.success ? inputParse.data.query : ''
+  const resultCount = outputParse.success ? outputParse.data.length : 0
+  const resultText =
+    resultCount === 0
+      ? t('message.websearch.fetch_empty')
+      : t('message.websearch.fetch_complete', { count: resultCount })
+
+  if (toolResponse.status !== 'done') {
+    return (
+      <Spinner
+        text={
+          <span className="flex min-w-0 items-center gap-1 py-0.5 text-[13px] leading-5">
+            {t('message.searching')}
+            <span className="min-w-0 truncate">{query}</span>
+          </span>
+        }
+      />
+    )
+  }
+
+  // Query on the left, result count on the right (mirrors the reference layout).
+  return (
+    <span className="flex min-w-0 flex-1 items-center justify-between gap-3 py-0.5 text-[13px] text-foreground-secondary leading-5 transition-colors duration-150 group-hover/tool:text-foreground">
+      <span className="min-w-0 truncate">{query || resultText}</span>
+      {query && <span className="shrink-0 text-foreground-muted">{resultText}</span>}
+    </span>
+  )
+}
+
+export const MessageWebSearchToolTitle = ({ toolResponse }: { toolResponse: NormalToolResponse }) => {
+  const outputParse = webSearchOutputSchema.safeParse(toolResponse.response)
+  const hasResults = toolResponse.status === 'done' && outputParse.success && outputParse.data.length > 0
+  const label = <MessageWebSearchToolLabel toolResponse={toolResponse} />
+
+  if (!hasResults) return label
+
+  return (
+    <div className="group/tool my-px first:mt-0 first:pt-0">
+      <ToolDisclosure
+        variant="light"
+        className="message-tools-container border-none"
+        items={[
+          {
+            key: toolResponse.id,
+            label,
+            children: <MessageWebSearchToolBody toolResponse={toolResponse} />
+          }
+        ]}
+      />
+    </div>
+  )
+}
+
+export const MessageWebSearchToolBody = ({ toolResponse }: { toolResponse: NormalToolResponse }) => {
+  const outputParse = webSearchOutputSchema.safeParse(toolResponse.response)
+  if (toolResponse.status !== 'done' || !outputParse.success) return null
+
+  return (
+    <ul className="flex flex-col gap-0.5 p-0 text-[13px] leading-5 [&>li]:m-0 [&>li]:p-0">
+      {outputParse.data.map((result: WebSearchOutputItem) => {
+        const { hostname, domain } = parseResultUrl(result.url)
+        return (
+          <li key={result.id}>
+            <Link
+              href={result.url}
+              className="-mx-2 flex min-w-0 items-center gap-2 rounded-md px-2 py-1 no-underline transition-colors hover:bg-foreground/5">
+              {hostname && <Favicon hostname={hostname} alt={result.title || domain} />}
+              <span className="min-w-0 flex-1 truncate text-foreground">{result.title || result.url}</span>
+              <span className="max-w-[40%] shrink-0 truncate text-foreground-muted">{domain}</span>
+            </Link>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/src/renderer/components/chat/messages/tools/web-search/__tests__/MessageWebSearch.test.tsx
+++ b/src/renderer/components/chat/messages/tools/web-search/__tests__/MessageWebSearch.test.tsx
@@ -1,0 +1,104 @@
+import type { NormalToolResponse } from '@renderer/types'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import type * as ReactI18next from 'react-i18next'
+import { describe, expect, it, vi } from 'vitest'
+
+import { MessageWebSearchToolTitle } from '../MessageWebSearch'
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactI18next>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, params?: Record<string, number>) => {
+        if (key === 'message.websearch.fetch_empty') return 'No search results found'
+        if (key === 'message.websearch.fetch_complete') return `${params?.count} search results`
+        return key
+      }
+    })
+  }
+})
+
+// Favicon fetches remote icons on mount; stub it so the test stays offline and we can assert the hostname.
+vi.mock('@renderer/components/Icons/FallbackFavicon', () => ({
+  default: ({ hostname, alt }: { hostname: string; alt: string }) => (
+    <span data-testid="favicon" data-hostname={hostname} aria-label={alt} />
+  )
+}))
+
+describe('MessageWebSearchToolTitle', () => {
+  it('shows the query and an empty-result label without a disclosure', () => {
+    render(
+      <MessageWebSearchToolTitle
+        toolResponse={
+          {
+            id: 'tool-call-1',
+            toolCallId: 'tool-call-1',
+            tool: { id: 'web-search', name: 'web_search', type: 'builtin' },
+            status: 'done',
+            arguments: { query: 'Cherry Studio' },
+            response: []
+          } as NormalToolResponse
+        }
+      />
+    )
+
+    expect(screen.getByText('Cherry Studio')).toBeInTheDocument()
+    expect(screen.getByText('No search results found')).toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('uses the compact tool-row text while searching', () => {
+    render(
+      <MessageWebSearchToolTitle
+        toolResponse={
+          {
+            id: 'tool-call-1',
+            toolCallId: 'tool-call-1',
+            tool: { id: 'web-search', name: 'web_search', type: 'builtin' },
+            status: 'invoking',
+            arguments: { query: 'Cherry Studio' },
+            response: []
+          } as NormalToolResponse
+        }
+      />
+    )
+
+    const searchingText = screen.getByText('message.searching').closest('span')
+    expect(searchingText).toHaveClass('py-0.5 text-[13px] leading-5')
+    expect(screen.getByText('Cherry Studio')).toHaveClass('truncate')
+  })
+
+  it('shows the query in the header and renders each result as a link with favicon and domain', async () => {
+    render(
+      <MessageWebSearchToolTitle
+        toolResponse={
+          {
+            id: 'tool-call-1',
+            toolCallId: 'tool-call-1',
+            tool: { id: 'web-search', name: 'web_search', type: 'builtin' },
+            status: 'done',
+            arguments: { query: 'Cherry Studio' },
+            response: [
+              { id: 1, title: 'Cherry Studio', url: 'https://www.cherry-ai.com/blog', content: 'Cherry Studio' }
+            ]
+          } as NormalToolResponse
+        }
+      />
+    )
+
+    // Header shows the query + the result count (collapse body is not rendered yet).
+    const header = screen.getByRole('button')
+    expect(within(header).getByText('Cherry Studio')).toBeInTheDocument()
+    expect(within(header).getByText('1 search results')).toBeInTheDocument()
+
+    fireEvent.click(header)
+
+    expect(screen.getByTestId('collapse-content-tool-call-1')).toHaveClass('rounded-xl bg-muted px-4 py-3')
+    const link = await screen.findByRole('link')
+    expect(link).toHaveAttribute('href', 'https://www.cherry-ai.com/blog')
+    expect(screen.getByTestId('favicon')).toHaveAttribute('data-hostname', 'www.cherry-ai.com')
+    expect(screen.getByText('cherry-ai.com')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/chat/messages/utils/filePath.ts
+++ b/src/renderer/components/chat/messages/utils/filePath.ts
@@ -1,0 +1,32 @@
+const PATH_SEGMENT_PATTERN = String.raw`[^/\n\r\`"'<>|]+`
+const ABSOLUTE_FILE_PATH_PATTERN = new RegExp(
+  String.raw`^/(?!/)(?:${PATH_SEGMENT_PATTERN}/)+${PATH_SEGMENT_PATTERN}/?$`
+)
+const RELATIVE_EXPLICIT_PATH_PATTERN = new RegExp(
+  String.raw`^\.{1,2}/(?:${PATH_SEGMENT_PATTERN}/)*${PATH_SEGMENT_PATTERN}/?$`
+)
+const WORKSPACE_RELATIVE_FILE_PATH_PATTERN = new RegExp(
+  String.raw`^(?:${PATH_SEGMENT_PATTERN}/)+${PATH_SEGMENT_PATTERN}\.[^/\`"'<>|.]+$`
+)
+const INLINE_FILE_PATH_LOCATION_PATTERN = /(?::\d+){1,2}$/
+
+export const normalizeInlineFilePath = (value: string) =>
+  value
+    .trim()
+    .replace(/^[`("'[]+|[`)"'\],.;:!?]+$/g, '')
+    .replace(INLINE_FILE_PATH_LOCATION_PATTERN, '')
+
+export function isInlineFilePath(value: string): boolean {
+  const normalizedPath = normalizeInlineFilePath(value)
+  return (
+    ABSOLUTE_FILE_PATH_PATTERN.test(normalizedPath) ||
+    RELATIVE_EXPLICIT_PATH_PATTERN.test(normalizedPath) ||
+    WORKSPACE_RELATIVE_FILE_PATH_PATTERN.test(normalizedPath)
+  )
+}
+
+export function containsInlineFilePath(value: string | undefined): boolean {
+  if (!value) return false
+
+  return value.split(/\s+/).some((token) => isInlineFilePath(token))
+}

--- a/src/renderer/hooks/useFileSize.ts
+++ b/src/renderer/hooks/useFileSize.ts
@@ -1,0 +1,49 @@
+import { loggerService } from '@logger'
+import type { FilePath } from '@shared/file/types/common'
+import { createFilePathHandle } from '@shared/file/types/handle'
+import { useEffect, useState } from 'react'
+
+const logger = loggerService.withContext('useFileSize')
+
+export type FileSizeState = { status: 'pending' } | { status: 'ok'; size: number } | { status: 'error' }
+
+const joinAbsPath = (base: string, rel: string): string => {
+  const trimmed = rel.replace(/^[/\\]+/, '')
+  return /[/\\]$/.test(base) ? `${base}${trimmed}` : `${base}/${trimmed}`
+}
+
+export function useFileSize(
+  workspacePath: string | null | undefined,
+  filePath: string | null | undefined
+): FileSizeState {
+  const [state, setState] = useState<FileSizeState>({ status: 'pending' })
+
+  useEffect(() => {
+    if (!workspacePath || !filePath) {
+      setState({ status: 'pending' })
+      return
+    }
+
+    setState({ status: 'pending' })
+    const absPath = joinAbsPath(workspacePath, filePath)
+    let cancelled = false
+
+    void (async () => {
+      try {
+        const metadata = await window.api.file.getMetadata(createFilePathHandle(absPath as FilePath))
+        if (!cancelled) setState({ status: 'ok', size: metadata.size })
+      } catch (err) {
+        if (cancelled) return
+        const normalized = err instanceof Error ? err : new Error(String(err))
+        logger.error(`Failed to read file metadata: ${absPath}`, normalized)
+        setState({ status: 'error' })
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [filePath, workspacePath])
+
+  return state
+}

--- a/src/renderer/pages/home/Messages/Blocks/CompactionAnchorBlock.tsx
+++ b/src/renderer/pages/home/Messages/Blocks/CompactionAnchorBlock.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+const CompactionAnchorBlock: React.FC = () => {
+  return (
+    <div className="my-3 flex w-full items-center gap-3 text-muted-foreground" role="separator">
+      <span className="h-px min-w-6 flex-1 border-border-subtle border-t border-dashed" aria-hidden />
+      <span className="size-1.5 shrink-0 rounded-full bg-border" aria-hidden />
+      <span className="h-px min-w-6 flex-1 border-border-subtle border-t border-dashed" aria-hidden />
+    </div>
+  )
+}
+
+export default React.memo(CompactionAnchorBlock)

--- a/src/renderer/pages/home/Messages/Tools/MessageAgentTools/ReportArtifacts.tsx
+++ b/src/renderer/pages/home/Messages/Tools/MessageAgentTools/ReportArtifacts.tsx
@@ -1,0 +1,140 @@
+import { Tooltip } from '@cherrystudio/ui'
+import { Icon } from '@iconify/react'
+import type { McpToolResponse, NormalToolResponse } from '@renderer/types'
+import { getFileIconName } from '@renderer/utils/fileIconName'
+import { REPORT_ARTIFACTS_TOOL_NAME, reportArtifactsInputSchema } from '@shared/ai/builtinTools'
+import { ExternalLink } from 'lucide-react'
+import { type MouseEvent, useCallback, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { useOptionalMessageListActions } from '../../MessageListProvider'
+import { normalizeInlineFilePath } from '../../utils/filePath'
+
+export type ReportArtifactsToolResponse = McpToolResponse | NormalToolResponse
+
+interface ReportArtifactView {
+  path: string
+  description?: string
+}
+
+interface ReportArtifactsViewModel {
+  artifacts: ReportArtifactView[]
+  summary?: string
+}
+
+export function isReportArtifactsToolResponse(toolResponse: ReportArtifactsToolResponse): boolean {
+  const toolName = toolResponse.tool.name
+  return toolName === REPORT_ARTIFACTS_TOOL_NAME || toolName.endsWith(`__${REPORT_ARTIFACTS_TOOL_NAME}`)
+}
+
+export function getReportArtifactsViewModel(
+  toolResponses: readonly ReportArtifactsToolResponse[]
+): ReportArtifactsViewModel | null {
+  const artifactByPath = new Map<string, ReportArtifactView>()
+  let summary: string | undefined
+
+  for (const toolResponse of toolResponses) {
+    if (!isReportArtifactsToolResponse(toolResponse)) continue
+
+    const parsed = reportArtifactsInputSchema.safeParse(toolResponse.arguments)
+    if (!parsed.success) continue
+
+    if (parsed.data.summary) summary = parsed.data.summary
+    for (const artifact of parsed.data.artifacts) {
+      const path = artifact.path.trim()
+      if (!path) continue
+      artifactByPath.set(path, {
+        path,
+        description: artifact.description
+      })
+    }
+  }
+
+  const artifacts = Array.from(artifactByPath.values())
+  return artifacts.length > 0 ? { artifacts, summary } : null
+}
+
+function getArtifactFileName(path: string): string {
+  const normalized = path.trim().replace(/[\\/]+$/g, '')
+  const segments = normalized.split(/[\\/]+/).filter(Boolean)
+  return segments.at(-1) ?? path
+}
+
+function ReportArtifactFileCard({ artifact }: { artifact: ReportArtifactView }) {
+  const { t } = useTranslation()
+  const actions = useOptionalMessageListActions()
+  const openArtifactFile = actions?.openArtifactFile
+  const openPath = actions?.openPath
+  const notifyError = actions?.notifyError
+  const normalizedPath = useMemo(() => normalizeInlineFilePath(artifact.path), [artifact.path])
+  const fileName = useMemo(() => getArtifactFileName(normalizedPath), [normalizedPath])
+  const iconName = useMemo(() => getFileIconName(normalizedPath), [normalizedPath])
+
+  const handlePreview = useCallback(() => {
+    if (!openArtifactFile) return
+    Promise.resolve(openArtifactFile(normalizedPath)).catch(() => {
+      notifyError?.(t('chat.input.tools.open_file_error', { path: normalizedPath }))
+    })
+  }, [normalizedPath, notifyError, openArtifactFile, t])
+
+  const handleOpenExternal = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation()
+      if (!openPath) return
+      Promise.resolve(openPath(normalizedPath)).catch(() => {
+        notifyError?.(t('chat.input.tools.open_file_error', { path: normalizedPath }))
+      })
+    },
+    [normalizedPath, notifyError, openPath, t]
+  )
+
+  return (
+    <div className="group/artifact flex w-full max-w-xl items-center overflow-hidden rounded-lg border-[0.5px] border-border bg-background-subtle transition-colors hover:bg-accent">
+      <button
+        type="button"
+        disabled={!openArtifactFile}
+        onClick={handlePreview}
+        title={normalizedPath}
+        aria-label={`${t('common.preview')} ${fileName}`}
+        className="flex min-h-12 min-w-0 flex-1 items-center gap-2.5 border-0 bg-transparent px-2.5 py-2 text-left disabled:cursor-default">
+        <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-background">
+          <Icon icon={`material-icon-theme:${iconName}`} className="text-[20px]" />
+        </span>
+        <span className="min-w-0 truncate font-medium text-[13px] text-foreground leading-5">{fileName}</span>
+      </button>
+      {openPath && (
+        <Tooltip content={t('chat.input.tools.open_file')} delay={500}>
+          <button
+            type="button"
+            aria-label={`${t('chat.input.tools.open_file')} ${fileName}`}
+            onClick={handleOpenExternal}
+            className="mr-2 flex size-7 shrink-0 items-center justify-center rounded-md text-foreground-muted opacity-70 transition-colors hover:bg-background hover:text-foreground hover:opacity-100">
+            <ExternalLink size={15} />
+          </button>
+        </Tooltip>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Message-level footer for `report_artifacts` declarations. The tool call itself is hidden from the
+ * inline tool stream; this card is appended after the complete message content so deliverables stay
+ * visually anchored to the final answer instead of the tool-call position.
+ */
+export const MessageReportArtifacts = ({
+  toolResponses
+}: {
+  toolResponses: readonly ReportArtifactsToolResponse[]
+}) => {
+  const viewModel = getReportArtifactsViewModel(toolResponses)
+  if (!viewModel) return null
+
+  return (
+    <div className="my-1 flex w-full flex-col gap-1.5">
+      {viewModel.artifacts.map((artifact) => (
+        <ReportArtifactFileCard key={artifact.path} artifact={artifact} />
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/pages/home/Messages/Tools/MessageAgentTools/__tests__/ReportArtifacts.test.tsx
+++ b/src/renderer/pages/home/Messages/Tools/MessageAgentTools/__tests__/ReportArtifacts.test.tsx
@@ -1,0 +1,142 @@
+import type { NormalToolResponse } from '@renderer/types'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import type * as ReactI18next from 'react-i18next'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { MessageListProvider } from '../../../MessageListProvider'
+import { defaultMessageRenderConfig, type MessageListProviderValue } from '../../../types'
+import { MessageReportArtifacts } from '../ReportArtifacts'
+
+vi.mock('react-i18next', async (importOriginal) => ({
+  ...(await importOriginal<typeof ReactI18next>()),
+  useTranslation: () => ({
+    t: (key: string) => {
+      if (key === 'common.preview') return 'Preview'
+      if (key === 'chat.input.tools.open_file') return 'Open File'
+      if (key === 'chat.input.tools.open_file_error') return 'Failed to open file'
+      return key
+    }
+  })
+}))
+
+vi.mock('@iconify/react', () => ({
+  Icon: ({ icon }: { icon: string }) => <span data-icon={icon} />
+}))
+
+const renderWithProvider = (ui: ReactElement, actions: MessageListProviderValue['actions'] = {}) => {
+  const value: MessageListProviderValue = {
+    state: {
+      topic: { id: 'topic-1', name: 'Topic' } as MessageListProviderValue['state']['topic'],
+      messages: [],
+      partsByMessageId: {},
+      messageNavigation: 'none',
+      estimateSize: 0,
+      overscan: 0,
+      loadOlderDelayMs: 0,
+      loadingResetDelayMs: 0,
+      renderConfig: defaultMessageRenderConfig
+    },
+    actions,
+    meta: { selectionLayer: false }
+  }
+
+  return render(<MessageListProvider value={value}>{ui}</MessageListProvider>)
+}
+
+describe('MessageReportArtifacts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders declared deliverables from tool arguments', () => {
+    renderWithProvider(
+      <MessageReportArtifacts
+        toolResponses={[
+          {
+            id: 'tool-call-1',
+            toolCallId: 'tool-call-1',
+            tool: { id: 'report-artifacts', name: 'report_artifacts', type: 'builtin' },
+            status: 'done',
+            arguments: {
+              summary: 'Created final outputs',
+              artifacts: [{ path: 'dist/report.md', description: 'Report' }]
+            },
+            response: 'Recorded 1 artifact(s).'
+          } as NormalToolResponse
+        ]}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Preview report.md' })).toBeInTheDocument()
+    expect(screen.getByText('report.md')).toBeInTheDocument()
+    expect(screen.queryByText('Created final outputs')).toBeNull()
+    expect(screen.queryByText('- Report')).toBeNull()
+  })
+
+  it('uses the latest declaration for duplicate artifact paths', () => {
+    renderWithProvider(
+      <MessageReportArtifacts
+        toolResponses={[
+          {
+            id: 'tool-call-1',
+            toolCallId: 'tool-call-1',
+            tool: { id: 'report-artifacts', name: 'report_artifacts', type: 'builtin' },
+            status: 'done',
+            arguments: {
+              summary: 'First summary',
+              artifacts: [{ path: 'dist/report.md', description: 'Draft' }]
+            }
+          } as NormalToolResponse,
+          {
+            id: 'tool-call-2',
+            toolCallId: 'tool-call-2',
+            tool: { id: 'report-artifacts', name: 'report_artifacts', type: 'builtin' },
+            status: 'done',
+            arguments: {
+              summary: 'Final summary',
+              artifacts: [{ path: 'dist/report.md', description: 'Final report' }]
+            }
+          } as NormalToolResponse
+        ]}
+      />
+    )
+
+    expect(screen.getAllByRole('button', { name: 'Preview report.md' })).toHaveLength(1)
+    expect(screen.queryByText('Final summary')).toBeNull()
+    expect(screen.queryByText('- Final report')).toBeNull()
+    expect(screen.queryByText('- Draft')).toBeNull()
+  })
+
+  it('previews on card click and opens externally from the side button', async () => {
+    const openArtifactFile = vi.fn().mockResolvedValue(undefined)
+    const openPath = vi.fn().mockResolvedValue(undefined)
+
+    renderWithProvider(
+      <MessageReportArtifacts
+        toolResponses={[
+          {
+            id: 'tool-call-1',
+            toolCallId: 'tool-call-1',
+            tool: { id: 'report-artifacts', name: 'report_artifacts', type: 'builtin' },
+            status: 'done',
+            arguments: {
+              artifacts: [{ path: 'dist/report.md' }]
+            }
+          } as NormalToolResponse
+        ]}
+      />,
+      { openArtifactFile, openPath }
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview report.md' }))
+    await waitFor(() => {
+      expect(openArtifactFile).toHaveBeenCalledWith('dist/report.md')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open File report.md' }))
+    await waitFor(() => {
+      expect(openPath).toHaveBeenCalledWith('dist/report.md')
+    })
+  })
+})

--- a/src/renderer/pages/home/Messages/Tools/MessageMetaTool.tsx
+++ b/src/renderer/pages/home/Messages/Tools/MessageMetaTool.tsx
@@ -3,22 +3,17 @@ import { useCodeStyle } from '@renderer/context/CodeStyleProvider'
 import { useTimer } from '@renderer/hooks/useTimer'
 import type { NormalToolResponse } from '@renderer/types'
 import { Collapse } from 'antd'
-import { Check, ChevronRight, CornerDownRight } from 'lucide-react'
+import { Check, ChevronRight } from 'lucide-react'
 import type { FC } from 'react'
 import { memo, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
-import { chooseTool } from './chooseTool'
 import { getEffectiveStatus, ToolStatusIndicator } from './MessageAgentTools/GenericTools'
+import type { MetaToolName } from './metaToolNames'
 import { ArgKey, ArgsSection, ArgsSectionTitle, ArgsTable, ArgValue, formatArgValue } from './shared/ArgsTable'
 
-export const META_TOOL_NAMES = ['tool_search', 'tool_inspect', 'tool_invoke', 'tool_exec'] as const
-export type MetaToolName = (typeof META_TOOL_NAMES)[number]
-
-export function isMetaToolName(name: string): name is MetaToolName {
-  return (META_TOOL_NAMES as readonly string[]).includes(name)
-}
+export { isMetaToolName, META_TOOL_NAMES, type MetaToolName } from './metaToolNames'
 
 interface Props {
   toolResponse: NormalToolResponse
@@ -190,16 +185,16 @@ const ToolInspectBody: FC<{ toolResponse: NormalToolResponse }> = ({ toolRespons
 // ── tool_invoke ────────────────────────────────────────────────────
 
 /**
- * Synthesise a NormalToolResponse for the inner tool the model called via
- * `tool_invoke`, then dispatch through `chooseTool` so the inner call gets
- * its proper card (MCP / kb / web / agent / generic-fallback). When the
- * inner tool has no registered card, fall back to a json args+response
- * block instead of leaving the row blank.
+ * `tool_invoke` wraps an inner tool call (`{ name, params }`). The outer card
+ * header already names the inner tool (`tool_invoke · <name>`), so the body
+ * shows the call's input + output flat — not a second nested collapsible card,
+ * which duplicated the name/status and buried the params an extra expand deep.
  */
 const ToolInvokeBody: FC<{ toolResponse: NormalToolResponse }> = ({ toolResponse }) => {
   const args = isRecord(toolResponse.arguments) ? toolResponse.arguments : undefined
   const innerName = typeof args?.name === 'string' ? args.name : undefined
   const innerParams = isRecord(args?.params) ? args.params : undefined
+  const response = toolResponse.response
 
   if (!innerName) {
     return (
@@ -209,38 +204,15 @@ const ToolInvokeBody: FC<{ toolResponse: NormalToolResponse }> = ({ toolResponse
     )
   }
 
-  const inner: NormalToolResponse = {
-    ...toolResponse,
-    id: `${toolResponse.id}::inner`,
-    tool: { ...toolResponse.tool, name: innerName },
-    arguments: innerParams,
-    response: toolResponse.response
-  }
-
-  const innerRendered = chooseTool(inner)
-
   return (
     <BodyContainer>
-      <InnerHint>
-        <CornerDownRight size={12} /> via <code>tool_invoke</code>
-      </InnerHint>
-      {innerRendered ?? <GenericInner toolResponse={inner} />}
-    </BodyContainer>
-  )
-}
-
-const GenericInner: FC<{ toolResponse: NormalToolResponse }> = ({ toolResponse }) => {
-  const args = isRecord(toolResponse.arguments) ? toolResponse.arguments : undefined
-  const response = toolResponse.response
-  return (
-    <>
-      <ArgsBlock args={args} />
+      <ArgsBlock args={innerParams} />
       {response !== undefined && response !== null && (
         <ResponseBlock title="Response">
           <CodeBlock>{stringifyResponse(response)}</CodeBlock>
         </ResponseBlock>
       )}
-    </>
+    </BodyContainer>
   )
 }
 
@@ -479,17 +451,6 @@ const Highlighted = styled.div`
     overflow: auto;
     max-height: 300px;
     font-size: 12px;
-  }
-`
-
-const InnerHint = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 11px;
-  color: var(--color-text-3);
-  code {
-    font-family: var(--font-family-mono, monospace);
   }
 `
 

--- a/src/renderer/pages/home/Messages/Tools/MessageTools.tsx
+++ b/src/renderer/pages/home/Messages/Tools/MessageTools.tsx
@@ -1,17 +1,39 @@
-import type { McpToolResponse, NormalToolResponse } from '@renderer/types'
+import type { McpTool, McpToolResponse, NormalToolResponse } from '@renderer/types'
 
-import MessageMcpTool from './MessageMcpTool'
-import MessageTool from './MessageTool'
+import { isReportArtifactsToolResponse } from './agent/ReportArtifacts'
+import MessageMcpTool from './mcp/MessageMcpTool'
+import MessageTool, { canRenderMessageToolResponse } from './MessageTool'
 
 interface Props {
   toolResponse: McpToolResponse | NormalToolResponse
 }
 
-export default function MessageTools({ toolResponse }: Props) {
-  const tool = toolResponse.tool
-  if (tool.type === 'mcp') {
-    return <MessageMcpTool toolResponse={toolResponse as McpToolResponse} />
-  }
+/**
+ * In-process cherry / agent-memory tools are MCP-typed but have dedicated cards (web search,
+ * knowledge, memory) — route them through `chooseTool` instead of the generic MCP renderer.
+ * Other MCP servers keep the generic card.
+ */
+const DEDICATED_AGENT_SERVERS = new Set(['cherry-tools', 'agent-memory'])
 
-  return <MessageTool toolResponse={toolResponse as NormalToolResponse} />
+function rendersThroughChooseTool(toolResponse: McpToolResponse | NormalToolResponse): boolean {
+  const tool = toolResponse.tool
+  if (tool.type !== 'mcp') return true
+  return (
+    DEDICATED_AGENT_SERVERS.has((tool as McpTool).serverId) &&
+    canRenderMessageToolResponse(toolResponse as NormalToolResponse)
+  )
+}
+
+export function canRenderMessageTool(toolResponse: McpToolResponse | NormalToolResponse) {
+  if (isReportArtifactsToolResponse(toolResponse)) return false
+  if (toolResponse.tool.type === 'mcp' && !rendersThroughChooseTool(toolResponse)) return true
+  return canRenderMessageToolResponse(toolResponse as NormalToolResponse)
+}
+
+export default function MessageTools({ toolResponse }: Props) {
+  if (isReportArtifactsToolResponse(toolResponse)) return null
+  if (rendersThroughChooseTool(toolResponse)) {
+    return <MessageTool toolResponse={toolResponse as NormalToolResponse} />
+  }
+  return <MessageMcpTool toolResponse={toolResponse as McpToolResponse} />
 }

--- a/src/renderer/pages/home/Messages/Tools/chooseTool.tsx
+++ b/src/renderer/pages/home/Messages/Tools/chooseTool.tsx
@@ -15,6 +15,8 @@ import { MessageWebSearchToolTitle } from './MessageWebSearch'
 const builtinToolsPrefix = 'builtin_'
 const agentMcpToolsPrefix = 'mcp__'
 const agentTools = Object.values(AgentToolsType)
+/** cherry-tools that carry short wire names (no `mcp__` prefix) and lack a bespoke card. */
+const CHERRY_AGENT_TOOL_NAMES = new Set(['web_fetch', 'kb_list', 'memory'])
 
 const isAgentTool = (toolName: AgentToolsType) => {
   if (agentTools.includes(toolName) || toolName.startsWith(agentMcpToolsPrefix)) {
@@ -30,12 +32,17 @@ export function chooseTool(toolResponse: NormalToolResponse): React.ReactNode | 
     return <MessageMetaTool toolResponse={toolResponse} />
   }
 
-  // New agentic builtin names (`kb__search`, `web__search`, future `web__fetch`).
-  if (toolName === 'kb__search') {
+  // In-process cherry-tools (web/knowledge/memory) carry short wire names, not the `mcp__` prefix.
+  if (toolName === 'kb_search') {
     return <MessageKnowledgeSearchToolTitle toolResponse={toolResponse} />
   }
-  if (toolName === 'web__search') {
+  if (toolName === 'web_search') {
     return toolType === 'provider' ? null : <MessageWebSearchToolTitle toolResponse={toolResponse} />
+  }
+  // web_fetch / kb_list / memory have no bespoke card yet — render them through the standard
+  // agent tool-call card rather than dropping them.
+  if (CHERRY_AGENT_TOOL_NAMES.has(toolName)) {
+    return <AgentExecutionTimeline toolResponse={toolResponse} />
   }
 
   // Legacy `builtin_*` prefix — kept for historical messages still in DB.

--- a/src/renderer/pages/home/Messages/Tools/metaToolNames.ts
+++ b/src/renderer/pages/home/Messages/Tools/metaToolNames.ts
@@ -1,0 +1,11 @@
+/**
+ * Meta-tool names (the deferred-tool dispatch tools). Kept in a standalone,
+ * React-free module so low-level utilities (e.g. `toolResponse`) can recognise
+ * them without importing the renderer component that displays them.
+ */
+export const META_TOOL_NAMES = ['tool_search', 'tool_inspect', 'tool_invoke', 'tool_exec'] as const
+export type MetaToolName = (typeof META_TOOL_NAMES)[number]
+
+export function isMetaToolName(name: string): name is MetaToolName {
+  return (META_TOOL_NAMES as readonly string[]).includes(name)
+}

--- a/src/renderer/pages/home/Messages/Tools/toolResponse.ts
+++ b/src/renderer/pages/home/Messages/Tools/toolResponse.ts
@@ -1,9 +1,9 @@
 import type { BaseTool, McpTool, McpToolResponse, McpToolResponseStatus, NormalToolResponse } from '@renderer/types'
 import type { CherryMessagePart } from '@shared/data/types/message'
-import type { CherryToolMeta } from '@shared/data/types/uiParts'
-import { readCherryMeta } from '@shared/data/types/uiParts'
-import type { UIMessagePart } from 'ai'
+import type { ProviderMetadata, UIMessagePart } from 'ai'
 import { isToolUIPart } from 'ai'
+
+import { isMetaToolName } from './meta/metaToolNames'
 
 /** AI-SDK-v6 ToolUIPart approval-state string literals. */
 export const APPROVAL_REQUESTED = 'approval-requested'
@@ -99,7 +99,54 @@ function extractCherryToolMetadata(part: CherryMessagePart): ToolMetadata | unde
   return meta?.tool
 }
 
-function resolveToolType(part: ToolPart, toolName: string, metadata?: ToolMetadata): ToolType {
+function isLegacyAgentToolName(toolName: string): boolean {
+  return AGENT_TOOL_NAMES.has(toolName) || toolName.startsWith(AGENT_MCP_TOOLS_PREFIX)
+}
+
+function extractCherryToolMetadataFrom(metadata: ProviderMetadata | undefined): ToolMetadata | undefined {
+  if (!isRecord(metadata)) return undefined
+  const cherry = isRecord(metadata.cherry) ? metadata.cherry : undefined
+  const tool = cherry && isRecord(cherry.tool) ? cherry.tool : undefined
+  if (!tool) return undefined
+  return {
+    description: typeof tool.description === 'string' ? tool.description : undefined,
+    name: typeof tool.name === 'string' ? tool.name : undefined,
+    serverId: typeof tool.serverId === 'string' ? tool.serverId : undefined,
+    serverName: typeof tool.serverName === 'string' ? tool.serverName : undefined,
+    type: isToolType(tool.type) ? tool.type : undefined
+  }
+}
+
+function extractCherryToolMetadata(part: ToolResponsePart): ToolMetadata | undefined {
+  const resultProviderMetadata = 'resultProviderMetadata' in part ? part.resultProviderMetadata : undefined
+  return (
+    extractCherryToolMetadataFrom(part.callProviderMetadata) ?? extractCherryToolMetadataFrom(resultProviderMetadata)
+  )
+}
+
+function extractClaudeParentToolCallIdFrom(metadata: ProviderMetadata | undefined): string | undefined {
+  if (!isRecord(metadata)) return undefined
+  const claudeCode = isRecord(metadata['claude-code']) ? metadata['claude-code'] : undefined
+  const parentToolCallId = claudeCode?.parentToolCallId ?? claudeCode?.parentToolUseId
+  return typeof parentToolCallId === 'string' && parentToolCallId ? parentToolCallId : undefined
+}
+
+function extractParentToolUseId(part: ToolResponsePart): string | undefined {
+  const resultProviderMetadata = 'resultProviderMetadata' in part ? part.resultProviderMetadata : undefined
+  return (
+    extractClaudeParentToolCallIdFrom(part.callProviderMetadata) ??
+    extractClaudeParentToolCallIdFrom(resultProviderMetadata)
+  )
+}
+
+function hasCherryTransport(metadata: ProviderMetadata | undefined): boolean {
+  if (!isRecord(metadata)) return false
+  const cherry = isRecord(metadata.cherry) ? metadata.cherry : undefined
+  return cherry?.transport === CLAUDE_AGENT_TRANSPORT
+}
+
+function resolveToolType(part: ToolResponsePart, toolName: string, metadata?: ToolMetadata): ToolType {
+  if (isMetaToolName(toolName)) return 'builtin'
   if (metadata?.type) return metadata.type
   if (part.type === 'dynamic-tool') return 'mcp'
   if (toolName.startsWith('builtin_')) return 'builtin'


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Message tool rendering did not have a dedicated presentation for agent deliverable artifacts.

After this PR:

Message tools render agent deliverables with structured artifact details.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The renderer only consumes structured metadata produced by earlier backend layers.

The following alternatives were considered:

Parsing deliverables from text output was rejected because it would be brittle and provider-dependent.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Stack PR 13/15 for the chat-page split. Base: `codex/chat-stack-12-agent-context-ui`; head: `codex/chat-stack-13-message-tools`.

Validated at the top of this stack with `pnpm lint`, `pnpm test`, `pnpm db:migrations:check`, and `git diff --check`. Local Node 22.22.0 emitted the expected engine warning for the repo requirement `>=24.11.1`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Chat messages now render agent deliverable artifacts.
```
