### PR TITLE
feat(agent-tool-settings): render registry tool toggles

### DIFF
--- a/src/renderer/components/chat/composer/tools/definitions/permissionModeTool.tsx
+++ b/src/renderer/components/chat/composer/tools/definitions/permissionModeTool.tsx
@@ -1,0 +1,114 @@
+import {
+  defineTool,
+  registerTool,
+  type ToolRenderContext,
+  TopicType
+} from '@renderer/components/chat/composer/tools/types'
+import { permissionModeCards } from '@renderer/config/agent'
+import { defaultConfiguration } from '@renderer/hooks/agents/agentConfiguration'
+import { useAgent } from '@renderer/hooks/agents/useAgent'
+import { useUpdateAgent } from '@renderer/hooks/agents/useAgent'
+import type { PermissionMode } from '@renderer/types'
+import { FolderPen, Pointer, RefreshCcw, Route } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
+
+const getPermissionModeIcon = (mode: PermissionMode): ReactNode => {
+  switch (mode) {
+    case 'default':
+      return <Pointer size={18} color="#00b96b" />
+    case 'plan':
+      return <Route size={18} color="#faad14" />
+    case 'acceptEdits':
+      return <FolderPen size={18} color="#52c41a" />
+    case 'bypassPermissions':
+      return <RefreshCcw size={18} color="#722ed1" />
+    default:
+      return <Pointer size={18} color="#00b96b" />
+  }
+}
+
+type PermissionModeContext = ToolRenderContext<readonly [], readonly []>
+
+const usePermissionModeToolController = (context: PermissionModeContext) => {
+  const { t, launcher, session: sessionContext } = context
+  const agentId = sessionContext?.agentId
+  const { agent } = useAgent(agentId ?? '')
+  const { updateAgent } = useUpdateAgent()
+
+  // Permission mode lives on the agent — sessions are pure instances. Approval is governed
+  // solely by the permission mode (the per-tool allow-list was removed).
+  const currentMode = agent?.configuration?.permission_mode ?? 'default'
+
+  const handleSelectMode = useCallback(
+    (nextMode: PermissionMode) => {
+      if (!agentId || !agent || nextMode === currentMode) return
+
+      const configuration = agent.configuration ?? defaultConfiguration
+      const updatedConfiguration = { ...configuration, permission_mode: nextMode }
+
+      // Disable soul mode when switching away from bypassPermissions
+      if (nextMode !== 'bypassPermissions' && configuration.soul_enabled === true) {
+        updatedConfiguration.soul_enabled = false
+      }
+
+      void updateAgent({ id: agentId, configuration: updatedConfiguration }, { showSuccessToast: false })
+    },
+    [currentMode, agent, agentId, updateAgent]
+  )
+
+  const modeCard = permissionModeCards.find((card) => card.mode === currentMode)
+  const tooltipTitle = modeCard ? t(modeCard.titleKey, modeCard.titleFallback) : ''
+  const modeSubmenu = useMemo(
+    () =>
+      permissionModeCards.map((card, index) => ({
+        id: `permission-mode-${card.mode}`,
+        kind: 'command' as const,
+        sources: ['popover'] as const,
+        order: 80 + index / 100,
+        label: t(card.titleKey, card.titleFallback),
+        description: t(card.descriptionKey, card.descriptionFallback),
+        icon: getPermissionModeIcon(card.mode),
+        active: card.mode === currentMode,
+        action: () => handleSelectMode(card.mode)
+      })),
+    [currentMode, handleSelectMode, t]
+  )
+
+  useEffect(() => {
+    return launcher.registerLaunchers([
+      {
+        id: 'permission-mode',
+        kind: 'group',
+        sources: ['popover'],
+        order: 80,
+        label: t('agent.settings.permissionMode.title', 'Permission Mode'),
+        description: '',
+        icon: getPermissionModeIcon(currentMode),
+        suffix: tooltipTitle,
+        submenu: modeSubmenu
+      }
+    ])
+  }, [currentMode, launcher, modeSubmenu, t, tooltipTitle])
+
+  return { currentMode, tooltipTitle }
+}
+
+const PermissionModeComposerRuntime = ({ context }: { context: PermissionModeContext }) => {
+  usePermissionModeToolController(context)
+  return null
+}
+
+const permissionModeTool = defineTool({
+  key: 'permission_mode',
+  label: (t) => t('agent.settings.permissionMode.title', 'Permission Mode'),
+  visibleInScopes: [TopicType.Session],
+
+  composer: {
+    runtime: ({ context }) => <PermissionModeComposerRuntime context={context} />
+  }
+})
+
+registerTool(permissionModeTool)
+
+export default permissionModeTool

--- a/src/renderer/hooks/agents/__tests__/permissionMode.test.ts
+++ b/src/renderer/hooks/agents/__tests__/permissionMode.test.ts
@@ -1,60 +1,18 @@
-import type { Tool } from '@shared/ai/tool'
 import { describe, expect, it } from 'vitest'
 
-import {
-  computeModeDefaults,
-  mergeAutoApprovedTools,
-  mergePermissionModeTools,
-  normalizeAllowedToolRules
-} from '../permissionMode'
+import { normalizePermissionMode } from '../permissionMode'
 
-const tools: Tool[] = [
-  {
-    id: 'Read',
-    name: 'Read',
-    origin: 'builtin',
-    approval: 'auto'
-  },
-  {
-    id: 'Edit',
-    name: 'Edit',
-    origin: 'builtin',
-    approval: 'prompt'
-  },
-  {
-    id: 'Bash',
-    name: 'Bash',
-    origin: 'builtin',
-    approval: 'prompt'
-  },
-  {
-    id: 'CustomDanger',
-    name: 'Custom danger',
-    origin: 'internal',
-    approval: 'prompt'
-  }
-]
-
-describe('permissionMode helpers', () => {
-  it('uses resolved auto tools from the main-side policy', () => {
-    expect(computeModeDefaults('default', tools)).toEqual(['Read'])
+describe('normalizePermissionMode', () => {
+  it('passes through the valid non-default modes', () => {
+    expect(normalizePermissionMode('plan')).toBe('plan')
+    expect(normalizePermissionMode('acceptEdits')).toBe('acceptEdits')
+    expect(normalizePermissionMode('bypassPermissions')).toBe('bypassPermissions')
   })
 
-  it('normalizes user-added tool names to runtime rules without adding mode defaults', () => {
-    expect(mergePermissionModeTools(['Read', 'CustomDanger'], 'default', 'acceptEdits', tools)).toEqual([
-      'Read',
-      'CustomDanger'
-    ])
-  })
-
-  it('combines explicit approvals with resolved auto tools for rendering', () => {
-    expect(mergeAutoApprovedTools(['Edit'], 'default', tools)).toEqual(['Edit', 'Read'])
-  })
-
-  it('preserves Claude runtime-native pattern rules and drops non-native rules', () => {
-    expect(normalizeAllowedToolRules(['Read', 'not-native:Edit', 'Bash(git *)'], tools)).toEqual([
-      'Read',
-      'Bash(git *)'
-    ])
+  it('falls back to default for unknown / empty values', () => {
+    expect(normalizePermissionMode('default')).toBe('default')
+    expect(normalizePermissionMode('bogus')).toBe('default')
+    expect(normalizePermissionMode(undefined)).toBe('default')
+    expect(normalizePermissionMode(null)).toBe('default')
   })
 })

--- a/src/renderer/hooks/agents/__tests__/useAgent.test.ts
+++ b/src/renderer/hooks/agents/__tests__/useAgent.test.ts
@@ -48,7 +48,6 @@ describe('useAgent', () => {
       name: 'Test Agent',
       model: 'claude-3',
       type: 'claude-code',
-      allowedTools: [],
       configuration: { permission_mode: 'default', max_turns: 100, env_vars: {} },
       createdAt: '2024-01-01T00:00:00Z',
       updatedAt: '2024-01-01T00:00:00Z'
@@ -75,7 +74,6 @@ describe('useAgent', () => {
       name: 'Test Agent',
       model: 'claude-3',
       type: 'claude-code',
-      allowedTools: [],
       configuration: { avatar: '🤖' },
       createdAt: '2024-01-01T00:00:00Z',
       updatedAt: '2024-01-01T00:00:00Z'
@@ -96,7 +94,6 @@ describe('useAgent', () => {
       name: 'Test Agent',
       model: 'claude-3',
       type: 'claude-code',
-      allowedTools: [],
       // permission_mode/'invalid' fails enum check; env_vars/null fails record check.
       // max_turns/200 is well-typed and must survive.
       configuration: { permission_mode: 'invalid', env_vars: null, max_turns: 200 },
@@ -175,8 +172,7 @@ describe('useAgents', () => {
         result.current.addAgent({
           name: 'New Agent',
           model: 'anthropic::claude-3',
-          type: 'claude-code',
-          allowedTools: []
+          type: 'claude-code'
         })
       )
 
@@ -198,8 +194,7 @@ describe('useAgents', () => {
         result.current.addAgent({
           name: 'New Agent',
           model: 'anthropic::claude-3',
-          type: 'claude-code',
-          allowedTools: []
+          type: 'claude-code'
         })
       )
 
@@ -256,7 +251,6 @@ describe('useUpdateAgent', () => {
         name: 'Updated',
         model: 'claude-3',
         type: 'claude-code',
-        allowedTools: [],
         configuration: { avatar: '🤖' },
         createdAt: '2024-01-01T00:00:00Z',
         updatedAt: '2024-01-01T00:00:00Z'
@@ -279,7 +273,6 @@ describe('useUpdateAgent', () => {
         name: 'Updated',
         model: 'claude-3',
         type: 'claude-code',
-        allowedTools: [],
         configuration: {},
         createdAt: '',
         updatedAt: ''
@@ -312,7 +305,6 @@ describe('useUpdateAgent', () => {
         name: 'A',
         model: 'anthropic::new-model',
         type: 'claude-code',
-        allowedTools: [],
         configuration: {},
         createdAt: '',
         updatedAt: ''

--- a/src/renderer/hooks/agents/permissionMode.ts
+++ b/src/renderer/hooks/agents/permissionMode.ts
@@ -1,6 +1,4 @@
 import type { PermissionMode } from '@renderer/types'
-import type { Tool } from '@shared/ai/tool'
-import { uniq } from 'lodash'
 
 export const DEFAULT_MAX_TURNS = 100
 export const DEFAULT_PERMISSION_MODE = 'default' as const
@@ -12,46 +10,4 @@ export function normalizePermissionMode(mode: string | undefined | null): Permis
     return mode
   }
   return DEFAULT_PERMISSION_MODE
-}
-
-/**
- * Computes tool rules currently approved by the effective main-side policy.
- */
-export function computeModeDefaults(_mode: PermissionMode, tools: Tool[]): string[] {
-  return tools.filter((tool) => tool.approval === 'auto').map((tool) => tool.id)
-}
-
-function matchesToolRule(value: string, tool: Tool): boolean {
-  return value === tool.id || value === tool.name
-}
-
-function isRuntimeNativeRule(value: string): boolean {
-  return !value.includes(':')
-}
-
-export function normalizeAllowedToolRules(allowedTools: readonly string[], tools: Tool[]): string[] {
-  return uniq(
-    allowedTools.flatMap((value) => {
-      const tool = tools.find((item) => matchesToolRule(value, item))
-      if (tool) return [tool.id]
-      return isRuntimeNativeRule(value) ? [value] : []
-    })
-  )
-}
-
-export function mergePermissionModeTools(
-  allowedTools: readonly string[],
-  _currentMode: PermissionMode,
-  _nextMode: PermissionMode,
-  tools: Tool[]
-): string[] {
-  return normalizeAllowedToolRules(allowedTools, tools)
-}
-
-export function mergeAutoApprovedTools(
-  allowedTools: readonly string[],
-  permissionMode: PermissionMode,
-  tools: Tool[]
-): string[] {
-  return uniq([...normalizeAllowedToolRules(allowedTools, tools), ...computeModeDefaults(permissionMode, tools)])
 }

--- a/src/renderer/hooks/agents/useAgentTools.ts
+++ b/src/renderer/hooks/agents/useAgentTools.ts
@@ -1,7 +1,6 @@
 import { cacheService } from '@renderer/data/CacheService'
 import { useMcpServers } from '@renderer/hooks/useMcpServer'
-import type { AgentType } from '@renderer/types'
-import { claudeCodeBuiltinToolDescriptors } from '@shared/ai/claudecode/builtinTools'
+import { claudeRegistrySdkDescriptors } from '@shared/ai/claudecode/toolRegistry'
 import {
   buildClaudeMcpToolName,
   type ClaudeToolDescriptor,
@@ -22,7 +21,6 @@ const mcpToolsCacheKey = (serverId: string): McpToolsCacheKey => `mcp.tools.${se
 export type AgentToolSource = {
   type?: AgentType
   mcps?: string[]
-  allowedTools?: string[]
   configuration?: Pick<AgentConfiguration, 'permission_mode'> | null
   permissionMode?: AgentPermissionMode | string | null
 }
@@ -52,8 +50,7 @@ function useMcpToolsCache(serverIds: readonly string[]): Record<string, McpTool[
 
 function toTool(descriptor: ClaudeToolDescriptor, source: AgentToolSource): Tool {
   const decision = resolveClaudeToolAccess(descriptor, {
-    permissionMode: source.configuration?.permission_mode ?? (source.permissionMode as AgentPermissionMode | undefined),
-    allowedTools: source.allowedTools ?? []
+    permissionMode: source.configuration?.permission_mode ?? (source.permissionMode as AgentPermissionMode | undefined)
   })
   return {
     id: descriptor.id,
@@ -109,7 +106,7 @@ export const useAgentTools = (source: AgentToolSource | null | undefined) => {
     if ((source?.type ?? 'claude-code') !== 'claude-code') return []
 
     const selectedServers = new Map(mcpServers.map((server) => [server.id, server]))
-    const descriptors: ClaudeToolDescriptor[] = [...claudeCodeBuiltinToolDescriptors()]
+    const descriptors: ClaudeToolDescriptor[] = [...claudeRegistrySdkDescriptors()]
     for (const id of mcpIds) {
       const server = selectedServers.get(id)
       if (!server) continue

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -724,17 +724,41 @@
     },
     "tools": {
       "builtin": {
+        "AgentMemory": {
+          "description": "Stores and recalls cross-session memory",
+          "label": "Memory"
+        },
         "Bash": {
-          "description": "Executes shell commands in your environment"
+          "description": "Executes shell commands in your environment",
+          "label": "Bash"
+        },
+        "CherryKbSearch": {
+          "description": "Searches your knowledge bases",
+          "label": "Knowledge Search"
+        },
+        "CherryWebFetch": {
+          "description": "Fetches and reads a web page",
+          "label": "Web Fetch"
+        },
+        "CherryWebSearch": {
+          "description": "Searches the web via your configured provider",
+          "label": "Web Search"
+        },
+        "ClawCron": {
+          "description": "Manages the in-app scheduler",
+          "label": "Scheduler"
         },
         "Edit": {
-          "description": "Makes targeted edits to specific files"
+          "description": "Makes targeted edits to specific files",
+          "label": "Edit"
         },
         "Glob": {
-          "description": "Finds files based on pattern matching"
+          "description": "Finds files based on pattern matching",
+          "label": "Glob"
         },
         "Grep": {
-          "description": "Searches for patterns in file contents"
+          "description": "Searches for patterns in file contents",
+          "label": "Grep"
         },
         "MultiEdit": {
           "description": "Performs multiple edits on a single file atomically"
@@ -746,7 +770,8 @@
           "description": "Reads and displays Jupyter notebook contents"
         },
         "Read": {
-          "description": "Reads the contents of files"
+          "description": "Reads the contents of files",
+          "label": "Read"
         },
         "Task": {
           "description": "Runs a sub-agent to handle complex, multi-step tasks"
@@ -763,8 +788,13 @@
         "WebSearch": {
           "description": "Performs web searches with domain filtering"
         },
+        "Workflow": {
+          "description": "Runs a multi-step workflow that orchestrates subagents",
+          "label": "Workflow"
+        },
         "Write": {
-          "description": "Creates or overwrites files"
+          "description": "Creates or overwrites files",
+          "label": "Write"
         }
       }
     },
@@ -2549,6 +2579,14 @@
           },
           "tools": {
             "add": "Add",
+            "category": {
+              "context": "Context",
+              "file": "File",
+              "media": "Media",
+              "orchestration": "Orchestration",
+              "search": "Search",
+              "shell": "Shell"
+            },
             "desc": "Configure tools and MCP servers the agent can use",
             "label": "Tools",
             "no_builtin_enabled": "No built-in tools enabled",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -724,17 +724,41 @@
     },
     "tools": {
       "builtin": {
+        "AgentMemory": {
+          "description": "跨会话存储和回忆记忆",
+          "label": "记忆"
+        },
         "Bash": {
-          "description": "在你的环境中执行 Shell 命令"
+          "description": "在你的环境中执行 Shell 命令",
+          "label": "Bash"
+        },
+        "CherryKbSearch": {
+          "description": "搜索你的知识库",
+          "label": "知识库搜索"
+        },
+        "CherryWebFetch": {
+          "description": "抓取并读取网页",
+          "label": "网页抓取"
+        },
+        "CherryWebSearch": {
+          "description": "通过你配置的提供方搜索网页",
+          "label": "网页搜索"
+        },
+        "ClawCron": {
+          "description": "管理应用内的定时调度",
+          "label": "定时任务"
         },
         "Edit": {
-          "description": "对特定文件进行精确编辑"
+          "description": "对特定文件进行精确编辑",
+          "label": "编辑文件"
         },
         "Glob": {
-          "description": "根据模式匹配查找文件"
+          "description": "根据模式匹配查找文件",
+          "label": "查找文件"
         },
         "Grep": {
-          "description": "在文件内容中搜索模式"
+          "description": "在文件内容中搜索模式",
+          "label": "搜索内容"
         },
         "MultiEdit": {
           "description": "在单个文件上原子性地执行多次编辑"
@@ -746,7 +770,8 @@
           "description": "读取并显示 Jupyter notebook 内容"
         },
         "Read": {
-          "description": "读取文件内容"
+          "description": "读取文件内容",
+          "label": "读取文件"
         },
         "Task": {
           "description": "运行子代理来处理复杂的多步骤任务"
@@ -763,8 +788,13 @@
         "WebSearch": {
           "description": "执行带有域名过滤的网络搜索"
         },
+        "Workflow": {
+          "description": "运行编排子智能体的多步工作流",
+          "label": "工作流"
+        },
         "Write": {
-          "description": "创建或覆盖文件"
+          "description": "创建或覆盖文件",
+          "label": "写入文件"
         }
       }
     },
@@ -2549,6 +2579,14 @@
           },
           "tools": {
             "add": "添加",
+            "category": {
+              "context": "上下文",
+              "file": "文件",
+              "media": "多媒体",
+              "orchestration": "编排",
+              "search": "搜索",
+              "shell": "终端"
+            },
             "desc": "配置智能体可使用的工具和 MCP Server",
             "label": "工具",
             "no_builtin_enabled": "未启用任何内置工具",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -724,17 +724,41 @@
     },
     "tools": {
       "builtin": {
+        "AgentMemory": {
+          "description": "跨工作階段儲存和回憶記憶",
+          "label": "記憶"
+        },
         "Bash": {
-          "description": "在你的環境中執行 Shell 命令"
+          "description": "在你的環境中執行 Shell 命令",
+          "label": "Bash"
+        },
+        "CherryKbSearch": {
+          "description": "搜尋你的知識庫",
+          "label": "知識庫搜尋"
+        },
+        "CherryWebFetch": {
+          "description": "擷取並讀取網頁",
+          "label": "網頁擷取"
+        },
+        "CherryWebSearch": {
+          "description": "透過你設定的提供方搜尋網頁",
+          "label": "網頁搜尋"
+        },
+        "ClawCron": {
+          "description": "管理應用內的定時排程",
+          "label": "定時任務"
         },
         "Edit": {
-          "description": "對特定檔案進行精確編輯"
+          "description": "對特定檔案進行精確編輯",
+          "label": "編輯檔案"
         },
         "Glob": {
-          "description": "根據模式匹配尋找檔案"
+          "description": "根據模式匹配尋找檔案",
+          "label": "尋找檔案"
         },
         "Grep": {
-          "description": "在檔案內容中搜尋模式"
+          "description": "在檔案內容中搜尋模式",
+          "label": "搜尋內容"
         },
         "MultiEdit": {
           "description": "在單一檔案上原子性地執行多次編輯"
@@ -746,7 +770,8 @@
           "description": "讀取並顯示 Jupyter notebook 內容"
         },
         "Read": {
-          "description": "讀取檔案內容"
+          "description": "讀取檔案內容",
+          "label": "讀取檔案"
         },
         "Task": {
           "description": "執行子代理來處理複雜的多步驟任務"
@@ -763,8 +788,13 @@
         "WebSearch": {
           "description": "執行帶有網域過濾的網路搜尋"
         },
+        "Workflow": {
+          "description": "執行編排子智能體的多步工作流",
+          "label": "工作流"
+        },
         "Write": {
-          "description": "建立或覆寫檔案"
+          "description": "建立或覆寫檔案",
+          "label": "寫入檔案"
         }
       }
     },
@@ -2549,6 +2579,14 @@
           },
           "tools": {
             "add": "新增",
+            "category": {
+              "context": "上下文",
+              "file": "檔案",
+              "media": "多媒體",
+              "orchestration": "編排",
+              "search": "搜尋",
+              "shell": "終端"
+            },
             "desc": "MCP 伺服器、允許的工具與執行階段設定",
             "label": "工具與執行階段",
             "no_builtin_enabled": "未啟用任何內建工具",

--- a/src/renderer/pages/library/dialogs/__tests__/EditDialogs.test.tsx
+++ b/src/renderer/pages/library/dialogs/__tests__/EditDialogs.test.tsx
@@ -1,0 +1,897 @@
+import type * as CherryStudioUi from '@cherrystudio/ui'
+import type { AgentDetail } from '@renderer/pages/library/types'
+import type { Assistant } from '@shared/data/types/assistant'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import type * as ReactI18next from 'react-i18next'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { EDIT_DIALOG_PROMPT_MAX_HEIGHT, EDIT_DIALOG_PROMPT_MIN_HEIGHT } from '../edit/EditDialogShared'
+
+const {
+  agentTools,
+  ensureTagsMock,
+  fetchGenerateMock,
+  mcpStatusState,
+  openSettingsWindowMock,
+  toastErrorMock,
+  toggleSkillMock,
+  updateAgentMock,
+  updateAssistantMock,
+  useMutationMock,
+  useQueryMock
+} = vi.hoisted(() => ({
+  agentTools: [
+    { id: 'Bash', name: 'Bash', description: 'Run shell commands', origin: 'builtin', approval: 'prompt' },
+    { id: 'Edit', name: 'Edit', description: 'Edit files', origin: 'builtin', approval: 'prompt' },
+    { id: 'Glob', name: 'Glob', description: 'Find files', origin: 'builtin', approval: 'auto' },
+    { id: 'Grep', name: 'Grep', description: 'Search files', origin: 'builtin', approval: 'auto' },
+    { id: 'MultiEdit', name: 'MultiEdit', description: 'Edit multiple ranges', origin: 'builtin', approval: 'prompt' },
+    {
+      id: 'NotebookEdit',
+      name: 'NotebookEdit',
+      description: 'Edit notebooks',
+      origin: 'builtin',
+      approval: 'prompt'
+    },
+    {
+      id: 'NotebookRead',
+      name: 'NotebookRead',
+      description: 'Read notebooks',
+      origin: 'builtin',
+      approval: 'auto'
+    },
+    { id: 'Read', name: 'Read', description: 'Read files', origin: 'builtin', approval: 'auto' },
+    { id: 'Task', name: 'Task', description: 'Run sub-agents', origin: 'builtin', approval: 'auto' },
+    { id: 'TodoWrite', name: 'TodoWrite', description: 'Manage todos', origin: 'builtin', approval: 'auto' },
+    { id: 'WebFetch', name: 'WebFetch', description: 'Fetch websites', origin: 'builtin', approval: 'prompt' },
+    { id: 'WebSearch', name: 'WebSearch', description: 'Search web', origin: 'builtin', approval: 'prompt' },
+    { id: 'Write', name: 'Write', description: 'Write files', origin: 'builtin', approval: 'prompt' }
+  ],
+  ensureTagsMock: vi.fn(),
+  fetchGenerateMock: vi.fn(),
+  mcpStatusState: { current: {} as Record<string, { state: string; lastCheckedAt: number }> },
+  openSettingsWindowMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  toggleSkillMock: vi.fn(),
+  updateAgentMock: vi.fn(),
+  updateAssistantMock: vi.fn(),
+  useMutationMock: vi.fn(),
+  useQueryMock: vi.fn()
+}))
+
+const MODEL = vi.hoisted(
+  () =>
+    ({
+      id: 'provider::updated-model',
+      providerId: 'provider',
+      name: 'Updated Model',
+      capabilities: [],
+      supportsStreaming: true,
+      isEnabled: true,
+      isHidden: false
+    }) as const
+)
+
+vi.mock('@renderer/components/Selector/model', () => ({
+  ModelSelector: ({ trigger, onSelect }: { trigger: ReactNode; onSelect: (modelId: string | undefined) => void }) => (
+    <div>
+      {trigger}
+      <button type="button" onClick={() => onSelect(MODEL.id)}>
+        Pick model
+      </button>
+    </div>
+  )
+}))
+
+vi.mock('@cherrystudio/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof CherryStudioUi>()
+  return actual
+})
+
+vi.mock('@renderer/components/EmojiPicker', () => ({
+  default: ({ onEmojiClick }: { onEmojiClick: (emoji: string) => void }) => (
+    <button type="button" onClick={() => onEmojiClick('🎓')}>
+      Choose emoji
+    </button>
+  )
+}))
+
+vi.mock('@renderer/components/PromptEditorField', () => ({
+  default: ({
+    actions,
+    label,
+    labelAddon,
+    value,
+    onChange,
+    placeholder
+  }: {
+    actions?: ReactNode
+    label?: ReactNode
+    labelAddon?: ReactNode
+    value: string
+    onChange: (value: string) => void
+    placeholder?: string
+  }) => (
+    <div>
+      <div>
+        {label}
+        {labelAddon}
+        {actions}
+      </div>
+      <textarea
+        aria-label="Prompt editor"
+        placeholder={placeholder}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    </div>
+  )
+}))
+
+vi.mock('@renderer/hooks/useTags', () => ({
+  useEnsureTags: () => ({ ensureTags: ensureTagsMock }),
+  useTagList: () => ({
+    tags: [
+      {
+        id: 'tag-work',
+        name: 'work',
+        color: '#8b5cf6',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z'
+      },
+      {
+        id: 'tag-personal',
+        name: 'personal',
+        color: '#10b981',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z'
+      }
+    ]
+  })
+}))
+
+vi.mock('@renderer/data/hooks/useDataApi', () => ({
+  useMutation: useMutationMock,
+  useQuery: useQueryMock
+}))
+
+vi.mock('@renderer/hooks/agents/useAgentTools', () => ({
+  useAgentTools: () => ({
+    tools: agentTools,
+    isLoading: false,
+    error: undefined
+  })
+}))
+
+vi.mock('@renderer/hooks/useMcpRuntimeStatus', () => ({
+  useMcpRuntimeStatusMap: () => mcpStatusState.current
+}))
+
+vi.mock('@renderer/hooks/useSkills', () => ({
+  useInstalledSkills: () => ({
+    skills: [
+      {
+        id: 'skill-1',
+        name: 'Skill One',
+        description: 'Skill description',
+        isEnabled: false
+      }
+    ],
+    loading: false,
+    toggle: toggleSkillMock
+  })
+}))
+
+vi.mock('@renderer/hooks/usePromptProcessor', () => ({
+  usePromptProcessor: ({ prompt }: { prompt: string }) => prompt
+}))
+
+vi.mock('@renderer/components/TopView/toast', () => ({
+  useToasts: () => ({ error: toastErrorMock })
+}))
+
+vi.mock('@renderer/services/ApiService', () => ({
+  fetchGenerate: fetchGenerateMock
+}))
+
+vi.mock('@renderer/services/SettingsWindowService', () => ({
+  openSettingsWindow: openSettingsWindowMock
+}))
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactI18next>()
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, fallback?: string) =>
+        ({
+          'agent.cherryClaw.heartbeat.enabledHelper': 'Send heartbeat messages.',
+          'agent.cherryClaw.heartbeat.intervalHelper': 'Heartbeat interval.',
+          'agent.settings.tooling.preapproved.autoBadge': 'Added by mode',
+          'agent.settings.tooling.preapproved.autoDisabledTooltip': 'Added by {{mode}}',
+          'common.avatar': 'Avatar',
+          'common.cancel': 'Cancel',
+          'common.clear': 'Clear',
+          'common.delete': 'Delete',
+          'common.description': 'Description',
+          'common.edit': 'Edit',
+          'common.help': 'Help',
+          'common.loading': 'Loading',
+          'common.model': 'Model',
+          'common.name': 'Name',
+          'common.preview': 'Preview',
+          'common.remove': 'Remove',
+          'common.required_field': 'Required',
+          'common.save': 'Save',
+          'common.undo': 'Undo',
+          'error.no_response': 'No response',
+          'library.action.enable': 'Enable',
+          'library.config.agent.field.description.hint': 'Short agent summary.',
+          'library.config.agent.field.description.label': 'Description',
+          'library.config.agent.field.description.placeholder': 'Describe this agent',
+          'library.config.agent.field.heartbeat_enabled.label': 'Heartbeat',
+          'library.config.agent.field.heartbeat_interval.label': 'Heartbeat interval',
+          'library.config.agent.field.model.hint': 'Primary agent model.',
+          'library.config.agent.field.model.label': 'Model',
+          'library.config.agent.field.name.hint': 'Shown in the selector.',
+          'library.config.agent.field.name.label': 'Name',
+          'library.config.agent.field.name.placeholder': 'Name this agent',
+          'library.config.agent.field.plan_model.hint': 'Plan model.',
+          'library.config.agent.field.plan_model.label': 'Plan model',
+          'library.config.agent.field.small_model.hint': 'Small model.',
+          'library.config.agent.field.small_model.label': 'Small model',
+          'library.config.agent.field.soul_enabled.help': 'Use workspace soul files and autonomous tools.',
+          'library.config.agent.field.soul_enabled.label': 'Autonomous mode',
+          'library.config.agent.field.instructions.label': 'Instructions',
+          'library.config.agent.field.instructions.placeholder': 'Tell this agent how to work',
+          'library.config.agent.field.env_vars.help': 'One KEY=VALUE per line',
+          'library.config.agent.field.env_vars.label': 'Environment variables',
+          'library.config.agent.field.env_vars.placeholder': 'KEY=value\nANOTHER_KEY=another_value',
+          'library.config.agent.field.permission_mode.label': 'Permission mode',
+          'library.config.agent.field.permission_mode.option.acceptEdits': 'Auto-edit Mode',
+          'library.config.agent.field.permission_mode.option.bypassPermissions': 'Full Auto Mode',
+          'library.config.agent.field.permission_mode.option.default': 'Normal Mode',
+          'library.config.agent.field.permission_mode.option.plan': 'Plan Mode',
+          'library.config.agent.section.permission.desc': 'Permission options.',
+          'library.config.agent.section.permission.title': 'Permission',
+          'library.config.agent.section.tools.add': 'Add',
+          'library.config.agent.section.tools.no_builtin_enabled': 'No built-in tools enabled',
+          'library.config.agent.section.tools.no_mcp_bound': 'No MCP servers bound',
+          'library.config.agent.section.tools.no_skills_enabled': 'No skills enabled',
+          'library.config.agent.section.tools.search_placeholder': 'Search tools',
+          'library.config.agent.section.tools.skills_require_save': 'Save before skills',
+          'library.config.agent.section.tools.tab.mcp': 'MCP',
+          'library.config.agent.section.tools.tab.skills': 'Skills',
+          'library.config.agent.section.tools.tab.tools': 'Built-in tools',
+          'library.config.agent.model_config': 'Model configuration',
+          'library.config.basic.field.description.hint': 'Short assistant summary.',
+          'library.config.basic.field.description.placeholder': 'Describe this assistant',
+          'library.config.basic.custom_params': 'Custom parameters',
+          'library.config.basic.custom_params_add': 'Add parameter',
+          'library.config.basic.custom_params_name': 'Parameter name',
+          'library.config.basic.default_value': 'Model default',
+          'library.config.basic.field.model.hint': 'Default chat model.',
+          'library.config.basic.field.name.hint': 'Shown in the selector.',
+          'library.config.basic.field.name.placeholder': 'Name this assistant',
+          'library.config.basic.field.tags.hint': 'Group related assistants.',
+          'library.config.basic.field.custom_params.hint': 'Extra provider parameters.',
+          'library.config.basic.field.max_tokens.hint': 'Caps response length.',
+          'library.config.basic.field.max_tool_calls.hint': 'Caps tool loops.',
+          'library.config.basic.field.stream_output.hint': 'Stream responses.',
+          'library.config.basic.field.temperature.hint': 'Controls randomness.',
+          'library.config.basic.field.top_p.hint': 'Controls nucleus sampling.',
+          'library.config.basic.creative': 'Creative',
+          'library.config.basic.json_invalid': 'Invalid JSON',
+          'library.config.basic.max_tokens': 'Max tokens',
+          'library.config.basic.max_tool_calls': 'Max tool calls',
+          'library.config.basic.model_clear': 'Clear',
+          'library.config.basic.model_pick': 'Pick model',
+          'library.config.basic.model_not_found': 'Model {{id}} is unavailable.',
+          'library.config.basic.precise': 'Precise',
+          'library.config.basic.stream_output': 'Stream output',
+          'library.config.basic.tag_empty': 'No tags',
+          'library.config.basic.tag_placeholder': 'Select tags',
+          'library.config.basic.tag_search': 'Search tags',
+          'library.config.basic.mcp_mode': 'MCP Mode',
+          'library.config.basic.temperature': 'Temperature',
+          'library.config.basic.top_p': 'Top-P',
+          'library.config.basic.unlimited': 'Unlimited',
+          'library.config.dialogs.edit.advanced_tab': 'Advanced',
+          'library.config.prompt.label': 'Prompt',
+          'library.config.prompt.placeholder': 'Tell this assistant how to respond',
+          'library.config.prompt.dblclick_hint': 'Double-click to edit',
+          'library.config.prompt.generate': 'Generate prompt',
+          'library.config.prompt.tokens_label': 'Tokens: ',
+          'library.config.prompt.variables_title': 'Variables',
+          'library.config.prompt.vars.arch': 'Architecture',
+          'library.config.prompt.vars.date': 'Date',
+          'library.config.prompt.vars.datetime': 'Datetime',
+          'library.config.prompt.vars.language': 'Language',
+          'library.config.prompt.vars.model_name': 'Model name',
+          'library.config.prompt.vars.os': 'OS',
+          'library.config.prompt.vars.time': 'Time',
+          'library.config.prompt.vars.username': 'Username',
+          'library.config.dialogs.create.avatar_aria': 'Pick avatar',
+          'library.config.dialogs.edit.agent_description': 'Edit the essentials for this agent.',
+          'library.config.dialogs.edit.agent_title': 'Edit Agent',
+          'library.config.dialogs.edit.assistant_description': 'Edit the essentials for this assistant.',
+          'library.config.dialogs.edit.assistant_title': 'Edit Assistant',
+          'library.config.dialogs.edit.basic_tab': 'Basic',
+          'library.config.dialogs.edit.knowledge_tab': 'Knowledge',
+          'library.config.dialogs.edit.permission_tab': 'Permission',
+          'library.config.dialogs.edit.prompt_tab': 'Prompt',
+          'library.config.dialogs.edit.save_failed': 'Save failed',
+          'library.config.dialogs.edit.tools_tab': 'Tools',
+          'library.config.knowledge.add': 'Add knowledge base',
+          'library.config.knowledge.doc_count': '{{count}} docs',
+          'library.config.knowledge.empty_desc': 'No knowledge description',
+          'library.config.knowledge.empty_title': 'No knowledge bases linked',
+          'library.config.knowledge.invalid_suffix': ' unavailable',
+          'library.config.knowledge.linked': 'Linked knowledge',
+          'library.config.knowledge.linked_hint': 'Choose knowledge bases.',
+          'library.config.knowledge.no_more': 'No more knowledge bases',
+          'library.config.knowledge.remove_aria': 'Remove knowledge base',
+          'library.config.knowledge.search': 'Search knowledge',
+          'library.config.tools.add_mcp': 'Add MCP server',
+          'library.config.tools.added': 'MCP services',
+          'library.config.tools.added_hint': 'Manual mode only uses these.',
+          'library.config.tools.empty_desc': 'No MCP description',
+          'library.config.tools.empty_title': 'No MCP servers added',
+          'library.config.tools.inactive_badge': 'Inactive',
+          'library.config.tools.info_main': 'MCP info.',
+          'library.config.tools.info_sub': 'MCP sub info.',
+          'library.config.tools.mode.auto.desc': 'Auto desc',
+          'library.config.tools.mode.auto.label': 'Auto',
+          'library.config.tools.mode.disabled.desc': 'Disabled desc',
+          'library.config.tools.mode.disabled.label': 'Disabled',
+          'library.config.tools.mode.manual.desc': 'Manual desc',
+          'library.config.tools.mode.manual.label': 'Manual',
+          'library.config.tools.no_more': 'No more servers',
+          'library.config.tools.search': 'Search servers',
+          'library.no_match': 'No match',
+          'settings.mcp.runtimeStatus.connected': 'Connected',
+          'settings.mcp.runtimeStatus.connecting': 'Connecting',
+          'settings.mcp.runtimeStatus.unavailable': 'Unavailable',
+          'settings.title': 'Settings'
+        })[key] ??
+        fallback ??
+        key
+    })
+  }
+})
+
+import { AgentEditDialog } from '../edit/AgentEditDialog'
+import { AssistantEditDialog } from '../edit/AssistantEditDialog'
+
+const ASSISTANT: Assistant = {
+  id: 'assistant-1',
+  source: 'user',
+  name: 'Alpha Assistant',
+  prompt: 'Original prompt',
+  emoji: '💬',
+  description: 'Original assistant description',
+  settings: {
+    temperature: 1,
+    enableTemperature: false,
+    topP: 1,
+    enableTopP: false,
+    maxTokens: 4096,
+    enableMaxTokens: false,
+    streamOutput: true,
+    reasoning_effort: 'default',
+    mcpMode: 'auto',
+    maxToolCalls: 20,
+    enableMaxToolCalls: true,
+    enableWebSearch: false,
+    customParameters: []
+  },
+  modelId: 'provider::old-model',
+  orderKey: 'a0',
+  mcpServerIds: [],
+  knowledgeBaseIds: [],
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+  tags: [
+    {
+      id: 'tag-work',
+      name: 'work',
+      color: '#8b5cf6',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z'
+    }
+  ],
+  modelName: 'Old Model'
+}
+
+const AGENT: AgentDetail = {
+  id: 'agent-1',
+  type: 'claude-code',
+  name: 'Alpha Agent',
+  description: 'Original agent description',
+  instructions: 'Original instructions',
+  model: 'provider::old-model',
+  planModel: undefined,
+  smallModel: undefined,
+  mcps: [],
+  configuration: {
+    avatar: '🤖',
+    soul_enabled: false,
+    heartbeat_enabled: true,
+    heartbeat_interval: 30
+  },
+  orderKey: 'a0',
+  modelName: 'Old Model',
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z'
+}
+
+beforeAll(() => {
+  if (!HTMLElement.prototype.hasPointerCapture) {
+    HTMLElement.prototype.hasPointerCapture = () => false
+  }
+  if (!HTMLElement.prototype.releasePointerCapture) {
+    HTMLElement.prototype.releasePointerCapture = () => {}
+  }
+  if (!HTMLElement.prototype.setPointerCapture) {
+    HTMLElement.prototype.setPointerCapture = () => {}
+  }
+  HTMLElement.prototype.scrollIntoView = () => {}
+})
+
+beforeEach(() => {
+  mcpStatusState.current = {
+    'mcp-1': { state: 'connected', lastCheckedAt: 1 }
+  }
+  useQueryMock.mockImplementation((path: string) => {
+    if (path.startsWith('/models/')) {
+      const id = path.slice('/models/'.length)
+      return {
+        data: {
+          ...MODEL,
+          id,
+          name: id === MODEL.id ? MODEL.name : 'Old Model'
+        },
+        isLoading: false
+      }
+    }
+    if (path === '/providers/:providerId') {
+      return {
+        data: { id: 'provider', name: 'Provider' },
+        isLoading: false
+      }
+    }
+    if (path === '/knowledge-bases') {
+      return {
+        data: {
+          items: [
+            {
+              id: 'kb-1',
+              name: 'Knowledge One',
+              itemCount: 3
+            }
+          ]
+        },
+        isLoading: false
+      }
+    }
+    if (path === '/mcp-servers') {
+      return {
+        data: {
+          items: [
+            {
+              id: 'mcp-1',
+              name: 'MCP One',
+              description: 'MCP description',
+              isActive: true
+            }
+          ]
+        },
+        isLoading: false
+      }
+    }
+    return { data: { items: [] }, isLoading: false }
+  })
+  useMutationMock.mockImplementation((method: string, path: string) => {
+    if (method === 'PATCH' && path.startsWith('/assistants/')) {
+      return { trigger: updateAssistantMock, isLoading: false, error: undefined }
+    }
+    if (method === 'PATCH' && path.startsWith('/agents/')) {
+      return { trigger: updateAgentMock, isLoading: false, error: undefined }
+    }
+    return { trigger: vi.fn(), isLoading: false, error: undefined }
+  })
+  updateAssistantMock.mockResolvedValue({ ...ASSISTANT, name: 'Updated Assistant' })
+  updateAgentMock.mockResolvedValue({ ...AGENT, instructions: 'Updated instructions' })
+  ensureTagsMock.mockResolvedValue([{ id: 'tag-work', name: 'work', color: '#8b5cf6' }])
+  fetchGenerateMock.mockResolvedValue('Generated prompt')
+  openSettingsWindowMock.mockResolvedValue('settings-window')
+  toggleSkillMock.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+function selectTab(name: string) {
+  const tab = screen.getByRole('tab', { name })
+  fireEvent.pointerDown(tab, { button: 0, ctrlKey: false })
+  fireEvent.mouseDown(tab, { button: 0, ctrlKey: false })
+  fireEvent.click(tab)
+  fireEvent.keyDown(tab, { key: 'Enter', code: 'Enter' })
+}
+
+function expectHelpTrigger(label: string, description: string) {
+  expect(screen.getByRole('button', { name: `${label} Help` })).toBeInTheDocument()
+  expect(screen.queryByText(description)).not.toBeInTheDocument()
+}
+
+async function expectVariablesHelpOnHover() {
+  const trigger = screen.getByRole('button', { name: 'Variables' })
+  expect(trigger).toHaveClass('size-4')
+  fireEvent.pointerMove(trigger, { pointerType: 'mouse' })
+  await waitFor(() => expect(screen.getAllByText('{{date}}').length).toBeGreaterThan(0))
+}
+
+describe('edit dialogs', () => {
+  it('submits assistant name, description, and model changes as a PATCH', async () => {
+    const onSaved = vi.fn()
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={onSaved} />)
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Updated Assistant' } })
+    fireEvent.change(screen.getByLabelText('Description'), { target: { value: 'Updated assistant description' } })
+    const modelTrigger = screen.getByRole('button', { name: 'Model' })
+    expect(modelTrigger).toHaveClass('h-8', 'rounded-md', 'bg-muted/45')
+    expect(screen.getByText(/Old Model/)).toBeInTheDocument()
+    fireEvent.click(modelTrigger)
+    fireEvent.click(screen.getByRole('button', { name: 'Pick model' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(updateAssistantMock).toHaveBeenCalledWith({
+        body: expect.objectContaining({
+          name: 'Updated Assistant',
+          description: 'Updated assistant description',
+          modelId: MODEL.id
+        })
+      })
+    )
+    await waitFor(() => expect(onSaved).toHaveBeenCalled())
+  })
+
+  it('submits assistant tag changes through ensureTags', async () => {
+    ensureTagsMock.mockResolvedValueOnce([
+      { id: 'tag-work', name: 'work', color: '#8b5cf6' },
+      { id: 'tag-personal', name: 'personal', color: '#10b981' }
+    ])
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'work' }))
+    fireEvent.click(await screen.findByText('personal'))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(ensureTagsMock).toHaveBeenCalledWith(['work', 'personal']))
+    expect(updateAssistantMock).toHaveBeenCalledWith({
+      body: expect.objectContaining({
+        tagIds: ['tag-work', 'tag-personal']
+      })
+    })
+  })
+
+  it('creates and binds a new tag typed in assistant editing', async () => {
+    ensureTagsMock.mockResolvedValueOnce([
+      { id: 'tag-work', name: 'work', color: '#8b5cf6' },
+      { id: 'tag-new', name: 'new-tag', color: '#10b981' }
+    ])
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'work' }))
+    fireEvent.change(screen.getByPlaceholderText('Search tags'), { target: { value: 'new-tag' } })
+    fireEvent.click(await screen.findByText('new-tag'))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(ensureTagsMock).toHaveBeenCalledWith(['work', 'new-tag']))
+    expect(updateAssistantMock).toHaveBeenCalledWith({
+      body: expect.objectContaining({
+        tagIds: ['tag-work', 'tag-new']
+      })
+    })
+  })
+
+  it('does not expose typed tag names beyond the server-side max length', async () => {
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+    // Open the combobox popover (CommandInput only mounts once the trigger is active)
+    fireEvent.click(screen.getByRole('button', { name: 'work' }))
+    const atLimit = 'y'.repeat(64) // TagNameSchema.max(64)
+    const tooLong = 'x'.repeat(65) // one over the limit — server would reject
+    const searchInput = screen.getByPlaceholderText('Search tags')
+
+    fireEvent.change(searchInput, { target: { value: tooLong } })
+    expect(screen.queryByText(tooLong)).not.toBeInTheDocument()
+
+    fireEvent.change(searchInput, { target: { value: atLimit } })
+    expect(await screen.findByText(atLimit)).toBeInTheDocument()
+  })
+
+  it('submits agent instructions and model changes as a PATCH', async () => {
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+
+    selectTab('Prompt')
+    await expectVariablesHelpOnHover()
+    const instructionsInput = screen.getByLabelText('Instructions')
+    expect(instructionsInput).toHaveStyle({
+      minHeight: EDIT_DIALOG_PROMPT_MIN_HEIGHT,
+      maxHeight: EDIT_DIALOG_PROMPT_MAX_HEIGHT
+    })
+    fireEvent.change(instructionsInput, { target: { value: 'Updated instructions' } })
+    selectTab('Basic')
+    fireEvent.click(screen.getByRole('button', { name: 'Model' }))
+    fireEvent.click(screen.getAllByRole('button', { name: 'Pick model' })[0])
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(updateAgentMock).toHaveBeenCalledWith({
+        body: expect.objectContaining({
+          model: MODEL.id,
+          instructions: 'Updated instructions'
+        })
+      })
+    )
+  })
+
+  it('submits assistant knowledge, MCP, and model parameter changes', async () => {
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+
+    expect(screen.queryByRole('tab', { name: 'Tools' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Tools' })).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByRole('tab', { name: 'MCP' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Knowledge' })).toBeInTheDocument()
+
+    selectTab('Knowledge')
+    await waitFor(() => expect(screen.getByText('Linked knowledge')).toBeVisible())
+    expectHelpTrigger('Linked knowledge', 'Choose knowledge bases.')
+    const addKnowledgeButton = screen.getByRole('button', { name: 'Add knowledge base' })
+    expect(addKnowledgeButton).toHaveClass('w-fit')
+    fireEvent.click(addKnowledgeButton)
+    expect(screen.getByText('Knowledge One')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('Knowledge One'))
+    expect(screen.getByText('Knowledge One').closest('.group')).toHaveClass('rounded-md')
+    expect(screen.getByRole('button', { name: 'Remove knowledge base' })).toHaveClass('rounded-md')
+
+    selectTab('MCP')
+    await waitFor(() => expect(screen.getByRole('switch', { name: 'Enable MCP' })).toBeVisible())
+    expect(screen.queryByRole('button', { name: 'Add MCP server' })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('combobox', { name: 'MCP Mode' }))
+    fireEvent.click(await screen.findByRole('option', { name: 'Manual' }))
+    fireEvent.click(screen.getByRole('switch', { name: 'MCP One' }))
+
+    selectTab('Model configuration')
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Temperature Help' })).toBeVisible())
+    expectHelpTrigger('Temperature', 'Controls randomness.')
+    expectHelpTrigger('Top-P', 'Controls nucleus sampling.')
+    expectHelpTrigger('Max tokens', 'Caps response length.')
+    expectHelpTrigger('Stream output', 'Stream responses.')
+    expectHelpTrigger('Max tool calls', 'Caps tool loops.')
+    expectHelpTrigger('Custom parameters', 'Extra provider parameters.')
+    fireEvent.click(screen.getByRole('switch', { name: 'Temperature' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(updateAssistantMock).toHaveBeenCalledWith({
+        body: expect.objectContaining({
+          knowledgeBaseIds: ['kb-1'],
+          mcpServerIds: ['mcp-1'],
+          settings: expect.objectContaining({
+            enableTemperature: true,
+            mcpMode: 'manual'
+          })
+        })
+      })
+    )
+  })
+
+  it('generates and restores assistant prompts inside the dialog', async () => {
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+
+    selectTab('Prompt')
+    await expectVariablesHelpOnHover()
+    fireEvent.click(screen.getByRole('button', { name: 'Generate prompt' }))
+
+    await waitFor(() => expect(screen.getByLabelText('Prompt editor')).toHaveValue('Generated prompt'))
+    fireEvent.click(screen.getByRole('button', { name: 'Undo' }))
+
+    expect(screen.getByLabelText('Prompt editor')).toHaveValue('Original prompt')
+  })
+
+  it('shows a toast when assistant prompt generation fails', async () => {
+    fetchGenerateMock.mockRejectedValueOnce(new Error('Model failed'))
+
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+
+    selectTab('Prompt')
+    fireEvent.click(screen.getByRole('button', { name: 'Generate prompt' }))
+
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith('Generate prompt: Model failed'))
+    expect(screen.getByLabelText('Prompt editor')).toHaveValue('Original prompt')
+    expect(fetchGenerateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'Original prompt',
+        throwOnError: true
+      })
+    )
+  })
+
+  it('shows a toast when assistant prompt generation returns no response', async () => {
+    fetchGenerateMock.mockResolvedValueOnce('')
+
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+
+    selectTab('Prompt')
+    fireEvent.click(screen.getByRole('button', { name: 'Generate prompt' }))
+
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith('No response'))
+    expect(screen.getByLabelText('Prompt editor')).toHaveValue('Original prompt')
+  })
+
+  it('submits agent permission defaults and advanced changes', async () => {
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+
+    expect(screen.queryByRole('tab', { name: 'Permission' })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('combobox', { name: 'Permission mode' }))
+    fireEvent.click(await screen.findByRole('option', { name: 'Plan Mode' }))
+
+    selectTab('Advanced')
+    expect(screen.queryByText('Max turns')).not.toBeInTheDocument()
+    expectHelpTrigger('Environment variables', 'One KEY=VALUE per line')
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'FOO=bar' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(updateAgentMock).toHaveBeenCalled())
+    const body = vi.mocked(updateAgentMock).mock.calls[0][0].body
+    expect(body).not.toHaveProperty('allowedTools')
+    expect(body).toEqual(
+      expect.objectContaining({
+        configuration: expect.not.objectContaining({ max_turns: expect.anything() })
+      })
+    )
+    expect(body.configuration).toEqual(
+      expect.objectContaining({
+        env_vars: { FOO: 'bar' },
+        permission_mode: 'plan'
+      })
+    )
+  })
+
+  it('hides permission mode while autonomous mode is enabled', async () => {
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+
+    expect(screen.getByRole('combobox', { name: 'Permission mode' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Autonomous mode' }))
+
+    expect(screen.queryByRole('combobox', { name: 'Permission mode' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(updateAgentMock).toHaveBeenCalledWith({
+        body: expect.objectContaining({
+          configuration: expect.objectContaining({
+            permission_mode: 'bypassPermissions',
+            soul_enabled: true
+          })
+        })
+      })
+    )
+  })
+
+  it('uses the left tools submenu to switch agent tool categories', async () => {
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+
+    expect(screen.queryByRole('tab', { name: 'Tools' })).not.toBeInTheDocument()
+
+    expect(screen.getByRole('button', { name: 'Tools' })).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByRole('tab', { name: 'Built-in tools' })).toHaveAttribute('aria-selected', 'false')
+    expect(screen.queryByText('No built-in tools enabled')).not.toBeInTheDocument()
+
+    selectTab('Built-in tools')
+    expect(screen.getByRole('tab', { name: 'Built-in tools' })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByText('Read')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tools' }))
+    expect(screen.getByRole('button', { name: 'Tools' })).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByRole('tab', { name: 'Built-in tools' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tools' }))
+    selectTab('MCP')
+    expect(screen.getByText('MCP One')).toBeInTheDocument()
+
+    selectTab('Skills')
+    expect(screen.getByText('Skill One')).toBeInTheDocument()
+  })
+
+  it('uses the same MCP server list presentation in assistant and agent editing', async () => {
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+
+    selectTab('MCP')
+    fireEvent.click(screen.getByRole('combobox', { name: 'MCP Mode' }))
+    fireEvent.click(await screen.findByRole('option', { name: 'Manual' }))
+
+    expect(screen.getByText('MCP services')).toBeInTheDocument()
+    expect(screen.getByText('MCP One')).toBeInTheDocument()
+    expect(screen.getByText('Connected')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'MCP services Settings' }))
+    expect(openSettingsWindowMock).toHaveBeenCalledWith('/settings/mcp/servers')
+
+    cleanup()
+    openSettingsWindowMock.mockClear()
+
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+
+    selectTab('MCP')
+
+    expect(screen.getByText('MCP services')).toBeInTheDocument()
+    expect(screen.getByText('MCP One')).toBeInTheDocument()
+    expect(screen.getByText('Connected')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'MCP services Settings' }))
+    expect(openSettingsWindowMock).toHaveBeenCalledWith('/settings/mcp/servers')
+  })
+
+  it('keeps popover content inside the dialog container', async () => {
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+
+    const dialog = screen.getByRole('dialog')
+    fireEvent.click(screen.getByLabelText('Pick avatar'))
+
+    expect(dialog).toContainElement(screen.getByRole('button', { name: 'Choose emoji' }))
+  })
+
+  it('keeps edited values while switching tabs before save', async () => {
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Draft Agent' } })
+    selectTab('Prompt')
+    selectTab('Basic')
+
+    expect(screen.getByLabelText('Name')).toHaveValue('Draft Agent')
+  })
+
+  it('keeps the dialog open and shows an error when save fails', async () => {
+    updateAssistantMock.mockRejectedValueOnce(new Error('Network down'))
+    const onOpenChange = vi.fn()
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Broken Assistant' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByText('Save failed')).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+  })
+
+  it('does not show a save error when the post-save callback fails', async () => {
+    const onOpenChange = vi.fn()
+    const onSaved = vi.fn().mockRejectedValue(new Error('Refresh failed'))
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} onSaved={onSaved} />)
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Saved Assistant' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(updateAssistantMock).toHaveBeenCalled())
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
+    await waitFor(() => expect(onSaved).toHaveBeenCalled())
+    expect(screen.queryByText('Save failed')).not.toBeInTheDocument()
+  })
+
+  it('closes after a successful save', async () => {
+    const onOpenChange = vi.fn()
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Updated Assistant' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
+  })
+})

--- a/src/renderer/pages/library/dialogs/edit/AgentEditDialog.tsx
+++ b/src/renderer/pages/library/dialogs/edit/AgentEditDialog.tsx
@@ -1,0 +1,738 @@
+import {
+  EditableNumber,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Switch,
+  TabsContent,
+  Textarea
+} from '@cherrystudio/ui'
+import { loggerService } from '@logger'
+import { useInstalledSkills } from '@renderer/hooks/useSkills'
+import { useAgentMutationsById } from '@renderer/pages/library/adapters/agentAdapter'
+import type { AgentDetail } from '@renderer/pages/library/types'
+import {
+  CLAUDE_TOOL_CATEGORIES,
+  type ClaudeToolCategory,
+  claudeUserFacingTools
+} from '@shared/ai/claudecode/toolRegistry'
+import type { Model, UniqueModelId } from '@shared/data/types/model'
+import { Sparkles, Wrench } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { useForm, type UseFormReturn } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+
+import { type CatalogItem, CatalogToggleGrid } from '../components/CatalogPicker'
+import { McpServerCatalogGrid } from '../components/McpServerCatalogGrid'
+import {
+  type AgentFormState,
+  applyAgentFormPatch,
+  buildInitialAgentFormState,
+  diffAgentSaveIntent
+} from '../form/agent'
+import {
+  AvatarField,
+  CompactModelField,
+  EDIT_DIALOG_PROMPT_MAX_HEIGHT,
+  EDIT_DIALOG_PROMPT_MIN_HEIGHT,
+  type EditDialogBaseProps,
+  EditDialogShell,
+  type EditDialogTab,
+  FieldLabelWithHelp,
+  type ModelLabels,
+  PromptVariablesPopover,
+  TextInputField
+} from './EditDialogShared'
+
+export type AgentEditDialogProps = EditDialogBaseProps<AgentDetail> & {
+  resource: AgentDetail | null
+}
+
+type AgentEditFormValues = {
+  avatar: string
+  name: string
+  description: string
+  modelId: UniqueModelId | null
+  planModelId: UniqueModelId | ''
+  smallModelId: UniqueModelId | ''
+  instructions: string
+  mcps: string[]
+  disabledTools: string[]
+  permissionMode: string
+  envVarsText: string
+  soulEnabled: boolean
+  heartbeatEnabled: boolean
+  heartbeatInterval: number
+}
+
+type ToolTab = 'tools.builtin' | 'tools.mcp' | 'tools.skills'
+
+const logger = loggerService.withContext('AgentEditDialog')
+const PERMISSION_MODES = ['default', 'plan', 'acceptEdits', 'bypassPermissions'] as const
+const PERMISSION_MODE_LABEL_KEYS: Record<(typeof PERMISSION_MODES)[number], string> = {
+  acceptEdits: 'library.config.agent.field.permission_mode.option.acceptEdits',
+  bypassPermissions: 'library.config.agent.field.permission_mode.option.bypassPermissions',
+  default: 'library.config.agent.field.permission_mode.option.default',
+  plan: 'library.config.agent.field.permission_mode.option.plan'
+}
+const DEFAULT_TOOL_TAB: ToolTab = 'tools.builtin'
+
+const CATEGORY_LABEL_KEYS: Record<ClaudeToolCategory, string> = {
+  file: 'library.config.agent.section.tools.category.file',
+  shell: 'library.config.agent.section.tools.category.shell',
+  search: 'library.config.agent.section.tools.category.search',
+  context: 'library.config.agent.section.tools.category.context',
+  orchestration: 'library.config.agent.section.tools.category.orchestration',
+  media: 'library.config.agent.section.tools.category.media'
+}
+const CATEGORY_LABEL_FALLBACKS: Record<ClaudeToolCategory, string> = {
+  file: 'File',
+  shell: 'Shell',
+  search: 'Search',
+  context: 'Context',
+  orchestration: 'Orchestration',
+  media: 'Media'
+}
+
+function isToolTab(value: string): value is ToolTab {
+  return value === 'tools.builtin' || value === 'tools.mcp' || value === 'tools.skills'
+}
+
+function getLeafTabIds(tabs: EditDialogTab[]) {
+  return tabs.flatMap((tab) => (tab.children?.length ? tab.children.map((child) => child.id) : [tab.id]))
+}
+
+function defaultValuesForAgent(resource: AgentDetail): AgentEditFormValues {
+  const form = buildInitialAgentFormState(resource)
+  return {
+    avatar: form.avatar || '🤖',
+    name: form.name,
+    description: form.description,
+    modelId: form.model || null,
+    planModelId: form.planModel,
+    smallModelId: form.smallModel,
+    instructions: form.instructions,
+    mcps: [...form.mcps],
+    disabledTools: [...form.disabledTools],
+    permissionMode: form.permissionMode,
+    envVarsText: form.envVarsText,
+    soulEnabled: form.soulEnabled,
+    heartbeatEnabled: form.heartbeatEnabled,
+    heartbeatInterval: form.heartbeatInterval
+  }
+}
+
+function modelLabelsForAgent(resource: AgentDetail): ModelLabels {
+  return {
+    modelId: resource.model ?? null,
+    planModelId: resource.planModel ?? null,
+    smallModelId: resource.smallModel ?? null
+  }
+}
+
+function buildAgentFormState(baseline: AgentFormState, values: AgentEditFormValues): AgentFormState {
+  return {
+    ...baseline,
+    avatar: values.avatar,
+    name: values.name,
+    description: values.description,
+    model: values.modelId ?? '',
+    planModel: values.planModelId || '',
+    smallModel: values.smallModelId || '',
+    instructions: values.instructions,
+    mcps: values.mcps,
+    disabledTools: values.disabledTools,
+    permissionMode: values.permissionMode,
+    envVarsText: values.envVarsText,
+    soulEnabled: values.soulEnabled,
+    heartbeatEnabled: values.heartbeatEnabled,
+    heartbeatInterval: values.heartbeatInterval
+  }
+}
+
+function syncAgentFormState(form: UseFormReturn<AgentEditFormValues>, next: AgentFormState) {
+  form.setValue('modelId', next.model || null, { shouldDirty: true })
+  form.setValue('planModelId', next.planModel, { shouldDirty: true })
+  form.setValue('smallModelId', next.smallModel, { shouldDirty: true })
+  form.setValue('mcps', next.mcps, { shouldDirty: true })
+  form.setValue('disabledTools', next.disabledTools, { shouldDirty: true })
+  form.setValue('permissionMode', next.permissionMode, { shouldDirty: true })
+  form.setValue('soulEnabled', next.soulEnabled, { shouldDirty: true })
+  form.setValue('heartbeatEnabled', next.heartbeatEnabled, { shouldDirty: true })
+  form.setValue('heartbeatInterval', next.heartbeatInterval, { shouldDirty: true })
+}
+
+function createAgentPatcher(form: UseFormReturn<AgentEditFormValues>, resource: AgentDetail) {
+  return (patch: Partial<AgentFormState>) => {
+    const baseline = buildInitialAgentFormState(resource)
+    const current = buildAgentFormState(baseline, form.getValues())
+    syncAgentFormState(form, applyAgentFormPatch(current, patch))
+  }
+}
+
+export function AgentEditDialog({ resource, open, onOpenChange, onSaved, modelFilter }: AgentEditDialogProps) {
+  if (!resource) return null
+
+  return (
+    <AgentEditDialogContent
+      resource={resource}
+      open={open}
+      onOpenChange={onOpenChange}
+      onSaved={onSaved}
+      modelFilter={modelFilter}
+    />
+  )
+}
+
+function AgentEditDialogContent({
+  resource,
+  open,
+  onOpenChange,
+  onSaved,
+  modelFilter
+}: EditDialogBaseProps<AgentDetail> & { resource: AgentDetail }) {
+  const { t } = useTranslation()
+  const [activeTab, setActiveTab] = useState('basic')
+  const [emojiPickerOpen, setEmojiPickerOpen] = useState(false)
+  const [dialogContentElement, setDialogContentElement] = useState<HTMLDivElement | null>(null)
+  const [modelLabels, setModelLabels] = useState<ModelLabels>(() => modelLabelsForAgent(resource))
+  const defaultValues = useMemo(() => defaultValuesForAgent(resource), [resource])
+  const form = useForm<AgentEditFormValues>({ defaultValues })
+  const values = form.watch()
+  const patchAgentForm = useMemo(() => createAgentPatcher(form, resource), [form, resource])
+  const { updateAgent } = useAgentMutationsById(resource.id)
+  const saveIntent = useMemo(() => {
+    const baseline = buildInitialAgentFormState(resource)
+    return diffAgentSaveIntent(buildAgentFormState(baseline, values), baseline, resource)
+  }, [resource, values])
+  const tabs = useMemo<EditDialogTab[]>(
+    () => [
+      { id: 'basic', label: t('library.config.dialogs.edit.basic_tab') },
+      { id: 'prompt', label: t('library.config.dialogs.edit.prompt_tab') },
+      {
+        id: 'tools',
+        label: t('library.config.dialogs.edit.tools_tab'),
+        children: [
+          { id: DEFAULT_TOOL_TAB, label: t('library.config.agent.section.tools.tab.tools') },
+          { id: 'tools.mcp', label: t('library.config.agent.section.tools.tab.mcp') },
+          { id: 'tools.skills', label: t('library.config.agent.section.tools.tab.skills') }
+        ]
+      },
+      { id: 'advanced', label: t('library.config.dialogs.edit.advanced_tab') }
+    ],
+    [t]
+  )
+  const leafTabIds = useMemo(() => new Set(getLeafTabIds(tabs)), [tabs])
+
+  useEffect(() => {
+    if (!open) return
+
+    form.reset(defaultValues)
+    form.clearErrors()
+    setActiveTab('basic')
+    setEmojiPickerOpen(false)
+    setModelLabels(modelLabelsForAgent(resource))
+  }, [defaultValues, form, open, resource])
+
+  useEffect(() => {
+    if (leafTabIds.has(activeTab)) return
+    setActiveTab('basic')
+  }, [activeTab, leafTabIds])
+
+  const isSubmitting = form.formState.isSubmitting
+  const canSave = Boolean(saveIntent) && !isSubmitting
+  const rootError = form.formState.errors.root?.message
+
+  const handleSubmit = form.handleSubmit(async () => {
+    const pending = saveIntent
+    if (!pending) return
+
+    form.clearErrors('root')
+
+    let updated: Awaited<ReturnType<typeof updateAgent>>
+    try {
+      updated = await updateAgent(pending.payload)
+    } catch (error) {
+      logger.error('Failed to save agent edit dialog', error as Error, { agentId: resource.id })
+      form.setError('root', { message: t('library.config.dialogs.edit.save_failed') })
+      return
+    }
+
+    onOpenChange(false)
+    try {
+      await onSaved(updated)
+    } catch (error) {
+      logger.warn('Failed to run agent edit dialog post-save callback', { error, agentId: resource.id })
+    }
+  })
+
+  return (
+    <EditDialogShell
+      activeTab={activeTab}
+      canSave={canSave}
+      form={form}
+      isSubmitting={isSubmitting}
+      onActiveTabChange={setActiveTab}
+      onOpenChange={onOpenChange}
+      onSubmit={handleSubmit}
+      open={open}
+      rootError={rootError}
+      setDialogContentElement={setDialogContentElement}
+      tabs={tabs}
+      title={t('library.config.dialogs.edit.agent_title')}>
+      <TabsContent value="basic" forceMount hidden={activeTab !== 'basic'} className="m-0">
+        <AgentBasicFields
+          form={form}
+          modelFilter={modelFilter}
+          portalContainer={dialogContentElement}
+          modelLabels={modelLabels}
+          setModelLabels={setModelLabels}
+          patchAgentForm={patchAgentForm}
+          emojiPickerOpen={emojiPickerOpen}
+          setEmojiPickerOpen={setEmojiPickerOpen}
+        />
+      </TabsContent>
+      <TabsContent value="prompt" forceMount hidden={activeTab !== 'prompt'} className="m-0">
+        <AgentPromptField form={form} portalContainer={dialogContentElement} />
+      </TabsContent>
+      {isToolTab(activeTab) ? (
+        <TabsContent value={activeTab} forceMount className="m-0">
+          <AgentToolsFields
+            agent={resource}
+            form={form}
+            activeToolTab={activeTab}
+            portalContainer={dialogContentElement}
+          />
+        </TabsContent>
+      ) : null}
+      <TabsContent value="advanced" forceMount hidden={activeTab !== 'advanced'} className="m-0">
+        <AgentAdvancedFields form={form} />
+      </TabsContent>
+    </EditDialogShell>
+  )
+}
+
+function AgentBasicFields({
+  form,
+  modelFilter,
+  portalContainer,
+  modelLabels,
+  setModelLabels,
+  patchAgentForm,
+  emojiPickerOpen,
+  setEmojiPickerOpen
+}: {
+  form: UseFormReturn<AgentEditFormValues>
+  modelFilter?: (model: Model) => boolean
+  portalContainer: HTMLElement | null
+  modelLabels: ModelLabels
+  setModelLabels: (labels: ModelLabels) => void
+  patchAgentForm: (patch: Partial<AgentFormState>) => void
+  emojiPickerOpen: boolean
+  setEmojiPickerOpen: (open: boolean) => void
+}) {
+  const { t } = useTranslation()
+  const heartbeatEnabled = form.watch('heartbeatEnabled')
+  const soulEnabled = form.watch('soulEnabled')
+
+  return (
+    <div className="grid gap-4">
+      <div className="grid grid-cols-[auto_1fr] gap-4">
+        <AvatarField
+          form={form}
+          emojiPickerOpen={emojiPickerOpen}
+          setEmojiPickerOpen={setEmojiPickerOpen}
+          fallback="🤖"
+          portalContainer={portalContainer}
+        />
+        <TextInputField
+          form={form}
+          name="name"
+          label={t('library.config.agent.field.name.label')}
+          placeholder={t('library.config.agent.field.name.placeholder')}
+          required
+        />
+      </div>
+      <div className="grid gap-3 sm:grid-cols-3">
+        <CompactModelField
+          form={form}
+          name="modelId"
+          label={t('library.config.agent.field.model.label')}
+          filter={modelFilter}
+          portalContainer={portalContainer}
+          modelLabels={modelLabels}
+          setModelLabels={setModelLabels}
+          onModelChange={(modelId) => patchAgentForm({ model: modelId ?? '' })}
+        />
+        <CompactModelField
+          form={form}
+          name="planModelId"
+          label={t('library.config.agent.field.plan_model.label')}
+          allowClear
+          filter={modelFilter}
+          portalContainer={portalContainer}
+          modelLabels={modelLabels}
+          setModelLabels={setModelLabels}
+          onModelChange={(modelId) => patchAgentForm({ planModel: modelId ?? '' })}
+        />
+        <CompactModelField
+          form={form}
+          name="smallModelId"
+          label={t('library.config.agent.field.small_model.label')}
+          allowClear
+          filter={modelFilter}
+          portalContainer={portalContainer}
+          modelLabels={modelLabels}
+          setModelLabels={setModelLabels}
+          onModelChange={(modelId) => patchAgentForm({ smallModel: modelId ?? '' })}
+        />
+      </div>
+      <TextInputField
+        form={form}
+        name="description"
+        label={t('library.config.agent.field.description.label')}
+        placeholder={t('library.config.agent.field.description.placeholder')}
+      />
+      <SoulModeField form={form} patchAgentForm={patchAgentForm} />
+      {!soulEnabled && (
+        <PermissionModeField form={form} portalContainer={portalContainer} patchAgentForm={patchAgentForm} />
+      )}
+      <HeartbeatSettingsField
+        form={form}
+        enabled={heartbeatEnabled}
+        onEnabledChange={(checked) => patchAgentForm({ heartbeatEnabled: checked })}
+      />
+    </div>
+  )
+}
+
+function SoulModeField({
+  form,
+  patchAgentForm
+}: {
+  form: UseFormReturn<AgentEditFormValues>
+  patchAgentForm: (patch: Partial<AgentFormState>) => void
+}) {
+  const { t } = useTranslation()
+  const label = t('library.config.agent.field.soul_enabled.label')
+
+  return (
+    <FormField
+      control={form.control}
+      name="soulEnabled"
+      render={({ field }) => (
+        <FormItem>
+          <div className="flex items-center justify-between gap-3">
+            <FieldLabelWithHelp label={label} help={t('library.config.agent.field.soul_enabled.help')} />
+            <Switch
+              size="sm"
+              checked={field.value}
+              aria-label={label}
+              onCheckedChange={(checked) => patchAgentForm({ soulEnabled: checked })}
+            />
+          </div>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}
+
+function PermissionModeField({
+  form,
+  portalContainer,
+  patchAgentForm
+}: {
+  form: UseFormReturn<AgentEditFormValues>
+  portalContainer: HTMLElement | null
+  patchAgentForm: (patch: Partial<AgentFormState>) => void
+}) {
+  const { t } = useTranslation()
+
+  return (
+    <FormField
+      control={form.control}
+      name="permissionMode"
+      render={({ field }) => (
+        <FormItem>
+          <div className="flex items-center justify-between gap-3">
+            <FormLabel>{t('library.config.agent.field.permission_mode.label')}</FormLabel>
+            <Select
+              value={field.value || 'default'}
+              onValueChange={(value) => patchAgentForm({ permissionMode: value })}>
+              <FormControl>
+                <SelectTrigger
+                  className="w-48 shrink-0"
+                  aria-label={t('library.config.agent.field.permission_mode.label')}>
+                  <SelectValue />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent portalContainer={portalContainer}>
+                {PERMISSION_MODES.map((mode) => (
+                  <SelectItem key={mode} value={mode}>
+                    {t(PERMISSION_MODE_LABEL_KEYS[mode])}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}
+
+function HeartbeatSettingsField({
+  form,
+  enabled,
+  onEnabledChange
+}: {
+  form: UseFormReturn<AgentEditFormValues>
+  enabled: boolean
+  onEnabledChange: (checked: boolean) => void
+}) {
+  const { t } = useTranslation()
+  const label = t('library.config.agent.field.heartbeat_enabled.label')
+
+  return (
+    <div className="grid gap-2">
+      <FormField
+        control={form.control}
+        name="heartbeatEnabled"
+        render={({ field }) => (
+          <FormItem>
+            <div className="flex items-center justify-between gap-3">
+              <FormLabel>{label}</FormLabel>
+              <FormControl>
+                <Switch size="sm" checked={field.value} onCheckedChange={onEnabledChange} aria-label={label} />
+              </FormControl>
+            </div>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      {enabled ? (
+        <FormField
+          control={form.control}
+          name="heartbeatInterval"
+          render={({ field }) => (
+            <FormItem>
+              <div className="flex items-center justify-between gap-3">
+                <FormLabel>{t('library.config.agent.field.heartbeat_interval.label')}</FormLabel>
+                <FormControl>
+                  <EditableNumber
+                    min={1}
+                    max={1440}
+                    step={1}
+                    precision={0}
+                    align="start"
+                    changeOnBlur
+                    className="w-28"
+                    value={field.value || null}
+                    onChange={(v) => field.onChange(typeof v === 'number' ? v : 0)}
+                  />
+                </FormControl>
+              </div>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+function AgentPromptField({
+  form,
+  portalContainer
+}: {
+  form: UseFormReturn<AgentEditFormValues>
+  portalContainer: HTMLElement | null
+}) {
+  const { t } = useTranslation()
+
+  return (
+    <FormField
+      control={form.control}
+      name="instructions"
+      render={({ field }) => (
+        <FormItem>
+          <FieldLabelWithHelp
+            label={t('library.config.agent.field.instructions.label')}
+            helpTrigger={<PromptVariablesPopover portalContainer={portalContainer} />}
+          />
+          <FormControl>
+            <Textarea.Input
+              value={field.value}
+              rows={6}
+              placeholder={t('library.config.agent.field.instructions.placeholder')}
+              onValueChange={field.onChange}
+              style={{ minHeight: EDIT_DIALOG_PROMPT_MIN_HEIGHT, maxHeight: EDIT_DIALOG_PROMPT_MAX_HEIGHT }}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}
+
+function AgentToolsFields({
+  agent,
+  form,
+  activeToolTab,
+  portalContainer
+}: {
+  agent: AgentDetail
+  form: UseFormReturn<AgentEditFormValues>
+  activeToolTab: ToolTab
+  portalContainer: HTMLElement | null
+}) {
+  const { t } = useTranslation()
+  const disabledTools = form.watch('disabledTools')
+  const mcps = form.watch('mcps')
+  const canManageSkills = Boolean(agent.id)
+
+  // Built-in catalog: registry user-facing tools grouped into category sections.
+  // The toggle is a real enable/disable that writes the opt-out `disabledTools` set
+  // (empty = all enabled); approval is governed solely by the permission-mode cards.
+  const disabledSet = useMemo(() => new Set(disabledTools), [disabledTools])
+  const builtinSections = useMemo(() => {
+    const tools = claudeUserFacingTools()
+    return CLAUDE_TOOL_CATEGORIES.map((category) => ({
+      category,
+      label: t(CATEGORY_LABEL_KEYS[category], CATEGORY_LABEL_FALLBACKS[category]),
+      items: tools
+        .filter((tool) => tool.category === category)
+        .map<CatalogItem>((tool) => ({
+          id: tool.name,
+          name: t(`agent.tools.builtin.${tool.key}.label`, tool.label),
+          description: t(`agent.tools.builtin.${tool.key}.description`, tool.description),
+          icon: <Wrench size={13} strokeWidth={1.5} className="text-foreground/55" />
+        }))
+    })).filter((section) => section.items.length > 0)
+  }, [t])
+  const enabledToolIds = useMemo<ReadonlySet<string>>(
+    () => new Set(builtinSections.flatMap((s) => s.items.map((i) => i.id)).filter((id) => !disabledSet.has(id))),
+    [builtinSections, disabledSet]
+  )
+  const setToolEnabled = (name: string, enabled: boolean) =>
+    form.setValue('disabledTools', enabled ? disabledTools.filter((n) => n !== name) : [...disabledTools, name], {
+      shouldDirty: true
+    })
+
+  const mcpIds = useMemo(() => new Set(mcps), [mcps])
+  const enableMCP = (id: string) => form.setValue('mcps', [...mcps, id], { shouldDirty: true })
+  const disableMCP = (id: string) =>
+    form.setValue(
+      'mcps',
+      mcps.filter((mcpId) => mcpId !== id),
+      { shouldDirty: true }
+    )
+
+  const { skills, loading: skillsLoading, toggle: toggleSkill } = useInstalledSkills(agent.id || undefined)
+  const skillCatalog = useMemo<CatalogItem[]>(
+    () =>
+      skills.map((skill) => ({
+        id: skill.id,
+        name: skill.name,
+        description: skill.description,
+        icon: <Sparkles size={13} strokeWidth={1.5} className="text-amber-500/60" />
+      })),
+    [skills]
+  )
+  const enabledSkillIds = useMemo(
+    () => new Set(skills.filter((skill) => skill.isEnabled).map((skill) => skill.id)),
+    [skills]
+  )
+  const flipSkill = async (id: string, nextEnabled: boolean) => {
+    try {
+      await toggleSkill(id, nextEnabled)
+    } catch {
+      // useInstalledSkills owns toast/logging for toggle failures.
+    }
+  }
+
+  return (
+    <div className="grid gap-4">
+      {activeToolTab === 'tools.builtin' ? (
+        <div className="grid gap-5">
+          {builtinSections.map((section) => (
+            <div key={section.category} className="grid gap-2">
+              <div className="font-medium text-foreground/55 text-xs">{section.label}</div>
+              <CatalogToggleGrid
+                items={section.items}
+                enabledIds={enabledToolIds}
+                onToggle={setToolEnabled}
+                emptyLabel={t('library.config.agent.section.tools.no_builtin_enabled')}
+                portalContainer={portalContainer}
+              />
+            </div>
+          ))}
+        </div>
+      ) : null}
+      {activeToolTab === 'tools.mcp' ? (
+        <McpServerCatalogGrid
+          title={t('library.config.tools.added')}
+          enabledIds={mcpIds}
+          onToggle={(id, enabled) => (enabled ? enableMCP(id) : disableMCP(id))}
+          emptyLabel={t('library.config.agent.section.tools.no_mcp_bound')}
+          portalContainer={portalContainer}
+        />
+      ) : null}
+      {activeToolTab === 'tools.skills' ? (
+        <CatalogToggleGrid
+          items={skillCatalog}
+          enabledIds={enabledSkillIds}
+          loading={skillsLoading}
+          disabled={!canManageSkills}
+          onToggle={flipSkill}
+          emptyLabel={
+            canManageSkills
+              ? t('library.config.agent.section.tools.no_skills_enabled')
+              : t('library.config.agent.section.tools.skills_require_save')
+          }
+          portalContainer={portalContainer}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+function AgentAdvancedFields({ form }: { form: UseFormReturn<AgentEditFormValues> }) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="grid gap-4">
+      <FormField
+        control={form.control}
+        name="envVarsText"
+        render={({ field }) => (
+          <FormItem>
+            <FieldLabelWithHelp
+              label={t('library.config.agent.field.env_vars.label')}
+              help={t('library.config.agent.field.env_vars.help')}
+            />
+            <FormControl>
+              <Textarea.Input
+                value={field.value}
+                onValueChange={field.onChange}
+                placeholder={t('library.config.agent.field.env_vars.placeholder')}
+                rows={5}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </div>
+  )
+}

--- a/src/renderer/pages/library/editor/agent/__tests__/descriptor.test.ts
+++ b/src/renderer/pages/library/editor/agent/__tests__/descriptor.test.ts
@@ -1,15 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { AgentDetail } from '../../../types'
-import {
-  type AgentFormState,
-  applyAgentFormPatch,
-  buildCreateAgentPayload,
-  buildInitialAgentFormState,
-  diffAgentUpdate,
-  isCreatePayloadValid,
-  validateAgentCreateForm
-} from '../descriptor'
+import { type AgentFormState, applyAgentFormPatch, buildInitialAgentFormState, diffAgentUpdate } from '../descriptor'
 
 function createAgent(overrides: Partial<AgentDetail> = {}): AgentDetail {
   return {
@@ -21,7 +13,6 @@ function createAgent(overrides: Partial<AgentDetail> = {}): AgentDetail {
     modelName: null,
     instructions: '',
     mcps: [],
-    allowedTools: [],
     configuration: {},
     createdAt: '2026-04-20T00:00:00.000Z',
     updatedAt: '2026-04-20T00:00:00.000Z',
@@ -38,8 +29,7 @@ describe('buildInitialAgentFormState', () => {
       planModel: 'p-1',
       smallModel: 's-1',
       instructions: 'hi',
-      mcps: ['mcp-1'],
-      allowedTools: ['Read']
+      mcps: ['mcp-1']
     })
     const state = buildInitialAgentFormState(agent)
     expect(state).toMatchObject({
@@ -49,8 +39,7 @@ describe('buildInitialAgentFormState', () => {
       planModel: 'p-1',
       smallModel: 's-1',
       instructions: 'hi',
-      mcps: ['mcp-1'],
-      allowedTools: ['Read']
+      mcps: ['mcp-1']
     })
   })
 
@@ -98,14 +87,12 @@ describe('buildInitialAgentFormState', () => {
   })
 })
 
-describe('agent create flow helpers', () => {
-  it('requires both name and model before create save is enabled', () => {
+describe('applyAgentFormPatch', () => {
+  it('switching permission mode does not enable soul mode', () => {
     const draft = buildInitialAgentFormState()
 
-    expect(isCreatePayloadValid(draft)).toBe(false)
-    expect(isCreatePayloadValid({ ...draft, name: 'Planner' })).toBe(false)
-    expect(isCreatePayloadValid({ ...draft, model: 'anthropic::claude-sonnet-4-5' })).toBe(false)
-    expect(isCreatePayloadValid({ ...draft, name: 'Planner', model: 'anthropic::claude-sonnet-4-5' })).toBe(true)
+    expect(next.permissionMode).toBe('acceptEdits')
+    expect(next.soulEnabled).toBe(false)
   })
 
   it('preserves UniqueModelIds in the create payload without legacy conversion', () => {
@@ -118,86 +105,21 @@ describe('agent create flow helpers', () => {
       smallModel: 'anthropic::claude-opus-4-5'
     }
 
-    expect(buildCreateAgentPayload(form)).toMatchObject({
-      model: 'anthropic::claude-sonnet-4-5',
-      planModel: 'anthropic::claude-haiku-4-5',
-      smallModel: 'anthropic::claude-opus-4-5'
-    })
+    expect(next.permissionMode).toBe('bypassPermissions')
+    expect(next.soulEnabled).toBe(false)
   })
 
-  it('reports missing required fields individually for page-level validation', () => {
-    const draft = buildInitialAgentFormState()
-
-    expect(validateAgentCreateForm(draft)).toEqual({
-      nameMissing: true,
-      modelMissing: true,
-      isValid: false
-    })
-    expect(validateAgentCreateForm({ ...draft, name: 'Planner' })).toEqual({
-      nameMissing: false,
-      modelMissing: true,
-      isValid: false
-    })
-  })
-
-  it('writes an explicit heartbeat disable in the create payload', () => {
-    const draft = buildInitialAgentFormState()
-    const payload = buildCreateAgentPayload({
-      ...draft,
-      name: 'Planner',
-      model: 'anthropic::claude-sonnet-4-5',
-      heartbeatEnabled: false
-    })
-
-    expect(payload.configuration).toMatchObject({
-      heartbeat_enabled: false
-    })
-  })
-})
-
-describe('applyAgentFormPatch', () => {
-  const tools = [
-    {
-      id: 'Read',
-      name: 'Read',
-      origin: 'builtin' as const,
-      approval: 'auto' as const
-    },
-    {
-      id: 'Glob',
-      name: 'Glob',
-      origin: 'builtin' as const,
-      approval: 'auto' as const
-    },
-    {
-      id: 'Edit',
-      name: 'Edit',
-      origin: 'builtin' as const,
-      approval: 'prompt' as const
-    }
-  ]
-
-  it('does not persist mode defaults when permission mode changes', () => {
-    const draft = buildInitialAgentFormState()
-    const next = applyAgentFormPatch(draft, { permissionMode: 'acceptEdits' }, tools)
-
-    expect(next.permissionMode).toBe('acceptEdits')
-    expect(next.allowedTools).toEqual([])
-  })
-
-  it('enabling soul mode switches to bypass permissions without mutating explicit tool approvals', () => {
+  it('enabling soul mode switches to bypass permissions', () => {
     const draft = buildInitialAgentFormState()
     const next = applyAgentFormPatch(draft, { soulEnabled: true }, tools)
 
     expect(next.soulEnabled).toBe(true)
     expect(next.permissionMode).toBe('bypassPermissions')
-    expect(next.allowedTools).toEqual([])
   })
 
   it('leaving bypass permissions disables soul mode to match the legacy settings popup', () => {
     const draft = buildInitialAgentFormState(
       createAgent({
-        allowedTools: ['Read', 'Glob', 'Edit'],
         configuration: { soul_enabled: true, permission_mode: 'bypassPermissions' }
       })
     )
@@ -225,6 +147,15 @@ describe('diffAgentUpdate', () => {
       name: 'Renamed',
       instructions: 'new prompt'
     })
+  })
+
+  it('includes disabled built-in tools in the PATCH payload', () => {
+    const agent = createAgent()
+    const baseline = buildInitialAgentFormState(agent)
+    const next = { ...baseline, disabledTools: ['Bash'] }
+
+    const result = diffAgentUpdate(baseline, next, agent)
+    expect(result?.dto).toEqual({ disabledTools: ['Bash'] })
   })
 
   it('preserves UniqueModelIds in the PATCH payload without legacy conversion', () => {

--- a/src/renderer/pages/library/editor/agent/descriptor.ts
+++ b/src/renderer/pages/library/editor/agent/descriptor.ts
@@ -74,7 +74,8 @@ export interface AgentFormState {
   smallModel: string
   instructions: string
   mcps: string[]
-  allowedTools: string[]
+  /** Opt-out list of disabled tool names (empty = all enabled). */
+  disabledTools: string[]
 
   // configuration.* derived fields we edit in the library UI.
   avatar: string
@@ -160,7 +161,7 @@ export function buildInitialAgentFormState(agent?: AgentDetail | null): AgentFor
     smallModel: agent?.smallModel ?? '',
     instructions: agent?.instructions ?? '',
     mcps: [...(agent?.mcps ?? [])],
-    allowedTools: [...(agent?.allowedTools ?? [])],
+    disabledTools: [...(agent?.disabledTools ?? [])],
     avatar: asString(cfg.avatar),
     permissionMode: asString(cfg.permission_mode),
     maxTurns: asFormMaxTurns(cfg.max_turns),
@@ -319,8 +320,8 @@ export function diffAgentUpdate(
     dto.mcps = next.mcps
     dirty = true
   }
-  if (!arraysEqual(baseline.allowedTools, next.allowedTools)) {
-    dto.allowedTools = next.allowedTools
+  if (!arraysEqual(baseline.disabledTools, next.disabledTools)) {
+    dto.disabledTools = next.disabledTools
     dirty = true
   }
 

--- a/src/renderer/types/agent.ts
+++ b/src/renderer/types/agent.ts
@@ -201,8 +201,9 @@ export type BaseAgentForm = {
   name: string
   description?: string
   instructions?: string
-  model: string
-  allowedTools: string[]
+  model: UniqueModelId
+  planModel?: UniqueModelId
+  smallModel?: UniqueModelId
   mcps?: string[]
   configuration?: AgentConfiguration
 }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Agent tool settings did not expose registry-provided tool toggles.

After this PR:

Agent tool settings render registry tool toggles using the declarative backend policy.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

This PR stays page-scoped and relies on earlier registry PRs for the actual tool metadata.

The following alternatives were considered:

Hardcoding the toggles in settings was rejected because it would drift from the runtime registry.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Stack PR 15/15 for the chat-page split. Base: `codex/chat-stack-14-trace-page`; head: `codex/chat-stack-15-agent-tool-settings`.

Validated at the top of this stack with `pnpm lint`, `pnpm test`, `pnpm db:migrations:check`, and `git diff --check`. Local Node 22.22.0 emitted the expected engine warning for the repo requirement `>=24.11.1`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Agent tool settings can show registry-backed tool toggles.
```
