### PR TITLE
fix: forward DeepSeek V4+ reasoning_effort for openai-compatible providers

### DIFF
--- a/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
+++ b/src/renderer/src/aiCore/utils/__tests__/reasoning.test.ts
@@ -480,6 +480,67 @@ describe('reasoning utils', () => {
       expect(result).toEqual({ enable_thinking: false })
     })
 
+    // DeepSeek V4+ reasoning effort must reach both the official @ai-sdk/deepseek path
+    // (reads snake_case `reasoning_effort`) and the @ai-sdk/openai-compatible path
+    // (drops snake_case, only honors camelCase `reasoningEffort`). getReasoningEffort cannot
+    // tell the two apart, so it emits both casings. Regression guard for
+    // https://github.com/CherryHQ/cherry-studio/issues/15824
+    it('should emit both snake_case and camelCase reasoning effort for DeepSeek V4+ with high', async () => {
+      const { isReasoningModel, isDeepSeekV4PlusModel } = await import('@renderer/config/models')
+
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+      vi.mocked(isDeepSeekV4PlusModel).mockReturnValue(true)
+
+      const model: Model = {
+        id: 'deepseek-v4-pro',
+        name: 'DeepSeek V4 Pro',
+        provider: 'my-openai-compatible'
+      } as Model
+
+      const assistant: Assistant = {
+        id: 'test',
+        name: 'Test',
+        settings: {
+          reasoning_effort: 'high'
+        }
+      } as Assistant
+
+      const result = getReasoningEffort(assistant, model)
+      expect(result).toEqual({
+        thinking: { type: 'enabled' },
+        reasoning_effort: 'high',
+        reasoningEffort: 'high'
+      })
+    })
+
+    it('should map xhigh to max in both casings for DeepSeek V4+', async () => {
+      const { isReasoningModel, isDeepSeekV4PlusModel } = await import('@renderer/config/models')
+
+      vi.mocked(isReasoningModel).mockReturnValue(true)
+      vi.mocked(isDeepSeekV4PlusModel).mockReturnValue(true)
+
+      const model: Model = {
+        id: 'deepseek-v4-pro',
+        name: 'DeepSeek V4 Pro',
+        provider: SystemProviderIds.deepseek
+      } as Model
+
+      const assistant: Assistant = {
+        id: 'test',
+        name: 'Test',
+        settings: {
+          reasoning_effort: 'xhigh'
+        }
+      } as Assistant
+
+      const result = getReasoningEffort(assistant, model)
+      expect(result).toEqual({
+        thinking: { type: 'enabled' },
+        reasoning_effort: 'max',
+        reasoningEffort: 'max'
+      })
+    })
+
     it('should return medium effort for deep research models', async () => {
       const { isReasoningModel, isOpenAIDeepResearchModel } = await import('@renderer/config/models')
 

--- a/src/renderer/src/aiCore/utils/reasoning.ts
+++ b/src/renderer/src/aiCore/utils/reasoning.ts
@@ -369,12 +369,31 @@ export function getReasoningEffort(assistant: Assistant, model: Model): Reasonin
     return {}
   }
 
-  // DeepSeek V4+ models support reasoning_effort: "high" | "max" alongside thinking control
-  // UI uses "xhigh" which maps to API's "max"; all other effort levels map to "high"
+  // DeepSeek V4+ models support reasoning_effort: "high" | "max" alongside thinking control.
+  // UI uses "xhigh" which maps to API's "max"; all other effort levels map to "high".
+  //
+  // Emit BOTH casings so the value survives whichever AI SDK serializes the request:
+  //   - Official @ai-sdk/deepseek (patched) reads snake_case `reasoning_effort` and ignores camelCase.
+  //   - @ai-sdk/openai-compatible drops snake_case (overwrites it to undefined) and only honors
+  //     camelCase `reasoningEffort`, which it re-serializes back to `reasoning_effort` in the request body.
+  // The two keys never conflict: deepseek strips the camelCase one, openai-compatible's camelCase value
+  // overwrites the snake_case one with the same value. See https://github.com/CherryHQ/cherry-studio/issues/15824
+  //
+  // ARCHITECTURAL DEBT: this dual-emit only exists because this function is reused by a provider it
+  // was never meant to serve. Per the header comment, getReasoningEffort is the *generic*
+  // (openai-compatible) builder, so on its own this branch should return camelCase `reasoningEffort`
+  // ONLY. The snake_case requirement leaks in from the official `deepseek` provider, which uses the
+  // dedicated @ai-sdk/deepseek serializer (snake_case) rather than openai-compatible, yet still routes
+  // through this generic builder (buildProviderOptions' 'deepseek' case falls to buildGenericProviderOptions).
+  // The right fix is a provider-specific getDeepSeekReasoningParams — mirroring the existing
+  // getOpenAIReasoningParams / getAnthropicReasoningParams / getGeminiReasoningParams split — after which
+  // this branch can drop snake_case. Tracked for the v2 provider-dispatch refactor.
   if (isDeepSeekV4PlusModel(model)) {
+    const effort = (reasoningEffort === 'xhigh' ? 'max' : 'high') as OpenAIReasoningEffort
     return {
       thinking: { type: 'enabled' as const },
-      reasoning_effort: reasoningEffort === 'xhigh' ? ('max' as OpenAIReasoningEffort) : 'high'
+      reasoning_effort: effort,
+      reasoningEffort: effort
     }
   }
 


### PR DESCRIPTION
### What this PR does

Before this PR:

For a custom OpenAI-compatible provider hosting a DeepSeek V4+ model (e.g. `deepseek-v4-pro`), selecting reasoning effort `high` or `xhigh` did not send the effort to the backend. `getReasoningEffort` emitted only snake_case `reasoning_effort`, but `@ai-sdk/openai-compatible` overwrites snake_case `reasoning_effort` to `undefined` (it only honors camelCase `reasoningEffort`), so the selected effort was silently dropped from the request body.

After this PR:

The DeepSeek V4+ branch emits **both** snake_case `reasoning_effort` and camelCase `reasoningEffort` (with `xhigh` mapped to `max`). The value now survives whichever AI SDK serializes the request: the official `@ai-sdk/deepseek` path reads snake_case, and the openai-compatible path reads camelCase and re-serializes it back to `reasoning_effort` in the body.

Fixes #15824

### Why we need it and why it was done in this way

`getReasoningEffort` is the **generic (openai-compatible) builder**, but the official `deepseek` provider — which uses the dedicated `@ai-sdk/deepseek` serializer (snake_case only) — currently routes through this same generic builder instead of having its own param builder. That is the root cause: a provider with a special SDK reuses the generic function. A minimal, regression-safe fix is to emit both casings.

The following tradeoffs were made:

- Dual-emit is a deliberate stopgap. The two keys never conflict: `@ai-sdk/deepseek` strips the camelCase key, and `@ai-sdk/openai-compatible` overwrites the snake_case key with the same camelCase value. Net request body is identical (`reasoning_effort: "high" | "max"`) on both paths.

The following alternatives were considered:

- **camelCase-only** — fixes openai-compatible but regresses the official `deepseek` provider (whose snake_case path was wired in #14572), since `@ai-sdk/deepseek` ignores camelCase.
- **Provider-specific `getDeepSeekReasoningParams`** (mirroring the existing `getOpenAIReasoningParams` / `getAnthropicReasoningParams` / `getGeminiReasoningParams` split) — the clean fix, but broader than this minimal bug fix; deferred to the v2 provider-dispatch refactor.

Links to places where the discussion took place: #15824

### Breaking changes

None.

### Special notes for your reviewer

- Added regression tests for the `getReasoningEffort` deepseek_v4 branch (`high` and `xhigh`), which previously had no direct coverage (only the Claude-endpoint `getAnthropicReasoningParams` path was tested).
- The dual-emit and its root cause are documented inline in `reasoning.ts` for the eventual v2 cleanup.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix DeepSeek V4+ reasoning effort (high/max) being dropped when used through custom OpenAI-compatible providers.
```
