### PR TITLE
fix(file-processing): group OCR menu by feature and reorder providers

### DIFF
--- a/src/renderer/pages/settings/FileProcessingSettings/index.tsx
+++ b/src/renderer/pages/settings/FileProcessingSettings/index.tsx
@@ -1,17 +1,19 @@
-import { Badge, MenuItem, MenuList, PageHeader } from '@cherrystudio/ui'
+import { Badge, MenuDivider, MenuItem, MenuList, PageHeader } from '@cherrystudio/ui'
 import Scrollbar from '@renderer/components/Scrollbar'
 import { useTheme } from '@renderer/context/ThemeProvider'
 import type { FC } from 'react'
-import { useEffect, useMemo, useState } from 'react'
+import { Fragment, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
   SettingsContentBody,
   settingsContentScrollClassName,
+  settingsSubmenuDividerClassName,
   settingsSubmenuItemClassName,
   settingsSubmenuItemLabelClassName,
   settingsSubmenuListClassName,
-  settingsSubmenuScrollClassName
+  settingsSubmenuScrollClassName,
+  settingsSubmenuSectionTitleClassName
 } from '..'
 import { ProcessorAvatar } from './components/ProcessorAvatar'
 import { ProcessorPanel } from './components/ProcessorPanel'
@@ -21,6 +23,7 @@ import {
   type FileProcessingMenuEntry,
   flattenFeatureSections,
   getFeatureSections,
+  getFileProcessingFeatureTitleKey,
   getProcessorNameKey
 } from './utils/fileProcessingMeta'
 
@@ -67,29 +70,37 @@ const FileProcessingSettings: FC = () => {
           <PageHeader title={t('settings.tool.file_processing.title')} />
           <Scrollbar className="min-h-0 flex-1">
             <MenuList className={settingsSubmenuListClassName}>
-              {menuEntries.map((entry) => (
-                <MenuItem
-                  key={entry.key}
-                  label={t(getProcessorNameKey(entry.processor.id))}
-                  active={activeEntryKey === entry.key}
-                  onClick={() => setActiveKey(entry.key)}
-                  icon={
-                    <ProcessorAvatar
-                      processorId={entry.processor.id}
-                      size="md"
-                      className="shrink-0 rounded-lg border border-border/30"
+              {featureSections.map((section, index) => (
+                <Fragment key={section.feature}>
+                  {index > 0 ? <MenuDivider className={settingsSubmenuDividerClassName} /> : null}
+                  <div className={settingsSubmenuSectionTitleClassName}>
+                    {t(getFileProcessingFeatureTitleKey(section.feature))}
+                  </div>
+                  {section.entries.map((entry) => (
+                    <MenuItem
+                      key={entry.key}
+                      label={t(getProcessorNameKey(entry.processor.id))}
+                      active={activeEntryKey === entry.key}
+                      onClick={() => setActiveKey(entry.key)}
+                      icon={
+                        <ProcessorAvatar
+                          processorId={entry.processor.id}
+                          size="md"
+                          className="shrink-0 rounded-lg border border-border/30"
+                        />
+                      }
+                      className={settingsSubmenuItemClassName}
+                      labelClassName={settingsSubmenuItemLabelClassName}
+                      suffix={
+                        isDefaultEntry(entry) ? (
+                          <Badge className="rounded-full border border-green-500/30 bg-green-500/10 px-2 py-0.5 font-medium text-green-600 text-xs dark:text-green-400">
+                            {t('common.default')}
+                          </Badge>
+                        ) : undefined
+                      }
                     />
-                  }
-                  className={settingsSubmenuItemClassName}
-                  labelClassName={settingsSubmenuItemLabelClassName}
-                  suffix={
-                    isDefaultEntry(entry) ? (
-                      <Badge className="rounded-full border border-green-500/30 bg-green-500/10 px-2 py-0.5 font-medium text-green-600 text-xs dark:text-green-400">
-                        {t('common.default')}
-                      </Badge>
-                    ) : undefined
-                  }
-                />
+                  ))}
+                </Fragment>
               ))}
             </MenuList>
           </Scrollbar>

--- a/src/renderer/pages/settings/FileProcessingSettings/utils/fileProcessingMeta.ts
+++ b/src/renderer/pages/settings/FileProcessingSettings/utils/fileProcessingMeta.ts
@@ -23,11 +23,11 @@ const FILE_PROCESSING_FEATURE_SECTIONS: readonly {
 }[] = [
   {
     feature: 'image_to_text',
-    processors: ['system', 'tesseract', 'paddleocr', 'mistral', 'ovocr']
+    processors: ['system', 'paddleocr', 'tesseract', 'mistral', 'ovocr']
   },
   {
     feature: 'document_to_markdown',
-    processors: ['mistral', 'mineru', 'doc2x', 'open-mineru', 'paddleocr']
+    processors: ['mineru', 'paddleocr', 'doc2x', 'mistral', 'open-mineru']
   }
 ] as const
 


### PR DESCRIPTION
### What this PR does

Before this PR:

- The Document Parsing (OCR) settings menu flattened both feature sections (`image_to_text` and `document_to_markdown`) into a single, undivided list. Providers that support both features — `mistral` and `paddleocr` — therefore appeared twice with no grouping context, looking like accidental duplicates (and both `paddleocr` rows even carried the "default" badge).

<img width="508" height="904" alt="CleanShot 2026-06-09 at 16 07 08@2x" src="https://github.com/user-attachments/assets/e9217bb8-d7d9-456c-8b17-b6524dbd4e53" />



After this PR:

- The menu is rendered grouped by feature, with section titles ("OCR" / "文档处理") and a divider between groups, mirroring the existing Web Search settings layout. The cross-feature providers now clearly belong to their respective groups instead of looking duplicated.
- Reuses the already-present-but-unused `getFileProcessingFeatureTitleKey` helper and its existing i18n titles — no new strings added.
- Reorders providers within each group: OCR → `system`, `paddleocr`, `tesseract`, `mistral` (`ovocr` last, shown only when available); Document → `mineru`, `paddleocr`, `doc2x`, `mistral`, `open-mineru`.

<img width="171" height="418" alt="image" src="https://github.com/user-attachments/assets/cef36afe-90e8-4603-8ed1-b17f7aae6688" />


Fixes # N/A

### Why we need it and why it was done in this way

The duplication was a rendering issue, not duplicate data: a provider legitimately supports two features and so has one entry per feature. Restoring the feature grouping (which the data layer already produced via `getFeatureSections`) makes the two entries self-explanatory.

The following tradeoffs were made:

- Kept both entries for dual-capability providers rather than deduplicating, since each entry configures a distinct feature (verified by existing per-feature tests).

The following alternatives were considered:

- Collapsing dual-capability providers into a single row — rejected because OCR and document settings are configured independently per feature.

Links to places where the discussion took place: N/A

### Breaking changes

None

### Special notes for your reviewer

Changes are confined to the renderer settings page:
- `src/renderer/pages/settings/FileProcessingSettings/index.tsx` — group-by-feature rendering with section titles + divider.
- `src/renderer/pages/settings/FileProcessingSettings/utils/fileProcessingMeta.ts` — in-section provider ordering.

Verification: 19 tests in the FileProcessingSettings suite pass; `pnpm lint` (typecheck / i18n / format) is green.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix the Document Parsing (OCR) settings menu showing providers as duplicates: the list is now grouped by feature (OCR / document processing), so providers that support both features are clearly separated instead of appearing twice.
```
