### PR TITLE
fix(tools): prevent AccordionTrigger toggle when clicking approval buttons in collapsed group header

### DIFF
--- a/src/renderer/src/pages/home/Messages/Tools/ToolApprovalActions.tsx
+++ b/src/renderer/src/pages/home/Messages/Tools/ToolApprovalActions.tsx
@@ -33,9 +33,12 @@ export const ToolApprovalActionsComponent: FC<ToolApprovalActionsProps> = ({
 }) => {
   const { t } = useTranslation()
 
-  // Stop event propagation to prevent collapse toggle
+  // Stop event propagation and prevent default to avoid triggering
+  // the parent AccordionTrigger's composeEventHandlers toggle when
+  // these buttons are rendered inside a collapsed group header.
   const handleClick = (e: MouseEvent, handler: () => void) => {
     e.stopPropagation()
+    e.preventDefault()
     handler()
   }
 
@@ -46,7 +49,10 @@ export const ToolApprovalActionsComponent: FC<ToolApprovalActionsProps> = ({
   if (isExecuting) {
     if (showAbort && onAbort) {
       return (
-        <ActionsContainer $compact={compact} onClick={(e) => e.stopPropagation()}>
+        <ActionsContainer
+          $compact={compact}
+          onClick={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}>
           <Button size="small" color="danger" variant="solid" onClick={(e) => handleClick(e, onAbort)}>
             {t('chat.input.pause')}
           </Button>
@@ -54,7 +60,10 @@ export const ToolApprovalActionsComponent: FC<ToolApprovalActionsProps> = ({
       )
     }
     return (
-      <ActionsContainer $compact={compact} onClick={(e) => e.stopPropagation()}>
+      <ActionsContainer
+        $compact={compact}
+        onClick={(e) => e.stopPropagation()}
+        onPointerDown={(e) => e.stopPropagation()}>
         <LoadingIndicator>
           <LoadingIcon />
           {!compact && <span>{t('message.tools.invoking')}</span>}
@@ -65,7 +74,10 @@ export const ToolApprovalActionsComponent: FC<ToolApprovalActionsProps> = ({
 
   // Waiting state - show confirm/cancel buttons
   return (
-    <ActionsContainer $compact={compact} onClick={(e) => e.stopPropagation()}>
+    <ActionsContainer
+      $compact={compact}
+      onClick={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}>
       <Button
         size="small"
         variant={compact ? 'text' : 'outlined'}


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: When multiple tool permission requests are collapsed into a single group in the Agent UI, clicking the "Allow" button in the collapsed group header does not approve the permission. The user must expand the group and click the inner approval button instead. This happens because the approval buttons are rendered inside a Radix `AccordionTrigger` (a `<button>` element), creating invalid nested `<button>` HTML. The `e.stopPropagation()` on the inner button's `onClick` was insufficient to prevent the AccordionTrigger's `composeEventHandlers` from firing its `onOpenToggle` handler, causing the accordion to toggle instead of (or alongside) the approval being sent.

After this PR: Clicking the "Allow" button in a collapsed tool group header correctly approves the tool permission without toggling the accordion.

Fixes #15566

### Why we need it and why it was done in this way

The root cause is that Radix UI's `AccordionTrigger` renders as a `<Primitive.button>`, and the approval buttons (`<Button>` from Ant Design) are nested inside it. Nested `<button>` elements are invalid HTML with unreliable event propagation behavior across browsers.

The `composeEventHandlers` from `@radix-ui/primitive` checks `event.defaultPrevented` before calling the toggle handler, but `stopPropagation` alone doesn't set this flag. Additionally, Radix uses pointer events internally for accordion toggle behavior, so `onClick` stopPropagation is insufficient.

The fix adds three layers of defense:
1. `onPointerDown` stopPropagation on `ActionsContainer` — stops pointer events from reaching the AccordionTrigger at the earliest stage
2. `onClick` stopPropagation on `ActionsContainer` — existing behavior, stops click bubbling
3. `e.preventDefault()` in `handleClick` — sets `defaultPrevented` flag, which `composeEventHandlers` checks before calling `onOpenToggle`

The following tradeoffs were made:
- Adding `preventDefault` is belt-and-suspenders but harmless since these buttons have no native form role
- An alternative would be to restructure the component to render approval buttons outside the `AccordionTrigger` entirely, but that would require significant layout refactoring

The following alternatives were considered:
- Moving approval buttons outside the AccordionTrigger (rejected as too invasive for this fix)
- Removing `stopPropagation` and relying solely on `preventDefault` (rejected — `stopPropagation` is still needed to prevent other parent handlers)

### Breaking changes

None

### Special notes for your reviewer

The `ToolApprovalActionsComponent` is used in three places: `WaitingToolHeader` (group header), `MessageMcpTool` (expanded tool card), and `ToolPermissionRequestCard` (permission card). Only the group header case has the nested-button issue. The other two cases are unaffected by these additions since they're not inside a trigger button.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/97-80596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix: "Allow" button in collapsed tool permission groups now correctly approves the tool request instead of toggling the accordion.