### PR TITLE
feat(data-api): support delete request bodies

### DIFF
--- a/src/renderer/data/DataApiService.ts
+++ b/src/renderer/data/DataApiService.ts
@@ -276,11 +276,13 @@ export class DataApiService implements ApiClient {
   async delete<TPath extends ConcreteApiPaths>(
     path: TPath,
     options?: {
+      body?: BodyForPath<TPath, 'DELETE'>
       query?: QueryParamsForPath<TPath, 'DELETE'>
       headers?: Record<string, string>
     }
   ): Promise<ResponseForPath<TPath, 'DELETE'>> {
     return this.makeRequest<ResponseForPath<TPath, 'DELETE'>>('DELETE', path as string, {
+      body: options?.body,
       params: options?.query,
       headers: options?.headers
     })

--- a/src/renderer/data/hooks/__tests__/useDataApi.test.ts
+++ b/src/renderer/data/hooks/__tests__/useDataApi.test.ts
@@ -26,6 +26,7 @@ import {
   __testing,
   useInfiniteFlatItems,
   useInfiniteQuery,
+  useMutation,
   usePaginatedQuery,
   useReadCache,
   useWriteCache
@@ -624,6 +625,30 @@ describe('useInfiniteFlatItems behavior', () => {
     expect(pages[0].items).toEqual(['a', 'b'])
     expect(pages[1].items).toBe(items1)
     expect(pages[1].items).toEqual(['c', 'd'])
+  })
+})
+
+describe('useMutation integration', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('passes request body through for DELETE mutations', async () => {
+    const deleteSpy = vi.spyOn(dataApiService, 'delete').mockResolvedValue({
+      deletedIds: ['topic-a'],
+      deletedCount: 1
+    } as never)
+    const { Wrapper } = makeWrapper()
+    const { result } = renderHook(() => useMutation('DELETE', '/topics'), { wrapper: Wrapper })
+
+    await act(async () => {
+      await result.current.trigger({ body: { ids: ['topic-a'] } })
+    })
+
+    expect(deleteSpy).toHaveBeenCalledWith('/topics', {
+      body: { ids: ['topic-a'] },
+      query: undefined
+    })
   })
 })
 

--- a/src/renderer/data/hooks/useDataApi.ts
+++ b/src/renderer/data/hooks/useDataApi.ts
@@ -1118,6 +1118,7 @@ function createApiFetcher<TPath extends ConcreteApiPaths, TMethod extends 'GET' 
         }) as Promise<ResponseForPath<TPath, TMethod>>
       case 'DELETE':
         return dataApiService.delete(path, {
+          body: options?.body as BodyForPath<TPath, 'DELETE'>,
           query: query as QueryParamsForPath<TPath, 'DELETE'>
         }) as Promise<ResponseForPath<TPath, TMethod>>
       case 'PATCH':

--- a/src/shared/data/api/apiTypes.ts
+++ b/src/shared/data/api/apiTypes.ts
@@ -479,6 +479,7 @@ export interface ApiClient {
   delete<TPath extends ConcreteApiPaths>(
     path: TPath,
     options?: {
+      body?: BodyForPath<TPath, 'DELETE'>
       query?: QueryParamsForPath<TPath, 'DELETE'>
       headers?: Record<string, string>
     }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Data API DELETE endpoints could not carry request bodies, which blocked REST-style delete operations that need scoped payloads.

After this PR:

Data API DELETE requests can forward validated request bodies while preserving existing handler behavior.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The transport contract stays narrow and only changes DELETE body handling instead of redesigning DataApi routing.

The following alternatives were considered:

Changing endpoints to use POST action routes was considered, but that would weaken the existing RESTful shape.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Full build gate passed when the branch was prepared: pnpm build:check.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Data API DELETE request bodies are now supported for scoped delete operations.
```
