### PR TITLE
feat(ui): add tree view composite

### DIFF
--- a/packages/ui/src/components/composites/TreeView/TreeRow.tsx
+++ b/packages/ui/src/components/composites/TreeView/TreeRow.tsx
@@ -1,0 +1,52 @@
+import { memo, useCallback } from 'react'
+
+import { useTreeActions, useTreeDrag, useTreeSelection } from './contexts'
+import type { RenderRowFn } from './types'
+
+interface TreeRowProps<T> {
+  id: string
+  node: T
+  depth: number
+  hasChildren: boolean
+  renderRow: RenderRowFn<T>
+}
+
+function TreeRowInner<T>(props: TreeRowProps<T>) {
+  const { id, node, depth, hasChildren, renderRow } = props
+  const { toggleExpanded, selectNode, getDragHandleProps } = useTreeActions()
+  const { expandedIds, selectedId } = useTreeSelection()
+  const { draggedId, dragOverId, dragPosition } = useTreeDrag()
+
+  const isExpanded = expandedIds.has(id)
+  const isSelected = selectedId === id
+  const isDragging = draggedId === id
+  const isDragOver = dragOverId === id
+  const effectiveDragPosition = isDragOver ? dragPosition : null
+
+  const toggle = useCallback(() => {
+    if (hasChildren) toggleExpanded(id)
+  }, [hasChildren, id, toggleExpanded])
+
+  const select = useCallback(() => {
+    selectNode(id)
+  }, [id, selectNode])
+
+  return (
+    <>
+      {renderRow({
+        node,
+        depth,
+        isExpanded,
+        isSelected,
+        isDragging,
+        isDragOver,
+        dragPosition: effectiveDragPosition,
+        toggleExpanded: toggle,
+        selectNode: select,
+        dragHandleProps: getDragHandleProps(id)
+      })}
+    </>
+  )
+}
+
+export const TreeRow = memo(TreeRowInner) as <T>(props: TreeRowProps<T>) => React.ReactElement

--- a/packages/ui/src/components/composites/TreeView/TreeView.tsx
+++ b/packages/ui/src/components/composites/TreeView/TreeView.tsx
@@ -1,0 +1,157 @@
+import { cn } from '@cherrystudio/ui/lib/utils'
+import { useCallback, useMemo } from 'react'
+
+import {
+  TreeActionsContext,
+  type TreeActionsContextValue,
+  TreeDragContext,
+  type TreeDragContextValue,
+  TreeSelectionContext,
+  type TreeSelectionContextValue
+} from './contexts'
+import { flattenTree } from './flattenTree'
+import { TreeRow } from './TreeRow'
+import type { FlatTreeItem, TreeViewProps } from './types'
+import { useExpandedState } from './useExpandedState'
+import { useSelectionState } from './useSelectionState'
+import { useTreeDragAndDrop } from './useTreeDragAndDrop'
+
+/**
+ * Data-agnostic tree renderer.
+ *
+ * Caller supplies:
+ * - `data`: root-level nodes.
+ * - `adapter`: how to read id / children / canHaveChildren / isSticky from a node.
+ * - `renderRow`: a render-prop that receives the node and its row state.
+ *
+ * Interactions are all opt-in:
+ * - Selection enables when `selectedId` or `onSelectedChange` is provided.
+ * - DnD enables only when `onMove` is provided. Without it, rows are not draggable.
+ *
+ * Virtualization is delegated to an optional `renderList` slot — TreeView produces
+ * the flat list + sticky metadata but never imports a virtualizer itself.
+ */
+export function TreeView<T>(props: TreeViewProps<T>) {
+  const {
+    data,
+    adapter,
+    expandedIds: controlledExpanded,
+    defaultExpandedIds,
+    onExpandedChange,
+    selectedId: controlledSelected,
+    defaultSelectedId,
+    onSelectedChange,
+    renderRow,
+    onMove,
+    renderList,
+    className,
+    emptyState
+  } = props
+
+  const expanded = useExpandedState({
+    expandedIds: controlledExpanded,
+    defaultExpandedIds,
+    onExpandedChange
+  })
+
+  const selection = useSelectionState({
+    selectedId: controlledSelected,
+    defaultSelectedId,
+    onSelectedChange
+  })
+
+  const flat = useMemo<FlatTreeItem<T>[]>(
+    () => flattenTree(data, adapter, expanded.expandedIds),
+    [data, adapter, expanded.expandedIds]
+  )
+
+  const canHaveChildrenById = useCallback(
+    (id: string): boolean => {
+      const found = flat.find((item) => item.id === id)
+      if (!found) return false
+      const fn = adapter.canHaveChildren
+      return fn ? fn(found.node) : true
+    },
+    [adapter, flat]
+  )
+
+  const drag = useTreeDragAndDrop({
+    onMove,
+    canHaveChildren: canHaveChildrenById
+  })
+
+  const actionsValue = useMemo<TreeActionsContextValue>(
+    () => ({
+      toggleExpanded: expanded.toggle,
+      selectNode: selection.select,
+      getDragHandleProps: drag.getDragHandleProps
+    }),
+    [expanded.toggle, selection.select, drag.getDragHandleProps]
+  )
+
+  const selectionValue = useMemo<TreeSelectionContextValue>(
+    () => ({
+      expandedIds: expanded.expandedIds,
+      selectedId: selection.selectedId
+    }),
+    [expanded.expandedIds, selection.selectedId]
+  )
+
+  const dragValue = useMemo<TreeDragContextValue>(
+    () => ({
+      draggedId: drag.draggedId,
+      dragOverId: drag.dragOverId,
+      dragPosition: drag.dragPosition
+    }),
+    [drag.draggedId, drag.dragOverId, drag.dragPosition]
+  )
+
+  const renderItem = useCallback(
+    (index: number) => {
+      const item = flat[index]
+      if (!item) return null
+      const children = adapter.getChildren(item.node)
+      const hasChildren = !!(children && children.length > 0)
+      return (
+        <TreeRow
+          key={item.id}
+          id={item.id}
+          node={item.node}
+          depth={item.depth}
+          hasChildren={hasChildren}
+          renderRow={renderRow}
+        />
+      )
+    },
+    [flat, adapter, renderRow]
+  )
+
+  const isSticky = useCallback(
+    (index: number): boolean => {
+      const item = flat[index]
+      if (!item) return false
+      return adapter.isSticky ? adapter.isSticky(item.node) : false
+    },
+    [adapter, flat]
+  )
+
+  const getItemDepth = useCallback((index: number): number => flat[index]?.depth ?? 0, [flat])
+
+  if (flat.length === 0 && emptyState !== undefined) {
+    return <div className={cn('flex h-full w-full items-center justify-center', className)}>{emptyState}</div>
+  }
+
+  const body = renderList ? (
+    renderList({ flat, isSticky, getItemDepth, renderItem })
+  ) : (
+    <div className={cn('flex flex-col', className)}>{flat.map((_item, index) => renderItem(index))}</div>
+  )
+
+  return (
+    <TreeActionsContext value={actionsValue}>
+      <TreeSelectionContext value={selectionValue}>
+        <TreeDragContext value={dragValue}>{body}</TreeDragContext>
+      </TreeSelectionContext>
+    </TreeActionsContext>
+  )
+}

--- a/packages/ui/src/components/composites/TreeView/__tests__/TreeView.test.tsx
+++ b/packages/ui/src/components/composites/TreeView/__tests__/TreeView.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { TreeView } from '../TreeView'
+import type { RenderRowFn, TreeNodeAdapter } from '../types'
+
+interface Node {
+  id: string
+  name: string
+  children?: Node[]
+}
+
+const adapter: TreeNodeAdapter<Node> = {
+  getId: (n) => n.id,
+  getChildren: (n) => n.children,
+  canHaveChildren: (n) => Array.isArray(n.children)
+}
+
+const data: Node[] = [
+  {
+    id: 'root',
+    name: 'Root',
+    children: [
+      { id: 'a', name: 'A' },
+      { id: 'b', name: 'B', children: [{ id: 'b1', name: 'B1' }] }
+    ]
+  }
+]
+
+const renderRow: RenderRowFn<Node> = ({
+  node,
+  depth,
+  isExpanded,
+  isSelected,
+  toggleExpanded,
+  selectNode,
+  dragHandleProps
+}) => (
+  <div
+    key={node.id}
+    {...dragHandleProps}
+    data-testid={`row-${node.id}`}
+    data-depth={depth}
+    data-expanded={isExpanded}
+    data-selected={isSelected}
+    onClick={selectNode}
+    onDoubleClick={toggleExpanded}>
+    {node.name}
+  </div>
+)
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('TreeView', () => {
+  it('renders the empty state slot when data is empty', () => {
+    render(<TreeView data={[]} adapter={adapter} renderRow={renderRow} emptyState={<span>No items</span>} />)
+    expect(screen.getByText('No items')).toBeInTheDocument()
+  })
+
+  it('renders only roots when nothing is expanded', () => {
+    render(<TreeView data={data} adapter={adapter} renderRow={renderRow} />)
+    expect(screen.getByTestId('row-root')).toBeInTheDocument()
+    expect(screen.queryByTestId('row-a')).toBeNull()
+  })
+
+  it('toggles expansion via uncontrolled state', async () => {
+    const user = userEvent.setup()
+    render(<TreeView data={data} adapter={adapter} renderRow={renderRow} />)
+    await user.dblClick(screen.getByTestId('row-root'))
+    expect(screen.getByTestId('row-a')).toBeInTheDocument()
+    expect(screen.getByTestId('row-b')).toBeInTheDocument()
+  })
+
+  it('calls onExpandedChange when controlled', async () => {
+    const onExpandedChange = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <TreeView
+        data={data}
+        adapter={adapter}
+        renderRow={renderRow}
+        expandedIds={new Set()}
+        onExpandedChange={onExpandedChange}
+      />
+    )
+    await user.dblClick(screen.getByTestId('row-root'))
+    expect(onExpandedChange).toHaveBeenCalled()
+    const lastCall = onExpandedChange.mock.calls.at(-1)?.[0] as Set<string>
+    expect(lastCall.has('root')).toBe(true)
+  })
+
+  it('selects on click and reports through onSelectedChange', async () => {
+    const onSelectedChange = vi.fn()
+    const user = userEvent.setup()
+    render(<TreeView data={data} adapter={adapter} renderRow={renderRow} onSelectedChange={onSelectedChange} />)
+    await user.click(screen.getByTestId('row-root'))
+    expect(onSelectedChange).toHaveBeenCalledWith('root')
+    expect(screen.getByTestId('row-root')).toHaveAttribute('data-selected', 'true')
+  })
+
+  it('passes correct depth to renderRow', async () => {
+    const user = userEvent.setup()
+    render(<TreeView data={data} adapter={adapter} renderRow={renderRow} defaultExpandedIds={new Set(['root', 'b'])} />)
+    expect(screen.getByTestId('row-root')).toHaveAttribute('data-depth', '0')
+    expect(screen.getByTestId('row-a')).toHaveAttribute('data-depth', '1')
+    expect(screen.getByTestId('row-b1')).toHaveAttribute('data-depth', '2')
+    await user.click(screen.getByTestId('row-a'))
+  })
+
+  it('disables drag handle when onMove is omitted', () => {
+    render(<TreeView data={data} adapter={adapter} renderRow={renderRow} />)
+    expect(screen.getByTestId('row-root')).toHaveAttribute('draggable', 'false')
+  })
+
+  it('enables drag handle when onMove is provided', () => {
+    render(<TreeView data={data} adapter={adapter} renderRow={renderRow} onMove={() => {}} />)
+    expect(screen.getByTestId('row-root')).toHaveAttribute('draggable', 'true')
+  })
+
+  it('invokes renderList slot with flat metadata', () => {
+    const renderList = vi.fn(({ flat }) => (
+      <div data-count={flat.length} data-testid="virt">
+        virt
+      </div>
+    ))
+    render(
+      <TreeView
+        data={data}
+        adapter={adapter}
+        renderRow={renderRow}
+        renderList={renderList}
+        defaultExpandedIds={new Set(['root'])}
+      />
+    )
+    expect(renderList).toHaveBeenCalled()
+    expect(screen.getByTestId('virt')).toHaveAttribute('data-count', '3')
+  })
+})

--- a/packages/ui/src/components/composites/TreeView/__tests__/flattenTree.test.ts
+++ b/packages/ui/src/components/composites/TreeView/__tests__/flattenTree.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+
+import { flattenTree } from '../flattenTree'
+import type { TreeNodeAdapter } from '../types'
+
+interface Node {
+  id: string
+  children?: Node[]
+}
+
+const adapter: TreeNodeAdapter<Node> = {
+  getId: (n) => n.id,
+  getChildren: (n) => n.children
+}
+
+describe('flattenTree', () => {
+  it('returns empty list for empty data', () => {
+    expect(flattenTree([], adapter, new Set())).toEqual([])
+  })
+
+  it('flattens a single root node without children', () => {
+    const result = flattenTree([{ id: 'a' }], adapter, new Set())
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ id: 'a', depth: 0 })
+  })
+
+  it('skips children of unexpanded nodes', () => {
+    const data: Node[] = [{ id: 'root', children: [{ id: 'child' }] }]
+    const result = flattenTree(data, adapter, new Set())
+    expect(result.map((r) => r.id)).toEqual(['root'])
+  })
+
+  it('includes children when parent is expanded', () => {
+    const data: Node[] = [{ id: 'root', children: [{ id: 'child' }] }]
+    const result = flattenTree(data, adapter, new Set(['root']))
+    expect(result.map((r) => r.id)).toEqual(['root', 'child'])
+    expect(result.map((r) => r.depth)).toEqual([0, 1])
+  })
+
+  it('walks 5 levels deep when fully expanded', () => {
+    const deep: Node = {
+      id: 'l0',
+      children: [{ id: 'l1', children: [{ id: 'l2', children: [{ id: 'l3', children: [{ id: 'l4' }] }] }] }]
+    }
+    const expanded = new Set(['l0', 'l1', 'l2', 'l3'])
+    const result = flattenTree([deep], adapter, expanded)
+    expect(result.map((r) => r.id)).toEqual(['l0', 'l1', 'l2', 'l3', 'l4'])
+    expect(result.map((r) => r.depth)).toEqual([0, 1, 2, 3, 4])
+  })
+
+  it('handles partial expansion across siblings', () => {
+    const data: Node[] = [
+      { id: 'a', children: [{ id: 'a1' }, { id: 'a2' }] },
+      { id: 'b', children: [{ id: 'b1' }] }
+    ]
+    const result = flattenTree(data, adapter, new Set(['a']))
+    expect(result.map((r) => r.id)).toEqual(['a', 'a1', 'a2', 'b'])
+  })
+
+  it('mixes leaves and branches preserving input order', () => {
+    const data: Node[] = [{ id: 'leaf1' }, { id: 'branch', children: [{ id: 'inner' }] }, { id: 'leaf2' }]
+    const result = flattenTree(data, adapter, new Set(['branch']))
+    expect(result.map((r) => r.id)).toEqual(['leaf1', 'branch', 'inner', 'leaf2'])
+  })
+})

--- a/packages/ui/src/components/composites/TreeView/__tests__/useTreeDragAndDrop.test.ts
+++ b/packages/ui/src/components/composites/TreeView/__tests__/useTreeDragAndDrop.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useTreeDragAndDrop } from '../useTreeDragAndDrop'
+
+function makeDragEvent(overrides: Partial<{ clientY: number; rect: DOMRect; data: string }> = {}) {
+  const rect = overrides.rect ?? ({ top: 0, bottom: 100, height: 100, left: 0, right: 100 } as DOMRect)
+  const data: Record<string, string> = overrides.data !== undefined ? { 'text/plain': overrides.data } : {}
+  return {
+    clientY: overrides.clientY ?? 50,
+    preventDefault: vi.fn(),
+    currentTarget: {
+      getBoundingClientRect: () => rect,
+      parentElement: null,
+      cloneNode: () => ({ style: {} })
+    },
+    dataTransfer: {
+      effectAllowed: '',
+      dropEffect: '',
+      setData: vi.fn((k: string, v: string) => {
+        data[k] = v
+      }),
+      getData: (k: string) => data[k] ?? '',
+      setDragImage: vi.fn()
+    }
+  } as unknown as React.DragEvent
+}
+
+describe('useTreeDragAndDrop', () => {
+  it('returns no-op handlers when onMove is undefined', () => {
+    const { result } = renderHook(() => useTreeDragAndDrop({}))
+    const handles = result.current.getDragHandleProps('a')
+    expect(handles.draggable).toBe(false)
+  })
+
+  it('reports "before" when cursor in top zone', () => {
+    const onMove = vi.fn()
+    const { result } = renderHook(() => useTreeDragAndDrop({ onMove }))
+    const handles = result.current.getDragHandleProps('target')
+    act(() => {
+      handles.onDragOver(makeDragEvent({ clientY: 5 }))
+    })
+    expect(result.current.dragPosition).toBe('before')
+    expect(result.current.dragOverId).toBe('target')
+  })
+
+  it('reports "after" when cursor in bottom zone', () => {
+    const onMove = vi.fn()
+    const { result } = renderHook(() => useTreeDragAndDrop({ onMove }))
+    const handles = result.current.getDragHandleProps('target')
+    act(() => {
+      handles.onDragOver(makeDragEvent({ clientY: 95 }))
+    })
+    expect(result.current.dragPosition).toBe('after')
+  })
+
+  it('reports "inside" by default in middle zone', () => {
+    const onMove = vi.fn()
+    const { result } = renderHook(() => useTreeDragAndDrop({ onMove }))
+    const handles = result.current.getDragHandleProps('target')
+    act(() => {
+      handles.onDragOver(makeDragEvent({ clientY: 50 }))
+    })
+    expect(result.current.dragPosition).toBe('inside')
+  })
+
+  it('substitutes "after" for "inside" when canHaveChildren returns false', () => {
+    const onMove = vi.fn()
+    const { result } = renderHook(() =>
+      useTreeDragAndDrop({
+        onMove,
+        canHaveChildren: () => false
+      })
+    )
+    const handles = result.current.getDragHandleProps('leaf')
+    act(() => {
+      handles.onDragOver(makeDragEvent({ clientY: 50 }))
+    })
+    expect(result.current.dragPosition).toBe('after')
+  })
+
+  it('calls onMove on drop with computed position', () => {
+    const onMove = vi.fn()
+    const { result } = renderHook(() => useTreeDragAndDrop({ onMove }))
+    const handles = result.current.getDragHandleProps('target')
+    act(() => {
+      handles.onDragOver(makeDragEvent({ clientY: 5 }))
+    })
+    act(() => {
+      handles.onDrop(makeDragEvent({ data: 'source' }))
+    })
+    expect(onMove).toHaveBeenCalledWith('source', 'target', 'before')
+  })
+
+  it('ignores self-drop', () => {
+    const onMove = vi.fn()
+    const { result } = renderHook(() => useTreeDragAndDrop({ onMove }))
+    const handles = result.current.getDragHandleProps('same')
+    act(() => {
+      handles.onDrop(makeDragEvent({ data: 'same' }))
+    })
+    expect(onMove).not.toHaveBeenCalled()
+  })
+
+  it('clears drag state on dragEnd', () => {
+    const onMove = vi.fn()
+    const { result } = renderHook(() => useTreeDragAndDrop({ onMove }))
+    const handles = result.current.getDragHandleProps('target')
+    act(() => {
+      handles.onDragOver(makeDragEvent({ clientY: 5 }))
+    })
+    expect(result.current.dragOverId).toBe('target')
+    act(() => {
+      handles.onDragEnd(makeDragEvent())
+    })
+    expect(result.current.dragOverId).toBeNull()
+    expect(result.current.dragPosition).toBeNull()
+  })
+})

--- a/packages/ui/src/components/composites/TreeView/contexts.ts
+++ b/packages/ui/src/components/composites/TreeView/contexts.ts
@@ -1,0 +1,49 @@
+import { createContext, use } from 'react'
+
+import type { DragPosition, TreeDragHandleProps } from './types'
+
+/**
+ * Split into three contexts so high-frequency drag updates do not re-render rows
+ * that only consume selection/expansion state. Mirrors the proven pattern in
+ * NotesSidebar (5 contexts) but collapsed to the minimum needed for v1.
+ */
+
+export interface TreeActionsContextValue {
+  toggleExpanded: (id: string) => void
+  selectNode: (id: string) => void
+  getDragHandleProps: (id: string) => TreeDragHandleProps
+}
+
+export interface TreeSelectionContextValue {
+  expandedIds: ReadonlySet<string>
+  selectedId: string | null
+}
+
+export interface TreeDragContextValue {
+  draggedId: string | null
+  dragOverId: string | null
+  dragPosition: DragPosition | null
+}
+
+export const TreeActionsContext = createContext<TreeActionsContextValue | null>(null)
+export const TreeSelectionContext = createContext<TreeSelectionContextValue | null>(null)
+export const TreeDragContext = createContext<TreeDragContextValue | null>(null)
+
+function ensure<T>(value: T | null, name: string): T {
+  if (value === null) {
+    throw new Error(`${name} must be used inside <TreeView />`)
+  }
+  return value
+}
+
+export function useTreeActions(): TreeActionsContextValue {
+  return ensure(use(TreeActionsContext), 'useTreeActions')
+}
+
+export function useTreeSelection(): TreeSelectionContextValue {
+  return ensure(use(TreeSelectionContext), 'useTreeSelection')
+}
+
+export function useTreeDrag(): TreeDragContextValue {
+  return ensure(use(TreeDragContext), 'useTreeDrag')
+}

--- a/packages/ui/src/components/composites/TreeView/flattenTree.ts
+++ b/packages/ui/src/components/composites/TreeView/flattenTree.ts
@@ -1,0 +1,25 @@
+import type { FlatTreeItem, TreeNodeAdapter } from './types'
+
+/**
+ * Walks a tree of nodes depth-first, producing a flat list with depth tags.
+ * Children of nodes whose id is not in `expandedIds` are skipped.
+ */
+export function flattenTree<T>(
+  data: readonly T[],
+  adapter: TreeNodeAdapter<T>,
+  expandedIds: ReadonlySet<string>
+): FlatTreeItem<T>[] {
+  const out: FlatTreeItem<T>[] = []
+  const walk = (nodes: readonly T[], depth: number) => {
+    for (const node of nodes) {
+      const id = adapter.getId(node)
+      out.push({ id, node, depth })
+      if (expandedIds.has(id)) {
+        const children = adapter.getChildren(node)
+        if (children && children.length > 0) walk(children, depth + 1)
+      }
+    }
+  }
+  walk(data, 0)
+  return out
+}

--- a/packages/ui/src/components/composites/TreeView/index.ts
+++ b/packages/ui/src/components/composites/TreeView/index.ts
@@ -1,0 +1,19 @@
+export { flattenTree } from './flattenTree'
+export { TreeView } from './TreeView'
+export type {
+  DragPosition,
+  FlatTreeItem,
+  RenderRowArgs,
+  RenderRowFn,
+  TreeDragHandleProps,
+  TreeListSlotArgs,
+  TreeNodeAdapter,
+  TreeViewProps
+} from './types'
+export { useExpandedState, type UseExpandedStateOptions, type UseExpandedStateReturn } from './useExpandedState'
+export { useSelectionState, type UseSelectionStateOptions, type UseSelectionStateReturn } from './useSelectionState'
+export {
+  useTreeDragAndDrop,
+  type UseTreeDragAndDropOptions,
+  type UseTreeDragAndDropReturn
+} from './useTreeDragAndDrop'

--- a/packages/ui/src/components/composites/TreeView/types.ts
+++ b/packages/ui/src/components/composites/TreeView/types.ts
@@ -1,0 +1,74 @@
+import type React from 'react'
+
+export type DragPosition = 'before' | 'inside' | 'after'
+
+export interface TreeNodeAdapter<T> {
+  getId: (node: T) => string
+  getChildren: (node: T) => T[] | undefined
+  /** When false, the node cannot accept 'inside' drops (used for leaves). Default: true. */
+  canHaveChildren?: (node: T) => boolean
+  /** When true, the row is treated as a sticky header at its depth. */
+  isSticky?: (node: T) => boolean
+}
+
+export interface FlatTreeItem<T> {
+  id: string
+  node: T
+  depth: number
+}
+
+export interface TreeDragHandleProps {
+  draggable: boolean
+  onDragStart: (e: React.DragEvent) => void
+  onDragOver: (e: React.DragEvent) => void
+  onDragLeave: (e: React.DragEvent) => void
+  onDrop: (e: React.DragEvent) => void
+  onDragEnd: (e: React.DragEvent) => void
+}
+
+export interface RenderRowArgs<T> {
+  node: T
+  depth: number
+  isExpanded: boolean
+  isSelected: boolean
+  isDragging: boolean
+  isDragOver: boolean
+  dragPosition: DragPosition | null
+  toggleExpanded: () => void
+  selectNode: () => void
+  /** Spread on the draggable element. Listeners are no-ops when DnD is disabled (no onMove prop). */
+  dragHandleProps: TreeDragHandleProps
+}
+
+export type RenderRowFn<T> = (args: RenderRowArgs<T>) => React.ReactNode
+
+export interface TreeListSlotArgs<T> {
+  flat: ReadonlyArray<FlatTreeItem<T>>
+  isSticky: (index: number) => boolean
+  getItemDepth: (index: number) => number
+  renderItem: (index: number) => React.ReactNode
+}
+
+export interface TreeViewProps<T> {
+  data: T[]
+  adapter: TreeNodeAdapter<T>
+
+  expandedIds?: ReadonlySet<string>
+  defaultExpandedIds?: ReadonlySet<string>
+  onExpandedChange?: (next: ReadonlySet<string>) => void
+
+  selectedId?: string | null
+  defaultSelectedId?: string | null
+  onSelectedChange?: (id: string | null) => void
+
+  renderRow: RenderRowFn<T>
+
+  /** When omitted, DnD is fully disabled — no listeners attached, draggable=false. */
+  onMove?: (sourceId: string, targetId: string, position: DragPosition) => void
+
+  /** Optional virtualizer slot. When omitted, rows render as a plain flat list. */
+  renderList?: (args: TreeListSlotArgs<T>) => React.ReactNode
+
+  className?: string
+  emptyState?: React.ReactNode
+}

--- a/packages/ui/src/components/composites/TreeView/useExpandedState.ts
+++ b/packages/ui/src/components/composites/TreeView/useExpandedState.ts
@@ -1,0 +1,37 @@
+import { useCallback, useState } from 'react'
+
+export interface UseExpandedStateOptions {
+  expandedIds?: ReadonlySet<string>
+  defaultExpandedIds?: ReadonlySet<string>
+  onExpandedChange?: (next: ReadonlySet<string>) => void
+}
+
+export interface UseExpandedStateReturn {
+  expandedIds: ReadonlySet<string>
+  toggle: (id: string) => void
+  isExpanded: (id: string) => boolean
+}
+
+const EMPTY_SET: ReadonlySet<string> = new Set()
+
+export function useExpandedState(options: UseExpandedStateOptions): UseExpandedStateReturn {
+  const { expandedIds: controlled, defaultExpandedIds, onExpandedChange } = options
+  const isControlled = controlled !== undefined
+  const [internal, setInternal] = useState<ReadonlySet<string>>(defaultExpandedIds ?? EMPTY_SET)
+  const current = isControlled ? controlled : internal
+
+  const toggle = useCallback(
+    (id: string) => {
+      const next = new Set(current)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      if (!isControlled) setInternal(next)
+      onExpandedChange?.(next)
+    },
+    [current, isControlled, onExpandedChange]
+  )
+
+  const isExpanded = useCallback((id: string) => current.has(id), [current])
+
+  return { expandedIds: current, toggle, isExpanded }
+}

--- a/packages/ui/src/components/composites/TreeView/useSelectionState.ts
+++ b/packages/ui/src/components/composites/TreeView/useSelectionState.ts
@@ -1,0 +1,32 @@
+import { useCallback, useState } from 'react'
+
+export interface UseSelectionStateOptions {
+  selectedId?: string | null
+  defaultSelectedId?: string | null
+  onSelectedChange?: (id: string | null) => void
+}
+
+export interface UseSelectionStateReturn {
+  selectedId: string | null
+  select: (id: string | null) => void
+  isSelected: (id: string) => boolean
+}
+
+export function useSelectionState(options: UseSelectionStateOptions): UseSelectionStateReturn {
+  const { selectedId: controlled, defaultSelectedId, onSelectedChange } = options
+  const isControlled = controlled !== undefined
+  const [internal, setInternal] = useState<string | null>(defaultSelectedId ?? null)
+  const current = isControlled ? (controlled ?? null) : internal
+
+  const select = useCallback(
+    (id: string | null) => {
+      if (!isControlled) setInternal(id)
+      onSelectedChange?.(id)
+    },
+    [isControlled, onSelectedChange]
+  )
+
+  const isSelected = useCallback((id: string) => current === id, [current])
+
+  return { selectedId: current, select, isSelected }
+}

--- a/packages/ui/src/components/composites/TreeView/useTreeDragAndDrop.ts
+++ b/packages/ui/src/components/composites/TreeView/useTreeDragAndDrop.ts
@@ -1,0 +1,141 @@
+import type React from 'react'
+import { useCallback, useRef, useState } from 'react'
+
+import type { DragPosition, TreeDragHandleProps } from './types'
+
+export interface UseTreeDragAndDropOptions {
+  /** Move callback. When undefined, all returned listeners are no-ops and draggable is false. */
+  onMove?: (sourceId: string, targetId: string, position: DragPosition) => void
+  /** Whether the target node accepts 'inside' drops. Default: true for everything. */
+  canHaveChildren?: (nodeId: string) => boolean
+}
+
+export interface UseTreeDragAndDropReturn {
+  draggedId: string | null
+  dragOverId: string | null
+  dragPosition: DragPosition | null
+  /** Returns the listener bundle bound for a specific row. Listeners are no-ops when DnD is disabled. */
+  getDragHandleProps: (nodeId: string) => TreeDragHandleProps
+}
+
+const NOOP = () => {}
+const DISABLED_HANDLE: TreeDragHandleProps = {
+  draggable: false,
+  onDragStart: NOOP,
+  onDragOver: NOOP,
+  onDragLeave: NOOP,
+  onDrop: NOOP,
+  onDragEnd: NOOP
+}
+
+export function useTreeDragAndDrop(options: UseTreeDragAndDropOptions): UseTreeDragAndDropReturn {
+  const { onMove, canHaveChildren } = options
+  const enabled = typeof onMove === 'function'
+  const [draggedId, setDraggedId] = useState<string | null>(null)
+  const [dragOverId, setDragOverId] = useState<string | null>(null)
+  const [dragPosition, setDragPosition] = useState<DragPosition | null>(null)
+  const positionRef = useRef<DragPosition | null>(null)
+
+  const clear = useCallback(() => {
+    setDraggedId(null)
+    setDragOverId(null)
+    setDragPosition(null)
+    positionRef.current = null
+  }, [])
+
+  const handleDragStart = useCallback(
+    (nodeId: string) => (e: React.DragEvent) => {
+      setDraggedId(nodeId)
+      e.dataTransfer.effectAllowed = 'move'
+      e.dataTransfer.setData('text/plain', nodeId)
+
+      const el = e.currentTarget as HTMLElement
+      if (el?.parentElement) {
+        const rect = el.getBoundingClientRect()
+        const ghost = el.cloneNode(true) as HTMLElement
+        ghost.style.width = `${rect.width}px`
+        ghost.style.opacity = '0.7'
+        ghost.style.position = 'absolute'
+        ghost.style.top = '-1000px'
+        document.body.appendChild(ghost)
+        e.dataTransfer.setDragImage(ghost, 10, 10)
+        setTimeout(() => {
+          if (ghost.parentNode) document.body.removeChild(ghost)
+        }, 0)
+      }
+    },
+    []
+  )
+
+  const handleDragOver = useCallback(
+    (nodeId: string) => (e: React.DragEvent) => {
+      e.preventDefault()
+      e.dataTransfer.dropEffect = 'move'
+
+      if (draggedId === nodeId) return
+
+      setDragOverId(nodeId)
+
+      const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+      const mouseY = e.clientY
+      const thresholdTop = rect.top + rect.height * 0.3
+      const thresholdBottom = rect.bottom - rect.height * 0.3
+
+      const allowInside = canHaveChildren ? canHaveChildren(nodeId) : true
+
+      let next: DragPosition
+      if (mouseY < thresholdTop) next = 'before'
+      else if (mouseY > thresholdBottom) next = 'after'
+      else next = allowInside ? 'inside' : 'after'
+
+      positionRef.current = next
+      setDragPosition(next)
+    },
+    [canHaveChildren, draggedId]
+  )
+
+  const handleDragLeave = useCallback(() => {
+    setDragOverId(null)
+    setDragPosition(null)
+    positionRef.current = null
+  }, [])
+
+  const handleDrop = useCallback(
+    (nodeId: string) => (e: React.DragEvent) => {
+      e.preventDefault()
+      const sourceId = e.dataTransfer.getData('text/plain')
+      const finalPosition = positionRef.current ?? 'inside'
+      if (sourceId && sourceId !== nodeId && onMove) {
+        onMove(sourceId, nodeId, finalPosition)
+      }
+      clear()
+    },
+    [onMove, clear]
+  )
+
+  const handleDragEnd = useCallback(() => {
+    clear()
+  }, [clear])
+
+  const getDragHandleProps = useCallback(
+    (nodeId: string): TreeDragHandleProps => {
+      if (!enabled) return DISABLED_HANDLE
+      return {
+        draggable: true,
+        onDragStart: handleDragStart(nodeId),
+        onDragOver: handleDragOver(nodeId),
+        onDragLeave: handleDragLeave,
+        onDrop: handleDrop(nodeId),
+        onDragEnd: handleDragEnd
+      }
+    },
+    [enabled, handleDragStart, handleDragOver, handleDragLeave, handleDrop, handleDragEnd]
+  )
+
+  return {
+    draggedId: enabled ? draggedId : null,
+    dragOverId: enabled ? dragOverId : null,
+    dragPosition: enabled ? dragPosition : null,
+    getDragHandleProps
+  }
+}

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -135,6 +135,22 @@ export {
   type SelectItem as CompositeInputSelectItem
 } from './composites/composite-input'
 export { Sortable } from './composites/sortable'
+// TreeView
+export {
+  type DragPosition,
+  flattenTree,
+  type FlatTreeItem,
+  type RenderRowArgs,
+  type RenderRowFn,
+  type TreeDragHandleProps,
+  type TreeListSlotArgs,
+  type TreeNodeAdapter,
+  TreeView,
+  type TreeViewProps,
+  useExpandedState,
+  useSelectionState,
+  useTreeDragAndDrop
+} from './composites/TreeView'
 
 /* Shadcn Primitive Components */
 export * from './primitives/accordion'


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Tree-style navigation and file-like lists had no shared composite in @cherrystudio/ui.

After this PR:

A tested TreeView composite is available in packages/ui for hierarchical rows, selection, expansion, and drag handling.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The composite is isolated in packages/ui so page-level consumers can migrate independently.

The following alternatives were considered:

Keeping separate page-specific tree implementations was considered, but repeated behavior warranted a reusable UI composite.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Full build gate passed when the branch was prepared: pnpm build:check.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
A reusable tree view component is available for hierarchical UI surfaces.
```
