### PR TITLE
feat(renderer-hooks): add overlay and resize utilities

### DIFF
--- a/src/renderer/hooks/__tests__/useMetaDataParser.test.ts
+++ b/src/renderer/hooks/__tests__/useMetaDataParser.test.ts
@@ -1,0 +1,58 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import axios from 'axios'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useMetaDataParser } from '../useMetaDataParser'
+
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn(),
+    isCancel: vi.fn(() => false)
+  }
+}))
+
+const axiosMock = vi.mocked(axios, true)
+
+describe('useMetaDataParser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('extracts document fallback metadata when Open Graph tags are absent', async () => {
+    axiosMock.get.mockResolvedValueOnce({
+      data: `
+        <!doctype html>
+        <html>
+          <head>
+            <title>习近平总书记的深情寄望鼓舞新时代少年儿童成长成才</title>
+            <meta name="description" content="Baijiahao article summary">
+            <meta property="og:imageAlt" content="Article cover image">
+            <link rel="preload" as="image" href="/cover.png">
+          </head>
+        </html>
+      `
+    })
+
+    const { result } = renderHook(() =>
+      useMetaDataParser('https://baijiahao.baidu.com/s?id=1866720970921273171', [
+        'title',
+        'description',
+        'og:imageAlt',
+        'image'
+      ] as const)
+    )
+
+    await act(async () => {
+      await result.current.parseMetadata()
+    })
+
+    await waitFor(() => {
+      expect(result.current.metadata).toEqual({
+        title: '习近平总书记的深情寄望鼓舞新时代少年儿童成长成才',
+        description: 'Baijiahao article summary',
+        'og:imageAlt': 'Article cover image',
+        image: 'https://baijiahao.baidu.com/cover.png'
+      })
+    })
+  })
+})

--- a/src/renderer/hooks/__tests__/useOverlayTriggerTooltip.test.ts
+++ b/src/renderer/hooks/__tests__/useOverlayTriggerTooltip.test.ts
@@ -1,0 +1,52 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useOverlayTriggerTooltip } from '../useOverlayTriggerTooltip'
+
+describe('useOverlayTriggerTooltip', () => {
+  it('tracks normal tooltip open changes', () => {
+    const { result } = renderHook(() => useOverlayTriggerTooltip())
+
+    act(() => {
+      result.current.tooltipProps.onOpenChange(true)
+    })
+
+    expect(result.current.tooltipProps.isOpen).toBe(true)
+
+    act(() => {
+      result.current.tooltipProps.onOpenChange(false)
+    })
+
+    expect(result.current.tooltipProps.isOpen).toBe(false)
+  })
+
+  it('keeps the tooltip closed after an overlay trigger until released', () => {
+    const trigger = { blur: vi.fn() }
+    const { result } = renderHook(() => useOverlayTriggerTooltip())
+
+    act(() => {
+      result.current.tooltipProps.onOpenChange(true)
+    })
+    expect(result.current.tooltipProps.isOpen).toBe(true)
+
+    act(() => {
+      result.current.suppress(trigger)
+    })
+
+    expect(trigger.blur).toHaveBeenCalledTimes(1)
+    expect(result.current.tooltipProps.isOpen).toBe(false)
+
+    act(() => {
+      result.current.tooltipProps.onOpenChange(true)
+    })
+
+    expect(result.current.tooltipProps.isOpen).toBe(false)
+
+    act(() => {
+      result.current.triggerProps.onPointerLeave()
+      result.current.tooltipProps.onOpenChange(true)
+    })
+
+    expect(result.current.tooltipProps.isOpen).toBe(true)
+  })
+})

--- a/src/renderer/hooks/__tests__/useResizeDrag.test.tsx
+++ b/src/renderer/hooks/__tests__/useResizeDrag.test.tsx
@@ -1,0 +1,190 @@
+import { act, renderHook } from '@testing-library/react'
+import type { MouseEvent as ReactMouseEvent } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useResizeDrag } from '../useResizeDrag'
+
+function startDrag(startResizing: (event: ReactMouseEvent) => void) {
+  const preventDefault = vi.fn()
+
+  act(() => {
+    startResizing({ preventDefault } as unknown as ReactMouseEvent)
+  })
+
+  expect(preventDefault).toHaveBeenCalledTimes(1)
+}
+
+describe('useResizeDrag', () => {
+  afterEach(() => {
+    document.body.style.cursor = ''
+    document.body.style.userSelect = ''
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      value: false
+    })
+    vi.restoreAllMocks()
+  })
+
+  it('cleans up on mouse up and ignores later mouse movement', () => {
+    const onMove = vi.fn()
+    const { result } = renderHook(() => useResizeDrag({ onMove }))
+
+    startDrag(result.current.startResizing)
+    expect(result.current.isResizing).toBe(true)
+    expect(document.body.style.cursor).toBe('col-resize')
+    expect(document.body.style.userSelect).toBe('none')
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 120 }))
+    })
+
+    expect(onMove).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mouseup'))
+    })
+
+    expect(result.current.isResizing).toBe(false)
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 140 }))
+    })
+
+    expect(onMove).toHaveBeenCalledTimes(1)
+  })
+
+  it('restores the previous document resize styles on window blur', () => {
+    const onMove = vi.fn()
+    document.body.style.cursor = 'grab'
+    document.body.style.userSelect = 'text'
+    const { result } = renderHook(() => useResizeDrag({ onMove }))
+
+    startDrag(result.current.startResizing)
+    expect(document.body.style.cursor).toBe('col-resize')
+    expect(document.body.style.userSelect).toBe('none')
+
+    act(() => {
+      window.dispatchEvent(new Event('blur'))
+    })
+
+    expect(result.current.isResizing).toBe(false)
+    expect(document.body.style.cursor).toBe('grab')
+    expect(document.body.style.userSelect).toBe('text')
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 140 }))
+    })
+
+    expect(onMove).not.toHaveBeenCalled()
+  })
+
+  it('cleans up when the document becomes hidden', () => {
+    const onMove = vi.fn()
+    const { result } = renderHook(() => useResizeDrag({ onMove }))
+
+    startDrag(result.current.startResizing)
+
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      value: true
+    })
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    expect(result.current.isResizing).toBe(false)
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+  })
+
+  it('cleans up when the pointer leaves the document', () => {
+    const onMove = vi.fn()
+    const { result } = renderHook(() => useResizeDrag({ onMove }))
+
+    startDrag(result.current.startResizing)
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mouseleave'))
+    })
+
+    expect(result.current.isResizing).toBe(false)
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+  })
+
+  it('cleans up on unmount', () => {
+    const onMove = vi.fn()
+    const { result, unmount } = renderHook(() => useResizeDrag({ onMove }))
+
+    startDrag(result.current.startResizing)
+
+    act(() => {
+      unmount()
+    })
+
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 140 }))
+    })
+
+    expect(onMove).not.toHaveBeenCalled()
+  })
+
+  it('ends the drag when onMove invokes the provided stop callback', () => {
+    const onMove = vi.fn((moveEvent: MouseEvent, stop: () => void) => {
+      expect(moveEvent.clientX).toBe(120)
+      stop()
+    })
+    const { result } = renderHook(() => useResizeDrag({ onMove }))
+
+    startDrag(result.current.startResizing)
+    expect(result.current.isResizing).toBe(true)
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 120 }))
+    })
+
+    expect(onMove).toHaveBeenCalledTimes(1)
+    expect(result.current.isResizing).toBe(false)
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 200 }))
+    })
+
+    expect(onMove).toHaveBeenCalledTimes(1)
+  })
+
+  it('cleans up the previous drag when a new drag starts', () => {
+    const onMove = vi.fn()
+    const { result } = renderHook(() => useResizeDrag({ onMove }))
+
+    startDrag(result.current.startResizing)
+    startDrag(result.current.startResizing)
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 120 }))
+    })
+
+    // Only the second drag's listener remains; the first was torn down.
+    expect(onMove).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mouseup'))
+    })
+
+    expect(result.current.isResizing).toBe(false)
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 200 }))
+    })
+
+    // A single mouseup fully ended the active drag — no leftover listener from drag #1.
+    expect(onMove).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/hooks/useMetaDataParser.ts
+++ b/src/renderer/hooks/useMetaDataParser.ts
@@ -35,14 +35,56 @@ export function useMetaDataParser<T extends string>(
 
       const htmlContent = response.data
       const parsedMetadata = {} as Record<T, string>
+      let isReadingTitle = false
+      let titleText = ''
+
+      const resolveUrl = (value: string) => {
+        try {
+          return new URL(value, link).href
+        } catch {
+          return value
+        }
+      }
+
+      const setMetadataValue = (key: string, value: string | undefined) => {
+        const trimmed = value?.trim()
+        if (!trimmed || !properties.includes(key as T) || parsedMetadata[key as T]) return
+        const shouldResolveUrl = key === 'image' || key === 'og:image'
+        parsedMetadata[key as T] = shouldResolveUrl ? resolveUrl(trimmed) : trimmed
+      }
 
       const parser = new htmlparser2.Parser({
         onopentag(tagName, attributes) {
+          if (tagName === 'title') {
+            isReadingTitle = true
+            titleText = ''
+            return
+          }
+
           if (tagName === 'meta') {
             const { name: metaName, property: metaProperty, content } = attributes
             const metaKey = metaName || metaProperty
-            if (!metaKey || !properties.includes(metaKey as T)) return
-            parsedMetadata[metaKey as T] = content
+            setMetadataValue(metaKey, content)
+            return
+          }
+
+          if (tagName === 'link') {
+            const rel = attributes.rel?.toLowerCase().split(/\s+/) ?? []
+            if (rel.includes('preload') && attributes.as?.toLowerCase() === 'image') {
+              setMetadataValue('image', attributes.href)
+            }
+          }
+        },
+        ontext(text) {
+          if (isReadingTitle) {
+            titleText += text
+          }
+        },
+        onclosetag(tagName) {
+          if (tagName === 'title') {
+            setMetadataValue('title', titleText)
+            isReadingTitle = false
+            titleText = ''
           }
         }
       })

--- a/src/renderer/hooks/useOverlayTriggerTooltip.ts
+++ b/src/renderer/hooks/useOverlayTriggerTooltip.ts
@@ -1,0 +1,40 @@
+import { useRef, useState } from 'react'
+
+type TooltipTriggerElement = {
+  blur?: () => void
+}
+
+export function useOverlayTriggerTooltip() {
+  const suppressedRef = useRef(false)
+  const [isOpen, setIsOpen] = useState(false)
+
+  const onOpenChange = (nextOpen: boolean) => {
+    if (suppressedRef.current && nextOpen) {
+      return
+    }
+
+    setIsOpen(nextOpen)
+  }
+
+  const suppress = (trigger?: TooltipTriggerElement | null) => {
+    trigger?.blur?.()
+    suppressedRef.current = true
+    setIsOpen(false)
+  }
+
+  const release = () => {
+    suppressedRef.current = false
+    setIsOpen(false)
+  }
+
+  return {
+    tooltipProps: {
+      isOpen,
+      onOpenChange
+    },
+    triggerProps: {
+      onPointerLeave: release
+    },
+    suppress
+  }
+}

--- a/src/renderer/hooks/useResizeDrag.ts
+++ b/src/renderer/hooks/useResizeDrag.ts
@@ -1,0 +1,71 @@
+import type { MouseEvent as ReactMouseEvent } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+interface UseResizeDragOptions {
+  onMove: (event: MouseEvent, stop: () => void) => void
+}
+
+export function useResizeDrag({ onMove }: UseResizeDragOptions) {
+  const onMoveRef = useRef(onMove)
+  const cleanupRef = useRef<(() => void) | null>(null)
+  const [isResizing, setIsResizing] = useState(false)
+
+  useEffect(() => {
+    onMoveRef.current = onMove
+  }, [onMove])
+
+  useEffect(() => {
+    return () => cleanupRef.current?.()
+  }, [])
+
+  const startResizing = useCallback((event: ReactMouseEvent) => {
+    event.preventDefault()
+    cleanupRef.current?.()
+
+    let active = true
+    const previousCursor = document.body.style.cursor
+    const previousUserSelect = document.body.style.userSelect
+
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+    setIsResizing(true)
+
+    const onMouseMove = (moveEvent: MouseEvent) => {
+      if (!active) return
+      onMoveRef.current(moveEvent, cleanup)
+    }
+
+    let cleanup = () => {}
+
+    const onVisibilityChange = () => {
+      if (document.hidden) cleanup()
+    }
+
+    cleanup = () => {
+      if (!active) return
+
+      active = false
+      setIsResizing(false)
+      document.body.style.cursor = previousCursor
+      document.body.style.userSelect = previousUserSelect
+      document.removeEventListener('mousemove', onMouseMove)
+      document.removeEventListener('mouseup', cleanup)
+      document.removeEventListener('mouseleave', cleanup)
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+      window.removeEventListener('blur', cleanup)
+      if (cleanupRef.current === cleanup) cleanupRef.current = null
+    }
+
+    document.addEventListener('mousemove', onMouseMove)
+    document.addEventListener('mouseup', cleanup)
+    document.addEventListener('mouseleave', cleanup)
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    window.addEventListener('blur', cleanup)
+    cleanupRef.current = cleanup
+  }, [])
+
+  return {
+    isResizing,
+    startResizing
+  }
+}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Renderer surfaces needed shared hooks for execution overlays and resize handling.

After this PR:

Reusable renderer hook utilities are added with focused tests.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The utilities are kept independent from page migrations so consumers can adopt them incrementally.

The following alternatives were considered:

Inlining the behavior in each page was considered, but hooks keep repeated state logic testable.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Full build gate passed when the branch was prepared: pnpm build:check.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Renderer utilities for overlays and resizing are available for shared use.
```
